### PR TITLE
feat: active-set selection (store + REST)

### DIFF
--- a/includes/resources/Design_Tokens/Database/Active_Set_Store.php
+++ b/includes/resources/Design_Tokens/Database/Active_Set_Store.php
@@ -1,0 +1,178 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Database;
+
+use KadenceWP\KadenceBlocks\Utils\Cast;
+
+/**
+ * Owns the active-set pointer: which token set the module treats as canonical.
+ *
+ * The pointer is a single slug, so it lives in a WordPress option rather than the
+ * kb_design_tokens table — Token_Store remains the sole gateway to that table,
+ * and this store is its analog for the active-set selection. It always resolves
+ * to a valid set: a pointer at a never-set or since-deleted set falls back to the
+ * default set, so reads can never surface a dangling selection.
+ *
+ * Setting the pointer is the REST layer's write surface; validating that a slug
+ * names an existing set is done there (a 404), while this store guarantees the
+ * read invariant and signals a real change so caches and projectors can react.
+ *
+ * @since TBD
+ */
+final class Active_Set_Store {
+
+	/**
+	 * @var string The option that holds the active token set slug.
+	 *
+	 * @since TBD
+	 */
+	private const OPTION = 'kadence_blocks_design_tokens_active_set';
+
+	/**
+	 * @var string Action fired after the active set changes, carrying the new and
+	 *             now-previous slug, so caches and projectors can react. Distinct
+	 *             from Token_Store's document-change signal: this announces the
+	 *             selection moving, not a set's contents changing.
+	 *
+	 * @since TBD
+	 */
+	private const CHANGED_ACTION = 'kadence_blocks_design_tokens_active_changed';
+
+	/**
+	 * The sole gateway to the kb_design_tokens table, used to validate that a stored
+	 * pointer still references an existing set.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Store $store The sole gateway to the kb_design_tokens table.
+	 */
+	public function __construct( Token_Store $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * The action hook that fires after the active set changes, for callers that need to react.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function changed_action(): string {
+		return self::CHANGED_ACTION;
+	}
+
+	/**
+	 * Read the active token set slug, always resolved to a valid set.
+	 *
+	 * Falls back to the default set when the pointer was never set or now references a set with no
+	 * row (a since-deleted set) — the default is the always-present canonical set, so the returned
+	 * slug always names a readable set.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The active set slug, or the default set when the stored pointer is empty or dangling.
+	 */
+	public function get(): string {
+		$slug = Cast::to_string( get_option( self::OPTION, '' ) );
+
+		if ( ! $this->is_known( $slug ) ) {
+			return Token_Store::default_slug();
+		}
+
+		return $slug;
+	}
+
+	/**
+	 * Point the active set at a slug, signalling the change.
+	 *
+	 * A no-op when the slug already resolves to the current active set: nothing is written and no
+	 * change is signalled, so subscribers only see a real move. Validating that the slug names an
+	 * existing set is the REST layer's job (a 404); this store persists the pointer and announces
+	 * the change.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token set slug to make active.
+	 *
+	 * @return void
+	 */
+	public function set( string $slug ): void {
+		$previous = $this->get();
+
+		if ( $slug === $previous ) {
+			return;
+		}
+
+		update_option( self::OPTION, $slug, true );
+
+		$this->changed( $slug, $previous );
+	}
+
+	/**
+	 * Drop the pointer when the set it references is deleted, resetting it to the default.
+	 *
+	 * Wired to Token_Store::deleted_action(), mirroring how Token_History_Store::forget() drops a
+	 * deleted set's trail: once the active set's row is gone, the now-dangling pointer is dropped and
+	 * the change is signalled so caches can rebuild against the default. Reads already fall back on
+	 * their own, so this only keeps the stored option clean and emits the change signal at deletion
+	 * time. A delete of any other set leaves the pointer untouched.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token set slug that was deleted.
+	 *
+	 * @return void
+	 */
+	public function forget( string $slug ): void {
+		if ( $slug !== Cast::to_string( get_option( self::OPTION, '' ) ) ) {
+			return;
+		}
+
+		delete_option( self::OPTION );
+
+		$this->changed( Token_Store::default_slug(), $slug );
+	}
+
+	/**
+	 * Whether a slug names a readable token set.
+	 *
+	 * The default set is always known — it renders from baseline even before it has a row — and any
+	 * other slug is known once it has a stored row. Mirrors Documents_Controller's read gate.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The slug to test.
+	 *
+	 * @return bool
+	 */
+	private function is_known( string $slug ): bool {
+		return $slug === Token_Store::default_slug() || $this->store->exists( $slug );
+	}
+
+	/**
+	 * Signal that the active set changed so caches and projectors can react.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $new The now-active set slug.
+	 * @param string $old The now-previous set slug.
+	 *
+	 * @return void
+	 */
+	private function changed( string $new, string $old ): void {
+		/**
+		 * Fires after the active design token set changes.
+		 *
+		 * @param string $new The now-active set slug.
+		 * @param string $old The now-previous set slug.
+		 */
+		do_action( self::CHANGED_ACTION, $new, $old );
+	}
+}

--- a/includes/resources/Design_Tokens/Database/Provider.php
+++ b/includes/resources/Design_Tokens/Database/Provider.php
@@ -22,6 +22,7 @@ final class Provider extends Provider_Contract {
 	public function register(): void {
 		$this->register_token_store();
 		$this->register_history_store();
+		$this->register_active_set_store();
 	}
 
 	/**
@@ -69,6 +70,29 @@ final class Provider extends Provider_Contract {
 		add_action(
 			Token_Store::deleted_action(),
 			$this->container->callback( Token_History_Store::class, 'forget' ),
+			10,
+			1
+		);
+	}
+
+	/**
+	 * Bind Active_Set_Store and reset its pointer when the active set is deleted.
+	 *
+	 * The store owns the active-set pointer (an option), separate from the table Token_Store guards.
+	 * Subscribing it to the delete signal here keeps Token_Store the sole writer of its own table — it
+	 * only announces the deletion, and the pointer drops back to the default as a separable consumer of
+	 * that signal, mirroring how history reacts.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	private function register_active_set_store(): void {
+		$this->container->singleton( Active_Set_Store::class, Active_Set_Store::class );
+
+		add_action(
+			Token_Store::deleted_action(),
+			$this->container->callback( Active_Set_Store::class, 'forget' ),
 			10,
 			1
 		);

--- a/includes/resources/Design_Tokens/Rest/V1/Active_Set_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Active_Set_Controller.php
@@ -1,0 +1,225 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
+use KadenceWP\KadenceBlocks\Utils\Cast;
+use WP_Error;
+use WP_Http;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * REST controller for the active token set pointer.
+ *
+ * Exposes which set the module treats as canonical: a read of the resolved pointer (get_item) and a
+ * write that points it at a named set (update_item). The pointer is the analog of the design-system
+ * addon's activePaletteId — a single selection, distinct from the per-set document surface that
+ * Documents_Controller owns.
+ *
+ * The read always returns a valid set: Active_Set_Store falls back to the default set when the pointer
+ * was never set or now names a deleted set. A write to an unknown set is a 404; a write to a known set
+ * persists the pointer and fires Active_Set_Store::changed_action() so caches and projectors can react.
+ *
+ * @since TBD
+ */
+final class Active_Set_Controller extends Controller {
+
+	/**
+	 * The request parameter that carries the token set slug.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const SLUG_PARAM = 'slug';
+
+	/**
+	 * The slug path segment for the write route. Built from SLUG_PARAM so the named capture and the read
+	 * parameter never drift apart.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const SLUG_ROUTE = '(?P<' . self::SLUG_PARAM . '>[\w-]+)';
+
+	/**
+	 * Owns the active-set pointer.
+	 *
+	 * @since TBD
+	 *
+	 * @var Active_Set_Store
+	 */
+	private Active_Set_Store $active;
+
+	/**
+	 * The sole gateway to the kb_design_tokens table, used to validate a write target exists.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * Memoised item schema for this request. Null until first built.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string, mixed>|null
+	 */
+	private ?array $item_schema = null;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Active_Set_Store $active Owns the active-set pointer.
+	 * @param Token_Store      $store  The sole gateway to the kb_design_tokens table.
+	 */
+	public function __construct( Active_Set_Store $active, Token_Store $store ) {
+		$this->active    = $active;
+		$this->store     = $store;
+		$this->rest_base = 'active-set';
+	}
+
+	/**
+	 * Register the read and write routes for the active-set pointer.
+	 *
+	 * The read is a singleton resource at the base; the write carries the target slug in the path,
+	 * mirroring the {slug} routing on the documents resource. Both carry their args and schema so the
+	 * MCP layer can introspect the request and response shapes.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			"/$this->rest_base",
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_item' ],
+					'permission_callback' => [ $this, 'get_item_permissions_check' ],
+					'args'                => [],
+				],
+				'schema' => [ $this, 'get_item_schema' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/' . self::SLUG_ROUTE,
+			[
+				[
+					'methods'             => 'PUT',
+					'callback'            => [ $this, 'update_item' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_slug_params(),
+				],
+				'schema' => [ $this, 'get_item_schema' ],
+			]
+		);
+	}
+
+	/**
+	 * Read the active token set pointer.
+	 *
+	 * Returns the resolved slug, which always names a readable set: the store falls back to the default
+	 * set when the stored pointer is empty or dangling.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		return new WP_REST_Response( [ self::SLUG_PARAM => $this->active->get() ], WP_Http::OK );
+	}
+
+	/**
+	 * Point the active set at a named set (PUT /active-set/{slug}).
+	 *
+	 * The target must name a known set — the default set is always known, any other slug once it has a
+	 * stored row — otherwise it is a 404. On success the pointer is persisted and the resolved active
+	 * slug is returned.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_item( $request ) {
+		$slug = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+
+		if ( $slug !== Token_Store::default_slug() && ! $this->store->exists( $slug ) ) {
+			return new WP_Error(
+				'rest_design_tokens_not_found',
+				__( 'Sorry, that design token set does not exist.', 'kadence-blocks' ),
+				[
+					'status'         => WP_Http::NOT_FOUND,
+					self::SLUG_PARAM => $slug,
+				]
+			);
+		}
+
+		$this->active->set( $slug );
+
+		return new WP_REST_Response( [ self::SLUG_PARAM => $this->active->get() ], WP_Http::OK );
+	}
+
+	/**
+	 * The JSON Schema for the active-set pointer.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_item_schema(): array {
+		if ( $this->item_schema !== null ) {
+			return $this->add_additional_fields_schema( $this->item_schema );
+		}
+
+		$this->item_schema = [
+			'$schema'    => 'http://json-schema.org/draft-07/schema#',
+			'title'      => 'design-token-active-set',
+			'type'       => 'object',
+			'properties' => [
+				self::SLUG_PARAM => [
+					'description' => __( 'The active token set slug, always resolved to an existing set.', 'kadence-blocks' ),
+					'type'        => 'string',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+			],
+		];
+
+		return $this->add_additional_fields_schema( $this->item_schema );
+	}
+
+	/**
+	 * The arguments for the write route: the target slug path parameter.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_slug_params(): array {
+		return [
+			self::SLUG_PARAM => [
+				'description'       => __( 'The token set slug to make active.', 'kadence-blocks' ),
+				'type'              => 'string',
+				'required'          => true,
+				'pattern'           => '^[\w-]+$',
+				'sanitize_callback' => 'sanitize_key',
+			],
+		];
+	}
+}

--- a/includes/resources/Design_Tokens/Rest/V1/Provider.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Provider.php
@@ -27,6 +27,7 @@ final class Provider extends Provider_Contract {
 		Documents_Controller::class,
 		Schema_Controller::class,
 		Variants_Controller::class,
+		Active_Set_Controller::class,
 	];
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Active_Set_StoreTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Active_Set_StoreTest.php
@@ -1,0 +1,149 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use Tests\Support\Classes\TestCase;
+
+final class Active_Set_StoreTest extends TestCase {
+
+	/**
+	 * @var Active_Set_Store
+	 */
+	private Active_Set_Store $active;
+
+	/**
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->active = $this->container->get( Active_Set_Store::class );
+		$this->store  = $this->container->get( Token_Store::class );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItDefaultsToTheDefaultSetWhenNothingIsStored(): void {
+		$this->assertSame( Token_Store::default_slug(), $this->active->get() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItRoundTripsAValidNonDefaultSet(): void {
+		$this->store->save_document( '{}', 'brand-b' );
+
+		$this->active->set( 'brand-b' );
+
+		$this->assertSame( 'brand-b', $this->active->get() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItFallsBackToTheDefaultSetWhenThePointerIsDangling(): void {
+		// Point at a set that has no row, bypassing the delete signal, to prove the read-time fallback
+		// resolves a dangling pointer rather than surfacing a non-existent set.
+		update_option( 'kadence_blocks_design_tokens_active_set', 'ghost', true );
+
+		$this->assertSame( Token_Store::default_slug(), $this->active->get() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSetFiresTheChangedActionWithTheNewAndPreviousSlug(): void {
+		$this->store->save_document( '{}', 'brand-b' );
+
+		$fired = [];
+		add_action(
+			Active_Set_Store::changed_action(),
+			static function ( $new, $old ) use ( &$fired ): void {
+				$fired[] = [ $new, $old ];
+			},
+			10,
+			2
+		);
+
+		$this->active->set( 'brand-b' );
+
+		$this->assertSame( [ [ 'brand-b', Token_Store::default_slug() ] ], $fired );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSetIsANoOpWhenThePointerIsUnchanged(): void {
+		$this->store->save_document( '{}', 'brand-b' );
+		$this->active->set( 'brand-b' );
+
+		$fired = 0;
+		add_action(
+			Active_Set_Store::changed_action(),
+			static function () use ( &$fired ): void {
+				++$fired;
+			}
+		);
+
+		// Re-pointing at the already-active set writes nothing and signals nothing.
+		$this->active->set( 'brand-b' );
+
+		$this->assertSame( 'brand-b', $this->active->get() );
+		$this->assertSame( 0, $fired );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeletingTheActiveSetResetsThePointerToTheDefaultAndSignals(): void {
+		$this->store->save_document( '{}', 'brand-b' );
+		$this->active->set( 'brand-b' );
+
+		$fired = [];
+		add_action(
+			Active_Set_Store::changed_action(),
+			static function ( $new, $old ) use ( &$fired ): void {
+				$fired[] = [ $new, $old ];
+			},
+			10,
+			2
+		);
+
+		// Deleting the active set fires Token_Store::deleted_action(), which the active-set store is wired
+		// to: the now-dangling pointer drops back to the default and the change is signalled.
+		$this->store->delete( 'brand-b' );
+
+		$this->assertSame( Token_Store::default_slug(), $this->active->get() );
+		$this->assertSame( [ [ Token_Store::default_slug(), 'brand-b' ] ], $fired );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeletingANonActiveSetLeavesThePointerUntouched(): void {
+		$this->store->save_document( '{}', 'brand-b' );
+		$this->store->save_document( '{}', 'brand-c' );
+		$this->active->set( 'brand-b' );
+
+		$fired = 0;
+		add_action(
+			Active_Set_Store::changed_action(),
+			static function () use ( &$fired ): void {
+				++$fired;
+			}
+		);
+
+		$this->store->delete( 'brand-c' );
+
+		$this->assertSame( 'brand-b', $this->active->get() );
+		$this->assertSame( 0, $fired );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Active_Set_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Active_Set_ControllerTest.php
@@ -1,0 +1,233 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Rest\V1;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Active_Set_Controller;
+use ReflectionClass;
+use ReflectionProperty;
+use Tests\Support\Classes\TestCase;
+use WP_Error;
+use WP_Http;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Covers the active-set pointer controller: reading the resolved pointer and pointing it at a set.
+ */
+final class Active_Set_ControllerTest extends TestCase {
+
+	/**
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @var Active_Set_Store
+	 */
+	private Active_Set_Store $active;
+
+	/**
+	 * @var Active_Set_Controller
+	 */
+	private Active_Set_Controller $controller;
+
+	/**
+	 * @var WP_REST_Server
+	 */
+	private WP_REST_Server $rest_server;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->store      = $this->container->get( Token_Store::class );
+		$this->active     = $this->container->get( Active_Set_Store::class );
+		$this->controller = $this->container->get( Active_Set_Controller::class );
+
+		global $wp_rest_server;
+		$this->rest_server = new WP_REST_Server();
+		$wp_rest_server    = $this->rest_server;
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		wp_set_current_user( 0 );
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItRegistersTheReadAndWriteRoutesWithArgsAndSchema(): void {
+		$namespace  = $this->controller_namespace();
+		$base       = $this->controller_rest_base();
+		$slug_route = $this->controller_constant( 'SLUG_ROUTE' );
+
+		$read  = "/$namespace/$base";
+		$write = "/$namespace/$base/$slug_route";
+
+		$this->assertContains( 'GET', $this->route_methods( $read ) );
+		$this->assertContains( 'PUT', $this->route_methods( $write ) );
+
+		foreach ( [ $read, $write ] as $route ) {
+			$options = $this->rest_server->get_route_options( $route );
+
+			$this->assertArrayHasKey( 'schema', $options, "Route $route should expose a schema." );
+			$this->assertIsCallable( $options['schema'] );
+		}
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetItemReturnsTheDefaultSetInitially(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+
+		$response = $this->controller->get_item( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertSame( Token_Store::default_slug(), $response->get_data()['slug'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testUpdateItemPointsTheActiveSetAtAKnownSet(): void {
+		$this->store->save_document( '{}', 'brand-b' );
+
+		$request = new WP_REST_Request( 'PUT' );
+		$request->set_param( 'slug', 'brand-b' );
+
+		$response = $this->controller->update_item( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertSame( 'brand-b', $response->get_data()['slug'] );
+
+		// The pointer is persisted, not just echoed.
+		$this->assertSame( 'brand-b', $this->active->get() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testUpdateItemAcceptsTheDefaultSetEvenWithNoRow(): void {
+		$request = new WP_REST_Request( 'PUT' );
+		$request->set_param( 'slug', Token_Store::default_slug() );
+
+		$response = $this->controller->update_item( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertSame( Token_Store::default_slug(), $response->get_data()['slug'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testUpdateItemReturnsNotFoundForAnUnknownSet(): void {
+		$request = new WP_REST_Request( 'PUT' );
+		$request->set_param( 'slug', 'ghost' );
+
+		$result = $this->controller->update_item( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_not_found', $result->get_error_code() );
+		$this->assertSame( WP_Http::NOT_FOUND, $result->get_error_data()['status'] );
+
+		// A rejected write leaves the pointer at its default.
+		$this->assertSame( Token_Store::default_slug(), $this->active->get() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItDeniesAccessToUsersWithoutTheCapability(): void {
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'subscriber' ] ) );
+
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+
+		foreach ( [ 'get_item_permissions_check', 'update_item_permissions_check' ] as $check ) {
+			$result = $this->controller->$check( $request );
+
+			$this->assertInstanceOf( WP_Error::class, $result, "$check should deny the subscriber." );
+			$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+		}
+	}
+
+	/**
+	 * The methods registered for a route, flattened across its endpoints.
+	 *
+	 * @param string $route The full route path.
+	 *
+	 * @return string[]
+	 */
+	private function route_methods( string $route ): array {
+		$methods = [];
+
+		foreach ( $this->rest_server->get_routes()[ $route ] ?? [] as $endpoint ) {
+			if ( isset( $endpoint['methods'] ) && is_array( $endpoint['methods'] ) ) {
+				$methods = array_merge( $methods, array_keys( array_filter( $endpoint['methods'] ) ) );
+			}
+		}
+
+		return $methods;
+	}
+
+	/**
+	 * The REST namespace the controller registers under, read off the instance so the tests do not
+	 * hardcode it.
+	 *
+	 * @return string
+	 */
+	private function controller_namespace(): string {
+		return $this->controller_property( 'namespace' );
+	}
+
+	/**
+	 * The rest base the controller registers under, read off the instance so the tests do not hardcode it.
+	 *
+	 * @return string
+	 */
+	private function controller_rest_base(): string {
+		return $this->controller_property( 'rest_base' );
+	}
+
+	/**
+	 * Read a protected property off the controller instance.
+	 *
+	 * @param string $property The property name.
+	 *
+	 * @return string
+	 */
+	private function controller_property( string $property ): string {
+		$reflection = new ReflectionProperty( $this->controller, $property );
+		$reflection->setAccessible( true );
+
+		return (string) $reflection->getValue( $this->controller );
+	}
+
+	/**
+	 * Read a class constant off the controller, so route segments are asserted from their single source.
+	 *
+	 * @param string $name The constant name.
+	 *
+	 * @return string
+	 */
+	private function controller_constant( string $name ): string {
+		return (string) ( new ReflectionClass( $this->controller ) )->getConstant( $name );
+	}
+}


### PR DESCRIPTION
🎫 https://linear.app/nexcess/issue/SOFT-3584/active-set-selection

> [!NOTE]
> Stacked on #1073 (SOFT-3583) — merge that first; this PR targets its branch.

Adds an active token set pointer — the analog of the design-system addon's `activePaletteId`. Storage + REST only; projection honoring the pointer is a follow-up.

- `Active_Set_Store`: an option-backed pointer that always resolves to a valid set (falls back to the default set when unset or pointing at a deleted set), fires a dedicated `active_changed` action on a real change, and resets to default when its set is deleted (wired to `Token_Store::deleted_action()`).
- `Active_Set_Controller`: `GET /active-set` reads the resolved pointer; `PUT /active-set/{slug}` points it at a known set (404 otherwise).

### Checklist
- [ ] I have performed a self-review.
- [ ] No unrelated files are modified.
- [ ] No debugging statements exist (Ex: console.log, error_log).
- [ ] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.