### PR TITLE
[DTM] Added Design_Tokens_Provider

### DIFF
--- a/includes/resources/App.php
+++ b/includes/resources/App.php
@@ -8,6 +8,7 @@ use KadenceWP\KadenceBlocks\Admin\Admin_Provider;
 use KadenceWP\KadenceBlocks\Asset\Asset_Provider;
 use KadenceWP\KadenceBlocks\Cache\Cache_Provider;
 use KadenceWP\KadenceBlocks\Database\Database_Provider;
+use KadenceWP\KadenceBlocks\Design_Tokens\Design_Tokens_Provider;
 use KadenceWP\KadenceBlocks\Health\Health_Provider;
 use KadenceWP\KadenceBlocks\Image_Downloader\Image_Downloader_Provider;
 use KadenceWP\KadenceBlocks\Log\Log_Provider;
@@ -50,6 +51,7 @@ final class App {
 		Image_Downloader_Provider::class,
 		Optimizer_Provider::class,
 		Cache_Provider::class,
+		Design_Tokens_Provider::class,
 		Shutdown_Provider::class,
 	];
 

--- a/includes/resources/Design_Tokens/Design_Tokens_Provider.php
+++ b/includes/resources/Design_Tokens/Design_Tokens_Provider.php
@@ -1,0 +1,18 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens;
+
+use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider;
+
+/**
+ * Registers the Design Tokens system bindings and hooks.
+ */
+final class Design_Tokens_Provider extends Provider {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function register(): void {
+		// Bindings and hooks will be registered here in a follow-up.
+	}
+}


### PR DESCRIPTION
🎫 [SOFT-3374](https://linear.app/nexcess/issue/SOFT-3374/module-scaffold-design-tokens-provider)

Adds the `Design_Tokens_Provider` service provider, breaking ground on the Design Tokens Module (DTM).