### PR TITLE
Captcha not validating when inserted into a form and relying on global kadence_blocks_settings keys

### DIFF
--- a/includes/advanced-form/advanced-form-captcha-settings.php
+++ b/includes/advanced-form/advanced-form-captcha-settings.php
@@ -119,7 +119,7 @@ class Kadence_Blocks_Form_Captcha_Settings {
 	}
 
 	private function is_using_kadence_blocks_settings( $attributes ) {
-		if ( isset( $attributes['useKbSettings'] ) && $attributes['useKbSettings'] ) {
+		if ( !isset( $attributes['useKbSettings'] ) || ( isset( $attributes['useKbSettings'] ) && $attributes['useKbSettings'] ) ) {
 			$this->using_kadence_blocks_settings = true;
 		} else {
 			$this->using_kadence_blocks_settings = false;

--- a/tests/wpunit/Classes/AdvancedFormCaptchaSettingsTest.php
+++ b/tests/wpunit/Classes/AdvancedFormCaptchaSettingsTest.php
@@ -27,13 +27,23 @@ class AdvancedFormCaptchaSettingsTest extends KadenceBlocksTestCase {
 	}
 
 	public function testIsUsingKadenceBlocksSettings() {
-		$attributes = [ 'useKbSettings' => null ];
+		$attributes = [];
 		$captchaSettings = new Kadence_Blocks_Form_Captcha_Settings( $attributes );
-		$this->assertFalse($captchaSettings->using_kadence_blocks_settings);
+		$this->assertTrue($captchaSettings->using_kadence_blocks_settings);
 
 		$attributes = [ 'useKbSettings' => true ];
 		$captchaSettings = new Kadence_Blocks_Form_Captcha_Settings( $attributes );
 		$this->assertTrue($captchaSettings->using_kadence_blocks_settings);
+
+		$attributes = [ 'useKbSettings' => false ];
+		$captchaSettings = new Kadence_Blocks_Form_Captcha_Settings( $attributes );
+		$this->assertFalse($captchaSettings->using_kadence_blocks_settings);
+	}
+
+	public function testBlankDefaults() {
+		$attributes = [];
+		$captchaSettings = new Kadence_Blocks_Form_Captcha_Settings( $attributes );
+		$this->assertEquals('googlev2', $captchaSettings->service);
 	}
 
 	public function testGetCaptchaService() {
@@ -56,19 +66,19 @@ class AdvancedFormCaptchaSettingsTest extends KadenceBlocksTestCase {
 
 	public function testGetPublicKey () {
 		// Using Block settings
-		$attributes = [ 'type' => '', 'recaptchaSiteKey' => 'my_recaptchaSiteKey' ];
+		$attributes = [ 'type' => '', 'useKbSettings' => false, 'recaptchaSiteKey' => 'my_recaptchaSiteKey' ];
 		$captchaSettings = new Kadence_Blocks_Form_Captcha_Settings( $attributes );
 		$this->assertEquals( 'my_recaptchaSiteKey', $captchaSettings->public_key);
 
-		$attributes = [ 'type' => 'turnstile', 'turnstileSiteKey' => 'my_turnstileSiteKey' ];
+		$attributes = [ 'type' => 'turnstile', 'useKbSettings' => false, 'turnstileSiteKey' => 'my_turnstileSiteKey' ];
 		$captchaSettings = new Kadence_Blocks_Form_Captcha_Settings( $attributes );
 		$this->assertEquals( 'my_turnstileSiteKey', $captchaSettings->public_key);
 
-		$attributes = [ 'type' => 'hcaptcha', 'hCaptchaSiteKey' => 'hCaptchaSiteKey' ];
+		$attributes = [ 'type' => 'hcaptcha', 'useKbSettings' => false, 'hCaptchaSiteKey' => 'hCaptchaSiteKey' ];
 		$captchaSettings = new Kadence_Blocks_Form_Captcha_Settings( $attributes );
 		$this->assertEquals( 'hCaptchaSiteKey', $captchaSettings->public_key);
 
-		// Using global settings
+		// Using using_kadence_blocks_settings settings
 		add_option( 'kadence_blocks_recaptcha_site_key', 'my_option_recaptchaSiteKey' );
 		$attributes = [ 'type' => 'googlev3', 'useKbSettings' => true, 'recaptchaSiteKey' => 'my_recaptchaSiteKey' ];
 		$captchaSettings = new Kadence_Blocks_Form_Captcha_Settings( $attributes );
@@ -89,19 +99,19 @@ class AdvancedFormCaptchaSettingsTest extends KadenceBlocksTestCase {
 
 	public function testGetPrivateKey () {
 		// Using Block settings
-		$attributes = [ 'type' => '', 'recaptchaSecretKey' => 'my_recaptchaSecretKey' ];
+		$attributes = [ 'type' => '',  'useKbSettings' => false, 'recaptchaSecretKey' => 'my_recaptchaSecretKey' ];
 		$captchaSettings = new Kadence_Blocks_Form_Captcha_Settings( $attributes );
 		$this->assertEquals( 'my_recaptchaSecretKey', $captchaSettings->secret_key);
 
-		$attributes = [ 'type' => 'turnstile', 'turnstileSecretKey' => 'my_turnstileSecretKey' ];
+		$attributes = [ 'type' => 'turnstile',  'useKbSettings' => false, 'turnstileSecretKey' => 'my_turnstileSecretKey' ];
 		$captchaSettings = new Kadence_Blocks_Form_Captcha_Settings( $attributes );
 		$this->assertEquals( 'my_turnstileSecretKey', $captchaSettings->secret_key);
 
-		$attributes = [ 'type' => 'hcaptcha', 'hCaptchaSecretKey' => 'hCaptchaSecretKey' ];
+		$attributes = [ 'type' => 'hcaptcha', 'useKbSettings' => false, 'hCaptchaSecretKey' => 'hCaptchaSecretKey' ];
 		$captchaSettings = new Kadence_Blocks_Form_Captcha_Settings( $attributes );
 		$this->assertEquals( 'hCaptchaSecretKey', $captchaSettings->secret_key);
 
-		// Using global settings
+		// Using using_kadence_blocks_settings settings
 		add_option( 'kadence_blocks_recaptcha_secret_key', 'my_option_recaptchaSecretKey' );
 		$attributes = [ 'type' => 'googlev3', 'useKbSettings' => true, 'recaptchaSecretKey' => 'my_recaptchaSecretKey' ];
 		$captchaSettings = new Kadence_Blocks_Form_Captcha_Settings( $attributes );


### PR DESCRIPTION
When `useKbSettings` was added the default value was set to true, but the attribute value isn't passed in the data if it's still the default value. On this line we only check if it's set and true, when we should also assume it's true when not set.

If this is set to false, we don't pull in the global keys and thus don't validate the form when these are otherwise set.

Mostly PRing for a second check to make sure that `using_kadence_blocks_settings` defaulting to true won't mess anything up.

https://github.com/stellarwp/kadence-blocks/commit/ca679a58dfce3dcf3c66a416bbeba0f5a8df5aa9#diff-2d4af50a9a461b86a01d175bdb2480e9c66bed9a9aaae021d98c559d27cdd153R121-R128