### PR TITLE
Adds Keywords length color indicator to AI intake form

### DIFF
--- a/src/plugins/prebuilt-library/ai-wizard/pages/about-your-site.js
+++ b/src/plugins/prebuilt-library/ai-wizard/pages/about-your-site.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { useEffect, useState } from '@wordpress/element';
 import {
 	Flex,
 	FlexBlock,
@@ -38,6 +39,10 @@ const styles = {
 	rightContent: {
 		backgroundColor: '#000000',
 	},
+	keywordsLength: {
+		'good': 'green',
+		'poor': 'red',
+	}
 }
 
 export function AboutYourSite() {
@@ -48,6 +53,24 @@ export function AboutYourSite() {
 		keywords,
 		tone
 	} = state;
+
+	const [ keywordsLengthError, setKeywordsLengthError ] = useState( null );
+
+	useEffect(() => {
+		if ( keywords.length > 0 && keywords.length < 5 ) {
+			setKeywordsLengthError( 'poor' );
+		} else if ( keywords.length >= 5 ) {
+			setKeywordsLengthError( 'good' );
+		}
+	}, [ keywords ])
+
+	function getKeywordsLengthStyle() {
+		if ( keywordsLengthError && styles.keywordsLength.hasOwnProperty( keywordsLengthError ) ) {
+			return styles.keywordsLength[ keywordsLengthError ];
+		}
+
+		return 'inherit';
+	}
 
 	return (
 		<Flex gap={ 0 } align="normal" style={ styles.container }>
@@ -76,7 +99,9 @@ export function AboutYourSite() {
 										<Flex>{ __('Separate with commas or the Enter key.', 'kadence-blocks') }</Flex>
 										<Flex>
 											<FlexBlock>{ __('Enter between 5 and 10 keywords', 'kadence-blocks') }</FlexBlock>
-											<FlexItem>{ `${ keywords.length }/${ maxTags }`}</FlexItem>
+											<FlexItem style={ { color: getKeywordsLengthStyle() } }>
+												{ `${ keywords.length }/${ maxTags }` }
+											</FlexItem>
 										</Flex>
 									</>
 								}


### PR DESCRIPTION
Provides better visual feedback on length requirements of the Keywords field, on the AI intake form.

![Keywords_Count_Indicator](https://github.com/stellarwp/kadence-blocks/assets/1146948/cd30cc68-1149-483a-a923-81b86f81a81e)
