### PR TITLE
Ensure all but polyfills are prefixed, move prefixed folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ zip/
 bin/strauss.phar
 .idea
 /vendor/
-/vendor-prefixed/
 bin/pup.phar
 bin/wp-cli.phar
 .pup-build

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ zip/
 bin/strauss.phar
 .idea
 /vendor/
+/vendor-prefixed/
 bin/pup.phar
 bin/wp-cli.phar
 .pup-build

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
 	},
 	"extra": {
 		"strauss": {
-			"target_directory": "vendor-prefixed",
+			"target_directory": "vendor/vendor-prefixed",
 			"classmap_prefix": "Kadence_Blocks_",
 			"constant_prefix": "KADENCE_BLOCKS_",
 			"namespace_prefix": "KadenceWP\\KadenceBlocks\\",
@@ -76,21 +76,7 @@
 			  "file_patterns": [
 				  "/symfony\\/polyfill-(.*)/"
 			  ]
-			},
-			"packages": [
-				"psr/container",
-				"adbario/php-dot-notation",
-				"stellarwp/container-contract",
-				"stellarwp/telemetry",
-				"stellarwp/uplink",
-				"stellarwp/prophecy-monorepo",
-				"stellarwp/prophecy-image-downloader",
-				"stellarwp/prophecy-storage",
-				"lucatume/di52",
-				"symfony/filesystem",
-				"symfony/http-client",
-				"symfony/translation-contracts"
-			]
+			}
 		}
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "86a2f8f0929c3e4d74883a991fa38d6c",
+    "content-hash": "dc16dcbd159700787c2e6434a42274cf",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -704,12 +704,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/stellarwp/uplink.git",
-                "reference": "0da95a8cb8e5d99fa7a6d39a8d79429763b4a7c7"
+                "reference": "5557bac22c82fa0091efd34b3438a4936f65d53d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stellarwp/uplink/zipball/0da95a8cb8e5d99fa7a6d39a8d79429763b4a7c7",
-                "reference": "0da95a8cb8e5d99fa7a6d39a8d79429763b4a7c7",
+                "url": "https://api.github.com/repos/stellarwp/uplink/zipball/5557bac22c82fa0091efd34b3438a4936f65d53d",
+                "reference": "5557bac22c82fa0091efd34b3438a4936f65d53d",
                 "shasum": ""
             },
             "require": {
@@ -762,7 +762,7 @@
                 "issues": "https://github.com/stellarwp/uplink/issues",
                 "source": "https://github.com/stellarwp/uplink/tree/feature/base64-encoded-callback"
             },
-            "time": "2023-11-21T19:28:08+00:00"
+            "time": "2023-11-21T21:12:57+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1901,5 +1901,5 @@
     "platform-overrides": {
         "php": "7.2.34"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/kadence-blocks.php
+++ b/kadence-blocks.php
@@ -22,7 +22,7 @@ define( 'KADENCE_BLOCKS_PATH', realpath( plugin_dir_path( __FILE__ ) ) . DIRECTO
 define( 'KADENCE_BLOCKS_URL', plugin_dir_url( __FILE__ ) );
 define( 'KADENCE_BLOCKS_VERSION', '3.2.5' );
 
-require_once plugin_dir_path( __FILE__ ) . 'vendor-prefixed/autoload.php';
+require_once plugin_dir_path( __FILE__ ) . 'vendor/vendor-prefixed/autoload.php';
 require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 
 


### PR DESCRIPTION
## Changes
- Ensures all dependencies are prefixed besides symfony polyfills.

## Instructions

1. Delete your root `vendor` and `vendor-prefixed` folders .
2. Run `composer install`.

@kadencewp run though your normal tests for AI functionality before merging just to make sure it's all good.