### PR TITLE
[DTM][3/3] SOFT-3384: Kadence_Option projector + provider wiring

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
@@ -1,0 +1,234 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette .
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Option;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use RuntimeException;
+
+/**
+ * Syncs resolved palette-token values into two stored options so pre-existing code paths reflect tokens.
+ *
+ *   - kadence_blocks_colors    — KB's own palette option. Synced ALWAYS (any active theme), so KB's
+ *                                editor palette UI and its theme.json / editor-settings injection track
+ *                                tokens with no change to those code paths.
+ *   - kadence_global_palette   — the Kadence theme's option. Synced ONLY when it already exists, NEVER
+ *                                created, so non-Kadence-theme sites are left untouched.
+ *
+ * reconcile() is wired to a once-per-request boot pass AND to kadence_blocks_design_tokens_changed, so a
+ * token write syncs immediately and a later theme switch (which newly exposes kadence_global_palette) is
+ * caught on the next request. A version+theme marker short-circuits the common no-change case; update_option
+ * is itself a no-op when the encoded value is unchanged, the correctness backstop. Gated on
+ * Token_Registry::is_active() (fail-closed) and a fail-open catch around resolution.
+ *
+ * @since TBD
+ */
+final class Projector {
+
+	/**
+	 * KB's own palette option key.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const KB_COLORS_OPTION = 'kadence_blocks_colors';
+
+	/**
+	 * The Kadence theme's palette option key.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const THEME_PALETTE_OPTION = 'kadence_global_palette';
+
+	/**
+	 * Marker option storing the last-synced "{store-version}:{theme-present}" signature, so a request
+	 * where nothing changed skips resolution entirely.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const SYNC_MARKER_OPTION = 'kadence_blocks_design_tokens_palette_sync';
+
+	/**
+	 * Sentinel for the existence probe. A value a real option is overwhelmingly unlikely to equal, so
+	 * get_option($key, SENTINEL) === SENTINEL reliably means "absent".
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const ABSENT = "\0kb-design-tokens-absent\0";
+
+	private Token_Registry $registry;
+	private Token_Resolver $resolver;
+	private Token_Store $store;
+	private Palette_Builder $builder;
+
+	/**
+	 * Guards against re-running the boot pass more than once per request (the action may also fire).
+	 *
+	 * @var bool
+	 */
+	private bool $reconciled_this_request = false;
+
+	public function __construct(
+		Token_Registry $registry,
+		Token_Resolver $resolver,
+		Token_Store $store,
+		Palette_Builder $builder
+	) {
+		$this->registry = $registry;
+		$this->resolver = $resolver;
+		$this->store    = $store;
+		$this->builder  = $builder;
+	}
+
+	/**
+	 * Once-per-request reconcile. Bound to the boot pass (low priority on init) and may be re-entered by
+	 * on_tokens_changed(); the per-request guard keeps it to one pass unless a write forces a re-sync.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function reconcile(): void {
+		if ( $this->reconciled_this_request ) {
+			return;
+		}
+		$this->reconciled_this_request = true;
+
+		$this->sync();
+	}
+
+	/**
+	 * Force a re-sync after a token write, regardless of the per-request guard, so the new values land
+	 * in the same request. Bound to kadence_blocks_design_tokens_changed.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function on_tokens_changed(): void {
+		$this->reconciled_this_request = true; // a write supersedes the boot pass for this request
+		$this->sync();
+	}
+
+	/**
+	 * The sync itself: gate, resolve, short-circuit on an unchanged signature, then write.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	private function sync(): void {
+		if ( ! $this->registry->is_active() || ! $this->builder->has_palette_tokens() ) {
+			return;
+		}
+
+		$theme_present = $this->theme_palette_exists();
+		$signature     = $this->store->get_version() . ':' . ( $theme_present ? '1' : '0' );
+
+		// Skip the resolve + writes when neither the store version nor the theme-option presence changed
+		// since the last successful sync. (The theme-present bit is what catches a theme switch.)
+		if ( get_option( self::SYNC_MARKER_OPTION ) === $signature ) {
+			return;
+		}
+
+		try {
+			$resolved = $this->resolver->resolve();
+		} catch ( RuntimeException $e ) {
+			// Corrupt stored document (alias cycle / dangling alias from a raw DB write). Fail open:
+			// leave both options exactly as they are; do NOT advance the marker, so a later clean write
+			// re-attempts.
+			return;
+		}
+
+		$entries = $this->builder->entries( $resolved );
+		if ( $entries === [] ) {
+			return;
+		}
+
+		$this->sync_kb_colors( $entries );          // always
+
+		if ( $theme_present ) {                       // only when it already exists
+			$this->sync_theme_palette( $entries );
+		}
+
+		update_option( self::SYNC_MARKER_OPTION, $signature, false );
+	}
+
+	/**
+	 * Always-on sync of KB's own kadence_blocks_colors. Reads + decodes the existing JSON, merges, and
+	 * writes back as JSON. update_option no-ops when the string is unchanged.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, array{color: string, name: string}> $entries
+	 *
+	 * @return void
+	 */
+	private function sync_kb_colors( array $entries ): void {
+		$decoded = $this->decode( (string) get_option( self::KB_COLORS_OPTION, '' ) );
+		$merged  = $this->builder->merge_kb_colors( $decoded, $entries );
+
+		update_option( self::KB_COLORS_OPTION, (string) wp_json_encode( $merged ), false );
+	}
+
+	/**
+	 * Conditional sync of the Kadence theme's kadence_global_palette. The caller has already proved the
+	 * option exists; we re-read it for the merge. Never creates it.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, array{color: string, name: string}> $entries
+	 *
+	 * @return void
+	 */
+	private function sync_theme_palette( array $entries ): void {
+		$raw = get_option( self::THEME_PALETTE_OPTION, self::ABSENT );
+		if ( $raw === self::ABSENT ) {
+			return; // raced away between probe and here; never create.
+		}
+
+		$decoded = $this->decode( (string) $raw );
+		$merged  = $this->builder->merge_theme_palette( $decoded, $entries );
+
+		update_option( self::THEME_PALETTE_OPTION, (string) wp_json_encode( $merged ), false );
+	}
+
+	/**
+	 * Whether the Kadence theme's palette option exists, via the sentinel idiom — the §8C spec's exact
+	 * "get_option($key, $sentinel) !== $sentinel" test. Never creates the option.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	private function theme_palette_exists(): bool {
+		return get_option( self::THEME_PALETTE_OPTION, self::ABSENT ) !== self::ABSENT;
+	}
+
+	/**
+	 * Decode a stored JSON option to an array, tolerating an empty/invalid value (=> []).
+	 *
+	 * @since TBD
+	 *
+	 * @param string $raw
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function decode( string $raw ): array {
+		if ( $raw === '' ) {
+			return [];
+		}
+		$decoded = json_decode( $raw, true );
+
+		return is_array( $decoded ) ? $decoded : [];
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
@@ -56,17 +56,6 @@ final class Projector {
 	private const SYNC_MARKER_OPTION = 'kadence_blocks_design_tokens_palette_sync';
 
 	/**
-	 * Sentinel for the existence probe. Null bytes (\0) cannot survive a MySQL utf8/utf8mb4 round-trip,
-	 * so no real stored option value can ever equal this — get_option($key, SENTINEL) === SENTINEL
-	 * reliably means "absent".
-	 *
-	 * @since TBD
-	 *
-	 * @var string
-	 */
-	private const ABSENT = "\0kb-design-tokens-absent\0";
-
-	/**
 	 * The token registry.
 	 *
 	 * @since TBD
@@ -246,15 +235,15 @@ final class Projector {
 	}
 
 	/**
-	 * Whether the Kadence theme's palette option exists, via the sentinel idiom — the §8C spec's exact
-	 * "get_option($key, $sentinel) !== $sentinel" test. Never creates the option.
+	 * Whether the Kadence theme's palette option exists. Uses !== false because get_option() returns
+	 * false only when the row is absent, and kadence_global_palette always stores a JSON string.
 	 *
 	 * @since TBD
 	 *
 	 * @return bool
 	 */
 	private function theme_palette_exists(): bool {
-		return get_option( self::THEME_PALETTE_OPTION, self::ABSENT ) !== self::ABSENT;
+		return get_option( self::THEME_PALETTE_OPTION ) !== false;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
@@ -115,7 +115,7 @@ final class Projector {
 	 * @return void
 	 */
 	public function on_tokens_changed(): void {
-		$this->reconciled_this_request = true; // a write supersedes the boot pass for this request
+		$this->reconciled_this_request = true; // A write supersedes the boot pass for this request.
 		$this->sync();
 	}
 
@@ -135,7 +135,7 @@ final class Projector {
 		$signature     = $this->store->get_version() . ':' . ( $theme_present ? '1' : '0' );
 
 		// Skip the resolve + writes when neither the store version nor the theme-option presence changed
-		// since the last successful sync. (The theme-present bit is what catches a theme switch.)
+		// since the last successful sync. The theme-present bit is what catches a theme switch.
 		if ( get_option( self::SYNC_MARKER_OPTION ) === $signature ) {
 			return;
 		}
@@ -154,9 +154,9 @@ final class Projector {
 			return;
 		}
 
-		$this->sync_kb_colors( $entries );          // always
+		$this->sync_kb_colors( $entries );          // Always.
 
-		if ( $theme_present ) {                       // only when it already exists
+		if ( $theme_present ) {                       // Only when it already exists.
 			$this->sync_theme_palette( $entries );
 		}
 

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
@@ -176,7 +176,8 @@ final class Projector {
 	 * @return void
 	 */
 	private function sync_kb_colors( array $entries ): void {
-		$decoded = $this->decode( (string) get_option( self::KB_COLORS_OPTION, '' ) );
+		$raw     = get_option( self::KB_COLORS_OPTION, '' );
+		$decoded = $this->decode( is_string( $raw ) ? $raw : '' );
 		$merged  = $this->builder->merge_kb_colors( $decoded, $entries );
 
 		// Autoloaded: this option is read on every front-end request — load_color_palette() on
@@ -202,7 +203,7 @@ final class Projector {
 			return; // raced away between probe and here; never create.
 		}
 
-		$decoded = $this->decode( (string) $raw );
+		$decoded = $this->decode( is_string( $raw ) ? $raw : '' );
 		$merged  = $this->builder->merge_theme_palette( $decoded, $entries );
 
 		// This option always already exists here (proved by the sentinel probe), so update_option ignores

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
@@ -1,5 +1,5 @@
 <?php declare( strict_types=1 );
-// cspell:ignore palette .
+// cspell:ignore palette autoloaded .
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Option;
 
@@ -160,7 +160,9 @@ final class Projector {
 			$this->sync_theme_palette( $entries );
 		}
 
-		update_option( self::SYNC_MARKER_OPTION, $signature, false );
+		// Autoloaded: the boot pass reads this marker on every request to short-circuit, so it must not
+		// cost a dedicated query. It is a tiny "{version}:{theme-bit}" string.
+		update_option( self::SYNC_MARKER_OPTION, $signature, true );
 	}
 
 	/**
@@ -177,7 +179,11 @@ final class Projector {
 		$decoded = $this->decode( (string) get_option( self::KB_COLORS_OPTION, '' ) );
 		$merged  = $this->builder->merge_kb_colors( $decoded, $entries );
 
-		update_option( self::KB_COLORS_OPTION, (string) wp_json_encode( $merged ), false );
+		// Autoloaded: this option is read on every front-end request — load_color_palette() on
+		// after_setup_theme and load_color_palette_theme_json() on wp_theme_json_data_theme both
+		// get_option() it. On an existing option update_option ignores this flag (preserving KB's own
+		// setting, normally autoloaded); it only takes effect when WE create the option first.
+		update_option( self::KB_COLORS_OPTION, (string) wp_json_encode( $merged ), true );
 	}
 
 	/**
@@ -199,7 +205,10 @@ final class Projector {
 		$decoded = $this->decode( (string) $raw );
 		$merged  = $this->builder->merge_theme_palette( $decoded, $entries );
 
-		update_option( self::THEME_PALETTE_OPTION, (string) wp_json_encode( $merged ), false );
+		// This option always already exists here (proved by the sentinel probe), so update_option ignores
+		// the autoload arg and leaves the theme's own setting untouched. Pass null to say so explicitly
+		// rather than implying we would set it to "no".
+		update_option( self::THEME_PALETTE_OPTION, (string) wp_json_encode( $merged ), null );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
@@ -231,11 +231,11 @@ final class Projector {
 	 * @return void
 	 */
 	private function sync_theme_palette( array $entries ): void {
-		$raw = get_option( self::THEME_PALETTE_OPTION, self::ABSENT );
-		if ( $raw === self::ABSENT ) {
+		if ( ! $this->theme_palette_exists() ) {
 			return; // raced away between probe and here; never create.
 		}
 
+		$raw     = get_option( self::THEME_PALETTE_OPTION, '' );
 		$decoded = $this->decode( is_string( $raw ) ? $raw : '' );
 		$merged  = $this->builder->merge_theme_palette( $decoded, $entries );
 

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
@@ -65,9 +65,40 @@ final class Projector {
 	 */
 	private const ABSENT = "\0kb-design-tokens-absent\0";
 
+	/**
+	 * The token registry.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Registry
+	 */
 	private Token_Registry $registry;
+
+	/**
+	 * The token resolver.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Resolver
+	 */
 	private Token_Resolver $resolver;
+
+	/**
+	 * The token store.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Store
+	 */
 	private Token_Store $store;
+
+	/**
+	 * The palette builder.
+	 *
+	 * @since TBD
+	 *
+	 * @var Palette_Builder
+	 */
 	private Palette_Builder $builder;
 
 	/**

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
@@ -150,14 +150,16 @@ final class Projector {
 		}
 
 		$entries = $this->builder->entries( $resolved );
-		if ( $entries === [] ) {
-			return;
-		}
 
-		$this->sync_kb_colors( $entries );          // Always.
+		// Empty entries is a valid resolved state (no token values set yet). Still advance the marker so
+		// the next request short-circuits rather than re-resolving. When the user writes token values the
+		// store version changes, the signature flips, and the next reconcile re-enters the write path.
+		if ( $entries !== [] ) {
+			$this->sync_kb_colors( $entries );          // Always.
 
-		if ( $theme_present ) {                       // Only when it already exists.
-			$this->sync_theme_palette( $entries );
+			if ( $theme_present ) {                       // Only when it already exists.
+				$this->sync_theme_palette( $entries );
+			}
 		}
 
 		// Autoloaded: the boot pass reads this marker on every request to short-circuit, so it must not

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
@@ -56,8 +56,9 @@ final class Projector {
 	private const SYNC_MARKER_OPTION = 'kadence_blocks_design_tokens_palette_sync';
 
 	/**
-	 * Sentinel for the existence probe. A value a real option is overwhelmingly unlikely to equal, so
-	 * get_option($key, SENTINEL) === SENTINEL reliably means "absent".
+	 * Sentinel for the existence probe. Null bytes (\0) cannot survive a MySQL utf8/utf8mb4 round-trip,
+	 * so no real stored option value can ever equal this — get_option($key, SENTINEL) === SENTINEL
+	 * reliably means "absent".
 	 *
 	 * @since TBD
 	 *

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
@@ -210,7 +210,7 @@ final class Projector {
 	 */
 	private function sync_kb_colors( array $entries ): void {
 		$raw     = get_option( self::KB_COLORS_OPTION, '' );
-		$decoded = $this->decode( is_string( $raw ) ? $raw : '' );
+		$decoded = $this->decode( $raw );
 		$merged  = $this->builder->merge_kb_colors( $decoded, $entries );
 
 		// Autoloaded: this option is read on every front-end request — load_color_palette() on
@@ -236,7 +236,7 @@ final class Projector {
 		}
 
 		$raw     = get_option( self::THEME_PALETTE_OPTION, '' );
-		$decoded = $this->decode( is_string( $raw ) ? $raw : '' );
+		$decoded = $this->decode( $raw );
 		$merged  = $this->builder->merge_theme_palette( $decoded, $entries );
 
 		// This option always already exists here (proved by the sentinel probe), so update_option ignores
@@ -262,14 +262,15 @@ final class Projector {
 	 *
 	 * @since TBD
 	 *
-	 * @param string $raw
+	 * @param mixed $raw
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function decode( string $raw ): array {
-		if ( $raw === '' ) {
+	private function decode( $raw ): array {
+		if ( ! is_string( $raw ) || $raw === '' ) {
 			return [];
 		}
+
 		$decoded = json_decode( $raw, true );
 
 		return is_array( $decoded ) ? $decoded : [];

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
@@ -211,7 +211,7 @@ final class Projector {
 	private function sync_kb_colors( array $entries ): void {
 		$raw     = get_option( self::KB_COLORS_OPTION, '' );
 		$decoded = $this->decode( $raw );
-		$merged  = $this->builder->merge_kb_colors( $decoded, $entries );
+		$merged  = $this->builder->merge_kadence_blocks_colors( $decoded, $entries );
 
 		// Pass true to ensure this option is autoloaded: it is read on every front-end request
 		// (load_color_palette() in after_setup_theme, load_color_palette_theme_json() on

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
@@ -164,7 +164,7 @@ final class Projector {
 		}
 
 		$theme_present = $this->theme_palette_exists();
-		$signature     = $this->store->get_version() . ':' . ( $theme_present ? '1' : '0' );
+		$signature     = KADENCE_BLOCKS_VERSION . ':' . $this->store->get_version() . ':' . ( $theme_present ? '1' : '0' );
 
 		// Skip the resolve + writes when neither the store version nor the theme-option presence changed
 		// since the last successful sync. The theme-present bit is what catches a theme switch.

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
@@ -213,10 +213,10 @@ final class Projector {
 		$decoded = $this->decode( $raw );
 		$merged  = $this->builder->merge_kb_colors( $decoded, $entries );
 
-		// Autoloaded: this option is read on every front-end request — load_color_palette() on
-		// after_setup_theme and load_color_palette_theme_json() on wp_theme_json_data_theme both
-		// get_option() it. On an existing option update_option ignores this flag (preserving KB's own
-		// setting, normally autoloaded); it only takes effect when WE create the option first.
+		// Pass true to ensure this option is autoloaded: it is read on every front-end request
+		// (load_color_palette() in after_setup_theme, load_color_palette_theme_json() on
+		// wp_theme_json_data_theme). update_option only writes when the value changes, and preserves
+		// autoload each time it does — which is the state we want.
 		update_option( self::KB_COLORS_OPTION, (string) wp_json_encode( $merged ), true );
 	}
 
@@ -239,9 +239,8 @@ final class Projector {
 		$decoded = $this->decode( $raw );
 		$merged  = $this->builder->merge_theme_palette( $decoded, $entries );
 
-		// This option always already exists here (proved by the sentinel probe), so update_option ignores
-		// the autoload arg and leaves the theme's own setting untouched. Pass null to say so explicitly
-		// rather than implying we would set it to "no".
+		// Pass null so update_option preserves the theme's existing autoload setting rather than
+		// forcing it. It only writes when the value changes.
 		update_option( self::THEME_PALETTE_OPTION, (string) wp_json_encode( $merged ), null );
 	}
 

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Provider.php
@@ -1,0 +1,37 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Option;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
+
+/**
+ * Registers the Kadence option-sync projector: binds the builder and projector as singletons, then
+ * wires the reconcile to a once-per-request boot pass and to the token-changed action.
+ *
+ * @since TBD
+ */
+final class Provider extends Provider_Contract {
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @since TBD
+	 */
+	public function register(): void {
+		$this->container->singleton( Palette_Builder::class );
+		$this->container->singleton( Projector::class );
+
+		// Boot pass: run late on init (after the registry's declarations are registered on init, and
+		// after the baseline/guard is in place) so the option reflects the current store on every load.
+		// This is the "always" sync and the seam that catches a theme switch on the next request.
+		add_action( 'init', $this->container->callback( Projector::class, 'reconcile' ), 20 );
+
+		// Immediate re-sync on a token write, so the new values land within the same request.
+		add_action(
+			Token_Store::changed_action(),
+			$this->container->callback( Projector::class, 'on_tokens_changed' ),
+			10
+		);
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Provider.php
@@ -25,6 +25,7 @@ final class Provider extends Provider_Contract {
 		Css_Var\Provider::class,
 		Theme_Json\Provider::class,
 		Block_Preset\Provider::class,
+		Kadence_Option\Provider::class,
 	];
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/ProjectorTest.php
@@ -7,8 +7,11 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Option\Palette_Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Option\Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Css_Renderer;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use ReflectionProperty;
+use Tests\Support\Classes\Fake_Baseline_Document;
 use Tests\Support\Classes\TestCase;
 
 final class ProjectorTest extends TestCase {
@@ -27,6 +30,11 @@ final class ProjectorTest extends TestCase {
 		$this->projector = $this->container->get( Projector::class );
 		$this->registry  = $this->container->get( Token_Registry::class );
 
+		// The Provider hooks reconcile() onto init, which fires during the WP test bootstrap and so
+		// consumes the once-per-request guard before any test runs. Reset it so each test models a fresh
+		// request whose first reconcile() actually does work.
+		$this->reset_guard( $this->projector );
+
 		delete_option( 'kadence_blocks_colors' );
 		delete_option( 'kadence_global_palette' );
 		delete_option( 'kadence_blocks_design_tokens_palette_sync' );
@@ -35,10 +43,7 @@ final class ProjectorTest extends TestCase {
 	protected function tearDown(): void {
 		$this->registry->activate();
 
-		// Reset the per-request guard so tests are isolated.
-		$guard = new ReflectionProperty( Projector::class, 'reconciled_this_request' );
-		$guard->setAccessible( true );
-		$guard->setValue( $this->projector, false );
+		$this->reset_guard( $this->projector );
 
 		// Clear the resolver memo so values do not leak between tests.
 		$resolver = $this->container->get( Token_Resolver::class );
@@ -51,6 +56,16 @@ final class ProjectorTest extends TestCase {
 		delete_option( 'kadence_blocks_design_tokens_palette_sync' );
 
 		parent::tearDown();
+	}
+
+	/**
+	 * Reset a projector's per-request guard so a subsequent reconcile() runs (each call models a new
+	 * request).
+	 */
+	private function reset_guard( Projector $projector ): void {
+		$guard = new ReflectionProperty( Projector::class, 'reconciled_this_request' );
+		$guard->setAccessible( true );
+		$guard->setValue( $projector, false );
 	}
 
 	// ---- Always-on KB colors sync ------------------------------------------------------------------
@@ -74,8 +89,10 @@ final class ProjectorTest extends TestCase {
 
 		$this->projector->reconcile();
 
-		// KB colors must be written regardless.
-		$this->assertNotFalse( get_option( 'kadence_blocks_colors' ) );
+		// KB colors must be written regardless: it decodes to a palette array.
+		$decoded = json_decode( (string) get_option( 'kadence_blocks_colors' ), true );
+		$this->assertIsArray( $decoded );
+		$this->assertArrayHasKey( 'palette', $decoded );
 	}
 
 	// ---- Theme option conditional sync -------------------------------------------------------------
@@ -83,9 +100,21 @@ final class ProjectorTest extends TestCase {
 	public function testReconcileUpdatesThemePaletteWhenItExists(): void {
 		$theme_palette = [
 			'palette' => [
-				[ 'color' => '#old1', 'name' => 'Palette Color 1', 'slug' => 'palette1' ],
-				[ 'color' => '#old2', 'name' => 'Palette Color 2', 'slug' => 'palette2' ],
-				[ 'color' => '#old5', 'name' => 'Palette Color 5', 'slug' => 'palette5' ],
+				[
+					'color' => '#old1',
+					'name'  => 'Palette Color 1',
+					'slug'  => 'palette1',
+				],
+				[
+					'color' => '#old2',
+					'name'  => 'Palette Color 2',
+					'slug'  => 'palette2',
+				],
+				[
+					'color' => '#old5',
+					'name'  => 'Palette Color 5',
+					'slug'  => 'palette5',
+				],
 			],
 		];
 		update_option( 'kadence_global_palette', wp_json_encode( $theme_palette ) );
@@ -115,25 +144,41 @@ final class ProjectorTest extends TestCase {
 
 		$this->projector->reconcile();
 
-		$this->assertFalse( get_option( 'kadence_blocks_colors' ) );
+		// kadence_blocks_colors is a registered setting with a '' default, so get_option never returns
+		// false — assert it was not populated with a token palette instead.
+		$this->assertEmpty( get_option( 'kadence_blocks_colors' ) );
+		// The sync marker is our own option and is only written after a successful sync.
 		$this->assertFalse( get_option( 'kadence_blocks_design_tokens_palette_sync' ) );
 	}
 
 	// ---- Fail-open on corrupt store ----------------------------------------------------------------
 
 	public function testReconcileDoesNotAdvanceMarkerOnResolverException(): void {
-		// Replace the resolver with one that always throws.
-		$throwing_resolver = new class extends Token_Resolver {
-			public function __construct() {}
-
-			public function resolve( string $slug = 'default' ): never {
-				throw new \RuntimeException( 'corrupt store' );
-			}
-		};
+		// A real resolver over a baseline whose only token aliases a missing path: resolve() throws a
+		// Dangling_Alias_Exception (a RuntimeException), exercising the genuine fail-open path. Token_Resolver
+		// is final, so we compose one rather than subclass it.
+		$corrupt_resolver = new Token_Resolver(
+			$this->container->get( Token_Store::class ),
+			new Effective_Document(
+				new Fake_Baseline_Document(
+					[
+						'semantic' => [
+							'color' => [
+								'button-bg' => [
+									'$type'  => 'color',
+									'$value' => '{primitive.color.missing}',
+								],
+							],
+						],
+					]
+				)
+			),
+			new Css_Renderer()
+		);
 
 		$projector = new Projector(
 			$this->registry,
-			$throwing_resolver,
+			$corrupt_resolver,
 			$this->container->get( Token_Store::class ),
 			$this->container->get( Palette_Builder::class )
 		);
@@ -141,7 +186,7 @@ final class ProjectorTest extends TestCase {
 		$projector->reconcile();
 
 		$this->assertFalse( get_option( 'kadence_blocks_design_tokens_palette_sync' ) );
-		$this->assertFalse( get_option( 'kadence_blocks_colors' ) );
+		$this->assertEmpty( get_option( 'kadence_blocks_colors' ) );
 	}
 
 	// ---- Idempotency -------------------------------------------------------------------------------
@@ -152,9 +197,7 @@ final class ProjectorTest extends TestCase {
 		$after_first = get_option( 'kadence_blocks_colors' );
 
 		// Reset the per-request guard to allow a second reconcile.
-		$guard = new ReflectionProperty( Projector::class, 'reconciled_this_request' );
-		$guard->setAccessible( true );
-		$guard->setValue( $this->projector, false );
+		$this->reset_guard( $this->projector );
 
 		$this->projector->reconcile();
 
@@ -164,7 +207,7 @@ final class ProjectorTest extends TestCase {
 
 	// ---- Token-changed action re-sync --------------------------------------------------------------
 
-	public function testOnTokensChangedBypasesPerRequestGuardAndSyncs(): void {
+	public function testOnTokensChangedBypassesPerRequestGuardAndSyncs(): void {
 		// Perform a boot reconcile first.
 		$this->projector->reconcile();
 
@@ -174,7 +217,8 @@ final class ProjectorTest extends TestCase {
 		// on_tokens_changed must bypass the guard and run sync again.
 		$this->projector->on_tokens_changed();
 
-		$this->assertNotFalse( get_option( 'kadence_blocks_colors' ) );
+		$decoded = json_decode( (string) get_option( 'kadence_blocks_colors' ), true );
+		$this->assertIsArray( $decoded );
 		$this->assertNotFalse( get_option( 'kadence_blocks_design_tokens_palette_sync' ) );
 	}
 
@@ -188,12 +232,23 @@ final class ProjectorTest extends TestCase {
 		$this->assertStringEndsWith( ':0', (string) $marker_after_first );
 
 		// Now "switch" the theme by introducing the kadence_global_palette option.
-		update_option( 'kadence_global_palette', wp_json_encode( [ 'palette' => [ [ 'color' => '#old', 'name' => 'P1', 'slug' => 'palette1' ] ] ] ) );
+		update_option(
+			'kadence_global_palette',
+			wp_json_encode(
+				[
+					'palette' => [
+						[
+							'color' => '#old',
+							'name'  => 'P1',
+							'slug'  => 'palette1',
+						],
+					],
+				]
+			)
+		);
 
 		// Reset the guard to allow another reconcile.
-		$guard = new ReflectionProperty( Projector::class, 'reconciled_this_request' );
-		$guard->setAccessible( true );
-		$guard->setValue( $this->projector, false );
+		$this->reset_guard( $this->projector );
 
 		$this->projector->reconcile();
 

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/ProjectorTest.php
@@ -1,0 +1,219 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Projection\Kadence_Option;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Option\Palette_Builder;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Option\Projector;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use ReflectionProperty;
+use Tests\Support\Classes\TestCase;
+
+final class ProjectorTest extends TestCase {
+
+	private Projector $projector;
+	private Token_Registry $registry;
+
+	/**
+	 * Sentinel string used to detect absent options.
+	 */
+	private const ABSENT = "\0kb-design-tokens-absent\0";
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->projector = $this->container->get( Projector::class );
+		$this->registry  = $this->container->get( Token_Registry::class );
+
+		delete_option( 'kadence_blocks_colors' );
+		delete_option( 'kadence_global_palette' );
+		delete_option( 'kadence_blocks_design_tokens_palette_sync' );
+	}
+
+	protected function tearDown(): void {
+		$this->registry->activate();
+
+		// Reset the per-request guard so tests are isolated.
+		$guard = new ReflectionProperty( Projector::class, 'reconciled_this_request' );
+		$guard->setAccessible( true );
+		$guard->setValue( $this->projector, false );
+
+		// Clear the resolver memo so values do not leak between tests.
+		$resolver = $this->container->get( Token_Resolver::class );
+		$memo     = new ReflectionProperty( Token_Resolver::class, 'memo' );
+		$memo->setAccessible( true );
+		$memo->setValue( $resolver, [] );
+
+		delete_option( 'kadence_blocks_colors' );
+		delete_option( 'kadence_global_palette' );
+		delete_option( 'kadence_blocks_design_tokens_palette_sync' );
+
+		parent::tearDown();
+	}
+
+	// ---- Always-on KB colors sync ------------------------------------------------------------------
+
+	public function testReconcileWritesKbColorsWithResolvedPaletteToken(): void {
+		$this->projector->reconcile();
+
+		$raw     = get_option( 'kadence_blocks_colors' );
+		$decoded = json_decode( (string) $raw, true );
+
+		$this->assertIsArray( $decoded );
+		$by_slug = array_column( $decoded['palette'], null, 'slug' );
+		// The shipped declarations include button-bg => palette1.
+		$this->assertArrayHasKey( 'palette1', $by_slug );
+		$this->assertNotEmpty( $by_slug['palette1']['color'] );
+	}
+
+	public function testReconcileSyncsKbColorsWithoutKadenceGlobalPalettePresent(): void {
+		// Explicitly confirm there is no kadence_global_palette option.
+		$this->assertSame( self::ABSENT, get_option( 'kadence_global_palette', self::ABSENT ) );
+
+		$this->projector->reconcile();
+
+		// KB colors must be written regardless.
+		$this->assertNotFalse( get_option( 'kadence_blocks_colors' ) );
+	}
+
+	// ---- Theme option conditional sync -------------------------------------------------------------
+
+	public function testReconcileUpdatesThemePaletteWhenItExists(): void {
+		$theme_palette = [
+			'palette' => [
+				[ 'color' => '#old1', 'name' => 'Palette Color 1', 'slug' => 'palette1' ],
+				[ 'color' => '#old2', 'name' => 'Palette Color 2', 'slug' => 'palette2' ],
+				[ 'color' => '#old5', 'name' => 'Palette Color 5', 'slug' => 'palette5' ],
+			],
+		];
+		update_option( 'kadence_global_palette', wp_json_encode( $theme_palette ) );
+
+		$this->projector->reconcile();
+
+		$raw     = get_option( 'kadence_global_palette' );
+		$decoded = json_decode( (string) $raw, true );
+		$by_slug = array_column( $decoded['palette'], null, 'slug' );
+
+		// Token-claimed slots must be overwritten.
+		$this->assertNotSame( '#old1', $by_slug['palette1']['color'] );
+		// Unclaimed slots must be untouched.
+		$this->assertSame( '#old5', $by_slug['palette5']['color'] );
+	}
+
+	public function testReconcileNeverCreatesThemePaletteWhenAbsent(): void {
+		$this->projector->reconcile();
+
+		$this->assertSame( self::ABSENT, get_option( 'kadence_global_palette', self::ABSENT ) );
+	}
+
+	// ---- Fail-closed guard -------------------------------------------------------------------------
+
+	public function testReconcileWritesNothingWhenRegistryIsDeactivated(): void {
+		$this->registry->deactivate();
+
+		$this->projector->reconcile();
+
+		$this->assertFalse( get_option( 'kadence_blocks_colors' ) );
+		$this->assertFalse( get_option( 'kadence_blocks_design_tokens_palette_sync' ) );
+	}
+
+	// ---- Fail-open on corrupt store ----------------------------------------------------------------
+
+	public function testReconcileDoesNotAdvanceMarkerOnResolverException(): void {
+		// Replace the resolver with one that always throws.
+		$throwing_resolver = new class extends Token_Resolver {
+			public function __construct() {}
+
+			public function resolve( string $slug = 'default' ): never {
+				throw new \RuntimeException( 'corrupt store' );
+			}
+		};
+
+		$projector = new Projector(
+			$this->registry,
+			$throwing_resolver,
+			$this->container->get( Token_Store::class ),
+			$this->container->get( Palette_Builder::class )
+		);
+
+		$projector->reconcile();
+
+		$this->assertFalse( get_option( 'kadence_blocks_design_tokens_palette_sync' ) );
+		$this->assertFalse( get_option( 'kadence_blocks_colors' ) );
+	}
+
+	// ---- Idempotency -------------------------------------------------------------------------------
+
+	public function testSecondReconcileWithUnchangedSignaturePerformsNoWrite(): void {
+		$this->projector->reconcile();
+
+		$after_first = get_option( 'kadence_blocks_colors' );
+
+		// Reset the per-request guard to allow a second reconcile.
+		$guard = new ReflectionProperty( Projector::class, 'reconciled_this_request' );
+		$guard->setAccessible( true );
+		$guard->setValue( $this->projector, false );
+
+		$this->projector->reconcile();
+
+		// The marker must have been set after the first reconcile; the second must short-circuit.
+		$this->assertSame( $after_first, get_option( 'kadence_blocks_colors' ) );
+	}
+
+	// ---- Token-changed action re-sync --------------------------------------------------------------
+
+	public function testOnTokensChangedBypasesPerRequestGuardAndSyncs(): void {
+		// Perform a boot reconcile first.
+		$this->projector->reconcile();
+
+		// Simulate a token write by clearing the marker so the sync runs again and re-writes.
+		delete_option( 'kadence_blocks_design_tokens_palette_sync' );
+
+		// on_tokens_changed must bypass the guard and run sync again.
+		$this->projector->on_tokens_changed();
+
+		$this->assertNotFalse( get_option( 'kadence_blocks_colors' ) );
+		$this->assertNotFalse( get_option( 'kadence_blocks_design_tokens_palette_sync' ) );
+	}
+
+	// ---- Theme-switch signature flip ---------------------------------------------------------------
+
+	public function testThemeSwitchCausesSignatureFlipAndSyncsThemePalette(): void {
+		// First reconcile without the theme palette present.
+		$this->projector->reconcile();
+
+		$marker_after_first = get_option( 'kadence_blocks_design_tokens_palette_sync' );
+		$this->assertStringEndsWith( ':0', (string) $marker_after_first );
+
+		// Now "switch" the theme by introducing the kadence_global_palette option.
+		update_option( 'kadence_global_palette', wp_json_encode( [ 'palette' => [ [ 'color' => '#old', 'name' => 'P1', 'slug' => 'palette1' ] ] ] ) );
+
+		// Reset the guard to allow another reconcile.
+		$guard = new ReflectionProperty( Projector::class, 'reconciled_this_request' );
+		$guard->setAccessible( true );
+		$guard->setValue( $this->projector, false );
+
+		$this->projector->reconcile();
+
+		$marker_after_second = get_option( 'kadence_blocks_design_tokens_palette_sync' );
+		$this->assertStringEndsWith( ':1', (string) $marker_after_second );
+
+		// The theme palette must have been updated.
+		$raw     = get_option( 'kadence_global_palette' );
+		$decoded = json_decode( (string) $raw, true );
+		$by_slug = array_column( $decoded['palette'], null, 'slug' );
+		$this->assertNotSame( '#old', $by_slug['palette1']['color'] );
+	}
+
+	// ---- Hook wiring -------------------------------------------------------------------------------
+
+	public function testInitActionHasReconcileCallbackAtPriority20(): void {
+		$this->assertNotFalse( has_action( 'init' ) );
+	}
+
+	public function testTokenChangedActionHasOnTokensChangedCallback(): void {
+		$this->assertNotFalse( has_action( Token_Store::changed_action() ) );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/ProjectorTest.php
@@ -83,6 +83,16 @@ final class ProjectorTest extends TestCase {
 		$this->assertMatchesRegularExpression( '/^#[0-9a-fA-F]{3,8}$/', $by_slug['palette1']['color'] );
 	}
 
+	public function testReconcileDecodesEmptyKbColorsOption(): void {
+		update_option( 'kadence_blocks_colors', '' );
+
+		$this->projector->reconcile();
+
+		$decoded = json_decode( (string) get_option( 'kadence_blocks_colors' ), true );
+		$this->assertIsArray( $decoded );
+		$this->assertArrayHasKey( 'palette', $decoded );
+	}
+
 	public function testReconcileSyncsKbColorsWithoutKadenceGlobalPalettePresent(): void {
 		// Explicitly confirm there is no kadence_global_palette option.
 		$this->assertSame( self::ABSENT, get_option( 'kadence_global_palette', self::ABSENT ) );
@@ -154,6 +164,30 @@ final class ProjectorTest extends TestCase {
 	// ---- Fail-open on corrupt store ----------------------------------------------------------------
 
 	public function testReconcileDoesNotAdvanceMarkerOnResolverException(): void {
+		$kb_colors     = [
+			'palette'  => [
+				[
+					'color' => '#seeded',
+					'name'  => 'Seeded',
+					'slug'  => 'palette1',
+				],
+			],
+			'override' => false,
+		];
+		$theme_palette = [
+			'palette' => [
+				[
+					'color' => '#theme-old',
+					'name'  => 'P1',
+					'slug'  => 'palette1',
+				],
+			],
+		];
+		$kb_json       = (string) wp_json_encode( $kb_colors );
+		$theme_json    = (string) wp_json_encode( $theme_palette );
+		update_option( 'kadence_blocks_colors', $kb_json );
+		update_option( 'kadence_global_palette', $theme_json );
+
 		// A real resolver over a baseline whose only token aliases a missing path: resolve() throws a
 		// Dangling_Alias_Exception (a RuntimeException), exercising the genuine fail-open path. Token_Resolver
 		// is final, so we compose one rather than subclass it.
@@ -186,23 +220,25 @@ final class ProjectorTest extends TestCase {
 		$projector->reconcile();
 
 		$this->assertFalse( get_option( 'kadence_blocks_design_tokens_palette_sync' ) );
-		$this->assertEmpty( get_option( 'kadence_blocks_colors' ) );
+		$this->assertSame( $kb_json, get_option( 'kadence_blocks_colors' ) );
+		$this->assertSame( $theme_json, get_option( 'kadence_global_palette' ) );
 	}
 
 	// ---- Idempotency -------------------------------------------------------------------------------
 
-	public function testSecondReconcileWithUnchangedSignaturePerformsNoWrite(): void {
+	public function testSecondReconcileWithUnchangedSignatureSkipsResolution(): void {
 		$this->projector->reconcile();
 
-		$after_first = get_option( 'kadence_blocks_colors' );
+		$resolver = $this->container->get( Token_Resolver::class );
+		$memo     = new ReflectionProperty( Token_Resolver::class, 'memo' );
+		$memo->setAccessible( true );
+		$memo->setValue( $resolver, [] );
 
-		// Reset the per-request guard to allow a second reconcile.
 		$this->reset_guard( $this->projector );
-
 		$this->projector->reconcile();
 
-		// The marker must have been set after the first reconcile; the second must short-circuit.
-		$this->assertSame( $after_first, get_option( 'kadence_blocks_colors' ) );
+		// Matching marker must short-circuit before resolve() repopulates the memo.
+		$this->assertSame( [], $memo->getValue( $resolver ) );
 	}
 
 	public function testMarkerIsAutoloaded(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/ProjectorTest.php
@@ -80,7 +80,7 @@ final class ProjectorTest extends TestCase {
 		$by_slug = array_column( $decoded['palette'], null, 'slug' );
 		// The shipped declarations include button-bg => palette1.
 		$this->assertArrayHasKey( 'palette1', $by_slug );
-		$this->assertNotEmpty( $by_slug['palette1']['color'] );
+		$this->assertMatchesRegularExpression( '/^#[0-9a-fA-F]{3,8}$/', $by_slug['palette1']['color'] );
 	}
 
 	public function testReconcileSyncsKbColorsWithoutKadenceGlobalPalettePresent(): void {
@@ -274,7 +274,10 @@ final class ProjectorTest extends TestCase {
 	// ---- Hook wiring -------------------------------------------------------------------------------
 
 	public function testInitActionHasReconcileCallbackAtPriority20(): void {
-		$this->assertNotFalse( has_action( 'init' ) );
+		global $wp_filter;
+		// has_action('init') is always non-false in WP core; check that priority 20 specifically has a
+		// callback, which is where the Provider wires reconcile().
+		$this->assertArrayHasKey( 20, $wp_filter['init']->callbacks );
 	}
 
 	public function testTokenChangedActionHasOnTokensChangedCallback(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/ProjectorTest.php
@@ -1,5 +1,5 @@
 <?php declare( strict_types=1 );
-// cspell:ignore palette .
+// cspell:ignore palette autoloaded alloptions .
 
 namespace Tests\wpunit\Resources\Design_Tokens\Projection\Kadence_Option;
 
@@ -203,6 +203,15 @@ final class ProjectorTest extends TestCase {
 
 		// The marker must have been set after the first reconcile; the second must short-circuit.
 		$this->assertSame( $after_first, get_option( 'kadence_blocks_colors' ) );
+	}
+
+	public function testMarkerIsAutoloaded(): void {
+		$this->projector->reconcile();
+
+		$this->assertNotFalse( get_option( 'kadence_blocks_design_tokens_palette_sync' ) );
+		// reconcile() reads the marker on every request to short-circuit, so it must be autoloaded
+		// rather than cost a dedicated query: assert it landed in the autoloaded set.
+		$this->assertArrayHasKey( 'kadence_blocks_design_tokens_palette_sync', wp_load_alloptions() );
 	}
 
 	// ---- Token-changed action re-sync --------------------------------------------------------------


### PR DESCRIPTION
**Stacked PR 3 of 3** — base: `SOFT-3384/phase-2-palette-builder`. Review only this phase's diff.

The write-time projector and its provider — the only layer that touches WordPress options and hooks.

- Syncs `kadence_blocks_colors` **always**; syncs the Kadence theme's `kadence_global_palette` **only when it already exists** (sentinel probe) and **never creates it**.
- `reconcile()` runs once per request on a late `init` pass and on `kadence_blocks_design_tokens_changed`, so a token write syncs immediately and a later theme switch is caught next request.
- A `{store-version}:{theme-present}` marker short-circuits the no-change case before any resolve; gated on `Token_Registry::is_active()` (fail-closed) with a fail-open catch around resolution.
- Both options read every request are written **autoloaded** (the marker and `kadence_blocks_colors`); the theme option is updated with `null` autoload (it always already exists).

Full `ProjectorTest` coverage incl. fail-closed, fail-open, idempotency, theme-switch, and the autoloaded-marker assertion.