### PR TITLE
Fix: Box-shadow icons not showing for InfoBox block

### DIFF
--- a/src/packages/components/src/shadow/responsive-shadow-control/index.js
+++ b/src/packages/components/src/shadow/responsive-shadow-control/index.js
@@ -206,7 +206,7 @@ export default function ResponsiveShadowControl ( {
 
 	return [
 		onEnableChange && (
-			<div className={ `components-base-control kb-responsive-range-control${ '' !== className ? ' ' + className : '' }` }>
+			<div className={ `components-base-control kt-box-shadow-container${ '' !== className ? ' ' + className : '' }` }>
 				<div className="kadence-title-bar">
 					{ label && (
 						<span className="kadence-control-title">


### PR DESCRIPTION

🎫  [#KAD-5329](https://stellarwp.atlassian.net/browse/KAD-5329)

...

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [x] Tested with Dynamic content & Elements.

Kadence components copy of the same change: https://github.com/stellarwp/kadence-components/pull/7
