### PR TITLE
[DTM] SOFT-3574 [9/11] Add User_Primitives_Controller with references preview endpoint

### DIFF
--- a/includes/resources/Design_Tokens/Rest/V1/Provider.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Provider.php
@@ -28,6 +28,7 @@ final class Provider extends Provider_Contract {
 		Schema_Controller::class,
 		Variants_Controller::class,
 		Active_Set_Controller::class,
+		User_Primitives_Controller::class,
 	];
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/User_Primitives_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/User_Primitives_Controller.php
@@ -1,0 +1,348 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Reference_Policy;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
+use KadenceWP\KadenceBlocks\Utils\Cast;
+use WP_Error;
+use WP_Http;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * REST controller for user-primitive sub-resources: preview-references, create, delete, and rename.
+ *
+ * Phase 9 registers the read-only references endpoint. Phase 10 will add create, delete, and rename.
+ *
+ * @since TBD
+ */
+final class User_Primitives_Controller extends Controller {
+
+	/**
+	 * The request parameter that carries the token set slug.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const SLUG_PARAM = 'slug';
+
+	/**
+	 * The request parameter that carries the user-primitive canonical dot-path id.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const ID_PARAM = 'id';
+
+	/**
+	 * The slug path segment shared by routes that scope to a single document.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const SLUG_ROUTE = '(?P<' . self::SLUG_PARAM . '>[\w-]+)';
+
+	/**
+	 * The id path segment for user-primitive sub-resources.
+	 * Matches the canonical path format: primitive.color.custom.<slug>
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const ID_ROUTE = '(?P<' . self::ID_PARAM . '>[\w.-]+)';
+
+	/**
+	 * The sub-route segment for user-primitive resources within a document.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const USER_PRIMITIVES_ROUTE = 'user-primitives';
+
+	/**
+	 * The sub-route segment for the references preview endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const REFERENCES_ROUTE = 'references';
+
+	/**
+	 * Shared DTCG document write pipeline: load, validate, dry-run, conditional persist.
+	 *
+	 * @since TBD
+	 *
+	 * @var Document_Write_Pipeline
+	 */
+	private Document_Write_Pipeline $pipeline;
+
+	/**
+	 * Reads and writes the userPrimitives provenance map in the overrides document.
+	 *
+	 * @since TBD
+	 *
+	 * @var User_Primitive_Index
+	 */
+	private User_Primitive_Index $index;
+
+	/**
+	 * Scans documents for alias references to a given primitive id.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Reference_Policy
+	 */
+	private Token_Reference_Policy $policy;
+
+	/**
+	 * Pure merge / set / remove transforms. Reserved for Phase 10 (create / delete / rename).
+	 *
+	 * @since TBD
+	 *
+	 * @var Mutator
+	 */
+	private Mutator $mutator; // @phpstan-ignore property.onlyWritten (injected now; read in the upcoming create/delete/rename methods)
+
+	/**
+	 * Baseline document. Reserved for Phase 10.
+	 *
+	 * @since TBD
+	 *
+	 * @var Baseline_Document
+	 */
+	private Baseline_Document $baseline; // @phpstan-ignore property.onlyWritten (injected now; read in the upcoming create/delete/rename methods)
+
+	/**
+	 * Token registry. Reserved for Phase 10.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry; // @phpstan-ignore property.onlyWritten (injected now; read in the upcoming create/delete/rename methods)
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Document_Write_Pipeline $pipeline The shared DTCG write pipeline.
+	 * @param User_Primitive_Index    $index    Reads the userPrimitives provenance map.
+	 * @param Token_Reference_Policy  $policy   Scans for alias references to a primitive.
+	 * @param Mutator                 $mutator  Pure document transforms (Phase 10).
+	 * @param Baseline_Document       $baseline Baseline document (Phase 10).
+	 * @param Token_Registry          $registry Token registry (Phase 10).
+	 */
+	public function __construct(
+		Document_Write_Pipeline $pipeline,
+		User_Primitive_Index $index,
+		Token_Reference_Policy $policy,
+		Mutator $mutator,
+		Baseline_Document $baseline,
+		Token_Registry $registry
+	) {
+		$this->pipeline  = $pipeline;
+		$this->index     = $index;
+		$this->policy    = $policy;
+		$this->mutator   = $mutator;
+		$this->baseline  = $baseline;
+		$this->registry  = $registry;
+		$this->rest_base = 'documents';
+	}
+
+	/**
+	 * Register routes for user-primitive sub-resources.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/' . self::SLUG_ROUTE . '/' . self::USER_PRIMITIVES_ROUTE . '/' . self::ID_ROUTE . '/' . self::REFERENCES_ROUTE,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_references' ],
+					'permission_callback' => [ $this, 'get_item_permissions_check' ],
+					'args'                => $this->get_references_params(),
+				],
+				'schema' => [ $this, 'get_references_schema' ],
+			]
+		);
+	}
+
+	/**
+	 * Return the set of alias references to a user primitive and whether deletion is safe.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_references( $request ) {
+		$slug  = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+		$id    = Cast::to_string( $request->get_param( self::ID_PARAM ) );
+		$error = $this->pipeline->guard_slug( $slug ) ?? $this->validate_canonical_id( $id );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$stored = $this->pipeline->load_document( $slug );
+
+		if ( ! $this->index->has( $stored, $id ) ) {
+			return new WP_Error(
+				'rest_design_tokens_not_found',
+				__( 'That custom token does not exist.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::NOT_FOUND,
+					'id'     => $id,
+				]
+			);
+		}
+
+		$references  = $this->policy->find( $stored, $id );
+		$all_support = $this->policy->all_supported( $references );
+		$ref_payload = [];
+
+		foreach ( $references as $ref ) {
+			$ref_payload[] = [
+				'kind'      => $ref->kind,
+				'path'      => $ref->path,
+				'supported' => $ref->supported,
+				'action'    => $ref->supported ? 'revert_to_baseline' : 'unsupported',
+			];
+		}
+
+		return new WP_REST_Response(
+			[
+				'id'         => $id,
+				'label'      => $this->index->label_for( $stored, $id ) ?? '',
+				'version'    => $this->pipeline->get_version( $slug ),
+				'deletable'  => $all_support,
+				'references' => $ref_payload,
+			],
+			WP_Http::OK
+		);
+	}
+
+	/**
+	 * The JSON Schema for the references preview response.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_references_schema(): array {
+		return $this->add_additional_fields_schema(
+			[
+				'$schema'    => 'http://json-schema.org/draft-07/schema#',
+				'title'      => 'design-token-user-primitive-references',
+				'type'       => 'object',
+				'properties' => [
+					'id'         => [
+						'description' => __( 'The canonical dot-path id of the user primitive.', 'kadence-blocks' ),
+						'type'        => 'string',
+						'context'     => [ 'view' ],
+						'readonly'    => true,
+					],
+					'label'      => [
+						'description' => __( 'The human-readable label stored in the provenance map.', 'kadence-blocks' ),
+						'type'        => 'string',
+						'context'     => [ 'view' ],
+						'readonly'    => true,
+					],
+					'version'    => [
+						'description' => __( 'The cache-busting version hash for the token set.', 'kadence-blocks' ),
+						'type'        => 'string',
+						'context'     => [ 'view' ],
+						'readonly'    => true,
+					],
+					'deletable'  => [
+						'description' => __( 'Whether the primitive can be safely deleted (all references are supported).', 'kadence-blocks' ),
+						'type'        => 'boolean',
+						'context'     => [ 'view' ],
+						'readonly'    => true,
+					],
+					'references' => [
+						'description' => __( 'All alias references to this primitive found in the document.', 'kadence-blocks' ),
+						'type'        => 'array',
+						'context'     => [ 'view' ],
+						'readonly'    => true,
+						'items'       => [
+							'type'       => 'object',
+							'properties' => [
+								'kind'      => [ 'type' => 'string' ],
+								'path'      => [ 'type' => 'string' ],
+								'supported' => [ 'type' => 'boolean' ],
+								'action'    => [ 'type' => 'string' ],
+							],
+						],
+					],
+				],
+			] 
+		);
+	}
+
+	/**
+	 * Validate that the supplied id is in the allowed phase-1 user-primitive namespace.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id
+	 *
+	 * @return WP_Error|null
+	 */
+	private function validate_canonical_id( string $id ): ?WP_Error {
+		if ( preg_match( '/^primitive\.color\.custom\.[a-z0-9]+(?:-[a-z0-9]+)*$/', $id ) ) {
+			return null;
+		}
+
+		return new WP_Error(
+			'rest_invalid_param',
+			__( 'The id must be a canonical color custom primitive path (primitive.color.custom.<slug>).', 'kadence-blocks' ),
+			[
+				'status' => WP_Http::BAD_REQUEST,
+				'id'     => $id,
+			]
+		);
+	}
+
+	/**
+	 * Route arguments for the references endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_references_params(): array {
+		return [
+			self::SLUG_PARAM => [
+				'description'       => __( 'The token set slug.', 'kadence-blocks' ),
+				'type'              => 'string',
+				'required'          => true,
+				'pattern'           => '^[\w-]+$',
+				'sanitize_callback' => 'sanitize_key',
+			],
+			self::ID_PARAM   => [
+				'description' => __( 'The canonical dot-path id of the user primitive.', 'kadence-blocks' ),
+				'type'        => 'string',
+				'required'    => true,
+				'pattern'     => '^[\w.-]+$',
+			],
+		];
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/User_Primitives_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/User_Primitives_ControllerTest.php
@@ -1,0 +1,368 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Rest\V1;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Reference;
+use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\User_Primitives_Controller;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+use Tests\Support\Classes\TestCase;
+use WP_Error;
+use WP_Http;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Covers the references preview endpoint on User_Primitives_Controller (Phase 9).
+ */
+final class User_Primitives_ControllerTest extends TestCase {
+
+	/**
+	 * @var User_Primitives_Controller
+	 */
+	private User_Primitives_Controller $controller;
+
+	/**
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @var WP_REST_Server
+	 */
+	private WP_REST_Server $rest_server;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->controller = $this->container->get( User_Primitives_Controller::class );
+		$this->store      = $this->container->get( Token_Store::class );
+
+		global $wp_rest_server;
+		$this->rest_server = new WP_REST_Server();
+		$wp_rest_server    = $this->rest_server;
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		wp_set_current_user( 0 );
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tearDown();
+	}
+
+	// -------------------------------------------------------------------------
+	// Route registration
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testItRegistersTheReferencesRouteWithArgsAndSchema(): void {
+		$routes    = $this->rest_server->get_routes();
+		$namespace = 'kb-design-tokens/v1';
+		$pattern   = '#^/' . preg_quote( $namespace, '#' ) . '/documents/\(\?P<slug>#';
+		$found     = false;
+
+		foreach ( array_keys( $routes ) as $route ) {
+			if ( preg_match( $pattern, $route ) && str_contains( $route, 'references' ) ) {
+				$found = true;
+				$opts  = $this->rest_server->get_route_options( $route );
+				$this->assertArrayHasKey( 'schema', $opts );
+				$this->assertIsCallable( $opts['schema'] );
+				break;
+			}
+		}
+
+		$this->assertTrue( $found, 'The references route must be registered.' );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_references — happy path: no references
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testItReturnsEmptyReferencesAndDeletableTrueWhenNothingReferencesThePrimitive(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.color.custom.my-brand';
+
+		$this->store->save_document( wp_json_encode( $this->doc_with_primitive( $id, 'My Brand' ) ) );
+
+		$response = $this->controller->get_references( $this->make_request( $slug, $id ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertSame( $id, $data['id'] );
+		$this->assertSame( 'My Brand', $data['label'] );
+		$this->assertTrue( $data['deletable'] );
+		$this->assertSame( [], $data['references'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_references — version is included
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testResponseIncludesCurrentDocumentVersion(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.color.custom.my-brand';
+
+		$this->store->save_document( wp_json_encode( $this->doc_with_primitive( $id, 'My Brand' ) ) );
+
+		$version = $this->store->get_version( $slug );
+
+		$data = $this->controller->get_references( $this->make_request( $slug, $id ) )->get_data();
+
+		$this->assertSame( $version, $data['version'] );
+		$this->assertNotSame( '', $data['version'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_references — semantic override reference
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testItReturnsSemanticOverrideReferenceAsSupportedWithRevertAction(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.color.custom.brand';
+		$doc  = $this->doc_with_primitive( $id, 'Brand' );
+
+		$doc['semantic'] = [
+			'color' => [
+				'primary' => [
+					'$type'  => 'color',
+					'$value' => '{' . $id . '}',
+				],
+			],
+		];
+
+		$this->store->save_document( wp_json_encode( $doc ) );
+
+		$data = $this->controller->get_references( $this->make_request( $slug, $id ) )->get_data();
+
+		$this->assertTrue( $data['deletable'] );
+		$this->assertCount( 1, $data['references'] );
+
+		$ref = $data['references'][0];
+
+		$this->assertSame( Token_Reference::get_kind_semantic_override(), $ref['kind'] );
+		$this->assertTrue( $ref['supported'] );
+		$this->assertSame( 'revert_to_baseline', $ref['action'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_references — composite field reference (unsupported)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testCompositeFieldReferenceIsUnsupportedAndBlocksDeletion(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.color.custom.shadow-color';
+		$doc  = $this->doc_with_primitive( $id, 'Shadow Color' );
+
+		$doc['primitive'] = array_merge(
+			$doc['primitive'] ?? [],
+			[
+				'shadow' => [
+					'soft' => [
+						'$type'  => 'shadow',
+						'$value' => [
+							'color'   => '{' . $id . '}',
+							'offsetX' => '0',
+							'offsetY' => '2px',
+							'blur'    => '4px',
+							'spread'  => '0',
+						],
+					],
+				],
+			] 
+		);
+
+		$this->store->save_document( wp_json_encode( $doc ) );
+
+		$data = $this->controller->get_references( $this->make_request( $slug, $id ) )->get_data();
+
+		$this->assertFalse( $data['deletable'] );
+		$this->assertCount( 1, $data['references'] );
+
+		$ref = $data['references'][0];
+
+		$this->assertFalse( $ref['supported'] );
+		$this->assertSame( 'unsupported', $ref['action'] );
+		$this->assertSame( Token_Reference::get_kind_composite_field(), $ref['kind'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_references — extension section reference (unsupported)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testExtensionSectionReferenceIsUnsupportedAndBlocksDeletion(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.color.custom.ext-color';
+		$doc  = $this->doc_with_primitive( $id, 'Ext Color' );
+
+		$doc[ Extensions::get_extensions_key() ][ Extensions::get_namespace() ][ Extensions::get_section_foundation_presets() ] = [
+			'color' => [
+				'my-preset' => [
+					Extensions::get_tokens_key() => [
+						'semantic.color.accent' => '{' . $id . '}',
+					],
+				],
+			],
+		];
+
+		$this->store->save_document( wp_json_encode( $doc ) );
+
+		$data = $this->controller->get_references( $this->make_request( $slug, $id ) )->get_data();
+
+		$this->assertFalse( $data['deletable'] );
+
+		$unsupported = array_filter( $data['references'], static fn( array $r ): bool => ! $r['supported'] );
+		$this->assertNotEmpty( $unsupported );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_references — error cases
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testItReturns404ForAnUnknownSlug(): void {
+		$result = $this->controller->get_references( $this->make_request( 'does-not-exist', 'primitive.color.custom.x' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_not_found', $result->get_error_code() );
+		$this->assertSame( WP_Http::NOT_FOUND, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItReturns404WhenIdIsValidFormatButNotInEnvelope(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.color.custom.ghost';
+
+		$this->store->save_document( wp_json_encode( $this->doc_with_primitive( 'primitive.color.custom.other', 'Other' ) ) );
+
+		$result = $this->controller->get_references( $this->make_request( $slug, $id ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_not_found', $result->get_error_code() );
+		$this->assertSame( WP_Http::NOT_FOUND, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItReturns400ForAnInvalidCanonicalIdFormat(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}' );
+
+		$result = $this->controller->get_references( $this->make_request( $slug, 'primitive.color.foo' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_invalid_param', $result->get_error_code() );
+		$this->assertSame( WP_Http::BAD_REQUEST, $result->get_error_data()['status'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_references — does not modify the stored document
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testGetReferencesDoesNotModifyTheStoredDocument(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.color.custom.safe';
+		$doc  = $this->doc_with_primitive( $id, 'Safe' );
+
+		$this->store->save_document( wp_json_encode( $doc ) );
+
+		$before = $this->store->get_document( $slug );
+
+		$this->controller->get_references( $this->make_request( $slug, $id ) );
+
+		$after = $this->store->get_document( $slug );
+
+		$this->assertSame( $before, $after );
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Build a minimal overrides document with one user primitive registered in the index.
+	 *
+	 * @param string $id    The canonical dot-path id.
+	 * @param string $label The label to store in the provenance map.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function doc_with_primitive( string $id, string $label ): array {
+		$segments = explode( '.', $id );
+		$slug     = end( $segments );
+
+		return [
+			'primitive'                      => [
+				'color' => [
+					'custom' => [
+						$slug => [
+							'$type'  => 'color',
+							'$value' => '#336699',
+						],
+					],
+				],
+			],
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					Extensions::get_section_user_primitives() => [
+						$id => [ 'label' => $label ],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Build a GET request for the references endpoint.
+	 *
+	 * @param string $slug The token set slug.
+	 * @param string $id   The user-primitive canonical id.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function make_request( string $slug, string $id ): WP_REST_Request {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', $slug );
+		$request->set_param( 'id', $id );
+
+		return $request;
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `User_Primitives_Controller`, a new REST controller (`kb-design-tokens/v1/documents/(?P<slug>...)/user-primitives/(?P<id>...)/references`) exposing a read-only delete-preview: given a user primitive's canonical id, it returns the current document version, every alias reference found by `Token_Reference_Policy::find()` (kind, path, whether the phase-1 cascade supports it), and a `deletable` flag.
- Gated by the same capability check as `Documents_Controller`'s write routes. Validates the slug via `Document_Write_Pipeline::guard_slug()` (404 for unknown sets) and the id via a strict canonical-path format check (400 on malformed input, 404 when well-formed but absent from the envelope).
- Purely read-side in this phase — no write path is reachable from the controller; create/delete/rename land in the next phase.

## Test plan
- [x] `User_Primitives_ControllerTest` covers route registration, empty-references/deletable case, version echoing, each reference kind (supported semantic override, unsupported composite field, unsupported extension section), unknown-slug 404, valid-format-but-absent-id 404, invalid-id-format 400, and that the preview never mutates the stored document.
- [x] PHPStan clean
- [x] cspell clean
- [x] Full wpunit/acceptance/snapshot suites pass (pre-push CI-equivalent hook)