### PR TITLE
bugfix/KAD-4413

### DIFF
--- a/src/blocks/image/edit.js
+++ b/src/blocks/image/edit.js
@@ -317,14 +317,17 @@ export function ImageEdit(props) {
 	}, [caption]);
 
 	const ref = useRef();
-	const { imageDefaultSize, mediaUpload } = useSelect((select) => {
-		const { getSettings } = select(blockEditorStore);
-		const settings = pick(getSettings(), ['imageDefaultSize', 'mediaUpload']);
-		return {
-			...settings,
-			imageDefaultSize: attributes.sizeSlug || settings.imageDefaultSize
-		};
-	}, [attributes.sizeSlug]);
+	const { imageDefaultSize, mediaUpload } = useSelect(
+		(select) => {
+			const { getSettings } = select(blockEditorStore);
+			const settings = pick(getSettings(), ['imageDefaultSize', 'mediaUpload']);
+			return {
+				...settings,
+				imageDefaultSize: attributes.sizeSlug || settings.imageDefaultSize,
+			};
+		},
+		[attributes.sizeSlug]
+	);
 	function onUploadError(message) {
 		noticeOperations.removeAllNotices();
 		noticeOperations.createErrorNotice(message);

--- a/src/blocks/image/edit.js
+++ b/src/blocks/image/edit.js
@@ -319,8 +319,12 @@ export function ImageEdit(props) {
 	const ref = useRef();
 	const { imageDefaultSize, mediaUpload } = useSelect((select) => {
 		const { getSettings } = select(blockEditorStore);
-		return pick(getSettings(), ['imageDefaultSize', 'mediaUpload']);
-	}, []);
+		const settings = pick(getSettings(), ['imageDefaultSize', 'mediaUpload']);
+		return {
+			...settings,
+			imageDefaultSize: attributes.sizeSlug || settings.imageDefaultSize
+		};
+	}, [attributes.sizeSlug]);
 	function onUploadError(message) {
 		noticeOperations.removeAllNotices();
 		noticeOperations.createErrorNotice(message);


### PR DESCRIPTION
[https://stellarwp.atlassian.net/browse/KAD-4413](https://stellarwp.atlassian.net/browse/KAD-4413)

The Image File Size setting gets saved as a default setting for the Image block. However, the default image size doesn't consider the default settings for new image blocks. This fix considers the size slug for the image default setting. 