### PR TITLE
Rebrand to Liquid Web | SCON-355

### DIFF
--- a/includes/class-kadence-blocks-ai-events.php
+++ b/includes/class-kadence-blocks-ai-events.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class responsible for sending events AI Events to Stellar Prophecy WP AI.
+ * Class responsible for sending events AI Events to Liquid Web Prophecy WP AI.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -13,7 +13,7 @@ use function KadenceWP\KadenceBlocks\StellarWP\Uplink\get_original_domain;
 use function KadenceWP\KadenceBlocks\StellarWP\Uplink\is_authorized;
 
 /**
- * Class responsible for sending events AI Events to Stellar Prophecy WP AI.
+ * Class responsible for sending events AI Events to Liquid Web Prophecy WP AI.
  */
 class Kadence_Blocks_AI_Events {
 

--- a/includes/resources/Database/Query.php
+++ b/includes/resources/Database/Query.php
@@ -6,7 +6,7 @@ use KadenceWP\KadenceBlocks\StellarWP\DB\DB;
 use KadenceWP\KadenceBlocks\StellarWP\DB\QueryBuilder\QueryBuilder;
 
 /**
- * A query wrapper for the StellarWP DB instance using a specific
+ * A query wrapper for the Liquid Web DB instance using a specific
  * table.
  *
  * This class should be extended and configured for a specific table


### PR DESCRIPTION
:ticket: [SCON-355]


Automated rebrand from StellarWP/Stellar WP to Liquid Web.

**Changes made:**
- Updated Author Name in WordPress plugin/theme headers to "Liquid Web"
- Updated Author URI in WordPress plugin/theme headers to "https://www.liquidweb.com/"
- Replaced "StellarWP" and "Stellar WP" brand references in text strings with "Liquid Web"

**Preserved (not changed):**
- PHP identifiers (class names, function names, variables, namespaces)
- CSS class/ID names
- File and directory names
- Text domains
- Non-brand URLs and email addresses

**Note:** This PR targets `bucket/product-consolidation`, which was created from the repo's default branch. If a more appropriate base branch exists, a reviewer can update the base accordingly.

[SCON-355]: https://stellarwp.atlassian.net/browse/SCON-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ