### PR TITLE
KAD-4318 comma separated cc and multi bcc email

### DIFF
--- a/includes/advanced-form/advanced-form-submit-actions.php
+++ b/includes/advanced-form/advanced-form-submit-actions.php
@@ -175,13 +175,18 @@ class Kadence_Blocks_Advanced_Form_Submit_Actions {
 			}
 			$cc_headers = 'Cc: ' . implode( ',', $sanitized_cc_emails ) . "\r\n";
 		}
-		$mail = wp_mail( $to, $subject, $body, $headers . $cc_headers );
+
+		$bcc_headers = '';
 		if ( $email_bcc ) {
 			$bcc_emails = explode( ',', $email_bcc );
+			$sanitized_bcc_emails = array();
 			foreach ( $bcc_emails as $bcc_email ) {
-				wp_mail( sanitize_email( trim( $bcc_email ) ), $subject, $body, $headers );
+				$sanitized_bcc_emails[] = sanitize_email( trim( $bcc_email ) );
 			}
+			$bcc_headers = 'Bcc: ' . implode( ',', $sanitized_bcc_emails ) . "\r\n";
 		}
+		
+		wp_mail( $to, $subject, $body, $headers . $cc_headers . $bcc_headers );
 	}
 	/**
 	 * Mailerlite rest call.

--- a/includes/form-ajax.php
+++ b/includes/form-ajax.php
@@ -280,13 +280,17 @@ class KB_Ajax_Form {
 								$cc_headers = 'Cc: ' . implode( ',', $sanitized_cc_emails ) . "\r\n";
 							}
 
-							wp_mail( $to, $subject, $body, $headers . $cc_headers );
+							$bcc_headers = '';
 							if ( isset( $form_args['email'][0]['bcc'] ) && ! empty( trim( $form_args['email'][0]['bcc'] ) ) ) {
-								$bcc_emails = explode( ',', $form_args['email'][0]['bcc'] );
+								$bcc_emails = explode( ',', trim( $form_args['email'][0]['bcc'] ) );
+								$sanitized_bcc_emails = array();
 								foreach ( $bcc_emails as $bcc_email ) {
-									wp_mail( sanitize_email( trim( $bcc_email ) ), $subject, $body, $headers );
+									$sanitized_bcc_emails[] = sanitize_email( trim( $bcc_email ) );
 								}
+								$bcc_headers = 'Bcc: ' . implode( ',', $sanitized_bcc_emails ) . "\r\n";
 							}
+
+							wp_mail( $to, $subject, $body, $headers . $cc_headers . $bcc_headers );
 							break;
 						case 'redirect':
 							if ( isset( $form_args['redirect'] ) && ! empty( trim( $form_args['redirect'] ) ) ) {


### PR DESCRIPTION
One issue addressed and one optimization 

- Issue: The entire value for CC emails were ran through validation, instead of exploding on commas and validating individually. This prevented the use of multiple CC addresses in emails.
- Optimization:  We called wp_mail for every bcc recipient. The BCC header can be added to the existing wp_mail call. This should greatly reduce submission time for forms with one or more BCC addresses