### PR TITLE
WPML - Advanced Heading Block Displays Twice in Translation Editor

### DIFF
--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -27,9 +27,7 @@
 		<gutenberg-block type="kadence/countup" translate="1">
 			<key name="title" />
 		</gutenberg-block>
-		<gutenberg-block type="kadence/advancedheading" translate="1">
-			<xpath>//*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6 or self::p or self::div or self::span.wp-block-kadence-advancedheading]</xpath>
-		</gutenberg-block>
+		<gutenberg-block type="kadence/advancedheading" translate="1"></gutenberg-block>
 		<gutenberg-block type="kadence/tabs" translate="1">
 			<xpath>//span[@class="kt-title-text"]</xpath>
 			<xpath>//span[@class="kt-title-sub-text"]</xpath>


### PR DESCRIPTION
Advanced Heading Block Displays Twice in Translation Editor:
It seems the xPath is not longer needed as the text is also available in the "general" text area:

Initially reported here:
https://wpml.org/forums/topic/advanced-translator-shows-translation-fields-twice/

Erratum:
https://wpml.org/errata/kadence-blocks-advanced-heading-block-displays-twice-in-translation-editor/

🎫  #[Jira Ticket]

...

### Checklist
- [ ] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
