### PR TITLE
Button (kadence/advancedbtn + singlebtn) token wiring + variants

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -38,6 +38,8 @@
         "crawlable",
         "curlopt",
         "customizer",
+        "dashicon",
+        "dashicons",
         "diffcs",
         "distignore",
         "dotlottie",
@@ -60,6 +62,10 @@
         "kadencewp",
         "kbcustom",
         "kbcustomicons",
+        "ktanimate",
+        "ktanimateadd",
+        "ktanimatepreview",
+        "ktdynamic",
         "lightbox",
         "LONGTEXT",
         "lottieanimation",
@@ -109,6 +115,7 @@
         "sunsetting",
         "tabindex",
         "tableofcontents",
+        "textcolor",
         "trailingslashit",
         "uncollapsed",
         "unrecognised",
@@ -122,6 +129,7 @@
         "wpdb",
         "wpml",
         "wpunit",
-        "writefunction"
+        "writefunction",
+        "xlarge"
     ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -90,6 +90,8 @@
         "recaptcha",
         "recognised",
         "Reselecting",
+        "retarget",
+        "retargeted",
         "retargets",
         "returntransfer",
         "rowlayout",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,19 @@ the team enforces in review; follow them exactly.
 - Ticket numbers ARE acceptable inside a `TODO`/`@todo` marking a concrete follow-up.
 - After edits, `grep -rn "SOFT-" includes/` to confirm none leaked in.
 
+### Design token ids are kebab-case
+
+- **Token names in `baseline.json` and `declarations.php` must be kebab-case, never camelCase.**
+  A registered token id is validated as `^[a-z0-9]+([.-][a-z0-9]+)*$` (lowercase alphanumeric
+  segments separated by `.` or `-`), because it feeds `Css_Var::from_id()` which only swaps `.`
+  for `--`. A camelCase segment (`iconSize`, `borderWidth`) throws at registration, so use
+  `icon-size`, `border-width`, etc. This applies to every layer of a token path — a `semantic`
+  alias and the `primitive` it points at must both be kebab-case, and any `{alias}` reference in
+  the baseline must match.
+- Note the DTCG `$type` values are a separate vocabulary and stay as the spec defines them
+  (`fontFamily`, `fontWeight`, `cubicBezier`); the kebab-case rule is about token *names* (keys
+  and ids), not `$type`.
+
 ## Tests
 
 - **Data providers use `Generator`, not arrays.** A provider `yield`s each case; the return

--- a/includes/blocks/class-kadence-blocks-singlebtn-block.php
+++ b/includes/blocks/class-kadence-blocks-singlebtn-block.php
@@ -5,6 +5,8 @@
  * @package Kadence Blocks
  */
 
+// cspell:ignore glight glightbox ktblocksvideopop plyr .
+
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -333,10 +335,10 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 	/**
 	 * Build HTML for dynamic blocks
 	 *
-	 * @param $attributes
-	 * @param $unique_id
-	 * @param $content
-	 * @param WP_Block   $block_instance The instance of the WP_Block class that represents the block being rendered.
+	 * @param array<string, mixed> $attributes The block attributes.
+	 * @param string               $unique_id The block's unique id.
+	 * @param string               $content The block inner content.
+	 * @param WP_Block             $block_instance The instance of the WP_Block class that represents the block being rendered.
 	 *
 	 * @return mixed
 	 */
@@ -361,7 +363,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 			 * projector's scoped CSS hooks. This is a dynamic block, so the class is added here rather than by
 			 * the editor save filter; the sanitizer mirrors the projector's so the class matches the selector.
 			 */
-			$classes[] = 'kb-variant--' . preg_replace( '/[^A-Za-z0-9_-]+/', '-', $attributes['kbVariant'] );
+			$classes[] = 'kb-variant--' . preg_replace( '/[^A-Za-z0-9_-]+/', '-', $this->attribute_string( $attributes, 'kbVariant' ) );
 		}
 
 		if ( ! empty( $attributes['target'] ) && 'video' === $attributes['target'] ) {
@@ -374,13 +376,13 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 			'class' => implode( ' ', $classes ),
 		];
 		if ( ! empty( $attributes['anchor'] ) ) {
-			$wrapper_args['id'] = $attributes['anchor'];
+			$wrapper_args['id'] = $this->attribute_string( $attributes, 'anchor' );
 		}
 		if ( ! empty( $attributes['label'] ) ) {
-			$wrapper_args['aria-label'] = $attributes['label'];
+			$wrapper_args['aria-label'] = $this->attribute_string( $attributes, 'label' );
 		}
 		if ( ! empty( $attributes['link'] ) ) {
-			$wrapper_args['href'] = esc_url( do_shortcode( $attributes['link'] ) );
+			$wrapper_args['href'] = esc_url( do_shortcode( $this->attribute_string( $attributes, 'link' ) ) );
 			$rel_add              = '';
 			if ( isset( $attributes['download'] ) && $attributes['download'] ) {
 				$wrapper_args['download'] = '';
@@ -403,9 +405,9 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 			$wrapper_args['type'] = 'submit';
 		}
 		if ( ! empty( $attributes['tooltip'] ) ) {
-			$wrapper_args['data-kb-tooltip-content'] = esc_attr( $attributes['tooltip'] );
+			$wrapper_args['data-kb-tooltip-content'] = esc_attr( $this->attribute_string( $attributes, 'tooltip' ) );
 			if ( ! empty( $attributes['tooltipPlacement'] ) ) {
-				$wrapper_args['data-tooltip-placement'] = esc_attr( $attributes['tooltipPlacement'] );
+				$wrapper_args['data-tooltip-placement'] = esc_attr( $this->attribute_string( $attributes, 'tooltipPlacement' ) );
 			}
 		}
 		if ( isset( $attributes['buttonRole'] ) && $attributes['buttonRole'] ) {
@@ -422,7 +424,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$text     = ! empty( $attributes['text'] ) ? '<span class="kt-btn-inner-text">' . $attributes['text'] . '</span>' : '';
 		$svg_icon = '';
 		if ( ! empty( $attributes['icon'] ) ) {
-			$type         = substr( $attributes['icon'], 0, 2 );
+			$type         = substr( $this->attribute_string( $attributes, 'icon' ), 0, 2 );
 			$line_icon    = ( ! empty( $type ) && 'fe' == $type ? true : false );
 			$fill         = ( $line_icon ? 'none' : 'currentColor' );
 			$stroke_width = false;
@@ -434,12 +436,12 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 			$hidden   = ( empty( $title ) ? true : false );
 			$svg_icon = Kadence_Blocks_Svg_Render::render( $attributes['icon'], $fill, $stroke_width, $title, $hidden );
 		}
-		$icon_left  = ! empty( $svg_icon ) && ! empty( $attributes['iconSide'] ) && 'left' === $attributes['iconSide'] ? '<span class="kb-svg-icon-wrap kb-svg-icon-' . esc_attr( $attributes['icon'] ) . ' kt-btn-icon-side-left">' . $svg_icon . '</span>' : '';
-		$icon_right = ! empty( $svg_icon ) && ! empty( $attributes['iconSide'] ) && 'right' === $attributes['iconSide'] ? '<span class="kb-svg-icon-wrap kb-svg-icon-' . esc_attr( $attributes['icon'] ) . ' kt-btn-icon-side-right">' . $svg_icon . '</span>' : '';
+		$icon_left  = ! empty( $svg_icon ) && ! empty( $attributes['iconSide'] ) && 'left' === $attributes['iconSide'] ? '<span class="kb-svg-icon-wrap kb-svg-icon-' . esc_attr( $this->attribute_string( $attributes, 'icon' ) ) . ' kt-btn-icon-side-left">' . $svg_icon . '</span>' : '';
+		$icon_right = ! empty( $svg_icon ) && ! empty( $attributes['iconSide'] ) && 'right' === $attributes['iconSide'] ? '<span class="kb-svg-icon-wrap kb-svg-icon-' . esc_attr( $this->attribute_string( $attributes, 'icon' ) ) . ' kt-btn-icon-side-right">' . $svg_icon . '</span>' : '';
 		$html_tag   = ! empty( $attributes['link'] ) ? 'a' : 'span';
 
 		// Try to Detect if this is a show more button and make it a button.
-		if ( isset( $attributes['lock'] ) && $attributes['lock'] && isset( $attributes['lock']['remove'] ) && $attributes['lock']['remove'] && isset( $attributes['lock']['move'] ) && $attributes['lock']['move'] && empty( $attributes['link'] ) ) {
+		if ( isset( $attributes['lock'] ) && $attributes['lock'] && is_array( $attributes['lock'] ) && isset( $attributes['lock']['remove'] ) && $attributes['lock']['remove'] && isset( $attributes['lock']['move'] ) && $attributes['lock']['move'] && empty( $attributes['link'] ) ) {
 			$html_tag = 'button';
 		}
 
@@ -479,6 +481,23 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		wp_register_script( 'kadence-blocks-glight-video-init', KADENCE_BLOCKS_URL . 'includes/assets/js/kb-glight-video-init.min.js', [ 'kadence-glightbox' ], KADENCE_BLOCKS_VERSION, true );
 		wp_register_script( 'kadence-blocks-popper', KADENCE_BLOCKS_URL . 'includes/assets/js/popper.min.js', [], KADENCE_BLOCKS_VERSION, true );
 		wp_register_script( 'kadence-blocks-tippy', KADENCE_BLOCKS_URL . 'includes/assets/js/kb-tippy.min.js', [ 'kadence-blocks-popper' ], KADENCE_BLOCKS_VERSION, true );
+	}
+
+	/**
+	 * Safely coerce a block attribute to a string.
+	 *
+	 * Block attributes arrive as mixed, so a non-scalar (or absent) value yields an empty string rather
+	 * than a type error.
+	 *
+	 * @param array<string, mixed> $attributes The block attributes.
+	 * @param string               $key        The attribute key to read.
+	 *
+	 * @return string
+	 */
+	private function attribute_string( array $attributes, string $key ): string {
+		$value = $attributes[ $key ] ?? '';
+
+		return is_scalar( $value ) ? (string) $value : '';
 	}
 }
 

--- a/includes/blocks/class-kadence-blocks-singlebtn-block.php
+++ b/includes/blocks/class-kadence-blocks-singlebtn-block.php
@@ -355,6 +355,14 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$classes[] = ! empty( $attributes['text'] ) ? 'kt-btn-has-text-true' : 'kt-btn-has-text-false';
 		$classes[] = ! empty( $attributes['icon'] ) ? 'kt-btn-has-svg-true' : 'kt-btn-has-svg-false';
 		$classes[] = ! empty( $attributes['iconReveal'] ) && ! empty( $attributes['icon'] ) ? 'icon-reveal' : '';
+		if ( ! empty( $attributes['kbVariant'] ) ) {
+			/**
+			 * The selected design-token variant outputs a kb-variant--<slug> class the Design Tokens variant
+			 * projector's scoped CSS hooks. This is a dynamic block, so the class is added here rather than by
+			 * the editor save filter; the sanitizer mirrors the projector's so the class matches the selector.
+			 */
+			$classes[] = 'kb-variant--' . preg_replace( '/[^A-Za-z0-9_-]+/', '-', $attributes['kbVariant'] );
+		}
 
 		if ( ! empty( $attributes['target'] ) && 'video' === $attributes['target'] ) {
 			$classes[] = 'ktblocksvideopop';

--- a/includes/resources/Design_Tokens/Design_Tokens_Provider.php
+++ b/includes/resources/Design_Tokens/Design_Tokens_Provider.php
@@ -23,6 +23,7 @@ final class Design_Tokens_Provider extends Provider {
 		Foundation_Presets\Provider::class,
 		Rest\Provider::class,
 		Admin\Provider::class,
+		Editor\Provider::class,
 	];
 
 	public function register(): void {

--- a/includes/resources/Design_Tokens/Editor/Localizer.php
+++ b/includes/resources/Design_Tokens/Editor/Localizer.php
@@ -48,23 +48,23 @@ final class Localizer {
 	private Token_Registry $registry;
 
 	/**
-	 * The catalog builder.
+	 * The variant catalog builder.
 	 *
 	 * @since TBD
 	 *
 	 * @var Variant_Catalog
 	 */
-	private Variant_Catalog $catalog;
+	private Variant_Catalog $variant_catalog;
 
 	/**
 	 * @since TBD
 	 *
-	 * @param Token_Registry  $registry The token registry.
-	 * @param Variant_Catalog $catalog  The catalog builder.
+	 * @param Token_Registry  $registry        The token registry.
+	 * @param Variant_Catalog $variant_catalog The variant catalog builder.
 	 */
-	public function __construct( Token_Registry $registry, Variant_Catalog $catalog ) {
-		$this->registry = $registry;
-		$this->catalog  = $catalog;
+	public function __construct( Token_Registry $registry, Variant_Catalog $variant_catalog ) {
+		$this->registry        = $registry;
+		$this->variant_catalog = $variant_catalog;
 	}
 
 	/**
@@ -84,7 +84,7 @@ final class Localizer {
 		}
 
 		$json = wp_json_encode(
-			$this->catalog->all(),
+			$this->variant_catalog->all(),
 			JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
 		);
 

--- a/includes/resources/Design_Tokens/Editor/Localizer.php
+++ b/includes/resources/Design_Tokens/Editor/Localizer.php
@@ -1,0 +1,101 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Editor;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+
+/**
+ * Attaches the variant catalog to the block editor's early-filters bundle.
+ *
+ * On enqueue_block_editor_assets (after the editor-assets class has enqueued the script) it attaches
+ * the catalog to the existing 'kadence-blocks-early-filters-js' handle as
+ * window.kadenceDesignTokensVariants, which the variant picker reads. Guarded on
+ * wp_script_is( …, 'enqueued' ) so it runs only where that bundle loads, and skipped entirely when the
+ * registry is fail-closed (a deactivated registry projects nothing, so the picker offers no variants).
+ *
+ * Emitted with wp_add_inline_script + wp_json_encode; the JSON_HEX_* flags make the payload safe to
+ * inline inside a <script> (no </script> breakout, no & ambiguity) without further escaping.
+ *
+ * @since TBD
+ */
+final class Localizer {
+
+	/**
+	 * The editor script handle the catalog is attached to (enqueued in class-kadence-blocks-editor-assets).
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const HANDLE = 'kadence-blocks-early-filters-js';
+
+	/**
+	 * The JS global the variant picker reads.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const OBJECT = 'kadenceDesignTokensVariants';
+
+	/**
+	 * The token registry, for the fail-closed gate.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * The catalog builder.
+	 *
+	 * @since TBD
+	 *
+	 * @var Variant_Catalog
+	 */
+	private Variant_Catalog $catalog;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry  $registry The token registry.
+	 * @param Variant_Catalog $catalog  The catalog builder.
+	 */
+	public function __construct( Token_Registry $registry, Variant_Catalog $catalog ) {
+		$this->registry = $registry;
+		$this->catalog  = $catalog;
+	}
+
+	/**
+	 * Attach the catalog to the editor bundle, when that bundle is on the page and the registry is active.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function localize(): void {
+		if ( ! wp_script_is( self::HANDLE, 'enqueued' ) ) {
+			return; // Not an editor screen with the bundle — nothing to attach to.
+		}
+
+		if ( ! $this->registry->is_active() ) {
+			return; // Fail-closed: no projection, so offer no variants.
+		}
+
+		$json = wp_json_encode(
+			$this->catalog->all(),
+			JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+		);
+
+		if ( $json === false ) {
+			return; // Catalog cannot be serialized — skip rather than inject malformed JS.
+		}
+
+		wp_add_inline_script(
+			self::HANDLE,
+			'window.' . self::OBJECT . ' = ' . $json . ';',
+			'before'
+		);
+	}
+}

--- a/includes/resources/Design_Tokens/Editor/Provider.php
+++ b/includes/resources/Design_Tokens/Editor/Provider.php
@@ -1,0 +1,35 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Editor;
+
+use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
+
+/**
+ * Registers the block-editor variant catalog: binds the catalog builder and localizer as singletons,
+ * then hooks the localizer onto enqueue_block_editor_assets so the early-filters bundle receives
+ * window.kadenceDesignTokensVariants for the variant picker.
+ *
+ * @since TBD
+ */
+final class Provider extends Provider_Contract {
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @since TBD
+	 */
+	public function register(): void {
+		$this->container->singleton( Variant_Catalog::class );
+		$this->container->singleton( Localizer::class );
+
+		/**
+		 * The editor-assets class enqueues kadence-blocks-early-filters-js on enqueue_block_editor_assets at
+		 * the default priority (10). The Localizer attaches its inline script to that handle, so it must run
+		 * strictly LATER — a higher priority guarantees the handle exists, where matching 10 would leave the
+		 * order registration-dependent. 20 sits clear of that default with headroom for others to slot
+		 * between. The Localizer also guards on wp_script_is( …, 'enqueued' ), so a missing handle no-ops
+		 * rather than fatals.
+		 */
+		add_action( 'enqueue_block_editor_assets', $this->container->callback( Localizer::class, 'localize' ), 20 );
+	}
+}

--- a/includes/resources/Design_Tokens/Editor/Provider.php
+++ b/includes/resources/Design_Tokens/Editor/Provider.php
@@ -28,7 +28,7 @@ final class Provider extends Provider_Contract {
 		 * strictly LATER — a higher priority guarantees the handle exists, where matching 10 would leave the
 		 * order registration-dependent. 20 sits clear of that default with headroom for others to slot
 		 * between. The Localizer also guards on wp_script_is( …, 'enqueued' ), so a missing handle no-ops
-		 * rather than fatals.
+		 * rather than triggering a fatal error.
 		 */
 		add_action( 'enqueue_block_editor_assets', $this->container->callback( Localizer::class, 'localize' ), 20 );
 	}

--- a/includes/resources/Design_Tokens/Editor/Variant_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Variant_Catalog.php
@@ -1,0 +1,85 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Editor;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Unknown_Variant_Exception;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
+
+/**
+ * Builds the compact per-block variant catalog the block editor's variant picker reads.
+ *
+ * Only the data the variant picker needs — each block's `$default` slug and its named variants as
+ * { slug, label } — so it carries no resolved token values and cannot raise the alias-cycle errors
+ * the admin feed must guard. A block registered but absent from the document
+ * (Unknown_Variant_Exception) is skipped, so one undefined block never empties the whole catalog.
+ *
+ * @since TBD
+ */
+final class Variant_Catalog {
+
+	/**
+	 * The token registry, source of the registered variant-set blocks.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * The variant resolver, source of each block's default, names and labels.
+	 *
+	 * @since TBD
+	 *
+	 * @var Variant_Resolver
+	 */
+	private Variant_Resolver $variants;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry   $registry The token registry.
+	 * @param Variant_Resolver $variants The variant resolver.
+	 */
+	public function __construct( Token_Registry $registry, Variant_Resolver $variants ) {
+		$this->registry = $registry;
+		$this->variants = $variants;
+	}
+
+	/**
+	 * The catalog, keyed by block name.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, array{default: string, variants: array<int, array{slug: string, label: string}>}>
+	 */
+	public function all(): array {
+		$out = [];
+
+		foreach ( $this->registry->variant_blocks() as $block ) {
+			try {
+				$names   = $this->variants->names( $block );
+				$default = $this->variants->default_variant( $block );
+			} catch ( Unknown_Variant_Exception $e ) {
+				continue; // Block registered but not defined in the document — skip, fail soft.
+			}
+
+			$variants = [];
+
+			foreach ( $names as $name ) {
+				$variants[] = [
+					'slug'  => $name,
+					'label' => $this->variants->label( $block, $name ) ?? $name,
+				];
+			}
+
+			$out[ $block ] = [
+				'default'  => $default,
+				'variants' => $variants,
+			];
+		}
+
+		return $out;
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Variant/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Variant/Css_Builder.php
@@ -3,6 +3,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Variant;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Style\Style;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Identifier;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Value;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Scope;
@@ -17,21 +18,24 @@ use RuntimeException;
  *
  * A Kadence block has no native style-variation system, so a selected variant reaches output purely
  * through the cascade: the editor adds a "kb-variant--<name>" class to the block, and this builder emits,
- * per (block, variant), a rule that retargets the --global-paletteN custom properties the block's
- * render_color() already consumes. Picking the variant therefore re-skins the block with zero changes to
- * its render path; an unselected block keeps its $default (the block preset).
+ * per (block, variant), a rule that retargets the --global-* custom properties (a numbered palette slot
+ * or a named button slot) the block's render_color() already consumes. Picking the variant therefore
+ * re-skins the block with zero changes to its render path.
  *
- * Two declaration blocks are emitted:
+ * Three declaration blocks are emitted:
  *
  *   1. A global --kb-token--variant--<block>--<variant>--<property> definition for every bound value, so
  *      a variant's values surface as named token vars in the same graph as every other token.
  *   2. Per (block, variant) scoped rules — ".wp-block-<block>.kb-variant--<variant>" — pointing each
- *      --global-paletteN at its variant var. The var is always co-emitted in (1) in the same stylesheet,
+ *      --global-<slot> at its variant var. The var is always co-emitted in (1) in the same stylesheet,
  *      so the reference resolves without a literal fallback.
+ *   3. A class-less ".wp-block-<block>" rule pointing each --global-<slot> at the $default variant's var,
+ *      so a block with no variant selected still shows its preset (the $default look) — the Kadence
+ *      analogue of the block preset, for color slots that have no attribute to seed.
  *
  * Scoping is per (block, variant): the same variant name on two blocks ("ghost" on a Button and a Row)
- * gets its own block-qualified rule, so values never collide. Only named variants are emitted; the
- * "$default" is the preset, applied through KB's attribute defaults rather than a class.
+ * gets its own block-qualified rule, so values never collide. Both named variants and the "$default"
+ * preset carry ordinary class/element specificity, so a per-instance edit still wins.
  *
  * Nothing here is !important and the scope carries ordinary class specificity, so a per-instance inline
  * style still wins over a variant. Values are sanitized defensively before they reach a declaration.
@@ -51,6 +55,23 @@ final class Css_Builder {
 	 * @var string
 	 */
 	private const VARIANT_SEGMENT = 'variant--';
+
+	/**
+	 * Kadence theme global custom-property slots a variant may retarget beyond the numbered palette
+	 * (palette1..9). These are the button's own color slots — the exact --global-* properties the
+	 * button render path already consumes — so a variant re-skins the button with no change to its
+	 * render path.
+	 *
+	 * @since TBD
+	 *
+	 * @var string[]
+	 */
+	private const NAMED_GLOBAL_SLOTS = [
+		'palette-btn-bg',
+		'palette-btn',
+		'palette-btn-bg-hover',
+		'palette-btn-hover',
+	];
 
 	/**
 	 * Object-cache group shared with the rest of the Design Tokens module.
@@ -97,8 +118,9 @@ final class Css_Builder {
 	}
 
 	/**
-	 * Build the full variant CSS for a token set: the global variant-var block followed by the per
-	 * (block, variant) scoped rules. Empty when no registered block contributes a palette-targeted value.
+	 * Build the full variant CSS for a token set: the global variant-var block, the per (block, variant)
+	 * scoped rules, and a class-less $default rule per block. Empty when no registered block contributes a
+	 * slot-targeted value.
 	 *
 	 * @since TBD
 	 *
@@ -111,6 +133,10 @@ final class Css_Builder {
 		$scoped  = '';
 
 		foreach ( $this->registry->variant_blocks() as $block ) {
+			if ( Style::is_native( $block ) ) {
+				continue; // Native blocks reach their variants through the Block_Style (register_block_style) path.
+			}
+
 			$set = $this->registry->for_block( $block );
 
 			if ( $set === null ) {
@@ -126,6 +152,9 @@ final class Css_Builder {
 			}
 
 			$selector = '.wp-block-' . self::sanitize_identifier( str_replace( '/', '-', $block ) );
+
+			// Keep each variant's slot declarations so the $default's can be re-emitted, class-less, below.
+			$variant_declarations = [];
 
 			foreach ( $names as $variant ) {
 				try {
@@ -143,7 +172,7 @@ final class Css_Builder {
 						continue;
 					}
 
-					$slot = $this->palette_slot( $binding );
+					$slot = $this->global_slot( $binding );
 
 					if ( $slot === null ) {
 						continue;
@@ -157,8 +186,25 @@ final class Css_Builder {
 				}
 
 				if ( $declarations !== '' ) {
-					$scoped .= $selector . '.kb-variant--' . self::sanitize_identifier( $variant ) . '{' . $declarations . '}';
+					$variant_declarations[ $variant ] = $declarations;
+					$scoped                          .= $selector . '.kb-variant--' . self::sanitize_identifier( $variant ) . '{' . $declarations . '}';
 				}
+			}
+
+			/**
+			 * The $default look: a block with no variant selected still shows its preset. Point the same slots
+			 * at the $default variant's var on the class-less block selector. Its lower specificity yields to
+			 * the kb-variant-- rules above (a selected variant) and to a per-instance edit, so it only fills
+			 * the gap.
+			 */
+			try {
+				$default = $this->variants->default_variant( $block );
+			} catch ( RuntimeException $e ) {
+				$default = '';
+			}
+
+			if ( $default !== '' && isset( $variant_declarations[ $default ] ) ) {
+				$scoped .= $selector . '{' . $variant_declarations[ $default ] . '}';
 			}
 		}
 
@@ -201,21 +247,27 @@ final class Css_Builder {
 	}
 
 	/**
-	 * The Kadence palette slot a binding targets (palette1..9), or null when it targets no palette slot.
+	 * The Kadence global custom-property slot a binding targets, or null when it targets none.
 	 *
-	 * Reads the binding's effective projections so a token-reference binding inherits the referenced
-	 * token's slot and an inline binding declares its own; both reach the same --global-paletteN.
+	 * Recognizes the numbered palette slots (palette1..9 → --global-paletteN) and the named button
+	 * slots in {@see NAMED_GLOBAL_SLOTS} (e.g. palette-btn-bg → --global-palette-btn-bg). Reads the
+	 * binding's effective projections so a token-reference binding inherits the referenced token's
+	 * slot and an inline binding declares its own; both reach the same --global-<slot>.
 	 *
 	 * @since TBD
 	 *
 	 * @param Binding $binding The variant binding.
 	 *
-	 * @return string|null The slot ("palette3"), or null.
+	 * @return string|null The slot ("palette3", "palette-btn-bg"), or null.
 	 */
-	private function palette_slot( Binding $binding ): ?string {
+	private function global_slot( Binding $binding ): ?string {
 		$slot = $this->registry->effective_projections( $binding )[ Binding::get_kadence_slot_key() ] ?? null;
 
-		if ( is_string( $slot ) && preg_match( '/^palette[1-9]$/', $slot ) === 1 ) {
+		if ( ! is_string( $slot ) ) {
+			return null;
+		}
+
+		if ( preg_match( '/^palette[1-9]$/', $slot ) === 1 || in_array( $slot, self::NAMED_GLOBAL_SLOTS, true ) ) {
 			return $slot;
 		}
 

--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -156,7 +156,7 @@
 					"$value": "4px"
 				}
 			},
-			"iconSize": {
+			"icon-size": {
 				"sm": {
 					"$type": "dimension",
 					"$value": "1rem"
@@ -297,10 +297,10 @@
 				"$value": "{primitive.dimension.borderWidth.sm}"
 			}
 		},
-		"iconSize": {
+		"icon-size": {
 			"default": {
 				"$type": "dimension",
-				"$value": "{primitive.dimension.iconSize.md}"
+				"$value": "{primitive.dimension.icon-size.md}"
 			}
 		},
 		"typography": {
@@ -449,7 +449,7 @@
 						}
 					}
 				},
-				"kadence/advancedbtn": {
+				"kadence/singlebtn": {
 					"$default": "primary",
 					"primary": {
 						"label": "Primary",
@@ -464,15 +464,6 @@
 						"tokens": {
 							"button-bg": "{primitive.color.brand.secondary}",
 							"button-text": "{primitive.color.neutral.0}",
-							"button-radius": "{semantic.radius.control}"
-						}
-					},
-					"ghost": {
-						"label": "Ghost",
-						"tokens": {
-							"button-bg": "transparent",
-							"button-text": "{primitive.color.brand.primary}",
-							"button-border": "{primitive.color.brand.primary}",
 							"button-radius": "{semantic.radius.control}"
 						}
 					}
@@ -493,7 +484,7 @@
 						"label": "Default",
 						"tokens": {
 							"color": "{semantic.color.icon}",
-							"size": "{semantic.iconSize.default}"
+							"size": "{semantic.icon-size.default}"
 						}
 					}
 				},
@@ -511,13 +502,6 @@
 						"tokens": {
 							"button-bg": "{primitive.color.brand.secondary}",
 							"button-text": "{primitive.color.neutral.0}"
-						}
-					},
-					"ghost": {
-						"label": "Ghost",
-						"tokens": {
-							"button-bg": "{primitive.color.transparent}",
-							"button-text": "{primitive.color.brand.primary}"
 						}
 					}
 				}

--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -7,10 +7,6 @@
 					"$type": "color",
 					"$value": "#3182CE"
 				},
-				"primary-dark": {
-					"$type": "color",
-					"$value": "#2C5282"
-				},
 				"secondary": {
 					"$type": "color",
 					"$value": "#2B6CB0"
@@ -18,6 +14,14 @@
 				"accent": {
 					"$type": "color",
 					"$value": "#ED8936"
+				},
+				"button": {
+					"$type": "color",
+					"$value": "#3633e1"
+				},
+				"button-hover": {
+					"$type": "color",
+					"$value": "#2f2ffc"
 				}
 			},
 			"neutral": {
@@ -264,15 +268,15 @@
 			},
 			"button-bg": {
 				"$type": "color",
-				"$value": "{semantic.color.button-primary-bg}"
+				"$value": "{primitive.color.brand.button}"
 			},
 			"button-text": {
 				"$type": "color",
-				"$value": "{semantic.color.button-primary-text}"
+				"$value": "{primitive.color.neutral.0}"
 			},
 			"button-primary-bg": {
 				"$type": "color",
-				"$value": "{primitive.color.brand.primary}"
+				"$value": "{primitive.color.brand.button}"
 			},
 			"button-primary-text": {
 				"$type": "color",
@@ -280,7 +284,7 @@
 			},
 			"button-primary-bg-hover": {
 				"$type": "color",
-				"$value": "{primitive.color.brand.primary-dark}"
+				"$value": "{primitive.color.brand.button-hover}"
 			},
 			"button-primary-text-hover": {
 				"$type": "color",

--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -9,7 +9,7 @@
 				},
 				"secondary": {
 					"$type": "color",
-					"$value": "#2C5282"
+					"$value": "#2B6CB0"
 				},
 				"accent": {
 					"$type": "color",
@@ -40,6 +40,10 @@
 				"500": {
 					"$type": "color",
 					"$value": "#718096"
+				},
+				"600": {
+					"$type": "color",
+					"$value": "#4A5568"
 				},
 				"700": {
 					"$type": "color",
@@ -256,9 +260,41 @@
 			},
 			"button-bg": {
 				"$type": "color",
-				"$value": "{primitive.color.brand.primary}"
+				"$value": "{semantic.color.button-primary-bg}"
 			},
 			"button-text": {
+				"$type": "color",
+				"$value": "{semantic.color.button-primary-text}"
+			},
+			"button-primary-bg": {
+				"$type": "color",
+				"$value": "{primitive.color.brand.primary}"
+			},
+			"button-primary-text": {
+				"$type": "color",
+				"$value": "{primitive.color.neutral.0}"
+			},
+			"button-primary-bg-hover": {
+				"$type": "color",
+				"$value": "{primitive.color.brand.secondary}"
+			},
+			"button-primary-text-hover": {
+				"$type": "color",
+				"$value": "{primitive.color.neutral.0}"
+			},
+			"button-secondary-bg": {
+				"$type": "color",
+				"$value": "{primitive.color.neutral.900}"
+			},
+			"button-secondary-text": {
+				"$type": "color",
+				"$value": "{primitive.color.neutral.0}"
+			},
+			"button-secondary-bg-hover": {
+				"$type": "color",
+				"$value": "{primitive.color.neutral.700}"
+			},
+			"button-secondary-text-hover": {
 				"$type": "color",
 				"$value": "{primitive.color.neutral.0}"
 			},
@@ -396,7 +432,7 @@
 						"label": "Kadence",
 						"tokens": {
 							"primitive.color.brand.primary": "#3182CE",
-							"primitive.color.brand.secondary": "#2C5282",
+							"primitive.color.brand.secondary": "#2B6CB0",
 							"primitive.color.brand.accent": "#ED8936"
 						}
 					},
@@ -454,16 +490,20 @@
 					"primary": {
 						"label": "Primary",
 						"tokens": {
-							"button-bg": "{semantic.color.button-bg}",
-							"button-text": "{semantic.color.button-text}",
+							"button-bg": "{semantic.color.button-primary-bg}",
+							"button-text": "{semantic.color.button-primary-text}",
+							"button-bg-hover": "{semantic.color.button-primary-bg-hover}",
+							"button-text-hover": "{semantic.color.button-primary-text-hover}",
 							"button-radius": "{semantic.radius.control}"
 						}
 					},
 					"secondary": {
 						"label": "Secondary",
 						"tokens": {
-							"button-bg": "{primitive.color.brand.secondary}",
-							"button-text": "{primitive.color.neutral.0}",
+							"button-bg": "{semantic.color.button-secondary-bg}",
+							"button-text": "{semantic.color.button-secondary-text}",
+							"button-bg-hover": "{semantic.color.button-secondary-bg-hover}",
+							"button-text-hover": "{semantic.color.button-secondary-text-hover}",
 							"button-radius": "{semantic.radius.control}"
 						}
 					}
@@ -493,15 +533,15 @@
 					"primary": {
 						"label": "Primary",
 						"tokens": {
-							"button-bg": "{semantic.color.button-bg}",
-							"button-text": "{semantic.color.button-text}"
+							"button-bg": "{semantic.color.button-primary-bg}",
+							"button-text": "{semantic.color.button-primary-text}"
 						}
 					},
 					"secondary": {
 						"label": "Secondary",
 						"tokens": {
-							"button-bg": "{primitive.color.brand.secondary}",
-							"button-text": "{primitive.color.neutral.0}"
+							"button-bg": "{semantic.color.button-secondary-bg}",
+							"button-text": "{semantic.color.button-secondary-text}"
 						}
 					}
 				}

--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -7,6 +7,10 @@
 					"$type": "color",
 					"$value": "#3182CE"
 				},
+				"primary-dark": {
+					"$type": "color",
+					"$value": "#2C5282"
+				},
 				"secondary": {
 					"$type": "color",
 					"$value": "#2B6CB0"
@@ -276,7 +280,7 @@
 			},
 			"button-primary-bg-hover": {
 				"$type": "color",
-				"$value": "{primitive.color.brand.secondary}"
+				"$value": "{primitive.color.brand.primary-dark}"
 			},
 			"button-primary-text-hover": {
 				"$type": "color",

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -44,18 +44,86 @@ $gap_tokens = array_map(
 	$gap_slugs
 );
 
+/**
+ * The brand + neutral primitives ARE the site's global color palette: each claims a Kadence palette slot
+ * (palette1..9), so --global-paletteN follows the primitive and the legacy kadence_blocks_colors palette
+ * stays in sync. Values mirror Kadence's default palette (brand at 1-2, a dark→light neutral ramp at 3-9,
+ * white at 9), so activation changes nothing until a primitive is overridden. Semantic colors deliberately
+ * do NOT claim a slot — they deliver at the block level — so writing a semantic never re-skins the palette.
+ */
+$palette_slots = [
+	'primitive.color.brand.primary'   => [ 'palette1', __( 'Brand Primary', 'kadence-blocks' ) ],
+	'primitive.color.brand.secondary' => [ 'palette2', __( 'Brand Secondary', 'kadence-blocks' ) ],
+	'primitive.color.neutral.900'     => [ 'palette3', __( 'Neutral 900', 'kadence-blocks' ) ],
+	'primitive.color.neutral.700'     => [ 'palette4', __( 'Neutral 700', 'kadence-blocks' ) ],
+	'primitive.color.neutral.600'     => [ 'palette5', __( 'Neutral 600', 'kadence-blocks' ) ],
+	'primitive.color.neutral.500'     => [ 'palette6', __( 'Neutral 500', 'kadence-blocks' ) ],
+	'primitive.color.neutral.100'     => [ 'palette7', __( 'Neutral 100', 'kadence-blocks' ) ],
+	'primitive.color.neutral.50'      => [ 'palette8', __( 'Neutral 50', 'kadence-blocks' ) ],
+	'primitive.color.neutral.0'       => [ 'palette9', __( 'Neutral 0', 'kadence-blocks' ) ],
+];
+
+$palette_tokens = [];
+foreach ( $palette_slots as $token_id => $slot_label ) {
+	$palette_tokens[] = [
+		'id'          => $token_id,
+		'type'        => 'color',
+		'label'       => $slot_label[1],
+		'group'       => __( 'Palette', 'kadence-blocks' ),
+		'projections' => [
+			'kadence_slot' => $slot_label[0],
+			'site_editor'  => true,
+		],
+	];
+}
+
+/**
+ * Per-variant button color semantics (primary/secondary, resting + hover). The Button variant maps
+ * reference these, and each is site_editor-surfaced so a site owner recolors one variant through the
+ * standard token path without touching the global palette. They carry no kadence_slot or wp_preset of
+ * their own: the Kadence button reads them via the variant's retarget bindings below, and the shared
+ * semantic.color.button-bg / button-text bucket (which keeps the wp_preset for core/button and aliases
+ * the primary pair) means overriding a primary semantic cascades to the native button too.
+ */
+$button_color_labels = [
+	'button-primary-bg'           => __( 'Button Primary Background', 'kadence-blocks' ),
+	'button-primary-text'         => __( 'Button Primary Text', 'kadence-blocks' ),
+	'button-primary-bg-hover'     => __( 'Button Primary Background (Hover)', 'kadence-blocks' ),
+	'button-primary-text-hover'   => __( 'Button Primary Text (Hover)', 'kadence-blocks' ),
+	'button-secondary-bg'         => __( 'Button Secondary Background', 'kadence-blocks' ),
+	'button-secondary-text'       => __( 'Button Secondary Text', 'kadence-blocks' ),
+	'button-secondary-bg-hover'   => __( 'Button Secondary Background (Hover)', 'kadence-blocks' ),
+	'button-secondary-text-hover' => __( 'Button Secondary Text (Hover)', 'kadence-blocks' ),
+];
+
+$button_color_tokens = [];
+foreach ( $button_color_labels as $suffix => $label ) {
+	$button_color_tokens[] = [
+		'id'          => 'semantic.color.' . $suffix,
+		'type'        => 'color',
+		'label'       => $label,
+		'group'       => __( 'Brand', 'kadence-blocks' ),
+		'projections' => [ 'site_editor' => true ],
+	];
+}
+
 return [
 	'tokens'       => array_merge(
 		[
 			[
+				/**
+				 * Semantic colors are a block-level intent, not a global-palette slot: they project to a
+				 * theme.json color preset (--wp--preset--color--button-bg, consumed by the button render path
+				 * and the variant system) but deliberately claim NO kadence_slot, so writing button-bg never
+				 * re-skins --global-paletteN. Mapping the brand primitives onto the global palette is separate.
+				 */
 				'id'          => 'semantic.color.button-bg',
 				'type'        => 'color',
 				'label'       => __( 'Button Background', 'kadence-blocks' ),
 				'group'       => __( 'Brand', 'kadence-blocks' ),
 				'projections' => [
-					'wp_preset'    => 'color',     // → theme.json preset + --wp--preset--color--button-bg.
-					'kadence_slot' => 'palette1',  // → --global-palette1 + kadence_blocks_colors slug.
-					'site_editor'  => true,
+					'wp_preset'   => 'color', // → theme.json preset + --wp--preset--color--button-bg.
+					'site_editor' => true,
 				],
 			],
 			[
@@ -64,9 +132,8 @@ return [
 				'label'       => __( 'Button Text', 'kadence-blocks' ),
 				'group'       => __( 'Brand', 'kadence-blocks' ),
 				'projections' => [
-					'wp_preset'    => 'color',
-					'kadence_slot' => 'palette2',
-					'site_editor'  => true,
+					'wp_preset'   => 'color',
+					'site_editor' => true,
 				],
 			],
 			[
@@ -102,6 +169,8 @@ return [
 				'group' => __( 'Brand', 'kadence-blocks' ),
 			],
 		],
+		$button_color_tokens,
+		$palette_tokens,
 		$spacing_tokens,
 		$gap_tokens
 	),
@@ -118,17 +187,21 @@ return [
 			 * not the advancedbtn container. Variants are a pure COLOR axis: they retarget the Kadence theme's
 			 * button-specific palette vars (the exact custom properties the button's render path already
 			 * consumes), so a variant composes with the block's existing "Button Inherit Styles" shape (Fill /
-			 * Outline / Theme Base) instead of fighting it — Fill reads --global-palette-btn-bg for its
-			 * background, Outline reads it for border+text, so one color variant skins both shapes. Picking a
-			 * variant re-skins a button with zero changes to its render path; a fresh button follows the
-			 * $default. The inline kadence_slot overrides the referenced token's numbered slot for this binding
-			 * only (Token_Registry::effective_projections merges inline over the token).
+			 * Outline / Theme Base) instead of fighting it — Fill reads --global-palette-btn-bg / -btn for its
+			 * background + text, Outline reads --global-palette-btn-bg for border + text, and both read the
+			 * matching -hover slots on :hover/:focus, so one color variant skins every shape and state. Each
+			 * binding names only the slot it retargets; the per-variant VALUE comes from the variant's token
+			 * map (which references the per-variant button-color semantics), so primary and secondary are
+			 * symmetric and each is overridable on its own semantic. Picking a variant re-skins a button with
+			 * zero changes to its render path; a fresh button follows the $default.
 			 */
 			'block'    => 'kadence/singlebtn',
 			'bindings' => [
-				'button-bg'     => [ 'token' => 'semantic.color.button-bg', 'kadence_slot' => 'palette-btn-bg' ],
-				'button-text'   => [ 'token' => 'semantic.color.button-text', 'kadence_slot' => 'palette-btn' ],
-				'button-radius' => [ 'css_var' => true ], // token-var only (no preset bucket).
+				'button-bg'         => [ 'kadence_slot' => 'palette-btn-bg' ],
+				'button-text'       => [ 'kadence_slot' => 'palette-btn' ],
+				'button-bg-hover'   => [ 'kadence_slot' => 'palette-btn-bg-hover' ],
+				'button-text-hover' => [ 'kadence_slot' => 'palette-btn-hover' ],
+				'button-radius'     => [ 'css_var' => true ], // token-var only (no preset bucket).
 			],
 		],
 		[

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -77,23 +77,58 @@ return [
 				'label' => __( 'Media Radius', 'kadence-blocks' ),
 				'group' => __( 'Brand', 'kadence-blocks' ),
 			],
+			[
+				/**
+				 * Control radius (buttons, inputs). Registered so Css_Var emits
+				 * --kb-token--semantic--radius--control; the button's own default border-radius rule references
+				 * that variable directly (the button is never empty, so the low-specificity block-default CSS
+				 * mechanism can't reach it). Resolves to the radius scale's "md" step, the design system's
+				 * control radius. A user's explicit radius still wins by specificity.
+				 */
+				'id'    => 'semantic.radius.control',
+				'type'  => 'dimension',
+				'label' => __( 'Control Radius', 'kadence-blocks' ),
+				'group' => __( 'Brand', 'kadence-blocks' ),
+			],
+			[
+				/**
+				 * Default icon size. Registered so Css_Var emits --kb-token--semantic--icon-size--default; the
+				 * button's --kb-button-icon-size default references it, so a button icon follows the token while
+				 * an explicit per-button icon size still wins.
+				 */
+				'id'    => 'semantic.icon-size.default',
+				'type'  => 'dimension',
+				'label' => __( 'Icon Size', 'kadence-blocks' ),
+				'group' => __( 'Brand', 'kadence-blocks' ),
+			],
 		],
 		$spacing_tokens,
 		$gap_tokens
 	),
-	// Variant set for the Button block: that it accepts variants, plus the per-property bindings (a
-	// token reference where the property is already a registered token, an inline target otherwise).
-	// The variant NAMES, the default ($default) and the values all live in the baseline document under
-	// $extensions…variants.<block>; this declares only the structural wiring. Inline slot values here
-	// (e.g. palette3) are placeholders until the per-block wiring tickets vet them against the block.
+	/**
+	 * Variant set for the Button block: that it accepts variants, plus the per-property bindings (a
+	 * token reference where the property is already a registered token, an inline target otherwise).
+	 * The variant NAMES, the default ($default) and the values all live in the baseline document under
+	 * $extensions…variants.<block>; this declares only the structural wiring.
+	 */
 	'variant_sets' => [
 		[
-			'block'    => 'kadence/advancedbtn',
+			/**
+			 * The variant lives on the child Single Button (each button in a group is skinned individually),
+			 * not the advancedbtn container. Variants are a pure COLOR axis: they retarget the Kadence theme's
+			 * button-specific palette vars (the exact custom properties the button's render path already
+			 * consumes), so a variant composes with the block's existing "Button Inherit Styles" shape (Fill /
+			 * Outline / Theme Base) instead of fighting it — Fill reads --global-palette-btn-bg for its
+			 * background, Outline reads it for border+text, so one color variant skins both shapes. Picking a
+			 * variant re-skins a button with zero changes to its render path; a fresh button follows the
+			 * $default. The inline kadence_slot overrides the referenced token's numbered slot for this binding
+			 * only (Token_Registry::effective_projections merges inline over the token).
+			 */
+			'block'    => 'kadence/singlebtn',
 			'bindings' => [
-				'button-bg'     => [ 'token' => 'semantic.color.button-bg' ],   // reuse the token's projections.
-				'button-text'   => [ 'token' => 'semantic.color.button-text' ],
-				'button-border' => [ 'kadence_slot' => 'palette3' ],            // not a token yet → inline target.
-				'button-radius' => [ 'css_var' => true ],                       // token-var only (no preset bucket).
+				'button-bg'     => [ 'token' => 'semantic.color.button-bg', 'kadence_slot' => 'palette-btn-bg' ],
+				'button-text'   => [ 'token' => 'semantic.color.button-text', 'kadence_slot' => 'palette-btn' ],
+				'button-radius' => [ 'css_var' => true ], // token-var only (no preset bucket).
 			],
 		],
 		[

--- a/src/blocks/advancedbtn/editor.scss
+++ b/src/blocks/advancedbtn/editor.scss
@@ -219,13 +219,13 @@
 	padding: 0.4em 1em;
 	cursor: pointer;
 	font-size: 1.125rem;
-	border-radius: 3px;
+	border-radius: var(--kb-token--semantic--radius--control, 3px);
 	transition: all 0.3s ease-in-out;
 	box-shadow: none;
 }
 .kt-button.kb-btn-global-fill {
 	border: 0px solid transparent;
-	border-radius: 3px;
+	border-radius: var(--kb-token--semantic--radius--control, 3px);
 	background: var(--global-palette-btn-bg, #3633e1);
 	color: var(--global-palette-btn, #ffffff);
 	&:hover {
@@ -379,7 +379,7 @@
 	gap: 0.5em;
 
 	&.icon-reveal {
-		$icon-size: var(--kb-button-icon-size, 24px);
+		$icon-size: var(--kb-button-icon-size, var(--kb-token--semantic--icon-size--default, 24px));
 
 		.kt-btn-svg-icon {
 			transition:

--- a/src/blocks/advancedbtn/style.scss
+++ b/src/blocks/advancedbtn/style.scss
@@ -38,7 +38,7 @@
 	padding: 0.4em 1em;
 	cursor: pointer;
 	font-size: 1.125rem;
-	border-radius: 3px;
+	border-radius: var(--kb-token--semantic--radius--control, 3px);
 	transition: all 0.3s ease-in-out;
 	box-shadow: none;
 	&:hover {
@@ -47,7 +47,7 @@
 }
 .kb-button.kb-btn-global-fill {
 	border: 0px solid transparent;
-	border-radius: 3px;
+	border-radius: var(--kb-token--semantic--radius--control, 3px);
 	background: var(--global-palette-btn-bg, #3633e1);
 	color: var(--global-palette-btn, #ffffff);
 	&:hover {
@@ -125,7 +125,7 @@
 	}
 }
 .kb-button.icon-reveal {
-	$icon-size: var(--kb-button-icon-size, 24px);
+	$icon-size: var(--kb-button-icon-size, var(--kb-token--semantic--icon-size--default, 24px));
 
 	.kb-svg-icon-wrap {
 		transition:

--- a/src/blocks/singlebtn/block.json
+++ b/src/blocks/singlebtn/block.json
@@ -753,6 +753,10 @@
 		"iconReveal": {
 			"type": "boolean",
 			"default": false
+		},
+		"kbVariant": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"supports": {
@@ -764,7 +768,8 @@
 		"html": false,
 		"reusable": false,
 		"kbMetadata": true,
-		"kbContentLabel": "text"
+		"kbContentLabel": "text",
+		"kbVariant": true
 	},
 	"usesContext": [
 		"postId",

--- a/src/early-filters.js
+++ b/src/early-filters.js
@@ -5,8 +5,10 @@
 import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport, getBlockSupport, createBlock } from '@wordpress/blocks';
 import { assign, get } from 'lodash';
-import { Button, Modal } from '@wordpress/components';
+import { Button, Modal, PanelBody } from '@wordpress/components';
+import { InspectorControls } from '@wordpress/block-editor';
 import { blockExists } from '@kadence/helpers';
+import { KadenceRadioButtons } from '@kadence/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
@@ -165,6 +167,67 @@ const withBlockVariantClass = createHigherOrderComponent((BlockListBlock) => {
 	};
 }, 'withBlockVariantClass');
 addFilter('editor.BlockListBlock', 'kadence/kb-variant-class', withBlockVariantClass);
+
+/**
+ * The design-token variant catalog the editor localizer prints — block name -> { default, variants } —
+ * or an empty object when the token registry is inactive (no variants offered).
+ *
+ * @return {Object} The catalog keyed by block name.
+ */
+function variantCatalog() {
+	return get(window, 'kadenceDesignTokensVariants', {}) || {};
+}
+
+/**
+ * Add a "Design Variant" picker to the inspector of any block that opts into kbVariant support and has
+ * variants defined in the design-token document. Selecting an option writes the kbVariant attribute,
+ * which the save/preview filters turn into the kb-variant--<slug> class the projector's scoped CSS hooks.
+ * An empty value selects the block's $default preset look.
+ *
+ * @since TBD
+ */
+const withVariantPicker = createHigherOrderComponent((BlockEdit) => {
+	return (props) => {
+		const { name, attributes, setAttributes, isSelected } = props;
+
+		if (!hasBlockSupport(name, 'kbVariant')) {
+			return <BlockEdit {...props} />;
+		}
+
+		const variants = get(variantCatalog(), [name, 'variants'], []);
+
+		if (!variants.length) {
+			return <BlockEdit {...props} />;
+		}
+
+		const options = [
+			{ label: __('Default', 'kadence-blocks'), value: '' },
+			...variants.map((variant) => ({ label: variant.label, value: variant.slug })),
+		];
+
+		return (
+			<>
+				<BlockEdit {...props} />
+				{isSelected && (
+					<InspectorControls>
+						<PanelBody title={__('Design Variant', 'kadence-blocks')} initialOpen={false}>
+							<KadenceRadioButtons
+								label={__('Variant', 'kadence-blocks')}
+								className={'kb-variant-picker'}
+								value={get(attributes, 'kbVariant', '')}
+								options={options}
+								hideLabel={false}
+								wrap={true}
+								onChange={(value) => setAttributes({ kbVariant: value })}
+							/>
+						</PanelBody>
+					</InspectorControls>
+				)}
+			</>
+		);
+	};
+}, 'withVariantPicker');
+addFilter('editor.BlockEdit', 'kadence/kb-variant-picker', withVariantPicker);
 
 const kadenceHeaderTemplatePartNotice = createHigherOrderComponent((BlockEdit) => {
 	return (props) => {

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
@@ -95,7 +95,7 @@ final class LocalizerTest extends TestCase {
 		$this->assertContains( 'semantic.color.button-bg', $ids );
 
 		// Values: keyed identically to the schema, the resolved hex.
-		$this->assertSame( '#3182CE', $feed['values']['semantic.color.button-bg'] );
+		$this->assertSame( '#3633e1', $feed['values']['semantic.color.button-bg'] );
 
 		// REST descriptor.
 		$this->assertSame( 'kb-design-tokens/v1', $feed['rest']['namespace'] );

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/VariantsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/VariantsTest.php
@@ -43,7 +43,7 @@ final class VariantsTest extends TestCase {
 		$this->assertArrayHasKey( 'button-bg', $button['bindings'] );
 
 		// Resolved preview values per variant — aliases flattened to their primitive color.
-		$this->assertSame( '#3182CE', $button['values']['primary']['button-bg'] );
+		$this->assertSame( '#3633e1', $button['values']['primary']['button-bg'] );
 		$this->assertSame( '#1A202C', $button['values']['secondary']['button-bg'] );
 	}
 

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/VariantsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/VariantsTest.php
@@ -14,7 +14,7 @@ use Tests\Support\Classes\TestCase;
  */
 final class VariantsTest extends TestCase {
 
-	private const BUTTON = 'kadence/advancedbtn';
+	private const BUTTON = 'kadence/singlebtn';
 
 	private Variant_Resolver $resolver;
 
@@ -35,16 +35,16 @@ final class VariantsTest extends TestCase {
 		$button = $variants[ self::BUTTON ];
 
 		$this->assertSame( 'primary', $button['default'] );
-		$this->assertSame( [ 'primary', 'secondary', 'ghost' ], $button['names'] );
+		$this->assertSame( [ 'primary', 'secondary' ], $button['names'] );
 		$this->assertContains( 'button-bg', $button['properties'] );
 
 		// Structure: bindings carry the token reference / inline targets.
 		$this->assertArrayHasKey( 'bindings', $button );
 		$this->assertArrayHasKey( 'button-bg', $button['bindings'] );
 
-		// Resolved preview values per variant — aliases flattened, literals passed through.
+		// Resolved preview values per variant — aliases flattened to their primitive color.
 		$this->assertSame( '#3182CE', $button['values']['primary']['button-bg'] );
-		$this->assertSame( 'transparent', $button['values']['ghost']['button-bg'] );
+		$this->assertSame( '#2C5282', $button['values']['secondary']['button-bg'] );
 	}
 
 	public function testABlockRegisteredButAbsentFromTheDocumentIsSkipped(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/VariantsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/VariantsTest.php
@@ -44,7 +44,7 @@ final class VariantsTest extends TestCase {
 
 		// Resolved preview values per variant — aliases flattened to their primitive color.
 		$this->assertSame( '#3182CE', $button['values']['primary']['button-bg'] );
-		$this->assertSame( '#2C5282', $button['values']['secondary']['button-bg'] );
+		$this->assertSame( '#1A202C', $button['values']['secondary']['button-bg'] );
 	}
 
 	public function testABlockRegisteredButAbsentFromTheDocumentIsSkipped(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Variant_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Variant_CatalogTest.php
@@ -45,8 +45,14 @@ final class Variant_CatalogTest extends TestCase {
 		$this->assertSame( 'primary', $button['default'] );
 		$this->assertSame(
 			[
-				[ 'slug' => 'primary', 'label' => 'Primary' ],
-				[ 'slug' => 'secondary', 'label' => 'Secondary' ],
+				[
+					'slug'  => 'primary',
+					'label' => 'Primary',
+				],
+				[
+					'slug'  => 'secondary',
+					'label' => 'Secondary',
+				],
 			],
 			$button['variants']
 		);

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Variant_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Variant_CatalogTest.php
@@ -1,0 +1,68 @@
+<?php declare( strict_types=1 );
+// cspell:ignore advancedbtn .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Editor;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Editor\Variant_Catalog;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Exercises the editor variant catalog against the real shipped baseline, so these assertions also
+ * guard the Button variant set the picker offers.
+ */
+final class Variant_CatalogTest extends TestCase {
+
+	private const BUTTON = 'kadence/singlebtn';
+
+	private Variant_Resolver $resolver;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->resolver = $this->container->get( Variant_Resolver::class );
+	}
+
+	/**
+	 * The shipped Button reports its default and its named variants as { slug, label } for the picker.
+	 *
+	 * @return void
+	 */
+	public function testItBuildsTheButtonCatalog(): void {
+		/** @var Token_Registry $registry */
+		$registry = $this->container->get( Token_Registry::class );
+
+		$catalog = ( new Variant_Catalog( $registry, $this->resolver ) )->all();
+
+		$this->assertArrayHasKey( self::BUTTON, $catalog );
+
+		$button = $catalog[ self::BUTTON ];
+
+		$this->assertSame( 'primary', $button['default'] );
+		$this->assertSame(
+			[
+				[ 'slug' => 'primary', 'label' => 'Primary' ],
+				[ 'slug' => 'secondary', 'label' => 'Secondary' ],
+			],
+			$button['variants']
+		);
+	}
+
+	/**
+	 * A block registered but absent from the document is skipped rather than emitted empty.
+	 *
+	 * @return void
+	 */
+	public function testItSkipsABlockAbsentFromTheDocument(): void {
+		$registry = new Token_Registry();
+		$registry->register_variant_set( [ 'block' => 'kadence/not-a-real-block' ] );
+
+		$catalog = ( new Variant_Catalog( $registry, $this->resolver ) )->all();
+
+		$this->assertSame( [], $catalog );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Preset/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Preset/ProjectorTest.php
@@ -16,7 +16,7 @@ use Tests\Support\Classes\TestCase;
  */
 final class ProjectorTest extends TestCase {
 
-	private const BUTTON = 'kadence/advancedbtn';
+	private const BUTTON = 'kadence/singlebtn';
 
 	private Variant_Resolver $resolver;
 

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Preset/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Preset/ProjectorTest.php
@@ -29,8 +29,8 @@ final class ProjectorTest extends TestCase {
 	public function testItMapsThePresetValuesOntoTheBoundBlockAttributes(): void {
 		$defaults = $this->projector( $this->button_set() )->add_preset_defaults( [], self::BUTTON );
 
-		// Button's $default is "primary": button-bg -> #3182CE, button-text -> #ffffff.
-		$this->assertSame( '#3182CE', $defaults['background'] );
+		// Button's $default is "primary": button-bg -> #3633e1, button-text -> #ffffff.
+		$this->assertSame( '#3633e1', $defaults['background'] );
 		$this->assertSame( '#ffffff', $defaults['color'] );
 		// button-radius has no block_attr, so it never reaches an attribute default.
 		$this->assertArrayNotHasKey( 'button-radius', $defaults );
@@ -47,7 +47,7 @@ final class ProjectorTest extends TestCase {
 		);
 
 		// The preset overwrites a default it binds...
-		$this->assertSame( '#3182CE', $defaults['background'] );
+		$this->assertSame( '#3633e1', $defaults['background'] );
 		// ...adds a binding the incoming defaults did not carry...
 		$this->assertSame( '#ffffff', $defaults['color'] );
 		// ...and leaves an unrelated default untouched, proving an overlay merge rather than a wholesale

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Style/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Style/Css_BuilderTest.php
@@ -54,9 +54,8 @@ final class Css_BuilderTest extends TestCase {
 	public function testItResolvesAliasedValuesAndScopesPerVariant(): void {
 		$css = $this->builder->css();
 
-		// ghost's button-bg aliases {primitive.color.transparent}, which flattens to transparent.
-		$this->assertStringContainsString( '--kb-token--variant--core-button--ghost--button-bg:transparent;', $css );
-		$this->assertStringContainsString( '.wp-block-button.is-style-kb-ghost{', $css );
+		// secondary's button-bg aliases {primitive.color.brand.secondary}, which flattens to its hex.
+		$this->assertStringContainsString( '--kb-token--variant--core-button--secondary--button-bg:#2C5282;', $css );
 		$this->assertStringContainsString( '.wp-block-button.is-style-kb-secondary{', $css );
 	}
 

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Style/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Style/Css_BuilderTest.php
@@ -37,7 +37,7 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder->css();
 
 		// core/button's primary resolves to the brand button colors, surfaced as variant vars...
-		$this->assertStringContainsString( '--kb-token--variant--core-button--primary--button-bg:#3182CE;', $css );
+		$this->assertStringContainsString( '--kb-token--variant--core-button--primary--button-bg:#3633e1;', $css );
 		$this->assertStringContainsString( '--kb-token--variant--core-button--primary--button-text:#ffffff;', $css );
 		// ...and the scoped rule re-targets the WordPress preset vars the block consumes at its $default.
 		$this->assertStringContainsString( '.wp-block-button.is-style-kb-primary{', $css );

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Style/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Style/Css_BuilderTest.php
@@ -54,8 +54,8 @@ final class Css_BuilderTest extends TestCase {
 	public function testItResolvesAliasedValuesAndScopesPerVariant(): void {
 		$css = $this->builder->css();
 
-		// secondary's button-bg aliases {primitive.color.brand.secondary}, which flattens to its hex.
-		$this->assertStringContainsString( '--kb-token--variant--core-button--secondary--button-bg:#2C5282;', $css );
+		// secondary's button-bg aliases {semantic.color.button-secondary-bg}, which flattens to neutral.900.
+		$this->assertStringContainsString( '--kb-token--variant--core-button--secondary--button-bg:#1A202C;', $css );
 		$this->assertStringContainsString( '.wp-block-button.is-style-kb-secondary{', $css );
 	}
 

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Style/RegistrarTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Style/RegistrarTest.php
@@ -28,8 +28,7 @@ final class RegistrarTest extends TestCase {
 
 		$this->assertArrayHasKey( 'kb-primary', $styles );
 		$this->assertArrayHasKey( 'kb-secondary', $styles );
-		$this->assertArrayHasKey( 'kb-ghost', $styles );
-		$this->assertSame( 'Ghost', $styles['kb-ghost']['label'] );
+		$this->assertSame( 'Secondary', $styles['kb-secondary']['label'] );
 	}
 
 	public function testItDoesNotRegisterStylesForKadenceBlocks(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/ProjectorTest.php
@@ -78,7 +78,7 @@ final class ProjectorTest extends TestCase {
 
 		$this->assertIsArray( $decoded );
 		$by_slug = array_column( $decoded['palette'], null, 'slug' );
-		// The shipped declarations include button-bg => palette1.
+		// The shipped declarations map primitive.color.brand.primary => palette1.
 		$this->assertArrayHasKey( 'palette1', $by_slug );
 		$this->assertMatchesRegularExpression( '/^#[0-9a-fA-F]{3,8}$/', $by_slug['palette1']['color'] );
 	}
@@ -121,9 +121,9 @@ final class ProjectorTest extends TestCase {
 					'slug'  => 'palette2',
 				],
 				[
-					'color' => '#old5',
-					'name'  => 'Palette Color 5',
-					'slug'  => 'palette5',
+					'color' => '#old3',
+					'name'  => 'Theme Extra',
+					'slug'  => 'theme-extra',
 				],
 			],
 		];
@@ -137,8 +137,8 @@ final class ProjectorTest extends TestCase {
 
 		// Token-claimed slots must be overwritten.
 		$this->assertNotSame( '#old1', $by_slug['palette1']['color'] );
-		// Unclaimed slots must be untouched.
-		$this->assertSame( '#old5', $by_slug['palette5']['color'] );
+		// A slug no token claims must be untouched.
+		$this->assertSame( '#old3', $by_slug['theme-extra']['color'] );
 	}
 
 	public function testReconcileNeverCreatesThemePaletteWhenAbsent(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Variant/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Variant/Css_BuilderTest.php
@@ -56,7 +56,9 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $this->registry )->css();
 
 		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--primary--button-bg:#3182CE;', $css );
-		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--secondary--button-bg:#2C5282;', $css );
+		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--primary--button-bg-hover:#2B6CB0;', $css );
+		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--secondary--button-bg:#1A202C;', $css );
+		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--secondary--button-bg-hover:#2D3748;', $css );
 	}
 
 	/**
@@ -71,7 +73,9 @@ final class Css_BuilderTest extends TestCase {
 		$this->assertStringContainsString(
 			'.wp-block-kadence-singlebtn.kb-variant--secondary{'
 				. '--global-palette-btn-bg:var(--kb-token--variant--kadence-singlebtn--secondary--button-bg);'
-				. '--global-palette-btn:var(--kb-token--variant--kadence-singlebtn--secondary--button-text);}',
+				. '--global-palette-btn:var(--kb-token--variant--kadence-singlebtn--secondary--button-text);'
+				. '--global-palette-btn-bg-hover:var(--kb-token--variant--kadence-singlebtn--secondary--button-bg-hover);'
+				. '--global-palette-btn-hover:var(--kb-token--variant--kadence-singlebtn--secondary--button-text-hover);}',
 			$css
 		);
 	}
@@ -88,7 +92,9 @@ final class Css_BuilderTest extends TestCase {
 		$this->assertStringContainsString(
 			'.wp-block-kadence-singlebtn{'
 				. '--global-palette-btn-bg:var(--kb-token--variant--kadence-singlebtn--primary--button-bg);'
-				. '--global-palette-btn:var(--kb-token--variant--kadence-singlebtn--primary--button-text);}',
+				. '--global-palette-btn:var(--kb-token--variant--kadence-singlebtn--primary--button-text);'
+				. '--global-palette-btn-bg-hover:var(--kb-token--variant--kadence-singlebtn--primary--button-bg-hover);'
+				. '--global-palette-btn-hover:var(--kb-token--variant--kadence-singlebtn--primary--button-text-hover);}',
 			$css
 		);
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Variant/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Variant/Css_BuilderTest.php
@@ -10,23 +10,29 @@ use ReflectionProperty;
 use Tests\Support\Classes\TestCase;
 
 /**
- * Exercises the selectable-variant CSS builder against the shipped Button variants, with a synthetic
- * variant set supplying the `kadence_slot` bindings the shipped declarations do not carry yet (those land
- * with the Button wiring, SOFT-3406). Values come from the baseline; this proves the per-(block, variant)
- * scoped --global-paletteN retargeting and the variant-var indirection.
+ * Exercises the selectable-variant CSS builder against the real shipped Button variant set, so these
+ * assertions also guard the Button wiring: the button-specific --global-palette-btn-* slot retargeting,
+ * the variant-var indirection, and the class-less $default rule.
  */
 final class Css_BuilderTest extends TestCase {
 
-	private const BUTTON = 'kadence/advancedbtn';
+	private Token_Registry $registry;
 
 	private Variant_Resolver $resolver;
 
+	/**
+	 * @return void
+	 */
 	protected function setUp(): void {
 		parent::setUp();
 
+		$this->registry = $this->container->get( Token_Registry::class );
 		$this->resolver = $this->container->get( Variant_Resolver::class );
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function tearDown(): void {
 		// The Variant_Resolver leans on the shared Token_Resolver singleton, whose per-slug memo is not
 		// rolled back between tests; clear it so a sibling test's stored overrides cannot leak in.
@@ -41,54 +47,77 @@ final class Css_BuilderTest extends TestCase {
 		parent::tearDown();
 	}
 
-	public function testItEmitsAScopedPaletteOverrideAndVariantVarForAVariant(): void {
-		$css = $this->builder( $this->button_set() )->css();
+	/**
+	 * Each variant's resolved value lives as a co-emitted global token var, aliases flattened to literals.
+	 *
+	 * @return void
+	 */
+	public function testItDefinesTheVariantVars(): void {
+		$css = $this->builder( $this->registry )->css();
 
-		// The variant's value lives as a global token var...
+		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--primary--button-bg:#3182CE;', $css );
+		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--secondary--button-bg:#2C5282;', $css );
+	}
+
+	/**
+	 * A named variant retargets the button's own --global-palette-btn-* slots (the vars the button render
+	 * path consumes), not the numbered palette, at the co-emitted variant var.
+	 *
+	 * @return void
+	 */
+	public function testItRetargetsButtonSlotsForANamedVariant(): void {
+		$css = $this->builder( $this->registry )->css();
+
 		$this->assertStringContainsString(
-			'--kb-token--variant--kadence-advancedbtn--primary--button-bg:#3182CE;',
-			$css
-		);
-		// ...and the scoped rule retargets the palette slot at that co-emitted var.
-		$this->assertStringContainsString( '.wp-block-kadence-advancedbtn.kb-variant--primary{', $css );
-		$this->assertStringContainsString(
-			'--global-palette1:var(--kb-token--variant--kadence-advancedbtn--primary--button-bg);',
-			$css
-		);
-		$this->assertStringContainsString(
-			'--global-palette9:var(--kb-token--variant--kadence-advancedbtn--primary--button-text);',
+			'.wp-block-kadence-singlebtn.kb-variant--secondary{'
+				. '--global-palette-btn-bg:var(--kb-token--variant--kadence-singlebtn--secondary--button-bg);'
+				. '--global-palette-btn:var(--kb-token--variant--kadence-singlebtn--secondary--button-text);}',
 			$css
 		);
 	}
 
-	public function testItSkipsAPropertyBoundToNoPaletteSlot(): void {
-		// button-radius is bound css_var only (no kadence_slot), so it never reaches a --global-paletteN.
-		$css = $this->builder( $this->button_set() )->css();
+	/**
+	 * The $default (primary) is re-emitted on the class-less block selector, so a button with no variant
+	 * selected still shows its preset look.
+	 *
+	 * @return void
+	 */
+	public function testItEmitsTheDefaultPresetOnTheBareSelector(): void {
+		$css = $this->builder( $this->registry )->css();
+
+		$this->assertStringContainsString(
+			'.wp-block-kadence-singlebtn{'
+				. '--global-palette-btn-bg:var(--kb-token--variant--kadence-singlebtn--primary--button-bg);'
+				. '--global-palette-btn:var(--kb-token--variant--kadence-singlebtn--primary--button-text);}',
+			$css
+		);
+	}
+
+	/**
+	 * button-radius is bound css_var only (no slot), so it never reaches a --global-* declaration.
+	 *
+	 * @return void
+	 */
+	public function testItSkipsAPropertyBoundToNoSlot(): void {
+		$css = $this->builder( $this->registry )->css();
 
 		$this->assertStringNotContainsString( 'button-radius', $css );
 	}
 
-	public function testItScopesEachVariantToTheBlockClassAndPassesLiteralsThrough(): void {
-		$css = $this->builder( $this->button_set() )->css();
-
-		// Every named variant gets its own block-qualified rule, so a shared name never collides.
-		$this->assertStringContainsString( '.wp-block-kadence-advancedbtn.kb-variant--secondary{', $css );
-		$this->assertStringContainsString( '.wp-block-kadence-advancedbtn.kb-variant--ghost{', $css );
-		// ghost's button-bg is the literal "transparent" in the baseline; it passes straight through into the
-		// co-emitted variant var.
-		$this->assertStringContainsString(
-			'--kb-token--variant--kadence-advancedbtn--ghost--button-bg:transparent;',
-			$css
-		);
-	}
-
+	/**
+	 * @return void
+	 */
 	public function testItIsEmptyWhenNoVariantSetsAreRegistered(): void {
 		$this->assertSame( '', $this->builder( new Token_Registry() )->css() );
 	}
 
+	/**
+	 * A registered binding for a block the baseline has no variants for contributes nothing, rather than
+	 * failing the whole build.
+	 *
+	 * @return void
+	 */
 	public function testItSkipsABlockWhoseDocumentDefinesNoVariants(): void {
-		// A registered binding for a block the baseline has no variants for contributes nothing, rather than
-		// failing the whole build.
 		$registry = new Token_Registry();
 		$registry->register_variant_set(
 			[
@@ -102,28 +131,12 @@ final class Css_BuilderTest extends TestCase {
 
 	/**
 	 * Build the CSS builder with a given registry and the real (baseline-backed) variant resolver.
+	 *
+	 * @param Token_Registry $registry The registry to build from.
+	 *
+	 * @return Css_Builder
 	 */
 	private function builder( Token_Registry $registry ): Css_Builder {
 		return new Css_Builder( $registry, $this->resolver );
-	}
-
-	/**
-	 * A registry holding a Button variant set whose bindings target Kadence palette slots — the targets the
-	 * shipped declarations omit until SOFT-3406.
-	 */
-	private function button_set(): Token_Registry {
-		$registry = new Token_Registry();
-		$registry->register_variant_set(
-			[
-				'block'    => self::BUTTON,
-				'bindings' => [
-					'button-bg'     => [ 'kadence_slot' => 'palette1' ],
-					'button-text'   => [ 'kadence_slot' => 'palette9' ],
-					'button-radius' => [ 'css_var' => true ], // no palette slot -> skipped.
-				],
-			]
-		);
-
-		return $registry;
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Variant/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Variant/Css_BuilderTest.php
@@ -56,7 +56,7 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $this->registry )->css();
 
 		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--primary--button-bg:#3182CE;', $css );
-		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--primary--button-bg-hover:#2B6CB0;', $css );
+		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--primary--button-bg-hover:#2C5282;', $css );
 		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--secondary--button-bg:#1A202C;', $css );
 		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--secondary--button-bg-hover:#2D3748;', $css );
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Variant/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Variant/Css_BuilderTest.php
@@ -55,8 +55,8 @@ final class Css_BuilderTest extends TestCase {
 	public function testItDefinesTheVariantVars(): void {
 		$css = $this->builder( $this->registry )->css();
 
-		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--primary--button-bg:#3182CE;', $css );
-		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--primary--button-bg-hover:#2C5282;', $css );
+		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--primary--button-bg:#3633e1;', $css );
+		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--primary--button-bg-hover:#2f2ffc;', $css );
 		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--secondary--button-bg:#1A202C;', $css );
 		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--secondary--button-bg-hover:#2D3748;', $css );
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Variant/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Variant/ProjectorTest.php
@@ -17,7 +17,7 @@ use Tests\Support\Classes\TestCase;
  */
 final class ProjectorTest extends TestCase {
 
-	private const BUTTON = 'kadence/advancedbtn';
+	private const BUTTON = 'kadence/singlebtn';
 
 	private Variant_Resolver $resolver;
 
@@ -59,8 +59,8 @@ final class ProjectorTest extends TestCase {
 
 		$css = implode( '', (array) wp_styles()->get_data( 'kadence-blocks-global-variables', 'after' ) );
 
-		$this->assertStringContainsString( '.wp-block-kadence-advancedbtn.kb-variant--primary{', $css );
-		$this->assertStringContainsString( '--global-palette1:var(--kb-token--variant--kadence-advancedbtn--primary--button-bg', $css );
+		$this->assertStringContainsString( '.wp-block-kadence-singlebtn.kb-variant--primary{', $css );
+		$this->assertStringContainsString( '--global-palette1:var(--kb-token--variant--kadence-singlebtn--primary--button-bg', $css );
 	}
 
 	public function testItIsANoopWhenTheRegistryIsDeactivated(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Baseline/Json_Baseline_DocumentTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Baseline/Json_Baseline_DocumentTest.php
@@ -151,7 +151,7 @@ final class Json_Baseline_DocumentTest extends TestCase {
 		$this->assertArrayHasKey( '$extensions', $document );
 		$this->assertSame( '#3182CE', $document['primitive']['color']['brand']['primary']['$value'] );
 		$this->assertArrayHasKey(
-			'kadence/advancedbtn',
+			'kadence/singlebtn',
 			$document['$extensions']['com.kadence.designTokens']['variants']
 		);
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Registry/RegistrationHelperTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/RegistrationHelperTest.php
@@ -56,10 +56,10 @@ final class RegistrationHelperTest extends TestCase {
 	}
 
 	public function testDeclarationsFileRegisteredTheButtonVariantSet(): void {
-		$set = $this->registry->for_block( 'kadence/advancedbtn' );
+		$set = $this->registry->for_block( 'kadence/singlebtn' );
 
 		$this->assertNotNull( $set );
-		$this->assertSame( 'kadence/advancedbtn', $set->block );
+		$this->assertSame( 'kadence/singlebtn', $set->block );
 		$this->assertNotNull( $set->binding( 'button-bg' ) );
 	}
 

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_DocumentTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_DocumentTest.php
@@ -18,13 +18,17 @@ final class Effective_DocumentTest extends TestCase {
 			'primitive'   => [
 				'color' => [
 					'brand' => [
+						/**
+						 * Synthetic sentinel values: this is a Fake_Baseline_Document exercising the merge
+						 * logic, intentionally independent of the shipped baseline's real palette.
+						 */
 						'primary'   => [
 							'$type'  => 'color',
-							'$value' => '#3182CE',
+							'$value' => '#111111',
 						],
 						'secondary' => [
 							'$type'  => 'color',
-							'$value' => '#2C5282',
+							'$value' => '#222222',
 						],
 					],
 				],
@@ -79,7 +83,7 @@ final class Effective_DocumentTest extends TestCase {
 
 		$this->assertSame( '#000000', $document['primitive']['color']['brand']['primary']['$value'] );
 		// Untouched siblings survive the merge.
-		$this->assertSame( '#2C5282', $document['primitive']['color']['brand']['secondary']['$value'] );
+		$this->assertSame( '#222222', $document['primitive']['color']['brand']['secondary']['$value'] );
 	}
 
 	public function testATokenAbsentFromOverridesFallsBackToBaseline(): void {
@@ -120,7 +124,7 @@ final class Effective_DocumentTest extends TestCase {
 
 		// RESET keeps the baseline value; the entry must survive with its original data.
 		$this->assertArrayHasKey( 'secondary', $document['primitive']['color']['brand'] );
-		$this->assertSame( '#2C5282', $document['primitive']['color']['brand']['secondary']['$value'] );
+		$this->assertSame( '#222222', $document['primitive']['color']['brand']['secondary']['$value'] );
 	}
 
 	public function testADisabledSentinelRemovesTheBaselineEntry(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_VariantsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_VariantsTest.php
@@ -80,7 +80,7 @@ final class Effective_VariantsTest extends TestCase {
 
 		// The overridden property wins; the variant's other baseline tokens and its label survive.
 		$this->assertSame( '#000000', $secondary['tokens']['button-bg'] );
-		$this->assertSame( '{primitive.color.neutral.0}', $secondary['tokens']['button-text'] );
+		$this->assertSame( '{semantic.color.button-secondary-text}', $secondary['tokens']['button-text'] );
 		$this->assertSame( 'Secondary', $secondary['label'] );
 	}
 

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_VariantsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_VariantsTest.php
@@ -13,7 +13,7 @@ use Tests\Support\Classes\TestCase;
  */
 final class Effective_VariantsTest extends TestCase {
 
-	private const BUTTON = 'kadence/advancedbtn';
+	private const BUTTON = 'kadence/singlebtn';
 
 	/**
 	 * @var Token_Store
@@ -45,7 +45,6 @@ final class Effective_VariantsTest extends TestCase {
 		$this->assertSame( 'primary', $node['$default'] );
 		$this->assertArrayHasKey( 'primary', $node );
 		$this->assertArrayHasKey( 'secondary', $node );
-		$this->assertArrayHasKey( 'ghost', $node );
 	}
 
 	/**
@@ -53,7 +52,7 @@ final class Effective_VariantsTest extends TestCase {
 	 */
 	public function testAStoredOverrideAddsAVariantAlongsideTheBaselineOnes(): void {
 		$this->store->save_document(
-			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/advancedbtn":{'
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{'
 			. '"outline":{"label":"Outline","tokens":{"button-bg":"transparent"}}}}}}}'
 		);
 
@@ -64,25 +63,25 @@ final class Effective_VariantsTest extends TestCase {
 		$this->assertArrayHasKey( 'outline', $node );
 		$this->assertSame( 'Outline', $node['outline']['label'] );
 		$this->assertArrayHasKey( 'primary', $node );
-		$this->assertArrayHasKey( 'ghost', $node );
+		$this->assertArrayHasKey( 'secondary', $node );
 	}
 
 	/**
 	 * @return void
 	 */
 	public function testAStoredOverrideMergesIntoAVariantsTokensPerProperty(): void {
-		// Override just one property of the baseline "ghost" variant.
+		// Override just one property of the baseline "secondary" variant.
 		$this->store->save_document(
-			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/advancedbtn":{'
-			. '"ghost":{"tokens":{"button-bg":"#000000"}}}}}}}'
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{'
+			. '"secondary":{"tokens":{"button-bg":"#000000"}}}}}}}'
 		);
 
-		$ghost = $this->variants->block( self::BUTTON )['ghost'];
+		$secondary = $this->variants->block( self::BUTTON )['secondary'];
 
 		// The overridden property wins; the variant's other baseline tokens and its label survive.
-		$this->assertSame( '#000000', $ghost['tokens']['button-bg'] );
-		$this->assertSame( '{primitive.color.brand.primary}', $ghost['tokens']['button-text'] );
-		$this->assertSame( 'Ghost', $ghost['label'] );
+		$this->assertSame( '#000000', $secondary['tokens']['button-bg'] );
+		$this->assertSame( '{primitive.color.neutral.0}', $secondary['tokens']['button-text'] );
+		$this->assertSame( 'Secondary', $secondary['label'] );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
@@ -324,7 +324,7 @@ final class Token_ResolverTest extends TestCase {
 
 		$before = $resolver->resolve();
 
-		$this->assertSame( '#3182CE', $before->value( 'semantic.color.button-bg' ) );
+		$this->assertSame( '#3633e1', $before->value( 'semantic.color.button-bg' ) );
 
 		$store->save_document(
 			(string) wp_json_encode(
@@ -332,7 +332,7 @@ final class Token_ResolverTest extends TestCase {
 					'primitive' => [
 						'color' => [
 							'brand' => [
-								'primary' => [
+								'button' => [
 									'$type'  => 'color',
 									'$value' => '#FF0000',
 								],
@@ -354,17 +354,17 @@ final class Token_ResolverTest extends TestCase {
 		/** @var Token_Store $store */
 		$store = $this->container->get( Token_Store::class );
 
-		// Empty store: button-bg resolves through the shipped baseline to brand.primary (#3182CE).
-		$this->assertSame( '#3182CE', $resolver->resolve()->value( 'semantic.color.button-bg' ) );
+		// Empty store: button-bg resolves through the shipped baseline to brand.button (#3633e1).
+		$this->assertSame( '#3633e1', $resolver->resolve()->value( 'semantic.color.button-bg' ) );
 
-		// Override brand.primary; the write bumps the store version, invalidating the per-request memo.
+		// Override brand.button; the write bumps the store version, invalidating the per-request memo.
 		$store->save_document(
 			(string) wp_json_encode(
 				[
 					'primitive' => [
 						'color' => [
 							'brand' => [
-								'primary' => [
+								'button' => [
 									'$type'  => 'color',
 									'$value' => '#000000',
 								],

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_ResolverTest.php
@@ -39,12 +39,12 @@ final class Variant_ResolverTest extends TestCase {
 	public function testItFlattensMultiHopAliasesForThePrimaryVariant(): void {
 		$values = $this->resolver->resolve( self::BUTTON, 'primary' );
 
-		// button-bg -> {semantic.color.button-primary-bg} -> {primitive.color.brand.primary} -> #3182CE
-		$this->assertSame( '#3182CE', $values['button-bg'] );
+		// button-bg -> {semantic.color.button-primary-bg} -> {primitive.color.brand.button} -> #3633e1
+		$this->assertSame( '#3633e1', $values['button-bg'] );
 		// button-text -> {semantic.color.button-primary-text} -> {primitive.color.neutral.0} -> #ffffff
 		$this->assertSame( '#ffffff', $values['button-text'] );
-		// Hover darkens to a dedicated darker-primary shade (brand.primary-dark), decoupled from brand.secondary.
-		$this->assertSame( '#2C5282', $values['button-bg-hover'] );
+		// Hover -> {semantic.color.button-primary-bg-hover} -> {primitive.color.brand.button-hover} -> #2f2ffc
+		$this->assertSame( '#2f2ffc', $values['button-bg-hover'] );
 		$this->assertSame( '#ffffff', $values['button-text-hover'] );
 	}
 

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_ResolverTest.php
@@ -14,7 +14,7 @@ use Tests\Support\Classes\TestCase;
  */
 final class Variant_ResolverTest extends TestCase {
 
-	private const BUTTON = 'kadence/advancedbtn';
+	private const BUTTON = 'kadence/singlebtn';
 
 	private Variant_Resolver $resolver;
 
@@ -24,13 +24,12 @@ final class Variant_ResolverTest extends TestCase {
 		$this->resolver = $this->container->get( Variant_Resolver::class );
 	}
 
-	public function testItResolvesGhostBindingsMixingLiteralsAndAliases(): void {
-		$values = $this->resolver->resolve( self::BUTTON, 'ghost' );
+	public function testItResolvesAliasBindingsForSecondary(): void {
+		$values = $this->resolver->resolve( self::BUTTON, 'secondary' );
 
-		// Literal passes through; aliases flatten through the token graph.
-		$this->assertSame( 'transparent', $values['button-bg'] );
-		$this->assertSame( '#3182CE', $values['button-text'] );   // {primitive.color.brand.primary}
-		$this->assertSame( '#3182CE', $values['button-border'] );
+		// Aliases flatten through the token graph.
+		$this->assertSame( '#2C5282', $values['button-bg'] );     // {primitive.color.brand.secondary}
+		$this->assertSame( '#ffffff', $values['button-text'] );   // {primitive.color.neutral.0}
 		$this->assertSame( '0.5rem', $values['button-radius'] );  // {semantic.radius.control} -> radius.md
 	}
 
@@ -52,7 +51,7 @@ final class Variant_ResolverTest extends TestCase {
 	}
 
 	public function testItListsTheDocumentsVariantNames(): void {
-		$this->assertSame( [ 'primary', 'secondary', 'ghost' ], $this->resolver->names( self::BUTTON ) );
+		$this->assertSame( [ 'primary', 'secondary' ], $this->resolver->names( self::BUTTON ) );
 	}
 
 	public function testDefaultVariantReadsTheDollarDefault(): void {
@@ -60,21 +59,22 @@ final class Variant_ResolverTest extends TestCase {
 	}
 
 	public function testHasVariant(): void {
-		$this->assertTrue( $this->resolver->has_variant( self::BUTTON, 'ghost' ) );
-		$this->assertFalse( $this->resolver->has_variant( self::BUTTON, 'outline' ) );
+		$this->assertTrue( $this->resolver->has_variant( self::BUTTON, 'secondary' ) );
+		// "ghost" is not a V1 Button variant (the native Outline style covers it).
+		$this->assertFalse( $this->resolver->has_variant( self::BUTTON, 'ghost' ) );
 		// Unknown block is false, not an error.
 		$this->assertFalse( $this->resolver->has_variant( 'kadence/nope', 'primary' ) );
 	}
 
 	public function testItReadsAVariantLabelFromTheDocument(): void {
-		$this->assertSame( 'Ghost', $this->resolver->label( self::BUTTON, 'ghost' ) );
+		$this->assertSame( 'Secondary', $this->resolver->label( self::BUTTON, 'secondary' ) );
 		$this->assertSame( 'Primary', $this->resolver->label( self::BUTTON, 'primary' ) );
 	}
 
 	public function testLabelIsNullForAnUnknownVariantOrBlock(): void {
 		// A non-throwing lookup, mirroring has_variant().
-		$this->assertNull( $this->resolver->label( self::BUTTON, 'outline' ) );
-		$this->assertNull( $this->resolver->label( 'kadence/nope', 'ghost' ) );
+		$this->assertNull( $this->resolver->label( self::BUTTON, 'ghost' ) );
+		$this->assertNull( $this->resolver->label( 'kadence/nope', 'primary' ) );
 	}
 
 	public function testValuePropertiesAreTheUnionAcrossVariants(): void {
@@ -82,7 +82,7 @@ final class Variant_ResolverTest extends TestCase {
 
 		sort( $properties );
 		$this->assertSame(
-			[ 'button-bg', 'button-border', 'button-radius', 'button-text' ],
+			[ 'button-bg', 'button-radius', 'button-text' ],
 			$properties
 		);
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_ResolverTest.php
@@ -43,8 +43,8 @@ final class Variant_ResolverTest extends TestCase {
 		$this->assertSame( '#3182CE', $values['button-bg'] );
 		// button-text -> {semantic.color.button-primary-text} -> {primitive.color.neutral.0} -> #ffffff
 		$this->assertSame( '#ffffff', $values['button-text'] );
-		// Hover points at the legacy darker shade (brand.secondary), matching the theme's palette2 hover.
-		$this->assertSame( '#2B6CB0', $values['button-bg-hover'] );
+		// Hover darkens to a dedicated darker-primary shade (brand.primary-dark), decoupled from brand.secondary.
+		$this->assertSame( '#2C5282', $values['button-bg-hover'] );
 		$this->assertSame( '#ffffff', $values['button-text-hover'] );
 	}
 

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_ResolverTest.php
@@ -3,6 +3,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Resolver;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Binding;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Unknown_Variant_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
@@ -27,19 +28,24 @@ final class Variant_ResolverTest extends TestCase {
 	public function testItResolvesAliasBindingsForSecondary(): void {
 		$values = $this->resolver->resolve( self::BUTTON, 'secondary' );
 
-		// Aliases flatten through the token graph.
-		$this->assertSame( '#2C5282', $values['button-bg'] );     // {primitive.color.brand.secondary}
-		$this->assertSame( '#ffffff', $values['button-text'] );   // {primitive.color.neutral.0}
-		$this->assertSame( '0.5rem', $values['button-radius'] );  // {semantic.radius.control} -> radius.md
+		// Aliases flatten through the token graph. Secondary is the dark/charcoal identity.
+		$this->assertSame( '#1A202C', $values['button-bg'] );           // {semantic.color.button-secondary-bg} -> neutral.900
+		$this->assertSame( '#ffffff', $values['button-text'] );         // {semantic.color.button-secondary-text} -> neutral.0
+		$this->assertSame( '#2D3748', $values['button-bg-hover'] );     // {semantic.color.button-secondary-bg-hover} -> neutral.700
+		$this->assertSame( '#ffffff', $values['button-text-hover'] );   // {semantic.color.button-secondary-text-hover} -> neutral.0
+		$this->assertSame( '0.5rem', $values['button-radius'] );        // {semantic.radius.control} -> radius.md
 	}
 
 	public function testItFlattensMultiHopAliasesForThePrimaryVariant(): void {
 		$values = $this->resolver->resolve( self::BUTTON, 'primary' );
 
-		// button-bg -> {semantic.color.button-bg} -> {primitive.color.brand.primary} -> #3182CE
+		// button-bg -> {semantic.color.button-primary-bg} -> {primitive.color.brand.primary} -> #3182CE
 		$this->assertSame( '#3182CE', $values['button-bg'] );
-		// button-text -> {semantic.color.button-text} -> {primitive.color.neutral.0} -> #ffffff
+		// button-text -> {semantic.color.button-primary-text} -> {primitive.color.neutral.0} -> #ffffff
 		$this->assertSame( '#ffffff', $values['button-text'] );
+		// Hover points at the legacy darker shade (brand.secondary), matching the theme's palette2 hover.
+		$this->assertSame( '#2B6CB0', $values['button-bg-hover'] );
+		$this->assertSame( '#ffffff', $values['button-text-hover'] );
 	}
 
 	public function testResolveDefaultUsesTheDeclaredDefault(): void {
@@ -82,7 +88,7 @@ final class Variant_ResolverTest extends TestCase {
 
 		sort( $properties );
 		$this->assertSame(
-			[ 'button-bg', 'button-radius', 'button-text' ],
+			[ 'button-bg', 'button-bg-hover', 'button-radius', 'button-text', 'button-text-hover' ],
 			$properties
 		);
 	}
@@ -100,15 +106,17 @@ final class Variant_ResolverTest extends TestCase {
 		$this->assertSame( [], $report['unbound'], 'Valued properties with no binding.' );
 		$this->assertSame( [], $report['unvalued'], 'Bindings no variant ever sets.' );
 
-		// A token-ref binding must resolve to the referenced token's projections. An empty result would
-		// mean a typo'd token id silently produced no projection (effective_projections fails soft), so
-		// assert the reference actually lands.
+		/**
+		 * The Kadence button bindings retarget a global slot directly — the per-variant VALUE comes from
+		 * the variant token map, so the binding carries a kadence_slot projection rather than a token ref.
+		 * Assert the slot actually lands (an empty result would mean the binding silently projected nothing).
+		 */
 		$binding = $set->binding( 'button-bg' );
 		$this->assertNotNull( $binding, 'button-bg should be bound.' );
-		$this->assertTrue( $binding->is_token_ref(), 'button-bg should be a token reference.' );
-		$this->assertNotEmpty(
-			$registry->effective_projections( $binding ),
-			'The button-bg token reference should resolve to the token projections.'
+		$this->assertSame(
+			'palette-btn-bg',
+			$registry->effective_projections( $binding )[ Binding::get_kadence_slot_key() ] ?? null,
+			'The button-bg binding should retarget the palette-btn-bg slot.'
 		);
 	}
 

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
@@ -20,7 +20,7 @@ use WP_REST_Server;
  */
 final class VariantsControllerTest extends TestCase {
 
-	private const BUTTON = 'kadence/advancedbtn';
+	private const BUTTON = 'kadence/singlebtn';
 
 	/**
 	 * @var Token_Store
@@ -127,7 +127,7 @@ final class VariantsControllerTest extends TestCase {
 		$this->assertSame( self::BUTTON, $data['block'] );
 		$this->assertSame( 'primary', $data['default'] );
 		$this->assertArrayHasKey( 'primary', $data['variants'] );
-		$this->assertArrayHasKey( 'ghost', $data['variants'] );
+		$this->assertArrayHasKey( 'secondary', $data['variants'] );
 	}
 
 	/**
@@ -135,7 +135,7 @@ final class VariantsControllerTest extends TestCase {
 	 */
 	public function testGetItemReflectsAStoredOverride(): void {
 		$this->store->save_document(
-			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/advancedbtn":{'
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{'
 			. '"outline":{"label":"Outline","tokens":{"button-bg":"transparent"}}}}}}}'
 		);
 
@@ -182,7 +182,7 @@ final class VariantsControllerTest extends TestCase {
 		// The new variant lands while the baseline siblings and the default survive.
 		$this->assertArrayHasKey( 'outline', $data['variants'] );
 		$this->assertArrayHasKey( 'primary', $data['variants'] );
-		$this->assertArrayHasKey( 'ghost', $data['variants'] );
+		$this->assertArrayHasKey( 'secondary', $data['variants'] );
 		$this->assertSame( 'primary', $data['default'] );
 	}
 
@@ -293,7 +293,7 @@ final class VariantsControllerTest extends TestCase {
 	 */
 	public function testDeleteVariantIsAnIdempotentNoOpWhenAbsent(): void {
 		$this->store->save_document(
-			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/advancedbtn":{'
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{'
 			. '"outline":{"tokens":{"button-bg":"transparent"}}}}}}}'
 		);
 
@@ -431,7 +431,7 @@ final class VariantsControllerTest extends TestCase {
 	 */
 	public function testAWriteBumpsTheVersion(): void {
 		$this->store->save_document(
-			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/advancedbtn":{'
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{'
 			. '"outline":{"tokens":{"button-bg":"transparent"}}}}}}}'
 		);
 
@@ -494,7 +494,7 @@ final class VariantsControllerTest extends TestCase {
 	 * carrying any extra body parameters.
 	 *
 	 * @param string               $method The HTTP method.
-	 * @param string               $block  The block name, e.g. "kadence/advancedbtn".
+	 * @param string               $block  The block name, e.g. "kadence/singlebtn".
 	 * @param array<string, mixed> $extra  Extra parameters (variant, label, tokens, variants, default).
 	 *
 	 * @return WP_REST_Request


### PR DESCRIPTION
🎫 https://linear.app/nexcess/issue/SOFT-3406/button-kadenceadvancedbtn-singlebtn-token-wiring-variants

📹 https://www.loom.com/share/4ab4371b14694e5493af499c2ea1cc54

Wires the Button to design-token variants, models its colors as overridable per-variant semantics, and tokenizes its dimension defaults.

## What this does

- **Color variants (Primary / Secondary).** `kadence/singlebtn` gets a "Design Variant" picker (a `KadenceRadioButtons` control fed by a per-block catalog localized to the editor). Variants are a pure color axis: they retarget the button palette vars — `--global-palette-btn-bg`/`-btn` and their `-hover` counterparts — so they compose with the existing "Button Inherit Styles" shape control (Fill / Outline / Theme Base) rather than replacing it (e.g. Secondary + Outline = a secondary-colored ghost), and hover/focus follow the variant too. `core/button` gets the same variants through WordPress's native block Styles panel (the Block_Style projector: `register_block_style` + theme.json default).
  - **Primary** reproduces the block's existing default look: `brand.button` `#3633e1` resting → `brand.button-hover` `#2f2ffc` on hover, white text (the block's own `--global-palette-btn-bg` / `-bg-hover` SCSS fallbacks), so activation changes nothing.
  - **Secondary** is a dark/charcoal button: `neutral.900` `#1A202C` → `neutral.700` `#2D3748` on hover, white text (WCAG AAA), clearly distinct from the Primary.
- **Per-variant color semantics.** Each variant's colors come from named semantics (`semantic.color.button-{primary,secondary}-{bg,text,bg-hover,text-hover}`), each surfaced to the site editor, so a site owner recolors one variant through the standard token path without touching the global palette. Every semantic resolves to a primitive (no semantic-to-semantic chains); button-specific colors live as role-named primitives (`brand.button` / `brand.button-hover`, named for the var they back rather than the hue).
- **Global palette follows the primitives.** The brand + neutral primitives each claim a Kadence palette slot (`palette1..9`), so `--global-paletteN` (and the legacy `kadence_blocks_colors` palette) follows the primitive. Values mirror Kadence's default palette, so activation changes nothing until a primitive is overridden. Semantic colors deliberately claim **no** palette slot — they deliver at the block level — so writing a button semantic never re-skins the global palette.
- **Radius.** Registers `semantic.radius.control` and tokenizes the button's own default `border-radius` to `var(--kb-token--semantic--radius--control, 3px)` (resolves to the design-system control radius); an explicit per-button radius still wins by specificity.
- **Icon size.** Registers `semantic.icon-size.default` and tokenizes the button icon default.
- **Conventions.** Renames the camelCase `iconSize` baseline token to `icon-size` and documents in `AGENTS.md` that design-token ids must be kebab-case (camelCase fails registration). Built assets (`dist/`) are gitignored and rebuilt in CI.

## Deferred (follow-up tickets under SOFT-3366)

- **SOFT-3529** — Button typography token wiring (the `btns[]`-array shape + `render_font_family` indirection is bespoke, so it is split out).
- **SOFT-3533** — Grouped (orthogonal) variant axes. Variants are single-axis today; "Ghost" stays the native Outline shape (Tertiary/Ghost are V2 per the design spec). Filed now so the variant schema set here can grow into groups without a breaking migration.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block.
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
