### PR TITLE
KAD-3806 Show the max progress as the initial state

### DIFF
--- a/includes/blocks/class-kadence-blocks-progress-bar-block.php
+++ b/includes/blocks/class-kadence-blocks-progress-bar-block.php
@@ -422,7 +422,7 @@ class Kadence_Blocks_Progress_Bar_Block extends Kadence_Blocks_Abstract_Block {
 
 		$prefix   = isset( $attributes['numberPrefix'] ) ? $attributes['numberPrefix'] : '';
 		$suffix   = isset( $attributes['numberSuffix'] ) ? $attributes['numberSuffix'] : '';
-		$starting = 0;
+		$starting = !empty( $attributes['progressMax'] ) && !empty( $attributes['showMaxProgressOnPageLoad'] ) ? $attributes['progressMax'] : 0;
 
 		$position = isset( $attributes['labelPosition'] ) ? $attributes['labelPosition'] : 'above';
 

--- a/src/blocks/progress-bar/block.json
+++ b/src/blocks/progress-bar/block.json
@@ -229,6 +229,10 @@
 		"ariaLabel": {
 			"type": "string",
 			"default": ""
+		},
+		"showMaxProgressOnPageLoad": {
+			"type": "boolean",
+			"default": true
 		}
 	}
 }

--- a/src/blocks/progress-bar/edit.js
+++ b/src/blocks/progress-bar/edit.js
@@ -112,6 +112,7 @@ export function Edit(props) {
 		maskSvg,
 		maskUrl,
 		ariaLabel,
+		showMaxProgressOnPageLoad,
 	} = attributes;
 
 	const { addUniqueID } = useDispatch('kadenceblocks/data');
@@ -1228,50 +1229,65 @@ export function Edit(props) {
 				)}
 
 				{activeTab === 'advanced' && (
-					<KadencePanelBody>
-						<ResponsiveMeasureRangeControl
-							label={__('Margin', 'kadence-blocks')}
-							value={margin}
-							tabletValue={tabletMargin}
-							mobileValue={mobileMargin}
-							onChange={(value) => {
-								setAttributes({ margin: value });
-							}}
-							onChangeTablet={(value) => setAttributes({ tabletMargin: value })}
-							onChangeMobile={(value) => setAttributes({ mobileMargin: value })}
-							min={marginType === 'em' || marginType === 'rem' ? -12 : -999}
-							max={marginType === 'em' || marginType === 'rem' ? 24 : 999}
-							step={marginType === 'em' || marginType === 'rem' ? 0.1 : 1}
-							unit={marginType}
-							units={['px', 'em', 'rem', '%', 'vh']}
-							onUnit={(value) => setAttributes({ marginType: value })}
-							// onMouseOver={ marginMouseOver.onMouseOver }
-							// onMouseOut={ marginMouseOver.onMouseOut }
-							allowAuto={true}
-						/>
-						<ResponsiveRangeControls
-							label={__('Max Width', 'kadence-blocks')}
-							value={containerMaxWidth}
-							onChange={(value) => setAttributes({ containerMaxWidth: value })}
-							tabletValue={tabletContainerMaxWidth ? tabletContainerMaxWidth : ''}
-							onChangeTablet={(value) => setAttributes({ tabletContainerMaxWidth: value })}
-							mobileValue={mobileContainerMaxWidth ? mobileContainerMaxWidth : ''}
-							onChangeMobile={(value) => setAttributes({ mobileContainerMaxWidth: value })}
-							min={0}
-							max={containerMaxWidthUnits === 'px' ? 3000 : 100}
-							step={1}
-							unit={containerMaxWidthUnits}
-							onUnit={(value) => setAttributes({ containerMaxWidthUnits: value })}
-							reset={() =>
-								setAttributes({
-									containerMaxWidth: 0,
-									tabletContainerMaxWidth: '',
-									mobileContainerMaxWidth: '',
-								})
-							}
-							units={['px', 'vh', '%']}
-						/>
-					</KadencePanelBody>
+					<>
+						<KadencePanelBody>
+							<ResponsiveMeasureRangeControl
+								label={__('Margin', 'kadence-blocks')}
+								value={margin}
+								tabletValue={tabletMargin}
+								mobileValue={mobileMargin}
+								onChange={(value) => {
+									setAttributes({ margin: value });
+								}}
+								onChangeTablet={(value) => setAttributes({ tabletMargin: value })}
+								onChangeMobile={(value) => setAttributes({ mobileMargin: value })}
+								min={marginType === 'em' || marginType === 'rem' ? -12 : -999}
+								max={marginType === 'em' || marginType === 'rem' ? 24 : 999}
+								step={marginType === 'em' || marginType === 'rem' ? 0.1 : 1}
+								unit={marginType}
+								units={['px', 'em', 'rem', '%', 'vh']}
+								onUnit={(value) => setAttributes({ marginType: value })}
+								// onMouseOver={ marginMouseOver.onMouseOver }
+								// onMouseOut={ marginMouseOver.onMouseOut }
+								allowAuto={true}
+							/>
+							<ResponsiveRangeControls
+								label={__('Max Width', 'kadence-blocks')}
+								value={containerMaxWidth}
+								onChange={(value) => setAttributes({ containerMaxWidth: value })}
+								tabletValue={tabletContainerMaxWidth ? tabletContainerMaxWidth : ''}
+								onChangeTablet={(value) => setAttributes({ tabletContainerMaxWidth: value })}
+								mobileValue={mobileContainerMaxWidth ? mobileContainerMaxWidth : ''}
+								onChangeMobile={(value) => setAttributes({ mobileContainerMaxWidth: value })}
+								min={0}
+								max={containerMaxWidthUnits === 'px' ? 3000 : 100}
+								step={1}
+								unit={containerMaxWidthUnits}
+								onUnit={(value) => setAttributes({ containerMaxWidthUnits: value })}
+								reset={() =>
+									setAttributes({
+										containerMaxWidth: 0,
+										tabletContainerMaxWidth: '',
+										mobileContainerMaxWidth: '',
+									})
+								}
+								units={['px', 'vh', '%']}
+							/>
+						</KadencePanelBody>
+						{displayPercent && (
+							<KadencePanelBody initialOpen={true} panelName={'kb-progress-preload-settings'}>
+								<ToggleControl
+									label={__('Show max progress on page load', 'kadence-blocks')}
+									help={__(
+										'The max progress value will be shown prior to the progress bar javascript executing or if javascript is disabled.',
+										'kadence-blocks'
+									)}
+									checked={showMaxProgressOnPageLoad}
+									onChange={(value) => setAttributes({ showMaxProgressOnPageLoad: value })}
+								/>
+							</KadencePanelBody>
+						)}
+					</>
 				)}
 			</InspectorControls>
 			<style>{maskStyles}</style>


### PR DESCRIPTION
Thoughts on changing this to the default behavior? 

On page load progressMax will show as the value until JS is executed. This prevents issues where the JS never inits and it looks like you have "0% uptime" or "0 sales"