### PR TITLE
bugfix/KAD-4111_remove_design_library_in_rows

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -178,6 +178,7 @@ Please report security bugs found in the Kadence Blocks plugin's source code thr
 Release Date: TBD
 * Add: Enhance Text(Adv) copy/paste.
 * Fix: TOC block margin unit type.
+* Fix: Design Library removed from new Row Layout when Design Library is disabled.
 
 = 3.5.1 =
 Release Date: 3rd April 2025

--- a/src/blocks/rowlayout/edit.js
+++ b/src/blocks/rowlayout/edit.js
@@ -1684,9 +1684,11 @@ function RowLayoutEditContainer(props) {
 								/>
 							))}
 						</ButtonGroup>
-						<Button className="kt-prebuilt" onClick={() => setAttributes({ isPrebuiltModal: true })}>
-							{__('Design Library', 'kadence-blocks')}
-						</Button>
+						{showSettings('show', 'kadence/designlibrary') && kadence_blocks_params.showDesignLibrary && (
+							<Button className="kt-prebuilt" onClick={() => setAttributes({ isPrebuiltModal: true })}>
+								{__('Design Library', 'kadence-blocks')}
+							</Button>
+						)}
 					</div>
 				)}
 				{colLayout && 'none' !== topSep && '' !== topSep && (


### PR DESCRIPTION
[https://stellarwp.atlassian.net/browse/KAD-4111](https://stellarwp.atlassian.net/browse/KAD-4111)

Checks the showDesignLibrary setting to determine if the Design Library button shows when adding a new row layout block.
