### PR TITLE
[KAD-1961]: Properly track collection_updated events

### DIFF
--- a/includes/class-kadence-blocks-ai-events.php
+++ b/includes/class-kadence-blocks-ai-events.php
@@ -228,10 +228,8 @@ class Kadence_Blocks_AI_Events {
 				];
 				break;
 			case 'collection_updated':
-				$event = 'Collection Updated';
-				$context = [
-					'collection_name' => $this->get_custom_collection_name_by_id( $event_data['customCollections'], $event_data['photoLibrary'] ),
-				];
+				$event   = 'Collection Updated';
+				$context = $this->build_collection_updated_event_data( $event_data['customCollections'], $event_data['photoLibrary'] );
 				break;
 			case 'ai_inline_requested':
 				$event   = 'AI Inline Requested';
@@ -253,20 +251,29 @@ class Kadence_Blocks_AI_Events {
 	}
 
 	/**
-	 * Searches an array of collections for the name of a collection with a specific ID.
+	 * Get the collection name of custom made collections, otherwise return the prepared collection name.
 	 *
-	 * @param array $collections An array of collections.
-	 * @param string $id The ID of a collection.
+	 * @param  array<array{label?: string, value: string}>  $collections  An array of custom collections.
+	 * @param  string                                        $id_or_name   The ID of a custom collection, or the name
+	 *                                                                     of a prepared collection.
 	 *
 	 * @return array
 	 */
-	private function get_custom_collection_name_by_id( array $collections, string $id ): string {
-		foreach ( $collections as $collection ) {
-			if ( $collection['value'] === $id ) {
-				return $collection['label'] ?? '';
-			}
+	private function build_collection_updated_event_data( array $collections, string $id_or_name ): array {
+		$event = [
+			'collection_name' => $id_or_name,
+			'is_custom'       => false,
+		];
 
-			return '';
+		foreach ( $collections as $collection ) {
+			if ( $collection['value'] === $id_or_name ) {
+				return [
+					'collection_name' => $collection['label'] ?? '',
+					'is_custom'       => true,
+				];
+			}
 		}
+
+		return $event;
 	}
 }

--- a/src/plugins/prebuilt-library/ai-wizard/context/kadence-ai-provider.js
+++ b/src/plugins/prebuilt-library/ai-wizard/context/kadence-ai-provider.js
@@ -25,6 +25,7 @@ const initialState = {
 	tone: "NEUTRAL",
 	privacyAgreement: false,
 	photoLibrary: 'aiGenerated',
+	photoCollectionChanged: false,
 	featuredImages: [],
 	backgroundImages: [],
 	customCollections: [ { label: __('My Images', 'kadence-blocks-pro'), value: 'my-images', galleries: [{ name: 'featured', isLocal: true, images: [] },{ name: 'background', isLocal: true, images: [] } ] } ],
@@ -99,6 +100,11 @@ function kadenceAiReducer(state, action) {
 			return {
 				...state,
 				photoLibrary: action.payload,
+			};
+		case "SET_PHOTO_LIBRARY_CHANGED":
+			return {
+				...state,
+				photoCollectionChanged: action.payload,
 			};
 		case "SET_FEATURED_IMAGES":
 			return {

--- a/src/plugins/prebuilt-library/ai-wizard/kadence-ai-wizard.js
+++ b/src/plugins/prebuilt-library/ai-wizard/kadence-ai-wizard.js
@@ -132,20 +132,17 @@ export function KadenceAiWizard( props ) {
 			return;
 		}
 
-		// Submit wizard data on finish buttton click.
+		// Submit wizard data on finish button click.
 		if (event.type === 'click' && event.target.classList.contains('components-wizard__primary-button')) {
-
 			if (photographyOnly) {
-				handleEvent('collection_updated');
-				onWizardClose();
+				// Fire off collection_updated event after data has saved.
+				handleSave().then( () => {
+					handleEvent( 'collection_updated' );
+				} );
 			} else {
 				handleComplete();
 				onPrimaryAction(event, true);
 			}
-
-			handleSave();
-
-			return;
 		}
 
 		onWizardClose();
@@ -157,9 +154,16 @@ export function KadenceAiWizard( props ) {
 			return;
 		}
 
-		// Submit wizard data on finish buttton click.
+		// Submit wizard data on finish button click.
 		if (event.type === 'click' && event.target.classList.contains('components-wizard__secondary-button')) {
-			handleSave();
+			if (state.photoCollectionChanged) {
+				// Fire off collection_updated event after data has saved.
+				handleSave().then( () => {
+					handleEvent( 'collection_updated' );
+				} );
+			} else {
+				handleSave();
+			}
 		}
 
 		onWizardClose();

--- a/src/plugins/prebuilt-library/ai-wizard/pages/photography.js
+++ b/src/plugins/prebuilt-library/ai-wizard/pages/photography.js
@@ -49,6 +49,10 @@ export function Photography(props) {
 	const [ isSearchQueryCleared, setIsSearchQueryCleared ] = useState( false );
 	const [popoverAnchor, setPopoverAnchor] = useState();
 
+	useEffect( () => {
+		dispatch({ type: 'SET_PHOTO_LIBRARY_CHANGED', payload: false });
+	}, [] );
+
 	useEffect(() => {
 		if ( preMadeCollections && wordpressCollections ) {
 			setAllVerticals([
@@ -95,9 +99,11 @@ export function Photography(props) {
 		}
 		if ( newSlug !== photoLibrary ) {
 			dispatch({ type: 'SET_PHOTO_LIBRARY', payload: newSlug });
+			dispatch({ type: 'SET_PHOTO_LIBRARY_CHANGED', payload: true });
 			setSelectedCollection([{}, {}]);
 			getSelectedGalleries( newSlug );
 		} else {
+			dispatch({ type: 'SET_PHOTO_LIBRARY_CHANGED', payload: false });
 			getSelectedGalleries( newSlug );
 		}
 	}
@@ -108,6 +114,7 @@ export function Photography(props) {
 		}
 		if ( newSlug !== photoLibrary ) {
 			dispatch({ type: 'SET_PHOTO_LIBRARY', payload: newSlug });
+			dispatch({ type: 'SET_PHOTO_LIBRARY_CHANGED', payload: true });
 			setSelectedCollection([{}, {}]);
 		} else {
 			getSelectedGalleries( newSlug );
@@ -168,8 +175,8 @@ export function Photography(props) {
 							label= { __('Use Images From:', 'kadence-blocks') }
 							options={ allVerticals || [] }
 							value={ allVerticals?.length > 0 ? findOptionWithValue( allVerticals, photoLibrary ) : '' }
-							onChange={ ( value ) => {
-								handlePhotoLibraryChange( value.value );
+							onChange={ ( collection ) => {
+								handlePhotoLibraryChange( collection.value );
 							} }
 							createRecord={ createNewCollection }
 							updateRecord={ updateCollection }


### PR DESCRIPTION
### Main Changes
> **NOTE:** I didn't have time to test a brand new wizard run, just an existing one and updating via the design library.

- If a collection wasn't custom (aka premade), it would be an empty string in the event payload.
- This event would previously send the user's old collection, because it was firing before saving was complete.
- This properly tracks changed collections each time a user changes it either through the Wizard, or through: _Design Library > Settings Icon > Update Design Library Images_.
- The event will now tell us if it's a custom collection.
- I wasn't sure why [handleSave() ](https://github.com/stellarwp/kadence-blocks/compare/bugfix/KAD-1961/collection-updated-event?expand=1#diff-3f260d3b955791cd26c02f4447e0032530d5546fa94b033c702d86704702b031L146)is called even after [handleComplete() ](https://github.com/stellarwp/kadence-blocks/compare/bugfix/KAD-1961/collection-updated-event?expand=1#diff-3f260d3b955791cd26c02f4447e0032530d5546fa94b033c702d86704702b031L142) is, both functions which save the AI data. Let me know if this change was wrong? I was seeing duplicate `Saved` notices come up.