### PR TITLE
Advanced Forms: Making radio options and submit button translatable

### DIFF
--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -157,6 +157,11 @@
 			<key name="errorMessage" />
 			<key name="requiredMessage" />
 			<key name="helpText" />
+			<key name="options">
+				<key name="*">
+					<key name="label" />
+				</key>
+			</key>
 		</gutenberg-block>
 		<gutenberg-block type="kadence/advanced-form-select" translate="1">
 			<key name="label" />
@@ -169,6 +174,7 @@
 		</gutenberg-block>
 		<gutenberg-block type="kadence/advanced-form-submit" translate="1">
 			<key name="label" />
+			<key name="text" />
 		</gutenberg-block>
 		<gutenberg-block type="kadence/advanced-form-telephone" translate="1">
 			<key name="label" />
@@ -295,5 +301,15 @@
 		<custom-field action="translate">_kad_form_maxwidthunit</custom-field>
 		<custom-field action="translate">_kad_form_maxwidth</custom-field>
 		<custom-field action="translate">_kad_form_importid</custom-field>
+		<custom-field action="copy">_kad_form_tabletFieldBorderStyle</custom-field>
+		<custom-field action="copy">_kad_form_mobileFieldBorderStyle</custom-field>
+		<custom-field action="copy">_kad_form_inputFont</custom-field>
+		<custom-field action="copy">_kad_form_style</custom-field>
+		<custom-field action="copy">_kad_form_fieldBorderRadius</custom-field>
+		<custom-field action="copy">_kad_form_tabletFieldBorderRadius</custom-field>
+		<custom-field action="copy">_kad_form_mobileFieldBorderRadius</custom-field>
+		<custom-field action="copy">_kad_form_fieldBorderRadiusUnit</custom-field>	
+		<custom-field action="copy">_kad_form_labelFont</custom-field>	
+		<custom-field action="copy">_kad_form_radioLabelFont</custom-field>			
 	</custom-fields>
 </wpml-config>


### PR DESCRIPTION
- Form - radio options do not show the translation, and the styling of the form is not being copied
- Making submit button translatable

Initially reported here:
https://wpml.org/forums/topic/kadence-form-adv-block-not-translateable-2/

🎫  #[Jira Ticket]

...

### Checklist
- [ ] I have performed a self-review.
- [ ] No unrelated files are modified.
- [ ] No debugging statements exist (Ex: console.log, error_log).
- [ ] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
