### PR TITLE
bugfix/KAD-4180

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -179,6 +179,7 @@ Release Date: TBD
 * Add: Enhance Text(Adv) copy/paste.
 * Fix: TOC block margin unit type.
 * Fix: Design Library removed from new Row Layout when Design Library is disabled.
+* Fix: Accordion header buttons no longer inherit box shadow from theme on active.
 
 = 3.5.1 =
 Release Date: 3rd April 2025

--- a/src/blocks/accordion/style.scss
+++ b/src/blocks/accordion/style.scss
@@ -45,6 +45,9 @@
 	background-color: var(--global-palette8, #f2f2f2);
 	color: var(--global-palette5, #555555);
 }
+.kt-blocks-accordion-header:active {
+	box-shadow: none;
+}
 .kt-blocks-accordion-header:hover {
 	background-color: var(--global-palette7, #eeeeee);
 	color: var(--global-palette5, #444444);

--- a/src/blocks/accordion/style.scss
+++ b/src/blocks/accordion/style.scss
@@ -42,6 +42,8 @@
 .kt-blocks-accordion-header:focus {
 	box-shadow: none;
 	text-shadow: none;
+	background-color: var(--global-palette8, #f2f2f2);
+	color: var(--global-palette5, #555555);
 }
 .kt-blocks-accordion-header:hover {
 	background-color: var(--global-palette7, #eeeeee);

--- a/src/blocks/accordion/style.scss
+++ b/src/blocks/accordion/style.scss
@@ -42,8 +42,6 @@
 .kt-blocks-accordion-header:focus {
 	box-shadow: none;
 	text-shadow: none;
-	background-color: var(--global-palette8, #f2f2f2);
-	color: var(--global-palette5, #555555);
 }
 .kt-blocks-accordion-header:active {
 	box-shadow: none;


### PR DESCRIPTION
[https://stellarwp.atlassian.net/browse/KAD-4180](https://stellarwp.atlassian.net/browse/KAD-4180)

style updated for accordion header focus. This prevents the headers from inheriting Kadence theme button setting in some cases when the button was on focus or active.