### PR TITLE
bugfix/KAD-2930

### DIFF
--- a/includes/blocks/class-kadence-blocks-accordion-block.php
+++ b/includes/blocks/class-kadence-blocks-accordion-block.php
@@ -147,7 +147,7 @@ class Kadence_Blocks_Accordion_Block extends Kadence_Blocks_Abstract_Block {
 				'mobile_key'  => 'paddingMobile',
 			);
 			$css->render_measure_output( $title_styles, 'padding', 'padding', $padding_args );
-			$css->set_selector( '.kt-accordion-wrap.kt-accordion-id' . $unique_id . ' > .kt-accordion-inner-wrap > .kt-accordion-pane > .kt-accordion-header-wrap' );
+			$css->set_selector( '.kt-accordion-wrap.kt-accordion-id' . $unique_id . ' > .kt-accordion-inner-wrap > .kt-accordion-pane:not(:first-child) > .kt-accordion-header-wrap' );
 			$css->render_range( $title_styles, 'marginTop', 'margin-top' );
 
 			// Override for Kadence Theme.


### PR DESCRIPTION
[https://stellarwp.atlassian.net/browse/KAD-2930](https://stellarwp.atlassian.net/browse/KAD-2930)
🎫  #[2930]

...

### Issue Info
- [x] Were you able to reproduce the issue?
- [x] Is the issue from the ticket solved? (If not, why?)

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


#### Are there dependent changes in another repository?
- [x] No.
- [ ] Yes. Please provide the link to the PR.
