### PR TITLE
Bugfix/border color for advanced form block

### DIFF
--- a/src/blocks/advanced-form/components/backend-styles/index.js
+++ b/src/blocks/advanced-form/components/backend-styles/index.js
@@ -67,6 +67,26 @@ export default function BackendStyles( { uniqueID, previewDevice, fieldStyle, la
 
 				${ fieldStyles?.boxShadow ? 'box-shadow: ' + fieldStyles.boxShadow + ';' : '' }
 		}
+		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form input[type="text"]:not(.ignore-field-styles):focus,
+		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form input[type="email"]:focus,
+		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form input[type="url"]:focus,
+		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form input[type="password"]:focus,
+		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form input[type="search"]:focus,
+		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form input[type="number"]:focus,
+		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form input[type="tel"]:focus,
+		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form input[type="range"]:focus,
+		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form input[type="date"]:focus,
+		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form input[type="month"]:focus,
+		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form input[type="week"]:focus,
+		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form input[type="time"]:focus,
+		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form input[type="datetime"]:focus,
+		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form input[type="datetime-local"]:focus,
+		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form input[type="color"]:focus,
+		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form input[type="file"]:focus,
+		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form select:focus,
+		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form textarea:focus {
+			${ fieldStyles?.borderActive ? 'border-color: ' + fieldStyles.borderActive + ';' : '' }
+		}
 		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form input:not(.ignore-field-styles):focus,
 		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form select:not(.ignore-field-styles):focus,
 		.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form textarea:focus {

--- a/src/blocks/advanced-form/components/get-styles/input-styles/index.js
+++ b/src/blocks/advanced-form/components/get-styles/input-styles/index.js
@@ -12,6 +12,7 @@ export default ( previewDevice, fieldStyle, inputFont, useFormMeta ) => {
 	const [ fieldBorderRadiusUnit ] = useFormMeta( '_kad_form_fieldBorderRadiusUnit' );
 
 	const [ fieldBorderStyle ] = useFormMeta( '_kad_form_fieldBorderStyle' );
+	const [ fieldBorderActive ] = useFormMeta( '_kad_form_fieldBorderActive' );
 	const [ tabletFieldBorderStyle ] = useFormMeta( '_kad_form_tabletFieldBorderStyle' );
 	const [ mobileFieldBorderStyle ] = useFormMeta( '_kad_form_mobileFieldBorderStyle' );
 
@@ -68,11 +69,13 @@ export default ( previewDevice, fieldStyle, inputFont, useFormMeta ) => {
 	styles.borderBottomColor = getBorderColor( previewDevice, 'bottom', [ fieldBorderStyle ], [ tabletFieldBorderStyle ], [ mobileFieldBorderStyle ] );
 	styles.borderLeftColor = getBorderColor( previewDevice, 'left', [ fieldBorderStyle ], [ tabletFieldBorderStyle ], [ mobileFieldBorderStyle ] );
 
+	styles.borderActive = fieldStyle?.borderActive ? fieldStyle.borderActive : '';
+
 	styles.borderTop = getBorderStyle( previewDevice, 'top', [ fieldBorderStyle ], [ tabletFieldBorderStyle ], [ mobileFieldBorderStyle ] );
 	styles.borderRight = getBorderStyle( previewDevice, 'right', [ fieldBorderStyle ], [ tabletFieldBorderStyle ], [ mobileFieldBorderStyle ] );
 	styles.borderBottom = getBorderStyle( previewDevice, 'bottom', [ fieldBorderStyle ], [ tabletFieldBorderStyle ], [ mobileFieldBorderStyle ] );
 	styles.borderLeft = getBorderStyle( previewDevice, 'left', [ fieldBorderStyle ], [ tabletFieldBorderStyle ], [ mobileFieldBorderStyle ] );
-
+	
 	styles.boxShadow = ( undefined !== fieldStyle?.boxShadow && undefined !== fieldStyle?.boxShadow[ 0 ] && fieldStyle?.boxShadow[ 0 ] ? ( undefined !== fieldStyle?.boxShadow[ 7 ] && fieldStyle?.boxShadow[ 7 ] ? 'inset ' : '' ) + ( undefined !== fieldStyle?.boxShadow[ 3 ] ? fieldStyle?.boxShadow[ 3 ] : 1 ) + 'px ' + ( undefined !== fieldStyle?.boxShadow[ 4 ] ? fieldStyle?.boxShadow[ 4 ] : 1 ) + 'px ' + ( undefined !== fieldStyle?.boxShadow[ 5 ] ? fieldStyle?.boxShadow[ 5 ] : 2 ) + 'px ' + ( undefined !== fieldStyle?.boxShadow[ 6 ] ? fieldStyle?.boxShadow[ 6 ] : 0 ) + 'px ' + KadenceColorOutput( ( undefined !== fieldStyle?.boxShadow[ 1 ] ? fieldStyle?.boxShadow[ 1 ] : '#000000' ), ( undefined !== fieldStyle?.boxShadow[ 2 ] ? fieldStyle?.boxShadow[ 2 ] : 1 ) ) : undefined );
 
 	if ( undefined !== fieldStyle?.backgroundType && 'gradient' === fieldStyle?.backgroundType && undefined !== fieldStyle?.gradient && '' !== fieldStyle?.gradient ) {

--- a/src/blocks/advanced-form/components/get-styles/input-styles/index.js
+++ b/src/blocks/advanced-form/components/get-styles/input-styles/index.js
@@ -10,9 +10,7 @@ export default ( previewDevice, fieldStyle, inputFont, useFormMeta ) => {
 	const [ tabletFieldBorderRadius ] = useFormMeta( '_kad_form_tabletFieldBorderRadius' );
 	const [ mobileFieldBorderRadius ] = useFormMeta( '_kad_form_mobileFieldBorderRadius' );
 	const [ fieldBorderRadiusUnit ] = useFormMeta( '_kad_form_fieldBorderRadiusUnit' );
-
 	const [ fieldBorderStyle ] = useFormMeta( '_kad_form_fieldBorderStyle' );
-	const [ fieldBorderActive ] = useFormMeta( '_kad_form_fieldBorderActive' );
 	const [ tabletFieldBorderStyle ] = useFormMeta( '_kad_form_tabletFieldBorderStyle' );
 	const [ mobileFieldBorderStyle ] = useFormMeta( '_kad_form_mobileFieldBorderStyle' );
 

--- a/src/blocks/advanced-form/components/style-options/field/index.js
+++ b/src/blocks/advanced-form/components/style-options/field/index.js
@@ -25,6 +25,8 @@ import {
 	ResponsiveGapSizeControl,
 	ResponsiveMeasureRangeControl,
 } from '@kadence/components';
+
+import { KadenceColorOutput } from '@kadence/helpers';
 import { useSetting } from '@wordpress/block-editor';
 
 import { default as useColorIsDark } from '../../use-color-is-dark';
@@ -181,7 +183,7 @@ export default function FieldStyles( { setMetaAttribute, inputFont, style, useFo
 							value={( style?.borderActive ? style.borderActive : '' )}
 							default={''}
 							onChange={ ( value ) => {
-								saveStyle( { borderActive: value } );
+								saveStyle( { borderActive: KadenceColorOutput(value) } );
 							}}
 						/>
 					</>
@@ -275,7 +277,7 @@ export default function FieldStyles( { setMetaAttribute, inputFont, style, useFo
 							onChange={( value ) => setMetaAttribute( value[0], 'fieldBorderStyle' ) }
 							onChangeTablet={( value ) => setMetaAttribute( value[0], 'tabletFieldBorderStyle')}
 							onChangeMobile={( value ) => setMetaAttribute( value[0], 'mobileFieldBorderStyle' )}
-						/>y
+						/>
 						<ResponsiveMeasurementControls
 							label={__( 'Border Radius', 'kadence-blocks' )}
 							value={fieldBorderRadius}

--- a/src/blocks/advanced-form/components/style-options/field/index.js
+++ b/src/blocks/advanced-form/components/style-options/field/index.js
@@ -266,98 +266,98 @@ export default function FieldStyles( { setMetaAttribute, inputFont, style, useFo
 								saveStyleBoxShadow( value, 7 );
 							}}
 						/>
+						<h2>{__( 'Border Settings', 'kadence-blocks' )}</h2>
+						<ResponsiveBorderControl
+							label={__( 'Border', 'kadence-blocks' )}
+							value={ [ fieldBorderStyle ] }
+							tabletValue={ [tabletFieldBorderStyle] }
+							mobileValue={ [mobileFieldBorderStyle] }
+							onChange={( value ) => setMetaAttribute( value[0], 'fieldBorderStyle' ) }
+							onChangeTablet={( value ) => setMetaAttribute( value[0], 'tabletFieldBorderStyle')}
+							onChangeMobile={( value ) => setMetaAttribute( value[0], 'mobileFieldBorderStyle' )}
+						/>y
+						<ResponsiveMeasurementControls
+							label={__( 'Border Radius', 'kadence-blocks' )}
+							value={fieldBorderRadius}
+							tabletValue={tabletFieldBorderRadius}
+							mobileValue={mobileFieldBorderRadius}
+							onChange={( value ) => setMetaAttribute( value, 'fieldBorderRadius')}
+							onChangeTablet={( value ) => setMetaAttribute( value, 'tabletFieldBorderRadius' )}
+							onChangeMobile={( value ) => setMetaAttribute( value, 'mobileFieldBorderRadius' )}
+							unit={fieldBorderRadiusUnit}
+							units={[ 'px', 'em', 'rem', '%' ]}
+							onUnit={( value ) => setMetaAttribute( value, 'fieldBorderRadiusUnit' ) }
+							max={(fieldBorderRadiusUnit === 'em' || fieldBorderRadiusUnit === 'rem' ? 24 : 500)}
+							step={(fieldBorderRadiusUnit === 'em' || fieldBorderRadiusUnit === 'rem' ? 0.1 : 1)}
+							min={ 0 }
+							isBorderRadius={ true }
+							allowEmpty={true}
+						/>
+						<TypographyControls
+							fontSize={inputFont.size}
+							onFontSize={( value ) => saveInputFont( { size: value } )}
+							fontSizeType={inputFont.sizeType}
+							onFontSizeType={( value ) => saveInputFont( { sizeType: value } )}
+							lineHeight={inputFont.lineHeight}
+							onLineHeight={( value ) => saveInputFont( { lineHeight: value } )}
+							lineHeightType={inputFont.lineType}
+							onLineHeightType={( value ) => saveInputFont( { lineType: value } )}
+						/>
+						<KadencePanelBody
+							title={__( 'Advanced Field Settings', 'kadence-blocks' )}
+							initialOpen={false}
+							panelName={'kb-form-advanced-field-settings'}
+						>
+							<TypographyControls
+								fontGroup={'body'}
+								reLetterSpacing={inputFont.letterSpacing}
+								onLetterSpacing={( value ) => saveInputFont( { letterSpacing: value } )}
+								letterSpacingType={inputFont?.letterType}
+								onLetterSpacingType={( value ) => saveInputFont( { letterType: value } )}
+								textTransform={inputFont.textTransform}
+								onTextTransform={( value ) => saveInputFont( { textTransform: value } )}
+								fontFamily={inputFont.family}
+								onFontFamily={( value ) => saveInputFont( { family: value } )}
+								onFontChange={( select ) => {
+									saveInputFont( {
+										family: select.value,
+										google: select.google,
+									} );
+								}}
+								onFontArrayChange={( values ) => saveInputFont( values )}
+								googleFont={inputFont.google}
+								onGoogleFont={( value ) => saveInputFont( { google: value } )}
+								loadGoogleFont={inputFont.loadGoogle}
+								onLoadGoogleFont={( value ) => saveInputFont( { loadGoogle: value } )}
+								fontVariant={inputFont.variant}
+								onFontVariant={( value ) => saveInputFont( { variant: value } )}
+								fontWeight={inputFont.weight}
+								onFontWeight={( value ) => saveInputFont( { weight: value } )}
+								fontStyle={inputFont.style}
+								onFontStyle={( value ) => saveInputFont( { style: value } )}
+								fontSubset={inputFont.subset}
+								onFontSubset={( value ) => saveInputFont( { subset: value } )}
+							/>
+							<ResponsiveMeasurementControls
+								label={__( 'Input Padding', 'kadence-blocks' )}
+								value={ style?.padding}
+								onChange={( value ) => saveStyle( { padding: value } )}
+								tabletValue={ style?.tabletPadding}
+								onChangeTablet={( value ) => saveStyle( { tabletPadding: value } )}
+								mobileValue={ style?.mobilePadding}
+								onChangeMobile={( value ) => saveStyle( { mobilePadding: value } )}
+								min={0}
+								max={( style?.paddingUnit === 'em' || style?.paddingUnit === 'rem' ? 12 : 200 )}
+								step={( style?.paddingUnit === 'em' || style?.paddingUnit === 'rem' ? 0.1 : 1 )}
+								unit={ style?.paddingUnit ? style?.paddingUnit : 'px' }
+								units={[ 'px', 'em', 'rem' ]}
+								onUnit={( value ) => saveStyle( { paddingUnit: value } )}
+								allowEmpty={true}
+							/>
+						</KadencePanelBody>
 					</>
 				}
 			/>
-			<h2>{__( 'Border Settings', 'kadence-blocks' )}</h2>
-			<ResponsiveBorderControl
-				label={__( 'Border', 'kadence-blocks' )}
-				value={ [ fieldBorderStyle ] }
-				tabletValue={ [tabletFieldBorderStyle] }
-				mobileValue={ [mobileFieldBorderStyle] }
-				onChange={( value ) => setMetaAttribute( value[0], 'fieldBorderStyle' ) }
-				onChangeTablet={( value ) => setMetaAttribute( value[0], 'tabletFieldBorderStyle')}
-				onChangeMobile={( value ) => setMetaAttribute( value[0], 'mobileFieldBorderStyle' )}
-			/>
-			<ResponsiveMeasurementControls
-				label={__( 'Border Radius', 'kadence-blocks' )}
-				value={fieldBorderRadius}
-				tabletValue={tabletFieldBorderRadius}
-				mobileValue={mobileFieldBorderRadius}
-				onChange={( value ) => setMetaAttribute( value, 'fieldBorderRadius')}
-				onChangeTablet={( value ) => setMetaAttribute( value, 'tabletFieldBorderRadius' )}
-				onChangeMobile={( value ) => setMetaAttribute( value, 'mobileFieldBorderRadius' )}
-				unit={fieldBorderRadiusUnit}
-				units={[ 'px', 'em', 'rem', '%' ]}
-				onUnit={( value ) => setMetaAttribute( value, 'fieldBorderRadiusUnit' ) }
-				max={(fieldBorderRadiusUnit === 'em' || fieldBorderRadiusUnit === 'rem' ? 24 : 500)}
-				step={(fieldBorderRadiusUnit === 'em' || fieldBorderRadiusUnit === 'rem' ? 0.1 : 1)}
-				min={ 0 }
-				isBorderRadius={ true }
-				allowEmpty={true}
-			/>
-			<TypographyControls
-				fontSize={inputFont.size}
-				onFontSize={( value ) => saveInputFont( { size: value } )}
-				fontSizeType={inputFont.sizeType}
-				onFontSizeType={( value ) => saveInputFont( { sizeType: value } )}
-				lineHeight={inputFont.lineHeight}
-				onLineHeight={( value ) => saveInputFont( { lineHeight: value } )}
-				lineHeightType={inputFont.lineType}
-				onLineHeightType={( value ) => saveInputFont( { lineType: value } )}
-			/>
-			<KadencePanelBody
-				title={__( 'Advanced Field Settings', 'kadence-blocks' )}
-				initialOpen={false}
-				panelName={'kb-form-advanced-field-settings'}
-			>
-				<TypographyControls
-					fontGroup={'body'}
-					reLetterSpacing={inputFont.letterSpacing}
-					onLetterSpacing={( value ) => saveInputFont( { letterSpacing: value } )}
-					letterSpacingType={inputFont?.letterType}
-					onLetterSpacingType={( value ) => saveInputFont( { letterType: value } )}
-					textTransform={inputFont.textTransform}
-					onTextTransform={( value ) => saveInputFont( { textTransform: value } )}
-					fontFamily={inputFont.family}
-					onFontFamily={( value ) => saveInputFont( { family: value } )}
-					onFontChange={( select ) => {
-						saveInputFont( {
-							family: select.value,
-							google: select.google,
-						} );
-					}}
-					onFontArrayChange={( values ) => saveInputFont( values )}
-					googleFont={inputFont.google}
-					onGoogleFont={( value ) => saveInputFont( { google: value } )}
-					loadGoogleFont={inputFont.loadGoogle}
-					onLoadGoogleFont={( value ) => saveInputFont( { loadGoogle: value } )}
-					fontVariant={inputFont.variant}
-					onFontVariant={( value ) => saveInputFont( { variant: value } )}
-					fontWeight={inputFont.weight}
-					onFontWeight={( value ) => saveInputFont( { weight: value } )}
-					fontStyle={inputFont.style}
-					onFontStyle={( value ) => saveInputFont( { style: value } )}
-					fontSubset={inputFont.subset}
-					onFontSubset={( value ) => saveInputFont( { subset: value } )}
-				/>
-				<ResponsiveMeasurementControls
-					label={__( 'Input Padding', 'kadence-blocks' )}
-					value={ style?.padding}
-					onChange={( value ) => saveStyle( { padding: value } )}
-					tabletValue={ style?.tabletPadding}
-					onChangeTablet={( value ) => saveStyle( { tabletPadding: value } )}
-					mobileValue={ style?.mobilePadding}
-					onChangeMobile={( value ) => saveStyle( { mobilePadding: value } )}
-					min={0}
-					max={( style?.paddingUnit === 'em' || style?.paddingUnit === 'rem' ? 12 : 200 )}
-					step={( style?.paddingUnit === 'em' || style?.paddingUnit === 'rem' ? 0.1 : 1 )}
-					unit={ style?.paddingUnit ? style?.paddingUnit : 'px' }
-					units={[ 'px', 'em', 'rem' ]}
-					onUnit={( value ) => saveStyle( { paddingUnit: value } )}
-					allowEmpty={true}
-				/>
-			</KadencePanelBody>
 		</>
 	);
 

--- a/src/blocks/advanced-form/components/style-options/field/index.js
+++ b/src/blocks/advanced-form/components/style-options/field/index.js
@@ -25,10 +25,8 @@ import {
 	ResponsiveGapSizeControl,
 	ResponsiveMeasureRangeControl,
 } from '@kadence/components';
-
 import { KadenceColorOutput } from '@kadence/helpers';
 import { useSetting } from '@wordpress/block-editor';
-
 import { default as useColorIsDark } from '../../use-color-is-dark';
 
 export default function FieldStyles( { setMetaAttribute, inputFont, style, useFormMeta } ) {


### PR DESCRIPTION
KAD-1578 When the "Focus" tab is selected, I made all options not related with focus to hide, so the user can only see those options in the "Normal" tab. Also I fixed the fields border in the backend, it wasn´t showing the right border color when on focus.