### PR TITLE
[DTM] SOFT-3574 [1/11] Add userPrimitives vocabulary and User_Primitive_Index

### DIFF
--- a/includes/resources/Design_Tokens/Document/User_Primitive_Index.php
+++ b/includes/resources/Design_Tokens/Document/User_Primitive_Index.php
@@ -1,0 +1,203 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Document;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+
+/**
+ * Reads and writes the userPrimitives provenance map. Stores label metadata only.
+ * $type and $value live exclusively in the primitive tree.
+ * Every mutating method returns the updated document; the original is not modified.
+ *
+ * @since TBD
+ */
+final class User_Primitive_Index {
+
+	/**
+	 * All user-primitive entries, keyed by canonical dot-path id.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function all( array $document ): array {
+		$map = $this->read_map( $document );
+
+		return is_array( $map ) ? $map : [];
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param string               $id Canonical dot-path id.
+	 *
+	 * @return bool
+	 */
+	public function has( array $document, string $id ): bool {
+		return isset( $this->all( $document )[ $id ] );
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param string               $id
+	 *
+	 * @return string|null
+	 */
+	public function label_for( array $document, string $id ): ?string {
+		$entry = $this->all( $document )[ $id ] ?? null;
+
+		if ( ! is_array( $entry ) ) {
+			return null;
+		}
+
+		$label = $entry['label'] ?? null;
+
+		return is_string( $label ) ? $label : null;
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param string               $id
+	 * @param string               $label
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function add( array $document, string $id, string $label ): array {
+		$ext = Extensions::get_extensions_key();
+		$ns  = Extensions::get_namespace();
+		$sec = Extensions::get_section_user_primitives();
+
+		$document = $this->ensure_path( $document );
+
+		/** @var array<string, mixed> $ext_data */
+		$ext_data = $document[ $ext ];
+		/** @var array<string, mixed> $ns_data */
+		$ns_data = $ext_data[ $ns ];
+		/** @var array<string, mixed> $sec_data */
+		$sec_data = $ns_data[ $sec ];
+
+		$sec_data[ $id ]  = [ 'label' => $label ];
+		$ns_data[ $sec ]  = $sec_data;
+		$ext_data[ $ns ]  = $ns_data;
+		$document[ $ext ] = $ext_data;
+
+		return $document;
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param string               $id
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function remove( array $document, string $id ): array {
+		if ( ! $this->has( $document, $id ) ) {
+			return $document;
+		}
+
+		$ext = Extensions::get_extensions_key();
+		$ns  = Extensions::get_namespace();
+		$sec = Extensions::get_section_user_primitives();
+
+		/** @var array<string, mixed> $ext_data */
+		$ext_data = $document[ $ext ];
+		/** @var array<string, mixed> $ns_data */
+		$ns_data = $ext_data[ $ns ];
+		/** @var array<string, mixed> $sec_data */
+		$sec_data = $ns_data[ $sec ];
+
+		unset( $sec_data[ $id ] );
+
+		$ns_data[ $sec ]  = $sec_data;
+		$ext_data[ $ns ]  = $ns_data;
+		$document[ $ext ] = $ext_data;
+
+		return $document;
+	}
+
+	/**
+	 * Swap the old id for the new id, updating the label.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param string               $old_id
+	 * @param string               $new_id
+	 * @param string               $new_label
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function rename( array $document, string $old_id, string $new_id, string $new_label ): array {
+		$document = $this->remove( $document, $old_id );
+
+		return $this->add( $document, $new_id, $new_label );
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 *
+	 * @return mixed
+	 */
+	private function read_map( array $document ) {
+		$ext_data = $document[ Extensions::get_extensions_key() ] ?? null;
+
+		if ( ! is_array( $ext_data ) ) {
+			return null;
+		}
+
+		$ns_data = $ext_data[ Extensions::get_namespace() ] ?? null;
+
+		if ( ! is_array( $ns_data ) ) {
+			return null;
+		}
+
+		return $ns_data[ Extensions::get_section_user_primitives() ] ?? null;
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function ensure_path( array $document ): array {
+		$ext = Extensions::get_extensions_key();
+		$ns  = Extensions::get_namespace();
+		$sec = Extensions::get_section_user_primitives();
+
+		if ( ! isset( $document[ $ext ] ) || ! is_array( $document[ $ext ] ) ) {
+			$document[ $ext ] = [];
+		}
+
+		/** @var array<string, mixed> $ext_data */
+		$ext_data = $document[ $ext ];
+
+		if ( ! isset( $ext_data[ $ns ] ) || ! is_array( $ext_data[ $ns ] ) ) {
+			$ext_data[ $ns ]  = [];
+			$document[ $ext ] = $ext_data;
+		}
+
+		/** @var array<string, mixed> $ns_data */
+		$ns_data = $ext_data[ $ns ];
+
+		if ( ! isset( $ns_data[ $sec ] ) || ! is_array( $ns_data[ $sec ] ) ) {
+			$ns_data[ $sec ]  = [];
+			$ext_data[ $ns ]  = $ns_data;
+			$document[ $ext ] = $ext_data;
+		}
+
+		return $document;
+	}
+}

--- a/includes/resources/Design_Tokens/Document/User_Primitive_Index.php
+++ b/includes/resources/Design_Tokens/Document/User_Primitive_Index.php
@@ -20,7 +20,7 @@ final class User_Primitive_Index {
 	 *
 	 * @param array<string, mixed> $document
 	 *
-	 * @return array<string, mixed>
+	 * @return array<string, array{label: string}>
 	 */
 	public function all( array $document ): array {
 		$map = $this->read_map( $document );
@@ -51,13 +51,7 @@ final class User_Primitive_Index {
 	public function label_for( array $document, string $id ): ?string {
 		$entry = $this->all( $document )[ $id ] ?? null;
 
-		if ( ! is_array( $entry ) ) {
-			return null;
-		}
-
-		$label = $entry['label'] ?? null;
-
-		return is_string( $label ) ? $label : null;
+		return is_array( $entry ) ? $entry['label'] : null;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
@@ -56,6 +56,16 @@ final class Extensions {
 	private const SECTION_VARIANTS = 'variants';
 
 	/**
+	 * The user-created primitives section in the $extensions namespace.
+	 * NOT returned by get_sections() — it is not preset/variant-shaped.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const SECTION_USER_PRIMITIVES = 'userPrimitives';
+
+	/**
 	 * The key naming a group's default preset slug.
 	 *
 	 * @since TBD
@@ -124,6 +134,18 @@ final class Extensions {
 	 */
 	public static function get_section_variants(): string {
 		return self::SECTION_VARIANTS;
+	}
+
+	/**
+	 * The user-created primitives section name in the $extensions namespace.
+	 * NOT returned by get_sections() — it is not preset/variant-shaped.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_section_user_primitives(): string {
+		return self::SECTION_USER_PRIMITIVES;
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Document/User_Primitive_IndexTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/User_Primitive_IndexTest.php
@@ -1,0 +1,241 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Document;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Covers the provenance-envelope read/write operations of User_Primitive_Index.
+ */
+final class User_Primitive_IndexTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->index = new User_Primitive_Index();
+	}
+
+	/**
+	 * @var User_Primitive_Index
+	 */
+	private User_Primitive_Index $index;
+
+	// -------------------------------------------------------------------------
+	// all()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testAllReturnsEmptyArrayForEmptyDocument(): void {
+		$result = $this->index->all( [] );
+
+		$this->assertSame( [], $result );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAllReturnsEmptyArrayWhenExtensionsKeyMissing(): void {
+		$doc = [ 'primitive' => [ 'color' => [] ] ];
+
+		$this->assertSame( [], $this->index->all( $doc ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAllReturnsStoredEntries(): void {
+		$id  = 'primitive.color.custom.my-brand';
+		$doc = $this->doc_with_entry( $id, 'My Brand' );
+
+		$result = $this->index->all( $doc );
+
+		$this->assertArrayHasKey( $id, $result );
+		$this->assertSame( 'My Brand', $result[ $id ]['label'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// has()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testHasReturnsFalseWhenAbsent(): void {
+		$this->assertFalse( $this->index->has( [], 'primitive.color.custom.missing' ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testHasReturnsTrueWhenPresent(): void {
+		$id  = 'primitive.color.custom.my-brand';
+		$doc = $this->doc_with_entry( $id, 'My Brand' );
+
+		$this->assertTrue( $this->index->has( $doc, $id ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// label_for()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testLabelForReturnsNullWhenAbsent(): void {
+		$this->assertNull( $this->index->label_for( [], 'primitive.color.custom.missing' ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testLabelForReturnsStoredLabel(): void {
+		$id  = 'primitive.color.custom.accent';
+		$doc = $this->doc_with_entry( $id, 'Accent Blue' );
+
+		$this->assertSame( 'Accent Blue', $this->index->label_for( $doc, $id ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// add()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testAddCreatesFullPathWhenMissing(): void {
+		$id     = 'primitive.color.custom.brand';
+		$result = $this->index->add( [], $id, 'Brand Color' );
+
+		$this->assertTrue( $this->index->has( $result, $id ) );
+		$this->assertSame( 'Brand Color', $this->index->label_for( $result, $id ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddDoesNotWriteTypeOrValue(): void {
+		$id     = 'primitive.color.custom.brand';
+		$result = $this->index->add( [], $id, 'Brand' );
+		$all    = $this->index->all( $result );
+
+		$this->assertArrayNotHasKey( '$type', $all[ $id ] );
+		$this->assertArrayNotHasKey( '$value', $all[ $id ] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddOverwritesExistingEntry(): void {
+		$id  = 'primitive.color.custom.brand';
+		$doc = $this->doc_with_entry( $id, 'Old Label' );
+
+		$result = $this->index->add( $doc, $id, 'New Label' );
+
+		$this->assertSame( 'New Label', $this->index->label_for( $result, $id ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAddPreservesSiblingEntries(): void {
+		$id_a = 'primitive.color.custom.alpha';
+		$id_b = 'primitive.color.custom.beta';
+		$doc  = $this->doc_with_entry( $id_a, 'Alpha' );
+
+		$result = $this->index->add( $doc, $id_b, 'Beta' );
+
+		$this->assertTrue( $this->index->has( $result, $id_a ) );
+		$this->assertTrue( $this->index->has( $result, $id_b ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// remove()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testRemoveIsNoOpWhenAbsent(): void {
+		$result = $this->index->remove( [], 'primitive.color.custom.missing' );
+
+		$this->assertSame( [], $result );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRemoveDeletesTargetEntryOnly(): void {
+		$id_a = 'primitive.color.custom.alpha';
+		$id_b = 'primitive.color.custom.beta';
+		$doc  = $this->doc_with_entry( $id_a, 'Alpha' );
+		$doc  = $this->index->add( $doc, $id_b, 'Beta' );
+
+		$result = $this->index->remove( $doc, $id_a );
+
+		$this->assertFalse( $this->index->has( $result, $id_a ) );
+		$this->assertTrue( $this->index->has( $result, $id_b ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// rename()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testRenameSwapsIdAndUpdatesLabel(): void {
+		$old_id = 'primitive.color.custom.old-brand';
+		$new_id = 'primitive.color.custom.new-brand';
+		$doc    = $this->doc_with_entry( $old_id, 'Old Brand' );
+
+		$result = $this->index->rename( $doc, $old_id, $new_id, 'New Brand' );
+
+		$this->assertFalse( $this->index->has( $result, $old_id ) );
+		$this->assertTrue( $this->index->has( $result, $new_id ) );
+		$this->assertSame( 'New Brand', $this->index->label_for( $result, $new_id ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRenameDoesNotWriteTypeOrValue(): void {
+		$old_id = 'primitive.color.custom.foo';
+		$new_id = 'primitive.color.custom.bar';
+		$doc    = $this->doc_with_entry( $old_id, 'Foo' );
+
+		$result = $this->index->rename( $doc, $old_id, $new_id, 'Bar' );
+		$all    = $this->index->all( $result );
+
+		$this->assertArrayNotHasKey( '$type', $all[ $new_id ] );
+		$this->assertArrayNotHasKey( '$value', $all[ $new_id ] );
+	}
+
+	// -------------------------------------------------------------------------
+	// helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @param string $id
+	 * @param string $label
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function doc_with_entry( string $id, string $label ): array {
+		return [
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					Extensions::get_section_user_primitives() => [
+						$id => [ 'label' => $label ],
+					],
+				],
+			],
+		];
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a dedicated `Extensions::get_section_user_primitives()` accessor for the `$extensions.com.kadence.designTokens.userPrimitives` namespace, kept separate from `get_sections()` since the shape isn't preset/variant-like.
- Adds `Document\User_Primitive_Index`, which reads and writes the userPrimitives provenance map (`{ label }` entries only — `$type`/`$value` stay in the primitive tree, never duplicated into the envelope).

## Test plan
- [x] `User_Primitive_IndexTest` covers `all()`/`has()`/`label_for()`/`add()`/`remove()`/`rename()`, including that mutators never touch `$type`/`$value` and that sibling entries are preserved.
- [x] PHPStan clean
- [x] cspell clean
- [x] Full wpunit/acceptance/snapshot suites pass (pre-push CI-equivalent hook)