### PR TITLE
Removing aria-labeledby from the progressbar display as it no longer …

### DIFF
--- a/includes/blocks/class-kadence-blocks-progress-bar-block.php
+++ b/includes/blocks/class-kadence-blocks-progress-bar-block.php
@@ -243,9 +243,6 @@ class Kadence_Blocks_Progress_Bar_Block extends Kadence_Blocks_Abstract_Block {
 		$progress_args = [
 			'class' => 'kb-progress-bar kb-progress-bar-' . esc_attr( $unique_id ),
 		];
-		if ( ! empty( $attributes['label'] ) && ( ! isset( $attributes['displayLabel'] ) || ( isset( $attributes['displayLabel'] ) && $attributes['displayLabel'] !== false ) ) ) {
-			$progress_args['aria-labelledby'] = 'kt-progress-label' . esc_attr( $unique_id );
-		}
 		$mask = ! empty( $attributes['maskSvg'] ) ? $attributes['maskSvg'] : 'star';
 		if ( ! empty( $attributes['ariaLabel'] ) ) {
 			$progress_args['aria-label'] = $attributes['ariaLabel'];


### PR DESCRIPTION
…has the progress bar role

https://stellarwp.atlassian.net/browse/KAD-3917

🎫  #[Jira Ticket]

...

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
