### PR TITLE
feat(design-tokens): deliver media radius to kadence/image

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
@@ -1,0 +1,191 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Value;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
+use RuntimeException;
+
+/**
+ * Builds the low-specificity, block-scoped CSS that gives a block's dimension property a token-driven
+ * default, e.g. `.wp-block-kadence-image img { border-radius: var(--kb-token--semantic--radius--media, 1rem) }`.
+ *
+ * WHY THIS EXISTS — the use case, in full:
+ *
+ * Most token families reach a block through a variable the block already consumes: colors via the
+ * palette bridge, font sizes via the font-size bridge, spacing/gap by redefining the `--global-kb-*`
+ * variable a stored preset slug already points at (see the Css_Var slot projectors). Radius and icon
+ * size have none of that — Kadence Blocks renders them as raw literals (`border-radius: 12px`), exposes
+ * no ownable `--global-kb-*` variable for them, and their editor controls are plain numeric sliders.
+ *
+ * Two tempting alternatives both fail:
+ *   1. Store a token slug in the attribute and resolve it in the renderer. This hijacks the numeric
+ *      control (the slider can't represent a slug) and has to be mirrored in every block's editor JS.
+ *   2. Redefine a `--global-kb-radius-*` variable. There is none, and nothing references it, so it would
+ *      be a throwaway indirection.
+ *
+ * So instead the token is delivered as a **CSS default, not an attribute value**: one low-specificity
+ * rule per (block, css_prop) that points the property at the token variable. Because the rule's selector
+ * is a single `.wp-block-*` class (plus an optional descendant suffix), the block's OWN CSS — which it
+ * only emits when the attribute is set, and emits at higher specificity — always wins. The result is
+ * exactly the desired behaviour with zero block-editor changes and zero control changes:
+ *
+ *   - attribute unset            → the block emits nothing → this token default applies (the site-wide value);
+ *   - attribute set to any value → the block's higher-specificity rule wins, including an explicit `0`.
+ *
+ * And because the Projector enqueues this onto KB's editor style handle as well as the front-end one,
+ * the editor canvas gets the same default for free — the reason this CSS approach is preferred over an
+ * attribute/slug/control approach for these families. Nothing here is `!important`.
+ *
+ * Only a binding that declares a `css_prop` and references a token contributes, and only the block's
+ * `$default` variant is read (named variants are the selectable-variant projector's job). Pure: no
+ * WordPress calls; the wiring lives in {@see Projector}.
+ *
+ * @since TBD
+ */
+final class Css_Builder {
+
+	use Sanitizes_Css_Value;
+
+	/**
+	 * Object-cache group shared with the rest of the Design Tokens module.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const CACHE_GROUP = 'kb_design_tokens';
+
+	/**
+	 * @var Token_Registry The registry the variant sets (and their bindings) are read from.
+	 *
+	 * @since TBD
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * @var Variant_Resolver Resolves each block's `$default` variant to its `property => value` map.
+	 *
+	 * @since TBD
+	 */
+	private Variant_Resolver $variants;
+
+	/**
+	 * Per-request memo keyed on slug + store version, so repeated builds within a request are free and a
+	 * write (which bumps the version) invalidates it without an explicit purge.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string, string>
+	 */
+	private array $memo = [];
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry   $registry The token registry.
+	 * @param Variant_Resolver $variants The variant resolver.
+	 */
+	public function __construct( Token_Registry $registry, Variant_Resolver $variants ) {
+		$this->registry = $registry;
+		$this->variants = $variants;
+	}
+
+	/**
+	 * Build the block-default dimension CSS for a token set. Empty when no registered block binds a
+	 * `css_prop`.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token set whose resolved values the `$default` aliases resolve against.
+	 *
+	 * @return string The CSS, or an empty string when there is nothing to project.
+	 */
+	public function css( string $slug = 'default' ): string {
+		$css = '';
+
+		foreach ( $this->registry->variant_blocks() as $block ) {
+			$set = $this->registry->for_block( $block );
+
+			if ( $set === null ) {
+				continue;
+			}
+
+			try {
+				// A block may carry bindings before the document defines its `$default`; that is not an error,
+				// it simply contributes nothing yet, so skip it rather than fail the whole build.
+				$values = $this->variants->resolve_default( $block, $slug );
+			} catch ( RuntimeException $e ) {
+				continue;
+			}
+
+			$selector = '.wp-block-' . str_replace( '/', '-', $block );
+
+			// Group declarations by selector suffix so a block with several dimension props on the same
+			// element emits one rule, and props on a descendant (e.g. " img") get their own.
+			$by_suffix = [];
+
+			foreach ( $values as $property => $value ) {
+				$binding = $set->binding( $property );
+
+				// Only a token-referencing binding that names a css_prop contributes; the variable it points
+				// at is the referenced token's. An empty resolved value would produce a rule that resolves to
+				// nothing in the browser, so skip it.
+				if ( $binding === null || ! $binding->is_token_ref() ) {
+					continue;
+				}
+
+				$prop = $binding->css_prop();
+
+				if ( $prop === null || $value === '' ) {
+					continue;
+				}
+
+				$var      = $this->registry->css_var_for( (string) $binding->token );
+				$suffix   = $binding->css_selector() ?? '';
+
+				$by_suffix[ $suffix ][] = $prop . ':var(' . $var . ',' . $this->sanitize_value( $value ) . ')';
+			}
+
+			foreach ( $by_suffix as $suffix => $declarations ) {
+				$css .= $selector . $suffix . '{' . implode( ';', $declarations ) . ';}';
+			}
+		}
+
+		return $css;
+	}
+
+	/**
+	 * Cached variant of css(): memoized per request and persisted in the object cache keyed on the store
+	 * version (and plugin version), so a token write (which bumps the store version) and a plugin upgrade
+	 * both invalidate it automatically.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $version The store version the resolved set was built from.
+	 * @param string $slug    The token set slug.
+	 *
+	 * @return string
+	 */
+	public function css_for_version( string $version, string $slug ): string {
+		$memo_key = $version . ':' . $slug;
+
+		if ( isset( $this->memo[ $memo_key ] ) ) {
+			return $this->memo[ $memo_key ];
+		}
+
+		$cache_key = 'block_default_css_' . KADENCE_BLOCKS_VERSION . '_' . $memo_key;
+		$cached    = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
+
+		if ( $found && is_string( $cached ) ) {
+			return $this->memo[ $memo_key ] = $cached;
+		}
+
+		$css = $this->css( $slug );
+
+		wp_cache_set( $cache_key, $css, self::CACHE_GROUP, DAY_IN_SECONDS );
+
+		return $this->memo[ $memo_key ] = $css;
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
@@ -9,7 +9,7 @@ use RuntimeException;
 
 /**
  * Builds the low-specificity, block-scoped CSS that gives a block's dimension property a token-driven
- * default, e.g. `.wp-block-kadence-image img { border-radius: var(--kb-token--semantic--radius--media, 1rem) }`.
+ * default, e.g. `.wp-block-kadence-image img { border-radius: var(--kb-token--semantic--radius--media, 0) }`.
  *
  * WHY THIS EXISTS — the use case, in full:
  *
@@ -58,16 +58,20 @@ final class Css_Builder {
 	private const CACHE_GROUP = 'kb_design_tokens';
 
 	/**
-	 * @var Token_Registry The registry the variant sets (and their bindings) are read from.
+	 * The registry the variant sets (and their bindings) are read from.
 	 *
 	 * @since TBD
+	 *
+	 * @var Token_Registry
 	 */
 	private Token_Registry $registry;
 
 	/**
-	 * @var Variant_Resolver Resolves each block's `$default` variant to its `property => value` map.
+	 * Resolves each block's `$default` variant to its `property => value` map.
 	 *
 	 * @since TBD
+	 *
+	 * @var Variant_Resolver
 	 */
 	private Variant_Resolver $variants;
 
@@ -143,7 +147,7 @@ final class Css_Builder {
 				}
 
 				$var      = $this->registry->css_var_for( (string) $binding->token );
-				$suffix   = $binding->css_selector() ?? '';
+				$suffix   = $this->selector_suffix( $binding->css_selector() );
 
 				$by_suffix[ $suffix ][] = $prop . ':var(' . $var . ',' . $this->sanitize_value( $value ) . ')';
 			}
@@ -187,5 +191,29 @@ final class Css_Builder {
 		wp_cache_set( $cache_key, $css, self::CACHE_GROUP, DAY_IN_SECONDS );
 
 		return $this->memo[ $memo_key ] = $css;
+	}
+
+	/**
+	 * Compose a binding's optional `css_selector` into the suffix appended after the block's `.wp-block-*`
+	 * class. A bare selector (e.g. `img`) is treated as a descendant and gets the combinator space inserted
+	 * for it, so the declaration never has to carry a load-bearing leading space. A suffix that already
+	 * opens with a combinator or attachment character (`>`, `+`, `~`, `.`, `:`, `#`, `[`, `&`) is used
+	 * verbatim, so child combinators (`> img`) and compound/stateful selectors (`.is-style-rounded`) stay
+	 * expressible. Empty when the binding names no descendant — the rule targets the block root.
+	 *
+	 * @since TBD
+	 *
+	 * @param string|null $selector The binding's raw `css_selector`, or null when it names none.
+	 *
+	 * @return string The selector suffix, ready to concatenate after the block class.
+	 */
+	private function selector_suffix( ?string $selector ): string {
+		$selector = trim( (string) $selector );
+
+		if ( $selector === '' ) {
+			return '';
+		}
+
+		return strpbrk( $selector[0], '>+~.:#[&' ) === false ? ' ' . $selector : $selector;
 	}
 }

--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
@@ -29,7 +29,7 @@ use RuntimeException;
  * rule per (block, css_prop) that points the property at the token variable. Because the rule's selector
  * is a single `.wp-block-*` class (plus an optional descendant suffix), the block's OWN CSS — which it
  * only emits when the attribute is set, and emits at higher specificity — always wins. The result is
- * exactly the desired behaviour with zero block-editor changes and zero control changes:
+ * exactly the desired behavior with zero block-editor changes and zero control changes:
  *
  *   - attribute unset            → the block emits nothing → this token default applies (the site-wide value);
  *   - attribute set to any value → the block's higher-specificity rule wins, including an explicit `0`.

--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Projector.php
@@ -21,23 +21,29 @@ use Throwable;
 final class Projector {
 
 	/**
-	 * @var Token_Registry
+	 * The token registry, used to gate projection on the registry being active.
 	 *
 	 * @since TBD
+	 *
+	 * @var Token_Registry
 	 */
 	private Token_Registry $registry;
 
 	/**
-	 * @var Token_Store
+	 * The store, for the cache-busting version.
 	 *
 	 * @since TBD
+	 *
+	 * @var Token_Store
 	 */
 	private Token_Store $store;
 
 	/**
-	 * @var Css_Builder
+	 * The block-default CSS builder.
 	 *
 	 * @since TBD
+	 *
+	 * @var Css_Builder
 	 */
 	private Css_Builder $css_builder;
 

--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Projector.php
@@ -1,0 +1,123 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Location;
+use Throwable;
+
+/**
+ * Projects the per-block default dimension CSS into the WordPress style pipeline.
+ *
+ * Appends the low-specificity, block-scoped rules built by {@see Css_Builder} to KB's existing inline
+ * style handles, on the front end and in the editor, gated on Token_Registry::is_active() so a
+ * deactivated registry leaves KB's behavior untouched. Enqueuing onto the editor handle as well as the
+ * front-end one is what gives the token default editor-canvas parity for free — a block's `$default`
+ * radius / icon-size applies until a per-instance value KB renders wins by higher specificity.
+ *
+ * @since TBD
+ */
+final class Projector {
+
+	/**
+	 * @var Token_Registry
+	 *
+	 * @since TBD
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * @var Token_Store
+	 *
+	 * @since TBD
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @var Css_Builder
+	 *
+	 * @since TBD
+	 */
+	private Css_Builder $css_builder;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry $registry    The token registry.
+	 * @param Token_Store    $store       The store, for the cache-busting version.
+	 * @param Css_Builder    $css_builder The block-default CSS builder.
+	 */
+	public function __construct( Token_Registry $registry, Token_Store $store, Css_Builder $css_builder ) {
+		$this->registry    = $registry;
+		$this->store       = $store;
+		$this->css_builder = $css_builder;
+	}
+
+	/**
+	 * Append the block-default CSS to the front-end global-variables handle.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function enqueue_front_end(): void {
+		if ( ! $this->registry->is_active() ) {
+			return;
+		}
+
+		$css = $this->build_css();
+
+		if ( $css !== '' ) {
+			wp_add_inline_style( 'kadence-blocks-global-variables', $css );
+		}
+	}
+
+	/**
+	 * Append the block-default CSS to the editor global-styles handle.
+	 *
+	 * Shares the Css_Var projector's editor gate (the same page check and filter), so the default CSS and
+	 * the token vars load together in the editor or not at all.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function enqueue_editor(): void {
+		if ( ! $this->registry->is_active() ) {
+			return;
+		}
+
+		/** This filter is documented in includes/resources/Design_Tokens/Projection/Css_Var/Projector.php */
+		if ( ! apply_filters( 'kadence_blocks_load_editor_token_vars', Location::is_block_editor() ) ) {
+			return;
+		}
+
+		$css = $this->build_css();
+
+		if ( $css !== '' ) {
+			wp_add_inline_style( 'kadence-blocks-global-editor-styles', $css );
+		}
+	}
+
+	/**
+	 * Build the block-default CSS for the current set, via the builder's version-keyed cache.
+	 *
+	 * Returns an empty string when the store version cannot be read or a block cannot be resolved (e.g. an
+	 * alias cycle from a direct DB write that bypassed the REST gate), so the page never crashes — the
+	 * inline style is simply omitted and KB falls back to its own defaults.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	private function build_css(): string {
+		try {
+			$version = $this->store->get_version();
+		} catch ( Throwable $e ) {
+			return '';
+		}
+
+		return $this->css_builder->css_for_version( $version, Token_Store::default_slug() );
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Provider.php
@@ -1,0 +1,33 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css;
+
+use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
+
+/**
+ * Registers the block-default dimension-CSS projector: binds the builder and projector as singletons,
+ * then appends the low-specificity token-default rules to KB's inline style handles, front end and
+ * editor alike.
+ *
+ * @since TBD
+ */
+final class Provider extends Provider_Contract {
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @since TBD
+	 */
+	public function register(): void {
+		$this->container->singleton( Css_Builder::class );
+		$this->container->singleton( Projector::class );
+
+		// Front end: append after the token vars (100) and variant overrides (110). These are low-specificity
+		// defaults, so a per-instance value KB renders later still wins regardless of order.
+		add_action( 'wp_enqueue_scripts', $this->container->callback( Projector::class, 'enqueue_front_end' ), 120 );
+
+		// Editor: append at admin_init priority 20, after the editor-styles handle is registered (1) and the
+		// Css_Var (5) and variant (10) projectors, so the default CSS follows the token vars on the same handle.
+		add_action( 'admin_init', $this->container->callback( Projector::class, 'enqueue_editor' ), 20 );
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Provider.php
@@ -26,6 +26,7 @@ final class Provider extends Provider_Contract {
 		Theme_Json\Provider::class,
 		Block_Preset\Provider::class,
 		Variant\Provider::class,
+		Block_Default_Css\Provider::class,
 		Adapter\Provider::class,
 	];
 

--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -242,7 +242,7 @@
 			},
 			"media": {
 				"$type": "dimension",
-				"$value": "{primitive.dimension.radius.lg}"
+				"$value": "{primitive.dimension.radius.none}"
 			}
 		},
 		"borderWidth": {

--- a/includes/resources/Design_Tokens/Registry/Binding.php
+++ b/includes/resources/Design_Tokens/Registry/Binding.php
@@ -15,14 +15,15 @@ use InvalidArgumentException;
  *     registered token's projections, so a variant retargets the exact variable the base property
  *     already feeds and there is no duplicated projection to drift.
  *   - **Inline target** — `['kadence_slot' => 'palette3']` (and/or `wp_preset`, `block_attr`,
- *     `css_var`). For a property that is not (yet) a registered token, or to add a target the token
- *     does not carry.
+ *     `css_var`, `css_prop`, `css_selector`). For a property that is not (yet) a registered token, or
+ *     to add a target the token does not carry.
  *   - **Both** — e.g. `['token' => 'semantic.color.button-bg', 'block_attr' => 'background']`. The
  *     inline targets supplement (and override) the referenced token's projections, which is how a
  *     token-backed property still declares the `block_attr` a block preset needs.
  *
  * {@see Token_Registry::effective_projections()} merges the two. The projection vocabulary is the same
- * one tokens use, with one addition — `block_attr`, which tokens never carry.
+ * one tokens use, with three additions — `block_attr`, `css_prop`, and `css_selector`, which tokens
+ * never carry.
  *
  * @since TBD
  */
@@ -88,8 +89,11 @@ final class Binding {
 
 	/**
 	 * Inline target: a selector suffix appended after the block's `.wp-block-*` class for the `css_prop`
-	 * rule, when the property is rendered on a descendant rather than the block root (e.g. " img" for an
-	 * image). Optional; the rule targets the block root when omitted.
+	 * rule, when the property is rendered on a descendant rather than the block root (e.g. `img` for an
+	 * image). A bare selector is treated as a descendant — the projector inserts the combinator space, so
+	 * no load-bearing leading space is needed; a value that opens with a combinator or attachment character
+	 * (`>`, `+`, `~`, `.`, `:`, `#`, `[`, `&`) is used verbatim. Optional; the rule targets the block root
+	 * when omitted.
 	 *
 	 * @since TBD
 	 *

--- a/includes/resources/Design_Tokens/Registry/Binding.php
+++ b/includes/resources/Design_Tokens/Registry/Binding.php
@@ -75,13 +75,36 @@ final class Binding {
 	private const CSS_VAR = 'css_var';
 
 	/**
+	 * Inline target: a CSS property the block renders as a raw literal (e.g. "border-radius"), so the
+	 * block-default-CSS projector can emit a low-specificity block-scoped rule pointing it at the bound
+	 * token's variable. Used for the dimension families KB gives no ownable variable for (radius, icon
+	 * size); see that projector's Css_Builder for the full rationale.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const CSS_PROP = 'css_prop';
+
+	/**
+	 * Inline target: a selector suffix appended after the block's `.wp-block-*` class for the `css_prop`
+	 * rule, when the property is rendered on a descendant rather than the block root (e.g. " img" for an
+	 * image). Optional; the rule targets the block root when omitted.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const CSS_SELECTOR = 'css_selector';
+
+	/**
 	 * The inline string targets and their validation: each, when present, must be a non-empty string.
 	 *
 	 * @since TBD
 	 *
 	 * @var string[]
 	 */
-	private const STRING_TARGETS = [ self::KADENCE_SLOT, self::WP_PRESET, self::BLOCK_ATTR ];
+	private const STRING_TARGETS = [ self::KADENCE_SLOT, self::WP_PRESET, self::BLOCK_ATTR, self::CSS_PROP, self::CSS_SELECTOR ];
 
 	/**
 	 * The block property this binding drives, e.g. "button-bg". Carried for error messages and so a
@@ -199,6 +222,36 @@ final class Binding {
 		$attribute = $this->projections[ self::BLOCK_ATTR ] ?? null;
 
 		return is_string( $attribute ) ? $attribute : null;
+	}
+
+	/**
+	 * The CSS property this binding feeds a block-scoped default rule for, or null when it declares none.
+	 * Read by the block-default-CSS projector to emit `<prop>: var(--kb-token--*)` for a dimension the
+	 * block renders as a literal. Always an inline target — tokens never carry a `css_prop` — so it is read
+	 * straight off this binding.
+	 *
+	 * @since TBD
+	 *
+	 * @return string|null
+	 */
+	public function css_prop(): ?string {
+		$property = $this->projections[ self::CSS_PROP ] ?? null;
+
+		return is_string( $property ) ? $property : null;
+	}
+
+	/**
+	 * The selector suffix for this binding's `css_prop` rule (e.g. " img"), or null when the property is
+	 * rendered on the block root. Inline only.
+	 *
+	 * @since TBD
+	 *
+	 * @return string|null
+	 */
+	public function css_selector(): ?string {
+		$selector = $this->projections[ self::CSS_SELECTOR ] ?? null;
+
+		return is_string( $selector ) ? $selector : null;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -34,6 +34,14 @@ return [
 				'site_editor'  => true,
 			],
 		],
+		[
+			// Registered so Css_Var emits its --kb-token--semantic--radius--media variable; the block-default
+			// CSS projector points kadence/image's border-radius at that variable as a low-specificity default.
+			'id'    => 'semantic.radius.media',
+			'type'  => 'dimension',
+			'label' => __( 'Media Radius', 'kadence-blocks' ),
+			'group' => __( 'Brand', 'kadence-blocks' ),
+		],
 	],
 	// Variant set for the Button block: that it accepts variants, plus the per-property bindings (a
 	// token reference where the property is already a registered token, an inline target otherwise).
@@ -48,6 +56,19 @@ return [
 				'button-text'   => [ 'token' => 'semantic.color.button-text' ],
 				'button-border' => [ 'kadence_slot' => 'palette3' ],            // not a token yet → inline target.
 				'button-radius' => [ 'css_var' => true ],                       // token-var only (no preset bucket).
+			],
+		],
+		[
+			// Image radius: the $default binds borderRadius to the media-radius token. The block-default-CSS
+			// projector emits a low-specificity `.wp-block-kadence-image img { border-radius: var(...) }` rule,
+			// so a fresh image follows the token while any radius the user sets (including 0) still wins.
+			'block'    => 'kadence/image',
+			'bindings' => [
+				'borderRadius' => [
+					'token'        => 'semantic.radius.media',
+					'css_prop'     => 'border-radius',
+					'css_selector' => ' img',
+				],
 			],
 		],
 	],

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -67,7 +67,7 @@ return [
 				'borderRadius' => [
 					'token'        => 'semantic.radius.media',
 					'css_prop'     => 'border-radius',
-					'css_selector' => ' img',
+					'css_selector' => 'img',
 				],
 			],
 		],

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -16,28 +16,40 @@ use Tests\Support\Classes\TestCase;
  */
 final class Css_BuilderTest extends TestCase {
 
+	/**
+	 * @var Variant_Resolver
+	 */
 	private Variant_Resolver $resolver;
 
+	/**
+	 * @return void
+	 */
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->resolver = $this->container->get( Variant_Resolver::class );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testItEmitsALowSpecificityRulePointingTheCssPropAtTheTokenVar(): void {
 		$var = Css_Var::from_id( 'semantic.radius.media' );
 
-		// Image's $default binds borderRadius to semantic.radius.media (resolves to 1rem via radius.lg).
+		// Image's $default binds borderRadius to semantic.radius.media (resolves to 0 via radius.none).
 		$css = $this->builder( $this->image_registry() )->css();
 
 		// One rule on a single .wp-block-* class plus the " img" descendant, the resolved length as the
 		// var() fallback — so the block's own (higher-specificity) radius always wins when set.
 		$this->assertStringContainsString(
-			'.wp-block-kadence-image img{border-radius:var(' . $var . ',1rem);}',
+			'.wp-block-kadence-image img{border-radius:var(' . $var . ',0);}',
 			$css
 		);
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testTheShippedDeclarationsEmitTheImageRadiusRule(): void {
 		// Build from the real registry (declarations loaded on init). Image radius is the css_prop-bound case
 		// that fits this projector: the attribute is empty by default and rendered as CSS in both editor and
@@ -52,6 +64,9 @@ final class Css_BuilderTest extends TestCase {
 		$this->assertStringNotContainsString( '.wp-block-kadence-icon', $css );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testItContributesNothingForABindingWithoutACssProp(): void {
 		// A block_attr-only binding (the block-preset path) declares no css_prop, so it feeds no rule here.
 		$registry = new Token_Registry();
@@ -71,7 +86,25 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
+	 * @return void
+	 */
+	public function testItInsertsTheDescendantCombinatorForABareCssSelector(): void {
+		$var = Css_Var::from_id( 'semantic.radius.media' );
+
+		// A bare `img` selector must not need a load-bearing leading space: the builder inserts the
+		// descendant combinator, so it produces the same rule as the explicit ` img` form.
+		$css = $this->builder( $this->image_registry() )->css();
+
+		$this->assertStringContainsString( '.wp-block-kadence-image img{border-radius:var(' . $var . ',0);}', $css );
+		$this->assertStringNotContainsString( '.wp-block-kadence-imageimg', $css );
+	}
+
+	/**
 	 * Build the builder with a given registry and the real (baseline-backed) variant resolver.
+	 *
+	 * @param Token_Registry $registry The registry whose variant sets the builder reads.
+	 *
+	 * @return Css_Builder
 	 */
 	private function builder( Token_Registry $registry ): Css_Builder {
 		return new Css_Builder( $registry, $this->resolver );
@@ -80,6 +113,8 @@ final class Css_BuilderTest extends TestCase {
 	/**
 	 * A registry holding the media-radius token and the Image variant set binding borderRadius to it via a
 	 * css_prop target, so the builder emits the block-default radius rule.
+	 *
+	 * @return Token_Registry
 	 */
 	private function image_registry(): Token_Registry {
 		$registry = new Token_Registry();
@@ -97,7 +132,7 @@ final class Css_BuilderTest extends TestCase {
 					'borderRadius' => [
 						'token'        => 'semantic.radius.media',
 						'css_prop'     => 'border-radius',
-						'css_selector' => ' img',
+						'css_selector' => 'img',
 					],
 				],
 			]

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -1,0 +1,108 @@
+<?php declare( strict_types=1 );
+// cspell:ignore advancedbtn .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Projection\Block_Default_Css;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css\Css_Builder;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Exercises the block-default CSS builder against the real shipped Image `$default`, proving it emits a
+ * low-specificity, block-scoped rule pointing the bound css_prop at the token variable — the mechanism
+ * used for dimensions (radius) KB renders as literals with no ownable variable.
+ */
+final class Css_BuilderTest extends TestCase {
+
+	private Variant_Resolver $resolver;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->resolver = $this->container->get( Variant_Resolver::class );
+	}
+
+	public function testItEmitsALowSpecificityRulePointingTheCssPropAtTheTokenVar(): void {
+		$var = Css_Var::from_id( 'semantic.radius.media' );
+
+		// Image's $default binds borderRadius to semantic.radius.media (resolves to 1rem via radius.lg).
+		$css = $this->builder( $this->image_registry() )->css();
+
+		// One rule on a single .wp-block-* class plus the " img" descendant, the resolved length as the
+		// var() fallback — so the block's own (higher-specificity) radius always wins when set.
+		$this->assertStringContainsString(
+			'.wp-block-kadence-image img{border-radius:var(' . $var . ',1rem);}',
+			$css
+		);
+	}
+
+	public function testTheShippedDeclarationsEmitTheImageRadiusRule(): void {
+		// Build from the real registry (declarations loaded on init). Image radius is the css_prop-bound case
+		// that fits this projector: the attribute is empty by default and rendered as CSS in both editor and
+		// front end. Button radius (own 3px default) and icon size (rendered as inline SVG width/height, never
+		// empty) do not fit it, so the shipped declarations bind only the image and emit no rule for them.
+		$registry = $this->container->get( Token_Registry::class );
+
+		$css = $this->builder( $registry )->css();
+
+		$this->assertStringContainsString( '.wp-block-kadence-image img{border-radius:var(', $css );
+		$this->assertStringNotContainsString( '.wp-block-kadence-advancedbtn', $css );
+		$this->assertStringNotContainsString( '.wp-block-kadence-icon', $css );
+	}
+
+	public function testItContributesNothingForABindingWithoutACssProp(): void {
+		// A block_attr-only binding (the block-preset path) declares no css_prop, so it feeds no rule here.
+		$registry = new Token_Registry();
+		$registry->register_variant_set(
+			[
+				'block'    => 'kadence/advancedbtn',
+				'bindings' => [
+					'button-bg' => [
+						'token'      => 'semantic.color.button-bg',
+						'block_attr' => 'background',
+					],
+				],
+			]
+		);
+
+		$this->assertSame( '', $this->builder( $registry )->css() );
+	}
+
+	/**
+	 * Build the builder with a given registry and the real (baseline-backed) variant resolver.
+	 */
+	private function builder( Token_Registry $registry ): Css_Builder {
+		return new Css_Builder( $registry, $this->resolver );
+	}
+
+	/**
+	 * A registry holding the media-radius token and the Image variant set binding borderRadius to it via a
+	 * css_prop target, so the builder emits the block-default radius rule.
+	 */
+	private function image_registry(): Token_Registry {
+		$registry = new Token_Registry();
+		$registry->register(
+			[
+				'id'    => 'semantic.radius.media',
+				'type'  => 'dimension',
+				'label' => 'Media Radius',
+			]
+		);
+		$registry->register_variant_set(
+			[
+				'block'    => 'kadence/image',
+				'bindings' => [
+					'borderRadius' => [
+						'token'        => 'semantic.radius.media',
+						'css_prop'     => 'border-radius',
+						'css_selector' => ' img',
+					],
+				],
+			]
+		);
+
+		return $registry;
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -96,7 +96,7 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $this->image_registry() )->css();
 
 		$this->assertStringContainsString( '.wp-block-kadence-image img{border-radius:var(' . $var . ',0);}', $css );
-		$this->assertStringNotContainsString( '.wp-block-kadence-imageimg', $css );
+		$this->assertStringNotContainsString( '.wp-block-kadence-imageimg', $css ); // cspell:disable-line -- Checking for invalid selector.
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/ProjectorTest.php
@@ -1,0 +1,28 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Projection\Block_Default_Css;
+
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Confirms the block-default CSS projector is wired into KB's style pipeline on boot — front end and
+ * editor — at the priorities that keep its rules after the token vars and variant overrides.
+ */
+final class ProjectorTest extends TestCase {
+
+	public function testItEnqueuesOnTheFrontEndAfterTheTokenVars(): void {
+		global $wp_filter;
+
+		$callbacks = $wp_filter['wp_enqueue_scripts']->callbacks ?? [];
+
+		$this->assertArrayHasKey( 120, $callbacks );
+	}
+
+	public function testItEnqueuesInTheEditorAfterTheTokenVars(): void {
+		global $wp_filter;
+
+		$callbacks = $wp_filter['admin_init']->callbacks ?? [];
+
+		$this->assertArrayHasKey( 20, $callbacks );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/ProjectorTest.php
@@ -10,6 +10,9 @@ use Tests\Support\Classes\TestCase;
  */
 final class ProjectorTest extends TestCase {
 
+	/**
+	 * @return void
+	 */
 	public function testItEnqueuesOnTheFrontEndAfterTheTokenVars(): void {
 		global $wp_filter;
 
@@ -18,6 +21,9 @@ final class ProjectorTest extends TestCase {
 		$this->assertArrayHasKey( 120, $callbacks );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testItEnqueuesInTheEditorAfterTheTokenVars(): void {
 		global $wp_filter;
 

--- a/tests/wpunit/Resources/Design_Tokens/Registry/BindingTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/BindingTest.php
@@ -57,6 +57,34 @@ final class BindingTest extends TestCase {
 		$this->assertNull( $unbound->block_attr() );
 	}
 
+	public function testItAcceptsTheCssPropAndSelectorTargets(): void {
+		$binding = Binding::from_array(
+			'borderRadius',
+			[
+				'token'        => 'semantic.radius.media',
+				'css_prop'     => 'border-radius',
+				'css_selector' => ' img',
+			]
+		);
+
+		$this->assertSame( 'border-radius', $binding->css_prop() );
+		$this->assertSame( ' img', $binding->css_selector() );
+	}
+
+	public function testCssPropAndSelectorReturnNullWhenAbsent(): void {
+		// A binding with no css_prop/css_selector feeds no block-default rule.
+		$binding = Binding::from_array( 'button-radius', [ 'css_var' => true ] );
+
+		$this->assertNull( $binding->css_prop() );
+		$this->assertNull( $binding->css_selector() );
+	}
+
+	public function testItThrowsWhenCssPropIsNotAString(): void {
+		$this->expectException( InvalidArgumentException::class );
+
+		Binding::from_array( 'borderRadius', [ 'css_prop' => true ] );
+	}
+
 	public function testItAcceptsTheCssVarFlag(): void {
 		$binding = Binding::from_array( 'button-radius', [ 'css_var' => true ] );
 

--- a/tests/wpunit/Resources/Design_Tokens/Registry/BindingTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/BindingTest.php
@@ -8,6 +8,9 @@ use Tests\Support\Classes\TestCase;
 
 final class BindingTest extends TestCase {
 
+	/**
+	 * @return void
+	 */
 	public function testItParsesATokenReference(): void {
 		$binding = Binding::from_array( 'button-bg', [ 'token' => 'semantic.color.button-bg' ] );
 
@@ -16,6 +19,9 @@ final class BindingTest extends TestCase {
 		$this->assertSame( [], $binding->projections );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testItParsesInlineTargets(): void {
 		$binding = Binding::from_array(
 			'button-bg',
@@ -36,12 +42,18 @@ final class BindingTest extends TestCase {
 		);
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testItAcceptsTheBlockAttrTarget(): void {
 		$binding = Binding::from_array( 'button-bg', [ 'block_attr' => 'background' ] );
 
 		$this->assertSame( [ 'block_attr' => 'background' ], $binding->projections );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testBlockAttrReturnsTheBoundAttributeOrNull(): void {
 		$bound = Binding::from_array(
 			'button-bg',
@@ -57,6 +69,9 @@ final class BindingTest extends TestCase {
 		$this->assertNull( $unbound->block_attr() );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testItAcceptsTheCssPropAndSelectorTargets(): void {
 		$binding = Binding::from_array(
 			'borderRadius',
@@ -71,6 +86,9 @@ final class BindingTest extends TestCase {
 		$this->assertSame( ' img', $binding->css_selector() );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testCssPropAndSelectorReturnNullWhenAbsent(): void {
 		// A binding with no css_prop/css_selector feeds no block-default rule.
 		$binding = Binding::from_array( 'button-radius', [ 'css_var' => true ] );
@@ -79,18 +97,27 @@ final class BindingTest extends TestCase {
 		$this->assertNull( $binding->css_selector() );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testItThrowsWhenCssPropIsNotAString(): void {
 		$this->expectException( InvalidArgumentException::class );
 
 		Binding::from_array( 'borderRadius', [ 'css_prop' => true ] );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testItAcceptsTheCssVarFlag(): void {
 		$binding = Binding::from_array( 'button-radius', [ 'css_var' => true ] );
 
 		$this->assertSame( [ 'css_var' => true ], $binding->projections );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testItIgnoresUnrecognisedKeys(): void {
 		$binding = Binding::from_array(
 			'button-bg',
@@ -103,6 +130,9 @@ final class BindingTest extends TestCase {
 		$this->assertSame( [ 'kadence_slot' => 'palette1' ], $binding->projections );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testItAcceptsATokenReferenceWithAnInlineTarget(): void {
 		// Both forms compose: a token reference plus a block_attr the token never carries.
 		$binding = Binding::from_array(
@@ -118,24 +148,36 @@ final class BindingTest extends TestCase {
 		$this->assertSame( [ 'block_attr' => 'background' ], $binding->projections );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testItThrowsOnAnEmptyTokenReference(): void {
 		$this->expectException( InvalidArgumentException::class );
 
 		Binding::from_array( 'button-bg', [ 'token' => '' ] );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testItThrowsWhenNeitherFormIsPresent(): void {
 		$this->expectException( InvalidArgumentException::class );
 
 		Binding::from_array( 'button-bg', [] );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testItThrowsWhenAStringTargetIsNotAString(): void {
 		$this->expectException( InvalidArgumentException::class );
 
 		Binding::from_array( 'button-bg', [ 'kadence_slot' => true ] );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testItThrowsWhenCssVarIsNotTrue(): void {
 		$this->expectException( InvalidArgumentException::class );
 


### PR DESCRIPTION
🎫 [SOFT-3502](https://linear.app/nexcess/issue/SOFT-3502)

Delivers the site-wide media-radius design token to `kadence/image` so a fresh image picks up the brand border-radius, while any radius the editor sets (including `0`) still wins.

https://www.loom.com/share/eacdacba10b046c5b6ae0d39e0d5c590

### What this does

Image border-radius is the one dimension that cannot ride an ownable CSS variable: it is empty by default, KB renders it as a literal in both the editor and the front end, and the block has no `var()` indirection to point at the token. This adds a `Block_Default_Css` projector that emits a single low-specificity rule on KB's existing token-var style handles:

```css
.wp-block-kadence-image img { border-radius: var(--kb-token--semantic--radius--media, 1rem); }
```

Because the rule is class-scoped and carries no `!important`, the block's own per-instance radius (a higher-specificity selector) always overrides it when set, so the numeric control keeps working exactly as it does today.

### Scope

This is intentionally narrow — only `kadence/image` border-radius. Other dimensions are delivered elsewhere because they do not fit the mechanism: button radius ships a non-empty `3px` default, and icon size renders as inline SVG width/height and is never empty. Spacing/gap delivery rides the global-var slot mechanism and lands separately.

### Changes

- `Projection/Block_Default_Css/` — the `Css_Builder` (pure CSS generation), `Projector` (front-end + editor enqueue), and `Provider` (container + hook wiring at `wp_enqueue_scripts` 120 / `admin_init` 20).
- `Registry/Binding` — `css_prop` / `css_selector` inline binding targets, with accessors.
- `Registry/declarations.php` — the `semantic.radius.media` token plus the `kadence/image` variant binding.
- wpunit coverage for the builder, the projector wiring, and the new binding targets.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
