### PR TITLE
KAD-4770 Add subtitle color settings to Tabs block

### DIFF
--- a/includes/blocks/class-kadence-blocks-tabs-block.php
+++ b/includes/blocks/class-kadence-blocks-tabs-block.php
@@ -294,6 +294,24 @@ class Kadence_Blocks_Tabs_Block extends Kadence_Blocks_Abstract_Block {
 			$css->add_property( 'background', '#ffffff' );
 		}
 
+		/*
+		 * Subtitle Colors
+		 */
+		$css->set_selector( '.kt-tabs-id' . $unique_id . ' > .kt-tabs-title-list li .kt-title-sub-text, .kt-tabs-id' . $unique_id . ' > .kt-tabs-content-wrap > .kt-tabs-accordion-title .kt-title-sub-text' );
+		if ( isset( $attributes['subtitleColor'] ) && ! empty( $attributes['subtitleColor'] ) ) {
+			$css->add_property( 'color', $css->sanitize_color( $attributes['subtitleColor'] ) );
+		}
+
+		$css->set_selector( '.kt-tabs-id' . $unique_id . ' > .kt-tabs-title-list li .kt-tab-title:hover .kt-title-sub-text, .kt-tabs-id' . $unique_id . ' > .kt-tabs-content-wrap > .kt-tabs-accordion-title .kt-tab-title:hover .kt-title-sub-text' );
+		if ( ! empty( $attributes['subtitleColorHover'] ) ) {
+			$css->add_property( 'color', $css->sanitize_color( $attributes['subtitleColorHover'] ) );
+		}
+
+		$css->set_selector( '.kt-tabs-id' . $unique_id . ' > .kt-tabs-title-list li.kt-tab-title-active .kt-title-sub-text, .kt-tabs-id' . $unique_id . ' > .kt-tabs-content-wrap > .kt-tabs-accordion-title.kt-tab-title-active .kt-title-sub-text' );
+		if ( ! empty( $attributes['subtitleColorActive'] ) ) {
+			$css->add_property( 'color', $css->sanitize_color( $attributes['subtitleColorActive'] ) );
+		}
+
 
 		if ( isset( $attributes['tabSize'] ) || isset( $attributes['tabLineHeight'] ) ) {
 			$css->set_media_state( 'tablet' );

--- a/src/blocks/tabs/block.json
+++ b/src/blocks/tabs/block.json
@@ -218,6 +218,15 @@
 		"titleBorderActive": {
 			"type": "string"
 		},
+		"subtitleColor": {
+			"type": "string"
+		},
+		"subtitleColorHover": {
+			"type": "string"
+		},
+		"subtitleColorActive": {
+			"type": "string"
+		},
 		"titleBorderWidth": {
 			"type": "array",
 			"default": ["", "", "", ""]

--- a/src/blocks/tabs/edit.js
+++ b/src/blocks/tabs/edit.js
@@ -201,6 +201,9 @@ function KadenceTabs(props) {
 		startTab,
 		enableSubtitle,
 		subtitleFont,
+		subtitleColor,
+		subtitleColorHover,
+		subtitleColorActive,
 		tabWidth,
 		gutter,
 		widthType,
@@ -1262,6 +1265,37 @@ function KadenceTabs(props) {
 		</Fragment>
 	);
 
+	const subtitleNormalSettings = (
+		<Fragment>
+			<PopColorControl
+				label={__('Subtitle Color', 'kadence-blocks')}
+				value={subtitleColor ? subtitleColor : ''}
+				default={''}
+				onChange={(value) => setAttributes({ subtitleColor: value })}
+			/>
+		</Fragment>
+	);
+	const subtitleHoverSettings = (
+		<Fragment>
+			<PopColorControl
+				label={__('Hover Color', 'kadence-blocks')}
+				value={subtitleColorHover ? subtitleColorHover : ''}
+				default={''}
+				onChange={(value) => setAttributes({ subtitleColorHover: value })}
+			/>
+		</Fragment>
+	);
+	const subtitleActiveSettings = (
+		<Fragment>
+			<PopColorControl
+				label={__('Active Color', 'kadence-blocks')}
+				value={subtitleColorActive ? subtitleColorActive : ''}
+				default={''}
+				onChange={(value) => setAttributes({ subtitleColorActive: value })}
+			/>
+		</Fragment>
+	);
+
 	const percentDesktopContent = (
 		<Fragment>
 			<RangeControl
@@ -1350,6 +1384,15 @@ function KadenceTabs(props) {
 					${titleColorActive ? 'color:' + KadenceColorOutput(titleColorActive) + '!important;' : ''}
 					${titleBorderActive ? 'border-color:' + KadenceColorOutput(titleBorderActive) + '!important;' : ''}
 					${titleBgActive ? 'background-color:' + KadenceColorOutput(titleBgActive) + '!important;' : ''}
+				}
+				.kt-tabs-id${uniqueID} .kt-title-item .kt-title-sub-text {
+					${subtitleColor ? 'color:' + KadenceColorOutput(subtitleColor) + '!important;' : ''}
+				}
+				.kt-tabs-id${uniqueID} .kt-title-item:hover .kt-title-sub-text {
+					${subtitleColorHover ? 'color:' + KadenceColorOutput(subtitleColorHover) + '!important;' : ''}
+				}
+				.kt-tabs-id${uniqueID} .kt-title-item.kt-tab-title-active .kt-title-sub-text, .kt-tabs-id${uniqueID} .kt-title-item.kt-tab-title-active:hover .kt-title-sub-text {
+					${subtitleColorActive ? 'color:' + KadenceColorOutput(subtitleColorActive) + '!important;' : ''}
 				}
 				.kt-tabs-id${uniqueID} > .kt-tabs-wrap > .kt-tabs-content-wrap > .block-editor-inner-blocks > .block-editor-block-list__layout > [data-tab="${currentTab}"] {
 					display: block;
@@ -1608,6 +1651,52 @@ function KadenceTabs(props) {
 													tabout = activeSettings;
 												} else {
 													tabout = normalSettings;
+												}
+											}
+											return (
+												<div className={tab.className} key={tab.className}>
+													{tabout}
+												</div>
+											);
+										}}
+									</TabPanel>
+								</KadencePanelBody>
+							)}
+							{showSettings('subtitle', 'kadence/tabs') && enableSubtitle && (
+								<KadencePanelBody
+									title={__('Tab Subtitle Color Settings', 'kadence-blocks')}
+									panelName={'kb-tab-subtitle-color'}
+								>
+									<TabPanel
+										className="kt-inspect-tabs kt-no-ho-ac-tabs kt-hover-tabs"
+										activeClass="active-tab"
+										tabs={[
+											{
+												name: 'normal',
+												title: __('Normal', 'kadence-blocks'),
+												className: 'kt-normal-tab',
+											},
+											{
+												name: 'hover',
+												title: __('Hover', 'kadence-blocks'),
+												className: 'kt-hover-tab',
+											},
+											{
+												name: 'active',
+												title: __('Active', 'kadence-blocks'),
+												className: 'kt-active-tab',
+											},
+										]}
+									>
+										{(tab) => {
+											let tabout;
+											if (tab.name) {
+												if ('hover' === tab.name) {
+													tabout = subtitleHoverSettings;
+												} else if ('active' === tab.name) {
+													tabout = subtitleActiveSettings;
+												} else {
+													tabout = subtitleNormalSettings;
 												}
 											}
 											return (


### PR DESCRIPTION
[https://stellarwp.atlassian.net/browse/KAD-4770](https://stellarwp.atlassian.net/browse/KAD-4770)

This fix adds a color control picker for tab subtitles that is similar to the existing color picker for the title. This isn't in the typography control, it is a separate control in a separate panel body. 
