### PR TITLE
Sanitize file names and escape file links

### DIFF
--- a/includes/advanced-form/advanced-form-ajax.php
+++ b/includes/advanced-form/advanced-form-ajax.php
@@ -307,7 +307,7 @@ class KB_Ajax_Advanced_Form {
 				if ( ! empty( $field_errors ) ) {
 					continue;
 				}
-				
+
 				// File required & skipped.
 				if ( isset( $_FILES[ $expected_field ] ) ) {
 					if ( empty( $file['size'] ) && ! empty( $field['required'] ) && $field['required'] ) {
@@ -325,7 +325,7 @@ class KB_Ajax_Advanced_Form {
 							continue;
 						}
 						foreach ( $post_file as $file ) {
-							$file_name_array[] = $file['name'];
+							$file_name_array[] = sanitize_file_name( $file['name'] );
 							if ( empty( $file['size'] ) && ! empty( $field['required'] ) && $field['required'] ) {
 								$required_message = ! empty( $field['required_message'] ) ? $field['required_message'] : __( 'Missing a required field', 'kadence-blocks' );
 

--- a/includes/templates/form-email.php
+++ b/includes/templates/form-email.php
@@ -129,17 +129,17 @@ defined( 'ABSPATH' ) || exit;
 									<p style="font-family: sans-serif; font-size: 14px; font-weight: Bold; margin: 0; Margin-bottom: 15px;"><?php echo esc_html( $data['label'] ); ?></p>
 									<?php if( !empty( $data['type'] ) && $data['type'] === 'file' && ! empty( $data['value'] ) ) { ?>
 										<?php
-										$file_name = ! empty( $data['file_name'] ) ? $data['file_name'] : esc_html__( 'View File', 'kadence-blocks' ); 
+										$file_name = ! empty( $data['file_name'] ) ? $data['file_name'] : esc_html__( 'View File', 'kadence-blocks' );
 										$file_name_array = explode( ', ', $file_name );
 										if ( count( $file_name_array ) > 1 ) {
 											$file_value_array = explode( ', ', $data['value'] );
 											$value_output = array();
 											foreach ( $file_name_array as $key => $name ) {
-												$value_output[] = '<a href="' . $file_value_array[ $key ] . '" target="_blank">' . $name . '</a>';
+												$value_output[] = '<a href="' . esc_url( $file_value_array[ $key ] ) . '" target="_blank">' . esc_html( $name ) . '</a>';
 											}
 											$file_output = implode( ', ', $value_output );
 										} else {
-											$file_output = '<a href="' . $data['value'] . '" target="_blank">' . $file_name . '</a>';
+											$file_output = '<a href="' . esc_url( $data['value'] ) . '" target="_blank">' . esc_html( $file_name ) . '</a>';
 										}
 										?>
 										<?php echo wpautop( '<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px; padding-bottom: 5px;">' . $file_output . '</p>' ); ?>


### PR DESCRIPTION
## Summary

Fixes missing sanitization and escaping for uploaded file names and URLs in the advanced form AJAX handler and email notification template.

## Changes

### `includes/advanced-form/advanced-form-ajax.php`
- Wrap uploaded file names with `sanitize_file_name()` before collecting them into `$file_name_array`. Previously the raw `$file['name']` value from `$_FILES` was used without sanitization.

### `includes/templates/form-email.php`
- Escape file attachment URLs with `esc_url()` inside anchor `href` attributes.
- Escape file names with `esc_html()` inside anchor link text.

## Why

Uploaded file names originate from user-controlled input via `$_FILES`.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)
