### PR TITLE
creating a more specific filter that only applies the backdrop filter…

### DIFF
--- a/includes/blocks/class-kadence-blocks-header-block.php
+++ b/includes/blocks/class-kadence-blocks-header-block.php
@@ -92,8 +92,8 @@ class Kadence_Blocks_Header_Block extends Kadence_Blocks_Abstract_Block {
 		$css->render_typography( $header_attributes );
 
 		if ( ! empty( $header_attributes['pro_backdropFilterString'] ) && class_exists( 'Kadence_Blocks_Pro' ) ) {
+			$css->set_selector( '.wp-block-kadence-header' . $unique_id . ' .kb-header-container:not(:has(.item-is-stuck)), .wp-block-kadence-header' . $unique_id . ' .item-is-stuck' );
 			$css->add_property( 'backdrop-filter', $header_attributes['pro_backdropFilterString'] );
-			$css->add_property( '-webkit-backdrop-filter', $header_attributes['pro_backdropFilterString'] );
 		}
 
 		return $css->css_output();


### PR DESCRIPTION
… to the header container when there's not a smaller part of the header meant to be sticking.

it creates a block context that messes with the sticky fixed position. 

https://stellarwp.atlassian.net/browse/KAD-4329

