### PR TITLE
fix: resolve PHPCS, PHPStan, and cspell CI failures

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -28,6 +28,7 @@
         "gulpfile",
         "hcaptcha",
         "kadence",
+        "LONGTEXT",
         "lottiefiles",
         "lwsw",
         "mbstring",
@@ -45,6 +46,7 @@
         "splide",
         "splidejs",
         "stellarwp",
+        "wpdb",
         "wpunit"
     ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -19,9 +19,11 @@
         "algoliasearch",
         "bunfig",
         "bunx",
+        "codecept",
         "codeception",
         "diffcs",
         "distignore",
+        "DTCG",
         "dotlottie",
         "gulpfile",
         "hcaptcha",
@@ -42,6 +44,7 @@
         "slidy",
         "splide",
         "splidejs",
-        "stellarwp"
+        "stellarwp",
+        "wpunit"
     ]
 }

--- a/includes/resources/App.php
+++ b/includes/resources/App.php
@@ -1,4 +1,5 @@
 <?php declare( strict_types=1 );
+// cspell:ignore Adbar .
 
 namespace KadenceWP\KadenceBlocks;
 

--- a/includes/resources/Design_Tokens/Database/Token_Store.php
+++ b/includes/resources/Design_Tokens/Database/Token_Store.php
@@ -72,7 +72,11 @@ final class Token_Store extends Query {
 					->where( 'slug', $slug )
 					->get( ARRAY_A );
 
-		return $row['document'] ?? '';
+		if ( ! is_array( $row ) ) {
+			return '';
+		}
+
+		return (string) ( $row['document'] ?? '' );
 	}
 
 	/**
@@ -93,7 +97,11 @@ final class Token_Store extends Query {
 					->where( 'slug', $slug )
 					->get( ARRAY_A );
 
-		return $row['version'] ?? '';
+		if ( ! is_array( $row ) ) {
+			return '';
+		}
+
+		return (string) ( $row['version'] ?? '' );
 	}
 
 	/**
@@ -156,7 +164,7 @@ final class Token_Store extends Query {
 					->where( 'slug', $slug )
 					->get( ARRAY_A );
 
-		if ( $row === null ) {
+		if ( ! is_array( $row ) ) {
 			return;
 		}
 

--- a/includes/resources/Design_Tokens/Registry/Baseline_Guard.php
+++ b/includes/resources/Design_Tokens/Registry/Baseline_Guard.php
@@ -12,7 +12,7 @@ use KadenceWP\KadenceBlocks\Psr\Log\LoggerInterface;
  * Policy:
  *   - Always log the missing ids.
  *   - Under WP_DEBUG: throw Missing_Baseline_Entry so dev/CI cannot miss the misconfiguration.
- *   - In production: deactivate token projection (fall back to existing KB behaviour) + admin notice.
+ *   - In production: deactivate token projection (fall back to existing KB behavior) + admin notice.
  *     Never white-screen a live site.
  *
  * @since TBD

--- a/includes/resources/Design_Tokens/Registry/Provider.php
+++ b/includes/resources/Design_Tokens/Registry/Provider.php
@@ -67,6 +67,7 @@ final class Provider extends Provider_Contract {
 	 * @return void
 	 */
 	public function register_declarations(): void {
+		/** @var Token_Registry $registry */
 		$registry     = $this->container->get( Token_Registry::class );
 		$declarations = require __DIR__ . '/declarations.php';
 
@@ -85,6 +86,8 @@ final class Provider extends Provider_Contract {
 	 * @return void
 	 */
 	public function guard_baseline(): void {
-		$this->container->get( Baseline_Guard::class )->run();
+		/** @var Baseline_Guard $guard */
+		$guard = $this->container->get( Baseline_Guard::class );
+		$guard->run();
 	}
 }

--- a/includes/resources/Design_Tokens/Registry/Token_Definition.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Definition.php
@@ -104,17 +104,9 @@ final class Token_Definition {
 	 * @return self
 	 */
 	public static function from_array( array $definition ): self {
-		foreach ( [ 'id', 'type', 'label' ] as $required ) {
-			// Require a present, non-empty string. Avoid empty() so a legitimate "0" string is not
-			// mistaken for a missing value.
-			if ( ! isset( $definition[ $required ] ) || ! is_string( $definition[ $required ] ) || $definition[ $required ] === '' ) {
-				throw new InvalidArgumentException(
-					sprintf( 'Design token declaration is missing required string "%s".', $required )
-				);
-			}
-		}
-
-		$id = $definition['id'];
+		$id    = self::require_string( $definition['id'] ?? null, 'id' );
+		$type  = self::require_string( $definition['type'] ?? null, 'type' );
+		$label = self::require_string( $definition['label'] ?? null, 'label' );
 
 		// Guard the id charset at declaration time: it feeds Css_Var::from_id() which only swaps "." for
 		// "--", so an id with a space or slash would silently yield an invalid CSS custom-property name.
@@ -125,29 +117,74 @@ final class Token_Definition {
 			);
 		}
 
-		// Optional keys are type-checked so a bad declaration raises the documented InvalidArgumentException
-		// rather than a raw TypeError from the constructor's typed params — this is a public helper.
-		if ( isset( $definition['group'] ) && ! is_string( $definition['group'] ) ) {
-			throw new InvalidArgumentException( 'Design token declaration "group" must be a string.' );
-		}
+		$group   = self::optional_string( $definition['group'] ?? null, 'group' );
+		$css_var = self::optional_string( $definition['css_var'] ?? null, 'css_var' );
 
-		if ( isset( $definition['css_var'] ) && ! is_string( $definition['css_var'] ) ) {
-			throw new InvalidArgumentException( 'Design token declaration "css_var" must be a string.' );
-		}
-
-		if ( isset( $definition['projections'] ) && ! is_array( $definition['projections'] ) ) {
+		// Type-checked here so a bad declaration raises the documented InvalidArgumentException rather than
+		// a raw TypeError from the constructor's typed param — this is a public helper.
+		$projections = $definition['projections'] ?? [];
+		if ( ! is_array( $projections ) ) {
 			throw new InvalidArgumentException( 'Design token declaration "projections" must be an array.' );
 		}
 
 		return new self(
 			$id,
-			$definition['type'],
-			$definition['label'],
-			$definition['group'] ?? '',
+			$type,
+			$label,
+			$group ?? '',
 			// css_var override is rare; default is derived and impossible to drift from the id.
-			$definition['css_var'] ?? Css_Var::from_id( $id ),
-			$definition['projections'] ?? []
+			$css_var ?? Css_Var::from_id( $id ),
+			$projections
 		);
+	}
+
+	/**
+	 * Require a declaration value to be a present, non-empty string.
+	 *
+	 * Avoid empty() so a legitimate "0" string is not mistaken for a missing value.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed  $value The raw declaration value.
+	 * @param string $key   The declaration key, used for the error message.
+	 *
+	 * @throws InvalidArgumentException When the value is missing or not a non-empty string.
+	 *
+	 * @return string
+	 */
+	private static function require_string( $value, string $key ): string {
+		if ( ! is_string( $value ) || $value === '' ) {
+			throw new InvalidArgumentException(
+				sprintf( 'Design token declaration is missing required string "%s".', $key )
+			);
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Type-check an optional declaration value: a string when present, otherwise null.
+	 *
+	 * Validated here so a bad declaration raises the documented InvalidArgumentException rather than a
+	 * raw TypeError from the constructor's typed params — this is a public helper.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed  $value The raw declaration value.
+	 * @param string $key   The declaration key, used for the error message.
+	 *
+	 * @throws InvalidArgumentException When the value is present but not a string.
+	 *
+	 * @return string|null
+	 */
+	private static function optional_string( $value, string $key ): ?string {
+		if ( $value !== null && ! is_string( $value ) ) {
+			throw new InvalidArgumentException(
+				sprintf( 'Design token declaration "%s" must be a string.', $key )
+			);
+		}
+
+		return $value;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Registry/Token_Registry.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Registry.php
@@ -1,4 +1,5 @@
 <?php declare( strict_types=1 );
+// cspell:ignore advancedbtn .
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry;
 
@@ -26,7 +27,7 @@ final class Token_Registry {
 
 	/**
 	 * Whether token projection is active. Flipped off by the fail-closed guard so projectors and the
-	 * UI surface fall back to existing KB behaviour rather than projecting a partial/broken set.
+	 * UI surface fall back to existing KB behavior rather than projecting a partial/broken set.
 	 *
 	 * @var bool
 	 */

--- a/includes/resources/Design_Tokens/Registry/Variant_Set.php
+++ b/includes/resources/Design_Tokens/Registry/Variant_Set.php
@@ -47,7 +47,7 @@ final class Variant_Set {
 	 *
 	 * @param array<string, mixed> $set The variant-set declaration.
 	 *
-	 * @throws InvalidArgumentException When "block" is missing.
+	 * @throws InvalidArgumentException When "block" is missing or "variants" is not a list of strings.
 	 *
 	 * @return self
 	 */
@@ -58,6 +58,22 @@ final class Variant_Set {
 			throw new InvalidArgumentException( 'Variant-set declaration is missing required string "block".' );
 		}
 
-		return new self( $set['block'], array_values( (array) ( $set['variants'] ?? [] ) ) );
+		$declared = $set['variants'] ?? [];
+		if ( ! is_array( $declared ) ) {
+			throw new InvalidArgumentException( 'Variant-set declaration "variants" must be an array of strings.' );
+		}
+
+		// Re-index to a list of validated strings: declarations may key variants (e.g. [ 2 => 'primary' ])
+		// and the $variants property is documented as string[]. Full payload validation is SOFT-3393.
+		$variants = [];
+		foreach ( $declared as $variant ) {
+			if ( ! is_string( $variant ) ) {
+				throw new InvalidArgumentException( 'Variant-set declaration "variants" must contain only strings.' );
+			}
+
+			$variants[] = $variant;
+		}
+
+		return new self( $set['block'], $variants );
 	}
 }

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -1,4 +1,5 @@
 <?php declare( strict_types=1 );
+// cspell:ignore advancedbtn .
 // The single declaration point. Adding an entry here automatically reaches every projector and the
 // admin UI. Returned as data (rather than calling the global helper) so the Provider can register it
 // directly against the container. v1 ships a small representative set; the full catalog lands with

--- a/includes/resources/Design_Tokens/functions.php
+++ b/includes/resources/Design_Tokens/functions.php
@@ -26,7 +26,9 @@ if ( ! function_exists( 'kadence_blocks_register_design_token' ) ) {
 	 * @return void
 	 */
 	function kadence_blocks_register_design_token( array $definition ): void {
-		kadence_blocks()->get( Token_Registry::class )->register( $definition );
+		/** @var Token_Registry $registry */
+		$registry = kadence_blocks()->get( Token_Registry::class );
+		$registry->register( $definition );
 	}
 }
 
@@ -44,6 +46,8 @@ if ( ! function_exists( 'kadence_blocks_register_design_variant_set' ) ) {
 	 * @return void
 	 */
 	function kadence_blocks_register_design_variant_set( array $set ): void {
-		kadence_blocks()->get( Token_Registry::class )->register_variant_set( $set );
+		/** @var Token_Registry $registry */
+		$registry = kadence_blocks()->get( Token_Registry::class );
+		$registry->register_variant_set( $set );
 	}
 }

--- a/tests/_support/Classes/SnapshotTestCase.php
+++ b/tests/_support/Classes/SnapshotTestCase.php
@@ -1,4 +1,5 @@
 <?php declare( strict_types=1 );
+// cspell:ignore Spatie .
 
 namespace Tests\Support\Classes;
 

--- a/tests/_support/Classes/SnapshotTestCase.php
+++ b/tests/_support/Classes/SnapshotTestCase.php
@@ -74,7 +74,7 @@ class SnapshotTestCase extends WPTestCase {
 		 * Increment the snapshot incrementor to ensure we are checking against the correct
 		 * file name.
 		 */
-		++$this->snapshotIncrementor;
+		++$this->snapshotIncrementor; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Property is defined by the spatie/phpunit-snapshot-assertions trait.
 
 		$snapshot = Snapshots\Snapshot::forTestCase(
 			$this->getSnapshotId(),
@@ -87,7 +87,7 @@ class SnapshotTestCase extends WPTestCase {
 		 * expected file name afterwards. We have to do this due to how we create a separate
 		 * Snapshot object above.
 		 */
-		--$this->snapshotIncrementor;
+		--$this->snapshotIncrementor; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Property is defined by the spatie/phpunit-snapshot-assertions trait.
 
 		if (
 			! $snapshot->exists()

--- a/tests/_support/Helper/Snapshot.php
+++ b/tests/_support/Helper/Snapshot.php
@@ -4,7 +4,7 @@ namespace Helper;
 // here you can define custom actions
 // all public methods declared in helper class will be available in $I
 
-class Snapshot extends \Codeception\Module
-{
+class Snapshot extends \Codeception\Module {
+
 
 }

--- a/tests/_support/SnapshotTester.php
+++ b/tests/_support/SnapshotTester.php
@@ -16,7 +16,7 @@
  *
  * @SuppressWarnings(PHPMD)
 */
-class SnapshotTester extends \Codeception\Actor
-{
-    use _generated\SnapshotTesterActions;
+class SnapshotTester extends \Codeception\Actor {
+
+	use _generated\SnapshotTesterActions;
 }

--- a/tests/snapshot.suite.yml
+++ b/tests/snapshot.suite.yml
@@ -1,3 +1,4 @@
+# cspell:ignore twentytwentyfour
 # Codeception Test Suite Configuration
 
 # Suite for WordPress snapshot tests.

--- a/tests/snapshot/_bootstrap.php
+++ b/tests/snapshot/_bootstrap.php
@@ -1,6 +1,6 @@
 <?php declare( strict_types=1 );
 
-/**
+/*
  * Codeception regenerates snapshots on `--debug`, while the spatie/phpunit-snapshot-assertions
  * library does the same on `--update-snapshots`. Codeception strictly validates its CLI
  * arguments, so appending `--update-snapshots` to the `codecept run` command directly would

--- a/tests/snapshot/_bootstrap.php
+++ b/tests/snapshot/_bootstrap.php
@@ -1,4 +1,5 @@
 <?php declare( strict_types=1 );
+// cspell:ignore spatie .
 
 /*
  * Codeception regenerates snapshots on `--debug`, while the spatie/phpunit-snapshot-assertions

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Baseline_GuardTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Baseline_GuardTest.php
@@ -35,7 +35,7 @@ final class Baseline_GuardTest extends TestCase {
 		// tests via the global $wp_filter, while leaving any bootstrap-registered callbacks intact.
 		global $wp_filter;
 		if ( $this->admin_notices_snapshot !== null ) {
-			$wp_filter['admin_notices'] = $this->admin_notices_snapshot;
+			$wp_filter['admin_notices'] = $this->admin_notices_snapshot; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restoring the snapshotted hook state captured in setUp() to avoid leaking into sibling tests.
 		} else {
 			unset( $wp_filter['admin_notices'] );
 		}

--- a/tests/wpunit/Resources/Design_Tokens/Registry/RegistrationHelperTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/RegistrationHelperTest.php
@@ -1,4 +1,5 @@
 <?php declare( strict_types=1 );
+// cspell:ignore advancedbtn .
 
 namespace Tests\wpunit\Resources\Design_Tokens\Registry;
 
@@ -17,7 +18,7 @@ final class RegistrationHelperTest extends TestCase {
 
 	protected function tearDown(): void {
 		// Token_Registry is a container singleton, so tokens these tests register (semantic.color.test-only,
-		// kadence/testblock) would otherwise leak into every later test in the run. Rebind a fresh registry
+		// kadence/test-block) would otherwise leak into every later test in the run. Rebind a fresh registry
 		// repopulated from the declarations so the container is restored to exactly its declared state —
 		// otherwise a leaked token with no baseline entry would trip the guard once SOFT-3377 binds a real
 		// baseline, giving an order-dependent failure.
@@ -80,12 +81,12 @@ final class RegistrationHelperTest extends TestCase {
 	public function testVariantSetHelperRegistersAgainstTheSharedRegistry(): void {
 		kadence_blocks_register_design_variant_set(
 			[
-				'block'    => 'kadence/testblock',
+				'block'    => 'kadence/test-block',
 				'variants' => [ 'a', 'b' ],
 			]
 		);
 
-		$set = $this->registry->for_block( 'kadence/testblock' );
+		$set = $this->registry->for_block( 'kadence/test-block' );
 
 		$this->assertNotNull( $set );
 		$this->assertSame( [ 'a', 'b' ], $set->variants );

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Token_DefinitionTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Token_DefinitionTest.php
@@ -91,10 +91,31 @@ final class Token_DefinitionTest extends TestCase {
 	 */
 	public function missingRequiredProvider(): array {
 		return [
-			'missing id'    => [ [ 'type' => 'color', 'label' => 'Button Background' ] ],
-			'missing type'  => [ [ 'id' => 'semantic.color.button-bg', 'label' => 'Button Background' ] ],
-			'missing label' => [ [ 'id' => 'semantic.color.button-bg', 'type' => 'color' ] ],
-			'empty id'      => [ [ 'id' => '', 'type' => 'color', 'label' => 'Button Background' ] ],
+			'missing id'    => [
+				[
+					'type'  => 'color',
+					'label' => 'Button Background',
+				],
+			],
+			'missing type'  => [
+				[
+					'id'    => 'semantic.color.button-bg',
+					'label' => 'Button Background',
+				],
+			],
+			'missing label' => [
+				[
+					'id'   => 'semantic.color.button-bg',
+					'type' => 'color',
+				],
+			],
+			'empty id'      => [
+				[
+					'id'    => '',
+					'type'  => 'color',
+					'label' => 'Button Background',
+				],
+			],
 		];
 	}
 
@@ -104,7 +125,13 @@ final class Token_DefinitionTest extends TestCase {
 	public function testItThrowsWhenIdHasAnInvalidCharset( string $id ): void {
 		$this->expectException( InvalidArgumentException::class );
 
-		Token_Definition::from_array( [ 'id' => $id, 'type' => 'color', 'label' => 'Button Background' ] );
+		Token_Definition::from_array(
+			[
+				'id'    => $id,
+				'type'  => 'color',
+				'label' => 'Button Background',
+			]
+		);
 	}
 
 	/**
@@ -135,7 +162,11 @@ final class Token_DefinitionTest extends TestCase {
 	 * @return array<string, array{0: array<string, mixed>}>
 	 */
 	public function wrongTypeOptionalProvider(): array {
-		$base = [ 'id' => 'semantic.color.button-bg', 'type' => 'color', 'label' => 'Button Background' ];
+		$base = [
+			'id'    => 'semantic.color.button-bg',
+			'type'  => 'color',
+			'label' => 'Button Background',
+		];
 
 		return [
 			'non-string group'      => [ $base + [ 'group' => [ 'Brand' ] ] ],

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
@@ -1,4 +1,5 @@
 <?php declare( strict_types=1 );
+// cspell:ignore advancedbtn .
 
 namespace Tests\wpunit\Resources\Design_Tokens\Registry;
 

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Variant_SetTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Variant_SetTest.php
@@ -30,7 +30,10 @@ final class Variant_SetTest extends TestCase {
 		$set = Variant_Set::from_array(
 			[
 				'block'    => 'kadence/advancedbtn',
-				'variants' => [ 2 => 'primary', 5 => 'secondary' ],
+				'variants' => [
+					2 => 'primary',
+					5 => 'secondary',
+				],
 			]
 		);
 

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Variant_SetTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Variant_SetTest.php
@@ -1,4 +1,5 @@
 <?php declare( strict_types=1 );
+// cspell:ignore advancedbtn .
 
 namespace Tests\wpunit\Resources\Design_Tokens\Registry;
 


### PR DESCRIPTION
Fixes the PHPCS, PHPStan, and cspell CI failures for the design tokens module.

- **PHPCS**: array/brace/indentation formatting, a misplaced file docblock, and targeted `phpcs:ignore` for the spatie-trait `$snapshotIncrementor` property and the intentional `$wp_filter` restore.
- **PHPStan**: narrowed container `get()` results to typed locals, replaced loop-based validation in `Token_Definition::from_array()` with typed helpers, and enforced that `Variant_Set` variants are an array of strings. Also narrowed the `qb()->get()` results in `Token_Store` (from the merged SOFT-3375 work) with `is_array()` so offset access no longer lands on `array|object`. No baseline entries added.
- **cspell**: globalized `DTCG`/`wpunit`/`codecept`/`wpdb`/`LONGTEXT`, fixed British spellings, renamed the dummy `kadence/testblock` slug, and file-level ignored project-specific terms.

Note: Tests CI currently appears to be failing due to a Docker issue on the runner, not these changes -- the changes here should be unrelated to Tests CI.
