### PR TITLE
Kadence blocks - Internal Link Translation

### DIFF
--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -2,7 +2,7 @@
 	<gutenberg-blocks>
 		<gutenberg-block type="kadence/advancedbtn" translate="0"/>
 		<gutenberg-block type="kadence/singlebtn" translate="1">
-			<key name="link" />
+			<key name="link" type="link" />
 			<key name="text" />
 		</gutenberg-block>
 		<gutenberg-block type="kadence/icon" translate="0"/>
@@ -29,6 +29,7 @@
 		</gutenberg-block>
 		<gutenberg-block type="kadence/advancedheading" translate="1">
 			<xpath>//*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6 or self::p or self::div or self::span.wp-block-kadence-advancedheading]</xpath>
+			<xpath type="link">//a/@href</xpath>
 		</gutenberg-block>
 		<gutenberg-block type="kadence/tabs" translate="1">
 			<xpath>//span[@class="kt-title-text"]</xpath>


### PR DESCRIPTION
When using the Kadence Block‘s “Advanced Button” or "Text (Adv)", WPML does not automatically translate the internal link to its corresponding translated version.

Specifying type=”link” for the link attribute enables WPML to automatically translate the URL.

Erratum: https://wpml.org/errata/kadence-block-advanced-button-internal-link-translation-not-applied-automatically/

🎫  #[Jira Ticket]

...

### Checklist
- [ ] I have performed a self-review.
- [ ] No unrelated files are modified.
- [ ] No debugging statements exist (Ex: console.log, error_log).
- [ ] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
