### PR TITLE
KAD-3459 Prevent flashing of design library in Lifter LMS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,6 +58,7 @@ const eslintConfig = {
 		Masonry: 'readable',
 		IntersectionObserver: 'readable',
 		getComputedStyle: 'readable',
+		MutationObserver: 'readonly',
 	},
 	rules: {
 		'@wordpress/i18n-text-domain': [


### PR DESCRIPTION
This prevents the flashing of the icon when editing an Lifter LMS course. Both us and lifter are trying to inject content, using the same method, and are overwriting each others buttons. I tried modifying the selector to make sure we're in the same div, different divs, etc, but switching to a mutation observer seems to be the most reliable way to prevent this from happening. Open to other ideas though

https://github.com/user-attachments/assets/8a12f889-1ed2-4d6b-97d6-aa3d69b7cff6

