### PR TITLE
Stop duplicating the custom class name in the frontend

### DIFF
--- a/includes/blocks/form/class-kadence-blocks-accept-block.php
+++ b/includes/blocks/form/class-kadence-blocks-accept-block.php
@@ -72,9 +72,6 @@ class Kadence_Blocks_Accept_Block extends Kadence_Blocks_Advanced_Form_Input_Blo
 		$is_required = $this->is_required( $attributes );
 		$class_id    = $this->class_id( $attributes );
 		$outer_classes = array( 'kb-adv-form-field', 'kb-field' . $class_id );
-		if ( ! empty( $attributes['className'] ) ) {
-			$outer_classes[] = $attributes['className'];
-		}
 		$wrapper_args = array(
 			'class' => implode( ' ', $outer_classes ),
 		);

--- a/includes/blocks/form/class-kadence-blocks-captcha-block.php
+++ b/includes/blocks/form/class-kadence-blocks-captcha-block.php
@@ -83,9 +83,6 @@ class Kadence_Blocks_Captcha_Block extends Kadence_Blocks_Advanced_Form_Input_Bl
 		}
 		$class_id = $this->class_id( $attributes );
 		$outer_classes = array( 'kb-adv-form-field', 'kb-field' . $class_id );
-		if ( ! empty( $attributes['className'] ) ) {
-			$outer_classes[] = $attributes['className'];
-		}
 		$wrapper_args       = array(
 			'class' => implode( ' ', $outer_classes ),
 		);

--- a/includes/blocks/form/class-kadence-blocks-checkbox-block.php
+++ b/includes/blocks/form/class-kadence-blocks-checkbox-block.php
@@ -71,9 +71,6 @@ class Kadence_Blocks_Checkbox_Block extends Kadence_Blocks_Advanced_Form_Input_B
 		$is_required   = $this->is_required( $attributes );
 		$class_id = $this->class_id( $attributes );
 		$outer_classes = array( 'kb-adv-form-field', 'kb-field' . $class_id );
-		if ( ! empty( $attributes['className'] ) ) {
-			$outer_classes[] = $attributes['className'];
-		}
 		$wrapper_args       = array(
 			'class' => implode( ' ', $outer_classes ),
 		);

--- a/includes/blocks/form/class-kadence-blocks-date-input-block.php
+++ b/includes/blocks/form/class-kadence-blocks-date-input-block.php
@@ -72,9 +72,6 @@ class Kadence_Blocks_Date_Input_Block extends Kadence_Blocks_Advanced_Form_Input
 		$is_required = $this->is_required( $attributes );
 		$class_id = $this->class_id( $attributes );
 		$outer_classes = array( 'kb-adv-form-field', 'kb-adv-form-infield-type-input', 'kb-field' . $class_id );
-		if ( ! empty( $attributes['className'] ) ) {
-			$outer_classes[] = $attributes['className'];
-		}
 		$wrapper_args = array(
 			'class' => implode( ' ', $outer_classes ),
 		);

--- a/includes/blocks/form/class-kadence-blocks-email-input-block.php
+++ b/includes/blocks/form/class-kadence-blocks-email-input-block.php
@@ -76,9 +76,6 @@ class Kadence_Blocks_Email_Input_Block extends Kadence_Blocks_Advanced_Form_Inpu
 		$is_required = $this->is_required( $attributes );
 		$class_id = $this->class_id( $attributes );
 		$outer_classes = array( 'kb-adv-form-field', 'kb-adv-form-text-type-input', 'kb-adv-form-infield-type-input', 'kb-field' . $class_id );
-		if ( ! empty( $attributes['className'] ) ) {
-			$outer_classes[] = $attributes['className'];
-		}
 		$wrapper_args = array(
 			'class' => implode( ' ', $outer_classes ),
 		);

--- a/includes/blocks/form/class-kadence-blocks-file-block.php
+++ b/includes/blocks/form/class-kadence-blocks-file-block.php
@@ -73,9 +73,6 @@ class Kadence_Blocks_File_Block extends Kadence_Blocks_Advanced_Form_Input_Block
 		$class_id = $this->class_id( $attributes );
 		$outer_classes = array( 'kb-adv-form-field', 'kb-adv-form-file-type-input', 'kb-adv-form-infield-type-input', 'kb-field' . $class_id );
 		$is_multiple = ( isset( $attributes['multiple'] ) && $attributes['multiple'] ? true : false );
-		if ( ! empty( $attributes['className'] ) ) {
-			$outer_classes[] = $attributes['className'];
-		}
 		$wrapper_args       = array(
 			'class' => implode( ' ', $outer_classes ),
 		);

--- a/includes/blocks/form/class-kadence-blocks-number-input-block.php
+++ b/includes/blocks/form/class-kadence-blocks-number-input-block.php
@@ -74,9 +74,6 @@ class Kadence_Blocks_Number_Input_Block extends Kadence_Blocks_Advanced_Form_Inp
 		$min = isset( $attributes['minValue'] ) && $attributes['minValue'] !== '' ? ' min="' . esc_attr( $attributes['minValue'] ) . '" ' : '';
 		$max = isset( $attributes['maxValue'] ) && $attributes['maxValue'] !== '' ? ' max="' . esc_attr( $attributes['maxValue'] ) . '" ' : '';
 		$outer_classes = array( 'kb-adv-form-field', 'kb-adv-form-text-type-input', 'kb-adv-form-infield-type-input', 'kb-field' . $class_id );
-		if ( ! empty( $attributes['className'] ) ) {
-			$outer_classes[] = $attributes['className'];
-		}
 		$wrapper_args = array(
 			'class' => implode( ' ', $outer_classes ),
 		);

--- a/includes/blocks/form/class-kadence-blocks-radio-block.php
+++ b/includes/blocks/form/class-kadence-blocks-radio-block.php
@@ -72,9 +72,6 @@ class Kadence_Blocks_Radio_Block extends Kadence_Blocks_Advanced_Form_Input_Bloc
 		$is_required = $this->is_required( $attributes );
 		$class_id = $this->class_id( $attributes );
 		$outer_classes = array( 'kb-adv-form-field', 'kb-field' . $class_id );
-		if ( ! empty( $attributes['className'] ) ) {
-			$outer_classes[] = $attributes['className'];
-		}
 		$wrapper_args = array(
 			'class' => implode( ' ', $outer_classes ),
 		);

--- a/includes/blocks/form/class-kadence-blocks-select-block.php
+++ b/includes/blocks/form/class-kadence-blocks-select-block.php
@@ -72,9 +72,6 @@ class Kadence_Blocks_Select_Block extends Kadence_Blocks_Advanced_Form_Input_Blo
 		$is_multiselect = ( isset( $attributes['multiSelect'] ) && $attributes['multiSelect'] === true ) ? 'multiple' : '';
 		$class_id = $this->class_id( $attributes );
 		$outer_classes = array( 'kb-adv-form-field', 'kb-adv-form-infield-type-input', 'kb-field' . $class_id );
-		if ( ! empty( $attributes['className'] ) ) {
-			$outer_classes[] = $attributes['className'];
-		}
 		$wrapper_args = array(
 			'class' => implode( ' ', $outer_classes ),
 		);

--- a/includes/blocks/form/class-kadence-blocks-telephone-input-block.php
+++ b/includes/blocks/form/class-kadence-blocks-telephone-input-block.php
@@ -72,9 +72,6 @@ class Kadence_Blocks_Telephone_Input_Block extends Kadence_Blocks_Advanced_Form_
 		$is_required = $this->is_required( $attributes );
 		$class_id = $this->class_id( $attributes );
 		$outer_classes = array( 'kb-adv-form-field', 'kb-adv-form-text-type-input', 'kb-adv-form-infield-type-input', 'kb-field' . $class_id );
-		if ( ! empty( $attributes['className'] ) ) {
-			$outer_classes[] = $attributes['className'];
-		}
 		$wrapper_args = array(
 			'class' => implode( ' ', $outer_classes ),
 		);

--- a/includes/blocks/form/class-kadence-blocks-text-input-block.php
+++ b/includes/blocks/form/class-kadence-blocks-text-input-block.php
@@ -76,9 +76,6 @@ class Kadence_Blocks_Text_Input_Block extends Kadence_Blocks_Advanced_Form_Input
 		$is_required = $this->is_required( $attributes );
 		$class_id = $this->class_id( $attributes );
 		$outer_classes = array( 'kb-adv-form-field', 'kb-adv-form-text-type-input', 'kb-adv-form-infield-type-input', 'kb-field' . $class_id );
-		if ( ! empty( $attributes['className'] ) ) {
-			$outer_classes[] = $attributes['className'];
-		}
 		$wrapper_args = array(
 			'class' => implode( ' ', $outer_classes ),
 		);

--- a/includes/blocks/form/class-kadence-blocks-textarea-input-block.php
+++ b/includes/blocks/form/class-kadence-blocks-textarea-input-block.php
@@ -74,9 +74,9 @@ class Kadence_Blocks_Textarea_Input_Block extends Kadence_Blocks_Advanced_Form_I
 		$rows = ! empty( $attributes['rows'] ) ? $attributes['rows'] : 3;
 
 		$outer_classes = array( 'kb-adv-form-field', 'kb-adv-form-text-type-input', 'kb-adv-form-infield-type-input', 'kb-field' . $class_id );
-		if ( ! empty( $attributes['className'] ) ) {
-			$outer_classes[] = $attributes['className'];
-		}
+		// if ( ! empty( $attributes['className'] ) ) {
+		// 	$outer_classes[] = $attributes['className'];
+		// }
 		$wrapper_args = array(
 			'class' => implode( ' ', $outer_classes ),
 		);

--- a/includes/blocks/form/class-kadence-blocks-time-input-block.php
+++ b/includes/blocks/form/class-kadence-blocks-time-input-block.php
@@ -72,9 +72,6 @@ class Kadence_Blocks_Time_Input_Block extends Kadence_Blocks_Advanced_Form_Input
 		$is_required = $this->is_required( $attributes );
 		$class_id = $this->class_id( $attributes );
 		$outer_classes = array( 'kb-adv-form-field', 'kb-adv-form-infield-type-input', 'kb-field' . $class_id);
-		if ( ! empty( $attributes['className'] ) ) {
-			$outer_classes[] = $attributes['className'];
-		}
 		$wrapper_args = array(
 			'class' => implode( ' ', $outer_classes ),
 		);


### PR DESCRIPTION
[KAD-2578](https://stellarwp.atlassian.net/browse/KAD-2578)

...

### Issue Info
- [ ] Were you able to reproduce the issue?
- [ ] Is the issue from the ticket solved? (If not, why?)

### Checklist
- [ ] I have performed a self-review.
- [ ] No unrelated files are modified.
- [ ] No debugging statements exist (Ex: console.log, error_log).
- [ ] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


#### Are there dependent changes in another repository?
- [x] No.
- [ ] Yes. Please provide the link to the PR.
