### PR TITLE
quickwin/KAD-4258_gallery_overflow

### DIFF
--- a/includes/blocks/class-kadence-blocks-advancedgallery-block.php
+++ b/includes/blocks/class-kadence-blocks-advancedgallery-block.php
@@ -105,7 +105,7 @@ class Kadence_Blocks_Advancedgallery_Block extends Kadence_Blocks_Abstract_Block
 		$css->set_style_id( 'kb-' . $this->block_name . $unique_style_id );
 		$gallery_type = ! empty( $attributes['type'] ) ? $attributes['type'] : 'masonry';
 
-		$css->set_selector('.wp-block-kadence-advancedgallery.kb-gallery-wrap-id-' . $unique_id );
+		$css->set_selector('.wp-block-kadence-advancedgallery.kb-gallery-wrap-id-' . $unique_id . ' .kb-gallery-ul' );
 
 		if ( isset( $attributes['margin'][0] ) ) {
 			// Fix for this margin unit being in a non-standard locaiton in array, should be updated.
@@ -455,8 +455,6 @@ class Kadence_Blocks_Advancedgallery_Block extends Kadence_Blocks_Abstract_Block
 
 		// Overflow for carousel
 		if ( 'carousel' === $gallery_type && ( isset( $attributes['overflow'] ) && $attributes['overflow'] ) ) {
-			$css->set_selector('.kb-gallery-wrap-id-' . $unique_id . '.wp-block-kadence-advancedgallery');
-			$css->add_property('overflow', 'visible' );
 			$css->set_selector('.kb-gallery-wrap-id-' . $unique_id . '.wp-block-kadence-advancedgallery .kt-blocks-carousel');
 			$css->add_property('overflow', 'visible' );
 			$css->set_selector('.kb-gallery-wrap-id-' . $unique_id . '.wp-block-kadence-advancedgallery .kt-blocks-carousel .splide__track');

--- a/includes/blocks/class-kadence-blocks-advancedgallery-block.php
+++ b/includes/blocks/class-kadence-blocks-advancedgallery-block.php
@@ -455,6 +455,8 @@ class Kadence_Blocks_Advancedgallery_Block extends Kadence_Blocks_Abstract_Block
 
 		// Overflow for carousel
 		if ( 'carousel' === $gallery_type && ( isset( $attributes['overflow'] ) && $attributes['overflow'] ) ) {
+			$css->set_selector('.kb-gallery-wrap-id-' . $unique_id . '.wp-block-kadence-advancedgallery');
+			$css->add_property('overflow', 'visible' );
 			$css->set_selector('.kb-gallery-wrap-id-' . $unique_id . '.wp-block-kadence-advancedgallery .kt-blocks-carousel');
 			$css->add_property('overflow', 'visible' );
 			$css->set_selector('.kb-gallery-wrap-id-' . $unique_id . '.wp-block-kadence-advancedgallery .kt-blocks-carousel .splide__track');

--- a/includes/blocks/class-kadence-blocks-advancedgallery-block.php
+++ b/includes/blocks/class-kadence-blocks-advancedgallery-block.php
@@ -453,6 +453,17 @@ class Kadence_Blocks_Advancedgallery_Block extends Kadence_Blocks_Abstract_Block
 			);
 		}
 
+		// Overflow for carousel
+		if ( 'carousel' === $gallery_type && ( isset( $attributes['overflow'] ) && $attributes['overflow'] ) ) {
+			$css->set_selector('.kb-gallery-wrap-id-' . $unique_id . '.wp-block-kadence-advancedgallery');
+			$css->add_property('overflow', 'visible' );
+			$css->set_selector('.kb-gallery-wrap-id-' . $unique_id . '.wp-block-kadence-advancedgallery .kt-blocks-carousel');
+			$css->add_property('overflow', 'visible' );
+			$css->set_selector('.kb-gallery-wrap-id-' . $unique_id . '.wp-block-kadence-advancedgallery .kt-blocks-carousel .splide__track');
+			$css->add_property('overflow', 'visible' );
+			$css->set_selector('.kb-gallery-wrap-id-' . $unique_id . '.wp-block-kadence-advancedgallery .kt-blocks-carousel .splide__pagination');
+			$css->add_property('overflow', 'hidden' );
+		}
 
 		return $css->css_output();
 	}

--- a/src/blocks/advancedgallery/block.json
+++ b/src/blocks/advancedgallery/block.json
@@ -9,6 +9,10 @@
 		"uniqueID": {
 			"type": "string"
 		},
+		"overflow": {
+			"type": "boolean",
+			"default": false
+		},
 		"columns": {
 			"type": "array",
 			"default": [3, 3, 3, 2, 1, 1]

--- a/src/blocks/advancedgallery/edit.js
+++ b/src/blocks/advancedgallery/edit.js
@@ -2070,11 +2070,7 @@ export default function GalleryEdit(props) {
 					.kb-gallery-id-${uniqueID}.kb-gallery-type-thumbslider .kt-blocks-carousel-main {
 						${previewGutter ? 'margin-bottom:' + previewGutter + previewGutterUnit + ';' : ''}
 					}
-					${
-						type === 'carousel' && overflow
-							? `.kb-gallery-id-${uniqueID} .splide__track { overflow: visible; }`
-							: ``
-					}
+					${type === 'carousel' && overflow ? `.kb-gallery-id-${uniqueID} .splide__track { overflow: visible; }` : ``}
 					${
 						captionStyles && undefined !== captionStyles[0] && undefined !== captionStyles[0].background
 							? `.kb-gallery-id-${uniqueID}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption { background: linear-gradient( 0deg, ` +

--- a/src/blocks/advancedgallery/edit.js
+++ b/src/blocks/advancedgallery/edit.js
@@ -201,6 +201,7 @@ export default function GalleryEdit(props) {
 		slideType,
 		mosaicRowHeight,
 		mosaicRowHeightUnit,
+		overflow,
 	} = attributes;
 	const mainRef = useRef(null);
 	const thumbsRef = useRef();
@@ -1544,6 +1545,13 @@ export default function GalleryEdit(props) {
 													checked={lazyLoad}
 													onChange={(value) => setAttributes({ lazyLoad: value })}
 												/>
+												{type === 'carousel' && (
+													<ToggleControl
+														label={__('Enable Carousel Overflow', 'kadence-blocks')}
+														checked={overflow}
+														onChange={(value) => setAttributes({ overflow: value })}
+													/>
+												)}
 											</KadencePanelBody>
 										)}
 									</>
@@ -2062,7 +2070,11 @@ export default function GalleryEdit(props) {
 					.kb-gallery-id-${uniqueID}.kb-gallery-type-thumbslider .kt-blocks-carousel-main {
 						${previewGutter ? 'margin-bottom:' + previewGutter + previewGutterUnit + ';' : ''}
 					}
-
+					${
+						type === 'carousel' && overflow
+							? `.kb-gallery-id-${uniqueID} .splide__track { overflow: visible; }`
+							: ``
+					}
 					${
 						captionStyles && undefined !== captionStyles[0] && undefined !== captionStyles[0].background
 							? `.kb-gallery-id-${uniqueID}.kb-gallery-main-contain .kadence-blocks-gallery-item .kadence-blocks-gallery-item-inner figcaption { background: linear-gradient( 0deg, ` +

--- a/src/blocks/advancedgallery/editor.scss
+++ b/src/blocks/advancedgallery/editor.scss
@@ -8,6 +8,7 @@
     margin-bottom: 0;
     margin-top: 0;
 	flex: 1;
+	 overflow: hidden;
 }
 .kt-blocks-carousel-thumbnails.splide:not( .is-overflow ) .splide__slide:last-child {
 	margin: 0 !important;


### PR DESCRIPTION
[https://stellarwp.atlassian.net/browse/KAD-4258](https://stellarwp.atlassian.net/browse/KAD-4258rl)

Adds overflow gallery option to carousel. There is also a selector change for the padding/margin on the frontend to help carousel look like the editor. This may need to be reviewed to make sure it doesn't affect other gallery types.