### PR TITLE
Upgrading the conversion functionality of the responsive measure range

### DIFF
--- a/src/packages/helpers/src/index.js
+++ b/src/packages/helpers/src/index.js
@@ -19,6 +19,6 @@ export { default as getTransferableAttributes } from './get-transferable-attribu
 export { default as getInQueryBlock } from './get-in-query-block';
 export { default as mouseOverVisualizer } from './mouse-over-visualizer';
 export { SPACING_SIZES_MAP, FONT_SIZES_MAP, GAP_SIZES_MAP, isRTL } from './constants';
-export { getSpacingOptionName, getSpacingOptionOutput, getSpacingOptionSize, getSpacingNameFromSize, getSpacingValueFromSize } from './spacing-utilities';
+export { getSpacingOptionName, getSpacingOptionOutput, getSpacingOptionSize, getSpacingNameFromSize, getSpacingValueFromSize, objectSameFill, clearNonMatchingValues } from './spacing-utilities';
 export { getFontSizeOptionOutput  } from './font-size-utilities';
 export { getGapSizeOptionOutput } from './gap-size-utilities';

--- a/src/packages/helpers/src/spacing-utilities/index.js
+++ b/src/packages/helpers/src/spacing-utilities/index.js
@@ -83,3 +83,64 @@ export function getSpacingValueFromSize( value, spacingMap = SPACING_SIZES_MAP )
 	}
 	return found.value;
 }
+
+/**
+ * Checks if two arrays have values that exist at the same indices and are of the same length
+ * @param {*} array1 
+ * @param {*} array2 
+ * @returns boolean
+ */
+export function objectSameFill( array1, array2 ) {
+	if ( typeof( array1 ) != 'object' || typeof( array2 ) != 'object' ) {
+		return false;
+	}
+
+	if ( array1.length != array2.length ) {
+		return false;
+	}
+
+	for ( let i = 0; i < array1.length; i++ ) {
+		const ele1 = array1[i];
+		const ele2 = array2[i];
+		
+		if ( ( ele1 && ! ele2 ) || ( ! ele1 && ele2 ) ) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Return incomingValue with any non matching (by data type) indices reset to ''
+ * Matching data type is determined by the last changed index from the reference
+ * @param {*} reference 
+ * @param {*} incomingValue 
+ * @returns {*}
+ */
+export function clearNonMatchingValues( reference, incomingValue ) {
+	if ( typeof( reference ) != 'object' || typeof( incomingValue ) != 'object' ) {
+		return incomingValue;
+	}
+
+	if ( reference.length != incomingValue.length ) {
+		return incomingValue;
+	}
+
+	let changedVal = null;
+
+	for ( let i = 0; i < reference.length; i++ ) {
+		const valPart = reference[i];
+		const incValPart = incomingValue[i];
+		
+		if ( valPart !== incValPart ) {
+			changedVal = incValPart;
+		}
+	}
+
+	if ( changedVal ) {
+		return incomingValue.map( val => typeof( val ) == typeof( changedVal ) ? val : '' );
+	}
+
+	return incomingValue;
+}


### PR DESCRIPTION
Addresses: https://app.clickup.com/t/865buf7ze

----
TLDR: I fixed and improved custom/option toggling in the responsive measure range control. This needs more testing.
----

So the issue with values disappearing in the responsive measure range control was two parts:

First, we are converting option values (xs, md, etc) to custom values (12, 9, etc) whenever the custom toggle is switched. This conversion always takes place and if any values can't be converted, they're cleared back to ''. 

Second, we only (and always) perform this conversion on the desktop values.

So what was happening was that someone could enter in some desktop custom values, then switch to tablet, then click the custom toggle. This triggered a conversion on the desktop custom values to option values. If they didn't convert, they were cleared.

My solution is two parts as well:

First, perform custom<->option conversions based on what the current device type is.

Second, during conversions, never clear values back to ''. The custom toggle should never directly affect your padding/margin values.
Conversions should only take place if all your values can be converted to an equivalent on the other side. I use a new helper function, objectSameFill, to determine this.

This change means that sometimes conversions don't happen. So now the component may be in the custom state, but still have option values and vice versa.
This enables a nice new feature where if you just toggle the custom switcher back and forth, your values don't change, even when you publish.
This also requires us to do some cleanup if you happen to be in the custom state, with option values underneath, and decide to set some custom values. We should clear all those old option values (since you can't see them in the custom state)
To this end I clear any non matching values in the onChange functions with the new clearNonMatchingValues helper.