### PR TITLE
[KADEN-293] [KADEN-294] Send failed and requested events

### DIFF
--- a/includes/class-kadence-blocks-prebuilt-library-rest-api.php
+++ b/includes/class-kadence-blocks-prebuilt-library-rest-api.php
@@ -1065,13 +1065,11 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 				return rest_ensure_response( $this->ai_cache->get( $available_prompts[ $context ] ) );
 			} catch ( NotFoundException $e ) {
 			}
-
 			// Log event for context generation request.
 			do_action( 'stellarwp/analytics/event', 'Context Generation Requested', [
 				'context_name'    => $context,
 				'is_regeneration' => true,
 			] );
-
 			// Check if we have a remote file.
 			$response = $this->get_remote_contents( $available_prompts[ $context ] );
 			$data     = json_decode( $response, true );

--- a/includes/class-kadence-blocks-prebuilt-library-rest-api.php
+++ b/includes/class-kadence-blocks-prebuilt-library-rest-api.php
@@ -1066,18 +1066,27 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 			} catch ( NotFoundException $e ) {
 			}
 
+			// Log event for context generation request.
+			do_action( 'stellarwp/analytics/event', 'Context Generation Requested', [
+				'context_name'    => $context,
+				'is_regeneration' => true,
+			] );
+
 			// Check if we have a remote file.
 			$response = $this->get_remote_contents( $available_prompts[ $context ] );
 			$data     = json_decode( $response, true );
 
 			if ( $response === 'error' ) {
 				$current_prompts = get_option( 'kb_design_library_prompts', array() );
-
 				if ( isset( $current_prompts[ $context ] ) ) {
 					unset( $current_prompts[ $context ] );
 					update_option( 'kb_design_library_prompts', $current_prompts );
 				}
-
+				// Log event for failed context generation.
+				do_action( 'stellarwp/analytics/event', 'Context Generation Failed', [
+					'context_name'    => $context,
+					'is_regeneration' => true,
+				] );
 				return rest_ensure_response( 'error' );
 			} else if ( $response === 'processing' || isset( $data['data']['status'] ) && 409 === $data['data']['status'] ) {
 				return rest_ensure_response( 'processing' );
@@ -1087,6 +1096,12 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 					unset( $current_prompts[ $context ] );
 					update_option( 'kb_design_library_prompts', $current_prompts );
 				}
+				// Log event for failed context generation.
+				do_action( 'stellarwp/analytics/event', 'Context Generation Failed', [
+					'context_name'    => $context,
+					'error_id'        => $data['data']['status'],
+					'is_regeneration' => true,
+				] );
 				return rest_ensure_response( 'error' );
 			} else {
 				$this->ai_cache->cache( $available_prompts[ $context ], $response );


### PR DESCRIPTION
This adds Context Generation Failed and Requested along with the existing Context Generation Completed event:

https://github.com/stellarwp/kadence-blocks/blob/dfda3d8ce2ae07a9a5a4371af214e45c95328aa0/includes/class-kadence-blocks-prebuilt-library-rest-api.php#L1094

