### PR TITLE
Hacky solution to make doubly sure the design library button has rendered

### DIFF
--- a/src/plugins/prebuilt-library/toolbar-library.js
+++ b/src/plugins/prebuilt-library/toolbar-library.js
@@ -2,20 +2,14 @@
  * WordPress dependencies
  */
  import { registerPlugin } from '@wordpress/plugins';
- import {
-	withDispatch,
-} from '@wordpress/data';
 import {
-    useEffect,
-    useState,
 	render,
 } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, subscribe } from '@wordpress/data';
 import { createBlock, isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import {
 	Button,
@@ -30,8 +24,6 @@ import { kadenceBlocksIcon } from '@kadence/icons';
  * Add Prebuilt Library button to Gutenberg toolbar
  */
 function ToolbarLibrary() {
-	// const [ borderWidthControl, setBorderWidthControl ] = useState( 'individual' );
-	// const [ borderRadiusControl, setBorderRadiusControl ] = useState( 'linked' );
 	const { getSelectedBlock, getBlockIndex, getBlockHierarchyRootClientId } = useSelect( blockEditorStore );
 	const {
 		replaceBlocks,
@@ -82,31 +74,24 @@ function ToolbarLibrary() {
 			{ __( 'Design Library', 'kadence-blocks' ) }
 		</Button>
 	);
-	const checkElement = async selector => {
-		while ( document.querySelector(selector) === null) {
-			await new Promise( resolve => requestAnimationFrame( resolve ) )
-		}
-		return document.querySelector(selector);
+	const renderButton = ( selector ) => {
+		const toolbarButton = document.createElement( 'div' );
+		toolbarButton.classList.add( 'kadence-toolbar-design-library' );
+		selector.appendChild( toolbarButton );
+		render( <LibraryButton />, toolbarButton );
 	}
-	const renderButton = () => {
-		checkElement( '.edit-post-header-toolbar' ).then( ( selector ) => {
-			if ( ! selector.querySelector( '.kadence-toolbar-design-library' ) ) {
-				const toolbarButton = document.createElement( 'div' );
-				toolbarButton.classList.add( 'kadence-toolbar-design-library' );
-
-				selector.appendChild( toolbarButton );
-				render( <LibraryButton />, toolbarButton );
-
-				setTimeout(() => {
-					renderButton()
-				}, 1000)
+	if ( showSettings( 'show', 'kadence/designlibrary' ) && kadence_blocks_params.showDesignLibrary ) {
+		// Watch for the toolbar to be visible and the design library button to be missing.
+		let unsubscribe = subscribe( () => {
+			const editToolbar = document.querySelector( '.edit-post-header-toolbar' )
+			if ( ! editToolbar ) {
+				return
+			}
+			if ( ! editToolbar.querySelector( '.kadence-toolbar-design-library' ) ) {
+				renderButton( editToolbar );
 			}
 		} );
 		
-	}
-
-	if ( showSettings( 'show', 'kadence/designlibrary' ) && kadence_blocks_params.showDesignLibrary ) {
-		renderButton()
 	}
 
 	return null;

--- a/src/plugins/prebuilt-library/toolbar-library.js
+++ b/src/plugins/prebuilt-library/toolbar-library.js
@@ -88,7 +88,7 @@ function ToolbarLibrary() {
 		}
 		return document.querySelector(selector);
 	}
-	if ( showSettings( 'show', 'kadence/designlibrary' ) && kadence_blocks_params.showDesignLibrary ) {
+	const renderButton = () => {
 		checkElement( '.edit-post-header-toolbar' ).then( ( selector ) => {
 			if ( ! selector.querySelector( '.kadence-toolbar-design-library' ) ) {
 				const toolbarButton = document.createElement( 'div' );
@@ -96,8 +96,17 @@ function ToolbarLibrary() {
 
 				selector.appendChild( toolbarButton );
 				render( <LibraryButton />, toolbarButton );
+
+				setTimeout(() => {
+					renderButton()
+				}, 1000)
 			}
 		} );
+		
+	}
+
+	if ( showSettings( 'show', 'kadence/designlibrary' ) && kadence_blocks_params.showDesignLibrary ) {
+		renderButton()
 	}
 
 	return null;


### PR DESCRIPTION
addresses: https://app.clickup.com/t/863g28vdu

The problem is that we're using the editor plugin system's render method to append a button to the toolbar. 

I think the editor plugin system is linked more to the sidebar? In any case, it's not really in sync with the header toolbar. There's nothing promising that the toolbar's rendering will cause a re-render of an editor plugin. and so our button can get lost that way.

According to my testing, our plugin runs it's render, checks for the existence of the toolbar element, and renders the button as it should.
Then almost immediately after, the toolbar element re-renders itself. Thus the button is no longer appended. Our plugin does not re-run it's render at this point, only when it's given a reason to like the screen size changing or something like that.

I guess the render patterns for editor plugins and that tool bar were just sort of in sync before. I didn't find any obvious reason the toolbar changed it's rendering pattern in the last gutenberg / wp version, but it must have.

Anyways, I didn't find any good answers on this one. People have requested an official way to add elements to this toolbar:
https://github.com/WordPress/gutenberg/issues/16988
https://github.com/WordPress/gutenberg/issues/30901
but they haven't gone anywhere.

So I tried to keep my solution simple, if hacky. A timeout to double check that the button is rendered in the toolbar element. It seems to work in my testing.
