### PR TITLE
Add the note role to progress bar if using aria-label

### DIFF
--- a/includes/blocks/class-kadence-blocks-progress-bar-block.php
+++ b/includes/blocks/class-kadence-blocks-progress-bar-block.php
@@ -246,9 +246,11 @@ class Kadence_Blocks_Progress_Bar_Block extends Kadence_Blocks_Abstract_Block {
 		$mask = ! empty( $attributes['maskSvg'] ) ? $attributes['maskSvg'] : 'star';
 		if ( ! empty( $attributes['ariaLabel'] ) ) {
 			$progress_args['aria-label'] = $attributes['ariaLabel'];
+			$progress_args['role'] = 'note';
 		} elseif ( ! empty( $attributes['barType'] ) && $attributes['barType'] === 'line-mask' && 'star' === $mask ) {
 			// translators: %1$s is the current progress amount, %2$s is the max progress amount.
 			$progress_args['aria-label'] = sprintf( __( '%1$s out of %2$s Stars', 'kadence-blocks' ), $progress_amount, $progress_max );
+			$progress_args['role'] = 'note';
 		}
 		$progress_div_attributes = [];
 		foreach ( $progress_args as $key => $value ) {


### PR DESCRIPTION
aria-labels are not allowed on elements without a role. Add the note role to the progress bar if using one. https://stellarwp.atlassian.net/browse/KAD-4303

See https://stellarwp.atlassian.net/browse/KAD-3917 for more background on why we don't use the progress bar role
