### PR TITLE
Share the Cast utility across the codebase

### DIFF
--- a/includes/blocks/class-kadence-blocks-singlebtn-block.php
+++ b/includes/blocks/class-kadence-blocks-singlebtn-block.php
@@ -12,6 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use KadenceWP\KadenceBlocks\Utils\Cast;
+
 /**
  * Class to Build the Single Button.
  *
@@ -363,7 +365,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 			 * projector's scoped CSS hooks. This is a dynamic block, so the class is added here rather than by
 			 * the editor save filter; the sanitizer mirrors the projector's so the class matches the selector.
 			 */
-			$classes[] = 'kb-variant--' . preg_replace( '/[^A-Za-z0-9_-]+/', '-', $this->attribute_string( $attributes, 'kbVariant' ) );
+			$classes[] = 'kb-variant--' . preg_replace( '/[^A-Za-z0-9_-]+/', '-', Cast::to_string( $attributes['kbVariant'] ) );
 		}
 
 		if ( ! empty( $attributes['target'] ) && 'video' === $attributes['target'] ) {
@@ -376,13 +378,13 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 			'class' => implode( ' ', $classes ),
 		];
 		if ( ! empty( $attributes['anchor'] ) ) {
-			$wrapper_args['id'] = $this->attribute_string( $attributes, 'anchor' );
+			$wrapper_args['id'] = Cast::to_string( $attributes['anchor'] );
 		}
 		if ( ! empty( $attributes['label'] ) ) {
-			$wrapper_args['aria-label'] = $this->attribute_string( $attributes, 'label' );
+			$wrapper_args['aria-label'] = Cast::to_string( $attributes['label'] );
 		}
 		if ( ! empty( $attributes['link'] ) ) {
-			$wrapper_args['href'] = esc_url( do_shortcode( $this->attribute_string( $attributes, 'link' ) ) );
+			$wrapper_args['href'] = esc_url( do_shortcode( Cast::to_string( $attributes['link'] ) ) );
 			$rel_add              = '';
 			if ( isset( $attributes['download'] ) && $attributes['download'] ) {
 				$wrapper_args['download'] = '';
@@ -405,9 +407,9 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 			$wrapper_args['type'] = 'submit';
 		}
 		if ( ! empty( $attributes['tooltip'] ) ) {
-			$wrapper_args['data-kb-tooltip-content'] = esc_attr( $this->attribute_string( $attributes, 'tooltip' ) );
+			$wrapper_args['data-kb-tooltip-content'] = esc_attr( Cast::to_string( $attributes['tooltip'] ) );
 			if ( ! empty( $attributes['tooltipPlacement'] ) ) {
-				$wrapper_args['data-tooltip-placement'] = esc_attr( $this->attribute_string( $attributes, 'tooltipPlacement' ) );
+				$wrapper_args['data-tooltip-placement'] = esc_attr( Cast::to_string( $attributes['tooltipPlacement'] ) );
 			}
 		}
 		if ( isset( $attributes['buttonRole'] ) && $attributes['buttonRole'] ) {
@@ -424,7 +426,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$text     = ! empty( $attributes['text'] ) ? '<span class="kt-btn-inner-text">' . $attributes['text'] . '</span>' : '';
 		$svg_icon = '';
 		if ( ! empty( $attributes['icon'] ) ) {
-			$type         = substr( $this->attribute_string( $attributes, 'icon' ), 0, 2 );
+			$type         = substr( Cast::to_string( $attributes['icon'] ), 0, 2 );
 			$line_icon    = ( ! empty( $type ) && 'fe' == $type ? true : false );
 			$fill         = ( $line_icon ? 'none' : 'currentColor' );
 			$stroke_width = false;
@@ -436,8 +438,8 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 			$hidden   = ( empty( $title ) ? true : false );
 			$svg_icon = Kadence_Blocks_Svg_Render::render( $attributes['icon'], $fill, $stroke_width, $title, $hidden );
 		}
-		$icon_left  = ! empty( $svg_icon ) && ! empty( $attributes['iconSide'] ) && 'left' === $attributes['iconSide'] ? '<span class="kb-svg-icon-wrap kb-svg-icon-' . esc_attr( $this->attribute_string( $attributes, 'icon' ) ) . ' kt-btn-icon-side-left">' . $svg_icon . '</span>' : '';
-		$icon_right = ! empty( $svg_icon ) && ! empty( $attributes['iconSide'] ) && 'right' === $attributes['iconSide'] ? '<span class="kb-svg-icon-wrap kb-svg-icon-' . esc_attr( $this->attribute_string( $attributes, 'icon' ) ) . ' kt-btn-icon-side-right">' . $svg_icon . '</span>' : '';
+		$icon_left  = ! empty( $svg_icon ) && ! empty( $attributes['iconSide'] ) && 'left' === $attributes['iconSide'] ? '<span class="kb-svg-icon-wrap kb-svg-icon-' . esc_attr( Cast::to_string( $attributes['icon'] ) ) . ' kt-btn-icon-side-left">' . $svg_icon . '</span>' : '';
+		$icon_right = ! empty( $svg_icon ) && ! empty( $attributes['iconSide'] ) && 'right' === $attributes['iconSide'] ? '<span class="kb-svg-icon-wrap kb-svg-icon-' . esc_attr( Cast::to_string( $attributes['icon'] ) ) . ' kt-btn-icon-side-right">' . $svg_icon . '</span>' : '';
 		$html_tag   = ! empty( $attributes['link'] ) ? 'a' : 'span';
 
 		// Try to Detect if this is a show more button and make it a button.
@@ -483,22 +485,6 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		wp_register_script( 'kadence-blocks-tippy', KADENCE_BLOCKS_URL . 'includes/assets/js/kb-tippy.min.js', [ 'kadence-blocks-popper' ], KADENCE_BLOCKS_VERSION, true );
 	}
 
-	/**
-	 * Safely coerce a block attribute to a string.
-	 *
-	 * Block attributes arrive as mixed, so a non-scalar (or absent) value yields an empty string rather
-	 * than a type error.
-	 *
-	 * @param array<string, mixed> $attributes The block attributes.
-	 * @param string               $key        The attribute key to read.
-	 *
-	 * @return string
-	 */
-	private function attribute_string( array $attributes, string $key ): string {
-		$value = $attributes[ $key ] ?? '';
-
-		return is_scalar( $value ) ? (string) $value : '';
-	}
 }
 
 Kadence_Blocks_Singlebtn_Block::get_instance();

--- a/includes/resources/Design_Tokens/Resolver/Css_Renderer.php
+++ b/includes/resources/Design_Tokens/Resolver/Css_Renderer.php
@@ -3,7 +3,7 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Resolver;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
-use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Cast;
+use KadenceWP\KadenceBlocks\Utils\Cast;
 
 /**
  * Renders an already-flattened (alias-free) DTCG value to a CSS-ready string,

--- a/includes/resources/Design_Tokens/Rest/V1/Contracts/Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Contracts/Controller.php
@@ -2,7 +2,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts;
 
-use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Cast;
+use KadenceWP\KadenceBlocks\Utils\Cast;
 use WP_Error;
 use WP_REST_Controller;
 use WP_REST_Request;

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -13,7 +13,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Dtcg_Validator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Layers;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Sentinels;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
-use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Cast;
+use KadenceWP\KadenceBlocks\Utils\Cast;
 use KadenceWP\KadenceBlocks\StellarWP\DB\Database\Exceptions\DatabaseQueryException;
 use WP_Error;
 use WP_Http;

--- a/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
@@ -12,7 +12,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Dtcg_Validator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
-use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Cast;
+use KadenceWP\KadenceBlocks\Utils\Cast;
 use KadenceWP\KadenceBlocks\StellarWP\DB\Database\Exceptions\DatabaseQueryException;
 use WP_Error;
 use WP_Http;

--- a/includes/resources/Utils/Cast.php
+++ b/includes/resources/Utils/Cast.php
@@ -1,6 +1,6 @@
 <?php declare( strict_types=1 );
 
-namespace KadenceWP\KadenceBlocks\Design_Tokens\Utils;
+namespace KadenceWP\KadenceBlocks\Utils;
 
 /**
  * Safe type-casting utilities for Design Token values.


### PR DESCRIPTION
🎫  #[Jira Ticket]

Promotes the `Cast` utility from the design-tokens module to a shared
`KadenceWP\KadenceBlocks\Utils` namespace so the whole codebase can use it.

Not being able to reach for `Cast` outside of the `Design_Tokens` namespace
was annoying — it is a generic, safe type-coercion helper with no design-token
specifics, so there is no reason to keep it walled off in that module. This
moves it somewhere the rest of the plugin can share it.

### Changes

- Moved `Cast` from `KadenceWP\KadenceBlocks\Design_Tokens\Utils` to
  `KadenceWP\KadenceBlocks\Utils` (`includes/resources/Design_Tokens/Utils/Cast.php`
  -> `includes/resources/Utils/Cast.php`), updating the `use` imports in the
  four design-tokens consumers (the REST controllers, the contract base
  controller, and the CSS renderer).
- Replaced the bespoke `attribute_string()` helper in the Single Button block
  with `Cast::to_string()`, dropping the duplicate scalar-coercion logic now
  that the utility is shareable. The attribute keys always exist (defaults are
  merged), so the redundant null-coalesce was removed too.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
