### PR TITLE
Variant endpoints (2/4): effective variants reader

### DIFF
--- a/includes/resources/Design_Tokens/Resolver/Effective_Variants.php
+++ b/includes/resources/Design_Tokens/Resolver/Effective_Variants.php
@@ -137,11 +137,7 @@ final class Effective_Variants {
 	private function variants_of( array $document ): array {
 		$node = $document;
 
-		$path = [
-			Extensions::get_extensions_key(),
-			Extensions::get_namespace(),
-			Extensions::get_section_variants(),
-		];
+		$path = Extensions::get_variants_path();
 
 		foreach ( $path as $key ) {
 			if ( ! is_array( $node ) || ! isset( $node[ $key ] ) ) {

--- a/includes/resources/Design_Tokens/Resolver/Effective_Variants.php
+++ b/includes/resources/Design_Tokens/Resolver/Effective_Variants.php
@@ -1,0 +1,156 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Resolver;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+
+/**
+ * Reads the effective variants section: the shipped baseline's variants deep-merged with a set's stored
+ * overrides, so a variant authored through the store is visible alongside the baseline ones.
+ *
+ * This is a thin reader, not a new merge: the deep-merge is {@see Mutator::merge()} (which preserves the
+ * whole "$extensions" layer untouched, exactly what a variants view needs), so this class only decodes the
+ * baseline and the stored overrides, walks each down to the `$extensions...variants` subtree, and delegates
+ * the merge. The sibling {@see Effective_Document} deliberately strips "$extensions", so it cannot be reused
+ * here — variants are read through this seam instead.
+ *
+ * The REST variants controller consumes this for its raw reads. It is also the seam a later projector that
+ * needs override-aware resolved values (the native-block and kbVariant projectors) can build on.
+ *
+ * @since TBD
+ */
+final class Effective_Variants {
+
+	/**
+	 * @var Baseline_Document The shipped baseline the variant definitions are merged onto.
+	 *
+	 * @since TBD
+	 */
+	private Baseline_Document $baseline;
+
+	/**
+	 * @var Token_Store The gateway the stored overrides are read from.
+	 *
+	 * @since TBD
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @var Mutator The pure deep-merge the baseline and overrides variants are combined through.
+	 *
+	 * @since TBD
+	 */
+	private Mutator $mutator;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Baseline_Document $baseline The shipped baseline document.
+	 * @param Token_Store       $store    The persistence gateway.
+	 * @param Mutator           $mutator  The pure deep-merge.
+	 */
+	public function __construct( Baseline_Document $baseline, Token_Store $store, Mutator $mutator ) {
+		$this->baseline = $baseline;
+		$this->store    = $store;
+		$this->mutator  = $mutator;
+	}
+
+	/**
+	 * The effective variants section for a stored set: baseline deep-merged with the set's overrides, keyed
+	 * by block name.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token set slug.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function section( string $slug = 'default' ): array {
+		return $this->for_overrides( $this->stored_document( $slug ) );
+	}
+
+	/**
+	 * The effective variants node for one block in a stored set, or null when neither the baseline nor the
+	 * overrides define variants for it.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block The block name, e.g. "kadence/advancedbtn".
+	 * @param string $slug  The token set slug.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public function block( string $block, string $slug = 'default' ): ?array {
+		$section = $this->section( $slug );
+
+		return isset( $section[ $block ] ) && is_array( $section[ $block ] ) ? $section[ $block ] : null;
+	}
+
+	/**
+	 * The effective variants section for an arbitrary candidate overrides document: the baseline variants
+	 * deep-merged with the candidate's variants subtree. Used to validate a write against its post-merge
+	 * effective set before it is committed (e.g. that a `$default` still names a present variant).
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $overrides A decoded overrides-only DTCG document.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function for_overrides( array $overrides ): array {
+		return $this->mutator->merge( $this->variants_of( $this->baseline->document() ), $this->variants_of( $overrides ) );
+	}
+
+	/**
+	 * Decode the set's stored overrides document, tolerating an absent/empty/malformed row as "no overrides".
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token set slug.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function stored_document( string $slug ): array {
+		$raw = $this->store->get_document( $slug );
+
+		if ( $raw === '' ) {
+			return [];
+		}
+
+		$decoded = json_decode( $raw, true );
+
+		return is_array( $decoded ) ? $decoded : [];
+	}
+
+	/**
+	 * Walk a decoded document down to its `$extensions...variants` subtree, or an empty array when absent.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document The decoded document.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function variants_of( array $document ): array {
+		$node = $document;
+
+		$path = [
+			Extensions::get_extensions_key(),
+			Extensions::get_namespace(),
+			Extensions::get_section_variants(),
+		];
+
+		foreach ( $path as $key ) {
+			if ( ! is_array( $node ) || ! isset( $node[ $key ] ) ) {
+				return [];
+			}
+
+			$node = $node[ $key ];
+		}
+
+		return is_array( $node ) ? $node : [];
+	}
+}

--- a/includes/resources/Design_Tokens/Resolver/Provider.php
+++ b/includes/resources/Design_Tokens/Resolver/Provider.php
@@ -17,10 +17,10 @@ final class Provider extends Provider_Contract {
 	 * @since TBD
 	 */
 	public function register(): void {
-		$this->container->singleton( Effective_Document::class, Effective_Document::class );
-		$this->container->singleton( Css_Renderer::class, Css_Renderer::class );
-		$this->container->singleton( Token_Resolver::class, Token_Resolver::class );
-		$this->container->singleton( Variant_Resolver::class, Variant_Resolver::class );
+		$this->container->singleton( Effective_Document::class );
+		$this->container->singleton( Css_Renderer::class );
+		$this->container->singleton( Token_Resolver::class );
+		$this->container->singleton( Variant_Resolver::class );
 		$this->container->singleton( Effective_Variants::class );
 	}
 }

--- a/includes/resources/Design_Tokens/Resolver/Provider.php
+++ b/includes/resources/Design_Tokens/Resolver/Provider.php
@@ -21,5 +21,6 @@ final class Provider extends Provider_Contract {
 		$this->container->singleton( Css_Renderer::class, Css_Renderer::class );
 		$this->container->singleton( Token_Resolver::class, Token_Resolver::class );
 		$this->container->singleton( Variant_Resolver::class, Variant_Resolver::class );
+		$this->container->singleton( Effective_Variants::class );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_VariantsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_VariantsTest.php
@@ -1,0 +1,118 @@
+<?php declare( strict_types=1 );
+// cspell:ignore advancedbtn .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Resolver;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Variants;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Covers the effective variants reader: the shipped baseline's variants deep-merged with the stored
+ * overrides, asserted against the real baseline so these also guard its variant definitions.
+ */
+final class Effective_VariantsTest extends TestCase {
+
+	private const BUTTON = 'kadence/advancedbtn';
+
+	/**
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @var Effective_Variants
+	 */
+	private Effective_Variants $variants;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->store    = $this->container->get( Token_Store::class );
+		$this->variants = $this->container->get( Effective_Variants::class );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItReturnsTheBaselineVariantsWhenNothingIsStored(): void {
+		$node = $this->variants->block( self::BUTTON );
+
+		$this->assertIsArray( $node );
+		$this->assertSame( 'primary', $node['$default'] );
+		$this->assertArrayHasKey( 'primary', $node );
+		$this->assertArrayHasKey( 'secondary', $node );
+		$this->assertArrayHasKey( 'ghost', $node );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAStoredOverrideAddsAVariantAlongsideTheBaselineOnes(): void {
+		$this->store->save_document(
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/advancedbtn":{'
+			. '"outline":{"label":"Outline","tokens":{"button-bg":"transparent"}}}}}}}'
+		);
+
+		$node = $this->variants->block( self::BUTTON );
+
+		$this->assertIsArray( $node );
+		// The override-only variant appears next to the baseline ones.
+		$this->assertArrayHasKey( 'outline', $node );
+		$this->assertSame( 'Outline', $node['outline']['label'] );
+		$this->assertArrayHasKey( 'primary', $node );
+		$this->assertArrayHasKey( 'ghost', $node );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAStoredOverrideMergesIntoAVariantsTokensPerProperty(): void {
+		// Override just one property of the baseline "ghost" variant.
+		$this->store->save_document(
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/advancedbtn":{'
+			. '"ghost":{"tokens":{"button-bg":"#000000"}}}}}}}'
+		);
+
+		$ghost = $this->variants->block( self::BUTTON )['ghost'];
+
+		// The overridden property wins; the variant's other baseline tokens and its label survive.
+		$this->assertSame( '#000000', $ghost['tokens']['button-bg'] );
+		$this->assertSame( '{primitive.color.brand.primary}', $ghost['tokens']['button-text'] );
+		$this->assertSame( 'Ghost', $ghost['label'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testForOverridesMergesACandidateWithoutTouchingTheStore(): void {
+		$candidate = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'variants' => [
+						self::BUTTON => [
+							'outline' => [ 'tokens' => [ 'button-bg' => 'transparent' ] ],
+						],
+					],
+				],
+			],
+		];
+
+		$section = $this->variants->for_overrides( $candidate );
+
+		$this->assertArrayHasKey( 'outline', $section[ self::BUTTON ] );
+		$this->assertArrayHasKey( 'primary', $section[ self::BUTTON ] );
+		// The store was never written.
+		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItReturnsNullForABlockWithNoVariants(): void {
+		$this->assertNull( $this->variants->block( 'kadence/not-a-block' ) );
+	}
+}


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3390/variant-readwrite-endpoints

Second of four stacked PRs. Based on `feature/SOFT-3390/variants-1-vocabulary`.

Adds `Effective_Variants`, a reader that deep-merges the shipped baseline variants section with the stored overrides so reads reflect writes, and registers it on the resolver provider. Covered by `Effective_VariantsTest`.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
