### PR TITLE
[DTM] SOFT-3574 [8/11] Add write guards to Documents_Controller for reserved namespaces

### DIFF
--- a/includes/resources/Design_Tokens/Document/Reserved_Namespace.php
+++ b/includes/resources/Design_Tokens/Document/Reserved_Namespace.php
@@ -5,12 +5,14 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
 
 /**
- * The single source of truth for the user-primitive reserved namespace: primitive.color.custom.*.
+ * The single source of truth for the user-primitive reserved namespace: primitive.<type>.custom.*.
  *
  * Every write surface that must recognize this namespace (the user-primitive document invariant, the
  * user-primitives controller's id validation, and the generic documents controller's write guards)
- * defers to this class instead of re-deriving the shape on its own, so the phase-1 scope (color only)
- * cannot drift between call sites.
+ * defers to this class instead of re-deriving the shape on its own, so the set of reserved <type>
+ * segments cannot drift between call sites. The <type> segment is validated against every registered
+ * Token_Type rather than hardcoding "color", so a future custom primitive under an existing $type (e.g.
+ * a gap or radius primitive, both "dimension") is guarded automatically.
  *
  * @since TBD
  */
@@ -35,7 +37,7 @@ final class Reserved_Namespace {
 	private const SEGMENT = 'custom';
 
 	/**
-	 * Whether a canonical dot-path id names a user-primitive leaf: primitive.color.custom.<slug>.
+	 * Whether a canonical dot-path id names a user-primitive leaf: primitive.<type>.custom.<slug>.
 	 *
 	 * @since TBD
 	 *
@@ -45,7 +47,7 @@ final class Reserved_Namespace {
 	 */
 	public static function is_reserved_id( string $id ): bool {
 		return (bool) preg_match(
-			'/^' . self::LAYER . '\.' . Token_Type::get_type_color() . '\.' . self::SEGMENT . '\.[a-z0-9]+(?:-[a-z0-9]+)*$/',
+			'/^' . self::LAYER . '\.(?:' . implode( '|', Token_Type::all() ) . ')\.' . self::SEGMENT . '\.[a-z0-9]+(?:-[a-z0-9]+)*$/',
 			$id
 		);
 	}
@@ -67,7 +69,7 @@ final class Reserved_Namespace {
 
 		return count( $segments ) >= 3
 			&& $segments[0] === self::LAYER
-			&& $segments[1] === Token_Type::get_type_color()
+			&& in_array( $segments[1], Token_Type::all(), true )
 			&& $segments[2] === self::SEGMENT;
 	}
 

--- a/includes/resources/Design_Tokens/Document/Reserved_Namespace.php
+++ b/includes/resources/Design_Tokens/Document/Reserved_Namespace.php
@@ -1,0 +1,104 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Document;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
+
+/**
+ * The single source of truth for the user-primitive reserved namespace: primitive.color.custom.*.
+ *
+ * Every write surface that must recognize this namespace (the user-primitive document invariant, the
+ * user-primitives controller's id validation, and the generic documents controller's write guards)
+ * defers to this class instead of re-deriving the shape on its own, so the phase-1 scope (color only)
+ * cannot drift between call sites.
+ *
+ * @since TBD
+ */
+final class Reserved_Namespace {
+
+	/**
+	 * The token layer the reserved namespace lives under.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const LAYER = 'primitive';
+
+	/**
+	 * The tree segment, directly under the reserved $type, that holds user-created primitives.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const SEGMENT = 'custom';
+
+	/**
+	 * Whether a canonical dot-path id names a user-primitive leaf: primitive.color.custom.<slug>.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id The canonical dot-path id.
+	 *
+	 * @return bool
+	 */
+	public static function is_reserved_id( string $id ): bool {
+		return (bool) preg_match(
+			'/^' . self::LAYER . '\.' . Token_Type::get_type_color() . '\.' . self::SEGMENT . '\.[a-z0-9]+(?:-[a-z0-9]+)*$/',
+			$id
+		);
+	}
+
+	/**
+	 * Whether a dot-path addresses the reserved namespace itself or anything nested below it.
+	 *
+	 * Unlike is_reserved_id(), this also matches a path deeper than a single custom-primitive leaf (e.g. a
+	 * sub-field of a composite value), so a write cannot reach into the namespace at any depth.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $path The dot-path to test.
+	 *
+	 * @return bool
+	 */
+	public static function contains_reserved_path( string $path ): bool {
+		$segments = explode( '.', $path );
+
+		return count( $segments ) >= 3
+			&& $segments[0] === self::LAYER
+			&& $segments[1] === Token_Type::get_type_color()
+			&& $segments[2] === self::SEGMENT;
+	}
+
+	/**
+	 * Walk a primitive-layer subtree and collect every path at or below the reserved namespace.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $node   The node to walk, e.g. a decoded document's "primitive" subtree.
+	 * @param string               $prefix The dot-path prefix of $node, e.g. "primitive".
+	 *
+	 * @return string[]
+	 */
+	public static function find_in( array $node, string $prefix ): array {
+		if ( self::contains_reserved_path( $prefix ) ) {
+			return [ $prefix ];
+		}
+
+		$found = [];
+
+		foreach ( $node as $key => $child ) {
+			if ( is_string( $key ) && strncmp( $key, '$', 1 ) === 0 ) {
+				continue;
+			}
+
+			if ( is_array( $child ) ) {
+				/** @var array<string, mixed> $child */
+				$found = array_merge( $found, self::find_in( $child, $prefix . '.' . $key ) );
+			}
+		}
+
+		return $found;
+	}
+}

--- a/includes/resources/Design_Tokens/Document/Reserved_Namespace.php
+++ b/includes/resources/Design_Tokens/Document/Reserved_Namespace.php
@@ -46,8 +46,13 @@ final class Reserved_Namespace {
 	 * @return bool
 	 */
 	public static function is_reserved_id( string $id ): bool {
+		$types = array_map(
+			static fn( string $type ): string => preg_quote( $type, '/' ),
+			Token_Type::all()
+		);
+
 		return (bool) preg_match(
-			'/^' . self::LAYER . '\.(?:' . implode( '|', Token_Type::all() ) . ')\.' . self::SEGMENT . '\.[a-z0-9]+(?:-[a-z0-9]+)*$/',
+			'/^' . self::LAYER . '\.(?:' . implode( '|', $types ) . ')\.' . self::SEGMENT . '\.[a-z0-9]+(?:-[a-z0-9]+)*$/',
 			$id
 		);
 	}

--- a/includes/resources/Design_Tokens/Document/User_Primitive_Document_Validator.php
+++ b/includes/resources/Design_Tokens/Document/User_Primitive_Document_Validator.php
@@ -98,7 +98,7 @@ final class User_Primitive_Document_Validator {
 	private function check_envelope_entry( array $document, string $id, $entry ): array {
 		$errors = [];
 
-		if ( ! $this->is_allowed_id( $id ) ) {
+		if ( ! Reserved_Namespace::is_reserved_id( $id ) ) {
 			$errors[] = new User_Primitive_Validation_Error(
 				$id,
 				sprintf( 'User primitive id "%s" is not in the allowed namespace (primitive.color.custom.*).', $id )
@@ -193,18 +193,5 @@ final class User_Primitive_Document_Validator {
 		}
 
 		return $orphans;
-	}
-
-	/**
-	 * Whether a canonical id is in the allowed phase-1 namespace.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $id
-	 *
-	 * @return bool
-	 */
-	private function is_allowed_id( string $id ): bool {
-		return (bool) preg_match( '/^primitive\.color\.custom\.[a-z0-9]+(?:-[a-z0-9]+)*$/', $id );
 	}
 }

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -508,7 +508,9 @@ final class Documents_Controller extends Controller {
 	/**
 	 * Replace the whole overrides document for the set (PUT /documents/{slug}).
 	 *
-	 * Unlike POST/PATCH, this drops any stored path absent from the body.
+	 * Unlike POST/PATCH, this drops any stored path absent from the body. Rejected with HTTP 409 while the
+	 * stored document has any user-created primitive, since a full replace has no way to express
+	 * "preserve these" — delete them first or use PATCH instead.
 	 *
 	 * @since TBD
 	 *

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -4,12 +4,14 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Dtcg_Validator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Layers;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Sentinels;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
@@ -163,6 +165,15 @@ final class Documents_Controller extends Controller {
 	private Effective_Document $effective;
 
 	/**
+	 * Inspects documents for the presence of user-created primitives.
+	 *
+	 * @since TBD
+	 *
+	 * @var User_Primitive_Index
+	 */
+	private User_Primitive_Index $user_primitive_index;
+
+	/**
 	 * Memoised item schema for this request. Null until first built.
 	 *
 	 * @since TBD
@@ -183,25 +194,28 @@ final class Documents_Controller extends Controller {
 	/**
 	 * @since TBD
 	 *
-	 * @param Token_Store        $store     The sole gateway to the kb_design_tokens table.
-	 * @param Token_Resolver     $resolver  Flattens a stored token set and dry-runs candidate overrides.
-	 * @param Dtcg_Validator     $validator Validates the DTCG grammar of a candidate document.
-	 * @param Mutator            $mutator   Assembles the candidate overrides document.
-	 * @param Effective_Document $effective Builds the effective document for $type inference.
+	 * @param Token_Store          $store                 The sole gateway to the kb_design_tokens table.
+	 * @param Token_Resolver       $resolver              Flattens a stored token set and dry-runs candidate overrides.
+	 * @param Dtcg_Validator       $validator             Validates the DTCG grammar of a candidate document.
+	 * @param Mutator              $mutator               Assembles the candidate overrides document.
+	 * @param Effective_Document   $effective             Builds the effective document for $type inference.
+	 * @param User_Primitive_Index $user_primitive_index  Inspects documents for user-created primitives.
 	 */
 	public function __construct(
 		Token_Store $store,
 		Token_Resolver $resolver,
 		Dtcg_Validator $validator,
 		Mutator $mutator,
-		Effective_Document $effective
+		Effective_Document $effective,
+		User_Primitive_Index $user_primitive_index
 	) {
-		$this->store     = $store;
-		$this->resolver  = $resolver;
-		$this->validator = $validator;
-		$this->mutator   = $mutator;
-		$this->effective = $effective;
-		$this->rest_base = 'documents';
+		$this->store                = $store;
+		$this->resolver             = $resolver;
+		$this->validator            = $validator;
+		$this->mutator              = $mutator;
+		$this->effective            = $effective;
+		$this->user_primitive_index = $user_primitive_index;
+		$this->rest_base            = 'documents';
 	}
 
 	/**
@@ -450,9 +464,16 @@ final class Documents_Controller extends Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function patch_item( $request ) {
-		$slug = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+		$slug    = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+		$partial = $this->read_document_param( $request );
 
-		$candidate = $this->mutator->merge( $this->read_stored_document( $slug ), $this->read_document_param( $request ) );
+		$error = $this->guard_reserved_in_partial( $partial, $slug );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$candidate = $this->mutator->merge( $this->read_stored_document( $slug ), $partial );
 
 		return $this->validate_and_save( $candidate, $slug, Cast::to_string( $request->get_param( self::TITLE_PARAM ) ) );
 	}
@@ -469,7 +490,19 @@ final class Documents_Controller extends Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function update_item( $request ) {
-		$slug = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+		$slug   = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+		$stored = $this->read_stored_document( $slug );
+
+		if ( ! empty( $this->user_primitive_index->all( $stored ) ) ) {
+			return new WP_Error(
+				'rest_design_tokens_put_not_allowed',
+				__( 'Bulk replace is not allowed while user-created primitives exist. Delete them first or use PATCH.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::CONFLICT,
+					'slug'   => $slug,
+				]
+			);
+		}
 
 		return $this->validate_and_save(
 			$this->read_document_param( $request ),
@@ -607,8 +640,19 @@ final class Documents_Controller extends Controller {
 	 */
 	public function delete_token( $request ) {
 		$slug = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+		$path = Cast::to_string( $request->get_param( self::PATH_PARAM ) );
 
-		$path      = Cast::to_string( $request->get_param( self::PATH_PARAM ) );
+		if ( $this->is_reserved_custom_path( $path ) ) {
+			return new WP_Error(
+				'rest_design_tokens_reserved_path',
+				__( 'Use the user-primitives endpoint to delete a custom primitive.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::FORBIDDEN,
+					'path'   => $path,
+				]
+			);
+		}
+
 		$stored    = $this->read_stored_document( $slug );
 		$candidate = $this->mutator->remove( $stored, $path );
 
@@ -1162,6 +1206,112 @@ final class Documents_Controller extends Controller {
 			'version'  => $this->store->get_version( $slug ),
 			'document' => $this->read_stored_document( $slug ),
 		];
+	}
+
+	/**
+	 * Reject a partial document that writes into reserved namespaces.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $partial The incoming partial (not the merged candidate).
+	 * @param string               $slug
+	 *
+	 * @return WP_Error|null
+	 */
+	private function guard_reserved_in_partial( array $partial, string $slug ): ?WP_Error {
+		$primitive = $partial['primitive'] ?? null;
+		/** @var array<string, mixed> $primitive_node */
+		$primitive_node = is_array( $primitive ) ? $primitive : [];
+		$paths          = $this->collect_reserved_paths_in( $primitive_node, 'primitive' );
+
+		if ( empty( $paths ) && ! $this->has_reserved_extension( $partial ) ) {
+			return null;
+		}
+
+		return new WP_Error(
+			'rest_design_tokens_reserved_path',
+			__( 'The primitive.*.custom.* namespace is reserved for user-created primitives. Use the user-primitives endpoint.', 'kadence-blocks' ),
+			[
+				'status' => WP_Http::FORBIDDEN,
+				'slug'   => $slug,
+				'paths'  => $paths,
+			]
+		);
+	}
+
+	/**
+	 * Walk the primitive subtree and collect paths at primitive.*.custom depth or deeper.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $node
+	 * @param string               $prefix
+	 *
+	 * @return string[]
+	 */
+	private function collect_reserved_paths_in( array $node, string $prefix ): array {
+		$found    = [];
+		$segments = explode( '.', $prefix );
+
+		// At primitive.<type>.custom depth (3 segments: primitive, type, custom) or deeper: reserved.
+		if ( count( $segments ) >= 3 && $segments[2] === 'custom' ) {
+			return [ $prefix ];
+		}
+
+		foreach ( $node as $key => $child ) {
+			if ( is_string( $key ) && strncmp( $key, '$', 1 ) === 0 ) {
+				continue;
+			}
+
+			if ( is_array( $child ) ) {
+				/** @var array<string, mixed> $child */
+				$found = array_merge( $found, $this->collect_reserved_paths_in( $child, $prefix . '.' . $key ) );
+			}
+		}
+
+		return $found;
+	}
+
+	/**
+	 * Whether the partial writes into the userPrimitives extension section.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $partial
+	 *
+	 * @return bool
+	 */
+	private function has_reserved_extension( array $partial ): bool {
+		$ext_data = $partial[ Extensions::get_extensions_key() ] ?? null;
+
+		if ( ! is_array( $ext_data ) ) {
+			return false;
+		}
+
+		$ns_data = $ext_data[ Extensions::get_namespace() ] ?? null;
+
+		if ( ! is_array( $ns_data ) ) {
+			return false;
+		}
+
+		return array_key_exists( Extensions::get_section_user_primitives(), $ns_data );
+	}
+
+	/**
+	 * Whether a dot-path addresses the custom sub-namespace of a primitive type.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $path
+	 *
+	 * @return bool
+	 */
+	private function is_reserved_custom_path( string $path ): bool {
+		$segments = explode( '.', $path );
+
+		return count( $segments ) >= 3
+			&& $segments[0] === 'primitive'
+			&& $segments[2] === 'custom';
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -656,10 +656,13 @@ final class Documents_Controller extends Controller {
 	/**
 	 * Remove a single token override by dot-path (DELETE /documents/{slug}/tokens/{path}).
 	 *
-	 * Dropping the override reverts that token to its baseline value. Idempotent: when nothing is stored
-	 * at the path, the set is returned unchanged without a write. The resulting document runs the same
-	 * write pipeline as every other write, so a delete that would leave another override aliasing the
-	 * removed token is rejected (HTTP 422) before commit rather than persisting a dangling alias.
+	 * Dropping the override reverts that token to its baseline value. Idempotent for any non-reserved path:
+	 * when nothing is stored there, the set is returned unchanged without a write. A path inside
+	 * primitive.*.custom.* is not idempotent — it is always rejected with HTTP 403, whether or not anything
+	 * is stored there, since deleting a custom primitive must go through the user-primitives endpoint. The
+	 * resulting document runs the same write pipeline as every other write, so a delete that would leave
+	 * another override aliasing the removed token is rejected (HTTP 422) before commit rather than
+	 * persisting a dangling alias.
 	 *
 	 * @since TBD
 	 *

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -5,6 +5,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Document_Path;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Reserved_Namespace;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Reference_Policy;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Document_Validator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Index;
@@ -674,7 +675,7 @@ final class Documents_Controller extends Controller {
 		$slug = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
 		$path = Cast::to_string( $request->get_param( self::PATH_PARAM ) );
 
-		if ( $this->is_reserved_custom_path( $path ) ) {
+		if ( Reserved_Namespace::contains_reserved_path( $path ) ) {
 			return new WP_Error(
 				'rest_design_tokens_reserved_path',
 				__( 'Use the user-primitives endpoint to delete a custom primitive.', 'kadence-blocks' ),
@@ -1280,7 +1281,7 @@ final class Documents_Controller extends Controller {
 		$primitive = $partial['primitive'] ?? null;
 		/** @var array<string, mixed> $primitive_node */
 		$primitive_node = is_array( $primitive ) ? $primitive : [];
-		$paths          = $this->collect_reserved_paths_in( $primitive_node, 'primitive' );
+		$paths          = Reserved_Namespace::find_in( $primitive_node, 'primitive' );
 
 		if ( empty( $paths ) && ! $this->has_reserved_extension( $partial ) && ! $this->has_unsupported_reserved_alias( $partial ) ) {
 			return null;
@@ -1317,50 +1318,21 @@ final class Documents_Controller extends Controller {
 			return false;
 		}
 
-		if ( ! preg_match_all( '/\{(primitive\.[a-z0-9]+(?:-[a-z0-9]+)*\.custom\.[a-z0-9]+(?:-[a-z0-9]+)*)\}/', $encoded, $matches ) ) {
+		if ( ! preg_match_all( '/\{([a-z0-9.-]+)\}/', $encoded, $matches ) ) {
 			return false;
 		}
 
 		foreach ( array_unique( $matches[1] ) as $referenced_id ) {
+			if ( ! Reserved_Namespace::is_reserved_id( $referenced_id ) ) {
+				continue;
+			}
+
 			if ( ! $this->reference_policy->all_supported( $this->reference_policy->find( $partial, $referenced_id ) ) ) {
 				return true;
 			}
 		}
 
 		return false;
-	}
-
-	/**
-	 * Walk the primitive subtree and collect paths at primitive.*.custom depth or deeper.
-	 *
-	 * @since TBD
-	 *
-	 * @param array<string, mixed> $node
-	 * @param string               $prefix
-	 *
-	 * @return string[]
-	 */
-	private function collect_reserved_paths_in( array $node, string $prefix ): array {
-		$found    = [];
-		$segments = explode( '.', $prefix );
-
-		// At primitive.<type>.custom depth (3 segments: primitive, type, custom) or deeper: reserved.
-		if ( count( $segments ) >= 3 && $segments[2] === 'custom' ) {
-			return [ $prefix ];
-		}
-
-		foreach ( $node as $key => $child ) {
-			if ( is_string( $key ) && strncmp( $key, '$', 1 ) === 0 ) {
-				continue;
-			}
-
-			if ( is_array( $child ) ) {
-				/** @var array<string, mixed> $child */
-				$found = array_merge( $found, $this->collect_reserved_paths_in( $child, $prefix . '.' . $key ) );
-			}
-		}
-
-		return $found;
 	}
 
 	/**
@@ -1386,23 +1358,6 @@ final class Documents_Controller extends Controller {
 		}
 
 		return array_key_exists( Extensions::get_section_user_primitives(), $ns_data );
-	}
-
-	/**
-	 * Whether a dot-path addresses the custom sub-namespace of a primitive type.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $path
-	 *
-	 * @return bool
-	 */
-	private function is_reserved_custom_path( string $path ): bool {
-		$segments = explode( '.', $path );
-
-		return count( $segments ) >= 3
-			&& $segments[0] === 'primitive'
-			&& $segments[2] === 'custom';
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -5,6 +5,8 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Document_Path;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Reference_Policy;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Document_Validator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
@@ -175,6 +177,24 @@ final class Documents_Controller extends Controller {
 	private User_Primitive_Index $user_primitive_index;
 
 	/**
+	 * Enforces the user-primitive document invariant on every write.
+	 *
+	 * @since TBD
+	 *
+	 * @var User_Primitive_Document_Validator
+	 */
+	private User_Primitive_Document_Validator $user_primitive_validator;
+
+	/**
+	 * Scans a candidate document for alias references to a user primitive.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Reference_Policy
+	 */
+	private Token_Reference_Policy $reference_policy;
+
+	/**
 	 * Memoised item schema for this request. Null until first built.
 	 *
 	 * @since TBD
@@ -195,12 +215,14 @@ final class Documents_Controller extends Controller {
 	/**
 	 * @since TBD
 	 *
-	 * @param Token_Store          $store                 The sole gateway to the kb_design_tokens table.
-	 * @param Token_Resolver       $resolver              Flattens a stored token set and dry-runs candidate overrides.
-	 * @param Dtcg_Validator       $validator             Validates the DTCG grammar of a candidate document.
-	 * @param Mutator              $mutator               Assembles the candidate overrides document.
-	 * @param Effective_Document   $effective             Builds the effective document for $type inference.
-	 * @param User_Primitive_Index $user_primitive_index  Inspects documents for user-created primitives.
+	 * @param Token_Store                       $store                 The sole gateway to the kb_design_tokens table.
+	 * @param Token_Resolver                    $resolver              Flattens a stored token set and dry-runs candidate overrides.
+	 * @param Dtcg_Validator                    $validator             Validates the DTCG grammar of a candidate document.
+	 * @param Mutator                           $mutator               Assembles the candidate overrides document.
+	 * @param Effective_Document                $effective             Builds the effective document for $type inference.
+	 * @param User_Primitive_Index              $user_primitive_index  Inspects documents for user-created primitives.
+	 * @param User_Primitive_Document_Validator $user_primitive_validator Enforces the user-primitive document invariant.
+	 * @param Token_Reference_Policy            $reference_policy      Scans for alias references to a user primitive.
 	 */
 	public function __construct(
 		Token_Store $store,
@@ -208,15 +230,19 @@ final class Documents_Controller extends Controller {
 		Dtcg_Validator $validator,
 		Mutator $mutator,
 		Effective_Document $effective,
-		User_Primitive_Index $user_primitive_index
+		User_Primitive_Index $user_primitive_index,
+		User_Primitive_Document_Validator $user_primitive_validator,
+		Token_Reference_Policy $reference_policy
 	) {
-		$this->store                = $store;
-		$this->resolver             = $resolver;
-		$this->validator            = $validator;
-		$this->mutator              = $mutator;
-		$this->effective            = $effective;
-		$this->user_primitive_index = $user_primitive_index;
-		$this->rest_base            = 'documents';
+		$this->store                    = $store;
+		$this->resolver                 = $resolver;
+		$this->validator                = $validator;
+		$this->mutator                  = $mutator;
+		$this->effective                = $effective;
+		$this->user_primitive_index     = $user_primitive_index;
+		$this->user_primitive_validator = $user_primitive_validator;
+		$this->reference_policy         = $reference_policy;
+		$this->rest_base                = 'documents';
 	}
 
 	/**
@@ -836,11 +862,48 @@ final class Documents_Controller extends Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	private function validate_and_save( array $candidate, string $slug, string $title ) {
+		$expected_version = $this->store->get_version( $slug );
+
 		// A brand-new set has no version yet; report 201 Created rather than 200 OK on first write.
-		$status = $this->store->get_version( $slug ) !== '' ? WP_Http::OK : WP_Http::CREATED;
+		$status = $expected_version !== '' ? WP_Http::OK : WP_Http::CREATED;
 
 		if ( $candidate === [] ) {
-			return $this->persist( '', $slug, $title, $status );
+			return $this->persist( '', $slug, $title, $status, $expected_version );
+		}
+
+		$invariant_errors = $this->user_primitive_validator->validate( $candidate );
+
+		if ( ! empty( $invariant_errors ) ) {
+			return new WP_Error(
+				'rest_design_tokens_user_primitive_invalid',
+				__( 'The user primitive document invariant failed.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::UNPROCESSABLE_ENTITY,
+					'slug'   => $slug,
+					'errors' => array_map(
+						static fn( $error ): array => [
+							'id'      => $error->get_id(),
+							'message' => $error->get_message(),
+						],
+						$invariant_errors
+					),
+				]
+			);
+		}
+
+		foreach ( array_keys( $this->user_primitive_index->all( $candidate ) ) as $user_primitive_id ) {
+			$references = $this->reference_policy->find( $candidate, (string) $user_primitive_id );
+
+			if ( ! $this->reference_policy->all_supported( $references ) ) {
+				return new WP_Error(
+					'rest_design_tokens_user_primitive_reference_unsupported',
+					__( 'The document contains an unsupported reference to a user primitive.', 'kadence-blocks' ),
+					[
+						'status' => WP_Http::UNPROCESSABLE_ENTITY,
+						'slug'   => $slug,
+					]
+				);
+			}
 		}
 
 		$result = $this->validator->validate( $candidate, Dtcg_Validator::get_context_overrides() );
@@ -884,30 +947,43 @@ final class Documents_Controller extends Controller {
 			);
 		}
 
-		return $this->persist( $encoded, $slug, $title, $status );
+		return $this->persist( $encoded, $slug, $title, $status, $expected_version );
 	}
 
 	/**
-	 * Commit a raw document string to the store and build the response, mapping a write failure to 500.
+	 * Commit a raw document string to the store and build the response, mapping a write failure to 500 and a
+	 * version mismatch to 409.
 	 *
 	 * @since TBD
 	 *
-	 * @param string $document The raw overrides-only DTCG JSON (empty string clears the set).
-	 * @param string $slug     The token set slug.
-	 * @param string $title    Optional label; left untouched on update when empty.
-	 * @param int    $status   The success status code.
+	 * @param string $document         The raw overrides-only DTCG JSON (empty string clears the set).
+	 * @param string $slug             The token set slug.
+	 * @param string $title            Optional label; left untouched on update when empty.
+	 * @param int    $status           The success status code.
+	 * @param string $expected_version The version read at the start of this write; empty only for a first write.
 	 *
 	 * @return WP_REST_Response|WP_Error
 	 */
-	private function persist( string $document, string $slug, string $title, int $status ) {
+	private function persist( string $document, string $slug, string $title, int $status, string $expected_version ) {
 		try {
-			$this->store->save_document( $document, $slug, $title );
+			$saved = $this->store->save_document_conditional( $document, $expected_version, $slug, $title );
 		} catch ( DatabaseQueryException $e ) {
 			return new WP_Error(
 				'rest_design_tokens_save_failed',
 				__( 'The design token set could not be saved.', 'kadence-blocks' ),
 				[
 					'status' => WP_Http::INTERNAL_SERVER_ERROR,
+					'slug'   => $slug,
+				]
+			);
+		}
+
+		if ( ! $saved ) {
+			return new WP_Error(
+				'rest_design_tokens_conflict',
+				__( 'The token set was modified since you last read it. Reload and try again.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::CONFLICT,
 					'slug'   => $slug,
 				]
 			);
@@ -1201,7 +1277,7 @@ final class Documents_Controller extends Controller {
 		$primitive_node = is_array( $primitive ) ? $primitive : [];
 		$paths          = $this->collect_reserved_paths_in( $primitive_node, 'primitive' );
 
-		if ( empty( $paths ) && ! $this->has_reserved_extension( $partial ) ) {
+		if ( empty( $paths ) && ! $this->has_reserved_extension( $partial ) && ! $this->has_unsupported_reserved_alias( $partial ) ) {
 			return null;
 		}
 
@@ -1214,6 +1290,39 @@ final class Documents_Controller extends Controller {
 				'paths'  => $paths,
 			]
 		);
+	}
+
+	/**
+	 * Whether the partial contains an alias pointing into the reserved custom-primitive namespace from a
+	 * location the phase-1 cascade does not support (anywhere other than a direct semantic-layer override).
+	 *
+	 * Reuses Token_Reference_Policy::find(), the same classifier the delete-reference-preview endpoint
+	 * uses, rather than re-implementing alias-location parsing here.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $partial The incoming partial (not the merged candidate).
+	 *
+	 * @return bool
+	 */
+	private function has_unsupported_reserved_alias( array $partial ): bool {
+		$encoded = wp_json_encode( $partial );
+
+		if ( ! is_string( $encoded ) ) {
+			return false;
+		}
+
+		if ( ! preg_match_all( '/\{(primitive\.[a-z0-9]+(?:-[a-z0-9]+)*\.custom\.[a-z0-9]+(?:-[a-z0-9]+)*)\}/', $encoded, $matches ) ) {
+			return false;
+		}
+
+		foreach ( array_unique( $matches[1] ) as $referenced_id ) {
+			if ( ! $this->reference_policy->all_supported( $this->reference_policy->find( $partial, $referenced_id ) ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Provider.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Provider.php
@@ -28,6 +28,7 @@ final class Provider extends Provider_Contract {
 		Schema_Controller::class,
 		Variants_Controller::class,
 		Active_Set_Controller::class,
+		User_Primitives_Controller::class,
 	];
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/User_Primitives_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/User_Primitives_Controller.php
@@ -1,0 +1,348 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Reference_Policy;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
+use KadenceWP\KadenceBlocks\Utils\Cast;
+use WP_Error;
+use WP_Http;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * REST controller for user-primitive sub-resources: preview-references, create, delete, and rename.
+ *
+ * Phase 9 registers the read-only references endpoint. Phase 10 will add create, delete, and rename.
+ *
+ * @since TBD
+ */
+final class User_Primitives_Controller extends Controller {
+
+	/**
+	 * The request parameter that carries the token set slug.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const SLUG_PARAM = 'slug';
+
+	/**
+	 * The request parameter that carries the user-primitive canonical dot-path id.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const ID_PARAM = 'id';
+
+	/**
+	 * The slug path segment shared by routes that scope to a single document.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const SLUG_ROUTE = '(?P<' . self::SLUG_PARAM . '>[\w-]+)';
+
+	/**
+	 * The id path segment for user-primitive sub-resources.
+	 * Matches the canonical path format: primitive.color.custom.<slug>
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const ID_ROUTE = '(?P<' . self::ID_PARAM . '>[\w.-]+)';
+
+	/**
+	 * The sub-route segment for user-primitive resources within a document.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const USER_PRIMITIVES_ROUTE = 'user-primitives';
+
+	/**
+	 * The sub-route segment for the references preview endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const REFERENCES_ROUTE = 'references';
+
+	/**
+	 * Shared DTCG document write pipeline: load, validate, dry-run, conditional persist.
+	 *
+	 * @since TBD
+	 *
+	 * @var Document_Write_Pipeline
+	 */
+	private Document_Write_Pipeline $pipeline;
+
+	/**
+	 * Reads and writes the userPrimitives provenance map in the overrides document.
+	 *
+	 * @since TBD
+	 *
+	 * @var User_Primitive_Index
+	 */
+	private User_Primitive_Index $index;
+
+	/**
+	 * Scans documents for alias references to a given primitive id.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Reference_Policy
+	 */
+	private Token_Reference_Policy $policy;
+
+	/**
+	 * Pure merge / set / remove transforms. Reserved for Phase 10 (create / delete / rename).
+	 *
+	 * @since TBD
+	 *
+	 * @var Mutator
+	 */
+	private Mutator $mutator; // @phpstan-ignore property.onlyWritten (injected now; read in the upcoming create/delete/rename methods)
+
+	/**
+	 * Baseline document. Reserved for Phase 10.
+	 *
+	 * @since TBD
+	 *
+	 * @var Baseline_Document
+	 */
+	private Baseline_Document $baseline; // @phpstan-ignore property.onlyWritten (injected now; read in the upcoming create/delete/rename methods)
+
+	/**
+	 * Token registry. Reserved for Phase 10.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry; // @phpstan-ignore property.onlyWritten (injected now; read in the upcoming create/delete/rename methods)
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Document_Write_Pipeline $pipeline The shared DTCG write pipeline.
+	 * @param User_Primitive_Index    $index    Reads the userPrimitives provenance map.
+	 * @param Token_Reference_Policy  $policy   Scans for alias references to a primitive.
+	 * @param Mutator                 $mutator  Pure document transforms (Phase 10).
+	 * @param Baseline_Document       $baseline Baseline document (Phase 10).
+	 * @param Token_Registry          $registry Token registry (Phase 10).
+	 */
+	public function __construct(
+		Document_Write_Pipeline $pipeline,
+		User_Primitive_Index $index,
+		Token_Reference_Policy $policy,
+		Mutator $mutator,
+		Baseline_Document $baseline,
+		Token_Registry $registry
+	) {
+		$this->pipeline  = $pipeline;
+		$this->index     = $index;
+		$this->policy    = $policy;
+		$this->mutator   = $mutator;
+		$this->baseline  = $baseline;
+		$this->registry  = $registry;
+		$this->rest_base = 'documents';
+	}
+
+	/**
+	 * Register routes for user-primitive sub-resources.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/' . self::SLUG_ROUTE . '/' . self::USER_PRIMITIVES_ROUTE . '/' . self::ID_ROUTE . '/' . self::REFERENCES_ROUTE,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_references' ],
+					'permission_callback' => [ $this, 'get_item_permissions_check' ],
+					'args'                => $this->get_references_params(),
+				],
+				'schema' => [ $this, 'get_references_schema' ],
+			]
+		);
+	}
+
+	/**
+	 * Return the set of alias references to a user primitive and whether deletion is safe.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_references( $request ) {
+		$slug  = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+		$id    = Cast::to_string( $request->get_param( self::ID_PARAM ) );
+		$error = $this->pipeline->guard_slug( $slug ) ?? $this->validate_canonical_id( $id );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$stored = $this->pipeline->load_document( $slug );
+
+		if ( ! $this->index->has( $stored, $id ) ) {
+			return new WP_Error(
+				'rest_design_tokens_not_found',
+				__( 'That custom token does not exist.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::NOT_FOUND,
+					'id'     => $id,
+				]
+			);
+		}
+
+		$references  = $this->policy->find( $stored, $id );
+		$all_support = $this->policy->all_supported( $references );
+		$ref_payload = [];
+
+		foreach ( $references as $ref ) {
+			$ref_payload[] = [
+				'kind'      => $ref->kind,
+				'path'      => $ref->path,
+				'supported' => $ref->supported,
+				'action'    => $ref->supported ? 'revert_to_baseline' : 'unsupported',
+			];
+		}
+
+		return new WP_REST_Response(
+			[
+				'id'         => $id,
+				'label'      => $this->index->label_for( $stored, $id ) ?? '',
+				'version'    => $this->pipeline->get_version( $slug ),
+				'deletable'  => $all_support,
+				'references' => $ref_payload,
+			],
+			WP_Http::OK
+		);
+	}
+
+	/**
+	 * The JSON Schema for the references preview response.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_references_schema(): array {
+		return $this->add_additional_fields_schema(
+			[
+				'$schema'    => 'http://json-schema.org/draft-07/schema#',
+				'title'      => 'design-token-user-primitive-references',
+				'type'       => 'object',
+				'properties' => [
+					'id'         => [
+						'description' => __( 'The canonical dot-path id of the user primitive.', 'kadence-blocks' ),
+						'type'        => 'string',
+						'context'     => [ 'view' ],
+						'readonly'    => true,
+					],
+					'label'      => [
+						'description' => __( 'The human-readable label stored in the provenance map.', 'kadence-blocks' ),
+						'type'        => 'string',
+						'context'     => [ 'view' ],
+						'readonly'    => true,
+					],
+					'version'    => [
+						'description' => __( 'The cache-busting version hash for the token set.', 'kadence-blocks' ),
+						'type'        => 'string',
+						'context'     => [ 'view' ],
+						'readonly'    => true,
+					],
+					'deletable'  => [
+						'description' => __( 'Whether the primitive can be safely deleted (all references are supported).', 'kadence-blocks' ),
+						'type'        => 'boolean',
+						'context'     => [ 'view' ],
+						'readonly'    => true,
+					],
+					'references' => [
+						'description' => __( 'All alias references to this primitive found in the document.', 'kadence-blocks' ),
+						'type'        => 'array',
+						'context'     => [ 'view' ],
+						'readonly'    => true,
+						'items'       => [
+							'type'       => 'object',
+							'properties' => [
+								'kind'      => [ 'type' => 'string' ],
+								'path'      => [ 'type' => 'string' ],
+								'supported' => [ 'type' => 'boolean' ],
+								'action'    => [ 'type' => 'string' ],
+							],
+						],
+					],
+				],
+			] 
+		);
+	}
+
+	/**
+	 * Validate that the supplied id is in the allowed phase-1 user-primitive namespace.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id
+	 *
+	 * @return WP_Error|null
+	 */
+	private function validate_canonical_id( string $id ): ?WP_Error {
+		if ( preg_match( '/^primitive\.color\.custom\.[a-z0-9]+(?:-[a-z0-9]+)*$/', $id ) ) {
+			return null;
+		}
+
+		return new WP_Error(
+			'rest_invalid_param',
+			__( 'The id must be a canonical color custom primitive path (primitive.color.custom.<slug>).', 'kadence-blocks' ),
+			[
+				'status' => WP_Http::BAD_REQUEST,
+				'id'     => $id,
+			]
+		);
+	}
+
+	/**
+	 * Route arguments for the references endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_references_params(): array {
+		return [
+			self::SLUG_PARAM => [
+				'description'       => __( 'The token set slug.', 'kadence-blocks' ),
+				'type'              => 'string',
+				'required'          => true,
+				'pattern'           => '^[\w-]+$',
+				'sanitize_callback' => 'sanitize_key',
+			],
+			self::ID_PARAM   => [
+				'description' => __( 'The canonical dot-path id of the user primitive.', 'kadence-blocks' ),
+				'type'        => 'string',
+				'required'    => true,
+				'pattern'     => '^[\w.-]+$',
+			],
+		];
+	}
+}

--- a/includes/resources/Design_Tokens/Rest/V1/User_Primitives_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/User_Primitives_Controller.php
@@ -3,6 +3,7 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Reserved_Namespace;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Reference_Policy;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
@@ -307,7 +308,7 @@ final class User_Primitives_Controller extends Controller {
 	 * @return WP_Error|null
 	 */
 	private function validate_canonical_id( string $id ): ?WP_Error {
-		if ( preg_match( '/^primitive\.color\.custom\.[a-z0-9]+(?:-[a-z0-9]+)*$/', $id ) ) {
+		if ( Reserved_Namespace::is_reserved_id( $id ) ) {
 			return null;
 		}
 

--- a/tests/wpunit/Resources/Design_Tokens/Document/Reserved_NamespaceTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/Reserved_NamespaceTest.php
@@ -1,0 +1,195 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Document;
+
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Reserved_Namespace;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Covers the single source of truth for the user-primitive reserved namespace: primitive.color.custom.*.
+ */
+final class Reserved_NamespaceTest extends TestCase {
+
+	// -------------------------------------------------------------------------
+	// is_reserved_id()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @dataProvider reservedIdProvider
+	 *
+	 * @param string $id       The canonical dot-path id under test.
+	 * @param bool   $expected Whether $id should be recognized as reserved.
+	 *
+	 * @return void
+	 */
+	public function testIsReservedId( string $id, bool $expected ): void {
+		$this->assertSame( $expected, Reserved_Namespace::is_reserved_id( $id ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function reservedIdProvider(): Generator {
+		yield 'a color custom leaf' => [
+			'id'       => 'primitive.color.custom.blue',
+			'expected' => true,
+		];
+
+		yield 'a hyphenated slug' => [
+			'id'       => 'primitive.color.custom.brand-accent',
+			'expected' => true,
+		];
+
+		yield 'a non custom color primitive' => [
+			'id'       => 'primitive.color.brand.accent',
+			'expected' => false,
+		];
+
+		yield 'a custom segment under a different type' => [
+			'id'       => 'primitive.spacing.custom.foo',
+			'expected' => false,
+		];
+
+		yield 'a semantic layer path' => [
+			'id'       => 'semantic.color.custom.foo',
+			'expected' => false,
+		];
+
+		yield 'a path deeper than a single leaf' => [
+			'id'       => 'primitive.color.custom.blue.extra',
+			'expected' => false,
+		];
+
+		yield 'the bucket itself with no slug' => [
+			'id'       => 'primitive.color.custom',
+			'expected' => false,
+		];
+	}
+
+	// -------------------------------------------------------------------------
+	// contains_reserved_path()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @dataProvider reservedPathProvider
+	 *
+	 * @param string $path     The dot-path under test.
+	 * @param bool   $expected Whether $path should be recognized as reserved.
+	 *
+	 * @return void
+	 */
+	public function testContainsReservedPath( string $path, bool $expected ): void {
+		$this->assertSame( $expected, Reserved_Namespace::contains_reserved_path( $path ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function reservedPathProvider(): Generator {
+		yield 'the bucket root' => [
+			'path'     => 'primitive.color.custom',
+			'expected' => true,
+		];
+
+		yield 'a leaf under the bucket' => [
+			'path'     => 'primitive.color.custom.blue',
+			'expected' => true,
+		];
+
+		yield 'a sub-field of a composite value' => [
+			'path'     => 'primitive.color.custom.blue.$value.h',
+			'expected' => true,
+		];
+
+		yield 'a non custom color primitive' => [
+			'path'     => 'primitive.color.brand.accent',
+			'expected' => false,
+		];
+
+		yield 'a custom segment under a different type' => [
+			'path'     => 'primitive.spacing.custom.foo',
+			'expected' => false,
+		];
+
+		yield 'too short to reach the custom segment' => [
+			'path'     => 'primitive.color',
+			'expected' => false,
+		];
+	}
+
+	// -------------------------------------------------------------------------
+	// find_in()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testFindInReturnsEmptyWhenNothingIsReserved(): void {
+		$node = [
+			'color' => [
+				'brand' => [
+					'accent' => [
+						'$type'  => 'color',
+						'$value' => '#3182CE',
+					],
+				],
+			],
+		];
+
+		$this->assertSame( [], Reserved_Namespace::find_in( $node, 'primitive' ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFindInReportsTheBucketRootRatherThanEveryLeafBeneathIt(): void {
+		$node = [
+			'color' => [
+				'custom' => [
+					'blue'  => [
+						'$type'  => 'color',
+						'$value' => '#0000ff',
+					],
+					'green' => [
+						'$type'  => 'color',
+						'$value' => '#00ff00',
+					],
+				],
+			],
+		];
+
+		$this->assertSame( [ 'primitive.color.custom' ], Reserved_Namespace::find_in( $node, 'primitive' ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFindInIgnoresACustomSegmentUnderADifferentType(): void {
+		$node = [
+			'spacing' => [
+				'custom' => [
+					'foo' => [
+						'$type'  => 'dimension',
+						'$value' => '4px',
+					],
+				],
+			],
+		];
+
+		$this->assertSame( [], Reserved_Namespace::find_in( $node, 'primitive' ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFindInSkipsDollarPrefixedKeys(): void {
+		$node = [
+			'color' => [
+				'$description' => 'ignored',
+			],
+		];
+
+		$this->assertSame( [], Reserved_Namespace::find_in( $node, 'primitive' ) );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerTest.php
@@ -871,6 +871,254 @@ final class DocumentsControllerTest extends TestCase {
 	}
 
 	/**
+	 * @return void
+	 */
+	public function testPatchBlocksWritingIntoPrimitiveCustomNamespace(): void {
+		$response = $this->controller->patch_item(
+			$this->write_request(
+				'PATCH',
+				Token_Store::default_slug(),
+				[
+					'primitive' => [
+						'color' => [
+							'custom' => [
+								'foo' => [
+									Token_Type::get_type_key() => 'color',
+									Sentinels::get_value_key() => '#aabbcc',
+								],
+							],
+						],
+					],
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_design_tokens_reserved_path', $response->get_error_code() );
+		$this->assertSame( WP_Http::FORBIDDEN, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testPatchBlocksWritingDeeperThanPrimitiveCustomNamespace(): void {
+		$response = $this->controller->patch_item(
+			$this->write_request(
+				'PATCH',
+				Token_Store::default_slug(),
+				[
+					'primitive' => [
+						'color' => [
+							'custom' => [
+								'foo' => [
+									'bar' => [
+										Token_Type::get_type_key() => 'color',
+										Sentinels::get_value_key() => '#aabbcc',
+									],
+								],
+							],
+						],
+					],
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_design_tokens_reserved_path', $response->get_error_code() );
+		$this->assertSame( WP_Http::FORBIDDEN, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testPatchBlocksWritingIntoReservedExtensionSection(): void {
+		$response = $this->controller->patch_item(
+			$this->write_request(
+				'PATCH',
+				Token_Store::default_slug(),
+				[
+					'$extensions' => [
+						'com.kadence.designTokens' => [
+							'userPrimitives' => [
+								'primitive.color.custom.foo' => [ 'label' => 'Foo' ],
+							],
+						],
+					],
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_design_tokens_reserved_path', $response->get_error_code() );
+		$this->assertSame( WP_Http::FORBIDDEN, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * PATCH with unreserved paths is allowed even when the stored document already contains user primitives.
+	 *
+	 * @return void
+	 */
+	public function testPatchWithUnreservedPathsSucceedsWhenStoredDocHasUserPrimitives(): void {
+		// Store a document that already carries a user primitive in $extensions.
+		$this->store->save_document(
+			wp_json_encode(
+				[
+					'primitive'   => [
+						'color' => [
+							'custom' => [
+								'my-color' => [
+									Token_Type::get_type_key() => 'color',
+									Sentinels::get_value_key() => '#112233',
+								],
+							],
+						],
+					],
+					'$extensions' => [
+						'com.kadence.designTokens' => [
+							'userPrimitives' => [
+								'primitive.color.custom.my-color' => [ 'label' => 'My Color' ],
+							],
+						],
+					],
+				] 
+			)
+		);
+
+		// A PATCH that only touches an unreserved path should succeed.
+		$response = $this->controller->patch_item(
+			$this->write_request(
+				'PATCH',
+				Token_Store::default_slug(),
+				[
+					'primitive' => [
+						'color' => [
+							'brand' => [
+								'primary' => [
+									Token_Type::get_type_key() => 'color',
+									Sentinels::get_value_key() => '#3182CE',
+								],
+							],
+						],
+					],
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testPutIsRejectedWhileUserPrimitivesExist(): void {
+		// Store a document that carries user primitives in $extensions.
+		$this->store->save_document(
+			wp_json_encode(
+				[
+					'primitive'   => [
+						'color' => [
+							'custom' => [
+								'my-color' => [
+									Token_Type::get_type_key() => 'color',
+									Sentinels::get_value_key() => '#112233',
+								],
+							],
+						],
+					],
+					'$extensions' => [
+						'com.kadence.designTokens' => [
+							'userPrimitives' => [
+								'primitive.color.custom.my-color' => [ 'label' => 'My Color' ],
+							],
+						],
+					],
+				] 
+			)
+		);
+
+		$response = $this->controller->update_item(
+			$this->write_request(
+				'PUT',
+				Token_Store::default_slug(),
+				[
+					'primitive' => [
+						'color' => [
+							'brand' => [
+								'primary' => [
+									Token_Type::get_type_key() => 'color',
+									Sentinels::get_value_key() => '#3182CE',
+								],
+							],
+						],
+					],
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_design_tokens_put_not_allowed', $response->get_error_code() );
+		$this->assertSame( WP_Http::CONFLICT, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testPutProceedsWhenStoredDocHasNoUserPrimitives(): void {
+		$this->store->save_document( '{"primitive":{"color":{"a":{"$type":"color","$value":"#aaaaaa"}}}}' );
+
+		$response = $this->controller->update_item(
+			$this->write_request(
+				'PUT',
+				Token_Store::default_slug(),
+				[
+					'primitive' => [
+						'color' => [
+							'b' => [
+								Token_Type::get_type_key() => 'color',
+								Sentinels::get_value_key() => '#bbbbbb',
+							],
+						],
+					],
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$document = $response->get_data()['document'];
+		$this->assertArrayNotHasKey( 'a', $document['primitive']['color'] );
+		$this->assertArrayHasKey( 'b', $document['primitive']['color'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeleteTokenBlocksReservedCustomPath(): void {
+		$response = $this->controller->delete_token(
+			$this->token_path_request( 'DELETE', Token_Store::default_slug(), 'primitive.color.custom.foo' )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_design_tokens_reserved_path', $response->get_error_code() );
+		$this->assertSame( WP_Http::FORBIDDEN, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeleteTokenDoesNotBlockNonCustomPath(): void {
+		$this->store->save_document( '{"primitive":{"color":{"brand":{"primary":{"$type":"color","$value":"#3182CE"}}}}}' );
+
+		$response = $this->controller->delete_token(
+			$this->token_path_request( 'DELETE', Token_Store::default_slug(), 'primitive.color.brand.primary' )
+		);
+
+		// The guard does not fire — the delete proceeds normally.
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+	}
+
+	/**
 	 * Build a bulk-write request carrying the slug, document and optional title as parameters.
 	 *
 	 * @param string               $method   The HTTP method.

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerTest.php
@@ -1119,6 +1119,130 @@ final class DocumentsControllerTest extends TestCase {
 	}
 
 	/**
+	 * @return void
+	 */
+	public function testPatchBlocksAnAliasIntoTheReservedNamespaceOutsideTheSemanticLayer(): void {
+		$response = $this->controller->patch_item(
+			$this->write_request(
+				'PATCH',
+				Token_Store::default_slug(),
+				[
+					'primitive' => [
+						'color' => [
+							'brand' => [
+								'accent' => [
+									Token_Type::get_type_key() => 'color',
+									Sentinels::get_value_key() => '{primitive.color.custom.blue}',
+								],
+							],
+						],
+					],
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_design_tokens_reserved_path', $response->get_error_code() );
+		$this->assertSame( WP_Http::FORBIDDEN, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testPatchAllowsASemanticAliasIntoTheReservedNamespace(): void {
+		$this->store->save_document(
+			wp_json_encode(
+				[
+					'primitive'   => [
+						'color' => [
+							'custom' => [
+								'blue' => [
+									Token_Type::get_type_key() => 'color',
+									Sentinels::get_value_key() => '#0000ff',
+								],
+							],
+						],
+					],
+					'$extensions' => [
+						'com.kadence.designTokens' => [
+							'userPrimitives' => [
+								'primitive.color.custom.blue' => [ 'label' => 'Blue' ],
+							],
+						],
+					],
+				]
+			)
+		);
+
+		$response = $this->controller->patch_item(
+			$this->write_request(
+				'PATCH',
+				Token_Store::default_slug(),
+				[
+					'semantic' => [
+						'color' => [
+							'accent' => [
+								Token_Type::get_type_key() => 'color',
+								Sentinels::get_value_key() => '{primitive.color.custom.blue}',
+							],
+						],
+					],
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSetTokenRejectsAnUnsupportedAliasIntoTheUserPrimitiveNamespace(): void {
+		$this->store->save_document(
+			wp_json_encode(
+				[
+					'primitive'   => [
+						'color' => [
+							'custom' => [
+								'blue' => [
+									Token_Type::get_type_key() => 'color',
+									Sentinels::get_value_key() => '#0000ff',
+								],
+							],
+						],
+					],
+					'$extensions' => [
+						'com.kadence.designTokens' => [
+							'userPrimitives' => [
+								'primitive.color.custom.blue' => [ 'label' => 'Blue' ],
+							],
+						],
+					],
+				]
+			)
+		);
+
+		// A PUT to a single baseline-layer token whose $value aliases a user primitive from outside the
+		// semantic layer must be rejected, even though set_token() never runs guard_reserved_in_partial().
+		$response = $this->controller->set_token(
+			$this->token_request(
+				'PUT',
+				Token_Store::default_slug(),
+				'primitive.color.brand.accent',
+				[
+					Token_Type::get_type_key() => 'color',
+					Sentinels::get_value_key() => '{primitive.color.custom.blue}',
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_design_tokens_user_primitive_reference_unsupported', $response->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $response->get_error_data()['status'] );
+	}
+
+	/**
 	 * Build a bulk-write request carrying the slug, document and optional title as parameters.
 	 *
 	 * @param string               $method   The HTTP method.

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/User_Primitives_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/User_Primitives_ControllerTest.php
@@ -1,0 +1,368 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Rest\V1;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Reference;
+use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\User_Primitives_Controller;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+use Tests\Support\Classes\TestCase;
+use WP_Error;
+use WP_Http;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Covers the references preview endpoint on User_Primitives_Controller (Phase 9).
+ */
+final class User_Primitives_ControllerTest extends TestCase {
+
+	/**
+	 * @var User_Primitives_Controller
+	 */
+	private User_Primitives_Controller $controller;
+
+	/**
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @var WP_REST_Server
+	 */
+	private WP_REST_Server $rest_server;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->controller = $this->container->get( User_Primitives_Controller::class );
+		$this->store      = $this->container->get( Token_Store::class );
+
+		global $wp_rest_server;
+		$this->rest_server = new WP_REST_Server();
+		$wp_rest_server    = $this->rest_server;
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		wp_set_current_user( 0 );
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tearDown();
+	}
+
+	// -------------------------------------------------------------------------
+	// Route registration
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testItRegistersTheReferencesRouteWithArgsAndSchema(): void {
+		$routes    = $this->rest_server->get_routes();
+		$namespace = 'kb-design-tokens/v1';
+		$pattern   = '#^/' . preg_quote( $namespace, '#' ) . '/documents/\(\?P<slug>#';
+		$found     = false;
+
+		foreach ( array_keys( $routes ) as $route ) {
+			if ( preg_match( $pattern, $route ) && str_contains( $route, 'references' ) ) {
+				$found = true;
+				$opts  = $this->rest_server->get_route_options( $route );
+				$this->assertArrayHasKey( 'schema', $opts );
+				$this->assertIsCallable( $opts['schema'] );
+				break;
+			}
+		}
+
+		$this->assertTrue( $found, 'The references route must be registered.' );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_references — happy path: no references
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testItReturnsEmptyReferencesAndDeletableTrueWhenNothingReferencesThePrimitive(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.color.custom.my-brand';
+
+		$this->store->save_document( wp_json_encode( $this->doc_with_primitive( $id, 'My Brand' ) ) );
+
+		$response = $this->controller->get_references( $this->make_request( $slug, $id ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertSame( $id, $data['id'] );
+		$this->assertSame( 'My Brand', $data['label'] );
+		$this->assertTrue( $data['deletable'] );
+		$this->assertSame( [], $data['references'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_references — version is included
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testResponseIncludesCurrentDocumentVersion(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.color.custom.my-brand';
+
+		$this->store->save_document( wp_json_encode( $this->doc_with_primitive( $id, 'My Brand' ) ) );
+
+		$version = $this->store->get_version( $slug );
+
+		$data = $this->controller->get_references( $this->make_request( $slug, $id ) )->get_data();
+
+		$this->assertSame( $version, $data['version'] );
+		$this->assertNotSame( '', $data['version'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_references — semantic override reference
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testItReturnsSemanticOverrideReferenceAsSupportedWithRevertAction(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.color.custom.brand';
+		$doc  = $this->doc_with_primitive( $id, 'Brand' );
+
+		$doc['semantic'] = [
+			'color' => [
+				'primary' => [
+					'$type'  => 'color',
+					'$value' => '{' . $id . '}',
+				],
+			],
+		];
+
+		$this->store->save_document( wp_json_encode( $doc ) );
+
+		$data = $this->controller->get_references( $this->make_request( $slug, $id ) )->get_data();
+
+		$this->assertTrue( $data['deletable'] );
+		$this->assertCount( 1, $data['references'] );
+
+		$ref = $data['references'][0];
+
+		$this->assertSame( Token_Reference::get_kind_semantic_override(), $ref['kind'] );
+		$this->assertTrue( $ref['supported'] );
+		$this->assertSame( 'revert_to_baseline', $ref['action'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_references — composite field reference (unsupported)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testCompositeFieldReferenceIsUnsupportedAndBlocksDeletion(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.color.custom.shadow-color';
+		$doc  = $this->doc_with_primitive( $id, 'Shadow Color' );
+
+		$doc['primitive'] = array_merge(
+			$doc['primitive'] ?? [],
+			[
+				'shadow' => [
+					'soft' => [
+						'$type'  => 'shadow',
+						'$value' => [
+							'color'   => '{' . $id . '}',
+							'offsetX' => '0',
+							'offsetY' => '2px',
+							'blur'    => '4px',
+							'spread'  => '0',
+						],
+					],
+				],
+			] 
+		);
+
+		$this->store->save_document( wp_json_encode( $doc ) );
+
+		$data = $this->controller->get_references( $this->make_request( $slug, $id ) )->get_data();
+
+		$this->assertFalse( $data['deletable'] );
+		$this->assertCount( 1, $data['references'] );
+
+		$ref = $data['references'][0];
+
+		$this->assertFalse( $ref['supported'] );
+		$this->assertSame( 'unsupported', $ref['action'] );
+		$this->assertSame( Token_Reference::get_kind_composite_field(), $ref['kind'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_references — extension section reference (unsupported)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testExtensionSectionReferenceIsUnsupportedAndBlocksDeletion(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.color.custom.ext-color';
+		$doc  = $this->doc_with_primitive( $id, 'Ext Color' );
+
+		$doc[ Extensions::get_extensions_key() ][ Extensions::get_namespace() ][ Extensions::get_section_foundation_presets() ] = [
+			'color' => [
+				'my-preset' => [
+					Extensions::get_tokens_key() => [
+						'semantic.color.accent' => '{' . $id . '}',
+					],
+				],
+			],
+		];
+
+		$this->store->save_document( wp_json_encode( $doc ) );
+
+		$data = $this->controller->get_references( $this->make_request( $slug, $id ) )->get_data();
+
+		$this->assertFalse( $data['deletable'] );
+
+		$unsupported = array_filter( $data['references'], static fn( array $r ): bool => ! $r['supported'] );
+		$this->assertNotEmpty( $unsupported );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_references — error cases
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testItReturns404ForAnUnknownSlug(): void {
+		$result = $this->controller->get_references( $this->make_request( 'does-not-exist', 'primitive.color.custom.x' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_not_found', $result->get_error_code() );
+		$this->assertSame( WP_Http::NOT_FOUND, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItReturns404WhenIdIsValidFormatButNotInEnvelope(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.color.custom.ghost';
+
+		$this->store->save_document( wp_json_encode( $this->doc_with_primitive( 'primitive.color.custom.other', 'Other' ) ) );
+
+		$result = $this->controller->get_references( $this->make_request( $slug, $id ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_not_found', $result->get_error_code() );
+		$this->assertSame( WP_Http::NOT_FOUND, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItReturns400ForAnInvalidCanonicalIdFormat(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}' );
+
+		$result = $this->controller->get_references( $this->make_request( $slug, 'primitive.color.foo' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_invalid_param', $result->get_error_code() );
+		$this->assertSame( WP_Http::BAD_REQUEST, $result->get_error_data()['status'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_references — does not modify the stored document
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testGetReferencesDoesNotModifyTheStoredDocument(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.color.custom.safe';
+		$doc  = $this->doc_with_primitive( $id, 'Safe' );
+
+		$this->store->save_document( wp_json_encode( $doc ) );
+
+		$before = $this->store->get_document( $slug );
+
+		$this->controller->get_references( $this->make_request( $slug, $id ) );
+
+		$after = $this->store->get_document( $slug );
+
+		$this->assertSame( $before, $after );
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Build a minimal overrides document with one user primitive registered in the index.
+	 *
+	 * @param string $id    The canonical dot-path id.
+	 * @param string $label The label to store in the provenance map.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function doc_with_primitive( string $id, string $label ): array {
+		$segments = explode( '.', $id );
+		$slug     = end( $segments );
+
+		return [
+			'primitive'                      => [
+				'color' => [
+					'custom' => [
+						$slug => [
+							'$type'  => 'color',
+							'$value' => '#336699',
+						],
+					],
+				],
+			],
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					Extensions::get_section_user_primitives() => [
+						$id => [ 'label' => $label ],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Build a GET request for the references endpoint.
+	 *
+	 * @param string $slug The token set slug.
+	 * @param string $id   The user-primitive canonical id.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function make_request( string $slug, string $id ): WP_REST_Request {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', $slug );
+		$request->set_param( 'id', $id );
+
+		return $request;
+	}
+}


### PR DESCRIPTION
## Summary
- Injects `User_Primitive_Index` into `Documents_Controller` and adds three write guards so the generic multi-set document endpoints can't be used to bypass user-primitive lifecycle rules:
  - **PATCH** inspects the incoming partial payload (not the merged/stored candidate) for reserved paths — writes touching `primitive.<type>.custom.*` or the `userPrimitives` extensions section are rejected with 403, while unreserved partials succeed even when the stored document already has user primitives.
  - **PUT** is rejected with 409 while the stored document has any user primitive, since a full replace has no way to express "preserve these"; a PUT against a document with none proceeds normally.
  - **Single-token DELETE** rejects deleting a reserved custom path directly; deleting a normal (non-custom) token is unaffected.
- All three guards run before any read/merge/persist step, so a rejected request never touches storage.

## Test plan
- [x] `DocumentsControllerTest` adds the 8 guard cases (PATCH shallow/deep custom path, PATCH reserved extension, PATCH unreserved-with-existing-user-primitives, PUT-with-user-primitives, PUT-with-clean-doc, DELETE-reserved-path, DELETE-non-custom-path), and the full existing suite (47 tests) still passes, confirming no regression to the pre-existing multi-set document API.
- [x] PHPStan clean
- [x] cspell clean
- [x] Full wpunit/acceptance/snapshot suites pass (pre-push CI-equivalent hook)