### PR TITLE
[DTM] SOFT-3574 [3/11] Add Token_Reference and Token_Reference_Policy alias scanner

### DIFF
--- a/includes/resources/Design_Tokens/Document/Token_Reference.php
+++ b/includes/resources/Design_Tokens/Document/Token_Reference.php
@@ -1,0 +1,105 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Document;
+
+/**
+ * A single alias reference from a stored token to another token id.
+ *
+ * @since TBD
+ */
+final class Token_Reference {
+
+	/**
+	 * Semantic layer override with a direct $value alias.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const KIND_SEMANTIC_OVERRIDE = 'semantic_override';
+
+	/**
+	 * Alias found inside a composite $value sub-field (e.g. shadow.color).
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const KIND_COMPOSITE_FIELD = 'composite_field';
+
+	/**
+	 * Alias found inside $extensions.variants or $extensions.foundationPresets.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const KIND_EXTENSION = 'extension';
+
+	/**
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_kind_semantic_override(): string {
+		return self::KIND_SEMANTIC_OVERRIDE;
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_kind_composite_field(): string {
+		return self::KIND_COMPOSITE_FIELD;
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_kind_extension(): string {
+		return self::KIND_EXTENSION;
+	}
+
+	/**
+	 * The reference kind. One of the KIND_* values.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public string $kind;
+
+	/**
+	 * The canonical dot-path of the token holding the reference.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public string $path;
+
+	/**
+	 * Whether the phase-1 cascade can automatically handle this reference.
+	 *
+	 * @since TBD
+	 *
+	 * @var bool
+	 */
+	public bool $supported;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param string $kind      One of the KIND_* values.
+	 * @param string $path      Canonical dot-path of the referencing token.
+	 * @param bool   $supported Whether the cascade can handle this reference.
+	 */
+	public function __construct( string $kind, string $path, bool $supported ) {
+		$this->kind      = $kind;
+		$this->path      = $path;
+		$this->supported = $supported;
+	}
+}

--- a/includes/resources/Design_Tokens/Document/Token_Reference.php
+++ b/includes/resources/Design_Tokens/Document/Token_Reference.php
@@ -10,6 +10,33 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Document;
 final class Token_Reference {
 
 	/**
+	 * The reference kind. One of the KIND_* values.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public string $kind;
+
+	/**
+	 * The canonical dot-path of the token holding the reference.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public string $path;
+
+	/**
+	 * Whether the phase-1 cascade can automatically handle this reference.
+	 *
+	 * @since TBD
+	 *
+	 * @var bool
+	 */
+	public bool $supported;
+
+	/**
 	 * Semantic layer override with a direct $value alias.
 	 *
 	 * @since TBD
@@ -39,6 +66,19 @@ final class Token_Reference {
 	/**
 	 * @since TBD
 	 *
+	 * @param string $kind      One of the KIND_* values.
+	 * @param string $path      Canonical dot-path of the referencing token.
+	 * @param bool   $supported Whether the cascade can handle this reference.
+	 */
+	public function __construct( string $kind, string $path, bool $supported ) {
+		$this->kind      = $kind;
+		$this->path      = $path;
+		$this->supported = $supported;
+	}
+
+	/**
+	 * @since TBD
+	 *
 	 * @return string
 	 */
 	public static function get_kind_semantic_override(): string {
@@ -61,45 +101,5 @@ final class Token_Reference {
 	 */
 	public static function get_kind_extension(): string {
 		return self::KIND_EXTENSION;
-	}
-
-	/**
-	 * The reference kind. One of the KIND_* values.
-	 *
-	 * @since TBD
-	 *
-	 * @var string
-	 */
-	public string $kind;
-
-	/**
-	 * The canonical dot-path of the token holding the reference.
-	 *
-	 * @since TBD
-	 *
-	 * @var string
-	 */
-	public string $path;
-
-	/**
-	 * Whether the phase-1 cascade can automatically handle this reference.
-	 *
-	 * @since TBD
-	 *
-	 * @var bool
-	 */
-	public bool $supported;
-
-	/**
-	 * @since TBD
-	 *
-	 * @param string $kind      One of the KIND_* values.
-	 * @param string $path      Canonical dot-path of the referencing token.
-	 * @param bool   $supported Whether the cascade can handle this reference.
-	 */
-	public function __construct( string $kind, string $path, bool $supported ) {
-		$this->kind      = $kind;
-		$this->path      = $path;
-		$this->supported = $supported;
 	}
 }

--- a/includes/resources/Design_Tokens/Document/Token_Reference_Policy.php
+++ b/includes/resources/Design_Tokens/Document/Token_Reference_Policy.php
@@ -4,7 +4,6 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Document;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Layers;
-use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
 
 /**
  * Scans all alias locations in a stored overrides document for references to a given id.
@@ -121,19 +120,44 @@ final class Token_Reference_Policy {
 				continue;
 			}
 
-			$type   = $child[ Token_Type::get_type_key() ] ?? '';
-			$fields = Token_Type::is_composite( (string) $type ) ? Token_Type::composite_fields( (string) $type ) : [];
+			if ( is_array( $value ) ) {
+				$this->scan_composite_value(
+					$value,
+					$path . '.$value',
+					$alias,
+					Token_Reference::get_kind_composite_field(),
+					$references
+				);
+			}
+		}
+	}
 
-			if ( is_array( $value ) && ! empty( $fields ) ) {
-				foreach ( $fields as $field => $_ ) {
-					if ( isset( $value[ $field ] ) && $value[ $field ] === $alias ) {
-						$references[] = new Token_Reference(
-							Token_Reference::get_kind_composite_field(),
-							$path . '.$value.' . $field,
-							false
-						);
-					}
-				}
+	/**
+	 * Recursively scan a composite $value structure for alias references at any nesting depth.
+	 * Generic over shape so future composite/list sub-fields cannot silently bypass detection.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<int|string, mixed> $value
+	 * @param string                   $prefix
+	 * @param string                   $alias
+	 * @param string                   $kind
+	 * @param Token_Reference[]        $references
+	 *
+	 * @return void
+	 */
+	private function scan_composite_value( array $value, string $prefix, string $alias, string $kind, array &$references ): void {
+		foreach ( $value as $field => $sub_value ) {
+			$path = $prefix . '.' . $field;
+
+			if ( $sub_value === $alias ) {
+				$references[] = new Token_Reference( $kind, $path, false );
+
+				continue;
+			}
+
+			if ( is_array( $sub_value ) ) {
+				$this->scan_composite_value( $sub_value, $path, $alias, $kind, $references );
 			}
 		}
 	}
@@ -201,12 +225,16 @@ final class Token_Reference_Policy {
 				}
 
 				foreach ( $tokens as $token_path => $value ) {
+					$path = $prefix . '.' . $group . '.' . $preset_name . '.' . Extensions::get_tokens_key() . '.' . $token_path;
+
 					if ( $value === $alias ) {
-						$references[] = new Token_Reference(
-							Token_Reference::get_kind_extension(),
-							$prefix . '.' . $group . '.' . $preset_name . '.' . Extensions::get_tokens_key() . '.' . $token_path,
-							false
-						);
+						$references[] = new Token_Reference( Token_Reference::get_kind_extension(), $path, false );
+
+						continue;
+					}
+
+					if ( is_array( $value ) ) {
+						$this->scan_composite_value( $value, $path, $alias, Token_Reference::get_kind_extension(), $references );
 					}
 				}
 			}

--- a/includes/resources/Design_Tokens/Document/Token_Reference_Policy.php
+++ b/includes/resources/Design_Tokens/Document/Token_Reference_Policy.php
@@ -1,0 +1,215 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Document;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Layers;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
+
+/**
+ * Scans all alias locations in a stored overrides document for references to a given id.
+ *
+ * Every location is classified with a kind and whether the phase-1 cascade supports it.
+ * Phase 1 supports only direct $value aliases in the semantic layer override.
+ * All other locations produce unsupported references that block deletion.
+ *
+ * @since TBD
+ */
+final class Token_Reference_Policy {
+
+	/**
+	 * Find all references to $primitive_id in the document.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document     The decoded stored overrides document.
+	 * @param string               $primitive_id The canonical dot-path of the target primitive.
+	 *
+	 * @return Token_Reference[]
+	 */
+	public function find( array $document, string $primitive_id ): array {
+		$alias      = '{' . $primitive_id . '}';
+		$references = [];
+
+		$this->scan_token_layers( $document, $alias, $references );
+		$this->scan_extensions( $document, $alias, $references );
+
+		return $references;
+	}
+
+	/**
+	 * Whether all found references are supported (i.e. deletion is safe to proceed).
+	 *
+	 * @since TBD
+	 *
+	 * @param Token_Reference[] $references
+	 *
+	 * @return bool
+	 */
+	public function all_supported( array $references ): bool {
+		foreach ( $references as $ref ) {
+			if ( ! $ref->supported ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Walk the primitive and semantic token layers for alias references.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param string               $alias
+	 * @param Token_Reference[]    $references
+	 *
+	 * @return void
+	 */
+	private function scan_token_layers( array $document, string $alias, array &$references ): void {
+		foreach ( Layers::token_layers() as $layer ) {
+			if ( ! isset( $document[ $layer ] ) || ! is_array( $document[ $layer ] ) ) {
+				continue;
+			}
+
+			$is_semantic = $layer === 'semantic';
+			$this->walk_node( $document[ $layer ], $layer, $alias, $is_semantic, $references );
+		}
+	}
+
+	/**
+	 * Walk one node, classifying every alias match.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $node
+	 * @param string               $prefix
+	 * @param string               $alias
+	 * @param bool                 $is_semantic
+	 * @param Token_Reference[]    $references
+	 *
+	 * @return void
+	 */
+	private function walk_node( array $node, string $prefix, string $alias, bool $is_semantic, array &$references ): void {
+		foreach ( $node as $key => $child ) {
+			if ( is_string( $key ) && strncmp( $key, '$', 1 ) === 0 ) {
+				continue;
+			}
+
+			if ( ! is_array( $child ) ) {
+				continue;
+			}
+
+			$path = $prefix . '.' . $key;
+
+			if ( ! array_key_exists( '$value', $child ) ) {
+				$this->walk_node( $child, $path, $alias, $is_semantic, $references );
+
+				continue;
+			}
+
+			$value = $child['$value'];
+
+			if ( $value === $alias ) {
+				$supported    = $is_semantic;
+				$kind         = $is_semantic
+					? Token_Reference::get_kind_semantic_override()
+					: Token_Reference::get_kind_composite_field();
+				$references[] = new Token_Reference( $kind, $path, $supported );
+
+				continue;
+			}
+
+			$type   = $child[ Token_Type::get_type_key() ] ?? '';
+			$fields = Token_Type::is_composite( (string) $type ) ? Token_Type::composite_fields( (string) $type ) : [];
+
+			if ( is_array( $value ) && ! empty( $fields ) ) {
+				foreach ( $fields as $field => $_ ) {
+					if ( isset( $value[ $field ] ) && $value[ $field ] === $alias ) {
+						$references[] = new Token_Reference(
+							Token_Reference::get_kind_composite_field(),
+							$path . '.$value.' . $field,
+							false
+						);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Scan $extensions for alias references.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param string               $alias
+	 * @param Token_Reference[]    $references
+	 *
+	 * @return void
+	 */
+	private function scan_extensions( array $document, string $alias, array &$references ): void {
+		$ext_root = $document[ Extensions::get_extensions_key() ] ?? null;
+
+		if ( ! is_array( $ext_root ) ) {
+			return;
+		}
+
+		$ext = $ext_root[ Extensions::get_namespace() ] ?? null;
+
+		if ( ! is_array( $ext ) ) {
+			return;
+		}
+
+		foreach ( Extensions::get_sections() as $section ) {
+			if ( ! isset( $ext[ $section ] ) || ! is_array( $ext[ $section ] ) ) {
+				continue;
+			}
+
+			$base = Extensions::get_extensions_key() . '.' . Extensions::get_namespace() . '.' . $section;
+
+			$this->scan_extension_section( $ext[ $section ], $base, $alias, $references );
+		}
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $section
+	 * @param string               $prefix
+	 * @param string               $alias
+	 * @param Token_Reference[]    $references
+	 *
+	 * @return void
+	 */
+	private function scan_extension_section( array $section, string $prefix, string $alias, array &$references ): void {
+		foreach ( $section as $group => $preset_set ) {
+			if ( ! is_array( $preset_set ) ) {
+				continue;
+			}
+
+			foreach ( $preset_set as $preset_name => $preset ) {
+				if ( $preset_name === Extensions::get_default_key() || ! is_array( $preset ) ) {
+					continue;
+				}
+
+				$tokens = $preset[ Extensions::get_tokens_key() ] ?? null;
+
+				if ( ! is_array( $tokens ) ) {
+					continue;
+				}
+
+				foreach ( $tokens as $token_path => $value ) {
+					if ( $value === $alias ) {
+						$references[] = new Token_Reference(
+							Token_Reference::get_kind_extension(),
+							$prefix . '.' . $group . '.' . $preset_name . '.' . Extensions::get_tokens_key() . '.' . $token_path,
+							false
+						);
+					}
+				}
+			}
+		}
+	}
+}

--- a/includes/resources/Design_Tokens/Registry/Token_Definition.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Definition.php
@@ -139,11 +139,6 @@ final class Token_Definition {
 			throw new InvalidArgumentException( 'Design token declaration "projections" must be an array.' );
 		}
 
-		$user_created = $definition['user_created'] ?? false;
-		if ( ! is_bool( $user_created ) ) {
-			throw new InvalidArgumentException( 'Design token declaration "user_created" must be a boolean.' );
-		}
-
 		return new self(
 			$id,
 			$type,
@@ -151,9 +146,36 @@ final class Token_Definition {
 			$group ?? '',
 			// css_var override is rare; default is derived and impossible to drift from the id.
 			$css_var ?? Css_Var::from_id( $id ),
-			$projections,
-			$user_created
+			$projections
 		);
+	}
+
+	/**
+	 * The only factory that produces a user-created definition.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id    Canonical dot-path id.
+	 * @param string $type  DTCG $type.
+	 * @param string $label Display label; derived from the terminal slug when empty.
+	 *
+	 * @throws \InvalidArgumentException When the id fails the charset check.
+	 *
+	 * @return self
+	 */
+	public static function from_user_primitive( string $id, string $type, string $label = '' ): self {
+		if ( ! preg_match( '/^[a-z0-9]+([.-][a-z0-9]+)*$/', $id ) ) {
+			throw new InvalidArgumentException(
+				sprintf( 'Design token id "%s" must be a dot-path of lowercase alphanumeric segments.', $id )
+			);
+		}
+
+		if ( $label === '' ) {
+			$segments = explode( '.', $id );
+			$label    = ucwords( str_replace( '-', ' ', (string) end( $segments ) ) );
+		}
+
+		return new self( $id, $type, $label, '', Css_Var::from_id( $id ), [], true );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Registry/Token_Registry.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Registry.php
@@ -39,6 +39,59 @@ final class Token_Registry {
 	private bool $active = true;
 
 	/**
+	 * Register a user-created primitive. Throws when the id is already held by a non-user-created token.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id
+	 * @param string $type
+	 * @param string $label
+	 *
+	 * @throws \RuntimeException When the id belongs to a system registration.
+	 *
+	 * @return void
+	 */
+	public function register_user_primitive( string $id, string $type, string $label = '' ): void {
+		if ( isset( $this->tokens[ $id ] ) && ! $this->tokens[ $id ]->is_user_created() ) {
+			throw new \RuntimeException(
+				sprintf( 'Cannot register user primitive "%s": id is already registered as a system token.', $id )
+			);
+		}
+
+		$this->tokens[ $id ] = Token_Definition::from_user_primitive( $id, $type, $label );
+	}
+
+	/**
+	 * Remove a user-created primitive. Only removes the entry when it is user-created.
+	 * No-op when the id is absent or belongs to a system token.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id
+	 *
+	 * @return void
+	 */
+	public function deregister_user_primitive( string $id ): void {
+		if ( isset( $this->tokens[ $id ] ) && $this->tokens[ $id ]->is_user_created() ) {
+			unset( $this->tokens[ $id ] );
+		}
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @return string[]
+	 */
+	public function user_created_ids(): array {
+		return array_keys(
+			array_filter(
+				$this->tokens,
+				static fn( Token_Definition $t ): bool => $t->is_user_created()
+			)
+		);
+	}
+
+	/**
 	 * Register a single token from its declaration array.
 	 *
 	 * @since TBD
@@ -289,6 +342,7 @@ final class Token_Registry {
 				'label'       => $token->label,
 				'cssVar'      => $token->css_var,
 				'projections' => $token->projections,
+				'userCreated' => $token->is_user_created(),
 			];
 		}
 
@@ -320,7 +374,11 @@ final class Token_Registry {
 	public function missing_from_baseline( Baseline_Document $baseline ): array {
 		$missing = [];
 
-		foreach ( $this->tokens as $id => $_token ) {
+		foreach ( $this->tokens as $id => $token ) {
+			if ( $token->is_user_created() ) {
+				continue;
+			}
+
 			if ( ! $baseline->has( $id ) ) {
 				$missing[] = $id;
 			}

--- a/tests/snapshot/Resources/Design_Tokens/Admin/Feed/__snapshots__/Builder_SnapshotTest__testFullPayloadMatchesSnapshot__1.txt
+++ b/tests/snapshot/Resources/Design_Tokens/Admin/Feed/__snapshots__/Builder_SnapshotTest__testFullPayloadMatchesSnapshot__1.txt
@@ -13,7 +13,8 @@
                     "projections": {
                         "wp_preset": "color",
                         "kadence_slot": "palette1"
-                    }
+                    },
+                    "userCreated": false
                 },
                 {
                     "id": "semantic.color.button-text",
@@ -22,7 +23,8 @@
                     "cssVar": "--kb-token--semantic--color--button-text",
                     "projections": {
                         "wp_preset": "color"
-                    }
+                    },
+                    "userCreated": false
                 }
             ],
             "Layout": [
@@ -33,7 +35,8 @@
                     "cssVar": "--kb-token--semantic--spacing--md",
                     "projections": {
                         "wp_preset": "spacing"
-                    }
+                    },
+                    "userCreated": false
                 }
             ]
         }

--- a/tests/wpunit/Resources/Design_Tokens/Document/Token_Reference_PolicyTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/Token_Reference_PolicyTest.php
@@ -1,0 +1,339 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Document;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Reference;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Reference_Policy;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Covers Token_Reference_Policy::find() and all_supported().
+ */
+final class Token_Reference_PolicyTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->policy = new Token_Reference_Policy();
+	}
+
+	/**
+	 * @var Token_Reference_Policy
+	 */
+	private Token_Reference_Policy $policy;
+
+	// -------------------------------------------------------------------------
+	// no references
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testEmptyDocumentReturnsNoReferences(): void {
+		$refs = $this->policy->find( [], 'primitive.color.custom.brand' );
+
+		$this->assertSame( [], $refs );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDocumentWithNoAliasReturnsNoReferences(): void {
+		$doc = [
+			'semantic' => [
+				'color' => [
+					'button-bg' => [
+						'$type'  => 'color',
+						'$value' => '#FFFFFF',
+					],
+				],
+			],
+		];
+
+		$refs = $this->policy->find( $doc, 'primitive.color.custom.brand' );
+
+		$this->assertSame( [], $refs );
+	}
+
+	// -------------------------------------------------------------------------
+	// semantic layer: direct $value alias (supported)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testSemanticDirectValueAliasReturnsSupportedSemanticOverrideReference(): void {
+		$id  = 'primitive.color.custom.brand';
+		$doc = [
+			'semantic' => [
+				'color' => [
+					'button-bg' => [
+						'$type'  => 'color',
+						'$value' => '{' . $id . '}',
+					],
+				],
+			],
+		];
+
+		$refs = $this->policy->find( $doc, $id );
+
+		$this->assertCount( 1, $refs );
+		$this->assertSame( Token_Reference::get_kind_semantic_override(), $refs[0]->kind );
+		$this->assertSame( 'semantic.color.button-bg', $refs[0]->path );
+		$this->assertTrue( $refs[0]->supported );
+	}
+
+	// -------------------------------------------------------------------------
+	// primitive layer: direct $value alias (unsupported)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testPrimitiveLayerDirectValueAliasReturnsUnsupportedCompositeFieldReference(): void {
+		$id  = 'primitive.color.custom.brand';
+		$doc = [
+			'primitive' => [
+				'color' => [
+					'alias-token' => [
+						'$type'  => 'color',
+						'$value' => '{' . $id . '}',
+					],
+				],
+			],
+		];
+
+		$refs = $this->policy->find( $doc, $id );
+
+		$this->assertCount( 1, $refs );
+		$this->assertSame( Token_Reference::get_kind_composite_field(), $refs[0]->kind );
+		$this->assertFalse( $refs[0]->supported );
+	}
+
+	// -------------------------------------------------------------------------
+	// composite field alias (unsupported)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testCompositeFieldAliasReturnsUnsupportedCompositeFieldReference(): void {
+		$id  = 'primitive.color.custom.shadow-base';
+		$doc = [
+			'semantic' => [
+				'shadow' => [
+					'card' => [
+						'$type'  => 'shadow',
+						'$value' => [
+							'color'   => '{' . $id . '}',
+							'offsetX' => '0px',
+							'offsetY' => '4px',
+							'blur'    => '8px',
+							'spread'  => '0px',
+						],
+					],
+				],
+			],
+		];
+
+		$refs = $this->policy->find( $doc, $id );
+
+		$this->assertCount( 1, $refs );
+		$this->assertSame( Token_Reference::get_kind_composite_field(), $refs[0]->kind );
+		$this->assertSame( 'semantic.shadow.card.$value.color', $refs[0]->path );
+		$this->assertFalse( $refs[0]->supported );
+	}
+
+	// -------------------------------------------------------------------------
+	// extension preset tokens map (unsupported)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testExtensionPresetTokensMapAliasReturnsUnsupportedExtensionReference(): void {
+		$id      = 'primitive.color.custom.brand';
+		$section = Extensions::get_section_variants();
+		$doc     = [
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					$section => [
+						'buttons' => [
+							Extensions::get_default_key() => 'default',
+							'dark'                        => [
+								Extensions::get_tokens_key() => [
+									'semantic.color.button-bg' => '{' . $id . '}',
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$refs = $this->policy->find( $doc, $id );
+
+		$this->assertCount( 1, $refs );
+		$this->assertSame( Token_Reference::get_kind_extension(), $refs[0]->kind );
+		$this->assertFalse( $refs[0]->supported );
+	}
+
+	// -------------------------------------------------------------------------
+	// all_supported
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testAllSupportedReturnsTrueWhenAllReferencesAreSupported(): void {
+		$refs = [
+			new Token_Reference( Token_Reference::get_kind_semantic_override(), 'semantic.color.a', true ),
+			new Token_Reference( Token_Reference::get_kind_semantic_override(), 'semantic.color.b', true ),
+		];
+
+		$this->assertTrue( $this->policy->all_supported( $refs ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAllSupportedReturnsTrueForEmptyArray(): void {
+		$this->assertTrue( $this->policy->all_supported( [] ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAllSupportedReturnsFalseWhenAnyReferenceIsUnsupported(): void {
+		$refs = [
+			new Token_Reference( Token_Reference::get_kind_semantic_override(), 'semantic.color.a', true ),
+			new Token_Reference( Token_Reference::get_kind_composite_field(), 'semantic.shadow.b.$value.color', false ),
+		];
+
+		$this->assertFalse( $this->policy->all_supported( $refs ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// $ -prefixed keys are skipped
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testDollarPrefixedKeysAreNotEmittedAsReferencePaths(): void {
+		$id  = 'primitive.color.custom.brand';
+		$doc = [
+			'semantic' => [
+				'$type'  => 'color',
+				'$value' => '{' . $id . '}',
+				'color'  => [
+					'button-bg' => [
+						'$type'  => 'color',
+						'$value' => '#FFFFFF',
+					],
+				],
+			],
+		];
+
+		$refs = $this->policy->find( $doc, $id );
+
+		$this->assertSame( [], $refs );
+	}
+
+	// -------------------------------------------------------------------------
+	// null $value (reset sentinel) is not matched
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testNullValueIsNotMatched(): void {
+		$id  = 'primitive.color.custom.brand';
+		$doc = [
+			'semantic' => [
+				'color' => [
+					'button-bg' => [
+						'$type'  => 'color',
+						'$value' => null,
+					],
+				],
+			],
+		];
+
+		$refs = $this->policy->find( $doc, $id );
+
+		$this->assertSame( [], $refs );
+	}
+
+	// -------------------------------------------------------------------------
+	// multiple references to the same id
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testMultipleReferencesToSameIdAreAllReturned(): void {
+		$id  = 'primitive.color.custom.brand';
+		$doc = [
+			'semantic' => [
+				'color' => [
+					'button-bg'  => [
+						'$type'  => 'color',
+						'$value' => '{' . $id . '}',
+					],
+					'link-color' => [
+						'$type'  => 'color',
+						'$value' => '{' . $id . '}',
+					],
+					'focus-ring' => [
+						'$type'  => 'color',
+						'$value' => '{' . $id . '}',
+					],
+				],
+			],
+		];
+
+		$refs = $this->policy->find( $doc, $id );
+
+		$this->assertCount( 3, $refs );
+
+		foreach ( $refs as $ref ) {
+			$this->assertSame( Token_Reference::get_kind_semantic_override(), $ref->kind );
+			$this->assertTrue( $ref->supported );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// $default sentinel key is skipped in extension scan
+	// -------------------------------------------------------------------------
+
+	/**
+	 * The $default metadata key (value: a string preset slug) is skipped and does not produce
+	 * references, while actual preset entries ARE scanned.
+	 *
+	 * @return void
+	 */
+	public function testDollarDefaultSentinelKeyDoesNotProduceReferences(): void {
+		$id      = 'primitive.color.custom.brand';
+		$section = Extensions::get_section_variants();
+		$doc     = [
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					$section => [
+						'buttons' => [
+							Extensions::get_default_key() => 'light',
+						],
+					],
+				],
+			],
+		];
+
+		$refs = $this->policy->find( $doc, $id );
+
+		$this->assertSame( [], $refs );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Document/Token_Reference_PolicyTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/Token_Reference_PolicyTest.php
@@ -149,6 +149,41 @@ final class Token_Reference_PolicyTest extends TestCase {
 	}
 
 	// -------------------------------------------------------------------------
+	// nested composite field alias (unsupported) — recursion is generic, not a
+	// fixed field-list walk, so a sub-field nested inside an array is still found
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testNestedCompositeFieldAliasReturnsUnsupportedCompositeFieldReference(): void {
+		$id  = 'primitive.color.custom.shadow-base';
+		$doc = [
+			'semantic' => [
+				'shadow' => [
+					'layered' => [
+						'$type'  => 'shadow',
+						'$value' => [
+							'layers' => [
+								[
+									'color' => '{' . $id . '}',
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$refs = $this->policy->find( $doc, $id );
+
+		$this->assertCount( 1, $refs );
+		$this->assertSame( Token_Reference::get_kind_composite_field(), $refs[0]->kind );
+		$this->assertSame( 'semantic.shadow.layered.$value.layers.0.color', $refs[0]->path );
+		$this->assertFalse( $refs[0]->supported );
+	}
+
+	// -------------------------------------------------------------------------
 	// extension preset tokens map (unsupported)
 	// -------------------------------------------------------------------------
 

--- a/tests/wpunit/Resources/Design_Tokens/Document/User_Primitive_Document_ValidatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/User_Primitive_Document_ValidatorTest.php
@@ -301,14 +301,7 @@ final class User_Primitive_Document_ValidatorTest extends TestCase {
 	public function testIdCollidingWithUserCreatedRegistryTokenReturnsNoSystemCollisionError(): void {
 		$id       = 'primitive.color.custom.brand';
 		$registry = new Token_Registry();
-		$registry->register(
-			[
-				'id'           => $id,
-				'type'         => 'color',
-				'label'        => 'User Brand',
-				'user_created' => true,
-			] 
-		);
+		$registry->register_user_primitive( $id, 'color', 'User Brand' );
 		$sut = new User_Primitive_Document_Validator( $this->index, $this->baseline, $registry );
 		$doc = $this->doc_with_color_entry( $id, 'Brand', '#3182CE' );
 

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Token_DefinitionTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Token_DefinitionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Registry;
 
+use Generator;
 use InvalidArgumentException;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Definition;
 use Tests\Support\Classes\TestCase;
@@ -178,5 +179,82 @@ final class Token_DefinitionTest extends TestCase {
 			'non-string css_var'    => [ $base + [ 'css_var' => 123 ] ],
 			'non-array projections' => [ $base + [ 'projections' => 'wp_preset' ] ],
 		];
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFromUserPrimitiveProducesUserCreatedToken(): void {
+		$token = Token_Definition::from_user_primitive( 'user.color.primary-blue', 'color', 'Primary Blue' );
+
+		$this->assertTrue( $token->is_user_created() );
+		$this->assertSame( 'user.color.primary-blue', $token->id );
+		$this->assertSame( 'color', $token->type );
+		$this->assertSame( 'Primary Blue', $token->label );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFromArrayProducesNonUserCreatedToken(): void {
+		$token = Token_Definition::from_array(
+			[
+				'id'    => 'semantic.color.button-bg',
+				'type'  => 'color',
+				'label' => 'Button Background',
+			]
+		);
+
+		$this->assertFalse( $token->is_user_created() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFromUserPrimitiveThrowsOnInvalidId(): void {
+		$this->expectException( InvalidArgumentException::class );
+
+		Token_Definition::from_user_primitive( 'user.color.primaryBlue', 'color' );
+	}
+
+	/**
+	 * @dataProvider userPrimitiveLabelDerivationProvider
+	 *
+	 * @param string $id
+	 * @param string $expected_label
+	 *
+	 * @return void
+	 */
+	public function testFromUserPrimitiveDerivesLabelFromTerminalSlug( string $id, string $expected_label ): void {
+		$token = Token_Definition::from_user_primitive( $id, 'color' );
+
+		$this->assertSame( $expected_label, $token->label );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function userPrimitiveLabelDerivationProvider(): Generator {
+		yield 'hyphenated slug' => [
+			'id'             => 'user.color.primary-blue',
+			'expected_label' => 'Primary Blue',
+		];
+		yield 'single segment' => [
+			'id'             => 'primary',
+			'expected_label' => 'Primary',
+		];
+		yield 'multi-word slug' => [
+			'id'             => 'user.color.brand-accent-dark',
+			'expected_label' => 'Brand Accent Dark',
+		];
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFromUserPrimitiveUsesExplicitLabelWhenProvided(): void {
+		$token = Token_Definition::from_user_primitive( 'user.color.primary-blue', 'color', 'My Custom Label' );
+
+		$this->assertSame( 'My Custom Label', $token->label );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
@@ -5,6 +5,7 @@ namespace Tests\wpunit\Resources\Design_Tokens\Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Definition;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use RuntimeException;
 use Tests\Support\Classes\TestCase;
 
 final class Token_RegistryTest extends TestCase {
@@ -119,7 +120,7 @@ final class Token_RegistryTest extends TestCase {
 
 		$entry = $schema['groups']['Brand'][0];
 		$this->assertSame(
-			[ 'id', 'type', 'label', 'cssVar', 'projections' ],
+			[ 'id', 'type', 'label', 'cssVar', 'projections', 'userCreated' ],
 			array_keys( $entry )
 		);
 		$this->assertArrayNotHasKey( 'value', $entry );
@@ -181,5 +182,118 @@ final class Token_RegistryTest extends TestCase {
 		};
 
 		$this->assertSame( [ 'semantic.spacing.md' ], $this->registry->missing_from_baseline( $baseline ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRegisterUserPrimitiveAddsUserCreatedToken(): void {
+		$this->registry->register_user_primitive( 'user.color.brand', 'color', 'Brand' );
+
+		$token = $this->registry->get( 'user.color.brand' );
+		$this->assertNotNull( $token );
+		$this->assertTrue( $token->is_user_created() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRegisterUserPrimitiveReplacesExistingUserCreatedToken(): void {
+		$this->registry->register_user_primitive( 'user.color.brand', 'color', 'Old Label' );
+		$this->registry->register_user_primitive( 'user.color.brand', 'color', 'New Label' );
+
+		$token = $this->registry->get( 'user.color.brand' );
+		$this->assertNotNull( $token );
+		$this->assertSame( 'New Label', $token->label );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRegisterUserPrimitiveThrowsWhenIdIsSystemToken(): void {
+		$this->register_button_bg();
+
+		$this->expectException( RuntimeException::class );
+
+		$this->registry->register_user_primitive( 'semantic.color.button-bg', 'color', 'Brand' );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeregisterUserPrimitiveRemovesUserCreatedToken(): void {
+		$this->registry->register_user_primitive( 'user.color.brand', 'color', 'Brand' );
+		$this->registry->deregister_user_primitive( 'user.color.brand' );
+
+		$this->assertNull( $this->registry->get( 'user.color.brand' ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeregisterUserPrimitiveIsNoOpForSystemToken(): void {
+		$this->register_button_bg();
+		$this->registry->deregister_user_primitive( 'semantic.color.button-bg' );
+
+		$this->assertNotNull( $this->registry->get( 'semantic.color.button-bg' ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeregisterUserPrimitiveIsNoOpForAbsentId(): void {
+		$this->registry->deregister_user_primitive( 'user.color.nonexistent' );
+
+		$this->assertFalse( $this->registry->has( 'user.color.nonexistent' ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testUserCreatedIdsReturnsOnlyUserCreatedIds(): void {
+		$this->register_button_bg();
+		$this->registry->register_user_primitive( 'user.color.brand', 'color', 'Brand' );
+		$this->registry->register_user_primitive( 'user.color.accent', 'color', 'Accent' );
+
+		$this->assertSame(
+			[ 'user.color.brand', 'user.color.accent' ],
+			$this->registry->user_created_ids()
+		);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMissingFromBaselineSkipsUserCreatedTokens(): void {
+		$this->register_button_bg();
+		$this->registry->register_user_primitive( 'user.color.brand', 'color', 'Brand' );
+
+		$baseline = new class() implements Baseline_Document {
+			public function has( string $id ): bool {
+				return false;
+			}
+
+			public function document(): array {
+				return [];
+			}
+		};
+
+		$this->assertSame( [ 'semantic.color.button-bg' ], $this->registry->missing_from_baseline( $baseline ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testToUiSchemaEmitsUserCreatedField(): void {
+		$this->register_button_bg();
+		$this->registry->register_user_primitive( 'user.color.brand', 'color', 'Brand' );
+
+		$schema = $this->registry->to_ui_schema();
+
+		$system_entry = $schema['groups']['Brand'][0];
+		$this->assertFalse( $system_entry['userCreated'] );
+
+		$user_entry = $schema['groups'][''][0];
+		$this->assertTrue( $user_entry['userCreated'] );
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `Token_Reference`, a value object describing a single alias reference (kind, referencing path, whether the phase-1 cascade supports it).
- Adds `Token_Reference_Policy`, a full scanner that recursively walks the primitive/semantic token layers and every `$extensions` preset section for aliases pointing at a given token id.
- The scanner classifies a direct `$value` alias in the semantic layer as the only phase-1 "supported" (actionable) reference kind; everything else (primitive-layer aliasing, composite sub-field aliasing at any nesting depth, extension preset token maps) is unsupported and blocks deletion.
- Composite/nested `$value` scanning is a generic recursive walk rather than a fixed field-list lookup, so a future composite or list-shaped sub-field can't silently bypass detection.

## Test plan
- [x] `Token_Reference_PolicyTest` covers no-references, semantic direct alias (supported), primitive direct alias (unsupported), composite field alias, a nested composite field alias two levels deep, extension preset token map alias, `all_supported()`, `$`-prefixed key skipping, `$value: null` non-match, and multiple references to the same id.
- [x] PHPStan clean
- [x] cspell clean
- [x] Full wpunit/acceptance/snapshot suites pass (pre-push CI-equivalent hook)