### PR TITLE
Make gradient control points more visible on lighter backgrounds

### DIFF
--- a/src/packages/components/src/gradient-control/editor.scss
+++ b/src/packages/components/src/gradient-control/editor.scss
@@ -72,7 +72,7 @@
 	width: inherit;
 	border-radius: 50%;
 	padding: 0;
-	box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) #fff,0 0 2px 0 rgba(0, 0, 0, 0.25);
+	box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) #fff,0 0 1px 0 rgba(0, 0, 0, 0.25);
 	outline: 2px solid transparent;
 	position: static;
     top: auto;


### PR DESCRIPTION
I've seen a few reports of people struggling to find the gradient control points when using lighter colors. This is most apparent when using a background overlay from white to transparent. 

I tried some borders but liked this approach better. 


![Screenshot 2023-02-23 at 11 11 57 AM](https://user-images.githubusercontent.com/61174/220980208-affc2dc0-6471-4032-8516-9437c788af5b.png)  Before
![Screenshot 2023-02-23 at 11 12 10 AM](https://user-images.githubusercontent.com/61174/220980201-f08cb79f-ad68-41b1-a06a-b0744957dc18.png)  After

![Screenshot 2023-02-23 at 11 11 50 AM](https://user-images.githubusercontent.com/61174/220980210-9eddf226-425c-46ef-b0d3-1f558d9a4c20.png)  Before
![Screenshot 2023-02-23 at 11 11 41 AM](https://user-images.githubusercontent.com/61174/220980213-75d84806-21d0-4709-a9a7-cfb9b0df8844.png)  After
