### PR TITLE
[SMTNC-771] Button (Adv) color settings aren’t working when using Shopkit + FSE theme.

### DIFF
--- a/changelog/smtnc-771-button-adv-color-settings-arent-working-when-using-shopkit-1782139769133.yaml
+++ b/changelog/smtnc-771-button-adv-color-settings-arent-working-when-using-shopkit-1782139769133.yaml
@@ -1,0 +1,5 @@
+significance: patch
+type: feature
+entry: "`kadence_blocks_render_footer_css` filter to control whether late,
+  body-rendered block CSS is output in the footer."
+timestamp: 2026-06-22T14:49:29.132Z

--- a/changelog/smtnc-771-button-adv-color-settings-arent-working-when-using-shopkit.yaml
+++ b/changelog/smtnc-771-button-adv-color-settings-arent-working-when-using-shopkit.yaml
@@ -1,0 +1,5 @@
+significance: patch
+type: fix
+entry: Improved CSS loading so block style and Custom CSS settings are output on
+  the frontend for blocks rendered in the page body under a block.
+timestamp: 2026-06-22T14:48:45.240Z

--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -38,13 +38,6 @@ class Kadence_Blocks_CSS {
 	public static $custom_styles = array();
 
 	/**
-	 * Custom CSS already printed in the head, snapshotted at head-print time.
-	 *
-	 * @var array<string, string>
-	 */
-	public static $head_custom_styles = array();
-
-	/**
 	 * The css group id.
 	 *
 	 * @access protected
@@ -266,7 +259,6 @@ class Kadence_Blocks_CSS {
 	 */
 	public function __construct() {
 		add_action( 'wp_enqueue_scripts', array( $this, 'frontend_block_css' ), 180 );
-		add_action( 'wp_footer', array( $this, 'frontend_footer_block_css' ) );
 	}
 
 	/**
@@ -274,8 +266,7 @@ class Kadence_Blocks_CSS {
 	 */
 	public function frontend_block_css() {
 		if ( ! empty( self::$styles ) ) {
-			self::$head_styles        = self::$styles;
-			self::$head_custom_styles = self::$custom_styles;
+			self::$head_styles = self::$styles;
 			$output = '';
 			foreach ( self::$styles as $key => $value ) {
 				$output .= $value;
@@ -298,56 +289,6 @@ class Kadence_Blocks_CSS {
 			}
 		}
 	}
-
-	/**
-	 * Print dynamic block CSS generated after the head style print.
-	 *
-	 * Under block (FSE) themes, blocks rendered in the page body — query loops,
-	 * template parts and third-party loop renderers such as Shop Kit product loops —
-	 * build their CSS after frontend_block_css() has already printed in the head, so
-	 * it would otherwise never reach the page. Flush that post-head delta here.
-	 * Classic themes inline this CSS in the block content during render, so they are
-	 * gated out to avoid duplicate output.
-	 *
-	 * @since 3.7.6
-	 *
-	 * @return void
-	 */
-	public function frontend_footer_block_css() {
-		if ( is_admin() || is_feed() || ( apply_filters( 'kadence_blocks_check_if_rest', false ) && kadence_blocks_is_rest() ) ) {
-			return;
-		}
-		if ( ! apply_filters( 'kadence_blocks_render_footer_css', wp_is_block_theme() ) ) {
-			return;
-		}
-		$late_styles = array_diff_key( self::$styles, self::$head_styles );
-		if ( ! empty( $late_styles ) ) {
-			$output = '';
-			foreach ( $late_styles as $value ) {
-				$output .= $value;
-			}
-			if ( ! empty( $output ) ) {
-				wp_register_style( 'kadence_blocks_footer_css', false );
-				wp_enqueue_style( 'kadence_blocks_footer_css' );
-				wp_add_inline_style( 'kadence_blocks_footer_css', $output );
-				wp_print_styles( 'kadence_blocks_footer_css' );
-			}
-		}
-		$late_custom_styles = array_diff_key( self::$custom_styles, self::$head_custom_styles );
-		if ( ! empty( $late_custom_styles ) ) {
-			$custom_output = '';
-			foreach ( $late_custom_styles as $value ) {
-				$custom_output .= $value;
-			}
-			if ( ! empty( $custom_output ) ) {
-				wp_register_style( 'kadence_blocks_footer_custom_css', false );
-				wp_enqueue_style( 'kadence_blocks_footer_custom_css' );
-				wp_add_inline_style( 'kadence_blocks_footer_custom_css', $custom_output );
-				wp_print_styles( 'kadence_blocks_footer_custom_css' );
-			}
-		}
-	}
-
 	/**
 	 * Sets a style id to keep a record of rendering.
 	 *

--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -38,6 +38,13 @@ class Kadence_Blocks_CSS {
 	public static $custom_styles = array();
 
 	/**
+	 * Custom CSS already printed in the head, snapshotted at head-print time.
+	 *
+	 * @var array<string, string>
+	 */
+	public static $head_custom_styles = array();
+
+	/**
 	 * The css group id.
 	 *
 	 * @access protected
@@ -259,6 +266,7 @@ class Kadence_Blocks_CSS {
 	 */
 	public function __construct() {
 		add_action( 'wp_enqueue_scripts', array( $this, 'frontend_block_css' ), 180 );
+		add_action( 'wp_footer', array( $this, 'frontend_footer_block_css' ) );
 	}
 
 	/**
@@ -266,7 +274,8 @@ class Kadence_Blocks_CSS {
 	 */
 	public function frontend_block_css() {
 		if ( ! empty( self::$styles ) ) {
-			self::$head_styles = self::$styles;
+			self::$head_styles        = self::$styles;
+			self::$head_custom_styles = self::$custom_styles;
 			$output = '';
 			foreach ( self::$styles as $key => $value ) {
 				$output .= $value;
@@ -289,6 +298,56 @@ class Kadence_Blocks_CSS {
 			}
 		}
 	}
+
+	/**
+	 * Print dynamic block CSS generated after the head style print.
+	 *
+	 * Under block (FSE) themes, blocks rendered in the page body — query loops,
+	 * template parts and third-party loop renderers such as Shop Kit product loops —
+	 * build their CSS after frontend_block_css() has already printed in the head, so
+	 * it would otherwise never reach the page. Flush that post-head delta here.
+	 * Classic themes inline this CSS in the block content during render, so they are
+	 * gated out to avoid duplicate output.
+	 *
+	 * @since 3.7.6
+	 *
+	 * @return void
+	 */
+	public function frontend_footer_block_css() {
+		if ( is_admin() || is_feed() || ( apply_filters( 'kadence_blocks_check_if_rest', false ) && kadence_blocks_is_rest() ) ) {
+			return;
+		}
+		if ( ! apply_filters( 'kadence_blocks_render_footer_css', wp_is_block_theme() ) ) {
+			return;
+		}
+		$late_styles = array_diff_key( self::$styles, self::$head_styles );
+		if ( ! empty( $late_styles ) ) {
+			$output = '';
+			foreach ( $late_styles as $value ) {
+				$output .= $value;
+			}
+			if ( ! empty( $output ) ) {
+				wp_register_style( 'kadence_blocks_footer_css', false );
+				wp_enqueue_style( 'kadence_blocks_footer_css' );
+				wp_add_inline_style( 'kadence_blocks_footer_css', $output );
+				wp_print_styles( 'kadence_blocks_footer_css' );
+			}
+		}
+		$late_custom_styles = array_diff_key( self::$custom_styles, self::$head_custom_styles );
+		if ( ! empty( $late_custom_styles ) ) {
+			$custom_output = '';
+			foreach ( $late_custom_styles as $value ) {
+				$custom_output .= $value;
+			}
+			if ( ! empty( $custom_output ) ) {
+				wp_register_style( 'kadence_blocks_footer_custom_css', false );
+				wp_enqueue_style( 'kadence_blocks_footer_custom_css' );
+				wp_add_inline_style( 'kadence_blocks_footer_custom_css', $custom_output );
+				wp_print_styles( 'kadence_blocks_footer_custom_css' );
+			}
+		}
+	}
+
 	/**
 	 * Sets a style id to keep a record of rendering.
 	 *

--- a/includes/class-kadence-blocks-footer-css.php
+++ b/includes/class-kadence-blocks-footer-css.php
@@ -36,6 +36,8 @@ class Kadence_Blocks_Footer_CSS {
 	/**
 	 * Instance control.
 	 *
+	 * @since TBD
+	 *
 	 * @return Kadence_Blocks_Footer_CSS
 	 */
 	public static function get_instance() {
@@ -47,6 +49,8 @@ class Kadence_Blocks_Footer_CSS {
 
 	/**
 	 * Constructor.
+	 *
+	 * @since TBD
 	 */
 	public function __construct() {
 		add_action( 'wp_enqueue_scripts', array( $this, 'capture_head_custom_styles' ), 181 );
@@ -60,6 +64,8 @@ class Kadence_Blocks_Footer_CSS {
 	 * the Custom CSS array after this point comes from body-rendered blocks and is the delta the
 	 * footer flushes.
 	 *
+	 * @since TBD
+	 *
 	 * @return void
 	 */
 	public function capture_head_custom_styles() {
@@ -71,6 +77,8 @@ class Kadence_Blocks_Footer_CSS {
 	 *
 	 * Classic themes inline this CSS in the block content during render, so they are gated out
 	 * via the kadence_blocks_render_footer_css filter to avoid duplicate output.
+	 *
+	 * @since TBD
 	 *
 	 * @return void
 	 */

--- a/includes/class-kadence-blocks-footer-css.php
+++ b/includes/class-kadence-blocks-footer-css.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Outputs block CSS generated after the head style print.
+ *
+ * @package Kadence Blocks
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Flushes dynamic block CSS that is generated after Kadence_Blocks_CSS prints in the head.
+ *
+ * Under block (FSE) themes, blocks rendered in the page body — query loops, template parts and
+ * third-party loop renderers such as Shop Kit product loops — build their CSS after
+ * Kadence_Blocks_CSS::frontend_block_css() has already printed in the head, so it would
+ * otherwise never reach the page. This collects the post-head delta and prints it in the footer.
+ */
+class Kadence_Blocks_Footer_CSS {
+
+	/**
+	 * Instance of this class.
+	 *
+	 * @var null|Kadence_Blocks_Footer_CSS
+	 */
+	private static $instance = null;
+
+	/**
+	 * Custom CSS already output in the head, captured at head-print time.
+	 *
+	 * @var array<string, string>
+	 */
+	private $head_custom_styles = array();
+
+	/**
+	 * Instance control.
+	 *
+	 * @return Kadence_Blocks_Footer_CSS
+	 */
+	public static function get_instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'wp_enqueue_scripts', array( $this, 'capture_head_custom_styles' ), 181 );
+		add_action( 'wp_footer', array( $this, 'render_footer_block_css' ) );
+	}
+
+	/**
+	 * Capture the Custom CSS present at head-print time so the footer flush can exclude it.
+	 *
+	 * Runs just after Kadence_Blocks_CSS::frontend_block_css() (priority 180). Anything added to
+	 * the Custom CSS array after this point comes from body-rendered blocks and is the delta the
+	 * footer flushes.
+	 *
+	 * @return void
+	 */
+	public function capture_head_custom_styles() {
+		$this->head_custom_styles = Kadence_Blocks_CSS::$custom_styles;
+	}
+
+	/**
+	 * Print dynamic block CSS generated after the head style print.
+	 *
+	 * Classic themes inline this CSS in the block content during render, so they are gated out
+	 * via the kadence_blocks_render_footer_css filter to avoid duplicate output.
+	 *
+	 * @return void
+	 */
+	public function render_footer_block_css() {
+		if ( is_admin() || is_feed() || ( apply_filters( 'kadence_blocks_check_if_rest', false ) && kadence_blocks_is_rest() ) ) {
+			return;
+		}
+		if ( ! apply_filters( 'kadence_blocks_render_footer_css', wp_is_block_theme() ) ) {
+			return;
+		}
+		$late_styles = array_diff_key( Kadence_Blocks_CSS::$styles, Kadence_Blocks_CSS::$head_styles );
+		if ( ! empty( $late_styles ) ) {
+			$output = '';
+			foreach ( $late_styles as $value ) {
+				$output .= $value;
+			}
+			if ( ! empty( $output ) ) {
+				wp_register_style( 'kadence_blocks_footer_css', false );
+				wp_enqueue_style( 'kadence_blocks_footer_css' );
+				wp_add_inline_style( 'kadence_blocks_footer_css', $output );
+				wp_print_styles( 'kadence_blocks_footer_css' );
+			}
+		}
+		$late_custom_styles = array_diff_key( Kadence_Blocks_CSS::$custom_styles, $this->head_custom_styles );
+		if ( ! empty( $late_custom_styles ) ) {
+			$custom_output = '';
+			foreach ( $late_custom_styles as $value ) {
+				$custom_output .= $value;
+			}
+			if ( ! empty( $custom_output ) ) {
+				wp_register_style( 'kadence_blocks_footer_custom_css', false );
+				wp_enqueue_style( 'kadence_blocks_footer_custom_css' );
+				wp_add_inline_style( 'kadence_blocks_footer_custom_css', $custom_output );
+				wp_print_styles( 'kadence_blocks_footer_custom_css' );
+			}
+		}
+	}
+}
+
+Kadence_Blocks_Footer_CSS::get_instance();

--- a/kadence-blocks.php
+++ b/kadence-blocks.php
@@ -68,6 +68,7 @@ function kadence_blocks_init(): void {
 	require_once KADENCE_BLOCKS_PATH . 'includes/class-kadence-blocks-google-fonts.php';
 	require_once KADENCE_BLOCKS_PATH . 'includes/settings/class-kadence-blocks-helper.php';
 	require_once KADENCE_BLOCKS_PATH . 'includes/class-kadence-blocks-css.php';
+	require_once KADENCE_BLOCKS_PATH . 'includes/class-kadence-blocks-footer-css.php';
 	require_once KADENCE_BLOCKS_PATH . 'includes/class-kadence-blocks-frontend.php';
 	require_once KADENCE_BLOCKS_PATH . 'includes/class-kadence-blocks-table-of-contents.php';
 	require_once KADENCE_BLOCKS_PATH . 'includes/class-kadence-blocks-duplicate-post.php';

--- a/tests/wpunit/Classes/FrontendFooterCssTest.php
+++ b/tests/wpunit/Classes/FrontendFooterCssTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\wpunit\Classes;
+
+use Kadence_Blocks_CSS;
+use Tests\Support\Classes\KadenceBlocksUnit;
+
+class FrontendFooterCssTest extends KadenceBlocksUnit {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Kadence_Blocks_CSS::$styles             = [];
+		Kadence_Blocks_CSS::$head_styles        = [];
+		Kadence_Blocks_CSS::$custom_styles      = [];
+		Kadence_Blocks_CSS::$head_custom_styles = [];
+	}
+
+	protected function tearDown(): void {
+		Kadence_Blocks_CSS::$styles             = [];
+		Kadence_Blocks_CSS::$head_styles        = [];
+		Kadence_Blocks_CSS::$custom_styles      = [];
+		Kadence_Blocks_CSS::$head_custom_styles = [];
+		wp_deregister_style( 'kadence_blocks_footer_css' );
+		wp_deregister_style( 'kadence_blocks_footer_custom_css' );
+		remove_all_filters( 'kadence_blocks_render_footer_css' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Body-rendered block CSS (collected after the head print) is flushed to the
+	 * footer, while CSS already printed in the head is not duplicated.
+	 */
+	public function test_footer_outputs_only_post_head_delta() {
+		add_filter( 'kadence_blocks_render_footer_css', '__return_true' );
+
+		Kadence_Blocks_CSS::$head_styles = [ 'kb-advancedbtnHEAD' => '.kb-head{color:red}' ];
+		Kadence_Blocks_CSS::$styles      = [
+			'kb-advancedbtnHEAD' => '.kb-head{color:red}',
+			'kb-advancedbtnBODY' => '.kb-body{background:blue}',
+		];
+
+		$css = Kadence_Blocks_CSS::get_instance();
+
+		ob_start();
+		$css->frontend_footer_block_css();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '.kb-body{background:blue}', $output, 'Body-rendered block CSS is flushed to the footer.' );
+		$this->assertStringNotContainsString( '.kb-head{color:red}', $output, 'Head-captured CSS is not duplicated in the footer.' );
+	}
+
+	/**
+	 * Body-rendered block Custom CSS (collected after the head print) is flushed
+	 * to the footer, while Custom CSS already printed in the head is not duplicated.
+	 */
+	public function test_footer_outputs_custom_css_post_head_delta() {
+		add_filter( 'kadence_blocks_render_footer_css', '__return_true' );
+
+		Kadence_Blocks_CSS::$head_custom_styles = [ 'kb-customHEAD' => '.kb-custom-head{margin:0}' ];
+		Kadence_Blocks_CSS::$custom_styles      = [
+			'kb-customHEAD' => '.kb-custom-head{margin:0}',
+			'kb-customBODY' => '.kb-custom-body{padding:10px}',
+		];
+
+		$css = Kadence_Blocks_CSS::get_instance();
+
+		ob_start();
+		$css->frontend_footer_block_css();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '.kb-custom-body{padding:10px}', $output, 'Body-rendered Custom CSS is flushed to the footer.' );
+		$this->assertStringNotContainsString( '.kb-custom-head{margin:0}', $output, 'Head-captured Custom CSS is not duplicated in the footer.' );
+	}
+
+	/**
+	 * When footer rendering is disabled (the classic-theme default), nothing is printed.
+	 */
+	public function test_footer_outputs_nothing_when_disabled() {
+		add_filter( 'kadence_blocks_render_footer_css', '__return_false' );
+
+		Kadence_Blocks_CSS::$styles        = [ 'kb-advancedbtnBODY' => '.kb-body{background:blue}' ];
+		Kadence_Blocks_CSS::$custom_styles = [ 'kb-customBODY' => '.kb-custom-body{padding:10px}' ];
+
+		$css = Kadence_Blocks_CSS::get_instance();
+
+		ob_start();
+		$css->frontend_footer_block_css();
+		$output = ob_get_clean();
+
+		$this->assertSame( '', trim( $output ), 'Nothing is printed when footer rendering is disabled.' );
+	}
+}

--- a/tests/wpunit/Classes/FrontendFooterCssTest.php
+++ b/tests/wpunit/Classes/FrontendFooterCssTest.php
@@ -3,23 +3,24 @@
 namespace Tests\wpunit\Classes;
 
 use Kadence_Blocks_CSS;
-use Tests\Support\Classes\KadenceBlocksUnit;
+use Kadence_Blocks_Footer_CSS;
+use Tests\wpunit\KadenceBlocksTestCase;
 
-class FrontendFooterCssTest extends KadenceBlocksUnit {
+class FrontendFooterCssTest extends KadenceBlocksTestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		Kadence_Blocks_CSS::$styles             = [];
-		Kadence_Blocks_CSS::$head_styles        = [];
-		Kadence_Blocks_CSS::$custom_styles      = [];
-		Kadence_Blocks_CSS::$head_custom_styles = [];
+		Kadence_Blocks_CSS::$styles        = [];
+		Kadence_Blocks_CSS::$head_styles   = [];
+		Kadence_Blocks_CSS::$custom_styles = [];
+		Kadence_Blocks_Footer_CSS::get_instance()->capture_head_custom_styles();
 	}
 
 	protected function tearDown(): void {
-		Kadence_Blocks_CSS::$styles             = [];
-		Kadence_Blocks_CSS::$head_styles        = [];
-		Kadence_Blocks_CSS::$custom_styles      = [];
-		Kadence_Blocks_CSS::$head_custom_styles = [];
+		Kadence_Blocks_CSS::$styles        = [];
+		Kadence_Blocks_CSS::$head_styles   = [];
+		Kadence_Blocks_CSS::$custom_styles = [];
+		Kadence_Blocks_Footer_CSS::get_instance()->capture_head_custom_styles();
 		wp_deregister_style( 'kadence_blocks_footer_css' );
 		wp_deregister_style( 'kadence_blocks_footer_custom_css' );
 		remove_all_filters( 'kadence_blocks_render_footer_css' );
@@ -39,10 +40,8 @@ class FrontendFooterCssTest extends KadenceBlocksUnit {
 			'kb-advancedbtnBODY' => '.kb-body{background:blue}',
 		];
 
-		$css = Kadence_Blocks_CSS::get_instance();
-
 		ob_start();
-		$css->frontend_footer_block_css();
+		Kadence_Blocks_Footer_CSS::get_instance()->render_footer_block_css();
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( '.kb-body{background:blue}', $output, 'Body-rendered block CSS is flushed to the footer.' );
@@ -56,16 +55,13 @@ class FrontendFooterCssTest extends KadenceBlocksUnit {
 	public function test_footer_outputs_custom_css_post_head_delta() {
 		add_filter( 'kadence_blocks_render_footer_css', '__return_true' );
 
-		Kadence_Blocks_CSS::$head_custom_styles = [ 'kb-customHEAD' => '.kb-custom-head{margin:0}' ];
-		Kadence_Blocks_CSS::$custom_styles      = [
-			'kb-customHEAD' => '.kb-custom-head{margin:0}',
-			'kb-customBODY' => '.kb-custom-body{padding:10px}',
-		];
+		Kadence_Blocks_CSS::$custom_styles = [ 'kb-customHEAD' => '.kb-custom-head{margin:0}' ];
+		Kadence_Blocks_Footer_CSS::get_instance()->capture_head_custom_styles();
 
-		$css = Kadence_Blocks_CSS::get_instance();
+		Kadence_Blocks_CSS::$custom_styles['kb-customBODY'] = '.kb-custom-body{padding:10px}';
 
 		ob_start();
-		$css->frontend_footer_block_css();
+		Kadence_Blocks_Footer_CSS::get_instance()->render_footer_block_css();
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( '.kb-custom-body{padding:10px}', $output, 'Body-rendered Custom CSS is flushed to the footer.' );
@@ -81,10 +77,8 @@ class FrontendFooterCssTest extends KadenceBlocksUnit {
 		Kadence_Blocks_CSS::$styles        = [ 'kb-advancedbtnBODY' => '.kb-body{background:blue}' ];
 		Kadence_Blocks_CSS::$custom_styles = [ 'kb-customBODY' => '.kb-custom-body{padding:10px}' ];
 
-		$css = Kadence_Blocks_CSS::get_instance();
-
 		ob_start();
-		$css->frontend_footer_block_css();
+		Kadence_Blocks_Footer_CSS::get_instance()->render_footer_block_css();
 		$output = ob_get_clean();
 
 		$this->assertSame( '', trim( $output ), 'Nothing is printed when footer rendering is disabled.' );


### PR DESCRIPTION
🎫  [SMTNC-771](https://linear.app/nexcess/issue/SMTNC-771/button-adv-color-settings-arent-working-when-using-shopkit-fse-theme)

### 🎥 Artifacts
[https://www.loom.com/share/07e166832b1444499d468a7a8cfd8cfd](https://www.loom.com/share/07e166832b1444499d468a7a8cfd8cfd)

### 🗒️ Description

Fixed Button (Adv) color settings (background, text, and border), and other block style settings, not applying on the frontend when the block is rendered in the page **body** under a block (FSE) theme, e.g. inside a Shop Kit Product Loop Item, a Query Loop, or an FSE template/template part.

...

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [x] Tested with Dynamic content & Elements.
