### PR TITLE
fixes columns set to 100% of the row height being limited by their max-content height

### DIFF
--- a/src/blocks/rowlayout/style.scss
+++ b/src/blocks/rowlayout/style.scss
@@ -19,9 +19,11 @@
 .kt-row-column-wrap {
 	display: grid;
     grid-template-columns: minmax(0, 1fr);
+    gap: var(--global-row-gutter-md, 2rem) var(--global-row-gutter-md, 2rem);
+}
+.kt-row-column-wrap:not(.kt-inner-column-height-full) {
 	/* autoprefixer: ignore next */
 	grid-auto-rows: minmax(min-content, max-content);
-    gap: var(--global-row-gutter-md, 2rem) var(--global-row-gutter-md, 2rem);
 }
 .wp-block-kadence-rowlayout .kt-row-column-wrap.kb-theme-content-width {
 	margin-left: auto;

--- a/src/blocks/rowlayout/style.scss
+++ b/src/blocks/rowlayout/style.scss
@@ -21,7 +21,8 @@
     grid-template-columns: minmax(0, 1fr);
     gap: var(--global-row-gutter-md, 2rem) var(--global-row-gutter-md, 2rem);
 }
-.kt-row-column-wrap:not(.kt-inner-column-height-full) {
+//don't give columns set to full height a limit of max content
+.kt-row-column-wrap:not(.kt-inner-column-height-full)  {
 	/* autoprefixer: ignore next */
 	grid-auto-rows: minmax(min-content, max-content);
 }
@@ -40,15 +41,26 @@
 .kt-inner-column-height-full > .wp-block-kadence-column > .kt-inside-inner-col {
 	height: 100%;
 }
+//tablet collapsed columns
 @media screen and (max-width: 1024px) {
-	.kt-inner-column-height-full.kt-tab-layout-inherit:not(.kt-row-layout-row) > .wp-block-kadence-column > .kt-inside-inner-col {
+	.kt-inner-column-height-full.kt-tab-layout-row,
+	.kt-inner-column-height-full.kt-tab-layout-inherit.kt-row-layout-row {
+		/* autoprefixer: ignore next */
+		grid-auto-rows: minmax(min-content, max-content);
+	}
+	.kt-inner-column-height-full.kt-tab-layout-inherit.kt-row-layout-row > .wp-block-kadence-column > .kt-inside-inner-col {
 		height: auto;
 	}
 	.kt-inner-column-height-full.kt-tab-layout-row > .wp-block-kadence-column > .kt-inside-inner-col {
 		height: auto;
 	}
 }
+//mobile collapsed columns
 @media screen and (max-width: 767px) {
+	.kt-inner-column-height-full.kt-mobile-layout-row {
+		/* autoprefixer: ignore next */
+		grid-auto-rows: minmax(min-content, max-content);
+	}
 	.kt-inner-column-height-full.kt-mobile-layout-row > .wp-block-kadence-column > .kt-inside-inner-col {
 		height: auto;
 	}


### PR DESCRIPTION
A good example is setting a row with two columns to min-height 100vh, set Inner Column Height 100%
then try to set the background on one of the columns. the background won't be 100vh, it will be the max-content of one of the columns.
<img width="879" alt="image" src="https://user-images.githubusercontent.com/49693677/221298120-76ae6920-5d21-42bc-8f64-89cbb5d326ab.png">


This css attempts to resolve that issue and keep the max-content behavior when the columns collapse or go into row layout.
<img width="885" alt="image" src="https://user-images.githubusercontent.com/49693677/221298053-59b76d75-c5f5-43ac-b142-07092a1dacf2.png">
