### PR TITLE
KAD-4411 removed label and added default aria-label for search block

### DIFF
--- a/includes/blocks/class-kadence-blocks-search-block.php
+++ b/includes/blocks/class-kadence-blocks-search-block.php
@@ -233,14 +233,11 @@ class Kadence_Blocks_Search_Block extends Kadence_Blocks_Abstract_Block {
                 %2$s
             </button>
             <div class="kb-search-modal-content">
-                <label class="screen-reader-text" for="kb-search-input%3$s">%4$s</label>
-                <form class="kb-search-form" role="search" method="get" action="%5$s">%6$s</form>
+                <form class="kb-search-form" role="search" method="get" action="%3$s">%4$s</form>
             </div>
         </div>',
-			esc_attr__( 'Close search', 'text-domain' ),
+			esc_attr__( 'Close search', 'kadence-blocks' ),
 			$close_icon,
-			esc_attr( $unique_id ),
-			esc_html__( 'Search for:', 'text-domain' ),
 			$form_action,
 			$this->build_input( $attributes )
 		);
@@ -258,7 +255,7 @@ class Kadence_Blocks_Search_Block extends Kadence_Blocks_Abstract_Block {
 	private function build_input( $attributes ) {
 		$input = '<div class="kb-search-input-wrapper">';
 		$placeholder = ! empty( $attributes['inputPlaceholder'] ) ? $attributes['inputPlaceholder'] : '';
-		$aria_label = !empty($attributes['label']) ? sprintf( 'aria-label="%s"', esc_attr( $attributes['label'] ) ) : '';
+		$aria_label = !empty($attributes['label']) ? sprintf( 'aria-label="%s"', esc_attr( $attributes['label'] ) ) : 'aria-label="' . esc_html__( 'Search', 'kadence-blocks' ) . '"';
 
 		$input .= sprintf(
 			'<input name="s" type="text" class="kb-search-input" placeholder="%s" %s>',

--- a/readme.txt
+++ b/readme.txt
@@ -177,6 +177,7 @@ Please report security bugs found in the Kadence Blocks plugin's source code thr
 = 3.5.9 =
 Release Date: 29th May 2025
 * Fix: Icon size preview for the Infobox block.
+* Update: Default aria-label for Search block input field.
 
 = 3.5.8 =
 Release Date: 15th May 2025


### PR DESCRIPTION
[https://stellarwp.atlassian.net/browse/KAD-4411](https://stellarwp.atlassian.net/browse/KAD-4411)

I opted to remove the label and add a default aria label instead. 

Now, there is always an aria-label and no need for an html label. If the user neglects to add a custom aria label, the aria label reads as “Search” for both the standard and modal input fields. 