### PR TITLE
Add snapshot test suite for DTCG documents

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,6 +119,9 @@ jobs:
             - name: Run acceptance tests
               run: ${SLIC_BIN} run acceptance --ext DotReporter
 
+            - name: Run snapshot tests
+              run: ${SLIC_BIN} run snapshot --ext DotReporter
+
             - name: Upload codeception output
               if: ${{ failure() }}
               uses: actions/upload-artifact@v6

--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,7 @@
 		"codeception/module-webdriver": "^1.4.1",
 		"codeception/util-universalframework": "^1.0",
 		"lucatume/wp-browser": "<3.5",
+		"lucatume/wp-snaphot-assertions": "^2",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"sabberworm/php-css-parser": "^8.4",
 		"stellarwp/coding-standards": "^2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b363a563784ab73a27482ad263c7374",
+    "content-hash": "bd33426c830436a593d92d6087b577c5",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -4948,6 +4948,53 @@
             "time": "2021-04-17T13:49:01+00:00"
         },
         {
+            "name": "electrolinux/phpquery",
+            "version": "0.9.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/electrolinux/phpquery.git",
+                "reference": "90029e2acffebebdb6e309509c778fe34e8028ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/electrolinux/phpquery/zipball/90029e2acffebebdb6e309509c778fe34e8028ba",
+                "reference": "90029e2acffebebdb6e309509c778fe34e8028ba",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "phpQuery/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "didier Belot",
+                    "homepage": "https://github.com/electrolinux/phpquery",
+                    "role": "Packager, maintainer"
+                },
+                {
+                    "name": "Tobiasz Cudnik",
+                    "email": "tobiasz.cudnik@gmail.com",
+                    "homepage": "https://github.com/TobiaszCudnik",
+                    "role": "Developer"
+                }
+            ],
+            "description": "phpQuery is a server-side, chainable, CSS3 selector driven Document Object Model (DOM) API based on jQuery JavaScript Library",
+            "homepage": "http://code.google.com/p/phpquery/",
+            "support": {
+                "source": "https://github.com/electrolinux/phpquery/tree/0.9.7"
+            },
+            "time": "2023-05-02T18:27:16+00:00"
+        },
+        {
             "name": "gettext/gettext",
             "version": "v4.8.12",
             "source": {
@@ -5881,6 +5928,55 @@
                 }
             ],
             "time": "2024-01-08T08:27:20+00:00"
+        },
+        {
+            "name": "lucatume/wp-snaphot-assertions",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lucatume/wp-snapshot-assertions.git",
+                "reference": "f4b3999eef1fb252eb660df2f6cb736f75500e93"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lucatume/wp-snapshot-assertions/zipball/f4b3999eef1fb252eb660df2f6cb736f75500e93",
+                "reference": "f4b3999eef1fb252eb660df2f6cb736f75500e93",
+                "shasum": ""
+            },
+            "require": {
+                "electrolinux/phpquery": "^0.9.6",
+                "ext-dom": "*",
+                "php": "^7.3|^7.4|^8.0",
+                "spatie/phpunit-snapshot-assertions": "^4.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "tad\\WP\\Snapshots\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "theAverageDev (Luca Tumedei)",
+                    "email": "luca@theaveragedev.com"
+                }
+            ],
+            "description": "A set of utilities to support snapshot testing of WordPress code.",
+            "homepage": "https://github.com/lucatume/wp-snaphot-assertions",
+            "keywords": [
+                "snapshot",
+                "testing",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/lucatume/wp-snapshot-assertions/issues",
+                "source": "https://github.com/lucatume/wp-snapshot-assertions/tree/2.0.0"
+            },
+            "time": "2022-10-14T10:40:10+00:00"
         },
         {
             "name": "marc-mabe/php-enum",
@@ -9155,6 +9251,74 @@
             "time": "2025-09-13T08:53:30+00:00"
         },
         {
+            "name": "spatie/phpunit-snapshot-assertions",
+            "version": "4.2.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/phpunit-snapshot-assertions.git",
+                "reference": "29a03a81f4c289e4769d4f4a010432cbef6ce39d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/phpunit-snapshot-assertions/zipball/29a03a81f4c289e4769d4f4a010432cbef6ce39d",
+                "reference": "29a03a81f4c289e4769d4f4a010432cbef6ce39d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.0",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "php": "^7.3|^7.4|^8.0",
+                "phpunit/phpunit": "^8.3|^9.0",
+                "symfony/property-access": "^4.0|^5.0|^6.0|^7.0",
+                "symfony/serializer": "^4.0|^5.0|^6.0|^7.0",
+                "symfony/yaml": "^4.0|^5.0|^6.0|^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Snapshots\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian De Deyne",
+                    "email": "sebastian@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Snapshot testing with PHPUnit",
+            "homepage": "https://github.com/spatie/phpunit-snapshot-assertions",
+            "keywords": [
+                "assert",
+                "phpunit",
+                "phpunit-snapshot-assertions",
+                "snapshot",
+                "spatie",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/phpunit-snapshot-assertions/issues",
+                "source": "https://github.com/spatie/phpunit-snapshot-assertions/tree/4.2.17"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                }
+            ],
+            "time": "2024-05-03T07:52:41+00:00"
+        },
+        {
             "name": "squizlabs/php_codesniffer",
             "version": "3.13.5",
             "source": {
@@ -9989,6 +10153,281 @@
                 }
             ],
             "time": "2026-04-10T18:47:49+00:00"
+        },
+        {
+            "name": "symfony/property-access",
+            "version": "v5.4.45",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-access.git",
+                "reference": "111e7ed617509f1a9139686055d234aad6e388e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/111e7ed617509f1a9139686055d234aad6e388e0",
+                "reference": "111e7ed617509f1a9139686055d234aad6e388e0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/property-info": "^5.2|^6.0"
+            },
+            "require-dev": {
+                "symfony/cache": "^4.4|^5.0|^6.0"
+            },
+            "suggest": {
+                "psr/cache-implementation": "To cache access methods."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyAccess\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides functions to read and write from/to an object or array using a simple string notation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "access",
+                "array",
+                "extraction",
+                "index",
+                "injection",
+                "object",
+                "property",
+                "property-path",
+                "reflection"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-access/tree/v5.4.45"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:11:13+00:00"
+        },
+        {
+            "name": "symfony/property-info",
+            "version": "v5.4.48",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-info.git",
+                "reference": "a0396295ad585f95fccd690bc6a281e5bd303902"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/a0396295ad585f95fccd690bc6a281e5bd303902",
+                "reference": "a0396295ad585f95fccd690bc6a281e5bd303902",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/string": "^5.1|^6.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<3.2.2",
+                "phpdocumentor/type-resolver": "<1.4.0",
+                "symfony/dependency-injection": "<4.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.10.4|^2",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+                "phpstan/phpdoc-parser": "^1.0|^2.0",
+                "symfony/cache": "^4.4|^5.0|^6.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/serializer": "^4.4|^5.0|^6.0"
+            },
+            "suggest": {
+                "phpdocumentor/reflection-docblock": "To use the PHPDoc",
+                "psr/cache-implementation": "To cache results",
+                "symfony/doctrine-bridge": "To use Doctrine metadata",
+                "symfony/serializer": "To use Serializer metadata"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts information about PHP class' properties using metadata of popular sources",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "doctrine",
+                "phpdoc",
+                "property",
+                "symfony",
+                "type",
+                "validator"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-info/tree/v5.4.48"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-25T16:14:41+00:00"
+        },
+        {
+            "name": "symfony/serializer",
+            "version": "v5.4.45",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/serializer.git",
+                "reference": "460c5df9fb6c39d10d5b7f386e4feae4b6370221"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/460c5df9fb6c39d10d5b7f386e4feae4b6370221",
+                "reference": "460c5df9fb6c39d10d5b7f386e4feae4b6370221",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "conflict": {
+                "doctrine/annotations": "<1.12",
+                "phpdocumentor/reflection-docblock": "<3.2.2",
+                "phpdocumentor/type-resolver": "<1.4.0",
+                "symfony/dependency-injection": "<4.4",
+                "symfony/property-access": "<5.4",
+                "symfony/property-info": "<5.4.24|>=6,<6.2.11",
+                "symfony/uid": "<5.3",
+                "symfony/yaml": "<4.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.12|^2",
+                "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",
+                "symfony/cache": "^4.4|^5.0|^6.0",
+                "symfony/config": "^4.4|^5.0|^6.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/error-handler": "^4.4|^5.0|^6.0",
+                "symfony/filesystem": "^4.4|^5.0|^6.0",
+                "symfony/form": "^4.4|^5.0|^6.0",
+                "symfony/http-foundation": "^4.4|^5.0|^6.0",
+                "symfony/http-kernel": "^4.4|^5.0|^6.0",
+                "symfony/mime": "^4.4|^5.0|^6.0",
+                "symfony/property-access": "^5.4.26|^6.3",
+                "symfony/property-info": "^5.4.24|^6.2.11",
+                "symfony/uid": "^5.3|^6.0",
+                "symfony/validator": "^4.4|^5.0|^6.0",
+                "symfony/var-dumper": "^4.4|^5.0|^6.0",
+                "symfony/var-exporter": "^4.4|^5.0|^6.0",
+                "symfony/yaml": "^4.4|^5.0|^6.0"
+            },
+            "suggest": {
+                "psr/cache-implementation": "For using the metadata cache.",
+                "symfony/config": "For using the XML mapping loader.",
+                "symfony/mime": "For using a MIME type guesser within the DataUriNormalizer.",
+                "symfony/property-access": "For using the ObjectNormalizer.",
+                "symfony/property-info": "To deserialize relations.",
+                "symfony/var-exporter": "For using the metadata compiler.",
+                "symfony/yaml": "For using the default YAML mapping loader."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Serializer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/serializer/tree/v5.4.45"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:11:13+00:00"
         },
         {
             "name": "symfony/translation",

--- a/tests/_support/Classes/SnapshotTestCase.php
+++ b/tests/_support/Classes/SnapshotTestCase.php
@@ -1,0 +1,99 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\Support\Classes;
+
+use Codeception\TestCase\WPTestCase;
+use Spatie\Snapshots;
+use Spatie\Snapshots\MatchesSnapshots;
+
+/**
+ * Base test case for snapshot tests.
+ *
+ * Boots WordPress (via the `snapshot` Codeception suite) and asserts generated output
+ * against stored snapshots in sibling `__snapshots__/` directories. Run with
+ * `slic run snapshot --debug` to (re)generate snapshots.
+ */
+class SnapshotTestCase extends WPTestCase {
+
+	/*
+	 * Alias the trait's JSON assertion so the original implementation stays callable from
+	 * within our override below ( `parent::` cannot reach a trait method ).
+	 */
+	use MatchesSnapshots {
+		assertMatchesJsonSnapshot as protected spatieAssertMatchesJsonSnapshot;
+	}
+
+	/**
+	 * Assert that a value matches its stored JSON snapshot.
+	 *
+	 * Overrides Spatie\Snapshots\MatchesSnapshots::assertMatchesJsonSnapshot().
+	 *
+	 * The Spatie version expects a pre-serialized JSON string and its JSON driver
+	 * decodes then re-encodes both sides before comparing; that round-trip is
+	 * lossy -- e.g. an empty object {} is normalized to an empty array [] -- which
+	 * fails an otherwise-identical document.
+	 *
+	 * For a non-string value this version encodes it to JSON once with
+	 * JSON_PRETTY_PRINT and compares it as text, so structures like {} are preserved
+	 * exactly. A string is assumed to be already-serialized JSON and is passed through to
+	 * Spatie's original implementation ( via the aliased spatieAssertMatchesJsonSnapshot() ).
+	 *
+	 * @param mixed $data Data to snapshot. Non-strings are JSON-encoded; a string is
+	 *                    treated as pre-serialized JSON and handled by Spatie.
+	 *
+	 * @return void
+	 */
+	protected function assertMatchesJsonSnapshot( $data ): void {
+		if ( is_string( $data ) ) {
+			$this->spatieAssertMatchesJsonSnapshot( $data );
+
+			return;
+		}
+
+		$this->assertMatchesSnapshot( wp_json_encode( $data, JSON_PRETTY_PRINT ) );
+	}
+
+	/**
+	 * Fails the test if the snapshot does not already exist.
+	 *
+	 * Useful in scenarios where you may be using a Data Provider to generate snapshots and
+	 * want to guard against a test silently passing because no snapshot was ever written.
+	 *
+	 * @param Snapshots\Driver|null $driver Snapshot driver. Must match the Driver used when
+	 *                                      writing the snapshot for the correct file name to
+	 *                                      be checked. Defaults to TextDriver.
+	 *
+	 * @return void
+	 */
+	protected function assertSnapshotExists( ?Snapshots\Driver $driver = null ): void {
+		if ( ! $driver ) {
+			$driver = new Snapshots\Drivers\TextDriver();
+		}
+
+		/*
+		 * Increment the snapshot incrementor to ensure we are checking against the correct
+		 * file name.
+		 */
+		++$this->snapshotIncrementor;
+
+		$snapshot = Snapshots\Snapshot::forTestCase(
+			$this->getSnapshotId(),
+			$this->getSnapshotDirectory(),
+			$driver
+		);
+
+		/*
+		 * Decrement the snapshot incrementor so a snapshot can still be created with the
+		 * expected file name afterwards. We have to do this due to how we create a separate
+		 * Snapshot object above.
+		 */
+		--$this->snapshotIncrementor;
+
+		if (
+			! $snapshot->exists()
+			&& ! $this->shouldUpdateSnapshots()
+		) {
+			$this->fail( 'A snapshot file does not exist for this test. Generate one with: slic run snapshot --debug' );
+		}
+	}
+}

--- a/tests/_support/Classes/SnapshotTestCase.php
+++ b/tests/_support/Classes/SnapshotTestCase.php
@@ -43,7 +43,7 @@ class SnapshotTestCase extends WPTestCase {
 	 *
 	 * @return void
 	 */
-	protected function assertMatchesJsonSnapshot( $data ): void {
+	public function assertMatchesJsonSnapshot( $data ): void {
 		if ( is_string( $data ) ) {
 			$this->spatieAssertMatchesJsonSnapshot( $data );
 

--- a/tests/_support/Helper/Snapshot.php
+++ b/tests/_support/Helper/Snapshot.php
@@ -1,0 +1,10 @@
+<?php
+namespace Helper;
+
+// here you can define custom actions
+// all public methods declared in helper class will be available in $I
+
+class Snapshot extends \Codeception\Module
+{
+
+}

--- a/tests/_support/SnapshotTester.php
+++ b/tests/_support/SnapshotTester.php
@@ -1,0 +1,22 @@
+<?php
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method void pause()
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class SnapshotTester extends \Codeception\Actor
+{
+    use _generated\SnapshotTesterActions;
+}

--- a/tests/snapshot.suite.yml
+++ b/tests/snapshot.suite.yml
@@ -1,0 +1,24 @@
+# Codeception Test Suite Configuration
+
+# Suite for WordPress snapshot tests.
+# Boots WordPress via WPLoader and asserts generated output against stored snapshots.
+class_name: SnapshotTester
+bootstrap: _bootstrap.php
+modules:
+    enabled: [WPLoader]
+    config:
+        WPLoader:
+            wpRootFolder: %WP_ROOT_FOLDER%
+            dbName: %WP_TEST_DB_NAME%
+            dbHost: %WP_TEST_DB_HOST%
+            dbUser: %WP_TEST_DB_USER%
+            dbPassword: %WP_TEST_DB_PASSWORD%
+            tablePrefix: test_
+            domain: %WP_DOMAIN%
+            adminEmail: admin@kadence.test
+            title: 'Kadence Blocks Snapshot Tests'
+            theme: twentytwentyfour
+            plugins:
+                - kadence-blocks/kadence-blocks.php
+            activatePlugins:
+                - kadence-blocks/kadence-blocks.php

--- a/tests/snapshot/_bootstrap.php
+++ b/tests/snapshot/_bootstrap.php
@@ -1,0 +1,12 @@
+<?php declare( strict_types=1 );
+
+/**
+ * Codeception regenerates snapshots on `--debug`, while the spatie/phpunit-snapshot-assertions
+ * library does the same on `--update-snapshots`. Codeception strictly validates its CLI
+ * arguments, so appending `--update-snapshots` to the `codecept run` command directly would
+ * throw an error. We translate the intent here: when running with `--debug`, also tell spatie
+ * to update snapshots.
+ */
+if ( in_array( '--debug', $_SERVER['argv'], true ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+	$_SERVER['argv'][] = '--update-snapshots';
+}


### PR DESCRIPTION
## Summary

Stands up a dedicated Codeception **`snapshot`** test suite so that snapshot tests can be written for generated DTCG (Design Tokens Community Group) documents as part of the Kadence AI -> Design System project.

This PR is **infrastructure only** -- no DTCG generation code exists in the repo yet, so no DTCG/example tests are included. Real snapshot tests get added once the generator lands.

## What's included

- **Dependency**: adds dev dependency `lucatume/wp-snaphot-assertions:^2` (a wp-browser/Codeception adapter around `spatie/phpunit-snapshot-assertions`). Resolves cleanly against the existing `lucatume/wp-browser:<3.5` constraint. Dev-only, so Strauss does not prefix it.
- **Suite config**: `tests/snapshot.suite.yml` (boots WordPress via `WPLoader`, actor `SnapshotTester`, theme `twentytwentyfour`).
- **Bootstrap glue**: `tests/snapshot/_bootstrap.php` translates Codeception's `--debug` into spatie's `--update-snapshots`, so `slic run snapshot --debug` (re)generates snapshots.
- **Actor + helper**: `tests/_support/SnapshotTester.php` and `tests/_support/Helper/Snapshot.php`.
- **Base class**: `Tests\Support\Classes\SnapshotTestCase` using `Spatie\Snapshots\MatchesSnapshots`, with:
  - A documented `assertMatchesJsonSnapshot()` override. Spatie's built-in version decodes then re-encodes JSON before comparing, and that round-trip is lossy -- e.g. an empty object `{}` gets normalized to an empty array `[]`, failing an otherwise-identical document. Our override encodes the value to JSON once with `JSON_PRETTY_PRINT` and compares it as text (so `{}` stays `{}`), producing stable, diff-friendly `.txt` golden files. A pre-serialized JSON **string** is passed straight through to Spatie's original (kept callable via a trait alias, since `parent::` cannot reach a trait method).
  - An `assertSnapshotExists()` helper (ported from sfwd-lms) to guard data-provider-driven tests against silently passing when no snapshot was ever written.
- **CI**: adds a `Run snapshot tests` step to `.github/workflows/tests.yml`.

## Verification

Ran locally via slic against a throwaway test (removed before commit):

- `slic run snapshot --debug` -> created the snapshot; confirmed `{}` is preserved (not coerced to `[]`).
- `slic run snapshot` -> matched the stored snapshot (OK, 1 test, 1 assertion).
- Empty suite (after removing the throwaway test) -> `No tests executed!`, exit 0, so the new CI step is green until real tests are added.

## How a future DTCG snapshot test will look

```php
namespace Tests\snapshot;

use Tests\Support\Classes\SnapshotTestCase;

class DtcgDocumentTest extends SnapshotTestCase {
    public function test_generated_dtcg_document(): void {
        $document = /* generator output as an array */;
        $this->assertMatchesJsonSnapshot( $document );
    }
}
```