### PR TITLE
Prophecy REST request improvements / bug fixes

### DIFF
--- a/includes/class-kadence-blocks-prebuilt-library-rest-api.php
+++ b/includes/class-kadence-blocks-prebuilt-library-rest-api.php
@@ -1185,14 +1185,15 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 			'image_type' => $image_type,
 			'sizes' => $sizes,
 		);
-		$api_url  = add_query_arg( $body, $this->remote_ai_url . 'images/collections' );
 		$response = wp_remote_post(
-			$api_url,
+			$this->remote_ai_url . 'images/collections',
 			array(
 				'timeout' => 20,
 				'headers' => array(
 					'X-Prophecy-Token' => base64_encode( json_encode( $auth ) ),
+					'Content-Type' => 'application/json',
 				),
+				'body' => json_encode( $body ),
 			)
 		);
 		// Early exit if there was an error.

--- a/includes/class-kadence-blocks-prebuilt-library-rest-api.php
+++ b/includes/class-kadence-blocks-prebuilt-library-rest-api.php
@@ -1029,14 +1029,15 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 				break;
 		}
 		//error_log( print_r( $body, true ));
-		$api_url  = add_query_arg( $body, $this->remote_ai_url . 'content/create' );
 		$response = wp_remote_post(
-			$api_url,
+			$this->remote_ai_url . 'content/create',
 			array(
 				'timeout' => 20,
 				'headers' => array(
 					'X-Prophecy-Token' => base64_encode( json_encode( $auth ) ),
+					'Content-Type' => 'application/json',
 				),
+				'body' => json_encode( $body ),
 			)
 		);
 		// Early exit if there was an error.


### PR DESCRIPTION
Updates all Prophecy post requests to send as a JSON body. This fixes a bug where if the any of the fields (company, mission etc...) had an `&` symbol, it was never urlencoded. All of these were previously sent as a query string, so when it came time for WordPress on the Content server to get the parameters, anything after the unescaped `&` was considered a variable and not the actual content.

This is a much safer way to send data as we'll also never hit max URI length limits etc...