### PR TITLE
Fix: prevent advanced text block crashing with optional chaining

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -57,6 +57,7 @@
         "lottiefiles",
         "lucatume",
         "lwsw",
+		"markformat",
         "mailerlite",
         "mbstring",
         "memize",

--- a/changelog/fix-smtnc-1487.yaml
+++ b/changelog/fix-smtnc-1487.yaml
@@ -1,5 +1,5 @@
 significance: patch
 type: fix
-entry: Resolve an issue with the Advanced Text Block after updating from earlier
+entry: Resolved an issue with the Advanced Text Block after updating from earlier
   Kadence Blocks versions
 timestamp: 2026-06-12T18:33:44.278Z

--- a/changelog/fix-smtnc-1487.yaml
+++ b/changelog/fix-smtnc-1487.yaml
@@ -1,0 +1,5 @@
+significance: patch
+type: fix
+entry: Resolve an issue with the Advanced Text Block after updating from earlier
+  Kadence Blocks versions
+timestamp: 2026-06-12T18:33:44.278Z

--- a/src/blocks/advancedheading/edit.js
+++ b/src/blocks/advancedheading/edit.js
@@ -1438,7 +1438,7 @@ function KadenceAdvancedHeading(props) {
 					}`}
 				{/* This style is used to override the default color which applied to already saved color palette with root css variable */}
 				{color &&
-					colorClass.includes('kb-palette') &&
+					colorClass?.includes('kb-palette') &&
 					(!textGradient || textGradient === '') &&
 					`.has-${colorClass}-color{
 						color: ${color} !important;


### PR DESCRIPTION
## Description 
Resolves: [SMTNC-1487](https://linear.app/nexcess/issue/SMTNC-1487/advanced-text-blocks-saved-before-update-break-after-upgrading)

This adds optional chaining to the block's `colorClass` property to prevent a type error.

### Root cause

The existing guard checks color but not colorClass. In block.json, colorClass is {"type": "string"} with no default — it's only ever set when the user picked a named palette color. Any block whose text color is a custom hex (like "color":"#474747") has color set but colorClass undefined, so colorClass.includes(...) throws TypeError: Cannot read properties of undefined (reading 'includes').


### DEMO

https://www.loom.com/share/4b5bcbedc559475b826acc5425e105d2

...

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [x] Tested with Dynamic content & Elements.
