### PR TITLE
Bugfix/kad 4331 form asterisk color

### DIFF
--- a/src/blocks/advanced-form/components/backend-styles/index.js
+++ b/src/blocks/advanced-form/components/backend-styles/index.js
@@ -142,7 +142,15 @@ export default function BackendStyles({
 			}
 
 			.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form .kb-adv-form-label .kb-adv-form-required {;
-				${fieldStyle?.requiredColor ? 'color:' + ( /^palette\d+$/.test(fieldStyle.requiredColor) ? 'var(--global-' + fieldStyle.requiredColor + ')' : fieldStyle.requiredColor ) + ';' : ''}
+				${
+					fieldStyle?.requiredColor
+						? 'color:' +
+						  (/^palette\d+$/.test(fieldStyle.requiredColor)
+								? 'var(--global-' + fieldStyle.requiredColor + ')'
+								: fieldStyle.requiredColor) +
+						  ';'
+						: ''
+				}
 			}
 
 			`}

--- a/src/blocks/advanced-form/components/backend-styles/index.js
+++ b/src/blocks/advanced-form/components/backend-styles/index.js
@@ -1,5 +1,5 @@
 import { GetHelpStyles, GetInputStyles, GetLabelStyles, GetRadioLabelStyles } from '../';
-import { getPreviewSize } from '@kadence/helpers';
+import { getPreviewSize, KadenceColorOutput } from '@kadence/helpers';
 
 export default function BackendStyles({
 	uniqueID,
@@ -142,15 +142,7 @@ export default function BackendStyles({
 			}
 
 			.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form .kb-adv-form-label .kb-adv-form-required {;
-				${
-					fieldStyle?.requiredColor
-						? 'color:' +
-						  (/^palette\d+$/.test(fieldStyle.requiredColor)
-								? 'var(--global-' + fieldStyle.requiredColor + ')'
-								: fieldStyle.requiredColor) +
-						  ';'
-						: ''
-				}
+				${fieldStyle?.requiredColor ? 'color:' + KadenceColorOutput(fieldStyle.requiredColor) + ';' : ''}
 			}
 
 			`}

--- a/src/blocks/advanced-form/components/backend-styles/index.js
+++ b/src/blocks/advanced-form/components/backend-styles/index.js
@@ -142,7 +142,7 @@ export default function BackendStyles({
 			}
 
 			.wp-block-kadence-advanced-form${uniqueID} .kb-advanced-form .kb-adv-form-label .kb-adv-form-required {;
-				${fieldStyle?.requiredColor ? 'color:' + fieldStyle.requiredColor + ';' : ''}
+				${fieldStyle?.requiredColor ? 'color:' + ( /^palette\d+$/.test(fieldStyle.requiredColor) ? 'var(--global-' + fieldStyle.requiredColor + ')' : fieldStyle.requiredColor ) + ';' : ''}
 			}
 
 			`}


### PR DESCRIPTION
[https://stellarwp.atlassian.net/browse/KAD-4331](https://stellarwp.atlassian.net/browse/KAD-4331)

The editor wasn't showing the color when the user selected a palette color (without opacity). This fixes the editor so that the required asterisk in the advanced form uses palette colors correctly for the labels.

