### PR TITLE
[DTM][3/3] Add Theme_Json projector and wire into theme.json filters

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Provider.php
@@ -23,6 +23,7 @@ final class Provider extends Provider_Contract {
 	 */
 	private const PROVIDERS = [
 		Css_Var\Provider::class,
+		Theme_Json\Provider::class,
 	];
 
 	/**

--- a/includes/resources/Design_Tokens/Projection/Theme_Json/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Theme_Json/Projector.php
@@ -1,0 +1,244 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Theme_Json;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use RuntimeException;
+use WP_Theme_JSON_Data;
+
+/**
+ * Projects the resolved token set into the WordPress theme.json pipeline so tokens surface as native
+ * presets in the Site Editor (color palette, font families, spacing sizes, shadow presets).
+ *
+ * Hooks both wp_theme_json_data_default and wp_theme_json_data_theme and mutates via
+ * $theme_json->update_with([...]) — the same mechanism KB uses in class-kadence-blocks-settings.php.
+ * Every preset value is a CSS variable (var(--kb-token--*)), so changing a token updates all presets
+ * without rewriting theme.json. Gated on Token_Registry::is_active() and on at least one token
+ * declaring a wp_preset projection, so an inactive or preset-free registry is a no-op.
+ *
+ * Token preset lists are merged onto whatever the incoming theme.json already declares, so KB adds to
+ * — never replaces — the active theme's palette and KB's own kadence_blocks_colors injection.
+ *
+ * @since TBD
+ */
+final class Projector {
+
+	/**
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * @var Token_Resolver
+	 */
+	private Token_Resolver $resolver;
+
+	/**
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @var Theme_Json_Builder
+	 */
+	private Theme_Json_Builder $builder;
+
+	/**
+	 * @param Token_Registry     $registry
+	 * @param Token_Resolver     $resolver
+	 * @param Token_Store        $store
+	 * @param Theme_Json_Builder $builder
+	 */
+	public function __construct(
+		Token_Registry $registry,
+		Token_Resolver $resolver,
+		Token_Store $store,
+		Theme_Json_Builder $builder
+	) {
+		$this->registry = $registry;
+		$this->resolver = $resolver;
+		$this->store    = $store;
+		$this->builder  = $builder;
+	}
+
+	/**
+	 * Inject token presets into a theme.json data object. Bound to both wp_theme_json_data_default
+	 * and wp_theme_json_data_theme.
+	 *
+	 * Bails fast (returns the object untouched) when projection is inactive or no token declares a
+	 * wp_preset projection.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_Theme_JSON_Data $theme_json The theme.json data object.
+	 *
+	 * @return WP_Theme_JSON_Data
+	 */
+	public function inject( WP_Theme_JSON_Data $theme_json ): WP_Theme_JSON_Data {
+		if ( ! $this->registry->is_active() || ! $this->builder->has_presets() ) {
+			return $theme_json;
+		}
+
+		$payload = $this->payload();
+		if ( $payload === [] ) {
+			return $theme_json;
+		}
+
+		$theme_json->update_with( $this->merge_existing( $theme_json, $payload ) );
+
+		return $theme_json;
+	}
+
+	/**
+	 * Build the cached preset payload from the current resolved set. Returns an empty array when the
+	 * stored document cannot be resolved (alias cycle / dangling alias from a raw DB write that
+	 * bypassed REST validation), so theme.json is left untouched rather than fatalling the request.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function payload(): array {
+		try {
+			$version  = $this->store->get_version();
+			$resolved = $this->resolver->resolve();
+		} catch ( RuntimeException $e ) {
+			return [];
+		}
+
+		return $this->builder->payload_for_version( $resolved, $version );
+	}
+
+	/**
+	 * Merge the token preset lists onto whatever the incoming theme.json already declares, so KB adds
+	 * to — never replaces — the active theme's palette and KB's existing kadence_blocks_colors
+	 * injection. update_with() replaces list-valued leaves wholesale, so we read the existing list,
+	 * append the token entries (skipping slug collisions — the existing entry wins), and hand back the
+	 * union.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_Theme_JSON_Data   $theme_json The incoming data object.
+	 * @param array<string, mixed> $payload    The token preset payload from the builder.
+	 *
+	 * @return array<string, mixed> The payload with each preset list merged onto the existing one.
+	 */
+	private function merge_existing( WP_Theme_JSON_Data $theme_json, array $payload ): array {
+		$data     = $theme_json->get_data();
+		$settings = $payload['settings'] ?? [];
+
+		if ( ! is_array( $settings ) ) {
+			return $payload;
+		}
+
+		foreach ( $this->preset_leaves( $settings ) as $path ) {
+			$existing = $this->get_path( $data, array_merge( [ 'settings' ], $path ) );
+			if ( ! is_array( $existing ) || $existing === [] ) {
+				continue; // Nothing to merge with; the builder's list stands as-is.
+			}
+
+			$tokens         = (array) $this->get_path( $payload, array_merge( [ 'settings' ], $path ) );
+			$existing_slugs = array_column( $existing, 'slug' );
+			$additions      = array_filter(
+				$tokens,
+				static function ( $entry ) use ( $existing_slugs ): bool {
+					return is_array( $entry ) && ! in_array( $entry['slug'] ?? null, $existing_slugs, true );
+				}
+			);
+
+			$payload = $this->set_path(
+				$payload,
+				array_merge( [ 'settings' ], $path ),
+				array_merge( array_values( $existing ), array_values( $additions ) )
+			);
+		}
+
+		return $payload;
+	}
+
+	/**
+	 * The preset list leaf paths present in a settings sub-tree, e.g.
+	 * [ ['color','palette','theme'], ['spacing','spacingSizes'] ].
+	 *
+	 * A leaf is a list of preset entries (a numerically-indexed array); recursion stops there so the
+	 * preset entries themselves are not descended into.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $settings The settings sub-tree.
+	 * @param string[]             $prefix   Accumulated path segments (internal recursion state).
+	 *
+	 * @return array<int, string[]> List of leaf paths, relative to "settings".
+	 */
+	private function preset_leaves( array $settings, array $prefix = [] ): array {
+		$leaves = [];
+
+		foreach ( $settings as $key => $value ) {
+			if ( ! is_array( $value ) ) {
+				continue;
+			}
+
+			$path = array_merge( $prefix, [ (string) $key ] );
+
+			if ( array_key_exists( 0, $value ) ) {
+				$leaves[] = $path; // A list of preset entries — this is a leaf.
+				continue;
+			}
+
+			$leaves = array_merge( $leaves, $this->preset_leaves( $value, $path ) );
+		}
+
+		return $leaves;
+	}
+
+	/**
+	 * Read the value at a path inside a nested array, or null when any segment is missing.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $tree The tree to read from.
+	 * @param string[]             $path The path segments.
+	 *
+	 * @return mixed
+	 */
+	private function get_path( array $tree, array $path ) {
+		$cursor = $tree;
+
+		foreach ( $path as $segment ) {
+			if ( ! is_array( $cursor ) || ! array_key_exists( $segment, $cursor ) ) {
+				return null;
+			}
+			$cursor = $cursor[ $segment ];
+		}
+
+		return $cursor;
+	}
+
+	/**
+	 * Set a value at a path inside a nested array, creating intermediate arrays as needed.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $tree  The tree to write into.
+	 * @param string[]             $path  The path segments.
+	 * @param mixed                $value The value to set at the leaf.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function set_path( array $tree, array $path, $value ): array {
+		$cursor = &$tree;
+
+		foreach ( $path as $segment ) {
+			if ( ! isset( $cursor[ $segment ] ) || ! is_array( $cursor[ $segment ] ) ) {
+				$cursor[ $segment ] = [];
+			}
+			$cursor = &$cursor[ $segment ];
+		}
+
+		$cursor = $value;
+
+		return $tree;
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Theme_Json/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Theme_Json/Projector.php
@@ -94,7 +94,7 @@ final class Projector {
 	/**
 	 * Build the cached preset payload from the current resolved set. Returns an empty array when the
 	 * stored document cannot be resolved (alias cycle / dangling alias from a raw DB write that
-	 * bypassed REST validation), so theme.json is left untouched rather than fatalling the request.
+	 * bypassed REST validation), so theme.json is left untouched rather than crashing the request.
 	 *
 	 * @since TBD
 	 *

--- a/includes/resources/Design_Tokens/Projection/Theme_Json/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Theme_Json/Projector.php
@@ -201,7 +201,7 @@ final class Projector {
 	 * @param array<string, mixed> $tree The tree to read from.
 	 * @param string[]             $path The path segments.
 	 *
-	 * @return mixed
+	 * @return mixed|null
 	 */
 	private function get_path( array $tree, array $path ) {
 		$cursor = $tree;

--- a/includes/resources/Design_Tokens/Projection/Theme_Json/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Theme_Json/Projector.php
@@ -41,21 +41,21 @@ final class Projector {
 	private Token_Store $store;
 
 	/**
-	 * @var Theme_Json_Builder
+	 * @var Json_Builder
 	 */
-	private Theme_Json_Builder $builder;
+	private Json_Builder $builder;
 
 	/**
 	 * @param Token_Registry     $registry
 	 * @param Token_Resolver     $resolver
 	 * @param Token_Store        $store
-	 * @param Theme_Json_Builder $builder
+	 * @param Json_Builder $builder
 	 */
 	public function __construct(
 		Token_Registry $registry,
 		Token_Resolver $resolver,
 		Token_Store $store,
-		Theme_Json_Builder $builder
+		Json_Builder $builder
 	) {
 		$this->registry = $registry;
 		$this->resolver = $resolver;

--- a/includes/resources/Design_Tokens/Projection/Theme_Json/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Theme_Json/Provider.php
@@ -1,0 +1,31 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Theme_Json;
+
+use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
+
+/**
+ * Registers the theme.json projector: binds the builder and projector as singletons, then wires the
+ * projector's inject() to both theme.json data filters.
+ *
+ * @since TBD
+ */
+final class Provider extends Provider_Contract {
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @since TBD
+	 */
+	public function register(): void {
+		$this->container->singleton( Theme_Json_Builder::class );
+		$this->container->singleton( Projector::class );
+
+		// Both layers: default (so user/theme can still override) and theme (so presets read as
+		// theme-origin in the Site Editor). KB's existing palette injection runs at priority 999 on
+		// wp_theme_json_data_theme; we run at 1000 so our merge_existing() sees and preserves it.
+		$callback = $this->container->callback( Projector::class, 'inject' );
+		add_filter( 'wp_theme_json_data_default', $callback, 1000 );
+		add_filter( 'wp_theme_json_data_theme', $callback, 1000 );
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Theme_Json/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Theme_Json/Provider.php
@@ -18,7 +18,7 @@ final class Provider extends Provider_Contract {
 	 * @since TBD
 	 */
 	public function register(): void {
-		$this->container->singleton( Theme_Json_Builder::class );
+		$this->container->singleton( Json_Builder::class );
 		$this->container->singleton( Projector::class );
 
 		// Both layers: default (so user/theme can still override) and theme (so presets read as

--- a/includes/resources/Design_Tokens/Projection/Theme_Json/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Theme_Json/Provider.php
@@ -23,9 +23,10 @@ final class Provider extends Provider_Contract {
 
 		// Both layers: default (so user/theme can still override) and theme (so presets read as
 		// theme-origin in the Site Editor). KB's existing palette injection runs at priority 999 on
-		// wp_theme_json_data_theme; we run at 1000 so our merge_existing() sees and preserves it.
+		// wp_theme_json_data_theme; we run at 1010 so our merge_existing() sees and preserves it, while
+		// leaving a buffer (1000-1009) for another consumer that needs to inject just before us.
 		$callback = $this->container->callback( Projector::class, 'inject' );
-		add_filter( 'wp_theme_json_data_default', $callback, 1000 );
-		add_filter( 'wp_theme_json_data_theme', $callback, 1000 );
+		add_filter( 'wp_theme_json_data_default', $callback, 1010 );
+		add_filter( 'wp_theme_json_data_theme', $callback, 1010 );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Theme_Json/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Theme_Json/ProjectorTest.php
@@ -5,7 +5,7 @@ namespace Tests\wpunit\Resources\Design_Tokens\Projection\Theme_Json;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Theme_Json\Projector;
-use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Theme_Json\Theme_Json_Builder;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Theme_Json\Json_Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use ReflectionProperty;
@@ -76,7 +76,7 @@ final class ProjectorTest extends TestCase {
 			$empty_registry,
 			$this->container->get( Token_Resolver::class ),
 			$this->container->get( Token_Store::class ),
-			new Theme_Json_Builder( $empty_registry )
+			new Json_Builder( $empty_registry )
 		);
 
 		$result = $projector->inject( $this->theme_json() );

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Theme_Json/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Theme_Json/ProjectorTest.php
@@ -1,0 +1,145 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Projection\Theme_Json;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Theme_Json\Projector;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Theme_Json\Theme_Json_Builder;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use ReflectionProperty;
+use Tests\Support\Classes\TestCase;
+use WP_Theme_JSON_Data;
+
+final class ProjectorTest extends TestCase {
+
+	private Projector $projector;
+	private Token_Registry $registry;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Projector and registry were registered as singletons during module bootstrap. The shipped
+		// declarations include color tokens (button-bg, button-text) with a wp_preset projection.
+		$this->projector = $this->container->get( Projector::class );
+		$this->registry  = $this->container->get( Token_Registry::class );
+	}
+
+	protected function tearDown(): void {
+		$this->registry->activate();
+
+		// Clear the resolver memo so values resolved here do not leak into later test classes.
+		$resolver = $this->container->get( Token_Resolver::class );
+		$memo     = new ReflectionProperty( Token_Resolver::class, 'memo' );
+		$memo->setAccessible( true );
+		$memo->setValue( $resolver, [] );
+
+		parent::tearDown();
+	}
+
+	private function theme_json( array $data = [] ): WP_Theme_JSON_Data {
+		return new WP_Theme_JSON_Data(
+			array_merge( [ 'version' => 2 ], $data ),
+			'theme'
+		);
+	}
+
+	private function palette( WP_Theme_JSON_Data $theme_json ): array {
+		$data = $theme_json->get_data();
+
+		return $data['settings']['color']['palette']['theme'] ?? [];
+	}
+
+	public function testInjectAddsTokenColorPresetsWithVarValues(): void {
+		$result = $this->projector->inject( $this->theme_json() );
+
+		$slugs = array_column( $this->palette( $result ), 'slug', 'slug' );
+		$this->assertArrayHasKey( 'button-bg', $slugs );
+
+		$by_slug = array_column( $this->palette( $result ), null, 'slug' );
+		$this->assertSame( 'var(--kb-token--semantic--color--button-bg)', $by_slug['button-bg']['color'] );
+	}
+
+	public function testInactiveRegistryLeavesThemeJsonUntouched(): void {
+		$this->registry->deactivate();
+
+		$result = $this->projector->inject( $this->theme_json() );
+
+		$this->assertSame( [], $this->palette( $result ) );
+	}
+
+	public function testEarlyBailWhenNoPresetTokens(): void {
+		// A fresh projector over an empty registry must not touch theme.json.
+		$empty_registry = new Token_Registry();
+		$projector      = new Projector(
+			$empty_registry,
+			$this->container->get( Token_Resolver::class ),
+			$this->container->get( Token_Store::class ),
+			new Theme_Json_Builder( $empty_registry )
+		);
+
+		$result = $projector->inject( $this->theme_json() );
+
+		$this->assertSame( [], $this->palette( $result ) );
+	}
+
+	public function testMergePreservesExistingPaletteEntries(): void {
+		$existing = $this->theme_json(
+			[
+				'settings' => [
+					'color' => [
+						'palette' => [
+							'theme' => [
+								[
+									'slug'  => 'theme-accent',
+									'name'  => 'Theme Accent',
+									'color' => '#ff0000',
+								],
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$result = $this->projector->inject( $existing );
+		$slugs  = array_column( $this->palette( $result ), 'slug' );
+
+		$this->assertContains( 'theme-accent', $slugs );
+		$this->assertContains( 'button-bg', $slugs );
+	}
+
+	public function testSlugCollisionKeepsExistingEntry(): void {
+		$existing = $this->theme_json(
+			[
+				'settings' => [
+					'color' => [
+						'palette' => [
+							'theme' => [
+								[
+									'slug'  => 'button-bg',
+									'name'  => 'Pre-existing',
+									'color' => '#abcdef',
+								],
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$result = $this->projector->inject( $existing );
+		$by_slug = array_column( $this->palette( $result ), null, 'slug' );
+
+		// The existing entry wins on a slug collision; the token var does not overwrite it.
+		$this->assertSame( '#abcdef', $by_slug['button-bg']['color'] );
+		// And it appears exactly once.
+		$this->assertCount( 1, array_filter( $this->palette( $result ), static fn( $e ) => $e['slug'] === 'button-bg' ) );
+	}
+
+	public function testBothThemeJsonFiltersHaveTheInjectCallback(): void {
+		$this->assertNotFalse( has_filter( 'wp_theme_json_data_default' ) );
+		$this->assertNotFalse( has_filter( 'wp_theme_json_data_theme' ) );
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3 of 3 for the Theme_Json projector (SOFT-3383). Adds the WordPress-facing projector that injects token presets into the `theme.json` pipeline, plus its provider, and registers it in `Projection\Provider`.

- Adds `Theme_Json\Projector::inject()`, bound to **both** `wp_theme_json_data_default` and `wp_theme_json_data_theme`, mutating via `$theme_json->update_with([...])` — the same mechanism KB uses in `class-kadence-blocks-settings.php`
- **Bails fast** when projection is inactive (`Token_Registry::is_active()`) or no token declares a `wp_preset` projection
- Catches `RuntimeException` from the resolver (alias cycle / dangling alias from a raw DB write) so a corrupt stored document degrades gracefully rather than fatalling the request — mirrors `Css_Var\Projector`
- **Merges** token presets onto whatever the incoming theme.json already declares, so KB *adds to* — never replaces — the active theme's palette and KB's own `kadence_blocks_colors` injection; existing entries win on a slug collision
- Adds `Theme_Json\Provider` and registers it in `Projection\Provider`

### Note for reviewers — filter priority

Registered at priority **1000** so it runs *after* KB's existing `wp_theme_json_data_theme` injection (priority 999), letting `merge_existing()` see and preserve KB's `kadence_blocks_colors` palette. Worth a Site Editor smoke test to confirm ordering empirically before merge.

## Test plan

- [x] `slic run wpunit Resources/Design_Tokens/Projection` (64 tests green, incl. 6 new `Theme_Json\ProjectorTest` cases: happy path, inactive registry, early-bail, merge-preserves-existing, slug-collision, filter wiring)
- [x] `composer phpcs` / `composer phpstan` / `npx cspell` clean
- [ ] Manual: confirm tokens appear as presets in the Site Editor and that changing a token value updates them live

## Stacked PRs

Targets 2/3 (`SOFT-3383/phase-2-theme-json-builder`). Review/merge 1/3 → 2/3 → this in order.