### PR TITLE
Fix optimizer bulk action hook compatibility

### DIFF
--- a/includes/resources/Optimizer/Post_List_Table/Bulk_Action_Manager.php
+++ b/includes/resources/Optimizer/Post_List_Table/Bulk_Action_Manager.php
@@ -18,9 +18,12 @@ final class Bulk_Action_Manager {
 	 * @filter bulk_actions-edit-page
 	 * 
 	 * Developer Notes:
-	 * This function used to be hooked to both 'bulk_actions-edit-post' and 'bulk_actions-edit-page' filters.
-	 * For this reason we can not force the type of $actions to be array because it be "null", "false", etc. depending on the third party plugin implementation in which it is called.
-	 * Therefore, we keep the type as "mixed" and handle it accordingly.
+	 * The $actions parameter is typed as `mixed` rather than `array` intentionally.
+	 * Although WordPress always passes an array, third-party plugins that hook into
+	 * 'bulk_actions-edit-post' or 'bulk_actions-edit-page' may return non-array values
+	 * (e.g. null, false) when they short-circuit the filter chain. Enforcing an `array`
+	 * type hint here would cause a fatal TypeError in those edge cases, so we accept
+	 * `mixed` and let the return type coerce the final value to an array.
 	 *
 	 * @param mixed $actions The existing actions.
 	 *

--- a/includes/resources/Optimizer/Post_List_Table/Bulk_Action_Manager.php
+++ b/includes/resources/Optimizer/Post_List_Table/Bulk_Action_Manager.php
@@ -30,6 +30,11 @@ final class Bulk_Action_Manager {
 	 * @return array<string, string|array<string, string>>
 	 */
 	public function register_actions( $actions ): array {
+		// Ensure $actions is an array to prevent fatal errors if a previous filter returns a non-array value.
+		if ( ! is_array( $actions ) ) {
+			$actions = [];
+		}
+
 		$actions[ __( 'KB Optimizer', 'kadence-blocks' ) ] = [
 			self::OPTIMIZE_POSTS      => __( 'Optimize', 'kadence-blocks' ),
 			self::REMOVE_OPTIMIZATION => __( 'Remove Optimization', 'kadence-blocks' ),

--- a/includes/resources/Optimizer/Post_List_Table/Bulk_Action_Manager.php
+++ b/includes/resources/Optimizer/Post_List_Table/Bulk_Action_Manager.php
@@ -16,12 +16,17 @@ final class Bulk_Action_Manager {
 	 *
 	 * @filter bulk_actions-edit-post
 	 * @filter bulk_actions-edit-page
+	 * 
+	 * Developer Notes:
+	 * This function used to be hooked to both 'bulk_actions-edit-post' and 'bulk_actions-edit-page' filters.
+	 * For this reason we can not force the type of $actions to be array because it be "null", "false", etc. depending on the third party plugin implementation in which it is called.
+	 * Therefore, we keep the type as "mixed" and handle it accordingly.
 	 *
-	 * @param array<string, string|array<string, string>> $actions The existing actions.
+	 * @param mixed $actions The existing actions.
 	 *
 	 * @return array<string, string|array<string, string>>
 	 */
-	public function register_actions( array $actions ): array {
+	public function register_actions( $actions ): array {
 		$actions[ __( 'KB Optimizer', 'kadence-blocks' ) ] = [
 			self::OPTIMIZE_POSTS      => __( 'Optimize', 'kadence-blocks' ),
 			self::REMOVE_OPTIMIZATION => __( 'Remove Optimization', 'kadence-blocks' ),


### PR DESCRIPTION
Resolve: [KAD-5565]

## Description

Fixes a compatibility issue in optimizer bulk actions when third-party plugins pass non-array values through bulk action hooks.

## Changes

- Update bulk action registration method to accept mixed input.
- Document why strict array typing cannot be enforced on this hook.


[KAD-5565]: https://stellarwp.atlassian.net/browse/KAD-5565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ