### PR TITLE
KAD-4953 Remove TOC links that are not conditionally displayed.

### DIFF
--- a/src/assets/js/kb-table-of-contents.js
+++ b/src/assets/js/kb-table-of-contents.js
@@ -268,17 +268,15 @@
 
 			const tocBlocks = document.querySelectorAll('.wp-block-kadence-tableofcontents');
 
-			tocBlocks.forEach(tocBlock => {
-				missingHeadings.forEach(missingHeading => {
+			tocBlocks.forEach((tocBlock) => {
+				missingHeadings.forEach((missingHeading) => {
 					const tocLinks = tocBlock.querySelectorAll('a.kb-table-of-contents__entry');
 
-					tocLinks.forEach(link => {
+					tocLinks.forEach((link) => {
 						const linkHref = link.getAttribute('href');
 						const linkText = link.textContent.trim();
 
-						if (linkHref === missingHeading.anchor ||
-							linkText === missingHeading.content) {
-
+						if (linkHref === missingHeading.anchor || linkText === missingHeading.content) {
 							const listItem = link.closest('li');
 							if (listItem) {
 								listItem.remove();
@@ -295,12 +293,12 @@
 		 */
 		cleanupEmptyLists(tocBlock) {
 			const emptyLists = tocBlock.querySelectorAll('.kb-table-of-contents-list-sub:empty');
-			emptyLists.forEach(emptyList => {
+			emptyLists.forEach((emptyList) => {
 				emptyList.remove();
 			});
 
 			const listItems = tocBlock.querySelectorAll('.kb-table-of-content-list li');
-			listItems.forEach(listItem => {
+			listItems.forEach((listItem) => {
 				const nestedList = listItem.querySelector('.kb-table-of-contents-list-sub');
 				if (nestedList && nestedList.children.length === 0) {
 					nestedList.remove();


### PR DESCRIPTION
[https://stellarwp.atlassian.net/browse/KAD-4953](https://stellarwp.atlassian.net/browse/KAD-4953)

When adding the anchors to the TOC, this fix removes links with missing headings (hidden with conditional display) and cleans up missing links. 

This is a JS fix as it seemed simpler than trying to come up with a PHP fix. That might require making updates in free and pro blocks, but I didn't explore a PHP solution. 
