### PR TITLE
KAD-4663 Add custom link options styling for mosaic gallery

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: gutenberg, blocks, page builder, editor, gutenberg blocks
 Donate link: https://www.kadencewp.com/about-us/
 Requires at least: 6.6
 Tested up to: 6.8.2
-Stable tag: 3.5.14
+Stable tag: 3.5.15
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -173,6 +173,10 @@ Please report security bugs found in the source code of the Kadence Blocks plugi
 Please report security bugs found in the Kadence Blocks plugin's source code through the Patchstack Vulnerability Disclosure Program https://patchstack.com/database/vdp/kadence-blocks. The Patchstack team will assist you with verification, CVE assignment, and notify the developers of this plugin.
 
 == Changelog ==
+= 3.5.15 =
+Release Date: 23rd July 2025
+* Fix: Mosaic gallery custom link in editor. 
+
 = 3.5.14 =
 Release Date: 15th July 2025
 * Fix: Issue editing kadence blocks in widget areas

--- a/src/blocks/advancedgallery/editor.scss
+++ b/src/blocks/advancedgallery/editor.scss
@@ -728,6 +728,17 @@
 					content: none !important;
 				}
 			}
+
+			// Ensure custom link options are visible in mosaic gallery
+			.kb-gallery-custom-options {
+				position: absolute;
+				bottom: 0;
+				left: 0;
+				right: 0;
+				z-index: 30;
+				background: #fff;
+				border-top: 4px solid var(--wp-admin-theme-color, #00669b);
+			}
 		}
 	}
 }


### PR DESCRIPTION
[https://stellarwp.atlassian.net/browse/KAD-4663](https://stellarwp.atlassian.net/browse/KAD-4663)

custom link options for mosaic gallery did not have the correct styles and the input field wasn't showing when an image was selected. This fix adds styles so the input field is visible in the editor. 