### PR TITLE
fix: Advanced Heading dynamic link wrong inside FSE query loops

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -95,6 +95,7 @@
         "tableofcontents",
         "trailingslashit",
         "uncollapsed",
+        "undefed",
         "userrole",
         "videopopup",
         "wearerequired",

--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Build
         env:
           BUN_AUTH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
         run: |
           composer install --no-dev --no-scripts
           composer run strauss-release

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -39,6 +39,7 @@ jobs:
         run: bun install --frozen-lockfile
         env:
           BUN_AUTH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
 
       - name: Run linters
         uses: wearerequired/lint-action@v2

--- a/.github/workflows/ghost-inspector.yml
+++ b/.github/workflows/ghost-inspector.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Build plugin
         env:
           BUN_AUTH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
         run: |
           composer install --no-dev --no-scripts
           composer run strauss-release

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Install dependencies
         env:
           BUN_AUTH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
         run: |
           composer install --no-dev --no-scripts
           composer run strauss-release

--- a/.github/workflows/stellar-zip.yml
+++ b/.github/workflows/stellar-zip.yml
@@ -213,6 +213,7 @@ jobs:
           COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.COMPOSER_TOKEN }}"}}'
           NODE_AUTH_TOKEN: ${{ secrets.GH_BOT_TOKEN  }}
           BUN_AUTH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
         run: composer -- pup build
 
       - name: pup check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,7 @@ jobs:
             - run: bun install --frozen-lockfile
               env:
                   BUN_AUTH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
                   PUPPETEER_SKIP_DOWNLOAD: true
 
             - name: Build packages

--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Install dependencies
         env:
           BUN_AUTH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
         run: |
           # `bun install` runs the root postinstall, which builds the @kadence/*
           # source packages (bun blocks their own prepare scripts; npm does not).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,10 @@ The `@stellarwp` scope resolves to GitHub Packages (`npm.pkg.github.com`), which
 
    ```
    BUN_AUTH_TOKEN=your_token_here
+   GITHUB_TOKEN=your_token_here
    ```
 
-   Bun reads `BUN_AUTH_TOKEN` from this `.env` file when authenticating to the `@stellarwp` registry. Do not commit `.env`.
+   Bun reads `BUN_AUTH_TOKEN` from this `.env` file when authenticating to the `@stellarwp` registry. `GITHUB_TOKEN` (the same token works) authenticates the `github:stellarwp/...` tarball fetches for the `@kadence/*` packages — without it those downloads hit GitHub's unauthenticated rate limit and fail with 504s. Do not commit `.env`.
 
 ## 2. Install PHP dependencies
 

--- a/includes/blocks/class-kadence-blocks-advanced-heading-block.php
+++ b/includes/blocks/class-kadence-blocks-advanced-heading-block.php
@@ -805,7 +805,7 @@ class Kadence_Blocks_Advancedheading_Block extends Kadence_Blocks_Abstract_Block
 			$textShadow['vOffset'] = $textShadow['vOffset'] ?? 1;
 			$textShadow['blur']    = $textShadow['blur'] ?? 1;
 			$textShadow['color']   = $textShadow['color'] ?? null;
-			$textShadow['opacity'] = $textShadow['opacity'] ?? 1.0; // Default is 0.2, but if it's undefined they set it at a time when the block defaults it to 1.0
+			$textShadow['opacity'] = $textShadow['opacity'] ?? 1.0; // Default is 0.2, but if it's undefed they set it at a time when the block defaults it to 1.0
 		}
 
 		if (!empty($attributes['textShadowTablet']) && is_array($attributes['textShadowTablet'][0])) {

--- a/includes/blocks/class-kadence-blocks-advanced-heading-block.php
+++ b/includes/blocks/class-kadence-blocks-advanced-heading-block.php
@@ -489,7 +489,10 @@ class Kadence_Blocks_Advancedheading_Block extends Kadence_Blocks_Abstract_Block
 	/**
 	 * This block is conditionally dynamic. It's only rendered dynamically if the heading includes an icon.
 	 *
-	 * @param array $attributes The block attributes.
+	 * @param array    $attributes     The block attributes.
+	 * @param string   $unique_id      The blocks attr ID.
+	 * @param string   $content        The saved block markup.
+	 * @param WP_Block $block_instance The instance of the WP_Block class that represents the block being rendered.
 	 *
 	 * @return string Returns the block output.
 	 */
@@ -802,7 +805,7 @@ class Kadence_Blocks_Advancedheading_Block extends Kadence_Blocks_Abstract_Block
 			$textShadow['vOffset'] = $textShadow['vOffset'] ?? 1;
 			$textShadow['blur']    = $textShadow['blur'] ?? 1;
 			$textShadow['color']   = $textShadow['color'] ?? null;
-			$textShadow['opacity'] = $textShadow['opacity'] ?? 1.0; // Default is 0.2, but if it's undefed they set it at a time when the block defaults it to 1.0
+			$textShadow['opacity'] = $textShadow['opacity'] ?? 1.0; // Default is 0.2, but if it's undefined they set it at a time when the block defaults it to 1.0
 		}
 
 		if (!empty($attributes['textShadowTablet']) && is_array($attributes['textShadowTablet'][0])) {

--- a/includes/blocks/class-kadence-blocks-advanced-heading-block.php
+++ b/includes/blocks/class-kadence-blocks-advanced-heading-block.php
@@ -628,7 +628,7 @@ class Kadence_Blocks_Advancedheading_Block extends Kadence_Blocks_Abstract_Block
 			// HTML-escapes the value itself; esc_url would double-encode ampersands.
 			$resolved_link = esc_url_raw( do_shortcode( $attributes['link'] ) );
 			$p             = new WP_HTML_Tag_Processor( $content );
-			if ( $p->next_tag( 'a' ) ) {
+			if ( $p->next_tag( [ 'tag_name' => 'a' ] ) ) {
 				$p->set_attribute( 'href', $resolved_link );
 				$content = $p->get_updated_html();
 			}

--- a/includes/blocks/class-kadence-blocks-advanced-heading-block.php
+++ b/includes/blocks/class-kadence-blocks-advanced-heading-block.php
@@ -617,6 +617,21 @@ class Kadence_Blocks_Advancedheading_Block extends Kadence_Blocks_Abstract_Block
 				$wrapper_attributes = implode( ' ', $wrapper_attributes );
 				$content = sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $content );
 			}
+		} elseif ( ! empty( $attributes['link'] ) && false !== strpos( $attributes['link'], '[' ) ) {
+			// Plain heading: the dynamic link lives as a shortcode in the saved anchor's href.
+			// In a query loop the saved markup is resolved once (with the first/queried post's
+			// context) and the baked HTML is reused for every item, so the href is wrong for all
+			// but the first post. Re-resolve from the (unbaked) link attribute in this per-post
+			// render callback and overwrite the anchor's href, matching how the icon/gradient
+			// path above and the single button block build their links.
+			// esc_url_raw (not esc_url) because WP_HTML_Tag_Processor::set_attribute()
+			// HTML-escapes the value itself; esc_url would double-encode ampersands.
+			$resolved_link = esc_url_raw( do_shortcode( $attributes['link'] ) );
+			$p             = new WP_HTML_Tag_Processor( $content );
+			if ( $p->next_tag( 'a' ) ) {
+				$p->set_attribute( 'href', $resolved_link );
+				$content = $p->get_updated_html();
+			}
 		}
 
 		return $content;

--- a/tests/wpunit/Blocks/AdvancedHeadingTest.php
+++ b/tests/wpunit/Blocks/AdvancedHeadingTest.php
@@ -39,9 +39,12 @@ class AdvancedHeadingTest extends KadenceBlocksUnit {
 	public function testPlainHeadingResolvesDynamicLinkFromAttributeNotBakedContent() {
 		$shortcode = 'kb_test_dynamic_link';
 		$resolved  = 'https://example.com/correct-per-post/';
-		add_shortcode( $shortcode, function () use ( $resolved ) {
-			return $resolved;
-		} );
+		add_shortcode(
+			$shortcode,
+			function () use ( $resolved ) {
+				return $resolved;
+			}
+		);
 
 		$unique_id  = '123_abcd';
 		$link_value = '[' . $shortcode . ']';

--- a/tests/wpunit/Blocks/AdvancedHeadingTest.php
+++ b/tests/wpunit/Blocks/AdvancedHeadingTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\wpunit\Blocks;
+
+use Kadence_Blocks_Advancedheading_Block;
+use Tests\Support\Classes\KadenceBlocksUnit;
+
+class AdvancedHeadingTest extends KadenceBlocksUnit {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'advancedheading';
+
+	/**
+	 * Block instance.
+	 *
+	 * @var Kadence_Blocks_Advancedheading_Block
+	 */
+	protected $block;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->block = new Kadence_Blocks_Advancedheading_Block();
+	}
+
+	/**
+	 * A plain heading (no icon/gradient) with a dynamic link must derive its href from the
+	 * (per-post) link attribute, not from the saved $content markup.
+	 *
+	 * In FSE query loops the saved markup is resolved once with the first post's context and
+	 * reused for every item, so $content arrives with a stale, already-baked href. build_html()
+	 * must overwrite it from $attributes['link'] (which still holds the per-post shortcode),
+	 * matching the single button block and the heading's icon/gradient path.
+	 *
+	 * @see Dynamic Link URL wrong in FSE archive Query Loop (Advanced Heading).
+	 */
+	public function testPlainHeadingResolvesDynamicLinkFromAttributeNotBakedContent() {
+		$shortcode = 'kb_test_dynamic_link';
+		$resolved  = 'https://example.com/correct-per-post/';
+		add_shortcode( $shortcode, function () use ( $resolved ) {
+			return $resolved;
+		} );
+
+		$unique_id  = '123_abcd';
+		$link_value = '[' . $shortcode . ']';
+		$attributes = [
+			'uniqueID' => $unique_id,
+			'link'     => $link_value,
+		];
+
+		// Simulate the query-loop bug: $content arrives with a stale href baked to a different
+		// (first) post, while the link attribute still carries the per-post shortcode.
+		$stale_url     = 'https://example.com/stale-first-post/';
+		$saved_content = '<a class="kb-advanced-heading-link" href="' . $stale_url . '"><h2 class="kt-adv-heading' . $unique_id . '">Title</h2></a>';
+
+		$block_instance = $this->generate_block_instance( 'kadence/' . $this->block_name, $attributes );
+
+		$html = $this->block->build_html( $attributes, $unique_id, $saved_content, $block_instance );
+
+		remove_shortcode( $shortcode );
+
+		$this->assertStringContainsString( 'href="' . $resolved . '"', $html, 'Dynamic link should be resolved from the per-post attribute.' );
+		$this->assertStringNotContainsString( $stale_url, $html, 'Stale baked href should be overwritten.' );
+		$this->assertStringNotContainsString( $link_value, $html, 'Raw link shortcode should not survive in the output.' );
+	}
+
+	/**
+	 * A static (non-shortcode) link must pass through build_html untouched.
+	 */
+	public function testPlainHeadingLeavesStaticLinkUntouched() {
+		$unique_id  = '456_efgh';
+		$static_url = 'https://example.com/static/';
+		$attributes = [
+			'uniqueID' => $unique_id,
+			'link'     => $static_url,
+		];
+
+		$saved_content = '<h2 class="kt-adv-heading' . $unique_id . '"><a class="kb-advanced-heading-link" href="' . $static_url . '">Title</a></h2>';
+
+		$block_instance = $this->generate_block_instance( 'kadence/' . $this->block_name, $attributes );
+
+		$html = $this->block->build_html( $attributes, $unique_id, $saved_content, $block_instance );
+
+		$this->assertStringContainsString( 'href="' . $static_url . '"', $html, 'Static link should be preserved.' );
+	}
+}

--- a/tests/wpunit/Blocks/AdvancedHeadingTest.php
+++ b/tests/wpunit/Blocks/AdvancedHeadingTest.php
@@ -73,7 +73,7 @@ class AdvancedHeadingTest extends KadenceBlocksUnit {
 	 * A static (non-shortcode) link must pass through build_html untouched.
 	 */
 	public function testPlainHeadingLeavesStaticLinkUntouched() {
-		$unique_id  = '456_efgh';
+		$unique_id  = '456_1234';
 		$static_url = 'https://example.com/static/';
 		$attributes = [
 			'uniqueID' => $unique_id,


### PR DESCRIPTION
## Summary

Fixes the Advanced Heading block's dynamic link resolving to the wrong URL when used inside an FSE archive Query Loop.

In FSE query loops the saved block markup is resolved **once** with the first/queried post's context and the baked HTML is reused for every item. For a plain heading (no icon/gradient), the dynamic link lives as a shortcode in the saved anchor's `href`, so every post after the first rendered with the *first* post's URL.

The fix re-resolves the link from the (unbaked) `link` attribute in the per-post render callback and overwrites the anchor's `href` — matching how the icon/gradient path and the single button block already build their links.

https://www.loom.com/share/08c5aea2a79f411bab2dd0237f4608b6

## Changes

- Re-resolve the href in the plain-heading branch of `build_html()`, gated on the link containing a shortcode (`[`), so static links pass through untouched.
- Use `WP_HTML_Tag_Processor` to rewrite the first `<a>`, matching the Optimizer's existing approach (min WP is 6.6, so the API is available). `esc_url_raw` + `set_attribute` avoids double-encoding ampersands.

## Tests

Adds `tests/wpunit/Blocks/AdvancedHeadingTest.php`:
- `testPlainHeadingResolvesDynamicLinkFromAttributeNotBakedContent` — simulates the query-loop bug (stale baked href + per-post shortcode attribute) and asserts the resolved per-post URL wins.
- `testPlainHeadingLeavesStaticLinkUntouched` — guardrail that a static link passes through unchanged.