### PR TITLE
bugfix/KAD-4769_button_border_color

### DIFF
--- a/src/packages/components/src/border/single-border-control/index.js
+++ b/src/packages/components/src/border/single-border-control/index.js
@@ -171,6 +171,7 @@ export default function SingleBorderControl({
 				)}
 				<div className={'kadence-single-border-control-wrap'}>
 					<PopColorControl
+						key={`border-color-${currentColor}-${instanceId}`}
 						value={currentColor}
 						default={''}
 						hideClear={true}


### PR DESCRIPTION
[https://stellarwp.atlassian.net/browse/KAD-4769](https://stellarwp.atlassian.net/browse/KAD-4769)

Adds a key to the PopColorControl on the SingleBorderControl.