### PR TITLE
Advanced Gallery blocks: Making Alt and Captions translatable

### DIFF
--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -105,5 +105,13 @@
 		<gutenberg-block type="kadence/column" translate="0"/>
 		<gutenberg-block type="kadence/tab" translate="0"/>
 		<gutenberg-block type="kadence/accordion" translate="0"/>
+		<gutenberg-block type="kadence/advancedgallery" translate="1">
+			<key name="imagesDynamic">
+				<key name="*">
+					<key name="alt" />
+					<key name="caption" />
+				</key>
+			</key>
+		</gutenberg-block>		
 	</gutenberg-blocks>
 </wpml-config>


### PR DESCRIPTION
This allows to translate Alt and Captions strings for Advanced Gallery blocks.
Initially, it was reported here:
https://wpml.org/de/forums/topic/uebersetzung-von-meiner-wodpress-seite/

🎫  #[Jira Ticket]

...

### Issue Info
- [x] Were you able to reproduce the issue?
- [] Is the issue from the ticket solved? (If not, why?)

### Checklist
- [ ] I have performed a self-review.
- [ ] No unrelated files are modified.
- [ ] No debugging statements exist (Ex: console.log, error_log).
- [ ] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


#### Are there dependent changes in another repository?
- [x] No.
- [ ] Yes. Please provide the link to the PR.
