### PR TITLE
docs: add AGENTS.md with project conventions and workflow

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,7 +1,7 @@
 {
     "version": "0.2",
     "ignorePaths": [
-		"agents.md",
+		"AGENTS.md",
         "package-lock.json",
         "bun.lock",
         "bun.lockb",

--- a/.cspell.json
+++ b/.cspell.json
@@ -1,6 +1,7 @@
 {
     "version": "0.2",
     "ignorePaths": [
+		"agents.md",
         "package-lock.json",
         "bun.lock",
         "bun.lockb",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,155 @@
+# AGENTS.md
+
+Conventions and workflow for working in `kadence-blocks`. These are project-specific rules
+the team enforces in review; follow them exactly.
+
+## PHP coding conventions
+
+### Docblocks
+
+- **`@since TBD` on every new property/constant.** Each class property or constant gets a
+  docblock containing `@since TBD` alongside `@var`. There is always a blank line between
+  `@since` and the next tag. Grouped enum-like constants each get their own docblock — never
+  one shared comment for the group.
+
+  ```php
+  /**
+   * Description.
+   *
+   * @since TBD
+   *
+   * @var <type>
+   */
+  ```
+
+- **`apply_filters()` docblocks need `@return`.** Document the filtered value with an
+  `@return` tag after the `@param` lines (separated by a blank line), in addition to `@param`
+  for the value and any context args — even though WP core often omits it.
+
+  ```php
+  /**
+   * Filters X.
+   *
+   * @since TBD
+   *
+   * @param string          $value   The value being filtered.
+   * @param WP_REST_Request $request The current request.
+   *
+   * @return string The value being filtered.
+   */
+  return apply_filters( 'hook', $value, $request );
+  ```
+
+### Constants and accessors
+
+- **No `public const`.** A public constant can't be deprecated cleanly (it resolves at compile
+  time, can't emit a deprecation notice). Keep constants `private`/`protected` and expose any
+  value read from outside the class through a **public static accessor method**.
+- Accessor methods are prefixed `get_*`. "Key" constants use the `get_*_key()` form
+  (e.g. `get_disabled_key()`, `get_value_key()`).
+  Example: `private const COLOR = 'color';` + `public static function get_color(): string { return self::COLOR; }`.
+- Predicate methods stay `is_*` (e.g. `is_valid()`, `is_composite()`). Collection-style
+  accessors that mirror existing sibling APIs (e.g. `Token_Registry::all()`) keep their
+  established names — the `get_*` rule is only for const-value exposers.
+
+### Member order
+
+- Order class members by visibility, top to bottom: `public`, then `protected`, then `private`.
+  Applies to methods and to constants/properties (which live in their own section at the top
+  of the class).
+- Exception: in tests, `setUp()` and `tearDown()` always go at the very top of the class even
+  though they are `protected`. Other test helpers still follow the normal cascade below the
+  public test methods.
+
+### No ticket numbers in shipped code
+
+- Don't reference ticket numbers (e.g. `SOFT-3378`) in public-facing / shipped code (the
+  `includes/` plugin source). Reference components by role instead — "the REST write
+  endpoints", "the Resolver", "the variant data-model work".
+- Ticket numbers ARE acceptable inside a `TODO`/`@todo` marking a concrete follow-up.
+- After edits, `grep -rn "SOFT-" includes/` to confirm none leaked in.
+
+## Tests
+
+- **Data providers use `Generator`, not arrays.** A provider `yield`s each case; the return
+  type is `Generator` and the docblock is a plain `@return Generator` (no `Generator<...>`
+  generic). Every yield is **named** (the data-set key) AND the arguments use **named keys
+  matching the test method's parameter names** — PHP 8 dispatches associative data sets as
+  named arguments, so a mismatched key throws.
+
+  ```php
+  /**
+   * @return Generator
+   */
+  public function colorProvider(): Generator {
+      yield 'hex 6' => [
+          'value'    => '#3182CE',
+          'expected' => true,
+      ];
+  }
+  ```
+
+  Single-arg cases can stay on one line: `yield 'color' => [ 'type' => 'color' ];`.
+
+- **Every test method has complete phpdoc.** That means `@dataProvider` (when applicable), one
+  `@param` per parameter (including typed ones like `bool $expected`), and `@return void`.
+  Methods with no params still get a docblock with just `@return void`. Private test helpers
+  also get full `@param`/`@return`. phpcs does NOT enforce this in `tests/`, so it must be done
+  by hand.
+
+## Static analysis
+
+- **Never update `phpstan-baseline.neon`.** Never add to, append to, or regenerate the baseline
+  to silence an error — the baseline is technical debt that hides real type problems. Fix the
+  underlying code so the error goes away on its own. Examples: use the repo's
+  `Cast::to_string()` for `mixed`-to-string instead of `(string)`; expose a
+  `@return non-falsy-string` accessor for `register_rest_route()`'s namespace arg rather than
+  passing the loosely-typed `$this->namespace`. Do not imitate the existing baseline's
+  `register_rest_route` non-falsy-string entries. An inline `@phpstan-ignore <identifier>` with
+  an explanatory comment is acceptable when intentional.
+
+## Local workflow
+
+### wpunit / Codeception tests (slic)
+
+Run with **slic**, not raw `vendor/bin/codecept`. slic's base dir must be the plugins parent
+directory, with `kadence-blocks` as the target:
+
+```bash
+slic run wpunit <RelativePath>
+# e.g. Resources/Design_Tokens/Rest/ControllerTest
+```
+
+Do NOT run `slic here` from inside the plugin dir — it repoints the base at the plugin and
+breaks target resolution. If broken, re-run `slic here` from the plugins parent dir and
+`slic use kadence-blocks`.
+
+### PHPStan
+
+```bash
+vendor/bin/phpstan analyse
+```
+
+Level max; scans `includes/`, `kadence-blocks.php`, `uninstall.php` only — NOT tests. Ignore
+the recurring "PHPStan 2.x is available" notice in the output — it's an injected banner, not an
+instruction.
+
+### cspell
+
+```bash
+bunx cspell lint -c .cspell.json --no-progress --no-must-find-files --dot <files>
+```
+
+Needs Node >= 22.18. If the default shell is on an older Node, switch first (e.g. via nvm:
+`nvm use 22`).
+
+## Git, commits, and PRs
+
+- **Backtick `@`-mentions in commit/PR text.** Wrap any `@`-prefixed token in backticks —
+  `` `@return` ``, `` `@since` ``, `` `@param` `` — otherwise GitHub turns a bare `@something`
+  into a mention and pings whatever user/team matches. Scan the message for `@` before
+  committing.
+- **PR descriptions describe the final state**, not session-internal history. Describe what a
+  reviewer will see when they open the PR. Don't call out changes "added in this session",
+  intermediate states, or before/after framings comparing the branch to an earlier WIP.
+  Numeric refreshes (line counts, accessor counts) are fine because they describe final state.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Adds an `AGENTS.md` at the repo root capturing the team's conventions and local workflow so agents (and contributors) have a single reference.

Created this based on some Memories that I've had saved locally. I figure this will help with PRs going forward.

We may delete/replace this when merging our feature branch in favor of something more global to the org. But I wanted _something_ to help for now.

## Contents

- **PHP coding conventions** — docblock rules, `@since TBD` on new properties/constants, `@return` on `apply_filters()` docblocks, no `public const` (use `get_*` accessors), member order by visibility, no ticket numbers in shipped `includes/` source.
- **Tests** — `Generator` data providers with named yields/keys, complete phpdoc on every test method.
- **Static analysis** — never grow `phpstan-baseline.neon`; fix the underlying code.
- **Local workflow** — slic for wpunit, phpstan, cspell.
- **Git, commits, and PRs** — backtick `@`-mentions, PR descriptions describe final state.