### PR TITLE
KAD-4405 suppress filters added for tribe_events when order_by is pos…

### DIFF
--- a/includes/class-kadence-blocks-posts-rest-api.php
+++ b/includes/class-kadence-blocks-posts-rest-api.php
@@ -243,6 +243,13 @@ class Kadence_Blocks_Post_Rest_Controller extends WP_REST_Controller {
 				}
 			}
 		}
+		// Add filter to suppress query modifications for tribe_events when using post__in ordering
+		if ( $allow_multiple && in_array( 'tribe_events', $prop_array ) && $request->get_param( self::PROP_ORDER_BY ) === 'post__in' ) {
+			add_filter( 'pre_get_posts', function( $query ) {
+				$query->set( 'suppress_filters', true );
+				return $query;
+			});
+		}
 		$query = new WP_Query( $query_args );
 		$posts = array();
 


### PR DESCRIPTION
[https://stellarwp.atlassian.net/browse/KAD-4405](https://stellarwp.atlassian.net/browse/KAD-4405)

This is a pro feature, but the fix is in free. This uses ssuppress_filters in the pre_get_posts hook when the query displays tribe_events and the user selects individual posts. 