### PR TITLE
bugfix/KAD-4448_fluid_carousel_gutter

### DIFF
--- a/includes/blocks/class-kadence-blocks-advancedgallery-block.php
+++ b/includes/blocks/class-kadence-blocks-advancedgallery-block.php
@@ -468,6 +468,9 @@ class Kadence_Blocks_Advancedgallery_Block extends Kadence_Blocks_Abstract_Block
 			$css->add_property('overflow', 'visible' );
 			$css->set_selector('.kb-gallery-wrap-id-' . $unique_id . '.wp-block-kadence-advancedgallery .kt-blocks-carousel');
 			$css->add_property('overflow', 'visible' );
+			if ( 'fluidcarousel' === $gallery_type ) {
+				$css->add_property('max-width', '100%' );
+			}
 		}
 
 		// Pro Arrow Settings

--- a/src/blocks/advancedgallery/edit.js
+++ b/src/blocks/advancedgallery/edit.js
@@ -2313,6 +2313,7 @@ export default function GalleryEdit(props) {
 					}
 					.block-editor-block-list__block[data-type="kadence/advancedgallery"] {
 						overflow: visible;
+						overflow-x: clip;
 					}
 					
 			`}


### PR DESCRIPTION
[https://stellarwp.atlassian.net/browse/KAD-4448](https://stellarwp.atlassian.net/browse/KAD-4448)

 If the gallery has a gutter, the overflow and the gutter can cause a strange layout. Additionally, when you set the gallery to a regular ‘Carousel’ and enable the carousel overflow, the editor shows a scroll bar for x-axis. This fix address both issues.