### PR TITLE
Bugfix/font size units in help text for adv form fields

### DIFF
--- a/includes/blocks/class-kadence-blocks-advanced-form-block.php
+++ b/includes/blocks/class-kadence-blocks-advanced-form-block.php
@@ -259,14 +259,27 @@ class Kadence_Blocks_Advanced_Form_Block extends Kadence_Blocks_Abstract_Block {
 		$css->set_selector( '.wp-block-kadence-advanced-form' . $unique_id . ' .kb-adv-form-help' );
 
 		if ( isset( $help_style['lineHeight'] ) ) {
-			$css->render_responsive_size( $help_style['lineHeight'], array( 0, 1, 2 ), 'line-height', 'lineType' );
+			$help_font_line_height = array( 
+				'lineHeight' => $help_style['lineHeight'][0],
+				'lineType' => $help_style['lineType'],
+			);
+			$css->render_responsive_size( $help_font_line_height, array( 'lineHeight', 1, 2 ), 'line-height', 'lineType' );
 		}
 
 		if ( isset( $help_style['size'] ) ) {
-			$css->render_responsive_size( $help_style['size'], array( 0, 1, 2 ), 'font-size', 'sizeType' );
+			$help_font_size = array( 
+				'size' => $help_style['size'][0],
+				'sizeType' => $help_style['sizeType'],
+			);
+			$css->render_responsive_size( $help_font_size, array( 'size', 1, 2 ), 'font-size', 'sizeType' );
 		}
 		if ( isset( $help_style['letterSpacing'] ) ) {
-			$css->render_responsive_size( $help_style['letterSpacing'], array( 0, 1, 2 ), 'letter-spacing', 'letterType' );
+			$help_font_letter_spacing = array( 
+				'letterSpacing' => $help_style['letterSpacing'][0],
+				'letterType' => $help_style['letterType'],
+			);
+			
+			$css->render_responsive_size( $help_font_letter_spacing, array( 'letterSpacing', 1, 2 ), 'letter-spacing', 'letterType' );
 		}
 
 		$css->render_color_output( $help_style, 'color', 'color' );

--- a/includes/blocks/class-kadence-blocks-advanced-form-block.php
+++ b/includes/blocks/class-kadence-blocks-advanced-form-block.php
@@ -257,7 +257,8 @@ class Kadence_Blocks_Advanced_Form_Block extends Kadence_Blocks_Abstract_Block {
 		 *
 		 */
 		$css->set_selector( '.wp-block-kadence-advanced-form' . $unique_id . ' .kb-adv-form-help' );
-
+		//var_dump($help_style);
+		//die();
 		if ( isset( $help_style['lineHeight'] ) ) {
 			$help_font_line_height = array( 
 				'lineHeight' => $help_style['lineHeight'][0],
@@ -269,16 +270,18 @@ class Kadence_Blocks_Advanced_Form_Block extends Kadence_Blocks_Abstract_Block {
 		if ( isset( $help_style['size'] ) ) {
 			$help_font_size = array( 
 				'size' => $help_style['size'][0],
+				'tabletSize' => $help_style['size'][1],
+				'mobileSize' => $help_style['size'][2],
 				'sizeType' => $help_style['sizeType'],
 			);
-			$css->render_responsive_size( $help_font_size, array( 'size', 1, 2 ), 'font-size', 'sizeType' );
+			$css->render_responsive_size( $help_font_size, array( 'size', 'tabletSize', 'mobileSize' ), 'font-size', 'sizeType' );
 		}
 		if ( isset( $help_style['letterSpacing'] ) ) {
 			$help_font_letter_spacing = array( 
 				'letterSpacing' => $help_style['letterSpacing'][0],
 				'letterType' => $help_style['letterType'],
 			);
-			
+
 			$css->render_responsive_size( $help_font_letter_spacing, array( 'letterSpacing', 1, 2 ), 'letter-spacing', 'letterType' );
 		}
 

--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -1600,19 +1600,31 @@ class Kadence_Blocks_CSS {
 
 		$this->set_media_state( 'desktop' );
 		if ( ! empty( $attributes[ $name[0] ] ) ) {
-			$this->add_property( $property, $attributes[ $name[0] ] . $unit );
+			if($property === 'font-size') {
+				$this->add_property( $property, $this->get_font_size($attributes[ $name[0] ], $unit) );
+			} else {
+				$this->add_property( $property, $attributes[ $name[0] ] . $unit );
+			}
 		} else if ( $defaults[0] ) {
 			$this->add_property( $property, $defaults[0] . $unit );
 		}
 		$this->set_media_state( 'tablet' );
 		if ( ! empty( $attributes[ $name[1] ] ) ) {
-			$this->add_property( $property, $attributes[ $name[1] ] . $unit );
+			if($property === 'font-size') {
+				$this->add_property( $property, $this->get_font_size($attributes[ $name[1] ], $unit) );
+			} else {
+				$this->add_property( $property, $attributes[ $name[1] ] . $unit );
+			}
 		} else if ( $defaults[1] ) {
 			$this->add_property( $property, $defaults[1] . $unit );
 		}
 		$this->set_media_state( 'mobile' );
 		if ( ! empty( $attributes[ $name[2] ] ) ) {
-			$this->add_property( $property, $attributes[ $name[2] ] . $unit );
+			if($property === 'font-size') {
+				$this->add_property( $property, $this->get_font_size($attributes[ $name[2] ], $unit) );
+			} else {
+				$this->add_property( $property, $attributes[ $name[2] ] . $unit );
+			}
 		} else if ( $defaults[2] ) {
 			$this->add_property( $property, $defaults[2] . $unit );
 		}

--- a/src/blocks/advanced-form/fields/checkbox/edit.js
+++ b/src/blocks/advanced-form/fields/checkbox/edit.js
@@ -73,6 +73,7 @@ function FieldCheckbox( { attributes, setAttributes, isSelected, clientId, conte
 	const previewMinWidth = getPreviewSize( previewDevice, ( minWidth && minWidth[ 0 ] ? minWidth[ 0 ] : '' ), ( minWidth && minWidth[ 1 ] ? minWidth[ 1 ] : '' ), ( minWidth && minWidth[ 2 ] ? minWidth[ 2 ] : '' ) );
 	const classes = classNames( {
 		'kb-adv-form-field': true,
+
 	} );
 	const blockProps = useBlockProps( {
 		className: classes,
@@ -452,7 +453,7 @@ function FieldCheckbox( { attributes, setAttributes, isSelected, clientId, conte
 						</div>
 					}
 
-					{helpText && <span className="kb-form-field-help">{helpText}</span>}
+					{helpText && <span className="kb-form-field-help kb-adv-form-help">{helpText}</span>}
 
 				</>
 				<FieldBlockAppender inline={true} className="kb-custom-inbetween-inserter" getRoot={clientId}/>


### PR DESCRIPTION
KAD-1593 Additional to the reported bug, also responsive font size for help text was not working and in general all options for hel text were not working on the frontend, in the backend also units where incosistent.