### PR TITLE
Adding filter to make sure wp offload media runs on all content that would render css

### DIFF
--- a/includes/blocks/class-kadence-blocks-column-block.php
+++ b/includes/blocks/class-kadence-blocks-column-block.php
@@ -696,9 +696,7 @@ class Kadence_Blocks_Column_Block extends Kadence_Blocks_Abstract_Block {
 		if ( isset( $attributes['kadenceBlockCSS'] ) && ! empty( $attributes['kadenceBlockCSS'] ) ) {
 			$css->add_css_string( str_replace( 'selector', '.kadence-column' . $unique_id, $attributes['kadenceBlockCSS'] ) );
 		}
-		// Filter with cdn support.
-		$css_output = apply_filters( 'as3cf_filter_post_local_to_provider', $css->css_output() );
-		return $css_output;
+		return $css->css_output();
 	}
 }
 Kadence_Blocks_Column_Block::get_instance();

--- a/includes/class-kadence-blocks-frontend.php
+++ b/includes/class-kadence-blocks-frontend.php
@@ -377,7 +377,8 @@ class Kadence_Blocks_Frontend {
 			return;
 		}
 		if ( ! method_exists( $post_object, 'post_content' ) ) {
-			$blocks = parse_blocks( $post_object->post_content );
+			$post_content = apply_filters( 'as3cf_filter_post_local_to_provider', $post_object->post_content );
+			$blocks = parse_blocks( $post_content );
 			if ( ! is_array( $blocks ) || empty( $blocks ) ) {
 				return;
 			}


### PR DESCRIPTION
addresses: https://app.clickup.com/t/8677kzz4k

Post content that gets passed into css and html build processes that happen after the 'render_callback' entry point are appropriately filtered by wp offload media

but for the row/column layout (and potentially others), they have image attributes that get output through a different process, namely the 'frontend_build_css' function

This function gets block content with the parse_blocks function and its post content straight from the global $post object. Straight from the tap so speak. So wp offload media doesn't have the chance to filter it.

Adding in their custom filter higher up in the chain when we initially grab post content resolves issues where the correct url is not used when outputting these attributes.