### PR TITLE
[DTM] SOFT-3574 [7/11] Add Document_Write_Pipeline

### DIFF
--- a/includes/resources/Design_Tokens/Document/Document_Path.php
+++ b/includes/resources/Design_Tokens/Document/Document_Path.php
@@ -1,0 +1,35 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Document;
+
+/**
+ * Dot-path lookups within a decoded DTCG document.
+ *
+ * @since TBD
+ */
+final class Document_Path {
+
+	/**
+	 * Read the node at a dot-path within a decoded document.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document The document to walk.
+	 * @param string               $path     The dot-path to look up.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function node_at( array $document, string $path ): ?array {
+		$node = $document;
+
+		foreach ( explode( '.', $path ) as $segment ) {
+			if ( ! is_array( $node ) || ! array_key_exists( $segment, $node ) ) {
+				return null;
+			}
+
+			$node = $node[ $segment ];
+		}
+
+		return is_array( $node ) ? $node : null;
+	}
+}

--- a/includes/resources/Design_Tokens/Document/User_Primitive_Document_Validator.php
+++ b/includes/resources/Design_Tokens/Document/User_Primitive_Document_Validator.php
@@ -121,7 +121,7 @@ final class User_Primitive_Document_Validator {
 			$errors[] = new User_Primitive_Validation_Error( $id, sprintf( 'User primitive "%s" collides with a system-registered token.', $id ) );
 		}
 
-		$leaf = $this->node_at( $document, $id );
+		$leaf = Document_Path::node_at( $document, $id );
 
 		if ( $leaf === null ) {
 			$errors[] = new User_Primitive_Validation_Error( $id, sprintf( 'User primitive "%s" envelope entry has no matching tree leaf.', $id ) );
@@ -206,29 +206,5 @@ final class User_Primitive_Document_Validator {
 	 */
 	private function is_allowed_id( string $id ): bool {
 		return (bool) preg_match( '/^primitive\.color\.custom\.[a-z0-9]+(?:-[a-z0-9]+)*$/', $id );
-	}
-
-	/**
-	 * Read a node by dot-path from a decoded document.
-	 *
-	 * @since TBD
-	 *
-	 * @param array<string, mixed> $document
-	 * @param string               $path
-	 *
-	 * @return array<string, mixed>|null
-	 */
-	private function node_at( array $document, string $path ): ?array {
-		$node = $document;
-
-		foreach ( explode( '.', $path ) as $segment ) {
-			if ( ! is_array( $node ) || ! array_key_exists( $segment, $node ) ) {
-				return null;
-			}
-
-			$node = $node[ $segment ];
-		}
-
-		return is_array( $node ) ? $node : null;
 	}
 }

--- a/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
@@ -3,6 +3,7 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Resolver;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Document_Path;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
@@ -320,15 +321,7 @@ final class Token_Resolver {
 	 * @return array<string,mixed>|null
 	 */
 	private function lookup( string $path, array $document ): ?array {
-		$node = $document;
-		foreach ( explode( '.', $path ) as $segment ) {
-			if ( ! is_array( $node ) || ! isset( $node[ $segment ] ) ) {
-				return null;
-			}
-			$node = $node[ $segment ];
-		}
-
-		return is_array( $node ) ? $node : null;
+		return Document_Path::node_at( $document, $path );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Document_Write_Pipeline.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Document_Write_Pipeline.php
@@ -3,6 +3,7 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Document_Path;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Reference_Policy;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Document_Validator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Index;
@@ -136,17 +137,7 @@ final class Document_Write_Pipeline {
 	 * @return array<string, mixed>|null
 	 */
 	public function node_at( array $document, string $path ): ?array {
-		$node = $document;
-
-		foreach ( explode( '.', $path ) as $segment ) {
-			if ( ! is_array( $node ) || ! array_key_exists( $segment, $node ) ) {
-				return null;
-			}
-
-			$node = $node[ $segment ];
-		}
-
-		return is_array( $node ) ? $node : null;
+		return Document_Path::node_at( $document, $path );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Document_Write_Pipeline.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Document_Write_Pipeline.php
@@ -1,0 +1,358 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Reference_Policy;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Document_Validator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Dtcg_Validator;
+use KadenceWP\KadenceBlocks\StellarWP\DB\Database\Exceptions\DatabaseQueryException;
+use WP_Error;
+use WP_Http;
+use WP_REST_Response;
+
+/**
+ * The shared DTCG document write pipeline: load, validate, dry-run resolve, conditional persist.
+ * Used by User_Primitives_Controller only.
+ *
+ * @since TBD
+ */
+final class Document_Write_Pipeline {
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Token_Resolver
+	 */
+	private Token_Resolver $resolver;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Dtcg_Validator
+	 */
+	private Dtcg_Validator $validator;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var User_Primitive_Document_Validator
+	 */
+	private User_Primitive_Document_Validator $user_primitive_validator;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var User_Primitive_Index
+	 */
+	private User_Primitive_Index $user_primitive_index;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Token_Reference_Policy
+	 */
+	private Token_Reference_Policy $reference_policy;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Store                       $store
+	 * @param Token_Resolver                    $resolver
+	 * @param Dtcg_Validator                    $validator
+	 * @param User_Primitive_Document_Validator $user_primitive_validator
+	 * @param User_Primitive_Index              $user_primitive_index
+	 * @param Token_Reference_Policy            $reference_policy
+	 */
+	public function __construct(
+		Token_Store $store,
+		Token_Resolver $resolver,
+		Dtcg_Validator $validator,
+		User_Primitive_Document_Validator $user_primitive_validator,
+		User_Primitive_Index $user_primitive_index,
+		Token_Reference_Policy $reference_policy
+	) {
+		$this->store                    = $store;
+		$this->resolver                 = $resolver;
+		$this->validator                = $validator;
+		$this->user_primitive_validator = $user_primitive_validator;
+		$this->user_primitive_index     = $user_primitive_index;
+		$this->reference_policy         = $reference_policy;
+	}
+
+	/**
+	 * Load and decode the stored overrides document for a set.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function load_document( string $slug ): array {
+		$raw = $this->store->get_document( $slug );
+
+		if ( $raw === '' ) {
+			return [];
+		}
+
+		$decoded = json_decode( $raw, true );
+
+		return is_array( $decoded ) ? $decoded : [];
+	}
+
+	/**
+	 * Read the current cache/concurrency version for a set.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token-set slug.
+	 *
+	 * @return string
+	 */
+	public function get_version( string $slug ): string {
+		return $this->store->get_version( $slug );
+	}
+
+	/**
+	 * Read the node at a dot-path within a decoded document.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param string               $path
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public function node_at( array $document, string $path ): ?array {
+		$node = $document;
+
+		foreach ( explode( '.', $path ) as $segment ) {
+			if ( ! is_array( $node ) || ! array_key_exists( $segment, $node ) ) {
+				return null;
+			}
+
+			$node = $node[ $segment ];
+		}
+
+		return is_array( $node ) ? $node : null;
+	}
+
+	/**
+	 * Apply the multi-set document API slug policy.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug
+	 *
+	 * @return WP_Error|null
+	 */
+	public function guard_slug( string $slug ): ?WP_Error {
+		if ( $slug === Token_Store::default_slug() || $this->store->exists( $slug ) ) {
+			return null;
+		}
+
+		return new WP_Error(
+			'rest_design_tokens_not_found',
+			__( 'The requested design token set does not exist.', 'kadence-blocks' ),
+			[
+				'status' => WP_Http::NOT_FOUND,
+				'slug'   => $slug,
+			]
+		);
+	}
+
+	/**
+	 * Check the stored version against the client-supplied version. Returns a 409 on mismatch.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug           The token set slug.
+	 * @param string $client_version The version the client last read. Empty only for first write.
+	 *
+	 * @return WP_Error|null
+	 */
+	public function guard_version( string $slug, string $client_version ): ?WP_Error {
+		$stored = $this->store->get_version( $slug );
+
+		if ( $stored === '' && $client_version === '' ) {
+			return null;
+		}
+
+		if ( $stored === $client_version ) {
+			return null;
+		}
+
+		return new WP_Error(
+			'rest_design_tokens_conflict',
+			__( 'The token set was modified since you last read it. Reload and try again.', 'kadence-blocks' ),
+			[
+				'status' => WP_Http::CONFLICT,
+				'slug'   => $slug,
+			]
+		);
+	}
+
+	/**
+	 * Validate a candidate document, dry-run resolve it, then conditionally persist.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $candidate        Full candidate overrides document.
+	 * @param string               $slug             Token set slug.
+	 * @param string               $title            Optional label.
+	 * @param string               $expected_version The version the caller last read.
+	 * @param int                  $success_status   HTTP status on success (200 or 201).
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function validate_and_save(
+		array $candidate,
+		string $slug,
+		string $title,
+		string $expected_version,
+		int $success_status = WP_Http::OK
+	) {
+		if ( $candidate !== [] ) {
+			$invariant_errors = $this->user_primitive_validator->validate( $candidate );
+
+			if ( ! empty( $invariant_errors ) ) {
+				return new WP_Error(
+					'rest_design_tokens_user_primitive_invalid',
+					__( 'The user primitive document invariant failed.', 'kadence-blocks' ),
+					[
+						'status' => WP_Http::UNPROCESSABLE_ENTITY,
+						'slug'   => $slug,
+						'errors' => array_map(
+							static fn( $error ): array => [
+								'id'      => $error->get_id(),
+								'message' => $error->get_message(),
+							],
+							$invariant_errors
+						),
+					]
+				);
+			}
+
+			foreach ( array_keys( $this->user_primitive_index->all( $candidate ) ) as $user_primitive_id ) {
+				$references = $this->reference_policy->find( $candidate, (string) $user_primitive_id );
+
+				if ( ! $this->reference_policy->all_supported( $references ) ) {
+					return new WP_Error(
+						'rest_design_tokens_user_primitive_reference_unsupported',
+						__( 'The document contains an unsupported reference to a user primitive.', 'kadence-blocks' ),
+						[
+							'status' => WP_Http::UNPROCESSABLE_ENTITY,
+							'slug'   => $slug,
+						]
+					);
+				}
+			}
+
+			$result = $this->validator->validate( $candidate, Dtcg_Validator::get_context_overrides() );
+
+			if ( ! $result->is_valid() ) {
+				return new WP_Error(
+					'rest_design_tokens_invalid',
+					__( 'The design token document failed validation.', 'kadence-blocks' ),
+					[
+						'status' => WP_Http::UNPROCESSABLE_ENTITY,
+						'slug'   => $slug,
+						'errors' => $result->to_array(),
+					]
+				);
+			}
+
+			try {
+				$this->resolver->resolve_overrides( $candidate );
+			} catch ( Alias_Cycle_Exception | Dangling_Alias_Exception $e ) {
+				return new WP_Error(
+					'rest_design_tokens_unresolvable',
+					$e->getMessage(),
+					[
+						'status' => WP_Http::UNPROCESSABLE_ENTITY,
+						'slug'   => $slug,
+					]
+				);
+			}
+		}
+
+		return $this->persist( $candidate, $slug, $title, $expected_version, $success_status );
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $candidate
+	 * @param string               $slug
+	 * @param string               $title
+	 * @param string               $expected_version
+	 * @param int                  $success_status
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	private function persist(
+		array $candidate,
+		string $slug,
+		string $title,
+		string $expected_version,
+		int $success_status
+	) {
+		$encoded = $candidate !== [] ? wp_json_encode( $candidate ) : '';
+
+		if ( $candidate !== [] && $encoded === false ) {
+			return new WP_Error(
+				'rest_design_tokens_save_failed',
+				__( 'The design token document could not be encoded.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::INTERNAL_SERVER_ERROR,
+					'slug'   => $slug,
+				]
+			);
+		}
+
+		try {
+			$saved = $this->store->save_document_conditional( (string) $encoded, $expected_version, $slug, $title );
+		} catch ( DatabaseQueryException $e ) {
+			return new WP_Error(
+				'rest_design_tokens_save_failed',
+				__( 'The design token set could not be saved.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::INTERNAL_SERVER_ERROR,
+					'slug'   => $slug,
+				]
+			);
+		}
+
+		if ( ! $saved ) {
+			return new WP_Error(
+				'rest_design_tokens_conflict',
+				__( 'The token set was modified since you last read it. Reload and try again.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::CONFLICT,
+					'slug'   => $slug,
+				]
+			);
+		}
+
+		return new WP_REST_Response(
+			[
+				'slug'     => $slug,
+				'version'  => $this->store->get_version( $slug ),
+				'document' => $candidate,
+			],
+			$success_status
+		);
+	}
+}

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -3,6 +3,7 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Document_Path;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
@@ -568,7 +569,7 @@ final class Documents_Controller extends Controller {
 		$is_sentinel = Sentinels::is_reset( $leaf ) || Sentinels::has_disabled( $leaf );
 
 		if ( ! $is_sentinel && ! array_key_exists( Token_Type::get_type_key(), $leaf ) ) {
-			$existing  = $this->node_at( $effective, $path );
+			$existing  = Document_Path::node_at( $effective, $path );
 			$node_type = is_array( $existing ) ? ( $existing[ Token_Type::get_type_key() ] ?? null ) : null;
 
 			if ( ! is_string( $node_type ) ) {
@@ -962,30 +963,6 @@ final class Documents_Controller extends Controller {
 		}
 
 		return null;
-	}
-
-	/**
-	 * Find the node at a dot-path within a document, or null when the path is absent.
-	 *
-	 * @since TBD
-	 *
-	 * @param array<string, mixed> $document The document to walk.
-	 * @param string               $path     The dot-path to look up.
-	 *
-	 * @return array<string, mixed>|null
-	 */
-	private function node_at( array $document, string $path ): ?array {
-		$node = $document;
-
-		foreach ( explode( '.', $path ) as $segment ) {
-			if ( ! is_array( $node ) || ! array_key_exists( $segment, $node ) ) {
-				return null;
-			}
-
-			$node = $node[ $segment ];
-		}
-
-		return is_array( $node ) ? $node : null;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Provider.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Provider.php
@@ -36,6 +36,8 @@ final class Provider extends Provider_Contract {
 	 * @since TBD
 	 */
 	public function register(): void {
+		$this->container->singleton( Document_Write_Pipeline::class, Document_Write_Pipeline::class );
+
 		foreach ( self::CONTROLLERS as $controller ) {
 			add_action( 'rest_api_init', $this->container->callback( $controller, 'register_routes' ) );
 		}

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Document_Write_PipelineTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Document_Write_PipelineTest.php
@@ -1,0 +1,361 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Rest\V1;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Document_Write_Pipeline;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+use Tests\Support\Classes\TestCase;
+use WP_Error;
+use WP_Http;
+use WP_REST_Response;
+
+/**
+ * Covers the Document_Write_Pipeline service: guard methods and the validate-and-save pipeline.
+ */
+final class Document_Write_PipelineTest extends TestCase {
+
+	/**
+	 * @var Document_Write_Pipeline
+	 */
+	private Document_Write_Pipeline $pipeline;
+
+	/**
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->pipeline = $this->container->get( Document_Write_Pipeline::class );
+		$this->store    = $this->container->get( Token_Store::class );
+	}
+
+	// -------------------------------------------------------------------------
+	// guard_slug
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testGuardSlugAllowsTheDefaultSlug(): void {
+		$result = $this->pipeline->guard_slug( Token_Store::default_slug() );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGuardSlugAllowsAnExistingNamedSet(): void {
+		$this->store->save_document( '{}', 'my-set' );
+
+		$result = $this->pipeline->guard_slug( 'my-set' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGuardSlugReturns404ForAnUnknownSlug(): void {
+		$result = $this->pipeline->guard_slug( 'does-not-exist' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_not_found', $result->get_error_code() );
+		$this->assertSame( WP_Http::NOT_FOUND, $result->get_error_data()['status'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// guard_version
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testGuardVersionReturnNullWhenBothVersionsAreEmpty(): void {
+		$result = $this->pipeline->guard_version( Token_Store::default_slug(), '' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGuardVersionReturnNullWhenVersionsMatch(): void {
+		$this->store->save_document( '{"primitive":{}}', Token_Store::default_slug() );
+		$version = $this->store->get_version( Token_Store::default_slug() );
+
+		$result = $this->pipeline->guard_version( Token_Store::default_slug(), $version );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGuardVersionReturns409OnMismatch(): void {
+		$this->store->save_document( '{"primitive":{}}', Token_Store::default_slug() );
+
+		$result = $this->pipeline->guard_version( Token_Store::default_slug(), 'stale-version' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_conflict', $result->get_error_code() );
+		$this->assertSame( WP_Http::CONFLICT, $result->get_error_data()['status'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// validate_and_save: user primitive invariant failure
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testValidateAndSaveReturns422WhenUserPrimitiveInvariantFails(): void {
+		// Envelope entry present but no matching tree leaf — invariant violation.
+		$id        = 'primitive.color.custom.brand';
+		$candidate = [
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					Extensions::get_section_user_primitives() => [
+						$id => [ 'label' => 'Brand' ],
+					],
+				],
+			],
+		];
+
+		$result = $this->pipeline->validate_and_save( $candidate, Token_Store::default_slug(), '', '', WP_Http::CREATED );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_user_primitive_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+
+		$errors = $result->get_error_data()['errors'];
+
+		$this->assertNotEmpty( $errors );
+		$this->assertArrayHasKey( 'id', $errors[0] );
+		$this->assertArrayHasKey( 'message', $errors[0] );
+		$this->assertSame( $id, $errors[0]['id'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// validate_and_save: unsupported user-primitive reference
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testValidateAndSaveReturns422WhenUserPrimitiveHasUnsupportedReference(): void {
+		// A user primitive referenced from the primitive layer is unsupported.
+		$id        = 'primitive.color.custom.brand';
+		$candidate = [
+			'primitive'                      => [
+				'color' => [
+					'custom'          => [
+						'brand' => [
+							'$type'  => 'color',
+							'$value' => '#3182CE',
+						],
+					],
+					// Unsupported: alias to a user primitive from another primitive token.
+					'alias-to-custom' => [
+						'$type'  => 'color',
+						'$value' => '{' . $id . '}',
+					],
+				],
+			],
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					Extensions::get_section_user_primitives() => [
+						$id => [ 'label' => 'Brand' ],
+					],
+				],
+			],
+		];
+
+		$result = $this->pipeline->validate_and_save( $candidate, Token_Store::default_slug(), '', '', WP_Http::CREATED );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_user_primitive_reference_unsupported', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// validate_and_save: DTCG validation failure
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testValidateAndSaveReturns422OnInvalidDtcg(): void {
+		$candidate = [
+			'primitive' => [
+				'color' => [
+					'bad-type' => [
+						'$type'  => 'bogus-unknown-type',
+						'$value' => '#ffffff',
+					],
+				],
+			],
+		];
+
+		$result = $this->pipeline->validate_and_save( $candidate, Token_Store::default_slug(), '', '', WP_Http::CREATED );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+		$this->assertNotEmpty( $result->get_error_data()['errors'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// validate_and_save: resolver alias cycle
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testValidateAndSaveReturns422OnAliasCycle(): void {
+		$candidate = [
+			'primitive' => [
+				'color' => [
+					'cycle-a' => [
+						'$type'  => 'color',
+						'$value' => '{primitive.color.cycle-b}',
+					],
+					'cycle-b' => [
+						'$type'  => 'color',
+						'$value' => '{primitive.color.cycle-a}',
+					],
+				],
+			],
+		];
+
+		$result = $this->pipeline->validate_and_save( $candidate, Token_Store::default_slug(), '', '', WP_Http::CREATED );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_unresolvable', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// validate_and_save: version mismatch → 409
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testValidateAndSaveReturns409WhenVersionMismatches(): void {
+		$this->store->save_document_conditional(
+			'{"primitive":{"color":{"brand":{"primary":{"$type":"color","$value":"#336699"}}}}}',
+			'',
+			Token_Store::default_slug()
+		);
+
+		$candidate = [
+			'primitive' => [
+				'color' => [
+					'brand' => [
+						'primary' => [
+							'$type'  => 'color',
+							'$value' => '#ff0000',
+						],
+					],
+				],
+			],
+		];
+
+		$result = $this->pipeline->validate_and_save(
+			$candidate,
+			Token_Store::default_slug(),
+			'',
+			'stale-version-xyz',
+			WP_Http::OK
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_conflict', $result->get_error_code() );
+		$this->assertSame( WP_Http::CONFLICT, $result->get_error_data()['status'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// validate_and_save: first write → 201
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testValidateAndSaveReturns201OnFirstWriteWithEmptyVersion(): void {
+		$slug      = 'brand-new-set';
+		$candidate = [
+			'primitive' => [
+				'color' => [
+					'brand' => [
+						'primary' => [
+							'$type'  => 'color',
+							'$value' => '#3182CE',
+						],
+					],
+				],
+			],
+		];
+
+		$result = $this->pipeline->validate_and_save( $candidate, $slug, 'Brand Set', '', WP_Http::CREATED );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( WP_Http::CREATED, $result->get_status() );
+
+		$data = $result->get_data();
+
+		$this->assertSame( $slug, $data['slug'] );
+		$this->assertNotEmpty( $data['version'] );
+		$this->assertSame( $candidate, $data['document'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// validate_and_save: successful update → 200
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testValidateAndSaveReturns200OnSuccessfulUpdateWithCorrectVersion(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document_conditional(
+			'{"primitive":{"color":{"brand":{"primary":{"$type":"color","$value":"#336699"}}}}}',
+			'',
+			$slug
+		);
+
+		$version   = $this->store->get_version( $slug );
+		$candidate = [
+			'primitive' => [
+				'color' => [
+					'brand' => [
+						'primary' => [
+							'$type'  => 'color',
+							'$value' => '#ff0000',
+						],
+					],
+				],
+			],
+		];
+
+		$result = $this->pipeline->validate_and_save( $candidate, $slug, '', $version, WP_Http::OK );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( WP_Http::OK, $result->get_status() );
+
+		$data = $result->get_data();
+
+		$this->assertSame( $slug, $data['slug'] );
+		$this->assertNotEmpty( $data['version'] );
+		$this->assertNotSame( $version, $data['version'] );
+		$this->assertSame( $candidate, $data['document'] );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `Document_Write_Pipeline`, a standalone shared write service for `User_Primitives_Controller`: load/decode, slug/version guards, and `validate_and_save()` (user-primitive invariant check → reference-policy check → DTCG schema validation → dry-run alias resolution → conditional persist via `Token_Store::save_document_conditional()`).
- Mirrors `Documents_Controller`'s existing private validate → dry-run-resolve → encode → persist pattern rather than extracting from it — `Documents_Controller`'s private `validate_and_save`, `persist`, `read_stored_document`, and `node_at` are untouched.
- Registers `Document_Write_Pipeline` as a container singleton in `Rest/V1/Provider`.

## Test plan
- [x] `Document_Write_PipelineTest` covers slug/version guard branches, each validation-failure path (invariant, unsupported reference, DTCG schema, alias cycle) returning 422, a version conflict returning 409, and both first-write (201) and update (200) success paths.
- [x] PHPStan clean
- [x] cspell clean
- [x] Full wpunit/acceptance/snapshot suites pass (pre-push CI-equivalent hook)