### PR TITLE
Bugfix/image block image overflowing

### DIFF
--- a/src/blocks/image/editor.scss
+++ b/src/blocks/image/editor.scss
@@ -183,6 +183,7 @@ figure.wp-block-kadence-image:not(.wp-block) {
 		display: block;
 		width: inherit;
 		height: inherit;
+		box-sizing: border-box;
 	}
 }
 .wp-block-kadence-image.kb-image-is-ratio-size .components-resizable-box__container {

--- a/src/blocks/image/style.scss
+++ b/src/blocks/image/style.scss
@@ -5,6 +5,7 @@
 	img {
 		max-width: 100%;
 		border: 0 solid currentColor;
+		box-sizing: border-box;
 	}
 
 	.aligncenter {


### PR DESCRIPTION
The image overflows from the container in Image Block, when border and overlay are used. So, I just modified the css to make it contain.