### PR TITLE
Don't perform an authorization check on Kadence Home if AI is disabled

### DIFF
--- a/includes/settings/class-kadence-blocks-settings.php
+++ b/includes/settings/class-kadence-blocks-settings.php
@@ -736,7 +736,7 @@ class Kadence_Blocks_Settings {
 		$license_key    = kadence_blocks_get_current_license_key();
 		$disconnect_url = '';
 		$is_authorized  = false;
-		if ( ! empty( $license_key ) ) {
+		if ( ! empty( $license_key ) && ! kadence_blocks_is_ai_disabled() ) {
 			$is_authorized = is_authorized( $license_key, 'kadence-blocks', ( ! empty( $token ) ? $token : '' ), get_license_domain() );
 		}
 


### PR DESCRIPTION
🎫  https://ithemeshelp.zendesk.com/agent/tickets/607623

[Slack thread](https://lw.slack.com/archives/C05D4PKNZ9V/p1715893408303279)

This disables the remote auth license checks on the Kadence home page if the user has defined `define( 'KADENCE_BLOCKS_AI_DISABLED', true );` in their wp-config.php.

> :warning:  As this forces [Authorization to false for the frontend](https://github.com/stellarwp/kadence-blocks/blob/8d0ab936c964e7f44b8d6f6d30106542eb726814/includes/settings/class-kadence-blocks-settings.php#L782), I am not sure if that used outside of AI at all, but if it is, it could potentially lead to some regressions. However, given this same logic applies in the [block editor assets](https://github.com/stellarwp/kadence-blocks/blob/975f84cd55bfeae9ae3872df3bbcdc3a01f86852/includes/class-kadence-blocks-editor-assets.php#L287), it should be fine.

**Before**

![image](https://github.com/user-attachments/assets/1aa3b931-6739-4123-be5c-b54715fe3115)

**After**

![image](https://github.com/user-attachments/assets/2e72f0ff-7c6b-4123-ba1e-4cd686eccaa9)

