### PR TITLE
Variant endpoints (1/4): vocabulary, registry, and resolver groundwork

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Token_Registry.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Registry.php
@@ -151,6 +151,18 @@ final class Token_Registry {
 	}
 
 	/**
+	 * The block names that have a registered variant set, in registration order — what the REST variants
+	 * collection enumerates as the blocks that accept variants.
+	 *
+	 * @since TBD
+	 *
+	 * @return string[]
+	 */
+	public function variant_blocks(): array {
+		return array_keys( $this->variant_sets );
+	}
+
+	/**
 	 * The effective projection targets for a binding: a token reference contributes the referenced
 	 * token's projections (so a variant reuses the variable the base property already feeds), and the
 	 * binding's inline targets are merged on top, supplementing or overriding them (e.g. adding a

--- a/includes/resources/Design_Tokens/Resolver/Variant_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Variant_Resolver.php
@@ -279,11 +279,7 @@ final class Variant_Resolver {
 	private function variants_section(): array {
 		$node = $this->baseline->document();
 
-		$path = [
-			Extensions::get_extensions_key(),
-			Extensions::get_namespace(),
-			Extensions::get_section_variants(),
-		];
+		$path = Extensions::get_variants_path();
 
 		foreach ( $path as $key ) {
 			if ( ! is_array( $node ) || ! isset( $node[ $key ] ) ) {

--- a/includes/resources/Design_Tokens/Resolver/Variant_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Variant_Resolver.php
@@ -5,6 +5,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Unknown_Variant_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
 
 /**
  * Flattens a block variant's token bindings to CSS-ready values — the variant counterpart of the
@@ -25,34 +26,6 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
  * @since TBD
  */
 final class Variant_Resolver {
-
-	/**
-	 * The `$extensions` path to the variants section. Inlined here because the shared vocabulary that
-	 * owns these spellings ships on a separate branch; centralise once it lands.
-	 *
-	 * @since TBD
-	 *
-	 * @var string[]
-	 */
-	private const VARIANTS_PATH = [ '$extensions', 'com.kadence.designTokens', 'variants' ];
-
-	/**
-	 * The key naming a block's default variant.
-	 *
-	 * @since TBD
-	 *
-	 * @var string
-	 */
-	private const DEFAULT_KEY = '$default';
-
-	/**
-	 * The key carrying a variant's property => value map.
-	 *
-	 * @since TBD
-	 *
-	 * @var string
-	 */
-	private const TOKENS_KEY = 'tokens';
 
 	/**
 	 * @var Baseline_Document The shipped baseline the variant definitions are read from.
@@ -248,7 +221,7 @@ final class Variant_Resolver {
 			throw Unknown_Variant_Exception::for_variant( $block, $variant );
 		}
 
-		$tokens = $block_variants[ $variant ][ self::TOKENS_KEY ] ?? [];
+		$tokens = $block_variants[ $variant ][ Extensions::get_tokens_key() ] ?? [];
 
 		return is_array( $tokens ) ? $tokens : [];
 	}
@@ -266,7 +239,7 @@ final class Variant_Resolver {
 	 * @return string
 	 */
 	public function default_variant( string $block ): string {
-		$default = $this->block_variants( $block )[ self::DEFAULT_KEY ] ?? '';
+		$default = $this->block_variants( $block )[ Extensions::get_default_key() ] ?? '';
 
 		if ( ! is_string( $default ) || $default === '' ) {
 			throw Unknown_Variant_Exception::no_default( $block );
@@ -306,7 +279,13 @@ final class Variant_Resolver {
 	private function variants_section(): array {
 		$node = $this->baseline->document();
 
-		foreach ( self::VARIANTS_PATH as $key ) {
+		$path = [
+			Extensions::get_extensions_key(),
+			Extensions::get_namespace(),
+			Extensions::get_section_variants(),
+		];
+
+		foreach ( $path as $key ) {
 			if ( ! is_array( $node ) || ! isset( $node[ $key ] ) ) {
 				return [];
 			}

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
@@ -116,6 +116,17 @@ final class Extensions {
 	}
 
 	/**
+	 * The variants section name: block presets / variants.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_section_variants(): string {
+		return self::SECTION_VARIANTS;
+	}
+
+	/**
 	 * Every section name the module owns under its namespace.
 	 *
 	 * @since TBD

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
@@ -138,6 +138,21 @@ final class Extensions {
 	}
 
 	/**
+	 * The literal key path to the variants section, from the document root.
+	 *
+	 * @since TBD
+	 *
+	 * @return string[]
+	 */
+	public static function get_variants_path(): array {
+		return [
+			self::get_extensions_key(),
+			self::get_namespace(),
+			self::get_section_variants(),
+		];
+	}
+
+	/**
 	 * The key naming a group's default preset slug.
 	 *
 	 * @since TBD


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3390/variant-readwrite-endpoints

First of four stacked PRs that split the variant read/write endpoints into reviewable pieces. Based on `feature/design-tokens-module`.

Groundwork shared by the variants reader and controller:

- Points `Variant_Resolver`'s DTCG keys at the shared `Extensions` vocabulary instead of hardcoded constants.
- Adds the `Extensions` accessor for the variants section.
- Adds `Token_Registry::variant_blocks()` to list the blocks that have a registered variant set.

No endpoint or behavior change ships here; this is the vocabulary and registry surface the later PRs build on.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
