### PR TITLE
KAD-4442 Fix pasting to default adv text overwriting content

### DIFF
--- a/src/blocks/advancedheading/edit.js
+++ b/src/blocks/advancedheading/edit.js
@@ -292,7 +292,7 @@ function KadenceAdvancedHeading(props) {
 		if (containsBlocks) {
 			const rawBlocks = wp.blocks.rawHandler({ HTML: pastedText });
 
-			if( !content ||content === '' ) {
+			if (!content || content === '') {
 				replaceBlocks(clientId, rawBlocks);
 			} else {
 				const { getBlockIndex, getBlockRootClientId } = wp.data.select('core/block-editor');


### PR DESCRIPTION
🎫  [KAD-4442
](https://stellarwp.atlassian.net/browse/KAD-4442)

When using the adv text as the default block, and text is pasted, we call `replaceBlocks` with the new content. This removed any existing content in the block.

I've updated this to append the text to the existing string. I've the user has pasted multiple blocks/paragraphs of text this will append the text from the first paragraph and insert new blocks below the existing blocks. If the user is pasting block HTML this will just insert below the existing content.