### PR TITLE
chore: add workflows to replace and guard @since TBD markers

### DIFF
--- a/.github/workflows/guard-since-tbd.yml
+++ b/.github/workflows/guard-since-tbd.yml
@@ -1,0 +1,43 @@
+name: Guard against @since TBD on master
+
+# Fails CI if any `@since TBD` markers reach master. Runs on:
+#   - PRs targeting master (blocks the merge button until clean)
+#   - Pushes to master (catches direct commits / merges that bypassed PR review)
+#
+# Companion to .github/workflows/replace-since-tbd.yml — the replacement
+# workflow is what fixes TBD markers; this workflow enforces that it ran.
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  guard:
+    name: Check for unresolved @since TBD markers
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan PHP files for @since TBD
+        run: |
+          # Same exclusions as the replacement workflow so the two stay in sync.
+          MATCHES=$(grep -rn --include='*.php' \
+            --exclude-dir=vendor \
+            --exclude-dir=vendor-prefixed \
+            --exclude-dir=node_modules \
+            --exclude-dir=dist \
+            --exclude-dir=build \
+            '@since TBD' . || true)
+
+          if [ -n "$MATCHES" ]; then
+            echo "::error::Found unresolved '@since TBD' markers. Run the 'Replace @since TBD with release version' workflow on the release branch and merge that PR before merging into master."
+            echo ""
+            echo "Locations:"
+            echo "$MATCHES"
+            exit 1
+          fi
+
+          echo "No '@since TBD' markers found — clear to merge."

--- a/.github/workflows/replace-since-tbd.yml
+++ b/.github/workflows/replace-since-tbd.yml
@@ -1,0 +1,71 @@
+name: Replace @since TBD with release version
+
+# Replaces `@since TBD` docblock markers with the actual release version on a
+# release branch, then opens a PR back into that same branch for review.
+#
+# Idempotent: re-run any time during QA to sweep up TBDs added by late fixes.
+# Run a final time right before merging the release branch into master.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to substitute for TBD (e.g. 3.8.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  replace:
+    runs-on: ubuntu-latest
+
+    # Guard: only allow this workflow to run on release branches, never on
+    # master or feature branches. Prevents accidental dispatch against the
+    # wrong base.
+    if: startsWith(github.ref, 'refs/heads/release/')
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Replace @since TBD in PHP files
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          # Single-line substring replacement; safe for sed (no multi-line or
+          # whitespace-sensitive content). Excludes:
+          #   - vendor/ and vendor-prefixed/ (Composer + Strauss output)
+          #   - node_modules/, dist/, build/ (JS build artifacts)
+          MATCHED=$(grep -rl --include='*.php' \
+            --exclude-dir=vendor \
+            --exclude-dir=vendor-prefixed \
+            --exclude-dir=node_modules \
+            --exclude-dir=dist \
+            --exclude-dir=build \
+            '@since TBD' . || true)
+
+          if [ -z "$MATCHED" ]; then
+            echo "No @since TBD found — nothing to do."
+            exit 0
+          fi
+
+          echo "Files to update:"
+          echo "$MATCHED"
+
+          echo "$MATCHED" | xargs sed -i "s/@since TBD/@since ${VERSION}/g"
+
+      - name: Open PR with replacements
+        uses: peter-evans/create-pull-request@v6
+        with:
+          base: ${{ github.ref_name }}
+          branch: chore/replace-since-tbd-${{ inputs.version }}
+          title: "chore: replace @since TBD with ${{ inputs.version }}"
+          commit-message: "chore: replace @since TBD with ${{ inputs.version }}"
+          body: |
+            Automated replacement of `@since TBD` placeholders with `${{ inputs.version }}`
+            on branch `${{ github.ref_name }}`.
+
+            Re-run this workflow if additional commits land during QA and
+            introduce new `@since TBD` markers.


### PR DESCRIPTION
## Summary
- Adds `replace-since-tbd.yml`: a manual (`workflow_dispatch`) workflow that runs on release branches, replaces `@since TBD` with the target release version across PHP files, and opens a PR back into the same release branch for review.
- Adds `guard-since-tbd.yml`: a CI check on `pull_request` and `push` to `master` that fails the run if any `@since TBD` markers remain — blocks the merge button until the replace workflow has run.
- Together these automate the convention currently described in `CLAUDE.md` (newly added docblocks use `@since TBD`, which a maintainer manually rewrites at release time).

## How it fits the release flow
1. Feature work merges into the active release branch (e.g. `release/M26.gardevoir`) with `@since TBD` markers as usual.
2. When the sprint is feature-complete, dispatch `replace-since-tbd.yml` with the target version; it opens a PR back into the release branch with the substitutions.
3. If QA-cycle fixes introduce new `@since TBD` markers, re-run the workflow — it's idempotent.
4. The PR from the release branch into `master` triggers `guard-since-tbd.yml`, which fails if any `@since TBD` slipped through.

## Design notes for reviewers
- **`replace` is gated to release branches only** (`if: startsWith(github.ref, 'refs/heads/release/')`) so it can't be misfired against `master`.
- **`peter-evans/create-pull-request@v6`** is the standard community action for "workflow opens a PR" patterns. If the team prefers no third-party actions, I can swap it for a raw `git push` + `gh pr create` flow using `GITHUB_TOKEN`.
- **Exclusion list is duplicated** between the two workflows (`vendor/`, `vendor-prefixed/`, `node_modules/`, `dist/`, `build/`). Comments in each file note that the two need to stay in sync; could be factored into a reusable workflow later if it grows.
- **PHP-only for now.** `@since TBD` shows up in JSDoc too — happy to extend the scope if the team wants, but starting with PHP keeps the blast radius small.
- **No auto-trigger.** The replace workflow is `workflow_dispatch` only; a follow-up could fire it on the version-bump commit if reviewers prefer.

## Test plan
- [ ] Dispatch `replace-since-tbd.yml` on this branch with a placeholder version, confirm it opens a PR with the expected substitutions and excludes `vendor*` / build dirs.
- [ ] Open a test PR into `master` with a known `@since TBD`, confirm `guard-since-tbd.yml` fails with a clear error annotation pointing to the file/line.
- [ ] Open a test PR into `master` with no TBDs, confirm `guard-since-tbd.yml` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)