### PR TITLE
Variant endpoints (3/4): variants REST read endpoints

### DIFF
--- a/includes/resources/Design_Tokens/Rest/V1/Provider.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Provider.php
@@ -26,6 +26,7 @@ final class Provider extends Provider_Contract {
 	private const CONTROLLERS = [
 		Documents_Controller::class,
 		Schema_Controller::class,
+		Variants_Controller::class,
 	];
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
@@ -209,11 +209,12 @@ final class Variants_Controller extends Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		$slug   = Token_Store::default_slug();
-		$blocks = [];
+		$slug    = Token_Store::default_slug();
+		$section = $this->variants->section( $slug );
+		$blocks  = [];
 
 		foreach ( $this->registry->variant_blocks() as $block ) {
-			$node = $this->variants->block( $block, $slug ) ?? [];
+			$node = isset( $section[ $block ] ) && is_array( $section[ $block ] ) ? $section[ $block ] : [];
 
 			$blocks[] = [
 				'block'   => $block,

--- a/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
@@ -1,0 +1,502 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Variants;
+use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Cast;
+use WP_Error;
+use WP_Http;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * REST controller for the Design Tokens variants resource.
+ *
+ * Exposes the raw read surface for a block's variant set: the named variants and the `$default` that live in
+ * the DTCG document under `$extensions.com.kadence.designTokens.variants.<block>`. Reads are served from the
+ * baseline deep-merged with the stored overrides (via {@see Effective_Variants}), so a variant authored
+ * through a write is visible on the next read. Resolved (CSS) variant values are out of scope here — they are
+ * produced by the variant projectors, which own the resolver's override-merging.
+ *
+ * A block is addressable only when it has a registered variant set ({@see Token_Registry::for_block()}); a
+ * block with no set has no bindings, so a variant authored for it could never project. Reads for such a block
+ * are a 404.
+ *
+ * The block name carries a slash ("kadence/advancedbtn"), so it is routed as two path segments and
+ * reassembled.
+ *
+ * v1 ships a single token set under Token_Store::default_slug(); every route operates on it.
+ *
+ * @since TBD
+ */
+final class Variants_Controller extends Controller {
+
+	/**
+	 * The request parameter that carries the block's vendor segment, e.g. "kadence".
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const VENDOR_PARAM = 'vendor';
+
+	/**
+	 * The request parameter that carries the block's name segment, e.g. "advancedbtn".
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const BLOCK_NAME_PARAM = 'block_name';
+
+	/**
+	 * The block vendor path segment. A slug-safe class with no slash; the block name is the second segment.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const VENDOR_ROUTE = '(?P<' . self::VENDOR_PARAM . '>[a-z][a-z0-9-]*)';
+
+	/**
+	 * The block name path segment.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const BLOCK_NAME_ROUTE = '(?P<' . self::BLOCK_NAME_PARAM . '>[a-z0-9][a-z0-9-]*)';
+
+	/**
+	 * The full block path: vendor + "/" + name, reassembled into "vendor/name" in each handler. A block
+	 * name carries a slash, so it is captured as two slug-free segments rather than one encoded segment.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const BLOCK_ROUTE = self::VENDOR_ROUTE . '/' . self::BLOCK_NAME_ROUTE;
+
+	/**
+	 * The literal sub-route, relative to a block, that reads the block's `$default`.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const DEFAULT_ROUTE = 'default';
+
+	/**
+	 * The sole gateway to the kb_design_tokens table.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * Reads the effective (baseline-merged) variants section, so reads reflect writes.
+	 *
+	 * @since TBD
+	 *
+	 * @var Effective_Variants
+	 */
+	private Effective_Variants $variants;
+
+	/**
+	 * Declares which blocks accept variants. A block with no registered set is a 404.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * Memoised item schema for this request. Null until first built.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string, mixed>|null
+	 */
+	private ?array $item_schema = null;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Store        $store    The sole gateway to the kb_design_tokens table.
+	 * @param Effective_Variants $variants Reads the baseline-merged variants section.
+	 * @param Token_Registry     $registry Declares which blocks accept variants.
+	 */
+	public function __construct(
+		Token_Store $store,
+		Effective_Variants $variants,
+		Token_Registry $registry
+	) {
+		$this->store     = $store;
+		$this->variants  = $variants;
+		$this->registry  = $registry;
+		$this->rest_base = 'variants';
+	}
+
+	/**
+	 * Register the read routes for the variants resource.
+	 *
+	 * A block's variant set and its `$default` are read through dedicated routes; the `$default` is read
+	 * through a literal sub-route relative to the block.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			"/$this->rest_base",
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_items' ],
+					'permission_callback' => [ $this, 'get_items_permissions_check' ],
+					'args'                => $this->get_collection_params(),
+				],
+				'schema' => [ $this, 'get_item_schema' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/' . self::BLOCK_ROUTE,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_item' ],
+					'permission_callback' => [ $this, 'get_item_permissions_check' ],
+					'args'                => $this->get_block_params(),
+				],
+				'schema' => [ $this, 'get_item_schema' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/' . self::BLOCK_ROUTE . '/' . self::DEFAULT_ROUTE,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_default' ],
+					'permission_callback' => [ $this, 'get_item_permissions_check' ],
+					'args'                => $this->get_block_params(),
+				],
+				'schema' => [ $this, 'get_item_schema' ],
+			]
+		);
+	}
+
+	/**
+	 * List the blocks that accept variants, each with its default and named variant slugs.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$slug   = Token_Store::default_slug();
+		$blocks = [];
+
+		foreach ( $this->registry->variant_blocks() as $block ) {
+			$node = $this->variants->block( $block, $slug ) ?? [];
+
+			$blocks[] = [
+				'block'   => $block,
+				'default' => $this->default_of( $node ),
+				'names'   => $this->variant_names( $node ),
+			];
+		}
+
+		return new WP_REST_Response( [ 'blocks' => $blocks ], WP_Http::OK );
+	}
+
+	/**
+	 * Read a single block's effective variant set.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_item( $request ) {
+		$block = $this->block_from( $request );
+		$error = $this->guard_block( $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		return new WP_REST_Response( $this->prepare_item( $block ), WP_Http::OK );
+	}
+
+	/**
+	 * Read a block's default variant slug (GET /variants/{block}/default).
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_default( $request ) {
+		$block = $this->block_from( $request );
+		$error = $this->guard_block( $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$node = $this->variants->block( $block, Token_Store::default_slug() ) ?? [];
+
+		return new WP_REST_Response(
+			[
+				'block'   => $block,
+				'default' => $this->default_of( $node ),
+			],
+			WP_Http::OK
+		);
+	}
+
+	/**
+	 * The JSON Schema for a block's variant set.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_item_schema(): array {
+		if ( $this->item_schema !== null ) {
+			return $this->add_additional_fields_schema( $this->item_schema );
+		}
+
+		$variant_schema = [
+			'type'       => 'object',
+			'properties' => [
+				Extensions::get_label_key()  => [
+					'description' => __( 'The variant\'s human-readable label.', 'kadence-blocks' ),
+					'type'        => 'string',
+				],
+				Extensions::get_tokens_key() => [
+					'description'          => __( 'The variant\'s property => alias-or-literal token map.', 'kadence-blocks' ),
+					'type'                 => 'object',
+					'additionalProperties' => [ 'type' => [ 'string', 'number' ] ],
+				],
+			],
+		];
+
+		$this->item_schema = [
+			'$schema'    => 'http://json-schema.org/draft-07/schema#',
+			'title'      => 'design-token-variant-set',
+			'type'       => 'object',
+			'properties' => [
+				'block'    => [
+					'description' => __( 'The block name the variant set belongs to.', 'kadence-blocks' ),
+					'type'        => 'string',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+				'slug'     => [
+					'description' => __( 'The token set slug.', 'kadence-blocks' ),
+					'type'        => 'string',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+				'version'  => [
+					'description' => __( 'The cache-busting version hash for the set, empty when it renders from baseline.', 'kadence-blocks' ),
+					'type'        => 'string',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+				'default'  => [
+					'description' => __( 'The default variant slug.', 'kadence-blocks' ),
+					'type'        => 'string',
+					'context'     => [ 'view' ],
+				],
+				'variants' => [
+					'description'          => __( 'The named variants, keyed by slug.', 'kadence-blocks' ),
+					'type'                 => 'object',
+					'context'              => [ 'view' ],
+					'additionalProperties' => $variant_schema,
+				],
+			],
+		];
+
+		return $this->add_additional_fields_schema( $this->item_schema );
+	}
+
+	/**
+	 * The query parameters accepted by the collection route.
+	 *
+	 * No collection parameters are accepted yet; the definition is declared explicitly so the surface
+	 * documents itself and gains parameters without changing shape.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_collection_params(): array {
+		return [];
+	}
+
+	/**
+	 * Reject a request for a block that has no registered variant set.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block The block name.
+	 *
+	 * @return WP_Error|null A WP_Error when the block accepts no variants, null otherwise.
+	 */
+	private function guard_block( string $block ): ?WP_Error {
+		if ( $this->registry->for_block( $block ) !== null ) {
+			return null;
+		}
+
+		return new WP_Error(
+			'rest_design_tokens_not_found',
+			__( 'Sorry, that block does not accept variants.', 'kadence-blocks' ),
+			[
+				'status' => WP_Http::NOT_FOUND,
+				'block'  => $block,
+			]
+		);
+	}
+
+	/**
+	 * Build the response payload for a block's variant set, read from the effective (baseline-merged) set.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block The block name.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function prepare_item( string $block ): array {
+		$slug = Token_Store::default_slug();
+		$node = $this->variants->block( $block, $slug ) ?? [];
+
+		return [
+			'block'    => $block,
+			'slug'     => $slug,
+			'version'  => $this->store->get_version( $slug ),
+			'default'  => $this->default_of( $node ),
+			'variants' => $this->named_variants( $node ),
+		];
+	}
+
+	/**
+	 * The `$default` slug of a variant node, or an empty string when none is set.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $node The block's variant node.
+	 *
+	 * @return string
+	 */
+	private function default_of( array $node ): string {
+		return Cast::to_string( $node[ Extensions::get_default_key() ] ?? '' );
+	}
+
+	/**
+	 * The named variant slugs of a variant node, skipping "$"-prefixed metadata keys.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $node The block's variant node.
+	 *
+	 * @return string[]
+	 */
+	private function variant_names( array $node ): array {
+		$names = [];
+
+		foreach ( array_keys( $node ) as $key ) {
+			if ( is_string( $key ) && strpos( $key, '$' ) === 0 ) {
+				continue;
+			}
+
+			$names[] = (string) $key;
+		}
+
+		return $names;
+	}
+
+	/**
+	 * The named variants of a variant node, keyed by slug, skipping "$"-prefixed metadata keys.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $node The block's variant node.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function named_variants( array $node ): array {
+		$variants = [];
+
+		foreach ( $node as $slug => $variant ) {
+			if ( is_string( $slug ) && strpos( $slug, '$' ) === 0 ) {
+				continue;
+			}
+
+			$variants[ (string) $slug ] = $variant;
+		}
+
+		return $variants;
+	}
+
+	/**
+	 * Reassemble the block name from its two captured path segments.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return string
+	 */
+	private function block_from( WP_REST_Request $request ): string {
+		return Cast::to_string( $request->get_param( self::VENDOR_PARAM ) )
+			. '/'
+			. Cast::to_string( $request->get_param( self::BLOCK_NAME_PARAM ) );
+	}
+
+	/**
+	 * The block path segment arguments shared by every single-block route.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_block_params(): array {
+		return [
+			self::VENDOR_PARAM     => [
+				'description'       => __( 'The block vendor segment, e.g. kadence.', 'kadence-blocks' ),
+				'type'              => 'string',
+				'required'          => true,
+				'pattern'           => '^[a-z][a-z0-9-]*$',
+				'sanitize_callback' => 'sanitize_key',
+			],
+			self::BLOCK_NAME_PARAM => [
+				'description'       => __( 'The block name segment, e.g. advancedbtn.', 'kadence-blocks' ),
+				'type'              => 'string',
+				'required'          => true,
+				'pattern'           => '^[a-z0-9][a-z0-9-]*$',
+				'sanitize_callback' => 'sanitize_key',
+			],
+		];
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
@@ -164,6 +164,44 @@ final class VariantsControllerTest extends TestCase {
 	}
 
 	/**
+	 * @return void
+	 */
+	public function testReadRoutesAreGatedByTheCapability(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+
+		// Both read callbacks gate the routes (get_items for the collection, get_item for a single block and
+		// its default), so both must deny a user without the capability and allow one that has it.
+		$checks = [ 'get_items_permissions_check', 'get_item_permissions_check' ];
+
+		// A logged-out user is denied.
+		wp_set_current_user( 0 );
+
+		foreach ( $checks as $check ) {
+			$result = $this->controller->$check( $request );
+
+			$this->assertInstanceOf( WP_Error::class, $result, "$check should deny a logged-out user." );
+			$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+		}
+
+		// An authenticated user without edit_theme_options is denied.
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'subscriber' ] ) );
+
+		foreach ( $checks as $check ) {
+			$result = $this->controller->$check( $request );
+
+			$this->assertInstanceOf( WP_Error::class, $result, "$check should deny a subscriber." );
+			$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+		}
+
+		// An administrator (edit_theme_options) is allowed.
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		foreach ( $checks as $check ) {
+			$this->assertTrue( $this->controller->$check( $request ), "$check should allow an administrator." );
+		}
+	}
+
+	/**
 	 * Build a request for a single block route, splitting the block name into its two path segments and
 	 * carrying any extra body parameters.
 	 *

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
@@ -1,0 +1,252 @@
+<?php declare( strict_types=1 );
+// cspell:ignore advancedbtn advancedheading .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Rest\V1;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Variants_Controller;
+use ReflectionClass;
+use ReflectionProperty;
+use Tests\Support\Classes\TestCase;
+use WP_Error;
+use WP_Http;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Covers the read surface of the Design Tokens variants controller: the registered read routes and the
+ * baseline-merged reads against the real shipped baseline.
+ */
+final class VariantsControllerTest extends TestCase {
+
+	private const BUTTON = 'kadence/advancedbtn';
+
+	/**
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @var Variants_Controller
+	 */
+	private Variants_Controller $controller;
+
+	/**
+	 * @var WP_REST_Server
+	 */
+	private WP_REST_Server $rest_server;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->store      = $this->container->get( Token_Store::class );
+		$this->controller = $this->container->get( Variants_Controller::class );
+
+		global $wp_rest_server;
+		$this->rest_server = new WP_REST_Server();
+		$wp_rest_server    = $this->rest_server;
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		wp_set_current_user( 0 );
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItRegistersEveryRouteWithASchema(): void {
+		$namespace     = $this->controller_namespace();
+		$base          = $this->controller_rest_base();
+		$block_route   = $this->controller_constant( 'BLOCK_ROUTE' );
+		$default_route = $this->controller_constant( 'DEFAULT_ROUTE' );
+
+		$collection = "/$namespace/$base";
+		$block      = "/$namespace/$base/$block_route";
+		$default    = "/$namespace/$base/$block_route/$default_route";
+
+		foreach ( [ $collection, $block, $default ] as $route ) {
+			$this->assertArrayHasKey( $route, $this->rest_server->get_routes(), "Route $route should be registered." );
+
+			$options = $this->rest_server->get_route_options( $route );
+			$this->assertArrayHasKey( 'schema', $options, "Route $route should expose a schema." );
+			$this->assertIsCallable( $options['schema'] );
+		}
+
+		// The block route declares both block path segments.
+		$this->assertArrayHasKey( $this->controller_constant( 'VENDOR_PARAM' ), $this->rest_server->get_routes()[ $block ][0]['args'] );
+		$this->assertArrayHasKey( $this->controller_constant( 'BLOCK_NAME_PARAM' ), $this->rest_server->get_routes()[ $block ][0]['args'] );
+
+		// Every read route is reachable through GET.
+		foreach ( [ $collection, $block, $default ] as $route ) {
+			$this->assertContains( 'GET', $this->route_methods( $route ), "Route $route should accept GET." );
+		}
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItListsTheRegisteredVariantBlocks(): void {
+		$response = $this->controller->get_items( new WP_REST_Request( WP_REST_Server::READABLE ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$blocks = wp_list_pluck( $response->get_data()['blocks'], 'default', 'block' );
+
+		$this->assertArrayHasKey( self::BUTTON, $blocks );
+		$this->assertSame( 'primary', $blocks[ self::BUTTON ] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetItemReturnsTheBaselineMergedVariantSet(): void {
+		$response = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+
+		$data = $response->get_data();
+
+		$this->assertSame( self::BUTTON, $data['block'] );
+		$this->assertSame( 'primary', $data['default'] );
+		$this->assertArrayHasKey( 'primary', $data['variants'] );
+		$this->assertArrayHasKey( 'ghost', $data['variants'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetItemReflectsAStoredOverride(): void {
+		$this->store->save_document(
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/advancedbtn":{'
+			. '"outline":{"label":"Outline","tokens":{"button-bg":"transparent"}}}}}}}'
+		);
+
+		$data = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) )->get_data();
+
+		$this->assertArrayHasKey( 'outline', $data['variants'] );
+		$this->assertSame( 'Outline', $data['variants']['outline']['label'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetItemReturns404ForABlockThatAcceptsNoVariants(): void {
+		// The baseline ships variant data for advancedheading, but no variant set is registered for it.
+		$result = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, 'kadence/advancedheading' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_not_found', $result->get_error_code() );
+		$this->assertSame( WP_Http::NOT_FOUND, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetDefaultReadsTheDefault(): void {
+		$data = $this->controller->get_default( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) )->get_data();
+
+		$this->assertSame( self::BUTTON, $data['block'] );
+		$this->assertSame( 'primary', $data['default'] );
+	}
+
+	/**
+	 * Build a request for a single block route, splitting the block name into its two path segments and
+	 * carrying any extra body parameters.
+	 *
+	 * @param string               $method The HTTP method.
+	 * @param string               $block  The block name, e.g. "kadence/advancedbtn".
+	 * @param array<string, mixed> $extra  Extra parameters (variant, label, tokens, variants, default).
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function block_request( string $method, string $block, array $extra = [] ): WP_REST_Request {
+		[ $vendor, $name ] = explode( '/', $block, 2 );
+
+		$request = new WP_REST_Request( $method );
+		$request->set_param( 'vendor', $vendor );
+		$request->set_param( 'block_name', $name );
+
+		foreach ( $extra as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+
+		return $request;
+	}
+
+	/**
+	 * Collect every HTTP method a registered route accepts across all of its endpoints.
+	 *
+	 * @param string $route The registered route pattern.
+	 *
+	 * @return string[]
+	 */
+	private function route_methods( string $route ): array {
+		$methods = [];
+
+		foreach ( $this->rest_server->get_routes()[ $route ] ?? [] as $endpoint ) {
+			if ( isset( $endpoint['methods'] ) && is_array( $endpoint['methods'] ) ) {
+				$methods = array_merge( $methods, array_keys( array_filter( $endpoint['methods'] ) ) );
+			}
+		}
+
+		return $methods;
+	}
+
+	/**
+	 * The REST namespace the controller registers under, read off the instance so the tests do not
+	 * hardcode it.
+	 *
+	 * @return string
+	 */
+	private function controller_namespace(): string {
+		return $this->controller_property( 'namespace' );
+	}
+
+	/**
+	 * The rest base the controller registers under, read off the instance so the tests do not hardcode it.
+	 *
+	 * @return string
+	 */
+	private function controller_rest_base(): string {
+		return $this->controller_property( 'rest_base' );
+	}
+
+	/**
+	 * Read a protected property off the controller instance.
+	 *
+	 * @param string $property The property name.
+	 *
+	 * @return string
+	 */
+	private function controller_property( string $property ): string {
+		$reflection = new ReflectionProperty( $this->controller, $property );
+		$reflection->setAccessible( true );
+
+		return (string) $reflection->getValue( $this->controller );
+	}
+
+	/**
+	 * Read a class constant off the controller, so route segments are asserted from their single source.
+	 *
+	 * @param string $name The constant name.
+	 *
+	 * @return string
+	 */
+	private function controller_constant( string $name ): string {
+		return (string) ( new ReflectionClass( $this->controller ) )->getConstant( $name );
+	}
+}


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3390/variant-readwrite-endpoints

Third of four stacked PRs. Based on `feature/SOFT-3390/variants-2-effective-reader`.

Adds `Variants_Controller` with the read surface of the variants resource (`kb-design-tokens/v1/variants`):

- List the blocks that have a registered variant set, each with its default and named variant slugs.
- Read a single block's baseline-merged variant set.
- Read a block's `$default`.

Reads merge the shipped baseline with stored overrides through `Effective_Variants`. Only blocks with a registered variant set are addressable; others are a 404. The block name carries a slash, so it is routed as two path segments and reassembled. The controller is registered on the v1 REST provider. Write endpoints land in the fourth PR.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
