### PR TITLE
docs(SOFT-3589): record the single-active-set policy across token sets

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
@@ -15,6 +15,12 @@ use Throwable;
  * styles and feeds the legacy color/font-size filters — all gated on Token_Registry::is_active()
  * so a deactivated registry leaves KB's behavior untouched.
  *
+ * This is the non-coercive surface: a custom property placed in :root styles nothing until something
+ * references it. When the module emits multiple token sets simultaneously, every non-active set appears
+ * here only as namespaced --kb-token--<set>--* custom properties; a non-active set never feeds the
+ * native-block or theme.json styling paths and is reachable only through an explicit per-block set
+ * override. Only the active set's tokens reach those coercive surfaces.
+ *
  * @since TBD
  */
 final class Projector {

--- a/includes/resources/Design_Tokens/Projection/Native/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Native/Projector.php
@@ -22,6 +22,13 @@ use KadenceWP\KadenceBlocks\Utils\Cast;
  * styling is gone, so the design system owns every such block's default; otherwise only a block that opts in
  * with a selected variant is styled. The same flag is passed to every companion.
  *
+ * This override gate plus per-variant opt-in is the only path by which a token set styles a native block,
+ * and it is the policy across multiple token sets: only the active set may own a native block's class-less
+ * default, and only under the override flag. A non-active set never force-styles a native block — it exists
+ * solely as namespaced CSS custom properties on the Css_Var surface, reachable only through an explicit
+ * per-block set override — so adding or switching sets cannot silently restyle existing native blocks on
+ * update.
+ *
  * @since TBD
  */
 final class Projector {

--- a/includes/resources/Design_Tokens/Projection/Theme_Json/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Theme_Json/Projector.php
@@ -21,6 +21,9 @@ use WP_Theme_JSON_Data;
  * Token preset lists are merged onto whatever the incoming theme.json already declares, so KB adds to
  * — never replaces — the active theme's palette and KB's own kadence_blocks_colors injection.
  *
+ * Only the active set's tokens populate these presets (the core color picker); non-active sets stay
+ * CSS-var-only and never enter theme.json.
+ *
  * @since TBD
  */
 final class Projector {


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3589/themejson-native-single-active-set-policy-decision

Records, in the projector docblocks, the policy for how multiple token sets interact with the surfaces that can style core/native blocks — so the simultaneous-emission and per-block-override tickets have a documented guardrail to build against. The pattern itself already shipped via the core/button wiring (#1065); this generalizes it across sets. Documentation only, no behavior change.

The recorded policy: non-active sets are CSS-var-only (addressable only by a per-block override); only the active set may own a native block's class-less default, and only under the `kadence_blocks_colors` override flag; only the active set populates the core color picker; no set silently restyles existing blocks on update.

Docblock additions only — `Projection/Native/Projector.php`, `Projection/Css_Var/Projector.php`, `Projection/Theme_Json/Projector.php`.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)
