### PR TITLE
Add scope option for tables when headers are set

### DIFF
--- a/includes/blocks/class-kadence-blocks-table-data-block.php
+++ b/includes/blocks/class-kadence-blocks-table-data-block.php
@@ -104,9 +104,10 @@ class Kadence_Blocks_Table_Data_Block extends Kadence_Blocks_Abstract_Block {
 		}
 
 		return sprintf(
-			'<%s class="kb-table-data kb-table-data%2$s">%3$s</%4$s>',
+			'<%s class="kb-table-data kb-table-data%2$s"%3$s>%4$s</%5$s>',
 			$tag,
 			esc_attr( $unique_id ),
+			$scope_attr,
 			$content,
 			$tag
 		);

--- a/includes/blocks/class-kadence-blocks-table-data-block.php
+++ b/includes/blocks/class-kadence-blocks-table-data-block.php
@@ -95,6 +95,14 @@ class Kadence_Blocks_Table_Data_Block extends Kadence_Blocks_Abstract_Block {
 	public function build_html( $attributes, $unique_id, $content, $block_instance ) {
 		$tag = $this->is_this_block_header( $attributes, $block_instance->context ) ? 'th' : 'td';
 
+		$scope_attr = '';
+		if ( 'th' === $tag && ! empty( $attributes['scope'] ) ) {
+			$allowed_scopes = [ 'col', 'row' ];
+			if ( in_array( $attributes['scope'], $allowed_scopes, true ) ) {
+				$scope_attr = ' scope="' . esc_attr( $attributes['scope'] ) . '"';
+			}
+		}
+
 		return sprintf(
 			'<%s class="kb-table-data kb-table-data%2$s">%3$s</%4$s>',
 			$tag,

--- a/src/blocks/table/children/data/block.json
+++ b/src/blocks/table/children/data/block.json
@@ -30,6 +30,10 @@
 		"paddingType": {
 			"type": "string",
 			"default": "px"
+		},
+		"scope": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"supports": {

--- a/src/blocks/table/children/data/block.json
+++ b/src/blocks/table/children/data/block.json
@@ -32,8 +32,7 @@
 			"default": "px"
 		},
 		"scope": {
-			"type": "string",
-			"default": ""
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/src/blocks/table/children/data/edit.js
+++ b/src/blocks/table/children/data/edit.js
@@ -24,7 +24,7 @@ const DEFAULT_BLOCK = [['core/paragraph', {}]];
 export function Edit(props) {
 	const { attributes, setAttributes, className, clientId, context } = props;
 
-	const { uniqueID, column, padding, tabletPadding, mobilePadding, paddingType, scope } = attributes;
+	const { uniqueID, column, padding, tabletPadding, mobilePadding, paddingType, scope = '' } = attributes;
 
 	const [activeTab, setActiveTab] = useState('general');
 

--- a/src/blocks/table/children/data/edit.js
+++ b/src/blocks/table/children/data/edit.js
@@ -156,7 +156,7 @@ export function Edit(props) {
 		if (Tag === 'td' && scope !== '') {
 			setAttributes({ scope: '' });
 		}
-	}, [Tag]);
+	}, [Tag, scope]);
 
 	return (
 		<Tag {...blockProps}>

--- a/src/blocks/table/children/data/edit.js
+++ b/src/blocks/table/children/data/edit.js
@@ -24,7 +24,7 @@ const DEFAULT_BLOCK = [['core/paragraph', {}]];
 export function Edit(props) {
 	const { attributes, setAttributes, className, clientId, context } = props;
 
-	const { uniqueID, column, padding, tabletPadding, mobilePadding, paddingType } = attributes;
+	const { uniqueID, column, padding, tabletPadding, mobilePadding, paddingType, scope } = attributes;
 
 	const [activeTab, setActiveTab] = useState('general');
 

--- a/src/blocks/table/children/data/edit.js
+++ b/src/blocks/table/children/data/edit.js
@@ -85,7 +85,7 @@ export function Edit(props) {
 
 	const blockProps = useBlockProps({
 		className: classes,
-		...(Tag === 'th' && scope ? { scope } : {}),
+		...(Tag === 'th' && ['col', 'row'].includes(scope) ? { scope } : {}),
 	});
 
 	uniqueIdHelper(props);

--- a/src/blocks/table/children/data/edit.js
+++ b/src/blocks/table/children/data/edit.js
@@ -186,7 +186,7 @@ export function Edit(props) {
 					<KadencePanelBody initialOpen={true}>
 						{Tag === 'th' && (
 							<SelectControl
-								label={__('Scope', 'kadence-blocks')}
+								label={__('Header Scope', 'kadence-blocks')}
 								value={scope}
 								options={[
 									{ label: __('None', 'kadence-blocks'), value: '' },
@@ -194,7 +194,7 @@ export function Edit(props) {
 									{ label: __('Row (row)', 'kadence-blocks'), value: 'row' },
 								]}
 								onChange={(value) => setAttributes({ scope: value })}
-								help={__('Defines which cells this header relates to.', 'kadence-blocks')}
+								help={__('Defines whether this header applies to its column or row.', 'kadence-blocks')}
 							/>
 						)}
 						<ResponsiveMeasureRangeControl

--- a/src/blocks/table/children/data/edit.js
+++ b/src/blocks/table/children/data/edit.js
@@ -150,8 +150,10 @@ export function Edit(props) {
 			? 'th'
 			: 'td';
 
+	const tagProps = Tag === 'th' && scope ? { ...blockProps, scope } : blockProps;
+
 	return (
-		<Tag {...blockProps}>
+		<Tag {...tagProps}>
 			<BackendStyles attributes={attributes} previewDevice={previewDevice} />
 			<BlockControls>
 				<TableControlsDropdown onAddRow={addRow} onAddColumn={addColumn} />

--- a/src/blocks/table/children/data/edit.js
+++ b/src/blocks/table/children/data/edit.js
@@ -150,6 +150,13 @@ export function Edit(props) {
 			? 'th'
 			: 'td';
 
+	// Clear scope when the cell is no longer a header so stale values don't persist.
+	useEffect(() => {
+		if (Tag === 'td' && scope !== '') {
+			setAttributes({ scope: '' });
+		}
+	}, [Tag]);
+
 	const tagProps = Tag === 'th' && scope ? { ...blockProps, scope } : blockProps;
 
 	return (

--- a/src/blocks/table/children/data/edit.js
+++ b/src/blocks/table/children/data/edit.js
@@ -68,6 +68,11 @@ export function Edit(props) {
 		}
 	}, [hasInnerBlocks]);
 
+	const Tag =
+		(index === 0 && context['kadence/table/isFirstColumnHeader']) || context['kadence/table/thisRowIsHeader']
+			? 'th'
+			: 'td';
+
 	const classes = useMemo(
 		() =>
 			classnames({
@@ -80,6 +85,7 @@ export function Edit(props) {
 
 	const blockProps = useBlockProps({
 		className: classes,
+		...(Tag === 'th' && scope ? { scope } : {}),
 	});
 
 	uniqueIdHelper(props);
@@ -145,11 +151,6 @@ export function Edit(props) {
 		});
 	};
 
-	const Tag =
-		(index === 0 && context['kadence/table/isFirstColumnHeader']) || context['kadence/table/thisRowIsHeader']
-			? 'th'
-			: 'td';
-
 	// Clear scope when the cell is no longer a header so stale values don't persist.
 	useEffect(() => {
 		if (Tag === 'td' && scope !== '') {
@@ -157,10 +158,8 @@ export function Edit(props) {
 		}
 	}, [Tag]);
 
-	const tagProps = Tag === 'th' && scope ? { ...blockProps, scope } : blockProps;
-
 	return (
-		<Tag {...tagProps}>
+		<Tag {...blockProps}>
 			<BackendStyles attributes={attributes} previewDevice={previewDevice} />
 			<BlockControls>
 				<TableControlsDropdown onAddRow={addRow} onAddColumn={addColumn} />

--- a/src/blocks/table/children/data/edit.js
+++ b/src/blocks/table/children/data/edit.js
@@ -17,7 +17,7 @@ import { uniqueIdHelper } from '@kadence/helpers';
 import { createBlock } from '@wordpress/blocks';
 import { flow } from 'lodash';
 import classnames from 'classnames';
-import { ToolbarDropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { ToolbarDropdownMenu, MenuGroup, MenuItem, SelectControl } from '@wordpress/components';
 import { TableControlsDropdown } from './table-controls';
 
 const DEFAULT_BLOCK = [['core/paragraph', {}]];
@@ -178,6 +178,19 @@ export function Edit(props) {
 
 				{activeTab === 'general' && (
 					<KadencePanelBody initialOpen={true}>
+						{Tag === 'th' && (
+							<SelectControl
+								label={__('Scope', 'kadence-blocks')}
+								value={scope}
+								options={[
+									{ label: __('None', 'kadence-blocks'), value: '' },
+									{ label: __('Column (col)', 'kadence-blocks'), value: 'col' },
+									{ label: __('Row (row)', 'kadence-blocks'), value: 'row' },
+								]}
+								onChange={(value) => setAttributes({ scope: value })}
+								help={__('Defines which cells this header relates to.', 'kadence-blocks')}
+							/>
+						)}
 						<ResponsiveMeasureRangeControl
 							label={__('Padding', 'kadence-blocks')}
 							value={padding}

--- a/tests/wpunit/Blocks/TableDataTest.php
+++ b/tests/wpunit/Blocks/TableDataTest.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace Tests\wpunit\Blocks;
+
+use Kadence_Blocks_Table_Data_Block;
+use Tests\Support\Classes\KadenceBlocksUnit;
+
+class TableDataTest extends KadenceBlocksUnit {
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'table-data';
+
+	/**
+	 * The block under test.
+	 *
+	 * @var Kadence_Blocks_Table_Data_Block
+	 */
+	protected $block;
+
+	/**
+	 * Set up the block instance for testing.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->block = new Kadence_Blocks_Table_Data_Block();
+	}
+
+	/**
+	 * Build a WP_Block instance for kadence/table-data with the given context.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @param array $context    Available block context values.
+	 * @return \WP_Block
+	 */
+	private function make_block_instance( array $attributes, array $context ): \WP_Block {
+		return new \WP_Block(
+			[
+				'blockName'    => 'kadence/table-data',
+				'attrs'        => $attributes,
+				'innerBlocks'  => [],
+				'innerHTML'    => '',
+				'innerContent' => [],
+			],
+			$context
+		);
+	}
+
+	/**
+	 * Returns context that makes the cell render as <th> via isFirstColumnHeader (column 0).
+	 *
+	 * @return array
+	 */
+	private function header_via_first_column(): array {
+		return [ 'kadence/table/isFirstColumnHeader' => true ];
+	}
+
+	/**
+	 * Returns context that makes the cell render as <th> via isFirstRowHeader (row 0).
+	 *
+	 * @return array
+	 */
+	private function header_via_first_row(): array {
+		return [
+			'kadence/table/isFirstRowHeader' => true,
+			'kadence/table/parentRow'        => 0,
+		];
+	}
+
+	/**
+	 * Returns context that produces a plain <td> with no header flags set.
+	 *
+	 * @return array
+	 */
+	private function non_header_context(): array {
+		return [];
+	}
+
+	/**
+	 * Tests that scope="col" is emitted on a <th> header cell driven by the first-column-header path.
+	 *
+	 * @return void
+	 */
+	public function testScopeColEmittedOnThViaFirstColumn() {
+		$attributes     = [
+			'column' => 0,
+			'scope'  => 'col',
+		];
+		$block_instance = $this->make_block_instance( $attributes, $this->header_via_first_column() );
+
+		$html = $this->block->build_html( $attributes, 'abc', '', $block_instance );
+
+		$this->assertStringContainsString( '<th', $html );
+		$this->assertStringContainsString( 'scope="col"', $html );
+	}
+
+	/**
+	 * Tests that scope="row" is emitted on a <th> header cell driven by the first-row-header path.
+	 * Uses column=1 to confirm it is the row-header path, not the column-header path, driving <th>.
+	 *
+	 * @return void
+	 */
+	public function testScopeRowEmittedOnThViaFirstRow() {
+		$attributes     = [
+			'column' => 1,
+			'scope'  => 'row',
+		];
+		$block_instance = $this->make_block_instance( $attributes, $this->header_via_first_row() );
+
+		$html = $this->block->build_html( $attributes, 'abc', '', $block_instance );
+
+		$this->assertStringContainsString( '<th', $html );
+		$this->assertStringContainsString( 'scope="row"', $html );
+	}
+
+	/**
+	 * Tests that no scope attribute is emitted when scope is an empty string, even on a <th> cell.
+	 *
+	 * @return void
+	 */
+	public function testNoScopeAttributeWhenScopeIsEmptyOnTh() {
+		$attributes     = [
+			'column' => 0,
+			'scope'  => '',
+		];
+		$block_instance = $this->make_block_instance( $attributes, $this->header_via_first_column() );
+
+		$html = $this->block->build_html( $attributes, 'abc', '', $block_instance );
+
+		$this->assertStringContainsString( '<th', $html );
+		$this->assertStringNotContainsString( 'scope=', $html );
+	}
+
+	/**
+	 * Tests that no scope attribute is emitted when the scope key is absent from attributes.
+	 *
+	 * @return void
+	 */
+	public function testNoScopeAttributeWhenScopeNotSetOnTh() {
+		$attributes     = [ 'column' => 0 ];
+		$block_instance = $this->make_block_instance( $attributes, $this->header_via_first_column() );
+
+		$html = $this->block->build_html( $attributes, 'abc', '', $block_instance );
+
+		$this->assertStringContainsString( '<th', $html );
+		$this->assertStringNotContainsString( 'scope=', $html );
+	}
+
+	/**
+	 * Tests that isFirstColumnHeader context alone does not make a header cell when column !== 0.
+	 * Covers the case where the first-column-header setting is enabled on the table but this
+	 * cell is not in column 0, so it must still render as <td>.
+	 *
+	 * @return void
+	 */
+	public function testFirstColumnHeaderFlagWithNonZeroColumnIsNotAHeader() {
+		$attributes     = [
+			'column' => 1,
+			'scope'  => 'col',
+		];
+		$block_instance = $this->make_block_instance( $attributes, $this->header_via_first_column() );
+
+		$html = $this->block->build_html( $attributes, 'abc', '', $block_instance );
+
+		$this->assertStringContainsString( '<td', $html );
+		$this->assertStringNotContainsString( 'scope=', $html );
+	}
+
+	/**
+	 * Tests that column position alone does not make a header cell when isFirstColumnHeader
+	 * context is not set. Verifies the && in is_this_block_header is not accidentally an ||.
+	 *
+	 * @return void
+	 */
+	public function testColumnZeroWithoutContextFlagIsNotAHeader() {
+		$attributes     = [
+			'column' => 0,
+			'scope'  => 'col',
+		];
+		$block_instance = $this->make_block_instance( $attributes, $this->non_header_context() );
+
+		$html = $this->block->build_html( $attributes, 'abc', '', $block_instance );
+
+		$this->assertStringContainsString( '<td', $html );
+		$this->assertStringNotContainsString( 'scope=', $html );
+	}
+
+	/**
+	 * Tests that scope is suppressed on <td> cells regardless of the scope attribute value.
+	 *
+	 * @return void
+	 */
+	public function testNoScopeAttributeOnTdRegardlessOfScopeValue() {
+		foreach ( [ 'col', 'row' ] as $scope ) {
+			$attributes     = [
+				'column' => 1,
+				'scope'  => $scope,
+			];
+			$block_instance = $this->make_block_instance( $attributes, $this->non_header_context() );
+
+			$html = $this->block->build_html( $attributes, 'abc', '', $block_instance );
+
+			$this->assertStringContainsString( '<td', $html, "Expected <td> for scope='{$scope}' on non-header cell." );
+			$this->assertStringNotContainsString( 'scope=', $html, "scope attribute must be suppressed on <td> for scope='{$scope}'." );
+		}
+	}
+
+	/**
+	 * Tests that unsupported scope values are rejected and not emitted even on a <th> cell.
+	 * Includes injection attempts to confirm the server-side allowlist is enforced.
+	 *
+	 * @return void
+	 */
+	public function testUnsupportedScopeValueNotEmittedOnTh() {
+		foreach ( [ 'colgroup', 'rowgroup', 'invalid', '<script>', '1' ] as $bad_scope ) {
+			$attributes     = [
+				'column' => 0,
+				'scope'  => $bad_scope,
+			];
+			$block_instance = $this->make_block_instance( $attributes, $this->header_via_first_column() );
+
+			$html = $this->block->build_html( $attributes, 'abc', '', $block_instance );
+
+			$this->assertStringContainsString( '<th', $html, "Expected <th> for scope value '{$bad_scope}'." );
+			$this->assertStringNotContainsString( 'scope=', $html, "scope attribute must not be emitted for unsupported value '{$bad_scope}'." );
+		}
+	}
+
+	/**
+	 * Tests that inner content is passed through to the rendered output on a <td> cell.
+	 *
+	 * @return void
+	 */
+	public function testTdTagUsedForNonHeaderCell() {
+		$attributes     = [ 'column' => 1 ];
+		$block_instance = $this->make_block_instance( $attributes, $this->non_header_context() );
+
+		$html = $this->block->build_html( $attributes, 'abc', 'Cell content', $block_instance );
+
+		$this->assertStringContainsString( '<td ', $html );
+		$this->assertStringContainsString( '</td>', $html );
+		$this->assertStringContainsString( 'Cell content', $html );
+	}
+}


### PR DESCRIPTION
Resolves [KAD-5556]

## Description


This pull request adds support for specifying the HTML `scope` attribute on table header cells (`th`) in the Kadence Blocks Table Data block. The main goal is to improve accessibility by allowing users to define whether a header cell applies to a row or column, both in the editor UI and the frontend output.

The most important changes are:

**Model Enhancements:**
* Added a new `scope` attribute to the table data block's `block.json`, enabling storage of the scope value for each cell.

**Editor UI Improvements:**
* Updated the block editor (`edit.js`) to include a `SelectControl` for choosing the scope (`None`, `Column (col)`, or `Row (row)`) when editing a table header cell (`th`). The selected value is saved to the block's attributes.
* Modified the editor rendering logic to pass the `scope` attribute to table header (`th`) elements when set, ensuring the attribute is present in the editor preview.

**Frontend Output:**
* Updated the PHP render callback to output the `scope` attribute on `th ' elements in the frontend, but only if a valid value (`col` or `row`) is set; there is no default passed to avoid any backcompat issues. If we would rather set a default on this for all instances of the block, let me know.

https://github.com/user-attachments/assets/2f2a819a-e252-4a73-ae8e-34fb0282b4ac

Fixes: #956 

...

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


[KAD-5556]: https://stellarwp.atlassian.net/browse/KAD-5556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ