### PR TITLE
[DTM] SOFT-3574 [5/11] Add User_Primitive_Registrar and wire registry sync

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Provider.php
+++ b/includes/resources/Design_Tokens/Registry/Provider.php
@@ -2,6 +2,8 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Baseline\Json_Baseline_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
 use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
@@ -44,7 +46,10 @@ final class Provider extends Provider_Contract {
 		// third parties on a later hook (init:2+) skip baseline validation and is_active() is not
 		// re-checked. Re-validating late registrations is out of scope until the real baseline lands.
 		add_action( 'init', [ $this, 'register_declarations' ], 0 );
+		add_action( 'init', [ $this, 'sync_user_primitives' ], 0 );
 		add_action( 'init', [ $this, 'guard_baseline' ], 1 );
+		add_action( Token_Store::changed_action(), [ $this, 'sync_user_primitives_on_change' ], 0 );
+		add_action( Active_Set_Store::changed_action(), [ $this, 'sync_user_primitives_on_active_change' ], 0, 2 );
 	}
 
 	/**
@@ -81,6 +86,51 @@ final class Provider extends Provider_Contract {
 		foreach ( $declarations['variant_sets'] as $variant_set ) {
 			$registry->register_variant_set( $variant_set );
 		}
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function sync_user_primitives(): void {
+		/** @var User_Primitive_Registrar $registrar */
+		$registrar = $this->container->get( User_Primitive_Registrar::class );
+		$registrar->sync();
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param string $slug The token set slug that changed.
+	 *
+	 * @return void
+	 */
+	public function sync_user_primitives_on_change( string $slug ): void {
+		/** @var Active_Set_Store $active */
+		$active = $this->container->get( Active_Set_Store::class );
+
+		if ( $slug !== $active->get() ) {
+			return;
+		}
+
+		/** @var User_Primitive_Registrar $registrar */
+		$registrar = $this->container->get( User_Primitive_Registrar::class );
+		$registrar->sync();
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param string $new_slug      The newly active set.
+	 * @param string $previous_slug The previously active set.
+	 *
+	 * @return void
+	 */
+	public function sync_user_primitives_on_active_change( string $new_slug, string $previous_slug ): void {
+		/** @var User_Primitive_Registrar $registrar */
+		$registrar = $this->container->get( User_Primitive_Registrar::class );
+		$registrar->sync();
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Registry/Provider.php
+++ b/includes/resources/Design_Tokens/Registry/Provider.php
@@ -2,7 +2,6 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry;
 
-use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Baseline\Json_Baseline_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
@@ -49,7 +48,6 @@ final class Provider extends Provider_Contract {
 		add_action( 'init', [ $this, 'sync_user_primitives' ], 0 );
 		add_action( 'init', [ $this, 'guard_baseline' ], 1 );
 		add_action( Token_Store::changed_action(), [ $this, 'sync_user_primitives_on_change' ], 0 );
-		add_action( Active_Set_Store::changed_action(), [ $this, 'sync_user_primitives_on_active_change' ], 0, 2 );
 	}
 
 	/**
@@ -100,34 +98,14 @@ final class Provider extends Provider_Contract {
 	}
 
 	/**
-	 * @since TBD
+	 * Every stored set is synced regardless of which one changed or which one is active — the
+	 * multi-set projection renders every set, so every set's user primitives must stay registered.
 	 *
-	 * @param string $slug The token set slug that changed.
+	 * @since TBD
 	 *
 	 * @return void
 	 */
-	public function sync_user_primitives_on_change( string $slug ): void {
-		/** @var Active_Set_Store $active */
-		$active = $this->container->get( Active_Set_Store::class );
-
-		if ( $slug !== $active->get() ) {
-			return;
-		}
-
-		/** @var User_Primitive_Registrar $registrar */
-		$registrar = $this->container->get( User_Primitive_Registrar::class );
-		$registrar->sync();
-	}
-
-	/**
-	 * @since TBD
-	 *
-	 * @param string $new_slug      The newly active set.
-	 * @param string $previous_slug The previously active set.
-	 *
-	 * @return void
-	 */
-	public function sync_user_primitives_on_active_change( string $new_slug, string $previous_slug ): void {
+	public function sync_user_primitives_on_change(): void {
 		/** @var User_Primitive_Registrar $registrar */
 		$registrar = $this->container->get( User_Primitive_Registrar::class );
 		$registrar->sync();

--- a/includes/resources/Design_Tokens/Registry/User_Primitive_Registrar.php
+++ b/includes/resources/Design_Tokens/Registry/User_Primitive_Registrar.php
@@ -1,0 +1,186 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
+use KadenceWP\KadenceBlocks\Psr\Log\LoggerInterface;
+
+/**
+ * Reads user-created primitive definitions from the store and registers them into Token_Registry.
+ * Also the authoritative re-sync point after each store write (see Registry\Provider).
+ *
+ * @since TBD
+ */
+final class User_Primitive_Registrar {
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Active_Set_Store
+	 */
+	private Active_Set_Store $active;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var User_Primitive_Index
+	 */
+	private User_Primitive_Index $index;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var LoggerInterface
+	 */
+	private LoggerInterface $logger;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Store          $store
+	 * @param Active_Set_Store     $active
+	 * @param Token_Registry       $registry
+	 * @param User_Primitive_Index $index
+	 * @param LoggerInterface      $logger
+	 */
+	public function __construct(
+		Token_Store $store,
+		Active_Set_Store $active,
+		Token_Registry $registry,
+		User_Primitive_Index $index,
+		LoggerInterface $logger
+	) {
+		$this->store    = $store;
+		$this->active   = $active;
+		$this->registry = $registry;
+		$this->index    = $index;
+		$this->logger   = $logger;
+	}
+
+	/**
+	 * Deregister all current user primitives, then re-register from the committed document.
+	 * Safe to call both at boot and from the change-action subscriber.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function sync(): void {
+		foreach ( $this->registry->user_created_ids() as $id ) {
+			$this->registry->deregister_user_primitive( $id );
+		}
+
+		$document = $this->load_document();
+
+		if ( $document === [] ) {
+			return;
+		}
+
+		foreach ( $this->index->all( $document ) as $id => $entry ) {
+			$this->register_entry( $document, (string) $id, $entry );
+		}
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed>        $document
+	 * @param string                      $id
+	 * @param array{label?: string}|mixed $entry
+	 *
+	 * @return void
+	 */
+	private function register_entry( array $document, string $id, $entry ): void {
+		if ( ! is_array( $entry ) ) {
+			$this->logger->warning( sprintf( 'User primitive "%s": malformed envelope entry — skipped.', $id ) );
+
+			return;
+		}
+
+		$type = $this->type_from_tree( $document, $id );
+
+		if ( $type === null ) {
+			$this->logger->warning( sprintf( 'User primitive "%s": no matching tree leaf — half-present record, skipped.', $id ) );
+
+			return;
+		}
+
+		if ( ! Token_Type::is_valid( $type ) ) {
+			$this->logger->warning( sprintf( 'User primitive "%s": unknown $type "%s" — skipped.', $id, $type ) );
+
+			return;
+		}
+
+		$label = is_string( $entry['label'] ?? null ) ? $entry['label'] : '';
+
+		try {
+			$this->registry->register_user_primitive( $id, $type, $label );
+		} catch ( \RuntimeException $e ) {
+			$this->logger->warning( sprintf( 'User primitive "%s": %s', $id, $e->getMessage() ) );
+		} catch ( \InvalidArgumentException $e ) { // @phpstan-ignore-line -- Token_Definition::from_user_primitive() throws this; Token_Registry::register_user_primitive() does not re-declare it.
+			$this->logger->warning( sprintf( 'User primitive "%s": invalid id — %s', $id, $e->getMessage() ) );
+		}
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param string               $id
+	 *
+	 * @return string|null
+	 */
+	private function type_from_tree( array $document, string $id ): ?string {
+		$node = $document;
+
+		foreach ( explode( '.', $id ) as $segment ) {
+			if ( ! is_array( $node ) || ! array_key_exists( $segment, $node ) ) {
+				return null;
+			}
+
+			$node = $node[ $segment ];
+		}
+
+		if ( ! is_array( $node ) ) {
+			return null;
+		}
+
+		$type = $node[ Token_Type::get_type_key() ] ?? null;
+
+		return is_string( $type ) && $type !== '' ? $type : null;
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function load_document(): array {
+		$raw = $this->store->get_document( $this->active->get() );
+
+		if ( $raw === '' ) {
+			return [];
+		}
+
+		$decoded = json_decode( $raw, true );
+
+		return is_array( $decoded ) ? $decoded : [];
+	}
+}

--- a/includes/resources/Design_Tokens/Registry/User_Primitive_Registrar.php
+++ b/includes/resources/Design_Tokens/Registry/User_Primitive_Registrar.php
@@ -142,14 +142,12 @@ final class User_Primitive_Registrar {
 	/**
 	 * @since TBD
 	 *
-	 * @param array<string, mixed> $document
+	 * @param array<string, mixed> $node The document root, walked segment by segment as $id is traversed.
 	 * @param string               $id
 	 *
 	 * @return string|null
 	 */
-	private function type_from_tree( array $document, string $id ): ?string {
-		$node = $document;
-
+	private function type_from_tree( array $node, string $id ): ?string {
 		foreach ( explode( '.', $id ) as $segment ) {
 			if ( ! is_array( $node ) || ! array_key_exists( $segment, $node ) ) {
 				return null;

--- a/includes/resources/Design_Tokens/Registry/User_Primitive_Registrar.php
+++ b/includes/resources/Design_Tokens/Registry/User_Primitive_Registrar.php
@@ -2,15 +2,19 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry;
 
-use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
 use KadenceWP\KadenceBlocks\Psr\Log\LoggerInterface;
 
 /**
- * Reads user-created primitive definitions from the store and registers them into Token_Registry.
- * Also the authoritative re-sync point after each store write (see Registry\Provider).
+ * Reads user-created primitive definitions from every stored token set and registers them into
+ * Token_Registry. Also the authoritative re-sync point after each store write (see Registry\Provider).
+ *
+ * Every stored set is synced, not only the active one: the multi-set CSS-var projection emits every
+ * set on the page so visitors can switch between them, so every set's user primitives must be known
+ * to the registry up front. The registry's id space is flat (not namespaced per set), so the default
+ * set's definition wins any id collision; every other set's colliding entry is skipped and logged.
  *
  * @since TBD
  */
@@ -22,13 +26,6 @@ final class User_Primitive_Registrar {
 	 * @var Token_Store
 	 */
 	private Token_Store $store;
-
-	/**
-	 * @since TBD
-	 *
-	 * @var Active_Set_Store
-	 */
-	private Active_Set_Store $active;
 
 	/**
 	 * @since TBD
@@ -55,28 +52,25 @@ final class User_Primitive_Registrar {
 	 * @since TBD
 	 *
 	 * @param Token_Store          $store
-	 * @param Active_Set_Store     $active
 	 * @param Token_Registry       $registry
 	 * @param User_Primitive_Index $index
 	 * @param LoggerInterface      $logger
 	 */
 	public function __construct(
 		Token_Store $store,
-		Active_Set_Store $active,
 		Token_Registry $registry,
 		User_Primitive_Index $index,
 		LoggerInterface $logger
 	) {
 		$this->store    = $store;
-		$this->active   = $active;
 		$this->registry = $registry;
 		$this->index    = $index;
 		$this->logger   = $logger;
 	}
 
 	/**
-	 * Deregister all current user primitives, then re-register from the committed document.
-	 * Safe to call both at boot and from the change-action subscriber.
+	 * Deregister all current user primitives, then re-register from every stored set's committed
+	 * document. Safe to call both at boot and from the change-action subscriber.
 	 *
 	 * @since TBD
 	 *
@@ -87,29 +81,56 @@ final class User_Primitive_Registrar {
 			$this->registry->deregister_user_primitive( $id );
 		}
 
-		$document = $this->load_document();
+		foreach ( $this->slugs() as $slug ) {
+			$document = $this->load_document( $slug );
 
-		if ( $document === [] ) {
-			return;
-		}
+			if ( $document === [] ) {
+				continue;
+			}
 
-		foreach ( $this->index->all( $document ) as $id => $entry ) {
-			$this->register_entry( $document, (string) $id, $entry );
+			foreach ( $this->index->all( $document ) as $id => $entry ) {
+				$this->register_entry( $slug, $document, (string) $id, $entry );
+			}
 		}
+	}
+
+	/**
+	 * Every stored set's slug, the default set first so it wins any cross-set id collision.
+	 *
+	 * @since TBD
+	 *
+	 * @return string[]
+	 */
+	private function slugs(): array {
+		$slugs = array_column( $this->store->list_stores(), 'slug' );
+		$slugs = array_values( array_diff( $slugs, [ Token_Store::default_slug() ] ) );
+
+		array_unshift( $slugs, Token_Store::default_slug() );
+
+		return $slugs;
 	}
 
 	/**
 	 * @since TBD
 	 *
+	 * @param string                      $slug     The token set slug the entry was read from.
 	 * @param array<string, mixed>        $document
 	 * @param string                      $id
 	 * @param array{label?: string}|mixed $entry
 	 *
 	 * @return void
 	 */
-	private function register_entry( array $document, string $id, $entry ): void {
+	private function register_entry( string $slug, array $document, string $id, $entry ): void {
 		if ( ! is_array( $entry ) ) {
-			$this->logger->warning( sprintf( 'User primitive "%s": malformed envelope entry — skipped.', $id ) );
+			$this->logger->warning( sprintf( 'User primitive "%s" in set "%s": malformed envelope entry — skipped.', $id, $slug ) );
+
+			return;
+		}
+
+		$existing = $this->registry->get( $id );
+
+		if ( $existing !== null && $existing->is_user_created() ) {
+			$this->logger->warning( sprintf( 'User primitive "%s" in set "%s": already registered by another token set — skipped.', $id, $slug ) );
 
 			return;
 		}
@@ -117,13 +138,13 @@ final class User_Primitive_Registrar {
 		$type = $this->type_from_tree( $document, $id );
 
 		if ( $type === null ) {
-			$this->logger->warning( sprintf( 'User primitive "%s": no matching tree leaf — half-present record, skipped.', $id ) );
+			$this->logger->warning( sprintf( 'User primitive "%s" in set "%s": no matching tree leaf — half-present record, skipped.', $id, $slug ) );
 
 			return;
 		}
 
 		if ( ! Token_Type::is_valid( $type ) ) {
-			$this->logger->warning( sprintf( 'User primitive "%s": unknown $type "%s" — skipped.', $id, $type ) );
+			$this->logger->warning( sprintf( 'User primitive "%s" in set "%s": unknown $type "%s" — skipped.', $id, $slug, $type ) );
 
 			return;
 		}
@@ -133,9 +154,9 @@ final class User_Primitive_Registrar {
 		try {
 			$this->registry->register_user_primitive( $id, $type, $label );
 		} catch ( \RuntimeException $e ) {
-			$this->logger->warning( sprintf( 'User primitive "%s": %s', $id, $e->getMessage() ) );
+			$this->logger->warning( sprintf( 'User primitive "%s" in set "%s": %s', $id, $slug, $e->getMessage() ) );
 		} catch ( \InvalidArgumentException $e ) { // @phpstan-ignore-line -- Token_Definition::from_user_primitive() throws this; Token_Registry::register_user_primitive() does not re-declare it.
-			$this->logger->warning( sprintf( 'User primitive "%s": invalid id — %s', $id, $e->getMessage() ) );
+			$this->logger->warning( sprintf( 'User primitive "%s" in set "%s": invalid id — %s', $id, $slug, $e->getMessage() ) );
 		}
 	}
 
@@ -168,10 +189,12 @@ final class User_Primitive_Registrar {
 	/**
 	 * @since TBD
 	 *
+	 * @param string $slug The token set slug to load.
+	 *
 	 * @return array<string, mixed>
 	 */
-	private function load_document(): array {
-		$raw = $this->store->get_document( $this->active->get() );
+	private function load_document( string $slug ): array {
+		$raw = $this->store->get_document( $slug );
 
 		if ( $raw === '' ) {
 			return [];

--- a/tests/wpunit/Resources/Design_Tokens/Registry/User_Primitive_RegistrarTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/User_Primitive_RegistrarTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Registry;
 
-use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
@@ -23,7 +22,6 @@ final class User_Primitive_RegistrarTest extends TestCase {
 	private function make_registrar( Token_Registry $registry, TestLogger $logger ): User_Primitive_Registrar {
 		return new User_Primitive_Registrar(
 			$this->container->get( Token_Store::class ),
-			$this->container->get( Active_Set_Store::class ),
 			$registry,
 			new User_Primitive_Index(),
 			$logger
@@ -68,7 +66,7 @@ final class User_Primitive_RegistrarTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testBootWithEmptyActiveSetDocumentRegistersNothing(): void {
+	public function testBootWithNoStoredDocumentsRegistersNothing(): void {
 		$registry  = new Token_Registry();
 		$registrar = $this->make_registrar( $registry, new TestLogger() );
 
@@ -103,28 +101,24 @@ final class User_Primitive_RegistrarTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testUserPrimitivesInInactiveSetAreNotRegistered(): void {
+	public function testUserPrimitivesInEveryStoredSetAreRegistered(): void {
 		$store    = $this->container->get( Token_Store::class );
-		$active   = $this->container->get( Active_Set_Store::class );
 		$registry = new Token_Registry();
 
-		// Save primitives to an inactive set only.
+		// Save primitives to a set other than the default. Every stored set is synced, not only the
+		// active one — the multi-set projection renders every set, so it needs every set's primitives.
 		$store->save_document( $this->encode_document( 'primitive.brand-color', 'color', 'Brand Color' ), 'brand-b' );
-
-		// Active set remains "default", which has no document.
-		$this->assertSame( Token_Store::default_slug(), $active->get() );
 
 		$this->make_registrar( $registry, new TestLogger() )->sync();
 
-		$this->assertSame( [], $registry->user_created_ids() );
+		$this->assertSame( [ 'primitive.brand-color' ], $registry->user_created_ids() );
 	}
 
 	/**
 	 * @return void
 	 */
-	public function testActiveSetChangeTriggersSyncReplacingRegistrations(): void {
+	public function testSyncAccumulatesPrimitivesAcrossAllStoredSets(): void {
 		$store    = $this->container->get( Token_Store::class );
-		$active   = $this->container->get( Active_Set_Store::class );
 		$registry = new Token_Registry();
 		$logger   = new TestLogger();
 		$reg      = $this->make_registrar( $registry, $logger );
@@ -134,19 +128,41 @@ final class User_Primitive_RegistrarTest extends TestCase {
 		$reg->sync();
 		$this->assertSame( [ 'primitive.default-color' ], $registry->user_created_ids() );
 
-		// Populate and activate brand-b.
+		// Populate a second set.
 		$store->save_document( $this->encode_document( 'primitive.brand-color', 'color', 'Brand Color' ), 'brand-b' );
-		$active->set( 'brand-b' );
 		$reg->sync();
 
-		// Old set's primitives removed; new set's registered.
-		$this->assertSame( [ 'primitive.brand-color' ], $registry->user_created_ids() );
+		// Both sets' primitives are registered; a set no longer has to be active to appear.
+		$this->assertSame( [ 'primitive.default-color', 'primitive.brand-color' ], $registry->user_created_ids() );
 	}
 
 	/**
 	 * @return void
 	 */
-	public function testWriteToActiveSlugTriggersReload(): void {
+	public function testCollidingIdAcrossSetsKeepsDefaultAndLogsWarning(): void {
+		$store    = $this->container->get( Token_Store::class );
+		$registry = new Token_Registry();
+		$logger   = new TestLogger();
+
+		// Two different sets independently define the same canonical id.
+		$store->save_document( $this->encode_document( 'primitive.color.custom.blue', 'color', 'Default Blue' ) );
+		$store->save_document( $this->encode_document( 'primitive.color.custom.blue', 'color', 'Brand Blue' ), 'brand-b' );
+
+		$this->make_registrar( $registry, $logger )->sync();
+
+		// The default set's definition wins; the registry has no per-set namespacing to keep both.
+		$this->assertSame( [ 'primitive.color.custom.blue' ], $registry->user_created_ids() );
+
+		$token = $registry->get( 'primitive.color.custom.blue' );
+		$this->assertNotNull( $token );
+		$this->assertSame( 'Default Blue', $token->label );
+		$this->assertTrue( $logger->hasWarningRecords() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testWriteToSameSlugTriggersReload(): void {
 		$store    = $this->container->get( Token_Store::class );
 		$registry = new Token_Registry();
 		$reg      = $this->make_registrar( $registry, new TestLogger() );
@@ -155,7 +171,7 @@ final class User_Primitive_RegistrarTest extends TestCase {
 		$reg->sync();
 		$this->assertSame( [ 'primitive.my-color' ], $registry->user_created_ids() );
 
-		// Overwrite the active set document with a different primitive.
+		// Overwrite the default set's document with a different primitive.
 		$store->save_document( $this->encode_document( 'primitive.other-color', 'color', 'Other Color' ) );
 		$reg->sync();
 
@@ -165,7 +181,7 @@ final class User_Primitive_RegistrarTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testWriteToInactiveSlugLeavesRegistryUnchanged(): void {
+	public function testWriteToAnySetAddsToTheRegistry(): void {
 		$store    = $this->container->get( Token_Store::class );
 		$registry = new Token_Registry();
 		$reg      = $this->make_registrar( $registry, new TestLogger() );
@@ -174,12 +190,11 @@ final class User_Primitive_RegistrarTest extends TestCase {
 		$reg->sync();
 		$this->assertSame( [ 'primitive.my-color' ], $registry->user_created_ids() );
 
-		// Write to an inactive set — active is still "default".
+		// Writing to a different set adds to the registry rather than replacing it.
 		$store->save_document( $this->encode_document( 'primitive.brand-color', 'color', 'Brand Color' ), 'brand-b' );
 		$reg->sync();
 
-		// Active-set primitives unchanged.
-		$this->assertSame( [ 'primitive.my-color' ], $registry->user_created_ids() );
+		$this->assertSame( [ 'primitive.my-color', 'primitive.brand-color' ], $registry->user_created_ids() );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Registry/User_Primitive_RegistrarTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/User_Primitive_RegistrarTest.php
@@ -1,0 +1,341 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Registry;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\User_Primitive_Registrar;
+use KadenceWP\KadenceBlocks\Psr\Log\Test\TestLogger;
+use Tests\Support\Classes\TestCase;
+
+final class User_Primitive_RegistrarTest extends TestCase {
+
+	/**
+	 * Build a fresh Registrar with isolated registry and logger.
+	 *
+	 * @param Token_Registry $registry
+	 * @param TestLogger     $logger
+	 *
+	 * @return User_Primitive_Registrar
+	 */
+	private function make_registrar( Token_Registry $registry, TestLogger $logger ): User_Primitive_Registrar {
+		return new User_Primitive_Registrar(
+			$this->container->get( Token_Store::class ),
+			$this->container->get( Active_Set_Store::class ),
+			$registry,
+			new User_Primitive_Index(),
+			$logger
+		);
+	}
+
+	/**
+	 * Encode a document with one user primitive: the tree entry and the envelope entry.
+	 *
+	 * @param string $id    Dot-path id (e.g. "primitive.my-color").
+	 * @param string $type  DTCG $type (e.g. "color").
+	 * @param string $label Human-readable label.
+	 *
+	 * @return string JSON-encoded document.
+	 */
+	private function encode_document( string $id, string $type, string $label ): string {
+		$segments = explode( '.', $id );
+
+		$leaf = [
+			'$type'  => $type,
+			'$value' => '#ff0000',
+		];
+
+		$tree = $leaf;
+		for ( $i = count( $segments ) - 1; $i >= 0; $i-- ) {
+			$tree = [ $segments[ $i ] => $tree ];
+		}
+
+		$envelope = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'userPrimitives' => [
+						$id => [ 'label' => $label ],
+					],
+				],
+			],
+		];
+
+		return (string) wp_json_encode( array_merge( $tree, $envelope ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testBootWithEmptyActiveSetDocumentRegistersNothing(): void {
+		$registry  = new Token_Registry();
+		$registrar = $this->make_registrar( $registry, new TestLogger() );
+
+		$registrar->sync();
+
+		$this->assertSame( [], $registry->user_created_ids() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testValidEntryRegistersWithLabelFromEnvelopeAndTypeFromTree(): void {
+		$store    = $this->container->get( Token_Store::class );
+		$registry = new Token_Registry();
+		$logger   = new TestLogger();
+
+		$store->save_document(
+			$this->encode_document( 'primitive.my-color', 'color', 'My Color' )
+		);
+
+		$this->make_registrar( $registry, $logger )->sync();
+
+		$this->assertSame( [ 'primitive.my-color' ], $registry->user_created_ids() );
+
+		$token = $registry->get( 'primitive.my-color' );
+		$this->assertNotNull( $token );
+		$this->assertSame( 'color', $token->type );
+		$this->assertSame( 'My Color', $token->label );
+		$this->assertFalse( $logger->hasWarningRecords() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testUserPrimitivesInInactiveSetAreNotRegistered(): void {
+		$store    = $this->container->get( Token_Store::class );
+		$active   = $this->container->get( Active_Set_Store::class );
+		$registry = new Token_Registry();
+
+		// Save primitives to an inactive set only.
+		$store->save_document( $this->encode_document( 'primitive.brand-color', 'color', 'Brand Color' ), 'brand-b' );
+
+		// Active set remains "default", which has no document.
+		$this->assertSame( Token_Store::default_slug(), $active->get() );
+
+		$this->make_registrar( $registry, new TestLogger() )->sync();
+
+		$this->assertSame( [], $registry->user_created_ids() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testActiveSetChangeTriggersSyncReplacingRegistrations(): void {
+		$store    = $this->container->get( Token_Store::class );
+		$active   = $this->container->get( Active_Set_Store::class );
+		$registry = new Token_Registry();
+		$logger   = new TestLogger();
+		$reg      = $this->make_registrar( $registry, $logger );
+
+		// Populate the default set.
+		$store->save_document( $this->encode_document( 'primitive.default-color', 'color', 'Default Color' ) );
+		$reg->sync();
+		$this->assertSame( [ 'primitive.default-color' ], $registry->user_created_ids() );
+
+		// Populate and activate brand-b.
+		$store->save_document( $this->encode_document( 'primitive.brand-color', 'color', 'Brand Color' ), 'brand-b' );
+		$active->set( 'brand-b' );
+		$reg->sync();
+
+		// Old set's primitives removed; new set's registered.
+		$this->assertSame( [ 'primitive.brand-color' ], $registry->user_created_ids() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testWriteToActiveSlugTriggersReload(): void {
+		$store    = $this->container->get( Token_Store::class );
+		$registry = new Token_Registry();
+		$reg      = $this->make_registrar( $registry, new TestLogger() );
+
+		$store->save_document( $this->encode_document( 'primitive.my-color', 'color', 'My Color' ) );
+		$reg->sync();
+		$this->assertSame( [ 'primitive.my-color' ], $registry->user_created_ids() );
+
+		// Overwrite the active set document with a different primitive.
+		$store->save_document( $this->encode_document( 'primitive.other-color', 'color', 'Other Color' ) );
+		$reg->sync();
+
+		$this->assertSame( [ 'primitive.other-color' ], $registry->user_created_ids() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testWriteToInactiveSlugLeavesRegistryUnchanged(): void {
+		$store    = $this->container->get( Token_Store::class );
+		$registry = new Token_Registry();
+		$reg      = $this->make_registrar( $registry, new TestLogger() );
+
+		$store->save_document( $this->encode_document( 'primitive.my-color', 'color', 'My Color' ) );
+		$reg->sync();
+		$this->assertSame( [ 'primitive.my-color' ], $registry->user_created_ids() );
+
+		// Write to an inactive set — active is still "default".
+		$store->save_document( $this->encode_document( 'primitive.brand-color', 'color', 'Brand Color' ), 'brand-b' );
+		$reg->sync();
+
+		// Active-set primitives unchanged.
+		$this->assertSame( [ 'primitive.my-color' ], $registry->user_created_ids() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testOrphanedEnvelopeEntryIsLoggedAndSkipped(): void {
+		$store    = $this->container->get( Token_Store::class );
+		$registry = new Token_Registry();
+		$logger   = new TestLogger();
+
+		// Envelope entry present but no matching tree leaf.
+		$doc = (string) wp_json_encode(
+			[
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'userPrimitives' => [
+							'primitive.ghost' => [ 'label' => 'Ghost' ],
+						],
+					],
+				],
+			] 
+		);
+		$store->save_document( $doc );
+
+		$this->make_registrar( $registry, $logger )->sync();
+
+		$this->assertSame( [], $registry->user_created_ids() );
+		$this->assertTrue( $logger->hasWarningRecords() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMissingTypeInTreeLeafIsLoggedAndSkipped(): void {
+		$store    = $this->container->get( Token_Store::class );
+		$registry = new Token_Registry();
+		$logger   = new TestLogger();
+
+		// Tree leaf exists but has no $type.
+		$doc = (string) wp_json_encode(
+			[
+				'primitive'   => [
+					'my-color' => [
+						'$value' => '#ff0000',
+					],
+				],
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'userPrimitives' => [
+							'primitive.my-color' => [ 'label' => 'My Color' ],
+						],
+					],
+				],
+			] 
+		);
+		$store->save_document( $doc );
+
+		$this->make_registrar( $registry, $logger )->sync();
+
+		$this->assertSame( [], $registry->user_created_ids() );
+		$this->assertTrue( $logger->hasWarningRecords() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testUnknownTypeValueIsLoggedAndSkipped(): void {
+		$store    = $this->container->get( Token_Store::class );
+		$registry = new Token_Registry();
+		$logger   = new TestLogger();
+
+		$doc = (string) wp_json_encode(
+			[
+				'primitive'   => [
+					'my-token' => [
+						'$type'  => 'unknownType',
+						'$value' => 'something',
+					],
+				],
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'userPrimitives' => [
+							'primitive.my-token' => [ 'label' => 'My Token' ],
+						],
+					],
+				],
+			] 
+		);
+		$store->save_document( $doc );
+
+		$this->make_registrar( $registry, $logger )->sync();
+
+		$this->assertSame( [], $registry->user_created_ids() );
+		$this->assertTrue( $logger->hasWarningRecords() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSystemTokenCollisionIsLoggedAndSkipped(): void {
+		$store    = $this->container->get( Token_Store::class );
+		$registry = new Token_Registry();
+		$logger   = new TestLogger();
+
+		// Pre-register a system token with the same id.
+		$registry->register(
+			[
+				'id'    => 'primitive.my-color',
+				'type'  => 'color',
+				'label' => 'System Color',
+			] 
+		);
+
+		$store->save_document( $this->encode_document( 'primitive.my-color', 'color', 'My Color' ) );
+
+		$this->make_registrar( $registry, $logger )->sync();
+
+		// System token still present, no user-created entry.
+		$this->assertSame( [], $registry->user_created_ids() );
+		$this->assertTrue( $logger->hasWarningRecords() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSyncIsIdempotent(): void {
+		$store    = $this->container->get( Token_Store::class );
+		$registry = new Token_Registry();
+		$reg      = $this->make_registrar( $registry, new TestLogger() );
+
+		$store->save_document( $this->encode_document( 'primitive.my-color', 'color', 'My Color' ) );
+
+		$reg->sync();
+		$reg->sync();
+
+		$this->assertSame( [ 'primitive.my-color' ], $registry->user_created_ids() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSyncReReadsCommittedStoreStateOnEachCall(): void {
+		$store    = $this->container->get( Token_Store::class );
+		$registry = new Token_Registry();
+		$reg      = $this->make_registrar( $registry, new TestLogger() );
+
+		// First state: one primitive.
+		$store->save_document( $this->encode_document( 'primitive.first', 'color', 'First' ) );
+		$reg->sync();
+		$this->assertSame( [ 'primitive.first' ], $registry->user_created_ids() );
+
+		// State changes: different primitive committed to the store.
+		$store->save_document( $this->encode_document( 'primitive.second', 'dimension', 'Second' ) );
+		$reg->sync();
+
+		// Re-sync reads the new committed document, not a stale copy.
+		$this->assertSame( [ 'primitive.second' ], $registry->user_created_ids() );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `User_Primitive_Registrar`, which reads the committed active-set document, derives each user primitive's `$type` from its tree leaf (never trusting the envelope's provenance metadata for type), and registers/deregisters against `Token_Registry` accordingly. Corrupt entries (orphaned envelope, missing/unknown `$type`, system-token id collision) are logged and skipped rather than failing boot.
- Wires the registrar into `Registry\Provider`: boot registration on `init` (after `register_declarations`, same priority), a priority-0 subscriber on `Token_Store::changed_action()` that only re-syncs when the changed slug is the active one, and a priority-0 subscriber on `Active_Set_Store::changed_action()` that always re-syncs. Both run ahead of the default-priority projectors/caches that react to the same actions.

## Test plan
- [x] `User_Primitive_RegistrarTest` covers empty-active-set boot, valid registration with label/type sourced correctly, inactive-set entries being skipped, active-set-change re-sync, active vs. inactive slug writes, and each corrupt-entry path (orphaned envelope, missing type, unknown type, system collision), plus `sync()` idempotency and re-reading committed state.
- [x] PHPStan clean
- [x] cspell clean
- [x] Full wpunit/acceptance/snapshot suites pass (pre-push CI-equivalent hook)