### PR TITLE
feat(design-tokens): wire Row Layout & Column background, border & radius to tokens

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -265,6 +265,14 @@
 			"icon": {
 				"$type": "color",
 				"$value": "{primitive.color.brand.primary}"
+			},
+			"rowlayout-bg": {
+				"$type": "color",
+				"$value": "{primitive.color.transparent}"
+			},
+			"column-bg": {
+				"$type": "color",
+				"$value": "{primitive.color.transparent}"
 			}
 		},
 		"spacing": {
@@ -424,7 +432,8 @@
 					"default": {
 						"label": "Default",
 						"tokens": {
-							"background": "{semantic.color.surface}",
+							"background": "{semantic.color.rowlayout-bg}",
+							"border": "{semantic.color.border}",
 							"padding": "{semantic.spacing.section}"
 						}
 					}
@@ -434,7 +443,8 @@
 					"default": {
 						"label": "Default",
 						"tokens": {
-							"background": "{semantic.color.surface-alt}",
+							"background": "{semantic.color.column-bg}",
+							"border": "{semantic.color.border}",
 							"padding": "{semantic.spacing.block}"
 						}
 					}

--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -297,6 +297,14 @@
 			"media": {
 				"$type": "dimension",
 				"$value": "{primitive.dimension.radius.none}"
+			},
+			"rowlayout": {
+				"$type": "dimension",
+				"$value": "{primitive.dimension.radius.none}"
+			},
+			"column": {
+				"$type": "dimension",
+				"$value": "{primitive.dimension.radius.none}"
 			}
 		},
 		"borderWidth": {
@@ -434,6 +442,7 @@
 						"tokens": {
 							"background": "{semantic.color.rowlayout-bg}",
 							"border": "{semantic.color.border}",
+							"borderRadius": "{semantic.radius.rowlayout}",
 							"padding": "{semantic.spacing.section}"
 						}
 					}
@@ -445,6 +454,7 @@
 						"tokens": {
 							"background": "{semantic.color.column-bg}",
 							"border": "{semantic.color.border}",
+							"borderRadius": "{semantic.radius.column}",
 							"padding": "{semantic.spacing.block}"
 						}
 					}

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -78,6 +78,21 @@ return [
 				'group' => __( 'Brand', 'kadence-blocks' ),
 			],
 			[
+				// Block-specific radius defaults, mirroring semantic.radius.media for the image. Each aliases
+				// radius.none (resolves to 0), so a fresh Row Layout / Column stays square — KB's own default —
+				// while a site owner can round one block type by overriding its token.
+				'id'    => 'semantic.radius.rowlayout',
+				'type'  => 'dimension',
+				'label' => __( 'Row Layout Radius', 'kadence-blocks' ),
+				'group' => __( 'Layout', 'kadence-blocks' ),
+			],
+			[
+				'id'    => 'semantic.radius.column',
+				'type'  => 'dimension',
+				'label' => __( 'Column Radius', 'kadence-blocks' ),
+				'group' => __( 'Layout', 'kadence-blocks' ),
+			],
+			[
 				// Block-specific background defaults for the block-default CSS projector. Each aliases the
 				// transparent primitive (see baseline), so a fresh Row Layout / Column stays transparent — KB's
 				// own default — while a site owner can brand one block type's background by overriding its token,
@@ -148,13 +163,17 @@ return [
 			// wins. Padding follows the spacing tokens through the slug bridge, not a binding here.
 			'block'    => 'kadence/rowlayout',
 			'bindings' => [
-				'background' => [
+				'background'   => [
 					'token'    => 'semantic.color.rowlayout-bg',
 					'css_prop' => 'background-color',
 				],
-				'border'     => [
+				'border'       => [
 					'token'    => 'semantic.color.border',
 					'css_prop' => 'border-color',
+				],
+				'borderRadius' => [
+					'token'    => 'semantic.radius.rowlayout',
+					'css_prop' => 'border-radius',
 				],
 			],
 		],
@@ -164,14 +183,19 @@ return [
 			// column's own transparent-by-default override seam, distinct from the row's.
 			'block'    => 'kadence/column',
 			'bindings' => [
-				'background' => [
+				'background'   => [
 					'token'        => 'semantic.color.column-bg',
 					'css_prop'     => 'background-color',
 					'css_selector' => '> .kt-inside-inner-col',
 				],
-				'border'     => [
+				'border'       => [
 					'token'        => 'semantic.color.border',
 					'css_prop'     => 'border-color',
+					'css_selector' => '> .kt-inside-inner-col',
+				],
+				'borderRadius' => [
+					'token'        => 'semantic.radius.column',
+					'css_prop'     => 'border-radius',
 					'css_selector' => '> .kt-inside-inner-col',
 				],
 			],

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -77,6 +77,29 @@ return [
 				'label' => __( 'Media Radius', 'kadence-blocks' ),
 				'group' => __( 'Brand', 'kadence-blocks' ),
 			],
+			[
+				// Block-specific background defaults for the block-default CSS projector. Each aliases the
+				// transparent primitive (see baseline), so a fresh Row Layout / Column stays transparent — KB's
+				// own default — while a site owner can brand one block type's background by overriding its token,
+				// without touching the shared surface colors or the transparent primitive. Registered here only
+				// so Css_Var emits each --kb-token--* variable the low-specificity rule points at.
+				'id'    => 'semantic.color.rowlayout-bg',
+				'type'  => 'color',
+				'label' => __( 'Row Layout Background', 'kadence-blocks' ),
+				'group' => __( 'Layout', 'kadence-blocks' ),
+			],
+			[
+				'id'    => 'semantic.color.column-bg',
+				'type'  => 'color',
+				'label' => __( 'Column Background', 'kadence-blocks' ),
+				'group' => __( 'Layout', 'kadence-blocks' ),
+			],
+			[
+				'id'    => 'semantic.color.border',
+				'type'  => 'color',
+				'label' => __( 'Border', 'kadence-blocks' ),
+				'group' => __( 'Brand', 'kadence-blocks' ),
+			],
 		],
 		$spacing_tokens,
 		$gap_tokens
@@ -113,6 +136,43 @@ return [
 					'token'        => 'semantic.radius.media',
 					'css_prop'     => 'border-radius',
 					'css_selector' => 'img',
+				],
+			],
+		],
+		[
+			// Row Layout: low-specificity block-default rules on the block root (where KB renders both).
+			// Background follows the block's own rowlayout-bg token, which aliases the transparent
+			// primitive — so an uncustomized row stays transparent (KB's own default) unless a site owner brands
+			// that token. Border color follows the brand border token (invisible until a border is added). A
+			// value the user sets is a per-instance rule of equal specificity but later source order, so it still
+			// wins. Padding follows the spacing tokens through the slug bridge, not a binding here.
+			'block'    => 'kadence/rowlayout',
+			'bindings' => [
+				'background' => [
+					'token'    => 'semantic.color.rowlayout-bg',
+					'css_prop' => 'background-color',
+				],
+				'border'     => [
+					'token'    => 'semantic.color.border',
+					'css_prop' => 'border-color',
+				],
+			],
+		],
+		[
+			// Column (Section): same as Row Layout, but KB renders the background and border on the inner
+			// `.kt-inside-inner-col` child, so the rules target that descendant. column-bg is the
+			// column's own transparent-by-default override seam, distinct from the row's.
+			'block'    => 'kadence/column',
+			'bindings' => [
+				'background' => [
+					'token'        => 'semantic.color.column-bg',
+					'css_prop'     => 'background-color',
+					'css_selector' => '> .kt-inside-inner-col',
+				],
+				'border'     => [
+					'token'        => 'semantic.color.border',
+					'css_prop'     => 'border-color',
+					'css_selector' => '> .kt-inside-inner-col',
 				],
 			],
 		],

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -81,10 +81,12 @@ final class Css_BuilderTest extends TestCase {
 			$css
 		);
 		$this->assertStringContainsString( 'border-color:var(' . Css_Var::from_id( 'semantic.color.border' ), $css );
+		$this->assertStringContainsString( 'border-radius:var(' . Css_Var::from_id( 'semantic.radius.rowlayout' ), $css );
 		$this->assertStringContainsString(
 			'.wp-block-kadence-column> .kt-inside-inner-col{background-color:var(' . Css_Var::from_id( 'semantic.color.column-bg' ),
 			$css
 		);
+		$this->assertStringContainsString( 'border-radius:var(' . Css_Var::from_id( 'semantic.radius.column' ), $css );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -67,6 +67,29 @@ final class Css_BuilderTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testTheShippedDeclarationsEmitTheRowLayoutAndColumnColorRules(): void {
+		// Row Layout / Column follow the tokens through a low-specificity block-default rule: the row on the
+		// block root, the column on its inner `.kt-inside-inner-col` child. Background follows each block's own
+		// background token (which aliases the transparent primitive, so an uncustomized block stays transparent
+		// — KB's own default); border color follows the brand border token.
+		$registry = $this->container->get( Token_Registry::class );
+
+		$css = $this->builder( $registry )->css();
+
+		$this->assertStringContainsString(
+			'.wp-block-kadence-rowlayout{background-color:var(' . Css_Var::from_id( 'semantic.color.rowlayout-bg' ),
+			$css
+		);
+		$this->assertStringContainsString( 'border-color:var(' . Css_Var::from_id( 'semantic.color.border' ), $css );
+		$this->assertStringContainsString(
+			'.wp-block-kadence-column> .kt-inside-inner-col{background-color:var(' . Css_Var::from_id( 'semantic.color.column-bg' ),
+			$css
+		);
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testItContributesNothingForABindingWithoutACssProp(): void {
 		// A block_attr-only binding (the block-preset path) declares no css_prop, so it feeds no rule here.
 		$registry = new Token_Registry();


### PR DESCRIPTION
🎫 [SOFT-3401](https://linear.app/nexcess/issue/SOFT-3401) · [SOFT-3402](https://linear.app/nexcess/issue/SOFT-3402)

> Stacked on [the spacing/gap delivery PR](https://github.com/stellarwp/kadence-blocks/pull/1061) — base it there; review/merge that first. This branch adds the color/border/radius half of the Row Layout / Section wiring.

This is largely the same, mechanically, as https://github.com/stellarwp/kadence-blocks/pull/1059 and uses the same underlying code.

Wires `kadence/rowlayout` and `kadence/column` background, border color, and border radius to design tokens, completing the per-block color wiring 3401/3402 call for (the spacing half lands in the base PR via the slug bridge).

### How it works

These blocks store their background, border color, and border radius as a literal value — a hex, a palette slug, or a number+unit — **only when a user manually sets one**; an uncustomized block stores nothing. To make the **default** state follow a token, this reuses the block-default-CSS projector — the same low-specificity, block-scoped mechanism that delivers image border-radius. One rule per block points each bound property at a token variable:

```css
.wp-block-kadence-rowlayout{background-color:var(--kb-token--semantic--color--rowlayout-bg,transparent);border-color:var(--kb-token--semantic--color--border,#E2E8F0);border-radius:var(--kb-token--semantic--radius--rowlayout,0);}
.wp-block-kadence-column> .kt-inside-inner-col{background-color:var(--kb-token--semantic--color--column-bg,transparent);border-color:var(--kb-token--semantic--color--border,#E2E8F0);border-radius:var(--kb-token--semantic--radius--column,0);}
```

The row targets the block root; the column targets its inner `.kt-inside-inner-col` (where KB renders all three). The rule is a single class emitted earlier in source order than KB's per-instance CSS, so it supplies the default while any literal value the user sets (a per-instance rule of equal specificity, later in source order) overrides it. This is the same fit as image radius: a property KB renders as a literal when set and leaves empty otherwise, where only a token-backed default was missing.

### Defaults match KB's own, so nothing is restyled

A Row Layout / Column has no background and no rounding by default in KB. So the tokens are chosen to resolve to those same defaults, and an uncustomized block looks identical to today:

- **Background** binds to block-specific tokens — `semantic.color.rowlayout-bg` / `semantic.color.column-bg` — that **alias `primitive.color.transparent`**.
- **Border radius** binds to block-specific tokens — `semantic.radius.rowlayout` / `semantic.radius.column` — that **alias `radius.none`** (resolve to `0`), mirroring `semantic.radius.media` for the image.
- **Border color** follows `semantic.color.border`; it is invisible until a user adds a border (border-width defaults to 0), then defaults to the brand border color.

Each block type has its own override seam: a site owner brands all rows by overriding `rowlayout-bg` / `semantic.radius.rowlayout` (columns independently), without touching the shared `surface` colors, the `transparent` primitive, or the `radius` scale.

### Changes

- `Registry/declarations.php` — register the `rowlayout-bg` / `column-bg` / `border` color tokens and the `rowlayout` / `column` radius tokens (bare, so `Css_Var` emits their variables), and the `kadence/rowlayout` + `kadence/column` variant sets binding `background-color` / `border-color` / `border-radius` via `css_prop`.
- `Registry/Baseline/baseline.json` — `semantic.color.rowlayout-bg` / `column-bg` aliasing the transparent primitive and `semantic.radius.rowlayout` / `column` aliasing `radius.none`; the rowlayout/column `$default` presets reference them. `surface` / `surface-alt` keep their real values (matching the design-system Storybook Background scale: base `#FFFFFF`, subtle `#F7FAFC`).
- wpunit coverage that the shipped declarations emit both blocks' background + border + radius rules.

### Follow-up

- The Kadence color/radius controls won't show a swatch *selected* for these defaults — the value comes from the CSS rule, not a stored attribute. Showing it as the selected value is the adapter / variant path (needs a Kadence variant picker UI, which doesn't exist yet).
- `semantic.color.border` (`#E2E8F0`) has no exact match in the Storybook palette; left as the baseline neutral for now.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
