### PR TITLE
Always show all custom fields

### DIFF
--- a/src/plugins/kadence-control-plugin.js
+++ b/src/plugins/kadence-control-plugin.js
@@ -20,7 +20,7 @@ import * as BlockIcons from '@kadence/icons';
  * Import Settings
  */
 import KadenceEditorWidth from './editor-width';
-import KadenceSettings from './settings';
+import KadenceSetting from './settings';
 import KadenceColors from './block-defaults/color-palette-defaults';
 
 /*
@@ -581,10 +581,26 @@ function KadenceConfig() {
 						title={__('Pexels Library Search', 'kadence-blocks')}
 						initialOpen={ false }
 					>
-						<KadenceSettings />
+						<KadenceSetting 
+							slug={'enable_image_picker'}
+							label={__('Enable Pexels Image Picker', 'kadence-blocks')}
+							type={'toggle'}
+							theDefault={true}
+						/>
 					</PanelBody>
-
-
+					{ 'undefined' !== typeof( window.kadenceDynamicParams ) && (
+						<PanelBody
+							title={__('Dynamic Content Settings', 'kadence-blocks')}
+							initialOpen={ false }
+						>
+							<KadenceSetting 
+								slug={'get_fields_show_all'}
+								label={__('Always show all fields', 'kadence-blocks')}
+								type={'toggle'}
+								theDefault={false}
+							/>
+						</PanelBody>
+					) }
 					</>
 					// End check for user = admin.
 				)}

--- a/src/plugins/settings.js
+++ b/src/plugins/settings.js
@@ -19,7 +19,8 @@ import {store as noticesStore} from '@wordpress/notices';
  */
 import {__} from '@wordpress/i18n';
 
-function KadenceSettings() {
+function KadenceSetting( props ) {
+    const { slug, label, type, theDefault} = props;
 
     const [isSaving, setIsSaving] = useState(false);
     const [settings, setSettings] = useState((kadence_blocks_params.globalSettings ? JSON.parse(kadence_blocks_params.globalSettings) : {}));
@@ -46,15 +47,17 @@ function KadenceSettings() {
 
     return (
         <>
-            <ToggleControl
-				label={__('Enable Pexels Image Picker', 'kadence-blocks')}
-				isBusy={isSaving}
-				checked={ ( undefined !== settings?.enable_image_picker && false === settings?.enable_image_picker ? false : true ) }
-				onChange={ ( value ) => saveConfig('enable_image_picker', value) }
-			/>
+            { type == 'toggle' && (
+                <ToggleControl
+                    label={label}
+                    isBusy={isSaving}
+                    checked={ ( undefined !== settings?.[slug] && ( ! theDefault ) === settings?.[slug] ? ( ! theDefault ) : theDefault ) }
+                    onChange={ ( value ) => saveConfig(slug, value) }
+                />
+            ) }
         </>
-    );
+    )
 
 }
 
-export default KadenceSettings;
+export default KadenceSetting;


### PR DESCRIPTION
Can stand alone, but requires a matching pro update to actually apply (only shows when pro is active)