### PR TITLE
chore: bump harbor to 1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 		"psr/container": "^1.0",
 		"stellarwp/container-contract": "^1.1",
 		"stellarwp/db": "^1.1",
-		"stellarwp/harbor": "^1.2",
+		"stellarwp/harbor": "^1.4",
 		"stellarwp/prophecy-image-downloader": "^3.0",
 		"stellarwp/prophecy-storage": "^3.0",
 		"stellarwp/schema": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b363a563784ab73a27482ad263c7374",
+    "content-hash": "edf1e462b2afc3092ef8d99e886c3ce8",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -1023,16 +1023,16 @@
         },
         {
             "name": "stellarwp/harbor",
-            "version": "v1.2.0",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stellarwp/harbor.git",
-                "reference": "f22783d0d79597d5b1acf6cce73e6f3ddb701334"
+                "reference": "0d21b6e6da4352364610168c053ed0ec9d59253d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stellarwp/harbor/zipball/f22783d0d79597d5b1acf6cce73e6f3ddb701334",
-                "reference": "f22783d0d79597d5b1acf6cce73e6f3ddb701334",
+                "url": "https://api.github.com/repos/stellarwp/harbor/zipball/0d21b6e6da4352364610168c053ed0ec9d59253d",
+                "reference": "0d21b6e6da4352364610168c053ed0ec9d59253d",
                 "shasum": ""
             },
             "require": {
@@ -1087,9 +1087,9 @@
             "description": "A library that integrates a WordPress product with the Liquid Web licensing system.",
             "support": {
                 "issues": "https://github.com/stellarwp/harbor/issues",
-                "source": "https://github.com/stellarwp/harbor/tree/v1.2.0"
+                "source": "https://github.com/stellarwp/harbor/tree/v1.4.0"
             },
-            "time": "2026-05-14T00:04:41+00:00"
+            "time": "2026-05-21T17:13:36+00:00"
         },
         {
             "name": "stellarwp/licensing-api-client",


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/CONS-323/update-harbor-to-140-in-kadence-blocks

This updates stellarwp/harbor to 1.4

...

### Checklist
- [ ] I have performed a self-review.
- [ ] No unrelated files are modified.
- [ ] No debugging statements exist (Ex: console.log, error_log).
- [ ] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
