### PR TITLE
KAD-4296 Show V3 captcha notice when set on block directly

### DIFF
--- a/includes/advanced-form/advanced-form-captcha-settings.php
+++ b/includes/advanced-form/advanced-form-captcha-settings.php
@@ -61,6 +61,13 @@ class Kadence_Blocks_Form_Captcha_Settings {
 
 	public $size = 'normal';
 
+	// Properties for custom recaptcha notice settings
+	public $hideRecaptcha = false;
+	
+	public $showRecaptchaNotice = false;
+	
+	public $recaptchaNotice = '';
+
 	public function __construct( $attributes ) {
 		$this->is_using_kadence_captcha_settings( $attributes );
 		$this->is_using_kadence_blocks_settings( $attributes );
@@ -69,6 +76,7 @@ class Kadence_Blocks_Form_Captcha_Settings {
 		$this->get_secret_key( $attributes );
 		$this->get_captcha_language( $attributes );
 		$this->get_styles( $attributes );
+		$this->get_notice_settings( $attributes );
 		$this->has_valid_settings();
 	}
 
@@ -280,6 +288,21 @@ class Kadence_Blocks_Form_Captcha_Settings {
 			if ( ! empty( $attributes['size'] ) ) {
 				$this->size = $attributes['size'];
 			}
+		}
+	}
+
+	// Get notice settings from attributes
+	private function get_notice_settings( $attributes ) {
+		if ( isset( $attributes['hideRecaptcha'] ) ) {
+			$this->hideRecaptcha = $attributes['hideRecaptcha'];
+		}
+		
+		if ( isset( $attributes['showRecaptchaNotice'] ) ) {
+			$this->showRecaptchaNotice = $attributes['showRecaptchaNotice'];
+		}
+		
+		if ( isset( $attributes['recaptchaNotice'] ) ) {
+			$this->recaptchaNotice = $attributes['recaptchaNotice'];
 		}
 	}
 }

--- a/includes/blocks/form/class-kadence-blocks-captcha-block.php
+++ b/includes/blocks/form/class-kadence-blocks-captcha-block.php
@@ -137,13 +137,25 @@ class Kadence_Blocks_Captcha_Block extends Kadence_Blocks_Advanced_Form_Input_Bl
 
 		$output = '<input type="hidden" name="recaptcha_response" class="kb_recaptcha_response kb_recaptcha_' . esc_attr( $unique_id ) . '" />';
 
-		$hide_v3 = $captcha_settings->get_kadence_captcha_stored_value( 'hide_v3_badge', false );
-		$add_notice = $captcha_settings->get_kadence_captcha_stored_value( 'show_v3_notice', false );
-		if ( $captcha_settings->using_kadence_captcha && $hide_v3 && $add_notice ) {
-			$default = __( 'This site is protected by reCAPTCHA and the Google Privacy Policy and Terms of Service apply', 'kadence-blocks' );
-			$custom_notice = $captcha_settings->get_kadence_captcha_stored_value( 'v3_notice', $default );
+		// Handle Kadence Captcha plugin settings
+		$recaptcha_notice_html = '<span style="max-width: 100%%; font-size: 11px; color: #555; line-height: 1.2; display: block; margin-bottom: 16px; padding: 10px; background: #f2f2f2;" class="kt-recaptcha-branding-string">%s</span>';
+		if ( $captcha_settings->using_kadence_captcha ) {
+			$hide_v3 = $captcha_settings->get_kadence_captcha_stored_value( 'hide_v3_badge', false );
+			$add_notice = $captcha_settings->get_kadence_captcha_stored_value( 'show_v3_notice', false );
+			if ( $hide_v3 && $add_notice ) {
+				$default = __( 'This site is protected by reCAPTCHA and the Google Privacy Policy and Terms of Service apply', 'kadence-blocks' );
+				$custom_notice = $captcha_settings->get_kadence_captcha_stored_value( 'v3_notice', $default );
 
-			$output .= '<span style="max-width: 100%; font-size: 11px; color: #555; line-height: 1.2; display: block; margin-bottom: 16px; padding: 10px; background: #f2f2f2;" class="kt-recaptcha-branding-string">' . $custom_notice . '</span>';
+				$output .= sprintf( $recaptcha_notice_html, $custom_notice );
+			}
+		} elseif ( isset( $captcha_settings->hideRecaptcha ) && $captcha_settings->hideRecaptcha && 
+				 isset( $captcha_settings->showRecaptchaNotice ) && $captcha_settings->showRecaptchaNotice ) {
+				
+				$default = __( 'This site is protected by reCAPTCHA and the Google Privacy Policy and Terms of Service apply', 'kadence-blocks' );
+				$custom_notice = isset( $captcha_settings->recaptchaNotice ) && ! empty( $captcha_settings->recaptchaNotice ) ? $captcha_settings->recaptchaNotice : $default;
+				
+				$output .= sprintf( $recaptcha_notice_html, $custom_notice );
+			
 		}
 
 		return $output;


### PR DESCRIPTION
The custom notice setup on the block directly was never setup to show on the front end. We now support this or using the notice set in the recaptcha plugin. 