### PR TITLE
Feature: add health check

### DIFF
--- a/includes/resources/App.php
+++ b/includes/resources/App.php
@@ -5,6 +5,7 @@ namespace KadenceWP\KadenceBlocks;
 use InvalidArgumentException;
 use KadenceWP\KadenceBlocks\Adbar\Dot;
 use KadenceWP\KadenceBlocks\Cache\Cache_Provider;
+use KadenceWP\KadenceBlocks\Health\Health_Provider;
 use KadenceWP\KadenceBlocks\Image_Downloader\Image_Downloader_Provider;
 use KadenceWP\KadenceBlocks\Shutdown\Shutdown_Provider;
 use KadenceWP\KadenceBlocks\StellarWP\ContainerContract\ContainerInterface;
@@ -34,6 +35,7 @@ final class App {
 	 */
 	private $providers = array(
 		Uplink_Provider::class,
+		Health_Provider::class,
 		Image_Downloader_Provider::class,
 		Cache_Provider::class,
 		Shutdown_Provider::class,

--- a/includes/resources/Health/Health_Provider.php
+++ b/includes/resources/Health/Health_Provider.php
@@ -3,6 +3,7 @@
 namespace KadenceWP\KadenceBlocks\Health;
 
 use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider;
+use KadenceWP\KadenceBlocks\StellarWP\Uplink\Notice\Notice;
 
 /**
  * Check the Health aka the status of requirements, dependencies or anything that
@@ -15,8 +16,8 @@ final class Health_Provider extends Provider {
 	 */
 	public function register(): void {
 		/*
-		 * An array indexed by PHP function names to check are enabled, where a true value is
-		 * they are required and a false value is they are suggested.
+		 * An array indexed by PHP function names to check are enabled and the Notice
+		 * type to render if they aren't.
 		 *
 		 * Adjust as needed.
 		 */
@@ -24,8 +25,8 @@ final class Health_Provider extends Provider {
 		                ->needs( '$function_map' )
 		                ->give( static function (): array {
 			                return [
-				                'error_log'       => true,
-				                'curl_multi_exec' => true,
+				                'error_log'       => Notice::ERROR,
+				                'curl_multi_exec' => Notice::WARNING,
 			                ];
 		                } );
 

--- a/includes/resources/Health/Health_Provider.php
+++ b/includes/resources/Health/Health_Provider.php
@@ -1,0 +1,38 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Health;
+
+use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider;
+
+/**
+ * Check the Health aka the status of requirements, dependencies or anything that
+ * could affect the running of the plugin.
+ */
+final class Health_Provider extends Provider {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function register(): void {
+		/*
+		 * An array indexed by PHP function names to check are enabled, where a true value is
+		 * they are required and a false value is they are suggested.
+		 *
+		 * Adjust as needed.
+		 */
+		$this->container->when( Required_Function_Verifier::class )
+		                ->needs( '$function_map' )
+		                ->give( static function (): array {
+			                return [
+				                'error_log'       => true,
+				                'curl_multi_exec' => true,
+			                ];
+		                } );
+
+		add_action(
+			'admin_notices',
+			$this->container->callback( Required_Function_Verifier::class, 'verify_functions' )
+		);
+	}
+
+}

--- a/includes/resources/Health/Required_Function_Verifier.php
+++ b/includes/resources/Health/Required_Function_Verifier.php
@@ -8,10 +8,10 @@ use KadenceWP\KadenceBlocks\StellarWP\Uplink\Notice\Notice;
 final class Required_Function_Verifier {
 
 	/**
-	 * An array indexed by PHP function names to check are enabled, where a true value is
-	 *  they are required and a false value is they are suggested.
+	 * An array indexed by PHP function names to check are enabled and the Notice
+	 * type to render if they aren't.
 	 *
-	 * @var array<string, bool>
+	 * @var array<string, string>
 	 */
 	private array $function_map;
 
@@ -34,17 +34,17 @@ final class Required_Function_Verifier {
 			return;
 		}
 
-		foreach ( $this->function_map as $function => $required ) {
+		foreach ( $this->function_map as $function => $type ) {
 			if ( function_exists( $function ) ) {
 				continue;
 			}
 
 			$this->notice_handler->add( new Notice(
-				$required ? Notice::ERROR : Notice::WARNING,
+				$type,
 				sprintf(
-					__( 'The <code>%s</code> function is disabled via PHP and is %s by Kadence Blocks. Ask your administrator to enable it.', 'kadence-blocks' ),
-					$required ? __( 'required', 'kadence-blocks' ) : __( 'suggested', 'kadence-blocks' ),
-					$function
+					__( 'The "%s" function is disabled via PHP and is %s by Kadence Blocks. Ask your administrator to enable it.', 'kadence-blocks' ),
+					$function,
+					$type === Notice::ERROR ? __( 'required', 'kadence-blocks' ) : __( 'suggested', 'kadence-blocks' ),
 				),
 			) );
 		}

--- a/includes/resources/Health/Required_Function_Verifier.php
+++ b/includes/resources/Health/Required_Function_Verifier.php
@@ -49,6 +49,7 @@ final class Required_Function_Verifier {
 					$function,
 					$type === Notice::ERROR ? __( 'required', 'kadence-blocks' ) : __( 'suggested', 'kadence-blocks' ),
 				),
+				true
 			) );
 		}
 

--- a/includes/resources/Health/Required_Function_Verifier.php
+++ b/includes/resources/Health/Required_Function_Verifier.php
@@ -17,6 +17,9 @@ final class Required_Function_Verifier {
 
 	private Notice_Handler $notice_handler;
 
+	/**
+	 * @param array<string, string> $function_map
+	 */
 	public function __construct( array $function_map, Notice_Handler $notice_handler ) {
 		$this->function_map   = $function_map;
 		$this->notice_handler = $notice_handler;

--- a/includes/resources/Health/Required_Function_Verifier.php
+++ b/includes/resources/Health/Required_Function_Verifier.php
@@ -1,0 +1,54 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Health;
+
+use KadenceWP\KadenceBlocks\Notice\Notice_Handler;
+use KadenceWP\KadenceBlocks\StellarWP\Uplink\Notice\Notice;
+
+final class Required_Function_Verifier {
+
+	/**
+	 * An array indexed by PHP function names to check are enabled, where a true value is
+	 *  they are required and a false value is they are suggested.
+	 *
+	 * @var array<string, bool>
+	 */
+	private array $function_map;
+
+	private Notice_Handler $notice_handler;
+
+	public function __construct( array $function_map, Notice_Handler $notice_handler ) {
+		$this->function_map   = $function_map;
+		$this->notice_handler = $notice_handler;
+	}
+
+	/**
+	 * When on the Kadence Blocks settings page, show notices if any functions are disabled.
+	 *
+	 * @hook admin_notices
+	 */
+	public function verify_functions(): void {
+		$screen = get_current_screen();
+
+		if ( $screen && $screen->id !== 'toplevel_page_kadence-blocks' ) {
+			return;
+		}
+
+		foreach ( $this->function_map as $function => $required ) {
+			if ( function_exists( $function ) ) {
+				continue;
+			}
+
+			$this->notice_handler->add( new Notice(
+				$required ? Notice::ERROR : Notice::WARNING,
+				sprintf(
+					__( 'The <code>%s</code> function is disabled via PHP and is %s by Kadence Blocks. Ask your administrator to enable it.', 'kadence-blocks' ),
+					$required ? __( 'required', 'kadence-blocks' ) : __( 'suggested', 'kadence-blocks' ),
+					$function
+				),
+			) );
+		}
+
+		$this->notice_handler->display();
+	}
+}

--- a/includes/resources/Image_Downloader/Image_Downloader_Provider.php
+++ b/includes/resources/Image_Downloader/Image_Downloader_Provider.php
@@ -44,8 +44,8 @@ final class Image_Downloader_Provider extends Provider {
 	}
 
 	private function register_logging(): void {
-		// Enable logging to the error log if WP_DEBUG is enabled.
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		// Enable logging to the error log if WP_DEBUG is enabled and error_log is not listed in the php.ini/fpm disable_functions directive.
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG && function_exists( 'error_log' ) ) {
 			/**
 			 * Filter the log level to use when debugging.
 			 *

--- a/includes/resources/Notice/Notice_Handler.php
+++ b/includes/resources/Notice/Notice_Handler.php
@@ -1,0 +1,71 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Notice;
+
+use KadenceWP\KadenceBlocks\StellarWP\Uplink\Notice\Notice;
+use KadenceWP\KadenceBlocks\StellarWP\Uplink\Notice\Notice_Controller;
+
+/**
+ * Handles rendering multiple admin notices at once.
+ */
+final class Notice_Handler {
+
+	/**
+	 * Controller responsible for rendering notices.
+	 */
+	private Notice_Controller $controller;
+
+	/**
+	 * @var Notice[]
+	 */
+	private array $notices = [];
+
+	public function __construct( Notice_Controller $controller ) {
+		$this->controller = $controller;
+	}
+
+	/**
+	 * Add a notice to the stack.
+	 *
+	 * @param  Notice  $notice
+	 *
+	 * @return self
+	 */
+	public function add( Notice $notice ): self {
+		$this->notices[] = $notice;
+
+		return $this;
+	}
+
+	/**
+	 * Display all notices in the stack.
+	 */
+	public function display(): void {
+		if ( count( $this->notices ) <= 0 ) {
+			return;
+		}
+
+		foreach ( $this->notices as $notice ) {
+			$this->controller->render( $notice->toArray() );
+		}
+	}
+
+	/**
+	 * Get all the notices.
+	 *
+	 * @return Notice[]
+	 */
+	public function all(): array {
+		return $this->notices;
+	}
+
+	/**
+	 * Clear all notices in the stack.
+	 */
+	public function clear(): self {
+		$this->notices = [];
+
+		return $this;
+	}
+
+}

--- a/tests/_support/Classes/TestCase.php
+++ b/tests/_support/Classes/TestCase.php
@@ -1,0 +1,20 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\Support\Classes;
+
+use Codeception\TestCase\WPTestCase;
+use KadenceWP\KadenceBlocks\App;
+use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\ContainerAdapter;
+use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Container;
+
+class TestCase extends WPTestCase {
+
+	protected Container $container;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->container = App::instance( new ContainerAdapter( new \KadenceWP\KadenceBlocks\lucatume\DI52\Container() ) )->container();
+	}
+
+}

--- a/tests/wpunit/Resources/Notice/NoticeHandlerTest.php
+++ b/tests/wpunit/Resources/Notice/NoticeHandlerTest.php
@@ -1,0 +1,47 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Notice;
+
+use KadenceWP\KadenceBlocks\Notice\Notice_Handler;
+use KadenceWP\KadenceBlocks\StellarWP\Uplink\Notice\Notice;
+use Tests\Support\Classes\TestCase;
+
+final class NoticeHandlerTest extends TestCase {
+
+	private Notice_Handler $notice_handler;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->notice_handler = $this->container->get( Notice_Handler::class );
+	}
+
+	public function test_it_stores_and_retrieves_notices(): void {
+		$notice_1 = new Notice(
+			Notice::INFO,
+			__( 'Notice 1 message', 'kadence-blocks' )
+		);
+
+		$notice_2 = new Notice(
+			Notice::ERROR,
+			__( 'Notice 2 message', 'kadence-blocks' )
+		);
+
+		$this->notice_handler->add( $notice_1 );
+
+		$this->assertCount( 1, $this->notice_handler->all() );
+
+		$this->notice_handler->add( $notice_2 );
+
+		$this->assertCount( 2, $this->notice_handler->all() );
+
+		$all = $this->notice_handler->all();
+
+		$this->assertSame( $notice_1, $all[0] );
+		$this->assertSame( $notice_2, $all[1] );
+
+		$this->notice_handler->clear();
+
+		$this->assertCount( 0, $this->notice_handler->all() );
+	}
+}


### PR DESCRIPTION
### Main Changes

1. We no longer use the Monolog error logger if the `error_log` function is disabled, preventing a fatal error for an undefined function.
2. Adds a Health Check system, with a PHP function checker, this way, logs aren't just silently writing no where when debugging needs to happen and will warn the user.
3. If any PHP functions we define are disabled, notices will appear on the Kadence Settings Page, which support can now ask users to visit to verify there are no notices displayed there.

> Note: If you have better wording for the notices, please let me know.

![image](https://github.com/stellarwp/kadence-blocks/assets/1066195/3d1ff264-8533-4547-984f-0066c5d7c91d)


🎫  #[Jira Ticket]

https://ithemeshelp.zendesk.com/agent/tickets/589622

### Issue Info
- [x] Were you able to reproduce the issue?
- [x] Is the issue from the ticket solved? (If not, why?)

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


#### Are there dependent changes in another repository?
- [x] No.
- [ ] Yes. Please provide the link to the PR.
