### PR TITLE
Set up PHPStan static analysis

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -34,3 +34,7 @@ codeception.slic.yml
 .wordpress-org/
 .npmrc
 bunfig.toml
+.phpstan/
+phpstan-baseline.neon
+phpstan-cache/
+phpstan.neon

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,59 @@
+name: Run PHPStan on pull requests
+on: pull_request
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+    env:
+        COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 # fetch all history.
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+          tools: composer
+
+      - name: Configure Composer Auth
+        run: composer config --global github-oauth.github.com ${{ secrets.GH_BOT_TOKEN }}
+
+      - name: Cache Dependencies
+        id: deps-cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            vendor
+            vendor/vendor-prefixed
+          key: v1-deps-${{ runner.os }}-${{ github.ref_name }}-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            v1-deps-${{ runner.os }}-${{ github.ref_name }}-
+            v1-deps-${{ runner.os }}-
+
+      - name: Composer Install
+        if: steps.deps-cache.outputs.cache-hit != 'true'
+        run: composer install --no-progress --no-interaction --ignore-platform-reqs
+
+      - name: Restore PHPStan cache
+        uses: actions/cache/restore@v5
+        with:
+          path: phpstan-cache
+          key: v1-phpstan-${{ runner.os }}-${{ github.ref_name }}-${{ github.run_id }}
+          restore-keys: |
+            v1-phpstan-${{ runner.os }}-${{ github.ref_name }}-
+            v1-phpstan-${{ runner.os }}-
+            v1-phpstan-
+
+      - name: Run PHPStan
+        run: composer phpstan
+
+      - name: Save PHPStan cache
+        uses: actions/cache/save@v5
+        if: ${{ !cancelled() }}
+        with:
+          path: phpstan-cache
+          key: v1-phpstan-${{ runner.os }}-${{ github.ref_name }}-${{ github.run_id }}

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,13 +1,19 @@
 name: Run PHPStan on pull requests
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - '**.php'
+      - 'composer.lock'
+      - 'phpstan.neon'
+      - 'phpstan-baseline.neon'
+      - '.phpstan/**'
+      - '.github/workflows/phpstan.yml'
 jobs:
   phpstan:
     runs-on: ubuntu-latest
-    env:
-        COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # fetch all history.

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ bin/wp-cli.phar
 # Remove this when fully transitioning to bun.
 /bun.lock*
 /.kadence-packages-root
+phpstan-cache/

--- a/.phpstan/phpstan-stubs.php
+++ b/.phpstan/phpstan-stubs.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * PHPStan stubs for constants defined at runtime.
+ */
+
+// Defined in kadence-blocks.php.
+define( 'KADENCE_BLOCKS_PATH', '' );
+define( 'KADENCE_BLOCKS_URL', '' );
+define( 'KADENCE_BLOCKS_VERSION', '' );
+define( 'KADENCE_BLOCKS_PLUGIN_BASENAME', '' );

--- a/.phpstan/phpstan-wp-polyfills.php
+++ b/.phpstan/phpstan-wp-polyfills.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * PHPStan stubs for WordPress polyfills (wp-includes/compat.php).
+ *
+ * These are not included in php-stubs/wordpress-stubs.
+ *
+ * @link https://github.com/php-stubs/wordpress-stubs/issues/100
+ */
+
+function str_contains( string $haystack, string $needle ): bool {}
+
+function str_starts_with( string $haystack, string $needle ): bool {}
+
+function str_ends_with( string $haystack, string $needle ): bool {}

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
 		},
 		"allow-plugins": {
 			"composer/installers": true,
-			"dealerdirect/phpcodesniffer-composer-installer": true
+			"dealerdirect/phpcodesniffer-composer-installer": true,
+			"phpstan/extension-installer": true
 		}
 	},
 	"repositories": [
@@ -63,8 +64,10 @@
 		"codeception/util-universalframework": "^1.0",
 		"lucatume/wp-browser": "<3.5",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
+		"phpstan/extension-installer": "^1.4",
 		"sabberworm/php-css-parser": "^8.4",
-		"stellarwp/coding-standards": "^2.0"
+		"stellarwp/coding-standards": "^2.0",
+		"szepeviktor/phpstan-wordpress": "^1.3"
 	},
 	"autoload": {
 		"psr-4": {
@@ -129,7 +132,9 @@
 			"@compatibility:php-8.3",
 			"@compatibility:php-8.4"
 		],
-		"phpcs": "phpcs --standard=phpcs.xml"
+		"phpcs": "phpcs --standard=phpcs.xml",
+		"phpstan": "./vendor/bin/phpstan analyse --memory-limit=4096M",
+		"phpstan-baseline": "./vendor/bin/phpstan analyse --memory-limit=4096M --level max --configuration phpstan.neon --generate-baseline"
 	},
 	"extra": {
 		"strauss": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "edf1e462b2afc3092ef8d99e886c3ce8",
+    "content-hash": "cf594043d6cfad2b704f3d18481b41d9",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -6587,6 +6587,58 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v6.9.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/90a9412826b9944f93b10bf41d795b5fe68abcd5",
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5",
+                "shasum": ""
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "5.6.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "nikic/php-parser": "^5.5",
+                "php": "^7.4 || ^8.0",
+                "php-stubs/generator": "^0.8.6",
+                "phpdocumentor/reflection-docblock": "^6.0",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^9.5",
+                "symfony/polyfill-php80": "*",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+                "symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wordpress-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.4"
+            },
+            "time": "2026-05-01T20:36:01+00:00"
+        },
+        {
             "name": "php-webdriver/webdriver",
             "version": "1.16.0",
             "source": {
@@ -7041,6 +7093,54 @@
             "time": "2025-12-08T14:27:58+00:00"
         },
         {
+            "name": "phpstan/extension-installer",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/85e90b3942d06b2326fba0403ec24fe912372936",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.9.0 || ^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12 || ^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.4.3"
+            },
+            "time": "2024-09-04T20:21:43+00:00"
+        },
+        {
             "name": "phpstan/phpdoc-parser",
             "version": "2.3.2",
             "source": {
@@ -7086,6 +7186,59 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
             "time": "2026-01-25T14:56:51+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.12.33",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "reference": "37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-28T20:30:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -10161,6 +10314,69 @@
                 }
             ],
             "time": "2024-09-25T14:11:13+00:00"
+        },
+        {
+            "name": "szepeviktor/phpstan-wordpress",
+            "version": "v1.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
+                "reference": "7f8cfe992faa96b6a33bbd75c7bace98864161e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/7f8cfe992faa96b6a33bbd75c7bace98864161e7",
+                "reference": "7f8cfe992faa96b6a33bbd75c7bace98864161e7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0",
+                "phpstan/phpstan": "^1.10.31",
+                "symfony/polyfill-php73": "^1.12.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.1.14",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.2",
+                "phpunit/phpunit": "^8.0 || ^9.0",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.0",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "swissspidy/phpstan-no-private": "Detect usage of internal core functions, classes and methods"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SzepeViktor\\PHPStan\\WordPress\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress extensions for PHPStan",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v1.3.5"
+            },
+            "time": "2024-06-28T22:27:19+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/includes/blocks/class-kadence-blocks-posts-block.php
+++ b/includes/blocks/class-kadence-blocks-posts-block.php
@@ -194,7 +194,7 @@ class Kadence_Blocks_Posts_Block extends Kadence_Blocks_Abstract_Block {
 		}
 		// Add custom CSS classes to class string.
 		if ( isset( $attributes['className'] ) ) {
-			$classes[] .= ' ' . $attributes['className'];
+			$classes[] = $attributes['className'];
 		}
 		$classes = apply_filters( 'kadence_blocks_posts_container_classes', $classes );
 		do_action( 'kadence_blocks_posts_before_query', $attributes );

--- a/includes/class-kadence-blocks-prebuilt-library.php
+++ b/includes/class-kadence-blocks-prebuilt-library.php
@@ -321,7 +321,7 @@ class Kadence_Blocks_Prebuilt_Library {
 					} else {
 						$expires_add = MONTH_IN_SECONDS;
 					}
-					$cloud_settings['connections'][ $this->package ]['expires'] = gmdate( 'Y-m-d H:i:s', strtotime( current_time() ) + $expires_add );
+					$cloud_settings['connections'][ $this->package ]['expires'] = gmdate( 'Y-m-d H:i:s', strtotime( current_time( 'Y-m-d H:i:s' ) ) + $expires_add );
 					update_option( 'kadence_blocks_cloud', json_encode( $cloud_settings ) );
 					if ( $this->create_template_data_file( true ) ) {
 						return $this->get_local_template_data_contents();

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12276,6 +12276,11 @@ parameters:
 			path: includes/resources/Database/Database_Provider.php
 
 		-
+			message: "#^Offset 'is_premium' does not exist on array\\{name\\: string, page_url\\: string\\}\\.$#"
+			count: 1
+			path: includes/resources/Harbor/Actions/Get_Known_Plugins.php
+
+		-
 			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Harbor\\\\Actions\\\\Report_Legacy_Licenses\\:\\:__invoke\\(\\) has parameter \\$licenses with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: includes/resources/Harbor/Actions/Report_Legacy_Licenses.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2441,6 +2441,11 @@ parameters:
 			path: includes/blocks/class-kadence-blocks-googlemaps-block.php
 
 		-
+			message: "#^Method Kadence_Blocks_Googlemaps_Block\\:\\:sanitize_custom_snazzy_styles\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-googlemaps-block.php
+
+		-
 			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Googlemaps_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
 			count: 1
 			path: includes/blocks/class-kadence-blocks-googlemaps-block.php
@@ -7391,6 +7396,11 @@ parameters:
 			path: includes/class-kadence-blocks-ai-events.php
 
 		-
+			message: "#^Parameter \\#2 \\$args of function wp_remote_post expects array\\{method\\?\\: string, timeout\\?\\: float, redirection\\?\\: int, httpversion\\?\\: string, user\\-agent\\?\\: string, reject_unsafe_urls\\?\\: bool, blocking\\?\\: bool, headers\\?\\: array\\|string, \\.\\.\\.\\}, array\\{timeout\\: 20, blocking\\: false, headers\\: array\\{X\\-Prophecy\\-Token\\: string, Content\\-Type\\: 'application/json'\\}, body\\: non\\-empty\\-string\\|false\\} given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
 			message: "#^Parameter \\#2 \\$id_or_name of method Kadence_Blocks_AI_Events\\:\\:build_collection_updated_event_data\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: includes/class-kadence-blocks-ai-events.php
@@ -7602,6 +7612,16 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Parameter \\#1 \\$postarr of function wp_update_post expects array\\{ID\\?\\: int, post_author\\?\\: int, post_date\\?\\: string, post_date_gmt\\?\\: string, post_content\\?\\: string, post_content_filtered\\?\\: string, post_title\\?\\: string, post_excerpt\\?\\: string, \\.\\.\\.\\}, array\\{ID\\: int\\<1, max\\>, post_content\\: array\\|string\\} given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Parameter \\#1 \\$postarr of function wp_update_post expects array\\{ID\\?\\: int, post_author\\?\\: int, post_date\\?\\: string, post_date_gmt\\?\\: string, post_content\\?\\: string, post_content_filtered\\?\\: string, post_title\\?\\: string, post_excerpt\\?\\: string, \\.\\.\\.\\}, array\\{ID\\: mixed, post_content\\: array\\|string\\} given\\.$#"
 			count: 1
 			path: includes/class-kadence-blocks-cpt-import-export.php
 
@@ -8831,6 +8851,11 @@ parameters:
 			path: includes/class-kadence-blocks-duplicate-post.php
 
 		-
+			message: "#^Parameter \\#1 \\$post of function get_post expects int\\|WP_Post\\|null, int\\|string given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
 			message: "#^Parameter \\#1 \\$post of method Kadence_Blocks_Duplicate_Post\\:\\:duplicate\\(\\) expects POST, WP_Post given\\.$#"
 			count: 1
 			path: includes/class-kadence-blocks-duplicate-post.php
@@ -8842,6 +8867,16 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$post of method Kadence_Blocks_Duplicate_Post\\:\\:recursive_duplicate\\(\\) expects WP_Post, POST given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_html expects string, int\\|string given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function wp_slash expects array\\|string, mixed given\\.$#"
 			count: 1
 			path: includes/class-kadence-blocks-duplicate-post.php
 
@@ -9343,6 +9378,11 @@ parameters:
 		-
 			message: "#^Method Kadence_Blocks_Image_Picker_REST_Controller\\:\\:sanitize_image_sizes_array\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
+			path: includes/class-kadence-blocks-image-picker-rest.php
+
+		-
+			message: "#^Parameter \\#1 \\$maybeint of function absint expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 2
 			path: includes/class-kadence-blocks-image-picker-rest.php
 
 		-
@@ -10161,13 +10201,13 @@ parameters:
 			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
 
 		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, array\\<int, string\\>\\|string given\\.$#"
-			count: 1
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
+			count: 3
 			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
 
 		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
-			count: 3
+			message: "#^Parameter \\#1 \\$maybeint of function absint expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 2
 			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
 
 		-
@@ -10228,6 +10268,11 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$args of function wp_safe_remote_get expects array\\{method\\?\\: string, timeout\\?\\: float, redirection\\?\\: int, httpversion\\?\\: string, user\\-agent\\?\\: string, reject_unsafe_urls\\?\\: bool, blocking\\?\\: bool, headers\\?\\: array\\|string, \\.\\.\\.\\}, array\\{timeout\\: '60', sslverify\\: false\\} given\\.$#"
 			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|false given\\.$#"
+			count: 2
 			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
 
 		-
@@ -10497,7 +10542,7 @@ parameters:
 
 		-
 			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:get_template_data\\(\\) should return string but returns string\\|false\\.$#"
-			count: 3
+			count: 4
 			path: includes/class-kadence-blocks-prebuilt-library.php
 
 		-
@@ -11416,7 +11461,7 @@ parameters:
 			path: includes/form-ajax.php
 
 		-
-			message: "#^Cannot access offset mixed on mixed\\.$#"
+			message: "#^Cannot access offset int\\<0, max\\> on mixed\\.$#"
 			count: 1
 			path: includes/form-ajax.php
 
@@ -12316,16 +12361,6 @@ parameters:
 			path: includes/resources/Image_Downloader/Cache_Primer.php
 
 		-
-			message: "#^Call to an undefined method Throwable\\:\\:getMessage\\(\\)\\.$#"
-			count: 1
-			path: includes/resources/Image_Downloader/Image_Downloader.php
-
-		-
-			message: "#^Call to an undefined method Throwable\\:\\:getTraceAsString\\(\\)\\.$#"
-			count: 1
-			path: includes/resources/Image_Downloader/Image_Downloader.php
-
-		-
 			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Image_Downloader\\\\Image_Downloader\\:\\:get_existing_images\\(\\) should return array\\<array\\{id\\: int, url\\: string\\}\\> but returns non\\-empty\\-array\\<int\\<0, max\\>, array\\{id\\: false, url\\: string\\|false\\}\\>\\.$#"
 			count: 1
 			path: includes/resources/Image_Downloader/Image_Downloader.php
@@ -12464,16 +12499,6 @@ parameters:
 			message: "#^PHPDoc tag @return with type mixed is not subtype of native type array\\.$#"
 			count: 1
 			path: includes/resources/Optimizer/Analysis_Registry.php
-
-		-
-			message: "#^Call to an undefined method Throwable\\:\\:getMessage\\(\\)\\.$#"
-			count: 1
-			path: includes/resources/Optimizer/Database/Optimizer_Table.php
-
-		-
-			message: "#^Call to an undefined method Throwable\\:\\:getMessage\\(\\)\\.$#"
-			count: 1
-			path: includes/resources/Optimizer/Database/Viewport_Hash_Table.php
 
 		-
 			message: "#^PHPDoc type array\\<string\\> of property KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Database\\\\Viewport_Hash_Table\\:\\:\\$uid_column is not covariant with PHPDoc type string of overridden property KadenceWP\\\\KadenceBlocks\\\\StellarWP\\\\Schema\\\\Tables\\\\Contracts\\\\Table\\:\\:\\$uid_column\\.$#"
@@ -12641,9 +12666,19 @@ parameters:
 			path: includes/resources/Optimizer/Post_List_Table/Renderers/Optimizer_Renderer.php
 
 		-
+			message: "#^Parameter \\#1 \\$value of function trailingslashit expects string, string\\|false given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Post_List_Table/Renderers/Optimizer_Renderer.php
+
+		-
 			message: "#^is_wp_error\\(string\\) will always evaluate to false\\.$#"
 			count: 1
 			path: includes/resources/Optimizer/Post_List_Table/Renderers/Optimizer_Renderer.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function trailingslashit expects string, string\\|false given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Post_List_Table/Row_Action.php
 
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
@@ -12856,6 +12891,11 @@ parameters:
 			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
 
 		-
+			message: "#^Parameter \\#1 \\$value of function trailingslashit expects string, string\\|false given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
+
+		-
 			message: "#^Parameter \\#2 \\$post_id of class KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Path\\\\Path constructor expects int\\|null, mixed given\\.$#"
 			count: 4
 			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
@@ -12879,6 +12919,11 @@ parameters:
 			message: "#^Cannot cast mixed to string\\.$#"
 			count: 1
 			path: includes/resources/Optimizer/State.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function trailingslashit expects string, string\\|false given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Status/Meta.php
 
 		-
 			message: "#^Property KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Status\\\\Meta\\:\\:\\$asset is never read, only written\\.$#"
@@ -13489,8 +13534,3 @@ parameters:
 			message: "#^Class Kadence_Blocks not found\\.$#"
 			count: 1
 			path: kadence-blocks.php
-
-		-
-			message: "#^Call to an undefined method Throwable\\:\\:getMessage\\(\\)\\.$#"
-			count: 1
-			path: uninstall.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,13496 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Method Kadence_ActiveCampaign_REST_Controller\\:\\:get_collection_params\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/activecampaign-rest-api.php
+
+		-
+			message: "#^Method Kadence_ActiveCampaign_REST_Controller\\:\\:get_items\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/activecampaign-rest-api.php
+
+		-
+			message: "#^Method Kadence_ActiveCampaign_REST_Controller\\:\\:get_items_permission_check\\(\\) should return WP_Error\\|true but returns bool\\.$#"
+			count: 1
+			path: includes/advanced-form/activecampaign-rest-api.php
+
+		-
+			message: "#^Method Kadence_ActiveCampaign_REST_Controller\\:\\:register_routes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/activecampaign-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$route_namespace of function register_rest_route expects non\\-falsy\\-string, string given\\.$#"
+			count: 1
+			path: includes/advanced-form/activecampaign-rest-api.php
+
+		-
+			message: "#^@param string \\$value does not accept actual type of parameter\\: mixed\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^@param string\\|null \\$buffer does not accept actual type of parameter\\: string\\|false\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Call to function is_array\\(\\) with string will always evaluate to false\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Call to function is_object\\(\\) with string will always evaluate to false\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:after_submit_actions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:after_submit_actions\\(\\) has parameter \\$form_args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:after_submit_actions\\(\\) has parameter \\$processed_fields with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:get_allowed_mimes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:get_allowed_mimes\\(\\) has parameter \\$categories with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:get_downloader_url\\(\\) has parameter \\$file_url with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:get_form\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:get_messages\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:get_messages\\(\\) has parameter \\$form_attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:html_from_notices\\(\\) has parameter \\$notices with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:override_upload_directory\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:override_upload_directory\\(\\) has parameter \\$file with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:process_ajax\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:process_bail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:process_bail\\(\\) has parameter \\$field_errors with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:process_fields\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:process_fields\\(\\) has parameter \\$fields with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:rearrange_array_files\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:rearrange_array_files\\(\\) has parameter \\$file_post with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:recursively_parse_blocks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:remove_set_custom_upload_directory\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:remove_set_custom_upload_directory\\(\\) has parameter \\$fileinfo with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:remove_set_custom_upload_directory\\(\\) has parameter \\$param with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:sanitize_field\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:sanitize_field\\(\\) has parameter \\$multi_select with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:send_json\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:send_json\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:set_custom_upload_directory\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:set_custom_upload_directory\\(\\) has parameter \\$param with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:set_custom_upload_unique_filename\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Advanced_Form\\:\\:start_buffer\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Offset 'blockName' on \\*NEVER\\* in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Offset 'innerBlocks' on \\*NEVER\\* in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Offset 0 does not exist on ''\\|array\\<int\\|string, array\\{blockName\\: string\\|null, attrs\\: array, innerBlocks\\: array\\<array\\>, innerHTML\\: string, innerContent\\: array\\}\\>\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$form_id$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Parameter \\#1 \\$block of method KB_Ajax_Advanced_Form\\:\\:recursively_parse_blocks\\(\\) expects string, array given\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Parameter \\#1 \\$data of function maybe_unserialize expects string, mixed given\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, mixed given\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Parameter \\#1 \\$post_id of method KB_Ajax_Advanced_Form\\:\\:get_form\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Parameter \\#1 \\$separator of function explode expects string, mixed given\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function sanitize_text_field expects string, mixed given\\.$#"
+			count: 3
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function sanitize_textarea_field expects string, mixed given\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function trim expects string, mixed given\\.$#"
+			count: 2
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Parameter \\#3 \\$post_id of method KB_Ajax_Advanced_Form\\:\\:after_submit_actions\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, mixed given\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Possibly invalid array key type \\(array\\<int, string\\>\\|string\\)\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Property KB_Ajax_Advanced_Form\\:\\:\\$captcha_attrs has no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Property KB_Ajax_Advanced_Form\\:\\:\\$fields has no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Property KB_Ajax_Advanced_Form\\:\\:\\$redirect has no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 2
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 5
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Static property KB_Ajax_Advanced_Form\\:\\:\\$instance \\(null\\) does not accept KB_Ajax_Advanced_Form\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-ajax.php
+
+		-
+			message: "#^Cannot access offset mixed on mixed\\.$#"
+			count: 2
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:__construct\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:get_captcha_language\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:get_captcha_language\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:get_captcha_service\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:get_captcha_service\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:get_kadence_captcha_stored_value\\(\\) has parameter \\$default with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:get_kadence_captcha_stored_value\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:get_notice_settings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:get_notice_settings\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:get_public_key\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:get_public_key\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:get_secret_key\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:get_secret_key\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:get_styles\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:get_styles\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:has_valid_settings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:is_using_kadence_blocks_settings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:is_using_kadence_blocks_settings\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:is_using_kadence_captcha_settings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Settings\\:\\:is_using_kadence_captcha_settings\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Property Kadence_Blocks_Form_Captcha_Settings\\:\\:\\$hideRecaptcha has no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Property Kadence_Blocks_Form_Captcha_Settings\\:\\:\\$language \\(bool\\|string\\) does not accept mixed\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Property Kadence_Blocks_Form_Captcha_Settings\\:\\:\\$pass_score has no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Property Kadence_Blocks_Form_Captcha_Settings\\:\\:\\$recaptchaNotice has no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Property Kadence_Blocks_Form_Captcha_Settings\\:\\:\\$showRecaptchaNotice has no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Property Kadence_Blocks_Form_Captcha_Settings\\:\\:\\$size has no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Property Kadence_Blocks_Form_Captcha_Settings\\:\\:\\$theme has no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Variable \\$option_key might not be defined\\.$#"
+			count: 4
+			path: includes/advanced-form/advanced-form-captcha-settings.php
+
+		-
+			message: "#^Call to function is_wp_error\\(\\) with string will always evaluate to false\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-verify.php
+
+		-
+			message: "#^Cannot access offset 'success' on mixed\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-verify.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Verify\\:\\:__construct\\(\\) has parameter \\$captcha_settings with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-verify.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Verify\\:\\:verify_generic\\(\\) should return bool but returns mixed\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-verify.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Verify\\:\\:verify_google\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-verify.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Verify\\:\\:verify_google\\(\\) has parameter \\$token with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-verify.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Verify\\:\\:verify_hcaptcha\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-verify.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Verify\\:\\:verify_hcaptcha\\(\\) has parameter \\$token with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-verify.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Verify\\:\\:verify_turnstile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-verify.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Captcha_Verify\\:\\:verify_turnstile\\(\\) has parameter \\$token with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-verify.php
+
+		-
+			message: "#^is_wp_error\\(string\\) will always evaluate to false\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-captcha-verify.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$post_type\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-cpt.php
+
+		-
+			message: "#^Array has 2 duplicate keys with value 'menu_name' \\('menu_name', 'menu_name'\\)\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-cpt.php
+
+		-
+			message: "#^Cannot access property \\$template on WP_Post_Type\\|null\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-cpt.php
+
+		-
+			message: "#^Cannot access property \\$template_lock on WP_Post_Type\\|null\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_CPT_Controller\\:\\:filter_post_type_columns\\(\\) has parameter \\$columns with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_CPT_Controller\\:\\:filter_post_type_columns\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_CPT_Controller\\:\\:filter_post_type_user_caps\\(\\) has parameter \\$allcaps with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_CPT_Controller\\:\\:filter_post_type_user_caps\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_CPT_Controller\\:\\:form_gutenberg_template\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_CPT_Controller\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_CPT_Controller\\:\\:meta_auth_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_CPT_Controller\\:\\:register_meta\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_CPT_Controller\\:\\:register_post_type\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_CPT_Controller\\:\\:render_post_type_column\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_CPT_Controller\\:\\:single_form_layout\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_CPT_Controller\\:\\:single_form_layout\\(\\) has parameter \\$layout with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-cpt.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_html expects string, mixed given\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-cpt.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Form_CPT_Controller\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Form_CPT_Controller\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-cpt.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between \\*NEVER\\* and 'object' will always evaluate to false\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-cpt.php
+
+		-
+			message: "#^Cannot access property \\$cap on WP_Post_Type\\|null\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_CPT_Rest_Controller\\:\\:register_routes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$route_namespace of function register_rest_route expects non\\-falsy\\-string, string given\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-rest-api.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$ID\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Call to an undefined method Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:process_bail\\(\\)\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:__construct\\(\\) has parameter \\$form_args with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:__construct\\(\\) has parameter \\$post_id with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:__construct\\(\\) has parameter \\$responses with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:do_field_replacements\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:email\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:fluentCRM\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:get_email_from_responses\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:get_email_from_responses\\(\\) has parameter \\$map with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:get_mapped_attributes_from_responses\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:get_mapped_attributes_from_responses\\(\\) has parameter \\$map with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:get_response_field_by_name\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:get_response_field_by_name\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:mailerlite\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:mailerlite_rest_call\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:mailerlite_rest_call\\(\\) has parameter \\$body with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Offset 'code' on array\\{code\\: int, message\\: string\\} in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Offset 'response' on array\\{headers\\: WpOrg\\\\Requests\\\\Utility\\\\CaseInsensitiveDictionary, body\\: string, response\\: array\\{code\\: int, message\\: string\\}, cookies\\: array\\<int, WP_Http_Cookie\\>, filename\\: string\\|null, http_response\\: WP_HTTP_Requests_Response\\} in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Offset 1 on array\\{array\\<int, string\\>, array\\<int, string\\>\\} in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$auto_map$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$map$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$no_email$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of method Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:do_field_replacements\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Parameter \\#1 \\$url of function url_to_postid expects string, string\\|false given\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Parameter \\#2 \\$args of function wp_remote_post expects array\\{method\\?\\: string, timeout\\?\\: float, redirection\\?\\: int, httpversion\\?\\: string, user\\-agent\\?\\: string, reject_unsafe_urls\\?\\: bool, blocking\\?\\: bool, headers\\?\\: array\\|string, \\.\\.\\.\\}, array\\{method\\: string, timeout\\: 10, headers\\: array\\{accept\\: 'application/json', content\\-type\\: 'application/json', X\\-MailerLite\\-ApiKey\\: mixed\\}, body\\: non\\-empty\\-string\\|false\\} given\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Parameter \\#2 \\$str of function explode expects string, array given\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Property Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:\\$form_args has no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Property Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:\\$post_id has no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Property Kadence_Blocks_Advanced_Form_Submit_Actions\\:\\:\\$responses has no type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Result of && is always true\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Result of \\|\\| is always false\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Variable \\$field_name in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Variable \\$group_id in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: includes/advanced-form/advanced-form-submit-actions.php
+
+		-
+			message: "#^Method Kadence_GetResponse_REST_Controller\\:\\:get_collection_params\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/getresponse-rest-api.php
+
+		-
+			message: "#^Method Kadence_GetResponse_REST_Controller\\:\\:get_items\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/advanced-form/getresponse-rest-api.php
+
+		-
+			message: "#^Method Kadence_GetResponse_REST_Controller\\:\\:register_routes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/advanced-form/getresponse-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$route_namespace of function register_rest_route expects non\\-falsy\\-string, string given\\.$#"
+			count: 1
+			path: includes/advanced-form/getresponse-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function rtrim expects string, mixed given\\.$#"
+			count: 1
+			path: includes/advanced-form/getresponse-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:add_block_to_post_generate_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:add_block_to_post_generate_css\\(\\) has parameter \\$block_class_array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:do_inline_styles\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:do_inline_styles\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:do_inline_styles\\(\\) has parameter \\$css with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:do_inline_styles\\(\\) has parameter \\$unique_style_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:enqueue_script\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:enqueue_style\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:get_attributes_with_defaults\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:get_attributes_with_defaults\\(\\) has parameter \\$cache with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:get_attributes_with_defaults\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:get_attributes_with_defaults_cpt\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:get_block_default_attributes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:get_cpt_default_attributes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:get_html_tag\\(\\) has parameter \\$allowed_tags with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:get_html_tag\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:merge_attributes_with_defaults\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:merge_attributes_with_defaults\\(\\) has parameter \\$default_attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:merge_attributes_with_defaults\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:on_init\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:output_head_data\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:output_head_data\\(\\) has parameter \\$block with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:render_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:render_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:render_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:render_scripts\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:render_styles_footer\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:render_styles_footer\\(\\) has parameter \\$css with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:should_render_inline\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:should_render_inline_stylesheet\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$block_name$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, float\\|int\\|string given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Abstract_Block\\:\\:\\$attributes_with_defaults type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Abstract_Block\\:\\:\\$default_attributes_cache type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Abstract_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Abstract_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Abstract_Block\\:\\:\\$is_cpt_block type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Abstract_Block\\:\\:\\$supports_merged_defaults type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-abstract-block.php
+
+		-
+			message: "#^Cannot call method add_property\\(\\) on string\\.$#"
+			count: 17
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Cannot call method render_border_color\\(\\) on string\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Cannot call method render_border_radius\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Cannot call method render_border_styles\\(\\) on string\\.$#"
+			count: 4
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Cannot call method render_color\\(\\) on string\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Cannot call method render_color_output\\(\\) on string\\.$#"
+			count: 22
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Cannot call method render_gap\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Cannot call method render_measure_output\\(\\) on string\\.$#"
+			count: 4
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Cannot call method render_measure_range\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Cannot call method render_range\\(\\) on string\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Cannot call method render_typography\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Cannot call method set_media_state\\(\\) on string\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 22
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Accordion_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Accordion_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Accordion_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Accordion_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Accordion_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Accordion_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Accordion_Block\\:\\:output_head_data\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Accordion_Block\\:\\:output_head_data\\(\\) has parameter \\$block with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Accordion_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Accordion_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Accordion_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Accordion_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-accordion-block.php
+
+		-
+			message: "#^Cannot access offset 'anchor' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'background' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'backgroundActiveType' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'backgroundType' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'basicStyles' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'borderActive' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'boxShadow' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'boxShadowActive' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'browserValidation' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'className' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'color' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'enableAnalytics' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'fieldBorderStyle' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'gradient' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'gradientActive' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'helpFont' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'inputFont' on mixed\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'isDark' on mixed\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'labelFont' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'labelStyle' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'messageBorderError' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'messageBorderSuccess' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'messageFont' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'messageMargin' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'messageMarginUnit' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'messagePadding' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'messagePaddingUnit' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'messages' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'mobileFieldBorderSt…' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'mobileMessageBorder…' on mixed\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'preError' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'radioLabelFont' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'showRequired' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'size' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'sizeType' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'sizetype' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'style' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'submit' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'submitFont' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'tabletFieldBorderSt…' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 'tabletMessageBorder…' on mixed\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 4
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 1 on mixed\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 2 on mixed\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 3 on mixed\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 4 on mixed\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 5 on mixed\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 6 on mixed\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Cannot access offset 7 on mixed\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Block\\:\\:get_form_attributes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Block\\:\\:get_form_fields\\(\\) is unused\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Block\\:\\:get_form_fields\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Block\\:\\:get_form_fields\\(\\) should return array but returns array\\<array\\>\\|float\\|int\\|string\\|false\\|null\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Offset mixed on null in isset\\(\\) does not exist\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$attributes of method Kadence_Blocks_CSS\\:\\:render_color_output\\(\\) expects array, mixed given\\.$#"
+			count: 13
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$attributes of method Kadence_Blocks_CSS\\:\\:render_gap\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$attributes of method Kadence_Blocks_CSS\\:\\:render_measure_output\\(\\) expects array, mixed given\\.$#"
+			count: 9
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$attributes of method Kadence_Blocks_CSS\\:\\:render_responsive_range\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$attributes of method Kadence_Blocks_CSS\\:\\:render_typography\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$color of method Kadence_Blocks_CSS\\:\\:render_color\\(\\) expects string, mixed given\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$color of method Kadence_Blocks_CSS\\:\\:sanitize_color\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$extra_attributes of function get_block_wrapper_attributes expects array\\<string, string\\>, array\\<string, mixed\\> given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, mixed given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Advanced_Form_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Parameter \\#6 \\$single_styles of method Kadence_Blocks_CSS\\:\\:get_border_value\\(\\) expects string, true given\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Advanced_Form_Block\\:\\:\\$form_attributes has no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Advanced_Form_Block\\:\\:\\$form_fields has no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Advanced_Form_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Advanced_Form_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Advanced_Form_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Advanced_Form_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Advanced_Form_Block\\:\\:\\$seen_refs \\(null\\) does not accept array\\<bool\\>\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Advanced_Form_Block\\:\\:\\$seen_refs \\(null\\) does not accept array\\<true\\>\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Advanced_Form_Block\\:\\:\\$seen_refs \\(null\\) does not accept default value of type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
+
+		-
+			message: "#^Call to an undefined method object\\:\\:add_property\\(\\)\\.$#"
+			count: 9
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedheading_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedheading_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedheading_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedheading_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedheading_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedheading_Block\\:\\:get_cascading_value\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedheading_Block\\:\\:get_icon\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedheading_Block\\:\\:get_icon\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedheading_Block\\:\\:get_inner_content\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedheading_Block\\:\\:get_inner_content\\(\\) has parameter \\$string with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedheading_Block\\:\\:get_inner_content\\(\\) has parameter \\$tagname with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedheading_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedheading_Block\\:\\:handle_max_height\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedheading_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedheading_Block\\:\\:render_text_shadow\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedheading_Block\\:\\:render_text_shadow\\(\\) has parameter \\$css with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Offset 'linkColor' on array in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$attributes$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Advancedheading_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Advancedheading_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Advancedheading_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Advancedheading_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Variable \\$textShadow might not be defined\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
+
+		-
+			message: "#^Cannot call method add_property\\(\\) on string\\.$#"
+			count: 94
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Cannot call method get_font_size\\(\\) on string\\.$#"
+			count: 6
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Cannot call method render_color\\(\\) on string\\.$#"
+			count: 21
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Cannot call method render_font_family\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Cannot call method render_font_weight\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Cannot call method render_gap\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Cannot call method render_measure_output\\(\\) on string\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Cannot call method set_media_state\\(\\) on string\\.$#"
+			count: 19
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 24
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedbtn_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedbtn_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedbtn_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedbtn_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Offset 'btnSize' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Offset 'inheritStyles' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Offset 7 on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Advancedbtn_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Result of && is always true\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Advancedbtn_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Advancedbtn_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and mixed will always evaluate to false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
+
+		-
+			message: "#^Argument of an invalid type DOMNodeList\\<DOMNode\\>\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Cannot access property \\$childNodes on DOMNode\\|null\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Cannot access property \\$length on DOMNodeList\\<DOMNode\\>\\|false\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Cannot call method getAttribute\\(\\) on DOMNode\\|null\\.$#"
+			count: 11
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Cannot call method item\\(\\) on DOMNodeList\\<DOMNode\\>\\|false\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:get_image_srcset\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:get_image_srcset_output\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:parse_images_from_content\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:render_gallery_images\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:render_gallery_images\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:render_gallery_images\\(\\) has parameter \\$image with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:render_gallery_thumb_images\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:render_gallery_thumb_images\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:render_gallery_thumb_images\\(\\) has parameter \\$image with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:render_mosaic_gallery\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:render_mosaic_gallery\\(\\) has parameter \\$gallery_classes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:render_mosaic_gallery\\(\\) has parameter \\$images with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:render_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:render_scripts\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Offset 'captionStyle' on non\\-empty\\-array in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Offset 'linkTo' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Offset 'shadow' on non\\-empty\\-array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Offset 'type' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$node of method DOMDocument\\:\\:saveHTML\\(\\) expects DOMNode\\|null, mixed given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$size_array of function wp_calculate_image_srcset expects array\\{int, int\\}, array\\{non\\-falsy\\-string, non\\-falsy\\-string\\} given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, bool given\\.$#"
+			count: 4
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, float given\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, string\\|null given\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Advancedgallery_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Advancedgallery_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Advancedgallery_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 7
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Advancedgallery_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Advancedgallery_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Variable \\$figcap in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Variable \\$image_ratio in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 6
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Variable \\$padding_bottom in empty\\(\\) always exists and is always falsy\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Call to an undefined method object\\:\\:add_property\\(\\)\\.$#"
+			count: 7
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Call to an undefined method object\\:\\:set_media_state\\(\\)\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Call to an undefined method object\\:\\:set_selector\\(\\)\\.$#"
+			count: 6
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Cannot call method add_css_string\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Cannot call method add_property\\(\\) on string\\.$#"
+			count: 195
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Cannot call method is_number\\(\\) on string\\.$#"
+			count: 81
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Cannot call method render_border_styles\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Cannot call method render_color\\(\\) on string\\.$#"
+			count: 13
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Cannot call method render_color_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Cannot call method render_measure_output\\(\\) on string\\.$#"
+			count: 6
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Cannot call method render_row_gap\\(\\) on string\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Cannot call method set_media_state\\(\\) on string\\.$#"
+			count: 39
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 82
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Column_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Column_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Column_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Column_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Column_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Column_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Column_Block\\:\\:set_vertical_align\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Column_Block\\:\\:set_vertical_align\\(\\) has parameter \\$media_state with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$media_state of method Kadence_Blocks_Column_Block\\:\\:set_vertical_align\\(\\) expects array, string given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Parameter \\#4 \\$css of method Kadence_Blocks_Column_Block\\:\\:set_vertical_align\\(\\) expects object, string given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Column_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Column_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-column-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Countdown_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countdown-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Countdown_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countdown-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Countdown_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countdown-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Countdown_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countdown-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Countdown_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countdown-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Countdown_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countdown-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Countdown_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countdown-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Countdown_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countdown-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Countdown_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countdown-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Countdown_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Countdown_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countdown-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Countup_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countup-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Countup_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countup-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Countup_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countup-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Countup_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countup-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Countup_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countup-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Countup_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countup-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Countup_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countup-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Countup_Block\\:\\:render_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countup-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Countup_Block\\:\\:render_scripts\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countup-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Countup_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countup-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Countup_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countup-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Countup_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countup-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Countup_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Countup_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-countup-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-form-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-form-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-form-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-form-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-form-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-form-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Form_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-form-block.php
+
+		-
+			message: "#^Offset 'family' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-form-block.php
+
+		-
+			message: "#^Offset 'honeyPot' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-form-block.php
+
+		-
+			message: "#^Offset 0 on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 6
+			path: includes/blocks/class-kadence-blocks-form-block.php
+
+		-
+			message: "#^Offset 7 on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-form-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, mixed given\\.$#"
+			count: 4
+			path: includes/blocks/class-kadence-blocks-form-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Form_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-form-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Form_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-form-block.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-form-block.php
+
+		-
+			message: "#^Result of && is always true\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-form-block.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 12
+			path: includes/blocks/class-kadence-blocks-form-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Form_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Form_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-form-block.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and mixed will always evaluate to false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-form-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Googlemaps_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-googlemaps-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Googlemaps_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-googlemaps-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Googlemaps_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-googlemaps-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Googlemaps_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-googlemaps-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Googlemaps_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-googlemaps-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Googlemaps_Block\\:\\:escape_for_js_variable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-googlemaps-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Googlemaps_Block\\:\\:escape_for_js_variable\\(\\) has parameter \\$string with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-googlemaps-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Googlemaps_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-googlemaps-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Googlemaps_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-googlemaps-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Googlemaps_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-googlemaps-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$replace of function str_replace expects array\\|string, mixed given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-googlemaps-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Googlemaps_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-googlemaps-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Googlemaps_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-googlemaps-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Googlemaps_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Googlemaps_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-googlemaps-block.php
+
+		-
+			message: "#^Cannot access offset 'anchor' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Cannot access offset 'autoTransparentSpac…' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Cannot access offset 'className' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Cannot access offset 'isSticky' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Cannot access offset 'isStickyMobile' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Cannot access offset 'isStickyTablet' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Cannot access offset 'mobileBreakpoint' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Cannot access offset 'revealScrollUp' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Cannot access offset 'shrinkMain' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Cannot access offset 'shrinkMainHeight' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Cannot access offset 'shrinkMainHeightMob…' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Cannot access offset 'shrinkMainHeightTab…' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Cannot access offset 'stickySection' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Cannot access offset 'stickySectionMobile' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Cannot access offset 'stickySectionTablet' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Function is_shop not found\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Function wc_get_page_id not found\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Block\\:\\:is_header_transparent\\(\\) has parameter \\$header_attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Block\\:\\:is_header_transparent\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$css with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Block\\:\\:sized_dynamic_styles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Block\\:\\:sized_dynamic_styles\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Block\\:\\:transparent_allowed_on_post_type\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Block\\:\\:transparent_postmeta_setting\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Block\\:\\:transparent_postmeta_setting\\(\\) should return string but returns null\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Block\\:\\:transparent_postmeta_setting\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Negated boolean expression is always true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$attributes of method Kadence_Blocks_Abstract_Block\\:\\:get_html_tag\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$header_attributes of method Kadence_Blocks_Header_Block\\:\\:is_header_transparent\\(\\) expects array, mixed given\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$post_id of function get_post_meta expects int, int\\|false given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Header_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$post_id of method Kadence_Blocks_Header_Block\\:\\:transparent_postmeta_setting\\(\\) expects int\\|null, mixed given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Header_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Header_Block\\:\\:\\$responsive_transparent_settings type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Header_Block\\:\\:\\$seen_refs type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Header_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Header_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-header-block.php
+
+		-
+			message: "#^Cannot call method add_property\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-icon-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-icon-block.php
+
+		-
+			message: "#^Cannot call method render_color_output\\(\\) on string\\.$#"
+			count: 6
+			path: includes/blocks/class-kadence-blocks-icon-block.php
+
+		-
+			message: "#^Cannot call method render_flex_align\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-icon-block.php
+
+		-
+			message: "#^Cannot call method render_gap\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-icon-block.php
+
+		-
+			message: "#^Cannot call method render_measure_output\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-icon-block.php
+
+		-
+			message: "#^Cannot call method render_range\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-icon-block.php
+
+		-
+			message: "#^Cannot call method render_responsive_size\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-icon-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-icon-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-icon-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Icon_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-icon-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Icon_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-icon-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Icon_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-icon-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Icon_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Icon_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-icon-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Iconlist_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-icon-list-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Iconlist_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-icon-list-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Iconlist_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-icon-list-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Iconlist_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-icon-list-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Iconlist_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-icon-list-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Iconlist_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Iconlist_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-icon-list-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Identity_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-identity-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Identity_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-identity-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Identity_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-identity-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Identity_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-identity-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Identity_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-identity-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Identity_Block\\:\\:strip_anchor_tags\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-identity-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Identity_Block\\:\\:strip_anchor_tags\\(\\) has parameter \\$html with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-identity-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Identity_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-identity-block.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#"
+			count: 6
+			path: includes/blocks/class-kadence-blocks-identity-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Identity_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-identity-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Identity_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-identity-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Identity_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Identity_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-identity-block.php
+
+		-
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-image-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Image_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-image-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Image_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-image-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Image_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-image-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Image_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-image-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Image_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-image-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Image_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-image-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Image_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-image-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, mixed given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-image-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Image_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-image-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Image_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-image-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Image_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Image_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-image-block.php
+
+		-
+			message: "#^Ternary operator condition is always true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-image-block.php
+
+		-
+			message: "#^Cannot call method add_property\\(\\) on string\\.$#"
+			count: 175
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Cannot call method get_font_size\\(\\) on string\\.$#"
+			count: 9
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Cannot call method is_number\\(\\) on string\\.$#"
+			count: 14
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Cannot call method render_border_styles\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Cannot call method render_color\\(\\) on string\\.$#"
+			count: 25
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Cannot call method render_font_family\\(\\) on string\\.$#"
+			count: 4
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Cannot call method render_font_weight\\(\\) on string\\.$#"
+			count: 4
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Cannot call method render_measure_output\\(\\) on string\\.$#"
+			count: 5
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Cannot call method render_shadow\\(\\) on string\\.$#"
+			count: 6
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Cannot call method set_media_state\\(\\) on string\\.$#"
+			count: 46
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 60
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Infobox_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Infobox_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Infobox_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Offset 'alignLearnMore' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Offset 'containerBackground…' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Offset 'containerHoverBackg…' on array in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Offset 'containerHoverBackg…' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Offset 'containerHoverBorder' on array in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Offset 'containerHoverBorder' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Offset 'mediaAlign' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Result of && is always true\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Infobox_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Infobox_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-infobox-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Lottie_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-lottie-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Lottie_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-lottie-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Lottie_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-lottie-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Lottie_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-lottie-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Lottie_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-lottie-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Lottie_Block\\:\\:getAnimationUrl\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-lottie-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Lottie_Block\\:\\:getAnimationUrl\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-lottie-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Lottie_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-lottie-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Lottie_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-lottie-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Lottie_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-lottie-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Lottie_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-lottie-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Lottie_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-lottie-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Lottie_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Lottie_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-lottie-block.php
+
+		-
+			message: "#^Cannot access offset 'anchor' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'className' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'collapseSubMenus' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'collapseSubMenusMob…' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'collapseSubMenusTab…' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'dropdownReveal' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'dropdownRevealMobile' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'dropdownRevealTablet' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'dropdownShadow' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'enable' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'enableScrollSpy' on mixed\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'horizontalLayout' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'horizontalLayoutMob…' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'horizontalLayoutTab…' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'orientation' on mixed\\.$#"
+			count: 4
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'orientationMobile' on mixed\\.$#"
+			count: 4
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'orientationTablet' on mixed\\.$#"
+			count: 4
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'parentActive' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'parentActiveMobile' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'parentActiveTablet' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'parentTogglesMenus' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'parentTogglesMenusM…' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'parentTogglesMenusT…' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'scrollSpyOffset' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'scrollSpyOffsetManu…' on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'stretchFill' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'stretchFillMobile' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'stretchFillTablet' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'style' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'styleMobile' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 'styleTablet' on mixed\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Block\\:\\:applyTemplateKeyBlocks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Block\\:\\:applyTemplateKeyBlocks\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Block\\:\\:build_html_attributes\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Block\\:\\:build_html_attributes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Block\\:\\:build_html_attributes\\(\\) should return array but returns string\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$css with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Block\\:\\:sized_dynamic_styles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Block\\:\\:sized_dynamic_styles\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Offset mixed on null in isset\\(\\) does not exist\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^PHPDoc type bool of property Kadence_Blocks_Navigation_Block\\:\\:\\$has_script is not covariant with PHPDoc type string of overridden property Kadence_Blocks_Abstract_Block\\:\\:\\$has_script\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$attributes of method Kadence_Blocks_CSS\\:\\:render_measure_output\\(\\) expects array, mixed given\\.$#"
+			count: 8
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$attributes of method Kadence_Blocks_CSS\\:\\:render_typography\\(\\) expects array, mixed given\\.$#"
+			count: 4
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$shadow of method Kadence_Blocks_CSS\\:\\:render_shadow\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$attributes of method Kadence_Blocks_CSS\\:\\:render_button_styles_with_states\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Navigation_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Parameter \\#3 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, array given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Parameter \\#4 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, array given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Navigation_Block\\:\\:\\$nav_attributes has no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Navigation_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Navigation_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Navigation_Block\\:\\:\\$seen_refs \\(null\\) does not accept array\\<bool\\>\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Navigation_Block\\:\\:\\$seen_refs \\(null\\) does not accept array\\<true\\>\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Navigation_Block\\:\\:\\$seen_refs \\(null\\) does not accept default value of type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 4
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Variable \\$navigation_horizontal_spacing in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Variable \\$navigation_vertical_spacing in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-block.php
+
+		-
+			message: "#^Access to property \\$inner_blocks on an unknown class stdObject\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Binary operation \"\\.\" between '\\<ul ' and array results in an error\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Cannot unset offset mixed on null\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:add_property\\(\\) invoked with 4 parameters, 1\\-3 required\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Link_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Link_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Link_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Link_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Link_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Link_Block\\:\\:build_html_attributes\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Link_Block\\:\\:build_html_attributes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Link_Block\\:\\:build_html_attributes\\(\\) should return array but returns string\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Link_Block\\:\\:get_child_info\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Link_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Link_Block\\:\\:get_url\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Link_Block\\:\\:is_current\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Link_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Link_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$css with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Link_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Link_Block\\:\\:sized_dynamic_styles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_Link_Block\\:\\:sized_dynamic_styles\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Offset mixed on null in isset\\(\\) does not exist\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$block_instance of method Kadence_Blocks_Navigation_Link_Block\\:\\:get_child_info\\(\\) expects stdObject, WP_Block given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Navigation_Link_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Parameter \\$block_instance of method Kadence_Blocks_Navigation_Link_Block\\:\\:get_child_info\\(\\) has invalid type stdObject\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Navigation_Link_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Navigation_Link_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Navigation_Link_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Navigation_Link_Block\\:\\:\\$seen_refs \\(null\\) does not accept array\\<bool\\>\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Navigation_Link_Block\\:\\:\\$seen_refs \\(null\\) does not accept default value of type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-navigation-link-block.php
+
+		-
+			message: "#^Expected 1 @param tags, found 2\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-posts-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Posts_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-posts-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Posts_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-posts-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Posts_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-posts-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Posts_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-posts-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Posts_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-posts-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Posts_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-posts-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Posts_Block\\:\\:render_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-posts-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Posts_Block\\:\\:render_scripts\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-posts-block.php
+
+		-
+			message: "#^Offset 'taxType' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-posts-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Posts_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-posts-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Posts_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-posts-block.php
+
+		-
+			message: "#^Result of && is always true\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-posts-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Posts_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Posts_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-posts-block.php
+
+		-
+			message: "#^Variable \\$attributes in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-posts-block.php
+
+		-
+			message: "#^Variable \\$kadence_blocks_posts_not_in in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-posts-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Progress_Bar_Block\\:\\:array_recursive_diff\\(\\) has parameter \\$a_array with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Progress_Bar_Block\\:\\:array_recursive_diff\\(\\) has parameter \\$b_array with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Progress_Bar_Block\\:\\:array_recursive_diff\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Progress_Bar_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Progress_Bar_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Progress_Bar_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Progress_Bar_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Progress_Bar_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Progress_Bar_Block\\:\\:data_enqueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Progress_Bar_Block\\:\\:get_content_svg\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Progress_Bar_Block\\:\\:get_default_font\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Progress_Bar_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Progress_Bar_Block\\:\\:get_label\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Progress_Bar_Block\\:\\:get_label\\(\\) has parameter \\$position with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Progress_Bar_Block\\:\\:get_percent\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Progress_Bar_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Progress_Bar_Block\\:\\:responsive_alignment\\(\\) has parameter \\$alignment with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Progress_Bar_Block\\:\\:responsive_alignment\\(\\) has parameter \\$css with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Offset 'barType' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Offset 'labelPosition' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, \\(float\\|int\\) given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, float given\\.$#"
+			count: 6
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Progress_Bar_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$name of method Kadence_Blocks_CSS\\:\\:render_responsive_size\\(\\) expects string, array\\<int, string\\> given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Progress_Bar_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Progress_Bar_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Progress_Bar_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Progress_Bar_Block\\:\\:\\$progress_bars \\(string\\) does not accept default value of type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-progress-bar-block.php
+
+		-
+			message: "#^Call to an undefined method object\\:\\:add_property\\(\\)\\.$#"
+			count: 4
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Call to an undefined method object\\:\\:set_selector\\(\\)\\.$#"
+			count: 8
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Call to function is_array\\(\\) with non\\-falsy\\-string will always evaluate to false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Cannot call method add_css_string\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Cannot call method add_property\\(\\) on string\\.$#"
+			count: 174
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Cannot call method get_variable_value\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Cannot call method is_number\\(\\) on string\\.$#"
+			count: 63
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Cannot call method is_variable_value\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Cannot call method render_border_styles\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Cannot call method render_color\\(\\) on string\\.$#"
+			count: 13
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Cannot call method render_color_output\\(\\) on string\\.$#"
+			count: 10
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Cannot call method render_gradient\\(\\) on string\\.$#"
+			count: 6
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Cannot call method render_measure_output\\(\\) on string\\.$#"
+			count: 5
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Cannot call method render_opacity_from_100\\(\\) on string\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Cannot call method render_row_gap\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Cannot call method render_row_gap_property\\(\\) on string\\.$#"
+			count: 7
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Cannot call method set_media_state\\(\\) on string\\.$#"
+			count: 56
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 80
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Cannot call method start_media_query\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Cannot call method stop_media_query\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:get_custom_layout\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:get_divider_render\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:get_slider_render\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:get_slider_render\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:get_template_columns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:get_video_render\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:get_video_render\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:has_custom_widths\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:has_overlay\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:has_overlay\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:output_color\\(\\) has parameter \\$opacity with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:output_color\\(\\) should return string but returns false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:prevent_preload_when_hidden\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:prevent_preload_when_hidden\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:render_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:render_scripts\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:reset_grid_colum_for_template_columns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:reset_grid_colum_for_template_columns\\(\\) has parameter \\$css with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:reset_grid_colum_for_template_columns\\(\\) has parameter \\$inner_selector with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Offset 'borderRadiusOverflow' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$attributes of method Kadence_Blocks_Abstract_Block\\:\\:build_escaped_html_attributes\\(\\) expects array\\<string, bool\\|float\\|int\\|string\\>, array\\<string, mixed\\> given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$css of method Kadence_Blocks_Rowlayout_Block\\:\\:get_template_columns\\(\\) expects object, string given\\.$#"
+			count: 6
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$extra_attributes of function get_block_wrapper_attributes expects array\\<string, string\\>, array\\<string, mixed\\> given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, mixed given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$alpha of function kadence_blocks_hex2rgba expects float\\|int, float\\|int\\|string given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Rowlayout_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Rowlayout_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Search_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-search-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Search_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-search-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Search_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-search-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Search_Block\\:\\:build_input\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-search-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Search_Block\\:\\:build_modal_content\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-search-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Search_Block\\:\\:build_search_form\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-search-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Search_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-search-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Search_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-search-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Search_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-search-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Search_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-search-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Search_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-search-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Search_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Search_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-search-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Show_More_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-show-more-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Show_More_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-show-more-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Show_More_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-show-more-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Show_More_Block\\:\\:build_html\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-show-more-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Show_More_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-show-more-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Show_More_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-show-more-block.php
+
+		-
+			message: "#^Offset 'defaultExpandedMobi…' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-show-more-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Show_More_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-show-more-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Show_More_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-show-more-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Show_More_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-show-more-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Show_More_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Show_More_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-show-more-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-block.php
+
+		-
+			message: "#^Cannot call method render_color_output\\(\\) on string\\.$#"
+			count: 6
+			path: includes/blocks/class-kadence-blocks-single-icon-block.php
+
+		-
+			message: "#^Cannot call method render_measure_output\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-single-icon-block.php
+
+		-
+			message: "#^Cannot call method render_range\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-single-icon-block.php
+
+		-
+			message: "#^Cannot call method render_responsive_size\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-single-icon-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Single_Icon_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Single_Icon_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Single_Icon_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Single_Icon_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Single_Icon_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Single_Icon_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Single_Icon_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Single_Icon_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-block.php
+
+		-
+			message: "#^Result of && is always true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Single_Icon_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Single_Icon_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-block.php
+
+		-
+			message: "#^Variable \\$attributes in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Listitem_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-list-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Listitem_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-list-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Listitem_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-list-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Listitem_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-list-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Listitem_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-list-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Listitem_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-list-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Listitem_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-list-block.php
+
+		-
+			message: "#^Offset 'enableMarkGradient' on array in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-list-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Listitem_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-list-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Listitem_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-list-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Listitem_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-list-block.php
+
+		-
+			message: "#^Result of && is always true\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-single-icon-list-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Listitem_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Listitem_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-single-icon-list-block.php
+
+		-
+			message: "#^Variable \\$block_instance in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-single-icon-list-block.php
+
+		-
+			message: "#^Cannot call method add_property\\(\\) on string\\.$#"
+			count: 31
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Cannot call method render_border_styles\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Cannot call method render_color\\(\\) on string\\.$#"
+			count: 9
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Cannot call method render_measure_output\\(\\) on string\\.$#"
+			count: 5
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Cannot call method render_responsive_range\\(\\) on string\\.$#"
+			count: 3
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Cannot call method render_typography\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Cannot call method set_media_state\\(\\) on string\\.$#"
+			count: 6
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 19
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:render_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:render_scripts\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$css with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:sized_dynamic_styles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:sized_dynamic_styles\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Singlebtn_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Singlebtn_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Singlebtn_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Singlebtn_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Spacer_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-spacer-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Spacer_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-spacer-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Spacer_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-spacer-block.php
+
+		-
+			message: "#^Offset 'dividerHeight' on array in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-spacer-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Spacer_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-spacer-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Spacer_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-spacer-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Spacer_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Spacer_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-spacer-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-block.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Table_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$name of method Kadence_Blocks_CSS\\:\\:render_responsive_size\\(\\) expects string, array\\<int, string\\> given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Table_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Table_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-block.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-table-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Table_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Table_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Data_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-data-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Data_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-data-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Data_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-data-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Data_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-data-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Data_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-data-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Data_Block\\:\\:get_block_header_scope\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-data-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Data_Block\\:\\:get_block_header_scope\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-data-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Data_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-data-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Data_Block\\:\\:on_init\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-data-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Table_Data_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-data-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Table_Data_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-data-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Table_Data_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-data-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Table_Data_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Table_Data_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-data-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Tableofcontents_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-of-contents-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Tableofcontents_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-of-contents-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Tableofcontents_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-of-contents-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Tableofcontents_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-of-contents-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Tableofcontents_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-of-contents-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Tableofcontents_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-of-contents-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Tableofcontents_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-of-contents-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Tableofcontents_Block\\:\\:toc_filter_rankmath\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-of-contents-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Tableofcontents_Block\\:\\:toc_filter_rankmath\\(\\) has parameter \\$toc_plugins with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-of-contents-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Tableofcontents_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-of-contents-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Tableofcontents_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-of-contents-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Tableofcontents_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Tableofcontents_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-of-contents-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Row_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Row_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Row_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Row_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Row_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Row_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Row_Block\\:\\:on_init\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-row-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Table_Row_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-row-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$name of method Kadence_Blocks_CSS\\:\\:render_responsive_size\\(\\) expects string, array\\<int, string\\> given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-row-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Table_Row_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-row-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Table_Row_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-row-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Table_Row_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Table_Row_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-table-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Tabs_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-tabs-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Tabs_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-tabs-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Tabs_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-tabs-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Tabs_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-tabs-block.php
+
+		-
+			message: "#^Offset 'layout' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-tabs-block.php
+
+		-
+			message: "#^Offset 'minHeight' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-tabs-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Tabs_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-tabs-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Tabs_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-tabs-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Tabs_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Tabs_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-tabs-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:get_context\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:get_context\\(\\) has parameter \\$context with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:get_context\\(\\) has parameter \\$default with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:get_context\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:get_media_output_html\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:get_media_output_html\\(\\) has parameter \\$container_max_width with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:get_media_output_html\\(\\) has parameter \\$media_styles with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:get_media_url\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:get_media_url\\(\\) has parameter \\$mediaStyles with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:render_content\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:render_content\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:render_icon\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:render_icon\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:render_icon\\(\\) has parameter \\$iconStyles with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:render_media\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:render_media\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:render_media\\(\\) has parameter \\$container_max_width with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:render_media\\(\\) has parameter \\$media_styles with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:render_media\\(\\) has parameter \\$style with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:render_rating\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:render_rating\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:render_rating\\(\\) has parameter \\$ratingStyles with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:render_title\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:render_title\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonial_Block\\:\\:render_title\\(\\) has parameter \\$titleFont with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$containerMaxWidth$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$mediaStyles$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Testimonial_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Testimonial_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Testimonial_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Testimonial_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonial-block.php
+
+		-
+			message: "#^Binary operation \"\\.\\=\" between non\\-falsy\\-string and array\\<int, string\\>\\|string results in an error\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonials_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonials_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonials_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonials_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonials_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonials_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonials_Block\\:\\:get_usable_value\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonials_Block\\:\\:get_usable_value\\(\\) has parameter \\$css with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonials_Block\\:\\:get_usable_value\\(\\) has parameter \\$is_font with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonials_Block\\:\\:get_usable_value\\(\\) has parameter \\$unit with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonials_Block\\:\\:get_usable_value\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Testimonials_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Offset 'displayMedia' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, bool given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Testimonials_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Parameter \\#3 \\$single_styles of method Kadence_Blocks_CSS\\:\\:render_border_styles\\(\\) expects bool, string given\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Testimonials_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Testimonials_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Testimonials_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-testimonials-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Vector_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-vector-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Vector_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-vector-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Vector_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-vector-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Vector_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-vector-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Vector_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-vector-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Vector_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-vector-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Vector_Block\\:\\:get_vector_svg\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-vector-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Vector_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-vector-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Vector_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-vector-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Vector_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-vector-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Vector_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Vector_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-vector-block.php
+
+		-
+			message: "#^Variable \\$post_id in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-vector-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Videopopup_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-videopopup-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Videopopup_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-videopopup-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Videopopup_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-videopopup-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Videopopup_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-videopopup-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Videopopup_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-videopopup-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Videopopup_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-videopopup-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Videopopup_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-videopopup-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Videopopup_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-videopopup-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Videopopup_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-videopopup-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Videopopup_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Videopopup_Block\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-videopopup-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-accept-block.php
+
+		-
+			message: "#^Cannot call method render_responsive_range\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-accept-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-accept-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-accept-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Accept_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-accept-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Accept_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-accept-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Accept_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-accept-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Accept_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-accept-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Accept_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-accept-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Accept_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-accept-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:class_id\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-accept-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_help_text\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-accept-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_id\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-accept-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_legend\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-accept-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_name\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-accept-block.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-accept-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Accept_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Accept_Block\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-accept-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:a11y_helpers\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:add_block_to_post_generate_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:add_block_to_post_generate_css\\(\\) has parameter \\$block_class_array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:additional_field_attributes\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:additional_fieldset_attributes\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:aria_described_by\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:class_id\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:class_id\\(\\) with return type void returns string but should not return anything\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:custom_required_message\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_aria_label\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_help_text\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_help_text\\(\\) with return type void returns string but should not return anything\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_id\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_id\\(\\) with return type void returns mixed but should not return anything\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_label\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_label\\(\\) with return type void returns string but should not return anything\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_legend\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_legend\\(\\) with return type void returns string but should not return anything\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_name\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_name\\(\\) with return type void returns mixed but should not return anything\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:get_accept_default\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:get_auto_complete\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:get_block_default_attributes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:get_default\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:get_label\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:get_option_value\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:get_placeholder\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:is_required\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:is_required\\(\\) has parameter \\$false with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:is_required\\(\\) has parameter \\$true with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:on_init\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function sanitize_text_field expects string, mixed given\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, null given\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Advanced_Form_Input_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Advanced_Form_Input_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_id\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 3
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and non\\-falsy\\-string will always evaluate to false\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Variable \\$default in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+
+		-
+			message: "#^Cannot call method add_property\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Cannot call method render_responsive_range\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Captcha_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Captcha_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Captcha_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Captcha_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Captcha_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Captcha_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Captcha_Block\\:\\:register_scripts_with_attrs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Captcha_Block\\:\\:register_scripts_with_attrs\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Captcha_Block\\:\\:register_scripts_with_attrs\\(\\) has parameter \\$captcha_settings with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Captcha_Block\\:\\:render_google_v2\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Captcha_Block\\:\\:render_google_v2\\(\\) has parameter \\$captcha_settings with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Captcha_Block\\:\\:render_google_v3\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Captcha_Block\\:\\:render_google_v3\\(\\) has parameter \\$captcha_settings with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Captcha_Block\\:\\:render_google_v3\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Captcha_Block\\:\\:render_hcaptcha\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Captcha_Block\\:\\:render_hcaptcha\\(\\) has parameter \\$captcha_settings with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Captcha_Block\\:\\:render_turnstile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Captcha_Block\\:\\:render_turnstile\\(\\) has parameter \\$captcha_settings with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:class_id\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Captcha_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Captcha_Block\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-captcha-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-checkbox-block.php
+
+		-
+			message: "#^Cannot call method render_responsive_range\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-checkbox-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-checkbox-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-checkbox-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Checkbox_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-checkbox-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Checkbox_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-checkbox-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Checkbox_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-checkbox-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Checkbox_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-checkbox-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Checkbox_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-checkbox-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Checkbox_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-checkbox-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, null given\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-checkbox-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:class_id\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-checkbox-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_help_text\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-checkbox-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_label\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-checkbox-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_legend\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-checkbox-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_name\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-checkbox-block.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-checkbox-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Checkbox_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Checkbox_Block\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-checkbox-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-date-input-block.php
+
+		-
+			message: "#^Cannot call method render_responsive_range\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-date-input-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-date-input-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-date-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Date_Input_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-date-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Date_Input_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-date-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Date_Input_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-date-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Date_Input_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-date-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Date_Input_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-date-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Date_Input_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-date-input-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, null given\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-date-input-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, string\\|false given\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-date-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:class_id\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-date-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_help_text\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-date-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_id\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-date-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_label\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-date-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_name\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-date-input-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Date_Input_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Date_Input_Block\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-date-input-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-email-input-block.php
+
+		-
+			message: "#^Cannot call method render_responsive_range\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-email-input-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-email-input-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-email-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Email_Input_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-email-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Email_Input_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-email-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Email_Input_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-email-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Email_Input_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-email-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Email_Input_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-email-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Email_Input_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-email-input-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, null given\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-email-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:class_id\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-email-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_help_text\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-email-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_id\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-email-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_label\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-email-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_name\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-email-input-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Email_Input_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Email_Input_Block\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-email-input-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-file-block.php
+
+		-
+			message: "#^Cannot call method render_responsive_range\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-file-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-file-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-file-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_File_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-file-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_File_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-file-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_File_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-file-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_File_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-file-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_File_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-file-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_File_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-file-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, null given\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-file-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:class_id\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-file-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_help_text\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-file-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_id\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-file-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_label\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-file-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_name\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-file-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_File_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_File_Block\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-file-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Hidden_Input_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-hidden-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Hidden_Input_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-hidden-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Hidden_Input_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-hidden-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Hidden_Input_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-hidden-input-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, null given\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-hidden-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_id\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-hidden-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_name\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-hidden-input-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Hidden_Input_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Hidden_Input_Block\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-hidden-input-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-number-input-block.php
+
+		-
+			message: "#^Cannot call method render_responsive_range\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-number-input-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-number-input-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-number-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Number_Input_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-number-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Number_Input_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-number-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Number_Input_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-number-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Number_Input_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-number-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Number_Input_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-number-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Number_Input_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-number-input-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, null given\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-number-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:class_id\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-number-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_help_text\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-number-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_id\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-number-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_label\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-number-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_name\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-number-input-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Number_Input_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Number_Input_Block\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-number-input-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-radio-block.php
+
+		-
+			message: "#^Cannot call method render_responsive_range\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-radio-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-radio-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-radio-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Radio_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-radio-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Radio_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-radio-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Radio_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-radio-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Radio_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-radio-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Radio_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-radio-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Radio_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-radio-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, null given\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-radio-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:class_id\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-radio-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_help_text\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-radio-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_label\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-radio-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_legend\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-radio-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_name\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-radio-block.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-radio-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Radio_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Radio_Block\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-radio-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-select-block.php
+
+		-
+			message: "#^Cannot call method render_responsive_range\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-select-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-select-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-select-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Select_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-select-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Select_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-select-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Select_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-select-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Select_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-select-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Select_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-select-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Select_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-select-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, null given\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-select-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, string\\|null given\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-select-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:class_id\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-select-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_help_text\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-select-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_id\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-select-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_label\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-select-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_name\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-select-block.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-select-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Select_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Select_Block\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-select-block.php
+
+		-
+			message: "#^Cannot call method add_property\\(\\) on string\\.$#"
+			count: 26
+			path: includes/blocks/form/class-kadence-blocks-submit-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-submit-block.php
+
+		-
+			message: "#^Cannot call method render_border_styles\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-submit-block.php
+
+		-
+			message: "#^Cannot call method render_color\\(\\) on string\\.$#"
+			count: 9
+			path: includes/blocks/form/class-kadence-blocks-submit-block.php
+
+		-
+			message: "#^Cannot call method render_measure_output\\(\\) on string\\.$#"
+			count: 5
+			path: includes/blocks/form/class-kadence-blocks-submit-block.php
+
+		-
+			message: "#^Cannot call method render_responsive_range\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-submit-block.php
+
+		-
+			message: "#^Cannot call method render_typography\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-submit-block.php
+
+		-
+			message: "#^Cannot call method set_media_state\\(\\) on string\\.$#"
+			count: 5
+			path: includes/blocks/form/class-kadence-blocks-submit-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 16
+			path: includes/blocks/form/class-kadence-blocks-submit-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-submit-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Submit_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-submit-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Submit_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-submit-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Submit_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-submit-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Submit_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-submit-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:class_id\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-submit-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Submit_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Submit_Block\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-submit-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-telephone-input-block.php
+
+		-
+			message: "#^Cannot call method render_responsive_range\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-telephone-input-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-telephone-input-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-telephone-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Telephone_Input_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-telephone-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Telephone_Input_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-telephone-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Telephone_Input_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-telephone-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Telephone_Input_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-telephone-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Telephone_Input_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-telephone-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Telephone_Input_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-telephone-input-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, null given\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-telephone-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:class_id\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-telephone-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_help_text\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-telephone-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_id\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-telephone-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_label\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-telephone-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_name\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-telephone-input-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Telephone_Input_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Telephone_Input_Block\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-telephone-input-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-text-input-block.php
+
+		-
+			message: "#^Cannot call method render_responsive_range\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-text-input-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-text-input-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-text-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Text_Input_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-text-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Text_Input_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-text-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Text_Input_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-text-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Text_Input_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-text-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Text_Input_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-text-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Text_Input_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-text-input-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, null given\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-text-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:class_id\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-text-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_help_text\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-text-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_id\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-text-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_label\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-text-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_name\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-text-input-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Text_Input_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Text_Input_Block\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-text-input-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-textarea-input-block.php
+
+		-
+			message: "#^Cannot call method render_responsive_range\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-textarea-input-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-textarea-input-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-textarea-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Textarea_Input_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-textarea-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Textarea_Input_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-textarea-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Textarea_Input_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-textarea-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Textarea_Input_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-textarea-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Textarea_Input_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-textarea-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Textarea_Input_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-textarea-input-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, null given\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-textarea-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:class_id\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-textarea-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_help_text\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-textarea-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_id\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-textarea-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_label\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-textarea-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_name\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-textarea-input-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Textarea_Input_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Textarea_Input_Block\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-textarea-input-block.php
+
+		-
+			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-time-input-block.php
+
+		-
+			message: "#^Cannot call method render_responsive_range\\(\\) on string\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-time-input-block.php
+
+		-
+			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-time-input-block.php
+
+		-
+			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-time-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Time_Input_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-time-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Time_Input_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-time-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Time_Input_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-time-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Time_Input_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-time-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Time_Input_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-time-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Time_Input_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-time-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:class_id\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: includes/blocks/form/class-kadence-blocks-time-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_help_text\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-time-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_id\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-time-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_label\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-time-input-block.php
+
+		-
+			message: "#^Result of method Kadence_Blocks_Advanced_Form_Input_Block\\:\\:field_name\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-time-input-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Time_Input_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Time_Input_Block\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-time-input-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Column_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-column-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Column_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-column-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Column_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-column-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Column_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-column-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Column_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-column-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Column_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-column-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Column_Block\\:\\:on_init\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-column-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Header_Column_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-column-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Header_Column_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-column-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Header_Column_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-column-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Header_Column_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Header_Column_Block\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-column-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Container_Desktop_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-desktop-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Container_Desktop_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-desktop-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Container_Desktop_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-desktop-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Container_Desktop_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-desktop-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Container_Desktop_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-desktop-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Container_Desktop_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-desktop-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Container_Desktop_Block\\:\\:on_init\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-desktop-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Header_Container_Desktop_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-desktop-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Header_Container_Desktop_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-desktop-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Header_Container_Desktop_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-desktop-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Header_Container_Desktop_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Header_Container_Desktop_Block\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-desktop-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Container_Tablet_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-tablet-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Container_Tablet_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-tablet-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Container_Tablet_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-tablet-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Container_Tablet_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-tablet-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Container_Tablet_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-tablet-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Container_Tablet_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-tablet-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Container_Tablet_Block\\:\\:on_init\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-tablet-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Header_Container_Tablet_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-tablet-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Header_Container_Tablet_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-tablet-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Header_Container_Tablet_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-tablet-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Header_Container_Tablet_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Header_Container_Tablet_Block\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-container-tablet-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Row_Block\\:\\:are_innerblocks_empty\\(\\) has parameter \\$block_instance with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Row_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Row_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Row_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Row_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Row_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Row_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Row_Block\\:\\:on_init\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Row_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Row_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$css with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Row_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Row_Block\\:\\:sized_dynamic_styles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Row_Block\\:\\:sized_dynamic_styles\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-row-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Header_Row_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-row-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Header_Row_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-row-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Header_Row_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-row-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Header_Row_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Header_Row_Block\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-row-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Section_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-section-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Section_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-section-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Section_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-section-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Section_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-section-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Section_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-section-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Section_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-section-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_Section_Block\\:\\:on_init\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-section-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Header_Section_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-section-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Header_Section_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-section-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Header_Section_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-section-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Header_Section_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Header_Section_Block\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-header-section-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Block\\:\\:on_init\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$css with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Block\\:\\:sized_dynamic_styles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Block\\:\\:sized_dynamic_styles\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Off_Canvas_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Off_Canvas_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Off_Canvas_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Off_Canvas_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Off_Canvas_Block\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Trigger_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-trigger-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Trigger_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-trigger-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Trigger_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-trigger-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Trigger_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-trigger-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Trigger_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-trigger-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Trigger_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-trigger-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Trigger_Block\\:\\:on_init\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-trigger-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Trigger_Block\\:\\:register_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-trigger-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Trigger_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-trigger-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Trigger_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$css with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-trigger-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Trigger_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$unique_id with no type specified\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-trigger-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Trigger_Block\\:\\:sized_dynamic_styles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-trigger-block.php
+
+		-
+			message: "#^Method Kadence_Blocks_Off_Canvas_Trigger_Block\\:\\:sized_dynamic_styles\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-trigger-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Off_Canvas_Trigger_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-trigger-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Off_Canvas_Trigger_Block\\:\\:\\$has_script \\(string\\) does not accept default value of type true\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-trigger-block.php
+
+		-
+			message: "#^Property Kadence_Blocks_Off_Canvas_Trigger_Block\\:\\:\\$has_style \\(string\\) does not accept default value of type false\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-trigger-block.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Off_Canvas_Trigger_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Off_Canvas_Trigger_Block\\.$#"
+			count: 1
+			path: includes/blocks/header/class-kadence-blocks-off-canvas-trigger-block.php
+
+		-
+			message: "#^Method Kadence_FluentCRM_REST_Controller\\:\\:get_collection_params\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-fluentcrm-form-rest-api.php
+
+		-
+			message: "#^Method Kadence_FluentCRM_REST_Controller\\:\\:get_items\\(\\) should return WP_Error\\|WP_REST_Response but returns array\\.$#"
+			count: 3
+			path: includes/class-fluentcrm-form-rest-api.php
+
+		-
+			message: "#^Method Kadence_FluentCRM_REST_Controller\\:\\:get_items_permission_check\\(\\) should return WP_Error\\|true but returns bool\\.$#"
+			count: 1
+			path: includes/class-fluentcrm-form-rest-api.php
+
+		-
+			message: "#^Method Kadence_FluentCRM_REST_Controller\\:\\:register_routes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-fluentcrm-form-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$route_namespace of function register_rest_route expects non\\-falsy\\-string, string given\\.$#"
+			count: 1
+			path: includes/class-fluentcrm-form-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'categories' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'context' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'credits_after' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'credits_before' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'credits_used' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'customCollections' on mixed\\.$#"
+			count: 3
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'entityType' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'goals' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'industry' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'initial_text' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'is_ai' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'keywords' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'lang' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'location' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'locationType' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'missionStatement' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'photoLibrary' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'result' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'slug' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'style' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'tone' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'tool_name' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Cannot access offset 'type' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Method Kadence_Blocks_AI_Events\\:\\:build_collection_updated_event_data\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Method Kadence_Blocks_AI_Events\\:\\:get_prophecy_token_header\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Method Kadence_Blocks_AI_Events\\:\\:handle_event\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Offset 'env' does not exist on array\\{key\\: string, email\\: string, product\\: string\\}\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Offset 'env' on array\\{key\\: string, email\\: string, product\\: string\\} in empty\\(\\) does not exist\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^One or more @param tags has an invalid name or invalid syntax\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(string The URL to use when sending events\\.\\)\\: Unexpected token \"The\", expected variable at offset 73$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Parameter \\#1 \\$collections of method Kadence_Blocks_AI_Events\\:\\:build_collection_updated_event_data\\(\\) expects array\\<array\\{label\\?\\: string, value\\: string\\}\\>, mixed given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function base64_encode expects string, string\\|false given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Parameter \\#2 \\$id_or_name of method Kadence_Blocks_AI_Events\\:\\:build_collection_updated_event_data\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-ai-events.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 3
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Cannot access offset 'ID' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Cannot access offset 'post_content' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Cannot access offset 'posts' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Cannot access offset 'related_posts' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Cannot access property \\$post_type on WP_Screen\\|null\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:__construct\\(\\) has parameter \\$slug with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:add_import_export_buttons\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:add_import_modal_styles\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:display_import_notices\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:enqueue_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:enqueue_scripts\\(\\) has parameter \\$hook with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:get_related_posts_recursive\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:get_related_posts_recursive\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:get_related_posts_recursive\\(\\) has parameter \\$parent_id with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:get_related_posts_recursive\\(\\) has parameter \\$related_posts with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:handle_bulk_export\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:handle_bulk_export\\(\\) has parameter \\$action with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:handle_bulk_export\\(\\) has parameter \\$post_ids with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:handle_bulk_export\\(\\) has parameter \\$redirect_to with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:handle_export\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:handle_export\\(\\) has parameter \\$check_referrer with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:handle_export\\(\\) has parameter \\$post_ids with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:handle_import\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:import_single_post\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:import_single_post\\(\\) has parameter \\$id_map with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:import_single_post\\(\\) has parameter \\$post_data with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:prepare_post_for_export\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:prepare_post_for_export\\(\\) has parameter \\$post with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:redirect_with_error\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:redirect_with_error\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:register_bulk_export_action\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:register_bulk_export_action\\(\\) has parameter \\$bulk_actions with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:render_import_export_buttons\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:update_block_ids\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:update_block_ids\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Method Kadence_Blocks_Cpt_Import_Export\\:\\:update_block_ids\\(\\) has parameter \\$id_map with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Parameter \\#1 \\$arr1 of function array_merge expects array, mixed given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Parameter \\#1 \\$blocks of function serialize_blocks expects array\\<int\\|string, array\\{blockName\\: string\\|null, attrs\\: array, innerBlocks\\: array\\<array\\>, innerHTML\\: string, innerContent\\: array\\}\\>, array\\{array\\} given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Parameter \\#1 \\$blocks of function serialize_blocks expects array\\<int\\|string, array\\{blockName\\: string\\|null, attrs\\: array, innerBlocks\\: array\\<array\\>, innerHTML\\: string, innerContent\\: array\\}\\>, non\\-empty\\-array\\<array\\> given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(mixed\\)\\: mixed\\)\\|null, 'maybe_unserialize' given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of function array_map expects array, mixed given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function array_merge expects array, mixed given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Property Kadence_Blocks_Cpt_Import_Export\\:\\:\\$excluded_meta_keys has no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Property Kadence_Blocks_Cpt_Import_Export\\:\\:\\$kadence_cpt_blocks type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Property Kadence_Blocks_Cpt_Import_Export\\:\\:\\$processed_posts type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Property Kadence_Blocks_Cpt_Import_Export\\:\\:\\$relationship_map type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-cpt-import-export.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'calc\\(' and '0'\\|non\\-empty\\-array results in an error\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Binary operation \"\\.\" between non\\-empty\\-array and string results in an error\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Call to an undefined method object\\:\\:add_property\\(\\)\\.$#"
+			count: 10
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Call to function is_array\\(\\) with ''\\|null will always evaluate to false\\.$#"
+			count: 4
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Call to function is_array\\(\\) with non\\-falsy\\-string will always evaluate to false\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Call to function is_numeric\\(\\) with array\\|null will always evaluate to false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Comparison operation \"\\!\\=\" between array\\{\\} and 0 results in an error\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Default value of the parameter \\#2 \\$name \\(array\\<int, string\\>\\) of method Kadence_Blocks_CSS\\:\\:render_responsive_size\\(\\) is incompatible with type string\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Default value of the parameter \\#5 \\$defaults \\(array\\<int, string\\>\\) of method Kadence_Blocks_CSS\\:\\:render_responsive_size\\(\\) is incompatible with type string\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:add_properties\\(\\) has parameter \\$properties with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:add_selector_state\\(\\) has parameter \\$reset with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:add_selector_state\\(\\) has parameter \\$state with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:add_selector_states\\(\\) has parameter \\$states with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:auto_inherit_attribtues\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:auto_inherit_attribtues\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:clear\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:convert_hex\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:fonts_output\\(\\) should return string but returns array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:frontend_block_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:get_border_value\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:get_border_value\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:get_font_size\\(\\) has parameter \\$size with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:get_font_size\\(\\) has parameter \\$unit with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:get_font_size\\(\\) should return string but returns bool\\|string\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:get_gap_size\\(\\) should return string but returns bool\\|string\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:get_media_state\\(\\) should return string but returns array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:get_sized_attribute\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:get_sized_attributes_auto\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:get_sized_attributes_auto\\(\\) has parameter \\$special_keys with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:get_variable_font_size_value\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:get_variable_gap_value\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:get_variable_value\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:has_header_styles\\(\\) should return \\$this\\(Kadence_Blocks_CSS\\) but returns false\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:has_header_styles\\(\\) should return \\$this\\(Kadence_Blocks_CSS\\) but returns true\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:has_styles\\(\\) should return \\$this\\(Kadence_Blocks_CSS\\) but returns false\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:has_styles\\(\\) should return \\$this\\(Kadence_Blocks_CSS\\) but returns true\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:is_variable_font_size_value\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:is_variable_gap_value\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:is_variable_value\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:maybe_add_google_font\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:maybe_add_google_font\\(\\) has parameter \\$font_variant with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_align_by_margin\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_align_by_margin\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_align_by_margin\\(\\) should return string but returns false\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_background\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_background\\(\\) has parameter \\$background with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_background\\(\\) has parameter \\$property with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_border\\(\\) has parameter \\$border with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_border\\(\\) has parameter \\$side with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_border\\(\\) should return string but returns false\\.$#"
+			count: 4
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_border_color\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_border_color\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_border_color\\(\\) should return string but returns false\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_border_radius\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_border_radius\\(\\) has parameter \\$unit with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_border_radius\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_border_radius\\(\\) should return string but returns false\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_border_styles\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_border_styles\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_border_styles\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_border_styles\\(\\) should return string but returns false\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_button_styles_with_states\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_button_styles_with_states\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_color\\(\\) has parameter \\$opacity with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_color\\(\\) should return string but returns false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_color_output\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_color_output\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_color_output\\(\\) should return string but returns false\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_flex_align\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_flex_align\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_flex_align\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_flex_align\\(\\) should return string but returns false\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_font\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_font\\(\\) has parameter \\$typography with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_font_family\\(\\) has parameter \\$font_name with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_font_family\\(\\) has parameter \\$google with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_font_family\\(\\) has parameter \\$subset with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_font_family\\(\\) has parameter \\$variant with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_font_family\\(\\) should return string but returns false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_font_height\\(\\) has parameter \\$font with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_font_height\\(\\) should return string but returns false\\.$#"
+			count: 6
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_font_weight\\(\\) has parameter \\$google with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_font_weight\\(\\) has parameter \\$weight with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_font_weight\\(\\) should return string but returns false\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_gap\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_gap\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_gap\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_gap\\(\\) has parameter \\$property with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_gap\\(\\) has parameter \\$unit_name with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_gap\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_gap\\(\\) should return string but returns false\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_gradient\\(\\) should return string but returns false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_half_size\\(\\) has parameter \\$size with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_half_size\\(\\) has parameter \\$unit with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_half_size\\(\\) should return string but returns false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_measure\\(\\) has parameter \\$measure with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_measure\\(\\) has parameter \\$unit with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_measure\\(\\) should return string but returns false\\.$#"
+			count: 4
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_measure_output\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_measure_output\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_measure_output\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_measure_output\\(\\) should return string but returns false\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_measure_range\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_measure_range\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_measure_range\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_measure_range\\(\\) should return string but returns false\\.$#"
+			count: 3
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_number\\(\\) has parameter \\$number with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_number\\(\\) should return string but returns false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_opacity_from_100\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_opacity_from_100\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_range\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_range\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_range\\(\\) has parameter \\$property with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_range\\(\\) has parameter \\$unit with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_range\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_range\\(\\) should return string but returns false\\.$#"
+			count: 5
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_responsive_range\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_responsive_range\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_responsive_range\\(\\) should return string but returns false\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_responsive_size\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_responsive_size\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_responsive_size\\(\\) should return string but returns false\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_row_gap\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_row_gap\\(\\) has parameter \\$custom with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_row_gap\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_row_gap\\(\\) has parameter \\$property with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_row_gap\\(\\) has parameter \\$unit_name with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_row_gap\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_row_gap\\(\\) should return string but returns false\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_row_gap_property\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_row_gap_property\\(\\) has parameter \\$attributes with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_row_gap_property\\(\\) has parameter \\$custom with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_row_gap_property\\(\\) has parameter \\$device with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_row_gap_property\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_row_gap_property\\(\\) has parameter \\$unit_name with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_shadow\\(\\) has parameter \\$shadow with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_shadow\\(\\) should return string but returns false\\.$#"
+			count: 9
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_size\\(\\) has parameter \\$size with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_size\\(\\) has parameter \\$unit with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_size\\(\\) should return string but returns false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_string\\(\\) has parameter \\$string with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_string\\(\\) should return string but returns false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_text_align\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_text_align\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_text_align\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_text_align\\(\\) should return string but returns false\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_typography\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_typography\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:render_typography\\(\\) should return string but returns false\\.$#"
+			count: 4
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:sanitize_color\\(\\) has parameter \\$opacity with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:sanitize_color\\(\\) should return string but returns false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:set_spacing_sizes\\(\\) has parameter \\$sizes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Method Kadence_Blocks_CSS\\:\\:set_style_id\\(\\) should return \\$this\\(Kadence_Blocks_CSS\\) but empty return statement found\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Negated boolean expression is always true\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Offset string on null in isset\\(\\) does not exist\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(reset \\- if true the        \\$_selector_states variable will be reset\\)\\: Unexpected token \"\\-\", expected variable at offset 173$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$css$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$device$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$font$#"
+			count: 3
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$inherit$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$shadow$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$size$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$variant$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function wp_strip_all_tags expects string, mixed given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of method Kadence_Blocks_CSS\\:\\:start_media_query\\(\\) expects string, \\$this\\(Kadence_Blocks_CSS\\) given\\.$#"
+			count: 6
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of method Kadence_Blocks_CSS\\:\\:start_media_query\\(\\) expects string, null given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Parameter \\#2 \\$alpha of function kadence_blocks_hex2rgba expects float\\|int, float\\|int\\|string given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Parameter \\#2 \\$alpha of method Kadence_Blocks_CSS\\:\\:convert_hex\\(\\) expects float\\|int, float\\|int\\|string given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Parameter \\#6 \\$single_styles of method Kadence_Blocks_CSS\\:\\:get_border_value\\(\\) expects string, bool given\\.$#"
+			count: 3
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Parameter \\#6 \\$single_styles of method Kadence_Blocks_CSS\\:\\:get_border_value\\(\\) expects string, true given\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$_desktop_only_media_query \\(array\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$_desktop_only_media_query type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$_media_query \\(null\\) does not accept string\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$_media_state \\(array\\) does not accept default value of type string\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$_media_state \\(array\\) does not accept string\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$_media_state type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$_mobile_media_query \\(array\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$_mobile_media_query type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$_selector_states type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$_special_properties_list type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$_tablet_media_query \\(array\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$_tablet_media_query type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$_tablet_only_media_query \\(array\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$_tablet_only_media_query type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$_tablet_only_pro_media_query \\(array\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$_tablet_only_pro_media_query type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$_tablet_pro_media_query \\(array\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$_tablet_pro_media_query type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$custom_styles type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$font_sizes has no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$gap_sizes has no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$google_fonts type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$head_styles type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$instance has no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$media_queries \\(null\\) does not accept array\\<string, mixed\\>\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$spacing_sizes has no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Property Kadence_Blocks_CSS\\:\\:\\$styles type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 4
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 9
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between 'desktopOnly' and array will always evaluate to false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between 'mobile' and array will always evaluate to false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between 'tablet' and array will always evaluate to false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between 'tabletOnly' and array will always evaluate to false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between 'tabletOnlyPro' and array will always evaluate to false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between 'tabletPro' and array will always evaluate to false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Ternary operator condition is always true\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Variable \\$array_value in empty\\(\\) is never defined\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Variable \\$name in empty\\(\\) always exists and is always falsy\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Variable \\$value in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Variable \\$value in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Variable \\$value_mobile in empty\\(\\) is never defined\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Variable \\$value_tablet in empty\\(\\) is never defined\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-css.php
+
+		-
+			message: "#^Access to property \\$comment_status on an unknown class POST\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Access to property \\$menu_order on an unknown class POST\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Access to property \\$ping_status on an unknown class POST\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Access to property \\$post_content_filtered on an unknown class POST\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Access to property \\$post_excerpt on an unknown class POST\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Access to property \\$post_mime_type on an unknown class POST\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Access to property \\$post_name on an unknown class POST\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Access to property \\$post_parent on an unknown class POST\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Access to property \\$post_password on an unknown class POST\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Access to property \\$post_title on an unknown class POST\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Access to property \\$post_type on an unknown class POST\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Argument of an invalid type array\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Method Kadence_Blocks_Duplicate_Post\\:\\:__construct\\(\\) has parameter \\$slug with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Method Kadence_Blocks_Duplicate_Post\\:\\:dupe_link\\(\\) has parameter \\$actions with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Method Kadence_Blocks_Duplicate_Post\\:\\:dupe_link\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Method Kadence_Blocks_Duplicate_Post\\:\\:dupe_link\\(\\) should return array but empty return statement found\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Method Kadence_Blocks_Duplicate_Post\\:\\:duplicate\\(\\) has invalid return type POST\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Method Kadence_Blocks_Duplicate_Post\\:\\:duplicate\\(\\) should return POST but returns int\\<1, max\\>\\|WP_Error\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Method Kadence_Blocks_Duplicate_Post\\:\\:duplicate_action\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Method Kadence_Blocks_Duplicate_Post\\:\\:duplicate_meta_info\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Method Kadence_Blocks_Duplicate_Post\\:\\:recursive_duplicate\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Method Kadence_Blocks_Duplicate_Post\\:\\:recursive_duplicate\\(\\) should return array but returns string\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Method Kadence_Blocks_Duplicate_Post\\:\\:update_post_ids_in_content\\(\\) has parameter \\$block_name with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Method Kadence_Blocks_Duplicate_Post\\:\\:update_post_ids_in_content\\(\\) has parameter \\$id_mapping with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Parameter \\#1 \\$post of method Kadence_Blocks_Duplicate_Post\\:\\:duplicate\\(\\) expects POST, WP_Post given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Parameter \\#1 \\$post of method Kadence_Blocks_Duplicate_Post\\:\\:duplicate\\(\\) expects POST, WP_Post\\|null given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Parameter \\#1 \\$post of method Kadence_Blocks_Duplicate_Post\\:\\:recursive_duplicate\\(\\) expects WP_Post, POST given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Parameter \\#2 \\$post of method Kadence_Blocks_Duplicate_Post\\:\\:duplicate_meta_info\\(\\) expects WP_Post, POST given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Parameter \\$post of method Kadence_Blocks_Duplicate_Post\\:\\:duplicate\\(\\) has invalid type POST\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Property WP_Post\\:\\:\\$post_type \\(string\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between false and WP_Post\\|null will always evaluate to false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^is_wp_error\\(POST\\) will always evaluate to false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-duplicate-post.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with array will always evaluate to false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Cannot access offset 'enable_editor_width' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Cannot access offset 'lang' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Cannot access offset 'nosidebar' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Cannot access offset 'page_default' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Cannot access offset 'post_default' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Cannot access offset 'sidebar' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Function Kadence\\\\kadence not found\\.$#"
+			count: 9
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Function rcp_get_membership_levels not found\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Editor_Assets\\:\\:early_editor_assets\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Editor_Assets\\:\\:editor_assets_variables\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Editor_Assets\\:\\:editor_plugin_enqueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Editor_Assets\\:\\:get_all_google_fonts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Editor_Assets\\:\\:get_body_weights\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Editor_Assets\\:\\:get_button_weights\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Editor_Assets\\:\\:get_google_font_weights\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Editor_Assets\\:\\:get_google_font_weights\\(\\) has parameter \\$font with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Editor_Assets\\:\\:get_headings_weights\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Editor_Assets\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Editor_Assets\\:\\:get_user_visibility_options\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Editor_Assets\\:\\:get_weight_label\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Editor_Assets\\:\\:get_weight_label\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Editor_Assets\\:\\:on_init_editor_assets\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Editor_Assets\\:\\:show_editor_width\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Offset 'domain' on array\\{key\\: string, email\\: string, product\\: string, api_key\\?\\: non\\-falsy\\-string, api_email\\?\\: non\\-falsy\\-string\\} in empty\\(\\) does not exist\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Offset 'env' does not exist on array\\{key\\: string, email\\: string, product\\: string, api_key\\?\\: non\\-falsy\\-string, api_email\\?\\: non\\-falsy\\-string, domain\\: string\\}\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Offset 'env' on array\\{key\\: string, email\\: string, product\\: string, api_key\\?\\: non\\-falsy\\-string, api_email\\?\\: non\\-falsy\\-string, domain\\: string\\} in empty\\(\\) does not exist\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Parameter \\#1 \\$post of function get_the_title expects int\\|WP_Post, mixed given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Property KadenceWP\\\\KadenceBlocks\\\\Editor_Assets\\:\\:\\$google_fonts type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Static property KadenceWP\\\\KadenceBlocks\\\\Editor_Assets\\:\\:\\$instance \\(null\\) does not accept KadenceWP\\\\KadenceBlocks\\\\Editor_Assets\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Used function rcp_get_access_levels not found\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Used function rcp_get_membership_levels not found\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Variable \\$post_type in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-editor-assets.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$post_content\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Action callback returns mixed but should not return anything\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Call to an undefined method Kadence_Blocks_Frontend\\:\\:register_scripts\\(\\)\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Cannot access offset 'load_fonts_local' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Function rcp_get_customer_membership_level_ids not found\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:add_blocks_to_excerpt\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:add_blocks_to_excerpt\\(\\) has parameter \\$allowed with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:add_wrapper_blocks_to_excerpt\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:add_wrapper_blocks_to_excerpt\\(\\) has parameter \\$allowed with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:blocks_cycle_through\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:blocks_cycle_through\\(\\) has parameter \\$inner_blocks with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:blocks_cycle_through\\(\\) has parameter \\$kadence_blocks with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:conditionally_render_block\\(\\) has parameter \\$block with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:enqueue_style\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:enqueue_surecart_single_product_template\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:faq_schema\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:frontend_build_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:frontend_build_css\\(\\) has parameter \\$post_object with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:frontend_css_parse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:frontend_css_parse\\(\\) has parameter \\$blocks with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:frontend_footer_gfonts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:frontend_gfonts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:frontend_inline_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:is_rest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:on_init\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:print_gfonts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:print_gfonts\\(\\) has parameter \\$gfonts with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:render_accordion_scheme_head\\(\\) has parameter \\$accorion with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:render_pane_scheme_head\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Method Kadence_Blocks_Frontend\\:\\:render_pane_scheme_head\\(\\) has parameter \\$block with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Offset 'attrs' on array\\{blockName\\: 'core/block', attrs\\: array, innerBlocks\\: array\\<array\\>, innerHTML\\: string, innerContent\\: array\\} in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Parameter \\#1 \\$post of function has_blocks expects int\\|string\\|WP_Post\\|null, int\\|false given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function strip_tags expects string, string\\|null given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function trim expects string, string\\|null given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Property Kadence_Blocks_Frontend\\:\\:\\$footer_gfonts type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Property Kadence_Blocks_Frontend\\:\\:\\$gfonts type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Frontend\\:\\:\\$faq_schema \\(null\\) does not accept array\\<int, string\\>\\|string\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Frontend\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Frontend\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-frontend.php
+
+		-
+			message: "#^Cannot access offset 'load_fonts_local' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-google-fonts.php
+
+		-
+			message: "#^Method Kadence_Blocks_Google_Fonts\\:\\:add_fonts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-google-fonts.php
+
+		-
+			message: "#^Method Kadence_Blocks_Google_Fonts\\:\\:add_fonts\\(\\) has parameter \\$fonts with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-google-fonts.php
+
+		-
+			message: "#^Method Kadence_Blocks_Google_Fonts\\:\\:frontend_footer_gfonts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-google-fonts.php
+
+		-
+			message: "#^Method Kadence_Blocks_Google_Fonts\\:\\:frontend_gfonts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-google-fonts.php
+
+		-
+			message: "#^Method Kadence_Blocks_Google_Fonts\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-google-fonts.php
+
+		-
+			message: "#^Method Kadence_Blocks_Google_Fonts\\:\\:print_gfonts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-google-fonts.php
+
+		-
+			message: "#^Method Kadence_Blocks_Google_Fonts\\:\\:print_gfonts\\(\\) has parameter \\$gfonts with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-google-fonts.php
+
+		-
+			message: "#^Property Kadence_Blocks_Google_Fonts\\:\\:\\$footer_gfonts type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-google-fonts.php
+
+		-
+			message: "#^Property Kadence_Blocks_Google_Fonts\\:\\:\\$gfonts type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-google-fonts.php
+
+		-
+			message: "#^Property Kadence_Blocks_Google_Fonts\\:\\:\\$instance has no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-google-fonts.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker-rest.php
+
+		-
+			message: "#^Cannot access offset 'crop' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker-rest.php
+
+		-
+			message: "#^Cannot access offset 'height' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker-rest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker-rest.php
+
+		-
+			message: "#^Cannot access offset 'width' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker-rest.php
+
+		-
+			message: "#^Cannot call method download\\(\\) on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker-rest.php
+
+		-
+			message: "#^Method Kadence_Blocks_Image_Picker_REST_Controller\\:\\:get_collection_params\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker-rest.php
+
+		-
+			message: "#^Method Kadence_Blocks_Image_Picker_REST_Controller\\:\\:get_items_permission_check\\(\\) should return WP_Error\\|true but returns bool\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker-rest.php
+
+		-
+			message: "#^Method Kadence_Blocks_Image_Picker_REST_Controller\\:\\:register_routes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker-rest.php
+
+		-
+			message: "#^Method Kadence_Blocks_Image_Picker_REST_Controller\\:\\:sanitize_image_sizes_array\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker-rest.php
+
+		-
+			message: "#^Parameter \\#1 \\$route_namespace of function register_rest_route expects non\\-falsy\\-string, string given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker-rest.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function sanitize_text_field expects string, mixed given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker-rest.php
+
+		-
+			message: "#^Cannot access offset 'enable_image_picker' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker.php
+
+		-
+			message: "#^Method Kadence_Blocks_Image_Picker\\:\\:add_photographer_field\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker.php
+
+		-
+			message: "#^Method Kadence_Blocks_Image_Picker\\:\\:add_photographer_field\\(\\) has parameter \\$form_fields with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker.php
+
+		-
+			message: "#^Method Kadence_Blocks_Image_Picker\\:\\:add_photographer_field\\(\\) has parameter \\$post with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker.php
+
+		-
+			message: "#^Method Kadence_Blocks_Image_Picker\\:\\:enqueue_media\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker.php
+
+		-
+			message: "#^Method Kadence_Blocks_Image_Picker\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker.php
+
+		-
+			message: "#^Method Kadence_Blocks_Image_Picker\\:\\:register_assets\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_html expects string, mixed given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker.php
+
+		-
+			message: "#^Parameter \\#1 \\$url of function esc_url expects string, mixed given\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-image-picker.php
+
+		-
+			message: "#^Property Kadence_Blocks_Image_Picker\\:\\:\\$image_sizes_cache \\(array\\<array\\<string, bool\\|int\\|string\\>\\>\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-image-picker.php
+
+		-
+			message: "#^Access to an undefined property Kadence_Blocks_Post_Rest_Controller\\:\\:\\$query_base\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Access to an undefined property Kadence_Blocks_Post_Rest_Controller\\:\\:\\$taxonomies_select\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Access to an undefined property Kadence_Blocks_Post_Rest_Controller\\:\\:\\$term_select\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Access to an undefined property WP_Term\\:\\:\\$archive_category_color\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Access to an undefined property WP_Term\\:\\:\\$archive_category_hover_color\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Argument of an invalid type array\\<WP_Term\\>\\|WP_Error supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Argument of an invalid type array\\<int, int\\|string\\|WP_Term\\>\\|string\\|WP_Error supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Cannot access property \\$name on int\\|string\\|WP_Term\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Cannot access property \\$term_id on int\\|string\\|WP_Term\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:get_allowed_post_types\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:get_allowed_tax_filters\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:get_items_permission_check\\(\\) should return WP_Error\\|true but returns bool\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:get_query_items\\(\\) should return WP_Error\\|WP_REST_Response but returns array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:get_query_params\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:get_tax_select_params\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:get_taxonomies_content\\(\\) should return WP_Error\\|WP_REST_Response but returns string\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:get_term_content\\(\\) should return WP_Error\\|WP_REST_Response but returns string\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:get_term_params\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:prepare_date_response\\(\\) should return string\\|null but returns string\\|false\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:prepare_query_item_for_response\\(\\) has parameter \\$post with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:prepare_query_item_for_response\\(\\) should return WP_REST_Response but returns array\\<string, mixed\\>\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:register_routes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:sanitize_post_ids\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:sanitize_post_ids\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:sanitize_post_source_string\\(\\) has parameter \\$source with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:sanitize_post_source_string\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:sanitize_post_source_string\\(\\) should return array\\|WP_Error but returns string\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:sanitize_post_type_string\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:sanitize_post_type_string\\(\\) should return array\\|WP_Error but returns string\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:sanitize_post_types\\(\\) has parameter \\$post_types with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:sanitize_post_types\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:validate_post_ids\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:validate_post_source_string\\(\\) has parameter \\$value with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:validate_post_type_string\\(\\) has parameter \\$value with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Post_Rest_Controller\\:\\:validate_post_types\\(\\) has parameter \\$value with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$id$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$parameter$#"
+			count: 3
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$post_type$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$args of function get_terms expects array\\{taxonomy\\?\\: array\\<string\\>\\|string, object_ids\\?\\: array\\<int\\>\\|int, orderby\\?\\: string, order\\?\\: string, hide_empty\\?\\: bool\\|int, include\\?\\: array\\<int\\>\\|string, exclude\\?\\: array\\<int\\>\\|string, exclude_tree\\?\\: array\\<int\\>\\|string, \\.\\.\\.\\}, mixed given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$attachment_id of function wp_get_attachment_image_src expects int, int\\|false given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$input_list of function wp_parse_list expects array\\|string, mixed given\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$post of function get_post_type expects int\\|WP_Post\\|null, mixed given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$route_namespace of function register_rest_route expects non\\-falsy\\-string, string given\\.$#"
+			count: 3
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Variable \\$tax_type in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-posts-rest-api.php
+
+		-
+			message: "#^Access to an undefined property Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:\\$reset\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Call to function is_array\\(\\) with non\\-falsy\\-string will always evaluate to false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Call to function is_wp_error\\(\\) with string will always evaluate to false\\.$#"
+			count: 13
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'about'\\|'achievements'\\|'blog'\\|'call\\-to\\-action'\\|'careers'\\|'contact\\-form'\\|'donate'\\|'events'\\|'faq'\\|'get\\-started'\\|'history'\\|'industries'\\|'location'\\|'mission'\\|'news'\\|'partners'\\|'pricing\\-table'\\|'products\\-services'\\|'profile'\\|'subscribe\\-form'\\|'support'\\|'team'\\|'testimonials'\\|'value\\-prop'\\|'volunteer'\\|'welcome'\\|'work' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'code' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'companyName' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'connections' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'crop' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'data' on mixed\\.$#"
+			count: 4
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'detail' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'error' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'expires' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'height' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'industry' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'industryOther' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'industrySpecific' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'job_id' on mixed\\.$#"
+			count: 3
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'keywords' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'lang' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'location' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'missionStatement' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'refresh' on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'tone' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset 'width' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset \\*NEVER\\* on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot access offset mixed on mixed\\.$#"
+			count: 6
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Cannot call method download\\(\\) on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^If condition is always false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:check_for_image\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:check_for_local_image\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:check_for_local_image\\(\\) has parameter \\$image_data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:cpt_switch_color\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:cpt_switch_color\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:cpt_switch_color\\(\\) has parameter \\$style with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:cpt_switch_meta_color\\(\\) has parameter \\$meta_key with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:cpt_switch_meta_color\\(\\) has parameter \\$meta_value with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:cpt_switch_meta_color\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:create_filename_from_alt\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:create_filename_from_alt\\(\\) has parameter \\$alt with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_collection_params\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_connection\\(\\) should return WP_REST_Response but returns WP_Error\\.$#"
+			count: 5
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_image_info\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_image_info\\(\\) has parameter \\$images with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_image_search_query\\(\\) has parameter \\$request with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_items_permission_check\\(\\) should return WP_Error\\|true but returns bool\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_library\\(\\) should return WP_REST_Response but returns WP_Error\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_license_keys\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_local_library_data\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_local_library_data\\(\\) has parameter \\$type with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_new_remote_contents\\(\\) has parameter \\$context with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_remote_contents\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_remote_contents\\(\\) should return array\\{headers\\: array, body\\: string, response\\: array\\{code\\: int, message\\: string\\}, cookies\\: array\\<WP_Http_Cookie\\>\\}\\|WP_Error but returns array\\{headers\\: WpOrg\\\\Requests\\\\Utility\\\\CaseInsensitiveDictionary, body\\: string, response\\: array\\{code\\: int, message\\: string\\}, cookies\\: array\\<int, WP_Http_Cookie\\>, filename\\: string\\|null, http_response\\: WP_HTTP_Requests_Response\\}\\|WP_Error\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_remote_industry_images\\(\\) has parameter \\$image_type with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_remote_industry_images\\(\\) has parameter \\$industries with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_remote_industry_images\\(\\) has parameter \\$sizes with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_remote_library_categories\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_remote_library_categories\\(\\) has parameter \\$library with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_remote_library_categories\\(\\) has parameter \\$library_url with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_remote_library_contents\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_remote_library_contents\\(\\) has parameter \\$library with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_remote_library_contents\\(\\) has parameter \\$library_url with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_remote_library_contents\\(\\) has parameter \\$meta with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_remote_library_contents\\(\\) should return string but returns WP_Error\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_remote_search_images\\(\\) has parameter \\$image_type with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_remote_search_images\\(\\) has parameter \\$search_query with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_remote_search_images\\(\\) has parameter \\$sizes with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_src_from_image_data\\(\\) has parameter \\$image_data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_token_header\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:import_image\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:import_image\\(\\) has parameter \\$image_data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:install_inner_posts_cpt\\(\\) has parameter \\$cpt_data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:install_inner_posts_cpt\\(\\) has parameter \\$id_map with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:install_single_cpt\\(\\) has parameter \\$cpt_data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:install_single_cpt\\(\\) has parameter \\$id_map with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:install_single_cpt\\(\\) should return int but returns false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:is_ai_job_processing\\(\\) has parameter \\$response with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:is_response_code_error\\(\\) has parameter \\$response with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:process_cpt\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:process_cpt\\(\\) has parameter \\$cpt_blocks with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:process_cpt\\(\\) has parameter \\$style with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:register_routes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:sanitize_filename\\(\\) has parameter \\$ext with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:sanitize_image_sizes_array\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:sanitize_industries_array\\(\\) has parameter \\$industries with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:sanitize_industries_array\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:update_block_ids\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:update_block_ids\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:update_block_ids\\(\\) has parameter \\$id_map with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Offset 'code' on array\\{code\\: int, message\\: string\\} in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Offset 'env' does not exist on array\\{key\\: string, email\\: string, product\\: string\\}\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Offset 'env' on array\\{key\\: string, email\\: string, product\\: string\\} in empty\\(\\) does not exist\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Offset 0 on array\\{string, numeric\\-string, string, non\\-empty\\-string\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Offset 1 on array\\{string, numeric\\-string, string, non\\-empty\\-string\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Offset 3 on array\\{string, numeric\\-string, string, non\\-empty\\-string\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$content$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$parameter$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$blocks of function serialize_blocks expects array\\<int\\|string, array\\{blockName\\: string\\|null, attrs\\: array, innerBlocks\\: array\\<array\\>, innerHTML\\: string, innerContent\\: array\\}\\>, non\\-empty\\-array\\<array\\> given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$collections of method KadenceWP\\\\KadenceBlocks\\\\Image_Downloader\\\\Cache_Primer\\:\\:init\\(\\) expects array\\<array\\{collection_slug\\: string, image_type\\: string, images\\: array\\<int, array\\{id\\: int, width\\: int, height\\: int, alt\\: string, url\\: string, photographer\\: string, photographer_url\\: string, avg_color\\: string, \\.\\.\\.\\}\\>\\}\\>, mixed given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$date_string of function get_date_from_gmt expects string, mixed given\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$job of method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_remote_contents\\(\\) expects int, mixed given\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, array\\<int, string\\>\\|string given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
+			count: 3
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$name of function wp_upload_bits expects non\\-empty\\-string, string given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of function basename expects string, string\\|false\\|null given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$response of method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:is_ai_job_processing\\(\\) expects array\\{headers\\: array, body\\: string, response\\: array\\{code\\: int, message\\: string\\}, cookies\\: array\\<WP_Http_Cookie\\>\\}, array\\{headers\\: array, body\\: string, response\\: array\\{code\\: int, message\\: string\\}, cookies\\: array\\<WP_Http_Cookie\\>\\}\\|WP_Error given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$response of method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:is_response_code_error\\(\\) expects array, array\\<string, array\\|string\\>\\|WP_Error given\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$route_namespace of function register_rest_route expects non\\-falsy\\-string, string given\\.$#"
+			count: 19
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function base64_encode expects string, string\\|false given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function rtrim expects string, mixed given\\.$#"
+			count: 6
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function sanitize_text_field expects string, mixed given\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_string_inbetween\\(\\) expects string, array\\<int, string\\>\\|string given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:get_string_inbetween_when\\(\\) expects string, array\\<int, string\\>\\|string given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#2 \\$args of function wp_remote_post expects array\\{method\\?\\: string, timeout\\?\\: float, redirection\\?\\: int, httpversion\\?\\: string, user\\-agent\\?\\: string, reject_unsafe_urls\\?\\: bool, blocking\\?\\: bool, headers\\?\\: array\\|string, \\.\\.\\.\\}, array\\{timeout\\: 20, headers\\: array\\{X\\-Prophecy\\-Token\\: string, Content\\-Type\\: 'application/json'\\}, body\\: non\\-empty\\-string\\|false\\} given\\.$#"
+			count: 5
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#2 \\$args of function wp_safe_remote_get expects array\\{method\\?\\: string, timeout\\?\\: float, redirection\\?\\: int, httpversion\\?\\: string, user\\-agent\\?\\: string, reject_unsafe_urls\\?\\: bool, blocking\\?\\: bool, headers\\?\\: array\\|string, \\.\\.\\.\\}, array\\{timeout\\: '60', sslverify\\: false\\} given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Property Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:\\$ai_cache \\(KadenceWP\\\\KadenceBlocks\\\\Cache\\\\Ai_Cache\\) does not accept mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Property Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:\\$all_contexts \\(string\\) does not accept default value of type array\\<int, string\\>\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Property Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:\\$api_key \\(null\\) does not accept default value of type string\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Property Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:\\$api_key \\(null\\) does not accept string\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Property Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:\\$api_key \\(null\\) in empty\\(\\) is always falsy\\.$#"
+			count: 3
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Property Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:\\$block_library_cache \\(KadenceWP\\\\KadenceBlocks\\\\Cache\\\\Block_Library_Cache\\) does not accept mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Property Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:\\$cache_primer \\(KadenceWP\\\\KadenceBlocks\\\\Image_Downloader\\\\Cache_Primer\\) does not accept mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Property Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:\\$initial_contexts \\(string\\) does not accept default value of type array\\<int, string\\>\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Property Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:\\$kadence_cpt_blocks type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Property Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:\\$product_id \\(string\\) does not accept mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Variable \\$key in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Variable \\$library_url in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^is_wp_error\\(string\\) will always evaluate to false\\.$#"
+			count: 13
+			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
+
+		-
+			message: "#^Action callback returns bool but should not return anything\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Call to function is_wp_error\\(\\) with string will always evaluate to false\\.$#"
+			count: 4
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Call to method delete\\(\\) on an unknown class WP_Filesystem\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Call to method exists\\(\\) on an unknown class WP_Filesystem\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Call to method mkdir\\(\\) on an unknown class WP_Filesystem\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Call to method put_contents\\(\\) on an unknown class WP_Filesystem\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Call to method touch\\(\\) on an unknown class WP_Filesystem\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Call to method wp_content_dir\\(\\) on an unknown class WP_Filesystem\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Cannot access offset 'connections' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Cannot access offset 'expires' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Cannot access offset 'refresh' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Cannot access offset string on mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Else branch is unreachable because previous condition is always true\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:add_monthly_to_cron_schedule\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:add_monthly_to_cron_schedule\\(\\) has parameter \\$schedules with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:check_for_image\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:check_for_local_image\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:check_for_local_image\\(\\) has parameter \\$image_data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:create_template_data_file\\(\\) has parameter \\$skip_local with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:get_connection_data\\(\\) has parameter \\$skip_local with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:get_connection_data\\(\\) should return string but returns array\\<string, mixed\\>\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:get_connection_data\\(\\) should return string but returns array\\<string, string\\|true\\>\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:get_filesystem\\(\\) has invalid return type WP_Filesystem\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:get_image_info\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:get_image_info\\(\\) has parameter \\$images with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:get_importer_files\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:get_importer_files\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:get_only_local_template_data\\(\\) has parameter \\$skip_local with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:get_only_local_template_data\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:get_page_prebuilt_data\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:get_page_prebuilt_data\\(\\) has parameter \\$pro_data with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:get_remote_url_contents\\(\\) should return string but empty return statement found\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:get_section_prebuilt_data\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:get_section_prebuilt_data\\(\\) has parameter \\$pro_data with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:get_template_data\\(\\) has parameter \\$skip_local with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:get_template_data\\(\\) should return string but returns string\\|false\\.$#"
+			count: 3
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:import_image\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:import_image\\(\\) has parameter \\$image_data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:prebuilt_connection_info_ajax_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:prebuilt_data_ajax_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:prebuilt_data_reload_ajax_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:prebuilt_pages_data_ajax_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:prebuilt_pages_data_reload_ajax_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:prebuilt_templates_data_ajax_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:prebuilt_templates_data_reload_ajax_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:process_content\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:process_content\\(\\) has parameter \\$import_id with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:process_content\\(\\) has parameter \\$import_library with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:process_content\\(\\) has parameter \\$import_style with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:process_content\\(\\) has parameter \\$import_type with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:process_data_ajax_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:process_image_content\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:process_image_content\\(\\) has parameter \\$image_library with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:process_image_data_ajax_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:process_individual_import\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:process_individual_import\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:process_individual_import\\(\\) has parameter \\$import_id with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:process_individual_import\\(\\) has parameter \\$import_library with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:process_individual_import\\(\\) has parameter \\$import_style with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:process_individual_import\\(\\) has parameter \\$import_type with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:process_pattern_ajax_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:process_pattern_content\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:process_subscribe_ajax_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Method Kadence_Blocks_Prebuilt_Library\\:\\:verify_ajax_call\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Offset 'error' on non\\-falsy\\-string in isset\\(\\) does not exist\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Parameter \\#1 \\$date_string of function get_date_from_gmt expects string, mixed given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Parameter \\#1 \\$message of function wp_die expects string\\|WP_Error, int given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Parameter \\#1 \\$name of function wp_upload_bits expects non\\-empty\\-string, string given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of function basename expects string, string\\|false\\|null given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Parameter \\#2 \\$args of function wp_safe_remote_get expects array\\{method\\?\\: string, timeout\\?\\: float, redirection\\?\\: int, httpversion\\?\\: string, user\\-agent\\?\\: string, reject_unsafe_urls\\?\\: bool, blocking\\?\\: bool, headers\\?\\: array\\|string, \\.\\.\\.\\}, array\\{timeout\\: '60', sslverify\\: false\\} given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Property Kadence_Blocks_Prebuilt_Library\\:\\:\\$api_key \\(null\\) does not accept default value of type string\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Property Kadence_Blocks_Prebuilt_Library\\:\\:\\$api_key \\(null\\) does not accept mixed\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Property Kadence_Blocks_Prebuilt_Library\\:\\:\\$api_key \\(null\\) does not accept string\\.$#"
+			count: 8
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Property Kadence_Blocks_Prebuilt_Library\\:\\:\\$api_key \\(null\\) in empty\\(\\) is always falsy\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Prebuilt_Library\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Prebuilt_Library\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 12
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^is_wp_error\\(string\\) will always evaluate to false\\.$#"
+			count: 4
+			path: includes/class-kadence-blocks-prebuilt-library.php
+
+		-
+			message: "#^Cannot access offset 'google' on mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-schema-updater.php
+
+		-
+			message: "#^Method Kadence_Blocks_Schema_Updater\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-schema-updater.php
+
+		-
+			message: "#^Method Kadence_Blocks_Schema_Updater\\:\\:needs_update\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-schema-updater.php
+
+		-
+			message: "#^Method Kadence_Blocks_Schema_Updater\\:\\:update\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-schema-updater.php
+
+		-
+			message: "#^Method Kadence_Blocks_Schema_Updater\\:\\:update\\(\\) has parameter \\$version with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-schema-updater.php
+
+		-
+			message: "#^Property Kadence_Blocks_Schema_Updater\\:\\:\\$current_version \\(int\\) does not accept mixed\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-schema-updater.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Schema_Updater\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Schema_Updater\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-schema-updater.php
+
+		-
+			message: "#^Call to function is_array\\(\\) with bool will always evaluate to false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Call to function is_array\\(\\) with string will always evaluate to false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Call to function is_wp_error\\(\\) with WP_Post will always evaluate to false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Filter callback return statement is missing\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Method Kadence_Blocks_Svg_Render\\:\\:fix_wp_get_attachment_image_svg\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Method Kadence_Blocks_Svg_Render\\:\\:fix_wp_get_attachment_image_svg\\(\\) should return array\\|bool but returns string\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Method Kadence_Blocks_Svg_Render\\:\\:generate_svg_elements\\(\\) has parameter \\$elements with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Method Kadence_Blocks_Svg_Render\\:\\:get_icons\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Method Kadence_Blocks_Svg_Render\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Method Kadence_Blocks_Svg_Render\\:\\:render\\(\\) has parameter \\$echo with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Method Kadence_Blocks_Svg_Render\\:\\:render\\(\\) has parameter \\$extras with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Method Kadence_Blocks_Svg_Render\\:\\:render\\(\\) has parameter \\$fill with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Method Kadence_Blocks_Svg_Render\\:\\:render\\(\\) has parameter \\$hidden with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Method Kadence_Blocks_Svg_Render\\:\\:render\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Method Kadence_Blocks_Svg_Render\\:\\:render\\(\\) has parameter \\$stroke_width with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Method Kadence_Blocks_Svg_Render\\:\\:render\\(\\) has parameter \\$title with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Parameter \\#1 \\$post of function get_post expects int\\|WP_Post\\|null, \\(array\\<int, string\\>\\|string\\) given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Property Kadence_Blocks_Svg_Render\\:\\:\\$cached_render has no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Svg_Render\\:\\:\\$all_icons \\(null\\) does not accept array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Svg_Render\\:\\:\\$all_icons \\(null\\) does not accept array\\<mixed\\>\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Svg_Render\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Svg_Render\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^is_wp_error\\(WP_Post\\) will always evaluate to false\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-svg.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$parentNode\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$textContent\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Argument of an invalid type null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Binary operation \"\\+\" between int\\|string and 1 results in an error\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Call to an undefined method object\\:\\:removeChild\\(\\)\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Cannot access property \\$post_content on WP_Post\\|null\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Cannot call method getElementsByTagName\\(\\) on DOMElement\\|null\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Function is_checkout not found\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^If condition is always false\\.$#"
+			count: 6
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:get_ignore_classes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:get_ignore_list\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:get_inner_block_ignore_list\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:get_post_from_context\\(\\) should return WP_Post\\|null but returns string\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:headings_enqueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:recursively_parse_blocks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:recursively_parse_blocks\\(\\) has parameter \\$the_post_content with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:render_table_of_content\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:render_table_of_content\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:render_table_of_content\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:reset_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:table_of_contents_delete_node_and_children\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:table_of_contents_delete_node_children\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:table_of_contents_get_headings\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:table_of_contents_get_headings\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:table_of_contents_get_headings_from_content\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:table_of_contents_get_headings_from_content\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:table_of_contents_linear_to_nested_heading_list\\(\\) has parameter \\$heading_list with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:table_of_contents_linear_to_nested_heading_list\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Method Kadence_Blocks_Table_Of_Contents\\:\\:table_of_contents_render_list\\(\\) has parameter \\$nested_heading_list with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Offset 'blockName' does not exist on string\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Offset 'innerBlocks' on string in isset\\(\\) does not exist\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Parameter \\#1 \\$block of method Kadence_Blocks_Table_Of_Contents\\:\\:recursively_parse_blocks\\(\\) expects string, array\\<string, array\\|string\\|null\\> given\\.$#"
+			count: 6
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Parameter \\#1 \\$iterator of function iterator_to_array expects Traversable, DOMNodeList\\<DOMNode\\>\\|false given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Parameter \\#1 \\$parsed_block of function render_block expects array\\{blockName\\?\\: string\\|null, attrs\\?\\: array, innerBlocks\\?\\: array\\<array\\>, innerHTML\\?\\: string, innerContent\\?\\: array\\}, string given\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function htmlspecialchars_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, float\\|int\\|string given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of function in_array expects array, null given\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method Kadence_Blocks_Table_Of_Contents\\:\\:table_of_contents_linear_to_nested_heading_list\\(\\) expects int, false given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Static method Kadence_Blocks_Table_Of_Contents\\:\\:reset_instance\\(\\) is unused\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Table_Of_Contents\\:\\:\\$anchors \\(null\\) does not accept array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Table_Of_Contents\\:\\:\\$anchors \\(null\\) does not accept array\\<int, string\\>\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Table_Of_Contents\\:\\:\\$anchors \\(null\\) does not accept default value of type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Table_Of_Contents\\:\\:\\$headings \\(null\\) does not accept array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Table_Of_Contents\\:\\:\\$headings \\(null\\) does not accept array\\<int, array\\<string, bool\\|int\\|string\\>\\>\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Table_Of_Contents\\:\\:\\$headings \\(null\\) does not accept default value of type array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Table_Of_Contents\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Table_Of_Contents\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Table_Of_Contents\\:\\:\\$the_headings \\(null\\) does not accept array\\.$#"
+			count: 1
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Variable \\$level might not be defined\\.$#"
+			count: 2
+			path: includes/class-kadence-blocks-table-of-contents.php
+
+		-
+			message: "#^Action callback returns bool but should not return anything\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Call to function is_wp_error\\(\\) with string will always evaluate to false\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Call to method delete\\(\\) on an unknown class KadenceWP\\\\KadenceBlocks\\\\WP_Filesystem\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Call to method exists\\(\\) on an unknown class KadenceWP\\\\KadenceBlocks\\\\WP_Filesystem\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Call to method mkdir\\(\\) on an unknown class KadenceWP\\\\KadenceBlocks\\\\WP_Filesystem\\.$#"
+			count: 3
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Call to method move\\(\\) on an unknown class KadenceWP\\\\KadenceBlocks\\\\WP_Filesystem\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Call to method put_contents\\(\\) on an unknown class KadenceWP\\\\KadenceBlocks\\\\WP_Filesystem\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Call to method touch\\(\\) on an unknown class KadenceWP\\\\KadenceBlocks\\\\WP_Filesystem\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Call to method wp_content_dir\\(\\) on an unknown class KadenceWP\\\\KadenceBlocks\\\\WP_Filesystem\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Cannot access offset mixed on mixed\\.$#"
+			count: 4
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Function KadenceWP\\\\KadenceBlocks\\\\print_webfont_preload\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\WebFont_Loader\\:\\:get_filesystem\\(\\) has invalid return type KadenceWP\\\\KadenceBlocks\\\\WP_Filesystem\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\WebFont_Loader\\:\\:get_local_files_from_css\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\WebFont_Loader\\:\\:get_local_files_from_css\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\WebFont_Loader\\:\\:get_main_files_from_css\\(\\) has parameter \\$css with no type specified\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\WebFont_Loader\\:\\:get_main_files_from_css\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\WebFont_Loader\\:\\:get_remote_files_from_css\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\WebFont_Loader\\:\\:get_remote_url_contents\\(\\) should return string but empty return statement found\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\WebFont_Loader\\:\\:print_preload_fonts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Offset 0 on array\\{array\\<int, string\\>\\} in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 2
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file_exists expects string, mixed given\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of function basename expects string, string\\|false\\|null given\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^is_wp_error\\(string\\) will always evaluate to false\\.$#"
+			count: 1
+			path: includes/class-local-gfonts.php
+
+		-
+			message: "#^Method Kadence_LottieAnimation_get_REST_Controller\\:\\:get_animation\\(\\) should return WP_Error\\|WP_REST_Response but returns mixed\\.$#"
+			count: 1
+			path: includes/class-lottieanimation-get-rest-api.php
+
+		-
+			message: "#^Method Kadence_LottieAnimation_get_REST_Controller\\:\\:register_routes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-lottieanimation-get-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$post of function get_post expects int\\|WP_Post\\|null, \\(array\\<int, string\\>\\|string\\) given\\.$#"
+			count: 1
+			path: includes/class-lottieanimation-get-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$route_namespace of function register_rest_route expects non\\-falsy\\-string, string given\\.$#"
+			count: 1
+			path: includes/class-lottieanimation-get-rest-api.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, mixed given\\.$#"
+			count: 1
+			path: includes/class-lottieanimation-get-rest-api.php
+
+		-
+			message: "#^Method Kadence_LottieAnimation_post_REST_Controller\\:\\:create_animation\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-lottieanimation-post-rest-api.php
+
+		-
+			message: "#^Method Kadence_LottieAnimation_post_REST_Controller\\:\\:create_animation\\(\\) should return array but returns WP_Error\\.$#"
+			count: 1
+			path: includes/class-lottieanimation-post-rest-api.php
+
+		-
+			message: "#^Method Kadence_LottieAnimation_post_REST_Controller\\:\\:create_animation_permission_check\\(\\) should return WP_Error\\|true but returns bool\\.$#"
+			count: 1
+			path: includes/class-lottieanimation-post-rest-api.php
+
+		-
+			message: "#^Method Kadence_LottieAnimation_post_REST_Controller\\:\\:register_routes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-lottieanimation-post-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$postarr of function wp_insert_post expects array\\{ID\\?\\: int, post_author\\?\\: int, post_date\\?\\: string, post_date_gmt\\?\\: string, post_content\\?\\: string, post_content_filtered\\?\\: string, post_title\\?\\: string, post_excerpt\\?\\: string, \\.\\.\\.\\}, array\\{post_title\\: non\\-falsy\\-string, post_content\\: non\\-empty\\-string\\|false, post_type\\: 'kadence_lottie', post_status\\: 'publish', post_mime_type\\: 'application/json'\\} given\\.$#"
+			count: 1
+			path: includes/class-lottieanimation-post-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$route_namespace of function register_rest_route expects non\\-falsy\\-string, string given\\.$#"
+			count: 1
+			path: includes/class-lottieanimation-post-rest-api.php
+
+		-
+			message: "#^Method Kadence_MailerLite_REST_Controller\\:\\:get_collection_params\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-mailerlite-form-rest-api.php
+
+		-
+			message: "#^Method Kadence_MailerLite_REST_Controller\\:\\:get_items\\(\\) should return WP_Error\\|WP_REST_Response but returns array\\.$#"
+			count: 1
+			path: includes/class-mailerlite-form-rest-api.php
+
+		-
+			message: "#^Method Kadence_MailerLite_REST_Controller\\:\\:get_items\\(\\) should return WP_Error\\|WP_REST_Response but returns string\\.$#"
+			count: 5
+			path: includes/class-mailerlite-form-rest-api.php
+
+		-
+			message: "#^Method Kadence_MailerLite_REST_Controller\\:\\:get_items_permission_check\\(\\) should return WP_Error\\|true but returns bool\\.$#"
+			count: 1
+			path: includes/class-mailerlite-form-rest-api.php
+
+		-
+			message: "#^Method Kadence_MailerLite_REST_Controller\\:\\:register_routes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-mailerlite-form-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$route_namespace of function register_rest_route expects non\\-falsy\\-string, string given\\.$#"
+			count: 1
+			path: includes/class-mailerlite-form-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, mixed given\\.$#"
+			count: 1
+			path: includes/class-mailerlite-form-rest-api.php
+
+		-
+			message: "#^Method KadenceBlocksAllowedAttributes\\:\\:getAttributes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-vector-post-rest-api.php
+
+		-
+			message: "#^Method Kadence_Vector_post_REST_Controller\\:\\:create_vector\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/class-vector-post-rest-api.php
+
+		-
+			message: "#^Method Kadence_Vector_post_REST_Controller\\:\\:create_vector\\(\\) should return array but returns WP_Error\\.$#"
+			count: 1
+			path: includes/class-vector-post-rest-api.php
+
+		-
+			message: "#^Method Kadence_Vector_post_REST_Controller\\:\\:create_vector_permission_check\\(\\) should return WP_Error\\|true but returns bool\\.$#"
+			count: 1
+			path: includes/class-vector-post-rest-api.php
+
+		-
+			message: "#^Method Kadence_Vector_post_REST_Controller\\:\\:register_routes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/class-vector-post-rest-api.php
+
+		-
+			message: "#^Method Kadence_Vector_post_REST_Controller\\:\\:sanitize_svg_content\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: includes/class-vector-post-rest-api.php
+
+		-
+			message: "#^Parameter \\#1 \\$route_namespace of function register_rest_route expects non\\-falsy\\-string, string given\\.$#"
+			count: 1
+			path: includes/class-vector-post-rest-api.php
+
+		-
+			message: "#^@param string \\$value does not accept actual type of parameter\\: mixed\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^@param string\\|null \\$buffer does not accept actual type of parameter\\: string\\|false\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$ID\\.$#"
+			count: 2
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Call to an undefined method object\\:\\:parse\\(\\)\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Call to function is_wp_error\\(\\) with string will always evaluate to false\\.$#"
+			count: 2
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Cannot access offset 'content' on mixed\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Cannot access offset 'success' on mixed\\.$#"
+			count: 2
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Cannot access offset mixed on mixed\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Form\\:\\:get_form_args\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Form\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Form\\:\\:html_from_notices\\(\\) has parameter \\$notices with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Form\\:\\:parse_blocks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Form\\:\\:parse_inner_blocks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Form\\:\\:parse_inner_blocks\\(\\) has parameter \\$blocks with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Form\\:\\:process_ajax\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Form\\:\\:process_bail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Form\\:\\:process_bail\\(\\) has parameter \\$required with no type specified\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Form\\:\\:sanitize_field\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Form\\:\\:sanitize_field\\(\\) has parameter \\$multi_select with no type specified\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Form\\:\\:send_json\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Form\\:\\:send_json\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Form\\:\\:start_buffer\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Method KB_Ajax_Form\\:\\:verify_recaptcha\\(\\) should return bool but returns mixed\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Offset 'code' on array\\{code\\: int, message\\: string\\} in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Offset 'response' on array\\{headers\\: WpOrg\\\\Requests\\\\Utility\\\\CaseInsensitiveDictionary, body\\: string, response\\: array\\{code\\: int, message\\: string\\}, cookies\\: array\\<int, WP_Http_Cookie\\>, filename\\: string\\|null, http_response\\: WP_HTTP_Requests_Response\\} in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Offset 1 on array\\{array\\<int, string\\>, array\\<int, string\\>\\} in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 2
+			path: includes/form-ajax.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$action$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of method KB_Ajax_Form\\:\\:parse_blocks\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, int given\\.$#"
+			count: 2
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Parameter \\#1 \\$post of function get_the_title expects int\\|WP_Post, mixed given\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Parameter \\#1 \\$post_id of method KB_Ajax_Form\\:\\:get_form_args\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function sanitize_text_field expects string, mixed given\\.$#"
+			count: 3
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function sanitize_textarea_field expects string, mixed given\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function trim expects string, mixed given\\.$#"
+			count: 2
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, mixed given\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Parameter \\#1 \\$to of function wp_mail expects array\\<string\\>\\|string, mixed given\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Parameter \\#1 \\$url of function url_to_postid expects string, string\\|false given\\.$#"
+			count: 2
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Parameter \\#2 \\$args of function wp_remote_post expects array\\{method\\?\\: string, timeout\\?\\: float, redirection\\?\\: int, httpversion\\?\\: string, user\\-agent\\?\\: string, reject_unsafe_urls\\?\\: bool, blocking\\?\\: bool, headers\\?\\: array\\|string, \\.\\.\\.\\}, array\\{method\\: 'POST', timeout\\: 15, headers\\: non\\-empty\\-array\\<'accept'\\|'Authorization'\\|'content\\-type'\\|'X\\-MailerLite\\-ApiKey', mixed\\>, body\\: non\\-empty\\-string\\|false\\} given\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Parameter \\#2 \\$replace of function str_replace expects array\\|string, string\\|false given\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Parameter \\#2 \\$str of function explode expects string, array given\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, int given\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Result of && is always true\\.$#"
+			count: 2
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Result of \\|\\| is always false\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 4
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Static property KB_Ajax_Form\\:\\:\\$instance \\(null\\) does not accept KB_Ajax_Form\\.$#"
+			count: 1
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Variable \\$field_id in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 2
+			path: includes/form-ajax.php
+
+		-
+			message: "#^is_wp_error\\(string\\) will always evaluate to false\\.$#"
+			count: 2
+			path: includes/form-ajax.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$post_type\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Cannot access offset 'show_headers_in…' on mixed\\.$#"
+			count: 2
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Cannot access property \\$template on WP_Post_Type\\|null\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Cannot access property \\$template_lock on WP_Post_Type\\|null\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Function Kadence\\\\kadence not found\\.$#"
+			count: 4
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_CPT_Controller\\:\\:add_display_post_states\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_CPT_Controller\\:\\:add_display_post_states\\(\\) has parameter \\$post_states with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_CPT_Controller\\:\\:add_new_header_to_admin_bar\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_CPT_Controller\\:\\:filter_post_type_user_caps\\(\\) has parameter \\$allcaps with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_CPT_Controller\\:\\:filter_post_type_user_caps\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_CPT_Controller\\:\\:form_gutenberg_template\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_CPT_Controller\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_CPT_Controller\\:\\:header_single_layout\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_CPT_Controller\\:\\:header_single_layout\\(\\) has parameter \\$layout with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_CPT_Controller\\:\\:meta_auth_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_CPT_Controller\\:\\:register_meta\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_CPT_Controller\\:\\:register_post_type\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_CPT_Controller\\:\\:script_enqueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_CPT_Controller\\:\\:title_styles_enqueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_CPT_Controller\\:\\:top_headers_admin_bar\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Offset 'default' on array\\{key\\: '_kad_header_anchor'\\|'_kad_header…'\\|'_kad_header_isSticky'\\|'_kad_header_pro…', type\\: 'string', default\\: ''\\}\\|array\\{key\\: '_kad_header_border'\\|'_kad_header…', type\\: 'array', children_type\\: 'object', default\\: array\\{array\\{top\\: array\\{'', 'solid', ''\\}, right\\: array\\{'', 'solid', ''\\}, bottom\\: array\\{'', 'solid', ''\\}, left\\: array\\{'', 'solid', ''\\}, unit\\: 'px'\\}\\}, properties\\: array\\{top\\: array\\{type\\: 'array'\\}, right\\: array\\{type\\: 'array'\\}, bottom\\: array\\{type\\: 'array'\\}, left\\: array\\{type\\: 'array'\\}, unit\\: array\\{type\\: 'string'\\}\\}\\}\\|array\\{key\\: '_kad_header_height'\\|'_kad_header_margin'\\|'_kad_header…'\\|'_kad_header_padding'\\|'_kad_header_width', default\\: array\\{0\\: '', 1\\: '', 2\\: '', 3\\?\\: ''\\}, type\\: 'array', children_type\\: 'string'\\}\\|array\\{key\\: '_kad_header_pro…', type\\: 'number', default\\: 1\\}\\|array\\{key\\: '_kad_header_shadow', type\\: 'array', children_type\\: 'object', default\\: array\\{array\\{enable\\: false, color\\: '\\#000000', opacity\\: 0\\.2, spread\\: 0, blur\\: 2, hOffset\\: 0, vOffset\\: 1, inset\\: false\\}\\}, properties\\: array\\{enable\\: array\\{type\\: 'boolean'\\}, color\\: array\\{type\\: 'string'\\}, opacity\\: array\\{type\\: 'number'\\}, spread\\: array\\{type\\: 'number'\\}, blur\\: array\\{type\\: 'number'\\}, hOffset\\: array\\{type\\: 'number'\\}, vOffset\\: array\\{type\\: 'number'\\}, inset\\: array\\{type\\: 'boolean'\\}\\}\\}\\|array\\{key\\: '_kad_header…', default\\: 'px', type\\: 'string'\\}\\|array\\{key\\: '_kad_header…', default\\: array\\{0, 0, 0, 0\\}, type\\: 'array', children_type\\: 'integer'\\}\\|array\\{key\\: '_kad_header…', default\\: false, type\\: 'boolean'\\}\\|array\\{key\\: '_kad_header…', default\\: true, type\\: 'boolean'\\}\\|array\\{key\\: '_kad_header…', type\\: 'array', properties\\: array\\{\\}, children_type\\: 'string', default\\: array\\{\\}\\}\\|array\\{key\\: '_kad_header…', type\\: 'number', default\\: 0\\}\\|array\\{key\\: '_kad_header…', type\\: 'object', default\\: array\\{color\\: '', image\\: '', imageID\\: '', position\\: 'center center', size\\: 'cover', repeat\\: 'no\\-repeat', attachment\\: 'scroll', type\\: 'normal', \\.\\.\\.\\}, properties\\: array\\{color\\: array\\{type\\: 'string'\\}, image\\: array\\{type\\: 'string'\\}, imageID\\: array\\{type\\: 'string'\\}, position\\: array\\{type\\: 'string'\\}, size\\: array\\{type\\: 'string'\\}, repeat\\: array\\{type\\: 'string'\\}, attachment\\: array\\{type\\: 'string'\\}, type\\: array\\{type\\: 'string'\\}, \\.\\.\\.\\}\\}\\|array\\{key\\: '_kad_header…', type\\: 'object', default\\: array\\{color\\: '', size\\: array\\{'', '', ''\\}, sizeType\\: 'px', lineHeight\\: array\\{'', '', ''\\}, lineType\\: '', letterSpacing\\: array\\{'', '', ''\\}, letterType\\: 'px', textTransform\\: '', \\.\\.\\.\\}, properties\\: array\\{color\\: array\\{type\\: 'string'\\}, size\\: array\\{type\\: 'array'\\}, sizeType\\: array\\{type\\: 'string'\\}, lineHeight\\: array\\{type\\: 'array'\\}, lineType\\: array\\{type\\: 'string'\\}, letterSpacing\\: array\\{type\\: 'array'\\}, letterType\\: array\\{type\\: 'string'\\}, textTransform\\: array\\{type\\: 'string'\\}, \\.\\.\\.\\}\\} in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Parameter \\#1 \\$args of method WP_Admin_Bar\\:\\:add_node\\(\\) expects array\\{id\\?\\: string, title\\?\\: string, parent\\?\\: string, href\\?\\: string, group\\?\\: bool, meta\\?\\: array\\}, array\\{id\\: 'kadence\\-header…', title\\: string, parent\\: 'kadence\\-top\\-headers', href\\: string\\|null\\} given\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Parameter \\#1 \\$args of method WP_Admin_Bar\\:\\:add_node\\(\\) expects array\\{id\\?\\: string, title\\?\\: string, parent\\?\\: string, href\\?\\: string, group\\?\\: bool, meta\\?\\: array\\}, array\\{id\\: non\\-falsy\\-string, title\\: string, parent\\: 'kadence\\-top\\-headers', href\\: string\\|null\\} given\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Parameter \\#1 \\$post_type of function register_post_type expects lowercase\\-string&non\\-empty\\-string, string given\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Header_CPT_Controller\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Header_CPT_Controller\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Variable \\$show_in_rest might not be defined\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-cpt.php
+
+		-
+			message: "#^Cannot access property \\$cap on WP_Post_Type\\|null\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-rest.php
+
+		-
+			message: "#^Method Kadence_Blocks_Header_CPT_Rest_Controller\\:\\:register_routes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-rest.php
+
+		-
+			message: "#^Parameter \\#1 \\$route_namespace of function register_rest_route expects non\\-falsy\\-string, string given\\.$#"
+			count: 1
+			path: includes/header/class-kadence-header-rest.php
+
+		-
+			message: "#^Cannot access offset 'activation_email' on mixed\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Cannot access offset 'ithemes' on false\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Cannot access offset 'kt_api_key' on mixed\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Function kadence_apply_aos_wrapper_args\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Function kadence_apply_aos_wrapper_args\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Function kadence_apply_aos_wrapper_args\\(\\) has parameter \\$wrapper_args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Function kadence_blocks_get_asset_file\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Function kadence_blocks_get_current_env\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Function kadence_blocks_get_current_license_data\\(\\) should return array\\{key\\: string, email\\: string, product\\: string\\} but returns array\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Function kadence_blocks_get_current_license_email\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Function kadence_blocks_get_current_license_key\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Function kadence_blocks_get_current_product_slug\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Function kadence_blocks_get_deprecated_pro_license_data\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Function kadence_blocks_get_deprecated_pro_license_data\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Function kadence_blocks_hex2rgba\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Function kadence_blocks_is_ai_disabled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Function kadence_blocks_is_network_authorize_enabled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Function kadence_blocks_is_not_amp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Function kadence_blocks_is_rest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Function kadence_blocks_wc_clean\\(\\) has parameter \\$var with no type specified\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function sanitize_text_field expects string, bool\\|float\\|int\\|string given\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Variable \\$value in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/helper-functions.php
+
+		-
+			message: "#^Cannot access property \\$base on WP_Screen\\|null\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Cannot cast mixed to string\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function Kadence\\\\kadence not found\\.$#"
+			count: 6
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_add_global_gutenberg_inline_styles\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_add_global_gutenberg_styles_frontend\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_admin_body_class\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_block_category\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_block_category\\(\\) has parameter \\$categories with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_block_category_all\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_block_category_all\\(\\) has parameter \\$categories with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_check_for_old_wp_block_category_filter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_convert_custom_fonts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_events_custom_excerpt_fix\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_events_custom_excerpt_remove_fix\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_events_custom_excerpt_remove_fix\\(\\) has parameter \\$html with no type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_events_custom_excerpt_stop_style_output\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_get_icon\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_get_icon\\(\\) has parameter \\$aria with no type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_get_post_types\\(\\) has parameter \\$other_args with no type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_get_post_types\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_get_template\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_get_template\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_get_template_html\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_get_template_html\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_print_icon\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_register_lottie_custom_post_type\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_register_vector_custom_post_type\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_skip_lazy_load\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_skip_lazy_load\\(\\) has parameter \\$context with no type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_skip_lazy_load\\(\\) has parameter \\$image with no type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_skip_lazy_load\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function kadence_blocks_update_global_gutenberg_inline_styles_dependencies\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function remove_filter invoked with 4 parameters, 2\\-3 required\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function wpmlcore_7207_fix_kadence_form_block\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Function wpmlcore_7207_fix_kadence_form_block\\(\\) has parameter \\$block with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$remove_blocks$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, mixed given\\.$#"
+			count: 1
+			path: includes/init.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$post_type\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-cpt.php
+
+		-
+			message: "#^Cannot access property \\$template on WP_Post_Type\\|null\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-cpt.php
+
+		-
+			message: "#^Cannot access property \\$template_lock on WP_Post_Type\\|null\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_CPT_Controller\\:\\:filter_post_type_user_caps\\(\\) has parameter \\$allcaps with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_CPT_Controller\\:\\:filter_post_type_user_caps\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_CPT_Controller\\:\\:form_gutenberg_template\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_CPT_Controller\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_CPT_Controller\\:\\:meta_auth_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_CPT_Controller\\:\\:navigation_single_layout\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_CPT_Controller\\:\\:navigation_single_layout\\(\\) has parameter \\$layout with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_CPT_Controller\\:\\:register_meta\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_CPT_Controller\\:\\:register_post_type\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-cpt.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_CPT_Controller\\:\\:script_enqueue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-cpt.php
+
+		-
+			message: "#^Offset 'children_type' on array\\{key\\: '_kad_navigation…', default\\: array\\{'', '', '', ''\\}, type\\: 'array', children_type\\: 'string'\\}\\|array\\{key\\: '_kad_navigation…', default\\: array\\{0, 0, 0, 0\\}, type\\: 'array', children_type\\: 'integer'\\}\\|array\\{key\\: '_kad_navigation…', default\\: array\\{array\\{size\\: array\\{'', '', ''\\}, sizeType\\: 'px', lineHeight\\: array\\{'', '', ''\\}, lineType\\: '', letterSpacing\\: array\\{'', '', ''\\}, letterType\\: 'px', textTransform\\: '', family\\: '', \\.\\.\\.\\}\\}, type\\: 'array', children_type\\: 'object', properties\\: array\\{size\\: array\\{type\\: 'array'\\}, sizeType\\: array\\{type\\: 'string'\\}, lineHeight\\: array\\{type\\: 'array'\\}, lineType\\: array\\{type\\: 'string'\\}, letterSpacing\\: array\\{type\\: 'array'\\}, letterType\\: array\\{type\\: 'string'\\}, textTransform\\: array\\{type\\: 'string'\\}, family\\: array\\{type\\: 'string'\\}, \\.\\.\\.\\}\\}\\|array\\{key\\: '_kad_navigation…', type\\: 'array', children_type\\: 'object', default\\: array\\{array\\{enable\\: false, color\\: '\\#000000', opacity\\: 0\\.1, spread\\: 0, blur\\: 13, hOffset\\: 0, vOffset\\: 2, inset\\: false\\}\\}, properties\\: array\\{enable\\: array\\{type\\: 'boolean'\\}, color\\: array\\{type\\: 'string'\\}, opacity\\: array\\{type\\: 'number'\\}, spread\\: array\\{type\\: 'number'\\}, blur\\: array\\{type\\: 'number'\\}, hOffset\\: array\\{type\\: 'number'\\}, vOffset\\: array\\{type\\: 'number'\\}, inset\\: array\\{type\\: 'boolean'\\}\\}\\}\\|array\\{key\\: '_kad_navigation…', type\\: 'array', children_type\\: 'object', default\\: array\\{array\\{enable\\: false, color\\: '\\#000000', opacity\\: 0\\.2, spread\\: 0, blur\\: 2, hOffset\\: 1, vOffset\\: 1, inset\\: false\\}\\}, properties\\: array\\{enable\\: array\\{type\\: 'boolean'\\}, color\\: array\\{type\\: 'string'\\}, opacity\\: array\\{type\\: 'number'\\}, spread\\: array\\{type\\: 'number'\\}, blur\\: array\\{type\\: 'number'\\}, hOffset\\: array\\{type\\: 'number'\\}, vOffset\\: array\\{type\\: 'number'\\}, inset\\: array\\{type\\: 'boolean'\\}\\}\\}\\|array\\{key\\: '_kad_navigation…', type\\: 'array', children_type\\: 'object', default\\: array\\{array\\{top\\: array\\{'', '', ''\\}, right\\: array\\{'', '', ''\\}, bottom\\: array\\{'', '', ''\\}, left\\: array\\{'', '', ''\\}, unit\\: 'px'\\}\\}, properties\\: array\\{top\\: array\\{type\\: 'array'\\}, right\\: array\\{type\\: 'array'\\}, bottom\\: array\\{type\\: 'array'\\}, left\\: array\\{type\\: 'array'\\}, unit\\: array\\{type\\: 'string'\\}\\}\\}\\|array\\{key\\: '_kad_navigation…', type\\: 'array', children_type\\: 'object', default\\: array\\{array\\{top\\: array\\{'', 'solid', ''\\}, right\\: array\\{'', 'solid', ''\\}, bottom\\: array\\{'', 'solid', ''\\}, left\\: array\\{'', 'solid', ''\\}, unit\\: 'px'\\}\\}, properties\\: array\\{top\\: array\\{type\\: 'array'\\}, right\\: array\\{type\\: 'array'\\}, bottom\\: array\\{type\\: 'array'\\}, left\\: array\\{type\\: 'array'\\}, unit\\: array\\{type\\: 'string'\\}\\}\\} in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-cpt.php
+
+		-
+			message: "#^Property Kadence_Blocks_Navigation_CPT_Controller\\:\\:\\$post_type has no type specified\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-cpt.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Navigation_CPT_Controller\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Navigation_CPT_Controller\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-cpt.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between 'boolean' and 'object' will always evaluate to false\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-cpt.php
+
+		-
+			message: "#^Variable \\$show_in_rest might not be defined\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-cpt.php
+
+		-
+			message: "#^Cannot access property \\$cap on WP_Post_Type\\|null\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-rest.php
+
+		-
+			message: "#^Method Kadence_Blocks_Navigation_CPT_Rest_Controller\\:\\:register_routes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-rest.php
+
+		-
+			message: "#^Parameter \\#1 \\$route_namespace of function register_rest_route expects non\\-falsy\\-string, string given\\.$#"
+			count: 1
+			path: includes/navigation/class-kadence-navigation-rest.php
+
+		-
+			message: "#^Cannot call method enqueue_script\\(\\) on mixed\\.$#"
+			count: 1
+			path: includes/resources/Admin/Admin_Provider.php
+
+		-
+			message: "#^Argument of an invalid type class\\-string\\<KadenceWP\\\\KadenceBlocks\\\\StellarWP\\\\ProphecyMonorepo\\\\Container\\\\Contracts\\\\Providable\\> supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: includes/resources/App.php
+
+		-
+			message: "#^Property KadenceWP\\\\KadenceBlocks\\\\App\\:\\:\\$providers \\(class\\-string\\<KadenceWP\\\\KadenceBlocks\\\\StellarWP\\\\ProphecyMonorepo\\\\Container\\\\Contracts\\\\Providable\\>\\) does not accept default value of type array\\<int, string\\>\\.$#"
+			count: 1
+			path: includes/resources/App.php
+
+		-
+			message: "#^Property KadenceWP\\\\KadenceBlocks\\\\Cache\\\\Block_Library_Cache\\:\\:\\$items \\(array\\<string, mixed\\>\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: includes/resources/Cache/Block_Library_Cache.php
+
+		-
+			message: "#^Cannot call method base_path\\(\\) on mixed\\.$#"
+			count: 2
+			path: includes/resources/Cache/Cache_Provider.php
+
+		-
+			message: "#^Parameter \\#1 \\$filesystem of class KadenceWP\\\\KadenceBlocks\\\\StellarWP\\\\ProphecyMonorepo\\\\Storage\\\\Drivers\\\\LocalStorage constructor expects KadenceWP\\\\KadenceBlocks\\\\Symfony\\\\Component\\\\Filesystem\\\\Filesystem, mixed given\\.$#"
+			count: 2
+			path: includes/resources/Cache/Cache_Provider.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Container\\:\\:__call\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/resources/Container.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Container\\:\\:__call\\(\\) has parameter \\$args with no type specified\\.$#"
+			count: 1
+			path: includes/resources/Container.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Container\\:\\:__call\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: includes/resources/Container.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Container\\:\\:bind\\(\\) has parameter \\$afterBuildMethods with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Container.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Container\\:\\:singleton\\(\\) has parameter \\$afterBuildMethods with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Container.php
+
+		-
+			message: "#^Call to an undefined method KadenceWP\\\\KadenceBlocks\\\\StellarWP\\\\ProphecyMonorepo\\\\Container\\\\Contracts\\\\Container\\:\\:getVar\\(\\)\\.$#"
+			count: 1
+			path: includes/resources/Database/Database_Provider.php
+
+		-
+			message: "#^Call to an undefined method KadenceWP\\\\KadenceBlocks\\\\StellarWP\\\\ProphecyMonorepo\\\\Container\\\\Contracts\\\\Container\\:\\:setVar\\(\\)\\.$#"
+			count: 1
+			path: includes/resources/Database/Database_Provider.php
+
+		-
+			message: "#^Cannot call method emergency\\(\\) on mixed\\.$#"
+			count: 1
+			path: includes/resources/Database/Database_Provider.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Harbor\\\\Actions\\\\Report_Legacy_Licenses\\:\\:__invoke\\(\\) has parameter \\$licenses with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Harbor/Actions/Report_Legacy_Licenses.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Harbor\\\\Actions\\\\Report_Legacy_Licenses\\:\\:__invoke\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Harbor/Actions/Report_Legacy_Licenses.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Hasher\\:\\:hash\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Hasher.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between array\\|float\\|int\\|object\\|string and null will always evaluate to false\\.$#"
+			count: 1
+			path: includes/resources/Hasher.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Home\\\\Home_Content_View_Model\\:\\:exports\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Home/Home_Content_View_Model.php
+
+		-
+			message: "#^Argument of an invalid type array\\<int\\|string, array\\<int\\|string, array\\<int\\|string, array\\<int\\|string, array\\<string, string\\>\\|string\\>\\|int\\|string\\>\\|int\\|string\\>\\|string\\>\\|string supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Cache_Primer.php
+
+		-
+			message: "#^Argument of an invalid type array\\<int\\|string, array\\<int\\|string, array\\<string, string\\>\\|string\\>\\|int\\|string\\>\\|int\\|string supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Cache_Primer.php
+
+		-
+			message: "#^Cannot access offset 'src' on non\\-empty\\-array\\<'name'\\|'src'\\|int, array\\{name\\: string, src\\: string\\}\\|string\\>\\|int\\|string\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Cache_Primer.php
+
+		-
+			message: "#^Dead catch \\- Throwable is never thrown in the try block\\.$#"
+			count: 2
+			path: includes/resources/Image_Downloader/Cache_Primer.php
+
+		-
+			message: "#^Offset 'sizes' does not exist on array\\<'alt'\\|'avg_color'\\|'height'\\|'id'\\|'photographer'\\|'photographer_url'\\|'sizes'\\|'url'\\|'width'\\|int, non\\-empty\\-array\\<'alt'\\|'avg_color'\\|'height'\\|'id'\\|'photographer'\\|'photographer_url'\\|'sizes'\\|'url'\\|'width'\\|int, non\\-empty\\-array\\<'name'\\|'src'\\|int, array\\{name\\: string, src\\: string\\}\\|string\\>\\|int\\|string\\>\\|int\\|string\\>\\|string\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Cache_Primer.php
+
+		-
+			message: "#^Offset 'url' does not exist on array\\<'alt'\\|'avg_color'\\|'height'\\|'id'\\|'photographer'\\|'photographer_url'\\|'sizes'\\|'url'\\|'width'\\|int, non\\-empty\\-array\\<'alt'\\|'avg_color'\\|'height'\\|'id'\\|'photographer'\\|'photographer_url'\\|'sizes'\\|'url'\\|'width'\\|int, non\\-empty\\-array\\<'name'\\|'src'\\|int, array\\{name\\: string, src\\: string\\}\\|string\\>\\|int\\|string\\>\\|int\\|string\\>\\|string\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Cache_Primer.php
+
+		-
+			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, array\\<int\\|string, array\\<int\\|string, array\\<int\\|string, array\\<int\\|string, array\\<string, string\\>\\|string\\>\\|int\\|string\\>\\|int\\|string\\>\\|string\\>\\|string given\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Cache_Primer.php
+
+		-
+			message: "#^Parameter \\#2 \\$url of method KadenceWP\\\\KadenceBlocks\\\\Symfony\\\\Contracts\\\\HttpClient\\\\HttpClientInterface\\:\\:request\\(\\) expects string, array\\<string, string\\>\\|string given\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Cache_Primer.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\<int\\|string, array\\<int\\|string, array\\<string, string\\>\\|string\\>\\|int\\|string\\>\\|int\\|string given\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Cache_Primer.php
+
+		-
+			message: "#^Possibly invalid array key type array\\<string, string\\>\\|string\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Cache_Primer.php
+
+		-
+			message: "#^Property KadenceWP\\\\KadenceBlocks\\\\Image_Downloader\\\\Cache_Primer\\:\\:\\$collections \\(array\\<array\\<string, array\\<int, array\\<string, array\\<int, array\\<string, string\\>\\>\\|int\\|string\\>\\>\\|string\\>\\>\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Cache_Primer.php
+
+		-
+			message: "#^Property KadenceWP\\\\KadenceBlocks\\\\Image_Downloader\\\\Cache_Primer\\:\\:\\$collections \\(array\\<array\\{collection_slug\\: string, image_type\\: string, images\\: array\\<int, array\\{id\\: int, width\\: int, height\\: int, alt\\: string, url\\: string, photographer\\: string, photographer_url\\: string, avg_color\\: string, \\.\\.\\.\\}\\>\\}\\>\\) does not accept array\\{array\\<array\\{collection_slug\\: string, image_type\\: string, images\\: array\\<int, array\\{id\\: int, width\\: int, height\\: int, alt\\: string, url\\: string, photographer\\: string, photographer_url\\: string, avg_color\\: string, \\.\\.\\.\\}\\>\\}\\>\\}\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Cache_Primer.php
+
+		-
+			message: "#^Call to an undefined method Throwable\\:\\:getMessage\\(\\)\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Image_Downloader.php
+
+		-
+			message: "#^Call to an undefined method Throwable\\:\\:getTraceAsString\\(\\)\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Image_Downloader.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Image_Downloader\\\\Image_Downloader\\:\\:get_existing_images\\(\\) should return array\\<array\\{id\\: int, url\\: string\\}\\> but returns non\\-empty\\-array\\<int\\<0, max\\>, array\\{id\\: false, url\\: string\\|false\\}\\>\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Image_Downloader.php
+
+		-
+			message: "#^Offset 'id' on array\\<int, array\\{id\\: int, post_id\\?\\: int, width\\: int, height\\: int, alt\\: string, url\\: string, photographer\\: string, photographer_url\\: string, \\.\\.\\.\\}\\>\\|string on left side of \\?\\? does not exist\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Image_Downloader.php
+
+		-
+			message: "#^Offset 'post_id' on array\\<int, array\\{id\\: int, post_id\\?\\: int, width\\: int, height\\: int, alt\\: string, url\\: string, photographer\\: string, photographer_url\\: string, \\.\\.\\.\\}\\>\\|string on left side of \\?\\? does not exist\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Image_Downloader.php
+
+		-
+			message: "#^Parameter \\#1 \\$attachment_id of function wp_get_attachment_image_url expects int, false given\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Image_Downloader.php
+
+		-
+			message: "#^Parameter \\#1 \\$image_response of method KadenceWP\\\\KadenceBlocks\\\\StellarWP\\\\ProphecyMonorepo\\\\ImageDownloader\\\\ImageDownloader\\:\\:download\\(\\) expects array\\<array\\{collection_slug\\: string, image_type\\: string, images\\: array\\<int, array\\{id\\: int, width\\: int, height\\: int, alt\\: string, url\\: string, photographer\\: string, photographer_url\\: string, avg_color\\: string, \\.\\.\\.\\}\\>\\}\\>, array\\{array\\<array\\{collection_slug\\?\\: string, image_type\\?\\: string, images\\: array\\<int, array\\{id\\: int, post_id\\?\\: int, width\\: int, height\\: int, alt\\: string, url\\: string, photographer\\: string, photographer_url\\: string, \\.\\.\\.\\}\\>\\}\\|string\\>\\} given\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Image_Downloader.php
+
+		-
+			message: "#^Strict comparison using \\!\\=\\= between false and false will always evaluate to false\\.$#"
+			count: 2
+			path: includes/resources/Image_Downloader/Image_Downloader.php
+
+		-
+			message: "#^Cannot access offset 'mime' on array\\|false\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Image_Editor.php
+
+		-
+			message: "#^Cannot access offset 0 on array\\|false\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Image_Editor.php
+
+		-
+			message: "#^Cannot access offset 1 on array\\|false\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Image_Editor.php
+
+		-
+			message: "#^Cannot call method error\\(\\) on mixed\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Image_Editor.php
+
+		-
+			message: "#^Cannot call method images\\(\\) on mixed\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Image_Editor.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Image_Downloader\\\\Image_Editor\\:\\:test\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Image_Editor.php
+
+		-
+			message: "#^Property KadenceWP\\\\KadenceBlocks\\\\Image_Downloader\\\\Image_Editor\\:\\:\\$image_sizes_cache \\(array\\<array\\<string, bool\\|int\\|string\\>\\>\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Image_Editor.php
+
+		-
+			message: "#^Property KadenceWP\\\\KadenceBlocks\\\\Image_Downloader\\\\Image_Editor\\:\\:\\$logger \\(KadenceWP\\\\KadenceBlocks\\\\Psr\\\\Log\\\\LoggerInterface\\) does not accept mixed\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Image_Editor.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Image_Editor.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function sanitize_text_field expects string, int\\|string given\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Meta.php
+
+		-
+			message: "#^Property KadenceWP\\\\KadenceBlocks\\\\Image_Downloader\\\\Pexels_ID_Registry\\:\\:\\$ids \\(array\\{post_ids\\: array\\<int, int\\>, pexels_ids\\: array\\<int, int\\>\\}\\) does not accept default value of type array\\{\\}\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Pexels_ID_Registry.php
+
+		-
+			message: "#^Variable \\$hashes in PHPDoc tag @var does not match assigned variable \\$ids\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/Pexels_ID_Registry.php
+
+		-
+			message: "#^Cannot access property \\$file on KadenceWP\\\\KadenceBlocks\\\\StellarWP\\\\ProphecyMonorepo\\\\ImageDownloader\\\\Models\\\\DownloadedImage\\|false\\.$#"
+			count: 4
+			path: includes/resources/Image_Downloader/WordPress_Importer.php
+
+		-
+			message: "#^Cannot access property \\$photographer on KadenceWP\\\\KadenceBlocks\\\\StellarWP\\\\ProphecyMonorepo\\\\ImageDownloader\\\\Models\\\\DownloadedImage\\|false\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/WordPress_Importer.php
+
+		-
+			message: "#^Parameter \\#1 \\$image of method KadenceWP\\\\KadenceBlocks\\\\Image_Downloader\\\\WordPress_Importer\\:\\:get_file_name\\(\\) expects KadenceWP\\\\KadenceBlocks\\\\StellarWP\\\\ProphecyMonorepo\\\\ImageDownloader\\\\Models\\\\DownloadedImage, KadenceWP\\\\KadenceBlocks\\\\StellarWP\\\\ProphecyMonorepo\\\\ImageDownloader\\\\Models\\\\DownloadedImage\\|false given\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/WordPress_Importer.php
+
+		-
+			message: "#^Parameter \\#2 \\$image of method KadenceWP\\\\KadenceBlocks\\\\Image_Downloader\\\\Meta\\:\\:add\\(\\) expects KadenceWP\\\\KadenceBlocks\\\\StellarWP\\\\ProphecyMonorepo\\\\ImageDownloader\\\\Models\\\\DownloadedImage, KadenceWP\\\\KadenceBlocks\\\\StellarWP\\\\ProphecyMonorepo\\\\ImageDownloader\\\\Models\\\\DownloadedImage\\|false given\\.$#"
+			count: 1
+			path: includes/resources/Image_Downloader/WordPress_Importer.php
+
+		-
+			message: "#^Cannot call method setFormatter\\(\\) on mixed\\.$#"
+			count: 1
+			path: includes/resources/Log/Log_Provider.php
+
+		-
+			message: "#^Parameter \\#1 \\$handler of method KadenceWP\\\\KadenceBlocks\\\\Monolog\\\\Logger\\:\\:pushHandler\\(\\) expects KadenceWP\\\\KadenceBlocks\\\\Monolog\\\\Handler\\\\HandlerInterface, mixed given\\.$#"
+			count: 1
+			path: includes/resources/Log/Log_Provider.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Analysis_Registry\\:\\:get_valid_sections\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Analysis_Registry.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Analysis_Registry\\:\\:get_valid_sections\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Analysis_Registry.php
+
+		-
+			message: "#^PHPDoc tag @phpstan\\-type HtmlClassHeightMap has invalid value\\: Unexpected token \"Class\", expected TOKEN_PHPDOC_EOL at offset 129$#"
+			count: 1
+			path: includes/resources/Optimizer/Analysis_Registry.php
+
+		-
+			message: "#^PHPDoc tag @return with type mixed is not subtype of native type array\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Analysis_Registry.php
+
+		-
+			message: "#^Call to an undefined method Throwable\\:\\:getMessage\\(\\)\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Database/Optimizer_Table.php
+
+		-
+			message: "#^Call to an undefined method Throwable\\:\\:getMessage\\(\\)\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Database/Viewport_Hash_Table.php
+
+		-
+			message: "#^PHPDoc type array\\<string\\> of property KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Database\\\\Viewport_Hash_Table\\:\\:\\$uid_column is not covariant with PHPDoc type string of overridden property KadenceWP\\\\KadenceBlocks\\\\StellarWP\\\\Schema\\\\Tables\\\\Contracts\\\\Table\\:\\:\\$uid_column\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Database/Viewport_Hash_Table.php
+
+		-
+			message: "#^Static property KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Database\\\\Viewport_Hash_Table\\:\\:\\$uid_column \\(array\\<string\\>\\) does not accept default value of type string\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Database/Viewport_Hash_Table.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Hash\\\\Hash_Builder\\:\\:parse_composite_hash\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Hash/Hash_Builder.php
+
+		-
+			message: "#^Offset 0 on array\\{array\\<int, string\\>\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Hash/Hash_Builder.php
+
+		-
+			message: "#^Offset 1 on array\\{array\\<int, string\\>, array\\<int, non\\-falsy\\-string\\>\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Hash/Hash_Builder.php
+
+		-
+			message: "#^@param string \\$src does not accept actual type of parameter\\: string\\|true\\|null\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Image/Image_Processor.php
+
+		-
+			message: "#^@param string\\|null \\$classes does not accept actual type of parameter\\: string\\|true\\|null\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Image/Image_Processor.php
+
+		-
+			message: "#^Parameter \\#1 \\$query of method WP_HTML_Tag_Processor\\:\\:next_tag\\(\\) expects array\\{tag_name\\?\\: string\\|null, match_offset\\?\\: int\\|null, class_name\\?\\: string\\|null, tag_closers\\?\\: string\\|null\\}\\|null, 'body' given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Image/Image_Processor.php
+
+		-
+			message: "#^Parameter \\#1 \\$query of method WP_HTML_Tag_Processor\\:\\:next_tag\\(\\) expects array\\{tag_name\\?\\: string\\|null, match_offset\\?\\: int\\|null, class_name\\?\\: string\\|null, tag_closers\\?\\: string\\|null\\}\\|null, 'img' given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Image/Image_Processor.php
+
+		-
+			message: "#^Cannot cast mixed to string\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Lazy_Load/Background_Lazy_Loader.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Lazy_Load\\\\Background_Lazy_Loader\\:\\:lazy_load_column_backgrounds\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Lazy_Load/Background_Lazy_Loader.php
+
+		-
+			message: "#^Cannot cast mixed to string\\.$#"
+			count: 2
+			path: includes/resources/Optimizer/Lazy_Load/Element_Lazy_Loader.php
+
+		-
+			message: "#^PHPDoc tag @phpstan\\-type HtmlClassHeightMap has invalid value\\: Unexpected token \"Class\", expected TOKEN_PHPDOC_EOL at offset 174$#"
+			count: 1
+			path: includes/resources/Optimizer/Lazy_Load/Element_Lazy_Loader.php
+
+		-
+			message: "#^Parameter \\#1 \\$class_attr of method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Lazy_Load\\\\Sections\\\\Lazy_Render_Decider\\:\\:get_section_height_by_class_attr\\(\\) expects string, string\\|true given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Lazy_Load/Element_Lazy_Loader.php
+
+		-
+			message: "#^Parameter \\#1 \\$input of function array_filter expects array, array\\<int, string\\>\\|false given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Lazy_Load/Element_Lazy_Loader.php
+
+		-
+			message: "#^Parameter \\#1 \\$unique_id of method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Lazy_Load\\\\Sections\\\\Lazy_Render_Decider\\:\\:get_section_height_by_unique_id\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Lazy_Load/Element_Lazy_Loader.php
+
+		-
+			message: "#^Cannot call method is_optimizer_request\\(\\) on mixed\\.$#"
+			count: 4
+			path: includes/resources/Optimizer/Lazy_Load/Provider.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Lazy_Load\\\\Sections\\\\Lazy_Render_Decider\\:\\:__construct\\(\\) has parameter \\$excluded_classes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Lazy_Load/Sections/Lazy_Render_Decider.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Lazy_Load/Slider_Lazy_Loader.php
+
+		-
+			message: "#^Cannot access offset 'bgImg' on mixed\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Lazy_Load/Slider_Lazy_Loader.php
+
+		-
+			message: "#^Cannot call method enabled\\(\\) on mixed\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Optimizer_Provider.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, mixed given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Path/Path_Factory.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Post_List_Table\\\\Column_Registrar\\:\\:mark_sortable\\(\\) has parameter \\$columns with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Post_List_Table/Column_Registrar.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Post_List_Table\\\\Column_Registrar\\:\\:mark_sortable\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Post_List_Table/Column_Registrar.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Post_List_Table/Filter.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, int given\\.$#"
+			count: 4
+			path: includes/resources/Optimizer/Post_List_Table/Filter.php
+
+		-
+			message: "#^Parameter \\#1 \\$column of class KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Post_List_Table\\\\Column_Registrar constructor expects KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Post_List_Table\\\\Column, mixed given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Post_List_Table/Provider.php
+
+		-
+			message: "#^Parameter \\#1 \\$store of class KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Store\\\\Cached_Store_Decorator constructor expects KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Store\\\\Contracts\\\\Store, mixed given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Post_List_Table/Provider.php
+
+		-
+			message: "#^Parameter \\#2 \\$renderable of class KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Post_List_Table\\\\Column_Registrar constructor expects KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Post_List_Table\\\\Contracts\\\\Renderable, mixed given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Post_List_Table/Provider.php
+
+		-
+			message: "#^Call to function is_wp_error\\(\\) with non\\-falsy\\-string will always evaluate to false\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Post_List_Table/Renderers/Optimizer_Renderer.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Post_List_Table\\\\Renderers\\\\Optimizer_Renderer\\:\\:render_action_link\\(\\) has parameter \\$render_data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Post_List_Table/Renderers/Optimizer_Renderer.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, int given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Post_List_Table/Renderers/Optimizer_Renderer.php
+
+		-
+			message: "#^Parameter \\#1 \\$url of function esc_url expects string, string\\|false given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Post_List_Table/Renderers/Optimizer_Renderer.php
+
+		-
+			message: "#^is_wp_error\\(string\\) will always evaluate to false\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Post_List_Table/Renderers/Optimizer_Renderer.php
+
+		-
+			message: "#^Cannot cast mixed to string\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Post_List_Table/Sorters/Optimizer_Sorter.php
+
+		-
+			message: "#^Cannot call method force_anonymous_request\\(\\) on mixed\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Request/Provider.php
+
+		-
+			message: "#^Parameter \\#1 \\$nonce of method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Nonce\\\\Nonce\\:\\:verify\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Request/Request_Anonymizer.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Resource_Hints\\\\Google_Font_Preconnector\\:\\:preconnect\\(\\) has parameter \\$urls with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Resource_Hints/Google_Font_Preconnector.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Resource_Hints\\\\Google_Font_Preconnector\\:\\:preconnect\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Resource_Hints/Google_Font_Preconnector.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Response\\\\DeviceAnalysis\\:\\:from\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Response/DeviceAnalysis.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Response\\\\DeviceAnalysis\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Response/DeviceAnalysis.php
+
+		-
+			message: "#^Parameter \\#1 \\$attributes of static method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Response\\\\Section\\:\\:from\\(\\) expects array\\{id\\: string, height\\: float, tagName\\: string, className\\: string, path\\: string, isAboveFold\\: bool, hasImages\\: bool, hasBackground\\: bool\\}, array given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Response/DeviceAnalysis.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Response\\\\ImageAnalysis\\:\\:from\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 2
+			path: includes/resources/Optimizer/Response/ImageAnalysis.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Response\\\\ImageAnalysis\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 2
+			path: includes/resources/Optimizer/Response/ImageAnalysis.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Response\\\\ImageAnalysis\\:\\:toArray\\(\\) should return array\\{path\\: string, src\\: string, srcset\\: array, width\\: int, height\\: int, widthAttr\\: string, heightAttr\\: string, naturalWidth\\: int, \\.\\.\\.\\} but returns array\\{path\\: string, src\\: string, srcset\\: array\\<array\\{url\\: string, width\\: int\\}\\>, width\\: int, height\\: int, widthAttr\\: string, heightAttr\\: string, naturalWidth\\: int, \\.\\.\\.\\}\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Response/ImageAnalysis.php
+
+		-
+			message: "#^Offset 'aspectRatio' on array\\{path\\: string, src\\: string, srcset\\: array, width\\: int, height\\: int, widthAttr\\: string, heightAttr\\: string, naturalWidth\\: int, \\.\\.\\.\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Response/ImageAnalysis.php
+
+		-
+			message: "#^Offset 'height' on array\\{path\\: string, src\\: string, srcset\\: array, width\\: int, height\\: int, widthAttr\\: string, heightAttr\\: string, naturalWidth\\: int, \\.\\.\\.\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Response/ImageAnalysis.php
+
+		-
+			message: "#^Offset 'heightAttr' on array\\{path\\: string, src\\: string, srcset\\: array, width\\: int, height\\: int, widthAttr\\: string, heightAttr\\: string, naturalWidth\\: int, \\.\\.\\.\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Response/ImageAnalysis.php
+
+		-
+			message: "#^Offset 'naturalHeight' on array\\{path\\: string, src\\: string, srcset\\: array, width\\: int, height\\: int, widthAttr\\: string, heightAttr\\: string, naturalWidth\\: int, \\.\\.\\.\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Response/ImageAnalysis.php
+
+		-
+			message: "#^Offset 'naturalWidth' on array\\{path\\: string, src\\: string, srcset\\: array, width\\: int, height\\: int, widthAttr\\: string, heightAttr\\: string, naturalWidth\\: int, \\.\\.\\.\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Response/ImageAnalysis.php
+
+		-
+			message: "#^Offset 'path' on array\\{path\\: string, src\\: string, srcset\\: array, width\\: int, height\\: int, widthAttr\\: string, heightAttr\\: string, naturalWidth\\: int, \\.\\.\\.\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Response/ImageAnalysis.php
+
+		-
+			message: "#^Offset 'src' on array\\{path\\: string, src\\: string, srcset\\: array, width\\: int, height\\: int, widthAttr\\: string, heightAttr\\: string, naturalWidth\\: int, \\.\\.\\.\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Response/ImageAnalysis.php
+
+		-
+			message: "#^Offset 'srcset' on array\\{path\\: string, src\\: string, srcset\\: array, width\\: int, height\\: int, widthAttr\\: string, heightAttr\\: string, naturalWidth\\: int, \\.\\.\\.\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Response/ImageAnalysis.php
+
+		-
+			message: "#^Offset 'width' on array\\{path\\: string, src\\: string, srcset\\: array, width\\: int, height\\: int, widthAttr\\: string, heightAttr\\: string, naturalWidth\\: int, \\.\\.\\.\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Response/ImageAnalysis.php
+
+		-
+			message: "#^Offset 'widthAttr' on array\\{path\\: string, src\\: string, srcset\\: array, width\\: int, height\\: int, widthAttr\\: string, heightAttr\\: string, naturalWidth\\: int, \\.\\.\\.\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Response/ImageAnalysis.php
+
+		-
+			message: "#^Parameter \\#1 \\$attributes of static method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Response\\\\ComputedStyle\\:\\:from\\(\\) expects array\\{width\\: string, height\\: string, objectFit\\: string, objectPosition\\: string\\}, array given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Response/ImageAnalysis.php
+
+		-
+			message: "#^Parameter \\#1 \\$attributes of static method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Response\\\\SrcsetEntry\\:\\:from\\(\\) expects array\\{url\\: string, width\\: int\\}, array given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Response/ImageAnalysis.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Response\\\\WebsiteAnalysis\\:\\:from\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			count: 3
+			path: includes/resources/Optimizer/Response/WebsiteAnalysis.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Response\\\\WebsiteAnalysis\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 3
+			path: includes/resources/Optimizer/Response/WebsiteAnalysis.php
+
+		-
+			message: "#^Offset 'images' on array\\{isStale\\?\\: bool, desktop\\: array, mobile\\: array, images\\: array\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Response/WebsiteAnalysis.php
+
+		-
+			message: "#^Parameter \\#1 \\$attributes of static method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Response\\\\DeviceAnalysis\\:\\:from\\(\\) expects array\\{criticalImages\\: array\\<string\\>, backgroundImages\\?\\: array\\<string\\>, sections\\?\\: array\\}, array given\\.$#"
+			count: 2
+			path: includes/resources/Optimizer/Response/WebsiteAnalysis.php
+
+		-
+			message: "#^Parameter \\#1 \\$attributes of static method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Response\\\\ImageAnalysis\\:\\:from\\(\\) expects array\\{path\\: string, src\\: string, srcset\\: array, width\\: int, height\\: int, widthAttr\\: string, heightAttr\\: string, naturalWidth\\: int, \\.\\.\\.\\}, array given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Response/WebsiteAnalysis.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 4
+			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
+
+		-
+			message: "#^Cannot access offset mixed on mixed\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Rest\\\\Optimize_Rest_Controller\\:\\:get_create_params\\(\\) should return array\\<string, array\\{type\\: string, description\\: string, minimum\\: int\\<1, max\\>, required\\: true, sanitize_callback\\: callable\\(\\)\\: mixed, properties\\: array\\<string, mixed\\>\\}\\> but returns non\\-empty\\-array\\<string, array\\{type\\: 'object', properties\\: array\\}\\|array\\{type\\: string, description\\: string, minimum\\: int\\<1, max\\>, required\\: true, sanitize_callback\\: callable\\(\\)\\: mixed\\}\\>\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Rest\\\\Optimize_Rest_Controller\\:\\:get_default_params\\(\\) should return array\\<string, array\\{type\\: string, description\\: string, minimum\\: int\\<1, max\\>, required\\: true, sanitize_callback\\: callable\\(\\)\\: mixed\\}\\> but returns array\\{post_path\\: array\\{type\\: 'string', description\\: string, required\\: true, sanitize_callback\\: 'sanitize_text_field'\\}, post_id\\: array\\{type\\: 'integer', description\\: string, minimum\\: 1, required\\: true, sanitize_callback\\: Closure\\(mixed\\)\\: int\\}\\}\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
+
+		-
+			message: "#^Parameter \\#1 \\$attributes of static method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Response\\\\WebsiteAnalysis\\:\\:from\\(\\) expects array\\{isStale\\?\\: bool, desktop\\: array, mobile\\: array, images\\: array\\}, mixed given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of class KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Path\\\\Path constructor expects string, mixed given\\.$#"
+			count: 4
+			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
+
+		-
+			message: "#^Parameter \\#1 \\$post of function get_permalink expects int\\|WP_Post, mixed given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
+
+		-
+			message: "#^Parameter \\#1 \\$post of function get_post expects int\\|WP_Post\\|null, mixed given\\.$#"
+			count: 4
+			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
+
+		-
+			message: "#^Parameter \\#1 \\$post of function get_post_status expects int\\|WP_Post\\|null, mixed given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
+
+		-
+			message: "#^Parameter \\#1 \\$post of method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Rest\\\\Optimize_Rest_Controller\\:\\:get_post_path\\(\\) expects int\\|WP_Post, mixed given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
+
+		-
+			message: "#^Parameter \\#1 \\$post_id of method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Rest\\\\Optimize_Rest_Controller\\:\\:update_post\\(\\) expects int, mixed given\\.$#"
+			count: 3
+			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
+
+		-
+			message: "#^Parameter \\#1 \\$post_id of method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Status\\\\Status\\:\\:is_excluded\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
+
+		-
+			message: "#^Parameter \\#1 \\$postarr of function wp_update_post expects array\\{ID\\?\\: int, post_author\\?\\: int, post_date\\?\\: string, post_date_gmt\\?\\: string, post_content\\?\\: string, post_content_filtered\\?\\: string, post_title\\?\\: string, post_excerpt\\?\\: string, \\.\\.\\.\\}, WP_Post given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
+
+		-
+			message: "#^Parameter \\#1 \\$route_namespace of function register_rest_route expects non\\-falsy\\-string, string given\\.$#"
+			count: 3
+			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
+
+		-
+			message: "#^Parameter \\#2 \\$post_id of class KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Path\\\\Path constructor expects int\\|null, mixed given\\.$#"
+			count: 4
+			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
+
+		-
+			message: "#^Cannot call method register_routes\\(\\) on mixed\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Rest/Provider.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Rest\\\\Schema\\:\\:get_item_schema\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Rest/Schema.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Rest\\\\Schema\\:\\:get_params\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Rest/Schema.php
+
+		-
+			message: "#^Cannot cast mixed to string\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/State.php
+
+		-
+			message: "#^Property KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Status\\\\Meta\\:\\:\\$asset is never read, only written\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Status/Meta.php
+
+		-
+			message: "#^Cannot call method maybe_clear_optimizer_data\\(\\) on mixed\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Status/Provider.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Status/Status.php
+
+		-
+			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Store\\\\Cached_Store_Decorator\\:\\:has\\(\\) should return bool but returns mixed\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Store/Cached_Store_Decorator.php
+
+		-
+			message: "#^Call to an undefined method KadenceWP\\\\KadenceBlocks\\\\StellarWP\\\\ProphecyMonorepo\\\\Container\\\\Contracts\\\\Container\\:\\:bindDecorators\\(\\)\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Store/Provider.php
+
+		-
+			message: "#^Parameter \\#1 \\$attributes of static method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Response\\\\WebsiteAnalysis\\:\\:from\\(\\) expects array\\{isStale\\?\\: bool, desktop\\: array, mobile\\: array, images\\: array\\}, mixed given\\.$#"
+			count: 1
+			path: includes/resources/Optimizer/Store/Table_Store.php
+
+		-
+			message: "#^Cannot access offset 'enable_editor_width' on mixed\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Cannot access offset 'kadence…' on mixed\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Cannot access offset 'limited_margins' on mixed\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Cannot access offset 'nosidebar' on mixed\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Cannot access offset 'override' on mixed\\.$#"
+			count: 3
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Cannot access offset 'page_default' on mixed\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Cannot access offset 'palette' on mixed\\.$#"
+			count: 2
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Cannot access offset 'post_default' on mixed\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Cannot access offset 'sidebar' on mixed\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:activation_redirect\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:add_color_palette_css_to_block_editor\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:add_color_palette_css_to_block_editor\\(\\) has parameter \\$settings with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:add_menu\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:add_network_menu\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:add_settings_link\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:add_settings_link\\(\\) has parameter \\$links with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:admin_bar_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:admin_editor_width\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:admin_pro_kadence_notice\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:ajax_blocks_activate_deactivate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:ajax_blocks_save_config\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:ajax_default_editor_width\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:blocks_array\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:config_page\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:deregister_blocks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:enabled_editor_width_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:exit_interview_args\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:exit_interview_args\\(\\) has parameter \\$default_args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:fonts_local_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:get_color_palette_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:get_data_options\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:get_upgrade_notice\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:home_page\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:home_scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:init_post_meta\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:limited_margins_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:load_api_settings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:load_color_palette\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:load_color_palette_editor_settings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:load_color_palette_editor_settings\\(\\) has parameter \\$settings with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:load_fonts_local_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:load_settings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:maxwidths_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:nosidebar_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:optin_notice_args\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:optin_notice_args\\(\\) has parameter \\$default_args with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:page_default_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:plugin_update_message\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:plugin_update_message\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:post_default_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:print_color_palette_css\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:scripts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:settings_link\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:settings_user_capabilities\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:show_editor_width\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:show_headers_in_admin_bar_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:sidebar_callback\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:validate_options\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Method Kadence_Blocks_Settings\\:\\:validate_options\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
+			count: 4
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, \\(float\\|int\\) given\\.$#"
+			count: 5
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, float\\|int given\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, float\\|int\\|string given\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Parameter \\#5 \\$callback of function add_menu_page expects ''\\|\\(callable\\(\\)\\: mixed\\), null given\\.$#"
+			count: 2
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Property Kadence_Blocks_Settings\\:\\:\\$settings type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Settings\\:\\:\\$authorized_cache is never read, only written\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Settings\\:\\:\\$editor_width \\(null\\) does not accept bool\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Static property Kadence_Blocks_Settings\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Settings\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Variable \\$post_type in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Variable \\$san_palette in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-settings.php
+
+		-
+			message: "#^Cannot access offset 'current_version' on mixed\\.$#"
+			count: 4
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Cannot access offset 'db_version' on mixed\\.$#"
+			count: 2
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Cannot access offset 'prior_version' on mixed\\.$#"
+			count: 4
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Cannot access offset 'version_history' on mixed\\.$#"
+			count: 10
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 4
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Cannot access offset int\\<1, max\\> on mixed\\.$#"
+			count: 2
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Method Kadence_Blocks_Site_Health\\:\\:add_site_health_info\\(\\) has parameter \\$debug_info with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Method Kadence_Blocks_Site_Health\\:\\:add_site_health_info\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Method Kadence_Blocks_Site_Health\\:\\:bool_to_on_off_string\\(\\) is unused\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Method Kadence_Blocks_Site_Health\\:\\:bool_to_yes_no_string\\(\\) is unused\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Method Kadence_Blocks_Site_Health\\:\\:get_fields\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Method Kadence_Blocks_Site_Health\\:\\:init_data_settings\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Method Kadence_Blocks_Site_Health\\:\\:init_data_settings\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Method Kadence_Blocks_Site_Health\\:\\:map_general_fields\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Parameter \\#1 \\$array_arg of function krsort expects array, mixed given\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Parameter \\#1 \\$input of function array_keys expects array, mixed given\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Parameter \\#1 \\$timestamp of method Kadence_Blocks_Site_Health\\:\\:adjust_date_time_display\\(\\) expects int, int\\<1, max\\>\\|string given\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of method Kadence_Blocks_Site_Health\\:\\:check_for_empty_json\\(\\) expects string, mixed given\\.$#"
+			count: 2
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Parameter \\#2 \\$version2 of function version_compare expects string, mixed given\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Property Kadence_Blocks_Site_Health\\:\\:\\$data_settings \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Property Kadence_Blocks_Site_Health\\:\\:\\$data_settings type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Property Kadence_Blocks_Site_Health\\:\\:\\$fields type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Variable \\$value in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/settings/class-kadence-blocks-site-health.php
+
+		-
+			message: "#^Variable \\$attributes might not be defined\\.$#"
+			count: 3
+			path: includes/templates/entry-loop-header.php
+
+		-
+			message: "#^Cannot access property \\$name on WP_Post_Type\\|null\\.$#"
+			count: 1
+			path: includes/templates/entry-loop-meta.php
+
+		-
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: includes/templates/entry-loop-meta.php
+
+		-
+			message: "#^Parameter \\#1 \\$author_id of function get_author_posts_url expects int, array\\<int\\>\\|int\\|string given\\.$#"
+			count: 2
+			path: includes/templates/entry-loop-meta.php
+
+		-
+			message: "#^Parameter \\#1 \\$post_type of function get_post_type_object expects string, string\\|false given\\.$#"
+			count: 1
+			path: includes/templates/entry-loop-meta.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, int\\|string\\|false given\\.$#"
+			count: 3
+			path: includes/templates/entry-loop-meta.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_html expects string, int\\|string given\\.$#"
+			count: 1
+			path: includes/templates/entry-loop-meta.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_html expects string, int\\|string\\|false given\\.$#"
+			count: 3
+			path: includes/templates/entry-loop-meta.php
+
+		-
+			message: "#^Parameter \\#1 \\$url of function esc_url expects string, string\\|false given\\.$#"
+			count: 1
+			path: includes/templates/entry-loop-meta.php
+
+		-
+			message: "#^Parameter \\#2 \\$post of function get_post_field expects int\\|WP_Post\\|null, int\\|false given\\.$#"
+			count: 1
+			path: includes/templates/entry-loop-meta.php
+
+		-
+			message: "#^Parameter \\#2 \\$user_id of function get_the_author_meta expects int\\|false, array\\<int\\>\\|int\\|string given\\.$#"
+			count: 5
+			path: includes/templates/entry-loop-meta.php
+
+		-
+			message: "#^Variable \\$time_string in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 2
+			path: includes/templates/entry-loop-meta.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, mixed given\\.$#"
+			count: 2
+			path: includes/templates/entry-loop-taxonomies.php
+
+		-
+			message: "#^Parameter \\#1 \\$url of function esc_url expects string, string\\|WP_Error given\\.$#"
+			count: 1
+			path: includes/templates/entry-loop-taxonomies.php
+
+		-
+			message: "#^Variable \\$attributes might not be defined\\.$#"
+			count: 1
+			path: includes/templates/entry-loop-taxonomies.php
+
+		-
+			message: "#^Parameter \\#1 \\$post_id of function get_post_meta expects int, int\\|false given\\.$#"
+			count: 1
+			path: includes/templates/entry-loop-thumbnail.php
+
+		-
+			message: "#^Parameter \\#1 \\$post_type of function post_type_supports expects string, string\\|false given\\.$#"
+			count: 1
+			path: includes/templates/entry-loop-thumbnail.php
+
+		-
+			message: "#^Variable \\$attributes might not be defined\\.$#"
+			count: 2
+			path: includes/templates/entry-loop-thumbnail.php
+
+		-
+			message: "#^Parameter \\#1 \\$url of function esc_url expects string, string\\|false given\\.$#"
+			count: 1
+			path: includes/templates/entry-loop-title.php
+
+		-
+			message: "#^Variable \\$attributes might not be defined\\.$#"
+			count: 4
+			path: includes/templates/entry.php
+
+		-
+			message: "#^Parameter \\#2 \\$str of function explode expects string, array given\\.$#"
+			count: 1
+			path: includes/templates/form-email.php
+
+		-
+			message: "#^Class Kadence_Blocks not found\\.$#"
+			count: 1
+			path: kadence-blocks.php
+
+		-
+			message: "#^Call to an undefined method Throwable\\:\\:getMessage\\(\\)\\.$#"
+			count: 1
+			path: uninstall.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,27 @@
+includes:
+	- phpstan-baseline.neon
+parameters:
+	phpVersion: 70400
+	tmpDir: phpstan-cache
+	parallel:
+		jobSize: 10
+		maximumNumberOfProcesses: 10
+		minimumNumberOfJobsPerProcess: 2
+		processTimeout: 600.0
+	reportUnmatchedIgnoredErrors: false
+	level: max
+	scanDirectories:
+		- vendor
+	paths:
+		- includes
+		- kadence-blocks.php
+		- uninstall.php
+	excludePaths:
+		analyse:
+			- includes/assets/*
+			# Generated data files (large literal arrays of icons/fonts) -- nothing to analyse, and they choke PHPStan at level max.
+			- includes/*-array.php
+	scanFiles:
+		- .phpstan/phpstan-wp-polyfills.php
+	bootstrapFiles:
+		- .phpstan/phpstan-stubs.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,8 +10,13 @@ parameters:
 		processTimeout: 600.0
 	reportUnmatchedIgnoredErrors: false
 	level: max
+	# Scan only the strauss-prefixed packages so PHPStan can resolve them.
+	# Do NOT scan all of vendor: that double-scans php-stubs/wordpress-stubs
+	# (also loaded by szepeviktor/phpstan-wordpress) and the winning signature
+	# becomes filesystem-iteration-order dependent, producing different results
+	# locally vs CI.
 	scanDirectories:
-		- vendor
+		- vendor/vendor-prefixed
 	paths:
 		- includes
 		- kadence-blocks.php


### PR DESCRIPTION
## Summary

Sets up PHPStan static analysis for the repository, following a configuration similar to `kadence-shop-kit`. Targets `feature/design-tokens-module`.

### What's included

- **`phpstan.neon`** — level `max`, analysing `includes/`, `kadence-blocks.php` and `uninstall.php`. Excludes `includes/assets/*` and the generated `includes/*-array.php` icon/font data files (large literal arrays that choke analysis at level max with nothing meaningful to check).
- **`.phpstan/`** — stubs for runtime-defined constants (`KADENCE_BLOCKS_*`) and the WordPress string polyfills (`str_contains` / `str_starts_with` / `str_ends_with`) that ship in WP core but are missing from `php-stubs/wordpress-stubs`.
- **`phpstan-baseline.neon`** — generated against the **`master`** branch state (~4,900 pre-existing items baselined) so only legacy debt is suppressed and new code is held to the standard.
- **Composer** — adds `phpstan/extension-installer` and `szepeviktor/phpstan-wordpress` dev deps, plus `phpstan` / `phpstan-baseline` scripts.
- **CI** — `.github/workflows/phpstan.yml` runs PHPStan on pull requests.
- **`.distignore` / `.gitignore`** — exclude the new config from the built plugin zip and ignore `phpstan-cache/`.

### Bugfixes (separate commits)

PHPStan reports a small class of **non-ignorable** errors that cannot be placed in the baseline and therefore *must* be fixed in code before analysis can pass. It surfaced two genuine latent bugs, each committed on its own:

1. **`current_time()` called with no arguments** in `class-kadence-blocks-prebuilt-library.php` — `current_time( $type, $gmt = 0 )` requires `$type`, so this would throw an `ArgumentCountError` at runtime. Fixed to use the same format string as the call a few lines above.
2. **`$classes[] .= ' ' . $attributes['className']`** in `class-kadence-blocks-posts-block.php` — `$classes[]` appends a new array element and `.=` immediately reads from it, which is invalid ("Cannot use [] for reading"). The effect was that the custom CSS class was never actually added. Fixed to assign the class name as a new element (it is imploded with spaces downstream).

**IMPORTANT** These are very minor and innocuous changes and the `current_time()` fix is required to prevent phpstan from straight up crashing, so these are going to be merged directly to `master` instead of a maintenance release to avoid possible issues.

## Notes

- The baseline was generated against `master` rather than this branch, so any PHPStan errors introduced by the design-tokens work surface in CI rather than being silently baselined.