### PR TITLE
BUG FIX: Ensure we set the log level on the error log handler as well

### DIFF
--- a/includes/resources/Image_Downloader/Image_Downloader_Provider.php
+++ b/includes/resources/Image_Downloader/Image_Downloader_Provider.php
@@ -61,6 +61,10 @@ final class Image_Downloader_Provider extends Provider {
 			                ->needs( '$level' )
 			                ->give( LogLevel::fromName( $log_level ) );
 
+			$this->container->when( ErrorLogHandler::class )
+			                ->needs( '$level' )
+			                ->give( LogLevel::fromName( $log_level ) );
+
 			$this->container->bind( LoggerInterface::class, function () {
 				$logger  = new Logger( 'kadence' );
 				$handler = $this->container->get( ErrorLogHandler::class );


### PR DESCRIPTION
> :rotating_light: If this code has been copied and pasted into other Kadence plugins, it should be applied there too.

I wasn't properly setting the log level for the error log handler, this fixes it so it can be properly customized by the `kadence_blocks_image_download_log_level` filter.