### PR TITLE
[DTM] Address review comments on Token Registry (#1006)

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Baseline_Guard.php
+++ b/includes/resources/Design_Tokens/Registry/Baseline_Guard.php
@@ -66,7 +66,7 @@ final class Baseline_Guard {
 	public function run(): void {
 		$missing = $this->registry->missing_from_baseline( $this->baseline );
 
-		if ( $missing === [] ) {
+		if ( empty( $missing ) ) {
 			return;
 		}
 

--- a/includes/resources/Design_Tokens/Registry/Baseline_Guard.php
+++ b/includes/resources/Design_Tokens/Registry/Baseline_Guard.php
@@ -26,6 +26,8 @@ final class Baseline_Guard {
 	/**
 	 * Whether a missing entry throws. Resolves to WP_DEBUG when null (the production/dev default).
 	 *
+	 * @since TBD
+	 *
 	 * @var bool|null
 	 */
 	private ?bool $throw_on_missing;

--- a/includes/resources/Design_Tokens/Registry/Baseline_Guard.php
+++ b/includes/resources/Design_Tokens/Registry/Baseline_Guard.php
@@ -64,6 +64,9 @@ final class Baseline_Guard {
 	 * @return void
 	 */
 	public function run(): void {
+		// TODO (SOFT-3377): this walks every declared token against the baseline on each run — O(n) per
+		// request once it runs against the real baseline. Cache the result and recompute only when a token
+		// is added/updated/removed so the common (unchanged-registry) path stays cheap.
 		$missing = $this->registry->missing_from_baseline( $this->baseline );
 
 		if ( empty( $missing ) ) {

--- a/includes/resources/Design_Tokens/Registry/Token_Definition.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Definition.php
@@ -14,23 +14,55 @@ use InvalidArgumentException;
  */
 final class Token_Definition {
 
-	/** @var string DTCG dot-path, e.g. "semantic.color.button-bg". */
+	/**
+	 * DTCG dot-path, e.g. "semantic.color.button-bg".
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
 	public string $id;
 
-	/** @var string DTCG $type: color | dimension | shadow | typography | … */
+	/**
+	 * DTCG $type: color | dimension | shadow | typography | …
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
 	public string $type;
 
-	/** @var string Human-readable label for the custom UI. */
+	/**
+	 * Human-readable label for the custom UI.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
 	public string $label;
 
-	/** @var string UI grouping bucket, e.g. "Brand". */
+	/**
+	 * UI grouping bucket, e.g. "Brand".
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
 	public string $group;
 
-	/** @var string The canonical (or overridden) CSS custom-property name. */
+	/**
+	 * The canonical (or overridden) CSS custom-property name.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
 	public string $css_var;
 
 	/**
 	 * Projection targets. Keys are projection ids; values are projection-specific config.
+	 *
+	 * @since TBD
 	 *
 	 * @var array<string, mixed> e.g. [ 'wp_preset' => 'color', 'kadence_slot' => 'palette1', 'site_editor' => true ]
 	 */

--- a/includes/resources/Design_Tokens/Registry/Variant_Set.php
+++ b/includes/resources/Design_Tokens/Registry/Variant_Set.php
@@ -13,9 +13,22 @@ use InvalidArgumentException;
  */
 final class Variant_Set {
 
+	/**
+	 * The block name.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
 	public string $block;
 
-	/** @var string[] */
+	/**
+	 * The declared variant names.
+	 *
+	 * @since TBD
+	 *
+	 * @var string[]
+	 */
 	public array $variants;
 
 	/**

--- a/includes/resources/Design_Tokens/functions.php
+++ b/includes/resources/Design_Tokens/functions.php
@@ -14,7 +14,14 @@ if ( ! function_exists( 'kadence_blocks_register_design_token' ) ) {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, mixed> $definition The token declaration.
+	 * @param array{
+	 *     id: string,
+	 *     type: string,
+	 *     label: string,
+	 *     group?: string,
+	 *     css_var?: string,
+	 *     projections?: array<string, mixed>,
+	 * } $definition The token declaration.
 	 *
 	 * @return void
 	 */
@@ -29,7 +36,10 @@ if ( ! function_exists( 'kadence_blocks_register_design_variant_set' ) ) {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, mixed> $set See Variant_Set::from_array().
+	 * @param array{
+	 *     block: string,
+	 *     variants?: string[],
+	 * } $set See Variant_Set::from_array().
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
Follow-up to #1006 addressing @d4mation's review comments. Each fix is its own commit.

## Changes

- **Baseline_Guard** — add `@since` to the `$throw_on_missing` vardoc.
- **functions.php** — give both registration helpers explicit array-shape param types (`array{id: string, ...}`) so the expected declaration shape is clear and PHPStan-friendly.
- **Token_Definition** — expand the single-line property vardocs to full blocks so each carries `@since`.
- **Variant_Set** — add property vardocs to `$block` / `$variants`.
- **Baseline_Guard** — early-return on `empty( $missing )` instead of `=== []` (array, no `"0"` concern).
- **Baseline_Guard** — add a `TODO (SOFT-3377)` to cache the O(n) `missing_from_baseline()` check rather than recomputing every run.
