### PR TITLE
Add Events for AI Inline Complete

### DIFF
--- a/includes/class-kadence-blocks-ai-events.php
+++ b/includes/class-kadence-blocks-ai-events.php
@@ -224,9 +224,8 @@ class Kadence_Blocks_AI_Events {
 			case 'ai_inline_completed':
 				$event   = 'AI Inline Completed';
 				$context = [
-					'page_id'        => $event_data['page_id'],
-					'page_title'     => get_the_title( $event_data['page_id'] ),
 					'tool_name'      => $event_data['tool_name'],
+					'type'           => $event_data['type'],
 					'initial_text'   => $event_data['initial_text'],
 					'result'         => $event_data['result'],
 					'credits_before' => $event_data['credits_before'],

--- a/includes/class-kadence-blocks-ai-events.php
+++ b/includes/class-kadence-blocks-ai-events.php
@@ -221,6 +221,18 @@ class Kadence_Blocks_AI_Events {
 					'pattern_categories' => $event_data['categories'] ?? [],
 				];
 				break;
+			case 'ai_inline_completed':
+				$event   = 'AI Inline Completed';
+				$context = [
+					'page_id'        => $event_data['page_id'],
+					'page_title'     => get_the_title( $event_data['page_id'] ),
+					'tool_name'      => $event_data['tool_name'],
+					'initial_text'   => $event_data['initial_text'],
+					'result'         => $event_data['result'],
+					'credits_before' => $event_data['credits_before'],
+					'credits_after'  => $event_data['credits_after'],
+					'credits_used'   => $event_data['credits_used'],
+				];
 		}
 
 		if ( strlen( $event ) !== 0 ) {

--- a/src/blocks/advancedheading/ai-text/ai-text.js
+++ b/src/blocks/advancedheading/ai-text/ai-text.js
@@ -36,6 +36,7 @@ import {
 	toggleFormat,
 	applyFormat,
 } from '@wordpress/rich-text';
+import { sendEvent } from '../../../extension/analytics/send-event';
 const name = 'kadence/ai-text';
 const allowedBlocks = [ 'kadence/advancedheading' ];
 export const AIText = {
@@ -81,6 +82,7 @@ export const AIText = {
 		const activeStorage = SafeParseJSON( localStorage.getItem( 'kadenceBlocksPrebuilt' ), true );
 		const savedCredits = ( undefined !== activeStorage?.credits && '' !== activeStorage?.credits && null !== activeStorage?.credits ? activeStorage.credits : 'fetch' );
 		const currentCredits = ( '' !== credits ? credits : savedCredits );
+		const currentPostId = parseInt((new URLSearchParams(window.location.search)).get('post')) ?? 0;
 		async function getRemoteAvailableCredits() {
 			const response = await getAvailableCredits();
 			const tempActiveStorage = SafeParseJSON( localStorage.getItem( 'kadenceBlocksPrebuilt' ), true );
@@ -121,6 +123,7 @@ export const AIText = {
 			}
 		}, [ value ] );
 		function handleGettingContent(value) {
+			let AIContent = '';
 			setIsLoading(true);
 			setAiSuggestion( '' );
 			setError('');
@@ -135,16 +138,28 @@ export const AIText = {
 							setIsOpen( true );
 							setTempCredits(parseInt( currentCredits ) - 1);
 							setCredits( 'fetch' );
+							sendEvent('ai_inline_completed', {
+								page_id: currentPostId,
+								page_title: '',
+								tool_name: AIText.title,
+								initial_text: '',
+								result: AIContent,
+								credits_before: parseInt(currentCredits),
+								credits_after: parseInt(currentCredits) - 1,
+								credits_used: 1,
+							});
 							return;
 						}
 
 						const eventData = convertStreamDataToJson(value);
-						
+
 						if (eventData?.content) {
+							AIContent = AIContent + eventData.content
 							setAiSuggestion((previousValue) => {
 								return previousValue + eventData.content;
 							});
 						}
+
 						return reader.read().then(processText);
 					});
 				})
@@ -159,6 +174,7 @@ export const AIText = {
 				});
 		}
 		function handleEditingContent(value, prompt, type) {
+			let AIContent = '';
 			setIsLoading(true);
 			setAiSuggestion( '' );
 			setError('');
@@ -173,16 +189,28 @@ export const AIText = {
 							setTempCredits(parseInt( currentCredits ) - 1);
 							setCredits( 'fetch' );
 							setIsOpen( true );
+							sendEvent('ai_inline_completed', {
+								page_id: currentPostId,
+								page_title: '',
+								tool_name: AIText.title,
+								initial_text: '',
+								result: AIContent,
+								credits_before: parseInt(currentCredits),
+								credits_after: parseInt(currentCredits) - 1,
+								credits_used: 1,
+							});
 							return;
 						}
 
 						const eventData = convertStreamDataToJson(value);
-						
+
 						if (eventData?.content) {
+							AIContent = AIContent + eventData.content;
 							setAiSuggestion((previousValue) => {
 								return previousValue + eventData.content;
 							});
 						}
+
 						return reader.read().then(processText);
 					});
 				})
@@ -197,6 +225,7 @@ export const AIText = {
 				});
 		}
 		function handleTransformingContent(value, type) {
+			let AIContent = '';
 			setIsLoading(true);
 			setAiSuggestion( '' );
 			setError('');
@@ -211,11 +240,22 @@ export const AIText = {
 							setIsOpen( true );
 							setTempCredits(parseInt( currentCredits ) - 1);
 							setCredits( 'fetch' );
+							sendEvent('ai_inline_completed', {
+								page_id: currentPostId,
+								page_title: '',
+								tool_name: AIText.title,
+								initial_text: '',
+								result: AIContent,
+								credits_before: parseInt(currentCredits),
+								credits_after: parseInt(currentCredits) - 1,
+								credits_used: 1,
+							});
 							return;
 						}
 
 						const eventData = convertStreamDataToJson(value);
 						if (eventData?.content) {
+							AIContent = AIContent + eventData.content;
 							setAiSuggestion((previousValue) => {
 								return previousValue + eventData.content;
 							});

--- a/src/blocks/advancedheading/ai-text/ai-text.js
+++ b/src/blocks/advancedheading/ai-text/ai-text.js
@@ -81,8 +81,7 @@ export const AIText = {
 		const [ isToneOpen, setIsToneOpen ] = useState(false);
 		const activeStorage = SafeParseJSON( localStorage.getItem( 'kadenceBlocksPrebuilt' ), true );
 		const savedCredits = ( undefined !== activeStorage?.credits && '' !== activeStorage?.credits && null !== activeStorage?.credits ? activeStorage.credits : 'fetch' );
-		const currentCredits = ( '' !== credits ? credits : savedCredits );
-		const currentPostId = parseInt((new URLSearchParams(window.location.search)).get('post')) ?? 0;
+		const currentCredits = ('' !== credits ? credits : savedCredits);
 		async function getRemoteAvailableCredits() {
 			const response = await getAvailableCredits();
 			const tempActiveStorage = SafeParseJSON( localStorage.getItem( 'kadenceBlocksPrebuilt' ), true );
@@ -139,9 +138,8 @@ export const AIText = {
 							setTempCredits(parseInt( currentCredits ) - 1);
 							setCredits( 'fetch' );
 							sendEvent('ai_inline_completed', {
-								page_id: currentPostId,
-								page_title: '',
-								tool_name: AIText.title,
+								tool_name: name,
+								type: 'get_new_content',
 								initial_text: '',
 								result: AIContent,
 								credits_before: parseInt(currentCredits),
@@ -175,6 +173,8 @@ export const AIText = {
 		}
 		function handleEditingContent(value, prompt, type) {
 			let AIContent = '';
+			let initial_text = value;
+			let action_type = type;
 			setIsLoading(true);
 			setAiSuggestion( '' );
 			setError('');
@@ -190,10 +190,9 @@ export const AIText = {
 							setCredits( 'fetch' );
 							setIsOpen( true );
 							sendEvent('ai_inline_completed', {
-								page_id: currentPostId,
-								page_title: '',
-								tool_name: AIText.title,
-								initial_text: '',
+								tool_name: name,
+								type: action_type,
+								initial_text: initial_text,
 								result: AIContent,
 								credits_before: parseInt(currentCredits),
 								credits_after: parseInt(currentCredits) - 1,
@@ -226,6 +225,8 @@ export const AIText = {
 		}
 		function handleTransformingContent(value, type) {
 			let AIContent = '';
+			let initial_text = value;
+			let action_type = type;
 			setIsLoading(true);
 			setAiSuggestion( '' );
 			setError('');
@@ -241,10 +242,9 @@ export const AIText = {
 							setTempCredits(parseInt( currentCredits ) - 1);
 							setCredits( 'fetch' );
 							sendEvent('ai_inline_completed', {
-								page_id: currentPostId,
-								page_title: '',
-								tool_name: AIText.title,
-								initial_text: '',
+								tool_name: name,
+								type: action_type,
+								initial_text: initial_text,
 								result: AIContent,
 								credits_before: parseInt(currentCredits),
 								credits_after: parseInt(currentCredits) - 1,


### PR DESCRIPTION
This adds functionality to capture events when users request AI content within the **Text (Adv)** block.

## Within Kadence Blocks
<img width="739" alt="Markup 2023-12-04 at 16 41 52" src="https://github.com/stellarwp/kadence-blocks/assets/6947218/e54e1812-fbb6-4abf-b512-b1112f971b78">

## Within Mixpanel
![Markup on 2023-12-04 at 16:42:56](https://github.com/stellarwp/kadence-blocks/assets/6947218/40b7d7ce-fa3a-46b0-9ec0-94708dab1f2d)
