### PR TITLE
Fix Strings Translation in advancedheading tooltips-popover.js

### DIFF
--- a/src/blocks/advancedheading/formats/tooltips-popover.js
+++ b/src/blocks/advancedheading/formats/tooltips-popover.js
@@ -12,7 +12,7 @@ const defaultLinkSettings = Array.isArray(LinkControl?.DEFAULT_LINK_SETTINGS)
 	: [
 			{
 				id: '"opensInNewTab"',
-				title: __('Open in new tab'),
+				title: __('Open in new tab', 'kadence-blocks'),
 			},
 	  ];
 
@@ -20,7 +20,7 @@ const LINK_SETTINGS = [
 	...defaultLinkSettings,
 	{
 		id: 'nofollow',
-		title: __('Mark as nofollow'),
+		title: __('Mark as nofollow', 'kadence-blocks'),
 	},
 ];
 


### PR DESCRIPTION
Fix Strings Translation in advancedheading tooltips-popover.js