### PR TITLE
WPML - Advanced Gallery blocks: Making Custom Links translatable

### DIFF
--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -110,6 +110,7 @@
 				<key name="*">
 					<key name="alt" />
 					<key name="caption" />
+					<key name="customLink" />
 				</key>
 			</key>
 		</gutenberg-block>


### PR DESCRIPTION
Advanced Gallery blocks: Making Custom links translatable Initially reported here:
https://wpml.org/forums/topic/video-gallery-links-in-secondary-language-redirecting-to-primary-language/

🎫  #[Jira Ticket]

...

### Issue Info
- [x] Were you able to reproduce the issue?
- [ ] Is the issue from the ticket solved? (If not, why?)

### Checklist
- [ ] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


#### Are there dependent changes in another repository?
- [x] No.
- [ ] Yes. Please provide the link to the PR.
