### PR TITLE
Fix spacer block imports

### DIFF
--- a/src/blocks/spacer/deprecated.js
+++ b/src/blocks/spacer/deprecated.js
@@ -6,6 +6,8 @@
  import SvgPattern from './svg-pattern';
  import { KadenceColorOutput, DeprecatedKadenceColorOutput } from '@kadence/helpers';
  import classnames from 'classnames';
+import { useBlockProps } from '@wordpress/block-editor';
+
 import {
 	Fragment,
 	renderToString,
@@ -17,6 +19,154 @@ import {
  import { __ } from '@wordpress/i18n';
 
  export default [
+ {
+	 attributes: {
+		 blockAlignment: {
+			 type: 'string',
+			 default: 'none',
+		 },
+		 hAlign: {
+			 type: 'string',
+			 default: 'center',
+		 },
+		 spacerHeight: {
+			 type: 'number',
+			 default: 60,
+		 },
+		 spacerHeightUnits: {
+			 type: 'string',
+			 default: 'px',
+		 },
+		 tabletSpacerHeight: {
+			 type: 'number',
+			 default: '',
+		 },
+		 mobileSpacerHeight: {
+			 type: 'number',
+			 default: '',
+		 },
+		 dividerEnable: {
+			 type: 'boolean',
+			 default: true,
+		 },
+		 dividerStyle: {
+			 type: 'string',
+			 default: 'solid',
+		 },
+		 dividerOpacity: {
+			 type: 'number',
+			 default: 100,
+		 },
+		 dividerColor: {
+			 type: 'string',
+			 default: '#eee',
+		 },
+		 dividerWidth: {
+			 type: 'number',
+			 default: 80,
+		 },
+		 dividerHeight: {
+			 type: 'number',
+			 default: 1,
+		 },
+		 uniqueID: {
+			 type: 'string',
+			 default: '',
+		 },
+		 rotate: {
+			 type: 'number',
+			 default: 40,
+		 },
+		 strokeWidth: {
+			 type: 'number',
+			 default: 4,
+		 },
+		 strokeGap: {
+			 type: 'number',
+			 default: 5,
+		 },
+		 tabletHAlign: {
+			 type: 'string',
+			 default: '',
+		 },
+		 mobileHAlign: {
+			 type: 'string',
+			 default: '',
+		 },
+		 vsdesk: {
+			 type: 'boolean',
+			 default: false,
+		 },
+		 vstablet: {
+			 type: 'boolean',
+			 default: false,
+		 },
+		 vsmobile: {
+			 type: 'boolean',
+			 default: false,
+		 },
+	 },
+	 save: ( props ) => {
+		 const { attributes } = props;
+		 const {
+			 className,
+			 blockAlignment,
+			 dividerEnable,
+			 dividerStyle,
+			 hAlign,
+			 dividerColor,
+			 dividerOpacity,
+			 uniqueID,
+			 rotate,
+			 strokeWidth,
+			 strokeGap,
+			 tabletHAlign,
+			 mobileHAlign,
+			 vsdesk,
+			 vstablet,
+			 vsmobile,
+		 } = attributes;
+
+		 const innerSpacerClasses = classnames( {
+			 'kt-block-spacer'                            : true,
+			 [ `kt-block-spacer-halign-${hAlign}` ]       : hAlign,
+			 [ `kt-block-spacer-thalign-${tabletHAlign}` ]: tabletHAlign,
+			 [ `kt-block-spacer-malign-${mobileHAlign}` ] : mobileHAlign,
+		 } );
+
+		 const blockProps = useBlockProps.save( {
+			 className: classnames( {
+					 [ `align${( blockAlignment ? blockAlignment : 'none' )}` ]: true,
+					 [ `kt-block-spacer-${uniqueID}` ]                         : uniqueID,
+					 'kvs-lg-false'                                            : vsdesk !== 'undefined' && vsdesk,
+					 'kvs-md-false'                                            : vstablet !== 'undefined' && vstablet,
+					 'kvs-sm-false'                                            : vsmobile !== 'undefined' && vsmobile,
+				 },
+				 className
+			 ),
+		 } );
+
+		 return (
+			 <div {...blockProps}>
+				 <div className={innerSpacerClasses}>
+					 {dividerEnable && (
+						 <>
+							 {dividerStyle === 'stripe' && (
+								 <span className="kt-divider-stripe">
+								<SvgPattern uniqueID={uniqueID} color={KadenceColorOutput( dividerColor )} opacity={dividerOpacity} rotate={rotate} strokeWidth={strokeWidth}
+											strokeGap={strokeGap}/>
+							</span>
+							 )}
+							 {dividerStyle !== 'stripe' && (
+								 <hr className="kt-divider"/>
+							 )}
+						 </>
+					 )}
+				 </div>
+			 </div>
+		 );
+	 }
+ },
 	{
 		attributes: {
 			blockAlignment: {

--- a/src/blocks/spacer/edit.js
+++ b/src/blocks/spacer/edit.js
@@ -57,9 +57,10 @@ const ktspacerUniqueIDs = [];
 /**
  * Build the spacer edit
  */
-function KadenceSpacerDivider( { attributes, className, clientId, setAttributes, toggleSelection, getPreviewDevice } ) {
+function KadenceSpacerDivider( { attributes, clientId, setAttributes, toggleSelection, getPreviewDevice } ) {
 
 	const {
+		className,
 		blockAlignment,
 		spacerHeight,
 		tabletSpacerHeight,
@@ -120,7 +121,6 @@ function KadenceSpacerDivider( { attributes, className, clientId, setAttributes,
 
 	const blockProps = useBlockProps( {
 		className: className,
-		style: { color: 'blue' },
 	} );
 
 	let alp;

--- a/src/blocks/spacer/save.js
+++ b/src/blocks/spacer/save.js
@@ -13,6 +13,7 @@ import SvgPattern from './svg-pattern';
 
 function Save( { attributes } ) {
 	const {
+		className,
 		blockAlignment,
 		dividerEnable,
 		dividerStyle,
@@ -44,7 +45,9 @@ function Save( { attributes } ) {
 			'kvs-lg-false'                                            : vsdesk !== 'undefined' && vsdesk,
 			'kvs-md-false'                                            : vstablet !== 'undefined' && vstablet,
 			'kvs-sm-false'                                            : vsmobile !== 'undefined' && vsmobile,
-		} ),
+		},
+			className
+		),
 	} );
 
 	return (


### PR DESCRIPTION
Created a deprecation with `blockAlignment` default value of none.

Saving a spacer with an unset (undefined) `blockAlignment` adds the "alignnone" class. The default value for `blockAlignment` is center. When the editor is loaded again and save verification runs, the default value is given and it wants to save with the class "aligncenter"