### PR TITLE
Stop sending context values with non-AI patterns

### DIFF
--- a/src/plugins/prebuilt-library/pattern-list.js
+++ b/src/plugins/prebuilt-library/pattern-list.js
@@ -478,8 +478,9 @@ function PatternList( {
 			slug: info.slug,
 			name: info.name,
 			style: selectedStyle ? selectedStyle : 'light',
-			context: contextLabel,
 			is_ai: contextTab === 'context',
+			// Only send context when using AI patterns.
+			context: contextTab === 'context' ? contextLabel : '',
 		} );
 
 		let newInfo = info.content;


### PR DESCRIPTION
Further inspecting the "Pattern added to Page" event, Donaldo helped me realize that non-ai patterns do not have a context. The event was incorrectly sending the AI-based context for non-ai patterns.