### PR TITLE
KAD-2743 spacerHeight default set at 60 to match editor

### DIFF
--- a/includes/blocks/class-kadence-blocks-spacer-block.php
+++ b/includes/blocks/class-kadence-blocks-spacer-block.php
@@ -61,10 +61,8 @@ class Kadence_Blocks_Spacer_Block extends Kadence_Blocks_Abstract_Block {
 
 		$css->set_style_id( 'kb-' . $this->block_name . $unique_style_id );
 
-		if ( ! empty( $attributes['spacerHeight'] ) ) {
 			$css->set_selector( '.wp-block-kadence-spacer.kt-block-spacer-' . $unique_id . ' .kt-block-spacer' );
-			$css->add_property( 'height', $attributes['spacerHeight'] . ( isset( $attributes['spacerHeightUnits'] ) ? $attributes['spacerHeightUnits'] : 'px' ) );
-		}
+			$css->add_property( 'height', ($attributes['spacerHeight'] ?? '60') . (isset($attributes['spacerHeightUnits']) ? $attributes['spacerHeightUnits'] : 'px'));
 		if ( ! empty( $attributes['tabletSpacerHeight'] ) ) {
 			$css->set_media_state( 'tablet' );
 			$css->set_selector( '.wp-block-kadence-spacer.kt-block-spacer-' . $unique_id . ' .kt-block-spacer' );
@@ -110,7 +108,7 @@ class Kadence_Blocks_Spacer_Block extends Kadence_Blocks_Abstract_Block {
 			$css->set_selector( '.wp-block-kadence-spacer.kt-block-spacer-' . $unique_id . ' .kt-divider' );
 			if ( isset( $attributes['dividerHeight'] ) && ! empty( $attributes['dividerHeight'] ) ) {
 				$css->add_property( 'border-top-width', $attributes['dividerHeight'] . 'px' );
-				// Adding this prevents a blur when browsers are rendering. 
+				// Adding this prevents a blur when browsers are rendering.
 				if( ! empty( $attributes['dividerHeight'] ) && intval( absint( $attributes['dividerHeight'] ) % 2 ) != 0 ){
 					$css->add_property( 'height', '1px' );
 				}


### PR DESCRIPTION
🎫  #[Jira Ticket]
[https://stellarwp.atlassian.net/browse/KAD-2743](https://stellarwp.atlassian.net/browse/KAD-2743)
...

### Issue Info
- [ ] Were you able to reproduce the issue?
- [ ] Is the issue from the ticket solved? (If not, why?)

### Checklist
- [ ] I have performed a self-review.
- [ ] No unrelated files are modified.
- [ ] No debugging statements exist (Ex: console.log, error_log).
- [ ] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


#### Are there dependent changes in another repository?
- [x] No.
- [ ] Yes. Please provide the link to the PR.
