### PR TITLE
KAD-4108 Fix setting numeric padding/margin on submenu links

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -174,6 +174,10 @@ Please report security bugs found in the Kadence Blocks plugin's source code thr
 
 == Changelog ==
 
+= 3.4.12 =
+Release Date: TBD March 2025
+* Fix: Setting numeric padding & margin on Adv Navigation sub menu links.
+
 = 3.4.11 =
 Release Date: 25th February 2025
 * Fix: Issue with advanced text color in editor when no color is selected.

--- a/src/blocks/navigation/edit-inner.js
+++ b/src/blocks/navigation/edit-inner.js
@@ -1980,9 +1980,9 @@ export function EditInner(props) {
 								/>
 								<ResponsiveMeasureRangeControl
 									label={__('Link Padding', 'kadence-blocks')}
-									value={paddingDropdownLink}
-									tabletValue={tabletPaddingDropdownLink}
-									mobileValue={mobilePaddingDropdownLink}
+									value={arrayStringToInt(paddingDropdownLink)}
+									tabletValue={arrayStringToInt(tabletPaddingDropdownLink)}
+									mobileValue={arrayStringToInt(mobilePaddingDropdownLink)}
 									onChange={(value) => {
 										setMetaAttribute(value.map(String), 'paddingDropdownLink');
 									}}
@@ -2009,9 +2009,9 @@ export function EditInner(props) {
 								/>
 								<ResponsiveMeasureRangeControl
 									label={__('Link Margin', 'kadence-blocks')}
-									value={marginDropdownLink}
-									tabletValue={tabletMarginDropdownLink}
-									mobileValue={mobileMarginDropdownLink}
+									value={arrayStringToInt(marginDropdownLink)}
+									tabletValue={arrayStringToInt(tabletMarginDropdownLink)}
+									mobileValue={arrayStringToInt(mobileMarginDropdownLink)}
 									onChange={(value) => {
 										setMetaAttribute(value.map(String), 'marginDropdownLink');
 									}}


### PR DESCRIPTION
[KAD-4108](https://stellarwp.atlassian.net/browse/KAD-4108)

This issue is due to CPT needing meta to be stored as a string, we convert the numeric padding values to a string. The padding component sees a string and thinks it's a variable value (SM, MD, LG). I created the `arrayStringToInt` helper a while back to support converting strings of number back into integers so the component handles them correctly.  We use this function in this file and the advanced header.

[KAD-4108]: https://stellarwp.atlassian.net/browse/KAD-4108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ