### PR TITLE
feat: projection honors the active set

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Projector.php
@@ -2,6 +2,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Location;
@@ -39,6 +40,15 @@ final class Projector {
 	private Token_Store $store;
 
 	/**
+	 * Owns the active-set pointer, read at build time so the projection follows the active set.
+	 *
+	 * @since TBD
+	 *
+	 * @var Active_Set_Store
+	 */
+	private Active_Set_Store $active;
+
+	/**
 	 * The block-default CSS builder.
 	 *
 	 * @since TBD
@@ -50,13 +60,15 @@ final class Projector {
 	/**
 	 * @since TBD
 	 *
-	 * @param Token_Registry $registry    The token registry.
-	 * @param Token_Store    $store       The store, for the cache-busting version.
-	 * @param Css_Builder    $css_builder The block-default CSS builder.
+	 * @param Token_Registry   $registry    The token registry.
+	 * @param Token_Store      $store       The store, for the cache-busting version.
+	 * @param Active_Set_Store $active      Owns the active-set pointer.
+	 * @param Css_Builder      $css_builder The block-default CSS builder.
 	 */
-	public function __construct( Token_Registry $registry, Token_Store $store, Css_Builder $css_builder ) {
+	public function __construct( Token_Registry $registry, Token_Store $store, Active_Set_Store $active, Css_Builder $css_builder ) {
 		$this->registry    = $registry;
 		$this->store       = $store;
+		$this->active      = $active;
 		$this->css_builder = $css_builder;
 	}
 
@@ -118,12 +130,14 @@ final class Projector {
 	 * @return string
 	 */
 	private function build_css(): string {
+		$slug = $this->active->get();
+
 		try {
-			$version = $this->store->get_version();
+			$version = $this->store->get_version( $slug );
 		} catch ( Throwable $e ) {
 			return '';
 		}
 
-		return $this->css_builder->css_for_version( $version, Token_Store::default_slug() );
+		return $this->css_builder->css_for_version( $version, $slug );
 	}
 }

--- a/includes/resources/Design_Tokens/Projection/Block_Preset/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Preset/Projector.php
@@ -2,6 +2,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Preset;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
 use Throwable;
@@ -40,14 +41,25 @@ final class Projector {
 	private Variant_Resolver $resolver;
 
 	/**
+	 * Owns the active-set pointer, read at render time so preset defaults follow the active set.
+	 *
+	 * @since TBD
+	 *
+	 * @var Active_Set_Store
+	 */
+	private Active_Set_Store $active;
+
+	/**
 	 * @since TBD
 	 *
 	 * @param Token_Registry   $registry The token registry.
 	 * @param Variant_Resolver $resolver The variant resolver.
+	 * @param Active_Set_Store $active   Owns the active-set pointer.
 	 */
-	public function __construct( Token_Registry $registry, Variant_Resolver $resolver ) {
+	public function __construct( Token_Registry $registry, Variant_Resolver $resolver, Active_Set_Store $active ) {
 		$this->registry = $registry;
 		$this->resolver = $resolver;
+		$this->active   = $active;
 	}
 
 	/**
@@ -74,7 +86,7 @@ final class Projector {
 		}
 
 		try {
-			$values = $this->resolver->resolve_default( $block );
+			$values = $this->resolver->resolve_default( $block, $this->active->get() );
 		} catch ( Throwable $e ) {
 			// No `$default` defined for the block, or the token graph cannot resolve (alias cycle/dangling
 			// reference). This runs in the render path, so fail soft to KB's defaults rather than fatally.

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
@@ -55,6 +55,8 @@ final class Projector {
 	private Legacy_Filter_Bridge $bridge;
 
 	/**
+	 * @since TBD
+	 *
 	 * @param Token_Registry       $registry
 	 * @param Token_Resolver       $resolver
 	 * @param Token_Store          $store

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
@@ -2,6 +2,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
@@ -35,6 +36,15 @@ final class Projector {
 	private Token_Store $store;
 
 	/**
+	 * Owns the active-set pointer, read at build time so the projection follows the active set.
+	 *
+	 * @since TBD
+	 *
+	 * @var Active_Set_Store
+	 */
+	private Active_Set_Store $active;
+
+	/**
 	 * @var Css_Builder
 	 */
 	private Css_Builder $css_builder;
@@ -48,6 +58,7 @@ final class Projector {
 	 * @param Token_Registry       $registry
 	 * @param Token_Resolver       $resolver
 	 * @param Token_Store          $store
+	 * @param Active_Set_Store     $active
 	 * @param Css_Builder          $css_builder
 	 * @param Legacy_Filter_Bridge $bridge
 	 */
@@ -55,12 +66,14 @@ final class Projector {
 		Token_Registry $registry,
 		Token_Resolver $resolver,
 		Token_Store $store,
+		Active_Set_Store $active,
 		Css_Builder $css_builder,
 		Legacy_Filter_Bridge $bridge
 	) {
 		$this->registry    = $registry;
 		$this->resolver    = $resolver;
 		$this->store       = $store;
+		$this->active      = $active;
 		$this->css_builder = $css_builder;
 		$this->bridge      = $bridge;
 	}
@@ -157,9 +170,11 @@ final class Projector {
 	 * @return string
 	 */
 	private function build_css(): string {
+		$slug = $this->active->get();
+
 		try {
-			$version  = $this->store->get_version();
-			$resolved = $this->resolver->resolve();
+			$version  = $this->store->get_version( $slug );
+			$resolved = $this->resolver->resolve( $slug );
 		} catch ( Throwable $e ) {
 			return '';
 		}

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
@@ -3,6 +3,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Option;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
@@ -83,6 +84,15 @@ final class Projector {
 	private Token_Store $store;
 
 	/**
+	 * Owns the active-set pointer, read at sync time so the synced options follow the active set.
+	 *
+	 * @since TBD
+	 *
+	 * @var Active_Set_Store
+	 */
+	private Active_Set_Store $active;
+
+	/**
 	 * The palette builder.
 	 *
 	 * @since TBD
@@ -102,11 +112,13 @@ final class Projector {
 		Token_Registry $registry,
 		Token_Resolver $resolver,
 		Token_Store $store,
+		Active_Set_Store $active,
 		Palette_Builder $builder
 	) {
 		$this->registry = $registry;
 		$this->resolver = $resolver;
 		$this->store    = $store;
+		$this->active   = $active;
 		$this->builder  = $builder;
 	}
 
@@ -152,17 +164,19 @@ final class Projector {
 			return;
 		}
 
+		$slug          = $this->active->get();
 		$theme_present = $this->theme_palette_exists();
-		$signature     = KADENCE_BLOCKS_VERSION . ':' . $this->store->get_version() . ':' . ( $theme_present ? '1' : '0' );
+		$signature     = KADENCE_BLOCKS_VERSION . ':' . $this->store->get_version( $slug ) . ':' . ( $theme_present ? '1' : '0' );
 
-		// Skip the resolve + writes when neither the store version nor the theme-option presence changed
-		// since the last successful sync. The theme-present bit is what catches a theme switch.
+		// Skip the resolve + writes when neither the active set's version nor the theme-option presence
+		// changed since the last successful sync. Switching the active set changes its version, so the
+		// signature flips and the next reconcile re-syncs; the theme-present bit catches a theme switch.
 		if ( get_option( self::SYNC_MARKER_OPTION ) === $signature ) {
 			return;
 		}
 
 		try {
-			$resolved = $this->resolver->resolve();
+			$resolved = $this->resolver->resolve( $slug );
 		} catch ( RuntimeException $e ) {
 			// Corrupt stored document (alias cycle / dangling alias from a raw DB write). Fail open:
 			// leave both options exactly as they are; do NOT advance the marker, so a later clean write

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
@@ -108,6 +108,15 @@ final class Projector {
 	 */
 	private bool $reconciled_this_request = false;
 
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry   $registry
+	 * @param Token_Resolver   $resolver
+	 * @param Token_Store      $store
+	 * @param Active_Set_Store $active
+	 * @param Palette_Builder  $builder
+	 */
 	public function __construct(
 		Token_Registry $registry,
 		Token_Resolver $resolver,

--- a/includes/resources/Design_Tokens/Projection/Theme_Json/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Theme_Json/Projector.php
@@ -2,6 +2,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Theme_Json;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
@@ -41,25 +42,37 @@ final class Projector {
 	private Token_Store $store;
 
 	/**
+	 * Owns the active-set pointer, read at build time so the projection follows the active set.
+	 *
+	 * @since TBD
+	 *
+	 * @var Active_Set_Store
+	 */
+	private Active_Set_Store $active;
+
+	/**
 	 * @var Json_Builder
 	 */
 	private Json_Builder $builder;
 
 	/**
-	 * @param Token_Registry     $registry
-	 * @param Token_Resolver     $resolver
-	 * @param Token_Store        $store
-	 * @param Json_Builder $builder
+	 * @param Token_Registry   $registry
+	 * @param Token_Resolver   $resolver
+	 * @param Token_Store      $store
+	 * @param Active_Set_Store $active
+	 * @param Json_Builder     $builder
 	 */
 	public function __construct(
 		Token_Registry $registry,
 		Token_Resolver $resolver,
 		Token_Store $store,
+		Active_Set_Store $active,
 		Json_Builder $builder
 	) {
 		$this->registry = $registry;
 		$this->resolver = $resolver;
 		$this->store    = $store;
+		$this->active   = $active;
 		$this->builder  = $builder;
 	}
 
@@ -101,9 +114,11 @@ final class Projector {
 	 * @return array<string, mixed>
 	 */
 	private function payload(): array {
+		$slug = $this->active->get();
+
 		try {
-			$version  = $this->store->get_version();
-			$resolved = $this->resolver->resolve();
+			$version  = $this->store->get_version( $slug );
+			$resolved = $this->resolver->resolve( $slug );
 		} catch ( RuntimeException $e ) {
 			return [];
 		}

--- a/includes/resources/Design_Tokens/Projection/Theme_Json/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Theme_Json/Projector.php
@@ -56,6 +56,8 @@ final class Projector {
 	private Json_Builder $builder;
 
 	/**
+	 * @since TBD
+	 *
 	 * @param Token_Registry   $registry
 	 * @param Token_Resolver   $resolver
 	 * @param Token_Store      $store

--- a/includes/resources/Design_Tokens/Projection/Variant/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Variant/Projector.php
@@ -2,6 +2,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Variant;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Location;
@@ -34,6 +35,15 @@ final class Projector {
 	private Token_Store $store;
 
 	/**
+	 * Owns the active-set pointer, read at build time so the projection follows the active set.
+	 *
+	 * @since TBD
+	 *
+	 * @var Active_Set_Store
+	 */
+	private Active_Set_Store $active;
+
+	/**
 	 * @var Css_Builder
 	 *
 	 * @since TBD
@@ -43,13 +53,15 @@ final class Projector {
 	/**
 	 * @since TBD
 	 *
-	 * @param Token_Registry $registry    The token registry.
-	 * @param Token_Store    $store       The store, for the cache-busting version.
-	 * @param Css_Builder    $css_builder The variant CSS builder.
+	 * @param Token_Registry   $registry    The token registry.
+	 * @param Token_Store      $store       The store, for the cache-busting version.
+	 * @param Active_Set_Store $active      Owns the active-set pointer.
+	 * @param Css_Builder      $css_builder The variant CSS builder.
 	 */
-	public function __construct( Token_Registry $registry, Token_Store $store, Css_Builder $css_builder ) {
+	public function __construct( Token_Registry $registry, Token_Store $store, Active_Set_Store $active, Css_Builder $css_builder ) {
 		$this->registry    = $registry;
 		$this->store       = $store;
+		$this->active      = $active;
 		$this->css_builder = $css_builder;
 	}
 
@@ -111,12 +123,14 @@ final class Projector {
 	 * @return string
 	 */
 	private function build_css(): string {
+		$slug = $this->active->get();
+
 		try {
-			$version = $this->store->get_version();
+			$version = $this->store->get_version( $slug );
 		} catch ( Throwable $e ) {
 			return '';
 		}
 
-		return $this->css_builder->css_for_version( $version, Token_Store::default_slug() );
+		return $this->css_builder->css_for_version( $version, $slug );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Preset/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Preset/ProjectorTest.php
@@ -3,6 +3,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Projection\Block_Preset;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Preset\Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
@@ -103,7 +104,7 @@ final class ProjectorTest extends TestCase {
 	 * Build the projector with a given registry and the real (baseline-backed) variant resolver.
 	 */
 	private function projector( Token_Registry $registry ): Projector {
-		return new Projector( $registry, $this->resolver );
+		return new Projector( $registry, $this->resolver, $this->container->get( Active_Set_Store::class ) );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/ProjectorTest.php
@@ -1,7 +1,7 @@
 <?php declare( strict_types=1 );
 // cspell:ignore palette pagenow .
 
-namespace Tests\wpunit\Resources\Design_Tokens\Projection;
+namespace Tests\wpunit\Resources\Design_Tokens\Projection\Css_Var;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Scope;
@@ -10,11 +10,26 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use ReflectionProperty;
 use Tests\Support\Classes\TestCase;
 
-final class Projection_ProviderTest extends TestCase {
+/**
+ * Covers the CSS-variable projector: it appends the resolved --kb-token--* declarations to KB's front-end
+ * and editor style handles, routes the legacy color/font-size filters through the bridge, and is a no-op
+ * when the registry is deactivated.
+ */
+final class ProjectorTest extends TestCase {
 
+	/**
+	 * @var Projector
+	 */
 	private Projector $projector;
+
+	/**
+	 * @var Token_Registry
+	 */
 	private Token_Registry $registry;
 
+	/**
+	 * @return void
+	 */
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -31,16 +46,18 @@ final class Projection_ProviderTest extends TestCase {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function tearDown(): void {
 		wp_deregister_style( 'kadence-blocks-global-variables' );
 		wp_deregister_style( 'kadence-blocks-global-editor-styles' );
 
 		// Re-activate the registry in case a test called deactivate() on the singleton.
-		$this->container->get( Token_Registry::class )->activate();
+		$this->registry->activate();
 
-		// Clear the Token_Resolver singleton's in-memory memo so calls to resolve() made
-		// during these tests do not short-circuit object-cache checks in later test classes.
-		/** @var Token_Resolver $resolver */
+		// Clear the Token_Resolver singleton's in-memory memo so calls to resolve() made during these
+		// tests do not short-circuit object-cache checks in later test classes.
 		$resolver      = $this->container->get( Token_Resolver::class );
 		$memo_property = new ReflectionProperty( Token_Resolver::class, 'memo' );
 		$memo_property->setAccessible( true );
@@ -51,6 +68,9 @@ final class Projection_ProviderTest extends TestCase {
 
 	// ---- Front-end enqueue ---------------------------------------------------------------------------
 
+	/**
+	 * @return void
+	 */
 	public function testEnqueueFrontEndAppendsInlineStyleToGlobalVariablesHandle(): void {
 		$this->projector->enqueue_front_end();
 
@@ -65,6 +85,9 @@ final class Projection_ProviderTest extends TestCase {
 
 	// ---- Editor enqueue -------------------------------------------------------------------------------
 
+	/**
+	 * @return void
+	 */
 	public function testEnqueueEditorAppendsInlineStyleToEditorHandle(): void {
 		global $pagenow;
 		$prev    = $pagenow;
@@ -85,6 +108,9 @@ final class Projection_ProviderTest extends TestCase {
 
 	// ---- Filter routing -------------------------------------------------------------------------------
 
+	/**
+	 * @return void
+	 */
 	public function testFilterGlobalColorsRoutesToBridge(): void {
 		$input  = [
 			'--global-palette1' => '#3182CE',
@@ -97,6 +123,9 @@ final class Projection_ProviderTest extends TestCase {
 		$this->assertArrayHasKey( '--global-palette2', $result );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testFilterFontSizesPassesThroughWhenNoFontSizeTokensRegistered(): void {
 		$input  = [ 'sm' => 'clamp(0.8rem, 0.73rem + 0.217vw, 0.9rem)' ];
 		$result = $this->projector->filter_font_sizes( $input );
@@ -107,6 +136,9 @@ final class Projection_ProviderTest extends TestCase {
 
 	// ---- Deactivated registry (fail-closed) ----------------------------------------------------------
 
+	/**
+	 * @return void
+	 */
 	public function testNothingIsEmittedWhenRegistryIsDeactivated(): void {
 		$this->registry->deactivate();
 
@@ -120,6 +152,9 @@ final class Projection_ProviderTest extends TestCase {
 		$this->assertEmpty( $editor_inline );
 	}
 
+	/**
+	 * @return void
+	 */
 	public function testFiltersReturnInputUnchangedWhenRegistryIsDeactivated(): void {
 		$this->registry->deactivate();
 

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/ProjectorTest.php
@@ -3,6 +3,8 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Projection\Css_Var;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Scope;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
@@ -12,10 +14,26 @@ use Tests\Support\Classes\TestCase;
 
 /**
  * Covers the CSS-variable projector: it appends the resolved --kb-token--* declarations to KB's front-end
- * and editor style handles, routes the legacy color/font-size filters through the bridge, and is a no-op
- * when the registry is deactivated.
+ * and editor style handles, routes the legacy color/font-size filters through the bridge, is a no-op when
+ * the registry is deactivated, and honors the active set — the declarations carry the active set's resolved
+ * values, so pointing the active-set pointer at another set changes what is projected to the front end.
  */
 final class ProjectorTest extends TestCase {
+
+	/**
+	 * The shipped baseline resolves semantic.color.button-bg through primitive.color.brand.button, so an
+	 * override of that primitive surfaces as a literal in the projected CSS.
+	 *
+	 * @var string
+	 */
+	private const BASELINE_BUTTON = '#3633e1';
+
+	/**
+	 * A sentinel value, absent from the baseline, that a non-default set overrides the button primitive to.
+	 *
+	 * @var string
+	 */
+	private const BRAND_B_BUTTON = '#123456';
 
 	/**
 	 * @var Projector
@@ -28,6 +46,16 @@ final class ProjectorTest extends TestCase {
 	private Token_Registry $registry;
 
 	/**
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @var Active_Set_Store
+	 */
+	private Active_Set_Store $active;
+
+	/**
 	 * @return void
 	 */
 	protected function setUp(): void {
@@ -36,11 +64,11 @@ final class ProjectorTest extends TestCase {
 		// Projector was registered as a singleton during module bootstrap.
 		$this->projector = $this->container->get( Projector::class );
 		$this->registry  = $this->container->get( Token_Registry::class );
+		$this->store     = $this->container->get( Token_Store::class );
+		$this->active    = $this->container->get( Active_Set_Store::class );
 
 		// Register the KB style handles the hooks append to.
-		if ( ! wp_style_is( 'kadence-blocks-global-variables', 'registered' ) ) {
-			wp_register_style( 'kadence-blocks-global-variables', false ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
-		}
+		$this->register_front_handle();
 		if ( ! wp_style_is( 'kadence-blocks-global-editor-styles', 'registered' ) ) {
 			wp_register_style( 'kadence-blocks-global-editor-styles', false ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 		}
@@ -163,5 +191,104 @@ final class ProjectorTest extends TestCase {
 
 		$this->assertSame( $colors, $this->projector->filter_global_colors( $colors ) );
 		$this->assertSame( $sizes, $this->projector->filter_font_sizes( $sizes ) );
+	}
+
+	// ---- Active set ----------------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testItProjectsTheDefaultSetsBaselineValuesWhenDefaultIsActive(): void {
+		$this->projector->enqueue_front_end();
+
+		$css = $this->inline_css();
+
+		$this->assertStringContainsString( self::BASELINE_BUTTON, $css );
+		$this->assertStringNotContainsString( self::BRAND_B_BUTTON, $css );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItProjectsTheActiveSetsResolvedValuesToTheFrontEnd(): void {
+		$this->store->save_document( $this->brand_b_document(), 'brand-b' );
+		$this->active->set( 'brand-b' );
+
+		$this->projector->enqueue_front_end();
+
+		$css = $this->inline_css();
+
+		$this->assertStringContainsString( self::BRAND_B_BUTTON, $css );
+		$this->assertStringNotContainsString( self::BASELINE_BUTTON, $css );
+	}
+
+	/**
+	 * Pointing the pointer back at the default set reverts what is projected, proving the projector reads
+	 * the pointer on each build rather than caching the first set it saw.
+	 *
+	 * @return void
+	 */
+	public function testPointingBackAtTheDefaultRevertsWhatIsProjected(): void {
+		$this->store->save_document( $this->brand_b_document(), 'brand-b' );
+
+		$this->active->set( 'brand-b' );
+		$this->projector->enqueue_front_end();
+		$this->assertStringContainsString( self::BRAND_B_BUTTON, $this->inline_css() );
+
+		// A fresh handle drops the brand-b declarations so the next build is asserted in isolation.
+		$this->register_front_handle();
+
+		$this->active->set( Token_Store::default_slug() );
+		$this->projector->enqueue_front_end();
+
+		$css = $this->inline_css();
+
+		$this->assertStringContainsString( self::BASELINE_BUTTON, $css );
+		$this->assertStringNotContainsString( self::BRAND_B_BUTTON, $css );
+	}
+
+	/**
+	 * An overrides-only DTCG document that retargets the button primitive the shipped baseline resolves
+	 * semantic.color.button-bg through.
+	 *
+	 * @return string
+	 */
+	private function brand_b_document(): string {
+		return (string) wp_json_encode(
+			[
+				'primitive' => [
+					'color' => [
+						'brand' => [
+							'button' => [
+								'$type'  => 'color',
+								'$value' => self::BRAND_B_BUTTON,
+							],
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Register (or reset) the KB front-end style handle the projector appends its declarations to.
+	 *
+	 * @return void
+	 */
+	private function register_front_handle(): void {
+		if ( wp_style_is( 'kadence-blocks-global-variables', 'registered' ) ) {
+			wp_deregister_style( 'kadence-blocks-global-variables' );
+		}
+
+		wp_register_style( 'kadence-blocks-global-variables', false ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+	}
+
+	/**
+	 * The inline CSS the projector appended to the front-end handle, flattened to a single string.
+	 *
+	 * @return string
+	 */
+	private function inline_css(): string {
+		return implode( '', (array) wp_styles()->get_data( 'kadence-blocks-global-variables', 'after' ) );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/ProjectorTest.php
@@ -3,6 +3,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Projection\Kadence_Option;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Option\Palette_Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Option\Projector;
@@ -214,6 +215,7 @@ final class ProjectorTest extends TestCase {
 			$this->registry,
 			$corrupt_resolver,
 			$this->container->get( Token_Store::class ),
+			$this->container->get( Active_Set_Store::class ),
 			$this->container->get( Palette_Builder::class )
 		);
 

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Theme_Json/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Theme_Json/ProjectorTest.php
@@ -3,6 +3,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Projection\Theme_Json;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Theme_Json\Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Theme_Json\Json_Builder;
@@ -76,6 +77,7 @@ final class ProjectorTest extends TestCase {
 			$empty_registry,
 			$this->container->get( Token_Resolver::class ),
 			$this->container->get( Token_Store::class ),
+			$this->container->get( Active_Set_Store::class ),
 			new Json_Builder( $empty_registry )
 		);
 

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Variant/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Variant/ProjectorTest.php
@@ -3,6 +3,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Projection\Variant;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Variant\Css_Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Variant\Projector;
@@ -23,11 +24,14 @@ final class ProjectorTest extends TestCase {
 
 	private Token_Store $store;
 
+	private Active_Set_Store $active;
+
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->resolver = $this->container->get( Variant_Resolver::class );
 		$this->store    = $this->container->get( Token_Store::class );
+		$this->active   = $this->container->get( Active_Set_Store::class );
 
 		// Register the KB style handles the projector appends to.
 		if ( ! wp_style_is( 'kadence-blocks-global-variables', 'registered' ) ) {
@@ -84,7 +88,7 @@ final class ProjectorTest extends TestCase {
 	 * Build the projector with a given registry, the real variant resolver and the store.
 	 */
 	private function projector( Token_Registry $registry ): Projector {
-		return new Projector( $registry, $this->store, new Css_Builder( $registry, $this->resolver ) );
+		return new Projector( $registry, $this->store, $this->active, new Css_Builder( $registry, $this->resolver ) );
 	}
 
 	/**


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3585/projection-honors-the-active-set

> **Depends on #1074** (active-set selection). This is stacked on `soft-3584-active-set-selection`; merge #1074 first.

Make projection render the active token set instead of always the default. Each projector reads the active-set pointer at build time (`Active_Set_Store::get()`) and threads the resolved slug into the version lookup and the resolve/build call, replacing the hardwired `Token_Store::default_slug()` reads. Switching the active set then changes what is projected to the front end and editor, with cache invalidation falling out of the per-set version hash (no new change-signal wiring needed). The Native projector is untouched — it rides the Variant builder's now-active-set-aware slot retarget.

The test consolidation (the misnamed `Projection_ProviderTest` moved into a correctly named `Css_Var/ProjectorTest`) is isolated in its own commit ahead of the feature commit.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.