### PR TITLE
KAD-5477 Fix type casting for post ID in optimizer data clearing function

### DIFF
--- a/includes/resources/Optimizer/Status/Provider.php
+++ b/includes/resources/Optimizer/Status/Provider.php
@@ -18,7 +18,7 @@ final class Provider extends Provider_Contract {
 		add_action(
 			'updated_post_meta',
 			function ( $meta_id, $post_id, $meta_key, $value ) {
-				$this->container->get( Meta::class )->maybe_clear_optimizer_data( $post_id, $meta_key, $value );
+				$this->container->get( Meta::class )->maybe_clear_optimizer_data( (int) $post_id, $meta_key, $value );
 			},
 			10,
 			4


### PR DESCRIPTION
🎫  #[KAD-5477]

WordPress passes hook arguments loosely typed, but the file uses declare(strict_types=1) which rejects implicit string-to-int coercion. The (int) cast in the closure handles the conversion before it hits the typed method signature.  

### Checklist
- [ ] I have performed a self-review.
- [ ] No unrelated files are modified.
- [ ] No debugging statements exist (Ex: console.log, error_log).
- [ ] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


[KAD-5477]: https://stellarwp.atlassian.net/browse/KAD-5477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ