### PR TITLE
[KAD-5441] Table (Adv) Block does not use Widths properly when using Column Headings.

### DIFF
--- a/includes/blocks/class-kadence-blocks-table-block.php
+++ b/includes/blocks/class-kadence-blocks-table-block.php
@@ -100,8 +100,7 @@ class Kadence_Blocks_Table_Block extends Kadence_Blocks_Abstract_Block {
 					$width_unit = ! empty( $settings['unit'] ) ? $settings['unit'] : '%';
 
 					if( isset( $settings['width'] ) && '' !== $settings['width'] ) {
-						$css->set_selector('.kb-table' . esc_attr($unique_id) . ' td:nth-of-type(' . ($index + 1) . '), ' .
-							'.kb-table' . esc_attr($unique_id) . ' th:nth-of-type(' . ($index + 1) . ')');
+						$css->set_selector('.kb-table' . esc_attr($unique_id) . ' tr > *:nth-child(' . ($index + 1) . ')');
 						$css->add_property('width', $settings['width'] . $width_unit);
 					}
 


### PR DESCRIPTION
🎫  #[KAD-5441](https://stellarwp.atlassian.net/browse/KAD-5441)

### 🗒️ Description

**Fix** (bug fix - broken column widths with headers)
Fixed the Table (Adv) Block column widths not working when Column Headers are enabled. The CSS selector was using `:nth-of-type()` which counts elements of the same type separately, causing width mismatches between header rows (`<th>`) and data rows (`<td>`).

**Change in `class-kadence-blocks-table-block.php`:**
- **CSS Selector:** `td:nth-of-type(N), th:nth-of-type(N)` → `tr > *:nth-child(N)`
- The old selector counted `<th>` and `<td>` elements separately, breaking column alignment when headers were enabled.
- The new selector uses the universal selector `*` with `:nth-child()` to count ALL children regardless of tag type, ensuring consistent column widths across header and data rows.

### ⚠️ Blockers
None.

### 🧪 Testing Instructions for QA

1. Create a new page with a **Table (Adv)** Block
2. Add 2 columns with content in the table cells
3. Set the first column width to **10%** and the second column to **90%**
4. View the frontend - column widths should display correctly (10% / 90%)
5. Go back to the editor and enable **"First Row Header"** in the Table Settings panel
6. Save and view the frontend again
7. Verify the column widths are still **10% and 90%** (not 50/50 split)
8. Confirm the header row (`<th>`) and data rows (`<td>`) both respect the configured widths
9. Test with **"First Column Header"** enabled as well
10. Test responsive widths (tablet/mobile) if configured

...

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


[KAD-5441]: https://stellarwp.atlassian.net/browse/KAD-5441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ