### PR TITLE
fix: point strauss-release at prefixed harbor binary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,7 @@
 		"strauss-release": [
 			"@strauss-install",
 			"@php bin/strauss.phar --deleteVendorPackages=true",
-			"@php vendor/stellarwp/harbor/bin/stellar-harbor domain=kadence-blocks",
+			"@php vendor/vendor-prefixed/stellarwp/harbor/bin/stellar-harbor domain=kadence-blocks",
 			"@composer dump-autoload"
 		],
 		"strauss-clean": [


### PR DESCRIPTION
## Summary

The `Deploy to WP.org` workflow's Build step has been failing because the `strauss-release` composer script deletes the `stellarwp/harbor` package directory and then immediately tries to execute a binary inside it.

The script was:

```json
"@php bin/strauss.phar --deleteVendorPackages=true",
"@php vendor/stellarwp/harbor/bin/stellar-harbor domain=kadence-blocks",
```

Strauss with `--deleteVendorPackages=true` copies prefixed dependencies into `vendor/vendor-prefixed/` and then deletes the originals from `vendor/`. Harbor was one of the prefixed packages, so by the time the next line ran, `vendor/stellarwp/harbor/bin/stellar-harbor` no longer existed:

```
[warning] Package directory unexpectedly DOES NOT exist: .../vendor/stellarwp/harbor
Could not open input file: vendor/stellarwp/harbor/bin/stellar-harbor
Script @php vendor/stellarwp/harbor/bin/stellar-harbor domain=kadence-blocks handling the strauss-release event returned with error code 1
##[error]Process completed with exit code 1.
```

This only affected the release path; pup `--dev` runs the plain `strauss` script (no `--deleteVendorPackages`), so harbor stayed in place locally.

## Fix

Point the call at the strauss-prefixed copy that survives the prune: `vendor/vendor-prefixed/stellarwp/harbor/bin/stellar-harbor`.

## Reference

Failing run: https://github.com/stellarwp/kadence-blocks/actions/runs/25710505026/job/75489491366