### PR TITLE
Move post classes to parent list item in entry template.

### DIFF
--- a/includes/templates/entry.php
+++ b/includes/templates/entry.php
@@ -10,8 +10,8 @@
 defined( 'ABSPATH' ) || exit;
 $enabled_image = ( isset( $attributes ) && is_array( $attributes ) && isset( $attributes['image'] ) && ! $attributes['image'] ? false : true );
 ?>
-<li class="kb-post-list-item">
-	<article <?php post_class( 'entry content-bg loop-entry' . ( ! $enabled_image ? ' kb-post-no-image' : '' ) ); ?>>
+<li <?php post_class( 'kb-post-list-item' . ( ! $enabled_image ? ' kb-post-no-image' : '' ) ); ?>>
+	<article class="entry content-bg loop-entry">
 		<?php
 			kadence_blocks_get_template( 'entry-loop-thumbnail.php', [ 'attributes' => $attributes ] );
 		?>


### PR DESCRIPTION
per [https://github.com/stellarwp/kadence-blocks/issues/813](https://github.com/stellarwp/kadence-blocks/issues/813)

Move the post classes to the li element. Left the entry, content-bg, and loop-entry classes on the article element. In the past, the article had the post classes and the remaining entry, content-bg, and loop-entry classes too. This may break some CSS. Requesting further review. 