### PR TITLE
accessibility/KAD-4177 Improve Link Title visibility on section overlay link

### DIFF
--- a/src/packages/components/src/links/link-control/index.js
+++ b/src/packages/components/src/links/link-control/index.js
@@ -149,13 +149,6 @@ class URLInputControl extends Component {
 						checked={ linkDownload }
 					/>
 				) }
-				{ onChangeTitle && (
-					<TextControl
-						label={ __( 'Title', 'kadence-blocks' ) }
-						onChange={ onSetLinkTitle }
-						value={ linkTitle }
-					/>
-				) }
 				{ onChangeLinkClass && (
 					<TextControl
 						label={ __( 'Link CSS Class', 'kadence-blocks' ) }
@@ -183,6 +176,15 @@ class URLInputControl extends Component {
 					allowClear={ allowClear }
 					{ ...this.props }
 				/>
+				{ onChangeTitle && (
+					<TextControl
+						label={ __( 'Title', 'kadence-blocks' ) }
+						onChange={ onSetLinkTitle }
+						value={ linkTitle }
+						style={ url  && !linkTitle ? { backgroundColor: 'yellow' } : {} }
+						placeholder={ url  && !linkTitle ? __( 'Add a Title', 'kadence-blocks' ) : '' }
+					/>
+				) }
 			</div>
 		);
 	}


### PR DESCRIPTION
[https://stellarwp.atlassian.net/browse/KAD-4177](https://stellarwp.atlassian.net/browse/KAD-4177)
Moves the TextControl for the title so that it always shows. Also, it has a yellow background and a placeholder if there is a link but no title set.
