### PR TITLE
fixing an issue with the widgets editor and preview device selecting.

### DIFF
--- a/src/extension/stores/index.js
+++ b/src/extension/stores/index.js
@@ -153,6 +153,11 @@ const controls = {
 };
 
 const getPreviewDeviceType = createRegistrySelector((select) => (state) => {
+	// In widgets editor, always return the state's preview device
+	if (typeof pagenow !== 'undefined' && pagenow === 'widgets') {
+		return state.previewDevice;
+	}
+
 	const editor = select('core/editor');
 
 	if (editor && editor?.getDeviceType) {


### PR DESCRIPTION
This doesn't address the root cause, which I couldn't find, but puts a suitable bandaid on for the widgets page. https://stellarwp.atlassian.net/browse/KAD-4327

Note that I couldn't consistently reproduce the issue. Some of my sites had it and others didn't.
