### PR TITLE
KAD-4564_navigation_warning

### DIFF
--- a/includes/navigation/class-kadence-navigation-cpt.php
+++ b/includes/navigation/class-kadence-navigation-cpt.php
@@ -147,7 +147,7 @@ class Kadence_Blocks_Navigation_CPT_Controller {
 				'kadence/navigation',
 			),
 		);
-		$post_type_object->template_lock = 'all';
+		$post_type_object->template_lock = 'insert';
 	}
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -179,6 +179,7 @@ Release Date: 3rd July 2025
 * Fix: Count Up block responsive font/number size/lineheight preview in editor.
 * Fix: Content for Testimonial block when copy/paste styles.
 * Update: Header block off canvas trigger focus styles. 
+* Fix: Warning that content doesn't match template while editing Navigation posts.
 
 = 3.5.11 =
 Release Date: 19th June 2025


### PR DESCRIPTION
…PT_Controller to 'insert'

[https://stellarwp.atlassian.net/browse/KAD-4564](https://stellarwp.atlassian.net/browse/KAD-4564)

Changed the template lock for the Navigation CPT to 'insert' instead of all. This stops the warning about the content not matching the template assigned to the post.
