### PR TITLE
KAD-5486 Block Settings - Border Color Picker isn't working properly. Closes on first input.

### DIFF
--- a/src/packages/components/src/border/single-border-control/index.js
+++ b/src/packages/components/src/border/single-border-control/index.js
@@ -64,13 +64,13 @@ export default function SingleBorderControl({
 }) {
 	const instanceId = useInstanceId(SingleBorderControl);
 	const onChangeStyle = (style) => {
-		const newVal = value;
+		const newVal = [...value];
 		newVal[1] = style;
 		onChange(newVal);
 	};
 	const currentStyle = value?.[1] || 'solid';
 	const onChangeColor = (color) => {
-		const newVal = value;
+		const newVal = [...value];
 		newVal[0] = color;
 		onChange(newVal);
 	};
@@ -79,7 +79,7 @@ export default function SingleBorderControl({
 	const onChangeSize = (size) => {
 		const isNumeric = !isNaN(parseFloat(size));
 		const nextValue = isNumeric ? parseFloat(size) : '';
-		const newVal = value;
+		const newVal = [...value];
 		newVal[2] = nextValue;
 		onChange(newVal);
 	};
@@ -171,7 +171,7 @@ export default function SingleBorderControl({
 				)}
 				<div className={'kadence-single-border-control-wrap'}>
 					<PopColorControl
-						key={`border-color-${currentColor}-${instanceId}`}
+						key={`border-color-${instanceId}`}
 						value={currentColor}
 						default={''}
 						hideClear={true}


### PR DESCRIPTION
🎫  #[KAD-5486](https://stellarwp.atlassian.net/browse/KAD-5486)

### 🗒️ Description
**Fix** (bug fix - color picker closing on interaction)
Fixed the Border Color Picker closing immediately whenever the user interacts with it (dragging the focus point, using sliders, or inputting RGBA/HEX values).

**Changes in `single-border-control/index.js`:**
- **Dynamic `key` prop:** `key={`border-color-${currentColor}-${instanceId}`}` → `key={`border-color-${instanceId}`}`
  The `key` included the current color value, causing React to unmount and remount the `PopColorControl` component on every color change, which reset the popover's open state to `false`.
- **Array mutation in onChange handlers:** `const newVal = value` → `const newVal = [...value]`
  The `onChangeColor`, `onChangeStyle`, and `onChangeSize` handlers were mutating the original array reference instead of creating a copy, which could cause React to miss state changes.

...

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


[KAD-5486]: https://stellarwp.atlassian.net/browse/KAD-5486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ