### PR TITLE
Fix autofill issue when using basic honeypot

### DIFF
--- a/includes/blocks/class-kadence-blocks-form-block.php
+++ b/includes/blocks/class-kadence-blocks-form-block.php
@@ -758,6 +758,14 @@ class Kadence_Blocks_Form_Block extends Kadence_Blocks_Abstract_Block {
 	 */
 	public function build_html( $attributes, $unique_id, $content, $block_instance ) {
 		$content .= '<noscript><div class="kadence-blocks-form-message kadence-blocks-form-warning">' . __( 'Please enable JavaScript in your browser to submit the form', 'kadence-blocks' ) . '</div><style>.kadence-form-' . $unique_id . ' .kadence-blocks-form-field.kb-submit-field { display: none; }</style></noscript>';
+
+		// Update honeypot autocomplete value.
+		if( ( !isset( $attributes['honeyPot']) || isset( $attributes['honeyPot'] ) && $attributes['honeyPot'] ) ) {
+			$default = '<input class="kadence-blocks-field verify" type="text" name="_kb_verify_email" autocomplete="off" aria-hidden="true" placeholder="Email" tabindex="-1"/>';
+			$new     = '<input class="kadence-blocks-field verify" type="text" name="_kb_verify_email" autocomplete="new-password" aria-hidden="true" placeholder="Email" tabindex="-1" data-1p-ignore="true" data-lpignore="true" />';
+			$content = str_replace( $default, $new, $content );
+		}
+
 		return $content;
 	}
 


### PR DESCRIPTION
According to [this article](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#the_autocomplete_attribute_and_login_fields), most browsers no longer respect the autocomplete="off" attribute. I've implemented the [proposed unofficial approach](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#preventing_autofilling_with_autocompletenew-password) of using `autocomplete="new-password"`, which browsers do not autofill or save. 

Although I was unable to reproduce the autocomplete issue using Chrome or Firefox's native autofill, it did occur when using 1Password and LastPass. I've added the `data-1p-ignore` and `data-lpignore` attributes to address that problem.

I can send a zip of these changes to Karla to determine if this solve the native autofill issue with Chrome.