### PR TITLE
Bugfix: The “Slide In From” setting in the Off Canvas panel does not apply on mobile 

### DIFF
--- a/src/blocks/header/children/off-canvas/style.scss
+++ b/src/blocks/header/children/off-canvas/style.scss
@@ -44,7 +44,7 @@ $admin-bar-height-mobile: 46px;
 			@include open-right-styles();
 		}
 	}
-	&.open-tablet-right {
+	&.open-mobile-right {
 		@media (max-width: vars.$phone-minus-query) {
 			@include open-right-styles();
 		}


### PR DESCRIPTION
🎫  [https://stellarwp.atlassian.net/browse/KAD-5325](https://stellarwp.atlassian.net/browse/KAD-5325)


https://github.com/user-attachments/assets/6917e258-4096-4102-b1d0-3a481a07f560


### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
