### PR TITLE
[DTM][2/3] SOFT-3384: pure Palette_Builder

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Palette_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Palette_Builder.php
@@ -10,11 +10,17 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Resolved_Tokens;
 /**
  * Pure builder for the two palette options the Kadence_Option projector writes.
  *
- * Produces a slot => resolved-hex map from every token that declares a palette kadence_slot, then
- * MERGES that map onto a decoded existing option payload — overwriting only the color of token-claimed
- * slots, keyed by slug, and preserving every other entry, key and flag (e.g. kadence_blocks_colors'
- * "override"). No WordPress calls, no globals, no I/O: the projector owns get_option/update_option and
- * hands decoded arrays in and takes decoded arrays out.
+ * Produces a slug => { color, name } map from every token that claims a palette kadence_slot and
+ * resolves to a value, then merges that map onto a decoded existing option. No WordPress calls, no
+ * globals, no I/O: the projector owns get_option/update_option and hands decoded arrays in and out, so
+ * every merge rule here is unit-testable without the database.
+ *
+ * The two options have deliberately different merge rules:
+ *
+ *   - kadence_blocks_colors (KB's own) — overwrite color AND name of a claimed slug, append a claimed
+ *     slug not yet present, and preserve every other entry plus the "override" flag.
+ *   - kadence_global_palette (the theme's) — overwrite ONLY color of a claimed slug; never append and
+ *     never touch names, since the theme owns the slot labels and structure.
  *
  * @since TBD
  */
@@ -37,14 +43,21 @@ final class Palette_Builder {
 	}
 
 	/**
-	 * Whether any token claims a palette slot — the early-bail gate.
+	 * Whether any token claims a palette slot — the value-independent, in-memory gate the projector
+	 * checks before resolving (resolution is the expensive step).
 	 *
 	 * @since TBD
 	 *
 	 * @return bool
 	 */
 	public function has_palette_tokens(): bool {
-		return $this->slugged( $this->registry ) !== [];
+		foreach ( $this->registry->by_projection( Kadence_Palette_Slot::get_projection_key() ) as $token ) {
+			if ( Kadence_Palette_Slot::from_token( $token ) !== null ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -81,11 +94,12 @@ final class Palette_Builder {
 	}
 
 	/**
-	 * Merge token entries into a decoded kadence_blocks_colors payload.
+	 * Merge token entries into a decoded kadence_blocks_colors payload (KB's own option).
 	 *
-	 * Overwrites the color of any palette entry whose slug a token claims (and refreshes its name);
-	 * appends an entry for a claimed slug not yet present; preserves all other entries and the
-	 * "override" flag. Entry shape is { color, name, slug } — exactly what KB's consumers read.
+	 * Overwrites the color and name of any entry whose slug a token claims, appends an entry for a
+	 * claimed slug not yet present, and preserves all other entries plus the "override" flag (defaulting
+	 * it to false on a fresh write so KB merges rather than replaces the theme palette). Entry shape is
+	 * { color, name, slug } — exactly what KB's consumers read.
 	 *
 	 * @since TBD
 	 *
@@ -95,14 +109,39 @@ final class Palette_Builder {
 	 * @return array<string, mixed> The merged payload (re-encode and store).
 	 */
 	public function merge_kb_colors( array $existing, array $entries ): array {
-		$palette = isset( $existing['palette'] ) && is_array( $existing['palette'] ) ? $existing['palette'] : [];
+		$palette = $this->palette_list( $existing );
+		$claimed = [];
 
-		$palette = $this->apply( $palette, $entries, true /* append unclaimed */ );
+		foreach ( $palette as $index => $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$slug = $this->entry_slug( $entry );
+			if ( $slug === null || ! isset( $entries[ $slug ] ) ) {
+				continue;
+			}
+
+			$entry['color']    = $entries[ $slug ]['color'];
+			$entry['name']     = $entries[ $slug ]['name'];
+			$palette[ $index ] = $entry;
+			$claimed[ $slug ]  = true;
+		}
+
+		foreach ( $entries as $slug => $data ) {
+			if ( isset( $claimed[ $slug ] ) ) {
+				continue;
+			}
+
+			$palette[] = [
+				'color' => $data['color'],
+				'name'  => $data['name'],
+				'slug'  => $slug,
+			];
+		}
 
 		$existing['palette'] = array_values( $palette );
 
-		// Preserve override when present; default it false on a fresh write so KB merges rather than
-		// replaces the theme palette.
 		if ( ! array_key_exists( 'override', $existing ) ) {
 			$existing['override'] = false;
 		}
@@ -111,15 +150,15 @@ final class Palette_Builder {
 	}
 
 	/**
-	 * Merge token entries into a decoded kadence_global_palette payload.
+	 * Merge token entries into a decoded kadence_global_palette payload (the Kadence theme's option).
 	 *
-	 * Overwrites ONLY the color of palette entries whose slug a token claims; never appends and never
-	 * touches names (the theme owns slot labels/structure). Preserves every other entry and top-level
-	 * key untouched.
+	 * Overwrites ONLY the color of entries whose slug a token claims; never appends and never rewrites a
+	 * name (the theme owns slot labels and structure). An unexpected shape (no list under "palette") is
+	 * returned untouched, so the theme's option is left exactly as found.
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, mixed>                              $existing Decoded option (guaranteed to exist by the caller).
+	 * @param array<string, mixed>                              $existing Decoded option (caller guarantees it exists).
 	 * @param array<string, array{color: string, name: string}> $entries  slug => {color,name} from entries().
 	 *
 	 * @return array<string, mixed> The merged payload (re-encode and store).
@@ -129,76 +168,54 @@ final class Palette_Builder {
 			return $existing; // Unexpected shape — leave the theme's option exactly as found.
 		}
 
-		$existing['palette'] = array_values( $this->apply( $existing['palette'], $entries, false /* color-only */ ) );
+		$palette = $existing['palette'];
+
+		foreach ( $palette as $index => $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$slug = $this->entry_slug( $entry );
+			if ( $slug === null || ! isset( $entries[ $slug ] ) ) {
+				continue;
+			}
+
+			$entry['color']    = $entries[ $slug ]['color'];
+			$palette[ $index ] = $entry;
+		}
+
+		$existing['palette'] = array_values( $palette );
 
 		return $existing;
 	}
 
 	/**
-	 * Overwrite the color (and, when $append, the name) of entries whose slug is claimed; optionally
-	 * append an entry for a claimed slug not present.
+	 * The "palette" list from a decoded option, or [] when missing or malformed.
 	 *
 	 * @since TBD
 	 *
-	 * @param array<int, mixed>                                 $palette List of {color,slug,name,…} entries.
-	 * @param array<string, array{color: string, name: string}> $entries slug => {color,name}.
-	 * @param bool                                              $append  Append claimed slugs not present.
+	 * @param array<string, mixed> $existing Decoded option.
 	 *
 	 * @return array<int, mixed>
 	 */
-	private function apply( array $palette, array $entries, bool $append ): array {
-		$seen = [];
-
-		foreach ( $palette as $i => $entry ) {
-			if ( ! is_array( $entry ) || ! isset( $entry['slug'] ) ) {
-				continue;
-			}
-			$slug = (string) $entry['slug'];
-			if ( ! isset( $entries[ $slug ] ) ) {
-				continue;
-			}
-
-			// $entry is a confirmed array (is_array check above); write through it so PHPStan can
-			// track the type, then put the modified entry back into the palette list.
-			$entry['color'] = $entries[ $slug ]['color'];
-			if ( $append ) {
-				$entry['name'] = $entries[ $slug ]['name'];
-			}
-			$palette[ $i ] = $entry;
-			$seen[ $slug ] = true;
-		}
-
-		if ( $append ) {
-			foreach ( $entries as $slug => $data ) {
-				if ( isset( $seen[ $slug ] ) ) {
-					continue;
-				}
-				$palette[] = [
-					'color' => $data['color'],
-					'name'  => $data['name'],
-					'slug'  => $slug,
-				];
-			}
-		}
-
-		return $palette;
+	private function palette_list( array $existing ): array {
+		return isset( $existing['palette'] ) && is_array( $existing['palette'] ) ? $existing['palette'] : [];
 	}
 
 	/**
-	 * Internal: are there any palette-slot tokens at all (value-independent), for has_palette_tokens().
+	 * A palette entry's slug as a string, or null when it has no usable string "slug".
 	 *
 	 * @since TBD
 	 *
-	 * @param Token_Registry $registry
+	 * @param array<array-key, mixed> $entry A single (already array-typed) palette entry.
 	 *
-	 * @return array<string, mixed>
+	 * @return string|null
 	 */
-	private function slugged( Token_Registry $registry ): array {
-		return array_filter(
-			$registry->by_projection( Kadence_Palette_Slot::get_projection_key() ),
-			static function ( $token ): bool {
-				return Kadence_Palette_Slot::from_token( $token ) !== null;
-			}
-		);
+	private function entry_slug( array $entry ): ?string {
+		if ( ! isset( $entry['slug'] ) || ! is_string( $entry['slug'] ) ) {
+			return null;
+		}
+
+		return $entry['slug'];
 	}
 }

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Palette_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Palette_Builder.php
@@ -48,7 +48,7 @@ final class Palette_Builder {
 	}
 
 	/**
-	 * slug => [ 'color' => hex, 'name' => label ] for every token that claims a palette slot AND
+	 * Slug => [ 'color' => hex, 'name' => label ] for every token that claims a palette slot AND
 	 * resolves to a non-empty value. Returns [] when nothing applies, so the caller skips both writes.
 	 *
 	 * @since TBD
@@ -142,7 +142,7 @@ final class Palette_Builder {
 	 *
 	 * @param array<int, mixed>                                 $palette List of {color,slug,name,…} entries.
 	 * @param array<string, array{color: string, name: string}> $entries slug => {color,name}.
-	 * @param bool                                               $append  Append claimed slugs not present.
+	 * @param bool                                              $append  Append claimed slugs not present.
 	 *
 	 * @return array<int, mixed>
 	 */
@@ -158,10 +158,13 @@ final class Palette_Builder {
 				continue;
 			}
 
-			$palette[ $i ]['color'] = $entries[ $slug ]['color'];
+			// $entry is a confirmed array (is_array check above); write through it so PHPStan can
+			// track the type, then put the modified entry back into the palette list.
+			$entry['color'] = $entries[ $slug ]['color'];
 			if ( $append ) {
-				$palette[ $i ]['name'] = $entries[ $slug ]['name'];
+				$entry['name'] = $entries[ $slug ]['name'];
 			}
+			$palette[ $i ] = $entry;
 			$seen[ $slug ] = true;
 		}
 

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Palette_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Palette_Builder.php
@@ -108,7 +108,7 @@ final class Palette_Builder {
 	 *
 	 * @return array<string, mixed> The merged payload (re-encode and store).
 	 */
-	public function merge_kb_colors( array $existing, array $entries ): array {
+	public function merge_kadence_blocks_colors( array $existing, array $entries ): array {
 		$palette = $this->palette_list( $existing );
 		$claimed = [];
 
@@ -164,11 +164,10 @@ final class Palette_Builder {
 	 * @return array<string, mixed> The merged payload (re-encode and store).
 	 */
 	public function merge_theme_palette( array $existing, array $entries ): array {
-		if ( ! isset( $existing['palette'] ) || ! is_array( $existing['palette'] ) ) {
+		$palette = $this->palette_list( $existing );
+		if ( $palette === [] ) {
 			return $existing; // Unexpected shape — leave the theme's option exactly as found.
 		}
-
-		$palette = $existing['palette'];
 
 		foreach ( $palette as $index => $entry ) {
 			if ( ! is_array( $entry ) ) {

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Palette_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Palette_Builder.php
@@ -1,0 +1,201 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette .
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Option;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Palette_Slot;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Resolved_Tokens;
+
+/**
+ * Pure builder for the two palette options the Kadence_Option projector writes.
+ *
+ * Produces a slot => resolved-hex map from every token that declares a palette kadence_slot, then
+ * MERGES that map onto a decoded existing option payload — overwriting only the color of token-claimed
+ * slots, keyed by slug, and preserving every other entry, key and flag (e.g. kadence_blocks_colors'
+ * "override"). No WordPress calls, no globals, no I/O: the projector owns get_option/update_option and
+ * hands decoded arrays in and takes decoded arrays out.
+ *
+ * @since TBD
+ */
+final class Palette_Builder {
+
+	/**
+	 * The token registry.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * @param Token_Registry $registry
+	 */
+	public function __construct( Token_Registry $registry ) {
+		$this->registry = $registry;
+	}
+
+	/**
+	 * Whether any token claims a palette slot — the early-bail gate.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function has_palette_tokens(): bool {
+		return $this->slugged( $this->registry ) !== [];
+	}
+
+	/**
+	 * slug => [ 'color' => hex, 'name' => label ] for every token that claims a palette slot AND
+	 * resolves to a non-empty value. Returns [] when nothing applies, so the caller skips both writes.
+	 *
+	 * @since TBD
+	 *
+	 * @param Resolved_Tokens $resolved The resolved token maps.
+	 *
+	 * @return array<string, array{color: string, name: string}>
+	 */
+	public function entries( Resolved_Tokens $resolved ): array {
+		$entries = [];
+
+		foreach ( $this->registry->by_projection( Kadence_Palette_Slot::get_projection_key() ) as $id => $token ) {
+			$slot = Kadence_Palette_Slot::from_token( $token );
+			if ( $slot === null ) {
+				continue;
+			}
+
+			$value = $resolved->value( $id );
+			if ( $value === null || $value === '' ) {
+				continue;
+			}
+
+			$entries[ $slot->slug ] = [
+				'color' => $value,
+				'name'  => $token->label,
+			];
+		}
+
+		return $entries;
+	}
+
+	/**
+	 * Merge token entries into a decoded kadence_blocks_colors payload.
+	 *
+	 * Overwrites the color of any palette entry whose slug a token claims (and refreshes its name);
+	 * appends an entry for a claimed slug not yet present; preserves all other entries and the
+	 * "override" flag. Entry shape is { color, name, slug } — exactly what KB's consumers read.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed>                              $existing Decoded option, or [] when absent.
+	 * @param array<string, array{color: string, name: string}> $entries  slug => {color,name} from entries().
+	 *
+	 * @return array<string, mixed> The merged payload (re-encode and store).
+	 */
+	public function merge_kb_colors( array $existing, array $entries ): array {
+		$palette = isset( $existing['palette'] ) && is_array( $existing['palette'] ) ? $existing['palette'] : [];
+
+		$palette = $this->apply( $palette, $entries, true /* append unclaimed */ );
+
+		$existing['palette'] = array_values( $palette );
+
+		// Preserve override when present; default it false on a fresh write so KB merges rather than
+		// replaces the theme palette.
+		if ( ! array_key_exists( 'override', $existing ) ) {
+			$existing['override'] = false;
+		}
+
+		return $existing;
+	}
+
+	/**
+	 * Merge token entries into a decoded kadence_global_palette payload.
+	 *
+	 * Overwrites ONLY the color of palette entries whose slug a token claims; never appends and never
+	 * touches names (the theme owns slot labels/structure). Preserves every other entry and top-level
+	 * key untouched.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed>                              $existing Decoded option (guaranteed to exist by the caller).
+	 * @param array<string, array{color: string, name: string}> $entries  slug => {color,name} from entries().
+	 *
+	 * @return array<string, mixed> The merged payload (re-encode and store).
+	 */
+	public function merge_theme_palette( array $existing, array $entries ): array {
+		if ( ! isset( $existing['palette'] ) || ! is_array( $existing['palette'] ) ) {
+			return $existing; // Unexpected shape — leave the theme's option exactly as found.
+		}
+
+		$existing['palette'] = array_values( $this->apply( $existing['palette'], $entries, false /* color-only */ ) );
+
+		return $existing;
+	}
+
+	/**
+	 * Overwrite the color (and, when $append, the name) of entries whose slug is claimed; optionally
+	 * append an entry for a claimed slug not present.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<int, mixed>                                 $palette List of {color,slug,name,…} entries.
+	 * @param array<string, array{color: string, name: string}> $entries slug => {color,name}.
+	 * @param bool                                               $append  Append claimed slugs not present.
+	 *
+	 * @return array<int, mixed>
+	 */
+	private function apply( array $palette, array $entries, bool $append ): array {
+		$seen = [];
+
+		foreach ( $palette as $i => $entry ) {
+			if ( ! is_array( $entry ) || ! isset( $entry['slug'] ) ) {
+				continue;
+			}
+			$slug = (string) $entry['slug'];
+			if ( ! isset( $entries[ $slug ] ) ) {
+				continue;
+			}
+
+			$palette[ $i ]['color'] = $entries[ $slug ]['color'];
+			if ( $append ) {
+				$palette[ $i ]['name'] = $entries[ $slug ]['name'];
+			}
+			$seen[ $slug ] = true;
+		}
+
+		if ( $append ) {
+			foreach ( $entries as $slug => $data ) {
+				if ( isset( $seen[ $slug ] ) ) {
+					continue;
+				}
+				$palette[] = [
+					'color' => $data['color'],
+					'name'  => $data['name'],
+					'slug'  => $slug,
+				];
+			}
+		}
+
+		return $palette;
+	}
+
+	/**
+	 * Internal: are there any palette-slot tokens at all (value-independent), for has_palette_tokens().
+	 *
+	 * @since TBD
+	 *
+	 * @param Token_Registry $registry
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function slugged( Token_Registry $registry ): array {
+		return array_filter(
+			$registry->by_projection( Kadence_Palette_Slot::get_projection_key() ),
+			static function ( $token ): bool {
+				return Kadence_Palette_Slot::from_token( $token ) !== null;
+			}
+		);
+	}
+}

--- a/tests/snapshot/Resources/Design_Tokens/Projection/Kadence_Option/Palette_Builder_SnapshotTest.php
+++ b/tests/snapshot/Resources/Design_Tokens/Projection/Kadence_Option/Palette_Builder_SnapshotTest.php
@@ -55,7 +55,7 @@ final class Palette_Builder_SnapshotTest extends SnapshotTestCase {
 					'projections' => $token['projections'],
 				]
 			);
-			$by_id[ $token['id'] ]                  = $token['value'];
+			$by_id[ $token['id'] ]                      = $token['value'];
 			$by_var[ Css_Var::from_id( $token['id'] ) ] = $token['value'];
 		}
 
@@ -63,9 +63,17 @@ final class Palette_Builder_SnapshotTest extends SnapshotTestCase {
 		$builder  = new Palette_Builder( $this->registry );
 
 		$existing = [
-			'palette' => [
-				[ 'color' => '#old-palette1', 'name' => 'Old Name 1', 'slug' => 'palette1' ],
-				[ 'color' => '#aabbcc', 'name' => 'Custom Entry', 'slug' => 'palette5' ],
+			'palette'  => [
+				[
+					'color' => '#old-palette1',
+					'name'  => 'Old Name 1',
+					'slug'  => 'palette1',
+				],
+				[
+					'color' => '#aabbcc',
+					'name'  => 'Custom Entry',
+					'slug'  => 'palette5',
+				],
 			],
 			'override' => false,
 		];

--- a/tests/snapshot/Resources/Design_Tokens/Projection/Kadence_Option/Palette_Builder_SnapshotTest.php
+++ b/tests/snapshot/Resources/Design_Tokens/Projection/Kadence_Option/Palette_Builder_SnapshotTest.php
@@ -1,0 +1,78 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette .
+
+namespace Tests\snapshot\Resources\Design_Tokens\Projection\Kadence_Option;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Option\Palette_Builder;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Resolved_Tokens;
+use Tests\Support\Classes\SnapshotTestCase;
+
+/**
+ * Snapshot the exact merged kadence_blocks_colors payload of Palette_Builder so any format change is
+ * an explicit, reviewable diff.
+ *
+ * @since TBD
+ */
+final class Palette_Builder_SnapshotTest extends SnapshotTestCase {
+
+	private Token_Registry $registry;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->registry = new Token_Registry();
+	}
+
+	public function testMergedKbColorsPayloadMatchesSnapshot(): void {
+		$tokens = [
+			[
+				'id'          => 'semantic.color.button-bg',
+				'type'        => 'color',
+				'label'       => 'Button Background',
+				'projections' => [ 'kadence_slot' => 'palette1' ],
+				'value'       => '#3182CE',
+			],
+			[
+				'id'          => 'semantic.color.button-text',
+				'type'        => 'color',
+				'label'       => 'Button Text',
+				'projections' => [ 'kadence_slot' => 'palette2' ],
+				'value'       => '#FFFFFF',
+			],
+		];
+
+		$by_id  = [];
+		$by_var = [];
+
+		foreach ( $tokens as $token ) {
+			$this->registry->register(
+				[
+					'id'          => $token['id'],
+					'type'        => $token['type'],
+					'label'       => $token['label'],
+					'projections' => $token['projections'],
+				]
+			);
+			$by_id[ $token['id'] ]                  = $token['value'];
+			$by_var[ Css_Var::from_id( $token['id'] ) ] = $token['value'];
+		}
+
+		$resolved = new Resolved_Tokens( $by_id, $by_var );
+		$builder  = new Palette_Builder( $this->registry );
+
+		$existing = [
+			'palette' => [
+				[ 'color' => '#old-palette1', 'name' => 'Old Name 1', 'slug' => 'palette1' ],
+				[ 'color' => '#aabbcc', 'name' => 'Custom Entry', 'slug' => 'palette5' ],
+			],
+			'override' => false,
+		];
+
+		$entries = $builder->entries( $resolved );
+		$merged  = $builder->merge_kb_colors( $existing, $entries );
+
+		$this->assertMatchesSnapshot( wp_json_encode( $merged, JSON_PRETTY_PRINT ) );
+	}
+}

--- a/tests/snapshot/Resources/Design_Tokens/Projection/Kadence_Option/Palette_Builder_SnapshotTest.php
+++ b/tests/snapshot/Resources/Design_Tokens/Projection/Kadence_Option/Palette_Builder_SnapshotTest.php
@@ -79,7 +79,7 @@ final class Palette_Builder_SnapshotTest extends SnapshotTestCase {
 		];
 
 		$entries = $builder->entries( $resolved );
-		$merged  = $builder->merge_kb_colors( $existing, $entries );
+		$merged  = $builder->merge_kadence_blocks_colors( $existing, $entries );
 
 		$this->assertMatchesSnapshot( wp_json_encode( $merged, JSON_PRETTY_PRINT ) );
 	}

--- a/tests/snapshot/Resources/Design_Tokens/Projection/Kadence_Option/__snapshots__/Palette_Builder_SnapshotTest__testMergedKbColorsPayloadMatchesSnapshot__1.txt
+++ b/tests/snapshot/Resources/Design_Tokens/Projection/Kadence_Option/__snapshots__/Palette_Builder_SnapshotTest__testMergedKbColorsPayloadMatchesSnapshot__1.txt
@@ -1,0 +1,20 @@
+{
+    "palette": [
+        {
+            "color": "#3182CE",
+            "name": "Button Background",
+            "slug": "palette1"
+        },
+        {
+            "color": "#aabbcc",
+            "name": "Custom Entry",
+            "slug": "palette5"
+        },
+        {
+            "color": "#FFFFFF",
+            "name": "Button Text",
+            "slug": "palette2"
+        }
+    ],
+    "override": false
+}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/Palette_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/Palette_BuilderTest.php
@@ -144,7 +144,7 @@ final class Palette_BuilderTest extends TestCase {
 			]
 		);
 
-		$this->assertSame( '#3182CE', $result['palette']['palette1']['color'] ?? $result['palette'][0]['color'] );
+		$this->assertSame( '#3182CE', $result['palette'][0]['color'] );
 	}
 
 	public function testMergeKbColorsPreservesPositionOfExistingEntry(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/Palette_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/Palette_BuilderTest.php
@@ -29,8 +29,8 @@ final class Palette_BuilderTest extends TestCase {
 
 		foreach ( $definitions_and_values as [ $definition, $value ] ) {
 			$this->registry->register( $definition );
-			$id           = (string) $definition['id'];
-			$by_id[ $id ] = $value;
+			$id                                = (string) $definition['id'];
+			$by_id[ $id ]                      = $value;
 			$by_var[ Css_Var::from_id( $id ) ] = $value;
 		}
 
@@ -124,15 +124,24 @@ final class Palette_BuilderTest extends TestCase {
 
 	public function testMergeKbColorsOverwritesColorOfExistingEntry(): void {
 		$existing = [
-			'palette' => [
-				[ 'color' => '#old', 'name' => 'Old Name', 'slug' => 'palette1' ],
+			'palette'  => [
+				[
+					'color' => '#old',
+					'name'  => 'Old Name',
+					'slug'  => 'palette1',
+				],
 			],
 			'override' => false,
 		];
 
 		$result = $this->builder()->merge_kb_colors(
 			$existing,
-			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+			[
+				'palette1' => [
+					'color' => '#3182CE',
+					'name'  => 'Button Background',
+				],
+			]
 		);
 
 		$this->assertSame( '#3182CE', $result['palette']['palette1']['color'] ?? $result['palette'][0]['color'] );
@@ -140,16 +149,29 @@ final class Palette_BuilderTest extends TestCase {
 
 	public function testMergeKbColorsPreservesPositionOfExistingEntry(): void {
 		$existing = [
-			'palette' => [
-				[ 'color' => '#aaa', 'name' => 'First', 'slug' => 'palette3' ],
-				[ 'color' => '#old', 'name' => 'Old', 'slug' => 'palette1' ],
+			'palette'  => [
+				[
+					'color' => '#aaa',
+					'name'  => 'First',
+					'slug'  => 'palette3',
+				],
+				[
+					'color' => '#old',
+					'name'  => 'Old',
+					'slug'  => 'palette1',
+				],
 			],
 			'override' => false,
 		];
 
 		$result  = $this->builder()->merge_kb_colors(
 			$existing,
-			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+			[
+				'palette1' => [
+					'color' => '#3182CE',
+					'name'  => 'Button Background',
+				],
+			]
 		);
 		$palette = $result['palette'];
 
@@ -166,7 +188,12 @@ final class Palette_BuilderTest extends TestCase {
 
 		$result  = $this->builder()->merge_kb_colors(
 			$existing,
-			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+			[
+				'palette1' => [
+					'color' => '#3182CE',
+					'name'  => 'Button Background',
+				],
+			]
 		);
 		$palette = $result['palette'];
 
@@ -178,15 +205,24 @@ final class Palette_BuilderTest extends TestCase {
 
 	public function testMergeKbColorsPreservesNonTokenEntry(): void {
 		$existing = [
-			'palette' => [
-				[ 'color' => '#ff0000', 'name' => 'Red', 'slug' => 'palette5' ],
+			'palette'  => [
+				[
+					'color' => '#ff0000',
+					'name'  => 'Red',
+					'slug'  => 'palette5',
+				],
 			],
 			'override' => false,
 		];
 
 		$result  = $this->builder()->merge_kb_colors(
 			$existing,
-			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+			[
+				'palette1' => [
+					'color' => '#3182CE',
+					'name'  => 'Button Background',
+				],
+			]
 		);
 		$by_slug = array_column( $result['palette'], null, 'slug' );
 
@@ -202,7 +238,12 @@ final class Palette_BuilderTest extends TestCase {
 
 		$result = $this->builder()->merge_kb_colors(
 			$existing,
-			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+			[
+				'palette1' => [
+					'color' => '#3182CE',
+					'name'  => 'Button Background',
+				],
+			]
 		);
 
 		$this->assertTrue( $result['override'] );
@@ -216,7 +257,12 @@ final class Palette_BuilderTest extends TestCase {
 
 		$result = $this->builder()->merge_kb_colors(
 			$existing,
-			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+			[
+				'palette1' => [
+					'color' => '#3182CE',
+					'name'  => 'Button Background',
+				],
+			]
 		);
 
 		$this->assertFalse( $result['override'] );
@@ -225,7 +271,12 @@ final class Palette_BuilderTest extends TestCase {
 	public function testMergeKbColorsDefaultsOverrideFalseWhenAbsent(): void {
 		$result = $this->builder()->merge_kb_colors(
 			[],
-			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+			[
+				'palette1' => [
+					'color' => '#3182CE',
+					'name'  => 'Button Background',
+				],
+			]
 		);
 
 		$this->assertFalse( $result['override'] );
@@ -236,13 +287,22 @@ final class Palette_BuilderTest extends TestCase {
 	public function testMergeThemePaletteOverwritesColorOnly(): void {
 		$existing = [
 			'palette' => [
-				[ 'color' => '#old', 'name' => 'Palette 1', 'slug' => 'palette1' ],
+				[
+					'color' => '#old',
+					'name'  => 'Palette 1',
+					'slug'  => 'palette1',
+				],
 			],
 		];
 
 		$result  = $this->builder()->merge_theme_palette(
 			$existing,
-			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+			[
+				'palette1' => [
+					'color' => '#3182CE',
+					'name'  => 'Button Background',
+				],
+			]
 		);
 		$palette = $result['palette'];
 
@@ -253,13 +313,22 @@ final class Palette_BuilderTest extends TestCase {
 	public function testMergeThemePaletteNeverAppends(): void {
 		$existing = [
 			'palette' => [
-				[ 'color' => '#aaa', 'name' => 'Other', 'slug' => 'palette5' ],
+				[
+					'color' => '#aaa',
+					'name'  => 'Other',
+					'slug'  => 'palette5',
+				],
 			],
 		];
 
 		$result = $this->builder()->merge_theme_palette(
 			$existing,
-			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+			[
+				'palette1' => [
+					'color' => '#3182CE',
+					'name'  => 'Button Background',
+				],
+			]
 		);
 
 		// palette1 was not present and must not be appended.
@@ -270,14 +339,27 @@ final class Palette_BuilderTest extends TestCase {
 	public function testMergeThemePalettePreservesUnclaimed(): void {
 		$existing = [
 			'palette' => [
-				[ 'color' => '#aaa', 'name' => 'Unclaimed', 'slug' => 'palette7' ],
-				[ 'color' => '#old', 'name' => 'Palette 1', 'slug' => 'palette1' ],
+				[
+					'color' => '#aaa',
+					'name'  => 'Unclaimed',
+					'slug'  => 'palette7',
+				],
+				[
+					'color' => '#old',
+					'name'  => 'Palette 1',
+					'slug'  => 'palette1',
+				],
 			],
 		];
 
 		$result  = $this->builder()->merge_theme_palette(
 			$existing,
-			[ 'palette1' => [ 'color' => '#new', 'name' => 'Ignored' ] ]
+			[
+				'palette1' => [
+					'color' => '#new',
+					'name'  => 'Ignored',
+				],
+			]
 		);
 		$by_slug = array_column( $result['palette'], null, 'slug' );
 
@@ -289,7 +371,12 @@ final class Palette_BuilderTest extends TestCase {
 
 		$result = $this->builder()->merge_theme_palette(
 			$existing,
-			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+			[
+				'palette1' => [
+					'color' => '#3182CE',
+					'name'  => 'Button Background',
+				],
+			]
 		);
 
 		$this->assertSame( $existing, $result );
@@ -297,13 +384,24 @@ final class Palette_BuilderTest extends TestCase {
 
 	public function testMergeThemePalettePreservesSiblingTopLevelKeys(): void {
 		$existing = [
-			'palette'   => [ [ 'color' => '#old', 'name' => 'Palette 1', 'slug' => 'palette1' ] ],
+			'palette'   => [
+				[
+					'color' => '#old',
+					'name'  => 'Palette 1',
+					'slug'  => 'palette1',
+				],
+			],
 			'some_meta' => 'keep-me',
 		];
 
 		$result = $this->builder()->merge_theme_palette(
 			$existing,
-			[ 'palette1' => [ 'color' => '#new', 'name' => 'Ignored' ] ]
+			[
+				'palette1' => [
+					'color' => '#new',
+					'name'  => 'Ignored',
+				],
+			]
 		);
 
 		$this->assertSame( 'keep-me', $result['some_meta'] );

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/Palette_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/Palette_BuilderTest.php
@@ -120,7 +120,7 @@ final class Palette_BuilderTest extends TestCase {
 		$this->assertSame( [], $entries );
 	}
 
-	// ---- merge_kb_colors() -------------------------------------------------------------------------
+	// ---- merge_kadence_blocks_colors() -------------------------------------------------------------------------
 
 	public function testMergeKbColorsOverwritesColorOfExistingEntry(): void {
 		$existing = [
@@ -134,7 +134,7 @@ final class Palette_BuilderTest extends TestCase {
 			'override' => false,
 		];
 
-		$result = $this->builder()->merge_kb_colors(
+		$result = $this->builder()->merge_kadence_blocks_colors(
 			$existing,
 			[
 				'palette1' => [
@@ -164,7 +164,7 @@ final class Palette_BuilderTest extends TestCase {
 			'override' => false,
 		];
 
-		$result  = $this->builder()->merge_kb_colors(
+		$result  = $this->builder()->merge_kadence_blocks_colors(
 			$existing,
 			[
 				'palette1' => [
@@ -186,7 +186,7 @@ final class Palette_BuilderTest extends TestCase {
 			'override' => false,
 		];
 
-		$result  = $this->builder()->merge_kb_colors(
+		$result  = $this->builder()->merge_kadence_blocks_colors(
 			$existing,
 			[
 				'palette1' => [
@@ -215,7 +215,7 @@ final class Palette_BuilderTest extends TestCase {
 			'override' => false,
 		];
 
-		$result  = $this->builder()->merge_kb_colors(
+		$result  = $this->builder()->merge_kadence_blocks_colors(
 			$existing,
 			[
 				'palette1' => [
@@ -236,7 +236,7 @@ final class Palette_BuilderTest extends TestCase {
 			'override' => true,
 		];
 
-		$result = $this->builder()->merge_kb_colors(
+		$result = $this->builder()->merge_kadence_blocks_colors(
 			$existing,
 			[
 				'palette1' => [
@@ -255,7 +255,7 @@ final class Palette_BuilderTest extends TestCase {
 			'override' => false,
 		];
 
-		$result = $this->builder()->merge_kb_colors(
+		$result = $this->builder()->merge_kadence_blocks_colors(
 			$existing,
 			[
 				'palette1' => [
@@ -269,7 +269,7 @@ final class Palette_BuilderTest extends TestCase {
 	}
 
 	public function testMergeKbColorsDefaultsOverrideFalseWhenAbsent(): void {
-		$result = $this->builder()->merge_kb_colors(
+		$result = $this->builder()->merge_kadence_blocks_colors(
 			[],
 			[
 				'palette1' => [

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/Palette_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/Palette_BuilderTest.php
@@ -1,0 +1,343 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Projection\Kadence_Option;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Option\Palette_Builder;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Resolved_Tokens;
+use Tests\Support\Classes\TestCase;
+
+final class Palette_BuilderTest extends TestCase {
+
+	private Token_Registry $registry;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->registry = new Token_Registry();
+	}
+
+	private function builder(): Palette_Builder {
+		return new Palette_Builder( $this->registry );
+	}
+
+	private function resolved_for( array $definitions_and_values ): Resolved_Tokens {
+		$by_id  = [];
+		$by_var = [];
+
+		foreach ( $definitions_and_values as [ $definition, $value ] ) {
+			$this->registry->register( $definition );
+			$id           = (string) $definition['id'];
+			$by_id[ $id ] = $value;
+			$by_var[ Css_Var::from_id( $id ) ] = $value;
+		}
+
+		return new Resolved_Tokens( $by_id, $by_var );
+	}
+
+	// ---- entries() ---------------------------------------------------------------------------------
+
+	public function testEntriesMapsShippedPaletteTokensToColorAndName(): void {
+		$resolved = $this->resolved_for(
+			[
+				[
+					[
+						'id'          => 'semantic.color.button-bg',
+						'type'        => 'color',
+						'label'       => 'Button Background',
+						'projections' => [ 'kadence_slot' => 'palette1' ],
+					],
+					'#3182CE',
+				],
+				[
+					[
+						'id'          => 'semantic.color.button-text',
+						'type'        => 'color',
+						'label'       => 'Button Text',
+						'projections' => [ 'kadence_slot' => 'palette2' ],
+					],
+					'#FFFFFF',
+				],
+			]
+		);
+
+		$entries = $this->builder()->entries( $resolved );
+
+		$this->assertArrayHasKey( 'palette1', $entries );
+		$this->assertSame( '#3182CE', $entries['palette1']['color'] );
+		$this->assertSame( 'Button Background', $entries['palette1']['name'] );
+
+		$this->assertArrayHasKey( 'palette2', $entries );
+		$this->assertSame( '#FFFFFF', $entries['palette2']['color'] );
+	}
+
+	public function testEntriesSkipsTokensWithNullResolvedValue(): void {
+		$this->registry->register(
+			[
+				'id'          => 'semantic.color.missing',
+				'type'        => 'color',
+				'label'       => 'Missing',
+				'projections' => [ 'kadence_slot' => 'palette3' ],
+			]
+		);
+
+		$entries = $this->builder()->entries( new Resolved_Tokens( [], [] ) );
+
+		$this->assertArrayNotHasKey( 'palette3', $entries );
+	}
+
+	public function testEntriesSkipsTokensWithEmptyResolvedValue(): void {
+		$id = 'semantic.color.empty';
+		$this->registry->register(
+			[
+				'id'          => $id,
+				'type'        => 'color',
+				'label'       => 'Empty',
+				'projections' => [ 'kadence_slot' => 'palette4' ],
+			]
+		);
+
+		$entries = $this->builder()->entries( new Resolved_Tokens( [ $id => '' ], [] ) );
+
+		$this->assertArrayNotHasKey( 'palette4', $entries );
+	}
+
+	public function testEntriesSkipsNonPaletteKadenceSlots(): void {
+		$id = 'semantic.dimension.font-sm';
+		$this->registry->register(
+			[
+				'id'          => $id,
+				'type'        => 'dimension',
+				'label'       => 'Font Small',
+				'projections' => [ 'kadence_slot' => 'sm' ],
+			]
+		);
+
+		$entries = $this->builder()->entries( new Resolved_Tokens( [ $id => '0.875rem' ], [] ) );
+
+		$this->assertSame( [], $entries );
+	}
+
+	// ---- merge_kb_colors() -------------------------------------------------------------------------
+
+	public function testMergeKbColorsOverwritesColorOfExistingEntry(): void {
+		$existing = [
+			'palette' => [
+				[ 'color' => '#old', 'name' => 'Old Name', 'slug' => 'palette1' ],
+			],
+			'override' => false,
+		];
+
+		$result = $this->builder()->merge_kb_colors(
+			$existing,
+			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+		);
+
+		$this->assertSame( '#3182CE', $result['palette']['palette1']['color'] ?? $result['palette'][0]['color'] );
+	}
+
+	public function testMergeKbColorsPreservesPositionOfExistingEntry(): void {
+		$existing = [
+			'palette' => [
+				[ 'color' => '#aaa', 'name' => 'First', 'slug' => 'palette3' ],
+				[ 'color' => '#old', 'name' => 'Old', 'slug' => 'palette1' ],
+			],
+			'override' => false,
+		];
+
+		$result  = $this->builder()->merge_kb_colors(
+			$existing,
+			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+		);
+		$palette = $result['palette'];
+
+		$this->assertSame( 'palette3', $palette[0]['slug'] );
+		$this->assertSame( 'palette1', $palette[1]['slug'] );
+		$this->assertSame( '#3182CE', $palette[1]['color'] );
+	}
+
+	public function testMergeKbColorsAppendsClaimedSlugNotPresent(): void {
+		$existing = [
+			'palette'  => [],
+			'override' => false,
+		];
+
+		$result  = $this->builder()->merge_kb_colors(
+			$existing,
+			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+		);
+		$palette = $result['palette'];
+
+		$this->assertCount( 1, $palette );
+		$this->assertSame( 'palette1', $palette[0]['slug'] );
+		$this->assertSame( '#3182CE', $palette[0]['color'] );
+		$this->assertSame( 'Button Background', $palette[0]['name'] );
+	}
+
+	public function testMergeKbColorsPreservesNonTokenEntry(): void {
+		$existing = [
+			'palette' => [
+				[ 'color' => '#ff0000', 'name' => 'Red', 'slug' => 'palette5' ],
+			],
+			'override' => false,
+		];
+
+		$result  = $this->builder()->merge_kb_colors(
+			$existing,
+			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+		);
+		$by_slug = array_column( $result['palette'], null, 'slug' );
+
+		$this->assertArrayHasKey( 'palette5', $by_slug );
+		$this->assertSame( '#ff0000', $by_slug['palette5']['color'] );
+	}
+
+	public function testMergeKbColorsPreservesOverrideFlagWhenTrue(): void {
+		$existing = [
+			'palette'  => [],
+			'override' => true,
+		];
+
+		$result = $this->builder()->merge_kb_colors(
+			$existing,
+			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+		);
+
+		$this->assertTrue( $result['override'] );
+	}
+
+	public function testMergeKbColorsPreservesOverrideFlagWhenFalse(): void {
+		$existing = [
+			'palette'  => [],
+			'override' => false,
+		];
+
+		$result = $this->builder()->merge_kb_colors(
+			$existing,
+			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+		);
+
+		$this->assertFalse( $result['override'] );
+	}
+
+	public function testMergeKbColorsDefaultsOverrideFalseWhenAbsent(): void {
+		$result = $this->builder()->merge_kb_colors(
+			[],
+			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+		);
+
+		$this->assertFalse( $result['override'] );
+	}
+
+	// ---- merge_theme_palette() -----------------------------------------------------------------------
+
+	public function testMergeThemePaletteOverwritesColorOnly(): void {
+		$existing = [
+			'palette' => [
+				[ 'color' => '#old', 'name' => 'Palette 1', 'slug' => 'palette1' ],
+			],
+		];
+
+		$result  = $this->builder()->merge_theme_palette(
+			$existing,
+			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+		);
+		$palette = $result['palette'];
+
+		$this->assertSame( '#3182CE', $palette[0]['color'] );
+		$this->assertSame( 'Palette 1', $palette[0]['name'] ); // name untouched.
+	}
+
+	public function testMergeThemePaletteNeverAppends(): void {
+		$existing = [
+			'palette' => [
+				[ 'color' => '#aaa', 'name' => 'Other', 'slug' => 'palette5' ],
+			],
+		];
+
+		$result = $this->builder()->merge_theme_palette(
+			$existing,
+			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+		);
+
+		// palette1 was not present and must not be appended.
+		$this->assertCount( 1, $result['palette'] );
+		$this->assertSame( 'palette5', $result['palette'][0]['slug'] );
+	}
+
+	public function testMergeThemePalettePreservesUnclaimed(): void {
+		$existing = [
+			'palette' => [
+				[ 'color' => '#aaa', 'name' => 'Unclaimed', 'slug' => 'palette7' ],
+				[ 'color' => '#old', 'name' => 'Palette 1', 'slug' => 'palette1' ],
+			],
+		];
+
+		$result  = $this->builder()->merge_theme_palette(
+			$existing,
+			[ 'palette1' => [ 'color' => '#new', 'name' => 'Ignored' ] ]
+		);
+		$by_slug = array_column( $result['palette'], null, 'slug' );
+
+		$this->assertSame( '#aaa', $by_slug['palette7']['color'] );
+	}
+
+	public function testMergeThemePaletteReturnsExistingWhenPaletteKeyMissing(): void {
+		$existing = [ 'extra_key' => 'value' ];
+
+		$result = $this->builder()->merge_theme_palette(
+			$existing,
+			[ 'palette1' => [ 'color' => '#3182CE', 'name' => 'Button Background' ] ]
+		);
+
+		$this->assertSame( $existing, $result );
+	}
+
+	public function testMergeThemePalettePreservesSiblingTopLevelKeys(): void {
+		$existing = [
+			'palette'   => [ [ 'color' => '#old', 'name' => 'Palette 1', 'slug' => 'palette1' ] ],
+			'some_meta' => 'keep-me',
+		];
+
+		$result = $this->builder()->merge_theme_palette(
+			$existing,
+			[ 'palette1' => [ 'color' => '#new', 'name' => 'Ignored' ] ]
+		);
+
+		$this->assertSame( 'keep-me', $result['some_meta'] );
+	}
+
+	// ---- has_palette_tokens() -----------------------------------------------------------------------
+
+	public function testHasPaletteTokensIsTrueWithShippedTokens(): void {
+		$this->registry->register(
+			[
+				'id'          => 'semantic.color.button-bg',
+				'type'        => 'color',
+				'label'       => 'Button Background',
+				'projections' => [ 'kadence_slot' => 'palette1' ],
+			]
+		);
+
+		$this->assertTrue( $this->builder()->has_palette_tokens() );
+	}
+
+	public function testHasPaletteTokensIsFalseOnEmptyRegistry(): void {
+		$this->assertFalse( $this->builder()->has_palette_tokens() );
+	}
+
+	public function testHasPaletteTokensIsFalseWhenOnlyFontSizeTokens(): void {
+		$this->registry->register(
+			[
+				'id'          => 'semantic.dimension.font-sm',
+				'type'        => 'dimension',
+				'label'       => 'Font Small',
+				'projections' => [ 'kadence_slot' => 'sm' ],
+			]
+		);
+
+		$this->assertFalse( $this->builder()->has_palette_tokens() );
+	}
+}


### PR DESCRIPTION
**Stacked PR 2 of 3** — base: `SOFT-3384/phase-1-palette-slot`. Review only this phase's diff.

Adds the pure `Palette_Builder`: turns the registry + resolved tokens into a `slug => {color,name}` map, then merges that onto a decoded existing option. No WordPress calls — the projector (Phase 3) owns all I/O. Two deliberately different merge rules:

- `kadence_blocks_colors` (KB's own) — overwrite color + name of a claimed slug, append a claimed slug not present, preserve every other entry and the `override` flag.
- `kadence_global_palette` (the theme's) — overwrite **only** color of a claimed slug; never append, never touch names.

Includes unit tests for every merge rule plus a committed snapshot of the merged `kadence_blocks_colors` payload.