### PR TITLE
KAD-5303 Reload design library previews if no data exists

### DIFF
--- a/src/plugins/prebuilt-library/pattern-library.js
+++ b/src/plugins/prebuilt-library/pattern-library.js
@@ -549,20 +549,24 @@ function PatternLibrary({ importContent, clientId, reload = false, onReload }) {
 					setPatterns(o);
 					setCategories(JSON.parse(JSON.stringify(cats)));
 					const htmlPatternsResponse = await getPatterns('section', tempReload, null, null, 'html');
-					if (htmlPatternsResponse === 'failed') {
-						console.log('Permissions Error getting library htmlContent');
-						setPatternsHTML([]);
-					} else if (htmlPatternsResponse === 'error') {
-						console.log('Error getting library htmlContent.');
-						setPatternsHTML([]);
+					let parsedHtml = htmlPatternsResponse;
+
+					if (htmlPatternsResponse === 'failed' || htmlPatternsResponse === 'error') {
+						parsedHtml = false;
 					} else {
-						const o = SafeParseJSON(htmlPatternsResponse, false);
-						if (o) {
-							setPatternsHTML(o);
-						} else {
-							setPatternsHTML([]);
+						parsedHtml = SafeParseJSON(htmlPatternsResponse, false);
+					}
+
+					if (!parsedHtml && !tempReload) {
+						// If the cached response is empty or missing, force a reload once so previews populate without manual sync.
+						const freshHtml = await getPatterns('section', true, null, null, 'html');
+
+						if (freshHtml !== 'failed' && freshHtml !== 'error') {
+							parsedHtml = SafeParseJSON(freshHtml, false);
 						}
 					}
+
+					setPatternsHTML(parsedHtml ? parsedHtml : []);
 				}
 			} else {
 				if (tempSubTab === 'pages') {


### PR DESCRIPTION
This issue with design library previews not loading is related to how much of data we're passing in wp_localize_script. This automatically reloads the data if non is present to fix the issue.


The original plan was to load the icons via a rest request to reduce the size of data we're passing. That was working in my testing last month, but it seems something has changed and that no longer works. The larger fix here is to load the design library data via a rest request, maybe even store it in the cache using the [browser cache api](https://developer.mozilla.org/en-US/docs/Web/API/Cache). This should work for now though