### PR TITLE
KAD-4265 Allow equal height column layouts on tablet/mobile if collapsed rows on desktop

### DIFF
--- a/src/blocks/rowlayout/style.scss
+++ b/src/blocks/rowlayout/style.scss
@@ -89,6 +89,15 @@
 	.kt-inner-column-height-full.kt-tab-layout-row > .wp-block-kadence-column > .kt-inside-inner-col {
 		height: auto;
 	}
+	// Add support for tablet equal layout even when desktop is row layout
+	.kt-inner-column-height-full.kt-tab-layout-equal,
+	.kt-inner-column-height-full:not(.kt-tab-layout-inherit):not(.kt-tab-layout-row) {
+		grid-auto-rows: minmax(0, 1fr);
+	}
+	.kt-inner-column-height-full.kt-tab-layout-equal > .wp-block-kadence-column > .kt-inside-inner-col,
+	.kt-inner-column-height-full:not(.kt-tab-layout-inherit):not(.kt-tab-layout-row) > .wp-block-kadence-column > .kt-inside-inner-col {
+		height: 100%;
+	}
 }
 //mobile collapsed columns
 @media screen and (max-width: 767px) {
@@ -98,6 +107,15 @@
 	}
 	.kt-inner-column-height-full.kt-mobile-layout-row > .wp-block-kadence-column > .kt-inside-inner-col {
 		height: auto;
+	}
+	// Add support for mobile equal layout even when desktop/tablet is row layout
+	.kt-inner-column-height-full.kt-mobile-layout-equal,
+	.kt-inner-column-height-full:not(.kt-mobile-layout-inherit):not(.kt-mobile-layout-row) {
+		grid-auto-rows: minmax(0, 1fr);
+	}
+	.kt-inner-column-height-full.kt-mobile-layout-equal > .wp-block-kadence-column > .kt-inside-inner-col,
+	.kt-inner-column-height-full:not(.kt-mobile-layout-inherit):not(.kt-mobile-layout-row) > .wp-block-kadence-column > .kt-inside-inner-col {
+		height: 100%;
 	}
 }
 .kt-row-layout-overlay {


### PR DESCRIPTION
🎫  [KAD-4265](https://stellarwp.atlassian.net/browse/KAD-4265)

Equal column height doesn't work on side-by-side columns in tablet or mobile if the desktop is using a collapse to rows.

If your desktop view is collapse to rows and you have "Inner Column Height 100%" enabled, this change will cause any tablet or mobile layouts with column based layouts to use the inner column height of 100%. 

How to reproduce:
```
Add a Row Layout block.
Choose two or more columns
Set Inner Column Height to 100% in the Row Layout Structure Settings
On Desktop, select Collapse to Rows Layout
Select Equal Layout for Tablet and Mobile
Save page
Switch to Tablet or Mobile view in the frontend
Notice that the columns do not maintain equal height
```

[KAD-4265]: https://stellarwp.atlassian.net/browse/KAD-4265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ