### PR TITLE
KAD-5471 Handle exceptions when dropping optimizer and viewport hash tables during schema updates

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -15,7 +15,7 @@ jobs:
         php-version: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
 
     env:
-      COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.COMPOSER_TOKEN }}"}}'
+      COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.GH_BOT_TOKEN }}"}}'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
         runs-on: ubuntu-latest
 
         env:
-            COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.COMPOSER_TOKEN }}"}}'
+            COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.GH_BOT_TOKEN }}"}}'
 
         strategy:
             matrix:

--- a/includes/resources/Optimizer/Database/Optimizer_Table.php
+++ b/includes/resources/Optimizer/Database/Optimizer_Table.php
@@ -41,7 +41,12 @@ final class Optimizer_Table extends Table {
 	 */
 	public function update() {
 		if ( $this->exists() ) {
-			$this->drop();
+			try {
+				$this->drop();
+			} catch ( DatabaseQueryException $e ) {
+				error_log( '[Kadence Blocks]: Unable to drop optimizer table during schema update: ' . $e->getMessage() );
+				return [];
+			}
 		}
 
 		return parent::update();

--- a/includes/resources/Optimizer/Database/Optimizer_Table.php
+++ b/includes/resources/Optimizer/Database/Optimizer_Table.php
@@ -43,8 +43,8 @@ final class Optimizer_Table extends Table {
 		if ( $this->exists() ) {
 			try {
 				$this->drop();
-			} catch ( DatabaseQueryException $e ) {
-				error_log( '[Kadence Blocks]: Unable to drop optimizer table during schema update: ' . $e->getMessage() );
+			} catch ( \Throwable $e ) {
+				function_exists( 'error_log' ) && error_log( '[Kadence Blocks]: Unable to drop optimizer table during schema update: ' . $e->getMessage() );
 				return [];
 			}
 		}

--- a/includes/resources/Optimizer/Database/Optimizer_Table.php
+++ b/includes/resources/Optimizer/Database/Optimizer_Table.php
@@ -40,13 +40,13 @@ final class Optimizer_Table extends Table {
 	 * @return string[]
 	 */
 	public function update() {
-		if ( $this->exists() ) {
-			try {
+		try {
+			if ( $this->exists() ) {
 				$this->drop();
-			} catch ( \Throwable $e ) {
-				function_exists( 'error_log' ) && error_log( '[Kadence Blocks]: Unable to drop optimizer table during schema update: ' . $e->getMessage() );
-				return [];
 			}
+		} catch ( \Throwable $e ) {
+			function_exists( 'error_log' ) && error_log( '[Kadence Blocks]: Unable to drop optimizer table during schema update: ' . $e->getMessage() );
+			return [];
 		}
 
 		return parent::update();

--- a/includes/resources/Optimizer/Database/Viewport_Hash_Table.php
+++ b/includes/resources/Optimizer/Database/Viewport_Hash_Table.php
@@ -44,8 +44,8 @@ final class Viewport_Hash_Table extends Table {
 		if ( $this->exists() ) {
 			try {
 				$this->drop();
-			} catch ( DatabaseQueryException $e ) {
-				error_log( '[Kadence Blocks]: Unable to drop viewport_hash table during schema update: ' . $e->getMessage() );
+			} catch ( \Throwable $e ) {
+				function_exists( 'error_log' ) && error_log( '[Kadence Blocks]: Unable to drop viewport_hash table during schema update: ' . $e->getMessage() );
 				return [];
 			}
 		}

--- a/includes/resources/Optimizer/Database/Viewport_Hash_Table.php
+++ b/includes/resources/Optimizer/Database/Viewport_Hash_Table.php
@@ -42,7 +42,12 @@ final class Viewport_Hash_Table extends Table {
 	 */
 	public function update() {
 		if ( $this->exists() ) {
-			$this->drop();
+			try {
+				$this->drop();
+			} catch ( DatabaseQueryException $e ) {
+				error_log( '[Kadence Blocks]: Unable to drop viewport_hash table during schema update: ' . $e->getMessage() );
+				return [];
+			}
 		}
 
 		return parent::update();

--- a/includes/resources/Optimizer/Database/Viewport_Hash_Table.php
+++ b/includes/resources/Optimizer/Database/Viewport_Hash_Table.php
@@ -41,13 +41,13 @@ final class Viewport_Hash_Table extends Table {
 	 * @return string[]
 	 */
 	public function update() {
-		if ( $this->exists() ) {
-			try {
+		try {
+			if ( $this->exists() ) {
 				$this->drop();
-			} catch ( \Throwable $e ) {
-				function_exists( 'error_log' ) && error_log( '[Kadence Blocks]: Unable to drop viewport_hash table during schema update: ' . $e->getMessage() );
-				return [];
 			}
+		} catch ( \Throwable $e ) {
+			function_exists( 'error_log' ) && error_log( '[Kadence Blocks]: Unable to drop viewport_hash table during schema update: ' . $e->getMessage() );
+			return [];
 		}
 
 		return parent::update();


### PR DESCRIPTION
🎫  #[KAD-5471]

Users experience a fatal crash when they lack database privileges to drop a table. This fix catches those errors and prevents the table drop. Essentially, the performance optimizer functionality silently fails but the site doesn't experience a fatal crash. The issue was reported for the Viewport_Hash_Table.php file, but the pattern was found in the Optimizer_Table.php file as well. 

### Checklist
- [ ] I have performed a self-review.
- [ ] No unrelated files are modified.
- [ ] No debugging statements exist (Ex: console.log, error_log).
- [ ] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


[KAD-5471]: https://stellarwp.atlassian.net/browse/KAD-5471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ