### PR TITLE
KAD-2926 height/width removed from kadence-info-box-image-intrisic

### DIFF
--- a/includes/blocks/class-kadence-blocks-infobox-block.php
+++ b/includes/blocks/class-kadence-blocks-infobox-block.php
@@ -237,6 +237,8 @@ class Kadence_Blocks_Infobox_Block extends Kadence_Blocks_Abstract_Block {
 			$media_number = array();
 		}
 		if ( isset( $attributes['mediaType'] ) && 'image' === $attributes['mediaType'] ) {
+			$css->set_selector( $base_selector . '.wp-block-kadence-infobox' );
+			$css->add_property( 'max-width', '100%' );
 			if ( isset( $media_image['maxWidth'] ) && ! empty( $media_image['maxWidth'] ) ) {
 				$css->set_selector( $base_selector . ' .kadence-info-box-image-inner-intrisic-container' );
 				$css->add_property( 'max-width', $media_image['maxWidth'] . 'px' );
@@ -275,6 +277,12 @@ class Kadence_Blocks_Infobox_Block extends Kadence_Blocks_Abstract_Block {
 				$css->add_property( 'padding-bottom', $image_ratio_padding );
 			} elseif ( isset( $media_image['height'] ) && is_numeric( $media_image['height'] ) && isset( $media_image['width'] ) && is_numeric( $media_image['width'] ) ) {
 				$css->add_property( 'padding-bottom', round( ( absint( $media_image['height'] ) / absint( $media_image['width'] ) ) * 100, 4 ) . '%' );
+			}
+			if ( isset( $media_image['width'] ) && ! empty( $media_image['width'] ) ) {
+				$css->add_property( 'width', $media_image['width'] . 'px' );
+			}
+			if ( isset( $media_image['height'] ) && ! empty( $media_image['height'] ) ) {
+				$css->add_property( 'height', '0px' );
 			}
 			$css->add_property( 'max-width', '100%' );
 		}

--- a/includes/blocks/class-kadence-blocks-infobox-block.php
+++ b/includes/blocks/class-kadence-blocks-infobox-block.php
@@ -276,12 +276,6 @@ class Kadence_Blocks_Infobox_Block extends Kadence_Blocks_Abstract_Block {
 			} elseif ( isset( $media_image['height'] ) && is_numeric( $media_image['height'] ) && isset( $media_image['width'] ) && is_numeric( $media_image['width'] ) ) {
 				$css->add_property( 'padding-bottom', round( ( absint( $media_image['height'] ) / absint( $media_image['width'] ) ) * 100, 4 ) . '%' );
 			}
-			if ( isset( $media_image['width'] ) && ! empty( $media_image['width'] ) ) {
-				$css->add_property( 'width', $media_image['width'] . 'px' );
-			}
-			if ( isset( $media_image['height'] ) && ! empty( $media_image['height'] ) ) {
-				$css->add_property( 'height', '0px' );
-			}
 			$css->add_property( 'max-width', '100%' );
 		}
 		if ( isset( $media_image['subtype'] ) && 'svg+xml' === $media_image['subtype'] ) {


### PR DESCRIPTION
🎫  #[Jira Ticket]
[https://stellarwp.atlassian.net/browse/KAD-2926](https://stellarwp.atlassian.net/browse/KAD-2926)
...

### Issue Info
- [x] Were you able to reproduce the issue?
- [x] Is the issue from the ticket solved? (If not, why?)

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


#### Are there dependent changes in another repository?
- [x] No.
- [ ] Yes. Please provide the link to the PR.
