### PR TITLE
Change fallback for locking inner blocks in row layout

### DIFF
--- a/src/blocks/column/edit.js
+++ b/src/blocks/column/edit.js
@@ -1156,7 +1156,7 @@ function SectionEdit(props) {
 				previewDirection === 'horizontal' || previewDirection === 'horizontal-reverse'
 					? 'horizontal'
 					: 'vertical',
-			templateLock: templateLock ? templateLock : false,
+			templateLock: templateLock ? templateLock : undefined,
 			renderAppender: hasInnerBlocks ? undefined : InnerBlocks.ButtonBlockAppender,
 			allowedBlocks: inFormBlock ? FORM_ALLOWED_BLOCKS : undefined,
 		}


### PR DESCRIPTION
[KAD-2321](https://stellarwp.atlassian.net/browse/KAD-2321)

...

### Issue Info
- [x] Were you able to reproduce the issue?
- [x] Is the issue from the ticket solved? (If not, why?)

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


#### Are there dependent changes in another repository?
- [x] No.
- [ ] Yes. Please provide the link to the PR.


[KAD-2321]: https://stellarwp.atlassian.net/browse/KAD-2321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ