### PR TITLE
bump slick to 1.5.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
               uses: actions/checkout@v4
               with:
                   repository: stellarwp/slic
-                  ref: 1.5.2
+                  ref: 1.5.4
                   path: slic
                   fetch-depth: 1
 


### PR DESCRIPTION
A bug fix for slic automatically updating WordPress in the background was recently merged and released which may help fix the issues we're seeing here.

https://github.com/stellarwp/slic/pull/181