### PR TITLE
[DTM][1/3] SOFT-3384: shared Kadence_Palette_Slot value object

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Css_Var/Legacy_Filter_Bridge.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Legacy_Filter_Bridge.php
@@ -3,6 +3,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Palette_Slot;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use RuntimeException;
@@ -95,10 +96,10 @@ final class Legacy_Filter_Bridge {
 			return $colors;
 		}
 
-		foreach ( $this->registry->by_projection( self::SLOT ) as $id => $token ) {
-			$slot = $token->projections[ self::SLOT ] ?? null;
-			if ( ! is_string( $slot ) || preg_match( '/^palette[1-9]$/', $slot ) !== 1 ) {
-				continue;
+		foreach ( $this->registry->by_projection( Kadence_Palette_Slot::get_projection_key() ) as $id => $token ) {
+			$slot = Kadence_Palette_Slot::from_token( $token );
+			if ( $slot === null ) {
+				continue; // not a palette slot (e.g. a font-size kadence_slot) — leave to font_sizes().
 			}
 
 			$value = $resolved->value( $id );
@@ -106,10 +107,9 @@ final class Legacy_Filter_Bridge {
 				continue;
 			}
 
-			// Point the slot at the token var so blocks react to variant overrides, with the
-			// resolved literal as a fallback for preview iframes that build their own palette
-			// CSS without the token definitions.
-			$colors[ '--global-' . $slot ] = sprintf( 'var(%s, %s)', $token->css_var, $value );
+			// Point the slot at the token var so blocks react to variant overrides, with the resolved
+			// literal as a fallback for preview iframes that build their own palette CSS.
+			$colors[ '--global-' . $slot->slug ] = sprintf( 'var(%s, %s)', $token->css_var, $value );
 		}
 
 		return $colors;

--- a/includes/resources/Design_Tokens/Projection/Kadence_Palette_Slot.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Palette_Slot.php
@@ -82,10 +82,8 @@ final class Kadence_Palette_Slot {
 	 * @return self|null
 	 */
 	public static function from_token( Token_Definition $token ): ?self {
-		if ( ! $token->has_projection( self::PROJECTION ) ) {
-			return null;
-		}
-
+		// A missing projection (?? null), a non-string value, and a string that is not palette1…palette9
+		// all collapse to "not a palette slot" here, so no separate has_projection() guard is needed.
 		$slot = $token->projections[ self::PROJECTION ] ?? null;
 
 		if ( ! is_string( $slot ) || preg_match( self::SLOT_PATTERN, $slot ) !== 1 ) {

--- a/includes/resources/Design_Tokens/Projection/Kadence_Palette_Slot.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Palette_Slot.php
@@ -1,0 +1,97 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette .
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Definition;
+
+/**
+ * Normalizes a token's "kadence_slot" projection into a Kadence color-palette slot.
+ *
+ * The Kadence ecosystem keys nine color slots palette1…palette9. That slug is the identifier in BOTH
+ * KB's own kadence_blocks_colors option AND the Kadence theme's kadence_global_palette option, and is
+ * also the suffix of the --global-paletteN CSS variable. Both the Css_Var legacy bridge (which rewrites
+ * the --global-paletteN filter on non-Kadence sites) and the Kadence_Option projector (which writes the
+ * two palette options) resolve through this one class, so the slot they target can never drift.
+ *
+ * A token opts in with a bare slug string under "kadence_slot":
+ *
+ *   'kadence_slot' => 'palette1'   // semantic.color.button-bg => slot "palette1"
+ *
+ * Font-size slots (sm/md/lg/…) also travel under "kadence_slot" but are NOT palette slots; from_token()
+ * returns null for them, so callers that only care about colors skip them cleanly.
+ *
+ * @since TBD
+ */
+final class Kadence_Palette_Slot {
+
+	/**
+	 * The projection key a token declares to claim a Kadence slot.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const PROJECTION = 'kadence_slot';
+
+	/**
+	 * Matches the nine Kadence palette slots, palette1…palette9.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const SLOT_PATTERN = '/^palette[1-9]$/';
+
+	/**
+	 * The palette slot slug, e.g. "palette1". This is the entry slug in both palette options and the
+	 * suffix of --global-paletteN.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public string $slug;
+
+	/**
+	 * @param string $slug Palette slot slug (palette1…palette9).
+	 */
+	private function __construct( string $slug ) {
+		$this->slug = $slug;
+	}
+
+	/**
+	 * The projection key.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_projection_key(): string {
+		return self::PROJECTION;
+	}
+
+	/**
+	 * Resolve a token's kadence_slot config to a palette slot, or null when the token declares no
+	 * kadence_slot, or declares one that is not a palette slot (e.g. a font-size key).
+	 *
+	 * @since TBD
+	 *
+	 * @param Token_Definition $token The token definition.
+	 *
+	 * @return self|null
+	 */
+	public static function from_token( Token_Definition $token ): ?self {
+		if ( ! $token->has_projection( self::PROJECTION ) ) {
+			return null;
+		}
+
+		$slot = $token->projections[ self::PROJECTION ] ?? null;
+
+		if ( ! is_string( $slot ) || preg_match( self::SLOT_PATTERN, $slot ) !== 1 ) {
+			return null;
+		}
+
+		return new self( $slot );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Palette_SlotTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Palette_SlotTest.php
@@ -27,14 +27,14 @@ final class Kadence_Palette_SlotTest extends TestCase {
 	public function testFromTokenReturnsPaletteSlotForPalette1(): void {
 		$slot = Kadence_Palette_Slot::from_token( $this->token( [ 'kadence_slot' => 'palette1' ] ) );
 
-		$this->assertNotNull( $slot );
+		$this->assertInstanceOf( Kadence_Palette_Slot::class, $slot );
 		$this->assertSame( 'palette1', $slot->slug );
 	}
 
 	public function testFromTokenReturnsPaletteSlotForPalette9(): void {
 		$slot = Kadence_Palette_Slot::from_token( $this->token( [ 'kadence_slot' => 'palette9' ] ) );
 
-		$this->assertNotNull( $slot );
+		$this->assertInstanceOf( Kadence_Palette_Slot::class, $slot );
 		$this->assertSame( 'palette9', $slot->slug );
 	}
 
@@ -44,6 +44,19 @@ final class Kadence_Palette_SlotTest extends TestCase {
 
 	public function testFromTokenReturnsNullForPalette10(): void {
 		$this->assertNull( Kadence_Palette_Slot::from_token( $this->token( [ 'kadence_slot' => 'palette10' ] ) ) );
+	}
+
+	public function testFromTokenReturnsNullForPaletteWithoutDigit(): void {
+		$this->assertNull( Kadence_Palette_Slot::from_token( $this->token( [ 'kadence_slot' => 'palette' ] ) ) );
+	}
+
+	public function testFromTokenReturnsNullForEmptyString(): void {
+		$this->assertNull( Kadence_Palette_Slot::from_token( $this->token( [ 'kadence_slot' => '' ] ) ) );
+	}
+
+	public function testFromTokenReturnsNullForUppercaseSlot(): void {
+		// The slot pattern is case-sensitive: the stored slug must be lowercase palette1…palette9.
+		$this->assertNull( Kadence_Palette_Slot::from_token( $this->token( [ 'kadence_slot' => 'Palette1' ] ) ) );
 	}
 
 	public function testFromTokenReturnsNullForFontSizeKey(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Palette_SlotTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Palette_SlotTest.php
@@ -1,0 +1,60 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Projection;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Palette_Slot;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Definition;
+use Tests\Support\Classes\TestCase;
+
+final class Kadence_Palette_SlotTest extends TestCase {
+
+	private function token( array $projections ): Token_Definition {
+		return Token_Definition::from_array(
+			[
+				'id'          => 'semantic.color.button-bg',
+				'type'        => 'color',
+				'label'       => 'Button Background',
+				'projections' => $projections,
+			]
+		);
+	}
+
+	public function testGetProjectionKeyReturnsPaletteSlotKey(): void {
+		$this->assertSame( 'kadence_slot', Kadence_Palette_Slot::get_projection_key() );
+	}
+
+	public function testFromTokenReturnsPaletteSlotForPalette1(): void {
+		$slot = Kadence_Palette_Slot::from_token( $this->token( [ 'kadence_slot' => 'palette1' ] ) );
+
+		$this->assertNotNull( $slot );
+		$this->assertSame( 'palette1', $slot->slug );
+	}
+
+	public function testFromTokenReturnsPaletteSlotForPalette9(): void {
+		$slot = Kadence_Palette_Slot::from_token( $this->token( [ 'kadence_slot' => 'palette9' ] ) );
+
+		$this->assertNotNull( $slot );
+		$this->assertSame( 'palette9', $slot->slug );
+	}
+
+	public function testFromTokenReturnsNullForPalette0(): void {
+		$this->assertNull( Kadence_Palette_Slot::from_token( $this->token( [ 'kadence_slot' => 'palette0' ] ) ) );
+	}
+
+	public function testFromTokenReturnsNullForPalette10(): void {
+		$this->assertNull( Kadence_Palette_Slot::from_token( $this->token( [ 'kadence_slot' => 'palette10' ] ) ) );
+	}
+
+	public function testFromTokenReturnsNullForFontSizeKey(): void {
+		$this->assertNull( Kadence_Palette_Slot::from_token( $this->token( [ 'kadence_slot' => 'md' ] ) ) );
+	}
+
+	public function testFromTokenReturnsNullForNonStringValue(): void {
+		$this->assertNull( Kadence_Palette_Slot::from_token( $this->token( [ 'kadence_slot' => 1 ] ) ) );
+	}
+
+	public function testFromTokenReturnsNullWhenNoKadenceSlotProjection(): void {
+		$this->assertNull( Kadence_Palette_Slot::from_token( $this->token( [ 'wp_preset' => 'color' ] ) ) );
+	}
+}


### PR DESCRIPTION
**Stacked PR 1 of 3** — base: `SOFT-3384/option-projector`. Review only this phase's diff.

Extracts the Kadence palette-slot parsing (`palette1`…`palette9`) into a shared `Kadence_Palette_Slot` value object and refactors `Css_Var\Legacy_Filter_Bridge::global_colors()` to consume it — so the legacy bridge and the upcoming `Kadence_Option` projector can never disagree on what counts as a palette slot or how it maps to a slug.

Pure refactor: no behavior change; existing bridge tests stay green. New unit test covers the value object.