### PR TITLE
KAD-4409 added style for nav mega menu to fix overflow on some themes

### DIFF
--- a/src/blocks/navigation/style.scss
+++ b/src/blocks/navigation/style.scss
@@ -944,6 +944,11 @@ $link-color-property: var(
 			}
 		}
 	}
+	// Fix for mega menu overflow for some FSE themes
+	.kadence-menu-mega-enabled.kb-nav-link-sub-click:not(.menu-item--toggled-on),
+	.kadence-menu-mega-enabled:not(.kb-nav-link-sub-click):not(:hover) {
+		overflow: clip;
+	}
 
 	.kb-link-wrap {
 		transition: all 0.2s ease-in-out;


### PR DESCRIPTION
[https://stellarwp.atlassian.net/browse/KAD-4409](https://stellarwp.atlassian.net/browse/KAD-4409)

In some themes, the mega menu option for the navigation block causes overflow. This adds a style to clip the overflow.
