### PR TITLE
[DTM] SOFT-3574 [4/11] Add Token_Registry user-primitive lifecycle

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Token_Definition.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Definition.php
@@ -139,11 +139,6 @@ final class Token_Definition {
 			throw new InvalidArgumentException( 'Design token declaration "projections" must be an array.' );
 		}
 
-		$user_created = $definition['user_created'] ?? false;
-		if ( ! is_bool( $user_created ) ) {
-			throw new InvalidArgumentException( 'Design token declaration "user_created" must be a boolean.' );
-		}
-
 		return new self(
 			$id,
 			$type,
@@ -151,9 +146,36 @@ final class Token_Definition {
 			$group ?? '',
 			// css_var override is rare; default is derived and impossible to drift from the id.
 			$css_var ?? Css_Var::from_id( $id ),
-			$projections,
-			$user_created
+			$projections
 		);
+	}
+
+	/**
+	 * The only factory that produces a user-created definition.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id    Canonical dot-path id.
+	 * @param string $type  DTCG $type.
+	 * @param string $label Display label; derived from the terminal slug when empty.
+	 *
+	 * @throws \InvalidArgumentException When the id fails the charset check.
+	 *
+	 * @return self
+	 */
+	public static function from_user_primitive( string $id, string $type, string $label = '' ): self {
+		if ( ! preg_match( '/^[a-z0-9]+([.-][a-z0-9]+)*$/', $id ) ) {
+			throw new InvalidArgumentException(
+				sprintf( 'Design token id "%s" must be a dot-path of lowercase alphanumeric segments.', $id )
+			);
+		}
+
+		if ( $label === '' ) {
+			$segments = explode( '.', $id );
+			$label    = ucwords( str_replace( '-', ' ', (string) end( $segments ) ) );
+		}
+
+		return new self( $id, $type, $label, '', Css_Var::from_id( $id ), [], true );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Registry/Token_Registry.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Registry.php
@@ -39,6 +39,59 @@ final class Token_Registry {
 	private bool $active = true;
 
 	/**
+	 * Register a user-created primitive. Throws when the id is already held by a non-user-created token.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id
+	 * @param string $type
+	 * @param string $label
+	 *
+	 * @throws \RuntimeException When the id belongs to a system registration.
+	 *
+	 * @return void
+	 */
+	public function register_user_primitive( string $id, string $type, string $label = '' ): void {
+		if ( isset( $this->tokens[ $id ] ) && ! $this->tokens[ $id ]->is_user_created() ) {
+			throw new \RuntimeException(
+				sprintf( 'Cannot register user primitive "%s": id is already registered as a system token.', $id )
+			);
+		}
+
+		$this->tokens[ $id ] = Token_Definition::from_user_primitive( $id, $type, $label );
+	}
+
+	/**
+	 * Remove a user-created primitive. Only removes the entry when it is user-created.
+	 * No-op when the id is absent or belongs to a system token.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id
+	 *
+	 * @return void
+	 */
+	public function deregister_user_primitive( string $id ): void {
+		if ( isset( $this->tokens[ $id ] ) && $this->tokens[ $id ]->is_user_created() ) {
+			unset( $this->tokens[ $id ] );
+		}
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @return string[]
+	 */
+	public function user_created_ids(): array {
+		return array_keys(
+			array_filter(
+				$this->tokens,
+				static fn( Token_Definition $t ): bool => $t->is_user_created()
+			)
+		);
+	}
+
+	/**
 	 * Register a single token from its declaration array.
 	 *
 	 * @since TBD
@@ -289,6 +342,7 @@ final class Token_Registry {
 				'label'       => $token->label,
 				'cssVar'      => $token->css_var,
 				'projections' => $token->projections,
+				'userCreated' => $token->is_user_created(),
 			];
 		}
 
@@ -320,7 +374,11 @@ final class Token_Registry {
 	public function missing_from_baseline( Baseline_Document $baseline ): array {
 		$missing = [];
 
-		foreach ( $this->tokens as $id => $_token ) {
+		foreach ( $this->tokens as $id => $token ) {
+			if ( $token->is_user_created() ) {
+				continue;
+			}
+
 			if ( ! $baseline->has( $id ) ) {
 				$missing[] = $id;
 			}

--- a/tests/snapshot/Resources/Design_Tokens/Admin/Feed/__snapshots__/Builder_SnapshotTest__testFullPayloadMatchesSnapshot__1.txt
+++ b/tests/snapshot/Resources/Design_Tokens/Admin/Feed/__snapshots__/Builder_SnapshotTest__testFullPayloadMatchesSnapshot__1.txt
@@ -13,7 +13,8 @@
                     "projections": {
                         "wp_preset": "color",
                         "kadence_slot": "palette1"
-                    }
+                    },
+                    "userCreated": false
                 },
                 {
                     "id": "semantic.color.button-text",
@@ -22,7 +23,8 @@
                     "cssVar": "--kb-token--semantic--color--button-text",
                     "projections": {
                         "wp_preset": "color"
-                    }
+                    },
+                    "userCreated": false
                 }
             ],
             "Layout": [
@@ -33,7 +35,8 @@
                     "cssVar": "--kb-token--semantic--spacing--md",
                     "projections": {
                         "wp_preset": "spacing"
-                    }
+                    },
+                    "userCreated": false
                 }
             ]
         }

--- a/tests/wpunit/Resources/Design_Tokens/Document/User_Primitive_Document_ValidatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/User_Primitive_Document_ValidatorTest.php
@@ -301,14 +301,7 @@ final class User_Primitive_Document_ValidatorTest extends TestCase {
 	public function testIdCollidingWithUserCreatedRegistryTokenReturnsNoSystemCollisionError(): void {
 		$id       = 'primitive.color.custom.brand';
 		$registry = new Token_Registry();
-		$registry->register(
-			[
-				'id'           => $id,
-				'type'         => 'color',
-				'label'        => 'User Brand',
-				'user_created' => true,
-			] 
-		);
+		$registry->register_user_primitive( $id, 'color', 'User Brand' );
 		$sut = new User_Primitive_Document_Validator( $this->index, $this->baseline, $registry );
 		$doc = $this->doc_with_color_entry( $id, 'Brand', '#3182CE' );
 

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Token_DefinitionTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Token_DefinitionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Registry;
 
+use Generator;
 use InvalidArgumentException;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Definition;
 use Tests\Support\Classes\TestCase;
@@ -178,5 +179,82 @@ final class Token_DefinitionTest extends TestCase {
 			'non-string css_var'    => [ $base + [ 'css_var' => 123 ] ],
 			'non-array projections' => [ $base + [ 'projections' => 'wp_preset' ] ],
 		];
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFromUserPrimitiveProducesUserCreatedToken(): void {
+		$token = Token_Definition::from_user_primitive( 'user.color.primary-blue', 'color', 'Primary Blue' );
+
+		$this->assertTrue( $token->is_user_created() );
+		$this->assertSame( 'user.color.primary-blue', $token->id );
+		$this->assertSame( 'color', $token->type );
+		$this->assertSame( 'Primary Blue', $token->label );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFromArrayProducesNonUserCreatedToken(): void {
+		$token = Token_Definition::from_array(
+			[
+				'id'    => 'semantic.color.button-bg',
+				'type'  => 'color',
+				'label' => 'Button Background',
+			]
+		);
+
+		$this->assertFalse( $token->is_user_created() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFromUserPrimitiveThrowsOnInvalidId(): void {
+		$this->expectException( InvalidArgumentException::class );
+
+		Token_Definition::from_user_primitive( 'user.color.primaryBlue', 'color' );
+	}
+
+	/**
+	 * @dataProvider userPrimitiveLabelDerivationProvider
+	 *
+	 * @param string $id
+	 * @param string $expected_label
+	 *
+	 * @return void
+	 */
+	public function testFromUserPrimitiveDerivesLabelFromTerminalSlug( string $id, string $expected_label ): void {
+		$token = Token_Definition::from_user_primitive( $id, 'color' );
+
+		$this->assertSame( $expected_label, $token->label );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function userPrimitiveLabelDerivationProvider(): Generator {
+		yield 'hyphenated slug' => [
+			'id'             => 'user.color.primary-blue',
+			'expected_label' => 'Primary Blue',
+		];
+		yield 'single segment' => [
+			'id'             => 'primary',
+			'expected_label' => 'Primary',
+		];
+		yield 'multi-word slug' => [
+			'id'             => 'user.color.brand-accent-dark',
+			'expected_label' => 'Brand Accent Dark',
+		];
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFromUserPrimitiveUsesExplicitLabelWhenProvided(): void {
+		$token = Token_Definition::from_user_primitive( 'user.color.primary-blue', 'color', 'My Custom Label' );
+
+		$this->assertSame( 'My Custom Label', $token->label );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
@@ -5,6 +5,7 @@ namespace Tests\wpunit\Resources\Design_Tokens\Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Definition;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use RuntimeException;
 use Tests\Support\Classes\TestCase;
 
 final class Token_RegistryTest extends TestCase {
@@ -119,7 +120,7 @@ final class Token_RegistryTest extends TestCase {
 
 		$entry = $schema['groups']['Brand'][0];
 		$this->assertSame(
-			[ 'id', 'type', 'label', 'cssVar', 'projections' ],
+			[ 'id', 'type', 'label', 'cssVar', 'projections', 'userCreated' ],
 			array_keys( $entry )
 		);
 		$this->assertArrayNotHasKey( 'value', $entry );
@@ -181,5 +182,118 @@ final class Token_RegistryTest extends TestCase {
 		};
 
 		$this->assertSame( [ 'semantic.spacing.md' ], $this->registry->missing_from_baseline( $baseline ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRegisterUserPrimitiveAddsUserCreatedToken(): void {
+		$this->registry->register_user_primitive( 'user.color.brand', 'color', 'Brand' );
+
+		$token = $this->registry->get( 'user.color.brand' );
+		$this->assertNotNull( $token );
+		$this->assertTrue( $token->is_user_created() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRegisterUserPrimitiveReplacesExistingUserCreatedToken(): void {
+		$this->registry->register_user_primitive( 'user.color.brand', 'color', 'Old Label' );
+		$this->registry->register_user_primitive( 'user.color.brand', 'color', 'New Label' );
+
+		$token = $this->registry->get( 'user.color.brand' );
+		$this->assertNotNull( $token );
+		$this->assertSame( 'New Label', $token->label );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRegisterUserPrimitiveThrowsWhenIdIsSystemToken(): void {
+		$this->register_button_bg();
+
+		$this->expectException( RuntimeException::class );
+
+		$this->registry->register_user_primitive( 'semantic.color.button-bg', 'color', 'Brand' );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeregisterUserPrimitiveRemovesUserCreatedToken(): void {
+		$this->registry->register_user_primitive( 'user.color.brand', 'color', 'Brand' );
+		$this->registry->deregister_user_primitive( 'user.color.brand' );
+
+		$this->assertNull( $this->registry->get( 'user.color.brand' ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeregisterUserPrimitiveIsNoOpForSystemToken(): void {
+		$this->register_button_bg();
+		$this->registry->deregister_user_primitive( 'semantic.color.button-bg' );
+
+		$this->assertNotNull( $this->registry->get( 'semantic.color.button-bg' ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeregisterUserPrimitiveIsNoOpForAbsentId(): void {
+		$this->registry->deregister_user_primitive( 'user.color.nonexistent' );
+
+		$this->assertFalse( $this->registry->has( 'user.color.nonexistent' ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testUserCreatedIdsReturnsOnlyUserCreatedIds(): void {
+		$this->register_button_bg();
+		$this->registry->register_user_primitive( 'user.color.brand', 'color', 'Brand' );
+		$this->registry->register_user_primitive( 'user.color.accent', 'color', 'Accent' );
+
+		$this->assertSame(
+			[ 'user.color.brand', 'user.color.accent' ],
+			$this->registry->user_created_ids()
+		);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMissingFromBaselineSkipsUserCreatedTokens(): void {
+		$this->register_button_bg();
+		$this->registry->register_user_primitive( 'user.color.brand', 'color', 'Brand' );
+
+		$baseline = new class() implements Baseline_Document {
+			public function has( string $id ): bool {
+				return false;
+			}
+
+			public function document(): array {
+				return [];
+			}
+		};
+
+		$this->assertSame( [ 'semantic.color.button-bg' ], $this->registry->missing_from_baseline( $baseline ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testToUiSchemaEmitsUserCreatedField(): void {
+		$this->register_button_bg();
+		$this->registry->register_user_primitive( 'user.color.brand', 'color', 'Brand' );
+
+		$schema = $this->registry->to_ui_schema();
+
+		$system_entry = $schema['groups']['Brand'][0];
+		$this->assertFalse( $system_entry['userCreated'] );
+
+		$user_entry = $schema['groups'][''][0];
+		$this->assertTrue( $user_entry['userCreated'] );
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `Token_Registry::register_user_primitive()` / `deregister_user_primitive()` / `user_created_ids()`, the registry-facing lifecycle for user-created tokens (building on `Token_Definition::from_user_primitive()` / `is_user_created()`, which landed earlier in the stack).
- `register_user_primitive()` throws when the id is already held by a non-user-created (system) token; re-registering an existing user-created id silently replaces it.
- `missing_from_baseline()` now skips user-created tokens (they intentionally have no baseline entry).
- `to_ui_schema()` now emits a `userCreated` flag per token.
- Fixes a pre-existing test (`User_Primitive_Document_ValidatorTest::testIdCollidingWithUserCreatedRegistryTokenReturnsNoSystemCollisionError`) that had been registering a user-created token through `register()`'s array shape — `from_array()` intentionally never produces a user-created definition, so the test now uses `register_user_primitive()`. Updates the Style Book feed snapshot fixture for the new `userCreated` field.

## Test plan
- [x] `Token_DefinitionTest` / `Token_RegistryTest` cover `from_user_primitive()` vs `from_array()` provenance, collision handling, deregistration, `missing_from_baseline()` skip, and `to_ui_schema()`'s `userCreated` flag.
- [x] PHPStan clean
- [x] cspell clean
- [x] Full wpunit/acceptance/snapshot suites pass (pre-push CI-equivalent hook)