### PR TITLE
bugfix/KAD-4854_image_size_dropdown

### DIFF
--- a/src/blocks/rowlayout/block.json
+++ b/src/blocks/rowlayout/block.json
@@ -152,7 +152,7 @@
 			"default": ""
 		},
 		"bgImgID": {
-			"type": "string",
+			"type": "number",
 			"default": ""
 		},
 		"bgImgSize": {
@@ -208,7 +208,7 @@
 			"default": ""
 		},
 		"overlayBgImgID": {
-			"type": "string",
+			"type": "number",
 			"default": ""
 		},
 		"overlayBgImgSize": {


### PR DESCRIPTION
[https://stellarwp.atlassian.net/browse/KAD-4854](https://stellarwp.atlassian.net/browse/KAD-4854)
The bgImgID and overlayBgImgID were set as strings in the block.json file. This caused a problem with the image file size dropdown because it didn't have the correct image id on page refreshes. 
