### PR TITLE
Advanced Form schema change

### DIFF
--- a/includes/advanced-form/advanced-form-init.php
+++ b/includes/advanced-form/advanced-form-init.php
@@ -9,8 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-require_once KADENCE_BLOCKS_PATH . 'includes/advanced-form/advanced-form-schema-updater.php';
-
 require_once KADENCE_BLOCKS_PATH . 'includes/blocks/class-kadence-blocks-advanced-form-block.php';
 require_once KADENCE_BLOCKS_PATH . 'includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php';
 require_once KADENCE_BLOCKS_PATH . 'includes/blocks/form/class-kadence-blocks-text-input-block.php';

--- a/includes/class-kadence-blocks-schema-updater.php
+++ b/includes/class-kadence-blocks-schema-updater.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * Schema updater for Kadence Form post meta.
+ * Schema updater for Kadence Blocks.
  *
  * @package Kadence Blocks.
  */
-class Kadence_Blocks_Form_Schema_Updater {
+class Kadence_Blocks_Schema_Updater {
 
 	/**
 	 * Instance Control
@@ -24,7 +24,7 @@ class Kadence_Blocks_Form_Schema_Updater {
 	/**
 	 * The option key for the schema version.
 	 */
-	const OPTION_KEY = 'kadence_blocks_form_schema_version';
+	const OPTION_KEY = 'kadence_blocks_schema_version';
 
 	/**
 	 * The current version of the schema.
@@ -79,6 +79,11 @@ class Kadence_Blocks_Form_Schema_Updater {
 	 * @return void
 	 */
 	private function update_0_to_1() {
+		$form_posts = get_posts( array(
+			'post_type'   => 'kadence_form',
+			'numberposts' => - 1,
+		) );
+
 		$meta_to_update = array(
 			'_kad_form_inputFont',
 			'_kad_form_labelFont',
@@ -87,7 +92,7 @@ class Kadence_Blocks_Form_Schema_Updater {
 			'_kad_form_messageFont'
 		);
 
-		foreach ( $this->get_form_posts() as $post ) {
+		foreach ( $form_posts as $post ) {
 			foreach ( $meta_to_update as $meta_key ) {
 				$meta_value = get_post_meta( $post->ID, $meta_key, true );
 
@@ -99,13 +104,6 @@ class Kadence_Blocks_Form_Schema_Updater {
 			}
 		}
 	}
-
-	private function get_form_posts() {
-		return get_posts( array(
-			'post_type'   => 'kadence_form',
-			'numberposts' => - 1,
-		) );
-	}
 }
 
-Kadence_Blocks_Form_Schema_Updater::get_instance();
+Kadence_Blocks_Schema_Updater::get_instance();

--- a/kadence-blocks.php
+++ b/kadence-blocks.php
@@ -44,6 +44,7 @@ function kadence_blocks_init() {
 	require_once KADENCE_BLOCKS_PATH . 'includes/init.php';
 	require_once KADENCE_BLOCKS_PATH . 'includes/form-ajax.php';
 	require_once KADENCE_BLOCKS_PATH . 'includes/helper-functions.php';
+	require_once KADENCE_BLOCKS_PATH . 'includes/class-kadence-blocks-schema-updater.php';
 	require_once KADENCE_BLOCKS_PATH . 'includes/class-kadence-blocks-prebuilt-library.php';
 	require_once KADENCE_BLOCKS_PATH . 'includes/class-kadence-blocks-google-fonts.php';
 	require_once KADENCE_BLOCKS_PATH . 'includes/class-kadence-blocks-css.php';


### PR DESCRIPTION
**Initial issue:** Cannot save the form after changing the font on labels, help text, messages. 

**Fix**: The `google` sub-attribute had a type of string, but needs to be a boolean.


This change will update existing data to match the schema. Without doing this, existing forms will throw an error in the editor. WordPress sees that the post meta data != schema and considers it invalid. 

My thinking is this update code can live in the codebase through the beta period and is to be removed once final release is out. This can also be used with a new version number if we need other schema changes.