### PR TITLE
[DTM][1/3] Extract shared Wp_Preset_Target value object

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Css_Var/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Css_Builder.php
@@ -156,7 +156,7 @@ final class Css_Builder {
 
 		// category, slug and css_var come from developer-declared registry config,
 		// not from the store — no sanitization needed here (contrast with token_block()).
-		foreach ( $this->registry->by_projection( Wp_Preset_Target::PROJECTION ) as $id => $token ) {
+		foreach ( $this->registry->by_projection( Wp_Preset_Target::get_projection_key() ) as $id => $token ) {
 			// Skip tokens whose value is absent or empty: an empty CSS value would produce a
 			// --wp--preset-- declaration that resolves to nothing in the browser.
 			$value = $resolved->value( $id );

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Css_Builder.php
@@ -2,7 +2,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var;
 
-use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Definition;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Wp_Preset_Target;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Resolved_Tokens;
 
@@ -37,15 +37,6 @@ final class Css_Builder {
 	 * @var string
 	 */
 	public const SCOPE = ':root,:root:where(.kb-tokens)';
-
-	/**
-	 * The projection key a token declares to opt into the --wp--preset--* bridge.
-	 *
-	 * @since TBD
-	 *
-	 * @var string
-	 */
-	private const WP_PRESET = 'wp_preset';
 
 	/**
 	 * Object-cache group shared with the resolver.
@@ -165,7 +156,7 @@ final class Css_Builder {
 
 		// category, slug and css_var come from developer-declared registry config,
 		// not from the store — no sanitization needed here (contrast with token_block()).
-		foreach ( $this->registry->by_projection( self::WP_PRESET ) as $id => $token ) {
+		foreach ( $this->registry->by_projection( Wp_Preset_Target::PROJECTION ) as $id => $token ) {
 			// Skip tokens whose value is absent or empty: an empty CSS value would produce a
 			// --wp--preset-- declaration that resolves to nothing in the browser.
 			$value = $resolved->value( $id );
@@ -173,66 +164,16 @@ final class Css_Builder {
 				continue;
 			}
 
-			[ $category, $slug ] = $this->preset_target( $token, $id );
-			if ( $category === '' ) {
+			$target = Wp_Preset_Target::from_token( $token );
+			if ( $target === null ) {
 				continue;
 			}
 
-			$preset        = Wp_Preset_Var::from( $category, $slug );
+			$preset        = Wp_Preset_Var::from( $target->category, $target->slug );
 			$declarations .= $preset . ':var(' . $token->css_var . ');';
 		}
 
 		return $declarations === '' ? '' : self::SCOPE . '{' . $declarations . '}';
-	}
-
-	/**
-	 * Resolve a token's wp_preset config to a (category, slug) pair.
-	 *
-	 * The projection value is either a bare category string (slug derived from the token id's last
-	 * dot-segment) or an explicit ['category' => …, 'slug' => …] array for the rare case the slug must
-	 * differ from the id segment.
-	 *
-	 *   'wp_preset' => 'color'                          // semantic.color.button-bg => color / button-bg
-	 *   'wp_preset' => ['category' => 'color', 'slug' => 'btn']
-	 *
-	 * @since TBD
-	 *
-	 * @param Token_Definition $token The token definition.
-	 * @param string           $id    The token id.
-	 *
-	 * @return array{0:string,1:string} [ category, slug ]; category '' means "skip".
-	 */
-	private function preset_target( Token_Definition $token, string $id ): array {
-		$config = $token->projections[ self::WP_PRESET ] ?? null;
-
-		if ( is_string( $config ) && $config !== '' ) {
-			return [ $config, $this->slug_from_id( $id ) ];
-		}
-
-		if ( is_array( $config ) && isset( $config['category'] ) && is_string( $config['category'] ) ) {
-			$slug = isset( $config['slug'] ) && is_string( $config['slug'] ) ? $config['slug'] : $this->slug_from_id( $id );
-
-			return [ $config['category'], $slug ];
-		}
-
-		return [ '', '' ];
-	}
-
-	/**
-	 * The last dot-segment of a token id, used as the default preset slug.
-	 *
-	 * Example: semantic.color.button-bg => button-bg
-	 *
-	 * @since TBD
-	 *
-	 * @param string $id The token id.
-	 *
-	 * @return string
-	 */
-	private function slug_from_id( string $id ): string {
-		$pos = strrpos( $id, '.' );
-
-		return $pos === false ? $id : substr( $id, $pos + 1 );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Projection/Wp_Preset_Target.php
+++ b/includes/resources/Design_Tokens/Projection/Wp_Preset_Target.php
@@ -31,7 +31,7 @@ final class Wp_Preset_Target {
 	 *
 	 * @var string
 	 */
-	public const PROJECTION = 'wp_preset';
+	private const PROJECTION = 'wp_preset';
 
 	/**
 	 * The preset category, e.g. "color", "font-family", "spacing", "shadow".
@@ -58,6 +58,17 @@ final class Wp_Preset_Target {
 	private function __construct( string $category, string $slug ) {
 		$this->category = $category;
 		$this->slug     = $slug;
+	}
+
+	/**
+	 * Get the projection key.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_projection_key(): string {
+		return self::PROJECTION;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Projection/Wp_Preset_Target.php
+++ b/includes/resources/Design_Tokens/Projection/Wp_Preset_Target.php
@@ -1,0 +1,111 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Definition;
+
+/**
+ * Normalizes a token's "wp_preset" projection config into a (category, slug) pair.
+ *
+ * The category becomes the "<category>" segment of the WordPress preset variable
+ * (--wp--preset--<category>--<slug>) and selects the theme.json bucket; the slug is the preset's
+ * identifier within that bucket. Both the Css_Var bridge and the Theme_Json projector resolve
+ * through this one class so the preset variable they emit and the theme.json preset slug can never
+ * drift apart.
+ *
+ * The projection config is either a bare category string (slug derived from the token id's last
+ * dot-segment) or an explicit ['category' => …, 'slug' => …] array for the rare case the slug must
+ * differ from the id segment:
+ *
+ *   'wp_preset' => 'color'                                  // semantic.color.button-bg => (color, button-bg)
+ *   'wp_preset' => ['category' => 'color', 'slug' => 'btn'] // => (color, btn)
+ *
+ * @since TBD
+ */
+final class Wp_Preset_Target {
+
+	/**
+	 * The projection key a token declares to opt into preset projection.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public const PROJECTION = 'wp_preset';
+
+	/**
+	 * The preset category, e.g. "color", "font-family", "spacing", "shadow".
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public string $category;
+
+	/**
+	 * The preset slug, e.g. "button-bg".
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public string $slug;
+
+	/**
+	 * @param string $category Preset category.
+	 * @param string $slug     Preset slug.
+	 */
+	private function __construct( string $category, string $slug ) {
+		$this->category = $category;
+		$this->slug     = $slug;
+	}
+
+	/**
+	 * Resolve a token's wp_preset config to a target, or null when the token does not declare a
+	 * usable wp_preset projection (so callers skip it).
+	 *
+	 * @since TBD
+	 *
+	 * @param Token_Definition $token The token definition.
+	 *
+	 * @return self|null
+	 */
+	public static function from_token( Token_Definition $token ): ?self {
+		if ( ! $token->has_projection( self::PROJECTION ) ) {
+			return null;
+		}
+
+		$config = $token->projections[ self::PROJECTION ] ?? null;
+
+		if ( is_string( $config ) && $config !== '' ) {
+			return new self( $config, self::slug_from_id( $token->id ) );
+		}
+
+		if ( is_array( $config ) && isset( $config['category'] ) && is_string( $config['category'] ) && $config['category'] !== '' ) {
+			$slug = isset( $config['slug'] ) && is_string( $config['slug'] ) && $config['slug'] !== ''
+				? $config['slug']
+				: self::slug_from_id( $token->id );
+
+			return new self( $config['category'], $slug );
+		}
+
+		return null;
+	}
+
+	/**
+	 * The last dot-segment of a token id, used as the default preset slug.
+	 *
+	 * Example: semantic.color.button-bg => button-bg
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id The token id.
+	 *
+	 * @return string
+	 */
+	public static function slug_from_id( string $id ): string {
+		$pos = strrpos( $id, '.' );
+
+		return $pos === false ? $id : substr( $id, $pos + 1 );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Wp_Preset_TargetTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Wp_Preset_TargetTest.php
@@ -1,0 +1,78 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Projection;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Wp_Preset_Target;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Definition;
+use Tests\Support\Classes\TestCase;
+
+final class Wp_Preset_TargetTest extends TestCase {
+
+	private function token( array $projections ): Token_Definition {
+		return Token_Definition::from_array(
+			[
+				'id'          => 'semantic.color.button-bg',
+				'type'        => 'color',
+				'label'       => 'Button Background',
+				'projections' => $projections,
+			]
+		);
+	}
+
+	public function testBareStringConfigDerivesSlugFromId(): void {
+		$target = Wp_Preset_Target::from_token( $this->token( [ 'wp_preset' => 'color' ] ) );
+
+		$this->assertNotNull( $target );
+		$this->assertSame( 'color', $target->category );
+		$this->assertSame( 'button-bg', $target->slug );
+	}
+
+	public function testArrayConfigWithExplicitSlugIsHonored(): void {
+		$token = $this->token(
+			[
+				'wp_preset' => [
+					'category' => 'color',
+					'slug'     => 'btn',
+				],
+			]
+		);
+
+		$target = Wp_Preset_Target::from_token( $token );
+
+		$this->assertNotNull( $target );
+		$this->assertSame( 'color', $target->category );
+		$this->assertSame( 'btn', $target->slug );
+	}
+
+	public function testArrayConfigWithoutSlugFallsBackToIdSegment(): void {
+		$target = Wp_Preset_Target::from_token(
+			$this->token( [ 'wp_preset' => [ 'category' => 'color' ] ] )
+		);
+
+		$this->assertNotNull( $target );
+		$this->assertSame( 'color', $target->category );
+		$this->assertSame( 'button-bg', $target->slug );
+	}
+
+	public function testTokenWithoutWpPresetReturnsNull(): void {
+		$this->assertNull( Wp_Preset_Target::from_token( $this->token( [ 'kadence_slot' => 'palette1' ] ) ) );
+	}
+
+	public function testEmptyStringCategoryReturnsNull(): void {
+		$this->assertNull( Wp_Preset_Target::from_token( $this->token( [ 'wp_preset' => '' ] ) ) );
+	}
+
+	public function testArrayConfigMissingCategoryReturnsNull(): void {
+		$this->assertNull(
+			Wp_Preset_Target::from_token( $this->token( [ 'wp_preset' => [ 'slug' => 'btn' ] ] ) )
+		);
+	}
+
+	public function testSlugFromIdReturnsLastDotSegment(): void {
+		$this->assertSame( 'button-bg', Wp_Preset_Target::slug_from_id( 'semantic.color.button-bg' ) );
+	}
+
+	public function testSlugFromIdReturnsWholeStringWhenNoDot(): void {
+		$this->assertSame( 'standalone', Wp_Preset_Target::slug_from_id( 'standalone' ) );
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of 3 for the Theme_Json projector (SOFT-3383). A behavior-preserving refactor that extracts the `(category, slug)` derivation out of `Css_Var\Css_Builder` into a shared `Projection\Wp_Preset_Target` value object.

This is the foundation for the theme.json projector: the theme.json preset `slug` **must** match the `--wp--preset--<category>--<slug>` segment the `Css_Var` bridge emits, or the editor swatch and the preset variable point at different names. Sharing one derivation guarantees the two projectors never drift.

- Adds `Projection\Wp_Preset_Target` — normalizes a token's `wp_preset` projection (bare-string category or `['category'=>…, 'slug'=>…]`) into a `(category, slug)` pair, or `null` to signal skip
- Refactors `Css_Var\Css_Builder::preset_block()` to consume it; removes the now-duplicated `preset_target()` / `slug_from_id()` private methods and the local `WP_PRESET` constant

No output change — the existing `Css_Var` builder + snapshot tests pass unchanged.

## Test plan

- [x] `slic run wpunit Resources/Design_Tokens/Projection` (45 tests green, incl. 8 new `Wp_Preset_Target` cases)
- [x] `composer phpcs` clean
- [x] `composer phpstan` clean
- [x] `npx cspell` clean on changed files

## Stacked PRs

1/3 — this PR → `SOFT-3383/theme-json-projector`
2/3 — `Theme_Json_Builder` → this branch
3/3 — `Theme_Json\Projector` + wiring → 2/3