### PR TITLE
feature: add use_for_updates flag to offload legacy updates to harbor

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -42,6 +42,7 @@
         "slidy",
         "splide",
         "splidejs",
-        "stellarwp"
+        "stellarwp",
+		"solidwp"
     ]
 }

--- a/includes/resources/Harbor/Actions/Get_Known_Plugins.php
+++ b/includes/resources/Harbor/Actions/Get_Known_Plugins.php
@@ -17,7 +17,9 @@ final class Get_Known_Plugins {
 	 *
 	 * @since 3.7.0
 	 *
-	 * @return array<string, array{name: string, page_url: string}>
+	 * @return array<string, array{name: string, page_url: string, constant: string, is_premium: bool}>
+	 *
+	 * @phpstan-return array<string, array{name: string, page_url: string, constant: string, is_premium: bool}>
 	 */
 	public function __invoke(): array {
 		$default_page = admin_url( 'admin.php?page=kadence-blocks' );

--- a/includes/resources/Harbor/Actions/Report_Legacy_Licenses.php
+++ b/includes/resources/Harbor/Actions/Report_Legacy_Licenses.php
@@ -49,6 +49,7 @@ final class Report_Legacy_Licenses {
 				'product'   => 'kadence',
 				'is_active' => $is_active,
 				'page_url'  => esc_url( $plugin['page_url'] ),
+				'use_for_updates' => $plugin['is_premium'] ? true : false,
 			];
 		}
 


### PR DESCRIPTION
## Description

🎫  [SMTNC-1489](https://linear.app/nexcess/issue/SMTNC-1489/add-harbor-use-for-updates-flag-to-kadence)

This adds the `use_for_updates` flag to offload legacy updates to harbor as [described in the docs](https://github.com/stellarwp/harbor/blob/e3a5db5bb559753345ba272c280a4176b1ff97ff/docs/guides/integration.md#how-harbor-uses-reported-legacy-keys).
...

### DEMO

With this PR installed and Kadence Blocks Pro set to a previous version, navigating to the WP dashboard updates screen shows an update to the latest version avaialable.

<img width="3012" height="860" alt="Screenshot 2026-06-10 at 4 37 31 PM" src="https://github.com/user-attachments/assets/7a1507f4-e248-48f2-8e8e-6c9b81dc1f25" />
