### PR TITLE
feat: multi-set authoring (store + REST)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,11 +104,28 @@ the team enforces in review; follow them exactly.
 
   Single-arg cases can stay on one line: `yield 'color' => [ 'type' => 'color' ];`.
 
-- **Every test method has complete phpdoc.** That means `@dataProvider` (when applicable), one
-  `@param` per parameter (including typed ones like `bool $expected`), and `@return void`.
-  Methods with no params still get a docblock with just `@return void`. Private test helpers
-  also get full `@param`/`@return`. phpcs does NOT enforce this in `tests/`, so it must be done
-  by hand.
+- **Every test method has complete phpdoc.** That means a one-line description summarizing what
+  the test asserts, then (separated by a blank line) `@dataProvider` (when applicable), one
+  `@param` per parameter (including typed ones like `bool $expected`), and `@return void`. The
+  description is required even when the method name is already descriptive — write the sentence,
+  don't lean on the name. Methods with no params still get the description plus `@return void`.
+  Private test helpers also get a description and full `@param`/`@return`. phpcs does NOT enforce
+  this in `tests/`, so it must be done by hand.
+
+  ```php
+  /**
+   * Deleting a non-default set removes only that row and leaves its siblings intact.
+   *
+   * @return void
+   */
+  public function testDeleteRemovesOnlyTheTargetSet(): void {
+  ```
+
+  This rule wins over the surrounding code. If existing methods in the file you're touching
+  have no docblocks (or docblocks with no description), do NOT match them — that's a pre-existing
+  gap, not the convention. Every test method you add or edit gets the complete docblock above
+  regardless of what its neighbors do, and you never drop the description or docblock to "stay
+  consistent" with undocumented siblings.
 
 ## Static analysis
 

--- a/includes/resources/Design_Tokens/Database/Provider.php
+++ b/includes/resources/Design_Tokens/Database/Provider.php
@@ -40,12 +40,13 @@ final class Provider extends Provider_Contract {
 	}
 
 	/**
-	 * Bind Token_History_Store and subscribe it to the Token_Store superseded action.
+	 * Bind Token_History_Store and subscribe it to the Token_Store change signals.
 	 *
-	 * The store archives the previous document each time a set is overwritten.
-	 * Subscribing here (rather than calling the store from Token_Store) keeps
-	 * Token_Store the sole writer of its own table — it only announces the prior
-	 * state, and history is a separable consumer of that signal.
+	 * The store archives the previous document each time a set is overwritten, and
+	 * drops a set's whole trail when its row is deleted. Subscribing here (rather
+	 * than calling the store from Token_Store) keeps Token_Store the sole writer of
+	 * its own table — it only announces the prior state and the deletion, and
+	 * history is a separable consumer of those signals.
 	 *
 	 * @since TBD
 	 *
@@ -63,6 +64,13 @@ final class Provider extends Provider_Contract {
 			$this->container->callback( Token_History_Store::class, 'record' ),
 			10,
 			3
+		);
+
+		add_action(
+			Token_Store::deleted_action(),
+			$this->container->callback( Token_History_Store::class, 'forget' ),
+			10,
+			1
 		);
 	}
 }

--- a/includes/resources/Design_Tokens/Database/Token_History_Store.php
+++ b/includes/resources/Design_Tokens/Database/Token_History_Store.php
@@ -142,6 +142,26 @@ final class Token_History_Store extends Query {
 	}
 
 	/**
+	 * Drop every snapshot for a token set.
+	 *
+	 * Called once a set's row has been deleted, so its trail leaves no orphaned history behind. Wired to
+	 * Token_Store's deleted action by Provider, keeping this store the sole writer of its own table.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token set slug whose snapshots to drop.
+	 *
+	 * @return void
+	 *
+	 * @throws DatabaseQueryException If the delete fails.
+	 */
+	public function forget( string $slug = '' ): void {
+		$this->qb()
+			->where( 'slug', $slug === '' ? self::default_slug() : $slug )
+			->delete();
+	}
+
+	/**
 	 * Prune a token set's trail to its retention limit, deleting the oldest
 	 * surplus snapshots so only the most-recent N remain.
 	 *

--- a/includes/resources/Design_Tokens/Database/Token_Store.php
+++ b/includes/resources/Design_Tokens/Database/Token_Store.php
@@ -244,7 +244,7 @@ final class Token_Store extends Query {
 	/**
 	 * List every stored token set, as its slug, title and version.
 	 *
-	 * The default set is not synthesised here: a set appears only once it has a row, so a site that has
+	 * The default set is not synthesized here: a set appears only once it has a row, so a site that has
 	 * never written the default returns an empty list. Callers that must always surface the default
 	 * (the REST collection) layer that invariant on top.
 	 *

--- a/includes/resources/Design_Tokens/Database/Token_Store.php
+++ b/includes/resources/Design_Tokens/Database/Token_Store.php
@@ -4,6 +4,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Database;
 
 use KadenceWP\KadenceBlocks\Database\Query;
 use KadenceWP\KadenceBlocks\StellarWP\DB\Database\Exceptions\DatabaseQueryException;
+use KadenceWP\KadenceBlocks\Utils\Cast;
 
 /**
  * The sole gateway to the kb_design_tokens table.
@@ -41,7 +42,15 @@ final class Token_Store extends Query {
 	private const SUPERSEDED_ACTION = 'kadence_blocks_design_tokens_superseded';
 
 	/**
-	 * @var string The default token set slug. v1 ships a single set under this slug.
+	 * @var string Action fired after a set's row is deleted, carrying the slug, so
+	 *             consumers (the history store) can drop the set's related state.
+	 *
+	 * @since TBD
+	 */
+	private const DELETED_ACTION = 'kadence_blocks_design_tokens_deleted';
+
+	/**
+	 * @var string The default token set slug, the always-present canonical set.
 	 *
 	 * @since TBD
 	 */
@@ -70,6 +79,18 @@ final class Token_Store extends Query {
 	 */
 	public static function superseded_action(): string {
 		return self::SUPERSEDED_ACTION;
+	}
+
+	/**
+	 * The action hook that fires after a set's row is deleted, for callers that need to drop a set's
+	 * related state once it is gone.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function deleted_action(): string {
+		return self::DELETED_ACTION;
 	}
 
 	/**
@@ -221,6 +242,99 @@ final class Token_Store extends Query {
 	}
 
 	/**
+	 * List every stored token set, as its slug, title and version.
+	 *
+	 * The default set is not synthesised here: a set appears only once it has a row, so a site that has
+	 * never written the default returns an empty list. Callers that must always surface the default
+	 * (the REST collection) layer that invariant on top.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<int,array{slug:string,title:string,version:string}> The sets, ordered by slug.
+	 */
+	public function list_stores(): array {
+		$rows = $this->qb()
+					->select( 'slug', 'title', 'version' )
+					->orderBy( 'slug', 'ASC' )
+					->getAll( ARRAY_A );
+
+		if ( ! is_array( $rows ) ) {
+			return [];
+		}
+
+		return array_map(
+			static fn( array $row ): array => [
+				'slug'    => Cast::to_string( $row['slug'] ?? '' ),
+				'title'   => Cast::to_string( $row['title'] ?? '' ),
+				'version' => Cast::to_string( $row['version'] ?? '' ),
+			],
+			$rows
+		);
+	}
+
+	/**
+	 * Whether a token set has a stored row.
+	 *
+	 * A set with no row renders entirely from baseline; the default set may legitimately have no row
+	 * yet, so callers that treat the default as always-known must account for that themselves.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token set slug.
+	 *
+	 * @return bool
+	 */
+	public function exists( string $slug ): bool {
+		return is_array(
+			$this->qb()
+				->where( 'slug', $slug )
+				->get( ARRAY_A )
+		);
+	}
+
+	/**
+	 * Delete a token set.
+	 *
+	 * The default set is the always-present canonical set and is never physically removed: deleting it
+	 * clears its overrides back to baseline (the row stays). Any other set's row is dropped outright,
+	 * which signals its removal so related state (its history) can be dropped too. Removing a set that
+	 * does not exist is a no-op — there is nothing to remove and nothing to signal. This guard is enforced
+	 * here so every caller is protected, not just the REST surface.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token set slug.
+	 *
+	 * @return void
+	 *
+	 * @throws DatabaseQueryException If the write fails. The deleted action only fires on a successful
+	 *                                removal, since a failed write throws before deleted() is reached.
+	 */
+	public function delete( string $slug = self::DEFAULT_SLUG ): void {
+		// The canonical set cannot be removed; clearing its overrides is the strongest delete it supports.
+		if ( $slug === self::DEFAULT_SLUG ) {
+			$this->save_document( '', $slug );
+
+			return;
+		}
+
+		$row = $this->qb()
+					->where( 'slug', $slug )
+					->get( ARRAY_A );
+
+		if ( ! is_array( $row ) ) {
+			return;
+		}
+
+		$this->qb()
+			->where( 'slug', $slug )
+			->delete();
+
+		// Reached only on a successful delete — a failed delete throws above.
+		$this->deleted( $slug );
+	}
+
+	/**
 	 * Derive a content-based, cache-busting version hash.
 	 *
 	 * The microtime() salt guarantees the hash changes on every write, so repeated
@@ -277,5 +391,23 @@ final class Token_Store extends Query {
 		 * @param string $version  The now-previous version hash.
 		 */
 		do_action( self::SUPERSEDED_ACTION, $slug, $document, $version );
+	}
+
+	/**
+	 * Signal that a token set's row was deleted so consumers can drop its related state.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token set slug that was deleted.
+	 *
+	 * @return void
+	 */
+	private function deleted( string $slug ): void {
+		/**
+		 * Fires after a design token set's row is deleted.
+		 *
+		 * @param string $slug The token set slug that was deleted.
+		 */
+		do_action( self::DELETED_ACTION, $slug );
 	}
 }

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -33,10 +33,11 @@ use WP_REST_Server;
  * rejects alias cycles and dangling aliases (HTTP 422) before anything is committed, then a single
  * Token_Store::save_document() that bumps the version and fires the change action.
  *
- * A single token set ships under Token_Store::default_slug(); the slug parameter and the collection
- * are modelled now so the surface does not change when multi-set support arrives. Until then a
- * non-default slug is rejected: reads return 404 (no such set), writes return 422 (multi-set authoring
- * is unsupported).
+ * The module holds any number of named token sets, each keyed by slug. The default set under
+ * Token_Store::default_slug() is the always-present canonical set; writing an arbitrary valid slug
+ * creates or updates that set, and reading or resolving an unknown slug returns 404. The default set
+ * cannot be deleted — a DELETE against it resets it to baseline, while a DELETE against any other set
+ * removes it entirely.
  *
  * @since TBD
  */
@@ -326,9 +327,8 @@ final class Documents_Controller extends Controller {
 	/**
 	 * Read the collection of token-set documents.
 	 *
-	 * Only a single set ships under Token_Store::default_slug() and the store exposes no listing method,
-	 * so the collection is the one default set. Enumerating multiple sets awaits a future
-	 * Token_Store::list_stores() that lands with multi-brand support.
+	 * Lists every stored set. The default set is always included even before it has a row, since it
+	 * renders from baseline and must always be addressable; a stored default is not duplicated.
 	 *
 	 * @since TBD
 	 *
@@ -337,16 +337,23 @@ final class Documents_Controller extends Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		$items = [ $this->prepare_item( Token_Store::default_slug() ) ];
+		$slugs = array_column( $this->store->list_stores(), 'slug' );
 
-		return new WP_REST_Response( $items, WP_Http::OK );
+		// The default set is always addressable, even with no row yet (it renders from baseline), so
+		// surface it whether or not the store has persisted it.
+		if ( ! in_array( Token_Store::default_slug(), $slugs, true ) ) {
+			array_unshift( $slugs, Token_Store::default_slug() );
+		}
+
+		$items = array_map( [ $this, 'prepare_item' ], $slugs );
+
+		return new WP_REST_Response( array_values( $items ), WP_Http::OK );
 	}
 
 	/**
 	 * Read a single token-set document by slug.
 	 *
-	 * Only the default set exists, so any other slug is unknown. Validating arbitrary slugs against the
-	 * stored sets awaits a future Token_Store::list_stores() that lands with multi-brand support.
+	 * The default set is always known; any other slug must have a stored row, otherwise it is a 404.
 	 *
 	 * @since TBD
 	 *
@@ -357,7 +364,7 @@ final class Documents_Controller extends Controller {
 	public function get_item( $request ) {
 		$slug = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
 
-		if ( $slug !== Token_Store::default_slug() ) {
+		if ( ! $this->is_known_set( $slug ) ) {
 			return $this->not_found( $slug );
 		}
 
@@ -380,7 +387,7 @@ final class Documents_Controller extends Controller {
 	public function get_resolved( $request ) {
 		$slug = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
 
-		if ( $slug !== Token_Store::default_slug() ) {
+		if ( ! $this->is_known_set( $slug ) ) {
 			return $this->not_found( $slug );
 		}
 
@@ -409,11 +416,11 @@ final class Documents_Controller extends Controller {
 	}
 
 	/**
-	 * Create-or-merge the default set from the collection route (POST /documents).
+	 * Create-or-merge a set from the collection route (POST /documents).
 	 *
 	 * Per the WordPress partial-update convention, the provided document is deep-merged into whatever is
-	 * stored; merging into an empty set simply creates it. v1 ships a single set, so an explicit
-	 * non-default slug is rejected as unsupported.
+	 * stored; merging into an empty (or not-yet-existing) set simply creates it. The slug defaults to the
+	 * default set when omitted, since the collection route carries no slug path segment.
 	 *
 	 * @since TBD
 	 *
@@ -472,9 +479,12 @@ final class Documents_Controller extends Controller {
 	}
 
 	/**
-	 * Reset the whole set to baseline (DELETE /documents/{slug}).
+	 * Delete a token set (DELETE /documents/{slug}).
 	 *
-	 * Stores an empty overrides document, so the set then renders entirely from baseline.
+	 * Delegates to Token_Store::delete(), which owns the rule that the default set is never removed
+	 * (deleting it clears its overrides to baseline) while any other set is dropped outright. An unknown
+	 * non-default set is a 404. The prior state is captured before the delete and returned as the deleted
+	 * resource, following the WordPress delete-response shape.
 	 *
 	 * @since TBD
 	 *
@@ -485,13 +495,32 @@ final class Documents_Controller extends Controller {
 	public function delete_item( $request ) {
 		$slug = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
 
-		$error = $this->guard_slug( $slug );
-
-		if ( $error instanceof WP_Error ) {
-			return $error;
+		if ( ! $this->is_known_set( $slug ) ) {
+			return $this->not_found( $slug );
 		}
 
-		return $this->persist( '', $slug, '', WP_Http::OK );
+		$previous = $this->prepare_item( $slug );
+
+		try {
+			$this->store->delete( $slug );
+		} catch ( DatabaseQueryException $e ) {
+			return new WP_Error(
+				'rest_design_tokens_delete_failed',
+				__( 'The design token set could not be deleted.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::INTERNAL_SERVER_ERROR,
+					'slug'   => $slug,
+				]
+			);
+		}
+
+		return new WP_REST_Response(
+			[
+				'deleted'  => true,
+				'previous' => $previous,
+			],
+			WP_Http::OK
+		);
 	}
 
 	/**
@@ -511,12 +540,6 @@ final class Documents_Controller extends Controller {
 	public function set_token( $request ) {
 		$slug = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
 		$path = Cast::to_string( $request->get_param( self::PATH_PARAM ) );
-
-		$error = $this->guard_slug( $slug );
-
-		if ( $error instanceof WP_Error ) {
-			return $error;
-		}
 
 		// The leaf is the whole JSON body. Decode the raw body directly rather than via
 		// get_json_params(), which is populated only once WordPress parses the request during dispatch.
@@ -584,12 +607,6 @@ final class Documents_Controller extends Controller {
 	 */
 	public function delete_token( $request ) {
 		$slug = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
-
-		$error = $this->guard_slug( $slug );
-
-		if ( $error instanceof WP_Error ) {
-			return $error;
-		}
 
 		$path      = Cast::to_string( $request->get_param( self::PATH_PARAM ) );
 		$stored    = $this->read_stored_document( $slug );
@@ -760,9 +777,9 @@ final class Documents_Controller extends Controller {
 	/**
 	 * Run the shared write pipeline against a candidate document, then commit it.
 	 *
-	 * Rejects a non-default slug as unsupported, then: validates the DTCG grammar (HTTP 422 on failure),
-	 * dry-runs the Resolver to reject alias cycles / dangling aliases before commit (HTTP 422), and
-	 * finally persists. An empty candidate clears the overrides (the set renders from baseline) and needs
+	 * Validates the DTCG grammar (HTTP 422 on failure), dry-runs the Resolver to reject alias cycles /
+	 * dangling aliases before commit (HTTP 422), and finally persists. Writing a slug with no row yet
+	 * creates that set. An empty candidate clears the overrides (the set renders from baseline) and needs
 	 * no validation or dry-run, since an empty document cannot carry an alias cycle.
 	 *
 	 * @since TBD
@@ -774,12 +791,6 @@ final class Documents_Controller extends Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	private function validate_and_save( array $candidate, string $slug, string $title ) {
-		$error = $this->guard_slug( $slug );
-
-		if ( $error instanceof WP_Error ) {
-			return $error;
-		}
-
 		// A brand-new set has no version yet; report 201 Created rather than 200 OK on first write.
 		$status = $this->store->get_version( $slug ) !== '' ? WP_Http::OK : WP_Http::CREATED;
 
@@ -861,28 +872,19 @@ final class Documents_Controller extends Controller {
 	}
 
 	/**
-	 * Reject a write to any set other than the default one. v1 ships a single set; multi-set support lands
-	 * later, so writing another slug is unsupported rather than a silent miss.
+	 * Whether a slug names a readable token set.
+	 *
+	 * The default set is always known — it renders from baseline even before it has a row — and any other
+	 * slug is known once it has a stored row.
 	 *
 	 * @since TBD
 	 *
 	 * @param string $slug The requested slug.
 	 *
-	 * @return WP_Error|null A WP_Error when the slug is unsupported, null when it is the default set.
+	 * @return bool
 	 */
-	private function guard_slug( string $slug ): ?WP_Error {
-		if ( $slug === Token_Store::default_slug() ) {
-			return null;
-		}
-
-		return new WP_Error(
-			'rest_design_tokens_unsupported_slug',
-			__( 'Only the default design token set can be written in this version.', 'kadence-blocks' ),
-			[
-				'status' => WP_Http::UNPROCESSABLE_ENTITY,
-				'slug'   => $slug,
-			]
-		);
+	private function is_known_set( string $slug ): bool {
+		return $slug === Token_Store::default_slug() || $this->store->exists( $slug );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Rest\V1;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_History_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Documents_Controller;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Sentinels;
@@ -580,7 +581,7 @@ final class DocumentsControllerTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testDeleteItemResetsTheSetToBaseline(): void {
+	public function testDeleteItemResetsTheDefaultSetToBaselineInsteadOfRemovingIt(): void {
 		$this->store->save_document( '{"primitive":{"color":{"brand":{"primary":{"$type":"color","$value":"#3182CE"}}}}}' );
 
 		$request = new WP_REST_Request( WP_REST_Server::DELETABLE );
@@ -589,7 +590,11 @@ final class DocumentsControllerTest extends TestCase {
 		$response = $this->controller->delete_item( $request );
 
 		$this->assertSame( WP_Http::OK, $response->get_status() );
-		$this->assertSame( [], $response->get_data()['document'] );
+		$this->assertTrue( $response->get_data()['deleted'] );
+
+		// The canonical set is never removed: its row survives and now renders from baseline.
+		$this->assertTrue( $this->store->exists( Token_Store::default_slug() ) );
+		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
 	}
 
 	/**
@@ -680,7 +685,7 @@ final class DocumentsControllerTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testCollectionPostRejectsANonDefaultSlug(): void {
+	public function testCollectionPostCreatesANonDefaultSet(): void {
 		$response = $this->controller->create_item(
 			$this->write_request(
 				'POST',
@@ -689,18 +694,106 @@ final class DocumentsControllerTest extends TestCase {
 					'primitive' => [
 						'color' => [
 							'brand' => [
-								Token_Type::get_type_key() => 'color',
-								Sentinels::get_value_key() => '#3182CE',
+								'primary' => [
+									Token_Type::get_type_key() => 'color',
+									Sentinels::get_value_key() => '#3182CE',
+								],
 							],
 						],
 					],
-				] 
+				]
 			)
 		);
 
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::CREATED, $response->get_status() );
+		$this->assertSame( 'other-brand', $response->get_data()['slug'] );
+		$this->assertTrue( $this->store->exists( 'other-brand' ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCollectionListsEveryStoredSetAndAlwaysIncludesTheDefault(): void {
+		$this->store->save_document( '{"set":"a"}', 'brand-a' );
+		$this->store->save_document( '{"set":"b"}', 'brand-b' );
+
+		$data  = $this->controller->get_items( new WP_REST_Request( WP_REST_Server::READABLE ) )->get_data();
+		$slugs = array_column( $data, 'slug' );
+
+		// The two stored sets plus the always-present default, which has no row of its own here.
+		$this->assertContains( Token_Store::default_slug(), $slugs );
+		$this->assertContains( 'brand-a', $slugs );
+		$this->assertContains( 'brand-b', $slugs );
+		$this->assertCount( 3, $slugs );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItReadsANonDefaultSet(): void {
+		$document = '{"primitive":{"color":{"brand":{"$type":"color","$value":"#112233"}}}}';
+		$this->store->save_document( $document, 'brand-b' );
+
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', 'brand-b' );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$this->assertSame( 'brand-b', $data['slug'] );
+		$this->assertSame( json_decode( $document, true ), $data['document'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeleteItemRemovesANonDefaultSet(): void {
+		$this->store->save_document( '{"primitive":{"color":{"brand":{"$type":"color","$value":"#112233"}}}}', 'brand-b' );
+
+		$request = new WP_REST_Request( WP_REST_Server::DELETABLE );
+		$request->set_param( 'slug', 'brand-b' );
+
+		$response = $this->controller->delete_item( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertTrue( $response->get_data()['deleted'] );
+		$this->assertSame( 'brand-b', $response->get_data()['previous']['slug'] );
+		$this->assertFalse( $this->store->exists( 'brand-b' ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeleteItemReturnsNotFoundForAnUnknownNonDefaultSet(): void {
+		$request = new WP_REST_Request( WP_REST_Server::DELETABLE );
+		$request->set_param( 'slug', 'never-existed' );
+
+		$response = $this->controller->delete_item( $request );
+
 		$this->assertInstanceOf( WP_Error::class, $response );
-		$this->assertSame( 'rest_design_tokens_unsupported_slug', $response->get_error_code() );
-		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $response->get_error_data()['status'] );
+		$this->assertSame( 'rest_design_tokens_not_found', $response->get_error_code() );
+		$this->assertSame( WP_Http::NOT_FOUND, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeleteItemPurgesTheSetsHistory(): void {
+		$history = $this->container->get( Token_History_Store::class );
+
+		// Two saves leave one archived snapshot for the set.
+		$this->store->save_document( '{"v":1}', 'brand-b' );
+		$this->store->save_document( '{"v":2}', 'brand-b' );
+		$this->assertSame( 1, $history->count( 'brand-b' ) );
+
+		$request = new WP_REST_Request( WP_REST_Server::DELETABLE );
+		$request->set_param( 'slug', 'brand-b' );
+
+		$this->controller->delete_item( $request );
+
+		// Deleting the set drops its trail too, leaving no orphaned history.
+		$this->assertSame( 0, $history->count( 'brand-b' ) );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerTest.php
@@ -579,6 +579,9 @@ final class DocumentsControllerTest extends TestCase {
 	}
 
 	/**
+	 * DELETE on the default set responds 200, reports deleted, and clears the row to baseline
+	 * while keeping it present rather than removing it.
+	 *
 	 * @return void
 	 */
 	public function testDeleteItemResetsTheDefaultSetToBaselineInsteadOfRemovingIt(): void {
@@ -683,6 +686,8 @@ final class DocumentsControllerTest extends TestCase {
 	}
 
 	/**
+	 * POST to the collection with a non-default slug creates that set and responds 201.
+	 *
 	 * @return void
 	 */
 	public function testCollectionPostCreatesANonDefaultSet(): void {
@@ -712,6 +717,9 @@ final class DocumentsControllerTest extends TestCase {
 	}
 
 	/**
+	 * The collection lists every stored set plus the always-present default, even when the
+	 * default has no row of its own.
+	 *
 	 * @return void
 	 */
 	public function testCollectionListsEveryStoredSetAndAlwaysIncludesTheDefault(): void {
@@ -729,6 +737,8 @@ final class DocumentsControllerTest extends TestCase {
 	}
 
 	/**
+	 * GET on a non-default slug returns that set's slug and decoded document.
+	 *
 	 * @return void
 	 */
 	public function testItReadsANonDefaultSet(): void {
@@ -745,6 +755,8 @@ final class DocumentsControllerTest extends TestCase {
 	}
 
 	/**
+	 * DELETE on a non-default set responds 200, reports the removed set, and drops its row.
+	 *
 	 * @return void
 	 */
 	public function testDeleteItemRemovesANonDefaultSet(): void {
@@ -763,6 +775,8 @@ final class DocumentsControllerTest extends TestCase {
 	}
 
 	/**
+	 * DELETE on a non-default slug that was never stored responds 404 not found.
+	 *
 	 * @return void
 	 */
 	public function testDeleteItemReturnsNotFoundForAnUnknownNonDefaultSet(): void {
@@ -777,6 +791,8 @@ final class DocumentsControllerTest extends TestCase {
 	}
 
 	/**
+	 * Deleting a non-default set also purges its history, leaving no orphaned snapshots.
+	 *
 	 * @return void
 	 */
 	public function testDeleteItemPurgesTheSetsHistory(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Token_StoreTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Token_StoreTest.php
@@ -288,10 +288,20 @@ final class Token_StoreTest extends TestCase {
 		$this->assertSame( 0, $history->count() );
 	}
 
+	/**
+	 * With no rows stored, listing the sets yields an empty array.
+	 *
+	 * @return void
+	 */
 	public function testListStoresIsEmptyWhenNoRowsExist(): void {
 		$this->assertSame( [], $this->store->list_stores() );
 	}
 
+	/**
+	 * Listing returns one slug/title/version entry per stored set, ordered by slug ascending.
+	 *
+	 * @return void
+	 */
 	public function testListStoresReturnsEverySetWithSlugTitleAndVersionOrderedBySlug(): void {
 		$this->store->save_document( '{"set":"b"}', 'set-b', 'Brand B' );
 		$this->store->save_document( '{"set":"a"}', 'set-a', 'Brand A' );
@@ -309,6 +319,11 @@ final class Token_StoreTest extends TestCase {
 		$this->assertMatchesRegularExpression( '/^[a-f0-9]{32}$/', $sets[0]['version'] );
 	}
 
+	/**
+	 * exists() is false before a set is saved and true once its row is written.
+	 *
+	 * @return void
+	 */
 	public function testExistsReflectsWhetherASetHasARow(): void {
 		$this->assertFalse( $this->store->exists( 'brand-b' ) );
 
@@ -317,6 +332,11 @@ final class Token_StoreTest extends TestCase {
 		$this->assertTrue( $this->store->exists( 'brand-b' ) );
 	}
 
+	/**
+	 * Deleting a non-default set removes only that row and leaves its siblings intact.
+	 *
+	 * @return void
+	 */
 	public function testDeleteRemovesOnlyTheTargetSet(): void {
 		$this->store->save_document( '{"set":"a"}', 'set-a' );
 		$this->store->save_document( '{"set":"b"}', 'set-b' );
@@ -328,6 +348,11 @@ final class Token_StoreTest extends TestCase {
 		$this->assertSame( 1, $this->count_rows() );
 	}
 
+	/**
+	 * Deleting a set fires the deleted action, passing the removed set's slug.
+	 *
+	 * @return void
+	 */
 	public function testDeleteFiresTheDeletedActionWithTheSlug(): void {
 		$this->store->save_document( '{}', 'set-a' );
 
@@ -344,6 +369,12 @@ final class Token_StoreTest extends TestCase {
 		$this->assertSame( [ 'set-a' ], $fired );
 	}
 
+	/**
+	 * Deleting the default set clears its row to baseline rather than removing it, and never
+	 * signals removal for the canonical set.
+	 *
+	 * @return void
+	 */
 	public function testDeleteResetsTheDefaultSetToBaselineInsteadOfRemovingItsRow(): void {
 		$this->store->save_document( '{"v":1}' );
 
@@ -364,6 +395,11 @@ final class Token_StoreTest extends TestCase {
 		$this->assertSame( 0, $fired );
 	}
 
+	/**
+	 * Deleting a set that was never saved is a no-op and does not fire the deleted action.
+	 *
+	 * @return void
+	 */
 	public function testDeleteIsANoOpAndDoesNotFireForAMissingSet(): void {
 		$fired = 0;
 		add_action(

--- a/tests/wpunit/Resources/Design_Tokens/Token_StoreTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Token_StoreTest.php
@@ -288,6 +288,97 @@ final class Token_StoreTest extends TestCase {
 		$this->assertSame( 0, $history->count() );
 	}
 
+	public function testListStoresIsEmptyWhenNoRowsExist(): void {
+		$this->assertSame( [], $this->store->list_stores() );
+	}
+
+	public function testListStoresReturnsEverySetWithSlugTitleAndVersionOrderedBySlug(): void {
+		$this->store->save_document( '{"set":"b"}', 'set-b', 'Brand B' );
+		$this->store->save_document( '{"set":"a"}', 'set-a', 'Brand A' );
+
+		$sets = $this->store->list_stores();
+
+		$this->assertCount( 2, $sets );
+
+		// Ordered by slug ascending, independent of insertion order.
+		$this->assertSame( 'set-a', $sets[0]['slug'] );
+		$this->assertSame( 'set-b', $sets[1]['slug'] );
+
+		$this->assertSame( 'Brand A', $sets[0]['title'] );
+		$this->assertSame( [ 'slug', 'title', 'version' ], array_keys( $sets[0] ) );
+		$this->assertMatchesRegularExpression( '/^[a-f0-9]{32}$/', $sets[0]['version'] );
+	}
+
+	public function testExistsReflectsWhetherASetHasARow(): void {
+		$this->assertFalse( $this->store->exists( 'brand-b' ) );
+
+		$this->store->save_document( '{}', 'brand-b' );
+
+		$this->assertTrue( $this->store->exists( 'brand-b' ) );
+	}
+
+	public function testDeleteRemovesOnlyTheTargetSet(): void {
+		$this->store->save_document( '{"set":"a"}', 'set-a' );
+		$this->store->save_document( '{"set":"b"}', 'set-b' );
+
+		$this->store->delete( 'set-a' );
+
+		$this->assertFalse( $this->store->exists( 'set-a' ) );
+		$this->assertTrue( $this->store->exists( 'set-b' ) );
+		$this->assertSame( 1, $this->count_rows() );
+	}
+
+	public function testDeleteFiresTheDeletedActionWithTheSlug(): void {
+		$this->store->save_document( '{}', 'set-a' );
+
+		$fired = [];
+		add_action(
+			Token_Store::deleted_action(),
+			static function ( $slug ) use ( &$fired ): void {
+				$fired[] = $slug;
+			}
+		);
+
+		$this->store->delete( 'set-a' );
+
+		$this->assertSame( [ 'set-a' ], $fired );
+	}
+
+	public function testDeleteResetsTheDefaultSetToBaselineInsteadOfRemovingItsRow(): void {
+		$this->store->save_document( '{"v":1}' );
+
+		$fired = 0;
+		add_action(
+			Token_Store::deleted_action(),
+			static function () use ( &$fired ): void {
+				++$fired;
+			}
+		);
+
+		$this->store->delete( Token_Store::default_slug() );
+
+		// The canonical set's row survives, cleared to baseline, and removal is never signalled for it.
+		$this->assertTrue( $this->store->exists( Token_Store::default_slug() ) );
+		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
+		$this->assertSame( 1, $this->count_rows() );
+		$this->assertSame( 0, $fired );
+	}
+
+	public function testDeleteIsANoOpAndDoesNotFireForAMissingSet(): void {
+		$fired = 0;
+		add_action(
+			Token_Store::deleted_action(),
+			static function () use ( &$fired ): void {
+				++$fired;
+			}
+		);
+
+		$this->store->delete( 'never-saved' );
+
+		$this->assertSame( 0, $fired );
+		$this->assertSame( 0, $this->count_rows() );
+	}
+
 	/**
 	 * Read the title column directly (test-only inspection of the table).
 	 */


### PR DESCRIPTION
🎫 [SOFT-3583 — Multi-set authoring (store + REST)](https://linear.app/nexcess/issue/SOFT-3583/multi-set-authoring-store-rest)

First ticket of the multi-palette / token-set epic ([SOFT-3582](https://linear.app/nexcess/issue/SOFT-3582/multi-palette-token-set-support)). The storage layer was already slug-keyed; this exposes create / list / delete and lifts the REST single-set restriction so the module can hold more than one token set.

- `Token_Store`: adds `list_stores()`, `exists()`, `delete()`, and a `deleted` action. The default set is guarded from removal in the store — deleting it clears its overrides to baseline; any other set's row is dropped.
- `Token_History_Store::forget()`, wired to the `deleted` action so a removed set's history is purged with no orphaned snapshots.
- `Documents_Controller`: lists every set (the default is always present), reads / creates / updates / deletes any valid slug, and returns a WordPress-style `{ deleted, previous }` response. The single-set 404 / 422 rejections are gone.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
