### PR TITLE
bugfix/KAD-4123 Adv Search > Aria Label setting not working

### DIFF
--- a/includes/blocks/class-kadence-blocks-search-block.php
+++ b/includes/blocks/class-kadence-blocks-search-block.php
@@ -258,11 +258,12 @@ class Kadence_Blocks_Search_Block extends Kadence_Blocks_Abstract_Block {
 	private function build_input( $attributes ) {
 		$input = '<div class="kb-search-input-wrapper">';
 		$placeholder = ! empty( $attributes['inputPlaceholder'] ) ? $attributes['inputPlaceholder'] : '';
-
+		$aria_label = !empty($attributes['label']) ? sprintf( 'aria-label="%s"', esc_attr( $attributes['label'] ) ) : '';
 
 		$input .= sprintf(
-			'<input name="s" type="text" class="kb-search-input" placeholder="%s">',
-			esc_attr( $placeholder )
+			'<input name="s" type="text" class="kb-search-input" placeholder="%s" %s>',
+			esc_attr( $placeholder ),
+			$aria_label
 		);
 
 		if( !empty( $attributes['inputIcon'] ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -177,6 +177,7 @@ Please report security bugs found in the Kadence Blocks plugin's source code thr
 = 3.4.12 =
 Release Date: TBD March 2025
 * Fix: Setting numeric padding & margin on Adv Navigation sub menu links.
+* Fix: Aria label for Search (Adv) block.
 
 = 3.4.11 =
 Release Date: 25th February 2025

--- a/src/blocks/search/block.json
+++ b/src/blocks/search/block.json
@@ -237,6 +237,10 @@
 		"closeIconHoverColor": {
 			"type": "string",
 			"default": ""
+		},
+		"label": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"supports": {


### PR DESCRIPTION
[https://stellarwp.atlassian.net/browse/KAD-4123](https://stellarwp.atlassian.net/browse/KAD-4123)

The block.json didn't declare the "label" attribute, so the aria label wasn't saving in the backend. Additionally, the frontend did not include the aria-label in the HTML. This fix lets the aria label get saved and adds it to the frontend HTML if it exists.