### PR TITLE
Bugfix/progressbar block not aligning center in editor

### DIFF
--- a/src/blocks/progress-bar/edit.js
+++ b/src/blocks/progress-bar/edit.js
@@ -204,7 +204,7 @@ export function Edit( props ) {
 		'kb-progress-bar-container'               : true,
 		[ `kb-progress-bar-container${uniqueID}` ]: true,
 		[ `kb-progress-bar-type-${barType}` ]     : true,
-		[ `kb-progress-bar-align${align}`]		  : true,	
+		[ `kb-progress-bar-align${ undefined !== align && align}`] : true,	
 	} );
 
 	const blockProps = useBlockProps( {

--- a/src/blocks/progress-bar/edit.js
+++ b/src/blocks/progress-bar/edit.js
@@ -204,6 +204,7 @@ export function Edit( props ) {
 		'kb-progress-bar-container'               : true,
 		[ `kb-progress-bar-container${uniqueID}` ]: true,
 		[ `kb-progress-bar-type-${barType}` ]     : true,
+		[ `kb-progress-bar-align${align}`]		  : true,	
 	} );
 
 	const blockProps = useBlockProps( {

--- a/src/blocks/progress-bar/edit.js
+++ b/src/blocks/progress-bar/edit.js
@@ -204,7 +204,7 @@ export function Edit( props ) {
 		'kb-progress-bar-container'               : true,
 		[ `kb-progress-bar-container${uniqueID}` ]: true,
 		[ `kb-progress-bar-type-${barType}` ]     : true,
-		[ `kb-progress-bar-align${ undefined !== align && align}`] : true,	
+		[ `kb-progress-bar-align${ undefined !== align ? align : ''}`] : true,	
 	} );
 
 	const blockProps = useBlockProps( {

--- a/src/blocks/progress-bar/editor.scss
+++ b/src/blocks/progress-bar/editor.scss
@@ -9,6 +9,10 @@
 	width: fit-content;
 }
 
+.kb-progress-bar-align {
+	float: none;
+}
+
 .kb-progress-bar-alignleft {
 	float: left;
 }

--- a/src/blocks/progress-bar/editor.scss
+++ b/src/blocks/progress-bar/editor.scss
@@ -7,6 +7,17 @@
 
 .kb-progress-bar-container {
 	width: fit-content;
+}
+
+.kb-progress-bar-alignleft {
+	float: left;
+}
+
+.kb-progress-bar-alignright {
+	float: right;
+}
+
+.kb-progress-bar-aligncenter {
 	margin: 0 auto;
 }
 

--- a/src/blocks/progress-bar/editor.scss
+++ b/src/blocks/progress-bar/editor.scss
@@ -5,6 +5,11 @@
  * which makes it higher in priority.
  */
 
+.kb-progress-bar-container {
+	width: fit-content;
+	margin: 0 auto;
+}
+
 .kb-progress-label-wrap {
 	display: flex;
 	flex-wrap: wrap;


### PR DESCRIPTION
KAD-1329 Alignment came from `<div class="wp-block" data-type="left">` but that div dissapeared when aligning center, to give consistency I injected classes in the other block container to handle all the alignments. I used the same styles that were used in the previously used alignment classes.