### PR TITLE
feat: variant read/write REST endpoints

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Token_Registry.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Registry.php
@@ -151,6 +151,18 @@ final class Token_Registry {
 	}
 
 	/**
+	 * The block names that have a registered variant set, in registration order — what the REST variants
+	 * collection enumerates as the blocks that accept variants.
+	 *
+	 * @since TBD
+	 *
+	 * @return string[]
+	 */
+	public function variant_blocks(): array {
+		return array_keys( $this->variant_sets );
+	}
+
+	/**
 	 * The effective projection targets for a binding: a token reference contributes the referenced
 	 * token's projections (so a variant reuses the variable the base property already feeds), and the
 	 * binding's inline targets are merged on top, supplementing or overriding them (e.g. adding a

--- a/includes/resources/Design_Tokens/Resolver/Effective_Variants.php
+++ b/includes/resources/Design_Tokens/Resolver/Effective_Variants.php
@@ -1,0 +1,156 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Resolver;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+
+/**
+ * Reads the effective variants section: the shipped baseline's variants deep-merged with a set's stored
+ * overrides, so a variant authored through the store is visible alongside the baseline ones.
+ *
+ * This is a thin reader, not a new merge: the deep-merge is {@see Mutator::merge()} (which preserves the
+ * whole "$extensions" layer untouched, exactly what a variants view needs), so this class only decodes the
+ * baseline and the stored overrides, walks each down to the `$extensions...variants` subtree, and delegates
+ * the merge. The sibling {@see Effective_Document} deliberately strips "$extensions", so it cannot be reused
+ * here — variants are read through this seam instead.
+ *
+ * The REST variants controller consumes this for its raw reads. It is also the seam a later projector that
+ * needs override-aware resolved values (the native-block and kbVariant projectors) can build on.
+ *
+ * @since TBD
+ */
+final class Effective_Variants {
+
+	/**
+	 * @var Baseline_Document The shipped baseline the variant definitions are merged onto.
+	 *
+	 * @since TBD
+	 */
+	private Baseline_Document $baseline;
+
+	/**
+	 * @var Token_Store The gateway the stored overrides are read from.
+	 *
+	 * @since TBD
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @var Mutator The pure deep-merge the baseline and overrides variants are combined through.
+	 *
+	 * @since TBD
+	 */
+	private Mutator $mutator;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Baseline_Document $baseline The shipped baseline document.
+	 * @param Token_Store       $store    The persistence gateway.
+	 * @param Mutator           $mutator  The pure deep-merge.
+	 */
+	public function __construct( Baseline_Document $baseline, Token_Store $store, Mutator $mutator ) {
+		$this->baseline = $baseline;
+		$this->store    = $store;
+		$this->mutator  = $mutator;
+	}
+
+	/**
+	 * The effective variants section for a stored set: baseline deep-merged with the set's overrides, keyed
+	 * by block name.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token set slug.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function section( string $slug = 'default' ): array {
+		return $this->for_overrides( $this->stored_document( $slug ) );
+	}
+
+	/**
+	 * The effective variants node for one block in a stored set, or null when neither the baseline nor the
+	 * overrides define variants for it.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block The block name, e.g. "kadence/advancedbtn".
+	 * @param string $slug  The token set slug.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public function block( string $block, string $slug = 'default' ): ?array {
+		$section = $this->section( $slug );
+
+		return isset( $section[ $block ] ) && is_array( $section[ $block ] ) ? $section[ $block ] : null;
+	}
+
+	/**
+	 * The effective variants section for an arbitrary candidate overrides document: the baseline variants
+	 * deep-merged with the candidate's variants subtree. Used to validate a write against its post-merge
+	 * effective set before it is committed (e.g. that a `$default` still names a present variant).
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $overrides A decoded overrides-only DTCG document.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function for_overrides( array $overrides ): array {
+		return $this->mutator->merge( $this->variants_of( $this->baseline->document() ), $this->variants_of( $overrides ) );
+	}
+
+	/**
+	 * Decode the set's stored overrides document, tolerating an absent/empty/malformed row as "no overrides".
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token set slug.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function stored_document( string $slug ): array {
+		$raw = $this->store->get_document( $slug );
+
+		if ( $raw === '' ) {
+			return [];
+		}
+
+		$decoded = json_decode( $raw, true );
+
+		return is_array( $decoded ) ? $decoded : [];
+	}
+
+	/**
+	 * Walk a decoded document down to its `$extensions...variants` subtree, or an empty array when absent.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document The decoded document.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function variants_of( array $document ): array {
+		$node = $document;
+
+		$path = [
+			Extensions::get_extensions_key(),
+			Extensions::get_namespace(),
+			Extensions::get_section_variants(),
+		];
+
+		foreach ( $path as $key ) {
+			if ( ! is_array( $node ) || ! isset( $node[ $key ] ) ) {
+				return [];
+			}
+
+			$node = $node[ $key ];
+		}
+
+		return is_array( $node ) ? $node : [];
+	}
+}

--- a/includes/resources/Design_Tokens/Resolver/Provider.php
+++ b/includes/resources/Design_Tokens/Resolver/Provider.php
@@ -21,5 +21,6 @@ final class Provider extends Provider_Contract {
 		$this->container->singleton( Css_Renderer::class, Css_Renderer::class );
 		$this->container->singleton( Token_Resolver::class, Token_Resolver::class );
 		$this->container->singleton( Variant_Resolver::class, Variant_Resolver::class );
+		$this->container->singleton( Effective_Variants::class );
 	}
 }

--- a/includes/resources/Design_Tokens/Resolver/Variant_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Variant_Resolver.php
@@ -5,6 +5,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Unknown_Variant_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
 
 /**
  * Flattens a block variant's token bindings to CSS-ready values — the variant counterpart of the
@@ -25,34 +26,6 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
  * @since TBD
  */
 final class Variant_Resolver {
-
-	/**
-	 * The `$extensions` path to the variants section. Inlined here because the shared vocabulary that
-	 * owns these spellings ships on a separate branch; centralise once it lands.
-	 *
-	 * @since TBD
-	 *
-	 * @var string[]
-	 */
-	private const VARIANTS_PATH = [ '$extensions', 'com.kadence.designTokens', 'variants' ];
-
-	/**
-	 * The key naming a block's default variant.
-	 *
-	 * @since TBD
-	 *
-	 * @var string
-	 */
-	private const DEFAULT_KEY = '$default';
-
-	/**
-	 * The key carrying a variant's property => value map.
-	 *
-	 * @since TBD
-	 *
-	 * @var string
-	 */
-	private const TOKENS_KEY = 'tokens';
 
 	/**
 	 * @var Baseline_Document The shipped baseline the variant definitions are read from.
@@ -248,7 +221,7 @@ final class Variant_Resolver {
 			throw Unknown_Variant_Exception::for_variant( $block, $variant );
 		}
 
-		$tokens = $block_variants[ $variant ][ self::TOKENS_KEY ] ?? [];
+		$tokens = $block_variants[ $variant ][ Extensions::get_tokens_key() ] ?? [];
 
 		return is_array( $tokens ) ? $tokens : [];
 	}
@@ -266,7 +239,7 @@ final class Variant_Resolver {
 	 * @return string
 	 */
 	public function default_variant( string $block ): string {
-		$default = $this->block_variants( $block )[ self::DEFAULT_KEY ] ?? '';
+		$default = $this->block_variants( $block )[ Extensions::get_default_key() ] ?? '';
 
 		if ( ! is_string( $default ) || $default === '' ) {
 			throw Unknown_Variant_Exception::no_default( $block );
@@ -306,7 +279,13 @@ final class Variant_Resolver {
 	private function variants_section(): array {
 		$node = $this->baseline->document();
 
-		foreach ( self::VARIANTS_PATH as $key ) {
+		$path = [
+			Extensions::get_extensions_key(),
+			Extensions::get_namespace(),
+			Extensions::get_section_variants(),
+		];
+
+		foreach ( $path as $key ) {
 			if ( ! is_array( $node ) || ! isset( $node[ $key ] ) ) {
 				return [];
 			}

--- a/includes/resources/Design_Tokens/Rest/V1/Provider.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Provider.php
@@ -26,6 +26,7 @@ final class Provider extends Provider_Contract {
 	private const CONTROLLERS = [
 		Documents_Controller::class,
 		Schema_Controller::class,
+		Variants_Controller::class,
 	];
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
@@ -815,9 +815,9 @@ final class Variants_Controller extends Controller {
 	}
 
 	/**
-	 * Reject a variant map whose entries are not well-formed: each named variant must be an object, its
-	 * label (when present) a string and its tokens (when present) an object. The alias-or-literal grammar of
-	 * the token values is left to the DTCG validator.
+	 * Reject a variant map whose entries are not well-formed: each named variant must have a non-empty
+	 * slug and be an object, its label (when present) a string and its tokens (when present) an object. The
+	 * alias-or-literal grammar of the token values is left to the DTCG validator.
 	 *
 	 * @since TBD
 	 *
@@ -831,6 +831,19 @@ final class Variants_Controller extends Controller {
 			// $default and any other "$"-prefixed metadata key is not a named variant.
 			if ( is_string( $slug ) && strpos( $slug, '$' ) === 0 ) {
 				continue;
+			}
+
+			// An empty slug would create a variant keyed by "" — a malformed node, the variant analogue of
+			// the empty dot-path segment the documents controller rejects. Refuse it before it is stored.
+			if ( (string) $slug === '' ) {
+				return new WP_Error(
+					'rest_design_tokens_invalid',
+					__( 'A variant slug cannot be empty.', 'kadence-blocks' ),
+					[
+						'status' => WP_Http::UNPROCESSABLE_ENTITY,
+						'block'  => $block,
+					]
+				);
 			}
 
 			$label_key  = Extensions::get_label_key();

--- a/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
@@ -1,0 +1,1268 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Variants;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Dtcg_Validator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Cast;
+use KadenceWP\KadenceBlocks\StellarWP\DB\Database\Exceptions\DatabaseQueryException;
+use WP_Error;
+use WP_Http;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * REST controller for the Design Tokens variants resource.
+ *
+ * Exposes the raw read and write surface for a block's variant set: the named variants and the `$default`
+ * that live in the DTCG document under `$extensions.com.kadence.designTokens.variants.<block>`. Reads are
+ * served from the baseline deep-merged with the stored overrides (via {@see Effective_Variants}), so a
+ * variant authored through a write is visible on the next read. Resolved (CSS) variant values are out of
+ * scope here — they are produced by the variant projectors, which own the resolver's override-merging.
+ *
+ * A block is addressable only when it has a registered variant set ({@see Token_Registry::for_block()}); a
+ * block with no set has no bindings, so a variant authored for it could never project. Reads and writes for
+ * such a block are a 404.
+ *
+ * Writes assemble a partial overrides document carrying only the addressed variants node and deep-merge it
+ * onto the stored set, then run the shared pipeline: DTCG grammar validation (HTTP 422), a dry-run Resolver
+ * pass that rejects alias cycles / dangling aliases in the token layers (HTTP 422), then a single
+ * Token_Store::save_document() that bumps the version and fires the change action. The block name carries a
+ * slash ("kadence/advancedbtn"), so it is routed as two path segments and reassembled.
+ *
+ * v1 ships a single token set under Token_Store::default_slug(); every route operates on it.
+ *
+ * @since TBD
+ */
+final class Variants_Controller extends Controller {
+
+	/**
+	 * The request parameter that carries the block's vendor segment, e.g. "kadence".
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const VENDOR_PARAM = 'vendor';
+
+	/**
+	 * The request parameter that carries the block's name segment, e.g. "advancedbtn".
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const BLOCK_NAME_PARAM = 'block_name';
+
+	/**
+	 * The request parameter that carries a single variant slug.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const VARIANT_PARAM = 'variant';
+
+	/**
+	 * The request parameter that carries a variant's human-readable label on a create.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const LABEL_PARAM = 'label';
+
+	/**
+	 * The request parameter that carries a variant's property => alias-or-literal token map.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const TOKENS_PARAM = 'tokens';
+
+	/**
+	 * The request parameter that carries the whole variant map on a replace (PUT).
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const VARIANTS_PARAM = 'variants';
+
+	/**
+	 * The request parameter that carries the default variant slug.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const DEFAULT_PARAM = 'default';
+
+	/**
+	 * The block vendor path segment. A slug-safe class with no slash; the block name is the second segment.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const VENDOR_ROUTE = '(?P<' . self::VENDOR_PARAM . '>[a-z][a-z0-9-]*)';
+
+	/**
+	 * The block name path segment.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const BLOCK_NAME_ROUTE = '(?P<' . self::BLOCK_NAME_PARAM . '>[a-z0-9][a-z0-9-]*)';
+
+	/**
+	 * The full block path: vendor + "/" + name, reassembled into "vendor/name" in each handler. A block
+	 * name carries a slash, so it is captured as two slug-free segments rather than one encoded segment.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const BLOCK_ROUTE = self::VENDOR_ROUTE . '/' . self::BLOCK_NAME_ROUTE;
+
+	/**
+	 * The single-variant path segment.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const VARIANT_ROUTE = '(?P<' . self::VARIANT_PARAM . '>[\w-]+)';
+
+	/**
+	 * The literal sub-route, relative to a block, that reads / sets the block's `$default`.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const DEFAULT_ROUTE = 'default';
+
+	/**
+	 * The sole gateway to the kb_design_tokens table.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * Pure merge transform used to assemble the candidate overrides document.
+	 *
+	 * @since TBD
+	 *
+	 * @var Mutator
+	 */
+	private Mutator $mutator;
+
+	/**
+	 * Dry-runs a candidate's token layers to reject alias cycles / dangling aliases before commit.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Resolver
+	 */
+	private Token_Resolver $resolver;
+
+	/**
+	 * Validates the DTCG grammar of a candidate document before it is committed.
+	 *
+	 * @since TBD
+	 *
+	 * @var Dtcg_Validator
+	 */
+	private Dtcg_Validator $validator;
+
+	/**
+	 * Reads the effective (baseline-merged) variants section, so reads reflect writes.
+	 *
+	 * @since TBD
+	 *
+	 * @var Effective_Variants
+	 */
+	private Effective_Variants $variants;
+
+	/**
+	 * Declares which blocks accept variants. A block with no registered set is a 404.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * Memoised item schema for this request. Null until first built.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string, mixed>|null
+	 */
+	private ?array $item_schema = null;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Store        $store     The sole gateway to the kb_design_tokens table.
+	 * @param Mutator            $mutator   Assembles the candidate overrides document.
+	 * @param Token_Resolver     $resolver  Dry-runs a candidate's token layers before commit.
+	 * @param Dtcg_Validator     $validator Validates the DTCG grammar of a candidate document.
+	 * @param Effective_Variants $variants  Reads the baseline-merged variants section.
+	 * @param Token_Registry     $registry  Declares which blocks accept variants.
+	 */
+	public function __construct(
+		Token_Store $store,
+		Mutator $mutator,
+		Token_Resolver $resolver,
+		Dtcg_Validator $validator,
+		Effective_Variants $variants,
+		Token_Registry $registry
+	) {
+		$this->store     = $store;
+		$this->mutator   = $mutator;
+		$this->resolver  = $resolver;
+		$this->validator = $validator;
+		$this->variants  = $variants;
+		$this->registry  = $registry;
+		$this->rest_base = 'variants';
+	}
+
+	/**
+	 * Register the read and write routes for the variants resource.
+	 *
+	 * Verb semantics follow the WordPress REST convention: POST creates or merges a single variant, PUT
+	 * replaces the block's whole variant set, DELETE on a block resets it to baseline, and DELETE on a
+	 * variant removes that one variant. The `$default` is read and set through a dedicated sub-route.
+	 *
+	 * The `default` sub-route is registered before the single-variant route so the literal segment is not
+	 * captured as a variant slug.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			"/$this->rest_base",
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_items' ],
+					'permission_callback' => [ $this, 'get_items_permissions_check' ],
+					'args'                => $this->get_collection_params(),
+				],
+				'schema' => [ $this, 'get_item_schema' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/' . self::BLOCK_ROUTE,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_item' ],
+					'permission_callback' => [ $this, 'get_item_permissions_check' ],
+					'args'                => $this->get_block_params(),
+				],
+				[
+					// POST = create-or-merge a single variant, leaving siblings and $default intact.
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'create_item' ],
+					'permission_callback' => [ $this, 'create_item_permissions_check' ],
+					'args'                => $this->get_create_params(),
+				],
+				[
+					// PUT replaces the block's whole variant set, dropping any variant absent from the body.
+					'methods'             => 'PUT',
+					'callback'            => [ $this, 'update_item' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_replace_params(),
+				],
+				[
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => [ $this, 'delete_item' ],
+					'permission_callback' => [ $this, 'delete_item_permissions_check' ],
+					'args'                => $this->get_block_params(),
+				],
+				'schema' => [ $this, 'get_item_schema' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/' . self::BLOCK_ROUTE . '/' . self::DEFAULT_ROUTE,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_default' ],
+					'permission_callback' => [ $this, 'get_item_permissions_check' ],
+					'args'                => $this->get_block_params(),
+				],
+				[
+					'methods'             => 'PUT',
+					'callback'            => [ $this, 'set_default' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_default_params(),
+				],
+				'schema' => [ $this, 'get_item_schema' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/' . self::BLOCK_ROUTE . '/' . self::VARIANT_ROUTE,
+			[
+				[
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => [ $this, 'delete_variant' ],
+					'permission_callback' => [ $this, 'delete_item_permissions_check' ],
+					'args'                => $this->get_variant_params(),
+				],
+				'schema' => [ $this, 'get_item_schema' ],
+			]
+		);
+	}
+
+	/**
+	 * List the blocks that accept variants, each with its default and named variant slugs.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$slug   = Token_Store::default_slug();
+		$blocks = [];
+
+		foreach ( $this->registry->variant_blocks() as $block ) {
+			$node = $this->variants->block( $block, $slug ) ?? [];
+
+			$blocks[] = [
+				'block'   => $block,
+				'default' => $this->default_of( $node ),
+				'names'   => $this->variant_names( $node ),
+			];
+		}
+
+		return new WP_REST_Response( [ 'blocks' => $blocks ], WP_Http::OK );
+	}
+
+	/**
+	 * Read a single block's effective variant set.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_item( $request ) {
+		$block = $this->block_from( $request );
+		$error = $this->guard_block( $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		return new WP_REST_Response( $this->prepare_item( $block ), WP_Http::OK );
+	}
+
+	/**
+	 * Create or merge a single variant (POST /variants/{block}).
+	 *
+	 * The body carries the variant slug, an optional label and its property => value token map. The variant
+	 * is deep-merged into the stored set, so sibling variants and the `$default` are left intact.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function create_item( $request ) {
+		$block = $this->block_from( $request );
+		$error = $this->guard_block( $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$variant = Cast::to_string( $request->get_param( self::VARIANT_PARAM ) );
+
+		if ( $variant === '' ) {
+			return new WP_Error(
+				'rest_design_tokens_invalid',
+				__( 'A variant slug is required.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::BAD_REQUEST,
+					'block'  => $block,
+				]
+			);
+		}
+
+		$block_node = [ $variant => $this->variant_definition( $request ) ];
+
+		$error = $this->guard_variant_shape( $block_node, $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$candidate = $this->mutator->merge( $this->stored_document(), $this->partial( $block, $block_node ) );
+
+		return $this->validate_and_save( $candidate, $block );
+	}
+
+	/**
+	 * Replace a block's whole variant set (PUT /variants/{block}).
+	 *
+	 * The stored variants for the block are dropped first, then the body's variant map (and optional
+	 * default) is written, so a variant absent from the body no longer applies.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_item( $request ) {
+		$block = $this->block_from( $request );
+		$error = $this->guard_block( $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$variants   = $request->get_param( self::VARIANTS_PARAM );
+		$block_node = is_array( $variants ) ? $variants : [];
+
+		$default = Cast::to_string( $request->get_param( self::DEFAULT_PARAM ) );
+
+		if ( $default !== '' ) {
+			$block_node[ Extensions::get_default_key() ] = $default;
+		}
+
+		$error = $this->guard_variant_shape( $block_node, $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		// Replace, not merge: drop the stored block node first so a variant the body omits does not survive.
+		$stored    = $this->unset_block( $this->stored_document(), $block );
+		$candidate = $this->mutator->merge( $stored, $this->partial( $block, $block_node ) );
+
+		$error = $this->guard_default_present( $candidate, $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		return $this->validate_and_save( $candidate, $block );
+	}
+
+	/**
+	 * Reset a block's variant set to baseline (DELETE /variants/{block}).
+	 *
+	 * Removes the whole stored `variants.<block>` node, so the block renders its baseline variants. A no-op
+	 * when nothing is stored for the block.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_item( $request ) {
+		$block = $this->block_from( $request );
+		$error = $this->guard_block( $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$stored    = $this->stored_document();
+		$candidate = $this->unset_block( $stored, $block );
+
+		if ( $candidate === $stored ) {
+			return new WP_REST_Response( $this->prepare_item( $block ), WP_Http::OK );
+		}
+
+		return $this->validate_and_save( $candidate, $block );
+	}
+
+	/**
+	 * Remove a single variant from a block (DELETE /variants/{block}/{variant}).
+	 *
+	 * Drops the stored override for that variant; a variant that also exists in the baseline reverts to its
+	 * baseline definition. Idempotent: a no-op when nothing is stored for the variant. The `$default` is
+	 * managed through the dedicated sub-route, so deleting "default" here is rejected; and removing a
+	 * variant the effective set still defaults to is rejected (HTTP 422) before commit.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_variant( $request ) {
+		$block = $this->block_from( $request );
+		$error = $this->guard_block( $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$variant = Cast::to_string( $request->get_param( self::VARIANT_PARAM ) );
+
+		if ( $variant === self::DEFAULT_ROUTE ) {
+			return new WP_Error(
+				'rest_design_tokens_invalid',
+				__( 'The default variant is managed through the default sub-route.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::BAD_REQUEST,
+					'block'  => $block,
+				]
+			);
+		}
+
+		$stored    = $this->stored_document();
+		$candidate = $this->unset_variant( $stored, $block, $variant );
+
+		if ( $candidate === $stored ) {
+			return new WP_REST_Response( $this->prepare_item( $block ), WP_Http::OK );
+		}
+
+		$error = $this->guard_default_present( $candidate, $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		return $this->validate_and_save( $candidate, $block );
+	}
+
+	/**
+	 * Read a block's default variant slug (GET /variants/{block}/default).
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_default( $request ) {
+		$block = $this->block_from( $request );
+		$error = $this->guard_block( $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$node = $this->variants->block( $block, Token_Store::default_slug() ) ?? [];
+
+		return new WP_REST_Response(
+			[
+				'block'   => $block,
+				'default' => $this->default_of( $node ),
+			],
+			WP_Http::OK
+		);
+	}
+
+	/**
+	 * Set a block's default variant slug (PUT /variants/{block}/default).
+	 *
+	 * The default must name a variant the effective set defines, otherwise the write is rejected (HTTP 422)
+	 * before commit.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function set_default( $request ) {
+		$block = $this->block_from( $request );
+		$error = $this->guard_block( $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$default = Cast::to_string( $request->get_param( self::DEFAULT_PARAM ) );
+
+		$candidate = $this->mutator->merge(
+			$this->stored_document(),
+			$this->partial( $block, [ Extensions::get_default_key() => $default ] )
+		);
+
+		$error = $this->guard_default_present( $candidate, $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		return $this->validate_and_save( $candidate, $block );
+	}
+
+	/**
+	 * The JSON Schema for a block's variant set.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_item_schema(): array {
+		if ( $this->item_schema !== null ) {
+			return $this->add_additional_fields_schema( $this->item_schema );
+		}
+
+		$variant_schema = [
+			'type'       => 'object',
+			'properties' => [
+				Extensions::get_label_key()  => [
+					'description' => __( 'The variant\'s human-readable label.', 'kadence-blocks' ),
+					'type'        => 'string',
+				],
+				Extensions::get_tokens_key() => [
+					'description'          => __( 'The variant\'s property => alias-or-literal token map.', 'kadence-blocks' ),
+					'type'                 => 'object',
+					'additionalProperties' => [ 'type' => [ 'string', 'number' ] ],
+				],
+			],
+		];
+
+		$this->item_schema = [
+			'$schema'    => 'http://json-schema.org/draft-07/schema#',
+			'title'      => 'design-token-variant-set',
+			'type'       => 'object',
+			'properties' => [
+				'block'    => [
+					'description' => __( 'The block name the variant set belongs to.', 'kadence-blocks' ),
+					'type'        => 'string',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+				'slug'     => [
+					'description' => __( 'The token set slug.', 'kadence-blocks' ),
+					'type'        => 'string',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+				'version'  => [
+					'description' => __( 'The cache-busting version hash for the set, empty when it renders from baseline.', 'kadence-blocks' ),
+					'type'        => 'string',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+				'default'  => [
+					'description' => __( 'The default variant slug.', 'kadence-blocks' ),
+					'type'        => 'string',
+					'context'     => [ 'view' ],
+				],
+				'variants' => [
+					'description'          => __( 'The named variants, keyed by slug.', 'kadence-blocks' ),
+					'type'                 => 'object',
+					'context'              => [ 'view' ],
+					'additionalProperties' => $variant_schema,
+				],
+			],
+		];
+
+		return $this->add_additional_fields_schema( $this->item_schema );
+	}
+
+	/**
+	 * The query parameters accepted by the collection route.
+	 *
+	 * No collection parameters are accepted yet; the definition is declared explicitly so the surface
+	 * documents itself and gains parameters without changing shape.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_collection_params(): array {
+		return [];
+	}
+
+	/**
+	 * Run the shared write pipeline against a candidate document, then commit it.
+	 *
+	 * Validates the DTCG grammar (HTTP 422 on failure), dry-runs the Resolver to reject alias cycles /
+	 * dangling aliases in the token layers before commit (HTTP 422), then persists. An empty candidate
+	 * clears the overrides, so the set renders from baseline, and needs no validation.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $candidate The full candidate overrides document to validate and store.
+	 * @param string               $block     The block being written, for error context.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	private function validate_and_save( array $candidate, string $block ) {
+		$slug = Token_Store::default_slug();
+
+		// A brand-new set has no version yet; report 201 Created rather than 200 OK on first write.
+		$status = $this->store->get_version( $slug ) !== '' ? WP_Http::OK : WP_Http::CREATED;
+
+		if ( $candidate === [] ) {
+			return $this->persist( '', $block, $status );
+		}
+
+		$result = $this->validator->validate( $candidate, Dtcg_Validator::get_context_overrides() );
+
+		if ( ! $result->is_valid() ) {
+			return new WP_Error(
+				'rest_design_tokens_invalid',
+				__( 'The design token document failed validation.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::UNPROCESSABLE_ENTITY,
+					'block'  => $block,
+					'errors' => $result->to_array(),
+				]
+			);
+		}
+
+		try {
+			$this->resolver->resolve_overrides( $candidate );
+		} catch ( Alias_Cycle_Exception | Dangling_Alias_Exception $e ) {
+			return new WP_Error(
+				'rest_design_tokens_unresolvable',
+				$e->getMessage(),
+				[
+					'status' => WP_Http::UNPROCESSABLE_ENTITY,
+					'block'  => $block,
+				]
+			);
+		}
+
+		return $this->persist( (string) wp_json_encode( $candidate ), $block, $status );
+	}
+
+	/**
+	 * Commit a raw document string to the store and build the response, mapping a write failure to 500.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $document The raw overrides-only DTCG JSON (empty string clears the set).
+	 * @param string $block    The block being written.
+	 * @param int    $status   The success status code.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	private function persist( string $document, string $block, int $status ) {
+		try {
+			$this->store->save_document( $document, Token_Store::default_slug() );
+		} catch ( DatabaseQueryException $e ) {
+			return new WP_Error(
+				'rest_design_tokens_save_failed',
+				__( 'The design token set could not be saved.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::INTERNAL_SERVER_ERROR,
+					'block'  => $block,
+				]
+			);
+		}
+
+		return new WP_REST_Response( $this->prepare_item( $block ), $status );
+	}
+
+	/**
+	 * Reject a request for a block that has no registered variant set.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block The block name.
+	 *
+	 * @return WP_Error|null A WP_Error when the block accepts no variants, null otherwise.
+	 */
+	private function guard_block( string $block ): ?WP_Error {
+		if ( $this->registry->for_block( $block ) !== null ) {
+			return null;
+		}
+
+		return new WP_Error(
+			'rest_design_tokens_not_found',
+			__( 'Sorry, that block does not accept variants.', 'kadence-blocks' ),
+			[
+				'status' => WP_Http::NOT_FOUND,
+				'block'  => $block,
+			]
+		);
+	}
+
+	/**
+	 * Reject a variant map whose entries are not well-formed: each named variant must be an object, its
+	 * label (when present) a string and its tokens (when present) an object. The alias-or-literal grammar of
+	 * the token values is left to the DTCG validator.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $block_node The block's variant node being written.
+	 * @param string               $block      The block name, for error context.
+	 *
+	 * @return WP_Error|null A WP_Error when a variant entry is malformed, null otherwise.
+	 */
+	private function guard_variant_shape( array $block_node, string $block ): ?WP_Error {
+		foreach ( $block_node as $slug => $variant ) {
+			// $default and any other "$"-prefixed metadata key is not a named variant.
+			if ( is_string( $slug ) && strpos( $slug, '$' ) === 0 ) {
+				continue;
+			}
+
+			$label_key  = Extensions::get_label_key();
+			$tokens_key = Extensions::get_tokens_key();
+
+			if (
+				! is_array( $variant )
+				|| ( isset( $variant[ $label_key ] ) && ! is_string( $variant[ $label_key ] ) )
+				|| ( isset( $variant[ $tokens_key ] ) && ! is_array( $variant[ $tokens_key ] ) )
+			) {
+				return new WP_Error(
+					'rest_design_tokens_invalid',
+					__( 'Each variant must be an object with an optional string label and a token map.', 'kadence-blocks' ),
+					[
+						'status'  => WP_Http::UNPROCESSABLE_ENTITY,
+						'block'   => $block,
+						'variant' => (string) $slug,
+					]
+				);
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Reject a candidate whose effective `$default` does not name a present variant.
+	 *
+	 * Evaluated against the post-merge effective set (baseline merged with the candidate), so a default that
+	 * resolves to a baseline variant is accepted and one left dangling by a removal is rejected.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $candidate The candidate overrides document.
+	 * @param string               $block     The block name.
+	 *
+	 * @return WP_Error|null A WP_Error when the default is dangling, null otherwise.
+	 */
+	private function guard_default_present( array $candidate, string $block ): ?WP_Error {
+		$node    = $this->variants->for_overrides( $candidate )[ $block ] ?? [];
+		$default = $this->default_of( is_array( $node ) ? $node : [] );
+
+		if ( $default === '' || in_array( $default, $this->variant_names( is_array( $node ) ? $node : [] ), true ) ) {
+			return null;
+		}
+
+		return new WP_Error(
+			'rest_design_tokens_invalid',
+			__( 'The default variant must name an existing variant.', 'kadence-blocks' ),
+			[
+				'status'  => WP_Http::UNPROCESSABLE_ENTITY,
+				'block'   => $block,
+				'default' => $default,
+			]
+		);
+	}
+
+	/**
+	 * Build the response payload for a block's variant set, read from the effective (baseline-merged) set.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block The block name.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function prepare_item( string $block ): array {
+		$slug = Token_Store::default_slug();
+		$node = $this->variants->block( $block, $slug ) ?? [];
+
+		return [
+			'block'    => $block,
+			'slug'     => $slug,
+			'version'  => $this->store->get_version( $slug ),
+			'default'  => $this->default_of( $node ),
+			'variants' => $this->named_variants( $node ),
+		];
+	}
+
+	/**
+	 * Assemble the variant definition for a create from the request: an optional label plus the token map.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function variant_definition( WP_REST_Request $request ): array {
+		$definition = [];
+
+		$label = Cast::to_string( $request->get_param( self::LABEL_PARAM ) );
+
+		if ( $label !== '' ) {
+			$definition[ Extensions::get_label_key() ] = $label;
+		}
+
+		$tokens = $request->get_param( self::TOKENS_PARAM );
+
+		$definition[ Extensions::get_tokens_key() ] = is_array( $tokens ) ? $tokens : [];
+
+		return $definition;
+	}
+
+	/**
+	 * Build a partial overrides document carrying only the given variant node for one block.
+	 *
+	 * @since TBD
+	 *
+	 * @param string               $block      The block name.
+	 * @param array<string, mixed> $block_node The block's variant node.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function partial( string $block, array $block_node ): array {
+		return [
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					Extensions::get_section_variants() => [
+						$block => $block_node,
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Remove the stored `variants.<block>` node, pruning any ancestor emptied by the removal.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document The stored overrides document.
+	 * @param string               $block    The block name.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function unset_block( array $document, string $block ): array {
+		return $this->unset_path( $document, array_merge( $this->variants_path(), [ $block ] ) );
+	}
+
+	/**
+	 * Remove the stored `variants.<block>.<variant>` node, pruning any ancestor emptied by the removal.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document The stored overrides document.
+	 * @param string               $block    The block name.
+	 * @param string               $variant  The variant slug.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function unset_variant( array $document, string $block, string $variant ): array {
+		return $this->unset_path( $document, array_merge( $this->variants_path(), [ $block, $variant ] ) );
+	}
+
+	/**
+	 * Recursively remove a node addressed by literal keys, pruning emptied ancestor groups on the way out.
+	 *
+	 * Addresses the document by discrete array keys rather than a dot-path, because the keys themselves
+	 * carry dots ("com.kadence.designTokens") and slashes ("kadence/advancedbtn").
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $node The current node.
+	 * @param string[]             $keys The remaining literal keys to the node to remove.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function unset_path( array $node, array $keys ): array {
+		$head = (string) array_shift( $keys );
+
+		if ( ! array_key_exists( $head, $node ) ) {
+			return $node;
+		}
+
+		if ( $keys === [] ) {
+			unset( $node[ $head ] );
+
+			return $node;
+		}
+
+		if ( ! is_array( $node[ $head ] ) ) {
+			return $node;
+		}
+
+		$node[ $head ] = $this->unset_path( $node[ $head ], $keys );
+
+		if ( $node[ $head ] === [] ) {
+			unset( $node[ $head ] );
+		}
+
+		return $node;
+	}
+
+	/**
+	 * The literal key path to the variants section.
+	 *
+	 * @since TBD
+	 *
+	 * @return string[]
+	 */
+	private function variants_path(): array {
+		return [
+			Extensions::get_extensions_key(),
+			Extensions::get_namespace(),
+			Extensions::get_section_variants(),
+		];
+	}
+
+	/**
+	 * The `$default` slug of a variant node, or an empty string when none is set.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $node The block's variant node.
+	 *
+	 * @return string
+	 */
+	private function default_of( array $node ): string {
+		return Cast::to_string( $node[ Extensions::get_default_key() ] ?? '' );
+	}
+
+	/**
+	 * The named variant slugs of a variant node, skipping "$"-prefixed metadata keys.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $node The block's variant node.
+	 *
+	 * @return string[]
+	 */
+	private function variant_names( array $node ): array {
+		$names = [];
+
+		foreach ( array_keys( $node ) as $key ) {
+			if ( is_string( $key ) && strpos( $key, '$' ) === 0 ) {
+				continue;
+			}
+
+			$names[] = (string) $key;
+		}
+
+		return $names;
+	}
+
+	/**
+	 * The named variants of a variant node, keyed by slug, skipping "$"-prefixed metadata keys.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $node The block's variant node.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function named_variants( array $node ): array {
+		$variants = [];
+
+		foreach ( $node as $slug => $variant ) {
+			if ( is_string( $slug ) && strpos( $slug, '$' ) === 0 ) {
+				continue;
+			}
+
+			$variants[ (string) $slug ] = $variant;
+		}
+
+		return $variants;
+	}
+
+	/**
+	 * Decode the stored overrides-only document for the default set.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed> The decoded document, empty when absent or unreadable.
+	 */
+	private function stored_document(): array {
+		$raw = $this->store->get_document( Token_Store::default_slug() );
+
+		if ( $raw === '' ) {
+			return [];
+		}
+
+		$decoded = json_decode( $raw, true );
+
+		return is_array( $decoded ) ? $decoded : [];
+	}
+
+	/**
+	 * Reassemble the block name from its two captured path segments.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return string
+	 */
+	private function block_from( WP_REST_Request $request ): string {
+		return Cast::to_string( $request->get_param( self::VENDOR_PARAM ) )
+			. '/'
+			. Cast::to_string( $request->get_param( self::BLOCK_NAME_PARAM ) );
+	}
+
+	/**
+	 * The block path segment arguments shared by every single-block route.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_block_params(): array {
+		return [
+			self::VENDOR_PARAM     => [
+				'description'       => __( 'The block vendor segment, e.g. kadence.', 'kadence-blocks' ),
+				'type'              => 'string',
+				'required'          => true,
+				'pattern'           => '^[a-z][a-z0-9-]*$',
+				'sanitize_callback' => 'sanitize_key',
+			],
+			self::BLOCK_NAME_PARAM => [
+				'description'       => __( 'The block name segment, e.g. advancedbtn.', 'kadence-blocks' ),
+				'type'              => 'string',
+				'required'          => true,
+				'pattern'           => '^[a-z0-9][a-z0-9-]*$',
+				'sanitize_callback' => 'sanitize_key',
+			],
+		];
+	}
+
+	/**
+	 * The arguments accepted by the single-variant route: the block segments plus the variant slug.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_variant_params(): array {
+		return array_merge(
+			$this->get_block_params(),
+			[
+				self::VARIANT_PARAM => [
+					'description'       => __( 'The variant slug.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => true,
+					'pattern'           => '^[\w-]+$',
+					'sanitize_callback' => 'sanitize_key',
+				],
+			]
+		);
+	}
+
+	/**
+	 * The arguments accepted by the create route: the block segments plus a variant slug, optional label and
+	 * its token map.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_create_params(): array {
+		return array_merge(
+			$this->get_block_params(),
+			[
+				self::VARIANT_PARAM => [
+					'description'       => __( 'The variant slug to create or merge.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => true,
+					'pattern'           => '^[\w-]+$',
+					'sanitize_callback' => 'sanitize_key',
+				],
+				self::LABEL_PARAM   => [
+					'description'       => __( 'Optional human-readable label for the variant.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => false,
+					'sanitize_callback' => 'sanitize_text_field',
+				],
+				self::TOKENS_PARAM  => [
+					'description'          => __( 'The variant\'s property => alias-or-literal token map.', 'kadence-blocks' ),
+					'type'                 => 'object',
+					'required'             => false,
+					'additionalProperties' => true,
+				],
+			]
+		);
+	}
+
+	/**
+	 * The arguments accepted by the replace route: the block segments plus the whole variant map and an
+	 * optional default.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_replace_params(): array {
+		return array_merge(
+			$this->get_block_params(),
+			[
+				self::VARIANTS_PARAM => [
+					'description'          => __( 'The variants to store, keyed by slug.', 'kadence-blocks' ),
+					'type'                 => 'object',
+					'required'             => true,
+					'additionalProperties' => true,
+				],
+				self::DEFAULT_PARAM  => [
+					'description'       => __( 'Optional default variant slug.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => false,
+					'sanitize_callback' => 'sanitize_key',
+				],
+			]
+		);
+	}
+
+	/**
+	 * The arguments accepted by the set-default route: the block segments plus the default variant slug.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_default_params(): array {
+		return array_merge(
+			$this->get_block_params(),
+			[
+				self::DEFAULT_PARAM => [
+					'description'       => __( 'The default variant slug.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => true,
+					'pattern'           => '^[\w-]+$',
+					'sanitize_callback' => 'sanitize_key',
+				],
+			]
+		);
+	}
+}

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
@@ -116,6 +116,17 @@ final class Extensions {
 	}
 
 	/**
+	 * The variants section name: block presets / variants.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_section_variants(): string {
+		return self::SECTION_VARIANTS;
+	}
+
+	/**
 	 * Every section name the module owns under its namespace.
 	 *
 	 * @since TBD

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_VariantsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_VariantsTest.php
@@ -1,0 +1,118 @@
+<?php declare( strict_types=1 );
+// cspell:ignore advancedbtn .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Resolver;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Variants;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Covers the effective variants reader: the shipped baseline's variants deep-merged with the stored
+ * overrides, asserted against the real baseline so these also guard its variant definitions.
+ */
+final class Effective_VariantsTest extends TestCase {
+
+	private const BUTTON = 'kadence/advancedbtn';
+
+	/**
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @var Effective_Variants
+	 */
+	private Effective_Variants $variants;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->store    = $this->container->get( Token_Store::class );
+		$this->variants = $this->container->get( Effective_Variants::class );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItReturnsTheBaselineVariantsWhenNothingIsStored(): void {
+		$node = $this->variants->block( self::BUTTON );
+
+		$this->assertIsArray( $node );
+		$this->assertSame( 'primary', $node['$default'] );
+		$this->assertArrayHasKey( 'primary', $node );
+		$this->assertArrayHasKey( 'secondary', $node );
+		$this->assertArrayHasKey( 'ghost', $node );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAStoredOverrideAddsAVariantAlongsideTheBaselineOnes(): void {
+		$this->store->save_document(
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/advancedbtn":{'
+			. '"outline":{"label":"Outline","tokens":{"button-bg":"transparent"}}}}}}}'
+		);
+
+		$node = $this->variants->block( self::BUTTON );
+
+		$this->assertIsArray( $node );
+		// The override-only variant appears next to the baseline ones.
+		$this->assertArrayHasKey( 'outline', $node );
+		$this->assertSame( 'Outline', $node['outline']['label'] );
+		$this->assertArrayHasKey( 'primary', $node );
+		$this->assertArrayHasKey( 'ghost', $node );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAStoredOverrideMergesIntoAVariantsTokensPerProperty(): void {
+		// Override just one property of the baseline "ghost" variant.
+		$this->store->save_document(
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/advancedbtn":{'
+			. '"ghost":{"tokens":{"button-bg":"#000000"}}}}}}}'
+		);
+
+		$ghost = $this->variants->block( self::BUTTON )['ghost'];
+
+		// The overridden property wins; the variant's other baseline tokens and its label survive.
+		$this->assertSame( '#000000', $ghost['tokens']['button-bg'] );
+		$this->assertSame( '{primitive.color.brand.primary}', $ghost['tokens']['button-text'] );
+		$this->assertSame( 'Ghost', $ghost['label'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testForOverridesMergesACandidateWithoutTouchingTheStore(): void {
+		$candidate = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'variants' => [
+						self::BUTTON => [
+							'outline' => [ 'tokens' => [ 'button-bg' => 'transparent' ] ],
+						],
+					],
+				],
+			],
+		];
+
+		$section = $this->variants->for_overrides( $candidate );
+
+		$this->assertArrayHasKey( 'outline', $section[ self::BUTTON ] );
+		$this->assertArrayHasKey( 'primary', $section[ self::BUTTON ] );
+		// The store was never written.
+		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItReturnsNullForABlockWithNoVariants(): void {
+		$this->assertNull( $this->variants->block( 'kadence/not-a-block' ) );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
@@ -1,0 +1,548 @@
+<?php declare( strict_types=1 );
+// cspell:ignore advancedbtn advancedheading .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Rest\V1;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Variants_Controller;
+use ReflectionClass;
+use ReflectionProperty;
+use Tests\Support\Classes\TestCase;
+use WP_Error;
+use WP_Http;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Covers the read and write surface of the Design Tokens variants controller: the registered routes, the
+ * baseline-merged reads, and the per-block / per-variant / default writes against the real shipped baseline.
+ */
+final class VariantsControllerTest extends TestCase {
+
+	private const BUTTON = 'kadence/advancedbtn';
+
+	/**
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @var Variants_Controller
+	 */
+	private Variants_Controller $controller;
+
+	/**
+	 * @var WP_REST_Server
+	 */
+	private WP_REST_Server $rest_server;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->store      = $this->container->get( Token_Store::class );
+		$this->controller = $this->container->get( Variants_Controller::class );
+
+		global $wp_rest_server;
+		$this->rest_server = new WP_REST_Server();
+		$wp_rest_server    = $this->rest_server;
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		wp_set_current_user( 0 );
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItRegistersEveryRouteWithASchema(): void {
+		$namespace     = $this->controller_namespace();
+		$base          = $this->controller_rest_base();
+		$block_route   = $this->controller_constant( 'BLOCK_ROUTE' );
+		$default_route = $this->controller_constant( 'DEFAULT_ROUTE' );
+		$variant_route = $this->controller_constant( 'VARIANT_ROUTE' );
+
+		$collection = "/$namespace/$base";
+		$block      = "/$namespace/$base/$block_route";
+		$default    = "/$namespace/$base/$block_route/$default_route";
+		$variant    = "/$namespace/$base/$block_route/$variant_route";
+
+		foreach ( [ $collection, $block, $default, $variant ] as $route ) {
+			$this->assertArrayHasKey( $route, $this->rest_server->get_routes(), "Route $route should be registered." );
+
+			$options = $this->rest_server->get_route_options( $route );
+			$this->assertArrayHasKey( 'schema', $options, "Route $route should expose a schema." );
+			$this->assertIsCallable( $options['schema'] );
+		}
+
+		// The block route declares both block path segments and accepts the full CRUD verb set.
+		$this->assertArrayHasKey( $this->controller_constant( 'VENDOR_PARAM' ), $this->rest_server->get_routes()[ $block ][0]['args'] );
+		$this->assertArrayHasKey( $this->controller_constant( 'BLOCK_NAME_PARAM' ), $this->rest_server->get_routes()[ $block ][0]['args'] );
+
+		foreach ( [ 'GET', 'POST', 'PUT', 'DELETE' ] as $method ) {
+			$this->assertContains( $method, $this->route_methods( $block ), "Block route should accept $method." );
+		}
+
+		$this->assertContains( 'DELETE', $this->route_methods( $variant ) );
+		$this->assertContains( 'PUT', $this->route_methods( $default ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItListsTheRegisteredVariantBlocks(): void {
+		$response = $this->controller->get_items( new WP_REST_Request( WP_REST_Server::READABLE ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$blocks = wp_list_pluck( $response->get_data()['blocks'], 'default', 'block' );
+
+		$this->assertArrayHasKey( self::BUTTON, $blocks );
+		$this->assertSame( 'primary', $blocks[ self::BUTTON ] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetItemReturnsTheBaselineMergedVariantSet(): void {
+		$response = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+
+		$data = $response->get_data();
+
+		$this->assertSame( self::BUTTON, $data['block'] );
+		$this->assertSame( 'primary', $data['default'] );
+		$this->assertArrayHasKey( 'primary', $data['variants'] );
+		$this->assertArrayHasKey( 'ghost', $data['variants'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetItemReflectsAStoredOverride(): void {
+		$this->store->save_document(
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/advancedbtn":{'
+			. '"outline":{"label":"Outline","tokens":{"button-bg":"transparent"}}}}}}}'
+		);
+
+		$data = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) )->get_data();
+
+		$this->assertArrayHasKey( 'outline', $data['variants'] );
+		$this->assertSame( 'Outline', $data['variants']['outline']['label'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetItemReturns404ForABlockThatAcceptsNoVariants(): void {
+		// The baseline ships variant data for advancedheading, but no variant set is registered for it.
+		$result = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, 'kadence/advancedheading' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_not_found', $result->get_error_code() );
+		$this->assertSame( WP_Http::NOT_FOUND, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCreateMergesASingleVariantPreservingSiblingsAndDefault(): void {
+		$response = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'variant' => 'outline',
+					'label'   => 'Outline',
+					'tokens'  => [ 'button-bg' => 'transparent' ],
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		// First write to the set reports 201 Created.
+		$this->assertSame( WP_Http::CREATED, $response->get_status() );
+
+		$data = $response->get_data();
+
+		// The new variant lands while the baseline siblings and the default survive.
+		$this->assertArrayHasKey( 'outline', $data['variants'] );
+		$this->assertArrayHasKey( 'primary', $data['variants'] );
+		$this->assertArrayHasKey( 'ghost', $data['variants'] );
+		$this->assertSame( 'primary', $data['default'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCreateRequiresAVariantSlug(): void {
+		$result = $this->controller->create_item(
+			$this->block_request( WP_REST_Server::CREATABLE, self::BUTTON, [ 'tokens' => [ 'button-bg' => 'transparent' ] ] )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::BAD_REQUEST, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testUpdateReplacesTheStoredVariantSet(): void {
+		// Seed two override-only variants, then PUT a set that keeps only one of them.
+		$this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'variant' => 'outline',
+					'tokens'  => [ 'button-bg' => 'transparent' ],
+				] 
+			)
+		);
+		$this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'variant' => 'dashed',
+					'tokens'  => [ 'button-bg' => 'transparent' ],
+				] 
+			)
+		);
+
+		$response = $this->controller->update_item(
+			$this->block_request(
+				'PUT',
+				self::BUTTON,
+				[ 'variants' => [ 'outline' => [ 'tokens' => [ 'button-bg' => 'transparent' ] ] ] ]
+			)
+		);
+
+		$data = $response->get_data();
+
+		// The override "dashed" is dropped; "outline" survives. Baseline variants always remain visible.
+		$this->assertArrayNotHasKey( 'dashed', $data['variants'] );
+		$this->assertArrayHasKey( 'outline', $data['variants'] );
+		$this->assertArrayHasKey( 'primary', $data['variants'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeleteItemResetsTheBlockToBaseline(): void {
+		$this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'variant' => 'outline',
+					'tokens'  => [ 'button-bg' => 'transparent' ],
+				] 
+			)
+		);
+
+		$response = $this->controller->delete_item( $this->block_request( WP_REST_Server::DELETABLE, self::BUTTON ) );
+
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$data = $response->get_data();
+
+		// The override is gone; the block renders its baseline variants again.
+		$this->assertArrayNotHasKey( 'outline', $data['variants'] );
+		$this->assertArrayHasKey( 'primary', $data['variants'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeleteVariantRemovesAnOverrideVariant(): void {
+		$this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'variant' => 'outline',
+					'tokens'  => [ 'button-bg' => 'transparent' ],
+				] 
+			)
+		);
+
+		$response = $this->controller->delete_variant( $this->variant_request( self::BUTTON, 'outline' ) );
+
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertArrayNotHasKey( 'outline', $response->get_data()['variants'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeleteVariantIsAnIdempotentNoOpWhenAbsent(): void {
+		$this->store->save_document(
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/advancedbtn":{'
+			. '"outline":{"tokens":{"button-bg":"transparent"}}}}}}}'
+		);
+
+		$version_before = $this->store->get_version( Token_Store::default_slug() );
+
+		$response = $this->controller->delete_variant( $this->variant_request( self::BUTTON, 'never-stored' ) );
+
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		// Nothing was removed, so no write happened and the version is unchanged.
+		$this->assertSame( $version_before, $this->store->get_version( Token_Store::default_slug() ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeletingTheDefaultVariantIsRejected(): void {
+		// Make an override-only variant the default, then try to delete it out from under the default.
+		$this->controller->update_item(
+			$this->block_request(
+				'PUT',
+				self::BUTTON,
+				[
+					'variants' => [ 'outline' => [ 'tokens' => [ 'button-bg' => 'transparent' ] ] ],
+					'default'  => 'outline',
+				]
+			)
+		);
+
+		$result = $this->controller->delete_variant( $this->variant_request( self::BUTTON, 'outline' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSetDefaultToAnExistingVariant(): void {
+		$response = $this->controller->set_default( $this->default_request( self::BUTTON, 'secondary' ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( 'secondary', $response->get_data()['default'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSetDefaultToAMissingVariantIsRejected(): void {
+		$result = $this->controller->set_default( $this->default_request( self::BUTTON, 'does-not-exist' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetDefaultReadsTheDefault(): void {
+		$data = $this->controller->get_default( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) )->get_data();
+
+		$this->assertSame( self::BUTTON, $data['block'] );
+		$this->assertSame( 'primary', $data['default'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAnInvalidVariantTokenValueReturns422(): void {
+		// An empty-string token value is neither an alias nor a non-empty literal; the DTCG validator rejects it.
+		$result = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'variant' => 'broken',
+					'tokens'  => [ 'button-bg' => '' ],
+				] 
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+		$this->assertNotEmpty( $result->get_error_data()['errors'] );
+		// The write was rejected before commit.
+		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAMalformedVariantShapeReturns422(): void {
+		$result = $this->controller->update_item(
+			$this->block_request( 'PUT', self::BUTTON, [ 'variants' => [ 'bad' => 'not-an-object' ] ] )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testWritesAreDeniedToUsersWithoutTheCapability(): void {
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'subscriber' ] ) );
+
+		$request = new WP_REST_Request( WP_REST_Server::CREATABLE );
+
+		$this->assertInstanceOf( WP_Error::class, $this->controller->create_item_permissions_check( $request ) );
+		$this->assertInstanceOf( WP_Error::class, $this->controller->update_item_permissions_check( $request ) );
+		$this->assertInstanceOf( WP_Error::class, $this->controller->delete_item_permissions_check( $request ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAWriteBumpsTheVersion(): void {
+		$this->store->save_document(
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/advancedbtn":{'
+			. '"outline":{"tokens":{"button-bg":"transparent"}}}}}}}'
+		);
+
+		$version_before = $this->store->get_version( Token_Store::default_slug() );
+
+		$this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'variant' => 'dashed',
+					'tokens'  => [ 'button-bg' => 'transparent' ],
+				] 
+			)
+		);
+
+		$this->assertNotSame( $version_before, $this->store->get_version( Token_Store::default_slug() ) );
+	}
+
+	/**
+	 * Build a request for a single block route, splitting the block name into its two path segments and
+	 * carrying any extra body parameters.
+	 *
+	 * @param string               $method The HTTP method.
+	 * @param string               $block  The block name, e.g. "kadence/advancedbtn".
+	 * @param array<string, mixed> $extra  Extra parameters (variant, label, tokens, variants, default).
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function block_request( string $method, string $block, array $extra = [] ): WP_REST_Request {
+		[ $vendor, $name ] = explode( '/', $block, 2 );
+
+		$request = new WP_REST_Request( $method );
+		$request->set_param( 'vendor', $vendor );
+		$request->set_param( 'block_name', $name );
+
+		foreach ( $extra as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+
+		return $request;
+	}
+
+	/**
+	 * Build a single-variant request: the block segments plus the variant slug.
+	 *
+	 * @param string $block   The block name.
+	 * @param string $variant The variant slug.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function variant_request( string $block, string $variant ): WP_REST_Request {
+		return $this->block_request( WP_REST_Server::DELETABLE, $block, [ 'variant' => $variant ] );
+	}
+
+	/**
+	 * Build a set-default request: the block segments plus the default variant slug.
+	 *
+	 * @param string $block        The block name.
+	 * @param string $default_slug The default variant slug.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function default_request( string $block, string $default_slug ): WP_REST_Request {
+		return $this->block_request( 'PUT', $block, [ 'default' => $default_slug ] );
+	}
+
+	/**
+	 * Collect every HTTP method a registered route accepts across all of its endpoints.
+	 *
+	 * @param string $route The registered route pattern.
+	 *
+	 * @return string[]
+	 */
+	private function route_methods( string $route ): array {
+		$methods = [];
+
+		foreach ( $this->rest_server->get_routes()[ $route ] ?? [] as $endpoint ) {
+			if ( isset( $endpoint['methods'] ) && is_array( $endpoint['methods'] ) ) {
+				$methods = array_merge( $methods, array_keys( array_filter( $endpoint['methods'] ) ) );
+			}
+		}
+
+		return $methods;
+	}
+
+	/**
+	 * The REST namespace the controller registers under, read off the instance so the tests do not
+	 * hardcode it.
+	 *
+	 * @return string
+	 */
+	private function controller_namespace(): string {
+		return $this->controller_property( 'namespace' );
+	}
+
+	/**
+	 * The rest base the controller registers under, read off the instance so the tests do not hardcode it.
+	 *
+	 * @return string
+	 */
+	private function controller_rest_base(): string {
+		return $this->controller_property( 'rest_base' );
+	}
+
+	/**
+	 * Read a protected property off the controller instance.
+	 *
+	 * @param string $property The property name.
+	 *
+	 * @return string
+	 */
+	private function controller_property( string $property ): string {
+		$reflection = new ReflectionProperty( $this->controller, $property );
+		$reflection->setAccessible( true );
+
+		return (string) $reflection->getValue( $this->controller );
+	}
+
+	/**
+	 * Read a class constant off the controller, so route segments are asserted from their single source.
+	 *
+	 * @param string $name The constant name.
+	 *
+	 * @return string
+	 */
+	private function controller_constant( string $name ): string {
+		return (string) ( new ReflectionClass( $this->controller ) )->getConstant( $name );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
@@ -400,6 +400,22 @@ final class VariantsControllerTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testAnEmptyVariantSlugIsRejected(): void {
+		// An empty key in the variants map would store a variant node keyed by "" — reject it, mirroring the
+		// documents controller's empty dot-path-segment guard.
+		$result = $this->controller->update_item(
+			$this->block_request( 'PUT', self::BUTTON, [ 'variants' => [ '' => [ 'tokens' => [ 'button-bg' => 'transparent' ] ] ] ] )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testWritesAreDeniedToUsersWithoutTheCapability(): void {
 		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'subscriber' ] ) );
 


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3390/variant-readwrite-endpoints

Adds a `Variants_Controller` (`kb-design-tokens/v1/variants`) for reading and writing block variants per block: list registered variant blocks, per-block create/merge/replace/reset, per-variant delete, and `$default` get/set. Reads merge the shipped baseline with stored overrides through a new `Effective_Variants` reader, so reads reflect writes; only blocks with a registered variant set are addressable. Writes reuse the existing DTCG validation and resolver dry-run pipeline. Resolved/preview values stay out of scope here, owned by the projector tickets `SOFT-3394` / `SOFT-3395`. Also points `Variant_Resolver`'s DTCG keys at the shared `Extensions` vocabulary.

### Checklist
- [ ] I have performed a self-review.
- [ ] No unrelated files are modified.
- [ ] No debugging statements exist (Ex: console.log, error_log).
- [ ] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
