### PR TITLE
[DTM][1/3] SOFT-3385: variant-set structure accessors for the admin UI feed

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Token_Registry.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Registry.php
@@ -151,6 +151,18 @@ final class Token_Registry {
 	}
 
 	/**
+	 * All registered variant sets, keyed by block name in registration order. The admin UI feed
+	 * (SOFT-3385) iterates this to render per-block variant editors; mirrors all() for tokens.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, Variant_Set>
+	 */
+	public function variant_sets(): array {
+		return $this->variant_sets;
+	}
+
+	/**
 	 * The effective projection targets for a binding: a token reference contributes the referenced
 	 * token's projections (so a variant reuses the variable the base property already feeds), and the
 	 * binding's inline targets are merged on top, supplementing or overriding them (e.g. adding a

--- a/includes/resources/Design_Tokens/Registry/Token_Registry.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Registry.php
@@ -152,7 +152,7 @@ final class Token_Registry {
 
 	/**
 	 * All registered variant sets, keyed by block name in registration order. The admin UI feed
-	 * (SOFT-3385) iterates this to render per-block variant editors; mirrors all() for tokens.
+	 * iterates this to render per-block variant editors; mirrors all() for tokens.
 	 *
 	 * @since TBD
 	 *
@@ -202,7 +202,7 @@ final class Token_Registry {
 	}
 
 	/**
-	 * The schema the admin React app consumes (SOFT-3385). A token registered in PHP appears in the
+	 * The schema the admin React app consumes. A token registered in PHP appears in the
 	 * UI with no JS change. Values are NOT included here — the resolver supplies current values
 	 * separately; this is structure only.
 	 *

--- a/includes/resources/Design_Tokens/Registry/Variant_Set.php
+++ b/includes/resources/Design_Tokens/Registry/Variant_Set.php
@@ -111,7 +111,7 @@ final class Variant_Set {
 	}
 
 	/**
-	 * Structure-only serialization for the admin UI feed (SOFT-3385): the bound properties and, per
+	 * Structure-only serialization for the admin UI feed: the bound properties and, per
 	 * property, the token reference and inline projection targets. Values, variant names and the default
 	 * are NOT here — those are document data read through the Variant_Resolver. Mirrors
 	 * {@see Token_Registry::to_ui_schema()}.

--- a/includes/resources/Design_Tokens/Registry/Variant_Set.php
+++ b/includes/resources/Design_Tokens/Registry/Variant_Set.php
@@ -120,7 +120,7 @@ final class Variant_Set {
 	 *
 	 * @return array{bindings: array<string, array{token: string|null, projections: array<string, mixed>}>}
 	 */
-	public function to_ui_array(): array {
+	public function to_ui_schema(): array {
 		$bindings = [];
 
 		foreach ( $this->bindings as $property => $binding ) {

--- a/includes/resources/Design_Tokens/Registry/Variant_Set.php
+++ b/includes/resources/Design_Tokens/Registry/Variant_Set.php
@@ -111,6 +111,29 @@ final class Variant_Set {
 	}
 
 	/**
+	 * Structure-only serialization for the admin UI feed (SOFT-3385): the bound properties and, per
+	 * property, the token reference and inline projection targets. Values, variant names and the default
+	 * are NOT here — those are document data read through the Variant_Resolver. Mirrors
+	 * {@see Token_Registry::to_ui_schema()}.
+	 *
+	 * @since TBD
+	 *
+	 * @return array{bindings: array<string, array{token: string|null, projections: array<string, mixed>}>}
+	 */
+	public function to_ui_array(): array {
+		$bindings = [];
+
+		foreach ( $this->bindings as $property => $binding ) {
+			$bindings[ $property ] = [
+				'token'       => $binding->token,
+				'projections' => $binding->projections,
+			];
+		}
+
+		return [ 'bindings' => $bindings ];
+	}
+
+	/**
 	 * Build the property => Binding map from a declaration's "bindings".
 	 *
 	 * @since TBD

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
@@ -1,5 +1,4 @@
 <?php declare( strict_types=1 );
-// cspell:ignore advancedbtn advancedheading .
 
 namespace Tests\wpunit\Resources\Design_Tokens\Registry;
 

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
@@ -156,6 +156,7 @@ final class Token_RegistryTest extends TestCase {
 			array_keys( $sets )
 		);
 		$this->assertSame( 'kadence/advancedbtn', $sets['kadence/advancedbtn']->block );
+		$this->assertSame( 'kadence/advancedheading', $sets['kadence/advancedheading']->block );
 	}
 
 	public function testIsActiveByDefaultAndDeactivates(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
@@ -1,5 +1,5 @@
 <?php declare( strict_types=1 );
-// cspell:ignore advancedbtn .
+// cspell:ignore advancedbtn advancedheading .
 
 namespace Tests\wpunit\Resources\Design_Tokens\Registry;
 
@@ -139,6 +139,23 @@ final class Token_RegistryTest extends TestCase {
 		$set = $this->registry->for_block( 'kadence/advancedbtn' );
 		$this->assertNotNull( $set );
 		$this->assertSame( 'kadence/advancedbtn', $set->block );
+	}
+
+	public function testVariantSetsIsEmptyUntilRegistered(): void {
+		$this->assertSame( [], $this->registry->variant_sets() );
+	}
+
+	public function testVariantSetsReturnsRegisteredSetsKeyedByBlockInOrder(): void {
+		$this->registry->register_variant_set( [ 'block' => 'kadence/advancedbtn' ] );
+		$this->registry->register_variant_set( [ 'block' => 'kadence/advancedheading' ] );
+
+		$sets = $this->registry->variant_sets();
+
+		$this->assertSame(
+			[ 'kadence/advancedbtn', 'kadence/advancedheading' ],
+			array_keys( $sets )
+		);
+		$this->assertSame( 'kadence/advancedbtn', $sets['kadence/advancedbtn']->block );
 	}
 
 	public function testIsActiveByDefaultAndDeactivates(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Variant_SetTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Variant_SetTest.php
@@ -87,4 +87,34 @@ final class Variant_SetTest extends TestCase {
 		$this->assertSame( [], $report['unbound'] );
 		$this->assertSame( [], $report['unvalued'] );
 	}
+
+	public function testToUiArrayEmitsTokenReferenceAndInlineTargetsPerProperty(): void {
+		$ui = Variant_Set::from_array( $this->declaration() )->to_ui_array();
+
+		$this->assertSame( [ 'bindings' ], array_keys( $ui ) );
+
+		// A token-reference binding: token id present, no inline projections.
+		$this->assertSame(
+			[
+				'token'       => 'semantic.color.button-bg',
+				'projections' => [],
+			],
+			$ui['bindings']['button-bg']
+		);
+
+		// An inline binding: null token, its projection targets carried.
+		$this->assertSame(
+			[
+				'token'       => null,
+				'projections' => [ 'kadence_slot' => 'palette3' ],
+			],
+			$ui['bindings']['button-border']
+		);
+	}
+
+	public function testToUiArrayIsEmptyWhenTheSetHasNoBindings(): void {
+		$ui = Variant_Set::from_array( [ 'block' => 'kadence/advancedbtn' ] )->to_ui_array();
+
+		$this->assertSame( [ 'bindings' => [] ], $ui );
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Variant_SetTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Variant_SetTest.php
@@ -88,8 +88,8 @@ final class Variant_SetTest extends TestCase {
 		$this->assertSame( [], $report['unvalued'] );
 	}
 
-	public function testToUiArrayEmitsTokenReferenceAndInlineTargetsPerProperty(): void {
-		$ui = Variant_Set::from_array( $this->declaration() )->to_ui_array();
+	public function testToUiSchemaEmitsTokenReferenceAndInlineTargetsPerProperty(): void {
+		$ui = Variant_Set::from_array( $this->declaration() )->to_ui_schema();
 
 		$this->assertSame( [ 'bindings' ], array_keys( $ui ) );
 
@@ -112,8 +112,8 @@ final class Variant_SetTest extends TestCase {
 		);
 	}
 
-	public function testToUiArrayIsEmptyWhenTheSetHasNoBindings(): void {
-		$ui = Variant_Set::from_array( [ 'block' => 'kadence/advancedbtn' ] )->to_ui_array();
+	public function testToUiSchemaIsEmptyWhenTheSetHasNoBindings(): void {
+		$ui = Variant_Set::from_array( [ 'block' => 'kadence/advancedbtn' ] )->to_ui_schema();
 
 		$this->assertSame( [ 'bindings' => [] ], $ui );
 	}


### PR DESCRIPTION
**Stack:** phase 1 of 3 for [SOFT-3385](https://linear.app/nexcess/issue/SOFT-3385) (admin UI schema feed). Targets the base branch; phase 2 and 3 stack on top.

Adds the two pure, structure-only accessors the feed builder needs to enumerate and serialize registered variant sets — mirroring the existing `Token_Registry::to_ui_schema()` for tokens:

- `Token_Registry::variant_sets()` — lists registered sets keyed by block (the registry had only the single-block `for_block()`).
- `Variant_Set::to_ui_array()` — serializes per-property bindings (token ref + inline projections). Structure only; variant names/default/values remain document data read through `Variant_Resolver`.

No behavior change to existing consumers. Unit tests added to `Token_RegistryTest` and `Variant_SetTest`.