### PR TITLE
AI Modal Feature

### DIFF
--- a/src/plugins/prebuilt-library/ai-wizard/components/image-select/index.js
+++ b/src/plugins/prebuilt-library/ai-wizard/components/image-select/index.js
@@ -62,7 +62,7 @@ export function ImageSelect(props) {
 
 		frame = media({
 			title,
-			multiple: true,
+			multiple: 'add',
 			button: {
 				text: mediaButtonText || 'Use these images'
 			}

--- a/src/plugins/prebuilt-library/ai-wizard/components/slider/slider.js
+++ b/src/plugins/prebuilt-library/ai-wizard/components/slider/slider.js
@@ -19,7 +19,7 @@ import './slider.scss';
 
 const styles = {
 	img: {
-		height: 'clamp(400px, 600px, 80vh)',
+		height: 'clamp(400px, 600px, 60vh)',
 		width: 'auto',
 		aspectRation: '11/15'
 	},

--- a/src/plugins/prebuilt-library/ai-wizard/index.js
+++ b/src/plugins/prebuilt-library/ai-wizard/index.js
@@ -16,7 +16,8 @@ import { collectionsHelper } from './utils/collections-helper';
 import './kadence-ai-wizard.scss';
 
 export function AiWizard( {
-	onClose,
+	photographyOnly = false,
+	onClose
 } ) {
 	const [ wizardData, setWizardData ] = useState();
 	//const [ wizardOpen, setWizardOpen ] = useState(false);
@@ -44,7 +45,11 @@ export function AiWizard( {
 		<>
 			{ ( wizardData && ! loading) && (
 				<KadenceAiProvider value={ wizardData }>
-					<KadenceAiWizard loading={ loading } handleWizardClose={ onClose }/>
+					<KadenceAiWizard
+						loading={ loading }
+						handleWizardClose={ onClose }
+						photographyOnly={ photographyOnly }
+					/>
 				</KadenceAiProvider>
 			) }
 		</>

--- a/src/plugins/prebuilt-library/ai-wizard/kadence-ai-wizard.js
+++ b/src/plugins/prebuilt-library/ai-wizard/kadence-ai-wizard.js
@@ -34,18 +34,22 @@ const pages = [
 	},
 ];
 
-function getPages() {
+function getPages(photographyOnly) {
 	const { state: { firstTime } } = useKadenceAi();
+
+	if (photographyOnly) {
+		return pages.filter((page) => page.id === 'photography');
+	}
 
 	return ! firstTime ? pages.filter((page) => page.id !== 'how-it-works') : pages;
 }
 
-export function KadenceAiWizard({ loading, handleWizardClose }) {
+export function KadenceAiWizard({ loading, handleWizardClose, photographyOnly }) {
 	const { state, dispatch } = useKadenceAi();
 	const {
 		isForwardButtonDisabled,
 		isFinishButtonDisabled
-	} = useAiWizardHelper(state, getPages());
+	} = useAiWizardHelper(state, getPages(photographyOnly));
 	const { saveAiWizardData } = useDatabase();
 
 	async function handleOnFinish(event) {
@@ -89,7 +93,7 @@ export function KadenceAiWizard({ loading, handleWizardClose }) {
 	return (
 		<Wizard
 			logo={ <KadenceK /> }
-			pages={ getPages() }
+			pages={ getPages(photographyOnly) }
 			forwardButtonDisabled={ isForwardButtonDisabled() }
 			finishButtonDisabled={ isFinishButtonDisabled() }
 			onPageChange={ (pageIndex) => dispatch({ type: 'SET_CURRENT_PAGE_INDEX', payload: pageIndex }) }

--- a/src/plugins/prebuilt-library/pattern-library.js
+++ b/src/plugins/prebuilt-library/pattern-library.js
@@ -142,7 +142,10 @@ function PatternLibrary( {
 	const [ previewMode, setPreviewMode ] = useState();
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ isImporting, setIsImporting ] = useState( false );
-	const [ isWizardVisible, setIsWizardVisible ] = useState( false );
+	const [ wizardState, setWizardState ] = useState( {
+		visible: false,
+		photographyOnly: false
+	} );
 	const [ isError, setIsError ] = useState( false );
 	const [ style, setStyle ] = useState( '' );
 	const [ fontSize, setFontSize ] = useState( '' );
@@ -158,7 +161,10 @@ function PatternLibrary( {
         setIsContextReloadVisible( ( state ) => ! state );
     };
 	const closeAIWizard = () => {
-		setIsWizardVisible( false );
+		setWizardState( {
+			visible: false,
+			photographyOnly: false
+		} );
 		triggerAIDataReload( ( state ) => ! state );
 	};
 	let data_key     = ( kadence_blocks_params.proData &&  kadence_blocks_params.proData.api_key ?  kadence_blocks_params.proData.api_key : '' );
@@ -674,7 +680,23 @@ function PatternLibrary( {
 										text={ __('Update My Information', 'kadence') }
 										onClick={ () => {
 											setIsVisible( false );
-											setIsWizardVisible( true );
+											setWizardState( {
+												visible: true,
+												photographyOnly: false
+											} );
+										}}
+									/>
+									<Button
+										className='kadence-ai-wizard-button'
+										iconPosition='right'
+										icon={ aiIcon }
+										text={ __('Update Image Collection', 'kadence') }
+										onClick={ () => {
+											setIsVisible( false );
+											setWizardState( {
+												visible: true,
+												photographyOnly: true
+											} );
 										}}
 									/>
 									<ToggleControl
@@ -690,8 +712,8 @@ function PatternLibrary( {
 									/>
 								</Popover>
 							) }
-							{ isWizardVisible && (
-								<AiWizard onClose={ closeAIWizard } />
+							{ wizardState.visible && (
+								<AiWizard onClose={ closeAIWizard } photographyOnly={ wizardState.photographyOnly } />
 							) }
 						</div>
 					</div>


### PR DESCRIPTION
https://www.loom.com/share/1d13684df60d4a95a41bbed358a098a8

- Adds the ability to open the AI Modal and see only the photography UI.
- Changes `wp.media` request to open in `add` mode, allowing the user to select multiple images without holding the CTRL key.
- Adjusts the clamp values on images within the AI Modal slideshow for better small-screen display.