### PR TITLE
Let users add label to custom fonts

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -56,22 +56,27 @@ function kadence_blocks_convert_custom_fonts() {
 	if ( ! is_admin() ) {
 		return;
 	}
-	$convert_fonts = apply_filters( 'kadence_blocks_add_custom_fonts', array() );
+	$convert_fonts = apply_filters( 'kadence_blocks_add_custom_fonts', [] );
 	if ( ! empty( $convert_fonts ) && is_array( $convert_fonts ) ) {
 		add_filter(
 			'kadence_blocks_custom_fonts',
 			function( $custom_fonts ) use( $convert_fonts ) {
 				foreach ( $convert_fonts as $font_name => $args ) {
-					$weights_arg = array();
+					$weights_arg = [];
 					if ( is_array( $args ) && isset( $args['weights'] ) && is_array( $args['weights'] ) ) {
 						$weights_arg = $args['weights'];
 					}
 					$font_slug = ( is_array( $args ) && isset( $args['fallback'] ) && ! empty( $args['fallback'] ) ? '"' . $font_name . '", ' . $args['fallback'] : $font_name );
-					$custom_fonts[ $font_slug  ] = array(
+
+					$font_entry = [
 						'name'    => $font_slug,
 						'weights' => $weights_arg,
-						'styles'  => array(),
-					);
+						'styles'  => [],
+					];
+					if ( is_array( $args ) && isset( $args['label'] ) && ! empty( $args['label'] ) ) {
+						$font_entry['label'] = $args['label'];
+					}
+					$custom_fonts[ $font_slug ] = $font_entry;
 				}
 				return $custom_fonts;
 			},

--- a/src/packages/components/src/typography/inline-typography-control/index.js
+++ b/src/packages/components/src/typography/inline-typography-control/index.js
@@ -85,6 +85,7 @@ class InlineTypographyControls extends Component {
 			const newOptions = [];
 			Object.keys( kadence_blocks_params.c_fonts ).forEach(function ( font ) {
 				const name = kadence_blocks_params.c_fonts[font].name;
+				const label = kadence_blocks_params.c_fonts[font].label ? kadence_blocks_params.c_fonts[font].label : name;
 				const weights = [];
 				Object.keys( kadence_blocks_params.c_fonts[font].weights ).forEach(function ( weight ) {
 					weights.push( {
@@ -100,7 +101,7 @@ class InlineTypographyControls extends Component {
 					} );
 				} );
 				newOptions.push( {
-					label: name,
+					label: label,
 					value: name,
 					google: false,
 					weights: weights,

--- a/src/packages/components/src/typography/typography-control/index.js
+++ b/src/packages/components/src/typography/typography-control/index.js
@@ -84,6 +84,7 @@ class TypographyControls extends Component {
 			const newOptions = [];
 			Object.keys( kadence_blocks_params.c_fonts ).forEach(function ( font ) {
 				const name = kadence_blocks_params.c_fonts[font].name;
+				const label = kadence_blocks_params.c_fonts[font].label ? kadence_blocks_params.c_fonts[font].label : name;
 				const weights = [];
 				Object.keys( kadence_blocks_params.c_fonts[font].weights ).forEach(function ( weight ) {
 					weights.push( {
@@ -99,7 +100,7 @@ class TypographyControls extends Component {
 					} );
 				} );
 				newOptions.push( {
-					label: name,
+					label: label,
 					value: name,
 					google: false,
 					weights: weights,


### PR DESCRIPTION
The `label` key when registering a custom font will let users set what gets displayed in the typography dropdown in the editor. If not defined, it'll fallback to the previous behavior of displaying the css name.

I've updated the kadence-components in pro to support this with identical changes.

```
function my_kadence_blocks_custom_fonts( $system_fonts ) {
 
	$system_fonts[ 'Forza Book' ] = array(
	  'fallback' => 'Verdana, Arial, sans-serif',
	  'weights' => array(
		'400',
	  ),
	  'label' => 'My custom label',
	);
	return $system_fonts;
   
  }
  add_filter( 'kadence_blocks_add_custom_fonts', 'my_kadence_blocks_custom_fonts' );
```