### PR TITLE
feat: add legacy license key validation function

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -16,6 +16,7 @@
         "**/*.svg"
     ],
     "words": [
+        "ABSPATH",
         "algoliasearch",
         "bunfig",
         "bunx",
@@ -25,11 +26,14 @@
         "dotlottie",
         "gulpfile",
         "hcaptcha",
+        "ithemes",
         "kadence",
         "lottiefiles",
         "lwsw",
         "mbstring",
         "memize",
+        "multisite",
+        "multisites",
         "nvmrc",
         "phar",
         "phpcs",
@@ -42,6 +46,7 @@
         "slidy",
         "splide",
         "splidejs",
-        "stellarwp"
+        "stellarwp",
+        "trailingslashit"
     ]
 }

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 use function KadenceWP\KadenceBlocks\StellarWP\Uplink\get_authorization_token;
 use function KadenceWP\KadenceBlocks\StellarWP\Uplink\get_license_domain;
 use function KadenceWP\KadenceBlocks\StellarWP\Uplink\get_license_key;
+use function KadenceWP\KadenceBlocks\StellarWP\Uplink\get_resource;
 use function KadenceWP\KadenceBlocks\StellarWP\Uplink\is_authorized;
 use function KadenceWP\KadenceBlocks\StellarWP\Uplink\validate_license;
 
@@ -247,9 +248,11 @@ function kadence_blocks_get_authorized_license_key(): string {
  * Legacy keys (e.g. "ktw...") are validated by checking the key directly against
  * the licensing server rather than via the V3 token-authorization handshake, so
  * {@see is_authorized()} returns false for them even when the key is good. This
- * mirrors how kadence-blocks-pro validates its own legacy license. The result is
- * cached in a transient (keyed by slug + key) so we don't hit the licensing
- * server on every editor/REST load.
+ * mirrors how kadence-blocks-pro validates its own legacy license. Uplink's own
+ * persisted license status is the source of truth for a positive result (it
+ * revalidates on its own schedule, so a revoked key is not kept "valid"); only
+ * the negative result is short-cached in a transient to avoid re-hitting the
+ * licensing server on every editor/REST load.
  *
  * @since TBD
  *
@@ -263,19 +266,31 @@ function kadence_blocks_is_legacy_key_valid( string $slug, string $key ): bool {
 		return false;
 	}
 
-	$transient = 'kadence_blocks_legacy_key_valid_' . md5( $slug . '_' . $key );
-	$cached    = get_transient( $transient );
-	if ( 'valid' === $cached ) {
+	$resource = get_resource( $slug );
+
+	// Authoritative positive signal: trust Uplink's persisted, self-maintained
+	// status when it already says the key is valid. Uplink revalidates and
+	// updates this status on its own schedule, so we avoid the false positives
+	// that a week-long positive transient could ship for a revoked key.
+	if ( $resource && $resource->get_license_object()->is_valid() ) {
 		return true;
 	}
-	if ( 'invalid' === $cached ) {
+
+	// No stored "valid" status yet (never validated, invalid, or revoked).
+	// Short-cache the negative so we don't re-POST on every load, then validate;
+	// a successful validate_license() persists the status, so the fast path
+	// above answers subsequent requests without another network call.
+	$transient = 'kadence_blocks_legacy_key_invalid_' . md5( $slug . '_' . $key );
+	if ( 'invalid' === get_transient( $transient ) ) {
 		return false;
 	}
 
 	$validation = validate_license( $slug, $key );
 	$is_valid   = $validation && method_exists( $validation, 'is_valid' ) && $validation->is_valid();
 
-	set_transient( $transient, $is_valid ? 'valid' : 'invalid', WEEK_IN_SECONDS );
+	if ( ! $is_valid ) {
+		set_transient( $transient, 'invalid', HOUR_IN_SECONDS );
+	}
 
 	return $is_valid;
 }

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -15,6 +15,7 @@ use function KadenceWP\KadenceBlocks\StellarWP\Uplink\get_authorization_token;
 use function KadenceWP\KadenceBlocks\StellarWP\Uplink\get_license_domain;
 use function KadenceWP\KadenceBlocks\StellarWP\Uplink\get_license_key;
 use function KadenceWP\KadenceBlocks\StellarWP\Uplink\is_authorized;
+use function KadenceWP\KadenceBlocks\StellarWP\Uplink\validate_license;
 
 /**
  * Check if we are in AMP Mode.
@@ -215,6 +216,15 @@ function kadence_blocks_get_authorized_license_key(): string {
 		if ( is_authorized( $candidate['key'], $candidate['slug'], $token ?? '', get_license_domain() ) ) {
 			return $candidate['key'];
 		}
+		// Legacy keys (e.g. "ktw...") are activated by direct license-key
+		// validation and never obtain a V3 authorization token, so is_authorized()
+		// above returns false for them. Fall back to the legacy validation flow so
+		// a valid legacy key still ships to the pattern/AI servers. A revoked or
+		// expired legacy key still fails here, preserving the original intent of
+		// not handing a stale key to remotes.
+		if ( kadence_blocks_is_legacy_key_valid( $candidate['slug'], $candidate['key'] ) ) {
+			return $candidate['key'];
+		}
 	}
 
 	if (
@@ -229,6 +239,45 @@ function kadence_blocks_get_authorized_license_key(): string {
 	}
 
 	return '';
+}
+
+/**
+ * Whether a license key is valid via the legacy (Uplink V2) validation flow.
+ *
+ * Legacy keys (e.g. "ktw...") are validated by checking the key directly against
+ * the licensing server rather than via the V3 token-authorization handshake, so
+ * {@see is_authorized()} returns false for them even when the key is good. This
+ * mirrors how kadence-blocks-pro validates its own legacy license. The result is
+ * cached in a transient (keyed by slug + key) so we don't hit the licensing
+ * server on every editor/REST load.
+ *
+ * @since TBD
+ *
+ * @param string $slug The Uplink resource slug.
+ * @param string $key  The license key to validate.
+ *
+ * @return bool
+ */
+function kadence_blocks_is_legacy_key_valid( string $slug, string $key ): bool {
+	if ( empty( $slug ) || empty( $key ) ) {
+		return false;
+	}
+
+	$transient = 'kadence_blocks_legacy_key_valid_' . md5( $slug . '_' . $key );
+	$cached    = get_transient( $transient );
+	if ( 'valid' === $cached ) {
+		return true;
+	}
+	if ( 'invalid' === $cached ) {
+		return false;
+	}
+
+	$validation = validate_license( $slug, $key );
+	$is_valid   = $validation && method_exists( $validation, 'is_valid' ) && $validation->is_valid();
+
+	set_transient( $transient, $is_valid ? 'valid' : 'invalid', WEEK_IN_SECONDS );
+
+	return $is_valid;
 }
 
 /**


### PR DESCRIPTION
Introduces a new function, `kadence_blocks_is_legacy_key_valid`, to validate
  legacy license keys directly against the licensing server. This ensures
  compatibility with older keys while maintaining the original intent of key
  validation. The result is cached to optimize performance during editor and
  REST loads.

  Legacy keys (e.g. non LWSW…) are activated via direct license-key validation
  against the kadencewp.com licensing server and never obtain a V3 authorization
  token, so is_authorized() returns false for them even when the key is good.
  As a result, `kadence_blocks_get_authorized_license_key()` returned an empty
  string for these accounts, which flowed through
  `kadence_blocks_get_current_license_data()` into an empty api_key on the
  pattern/template/AI requests to startertemplatecloud.com — so those servers
  rejected the imports as unlicensed. This adds a legacy-validation fallback
  inside the candidate loop: if the V3 token check fails, we validate the key
  directly via validate_license() (mirroring how kadence-blocks-pro validates
  its own legacy license). Revoked or expired legacy keys still fail validation,
  so we never ship a stale key. The result is cached in a transient keyed by
  slug + key (WEEK_IN_SECONDS) to avoid hitting the licensing server on every
  editor/REST load.

  🎫  [SMTNC-1449](https://linear.app/nexcess/issue/SMTNC-1449/legacy-licenses-cannot-import-premium-design-patterns-or-starter)

https://www.loom.com/share/8b98f1eb131f4529949eb76b8f0d8d86
  ...

  Checklist

  - [x] I have performed a self-review.
  - [x] No unrelated files are modified.
  - [x] No debugging statements exist (Ex: console.log, error_log).
  - [ ] There are no warnings or notices in the wordpress error log.
  - [ ] Passes all tests (linting, acceptance, & unit)

  Block specific checklist (where relevant)

  - [ ] Tested with an existing instance of this block .
  - [ ] Tested creating a new instance of this block.
  - [ ] Tested with Dynamic content & Elements.