### PR TITLE
Unset align on section when moved into row layout

### DIFF
--- a/src/blocks/column/edit.js
+++ b/src/blocks/column/edit.js
@@ -364,6 +364,10 @@ function SectionEdit( props ) {
 			}
 			setAttributes( { kbVersion: 2 } );
 		}
+
+		if( inRowBlock && align !== '' ) {
+			setAttributes( { align: '' } );
+		}
 	}, [] );
 
 	//set the dynamic image state


### PR DESCRIPTION
KAD-1982

Issue: Drag a "full width" aligned section into an existing row layout. When in a row layout, we hide align settings for sections.

Proposal: We unset the align on the section if this happens. We already defer alignment to the parent row in this situation.