### PR TITLE
Center infobox icon horizontally when max-width unit is %

### DIFF
--- a/includes/blocks/class-kadence-blocks-infobox-block.php
+++ b/includes/blocks/class-kadence-blocks-infobox-block.php
@@ -106,6 +106,12 @@ class Kadence_Blocks_Infobox_Block extends Kadence_Blocks_Abstract_Block {
 		}
 		$css->render_measure_output( $attributes, 'containerPadding', 'padding', array( 'tablet_key' => 'containerTabletPadding', 'mobile_key' => 'containerMobilePadding' ) );
 		$css->render_measure_output( $attributes, 'containerMargin', 'margin', array( 'unit_key' => 'containerMarginUnit' ) );
+		
+		$mw_is_percentage = isset( $attributes['maxWidthUnit'] ) && ! empty( $attributes['maxWidthUnit'] ) && '%' === $attributes['maxWidthUnit'];
+		if( $mw_is_percentage ) {
+			$css->set_selector( $base_selector . ' .kt-blocks-info-box-media-align-top .kt-blocks-info-box-media-container' );
+			$css->add_property( 'max-width', '100%');
+		}
 
 		// Hover.
 		$css->set_selector( $base_selector . ' .kt-blocks-info-box-link-wrap:hover' );


### PR DESCRIPTION
[KAD-2431](https://stellarwp.atlassian.net/browse/KAD-2431)
...

### Issue Info
- [ ] Were you able to reproduce the issue?
- [ ] Is the issue from the ticket solved? (If not, why?)

### Checklist
- [ ] I have performed a self-review.
- [ ] No unrelated files are modified.
- [ ] No debugging statements exist (Ex: console.log, error_log).
- [ ] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


#### Are there dependent changes in another repository?
- [x] No.
- [ ] Yes. Please provide the link to the PR.
