### PR TITLE
Remove magic quotes from email body

### DIFF
--- a/includes/advanced-form/advanced-form-submit-actions.php
+++ b/includes/advanced-form/advanced-form-submit-actions.php
@@ -100,7 +100,7 @@ class Kadence_Blocks_Advanced_Form_Submit_Actions {
 					if ( isset( $field_name ) ) {
 						$field_to_insert = $this->get_response_field_by_name( $field_name );
 						if ( $field_to_insert && isset( $field_to_insert['value'] ) ) {
-							$text = str_replace( '{' . $field_name . '}', $field_to_insert['value'], $text );
+							$text = str_replace( '{' . $field_name . '}', wp_unslash( $field_to_insert['value'] ), $text );
 						}
 					}
 				}
@@ -156,7 +156,7 @@ class Kadence_Blocks_Advanced_Form_Submit_Actions {
 			$headers = 'Content-Type: text/plain; charset=UTF-8' . "\r\n";
 		}
 
-		$body = $email_content
+		$body = $email_content;
 
 		if ( $reply_email ) {
 			$headers .= 'Reply-To: <' . $reply_email . '>' . "\r\n";

--- a/includes/advanced-form/advanced-form-submit-actions.php
+++ b/includes/advanced-form/advanced-form-submit-actions.php
@@ -156,7 +156,8 @@ class Kadence_Blocks_Advanced_Form_Submit_Actions {
 			$headers = 'Content-Type: text/plain; charset=UTF-8' . "\r\n";
 		}
 
-		$body = $email_content;
+		// Remove magic quotes from email body
+		$body = wp_unslash( $email_content );
 
 		if ( $reply_email ) {
 			$headers .= 'Reply-To: <' . $reply_email . '>' . "\r\n";

--- a/includes/advanced-form/advanced-form-submit-actions.php
+++ b/includes/advanced-form/advanced-form-submit-actions.php
@@ -151,13 +151,12 @@ class Kadence_Blocks_Advanced_Form_Submit_Actions {
 				if ( is_array( $data['value'] ) ) {
 					$data['value'] = explode( ', ', $data['value'] );
 				}
-				$email_content .= strip_tags( $data['label'] ) . ': ' . $data['value'] . "\n\n";
+				$email_content .= strip_tags( $data['label'] ) . ': ' . wp_unslash( $data['value'] ) . "\n\n";
 			}
 			$headers = 'Content-Type: text/plain; charset=UTF-8' . "\r\n";
 		}
 
-		// Remove magic quotes from email body
-		$body = wp_unslash( $email_content );
+		$body = $email_content
 
 		if ( $reply_email ) {
 			$headers .= 'Reply-To: <' . $reply_email . '>' . "\r\n";

--- a/includes/templates/form-email.php
+++ b/includes/templates/form-email.php
@@ -142,9 +142,9 @@ defined( 'ABSPATH' ) || exit;
 											$file_output = '<a href="' . $data['value'] . '" target="_blank">' . $file_name . '</a>';
 										}
 										?>
-										<?php echo wpautop( '<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px; padding-bottom: 5px;">' .$file_output . '</p>' ); ?>
+										<?php echo wpautop( '<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px; padding-bottom: 5px;">' . $file_output . '</p>' ); ?>
 									<?php } else { ?>
-										<?php echo wpautop( '<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px; padding-bottom: 5px;">' . esc_html( $data['value'] ) . '</p>' ); ?>
+										<?php echo wpautop( '<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px; padding-bottom: 5px;">' . esc_html( wp_unslash( $data['value'] ) ) . '</p>' ); ?>
 									<?php } ?>
 								</td>
 							</tr>


### PR DESCRIPTION
[KAD-1847](https://stellarwp.atlassian.net/browse/KAD-1847)

...

### Issue Info
- [x] Were you able to reproduce the issue?
- [x] Is the issue from the ticket solved? (If not, why?)

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


#### Are there dependent changes in another repository?
- [x] No.
- [ ] Yes. Please provide the link to the PR.


[KAD-1847]: https://stellarwp.atlassian.net/browse/KAD-1847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ