### PR TITLE
Improve allowOneBlockOfType check

### DIFF
--- a/src/blocks/advanced-form/edit-inner.js
+++ b/src/blocks/advanced-form/edit-inner.js
@@ -299,7 +299,7 @@ export function EditInner(props) {
 	useEffect(() => {
 		filterDuplicateBlocks(formInnerBlocks, 'kadence/advanced-form-submit', __('submit button', 'kadence-blocks'));
 		filterDuplicateBlocks(formInnerBlocks, 'kadence/advanced-form-captcha', __('captcha', 'kadence-blocks'));
-	}, [formInnerBlocks]);
+	}, [formInnerBlocks, filterDuplicateBlocks]);
 
 	const newBlock = useMemo(() => {
 		return get(blocks, [0], {});


### PR DESCRIPTION
The check to only all one submit or recaptcha block per form was not very smart. If a submit button was deleted, the uniquieId for that still existed in the local state. This would prevent a user from re-adding the submit they just removed. 