### PR TITLE
Fix for head rendered css with in loop dynamic content

### DIFF
--- a/includes/blocks/class-kadence-blocks-abstract-block.php
+++ b/includes/blocks/class-kadence-blocks-abstract-block.php
@@ -125,7 +125,8 @@ class Kadence_Blocks_Abstract_Block {
 
 				$unique_id = $attributes['uniqueID'];
 				$css_class = Kadence_Blocks_CSS::get_instance();
-				if ( ! $css_class->has_styles( 'kb-' . $this->block_name . $unique_id ) && apply_filters( 'kadence_blocks_render_head_css', true, $this->block_name, $attributes ) ) {
+				$has_dynamic_content = isset( $attributes['kadenceDynamic'] ) && ! empty( $attributes['kadenceDynamic'] );
+				if ( ! $css_class->has_styles( 'kb-' . $this->block_name . $unique_id ) && apply_filters( 'kadence_blocks_render_head_css', true, $this->block_name, $attributes ) && ! $has_dynamic_content ) {
 					// Filter attributes for easier dynamic css.
 					$attributes = apply_filters( 'kadence_blocks_' . $this->block_name . '_render_block_attributes', $attributes );
 					$this->build_css( $attributes, $css_class, $unique_id, $unique_id );

--- a/includes/blocks/class-kadence-blocks-abstract-block.php
+++ b/includes/blocks/class-kadence-blocks-abstract-block.php
@@ -125,8 +125,7 @@ class Kadence_Blocks_Abstract_Block {
 
 				$unique_id = $attributes['uniqueID'];
 				$css_class = Kadence_Blocks_CSS::get_instance();
-				$has_dynamic_content = isset( $attributes['kadenceDynamic'] ) && ! empty( $attributes['kadenceDynamic'] );
-				if ( ! $css_class->has_styles( 'kb-' . $this->block_name . $unique_id ) && apply_filters( 'kadence_blocks_render_head_css', true, $this->block_name, $attributes ) && ! $has_dynamic_content ) {
+				if ( ! $css_class->has_styles( 'kb-' . $this->block_name . $unique_id ) && apply_filters( 'kadence_blocks_render_head_css', true, $this->block_name, $attributes ) ) {
 					// Filter attributes for easier dynamic css.
 					$attributes = apply_filters( 'kadence_blocks_' . $this->block_name . '_render_block_attributes', $attributes );
 					$this->build_css( $attributes, $css_class, $unique_id, $unique_id );

--- a/src/packages/helpers/src/get-in-query-block/index.js
+++ b/src/packages/helpers/src/get-in-query-block/index.js
@@ -4,8 +4,9 @@
 export default function getInQueryBlock( context, inQueryBlock ) {
     const inQueryContext = Boolean( context && ( context.queryId || Number.isFinite( context.queryId ) ) && context.postId );
     const inRepeaterContext = Boolean( context && 'undefined' != typeof( context['kadence/dynamicSource'] ) && context['kadence/dynamicSource'] );
+    const inKPElement = 'undefined' != typeof( kbpData ) && 'undefined' != typeof( kbpData.isKadenceE ) && kbpData.isKadenceE;
 
-    if ( inQueryContext || inRepeaterContext ) {
+    if ( inQueryContext || inRepeaterContext || inKPElement ) {
         return true;
     }
     return false;

--- a/src/packages/helpers/src/get-in-query-block/index.js
+++ b/src/packages/helpers/src/get-in-query-block/index.js
@@ -4,9 +4,9 @@
 export default function getInQueryBlock( context, inQueryBlock ) {
     const inQueryContext = Boolean( context && ( context.queryId || Number.isFinite( context.queryId ) ) && context.postId );
     const inRepeaterContext = Boolean( context && 'undefined' != typeof( context['kadence/dynamicSource'] ) && context['kadence/dynamicSource'] );
-    const inKPElement = 'undefined' != typeof( kbpData ) && 'undefined' != typeof( kbpData.isKadenceE ) && kbpData.isKadenceE;
+    const inKadenceE = 'undefined' != typeof( kbpData ) && 'undefined' != typeof( kbpData.isKadenceE ) && kbpData.isKadenceE;
 
-    if ( inQueryContext || inRepeaterContext || inKPElement ) {
+    if ( inQueryContext || inRepeaterContext || inKadenceE ) {
         return true;
     }
     return false;


### PR DESCRIPTION
Addresses: https://app.clickup.com/t/8684xd7qk

An option that will fix dynamic css rendering in the head when the block itself might be in a loop, wnting to use the loop post context.