### PR TITLE
Resolve padding with issue within Text (Adv) block

### DIFF
--- a/includes/blocks/class-kadence-blocks-advanced-heading-block.php
+++ b/includes/blocks/class-kadence-blocks-advanced-heading-block.php
@@ -637,7 +637,7 @@ class Kadence_Blocks_Advancedheading_Block extends Kadence_Blocks_Abstract_Block
 			return;
 		}
 		wp_register_style( 'kadence-blocks-' . $this->block_name, false );
-		$heading_css = <<<CSS
+		$heading_css = <<<'CSS'
 			.wp-block-kadence-advancedheading mark{background:transparent;border-style:solid;border-width:0}
 			.wp-block-kadence-advancedheading mark.kt-highlight{color:#f76a0c;}
 			.kb-adv-heading-icon{display: inline-flex;justify-content: center;align-items: center;}
@@ -650,7 +650,7 @@ class Kadence_Blocks_Advancedheading_Block extends Kadence_Blocks_Abstract_Block
 
 		// Short term fix for an issue with heading wrapping.
 		if ( class_exists( '\Kadence\Theme' ) ) {
-			$heading_css .= <<<CSS
+			$heading_css .= <<<'CSS'
 				.single-content .kadence-advanced-heading-wrapper h1,
 				.single-content .kadence-advanced-heading-wrapper h2,
 				.single-content .kadence-advanced-heading-wrapper h3,

--- a/src/blocks/advancedheading/editor.scss
+++ b/src/blocks/advancedheading/editor.scss
@@ -671,19 +671,4 @@ button.components-button.kt-font-clear-btn {
 // A padding adds to heading tag if it has class "has-background" along with "has-theme-palette-*" class.
 // This CSS rule will override that padding issue.
 // Reference: https://stellarwp.atlassian.net/browse/KAD-5283
-h1.kadence-advancedheading-text.has-background[class*="has-theme-palette-"],
-h1.kadence-advancedheading-text.has-background[class*="has-kb-palette-"],
-h2.kadence-advancedheading-text.has-background[class*="has-theme-palette-"],
-h2.kadence-advancedheading-text.has-background[class*="has-kb-palette-"],
-h3.kadence-advancedheading-text.has-background[class*="has-theme-palette-"],
-h3.kadence-advancedheading-text.has-background[class*="has-kb-palette-"],
-h4.kadence-advancedheading-text.has-background[class*="has-theme-palette-"],
-h4.kadence-advancedheading-text.has-background[class*="has-kb-palette-"],
-h5.kadence-advancedheading-text.has-background[class*="has-theme-palette-"],
-h5.kadence-advancedheading-text.has-background[class*="has-kb-palette-"],
-h6.kadence-advancedheading-text.has-background[class*="has-theme-palette-"],
-h6.kadence-advancedheading-text.has-background[class*="has-kb-palette-"],
-p.kadence-advancedheading-text.has-background[class*="has-theme-palette-"],
-p.kadence-advancedheading-text.has-background[class*="has-kb-palette-"] {
-	padding: 0;
-}
+.kadence-advancedheading-text.has-background{padding: 0;}


### PR DESCRIPTION
🎫  #[KAD-5283]

This pull request resolves a padding issue occurring in the Text (Adv) block within the Gutenberg editor.

[KAD-5283]: https://stellarwp.atlassian.net/browse/KAD-5283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ