### PR TITLE
[Row Layout] Fix "Add another section" button not increasing column count

### DIFF
--- a/src/blocks/rowlayout/edit.js
+++ b/src/blocks/rowlayout/edit.js
@@ -138,7 +138,6 @@ const ALLOWED_BLOCKS = [ 'kadence/column' ];
 	attributes,
 	setAttributes,
 	updateAlignment,
-	insertSection,
 	context,
 	updateColumns,
 	toggleSelection,
@@ -651,8 +650,15 @@ const ALLOWED_BLOCKS = [ 'kadence/column' ];
 							className="kb-row-add-section"
 							icon={ plusCircle }
 							onClick={ () => {
-								const newBlock = createBlock( 'kadence/column', {} );
-								insertSection( newBlock );
+								updateColumns( innerItemCount, columns + 1 );
+								setAttributes( {
+									columns: columns + 1,
+									colLayout: 'equal',
+									firstColumnWidth: undefined,
+									secondColumnWidth: undefined,
+									tabletLayout: 'inherit',
+									mobileLayout: 'row',
+								} );
 							} }
 							label={  __( 'Add Another Section', 'kadence-blocks' ) }
 							showTooltip={ true }
@@ -1188,14 +1194,7 @@ const RowLayoutEditContainerWrapper = withDispatch(
 			}
 
 			replaceInnerBlocks( clientId, innerBlocks );
-		},
-		insertSection( newBlock ) {
-			const { clientId } = ownProps;
-			const { insertBlock } = dispatch( blockEditorStore );
-			const { getBlock } = registry.select( blockEditorStore );
-			const block = getBlock( clientId );
-			insertBlock( newBlock, parseInt( block.innerBlocks.length ), clientId );
-		},
+		}
 	} )
 )( RowLayoutEditContainer );
 const KadenceRowLayout = ( props ) => {


### PR DESCRIPTION
PRing this change in case there's some functionality I'm missing. This button inserts a section but does not increase the column count.