### PR TITLE
Bugfix/section block invalid css vertical alignment

### DIFF
--- a/includes/blocks/class-kadence-blocks-column-block.php
+++ b/includes/blocks/class-kadence-blocks-column-block.php
@@ -430,24 +430,28 @@ class Kadence_Blocks_Column_Block extends Kadence_Blocks_Abstract_Block {
 		}
 		// inside of Row.
 		if ( ! empty( $desktop_vertical_align ) ) {
+			$justify_content = '';
 			switch ( $desktop_vertical_align ) {
 				case 'top':
 					$align = 'flex-start';
+					$justify_content = 'flex-start';
 					break;
 				case 'bottom':
 					$align = 'flex-end';
+					$justify_content = 'flex-end';
 					break;
 				case 'space-between':
-					$align = 'space-between';
+					$justify_content = 'space-between';
 					break;
 				case 'space-around':
-					$align = 'space-around';
+					$justify_content= 'space-around';
 					break;
 				case 'space-evenly':
-					$align = 'space-evenly';
+					$justify_content = 'space-evenly';
 					break;
 				default:
 					$align = 'center';
+					$justify_content = 'center';
 					break;
 			}
 			if ( 'horizontal' === $desktop_direction || 'horizontal-reverse' === $desktop_direction ) {
@@ -464,7 +468,7 @@ class Kadence_Blocks_Column_Block extends Kadence_Blocks_Abstract_Block {
 				$css->add_property( 'align-self', 'auto' );
 				$css->set_selector( '.kt-inner-column-height-full:not(.kt-has-1-columns) > .wp-block-kadence-column.kadence-column' . $unique_id . ' > .kt-inside-inner-col' );
 				$css->add_property( 'flex-direction', 'column' );
-				$css->add_property( 'justify-content', $align );
+				$css->add_property( 'justify-content', $justify_content );
 			}
 		}
 		// Background.

--- a/includes/blocks/class-kadence-blocks-column-block.php
+++ b/includes/blocks/class-kadence-blocks-column-block.php
@@ -430,6 +430,8 @@ class Kadence_Blocks_Column_Block extends Kadence_Blocks_Abstract_Block {
 		}
 		// inside of Row.
 		if ( ! empty( $desktop_vertical_align ) ) {
+			// Restart $align variable to avoid inherit from above value assignment
+			$align = 'center';
 			$justify_content = '';
 			switch ( $desktop_vertical_align ) {
 				case 'top':
@@ -450,7 +452,6 @@ class Kadence_Blocks_Column_Block extends Kadence_Blocks_Abstract_Block {
 					$justify_content = 'space-evenly';
 					break;
 				default:
-					$align = 'center';
 					$justify_content = 'center';
 					break;
 			}


### PR DESCRIPTION
[KAD-2658](https://stellarwp.atlassian.net/browse/KAD-2658)


### Issue Info
- [x] Were you able to reproduce the issue?
- [x] Is the issue from the ticket solved? (If not, why?)

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


#### Are there dependent changes in another repository?
- [x] No.
- [ ] Yes. Please provide the link to the PR.


[KAD-2658]: https://stellarwp.atlassian.net/browse/KAD-2658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ