### PR TITLE
Simplify & Standardize X-Prophecy-Token creation for plugin REST API endpoints

### DIFF
--- a/includes/analytics/class-analytics.php
+++ b/includes/analytics/class-analytics.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * General Analytics class responsible for sending events to Prophecy WP.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+/**
+ * REST API Products controller class.
+ */
+class Analytics {
+
+	/**
+	 * The remote URL.
+	 *
+	 * @access protected
+	 * @var string
+	 */
+	protected $event_url = 'https://content.startertemplatecloud.com/wp-json/prophecy/v1/analytics/event';
+
+	/**
+	 * Registers all necessary hooks.
+	 *
+	 * @action plugins_loaded
+	 *
+	 * @return void
+	 */
+	public function register() {
+		add_action( 'stellarwp/analytics/event', [ $this, 'handle_event' ], 10, 2 );
+	}
+
+	/**
+	 * Sends events to Prophecy WP (if the user has opted-in to Telemetry).
+	 *
+	 * @return void
+	 */
+	public function handle_event( string $name, array $context ) {
+
+		// Only track events when Kadence Blocks Pro is active.
+		if ( ! class_exists( 'Kadence_Blocks_Pro' ) ) {
+			return;
+		}
+
+		wp_remote_post(
+			$this->event_url,
+			array(
+				'timeout' => 20,
+				'headers' => array(
+					'X-Prophecy-Token' => $this->get_prophecy_token_header(),
+					'Content-Type' => 'application/json',
+				),
+				'body' => json_encode( [
+					'name'    => $name,
+					'context' => $context,
+				] ),
+			)
+		);
+	}
+
+	/**
+	 * Constructs a consistent X-Prophecy-Token header.
+	 *
+	 * @param array $args An array of arguments to include in the encoded header.
+	 *
+	 * @return string The base64 encoded string.
+	 */
+	public static function get_prophecy_token_header( $args = [] ) {
+		if ( is_callable( 'network_home_url' ) ) {
+			$site_url = network_home_url( '', 'http' );
+		} else {
+			$site_url = get_bloginfo( 'url' );
+		}
+
+		$site_url     = str_replace( array( 'http://', 'https://', 'www.' ), array( '', '', '' ), $site_url );
+		$current_user = wp_get_current_user();
+		$site_name    = get_bloginfo( 'name' );
+
+		$defaults = [
+			'domain'          => $site_url,
+			'key'             => '',
+			'user_id'         => $current_user->ID,
+			'email'           => $current_user->email,
+			'site_name'       => $site_name,
+			'product_slug'    => 'kadence-blocks',
+			'product_version' => KADENCE_BLOCKS_VERSION
+		];
+
+		$parsed_args = wp_parse_args( $args, $defaults );
+
+		return base64_encode( json_encode( $parsed_args ) );
+	}
+
+}

--- a/includes/class-kadence-blocks-prebuilt-library-rest-api.php
+++ b/includes/class-kadence-blocks-prebuilt-library-rest-api.php
@@ -2301,16 +2301,17 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 			$site_url = get_bloginfo( 'url' );
 		}
 
-		$site_url        = str_replace( array( 'http://', 'https://', 'www.' ), array( '', '', '' ), $site_url );
-		$current_user_id = wp_get_current_user()->ID ?? 0;
-		$site_name       = get_bloginfo( 'name' );
+		$site_url     = str_replace( array( 'http://', 'https://', 'www.' ), array( '', '', '' ), $site_url );
+		$current_user = wp_get_current_user();
+		$site_name    = get_bloginfo( 'name' );
 
 		$defaults = [
-			'domain' => $site_url,
-			'key'  => $this->api_key,
-			'user_id' => $current_user_id,
-			'site_name' => $site_name,
-			'product_slug' => 'kadence-blocks',
+			'domain'          => $site_url,
+			'key'             => $this->api_key,
+			'user_id'         => $current_user->ID,
+			'email'           => $current_user->email,
+			'site_name'       => $site_name,
+			'product_slug'    => 'kadence-blocks',
 			'product_version' => KADENCE_BLOCKS_VERSION
 		];
 

--- a/includes/class-kadence-blocks-prebuilt-library-rest-api.php
+++ b/includes/class-kadence-blocks-prebuilt-library-rest-api.php
@@ -1456,7 +1456,7 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 			array(
 				'timeout' => 20,
 				'headers' => array(
-					'X-Prophecy-Token' => $this->get_prophecy_token_header(),
+					'X-Prophecy-Token' => Analytics::get_prophecy_token_header( ['key' => $this->api_key] ),
 					'Content-Type' => 'application/json',
 				),
 				'body' => json_encode( $body ),
@@ -1511,7 +1511,7 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 			array(
 				'timeout' => 20,
 				'headers' => array(
-					'X-Prophecy-Token' => $this->get_prophecy_token_header(),
+					'X-Prophecy-Token' => Analytics::get_prophecy_token_header( ['key' => $this->api_key] ),
 				),
 			)
 		);
@@ -1622,7 +1622,7 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 			array(
 				'timeout' => 20,
 				'headers' => array(
-					'X-Prophecy-Token' => $this->get_prophecy_token_header(),
+					'X-Prophecy-Token' => Analytics::get_prophecy_token_header( ['key' => $this->api_key] ),
 					'Content-Type' => 'application/json',
 				),
 				'body' => json_encode( $body ),
@@ -1675,7 +1675,7 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 			array(
 				'timeout' => 20,
 				'headers' => array(
-					'X-Prophecy-Token' => $this->get_prophecy_token_header(),
+					'X-Prophecy-Token' => Analytics::get_prophecy_token_header( ['key' => $this->api_key] ),
 					'Content-Type' => 'application/json',
 				),
 				'body' => json_encode( $body ),
@@ -1747,7 +1747,7 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 			array(
 				'timeout' => 20,
 				'headers' => array(
-					'X-Prophecy-Token' => $this->get_prophecy_token_header(),
+					'X-Prophecy-Token' => Analytics::get_prophecy_token_header( ['key' => $this->api_key] ),
 				),
 			)
 		);
@@ -1789,7 +1789,7 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 			array(
 				'timeout' => 20,
 				'headers' => array(
-					'X-Prophecy-Token' => $this->get_prophecy_token_header(),
+					'X-Prophecy-Token' => Analytics::get_prophecy_token_header( ['key' => $this->api_key] ),
 					'Content-Type' => 'application/json',
 				),
 				'body' => json_encode( $body ),
@@ -1828,7 +1828,7 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 			array(
 				'timeout' => 20,
 				'headers' => array(
-					'X-Prophecy-Token' => $this->get_prophecy_token_header(),
+					'X-Prophecy-Token' => Analytics::get_prophecy_token_header( ['key' => $this->api_key] ),
 					'Content-Type' => 'application/json',
 				),
 				'body' => json_encode( $body ),
@@ -2285,38 +2285,5 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 			WP_Filesystem();
 		}
 		return $wp_filesystem;
-	}
-
-	/**
-	 * Simplifies constructing an X-Prophecy-Token header.
-	 *
-	 * @param array $args An array of arguments to include in the encoded header.
-	 *
-	 * @return string The base64 encoded string.
-	 */
-	protected function get_prophecy_token_header( $args = [] ) {
-		if ( is_callable( 'network_home_url' ) ) {
-			$site_url = network_home_url( '', 'http' );
-		} else {
-			$site_url = get_bloginfo( 'url' );
-		}
-
-		$site_url     = str_replace( array( 'http://', 'https://', 'www.' ), array( '', '', '' ), $site_url );
-		$current_user = wp_get_current_user();
-		$site_name    = get_bloginfo( 'name' );
-
-		$defaults = [
-			'domain'          => $site_url,
-			'key'             => $this->api_key,
-			'user_id'         => $current_user->ID,
-			'email'           => $current_user->email,
-			'site_name'       => $site_name,
-			'product_slug'    => 'kadence-blocks',
-			'product_version' => KADENCE_BLOCKS_VERSION
-		];
-
-		$parsed_args = wp_parse_args( $args, $defaults );
-
-		return base64_encode( json_encode( $parsed_args ) );
 	}
 }

--- a/includes/class-kadence-blocks-prebuilt-library-rest-api.php
+++ b/includes/class-kadence-blocks-prebuilt-library-rest-api.php
@@ -1210,16 +1210,6 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 	 * @return string Returns the remote URL contents.
 	 */
 	public function get_new_remote_contents( $context ) {
-		if ( is_callable( 'network_home_url' ) ) {
-			$site_url = network_home_url( '', 'http' );
-		} else {
-			$site_url = get_bloginfo( 'url' );
-		}
-		$site_url = str_replace( array( 'http://', 'https://', 'www.' ), array( '', '', '' ), $site_url );
-		$auth = array(
-			'domain' => $site_url,
-			'key'    => $this->api_key,
-		);
 		$prophecy_data = json_decode( get_option( 'kadence_blocks_prophecy' ), true );
 		// Get the response.
 		$body = array(
@@ -1466,7 +1456,7 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 			array(
 				'timeout' => 20,
 				'headers' => array(
-					'X-Prophecy-Token' => base64_encode( json_encode( $auth ) ),
+					'X-Prophecy-Token' => $this->get_prophecy_token_header(),
 					'Content-Type' => 'application/json',
 				),
 				'body' => json_encode( $body ),
@@ -1515,23 +1505,13 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 	 * @return string Returns the remote URL contents.
 	 */
 	public function get_remote_contents( $job ) {
-		if ( is_callable( 'network_home_url' ) ) {
-			$site_url = network_home_url( '', 'http' );
-		} else {
-			$site_url = get_bloginfo( 'url' );
-		}
-		$site_url = str_replace( array( 'http://', 'https://', 'www.' ), array( '', '', '' ), $site_url );
-		$auth = array(
-			'domain' => $site_url,
-			'key'    => $this->api_key,
-		);
 		$api_url  = $this->remote_ai_url . 'content/job/' . $job;
 		$response = wp_remote_get(
 			$api_url,
 			array(
 				'timeout' => 20,
 				'headers' => array(
-					'X-Prophecy-Token' => base64_encode( json_encode( $auth ) ),
+					'X-Prophecy-Token' => $this->get_prophecy_token_header(),
 				),
 			)
 		);
@@ -1614,16 +1594,6 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 	 * @return string Returns the remote URL contents.
 	 */
 	public function get_remote_search_images( $search_query, $image_type = 'JPEG', $sizes = array() ) {
-		if ( is_callable( 'network_home_url' ) ) {
-			$site_url = network_home_url( '', 'http' );
-		} else {
-			$site_url = get_bloginfo( 'url' );
-		}
-		$site_url = str_replace( array( 'http://', 'https://', 'www.' ), array( '', '', '' ), $site_url );
-		$auth = array(
-			'domain' => $site_url,
-			'key'    => $this->api_key,
-		);
 		if ( empty( $search_query ) ) {
 			return 'error';
 		}
@@ -1652,7 +1622,7 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 			array(
 				'timeout' => 20,
 				'headers' => array(
-					'X-Prophecy-Token' => base64_encode( json_encode( $auth ) ),
+					'X-Prophecy-Token' => $this->get_prophecy_token_header(),
 					'Content-Type' => 'application/json',
 				),
 				'body' => json_encode( $body ),
@@ -1679,16 +1649,6 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 	 * @return string Returns the remote URL contents.
 	 */
 	public function get_remote_industry_images( $industries, $image_type = 'JPEG', $sizes = array() ) {
-		if ( is_callable( 'network_home_url' ) ) {
-			$site_url = network_home_url( '', 'http' );
-		} else {
-			$site_url = get_bloginfo( 'url' );
-		}
-		$site_url = str_replace( array( 'http://', 'https://', 'www.' ), array( '', '', '' ), $site_url );
-		$auth = array(
-			'domain' => $site_url,
-			'key'    => $this->api_key,
-		);
 		if ( empty( $industries ) ) {
 			return 'error';
 		}
@@ -1715,7 +1675,7 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 			array(
 				'timeout' => 20,
 				'headers' => array(
-					'X-Prophecy-Token' => base64_encode( json_encode( $auth ) ),
+					'X-Prophecy-Token' => $this->get_prophecy_token_header(),
 					'Content-Type' => 'application/json',
 				),
 				'body' => json_encode( $body ),
@@ -1781,23 +1741,13 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 	 * @return string Returns the remote URL contents.
 	 */
 	public function get_remote_image_collections() {
-		if ( is_callable( 'network_home_url' ) ) {
-			$site_url = network_home_url( '', 'http' );
-		} else {
-			$site_url = get_bloginfo( 'url' );
-		}
-		$site_url = str_replace( array( 'http://', 'https://', 'www.' ), array( '', '', '' ), $site_url );
-		$auth = array(
-			'domain' => $site_url,
-			'key'    => $this->api_key,
-		);
 		$api_url  = $this->remote_ai_url . 'images/collections';
 		$response = wp_remote_get(
 			$api_url,
 			array(
 				'timeout' => 20,
 				'headers' => array(
-					'X-Prophecy-Token' => base64_encode( json_encode( $auth ) ),
+					'X-Prophecy-Token' => $this->get_prophecy_token_header(),
 				),
 			)
 		);
@@ -1826,16 +1776,6 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 		if ( empty( $parameters['name'] ) || empty( $parameters['entity_type'] ) || empty($parameters['industry']) || empty($parameters['location']) || empty($parameters['description']) ) {
 			return new WP_REST_Response( array( 'error' => 'Missing parameters' ), 400 );
 		}
-		if ( is_callable( 'network_home_url' ) ) {
-			$site_url = network_home_url( '', 'http' );
-		} else {
-			$site_url = get_bloginfo( 'url' );
-		}
-		$site_url = str_replace( array( 'http://', 'https://', 'www.' ), array( '', '', '' ), $site_url );
-		$auth = array(
-			'domain' => $site_url,
-			'key'    => $request->get_param( self::PROP_API_KEY ),
-		);
 		$api_url  = $this->remote_ai_url . 'proxy/intake/search-query';
 		$body = array(
 			'name' => $parameters['name'],
@@ -1849,7 +1789,7 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 			array(
 				'timeout' => 20,
 				'headers' => array(
-					'X-Prophecy-Token' => base64_encode( json_encode( $auth ) ),
+					'X-Prophecy-Token' => $this->get_prophecy_token_header(),
 					'Content-Type' => 'application/json',
 				),
 				'body' => json_encode( $body ),
@@ -1874,16 +1814,6 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 		if ( empty( $parameters['name'] ) || empty($parameters['entity_type']) || empty($parameters['industry']) || empty($parameters['location']) || empty($parameters['description']) ) {
 			return new WP_REST_Response( array( 'error' => 'Missing parameters' ), 400 );
 		}
-		if ( is_callable( 'network_home_url' ) ) {
-			$site_url = network_home_url( '', 'http' );
-		} else {
-			$site_url = get_bloginfo( 'url' );
-		}
-		$site_url = str_replace( array( 'http://', 'https://', 'www.' ), array( '', '', '' ), $site_url );
-		$auth = array(
-			'domain' => $site_url,
-			'key'    => $request->get_param( self::PROP_API_KEY ),
-		);
 		$api_url  = $this->remote_ai_url . 'proxy/intake/suggest-keywords';
 		$body = array(
 			'name' => $parameters['name'],
@@ -1898,7 +1828,7 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 			array(
 				'timeout' => 20,
 				'headers' => array(
-					'X-Prophecy-Token' => base64_encode( json_encode( $auth ) ),
+					'X-Prophecy-Token' => $this->get_prophecy_token_header(),
 					'Content-Type' => 'application/json',
 				),
 				'body' => json_encode( $body ),
@@ -2355,5 +2285,35 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 			WP_Filesystem();
 		}
 		return $wp_filesystem;
+	}
+
+	/**
+	 * Simplifies constructing an X-Prophecy-Token header.
+	 *
+	 * @param array $args An array of arguments to include in the encoded header.
+	 *
+	 * @return string The base64 encoded string.
+	 */
+	protected function get_prophecy_token_header( $args = [] ) {
+		if ( is_callable( 'network_home_url' ) ) {
+			$site_url = network_home_url( '', 'http' );
+		} else {
+			$site_url = get_bloginfo( 'url' );
+		}
+		$site_url = str_replace( array( 'http://', 'https://', 'www.' ), array( '', '', '' ), $site_url );
+
+		$current_user_id = wp_get_current_user()->ID ?? 0;
+
+		$defaults = [
+			'domain' => $site_url,
+			'key'  => $this->api_key,
+			'user_id' => $current_user_id,
+			'product_slug' => 'kadence-blocks',
+			'product_version' => KADENCE_BLOCKS_VERSION
+		];
+
+		$parsed_args = wp_parse_args( $args, $defaults );
+
+		return base64_encode( json_encode( $parsed_args ) );
 	}
 }

--- a/includes/class-kadence-blocks-prebuilt-library-rest-api.php
+++ b/includes/class-kadence-blocks-prebuilt-library-rest-api.php
@@ -2300,14 +2300,16 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 		} else {
 			$site_url = get_bloginfo( 'url' );
 		}
-		$site_url = str_replace( array( 'http://', 'https://', 'www.' ), array( '', '', '' ), $site_url );
 
+		$site_url        = str_replace( array( 'http://', 'https://', 'www.' ), array( '', '', '' ), $site_url );
 		$current_user_id = wp_get_current_user()->ID ?? 0;
+		$site_name       = get_bloginfo( 'name' );
 
 		$defaults = [
 			'domain' => $site_url,
 			'key'  => $this->api_key,
 			'user_id' => $current_user_id,
+			'site_name' => $site_name,
 			'product_slug' => 'kadence-blocks',
 			'product_version' => KADENCE_BLOCKS_VERSION
 		];

--- a/kadence-blocks.php
+++ b/kadence-blocks.php
@@ -113,6 +113,14 @@ function kadence_blocks_init() {
 	Config::set_hook_prefix( 'kadence-blocks' );
 	Config::set_stellar_slug( 'kadence-blocks' );
 	Telemetry::instance()->init( __FILE__ );
+
+	/**
+	 * AI-specific analytics.
+	 */
+	require_once KADENCE_BLOCKS_PATH . 'includes/analytics/class-analytics.php';
+	$analytics = new Analytics();
+	$analytics->register();
+
 	/**
 	 * Uplink.
 	 */


### PR DESCRIPTION
Most of the plugin's registered REST routes were manually configuring the `X-Prophecy-Token` header. This reduces that code repetition and provides a single point where those values can be modified.