### PR TITLE
bugfix/KAD-5340_carousel_versioning

### DIFF
--- a/includes/blocks/class-kadence-blocks-advancedgallery-block.php
+++ b/includes/blocks/class-kadence-blocks-advancedgallery-block.php
@@ -614,8 +614,8 @@ class Kadence_Blocks_Advancedgallery_Block extends Kadence_Blocks_Abstract_Block
 
 		$xpath = new \DOMXPath( $doc );
 
-		// Find all gallery items.
-		$gallery_items = $xpath->query( "//*[contains(@class, 'kadence-blocks-gallery-item')]" );
+		// Find all gallery items (use word boundary matching to exclude kadence-blocks-gallery-item-inner, etc.).
+		$gallery_items = $xpath->query( "//*[contains(concat(' ', normalize-space(@class), ' '), ' kadence-blocks-gallery-item ')]" );
 
 		foreach ( $gallery_items as $item ) {
 			// Find the img element within this gallery item.


### PR DESCRIPTION
[https://stellarwp.atlassian.net/browse/KAD-5340](https://stellarwp.atlassian.net/browse/KAD-5340)

This fixes two issues. First, it removes some margin and padding from advanced galleries related to column gutter. Additionally, it fixes the gallery HTML when versioning is under 2 or missing. 
