### PR TITLE
Fix: Harden capability checks in pattern and template import

### DIFF
--- a/changelog/fix-svul-17.yaml
+++ b/changelog/fix-svul-17.yaml
@@ -1,0 +1,4 @@
+significance: patch
+type: security
+entry: Hardened capability checks in the pattern and template import process.
+timestamp: 2026-06-25T17:38:07.975Z

--- a/includes/class-kadence-blocks-prebuilt-library-rest-api.php
+++ b/includes/class-kadence-blocks-prebuilt-library-rest-api.php
@@ -2884,6 +2884,9 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 	 * @param array $image_data the image data to import.
 	 */
 	public function import_image( $image_data ) {
+		if ( ! current_user_can( 'upload_files' ) ) {
+			return $image_data;
+		}
 		$local_image = $this->check_for_local_image( $image_data );
 		if ( $local_image['status'] ) {
 			return $local_image['image'];

--- a/includes/class-kadence-blocks-prebuilt-library-rest-api.php
+++ b/includes/class-kadence-blocks-prebuilt-library-rest-api.php
@@ -2881,6 +2881,8 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 	/**
 	 * Import an image for the design library/patterns.
 	 *
+	 * @since TBD Require the upload_files capability.
+	 *
 	 * @param array $image_data the image data to import.
 	 */
 	public function import_image( $image_data ) {

--- a/includes/class-kadence-blocks-prebuilt-library.php
+++ b/includes/class-kadence-blocks-prebuilt-library.php
@@ -813,6 +813,8 @@ class Kadence_Blocks_Prebuilt_Library {
 	}
 	/**
 	 * Ajax function for processing the import data.
+	 *
+	 * @since TBD Require the upload_files capability.
 	 */
 	public function process_pattern_ajax_callback() {
 		// Verify if the AJAX call is valid (checks nonce and current_user_can).
@@ -917,6 +919,8 @@ class Kadence_Blocks_Prebuilt_Library {
 	}
 	/**
 	 * Ajax function for processing the import data.
+	 *
+	 * @since TBD Require the upload_files capability.
 	 */
 	public function process_data_ajax_callback() {
 		// Verify if the AJAX call is valid (checks nonce and current_user_can).
@@ -1049,6 +1053,8 @@ class Kadence_Blocks_Prebuilt_Library {
 	}
 	/**
 	 * Import an image.
+	 *
+	 * @since TBD Require the upload_files capability.
 	 *
 	 * @param array $image_data the image data to import.
 	 */

--- a/includes/class-kadence-blocks-prebuilt-library.php
+++ b/includes/class-kadence-blocks-prebuilt-library.php
@@ -817,6 +817,11 @@ class Kadence_Blocks_Prebuilt_Library {
 	public function process_pattern_ajax_callback() {
 		// Verify if the AJAX call is valid (checks nonce and current_user_can).
 		$this->verify_ajax_call();
+
+		if ( ! current_user_can( 'upload_files' ) ) {
+			wp_send_json_error( esc_html__( 'You do not have permission to upload files.', 'kadence-blocks' ) );
+		}
+
 		$data = empty( $_POST['import_content'] ) ? '' : stripslashes( $_POST['import_content'] );
 		$data = $this->process_pattern_content( $data );
 		if ( ! $data ) {
@@ -916,6 +921,11 @@ class Kadence_Blocks_Prebuilt_Library {
 	public function process_data_ajax_callback() {
 		// Verify if the AJAX call is valid (checks nonce and current_user_can).
 		$this->verify_ajax_call();
+
+		if ( ! current_user_can( 'upload_files' ) ) {
+			wp_send_json_error( esc_html__( 'You do not have permission to upload files.', 'kadence-blocks' ) );
+		}
+
 		$data           = empty( $_POST['import_content'] ) ? '' : stripslashes( $_POST['import_content'] );
 		$import_library = empty( $_POST['import_library'] ) ? 'standard' : sanitize_text_field( $_POST['import_library'] );
 		$import_type    = empty( $_POST['import_type'] ) ? 'pattern' : sanitize_text_field( $_POST['import_type'] );
@@ -1043,6 +1053,9 @@ class Kadence_Blocks_Prebuilt_Library {
 	 * @param array $image_data the image data to import.
 	 */
 	public function import_image( $image_data ) {
+		if ( ! current_user_can( 'upload_files' ) ) {
+			return $image_data;
+		}
 		$local_image = $this->check_for_local_image( $image_data );
 		if ( $local_image['status'] ) {
 			return $local_image['image'];

--- a/tests/wpunit/Classes/PrebuiltLibraryImportImageCapabilityTest.php
+++ b/tests/wpunit/Classes/PrebuiltLibraryImportImageCapabilityTest.php
@@ -69,7 +69,12 @@ class PrebuiltLibraryImportImageCapabilityTest extends KadenceBlocksTestCase {
 		$this->assertFalse( current_user_can( 'upload_files' ), 'Pre-condition: contributors lack upload_files.' );
 
 		$before = $this->attachment_count();
-		$result = $this->library()->import_image( [ 'url' => $source_url, 'id' => 0 ] );
+		$result = $this->library()->import_image(
+			[
+				'url' => $source_url,
+				'id'  => 0,
+			]
+		);
 
 		// The capability guard returns the input untouched before any attachment
 		// lookup or creation, so the seeded local image is NOT returned.
@@ -87,7 +92,12 @@ class PrebuiltLibraryImportImageCapabilityTest extends KadenceBlocksTestCase {
 		$this->assertFalse( current_user_can( 'upload_files' ), 'Pre-condition: subscribers lack upload_files.' );
 
 		$before = $this->attachment_count();
-		$result = $this->library()->import_image( [ 'url' => $source_url, 'id' => 0 ] );
+		$result = $this->library()->import_image(
+			[
+				'url' => $source_url,
+				'id'  => 0,
+			]
+		);
 
 		$this->assertSame( 0, $result['id'] );
 		$this->assertSame( $source_url, $result['url'] );
@@ -104,7 +114,12 @@ class PrebuiltLibraryImportImageCapabilityTest extends KadenceBlocksTestCase {
 
 		// Passing the capability guard, import_image() reaches check_for_local_image()
 		// and returns the existing local attachment (no remote download in the test).
-		$result = $this->library()->import_image( [ 'url' => $source_url, 'id' => 0 ] );
+		$result = $this->library()->import_image(
+			[
+				'url' => $source_url,
+				'id'  => 0,
+			]
+		);
 
 		$this->assertEquals( $attachment_id, $result['id'] );
 	}
@@ -115,7 +130,12 @@ class PrebuiltLibraryImportImageCapabilityTest extends KadenceBlocksTestCase {
 		$contributor = self::factory()->user->create( [ 'role' => 'contributor' ] );
 		wp_set_current_user( $contributor );
 
-		$result = $this->rest_controller()->import_image( [ 'url' => $source_url, 'id' => 0 ] );
+		$result = $this->rest_controller()->import_image(
+			[
+				'url' => $source_url,
+				'id'  => 0,
+			]
+		);
 
 		$this->assertSame( 0, $result['id'] );
 		$this->assertSame( $source_url, $result['url'] );

--- a/tests/wpunit/Classes/PrebuiltLibraryImportImageCapabilityTest.php
+++ b/tests/wpunit/Classes/PrebuiltLibraryImportImageCapabilityTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\wpunit\Classes;
+
+use Kadence_Blocks_Prebuilt_Library;
+use Kadence_Blocks_Prebuilt_Library_REST_Controller;
+use ReflectionClass;
+use Tests\wpunit\KadenceBlocksTestCase;
+
+/**
+ * Verifies the upload_files capability check on the prebuilt-library image
+ * import path. import_image() only performs its work for users who
+ * are allowed to upload files.
+ */
+class PrebuiltLibraryImportImageCapabilityTest extends KadenceBlocksTestCase {
+
+	/**
+	 * Build the library without its constructor so the assertions do not depend
+	 * on the DI container or the admin-only AJAX hooks registered there.
+	 */
+	private function library(): Kadence_Blocks_Prebuilt_Library {
+		return ( new ReflectionClass( Kadence_Blocks_Prebuilt_Library::class ) )
+			->newInstanceWithoutConstructor();
+	}
+
+	private function rest_controller(): Kadence_Blocks_Prebuilt_Library_REST_Controller {
+		return ( new ReflectionClass( Kadence_Blocks_Prebuilt_Library_REST_Controller::class ) )
+			->newInstanceWithoutConstructor();
+	}
+
+	/**
+	 * Seed an already-imported local image so check_for_local_image() would
+	 * match it, letting us prove whether import_image() reached that lookup.
+	 *
+	 * @return array{0:int,1:string} The attachment id and the remote source URL.
+	 */
+	private function seed_local_image(): array {
+		$source_url    = 'https://images.example.com/example-image.jpg';
+		$attachment_id = self::factory()->post->create(
+			[
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'Attachment Title',
+			]
+		);
+		update_post_meta( $attachment_id, '_kadence_blocks_image_hash', sha1( $source_url ) );
+
+		return [ $attachment_id, $source_url ];
+	}
+
+	private function attachment_count(): int {
+		return count(
+			get_posts(
+				[
+					'post_type'   => 'attachment',
+					'post_status' => 'any',
+					'numberposts' => -1,
+					'fields'      => 'ids',
+				]
+			)
+		);
+	}
+
+	public function testImportImageDeniedForUserWithoutUploadFiles() {
+		[ $attachment_id, $source_url ] = $this->seed_local_image();
+
+		$contributor = self::factory()->user->create( [ 'role' => 'contributor' ] );
+		wp_set_current_user( $contributor );
+		$this->assertFalse( current_user_can( 'upload_files' ), 'Pre-condition: contributors lack upload_files.' );
+
+		$before = $this->attachment_count();
+		$result = $this->library()->import_image( [ 'url' => $source_url, 'id' => 0 ] );
+
+		// The capability guard returns the input untouched before any attachment
+		// lookup or creation, so the seeded local image is NOT returned.
+		$this->assertSame( 0, $result['id'] );
+		$this->assertSame( $source_url, $result['url'] );
+		$this->assertNotSame( $attachment_id, $result['id'] );
+		$this->assertSame( $before, $this->attachment_count(), 'No attachment should be created.' );
+	}
+
+	public function testImportImageDeniedForSubscriber() {
+		[ $attachment_id, $source_url ] = $this->seed_local_image();
+
+		$subscriber = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber );
+		$this->assertFalse( current_user_can( 'upload_files' ), 'Pre-condition: subscribers lack upload_files.' );
+
+		$before = $this->attachment_count();
+		$result = $this->library()->import_image( [ 'url' => $source_url, 'id' => 0 ] );
+
+		$this->assertSame( 0, $result['id'] );
+		$this->assertSame( $source_url, $result['url'] );
+		$this->assertNotSame( $attachment_id, $result['id'] );
+		$this->assertSame( $before, $this->attachment_count(), 'No attachment should be created.' );
+	}
+
+	public function testImportImageAllowedForUserWithUploadFiles() {
+		[ $attachment_id, $source_url ] = $this->seed_local_image();
+
+		$administrator = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $administrator );
+		$this->assertTrue( current_user_can( 'upload_files' ), 'Pre-condition: administrators have upload_files.' );
+
+		// Passing the capability guard, import_image() reaches check_for_local_image()
+		// and returns the existing local attachment (no remote download in the test).
+		$result = $this->library()->import_image( [ 'url' => $source_url, 'id' => 0 ] );
+
+		$this->assertEquals( $attachment_id, $result['id'] );
+	}
+
+	public function testRestImportImageDeniedForUserWithoutUploadFiles() {
+		[ $attachment_id, $source_url ] = $this->seed_local_image();
+
+		$contributor = self::factory()->user->create( [ 'role' => 'contributor' ] );
+		wp_set_current_user( $contributor );
+
+		$result = $this->rest_controller()->import_image( [ 'url' => $source_url, 'id' => 0 ] );
+
+		$this->assertSame( 0, $result['id'] );
+		$this->assertSame( $source_url, $result['url'] );
+		$this->assertNotSame( $attachment_id, $result['id'] );
+	}
+}


### PR DESCRIPTION
🎫  [[SVUL-17]](https://linear.app/nexcess/issue/SVUL-17)

...

### Checklist
- [ ] I have performed a self-review.
- [ ] No unrelated files are modified.
- [ ] No debugging statements exist (Ex: console.log, error_log).
- [ ] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

[SVUL-17]: https://stellarwp.atlassian.net/browse/SVUL-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ