### PR TITLE
[DTM] Resolver caching — wp_cache L2 layer for Token_Resolver

### DIFF
--- a/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
@@ -21,6 +21,7 @@ final class Token_Resolver {
 	 * Object-cache group shared by all resolved-token entries.
 	 *
 	 * @since TBD
+	 *
 	 * @var string
 	 */
 	private const CACHE_GROUP = 'kb_design_tokens';

--- a/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
@@ -76,7 +76,9 @@ final class Token_Resolver {
 		$cached    = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
 
 		if ( $found && $cached instanceof Resolved_Tokens ) {
-			return $this->memo[ $key ] = $cached;
+			$this->memo[ $key ] = $cached;
+
+			return $cached;
 		}
 
 		$raw      = $this->store->get_document( $slug );

--- a/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
@@ -17,6 +17,12 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Layers;
  */
 final class Token_Resolver {
 
+	/**
+	 * Object-cache group shared by all resolved-token entries.
+	 *
+	 * @since TBD
+	 * @var string
+	 */
 	private const CACHE_GROUP = 'kb_design_tokens';
 
 	/**

--- a/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
@@ -17,6 +17,8 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Layers;
  */
 final class Token_Resolver {
 
+	private const CACHE_GROUP = 'kb_design_tokens';
+
 	/**
 	 * @var Token_Store
 	 */
@@ -69,14 +71,25 @@ final class Token_Resolver {
 			return $this->memo[ $key ];
 		}
 
+		// L2: object cache — survives across requests, keyed on the store version.
+		$cache_key = 'resolved_tokens_' . $slug . '_' . $version;
+		$cached    = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
+
+		if ( $found && $cached instanceof Resolved_Tokens ) {
+			return $this->memo[ $key ] = $cached;
+		}
+
 		$raw      = $this->store->get_document( $slug );
 		$decoded  = $raw === '' ? [] : json_decode( $raw, true );
 		$over     = is_array( $decoded ) ? $decoded : [];
 		$document = $this->effective->build( $over );
 
-		$this->memo[ $key ] = $this->resolve_document( $document );
+		$result = $this->resolve_document( $document );
 
-		return $this->memo[ $key ];
+		wp_cache_set( $cache_key, $result, self::CACHE_GROUP );
+		$this->memo[ $key ] = $result;
+
+		return $result;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
@@ -88,7 +88,7 @@ final class Token_Resolver {
 
 		$result = $this->resolve_document( $document );
 
-		wp_cache_set( $cache_key, $result, self::CACHE_GROUP );
+		wp_cache_set( $cache_key, $result, self::CACHE_GROUP, DAY_IN_SECONDS );
 		$this->memo[ $key ] = $result;
 
 		return $result;

--- a/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
@@ -71,7 +71,7 @@ final class Token_Resolver {
 			return $this->memo[ $key ];
 		}
 
-		// L2: object cache — survives across requests, keyed on the store version.
+		// L2: persistent object cache (requires a drop-in such as Memcached or Redis) — survives across requests, keyed on the store version.
 		$cache_key = 'resolved_tokens_' . $slug . '_' . $version;
 		$cached    = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
 

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
@@ -8,6 +8,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Css_Renderer;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Resolved_Tokens;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use Tests\Support\Classes\Fake_Baseline_Document;
 use Tests\Support\Classes\TestCase;
@@ -263,6 +264,79 @@ final class Token_ResolverTest extends TestCase {
 
 		// The override flows through the alias.
 		$this->assertSame( '#000000', $by_id['semantic.color.button-bg'] );
+	}
+
+	public function testResolvePopulatesObjectCacheOnColdPath(): void {
+		/** @var Token_Resolver $resolver */
+		$resolver = $this->container->get( Token_Resolver::class );
+		/** @var Token_Store $store */
+		$store = $this->container->get( Token_Store::class );
+
+		$version   = $store->get_version();
+		$cache_key = 'resolved_tokens_default_' . $version;
+
+		wp_cache_delete( $cache_key, 'kb_design_tokens' );
+
+		$result = $resolver->resolve();
+
+		$this->assertInstanceOf( Resolved_Tokens::class, $result );
+
+		$cached = wp_cache_get( $cache_key, 'kb_design_tokens', false, $found );
+
+		$this->assertTrue( $found );
+		$this->assertInstanceOf( Resolved_Tokens::class, $cached );
+		$this->assertSame( $result->by_id(), $cached->by_id() );
+	}
+
+	public function testResolveReturnsObjectCacheHitWithoutRebuildingDocument(): void {
+		/** @var Token_Resolver $resolver */
+		$resolver = $this->container->get( Token_Resolver::class );
+		/** @var Token_Store $store */
+		$store = $this->container->get( Token_Store::class );
+
+		$version   = $store->get_version();
+		$cache_key = 'resolved_tokens_default_' . $version;
+		$sentinel  = new Resolved_Tokens(
+			[ 'sentinel.token' => '#sentinel' ],
+			[ '--kb-token--sentinel--token' => '#sentinel' ]
+		);
+		wp_cache_set( $cache_key, $sentinel, 'kb_design_tokens' );
+
+		$result = $resolver->resolve();
+
+		$this->assertSame( '#sentinel', $result->by_id()['sentinel.token'] ?? null );
+	}
+
+	public function testVersionBumpInvalidatesObjectCacheImplicitly(): void {
+		/** @var Token_Resolver $resolver */
+		$resolver = $this->container->get( Token_Resolver::class );
+		/** @var Token_Store $store */
+		$store = $this->container->get( Token_Store::class );
+
+		$before = $resolver->resolve();
+
+		$this->assertSame( '#3182CE', $before->value( 'semantic.color.button-bg' ) );
+
+		$store->save_document(
+			(string) wp_json_encode(
+				[
+					'primitive' => [
+						'color' => [
+							'brand' => [
+								'primary' => [
+									'$type'  => 'color',
+									'$value' => '#FF0000',
+								],
+							],
+						],
+					],
+				]
+			)
+		);
+
+		$after = $resolver->resolve();
+
+		$this->assertSame( '#FF0000', $after->value( 'semantic.color.button-bg' ) );
 	}
 
 	public function testResolveReadsTheStoredOverridesAndInvalidatesOnVersionBump(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
@@ -289,10 +289,14 @@ final class Token_ResolverTest extends TestCase {
 	}
 
 	public function testResolveReturnsObjectCacheHitWithoutRebuildingDocument(): void {
-		/** @var Token_Resolver $resolver */
-		$resolver = $this->container->get( Token_Resolver::class );
 		/** @var Token_Store $store */
 		$store = $this->container->get( Token_Store::class );
+		// Fresh instance so the L1 memo is empty — the container singleton may already be warm.
+		$resolver = new Token_Resolver(
+			$store,
+			$this->container->get( Effective_Document::class ),
+			$this->container->get( Css_Renderer::class )
+		);
 
 		$version   = $store->get_version();
 		$cache_key = 'resolved_tokens_default_' . $version;


### PR DESCRIPTION
## Summary

- Adds a `wp_cache_get` / `wp_cache_set` L2 cache inside `Token_Resolver::resolve()`, between the existing per-request L1 memo and the cold document-walk
- Cache key is `resolved_tokens_{slug}_{version}` in group `kb_design_tokens`; TTL is 0 — invalidation is implicit via version rotation on every store write
- Adds three wpunit tests: cold-path cache write, L2 hit (sentinel), and implicit invalidation on version bump

## Test plan

- [x] `slic run wpunit Resources/Design_Tokens/Resolver/Token_ResolverTest` — 13/13 passing
- [ ] Confirm object-cache hits are observed in a staging environment with a persistent cache (Memcached or Redis)