### PR TITLE
fix: register Registry provider in the Design Tokens module (SOFT-3379)

### DIFF
--- a/includes/resources/Design_Tokens/Design_Tokens_Provider.php
+++ b/includes/resources/Design_Tokens/Design_Tokens_Provider.php
@@ -15,6 +15,7 @@ final class Design_Tokens_Provider extends Provider {
 	 * @var class-string<Provider>[]
 	 */
 	private const PROVIDERS = [
+		Registry\Provider::class,
 		Database\Provider::class,
 	];
 


### PR DESCRIPTION
🎫 SOFT-3379

### Summary

`Registry\Provider` was never added to `Design_Tokens_Provider`'s sub-provider list, so the Token Registry layer never bootstrapped — in production **and** CI. This wires it in.

### The bug

`Design_Tokens_Provider::PROVIDERS` only registered `Database\Provider::class`. Because `Registry\Provider` never ran, none of its `register()` work happened:

- `functions.php` was never `require_once`'d → `kadence_blocks_register_design_token()` / `kadence_blocks_register_design_variant_set()` were **undefined**.
- `Token_Registry` was never bound as a singleton → resolved fresh on every `get()`.
- `Baseline_Document` was never bound.
- Token declarations never auto-registered and the fail-closed baseline guard never ran.

In CI this surfaced as 5 red `Resources/Design_Tokens/Registry` tests (`RegistrationHelperTest` ×4, `Baseline_GuardTest` ×1). `git log -S "Registry\Provider::class"` confirms it was never wired — a gap from the SOFT-3379 merge, not a regression.

### The fix

Add `Registry\Provider::class` to the list (before `Database\Provider` — the registry is the structural foundation downstream consumers read).

### Safety

The baseline guard throws under `WP_DEBUG` if a declared token lacks a baseline entry. Verified both declared tokens (`semantic.color.button-bg`, `semantic.color.button-text`) exist in `baseline.json`, so the guard finds nothing missing and does not throw.

### Test plan

- `composer phpcs` — clean.
- `vendor/bin/phpstan analyse` (level max) — no errors.
- `slic run wpunit Resources/Design_Tokens` — **74 tests OK** (previously 3 errors + 2 failures).

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist.
- [ ] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, & unit)