### PR TITLE
[DTM] Token Registry + register_design_token() helper

### DIFF
--- a/includes/resources/Design_Tokens/Design_Tokens_Provider.php
+++ b/includes/resources/Design_Tokens/Design_Tokens_Provider.php
@@ -10,9 +10,20 @@ use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provi
 final class Design_Tokens_Provider extends Provider {
 
 	/**
+	 * Design Tokens sub-providers to register, in order.
+	 *
+	 * @var class-string<Provider>[]
+	 */
+	private const PROVIDERS = [
+		Registry\Provider::class,
+	];
+
+	/**
 	 * @inheritDoc
 	 */
 	public function register(): void {
-		// Bindings and hooks will be registered here in a follow-up.
+		foreach ( self::PROVIDERS as $provider ) {
+			$this->container->register( $provider );
+		}
 	}
 }

--- a/includes/resources/Design_Tokens/Registry/Baseline/Always_Present_Baseline_Document.php
+++ b/includes/resources/Design_Tokens/Registry/Baseline/Always_Present_Baseline_Document.php
@@ -1,0 +1,30 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry\Baseline;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
+
+/**
+ * Permissive baseline stub bound until SOFT-3377 ships the real DTCG document.
+ *
+ * Its has() always returns true, so the example declarations flow through registration, the guard
+ * and (later) projection end-to-end now — proving the path this ticket promises. The guard is therefore
+ * effectively a no-op at runtime until SOFT-3377 swaps this binding for the real document, at which
+ * point every declared token must have a genuine baseline entry or the guard fires. The fail-closed
+ * "missing" path is still fully covered by tests using a fake baseline.
+ *
+ * @since TBD
+ */
+final class Always_Present_Baseline_Document implements Baseline_Document {
+
+	/**
+	 * @since TBD
+	 *
+	 * @param string $id A token DTCG dot-path id.
+	 *
+	 * @return bool
+	 */
+	public function has( string $id ): bool {
+		return true;
+	}
+}

--- a/includes/resources/Design_Tokens/Registry/Baseline/Empty_Baseline_Document.php
+++ b/includes/resources/Design_Tokens/Registry/Baseline/Empty_Baseline_Document.php
@@ -1,0 +1,29 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry\Baseline;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
+
+/**
+ * Placeholder baseline whose has() is always false: with no real baseline, every declared token is
+ * "missing". Combined with the fail-closed policy this keeps token projection OFF until SOFT-3377
+ * ships the real document — the safe default when no baseline exists.
+ *
+ * Not the bound default in this ticket (see Always_Present_Baseline_Document); kept as the
+ * fail-closed reference stub and exercised by the guard's "missing" tests.
+ *
+ * @since TBD
+ */
+final class Empty_Baseline_Document implements Baseline_Document {
+
+	/**
+	 * @since TBD
+	 *
+	 * @param string $id A token DTCG dot-path id.
+	 *
+	 * @return bool
+	 */
+	public function has( string $id ): bool {
+		return false;
+	}
+}

--- a/includes/resources/Design_Tokens/Registry/Baseline_Guard.php
+++ b/includes/resources/Design_Tokens/Registry/Baseline_Guard.php
@@ -114,6 +114,12 @@ final class Baseline_Guard {
 		add_action(
 			'admin_notices',
 			static function () use ( $missing ): void {
+				// Only surface the misconfiguration to users who could act on it, and avoid leaking
+				// internal token ids to lower-privileged admin-area users.
+				if ( ! current_user_can( 'manage_options' ) ) {
+					return;
+				}
+
 				printf(
 					'<div class="notice notice-error"><p>%s</p></div>',
 					esc_html(

--- a/includes/resources/Design_Tokens/Registry/Baseline_Guard.php
+++ b/includes/resources/Design_Tokens/Registry/Baseline_Guard.php
@@ -1,0 +1,130 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Exception\Missing_Baseline_Entry;
+use KadenceWP\KadenceBlocks\Psr\Log\LoggerInterface;
+
+/**
+ * Enforces "every declared token must have a baseline entry."
+ *
+ * Policy:
+ *   - Always log the missing ids.
+ *   - Under WP_DEBUG: throw Missing_Baseline_Entry so dev/CI cannot miss the misconfiguration.
+ *   - In production: deactivate token projection (fall back to existing KB behaviour) + admin notice.
+ *     Never white-screen a live site.
+ *
+ * @since TBD
+ */
+final class Baseline_Guard {
+
+	private Token_Registry $registry;
+	private Baseline_Document $baseline;
+	private LoggerInterface $logger;
+
+	/**
+	 * Whether a missing entry throws. Resolves to WP_DEBUG when null (the production/dev default).
+	 *
+	 * @var bool|null
+	 */
+	private ?bool $throw_on_missing;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry    $registry         The registry whose declared tokens are validated.
+	 * @param Baseline_Document $baseline         The baseline to validate the declared tokens against.
+	 * @param LoggerInterface   $logger           Logger for the missing-entry diagnostics.
+	 * @param bool|null         $throw_on_missing Force the throw-vs-degrade decision; null defers to
+	 *                                            WP_DEBUG. Exposed for testability; the container
+	 *                                            leaves it null.
+	 */
+	public function __construct(
+		Token_Registry $registry,
+		Baseline_Document $baseline,
+		LoggerInterface $logger,
+		?bool $throw_on_missing = null
+	) {
+		$this->registry         = $registry;
+		$this->baseline         = $baseline;
+		$this->logger           = $logger;
+		$this->throw_on_missing = $throw_on_missing;
+	}
+
+	/**
+	 * Run the guard: log, then either throw (debug) or fail closed (production) on missing entries.
+	 *
+	 * @since TBD
+	 *
+	 * @throws Missing_Baseline_Entry When WP_DEBUG is on and any declared token lacks a baseline entry.
+	 *
+	 * @return void
+	 */
+	public function run(): void {
+		$missing = $this->registry->missing_from_baseline( $this->baseline );
+
+		if ( $missing === [] ) {
+			return;
+		}
+
+		$message = sprintf(
+			'Design tokens disabled: %d declared token(s) have no baseline entry: %s',
+			count( $missing ),
+			implode( ', ', $missing )
+		);
+
+		$this->logger->error( $message );
+
+		if ( $this->should_throw() ) {
+			throw new Missing_Baseline_Entry( $message );
+		}
+
+		// Production: fail closed but stay up.
+		$this->registry->deactivate();
+		$this->register_admin_notice( $missing );
+	}
+
+	/**
+	 * Whether to throw on a misconfiguration. Honours an injected override, else defers to WP_DEBUG —
+	 * the seam lets tests exercise both branches without redefining the WP_DEBUG constant.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	private function should_throw(): bool {
+		if ( $this->throw_on_missing !== null ) {
+			return $this->throw_on_missing;
+		}
+
+		return defined( 'WP_DEBUG' ) && WP_DEBUG;
+	}
+
+	/**
+	 * Register the production admin notice explaining why token projection is disabled.
+	 *
+	 * @since TBD
+	 *
+	 * @param string[] $missing The token ids missing a baseline entry.
+	 *
+	 * @return void
+	 */
+	private function register_admin_notice( array $missing ): void {
+		add_action(
+			'admin_notices',
+			static function () use ( $missing ): void {
+				printf(
+					'<div class="notice notice-error"><p>%s</p></div>',
+					esc_html(
+						sprintf(
+							/* translators: %s: comma-separated token ids. */
+							__( 'Kadence Blocks design tokens are disabled because these tokens have no baseline entry: %s', 'kadence-blocks' ),
+							implode( ', ', $missing )
+						)
+					)
+				);
+			}
+		);
+	}
+}

--- a/includes/resources/Design_Tokens/Registry/Baseline_Guard.php
+++ b/includes/resources/Design_Tokens/Registry/Baseline_Guard.php
@@ -74,6 +74,10 @@ final class Baseline_Guard {
 			implode( ', ', $missing )
 		);
 
+		// TODO (SOFT-3377): the guard moves off `init` and runs against the real baseline, so this would
+		// otherwise log once per front-end/admin/REST/AJAX/cron request on a misconfigured site. A missing
+		// baseline entry is a deterministic deploy-time error (identical every request), so throttle to
+		// once per process with a static flag before this stops being a no-op.
 		$this->logger->error( $message );
 
 		if ( $this->should_throw() ) {

--- a/includes/resources/Design_Tokens/Registry/Contracts/Baseline_Document.php
+++ b/includes/resources/Design_Tokens/Registry/Contracts/Baseline_Document.php
@@ -1,0 +1,23 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts;
+
+/**
+ * Read-only view of the shipped baseline DTCG document, narrowed to what the Registry guard needs:
+ * "does this token id exist in the baseline?".
+ *
+ * Fulfilled by SOFT-3377 (Baseline DTCG document). Until then, a stub is bound.
+ *
+ * @since TBD
+ */
+interface Baseline_Document {
+
+	/**
+	 * @since TBD
+	 *
+	 * @param string $id A token DTCG dot-path id.
+	 *
+	 * @return bool
+	 */
+	public function has( string $id ): bool;
+}

--- a/includes/resources/Design_Tokens/Registry/Css_Var.php
+++ b/includes/resources/Design_Tokens/Registry/Css_Var.php
@@ -1,0 +1,35 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry;
+
+/**
+ * Derives the canonical CSS custom-property name from a token id.
+ *
+ * The id is a DTCG dot-path (e.g. "semantic.color.button-bg"). The variable name is never
+ * declared — it is produced by a single deterministic rule so ids and var names cannot drift:
+ *
+ *   prefix "--kb-token--", then replace each "." with "--".
+ *
+ *   semantic.color.button-bg  →  --kb-token--semantic--color--button-bg
+ *
+ * The --kb-token-- prefix keeps the variable inside KB's --global-kb-* family.
+ *
+ * @since TBD
+ */
+final class Css_Var {
+
+	public const PREFIX = '--kb-token--';
+
+	/**
+	 * Derive the canonical CSS custom-property name from a token id.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id The DTCG dot-path id.
+	 *
+	 * @return string The derived CSS custom-property name.
+	 */
+	public static function from_id( string $id ): string {
+		return self::PREFIX . str_replace( '.', '--', $id );
+	}
+}

--- a/includes/resources/Design_Tokens/Registry/Exception/Missing_Baseline_Entry.php
+++ b/includes/resources/Design_Tokens/Registry/Exception/Missing_Baseline_Entry.php
@@ -1,0 +1,13 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry\Exception;
+
+use RuntimeException;
+
+/**
+ * Thrown (under WP_DEBUG) when a declared token has no entry in the baseline document.
+ *
+ * @since TBD
+ */
+final class Missing_Baseline_Entry extends RuntimeException {
+}

--- a/includes/resources/Design_Tokens/Registry/Provider.php
+++ b/includes/resources/Design_Tokens/Registry/Provider.php
@@ -28,8 +28,13 @@ final class Provider extends Provider_Contract {
 		$this->container->singleton( Baseline_Document::class, Always_Present_Baseline_Document::class );
 
 		$this->load_helper();
-		$this->register_declarations();
-		$this->guard_baseline();
+
+		// Declarations carry __() labels/groups, so they must not be evaluated before init or WordPress
+		// fires the _load_textdomain_just_in_time notice. register() runs on plugins_loaded, so defer the
+		// declaration load (and the guard that runs once tokens are in) to init. Early priority keeps the
+		// registry populated before any consumer (admin UI, projectors, resolver) reads it.
+		add_action( 'init', [ $this, 'register_declarations' ], 0 );
+		add_action( 'init', [ $this, 'guard_baseline' ], 0 );
 	}
 
 	/**
@@ -47,14 +52,14 @@ final class Provider extends Provider_Contract {
 	/**
 	 * The single declaration point — registers each declared token / variant set against the registry.
 	 *
-	 * Reads declarations.php as data and registers via the container so this runs during container
-	 * boot, before the global kadence_blocks() accessor is defined (see includes/init.php).
+	 * Reads declarations.php as data and registers via the container. Hooked on init (priority 0) because
+	 * declarations carry __() strings that must not resolve before the textdomain is available.
 	 *
 	 * @since TBD
 	 *
 	 * @return void
 	 */
-	private function register_declarations(): void {
+	public function register_declarations(): void {
 		$registry     = $this->container->get( Token_Registry::class );
 		$declarations = require __DIR__ . '/declarations.php';
 
@@ -72,7 +77,7 @@ final class Provider extends Provider_Contract {
 	 *
 	 * @return void
 	 */
-	private function guard_baseline(): void {
+	public function guard_baseline(): void {
 		$this->container->get( Baseline_Guard::class )->run();
 	}
 }

--- a/includes/resources/Design_Tokens/Registry/Provider.php
+++ b/includes/resources/Design_Tokens/Registry/Provider.php
@@ -36,6 +36,10 @@ final class Provider extends Provider_Contract {
 		//
 		// The guard validates the registered tokens, so it must run after register_declarations. The
 		// later priority makes that ordering explicit rather than relying on same-priority insertion order.
+		//
+		// The guard is one-shot at init:1 — v1 is central-declarations-only, so tokens declared by
+		// third parties on a later hook (init:2+) skip baseline validation and is_active() is not
+		// re-checked. Re-validating late registrations is out of scope until the real baseline lands.
 		add_action( 'init', [ $this, 'register_declarations' ], 0 );
 		add_action( 'init', [ $this, 'guard_baseline' ], 1 );
 	}

--- a/includes/resources/Design_Tokens/Registry/Provider.php
+++ b/includes/resources/Design_Tokens/Registry/Provider.php
@@ -1,0 +1,78 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Baseline\Always_Present_Baseline_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
+use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
+
+/**
+ * Wires the Token Registry: binds the singleton and the (stub) baseline, defines the global helper,
+ * registers the token declarations, then runs the fail-closed baseline guard once all tokens are in.
+ *
+ * @since TBD
+ */
+final class Provider extends Provider_Contract {
+
+	/**
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		$this->container->singleton( Token_Registry::class, Token_Registry::class );
+
+		// Bind the baseline contract to a permissive stub until SOFT-3377 supplies the real document.
+		// The example declarations flow through registration and the guard end-to-end; SOFT-3377 swaps
+		// this binding for the real document, at which point a token without a baseline entry fails closed.
+		$this->container->singleton( Baseline_Document::class, Always_Present_Baseline_Document::class );
+
+		$this->load_helper();
+		$this->register_declarations();
+		$this->guard_baseline();
+	}
+
+	/**
+	 * Define the public global helper. Always safe — it only declares functions; third-party callers
+	 * use it on their own hooks once the kadence_blocks() accessor exists.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	private function load_helper(): void {
+		require_once __DIR__ . '/../functions.php';
+	}
+
+	/**
+	 * The single declaration point — registers each declared token / variant set against the registry.
+	 *
+	 * Reads declarations.php as data and registers via the container so this runs during container
+	 * boot, before the global kadence_blocks() accessor is defined (see includes/init.php).
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	private function register_declarations(): void {
+		$registry     = $this->container->get( Token_Registry::class );
+		$declarations = require __DIR__ . '/declarations.php';
+
+		foreach ( $declarations['tokens'] as $token ) {
+			$registry->register( $token );
+		}
+
+		foreach ( $declarations['variant_sets'] as $variant_set ) {
+			$registry->register_variant_set( $variant_set );
+		}
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	private function guard_baseline(): void {
+		$this->container->get( Baseline_Guard::class )->run();
+	}
+}

--- a/includes/resources/Design_Tokens/Registry/Provider.php
+++ b/includes/resources/Design_Tokens/Registry/Provider.php
@@ -33,8 +33,11 @@ final class Provider extends Provider_Contract {
 		// fires the _load_textdomain_just_in_time notice. register() runs on plugins_loaded, so defer the
 		// declaration load (and the guard that runs once tokens are in) to init. Early priority keeps the
 		// registry populated before any consumer (admin UI, projectors, resolver) reads it.
+		//
+		// The guard validates the registered tokens, so it must run after register_declarations. The
+		// later priority makes that ordering explicit rather than relying on same-priority insertion order.
 		add_action( 'init', [ $this, 'register_declarations' ], 0 );
-		add_action( 'init', [ $this, 'guard_baseline' ], 0 );
+		add_action( 'init', [ $this, 'guard_baseline' ], 1 );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Registry/Token_Definition.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Definition.php
@@ -67,7 +67,7 @@ final class Token_Definition {
 	 *
 	 * @param array<string, mixed> $definition The token declaration.
 	 *
-	 * @throws InvalidArgumentException When required keys are missing.
+	 * @throws InvalidArgumentException When required keys are missing or an optional key is the wrong type.
 	 *
 	 * @return self
 	 */
@@ -82,6 +82,20 @@ final class Token_Definition {
 			}
 		}
 
+		// Optional keys are type-checked so a bad declaration raises the documented InvalidArgumentException
+		// rather than a raw TypeError from the constructor's typed params — this is a public helper.
+		if ( isset( $definition['group'] ) && ! is_string( $definition['group'] ) ) {
+			throw new InvalidArgumentException( 'Design token declaration "group" must be a string.' );
+		}
+
+		if ( isset( $definition['css_var'] ) && ! is_string( $definition['css_var'] ) ) {
+			throw new InvalidArgumentException( 'Design token declaration "css_var" must be a string.' );
+		}
+
+		if ( isset( $definition['projections'] ) && ! is_array( $definition['projections'] ) ) {
+			throw new InvalidArgumentException( 'Design token declaration "projections" must be an array.' );
+		}
+
 		$id = $definition['id'];
 
 		return new self(
@@ -90,7 +104,7 @@ final class Token_Definition {
 			$definition['label'],
 			$definition['group'] ?? '',
 			// css_var override is rare; default is derived and impossible to drift from the id.
-			isset( $definition['css_var'] ) ? (string) $definition['css_var'] : Css_Var::from_id( $id ),
+			$definition['css_var'] ?? Css_Var::from_id( $id ),
 			$definition['projections'] ?? []
 		);
 	}

--- a/includes/resources/Design_Tokens/Registry/Token_Definition.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Definition.php
@@ -1,0 +1,108 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry;
+
+use InvalidArgumentException;
+
+/**
+ * Immutable description of a single design token — structure only, no value.
+ *
+ * Built from a declaration array via from_array(); the css-var is derived from the id by default
+ * (Css_Var) and only overridden when a token must match a pre-existing variable name.
+ *
+ * @since TBD
+ */
+final class Token_Definition {
+
+	/** @var string DTCG dot-path, e.g. "semantic.color.button-bg". */
+	public string $id;
+
+	/** @var string DTCG $type: color | dimension | shadow | typography | … */
+	public string $type;
+
+	/** @var string Human-readable label for the custom UI. */
+	public string $label;
+
+	/** @var string UI grouping bucket, e.g. "Brand". */
+	public string $group;
+
+	/** @var string The canonical (or overridden) CSS custom-property name. */
+	public string $css_var;
+
+	/**
+	 * Projection targets. Keys are projection ids; values are projection-specific config.
+	 *
+	 * @var array<string, mixed> e.g. [ 'wp_preset' => 'color', 'kadence_slot' => 'palette1', 'site_editor' => true ]
+	 */
+	public array $projections;
+
+	/**
+	 * @param string               $id          DTCG dot-path id.
+	 * @param string               $type        DTCG $type.
+	 * @param string               $label       Human-readable label.
+	 * @param string               $group       UI grouping bucket.
+	 * @param string               $css_var     Canonical (or overridden) CSS custom-property name.
+	 * @param array<string, mixed> $projections Projection targets keyed by projection id.
+	 */
+	private function __construct(
+		string $id,
+		string $type,
+		string $label,
+		string $group,
+		string $css_var,
+		array $projections
+	) {
+		$this->id          = $id;
+		$this->type        = $type;
+		$this->label       = $label;
+		$this->group       = $group;
+		$this->css_var     = $css_var;
+		$this->projections = $projections;
+	}
+
+	/**
+	 * Build a token definition from its declaration array.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $definition The token declaration.
+	 *
+	 * @throws InvalidArgumentException When required keys are missing.
+	 *
+	 * @return self
+	 */
+	public static function from_array( array $definition ): self {
+		foreach ( [ 'id', 'type', 'label' ] as $required ) {
+			if ( empty( $definition[ $required ] ) || ! is_string( $definition[ $required ] ) ) {
+				throw new InvalidArgumentException(
+					sprintf( 'Design token declaration is missing required string "%s".', $required )
+				);
+			}
+		}
+
+		$id = $definition['id'];
+
+		return new self(
+			$id,
+			$definition['type'],
+			$definition['label'],
+			$definition['group'] ?? '',
+			// css_var override is rare; default is derived and impossible to drift from the id.
+			isset( $definition['css_var'] ) ? (string) $definition['css_var'] : Css_Var::from_id( $id ),
+			$definition['projections'] ?? []
+		);
+	}
+
+	/**
+	 * Whether the token declares the given projection target.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $projection A projection id, e.g. "wp_preset".
+	 *
+	 * @return bool
+	 */
+	public function has_projection( string $projection ): bool {
+		return array_key_exists( $projection, $this->projections );
+	}
+}

--- a/includes/resources/Design_Tokens/Registry/Token_Definition.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Definition.php
@@ -82,6 +82,17 @@ final class Token_Definition {
 			}
 		}
 
+		$id = $definition['id'];
+
+		// Guard the id charset at declaration time: it feeds Css_Var::from_id() which only swaps "." for
+		// "--", so an id with a space or slash would silently yield an invalid CSS custom-property name.
+		// A DTCG dot-path is lowercase alphanumeric segments separated by "." or "-".
+		if ( ! preg_match( '/^[a-z0-9]+([.-][a-z0-9]+)*$/', $id ) ) {
+			throw new InvalidArgumentException(
+				sprintf( 'Design token id "%s" must be a dot-path of lowercase alphanumeric segments separated by "." or "-".', $id )
+			);
+		}
+
 		// Optional keys are type-checked so a bad declaration raises the documented InvalidArgumentException
 		// rather than a raw TypeError from the constructor's typed params — this is a public helper.
 		if ( isset( $definition['group'] ) && ! is_string( $definition['group'] ) ) {
@@ -95,8 +106,6 @@ final class Token_Definition {
 		if ( isset( $definition['projections'] ) && ! is_array( $definition['projections'] ) ) {
 			throw new InvalidArgumentException( 'Design token declaration "projections" must be an array.' );
 		}
-
-		$id = $definition['id'];
 
 		return new self(
 			$id,

--- a/includes/resources/Design_Tokens/Registry/Token_Definition.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Definition.php
@@ -73,7 +73,9 @@ final class Token_Definition {
 	 */
 	public static function from_array( array $definition ): self {
 		foreach ( [ 'id', 'type', 'label' ] as $required ) {
-			if ( empty( $definition[ $required ] ) || ! is_string( $definition[ $required ] ) ) {
+			// Require a present, non-empty string. Avoid empty() so a legitimate "0" string is not
+			// mistaken for a missing value.
+			if ( ! isset( $definition[ $required ] ) || ! is_string( $definition[ $required ] ) || $definition[ $required ] === '' ) {
 				throw new InvalidArgumentException(
 					sprintf( 'Design token declaration is missing required string "%s".', $required )
 				);

--- a/includes/resources/Design_Tokens/Registry/Token_Registry.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Registry.php
@@ -1,0 +1,235 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
+
+/**
+ * The single declaration point for design tokens. Holds structure only — never values.
+ *
+ * Every projector and the admin UI read this one registry, so declaring a token once here makes it
+ * reach the custom UI, the theme.json presets, the Kadence palette and the Site Editor without a
+ * second source of truth.
+ *
+ * Resolved as a singleton from KB's container; tokens are declared during the module's Provider boot
+ * via kadence_blocks_register_design_token().
+ *
+ * @since TBD
+ */
+final class Token_Registry {
+
+	/** @var array<string, Token_Definition> Keyed by token id, insertion-ordered. */
+	private array $tokens = [];
+
+	/** @var array<string, Variant_Set> Keyed by block name. */
+	private array $variant_sets = [];
+
+	/**
+	 * Whether token projection is active. Flipped off by the fail-closed guard so projectors and the
+	 * UI surface fall back to existing KB behaviour rather than projecting a partial/broken set.
+	 *
+	 * @var bool
+	 */
+	private bool $active = true;
+
+	/**
+	 * Register a single token from its declaration array.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $definition See Token_Definition::from_array().
+	 *
+	 * @return void
+	 */
+	public function register( array $definition ): void {
+		$token = Token_Definition::from_array( $definition );
+
+		$this->tokens[ $token->id ] = $token;
+	}
+
+	/**
+	 * Register which blocks accept variants. Skeleton — the rich data model lands in SOFT-3393.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $set See Variant_Set::from_array().
+	 *
+	 * @return void
+	 */
+	public function register_variant_set( array $set ): void {
+		$variant_set = Variant_Set::from_array( $set );
+
+		$this->variant_sets[ $variant_set->block ] = $variant_set;
+	}
+
+	// ---- Lookups consumed by projectors and the UI ------------------------------------------------
+
+	/**
+	 * All registered tokens, keyed by id in insertion order.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, Token_Definition>
+	 */
+	public function all(): array {
+		return $this->tokens;
+	}
+
+	/**
+	 * A single token by id, or null when it is not registered.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id The token id.
+	 *
+	 * @return Token_Definition|null
+	 */
+	public function get( string $id ): ?Token_Definition {
+		return $this->tokens[ $id ] ?? null;
+	}
+
+	/**
+	 * Whether a token is registered for the given id.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id The token id.
+	 *
+	 * @return bool
+	 */
+	public function has( string $id ): bool {
+		return isset( $this->tokens[ $id ] );
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param string $type DTCG $type, e.g. "color".
+	 *
+	 * @return array<string, Token_Definition>
+	 */
+	public function by_type( string $type ): array {
+		return array_filter(
+			$this->tokens,
+			static function ( Token_Definition $t ) use ( $type ): bool {
+				return $t->type === $type;
+			}
+		);
+	}
+
+	/**
+	 * Tokens that declare a given projection target, e.g. all tokens with a "wp_preset" projection.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $projection Projection id.
+	 *
+	 * @return array<string, Token_Definition>
+	 */
+	public function by_projection( string $projection ): array {
+		return array_filter(
+			$this->tokens,
+			static function ( Token_Definition $t ) use ( $projection ): bool {
+				return $t->has_projection( $projection );
+			}
+		);
+	}
+
+	/**
+	 * Variant set registered for a block, or null. (Data model fleshed out in SOFT-3393.)
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block The block name, e.g. "kadence/advancedbtn".
+	 *
+	 * @return Variant_Set|null
+	 */
+	public function for_block( string $block ): ?Variant_Set {
+		return $this->variant_sets[ $block ] ?? null;
+	}
+
+	/**
+	 * Convenience: the canonical css-var for an id, honouring any override.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id The token id.
+	 *
+	 * @return string
+	 */
+	public function css_var_for( string $id ): string {
+		$token = $this->get( $id );
+
+		return $token !== null ? $token->css_var : Css_Var::from_id( $id );
+	}
+
+	/**
+	 * The schema the admin React app consumes (SOFT-3385). A token registered in PHP appears in the
+	 * UI with no JS change. Values are NOT included here — the resolver supplies current values
+	 * separately; this is structure only.
+	 *
+	 * @since TBD
+	 *
+	 * @return array{groups: array<string, array<int, array<string, mixed>>>}
+	 */
+	public function to_ui_schema(): array {
+		$groups = [];
+
+		foreach ( $this->tokens as $token ) {
+			$groups[ $token->group ][] = [
+				'id'          => $token->id,
+				'type'        => $token->type,
+				'label'       => $token->label,
+				'cssVar'      => $token->css_var,
+				'projections' => $token->projections,
+			];
+		}
+
+		return [ 'groups' => $groups ];
+	}
+
+	// ---- Fail-closed activation guard -------------------------------------------------------------
+
+	/**
+	 * Whether token projection is currently active.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function is_active(): bool {
+		return $this->active;
+	}
+
+	/**
+	 * Validate that every declared token has a baseline entry. See the fail-closed policy.
+	 *
+	 * @since TBD
+	 *
+	 * @param Baseline_Document $baseline The baseline to validate declared tokens against.
+	 *
+	 * @return string[] The ids missing from the baseline (empty when valid).
+	 */
+	public function missing_from_baseline( Baseline_Document $baseline ): array {
+		$missing = [];
+
+		foreach ( $this->tokens as $id => $_token ) {
+			if ( ! $baseline->has( $id ) ) {
+				$missing[] = $id;
+			}
+		}
+
+		return $missing;
+	}
+
+	/**
+	 * Disable projection (fail-closed degraded mode).
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function deactivate(): void {
+		$this->active = false;
+	}
+}

--- a/includes/resources/Design_Tokens/Registry/Variant_Set.php
+++ b/includes/resources/Design_Tokens/Registry/Variant_Set.php
@@ -39,7 +39,9 @@ final class Variant_Set {
 	 * @return self
 	 */
 	public static function from_array( array $set ): self {
-		if ( empty( $set['block'] ) || ! is_string( $set['block'] ) ) {
+		// Require a present, non-empty string. Avoid empty() so a legitimate "0" block name is not
+		// mistaken for a missing value, matching Token_Definition::from_array().
+		if ( ! isset( $set['block'] ) || ! is_string( $set['block'] ) || $set['block'] === '' ) {
 			throw new InvalidArgumentException( 'Variant-set declaration is missing required string "block".' );
 		}
 

--- a/includes/resources/Design_Tokens/Registry/Variant_Set.php
+++ b/includes/resources/Design_Tokens/Registry/Variant_Set.php
@@ -1,0 +1,48 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry;
+
+use InvalidArgumentException;
+
+/**
+ * Immutable record that a block accepts variants. Skeleton for SOFT-3379: holds the block name and
+ * the declared variant names. The $extensions…variants.<block> payload shape, $default handling and
+ * validation are SOFT-3393.
+ *
+ * @since TBD
+ */
+final class Variant_Set {
+
+	public string $block;
+
+	/** @var string[] */
+	public array $variants;
+
+	/**
+	 * @param string   $block    The block name.
+	 * @param string[] $variants The declared variant names.
+	 */
+	private function __construct( string $block, array $variants ) {
+		$this->block    = $block;
+		$this->variants = $variants;
+	}
+
+	/**
+	 * Build a variant set from its declaration array.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $set The variant-set declaration.
+	 *
+	 * @throws InvalidArgumentException When "block" is missing.
+	 *
+	 * @return self
+	 */
+	public static function from_array( array $set ): self {
+		if ( empty( $set['block'] ) || ! is_string( $set['block'] ) ) {
+			throw new InvalidArgumentException( 'Variant-set declaration is missing required string "block".' );
+		}
+
+		return new self( $set['block'], array_values( (array) ( $set['variants'] ?? [] ) ) );
+	}
+}

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -1,8 +1,11 @@
 <?php declare( strict_types=1 );
 // The single declaration point. Adding an entry here automatically reaches every projector and the
 // admin UI. Returned as data (rather than calling the global helper) so the Provider can register it
-// against the container during boot, before the kadence_blocks() accessor exists. v1 ships a small
-// representative set; the full catalog lands with SOFT-3377.
+// directly against the container. v1 ships a small representative set; the full catalog lands with
+// SOFT-3377.
+//
+// Loaded on `init` (see Registry\Provider) so the __() label/group calls don't trigger the
+// _load_textdomain_just_in_time notice — translations must not load before init.
 
 return [
 	'tokens'       => [

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -1,0 +1,40 @@
+<?php declare( strict_types=1 );
+// The single declaration point. Adding an entry here automatically reaches every projector and the
+// admin UI. Returned as data (rather than calling the global helper) so the Provider can register it
+// against the container during boot, before the kadence_blocks() accessor exists. v1 ships a small
+// representative set; the full catalog lands with SOFT-3377.
+
+return [
+	'tokens'       => [
+		[
+			'id'          => 'semantic.color.button-bg',
+			'type'        => 'color',
+			'label'       => __( 'Button Background', 'kadence-blocks' ),
+			'group'       => __( 'Brand', 'kadence-blocks' ),
+			'projections' => [
+				'wp_preset'    => 'color',     // → theme.json preset + --wp--preset--color--button-bg.
+				'kadence_slot' => 'palette1',  // → --global-palette1 + kadence_blocks_colors slug.
+				'site_editor'  => true,
+			],
+		],
+		[
+			'id'          => 'semantic.color.button-text',
+			'type'        => 'color',
+			'label'       => __( 'Button Text', 'kadence-blocks' ),
+			'group'       => __( 'Brand', 'kadence-blocks' ),
+			'projections' => [
+				'wp_preset'    => 'color',
+				'kadence_slot' => 'palette2',
+				'site_editor'  => true,
+			],
+		],
+	],
+	// Variant-set skeleton: declares that the Button block accepts variants. The variant payload shape
+	// and $default handling are SOFT-3393.
+	'variant_sets' => [
+		[
+			'block'    => 'kadence/advancedbtn',
+			'variants' => [ 'primary', 'secondary', 'ghost' ],
+		],
+	],
+];

--- a/includes/resources/Design_Tokens/functions.php
+++ b/includes/resources/Design_Tokens/functions.php
@@ -9,6 +9,9 @@ if ( ! function_exists( 'kadence_blocks_register_design_token' ) ) {
 	 * 'id' (DTCG dot-path), 'type' (DTCG $type), 'label', optional 'group', optional 'projections'
 	 * and an optional 'css_var' override. See Token_Definition::from_array().
 	 *
+	 * Register before `init` priority 1: the baseline guard runs once there and does not re-validate
+	 * tokens declared later, so a token registered on a later hook skips baseline validation entirely.
+	 *
 	 * @since TBD
 	 *
 	 * @param array<string, mixed> $definition The token declaration.

--- a/includes/resources/Design_Tokens/functions.php
+++ b/includes/resources/Design_Tokens/functions.php
@@ -1,0 +1,36 @@
+<?php declare( strict_types=1 );
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+
+if ( ! function_exists( 'kadence_blocks_register_design_token' ) ) {
+	/**
+	 * Declare a design token in the single Registry. Thin readability wrapper over
+	 * Token_Registry::register() that mirrors KB's existing global helpers. The declaration accepts
+	 * 'id' (DTCG dot-path), 'type' (DTCG $type), 'label', optional 'group', optional 'projections'
+	 * and an optional 'css_var' override. See Token_Definition::from_array().
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $definition The token declaration.
+	 *
+	 * @return void
+	 */
+	function kadence_blocks_register_design_token( array $definition ): void {
+		kadence_blocks()->get( Token_Registry::class )->register( $definition );
+	}
+}
+
+if ( ! function_exists( 'kadence_blocks_register_design_variant_set' ) ) {
+	/**
+	 * Declare which block accepts variants (skeleton; data model in SOFT-3393).
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $set See Variant_Set::from_array().
+	 *
+	 * @return void
+	 */
+	function kadence_blocks_register_design_variant_set( array $set ): void {
+		kadence_blocks()->get( Token_Registry::class )->register_variant_set( $set );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Baseline/Baseline_StubsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Baseline/Baseline_StubsTest.php
@@ -1,0 +1,24 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Registry\Baseline;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Baseline\Always_Present_Baseline_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Baseline\Empty_Baseline_Document;
+use Tests\Support\Classes\TestCase;
+
+final class Baseline_StubsTest extends TestCase {
+
+	public function testEmptyBaselineHasIsAlwaysFalse(): void {
+		$baseline = new Empty_Baseline_Document();
+
+		$this->assertFalse( $baseline->has( 'semantic.color.button-bg' ) );
+		$this->assertFalse( $baseline->has( 'anything' ) );
+	}
+
+	public function testAlwaysPresentBaselineHasIsAlwaysTrue(): void {
+		$baseline = new Always_Present_Baseline_Document();
+
+		$this->assertTrue( $baseline->has( 'semantic.color.button-bg' ) );
+		$this->assertTrue( $baseline->has( 'anything' ) );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Baseline_GuardTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Baseline_GuardTest.php
@@ -15,16 +15,30 @@ final class Baseline_GuardTest extends TestCase {
 
 	private TestLogger $logger;
 
+	/** @var \WP_Hook|null Clone of $wp_filter['admin_notices'] taken in setUp. */
+	private $admin_notices_snapshot;
+
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->logger = new TestLogger();
+
+		// Clone admin_notices so the production path's registered callback can be removed in tearDown
+		// without clobbering callbacks other code registered at bootstrap. A clone (not a reference) is
+		// required because WP_Hook is mutated in place by add_action().
+		global $wp_filter;
+		$this->admin_notices_snapshot = isset( $wp_filter['admin_notices'] ) ? clone $wp_filter['admin_notices'] : null;
 	}
 
 	protected function tearDown(): void {
-		// The production path registers an admin_notices callback; drop it so it can't leak into
-		// sibling tests via the global $wp_filter.
-		remove_all_actions( 'admin_notices' );
+		// Restore the snapshot so the production path's admin_notices callback can't leak into sibling
+		// tests via the global $wp_filter, while leaving any bootstrap-registered callbacks intact.
+		global $wp_filter;
+		if ( $this->admin_notices_snapshot !== null ) {
+			$wp_filter['admin_notices'] = $this->admin_notices_snapshot;
+		} else {
+			unset( $wp_filter['admin_notices'] );
+		}
 
 		parent::tearDown();
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Baseline_GuardTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Baseline_GuardTest.php
@@ -1,0 +1,96 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Registry;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Baseline\Always_Present_Baseline_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Baseline\Empty_Baseline_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Baseline_Guard;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Exception\Missing_Baseline_Entry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Psr\Log\Test\TestLogger;
+use Tests\Support\Classes\TestCase;
+
+final class Baseline_GuardTest extends TestCase {
+
+	private TestLogger $logger;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->logger = new TestLogger();
+	}
+
+	private function registry_with_one_token(): Token_Registry {
+		$registry = new Token_Registry();
+		$registry->register(
+			[
+				'id'    => 'semantic.color.button-bg',
+				'type'  => 'color',
+				'label' => 'Button Background',
+			]
+		);
+
+		return $registry;
+	}
+
+	private function guard( Token_Registry $registry, Baseline_Document $baseline, bool $debug ): Baseline_Guard {
+		return new Baseline_Guard( $registry, $baseline, $this->logger, $debug );
+	}
+
+	public function testValidBaselineDoesNotThrowOrDeactivateOrLog(): void {
+		$registry = $this->registry_with_one_token();
+
+		$this->guard( $registry, new Always_Present_Baseline_Document(), true )->run();
+
+		$this->assertTrue( $registry->is_active() );
+		$this->assertFalse( $this->logger->hasErrorRecords() );
+	}
+
+	public function testMissingEntriesUnderDebugThrows(): void {
+		$registry = $this->registry_with_one_token();
+
+		$this->expectException( Missing_Baseline_Entry::class );
+
+		$this->guard( $registry, new Empty_Baseline_Document(), true )->run();
+	}
+
+	public function testMissingEntriesUnderDebugLogsBeforeThrowing(): void {
+		$registry = $this->registry_with_one_token();
+
+		try {
+			$this->guard( $registry, new Empty_Baseline_Document(), true )->run();
+			$this->fail( 'Expected Missing_Baseline_Entry to be thrown.' );
+		} catch ( Missing_Baseline_Entry $e ) {
+			$this->assertTrue( $this->logger->hasErrorRecords() );
+			$this->assertStringContainsString( 'semantic.color.button-bg', $e->getMessage() );
+		}
+	}
+
+	public function testMissingEntriesInProductionDeactivatesLogsAndRegistersNotice(): void {
+		$registry = $this->registry_with_one_token();
+
+		$before = $this->count_admin_notices();
+
+		$this->guard( $registry, new Empty_Baseline_Document(), false )->run();
+
+		$this->assertFalse( $registry->is_active() );
+		$this->assertTrue( $this->logger->hasErrorRecords() );
+		$this->assertSame( $before + 1, $this->count_admin_notices() );
+	}
+
+	private function count_admin_notices(): int {
+		global $wp_filter;
+
+		if ( ! isset( $wp_filter['admin_notices'] ) ) {
+			return 0;
+		}
+
+		$count = 0;
+		foreach ( $wp_filter['admin_notices']->callbacks as $callbacks ) {
+			$count += count( $callbacks );
+		}
+
+		return $count;
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Baseline_GuardTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Baseline_GuardTest.php
@@ -21,6 +21,14 @@ final class Baseline_GuardTest extends TestCase {
 		$this->logger = new TestLogger();
 	}
 
+	protected function tearDown(): void {
+		// The production path registers an admin_notices callback; drop it so it can't leak into
+		// sibling tests via the global $wp_filter.
+		remove_all_actions( 'admin_notices' );
+
+		parent::tearDown();
+	}
+
 	private function registry_with_one_token(): Token_Registry {
 		$registry = new Token_Registry();
 		$registry->register(
@@ -77,6 +85,18 @@ final class Baseline_GuardTest extends TestCase {
 		$this->assertFalse( $registry->is_active() );
 		$this->assertTrue( $this->logger->hasErrorRecords() );
 		$this->assertSame( $before + 1, $this->count_admin_notices() );
+	}
+
+	public function testItResolvesFromTheContainerAgainstTheBoundStub(): void {
+		// Exercises the real autowiring path: Token_Registry singleton, the bound Baseline_Document
+		// stub, the LoggerInterface bound by Log_Provider, and the optional $throw_on_missing default.
+		// The bound Always_Present_Baseline_Document satisfies every declared token, so the guard is a
+		// no-op and projection stays active.
+		$registry = $this->container->get( Token_Registry::class );
+
+		$this->container->get( Baseline_Guard::class )->run();
+
+		$this->assertTrue( $registry->is_active() );
 	}
 
 	private function count_admin_notices(): int {

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Css_VarTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Css_VarTest.php
@@ -1,0 +1,34 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Registry;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
+use Tests\Support\Classes\TestCase;
+
+final class Css_VarTest extends TestCase {
+
+	public function testItMatchesTheWorkedExample(): void {
+		$this->assertSame(
+			'--kb-token--semantic--color--button-bg',
+			Css_Var::from_id( 'semantic.color.button-bg' )
+		);
+	}
+
+	public function testItPrefixesASingleSegmentId(): void {
+		$this->assertSame( '--kb-token--brand', Css_Var::from_id( 'brand' ) );
+	}
+
+	public function testItHandlesArbitraryDepth(): void {
+		$this->assertSame(
+			'--kb-token--a--b--c--d--e',
+			Css_Var::from_id( 'a.b.c.d.e' )
+		);
+	}
+
+	public function testItIsDeterministicAcrossCalls(): void {
+		$this->assertSame(
+			Css_Var::from_id( 'semantic.color.button-bg' ),
+			Css_Var::from_id( 'semantic.color.button-bg' )
+		);
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Registry/RegistrationHelperTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/RegistrationHelperTest.php
@@ -15,6 +15,36 @@ final class RegistrationHelperTest extends TestCase {
 		$this->registry = $this->container->get( Token_Registry::class );
 	}
 
+	protected function tearDown(): void {
+		// Token_Registry is a container singleton, so tokens these tests register (semantic.color.test-only,
+		// kadence/testblock) would otherwise leak into every later test in the run. Rebind a fresh registry
+		// repopulated from the declarations so the container is restored to exactly its declared state —
+		// otherwise a leaked token with no baseline entry would trip the guard once SOFT-3377 binds a real
+		// baseline, giving an order-dependent failure.
+		$this->container->singleton( Token_Registry::class, $this->declared_registry() );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * A fresh registry populated from the same declarations the Provider loads, so the container is
+	 * restored to its bootstrap state without leaking test-only tokens.
+	 */
+	private function declared_registry(): Token_Registry {
+		$registry     = new Token_Registry();
+		$declarations = require KADENCE_BLOCKS_PATH . 'includes/resources/Design_Tokens/Registry/declarations.php';
+
+		foreach ( $declarations['tokens'] as $token ) {
+			$registry->register( $token );
+		}
+
+		foreach ( $declarations['variant_sets'] as $variant_set ) {
+			$registry->register_variant_set( $variant_set );
+		}
+
+		return $registry;
+	}
+
 	public function testTheRegistryIsASingleton(): void {
 		$this->assertSame( $this->registry, $this->container->get( Token_Registry::class ) );
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Registry/RegistrationHelperTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/RegistrationHelperTest.php
@@ -1,0 +1,68 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Registry;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use Tests\Support\Classes\TestCase;
+
+final class RegistrationHelperTest extends TestCase {
+
+	private Token_Registry $registry;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->registry = $this->container->get( Token_Registry::class );
+	}
+
+	public function testTheRegistryIsASingleton(): void {
+		$this->assertSame( $this->registry, $this->container->get( Token_Registry::class ) );
+	}
+
+	public function testDeclarationsFileRegisteredTheExampleTokens(): void {
+		$this->assertTrue( $this->registry->has( 'semantic.color.button-bg' ) );
+		$this->assertTrue( $this->registry->has( 'semantic.color.button-text' ) );
+	}
+
+	public function testDeclarationsFileRegisteredTheButtonVariantSet(): void {
+		$set = $this->registry->for_block( 'kadence/advancedbtn' );
+
+		$this->assertNotNull( $set );
+		$this->assertSame( [ 'primary', 'secondary', 'ghost' ], $set->variants );
+	}
+
+	public function testHelperRegistersAgainstTheSharedRegistry(): void {
+		kadence_blocks_register_design_token(
+			[
+				'id'    => 'semantic.color.test-only',
+				'type'  => 'color',
+				'label' => 'Test Only',
+			]
+		);
+
+		$this->assertTrue( $this->registry->has( 'semantic.color.test-only' ) );
+		$this->assertSame(
+			'--kb-token--semantic--color--test-only',
+			$this->registry->css_var_for( 'semantic.color.test-only' )
+		);
+	}
+
+	public function testVariantSetHelperRegistersAgainstTheSharedRegistry(): void {
+		kadence_blocks_register_design_variant_set(
+			[
+				'block'    => 'kadence/testblock',
+				'variants' => [ 'a', 'b' ],
+			]
+		);
+
+		$set = $this->registry->for_block( 'kadence/testblock' );
+
+		$this->assertNotNull( $set );
+		$this->assertSame( [ 'a', 'b' ], $set->variants );
+	}
+
+	public function testHelperFunctionsExist(): void {
+		$this->assertTrue( function_exists( 'kadence_blocks_register_design_token' ) );
+		$this->assertTrue( function_exists( 'kadence_blocks_register_design_variant_set' ) );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Token_DefinitionTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Token_DefinitionTest.php
@@ -99,6 +99,28 @@ final class Token_DefinitionTest extends TestCase {
 	}
 
 	/**
+	 * @dataProvider malformedIdProvider
+	 */
+	public function testItThrowsWhenIdHasAnInvalidCharset( string $id ): void {
+		$this->expectException( InvalidArgumentException::class );
+
+		Token_Definition::from_array( [ 'id' => $id, 'type' => 'color', 'label' => 'Button Background' ] );
+	}
+
+	/**
+	 * @return array<string, array{0: string}>
+	 */
+	public function malformedIdProvider(): array {
+		return [
+			'space'        => [ 'semantic.color.button bg' ],
+			'slash'        => [ 'semantic/color/button-bg' ],
+			'uppercase'    => [ 'semantic.Color.button-bg' ],
+			'leading dot'  => [ '.semantic.color.button-bg' ],
+			'trailing dot' => [ 'semantic.color.button-bg.' ],
+		];
+	}
+
+	/**
 	 * @dataProvider wrongTypeOptionalProvider
 	 *
 	 * @param array<string, mixed> $definition

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Token_DefinitionTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Token_DefinitionTest.php
@@ -1,0 +1,100 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Registry;
+
+use InvalidArgumentException;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Definition;
+use Tests\Support\Classes\TestCase;
+
+final class Token_DefinitionTest extends TestCase {
+
+	public function testItDerivesTheCssVarFromTheId(): void {
+		$token = Token_Definition::from_array(
+			[
+				'id'    => 'semantic.color.button-bg',
+				'type'  => 'color',
+				'label' => 'Button Background',
+			]
+		);
+
+		$this->assertSame( '--kb-token--semantic--color--button-bg', $token->css_var );
+	}
+
+	public function testItHonoursAnExplicitCssVarOverride(): void {
+		$token = Token_Definition::from_array(
+			[
+				'id'      => 'semantic.color.button-bg',
+				'type'    => 'color',
+				'label'   => 'Button Background',
+				'css_var' => '--global-palette1',
+			]
+		);
+
+		$this->assertSame( '--global-palette1', $token->css_var );
+	}
+
+	public function testItDefaultsGroupAndProjections(): void {
+		$token = Token_Definition::from_array(
+			[
+				'id'    => 'semantic.color.button-bg',
+				'type'  => 'color',
+				'label' => 'Button Background',
+			]
+		);
+
+		$this->assertSame( '', $token->group );
+		$this->assertSame( [], $token->projections );
+	}
+
+	public function testItRetainsGroupAndProjections(): void {
+		$token = Token_Definition::from_array(
+			[
+				'id'          => 'semantic.color.button-bg',
+				'type'        => 'color',
+				'label'       => 'Button Background',
+				'group'       => 'Brand',
+				'projections' => [ 'wp_preset' => 'color' ],
+			]
+		);
+
+		$this->assertSame( 'Brand', $token->group );
+		$this->assertSame( [ 'wp_preset' => 'color' ], $token->projections );
+	}
+
+	public function testHasProjectionReportsDeclaredTargets(): void {
+		$token = Token_Definition::from_array(
+			[
+				'id'          => 'semantic.color.button-bg',
+				'type'        => 'color',
+				'label'       => 'Button Background',
+				'projections' => [ 'wp_preset' => 'color' ],
+			]
+		);
+
+		$this->assertTrue( $token->has_projection( 'wp_preset' ) );
+		$this->assertFalse( $token->has_projection( 'kadence_slot' ) );
+	}
+
+	/**
+	 * @dataProvider missingRequiredProvider
+	 *
+	 * @param array<string, mixed> $definition
+	 */
+	public function testItThrowsWhenRequiredKeysAreMissing( array $definition ): void {
+		$this->expectException( InvalidArgumentException::class );
+
+		Token_Definition::from_array( $definition );
+	}
+
+	/**
+	 * @return array<string, array{0: array<string, mixed>}>
+	 */
+	public function missingRequiredProvider(): array {
+		return [
+			'missing id'    => [ [ 'type' => 'color', 'label' => 'Button Background' ] ],
+			'missing type'  => [ [ 'id' => 'semantic.color.button-bg', 'label' => 'Button Background' ] ],
+			'missing label' => [ [ 'id' => 'semantic.color.button-bg', 'type' => 'color' ] ],
+			'empty id'      => [ [ 'id' => '', 'type' => 'color', 'label' => 'Button Background' ] ],
+		];
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Token_DefinitionTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Token_DefinitionTest.php
@@ -97,4 +97,28 @@ final class Token_DefinitionTest extends TestCase {
 			'empty id'      => [ [ 'id' => '', 'type' => 'color', 'label' => 'Button Background' ] ],
 		];
 	}
+
+	/**
+	 * @dataProvider wrongTypeOptionalProvider
+	 *
+	 * @param array<string, mixed> $definition
+	 */
+	public function testItThrowsWhenOptionalKeysAreTheWrongType( array $definition ): void {
+		$this->expectException( InvalidArgumentException::class );
+
+		Token_Definition::from_array( $definition );
+	}
+
+	/**
+	 * @return array<string, array{0: array<string, mixed>}>
+	 */
+	public function wrongTypeOptionalProvider(): array {
+		$base = [ 'id' => 'semantic.color.button-bg', 'type' => 'color', 'label' => 'Button Background' ];
+
+		return [
+			'non-string group'      => [ $base + [ 'group' => [ 'Brand' ] ] ],
+			'non-string css_var'    => [ $base + [ 'css_var' => 123 ] ],
+			'non-array projections' => [ $base + [ 'projections' => 'wp_preset' ] ],
+		];
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
@@ -1,0 +1,163 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Registry;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Definition;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use Tests\Support\Classes\TestCase;
+
+final class Token_RegistryTest extends TestCase {
+
+	private Token_Registry $registry;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->registry = new Token_Registry();
+	}
+
+	private function register_button_bg(): void {
+		$this->registry->register(
+			[
+				'id'          => 'semantic.color.button-bg',
+				'type'        => 'color',
+				'label'       => 'Button Background',
+				'group'       => 'Brand',
+				'projections' => [ 'wp_preset' => 'color' ],
+			]
+		);
+	}
+
+	private function register_spacing_md(): void {
+		$this->registry->register(
+			[
+				'id'    => 'semantic.spacing.md',
+				'type'  => 'dimension',
+				'label' => 'Spacing Medium',
+				'group' => 'Layout',
+			]
+		);
+	}
+
+	public function testAllGetHasRoundTrip(): void {
+		$this->register_button_bg();
+
+		$this->assertTrue( $this->registry->has( 'semantic.color.button-bg' ) );
+		$this->assertFalse( $this->registry->has( 'nope' ) );
+		$this->assertInstanceOf( Token_Definition::class, $this->registry->get( 'semantic.color.button-bg' ) );
+		$this->assertNull( $this->registry->get( 'nope' ) );
+		$this->assertCount( 1, $this->registry->all() );
+	}
+
+	public function testItPreservesInsertionOrder(): void {
+		$this->register_button_bg();
+		$this->register_spacing_md();
+
+		$this->assertSame(
+			[ 'semantic.color.button-bg', 'semantic.spacing.md' ],
+			array_keys( $this->registry->all() )
+		);
+	}
+
+	public function testByTypeFiltersAndKeepsIdKeys(): void {
+		$this->register_button_bg();
+		$this->register_spacing_md();
+
+		$colors = $this->registry->by_type( 'color' );
+
+		$this->assertSame( [ 'semantic.color.button-bg' ], array_keys( $colors ) );
+	}
+
+	public function testByProjectionFiltersAndKeepsIdKeys(): void {
+		$this->register_button_bg();
+		$this->register_spacing_md();
+
+		$presets = $this->registry->by_projection( 'wp_preset' );
+
+		$this->assertSame( [ 'semantic.color.button-bg' ], array_keys( $presets ) );
+	}
+
+	public function testCssVarForKnownToken(): void {
+		$this->register_button_bg();
+
+		$this->assertSame(
+			'--kb-token--semantic--color--button-bg',
+			$this->registry->css_var_for( 'semantic.color.button-bg' )
+		);
+	}
+
+	public function testCssVarForUnknownTokenFallsBackToDerivation(): void {
+		$this->assertSame(
+			'--kb-token--unknown--token',
+			$this->registry->css_var_for( 'unknown.token' )
+		);
+	}
+
+	public function testCssVarForHonoursOverride(): void {
+		$this->registry->register(
+			[
+				'id'      => 'semantic.color.button-bg',
+				'type'    => 'color',
+				'label'   => 'Button Background',
+				'css_var' => '--global-palette1',
+			]
+		);
+
+		$this->assertSame( '--global-palette1', $this->registry->css_var_for( 'semantic.color.button-bg' ) );
+	}
+
+	public function testToUiSchemaBucketsByGroupAndNeverLeaksAValue(): void {
+		$this->register_button_bg();
+		$this->register_spacing_md();
+
+		$schema = $this->registry->to_ui_schema();
+
+		$this->assertArrayHasKey( 'groups', $schema );
+		$this->assertArrayHasKey( 'Brand', $schema['groups'] );
+		$this->assertArrayHasKey( 'Layout', $schema['groups'] );
+
+		$entry = $schema['groups']['Brand'][0];
+		$this->assertSame(
+			[ 'id', 'type', 'label', 'cssVar', 'projections' ],
+			array_keys( $entry )
+		);
+		$this->assertArrayNotHasKey( 'value', $entry );
+	}
+
+	public function testForBlockReturnsNullUntilRegistered(): void {
+		$this->assertNull( $this->registry->for_block( 'kadence/advancedbtn' ) );
+
+		$this->registry->register_variant_set(
+			[
+				'block'    => 'kadence/advancedbtn',
+				'variants' => [ 'primary' ],
+			]
+		);
+
+		$set = $this->registry->for_block( 'kadence/advancedbtn' );
+		$this->assertNotNull( $set );
+		$this->assertSame( 'kadence/advancedbtn', $set->block );
+	}
+
+	public function testIsActiveByDefaultAndDeactivates(): void {
+		$this->assertTrue( $this->registry->is_active() );
+
+		$this->registry->deactivate();
+
+		$this->assertFalse( $this->registry->is_active() );
+	}
+
+	public function testMissingFromBaselineReturnsUnmatchedIds(): void {
+		$this->register_button_bg();
+		$this->register_spacing_md();
+
+		$baseline = new class() implements Baseline_Document {
+			public function has( string $id ): bool {
+				return $id === 'semantic.color.button-bg';
+			}
+		};
+
+		$this->assertSame( [ 'semantic.spacing.md' ], $this->registry->missing_from_baseline( $baseline ) );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Variant_SetTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Variant_SetTest.php
@@ -1,0 +1,45 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Registry;
+
+use InvalidArgumentException;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Variant_Set;
+use Tests\Support\Classes\TestCase;
+
+final class Variant_SetTest extends TestCase {
+
+	public function testItRetainsBlockAndVariants(): void {
+		$set = Variant_Set::from_array(
+			[
+				'block'    => 'kadence/advancedbtn',
+				'variants' => [ 'primary', 'secondary', 'ghost' ],
+			]
+		);
+
+		$this->assertSame( 'kadence/advancedbtn', $set->block );
+		$this->assertSame( [ 'primary', 'secondary', 'ghost' ], $set->variants );
+	}
+
+	public function testItDefaultsVariantsToAnEmptyList(): void {
+		$set = Variant_Set::from_array( [ 'block' => 'kadence/advancedbtn' ] );
+
+		$this->assertSame( [], $set->variants );
+	}
+
+	public function testItNormalizesVariantsToAList(): void {
+		$set = Variant_Set::from_array(
+			[
+				'block'    => 'kadence/advancedbtn',
+				'variants' => [ 2 => 'primary', 5 => 'secondary' ],
+			]
+		);
+
+		$this->assertSame( [ 'primary', 'secondary' ], $set->variants );
+	}
+
+	public function testItThrowsWhenBlockIsMissing(): void {
+		$this->expectException( InvalidArgumentException::class );
+
+		Variant_Set::from_array( [ 'variants' => [ 'primary' ] ] );
+	}
+}


### PR DESCRIPTION
🎫 [SOFT-3379](https://linear.app/nexcess/issue/SOFT-3379/token-registry-register-design-token-helper)

Adds the **Token Registry** — the single declaration point for design tokens — and the `kadence_blocks_register_design_token()` helper, building on the Design Tokens Module (DTM) scaffold.

The Registry holds **structure only, never values**. Each token is declared once in PHP and the Registry records where it must surface: its `type`, `label`, UI `group`, and `projections` (WordPress preset slug, Kadence palette slot, dedicated `--kb-token--*` CSS var, Site Editor visibility). Because every projector and the admin UI read this one Registry, adding a token is a single declaration that automatically reaches all of them.

### What's included

- `Css_Var` — the deterministic `id → --kb-token--*` derivation rule (`semantic.color.button-bg → --kb-token--semantic--color--button-bg`).
- `Token_Definition` — immutable VO for a single token declaration (derives the css-var, supports an explicit override).
- `Token_Registry` — the service: `all() / get() / has() / by_type() / by_projection() / for_block() / css_var_for() / to_ui_schema()`, plus the `is_active()` projection gate.
- `kadence_blocks_register_design_token()` + `kadence_blocks_register_design_variant_set()` global helpers.
- `Baseline_Document` contract + a **fail-closed `Baseline_Guard`**: under `WP_DEBUG` it throws on a token missing a baseline entry; in production it logs, deactivates projection, and shows an admin notice (never white-screens a live site).
- `Variant_Set` skeleton recording which blocks accept variants.
- Full wpunit coverage (40 tests).

### Downstream interfaces exposed

| Consumer | Reads |
| --- | --- |
| SOFT-3380 Resolver | `all()`, `by_type()`, `css_var_for($id)` — must gate on `is_active()` |
| SOFT-3385 Admin UI feed | `to_ui_schema()` |
| SOFT-3393 Variant data model | `for_block()`, `register_variant_set()` |
| Projectors | `by_projection('wp_preset' \| 'kadence_slot' \| 'site_editor')` |

---

### ⚠️ NOTE — Temporary scaffolding in this PR

Everything below is intentionally temporary so the path can be proven end-to-end before its owning ticket lands. Each row names the issue that will fix/replace/remove it and the action that ticket will take.

| Temporary item | Where | Owning issue | Action to be taken |
| --- | --- | --- | --- |
| **`Always_Present_Baseline_Document` is bound as the baseline** (its `has()` always returns `true`), so the example tokens flow through registration + the guard now. The guard is effectively a no-op at runtime until this is swapped. | `Registry/Provider.php`, `Registry/Baseline/Always_Present_Baseline_Document.php` | **SOFT-3377** | Swap the binding to the real `Baseline_Document`. At that point every declared token must have a genuine baseline entry or the guard fires — the intended fail-closed behaviour. |
| **`Empty_Baseline_Document` stub** kept as the fail-closed reference (`has()` always `false`). | `Registry/Baseline/Empty_Baseline_Document.php` | **SOFT-3377** | Superseded by the real baseline document; remove once SOFT-3377's `has()` exists. |
| **Example token declarations** (`semantic.color.button-bg`, `semantic.color.button-text`) — a small representative set, not the real catalog. | `Registry/declarations.php` | **SOFT-3377** | Replace with the full token catalog supplied by the Baseline document. |
| **Guard runs inline during `register()`.** Works because the current stub is in-memory. | `Registry/Provider.php` (`guard_baseline()`) | **SOFT-3377** | When the real baseline loads from a store/file that needs WP loaded, move the guard invocation to a late `init` / `plugins_loaded` hook. The guard logic itself does not change — only *when* it is invoked. |
| **`Variant_Set` is a skeleton** — holds only `block` + `variants` names. The example Button variant set is a placeholder. | `Registry/Variant_Set.php`, `Registry/declarations.php` | **SOFT-3393** | Extend with the rich `$extensions…variants.<block>` payload shape, `$default` handling, and validation. |

### To confirm during review

- **CSS-var prefix:** implemented the **double-dash** `--kb-token--` per the design-doc §6 worked example (the prose says single dash). Flag if single-dash was intended.
- **`to_ui_schema()` shape** (`{ groups: { <group>: [ {id,type,label,cssVar,projections} ] } }`) is a proposal for SOFT-3385 — confirm it matches what the React app expects, or let SOFT-3385 finalize it.
