### PR TITLE
feat(design-tokens): per-block adapter framework (SOFT-3400)

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Adapter/Contracts/Abstract_Adapter.php
+++ b/includes/resources/Design_Tokens/Projection/Adapter/Contracts/Abstract_Adapter.php
@@ -1,0 +1,35 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts;
+
+/**
+ * Base for per-block adapters: supplies get_block() from a block const so a concrete adapter only
+ * declares its block type and the transform.
+ *
+ * The const is protected, not private: a private const is visible only inside its declaring class, so
+ * the inherited get_block() could not read it through late static binding. Protected is the minimum
+ * that lets the accessor defined here resolve the child's value via static::BLOCK.
+ *
+ * @since TBD
+ */
+abstract class Abstract_Adapter implements Adapter_Interface {
+
+	/**
+	 * The Kadence Blocks block type this adapter is keyed to, e.g. "kadence/advancedheading". Concrete
+	 * adapters override with their own block.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	protected const BLOCK = '';
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @since TBD
+	 */
+	final public function get_block(): string {
+		return static::BLOCK;
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Adapter/Contracts/Adapter_Interface.php
+++ b/includes/resources/Design_Tokens/Projection/Adapter/Contracts/Adapter_Interface.php
@@ -1,0 +1,51 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts;
+
+/**
+ * A per-block adapter: a named transform keyed to a single Kadence Blocks block type, applied to that
+ * block's attributes while KB assembles them. Adapters are scoped to Kadence Blocks blocks only — they
+ * run through KB's own block-attributes seam, so a core or third-party block is never touched.
+ *
+ * Most blocks need none — when an attribute already holds a reference (a palette slug, a preset slug)
+ * it flows through an ownable CSS variable and rebrands for free. An adapter exists for the minority of
+ * blocks whose attributes are shaped so they cannot be expressed as a single such reference: a binding
+ * maps one property to one token, but an adapter is free-form and may read several tokens to build one
+ * CSS rule. For example kadence/image stores borderRadius as a four-element array of raw per-corner
+ * numbers with a separate unit attribute; it renders to literal lengths with no var() indirection, and
+ * the rule it feeds can draw on more than one radius token, so an adapter does the imperative work of
+ * turning the stored value into something the projected variables can carry. The default path is "no
+ * adapter — the CSS variable just works."
+ *
+ * The block key is read through a get_*() accessor over a const rather than a public const, matching
+ * the module's idiom (e.g. {@see \KadenceWP\KadenceBlocks\Design_Tokens\Projection\Wp_Preset_Target}).
+ * {@see Abstract_Adapter} supplies get_block() so a concrete adapter only declares its block const and
+ * the transform.
+ *
+ * @since TBD
+ */
+interface Adapter_Interface {
+
+	/**
+	 * The Kadence Blocks block type this adapter is keyed to, e.g. "kadence/advancedheading".
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_block(): string;
+
+	/**
+	 * Transform a block's attributes before its CSS is built, returning the rewritten attributes.
+	 *
+	 * Runs in the render path, so it must be a pure, side-effect-free function of its input: it receives
+	 * the block's attributes and returns them, leaving any value it does not handle untouched.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $attributes The block's attributes.
+	 *
+	 * @return array<string, mixed> The transformed attributes.
+	 */
+	public function apply( array $attributes ): array;
+}

--- a/includes/resources/Design_Tokens/Projection/Adapter/Contracts/Adapter_Interface.php
+++ b/includes/resources/Design_Tokens/Projection/Adapter/Contracts/Adapter_Interface.php
@@ -8,14 +8,14 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts;
  * run through KB's own block-attributes seam, so a core or third-party block is never touched.
  *
  * Most blocks need none — when an attribute already holds a reference (a palette slug, a preset slug)
- * it flows through an ownable CSS variable and rebrands for free. An adapter exists for the minority of
- * blocks whose attributes are shaped so they cannot be expressed as a single such reference: a binding
- * maps one property to one token, but an adapter is free-form and may read several tokens to build one
- * CSS rule. For example kadence/image stores borderRadius as a four-element array of raw per-corner
- * numbers with a separate unit attribute; it renders to literal lengths with no var() indirection, and
- * the rule it feeds can draw on more than one radius token, so an adapter does the imperative work of
- * turning the stored value into something the projected variables can carry. The default path is "no
- * adapter — the CSS variable just works."
+ * it flows through an ownable CSS variable, so changing a token updates it for free. An adapter exists
+ * for the minority of blocks whose attributes are shaped so they cannot be expressed as a single such
+ * reference: a binding maps one property to one token, but an adapter is free-form and may read several
+ * tokens to build one CSS rule. For example kadence/image stores borderRadius as a four-element array
+ * of raw per-corner numbers with a separate unit attribute; it renders to literal lengths with no var()
+ * indirection, and the rule it feeds can draw on more than one radius token, so an adapter does the
+ * imperative work of turning the stored value into something the projected variables can carry. The
+ * default path is "no adapter — the CSS variable just works."
  *
  * The block key is read through a get_*() accessor over a const rather than a public const, matching
  * the module's idiom (e.g. {@see \KadenceWP\KadenceBlocks\Design_Tokens\Projection\Wp_Preset_Target}).

--- a/includes/resources/Design_Tokens/Projection/Adapter/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Adapter/Projector.php
@@ -1,0 +1,67 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use Throwable;
+
+/**
+ * Applies a block's registered per-block adapter to its attributes while KB assembles them.
+ *
+ * The Provider wires apply() to KB's `kadence_blocks_block_default_attributes` filter, which passes the
+ * block name, so the adapter is looked up per render. It is a no-op — returning the attributes untouched
+ * — when projection is fail-closed, when no adapter is registered for the block, or when the adapter
+ * throws, so it is safe to run for every block on every render.
+ *
+ * @since TBD
+ */
+final class Projector {
+
+	/**
+	 * @var Token_Registry The registry the block's adapter is read from.
+	 *
+	 * @since TBD
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry $registry The token registry.
+	 */
+	public function __construct( Token_Registry $registry ) {
+		$this->registry = $registry;
+	}
+
+	/**
+	 * Run the block's adapter over its attributes, returning the transformed attributes.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $attributes The block's attributes.
+	 * @param string               $block      The Kadence Blocks block name, e.g. "kadence/advancedheading".
+	 *
+	 * @return array<string, mixed> The transformed attributes; unchanged when the block has no adapter.
+	 */
+	public function apply( array $attributes, string $block ): array {
+		// Respect the fail-closed guard: when projection is disabled (e.g. a declared token is missing
+		// from the baseline) leave the attributes as KB stored them rather than half-transforming them.
+		if ( ! $this->registry->is_active() ) {
+			return $attributes;
+		}
+
+		$adapter = $this->registry->adapter_for_block( $block );
+
+		if ( $adapter === null ) {
+			return $attributes;
+		}
+
+		try {
+			return $adapter->apply( $attributes );
+		} catch ( Throwable $e ) {
+			// This runs in the render path: a faulty adapter must never fatal a page, so fail soft to the
+			// untransformed attributes, matching the block-preset projector.
+			return $attributes;
+		}
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Adapter/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Adapter/Provider.php
@@ -1,0 +1,70 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts\Adapter_Interface;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
+
+/**
+ * Registers the per-block adapter projector and wires it into KB's render path.
+ *
+ * KB emits `kadence_blocks_block_default_attributes` while assembling a block's attributes (passing the
+ * block name), the same seam the block-preset projector uses. Running the adapter there — after the
+ * preset overlay (priority 20 vs 10) — lets it rewrite the values a block's attributes cannot express
+ * as a clean token/variable reference. The projector looks the adapter up by block at render time, so a
+ * block with no adapter is a no-op.
+ *
+ * @since TBD
+ */
+final class Provider extends Provider_Contract {
+
+	/**
+	 * The adapter classes registered against the Token Registry, resolved from the container so an adapter
+	 * can take the Registry or Resolver as a dependency. A Kadence Blocks block whose attributes cannot be
+	 * expressed as a clean token/variable reference lists its adapter here.
+	 *
+	 * @since TBD
+	 *
+	 * @var class-string<Adapter_Interface>[]
+	 */
+	private const ADAPTERS = [];
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @since TBD
+	 */
+	public function register(): void {
+		$this->container->singleton( Projector::class );
+
+		// Register the adapters on init, the same hook the token declarations use, so the registry is fully
+		// populated before render. The filter below then looks each adapter up by block.
+		add_action( 'init', [ $this, 'register_adapters' ], 0 );
+
+		add_filter(
+			'kadence_blocks_block_default_attributes',
+			$this->container->callback( Projector::class, 'apply' ),
+			20,
+			2
+		);
+	}
+
+	/**
+	 * Register the declared adapters against the Token Registry.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register_adapters(): void {
+		/** @var Token_Registry $registry */
+		$registry = $this->container->get( Token_Registry::class );
+
+		foreach ( self::ADAPTERS as $adapter ) { // @phpstan-ignore foreach.emptyArray (Remove once ADAPTERS lists an adapter.)
+			/** @var Adapter_Interface $instance */
+			$instance = $this->container->get( $adapter );
+			$registry->register_adapter( $instance );
+		}
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Adapter/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Adapter/Provider.php
@@ -38,9 +38,11 @@ final class Provider extends Provider_Contract {
 	public function register(): void {
 		$this->container->singleton( Projector::class );
 
-		// Register the adapters on init, the same hook the token declarations use, so the registry is fully
-		// populated before render. The filter below then looks each adapter up by block.
-		add_action( 'init', [ $this, 'register_adapters' ], 0 );
+		// Register the adapters on init at priority 10 — after the token declarations (priority 0) and the
+		// baseline guard (priority 1) so an adapter that depends on declared tokens sees a populated
+		// registry, and on a round increment that leaves room for other code to register adapters before
+		// us. The filter below then looks each adapter up by block.
+		add_action( 'init', [ $this, 'register_adapters' ], 10 );
 
 		add_filter(
 			'kadence_blocks_block_default_attributes',

--- a/includes/resources/Design_Tokens/Projection/Block_Preset/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Preset/Projector.php
@@ -4,7 +4,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Preset;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
-use RuntimeException;
+use Throwable;
 
 /**
  * Projects a block's preset — its `$default` variant — onto Kadence Blocks' per-block attribute defaults.
@@ -75,7 +75,7 @@ final class Projector {
 
 		try {
 			$values = $this->resolver->resolve_default( $block );
-		} catch ( RuntimeException $e ) {
+		} catch ( Throwable $e ) {
 			// No `$default` defined for the block, or the token graph cannot resolve (alias cycle/dangling
 			// reference). This runs in the render path, so fail soft to KB's defaults rather than fatally.
 			return $defaults;

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
@@ -6,7 +6,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Location;
-use RuntimeException;
+use Throwable;
 
 /**
  * Projects the resolved token set into the WordPress style pipeline.
@@ -160,7 +160,7 @@ final class Projector {
 		try {
 			$version  = $this->store->get_version();
 			$resolved = $this->resolver->resolve();
-		} catch ( RuntimeException $e ) {
+		} catch ( Throwable $e ) {
 			return '';
 		}
 

--- a/includes/resources/Design_Tokens/Projection/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Provider.php
@@ -25,6 +25,7 @@ final class Provider extends Provider_Contract {
 		Css_Var\Provider::class,
 		Theme_Json\Provider::class,
 		Block_Preset\Provider::class,
+		Adapter\Provider::class,
 	];
 
 	/**

--- a/includes/resources/Design_Tokens/Projection/Variant/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Variant/Projector.php
@@ -5,7 +5,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Variant;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Location;
-use RuntimeException;
+use Throwable;
 
 /**
  * Projects the selectable-variant CSS into the WordPress style pipeline.
@@ -113,7 +113,7 @@ final class Projector {
 	private function build_css(): string {
 		try {
 			$version = $this->store->get_version();
-		} catch ( RuntimeException $e ) {
+		} catch ( Throwable $e ) {
 			return '';
 		}
 

--- a/includes/resources/Design_Tokens/Registry/Token_Registry.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Registry.php
@@ -3,6 +3,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry;
 
+use InvalidArgumentException;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts\Adapter_Interface;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
 
@@ -76,10 +77,22 @@ final class Token_Registry {
 	 *
 	 * @param Adapter_Interface $adapter The adapter to register.
 	 *
+	 * @throws InvalidArgumentException When the adapter declares no block (an empty BLOCK const).
+	 *
 	 * @return void
 	 */
 	public function register_adapter( Adapter_Interface $adapter ): void {
-		$this->adapters[ $adapter->get_block() ] = $adapter;
+		$block = $adapter->get_block();
+
+		// A concrete adapter that forgets to override BLOCK would register under the empty key and silently
+		// never match, so its apply() would never run. Fail loudly so the misconfiguration surfaces.
+		if ( $block === '' ) {
+			throw new InvalidArgumentException(
+				sprintf( 'Adapter %s must override the BLOCK constant with the block type it adapts.', get_class( $adapter ) )
+			);
+		}
+
+		$this->adapters[ $block ] = $adapter;
 	}
 
 	// ---- Lookups consumed by projectors and the UI ------------------------------------------------

--- a/includes/resources/Design_Tokens/Registry/Token_Registry.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Registry.php
@@ -3,6 +3,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts\Adapter_Interface;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
 
 /**
@@ -24,6 +25,9 @@ final class Token_Registry {
 
 	/** @var array<string, Variant_Set> Keyed by block name. */
 	private array $variant_sets = [];
+
+	/** @var array<string, Adapter_Interface> Keyed by block name. */
+	private array $adapters = [];
 
 	/**
 	 * Whether token projection is active. Flipped off by the fail-closed guard so projectors and the
@@ -62,6 +66,20 @@ final class Token_Registry {
 		$variant_set = Variant_Set::from_array( $set );
 
 		$this->variant_sets[ $variant_set->block ] = $variant_set;
+	}
+
+	/**
+	 * Register a per-block adapter — a named transform keyed to the Kadence Blocks block type it adapts.
+	 * At most one adapter per block; a later registration for the same block replaces the earlier one.
+	 *
+	 * @since TBD
+	 *
+	 * @param Adapter_Interface $adapter The adapter to register.
+	 *
+	 * @return void
+	 */
+	public function register_adapter( Adapter_Interface $adapter ): void {
+		$this->adapters[ $adapter->get_block() ] = $adapter;
 	}
 
 	// ---- Lookups consumed by projectors and the UI ------------------------------------------------
@@ -148,6 +166,31 @@ final class Token_Registry {
 	 */
 	public function for_block( string $block ): ?Variant_Set {
 		return $this->variant_sets[ $block ] ?? null;
+	}
+
+	/**
+	 * The adapter registered for a Kadence Blocks block, or null when the block has none (the default —
+	 * its CSS vars already carry the tokens).
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block The Kadence Blocks block name, e.g. "kadence/advancedheading".
+	 *
+	 * @return Adapter_Interface|null
+	 */
+	public function adapter_for_block( string $block ): ?Adapter_Interface {
+		return $this->adapters[ $block ] ?? null;
+	}
+
+	/**
+	 * All registered adapters, keyed by Kadence Blocks block name.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, Adapter_Interface>
+	 */
+	public function adapters(): array {
+		return $this->adapters;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/functions.php
+++ b/includes/resources/Design_Tokens/functions.php
@@ -2,6 +2,7 @@
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Foundation_Presets\Catalog;
 use KadenceWP\KadenceBlocks\Design_Tokens\Foundation_Presets\Selector;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts\Adapter_Interface;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 
 if ( ! function_exists( 'kadence_blocks_register_design_token' ) ) {
@@ -49,6 +50,30 @@ if ( ! function_exists( 'kadence_blocks_register_design_variant_set' ) ) {
 		/** @var Token_Registry $registry */
 		$registry = kadence_blocks()->get( Token_Registry::class );
 		$registry->register_variant_set( $set );
+	}
+}
+
+if ( ! function_exists( 'kadence_blocks_register_design_token_adapter' ) ) {
+	/**
+	 * Register a per-block adapter — a named transform keyed to the Kadence Blocks block type whose
+	 * attributes cannot be expressed as a clean token/variable reference. Adapters apply to Kadence Blocks
+	 * blocks only: they run through KB's own block-attributes seam, so a core or third-party block is never
+	 * touched. Thin readability wrapper over Token_Registry::register_adapter() that mirrors KB's existing
+	 * global helpers. Most blocks need none.
+	 *
+	 * Register any time before the block renders (e.g. on `init`): the adapter projector looks the adapter
+	 * up by block when KB assembles the block's attributes, so registration order does not matter.
+	 *
+	 * @since TBD
+	 *
+	 * @param Adapter_Interface $adapter The adapter to register.
+	 *
+	 * @return void
+	 */
+	function kadence_blocks_register_design_token_adapter( Adapter_Interface $adapter ): void {
+		/** @var Token_Registry $registry */
+		$registry = kadence_blocks()->get( Token_Registry::class );
+		$registry->register_adapter( $adapter );
 	}
 }
 

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Adapter/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Adapter/ProjectorTest.php
@@ -1,0 +1,141 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Projection\Adapter;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts\Abstract_Adapter;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts\Adapter_Interface;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Projector;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use ReflectionClassConstant;
+use RuntimeException;
+use Tests\Support\Classes\TestCase;
+
+final class ProjectorTest extends TestCase {
+
+	/**
+	 * Real kadence/image attributes for the case the framework exists for: the per-corner borderRadius is
+	 * stored as raw numbers that render_measure_output() emits as literals, with no var() indirection for a
+	 * token to own. borderRadiusUnit rides alongside and must be left untouched.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private const IMAGE_ATTRIBUTES = [
+		'borderRadius'     => [ '8', '8', '8', '8' ],
+		'borderRadiusUnit' => 'px',
+	];
+
+	public function testItRunsTheRegisteredAdapterOverTheAttributes(): void {
+		$adapter  = $this->image_radius_adapter();
+		$registry = new Token_Registry();
+		$registry->register_adapter( $adapter );
+
+		$attributes = $this->projector( $registry )->apply( self::IMAGE_ATTRIBUTES, $this->declared_block( $adapter ) );
+
+		// Each raw per-corner radius is rewritten to reference the radius token's CSS variable, so the
+		// corner radius now follows the token instead of a baked-in literal.
+		$radius = 'var(--kb-token--semantic--radius--md)';
+		$this->assertSame( [ $radius, $radius, $radius, $radius ], $attributes['borderRadius'] );
+		// A sibling attribute the adapter does not touch survives unchanged.
+		$this->assertSame( 'px', $attributes['borderRadiusUnit'] );
+	}
+
+	public function testItIsANoopForABlockWithNoAdapter(): void {
+		// An empty registry knows no adapter for the block, so its attributes pass through untouched.
+		$attributes = $this->projector( new Token_Registry() )->apply(
+			self::IMAGE_ATTRIBUTES,
+			$this->declared_block( $this->image_radius_adapter() )
+		);
+
+		$this->assertSame( self::IMAGE_ATTRIBUTES, $attributes );
+	}
+
+	public function testItIsANoopWhenProjectionIsFailClosed(): void {
+		// The baseline guard deactivates projection on a broken token set; the projector must then leave the
+		// attributes as KB stored them even for a block that does have an adapter.
+		$adapter  = $this->image_radius_adapter();
+		$registry = new Token_Registry();
+		$registry->register_adapter( $adapter );
+		$registry->deactivate();
+
+		$attributes = $this->projector( $registry )->apply( self::IMAGE_ATTRIBUTES, $this->declared_block( $adapter ) );
+
+		$this->assertSame( self::IMAGE_ATTRIBUTES, $attributes );
+	}
+
+	public function testItFailsSoftWhenTheAdapterThrows(): void {
+		// A faulty adapter must never fatal a render: the projector swallows the throwable and returns the
+		// attributes untouched.
+		$adapter  = $this->throwing_adapter();
+		$registry = new Token_Registry();
+		$registry->register_adapter( $adapter );
+
+		$attributes = $this->projector( $registry )->apply( self::IMAGE_ATTRIBUTES, $this->declared_block( $adapter ) );
+
+		$this->assertSame( self::IMAGE_ATTRIBUTES, $attributes );
+	}
+
+	public function testTheProjectorIsWiredIntoTheBlockAttributesFilter(): void {
+		global $wp_filter;
+
+		// The Projection\Adapter\Provider hooks the projector at priority 20 on boot, after the block-preset
+		// overlay (priority 10), so it rewrites the assembled defaults.
+		$callbacks = $wp_filter['kadence_blocks_block_default_attributes']->callbacks ?? [];
+
+		$this->assertArrayHasKey( 20, $callbacks );
+	}
+
+	/**
+	 * Build the projector with a given registry.
+	 */
+	private function projector( Token_Registry $registry ): Projector {
+		return new Projector( $registry );
+	}
+
+	/**
+	 * The block an adapter declares, read straight off its BLOCK const so the test never restates the
+	 * literal that keys the registry.
+	 */
+	private function declared_block( Adapter_Interface $adapter ): string {
+		return (string) ( new ReflectionClassConstant( $adapter, 'BLOCK' ) )->getValue();
+	}
+
+	/**
+	 * A kadence/image adapter for the raw-numeric dimension case: it rewrites the block's raw per-corner
+	 * borderRadius into the radius token's CSS variable (leaving empty corners empty), the shape a real
+	 * SOFT-3404 wiring would take if the per-block mapping flags borderRadius as not mapping cleanly to a
+	 * variable.
+	 */
+	private function image_radius_adapter(): Adapter_Interface {
+		return new class() extends Abstract_Adapter {
+			protected const BLOCK = 'kadence/image';
+
+			public function apply( array $attributes ): array {
+				if ( empty( $attributes['borderRadius'] ) || ! is_array( $attributes['borderRadius'] ) ) {
+					return $attributes;
+				}
+
+				$attributes['borderRadius'] = array_map(
+					static function ( $corner ): string {
+						return $corner === '' ? '' : 'var(--kb-token--semantic--radius--md)';
+					},
+					$attributes['borderRadius']
+				);
+
+				return $attributes;
+			}
+		};
+	}
+
+	/**
+	 * A kadence/image adapter whose transform throws, to prove the projector fails soft.
+	 */
+	private function throwing_adapter(): Adapter_Interface {
+		return new class() extends Abstract_Adapter {
+			protected const BLOCK = 'kadence/image';
+
+			public function apply( array $attributes ): array {
+				throw new RuntimeException( 'boom' );
+			}
+		};
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Token_Registry_AdaptersTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Token_Registry_AdaptersTest.php
@@ -1,0 +1,91 @@
+<?php declare( strict_types=1 );
+// cspell:ignore advancedheading advancedbtn .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Registry;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts\Abstract_Adapter;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts\Adapter_Interface;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use ReflectionClassConstant;
+use Tests\Support\Classes\TestCase;
+
+final class Token_Registry_AdaptersTest extends TestCase {
+
+	private Token_Registry $registry;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->registry = new Token_Registry();
+	}
+
+	public function testRegisterAndLookupByBlock(): void {
+		$adapter = $this->heading_adapter();
+		$block   = $this->declared_block( $adapter );
+
+		$this->assertNull( $this->registry->adapter_for_block( $block ) );
+
+		$this->registry->register_adapter( $adapter );
+
+		$this->assertSame( $adapter, $this->registry->adapter_for_block( $block ) );
+	}
+
+	public function testLookupReturnsNullForAnUnregisteredBlock(): void {
+		$this->registry->register_adapter( $this->heading_adapter() );
+
+		$this->assertNull( $this->registry->adapter_for_block( $this->declared_block( $this->button_adapter() ) ) );
+	}
+
+	public function testAdaptersReturnsMapKeyedByBlock(): void {
+		$adapter = $this->heading_adapter();
+		$this->registry->register_adapter( $adapter );
+
+		$this->assertSame( [ $this->declared_block( $adapter ) => $adapter ], $this->registry->adapters() );
+	}
+
+	public function testReRegisteringTheSameBlockReplacesTheAdapter(): void {
+		$first  = $this->heading_adapter();
+		$second = $this->heading_adapter();
+
+		$this->registry->register_adapter( $first );
+		$this->registry->register_adapter( $second );
+
+		$this->assertCount( 1, $this->registry->adapters() );
+		$this->assertSame( $second, $this->registry->adapter_for_block( $this->declared_block( $second ) ) );
+	}
+
+	public function testAbstractAdapterExposesItsDeclaredBlockThroughTheAccessor(): void {
+		$adapter = $this->heading_adapter();
+
+		// The accessor must return exactly the BLOCK const the subclass declares.
+		$this->assertSame( $this->declared_block( $adapter ), $adapter->get_block() );
+	}
+
+	/**
+	 * The block an adapter declares, read straight off its BLOCK const so assertions never restate the
+	 * literal and stay independent of the get_block() accessor they may be checking.
+	 */
+	private function declared_block( Adapter_Interface $adapter ): string {
+		return (string) ( new ReflectionClassConstant( $adapter, 'BLOCK' ) )->getValue();
+	}
+
+	private function heading_adapter(): Adapter_Interface {
+		return new class() extends Abstract_Adapter {
+			protected const BLOCK = 'kadence/advancedheading';
+
+			public function apply( array $attributes ): array {
+				return $attributes;
+			}
+		};
+	}
+
+	private function button_adapter(): Adapter_Interface {
+		return new class() extends Abstract_Adapter {
+			protected const BLOCK = 'kadence/advancedbtn';
+
+			public function apply( array $attributes ): array {
+				return $attributes;
+			}
+		};
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Token_Registry_AdaptersTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Token_Registry_AdaptersTest.php
@@ -3,6 +3,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Registry;
 
+use InvalidArgumentException;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts\Abstract_Adapter;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts\Adapter_Interface;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
@@ -59,6 +60,20 @@ final class Token_Registry_AdaptersTest extends TestCase {
 
 		// The accessor must return exactly the BLOCK const the subclass declares.
 		$this->assertSame( $this->declared_block( $adapter ), $adapter->get_block() );
+	}
+
+	public function testRegisteringAnAdapterThatDeclaresNoBlockThrows(): void {
+		// An adapter that does not override BLOCK reports an empty block; registering it would store it under
+		// the empty key where it could never match, so the registry rejects it loudly.
+		$this->expectException( InvalidArgumentException::class );
+
+		$this->registry->register_adapter(
+			new class() extends Abstract_Adapter {
+				public function apply( array $attributes ): array {
+					return $attributes;
+				}
+			}
+		);
 	}
 
 	/**


### PR DESCRIPTION
🎫 [SOFT-3400 — Per-block adapter framework](https://linear.app/nexcess/issue/SOFT-3400/per-block-adapter-framework)

## Summary

Adds the per-block adapter framework for the Design Tokens module. An adapter is a named transform keyed to a single Kadence Blocks block type, registered in the Token Registry and applied to that block's attributes while KB assembles them. It exists for the minority of blocks whose attributes are shaped so they cannot be expressed as a single clean token/variable reference: a `Binding` maps one property to one token, but an adapter is free-form and may read several tokens to build one CSS rule (for example `kadence/image` storing `borderRadius` as a four-element array of raw per-corner numbers that render to literal lengths with no `var()` indirection).

The default path is unchanged — no adapter, the CSS variable just works. Adapters apply to Kadence Blocks blocks only; they run through KB's own block-attributes seam, so a WP Core or third-party block is never touched.

## How it works

- `Adapter_Interface` (contract) declares `get_block()` and `apply( array $attributes ): array`.
- `Abstract_Adapter` supplies `get_block()` from a `BLOCK` const, so a concrete adapter only declares the const and the transform.
- `Token_Registry` stores adapters keyed by block (`register_adapter()` / `adapter_for_block()` / `adapters()`), alongside tokens and variant sets.
- The adapter `Projector` is wired to `kadence_blocks_block_default_attributes` (priority 20, after the block-preset overlay) and looks the adapter up by block at render time — fail-soft (a throwing adapter never fatals a render) and fail-closed aware (a no-op when projection is deactivated).
- `kadence_blocks_register_design_token_adapter()` mirrors the module's other global helpers for third-party registration.

## For the other SOFT-3366 tickets

Each per-block wiring ticket that needs an adapter only has to define a class that extends `Abstract_Adapter` with its `BLOCK` constant and an `apply()` method, then add that class to the `ADAPTERS` list on `Projection\Adapter\Provider`. Registration into the Token Registry and invocation on KB's render seam are handled by the framework, so the adapter is auto-wired in place — no hook wiring or filter plumbing per ticket.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.