### PR TITLE
Only send AI Wizard Completed event once complete

### DIFF
--- a/src/plugins/prebuilt-library/ai-wizard/context/kadence-ai-provider.js
+++ b/src/plugins/prebuilt-library/ai-wizard/context/kadence-ai-provider.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { ENTITY_TYPE_INDIVIDUAL } from "../constants";
 
 const initialState = {
+	isComplete: false,
 	firstTime: true,
 	isSubmitted: false,
 	context: "kadence",

--- a/src/plugins/prebuilt-library/ai-wizard/kadence-ai-wizard.js
+++ b/src/plugins/prebuilt-library/ai-wizard/kadence-ai-wizard.js
@@ -77,6 +77,7 @@ export function KadenceAiWizard( props ) {
 
 	const { state, dispatch } = useKadenceAi();
 	const {
+		isComplete,
 		firstTime,
 		isSubmitted,
 		currentPageIndex,
@@ -95,12 +96,26 @@ export function KadenceAiWizard( props ) {
 		const saveStatus = await saveAiWizardData({
 			firstTime: false,
 			isSubmitted: true,
+			isComplete: isComplete,
 			...rest
 		});
 
 		if (saveStatus) {
 			onWizardClose( 'saved' );
 			handleEvent( 'ai_wizard_update' );
+		}
+	}
+
+	async function handleComplete() {
+		const complete = await saveAiWizardData({
+			firstTime: false,
+			isSubmitted: true,
+			isComplete: true,
+			...rest
+		});
+
+		if (complete) {
+			handleEvent('ai_wizard_complete');
 		}
 	}
 
@@ -120,7 +135,7 @@ export function KadenceAiWizard( props ) {
 		// Submit wizard data on finish buttton click.
 		if (event.type === 'click' && event.target.classList.contains('components-wizard__primary-button')) {
 			handleSave();
-			handleEvent( 'ai_wizard_complete' );
+			handleComplete();
 
 			if ( ! photographyOnly ) {
 				onPrimaryAction(event, true);

--- a/src/plugins/prebuilt-library/ai-wizard/kadence-ai-wizard.js
+++ b/src/plugins/prebuilt-library/ai-wizard/kadence-ai-wizard.js
@@ -135,9 +135,9 @@ export function KadenceAiWizard( props ) {
 		// Submit wizard data on finish buttton click.
 		if (event.type === 'click' && event.target.classList.contains('components-wizard__primary-button')) {
 			handleSave();
-			handleComplete();
 
 			if ( ! photographyOnly ) {
+				handleComplete();
 				onPrimaryAction(event, true);
 			}
 


### PR DESCRIPTION
This adds some additional state to the AI Wizard to track if a user has officially completed it. Complete meaning that they clicked the primary "Generate" button on the last step and generated all the contexts.