### PR TITLE
Variant endpoints (4/4): variants REST write endpoints

### DIFF
--- a/includes/resources/Design_Tokens/Document/Mutator.php
+++ b/includes/resources/Design_Tokens/Document/Mutator.php
@@ -115,27 +115,31 @@ final class Mutator {
 	 * @return array<string, mixed> The document with the path removed and empty ancestors pruned.
 	 */
 	public function remove( array $document, string $path ): array {
-		return $this->remove_segments( $document, explode( '.', $path ) );
+		return $this->remove_by_keys( $document, explode( '.', $path ) );
 	}
 
 	/**
-	 * Recursively remove the head-most segment chain from a node, pruning emptied groups on the way out.
+	 * Recursively remove the node addressed by a literal key chain, pruning emptied groups on the way out.
+	 *
+	 * Addresses the document by discrete array keys rather than a dot-path, so a caller whose keys themselves
+	 * carry dots ("com.kadence.designTokens") or slashes ("kadence/advancedbtn") can remove a node the
+	 * dot-path form could not express.
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, mixed> $node     The current node.
-	 * @param string[]             $segments The remaining dot-path segments.
+	 * @param array<string, mixed> $node The current node.
+	 * @param string[]             $keys The remaining literal keys to the node to remove.
 	 *
-	 * @return array<string, mixed> The node with the segment chain removed.
+	 * @return array<string, mixed> The node with the key chain removed.
 	 */
-	private function remove_segments( array $node, array $segments ): array {
-		$head = (string) array_shift( $segments );
+	public function remove_by_keys( array $node, array $keys ): array {
+		$head = (string) array_shift( $keys );
 
 		if ( ! array_key_exists( $head, $node ) ) {
 			return $node;
 		}
 
-		if ( $segments === [] ) {
+		if ( $keys === [] ) {
 			unset( $node[ $head ] );
 
 			return $node;
@@ -146,7 +150,7 @@ final class Mutator {
 			return $node;
 		}
 
-		$node[ $head ] = $this->remove_segments( $node[ $head ], $segments );
+		$node[ $head ] = $this->remove_by_keys( $node[ $head ], $keys );
 
 		// Prune a group that the removal just emptied so stored overrides do not accrue husks.
 		if ( $node[ $head ] === [] ) {

--- a/includes/resources/Design_Tokens/Resolver/Effective_Variants.php
+++ b/includes/resources/Design_Tokens/Resolver/Effective_Variants.php
@@ -69,7 +69,7 @@ final class Effective_Variants {
 	 * @return array<string, mixed>
 	 */
 	public function section( string $slug = 'default' ): array {
-		return $this->for_overrides( $this->stored_document( $slug ) );
+		return $this->for_overrides( $this->raw( $slug ) );
 	}
 
 	/**
@@ -105,7 +105,10 @@ final class Effective_Variants {
 	}
 
 	/**
-	 * Decode the set's stored overrides document, tolerating an absent/empty/malformed row as "no overrides".
+	 * Decode a set's stored overrides document, tolerating an absent/empty/malformed row as "no overrides".
+	 *
+	 * The single decode seam for the stored overrides: callers that need the raw decoded document, rather than
+	 * its merged variants view, reuse this instead of decoding the store themselves.
 	 *
 	 * @since TBD
 	 *
@@ -113,7 +116,7 @@ final class Effective_Variants {
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function stored_document( string $slug ): array {
+	public function raw( string $slug = 'default' ): array {
 		$raw = $this->store->get_document( $slug );
 
 		if ( $raw === '' ) {

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -814,7 +814,21 @@ final class Documents_Controller extends Controller {
 			);
 		}
 
-		return $this->persist( (string) wp_json_encode( $candidate ), $slug, $title, $status );
+		$encoded = wp_json_encode( $candidate );
+
+		// Guard the encode: a false return cast to "" would clear the whole set on persist instead of storing it.
+		if ( $encoded === false ) {
+			return new WP_Error(
+				'rest_design_tokens_save_failed',
+				__( 'The design token document could not be encoded.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::INTERNAL_SERVER_ERROR,
+					'slug'   => $slug,
+				]
+			);
+		}
+
+		return $this->persist( $encoded, $slug, $title, $status );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
@@ -760,7 +760,21 @@ final class Variants_Controller extends Controller {
 			);
 		}
 
-		return $this->persist( (string) wp_json_encode( $candidate ), $block, $status );
+		$encoded = wp_json_encode( $candidate );
+
+		// Guard the encode: a false return cast to "" would clear the whole set on persist instead of storing it.
+		if ( $encoded === false ) {
+			return new WP_Error(
+				'rest_design_tokens_save_failed',
+				__( 'The design token set could not be encoded.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::INTERNAL_SERVER_ERROR,
+					'block'  => $block,
+				]
+			);
+		}
+
+		return $this->persist( $encoded, $block, $status );
 	}
 
 	/**
@@ -982,7 +996,7 @@ final class Variants_Controller extends Controller {
 	 * @return array<string, mixed>
 	 */
 	private function unset_block( array $document, string $block ): array {
-		return $this->unset_path( $document, array_merge( $this->variants_path(), [ $block ] ) );
+		return $this->mutator->remove_by_keys( $document, array_merge( $this->variants_path(), [ $block ] ) );
 	}
 
 	/**
@@ -997,46 +1011,7 @@ final class Variants_Controller extends Controller {
 	 * @return array<string, mixed>
 	 */
 	private function unset_variant( array $document, string $block, string $variant ): array {
-		return $this->unset_path( $document, array_merge( $this->variants_path(), [ $block, $variant ] ) );
-	}
-
-	/**
-	 * Recursively remove a node addressed by literal keys, pruning emptied ancestor groups on the way out.
-	 *
-	 * Addresses the document by discrete array keys rather than a dot-path, because the keys themselves
-	 * carry dots ("com.kadence.designTokens") and slashes ("kadence/advancedbtn").
-	 *
-	 * @since TBD
-	 *
-	 * @param array<string, mixed> $node The current node.
-	 * @param string[]             $keys The remaining literal keys to the node to remove.
-	 *
-	 * @return array<string, mixed>
-	 */
-	private function unset_path( array $node, array $keys ): array {
-		$head = (string) array_shift( $keys );
-
-		if ( ! array_key_exists( $head, $node ) ) {
-			return $node;
-		}
-
-		if ( $keys === [] ) {
-			unset( $node[ $head ] );
-
-			return $node;
-		}
-
-		if ( ! is_array( $node[ $head ] ) ) {
-			return $node;
-		}
-
-		$node[ $head ] = $this->unset_path( $node[ $head ], $keys );
-
-		if ( $node[ $head ] === [] ) {
-			unset( $node[ $head ] );
-		}
-
-		return $node;
+		return $this->mutator->remove_by_keys( $document, array_merge( $this->variants_path(), [ $block, $variant ] ) );
 	}
 
 	/**
@@ -1047,11 +1022,7 @@ final class Variants_Controller extends Controller {
 	 * @return string[]
 	 */
 	private function variants_path(): array {
-		return [
-			Extensions::get_extensions_key(),
-			Extensions::get_namespace(),
-			Extensions::get_section_variants(),
-		];
+		return Extensions::get_variants_path();
 	}
 
 	/**
@@ -1116,20 +1087,15 @@ final class Variants_Controller extends Controller {
 	/**
 	 * Decode the stored overrides-only document for the default set.
 	 *
+	 * Reuses the reader's single decode seam ({@see Effective_Variants::raw()}) so the controller does not
+	 * decode the store itself.
+	 *
 	 * @since TBD
 	 *
 	 * @return array<string, mixed> The decoded document, empty when absent or unreadable.
 	 */
 	private function stored_document(): array {
-		$raw = $this->store->get_document( Token_Store::default_slug() );
-
-		if ( $raw === '' ) {
-			return [];
-		}
-
-		$decoded = json_decode( $raw, true );
-
-		return is_array( $decoded ) ? $decoded : [];
+		return $this->variants->raw( Token_Store::default_slug() );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
@@ -3,11 +3,17 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Variants;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Dtcg_Validator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
 use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Cast;
+use KadenceWP\KadenceBlocks\StellarWP\DB\Database\Exceptions\DatabaseQueryException;
 use WP_Error;
 use WP_Http;
 use WP_REST_Request;
@@ -17,18 +23,21 @@ use WP_REST_Server;
 /**
  * REST controller for the Design Tokens variants resource.
  *
- * Exposes the raw read surface for a block's variant set: the named variants and the `$default` that live in
- * the DTCG document under `$extensions.com.kadence.designTokens.variants.<block>`. Reads are served from the
- * baseline deep-merged with the stored overrides (via {@see Effective_Variants}), so a variant authored
- * through a write is visible on the next read. Resolved (CSS) variant values are out of scope here — they are
- * produced by the variant projectors, which own the resolver's override-merging.
+ * Exposes the raw read and write surface for a block's variant set: the named variants and the `$default`
+ * that live in the DTCG document under `$extensions.com.kadence.designTokens.variants.<block>`. Reads are
+ * served from the baseline deep-merged with the stored overrides (via {@see Effective_Variants}), so a
+ * variant authored through a write is visible on the next read. Resolved (CSS) variant values are out of
+ * scope here — they are produced by the variant projectors, which own the resolver's override-merging.
  *
  * A block is addressable only when it has a registered variant set ({@see Token_Registry::for_block()}); a
- * block with no set has no bindings, so a variant authored for it could never project. Reads for such a block
- * are a 404.
+ * block with no set has no bindings, so a variant authored for it could never project. Reads and writes for
+ * such a block are a 404.
  *
- * The block name carries a slash ("kadence/advancedbtn"), so it is routed as two path segments and
- * reassembled.
+ * Writes assemble a partial overrides document carrying only the addressed variants node and deep-merge it
+ * onto the stored set, then run the shared pipeline: DTCG grammar validation (HTTP 422), a dry-run Resolver
+ * pass that rejects alias cycles / dangling aliases in the token layers (HTTP 422), then a single
+ * Token_Store::save_document() that bumps the version and fires the change action. The block name carries a
+ * slash ("kadence/advancedbtn"), so it is routed as two path segments and reassembled.
  *
  * v1 ships a single token set under Token_Store::default_slug(); every route operates on it.
  *
@@ -53,6 +62,51 @@ final class Variants_Controller extends Controller {
 	 * @var string
 	 */
 	private const BLOCK_NAME_PARAM = 'block_name';
+
+	/**
+	 * The request parameter that carries a single variant slug.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const VARIANT_PARAM = 'variant';
+
+	/**
+	 * The request parameter that carries a variant's human-readable label on a create.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const LABEL_PARAM = 'label';
+
+	/**
+	 * The request parameter that carries a variant's property => alias-or-literal token map.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const TOKENS_PARAM = 'tokens';
+
+	/**
+	 * The request parameter that carries the whole variant map on a replace (PUT).
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const VARIANTS_PARAM = 'variants';
+
+	/**
+	 * The request parameter that carries the default variant slug.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const DEFAULT_PARAM = 'default';
 
 	/**
 	 * The block vendor path segment. A slug-safe class with no slash; the block name is the second segment.
@@ -83,7 +137,16 @@ final class Variants_Controller extends Controller {
 	private const BLOCK_ROUTE = self::VENDOR_ROUTE . '/' . self::BLOCK_NAME_ROUTE;
 
 	/**
-	 * The literal sub-route, relative to a block, that reads the block's `$default`.
+	 * The single-variant path segment.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const VARIANT_ROUTE = '(?P<' . self::VARIANT_PARAM . '>[\w-]+)';
+
+	/**
+	 * The literal sub-route, relative to a block, that reads / sets the block's `$default`.
 	 *
 	 * @since TBD
 	 *
@@ -99,6 +162,33 @@ final class Variants_Controller extends Controller {
 	 * @var Token_Store
 	 */
 	private Token_Store $store;
+
+	/**
+	 * Pure merge transform used to assemble the candidate overrides document.
+	 *
+	 * @since TBD
+	 *
+	 * @var Mutator
+	 */
+	private Mutator $mutator;
+
+	/**
+	 * Dry-runs a candidate's token layers to reject alias cycles / dangling aliases before commit.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Resolver
+	 */
+	private Token_Resolver $resolver;
+
+	/**
+	 * Validates the DTCG grammar of a candidate document before it is committed.
+	 *
+	 * @since TBD
+	 *
+	 * @var Dtcg_Validator
+	 */
+	private Dtcg_Validator $validator;
 
 	/**
 	 * Reads the effective (baseline-merged) variants section, so reads reflect writes.
@@ -130,26 +220,39 @@ final class Variants_Controller extends Controller {
 	/**
 	 * @since TBD
 	 *
-	 * @param Token_Store        $store    The sole gateway to the kb_design_tokens table.
-	 * @param Effective_Variants $variants Reads the baseline-merged variants section.
-	 * @param Token_Registry     $registry Declares which blocks accept variants.
+	 * @param Token_Store        $store     The sole gateway to the kb_design_tokens table.
+	 * @param Mutator            $mutator   Assembles the candidate overrides document.
+	 * @param Token_Resolver     $resolver  Dry-runs a candidate's token layers before commit.
+	 * @param Dtcg_Validator     $validator Validates the DTCG grammar of a candidate document.
+	 * @param Effective_Variants $variants  Reads the baseline-merged variants section.
+	 * @param Token_Registry     $registry  Declares which blocks accept variants.
 	 */
 	public function __construct(
 		Token_Store $store,
+		Mutator $mutator,
+		Token_Resolver $resolver,
+		Dtcg_Validator $validator,
 		Effective_Variants $variants,
 		Token_Registry $registry
 	) {
 		$this->store     = $store;
+		$this->mutator   = $mutator;
+		$this->resolver  = $resolver;
+		$this->validator = $validator;
 		$this->variants  = $variants;
 		$this->registry  = $registry;
 		$this->rest_base = 'variants';
 	}
 
 	/**
-	 * Register the read routes for the variants resource.
+	 * Register the read and write routes for the variants resource.
 	 *
-	 * A block's variant set and its `$default` are read through dedicated routes; the `$default` is read
-	 * through a literal sub-route relative to the block.
+	 * Verb semantics follow the WordPress REST convention: POST creates or merges a single variant, PUT
+	 * replaces the block's whole variant set, DELETE on a block resets it to baseline, and DELETE on a
+	 * variant removes that one variant. The `$default` is read and set through a dedicated sub-route.
+	 *
+	 * The `default` sub-route is registered before the single-variant route so the literal segment is not
+	 * captured as a variant slug.
 	 *
 	 * @since TBD
 	 *
@@ -180,6 +283,26 @@ final class Variants_Controller extends Controller {
 					'permission_callback' => [ $this, 'get_item_permissions_check' ],
 					'args'                => $this->get_block_params(),
 				],
+				[
+					// POST = create-or-merge a single variant, leaving siblings and $default intact.
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'create_item' ],
+					'permission_callback' => [ $this, 'create_item_permissions_check' ],
+					'args'                => $this->get_create_params(),
+				],
+				[
+					// PUT replaces the block's whole variant set, dropping any variant absent from the body.
+					'methods'             => 'PUT',
+					'callback'            => [ $this, 'update_item' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_replace_params(),
+				],
+				[
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => [ $this, 'delete_item' ],
+					'permission_callback' => [ $this, 'delete_item_permissions_check' ],
+					'args'                => $this->get_block_params(),
+				],
 				'schema' => [ $this, 'get_item_schema' ],
 			]
 		);
@@ -193,6 +316,26 @@ final class Variants_Controller extends Controller {
 					'callback'            => [ $this, 'get_default' ],
 					'permission_callback' => [ $this, 'get_item_permissions_check' ],
 					'args'                => $this->get_block_params(),
+				],
+				[
+					'methods'             => 'PUT',
+					'callback'            => [ $this, 'set_default' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_default_params(),
+				],
+				'schema' => [ $this, 'get_item_schema' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/' . self::BLOCK_ROUTE . '/' . self::VARIANT_ROUTE,
+			[
+				[
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => [ $this, 'delete_variant' ],
+					'permission_callback' => [ $this, 'delete_item_permissions_check' ],
+					'args'                => $this->get_variant_params(),
 				],
 				'schema' => [ $this, 'get_item_schema' ],
 			]
@@ -246,6 +389,181 @@ final class Variants_Controller extends Controller {
 	}
 
 	/**
+	 * Create or merge a single variant (POST /variants/{block}).
+	 *
+	 * The body carries the variant slug, an optional label and its property => value token map. The variant
+	 * is deep-merged into the stored set, so sibling variants and the `$default` are left intact.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function create_item( $request ) {
+		$block = $this->block_from( $request );
+		$error = $this->guard_block( $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$variant = Cast::to_string( $request->get_param( self::VARIANT_PARAM ) );
+
+		if ( $variant === '' ) {
+			return new WP_Error(
+				'rest_design_tokens_invalid',
+				__( 'A variant slug is required.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::BAD_REQUEST,
+					'block'  => $block,
+				]
+			);
+		}
+
+		$block_node = [ $variant => $this->variant_definition( $request ) ];
+
+		$error = $this->guard_variant_shape( $block_node, $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$candidate = $this->mutator->merge( $this->stored_document(), $this->partial( $block, $block_node ) );
+
+		return $this->validate_and_save( $candidate, $block );
+	}
+
+	/**
+	 * Replace a block's whole variant set (PUT /variants/{block}).
+	 *
+	 * The stored variants for the block are dropped first, then the body's variant map (and optional
+	 * default) is written, so a variant absent from the body no longer applies.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_item( $request ) {
+		$block = $this->block_from( $request );
+		$error = $this->guard_block( $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$variants   = $request->get_param( self::VARIANTS_PARAM );
+		$block_node = is_array( $variants ) ? $variants : [];
+
+		$default = Cast::to_string( $request->get_param( self::DEFAULT_PARAM ) );
+
+		if ( $default !== '' ) {
+			$block_node[ Extensions::get_default_key() ] = $default;
+		}
+
+		$error = $this->guard_variant_shape( $block_node, $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		// Replace, not merge: drop the stored block node first so a variant the body omits does not survive.
+		$stored    = $this->unset_block( $this->stored_document(), $block );
+		$candidate = $this->mutator->merge( $stored, $this->partial( $block, $block_node ) );
+
+		$error = $this->guard_default_present( $candidate, $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		return $this->validate_and_save( $candidate, $block );
+	}
+
+	/**
+	 * Reset a block's variant set to baseline (DELETE /variants/{block}).
+	 *
+	 * Removes the whole stored `variants.<block>` node, so the block renders its baseline variants. A no-op
+	 * when nothing is stored for the block.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_item( $request ) {
+		$block = $this->block_from( $request );
+		$error = $this->guard_block( $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$stored    = $this->stored_document();
+		$candidate = $this->unset_block( $stored, $block );
+
+		if ( $candidate === $stored ) {
+			return new WP_REST_Response( $this->prepare_item( $block ), WP_Http::OK );
+		}
+
+		return $this->validate_and_save( $candidate, $block );
+	}
+
+	/**
+	 * Remove a single variant from a block (DELETE /variants/{block}/{variant}).
+	 *
+	 * Drops the stored override for that variant; a variant that also exists in the baseline reverts to its
+	 * baseline definition. Idempotent: a no-op when nothing is stored for the variant. The `$default` is
+	 * managed through the dedicated sub-route, so deleting "default" here is rejected; and removing a
+	 * variant the effective set still defaults to is rejected (HTTP 422) before commit.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_variant( $request ) {
+		$block = $this->block_from( $request );
+		$error = $this->guard_block( $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$variant = Cast::to_string( $request->get_param( self::VARIANT_PARAM ) );
+
+		if ( $variant === self::DEFAULT_ROUTE ) {
+			return new WP_Error(
+				'rest_design_tokens_invalid',
+				__( 'The default variant is managed through the default sub-route.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::BAD_REQUEST,
+					'block'  => $block,
+				]
+			);
+		}
+
+		$stored    = $this->stored_document();
+		$candidate = $this->unset_variant( $stored, $block, $variant );
+
+		if ( $candidate === $stored ) {
+			return new WP_REST_Response( $this->prepare_item( $block ), WP_Http::OK );
+		}
+
+		$error = $this->guard_default_present( $candidate, $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		return $this->validate_and_save( $candidate, $block );
+	}
+
+	/**
 	 * Read a block's default variant slug (GET /variants/{block}/default).
 	 *
 	 * @since TBD
@@ -271,6 +589,42 @@ final class Variants_Controller extends Controller {
 			],
 			WP_Http::OK
 		);
+	}
+
+	/**
+	 * Set a block's default variant slug (PUT /variants/{block}/default).
+	 *
+	 * The default must name a variant the effective set defines, otherwise the write is rejected (HTTP 422)
+	 * before commit.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function set_default( $request ) {
+		$block = $this->block_from( $request );
+		$error = $this->guard_block( $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$default = Cast::to_string( $request->get_param( self::DEFAULT_PARAM ) );
+
+		$candidate = $this->mutator->merge(
+			$this->stored_document(),
+			$this->partial( $block, [ Extensions::get_default_key() => $default ] )
+		);
+
+		$error = $this->guard_default_present( $candidate, $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		return $this->validate_and_save( $candidate, $block );
 	}
 
 	/**
@@ -355,6 +709,88 @@ final class Variants_Controller extends Controller {
 	}
 
 	/**
+	 * Run the shared write pipeline against a candidate document, then commit it.
+	 *
+	 * Validates the DTCG grammar (HTTP 422 on failure), dry-runs the Resolver to reject alias cycles /
+	 * dangling aliases in the token layers before commit (HTTP 422), then persists. An empty candidate
+	 * clears the overrides, so the set renders from baseline, and needs no validation.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $candidate The full candidate overrides document to validate and store.
+	 * @param string               $block     The block being written, for error context.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	private function validate_and_save( array $candidate, string $block ) {
+		$slug = Token_Store::default_slug();
+
+		// A brand-new set has no version yet; report 201 Created rather than 200 OK on first write.
+		$status = $this->store->get_version( $slug ) !== '' ? WP_Http::OK : WP_Http::CREATED;
+
+		if ( $candidate === [] ) {
+			return $this->persist( '', $block, $status );
+		}
+
+		$result = $this->validator->validate( $candidate, Dtcg_Validator::get_context_overrides() );
+
+		if ( ! $result->is_valid() ) {
+			return new WP_Error(
+				'rest_design_tokens_invalid',
+				__( 'The design token document failed validation.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::UNPROCESSABLE_ENTITY,
+					'block'  => $block,
+					'errors' => $result->to_array(),
+				]
+			);
+		}
+
+		try {
+			$this->resolver->resolve_overrides( $candidate );
+		} catch ( Alias_Cycle_Exception | Dangling_Alias_Exception $e ) {
+			return new WP_Error(
+				'rest_design_tokens_unresolvable',
+				$e->getMessage(),
+				[
+					'status' => WP_Http::UNPROCESSABLE_ENTITY,
+					'block'  => $block,
+				]
+			);
+		}
+
+		return $this->persist( (string) wp_json_encode( $candidate ), $block, $status );
+	}
+
+	/**
+	 * Commit a raw document string to the store and build the response, mapping a write failure to 500.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $document The raw overrides-only DTCG JSON (empty string clears the set).
+	 * @param string $block    The block being written.
+	 * @param int    $status   The success status code.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	private function persist( string $document, string $block, int $status ) {
+		try {
+			$this->store->save_document( $document, Token_Store::default_slug() );
+		} catch ( DatabaseQueryException $e ) {
+			return new WP_Error(
+				'rest_design_tokens_save_failed',
+				__( 'The design token set could not be saved.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::INTERNAL_SERVER_ERROR,
+					'block'  => $block,
+				]
+			);
+		}
+
+		return new WP_REST_Response( $this->prepare_item( $block ), $status );
+	}
+
+	/**
 	 * Reject a request for a block that has no registered variant set.
 	 *
 	 * @since TBD
@@ -379,6 +815,93 @@ final class Variants_Controller extends Controller {
 	}
 
 	/**
+	 * Reject a variant map whose entries are not well-formed: each named variant must have a non-empty
+	 * slug and be an object, its label (when present) a string and its tokens (when present) an object. The
+	 * alias-or-literal grammar of the token values is left to the DTCG validator.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $block_node The block's variant node being written.
+	 * @param string               $block      The block name, for error context.
+	 *
+	 * @return WP_Error|null A WP_Error when a variant entry is malformed, null otherwise.
+	 */
+	private function guard_variant_shape( array $block_node, string $block ): ?WP_Error {
+		foreach ( $block_node as $slug => $variant ) {
+			// $default and any other "$"-prefixed metadata key is not a named variant.
+			if ( is_string( $slug ) && strpos( $slug, '$' ) === 0 ) {
+				continue;
+			}
+
+			// An empty slug would create a variant keyed by "" — a malformed node, the variant analogue of
+			// the empty dot-path segment the documents controller rejects. Refuse it before it is stored.
+			if ( (string) $slug === '' ) {
+				return new WP_Error(
+					'rest_design_tokens_invalid',
+					__( 'A variant slug cannot be empty.', 'kadence-blocks' ),
+					[
+						'status' => WP_Http::UNPROCESSABLE_ENTITY,
+						'block'  => $block,
+					]
+				);
+			}
+
+			$label_key  = Extensions::get_label_key();
+			$tokens_key = Extensions::get_tokens_key();
+
+			if (
+				! is_array( $variant )
+				|| ( isset( $variant[ $label_key ] ) && ! is_string( $variant[ $label_key ] ) )
+				|| ( isset( $variant[ $tokens_key ] ) && ! is_array( $variant[ $tokens_key ] ) )
+			) {
+				return new WP_Error(
+					'rest_design_tokens_invalid',
+					__( 'Each variant must be an object with an optional string label and a token map.', 'kadence-blocks' ),
+					[
+						'status'  => WP_Http::UNPROCESSABLE_ENTITY,
+						'block'   => $block,
+						'variant' => (string) $slug,
+					]
+				);
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Reject a candidate whose effective `$default` does not name a present variant.
+	 *
+	 * Evaluated against the post-merge effective set (baseline merged with the candidate), so a default that
+	 * resolves to a baseline variant is accepted and one left dangling by a removal is rejected.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $candidate The candidate overrides document.
+	 * @param string               $block     The block name.
+	 *
+	 * @return WP_Error|null A WP_Error when the default is dangling, null otherwise.
+	 */
+	private function guard_default_present( array $candidate, string $block ): ?WP_Error {
+		$node    = $this->variants->for_overrides( $candidate )[ $block ] ?? [];
+		$default = $this->default_of( is_array( $node ) ? $node : [] );
+
+		if ( $default === '' || in_array( $default, $this->variant_names( is_array( $node ) ? $node : [] ), true ) ) {
+			return null;
+		}
+
+		return new WP_Error(
+			'rest_design_tokens_invalid',
+			__( 'The default variant must name an existing variant.', 'kadence-blocks' ),
+			[
+				'status'  => WP_Http::UNPROCESSABLE_ENTITY,
+				'block'   => $block,
+				'default' => $default,
+			]
+		);
+	}
+
+	/**
 	 * Build the response payload for a block's variant set, read from the effective (baseline-merged) set.
 	 *
 	 * @since TBD
@@ -397,6 +920,136 @@ final class Variants_Controller extends Controller {
 			'version'  => $this->store->get_version( $slug ),
 			'default'  => $this->default_of( $node ),
 			'variants' => $this->named_variants( $node ),
+		];
+	}
+
+	/**
+	 * Assemble the variant definition for a create from the request: an optional label plus the token map.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function variant_definition( WP_REST_Request $request ): array {
+		$definition = [];
+
+		$label = Cast::to_string( $request->get_param( self::LABEL_PARAM ) );
+
+		if ( $label !== '' ) {
+			$definition[ Extensions::get_label_key() ] = $label;
+		}
+
+		$tokens = $request->get_param( self::TOKENS_PARAM );
+
+		$definition[ Extensions::get_tokens_key() ] = is_array( $tokens ) ? $tokens : [];
+
+		return $definition;
+	}
+
+	/**
+	 * Build a partial overrides document carrying only the given variant node for one block.
+	 *
+	 * @since TBD
+	 *
+	 * @param string               $block      The block name.
+	 * @param array<string, mixed> $block_node The block's variant node.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function partial( string $block, array $block_node ): array {
+		return [
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					Extensions::get_section_variants() => [
+						$block => $block_node,
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Remove the stored `variants.<block>` node, pruning any ancestor emptied by the removal.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document The stored overrides document.
+	 * @param string               $block    The block name.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function unset_block( array $document, string $block ): array {
+		return $this->unset_path( $document, array_merge( $this->variants_path(), [ $block ] ) );
+	}
+
+	/**
+	 * Remove the stored `variants.<block>.<variant>` node, pruning any ancestor emptied by the removal.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document The stored overrides document.
+	 * @param string               $block    The block name.
+	 * @param string               $variant  The variant slug.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function unset_variant( array $document, string $block, string $variant ): array {
+		return $this->unset_path( $document, array_merge( $this->variants_path(), [ $block, $variant ] ) );
+	}
+
+	/**
+	 * Recursively remove a node addressed by literal keys, pruning emptied ancestor groups on the way out.
+	 *
+	 * Addresses the document by discrete array keys rather than a dot-path, because the keys themselves
+	 * carry dots ("com.kadence.designTokens") and slashes ("kadence/advancedbtn").
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $node The current node.
+	 * @param string[]             $keys The remaining literal keys to the node to remove.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function unset_path( array $node, array $keys ): array {
+		$head = (string) array_shift( $keys );
+
+		if ( ! array_key_exists( $head, $node ) ) {
+			return $node;
+		}
+
+		if ( $keys === [] ) {
+			unset( $node[ $head ] );
+
+			return $node;
+		}
+
+		if ( ! is_array( $node[ $head ] ) ) {
+			return $node;
+		}
+
+		$node[ $head ] = $this->unset_path( $node[ $head ], $keys );
+
+		if ( $node[ $head ] === [] ) {
+			unset( $node[ $head ] );
+		}
+
+		return $node;
+	}
+
+	/**
+	 * The literal key path to the variants section.
+	 *
+	 * @since TBD
+	 *
+	 * @return string[]
+	 */
+	private function variants_path(): array {
+		return [
+			Extensions::get_extensions_key(),
+			Extensions::get_namespace(),
+			Extensions::get_section_variants(),
 		];
 	}
 
@@ -460,6 +1113,25 @@ final class Variants_Controller extends Controller {
 	}
 
 	/**
+	 * Decode the stored overrides-only document for the default set.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed> The decoded document, empty when absent or unreadable.
+	 */
+	private function stored_document(): array {
+		$raw = $this->store->get_document( Token_Store::default_slug() );
+
+		if ( $raw === '' ) {
+			return [];
+		}
+
+		$decoded = json_decode( $raw, true );
+
+		return is_array( $decoded ) ? $decoded : [];
+	}
+
+	/**
 	 * Reassemble the block name from its two captured path segments.
 	 *
 	 * @since TBD
@@ -498,5 +1170,112 @@ final class Variants_Controller extends Controller {
 				'sanitize_callback' => 'sanitize_key',
 			],
 		];
+	}
+
+	/**
+	 * The arguments accepted by the single-variant route: the block segments plus the variant slug.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_variant_params(): array {
+		return array_merge(
+			$this->get_block_params(),
+			[
+				self::VARIANT_PARAM => [
+					'description'       => __( 'The variant slug.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => true,
+					'pattern'           => '^[\w-]+$',
+					'sanitize_callback' => 'sanitize_key',
+				],
+			]
+		);
+	}
+
+	/**
+	 * The arguments accepted by the create route: the block segments plus a variant slug, optional label and
+	 * its token map.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_create_params(): array {
+		return array_merge(
+			$this->get_block_params(),
+			[
+				self::VARIANT_PARAM => [
+					'description'       => __( 'The variant slug to create or merge.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => true,
+					'pattern'           => '^[\w-]+$',
+					'sanitize_callback' => 'sanitize_key',
+				],
+				self::LABEL_PARAM   => [
+					'description'       => __( 'Optional human-readable label for the variant.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => false,
+					'sanitize_callback' => 'sanitize_text_field',
+				],
+				self::TOKENS_PARAM  => [
+					'description'          => __( 'The variant\'s property => alias-or-literal token map.', 'kadence-blocks' ),
+					'type'                 => 'object',
+					'required'             => false,
+					'additionalProperties' => true,
+				],
+			]
+		);
+	}
+
+	/**
+	 * The arguments accepted by the replace route: the block segments plus the whole variant map and an
+	 * optional default.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_replace_params(): array {
+		return array_merge(
+			$this->get_block_params(),
+			[
+				self::VARIANTS_PARAM => [
+					'description'          => __( 'The variants to store, keyed by slug.', 'kadence-blocks' ),
+					'type'                 => 'object',
+					'required'             => true,
+					'additionalProperties' => true,
+				],
+				self::DEFAULT_PARAM  => [
+					'description'       => __( 'Optional default variant slug.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => false,
+					'sanitize_callback' => 'sanitize_key',
+				],
+			]
+		);
+	}
+
+	/**
+	 * The arguments accepted by the set-default route: the block segments plus the default variant slug.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_default_params(): array {
+		return array_merge(
+			$this->get_block_params(),
+			[
+				self::DEFAULT_PARAM => [
+					'description'       => __( 'The default variant slug.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => true,
+					'pattern'           => '^[\w-]+$',
+					'sanitize_callback' => 'sanitize_key',
+				],
+			]
+		);
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
@@ -15,8 +15,8 @@ use WP_REST_Response;
 use WP_REST_Server;
 
 /**
- * Covers the read surface of the Design Tokens variants controller: the registered read routes and the
- * baseline-merged reads against the real shipped baseline.
+ * Covers the read and write surface of the Design Tokens variants controller: the registered routes, the
+ * baseline-merged reads, and the per-block / per-variant / default writes against the real shipped baseline.
  */
 final class VariantsControllerTest extends TestCase {
 
@@ -72,12 +72,14 @@ final class VariantsControllerTest extends TestCase {
 		$base          = $this->controller_rest_base();
 		$block_route   = $this->controller_constant( 'BLOCK_ROUTE' );
 		$default_route = $this->controller_constant( 'DEFAULT_ROUTE' );
+		$variant_route = $this->controller_constant( 'VARIANT_ROUTE' );
 
 		$collection = "/$namespace/$base";
 		$block      = "/$namespace/$base/$block_route";
 		$default    = "/$namespace/$base/$block_route/$default_route";
+		$variant    = "/$namespace/$base/$block_route/$variant_route";
 
-		foreach ( [ $collection, $block, $default ] as $route ) {
+		foreach ( [ $collection, $block, $default, $variant ] as $route ) {
 			$this->assertArrayHasKey( $route, $this->rest_server->get_routes(), "Route $route should be registered." );
 
 			$options = $this->rest_server->get_route_options( $route );
@@ -85,14 +87,16 @@ final class VariantsControllerTest extends TestCase {
 			$this->assertIsCallable( $options['schema'] );
 		}
 
-		// The block route declares both block path segments.
+		// The block route declares both block path segments and accepts the full CRUD verb set.
 		$this->assertArrayHasKey( $this->controller_constant( 'VENDOR_PARAM' ), $this->rest_server->get_routes()[ $block ][0]['args'] );
 		$this->assertArrayHasKey( $this->controller_constant( 'BLOCK_NAME_PARAM' ), $this->rest_server->get_routes()[ $block ][0]['args'] );
 
-		// Every read route is reachable through GET.
-		foreach ( [ $collection, $block, $default ] as $route ) {
-			$this->assertContains( 'GET', $this->route_methods( $route ), "Route $route should accept GET." );
+		foreach ( [ 'GET', 'POST', 'PUT', 'DELETE' ] as $method ) {
+			$this->assertContains( $method, $this->route_methods( $block ), "Block route should accept $method." );
 		}
+
+		$this->assertContains( 'DELETE', $this->route_methods( $variant ) );
+		$this->assertContains( 'PUT', $this->route_methods( $default ) );
 	}
 
 	/**
@@ -156,11 +160,295 @@ final class VariantsControllerTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testCreateMergesASingleVariantPreservingSiblingsAndDefault(): void {
+		$response = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'variant' => 'outline',
+					'label'   => 'Outline',
+					'tokens'  => [ 'button-bg' => 'transparent' ],
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		// First write to the set reports 201 Created.
+		$this->assertSame( WP_Http::CREATED, $response->get_status() );
+
+		$data = $response->get_data();
+
+		// The new variant lands while the baseline siblings and the default survive.
+		$this->assertArrayHasKey( 'outline', $data['variants'] );
+		$this->assertArrayHasKey( 'primary', $data['variants'] );
+		$this->assertArrayHasKey( 'ghost', $data['variants'] );
+		$this->assertSame( 'primary', $data['default'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCreateRequiresAVariantSlug(): void {
+		$result = $this->controller->create_item(
+			$this->block_request( WP_REST_Server::CREATABLE, self::BUTTON, [ 'tokens' => [ 'button-bg' => 'transparent' ] ] )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::BAD_REQUEST, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testUpdateReplacesTheStoredVariantSet(): void {
+		// Seed two override-only variants, then PUT a set that keeps only one of them.
+		$this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'variant' => 'outline',
+					'tokens'  => [ 'button-bg' => 'transparent' ],
+				] 
+			)
+		);
+		$this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'variant' => 'dashed',
+					'tokens'  => [ 'button-bg' => 'transparent' ],
+				] 
+			)
+		);
+
+		$response = $this->controller->update_item(
+			$this->block_request(
+				'PUT',
+				self::BUTTON,
+				[ 'variants' => [ 'outline' => [ 'tokens' => [ 'button-bg' => 'transparent' ] ] ] ]
+			)
+		);
+
+		$data = $response->get_data();
+
+		// The override "dashed" is dropped; "outline" survives. Baseline variants always remain visible.
+		$this->assertArrayNotHasKey( 'dashed', $data['variants'] );
+		$this->assertArrayHasKey( 'outline', $data['variants'] );
+		$this->assertArrayHasKey( 'primary', $data['variants'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeleteItemResetsTheBlockToBaseline(): void {
+		$this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'variant' => 'outline',
+					'tokens'  => [ 'button-bg' => 'transparent' ],
+				] 
+			)
+		);
+
+		$response = $this->controller->delete_item( $this->block_request( WP_REST_Server::DELETABLE, self::BUTTON ) );
+
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$data = $response->get_data();
+
+		// The override is gone; the block renders its baseline variants again.
+		$this->assertArrayNotHasKey( 'outline', $data['variants'] );
+		$this->assertArrayHasKey( 'primary', $data['variants'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeleteVariantRemovesAnOverrideVariant(): void {
+		$this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'variant' => 'outline',
+					'tokens'  => [ 'button-bg' => 'transparent' ],
+				] 
+			)
+		);
+
+		$response = $this->controller->delete_variant( $this->variant_request( self::BUTTON, 'outline' ) );
+
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertArrayNotHasKey( 'outline', $response->get_data()['variants'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeleteVariantIsAnIdempotentNoOpWhenAbsent(): void {
+		$this->store->save_document(
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/advancedbtn":{'
+			. '"outline":{"tokens":{"button-bg":"transparent"}}}}}}}'
+		);
+
+		$version_before = $this->store->get_version( Token_Store::default_slug() );
+
+		$response = $this->controller->delete_variant( $this->variant_request( self::BUTTON, 'never-stored' ) );
+
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		// Nothing was removed, so no write happened and the version is unchanged.
+		$this->assertSame( $version_before, $this->store->get_version( Token_Store::default_slug() ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeletingTheDefaultVariantIsRejected(): void {
+		// Make an override-only variant the default, then try to delete it out from under the default.
+		$this->controller->update_item(
+			$this->block_request(
+				'PUT',
+				self::BUTTON,
+				[
+					'variants' => [ 'outline' => [ 'tokens' => [ 'button-bg' => 'transparent' ] ] ],
+					'default'  => 'outline',
+				]
+			)
+		);
+
+		$result = $this->controller->delete_variant( $this->variant_request( self::BUTTON, 'outline' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSetDefaultToAnExistingVariant(): void {
+		$response = $this->controller->set_default( $this->default_request( self::BUTTON, 'secondary' ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( 'secondary', $response->get_data()['default'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSetDefaultToAMissingVariantIsRejected(): void {
+		$result = $this->controller->set_default( $this->default_request( self::BUTTON, 'does-not-exist' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testGetDefaultReadsTheDefault(): void {
 		$data = $this->controller->get_default( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) )->get_data();
 
 		$this->assertSame( self::BUTTON, $data['block'] );
 		$this->assertSame( 'primary', $data['default'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAnInvalidVariantTokenValueReturns422(): void {
+		// An empty-string token value is neither an alias nor a non-empty literal; the DTCG validator rejects it.
+		$result = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'variant' => 'broken',
+					'tokens'  => [ 'button-bg' => '' ],
+				] 
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+		$this->assertNotEmpty( $result->get_error_data()['errors'] );
+		// The write was rejected before commit.
+		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAMalformedVariantShapeReturns422(): void {
+		$result = $this->controller->update_item(
+			$this->block_request( 'PUT', self::BUTTON, [ 'variants' => [ 'bad' => 'not-an-object' ] ] )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAnEmptyVariantSlugIsRejected(): void {
+		// An empty key in the variants map would store a variant node keyed by "" — reject it, mirroring the
+		// documents controller's empty dot-path-segment guard.
+		$result = $this->controller->update_item(
+			$this->block_request( 'PUT', self::BUTTON, [ 'variants' => [ '' => [ 'tokens' => [ 'button-bg' => 'transparent' ] ] ] ] )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testWritesAreDeniedToUsersWithoutTheCapability(): void {
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'subscriber' ] ) );
+
+		$request = new WP_REST_Request( WP_REST_Server::CREATABLE );
+
+		$this->assertInstanceOf( WP_Error::class, $this->controller->create_item_permissions_check( $request ) );
+		$this->assertInstanceOf( WP_Error::class, $this->controller->update_item_permissions_check( $request ) );
+		$this->assertInstanceOf( WP_Error::class, $this->controller->delete_item_permissions_check( $request ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAWriteBumpsTheVersion(): void {
+		$this->store->save_document(
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/advancedbtn":{'
+			. '"outline":{"tokens":{"button-bg":"transparent"}}}}}}}'
+		);
+
+		$version_before = $this->store->get_version( Token_Store::default_slug() );
+
+		$this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'variant' => 'dashed',
+					'tokens'  => [ 'button-bg' => 'transparent' ],
+				] 
+			)
+		);
+
+		$this->assertNotSame( $version_before, $this->store->get_version( Token_Store::default_slug() ) );
 	}
 
 	/**
@@ -185,6 +473,30 @@ final class VariantsControllerTest extends TestCase {
 		}
 
 		return $request;
+	}
+
+	/**
+	 * Build a single-variant request: the block segments plus the variant slug.
+	 *
+	 * @param string $block   The block name.
+	 * @param string $variant The variant slug.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function variant_request( string $block, string $variant ): WP_REST_Request {
+		return $this->block_request( WP_REST_Server::DELETABLE, $block, [ 'variant' => $variant ] );
+	}
+
+	/**
+	 * Build a set-default request: the block segments plus the default variant slug.
+	 *
+	 * @param string $block        The block name.
+	 * @param string $default_slug The default variant slug.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function default_request( string $block, string $default_slug ): WP_REST_Request {
+		return $this->block_request( 'PUT', $block, [ 'default' => $default_slug ] );
 	}
 
 	/**


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3390/variant-readwrite-endpoints

Fourth of four stacked PRs. Based on `feature/SOFT-3390/variants-3-read-endpoints`.

Adds the write surface to `Variants_Controller`:

- POST creates or merges a single variant, leaving siblings and `$default` intact.
- PUT replaces a block's whole variant set, dropping any variant absent from the body.
- DELETE on a block resets it to baseline; DELETE on a variant removes that one variant.
- A `default` sub-route gets and sets the block's default.

Writes assemble a partial overrides document for the addressed variants node, deep-merge it onto the stored set, then run the shared pipeline: DTCG grammar validation (HTTP 422), a dry-run Resolver pass that rejects alias cycles and dangling aliases (HTTP 422), then a single `Token_Store::save_document()` that bumps the version. Empty variant slugs are rejected, and a `$default` that does not name a present variant is rejected before commit. Resolved/preview values stay out of scope here, owned by the projector tickets `SOFT-3394` / `SOFT-3395`.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
