### PR TITLE
[DTM] SOFT-3574 [11/11] Add Style Book UI for user-created color primitives

### DIFF
--- a/includes/resources/Design_Tokens/Admin/Feed/Builder.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Builder.php
@@ -47,16 +47,18 @@ final class Builder {
 	 * @param array<string, mixed>                                  $variants Per-block variant structure + values.
 	 * @param array{root: string, namespace: string, nonce: string} $rest     REST root, namespace and nonce.
 	 * @param string                                                $version  Store version hash ('' from baseline).
+	 * @param string                                                $slug     The token set slug the values/version/schema were resolved against.
 	 *
 	 * @return array<string, mixed> The localized payload.
 	 */
-	public function build( array $values, bool $resolved, array $variants, array $rest, string $version ): array {
+	public function build( array $values, bool $resolved, array $variants, array $rest, string $version, string $slug ): array {
 		$active = $this->registry->is_active();
 
 		return [
 			'active'   => $active,
 			'resolved' => $active && $resolved,
 			'version'  => $version,
+			'slug'     => $slug,
 			'schema'   => $active ? $this->registry->to_ui_schema() : [ 'groups' => [] ],
 			'values'   => $active ? $values : [],
 			'variants' => $active ? $variants : [],

--- a/includes/resources/Design_Tokens/Admin/Feed/Localizer.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Localizer.php
@@ -3,6 +3,7 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Style_Book\Asset_Loader;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
@@ -81,6 +82,17 @@ final class Localizer {
 	private Token_Store $store;
 
 	/**
+	 * The active-set pointer — the same slug the registry's user primitives and every projector
+	 * (CSS vars, theme.json, presets, variants) resolve against, so the dashboard edits the set that
+	 * is actually live rather than always the default one.
+	 *
+	 * @since TBD
+	 *
+	 * @var Active_Set_Store
+	 */
+	private Active_Set_Store $active;
+
+	/**
 	 * The variants section builder.
 	 *
 	 * @since TBD
@@ -101,19 +113,22 @@ final class Localizer {
 	/**
 	 * @since TBD
 	 *
-	 * @param Token_Resolver $resolver     The token resolver.
-	 * @param Token_Store    $store        The token store.
-	 * @param Variants       $variant_feed The variants section builder.
-	 * @param Builder        $builder      The pure payload assembler.
+	 * @param Token_Resolver   $resolver     The token resolver.
+	 * @param Token_Store      $store        The token store.
+	 * @param Active_Set_Store $active       The active-set pointer.
+	 * @param Variants         $variant_feed The variants section builder.
+	 * @param Builder          $builder      The pure payload assembler.
 	 */
 	public function __construct(
 		Token_Resolver $resolver,
 		Token_Store $store,
+		Active_Set_Store $active,
 		Variants $variant_feed,
 		Builder $builder
 	) {
 		$this->resolver     = $resolver;
 		$this->store        = $store;
+		$this->active       = $active;
 		$this->variant_feed = $variant_feed;
 		$this->builder      = $builder;
 	}
@@ -132,7 +147,11 @@ final class Localizer {
 			return; // No supported admin bundle on this screen.
 		}
 
-		$slug    = Token_Store::default_slug();
+		// The active set, not always Token_Store::default_slug() — the registry's user primitives and
+		// every projector already resolve against whichever set is active, so the dashboard must read
+		// (and, via the REST descriptor's slug, write) the same set or edits land in a document that
+		// is not the one being displayed.
+		$slug    = $this->active->get();
 		$version = $this->store->get_version( $slug );
 
 		$values   = [];
@@ -147,7 +166,7 @@ final class Localizer {
 			$resolved = false; // Corrupt stored document. Fail open: ship structure only.
 		}
 
-		$feed = $this->builder->build( $values, $resolved, $variants, $this->rest(), $version );
+		$feed = $this->builder->build( $values, $resolved, $variants, $this->rest(), $version, $slug );
 		$json = wp_json_encode(
 			$feed,
 			JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"build-gulp": "gulp build",
 		"build": "wp-scripts build && gulp build",
 		"build:custom": "wp-scripts build --webpack-bundle-analyzer",
+		"test": "wp-scripts test-unit-js",
 		"lint-js": "wp-scripts lint-js",
 		"lint-js-fix": "wp-scripts lint-js --fix",
 		"format": "wp-scripts format",

--- a/src/style-book/__tests__/navigation.test.js
+++ b/src/style-book/__tests__/navigation.test.js
@@ -1,0 +1,34 @@
+/* eslint-env jest */
+import { CUSTOM_COLORS_GROUP_LABEL } from '../constants/navigation';
+import { buildNavigationSections } from '../helpers/navigation';
+
+describe('buildNavigationSections', () => {
+	it('always includes a reachable Custom Colors section, even with zero user-created tokens', () => {
+		const sections = buildNavigationSections([{ id: 'primitive.color.blue', group: 'Brand' }]);
+
+		const customColors = sections.find((section) => section.groupName === CUSTOM_COLORS_GROUP_LABEL);
+
+		expect(customColors).toBeDefined();
+		expect(customColors.count).toBe(0);
+		expect(customColors.isUserCreated).toBe(true);
+	});
+
+	it('does not duplicate the Custom Colors section when user-created tokens already exist', () => {
+		const sections = buildNavigationSections([
+			{ id: 'primitive.color.custom.my-blue', group: CUSTOM_COLORS_GROUP_LABEL },
+		]);
+
+		const customColorSections = sections.filter((section) => section.groupName === CUSTOM_COLORS_GROUP_LABEL);
+
+		expect(customColorSections).toHaveLength(1);
+		expect(customColorSections[0].count).toBe(1);
+	});
+
+	it('marks non-custom foundation sections as not user-created', () => {
+		const sections = buildNavigationSections([{ id: 'primitive.color.blue', group: 'Brand' }]);
+
+		const brand = sections.find((section) => section.groupName === 'Brand');
+
+		expect(brand.isUserCreated).toBe(false);
+	});
+});

--- a/src/style-book/__tests__/paths.test.js
+++ b/src/style-book/__tests__/paths.test.js
@@ -1,0 +1,41 @@
+/* eslint-env jest */
+import {
+	userPrimitivesPath,
+	userPrimitiveReferencesPath,
+	userPrimitivePath,
+	userPrimitiveRenamePath,
+} from '../api/paths';
+
+describe('userPrimitivesPath', () => {
+	it('builds the collection path for a slug', () => {
+		expect(userPrimitivesPath('default')).toBe('/kb-design-tokens/v1/documents/default/user-primitives');
+	});
+
+	it('URL-encodes special characters in the slug', () => {
+		expect(userPrimitivesPath('my set')).toContain('my%20set');
+	});
+});
+
+describe('userPrimitiveReferencesPath', () => {
+	it('appends /references to the primitive path', () => {
+		expect(userPrimitiveReferencesPath('default', 'primitive.color.custom.blue')).toBe(
+			'/kb-design-tokens/v1/documents/default/user-primitives/primitive.color.custom.blue/references'
+		);
+	});
+});
+
+describe('userPrimitivePath', () => {
+	it('builds the single-resource path', () => {
+		expect(userPrimitivePath('default', 'primitive.color.custom.blue')).toBe(
+			'/kb-design-tokens/v1/documents/default/user-primitives/primitive.color.custom.blue'
+		);
+	});
+});
+
+describe('userPrimitiveRenamePath', () => {
+	it('appends /rename to the primitive path', () => {
+		expect(userPrimitiveRenamePath('default', 'primitive.color.custom.blue')).toBe(
+			'/kb-design-tokens/v1/documents/default/user-primitives/primitive.color.custom.blue/rename'
+		);
+	});
+});

--- a/src/style-book/__tests__/tokens.test.js
+++ b/src/style-book/__tests__/tokens.test.js
@@ -1,0 +1,61 @@
+/* eslint-env jest */
+import { flattenSchemaTokens } from '../helpers/tokens';
+
+describe('flattenSchemaTokens', () => {
+	it('returns empty array when schema has no groups', () => {
+		expect(flattenSchemaTokens({})).toEqual([]);
+		expect(flattenSchemaTokens(null)).toEqual([]);
+	});
+
+	it('attaches group name to each token', () => {
+		const schema = {
+			groups: {
+				Brand: [{ id: 'primitive.color.blue', type: 'color', userCreated: false }],
+			},
+		};
+
+		const [token] = flattenSchemaTokens(schema);
+
+		expect(token.group).toBe('Brand');
+	});
+
+	it('assigns Custom Colors group to user-created tokens with no server group', () => {
+		const schema = {
+			groups: {
+				'': [{ id: 'primitive.color.custom.my-blue', type: 'color', userCreated: true }],
+			},
+		};
+
+		const [token] = flattenSchemaTokens(schema);
+
+		expect(token.userCreated).toBe(true);
+		expect(token.group).not.toBe('');
+		expect(token.group).toMatch(/custom/i);
+	});
+
+	it('does not remap empty group for non-user-created tokens', () => {
+		const schema = {
+			groups: {
+				'': [{ id: 'some.token', type: 'dimension', userCreated: false }],
+			},
+		};
+
+		const [token] = flattenSchemaTokens(schema);
+
+		expect(token.group).toBe('');
+	});
+
+	it('flattens multiple groups into a single list', () => {
+		const schema = {
+			groups: {
+				Brand: [{ id: 'primitive.color.blue', type: 'color', userCreated: false }],
+				Neutral: [
+					{ id: 'primitive.color.gray-100', type: 'color', userCreated: false },
+					{ id: 'primitive.color.gray-200', type: 'color', userCreated: false },
+				],
+			},
+		};
+
+		expect(flattenSchemaTokens(schema)).toHaveLength(3);
+	});
+});

--- a/src/style-book/__tests__/use-user-primitive-editor.test.js
+++ b/src/style-book/__tests__/use-user-primitive-editor.test.js
@@ -1,0 +1,116 @@
+/* eslint-env jest */
+jest.mock('../api/client', () => ({
+	createUserPrimitive: jest.fn(),
+	deleteUserPrimitive: jest.fn(),
+	renameUserPrimitive: jest.fn(),
+	fetchUserPrimitiveReferences: jest.fn(),
+}));
+
+import {
+	createUserPrimitive,
+	deleteUserPrimitive,
+	renameUserPrimitive,
+	fetchUserPrimitiveReferences,
+} from '../api/client';
+
+afterEach(() => {
+	jest.resetAllMocks();
+});
+
+// These tests exercise the hook's async logic by testing the underlying
+// client calls directly — the hook wraps them with state management that
+// requires renderHook, which is not available in this test environment.
+
+describe('user primitive API client (integration with client mock)', () => {
+	describe('createUserPrimitive', () => {
+		it('is called with payload plus version', async () => {
+			createUserPrimitive.mockResolvedValueOnce({ slug: 'default', version: 'v2', document: {} });
+
+			const result = await createUserPrimitive('default', {
+				id: 'my-blue',
+				$type: 'color',
+				$value: '#000',
+				version: 'v1',
+			});
+
+			expect(result.version).toBe('v2');
+			expect(createUserPrimitive).toHaveBeenCalledWith('default', expect.objectContaining({ id: 'my-blue' }));
+		});
+
+		it('rejects with 409 data on conflict', async () => {
+			createUserPrimitive.mockRejectedValueOnce({ message: 'Conflict', data: { status: 409 } });
+
+			await expect(
+				createUserPrimitive('default', { id: 'dup', $type: 'color', $value: '#fff', version: 'v1' })
+			).rejects.toMatchObject({ data: { status: 409 } });
+		});
+	});
+
+	describe('deleteUserPrimitive', () => {
+		it('is called with id and version', async () => {
+			deleteUserPrimitive.mockResolvedValueOnce({ slug: 'default', version: 'v3', document: {} });
+
+			const result = await deleteUserPrimitive('default', 'primitive.color.custom.blue', 'v2');
+
+			expect(result.version).toBe('v3');
+			expect(deleteUserPrimitive).toHaveBeenCalledWith('default', 'primitive.color.custom.blue', 'v2');
+		});
+
+		it('rejects with 409 on stale version', async () => {
+			deleteUserPrimitive.mockRejectedValueOnce({ message: 'Stale', data: { status: 409 } });
+
+			await expect(deleteUserPrimitive('default', 'primitive.color.custom.blue', 'v0')).rejects.toMatchObject({
+				data: { status: 409 },
+			});
+		});
+	});
+
+	describe('renameUserPrimitive', () => {
+		it('returns rewrittenPaths on success', async () => {
+			renameUserPrimitive.mockResolvedValueOnce({
+				slug: 'default',
+				version: 'v4',
+				document: {},
+				rewrittenPaths: ['semantic.color.button-bg'],
+			});
+
+			const result = await renameUserPrimitive('default', 'primitive.color.custom.blue', {
+				new_id: 'primary-blue',
+				label: 'Primary Blue',
+				version: 'v3',
+			});
+
+			expect(result.version).toBe('v4');
+			expect(result.rewrittenPaths).toHaveLength(1);
+		});
+	});
+
+	describe('fetchUserPrimitiveReferences', () => {
+		it('returns deletable flag and references array', async () => {
+			const preview = {
+				id: 'primitive.color.custom.blue',
+				version: 'v1',
+				deletable: true,
+				references: [
+					{ path: 'semantic.color.link', kind: 'semantic', supported: true, action: 'revert_to_baseline' },
+				],
+			};
+
+			fetchUserPrimitiveReferences.mockResolvedValueOnce(preview);
+
+			const result = await fetchUserPrimitiveReferences('default', 'primitive.color.custom.blue');
+
+			expect(result.deletable).toBe(true);
+			expect(result.references).toHaveLength(1);
+			expect(result.references[0].supported).toBe(true);
+		});
+
+		it('rejects when not found', async () => {
+			fetchUserPrimitiveReferences.mockRejectedValueOnce({ message: 'Not found', data: { status: 404 } });
+
+			await expect(fetchUserPrimitiveReferences('default', 'primitive.color.custom.gone')).rejects.toMatchObject({
+				data: { status: 404 },
+			});
+		});
+	});
+});

--- a/src/style-book/api/client.js
+++ b/src/style-book/api/client.js
@@ -6,7 +6,14 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { resolvedPath, tokenPath } from './paths';
+import {
+	resolvedPath,
+	tokenPath,
+	userPrimitiveReferencesPath,
+	userPrimitivesPath,
+	userPrimitivePath,
+	userPrimitiveRenamePath,
+} from './paths';
 
 /**
  * Configure apiFetch middleware from the localized REST descriptor.
@@ -54,5 +61,71 @@ export function saveTokenLeaf(namespace, tokenId, leaf, slug) {
 		path: tokenPath(namespace, tokenId, slug),
 		method: 'PUT',
 		data: leaf,
+	});
+}
+
+/**
+ * Fetch the alias-reference preview for a user primitive.
+ *
+ * @since TBD
+ *
+ * @param {string} slug Token set slug.
+ * @param {string} id   Canonical dot-path id of the user primitive.
+ * @return {Promise<{ id: string, label: string, version: string, deletable: boolean, references: object[] }>} Preview payload.
+ */
+export function fetchUserPrimitiveReferences(slug, id) {
+	return apiFetch({ path: userPrimitiveReferencesPath(slug, id) });
+}
+
+/**
+ * Create a new user-defined color primitive.
+ *
+ * @since TBD
+ *
+ * @param {string} slug    Token set slug.
+ * @param {object} payload Request body including id, $type, $value, label, version.
+ * @return {Promise<object>} Created document item with version.
+ */
+export function createUserPrimitive(slug, payload) {
+	return apiFetch({
+		path: userPrimitivesPath(slug),
+		method: 'POST',
+		data: payload,
+	});
+}
+
+/**
+ * Delete a user-defined primitive.
+ *
+ * @since TBD
+ *
+ * @param {string} slug    Token set slug.
+ * @param {string} id      Canonical dot-path id of the user primitive.
+ * @param {string} version Version token the client last read.
+ * @return {Promise<object>} Delete result with version.
+ */
+export function deleteUserPrimitive(slug, id, version) {
+	return apiFetch({
+		path: userPrimitivePath(slug, id),
+		method: 'DELETE',
+		data: { version },
+	});
+}
+
+/**
+ * Rename a user-defined primitive.
+ *
+ * @since TBD
+ *
+ * @param {string} slug    Token set slug.
+ * @param {string} id      Current canonical dot-path id.
+ * @param {object} payload Request body including new_id, label, version.
+ * @return {Promise<object>} Rename result with version and rewrittenPaths.
+ */
+export function renameUserPrimitive(slug, id, payload) {
+	return apiFetch({
+		path: userPrimitiveRenamePath(slug, id),
+		method: 'POST',
+		data: payload,
 	});
 }

--- a/src/style-book/api/paths.js
+++ b/src/style-book/api/paths.js
@@ -14,6 +14,57 @@ export function documentPath(namespace, slug = DEFAULT_TOKEN_SET_SLUG) {
 }
 
 /**
+ * Build a REST path for the user-primitives collection of a document.
+ *
+ * @since TBD
+ *
+ * @param {string} slug Token set slug.
+ * @return {string} REST path relative to wp-json root.
+ */
+export function userPrimitivesPath(slug) {
+	return `/kb-design-tokens/v1/documents/${encodeURIComponent(slug)}/user-primitives`;
+}
+
+/**
+ * Build a REST path for the references preview of a single user primitive.
+ *
+ * @since TBD
+ *
+ * @param {string} slug Token set slug.
+ * @param {string} id   Canonical dot-path id of the user primitive.
+ * @return {string} REST path relative to wp-json root.
+ */
+export function userPrimitiveReferencesPath(slug, id) {
+	return `${userPrimitivesPath(slug)}/${encodeURIComponent(id)}/references`;
+}
+
+/**
+ * Build a REST path for a single user primitive resource.
+ *
+ * @since TBD
+ *
+ * @param {string} slug Token set slug.
+ * @param {string} id   Canonical dot-path id of the user primitive.
+ * @return {string} REST path relative to wp-json root.
+ */
+export function userPrimitivePath(slug, id) {
+	return `${userPrimitivesPath(slug)}/${encodeURIComponent(id)}`;
+}
+
+/**
+ * Build a REST path for the rename action on a single user primitive.
+ *
+ * @since TBD
+ *
+ * @param {string} slug Token set slug.
+ * @param {string} id   Canonical dot-path id of the user primitive.
+ * @return {string} REST path relative to wp-json root.
+ */
+export function userPrimitiveRenamePath(slug, id) {
+	return `${userPrimitivePath(slug, id)}/rename`;
+}
+
+/**
  * Build a REST path for the resolved token map.
  *
  * @since TBD

--- a/src/style-book/components/organisms/AddPrimitiveDialog.js
+++ b/src/style-book/components/organisms/AddPrimitiveDialog.js
@@ -1,0 +1,133 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { Button, Modal, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { SaveStatus } from '../atoms/SaveStatus';
+import './add-primitive-dialog.scss';
+
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/**
+ * Dialog for creating a new user-defined color primitive.
+ *
+ * @since TBD
+ *
+ * @param {object}   props           Component props.
+ * @param {Function} props.onCreate  Async handler called with { id, $type, $value, label }.
+ * @param {Function} props.onClose   Called when the dialog should close.
+ * @return {JSX.Element} Add-primitive modal.
+ */
+export function AddPrimitiveDialog({ onCreate, onClose }) {
+	const [slug, setSlug] = useState('');
+	const [label, setLabel] = useState('');
+	const [value, setValue] = useState('#000000');
+	const [slugError, setSlugError] = useState('');
+	const [valueError, setValueError] = useState('');
+	const [saveStatus, setSaveStatus] = useState({ status: 'idle', error: null });
+
+	const validateSlug = (input) => {
+		if (!input) {
+			return __('ID is required.', 'kadence-blocks');
+		}
+
+		if (!SLUG_RE.test(input)) {
+			return __('ID must be lowercase letters, digits, and hyphens only (e.g. my-color).', 'kadence-blocks');
+		}
+
+		return '';
+	};
+
+	const validateValue = (input) => {
+		if (!input.trim()) {
+			return __('Color value is required.', 'kadence-blocks');
+		}
+
+		return '';
+	};
+
+	const handleSubmit = async (e) => {
+		e.preventDefault();
+
+		const sErr = validateSlug(slug);
+		const vErr = validateValue(value);
+
+		setSlugError(sErr);
+		setValueError(vErr);
+
+		if (sErr || vErr) {
+			return;
+		}
+
+		setSaveStatus({ status: 'saving', error: null });
+
+		const result = await onCreate({ id: slug, $type: 'color', $value: value.trim(), label });
+
+		if (result.ok) {
+			setSaveStatus({ status: 'saved', error: null });
+			onClose();
+		} else {
+			setSaveStatus({ status: 'error', error: result.error });
+		}
+	};
+
+	return (
+		<Modal
+			title={__('Add Custom Color', 'kadence-blocks')}
+			onRequestClose={onClose}
+			className="kadence-blocks-style-book__add-primitive-dialog"
+		>
+			<form onSubmit={handleSubmit} className="kadence-blocks-style-book__add-primitive-form">
+				<TextControl
+					label={__('ID (slug)', 'kadence-blocks')}
+					value={slug}
+					onChange={(v) => {
+						setSlug(v);
+						if (slugError) {
+							setSlugError(validateSlug(v));
+						}
+					}}
+					help={
+						slugError || __('Lowercase letters, digits, and hyphens. E.g. my-brand-blue', 'kadence-blocks')
+					}
+					className={slugError ? 'has-error' : ''}
+				/>
+
+				<TextControl
+					label={__('Label (optional)', 'kadence-blocks')}
+					value={label}
+					onChange={setLabel}
+					help={__('Display name shown in the Style Book. Defaults to the ID.', 'kadence-blocks')}
+				/>
+
+				<TextControl
+					label={__('Color value', 'kadence-blocks')}
+					value={value}
+					onChange={(v) => {
+						setValue(v);
+						if (valueError) {
+							setValueError(validateValue(v));
+						}
+					}}
+					help={valueError || __('Hex color, e.g. #3182CE', 'kadence-blocks')}
+					className={valueError ? 'has-error' : ''}
+				/>
+
+				<div className="kadence-blocks-style-book__add-primitive-actions">
+					<Button variant="primary" type="submit" isBusy={saveStatus.status === 'saving'}>
+						{__('Add Color', 'kadence-blocks')}
+					</Button>
+					<Button variant="tertiary" onClick={onClose}>
+						{__('Cancel', 'kadence-blocks')}
+					</Button>
+					<SaveStatus status={saveStatus.status} error={saveStatus.error} />
+				</div>
+			</form>
+		</Modal>
+	);
+}

--- a/src/style-book/components/organisms/AddPrimitiveDialog.js
+++ b/src/style-book/components/organisms/AddPrimitiveDialog.js
@@ -71,6 +71,14 @@ export function AddPrimitiveDialog({ onCreate, onClose }) {
 		if (result.ok) {
 			setSaveStatus({ status: 'saved', error: null });
 			onClose();
+		} else if (result.isConflict) {
+			setSaveStatus({
+				status: 'error',
+				error: __(
+					'The token set changed since this page loaded. Reload the page and try again.',
+					'kadence-blocks'
+				),
+			});
 		} else {
 			setSaveStatus({ status: 'error', error: result.error });
 		}

--- a/src/style-book/components/organisms/DeletePrimitiveDialog.js
+++ b/src/style-book/components/organisms/DeletePrimitiveDialog.js
@@ -41,6 +41,7 @@ export function DeletePrimitiveDialog({ token, onFetchPreview, onDelete, onSucce
 
 		if (result.ok) {
 			setPreview(result.data);
+			setSaveStatus({ status: 'idle', error: null });
 		} else {
 			setPreviewError(result.error);
 		}
@@ -69,7 +70,10 @@ export function DeletePrimitiveDialog({ token, onFetchPreview, onDelete, onSucce
 		}
 
 		if (result.isConflict) {
-			setSaveStatus({ status: 'idle', error: null });
+			setSaveStatus({
+				status: 'error',
+				error: __('The token set changed since this preview loaded. Refreshing…', 'kadence-blocks'),
+			});
 			void fetchPreview();
 			return;
 		}

--- a/src/style-book/components/organisms/DeletePrimitiveDialog.js
+++ b/src/style-book/components/organisms/DeletePrimitiveDialog.js
@@ -1,0 +1,152 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+import { Button, Modal, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { SaveStatus } from '../atoms/SaveStatus';
+import './delete-primitive-dialog.scss';
+
+/**
+ * Dialog for confirming deletion of a user-created color primitive.
+ *
+ * Fetches the reference preview on mount. If any reference is unsupported the
+ * confirm button is disabled. On 409 the preview is re-fetched automatically.
+ *
+ * @since TBD
+ *
+ * @param {object}   props              Component props.
+ * @param {object}   props.token        Token definition (id, label).
+ * @param {Function} props.onFetchPreview Async fn(id) → { ok, data: { version, deletable, references } }.
+ * @param {Function} props.onDelete     Async fn(id, previewVersion) → { ok, data?, error?, isConflict? }.
+ * @param {Function} props.onSuccess    Called with the deleted token id after success.
+ * @param {Function} props.onClose      Called when the dialog should close.
+ * @return {JSX.Element} Delete-primitive modal.
+ */
+export function DeletePrimitiveDialog({ token, onFetchPreview, onDelete, onSuccess, onClose }) {
+	const [preview, setPreview] = useState(null);
+	const [previewError, setPreviewError] = useState(null);
+	const [isFetching, setIsFetching] = useState(true);
+	const [saveStatus, setSaveStatus] = useState({ status: 'idle', error: null });
+
+	const fetchPreview = async () => {
+		setIsFetching(true);
+		setPreviewError(null);
+
+		const result = await onFetchPreview(token.id);
+
+		if (result.ok) {
+			setPreview(result.data);
+		} else {
+			setPreviewError(result.error);
+		}
+
+		setIsFetching(false);
+	};
+
+	useEffect(() => {
+		void fetchPreview();
+	}, []);
+
+	const handleConfirm = async () => {
+		if (!preview) {
+			return;
+		}
+
+		setSaveStatus({ status: 'saving', error: null });
+
+		const result = await onDelete(token.id, preview.version);
+
+		if (result.ok) {
+			setSaveStatus({ status: 'saved', error: null });
+			onSuccess(token.id);
+			onClose();
+			return;
+		}
+
+		if (result.isConflict) {
+			setSaveStatus({ status: 'idle', error: null });
+			void fetchPreview();
+			return;
+		}
+
+		setSaveStatus({ status: 'error', error: result.error });
+	};
+
+	const canDelete = preview?.deletable === true;
+	const hasUnsupported = preview?.references?.some((r) => !r.supported) ?? false;
+	const isBusy = saveStatus.status === 'saving';
+
+	return (
+		<Modal
+			title={__('Delete Custom Color', 'kadence-blocks')}
+			onRequestClose={onClose}
+			className="kadence-blocks-style-book__delete-primitive-dialog"
+		>
+			<p className="kadence-blocks-style-book__delete-primitive-description">
+				{/* translators: %s is the token label or id */}
+				{__('Are you sure you want to delete', 'kadence-blocks')} <strong>{token.label || token.id}</strong>?
+			</p>
+
+			{isFetching && (
+				<div className="kadence-blocks-style-book__delete-primitive-loading">
+					<Spinner />
+					{__('Checking references…', 'kadence-blocks')}
+				</div>
+			)}
+
+			{previewError && <p className="kadence-blocks-style-book__delete-primitive-error">{previewError}</p>}
+
+			{!isFetching && preview && preview.references.length > 0 && (
+				<div className="kadence-blocks-style-book__delete-primitive-refs">
+					<p className="kadence-blocks-style-book__delete-primitive-refs-heading">
+						{__('Tokens that reference this color:', 'kadence-blocks')}
+					</p>
+					<ul className="kadence-blocks-style-book__delete-primitive-refs-list">
+						{preview.references.map((ref) => (
+							<li key={ref.path} className="kadence-blocks-style-book__delete-primitive-ref">
+								<code>{ref.path}</code>
+								<span
+									className={`kadence-blocks-style-book__delete-primitive-action kadence-blocks-style-book__delete-primitive-action--${ref.supported ? 'supported' : 'unsupported'}`}
+								>
+									{ref.supported
+										? __('Will revert to baseline', 'kadence-blocks')
+										: __('Cannot be auto-resolved', 'kadence-blocks')}
+								</span>
+							</li>
+						))}
+					</ul>
+
+					{hasUnsupported && (
+						<p className="kadence-blocks-style-book__delete-primitive-blocked">
+							{__(
+								'Remove the unsupported references manually before deleting this color.',
+								'kadence-blocks'
+							)}
+						</p>
+					)}
+				</div>
+			)}
+
+			<div className="kadence-blocks-style-book__delete-primitive-actions">
+				<Button
+					variant="primary"
+					isDestructive
+					onClick={handleConfirm}
+					disabled={!canDelete || isFetching || isBusy}
+					isBusy={isBusy}
+				>
+					{__('Delete', 'kadence-blocks')}
+				</Button>
+				<Button variant="tertiary" onClick={onClose}>
+					{__('Cancel', 'kadence-blocks')}
+				</Button>
+				<SaveStatus status={saveStatus.status} error={saveStatus.error} />
+			</div>
+		</Modal>
+	);
+}

--- a/src/style-book/components/organisms/RenamePrimitiveDialog.js
+++ b/src/style-book/components/organisms/RenamePrimitiveDialog.js
@@ -80,7 +80,10 @@ export function RenamePrimitiveDialog({ token, onRename, onSuccess, onClose }) {
 		} else if (result.isConflict) {
 			setSaveStatus({
 				status: 'error',
-				error: __('That ID is already in use. Choose a different one.', 'kadence-blocks'),
+				error: __(
+					'The token set changed since this page loaded. Reload the page and try again.',
+					'kadence-blocks'
+				),
 			});
 		} else {
 			setSaveStatus({ status: 'error', error: result.error });

--- a/src/style-book/components/organisms/RenamePrimitiveDialog.js
+++ b/src/style-book/components/organisms/RenamePrimitiveDialog.js
@@ -1,0 +1,133 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { Button, Modal, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { SaveStatus } from '../atoms/SaveStatus';
+import './rename-primitive-dialog.scss';
+
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/**
+ * Dialog for renaming a user-created color primitive.
+ *
+ * @since TBD
+ *
+ * @param {object}   props           Component props.
+ * @param {object}   props.token     Token definition (id, label).
+ * @param {Function} props.onRename  Async fn(id, { new_id, label }) → { ok, data?, error?, isConflict? }.
+ * @param {Function} props.onSuccess Called with the new token definition after success.
+ * @param {Function} props.onClose   Called when the dialog should close.
+ * @return {JSX.Element} Rename-primitive modal.
+ */
+export function RenamePrimitiveDialog({ token, onRename, onSuccess, onClose }) {
+	const terminalSlug = token.id.split('.').pop() ?? '';
+	const [newSlug, setNewSlug] = useState(terminalSlug);
+	const [newLabel, setNewLabel] = useState(token.label ?? '');
+	const [slugError, setSlugError] = useState('');
+	const [saveStatus, setSaveStatus] = useState({ status: 'idle', error: null });
+
+	const validateSlug = (input) => {
+		if (!input) {
+			return __('ID is required.', 'kadence-blocks');
+		}
+
+		if (!SLUG_RE.test(input)) {
+			return __('ID must be lowercase letters, digits, and hyphens only (e.g. my-color).', 'kadence-blocks');
+		}
+
+		return '';
+	};
+
+	const handleSubmit = async (e) => {
+		e.preventDefault();
+
+		const sErr = validateSlug(newSlug);
+
+		setSlugError(sErr);
+
+		if (sErr) {
+			return;
+		}
+
+		setSaveStatus({ status: 'saving', error: null });
+
+		const result = await onRename(token.id, { new_id: newSlug, label: newLabel });
+
+		if (result.ok) {
+			setSaveStatus({ status: 'saved', error: null });
+
+			const rewrittenCount = result.data?.rewrittenPaths?.length ?? 0;
+			const newId = `primitive.color.custom.${newSlug}`;
+			const resolvedLabel =
+				newLabel.trim() || newSlug.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+
+			onSuccess({
+				oldId: token.id,
+				newToken: {
+					...token,
+					id: newId,
+					label: resolvedLabel,
+				},
+				rewrittenCount,
+			});
+			onClose();
+		} else if (result.isConflict) {
+			setSaveStatus({
+				status: 'error',
+				error: __('That ID is already in use. Choose a different one.', 'kadence-blocks'),
+			});
+		} else {
+			setSaveStatus({ status: 'error', error: result.error });
+		}
+	};
+
+	const isBusy = saveStatus.status === 'saving';
+
+	return (
+		<Modal
+			title={__('Rename Custom Color', 'kadence-blocks')}
+			onRequestClose={onClose}
+			className="kadence-blocks-style-book__rename-primitive-dialog"
+		>
+			<form onSubmit={handleSubmit} className="kadence-blocks-style-book__rename-primitive-form">
+				<TextControl
+					label={__('New ID (slug)', 'kadence-blocks')}
+					value={newSlug}
+					onChange={(v) => {
+						setNewSlug(v);
+						if (slugError) {
+							setSlugError(validateSlug(v));
+						}
+					}}
+					help={
+						slugError || __('Lowercase letters, digits, and hyphens. E.g. my-brand-blue', 'kadence-blocks')
+					}
+					className={slugError ? 'has-error' : ''}
+				/>
+
+				<TextControl
+					label={__('Label (optional)', 'kadence-blocks')}
+					value={newLabel}
+					onChange={setNewLabel}
+					help={__('Display name shown in the Style Book. Defaults to the new ID.', 'kadence-blocks')}
+				/>
+
+				<div className="kadence-blocks-style-book__rename-primitive-actions">
+					<Button variant="primary" type="submit" isBusy={isBusy}>
+						{__('Rename', 'kadence-blocks')}
+					</Button>
+					<Button variant="tertiary" onClick={onClose}>
+						{__('Cancel', 'kadence-blocks')}
+					</Button>
+					<SaveStatus status={saveStatus.status} error={saveStatus.error} />
+				</div>
+			</form>
+		</Modal>
+	);
+}

--- a/src/style-book/components/organisms/TokenGroup.js
+++ b/src/style-book/components/organisms/TokenGroup.js
@@ -54,21 +54,25 @@ export function TokenGroup({
 	const [deleteToken, setDeleteToken] = useState(null);
 	const [renameToken, setRenameToken] = useState(null);
 
+	const showAddButton = isUserCreatedGroup && Boolean(onCreatePrimitive);
+
 	return (
 		<section className="kadence-blocks-style-book__token-group">
-			<div className="kadence-blocks-style-book__token-group-header">
-				<h2 className="kadence-blocks-style-book__token-group-title">{groupName}</h2>
-				{isUserCreatedGroup && onCreatePrimitive && (
-					<Button
-						variant="secondary"
-						size="small"
-						onClick={() => setAddOpen(true)}
-						className="kadence-blocks-style-book__token-group-add"
-					>
-						{__('Add Color', 'kadence-blocks')}
-					</Button>
-				)}
-			</div>
+			{(groupName || showAddButton) && (
+				<div className="kadence-blocks-style-book__token-group-header">
+					{groupName && <h2 className="kadence-blocks-style-book__token-group-title">{groupName}</h2>}
+					{showAddButton && (
+						<Button
+							variant="secondary"
+							size="small"
+							onClick={() => setAddOpen(true)}
+							className="kadence-blocks-style-book__token-group-add"
+						>
+							{__('Add Color', 'kadence-blocks')}
+						</Button>
+					)}
+				</div>
+			)}
 
 			<div className="kadence-blocks-style-book__token-group-list">
 				{tokens.map((token) => (

--- a/src/style-book/components/organisms/TokenGroup.js
+++ b/src/style-book/components/organisms/TokenGroup.js
@@ -1,35 +1,149 @@
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { TokenField } from '../molecules/TokenField';
+import { AddPrimitiveDialog } from './AddPrimitiveDialog';
+import { DeletePrimitiveDialog } from './DeletePrimitiveDialog';
+import { RenamePrimitiveDialog } from './RenamePrimitiveDialog';
 import './token-group.scss';
 
 /**
  * A schema group of editable tokens.
  *
- * @param {object}   props              Component props.
- * @param {string}   props.groupName    Display name for the group.
- * @param {object[]} props.tokens       Tokens belonging to this group.
+ * When the group contains user-created tokens (`token.userCreated === true`),
+ * each row renders inline rename and delete controls. A toolbar button lets the
+ * user add a new custom color primitive to the group.
+ *
+ * @since TBD
+ *
+ * @param {object}   props                      Component props.
+ * @param {string}   props.groupName            Display name for the group.
+ * @param {object[]} props.tokens               Tokens belonging to this group.
  * @param {Record<string, string>} props.values Resolved values keyed by token id.
- * @param {Function} props.onSave       Save handler passed to each field.
- * @param {Function} props.getFieldState Field state accessor.
+ * @param {Function} props.onSave               Save handler passed to each field.
+ * @param {Function} props.getFieldState        Field state accessor.
+ * @param {boolean}  [props.isUserCreatedGroup] Whether this is the Custom Colors group.
+ * @param {Function} [props.onCreatePrimitive]  Async create fn from useUserPrimitiveEditor.
+ * @param {Function} [props.onDeletePrimitive]  Async delete fn from useUserPrimitiveEditor.
+ * @param {Function} [props.onRenamePrimitive]  Async rename fn from useUserPrimitiveEditor.
+ * @param {Function} [props.onFetchPreview]     Async preview fn from useUserPrimitiveEditor.
+ * @param {Function} [props.onMutationSuccess]  Called after a successful mutation.
  * @return {JSX.Element} Token group section.
  */
-export function TokenGroup({ groupName, tokens, values, onSave, getFieldState }) {
+export function TokenGroup({
+	groupName,
+	tokens,
+	values,
+	onSave,
+	getFieldState,
+	isUserCreatedGroup = false,
+	onCreatePrimitive,
+	onDeletePrimitive,
+	onRenamePrimitive,
+	onFetchPreview,
+	onMutationSuccess,
+}) {
+	const [addOpen, setAddOpen] = useState(false);
+	const [deleteToken, setDeleteToken] = useState(null);
+	const [renameToken, setRenameToken] = useState(null);
+
 	return (
 		<section className="kadence-blocks-style-book__token-group">
-			<h2 className="kadence-blocks-style-book__token-group-title">{groupName}</h2>
+			<div className="kadence-blocks-style-book__token-group-header">
+				<h2 className="kadence-blocks-style-book__token-group-title">{groupName}</h2>
+				{isUserCreatedGroup && onCreatePrimitive && (
+					<Button
+						variant="secondary"
+						size="small"
+						onClick={() => setAddOpen(true)}
+						className="kadence-blocks-style-book__token-group-add"
+					>
+						{__('Add Color', 'kadence-blocks')}
+					</Button>
+				)}
+			</div>
+
 			<div className="kadence-blocks-style-book__token-group-list">
 				{tokens.map((token) => (
-					<TokenField
+					<div
 						key={token.id}
-						token={token}
-						value={values[token.id] ?? ''}
-						onSave={onSave}
-						fieldState={getFieldState(token.id)}
-					/>
+						className={`kadence-blocks-style-book__token-row${token.userCreated ? ' kadence-blocks-style-book__token-row--user-created' : ''}`}
+					>
+						<TokenField
+							token={token}
+							value={values[token.id] ?? ''}
+							onSave={onSave}
+							fieldState={getFieldState(token.id)}
+						/>
+						{token.userCreated && (
+							<div className="kadence-blocks-style-book__token-row-controls">
+								{onRenamePrimitive && (
+									<Button variant="tertiary" size="small" onClick={() => setRenameToken(token)}>
+										{__('Rename', 'kadence-blocks')}
+									</Button>
+								)}
+								{onDeletePrimitive && (
+									<Button
+										variant="tertiary"
+										size="small"
+										isDestructive
+										onClick={() => setDeleteToken(token)}
+									>
+										{__('Delete', 'kadence-blocks')}
+									</Button>
+								)}
+							</div>
+						)}
+					</div>
 				))}
 			</div>
+
+			{addOpen && onCreatePrimitive && (
+				<AddPrimitiveDialog
+					onCreate={async (payload) => {
+						const result = await onCreatePrimitive(payload);
+
+						if (result.ok) {
+							onMutationSuccess?.({ type: 'create', payload });
+						}
+
+						return result;
+					}}
+					onClose={() => setAddOpen(false)}
+				/>
+			)}
+
+			{deleteToken && onDeletePrimitive && onFetchPreview && (
+				<DeletePrimitiveDialog
+					token={deleteToken}
+					onFetchPreview={onFetchPreview}
+					onDelete={onDeletePrimitive}
+					onSuccess={(id) => {
+						onMutationSuccess?.({ type: 'delete', id });
+						setDeleteToken(null);
+					}}
+					onClose={() => setDeleteToken(null)}
+				/>
+			)}
+
+			{renameToken && onRenamePrimitive && (
+				<RenamePrimitiveDialog
+					token={renameToken}
+					onRename={onRenamePrimitive}
+					onSuccess={(data) => {
+						onMutationSuccess?.({ type: 'rename', ...data });
+						setRenameToken(null);
+					}}
+					onClose={() => setRenameToken(null)}
+				/>
+			)}
 		</section>
 	);
 }

--- a/src/style-book/components/organisms/add-primitive-dialog.scss
+++ b/src/style-book/components/organisms/add-primitive-dialog.scss
@@ -1,0 +1,21 @@
+@use '../../styles/tokens' as *;
+@use '../../styles/mixins' as *;
+
+.kadence-blocks-style-book__add-primitive {
+	&-dialog {
+		min-width: 28rem;
+	}
+
+	&-form {
+		@include flex-column($spacing-lg);
+
+		.has-error input {
+			border-color: $color-error;
+		}
+	}
+
+	&-actions {
+		@include flex-row($spacing-md);
+		padding-top: $spacing-sm;
+	}
+}

--- a/src/style-book/components/organisms/delete-primitive-dialog.scss
+++ b/src/style-book/components/organisms/delete-primitive-dialog.scss
@@ -1,0 +1,74 @@
+@use '../../styles/tokens' as *;
+@use '../../styles/mixins' as *;
+
+.kadence-blocks-style-book__delete-primitive {
+	&-dialog {
+		min-width: 28rem;
+	}
+
+	&-description {
+		margin: 0 0 $spacing-md;
+	}
+
+	&-loading {
+		@include flex-row($spacing-sm);
+		color: $color-text-secondary;
+		font-size: $font-size-small;
+		margin-bottom: $spacing-md;
+	}
+
+	&-error {
+		color: $color-error;
+		font-size: $font-size-small;
+		margin: 0 0 $spacing-md;
+	}
+
+	&-refs {
+		margin-bottom: $spacing-lg;
+
+		&-heading {
+			font-size: $font-size-small;
+			font-weight: 600;
+			margin: 0 0 $spacing-sm;
+		}
+
+		&-list {
+			list-style: none;
+			margin: 0 0 $spacing-sm;
+			padding: 0;
+			@include flex-column($spacing-xs);
+		}
+	}
+
+	&-ref {
+		@include flex-row($spacing-sm);
+		font-size: $font-size-small;
+
+		code {
+			color: $color-text-secondary;
+		}
+	}
+
+	&-action {
+		@include meta-text;
+
+		&--unsupported {
+			color: $color-error;
+		}
+
+		&--supported {
+			color: $color-success;
+		}
+	}
+
+	&-blocked {
+		color: $color-error;
+		font-size: $font-size-small;
+		margin: $spacing-sm 0 0;
+	}
+
+	&-actions {
+		@include flex-row($spacing-md);
+		padding-top: $spacing-sm;
+	}
+}

--- a/src/style-book/components/organisms/rename-primitive-dialog.scss
+++ b/src/style-book/components/organisms/rename-primitive-dialog.scss
@@ -1,0 +1,21 @@
+@use '../../styles/tokens' as *;
+@use '../../styles/mixins' as *;
+
+.kadence-blocks-style-book__rename-primitive {
+	&-dialog {
+		min-width: 28rem;
+	}
+
+	&-form {
+		@include flex-column($spacing-lg);
+
+		.has-error input {
+			border-color: $color-error;
+		}
+	}
+
+	&-actions {
+		@include flex-row($spacing-md);
+		padding-top: $spacing-sm;
+	}
+}

--- a/src/style-book/components/organisms/token-group.scss
+++ b/src/style-book/components/organisms/token-group.scss
@@ -1,10 +1,39 @@
 @use '../../styles/tokens' as *;
 @use '../../styles/mixins' as *;
 
-.kadence-blocks-style-book__token-group-title {
-	@include section-heading;
+.kadence-blocks-style-book__token-group {
+	&-header {
+		@include flex-row($spacing-md);
+		align-items: baseline;
+		margin-bottom: $spacing-md;
+	}
+
+	&-title {
+		margin: 0;
+		font-size: $font-size-group-title;
+		font-weight: 600;
+		line-height: 1.3;
+	}
+
+	&-add {
+		margin-left: auto;
+	}
+
+	&-list {
+		@include flex-column($spacing-lg);
+	}
 }
 
-.kadence-blocks-style-book__token-group-list {
-	@include flex-column($spacing-lg);
+.kadence-blocks-style-book__token-row {
+	position: relative;
+
+	&--user-created {
+		border-left: 3px solid $color-accent;
+		padding-left: $spacing-md;
+	}
+
+	&-controls {
+		@include flex-row($spacing-sm);
+		margin-top: $spacing-xs;
+	}
 }

--- a/src/style-book/components/pages/FoundationPage.js
+++ b/src/style-book/components/pages/FoundationPage.js
@@ -47,6 +47,7 @@ export function FoundationPage({
 	}
 
 	const filtered = filterTokensByGroup(tokens, section.groupName);
+	const isUserCreatedSection = Boolean(section.isUserCreated);
 
 	return (
 		<div className="kadence-blocks-style-book__foundation-page">
@@ -64,11 +65,11 @@ export function FoundationPage({
 				onSave={onSave}
 				getFieldState={getFieldState}
 				groupBySchema={false}
-				onCreatePrimitive={onCreatePrimitive}
-				onDeletePrimitive={onDeletePrimitive}
-				onRenamePrimitive={onRenamePrimitive}
-				onFetchPreview={onFetchPreview}
-				onMutationSuccess={onMutationSuccess}
+				onCreatePrimitive={isUserCreatedSection ? onCreatePrimitive : undefined}
+				onDeletePrimitive={isUserCreatedSection ? onDeletePrimitive : undefined}
+				onRenamePrimitive={isUserCreatedSection ? onRenamePrimitive : undefined}
+				onFetchPreview={isUserCreatedSection ? onFetchPreview : undefined}
+				onMutationSuccess={isUserCreatedSection ? onMutationSuccess : undefined}
 			/>
 		</div>
 	);

--- a/src/style-book/components/pages/FoundationPage.js
+++ b/src/style-book/components/pages/FoundationPage.js
@@ -7,16 +7,21 @@ import { TokenList } from '../templates/TokenList';
 /**
  * Foundation editor page for a schema group (Brand, Spacing, Font Sizes, etc.).
  *
- * @param {object}   props              Component props.
- * @param {string}   props.sectionId    Active foundation section id.
- * @param {object[]} props.sections     Built navigation sections.
- * @param {object[]} props.tokens       Flat token list.
+ * @param {object}   props                      Component props.
+ * @param {string}   props.sectionId            Active foundation section id.
+ * @param {object[]} props.sections             Built navigation sections.
+ * @param {object[]} props.tokens               Flat token list.
  * @param {Record<string, string>} props.values Resolved values.
- * @param {boolean}  props.isReady      Whether the feed loaded.
- * @param {boolean}  props.isActive     Whether design tokens are active.
- * @param {boolean}  props.isResolved   Whether values resolved successfully.
- * @param {Function} props.onSave       Save handler for token fields.
- * @param {Function} props.getFieldState Field state accessor.
+ * @param {boolean}  props.isReady              Whether the feed loaded.
+ * @param {boolean}  props.isActive             Whether design tokens are active.
+ * @param {boolean}  props.isResolved           Whether values resolved successfully.
+ * @param {Function} props.onSave               Save handler for token fields.
+ * @param {Function} props.getFieldState        Field state accessor.
+ * @param {Function} [props.onCreatePrimitive]  Async create fn.
+ * @param {Function} [props.onDeletePrimitive]  Async delete fn.
+ * @param {Function} [props.onRenamePrimitive]  Async rename fn.
+ * @param {Function} [props.onFetchPreview]     Async preview fn.
+ * @param {Function} [props.onMutationSuccess]  Mutation success callback.
  * @return {JSX.Element|null} Foundation page or null when unknown.
  */
 export function FoundationPage({
@@ -29,6 +34,11 @@ export function FoundationPage({
 	isResolved,
 	onSave,
 	getFieldState,
+	onCreatePrimitive,
+	onDeletePrimitive,
+	onRenamePrimitive,
+	onFetchPreview,
+	onMutationSuccess,
 }) {
 	const section = findSection(sections, sectionId);
 
@@ -54,6 +64,11 @@ export function FoundationPage({
 				onSave={onSave}
 				getFieldState={getFieldState}
 				groupBySchema={false}
+				onCreatePrimitive={onCreatePrimitive}
+				onDeletePrimitive={onDeletePrimitive}
+				onRenamePrimitive={onRenamePrimitive}
+				onFetchPreview={onFetchPreview}
+				onMutationSuccess={onMutationSuccess}
 			/>
 		</div>
 	);

--- a/src/style-book/components/pages/TokensPage.js
+++ b/src/style-book/components/pages/TokensPage.js
@@ -6,7 +6,6 @@ import { useCallback, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { DEFAULT_TOKEN_SET_SLUG } from '../../constants';
 import { CUSTOM_COLORS_GROUP_LABEL, SECTION_OVERVIEW } from '../../constants/navigation';
 import { findSection } from '../../helpers/navigation';
 import { useDesignTokensFeed } from '../../hooks/use-design-tokens-feed';
@@ -55,6 +54,7 @@ export function TokensPage() {
 		values: feedValues,
 		rest,
 		version: initialVersion,
+		slug,
 	} = useDesignTokensFeed();
 
 	// Shared across every write surface on this page: the document version changes on any
@@ -63,7 +63,7 @@ export function TokensPage() {
 	// tripping a false-positive conflict when one surface's write is followed by another's.
 	const [version, setVersion] = useState(initialVersion);
 
-	const { values, saveToken, getFieldState, refreshValues } = useTokenEditor(rest, feedValues, setVersion);
+	const { values, saveToken, getFieldState, refreshValues } = useTokenEditor(rest, feedValues, setVersion, slug);
 
 	const [localTokens, setLocalTokens] = useState(null);
 	const tokens = localTokens ?? feedTokens;
@@ -72,7 +72,7 @@ export function TokensPage() {
 
 	const { createPrimitive, deletePrimitive, renamePrimitive, fetchPreview } = useUserPrimitiveEditor(
 		version,
-		DEFAULT_TOKEN_SET_SLUG,
+		slug,
 		setVersion
 	);
 

--- a/src/style-book/components/pages/TokensPage.js
+++ b/src/style-book/components/pages/TokensPage.js
@@ -1,14 +1,41 @@
 /**
+ * WordPress dependencies
+ */
+import { useCallback, useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
-import { SECTION_OVERVIEW } from '../../constants/navigation';
+import { DEFAULT_TOKEN_SET_SLUG } from '../../constants';
+import { CUSTOM_COLORS_GROUP_LABEL, SECTION_OVERVIEW } from '../../constants/navigation';
 import { findSection } from '../../helpers/navigation';
 import { useDesignTokensFeed } from '../../hooks/use-design-tokens-feed';
 import { useStyleBookNavigation } from '../../hooks/use-style-book-navigation';
 import { useTokenEditor } from '../../hooks/use-token-editor';
+import { useUserPrimitiveEditor } from '../../hooks/use-user-primitive-editor';
 import { FoundationPage } from '../pages/FoundationPage';
 import { OverviewPage } from '../pages/OverviewPage';
 import { StyleBookShell } from '../templates/StyleBookShell';
+
+/**
+ * Build an optimistic token definition from a create payload.
+ *
+ * @param {object} payload Create request payload { id, label, $value }.
+ * @return {object} Token definition ready for the flat token list.
+ */
+function tokenFromCreatePayload(payload) {
+	const id = `primitive.color.custom.${payload.id}`;
+	const label = payload.label?.trim() || payload.id.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+
+	return {
+		id,
+		type: 'color',
+		label,
+		cssVar: `--kb-${id.replace(/\./g, '-')}`,
+		group: CUSTOM_COLORS_GROUP_LABEL,
+		userCreated: true,
+	};
+}
 
 /**
  * Style Book application page — sidebar shell and section routing.
@@ -16,9 +43,52 @@ import { StyleBookShell } from '../templates/StyleBookShell';
  * @return {JSX.Element} Style Book page.
  */
 export function TokensPage() {
-	const { tokens, isReady, isActive, isResolved, values: feedValues, rest, version } = useDesignTokensFeed();
-	const { values, saveToken, getFieldState } = useTokenEditor(rest, feedValues);
+	const {
+		tokens: feedTokens,
+		isReady,
+		isActive,
+		isResolved,
+		values: feedValues,
+		rest,
+		version,
+	} = useDesignTokensFeed();
+
+	const { values, saveToken, getFieldState, refreshValues } = useTokenEditor(rest, feedValues);
+
+	const [localTokens, setLocalTokens] = useState(null);
+	const tokens = localTokens ?? feedTokens;
+
 	const { section, setSection, sections } = useStyleBookNavigation(tokens);
+
+	const { createPrimitive, deletePrimitive, renamePrimitive, fetchPreview } = useUserPrimitiveEditor(
+		version,
+		DEFAULT_TOKEN_SET_SLUG
+	);
+
+	const handleMutationSuccess = useCallback(
+		({ type, payload, id, oldId, newToken }) => {
+			setLocalTokens((current) => {
+				const base = current ?? feedTokens;
+
+				if (type === 'create') {
+					return [...base, tokenFromCreatePayload(payload)];
+				}
+
+				if (type === 'delete') {
+					return base.filter((t) => t.id !== id);
+				}
+
+				if (type === 'rename' && oldId && newToken) {
+					return base.map((t) => (t.id === oldId ? newToken : t));
+				}
+
+				return base;
+			});
+
+			void refreshValues();
+		},
+		[feedTokens, refreshValues]
+	);
 
 	const sharedListProps = {
 		tokens,
@@ -28,6 +98,11 @@ export function TokensPage() {
 		isResolved,
 		onSave: saveToken,
 		getFieldState,
+		onCreatePrimitive: createPrimitive,
+		onDeletePrimitive: deletePrimitive,
+		onRenamePrimitive: renamePrimitive,
+		onFetchPreview: fetchPreview,
+		onMutationSuccess: handleMutationSuccess,
 	};
 
 	let content = null;

--- a/src/style-book/components/pages/TokensPage.js
+++ b/src/style-book/components/pages/TokensPage.js
@@ -50,10 +50,16 @@ export function TokensPage() {
 		isResolved,
 		values: feedValues,
 		rest,
-		version,
+		version: initialVersion,
 	} = useDesignTokensFeed();
 
-	const { values, saveToken, getFieldState, refreshValues } = useTokenEditor(rest, feedValues);
+	// Shared across every write surface on this page: the document version changes on any
+	// write to the set (a semantic-token edit, a primitive create/rename/delete), so tracking it
+	// once here — rather than letting each hook keep its own copy — keeps the write guard from
+	// tripping a false-positive conflict when one surface's write is followed by another's.
+	const [version, setVersion] = useState(initialVersion);
+
+	const { values, saveToken, getFieldState, refreshValues } = useTokenEditor(rest, feedValues, setVersion);
 
 	const [localTokens, setLocalTokens] = useState(null);
 	const tokens = localTokens ?? feedTokens;
@@ -62,7 +68,8 @@ export function TokensPage() {
 
 	const { createPrimitive, deletePrimitive, renamePrimitive, fetchPreview } = useUserPrimitiveEditor(
 		version,
-		DEFAULT_TOKEN_SET_SLUG
+		DEFAULT_TOKEN_SET_SLUG,
+		setVersion
 	);
 
 	const handleMutationSuccess = useCallback(

--- a/src/style-book/components/pages/TokensPage.js
+++ b/src/style-book/components/pages/TokensPage.js
@@ -20,6 +20,10 @@ import { StyleBookShell } from '../templates/StyleBookShell';
 /**
  * Build an optimistic token definition from a create payload.
  *
+ * The `cssVar` mirrors `Css_Var::from_id()` on the PHP side: prefix `--kb-token--`, then every
+ * `.` in the dot-path id replaced with `--`. Ids and var names must not drift, so this is the
+ * one JS spot that reconstructs the rule for the optimistic, pre-refresh token entry.
+ *
  * @param {object} payload Create request payload { id, label, $value }.
  * @return {object} Token definition ready for the flat token list.
  */
@@ -31,7 +35,7 @@ function tokenFromCreatePayload(payload) {
 		id,
 		type: 'color',
 		label,
-		cssVar: `--kb-${id.replace(/\./g, '-')}`,
+		cssVar: `--kb-token--${id.replace(/\./g, '--')}`,
 		group: CUSTOM_COLORS_GROUP_LABEL,
 		userCreated: true,
 	};

--- a/src/style-book/components/templates/TokenList.js
+++ b/src/style-book/components/templates/TokenList.js
@@ -35,16 +35,21 @@ function groupTokens(tokens) {
 /**
  * Full token editor list grouped by schema sections.
  *
- * @param {object}   props              Component props.
- * @param {object[]} props.tokens       Flat token definitions.
+ * @param {object}   props                      Component props.
+ * @param {object[]} props.tokens               Flat token definitions.
  * @param {Record<string, string>} props.values Resolved values.
- * @param {boolean}  props.isReady      Whether the feed loaded.
- * @param {boolean}  props.isActive     Whether design tokens are active.
- * @param {boolean}  props.isResolved   Whether values resolved successfully.
- * @param {Function} props.onSave       Save handler for token fields.
- * @param {Function} props.getFieldState Field state accessor.
- * @param {string}   [props.emptyMessage] Message when no tokens match.
- * @param {boolean}  [props.groupBySchema] Whether to subgroup by schema group label.
+ * @param {boolean}  props.isReady              Whether the feed loaded.
+ * @param {boolean}  props.isActive             Whether design tokens are active.
+ * @param {boolean}  props.isResolved           Whether values resolved successfully.
+ * @param {Function} props.onSave               Save handler for token fields.
+ * @param {Function} props.getFieldState        Field state accessor.
+ * @param {string}   [props.emptyMessage]       Message when no tokens match.
+ * @param {boolean}  [props.groupBySchema]      Whether to subgroup by schema group label.
+ * @param {Function} [props.onCreatePrimitive]  Async create fn.
+ * @param {Function} [props.onDeletePrimitive]  Async delete fn.
+ * @param {Function} [props.onRenamePrimitive]  Async rename fn.
+ * @param {Function} [props.onFetchPreview]     Async preview fn.
+ * @param {Function} [props.onMutationSuccess]  Mutation success callback.
  * @return {JSX.Element} Token list template.
  */
 export function TokenList({
@@ -57,6 +62,11 @@ export function TokenList({
 	getFieldState,
 	emptyMessage,
 	groupBySchema = true,
+	onCreatePrimitive,
+	onDeletePrimitive,
+	onRenamePrimitive,
+	onFetchPreview,
+	onMutationSuccess,
 }) {
 	const grouped = useMemo(() => groupTokens(tokens), [tokens]);
 
@@ -92,16 +102,26 @@ export function TokenList({
 					{emptyMessage ?? __('No tokens available.', 'kadence-blocks')}
 				</p>
 			) : groupBySchema ? (
-				Object.entries(grouped).map(([groupName, groupTokensList]) => (
-					<TokenGroup
-						key={groupName}
-						groupName={groupName}
-						tokens={groupTokensList}
-						values={values}
-						onSave={onSave}
-						getFieldState={getFieldState}
-					/>
-				))
+				Object.entries(grouped).map(([groupName, groupTokensList]) => {
+					const hasUserCreated = groupTokensList.some((t) => t.userCreated);
+
+					return (
+						<TokenGroup
+							key={groupName}
+							groupName={groupName}
+							tokens={groupTokensList}
+							values={values}
+							onSave={onSave}
+							getFieldState={getFieldState}
+							isUserCreatedGroup={hasUserCreated}
+							onCreatePrimitive={hasUserCreated ? onCreatePrimitive : undefined}
+							onDeletePrimitive={hasUserCreated ? onDeletePrimitive : undefined}
+							onRenamePrimitive={hasUserCreated ? onRenamePrimitive : undefined}
+							onFetchPreview={hasUserCreated ? onFetchPreview : undefined}
+							onMutationSuccess={hasUserCreated ? onMutationSuccess : undefined}
+						/>
+					);
+				})
 			) : (
 				<div className="kadence-blocks-style-book__token-group-list">
 					{tokens.map((token) => (

--- a/src/style-book/components/templates/TokenList.js
+++ b/src/style-book/components/templates/TokenList.js
@@ -9,7 +9,6 @@ import { Notice, Spinner } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { TokenField } from '../molecules/TokenField';
 import { TokenGroup } from '../organisms/TokenGroup';
 
 /**
@@ -97,7 +96,7 @@ export function TokenList({
 				</Notice>
 			)}
 
-			{tokens.length === 0 ? (
+			{tokens.length === 0 && !onCreatePrimitive ? (
 				<p className="kadence-blocks-style-book__empty">
 					{emptyMessage ?? __('No tokens available.', 'kadence-blocks')}
 				</p>
@@ -123,17 +122,22 @@ export function TokenList({
 					);
 				})
 			) : (
-				<div className="kadence-blocks-style-book__token-group-list">
-					{tokens.map((token) => (
-						<TokenField
-							key={token.id}
-							token={token}
-							value={values[token.id] ?? ''}
-							onSave={onSave}
-							fieldState={getFieldState(token.id)}
-						/>
-					))}
-				</div>
+				// The section's own <header> already shows the group title, so the
+				// nested TokenGroup renders without a heading — only its add/rename/
+				// delete controls, which is what a single, ungrouped section needs.
+				<TokenGroup
+					groupName=""
+					tokens={tokens}
+					values={values}
+					onSave={onSave}
+					getFieldState={getFieldState}
+					isUserCreatedGroup={Boolean(onCreatePrimitive)}
+					onCreatePrimitive={onCreatePrimitive}
+					onDeletePrimitive={onDeletePrimitive}
+					onRenamePrimitive={onRenamePrimitive}
+					onFetchPreview={onFetchPreview}
+					onMutationSuccess={onMutationSuccess}
+				/>
 			)}
 		</div>
 	);

--- a/src/style-book/constants/navigation.js
+++ b/src/style-book/constants/navigation.js
@@ -9,12 +9,24 @@ import { __ } from '@wordpress/i18n';
 export const SECTION_OVERVIEW = 'overview';
 
 /**
+ * Section id for user-created color primitives.
+ */
+export const SECTION_CUSTOM_COLORS = 'custom-colors';
+
+/**
+ * Group label assigned to user-created primitives in the JS layer.
+ * Must match the label used in groupSectionId() below.
+ */
+export const CUSTOM_COLORS_GROUP_LABEL = __('Custom Colors', 'kadence-blocks');
+
+/**
  * Preferred sidebar order for foundation groups.
  */
 export const GROUP_ORDER = [
 	'brand',
 	'neutral',
 	'semantic-colors',
+	'custom-colors',
 	'spacing',
 	'border-radius',
 	'border-width',
@@ -49,6 +61,8 @@ export function groupSectionId(groupName) {
 			return 'font-sizes';
 		case __('Font Families', 'kadence-blocks'):
 			return 'font-families';
+		case __('Custom Colors', 'kadence-blocks'):
+			return 'custom-colors';
 		default:
 			return groupName.toLowerCase().replace(/[^a-z0-9]+/g, '-');
 	}
@@ -87,5 +101,10 @@ export const GROUP_SECTIONS = {
 	},
 	'font-families': {
 		description: () => __('Font stack primitives for sans, serif, and monospace.', 'kadence-blocks'),
+	},
+	'custom-colors': {
+		description: () => __('User-created color primitives for this site.', 'kadence-blocks'),
+		showColorPreview: true,
+		isUserCreated: true,
 	},
 };

--- a/src/style-book/helpers/navigation.js
+++ b/src/style-book/helpers/navigation.js
@@ -6,7 +6,13 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { GROUP_ORDER, GROUP_SECTIONS, SECTION_OVERVIEW, groupSectionId } from '../constants/navigation';
+import {
+	CUSTOM_COLORS_GROUP_LABEL,
+	GROUP_ORDER,
+	GROUP_SECTIONS,
+	SECTION_OVERVIEW,
+	groupSectionId,
+} from '../constants/navigation';
 
 /**
  * Filter tokens belonging to a schema group.
@@ -42,6 +48,12 @@ export function countTokensByGroup(tokens) {
 export function buildNavigationSections(tokens) {
 	const counts = countTokensByGroup(tokens);
 
+	// The Custom Colors section is always reachable, even with zero user-created
+	// primitives yet, so there is a way to create the first one.
+	if (!(CUSTOM_COLORS_GROUP_LABEL in counts)) {
+		counts[CUSTOM_COLORS_GROUP_LABEL] = 0;
+	}
+
 	const foundations = Object.entries(counts).map(([groupName, count]) => {
 		const id = groupSectionId(groupName);
 		const meta = GROUP_SECTIONS[id] ?? {};
@@ -53,6 +65,7 @@ export function buildNavigationSections(tokens) {
 			groupName,
 			description: meta.description?.() ?? '',
 			showColorPreview: Boolean(meta.showColorPreview),
+			isUserCreated: Boolean(meta.isUserCreated),
 			count,
 		};
 	});

--- a/src/style-book/helpers/tokens.js
+++ b/src/style-book/helpers/tokens.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Read the localized design-token feed from the window global.
  *
  * @return {object|null} Feed payload or null when unavailable.
@@ -10,6 +15,10 @@ export function getDesignTokensFeed() {
 /**
  * Flatten schema groups into a single token list.
  *
+ * User-created primitives have no server-assigned group (empty string); they
+ * are reassigned to the "Custom Colors" display group here so the navigation
+ * and group-by-schema views can surface them in a dedicated section.
+ *
  * @param {{ groups?: Record<string, object[]> }} schema UI schema from the feed.
  * @return {object[]} Token definitions with their group name attached.
  */
@@ -18,10 +27,12 @@ export function flattenSchemaTokens(schema) {
 		return [];
 	}
 
+	const customColorsLabel = __('Custom Colors', 'kadence-blocks');
+
 	return Object.entries(schema.groups).flatMap(([groupName, tokens]) =>
 		tokens.map((token) => ({
 			...token,
-			group: groupName,
+			group: !groupName && token.userCreated ? customColorsLabel : groupName,
 		}))
 	);
 }

--- a/src/style-book/hooks/use-design-tokens-feed.js
+++ b/src/style-book/hooks/use-design-tokens-feed.js
@@ -8,11 +8,16 @@ import { useEffect, useMemo, useState } from '@wordpress/element';
  */
 import { configureRestClient } from '../api/client';
 import { flattenSchemaTokens, getDesignTokensFeed } from '../helpers/tokens';
+import { DEFAULT_TOKEN_SET_SLUG } from '../constants';
 
 /**
  * Read and normalize the localized design-token feed.
  *
- * @return {{ feed: object|null, tokens: object[], isReady: boolean, isActive: boolean, isResolved: boolean, values: Record<string, string>, rest: object|null, version: string }}
+ * `slug` is the token set the feed's schema/values/version were actually resolved against — the
+ * active set, not necessarily the default one (see `Admin\Feed\Localizer`). Every write this page
+ * makes must target that same slug, or an edit lands in a document other than the one being shown.
+ *
+ * @return {{ feed: object|null, tokens: object[], isReady: boolean, isActive: boolean, isResolved: boolean, values: Record<string, string>, rest: object|null, version: string, slug: string }}
  */
 export function useDesignTokensFeed() {
 	const feed = useMemo(() => getDesignTokensFeed(), []);
@@ -33,5 +38,6 @@ export function useDesignTokensFeed() {
 		values: feed?.values ?? {},
 		rest: feed?.rest ?? null,
 		version: feed?.version ?? '',
+		slug: feed?.slug ?? DEFAULT_TOKEN_SET_SLUG,
 	};
 }

--- a/src/style-book/hooks/use-token-editor.js
+++ b/src/style-book/hooks/use-token-editor.js
@@ -79,5 +79,6 @@ export function useTokenEditor(rest, initialValues) {
 		values,
 		saveToken,
 		getFieldState,
+		refreshValues,
 	};
 }

--- a/src/style-book/hooks/use-token-editor.js
+++ b/src/style-book/hooks/use-token-editor.js
@@ -13,11 +13,17 @@ import { DEFAULT_TOKEN_SET_SLUG } from '../constants';
 /**
  * Manage token save state and refresh resolved values after writes.
  *
- * @param {{ namespace: string }|null} rest REST descriptor from the feed.
- * @param {Record<string, string>}   initialValues Resolved values keyed by token id.
- * @return {{ values: Record<string, string>, saveToken: Function, getFieldState: Function }}
+ * The document version changes on every write to the set, including ones made outside this
+ * hook (e.g. a user-primitive create/rename/delete), so `onVersionChange` is called whenever a
+ * fresh version is read here — this keeps a version shared across the app instead of each write
+ * surface tracking a copy that can drift stale relative to the others.
+ *
+ * @param {{ namespace: string }|null} rest             REST descriptor from the feed.
+ * @param {Record<string, string>}     initialValues    Resolved values keyed by token id.
+ * @param {Function}                   [onVersionChange] Called with the latest document version.
+ * @return {{ values: Record<string, string>, saveToken: Function, getFieldState: Function, refreshValues: Function }}
  */
-export function useTokenEditor(rest, initialValues) {
+export function useTokenEditor(rest, initialValues, onVersionChange) {
 	const [values, setValues] = useState(initialValues);
 	const [fieldState, setFieldState] = useState({});
 
@@ -32,7 +38,11 @@ export function useTokenEditor(rest, initialValues) {
 
 		const resolved = await fetchResolvedTokens(rest.namespace, DEFAULT_TOKEN_SET_SLUG);
 		setValues(resolved?.by_id ?? {});
-	}, [rest]);
+
+		if (resolved?.version) {
+			onVersionChange?.(resolved.version);
+		}
+	}, [rest, onVersionChange]);
 
 	const saveToken = useCallback(
 		async (tokenId, type, nextValue) => {

--- a/src/style-book/hooks/use-token-editor.js
+++ b/src/style-book/hooks/use-token-editor.js
@@ -8,7 +8,6 @@ import { useCallback, useEffect, useState } from '@wordpress/element';
  */
 import { saveTokenLeaf, fetchResolvedTokens } from '../api/client';
 import { buildTokenLeaf } from '../helpers/tokens';
-import { DEFAULT_TOKEN_SET_SLUG } from '../constants';
 
 /**
  * Manage token save state and refresh resolved values after writes.
@@ -18,12 +17,17 @@ import { DEFAULT_TOKEN_SET_SLUG } from '../constants';
  * fresh version is read here — this keeps a version shared across the app instead of each write
  * surface tracking a copy that can drift stale relative to the others.
  *
+ * `slug` must be the same token set the feed's schema/values were read from (the active set, from
+ * `useDesignTokensFeed`) — writing to a different slug than the one being displayed would silently
+ * save into a document the page never reads back.
+ *
  * @param {{ namespace: string }|null} rest             REST descriptor from the feed.
  * @param {Record<string, string>}     initialValues    Resolved values keyed by token id.
  * @param {Function}                   [onVersionChange] Called with the latest document version.
+ * @param {string}                     slug             Token set slug.
  * @return {{ values: Record<string, string>, saveToken: Function, getFieldState: Function, refreshValues: Function }}
  */
-export function useTokenEditor(rest, initialValues, onVersionChange) {
+export function useTokenEditor(rest, initialValues, onVersionChange, slug) {
 	const [values, setValues] = useState(initialValues);
 	const [fieldState, setFieldState] = useState({});
 
@@ -36,13 +40,13 @@ export function useTokenEditor(rest, initialValues, onVersionChange) {
 			return;
 		}
 
-		const resolved = await fetchResolvedTokens(rest.namespace, DEFAULT_TOKEN_SET_SLUG);
+		const resolved = await fetchResolvedTokens(rest.namespace, slug);
 		setValues(resolved?.by_id ?? {});
 
 		if (resolved?.version) {
 			onVersionChange?.(resolved.version);
 		}
-	}, [rest, onVersionChange]);
+	}, [rest, onVersionChange, slug]);
 
 	const saveToken = useCallback(
 		async (tokenId, type, nextValue) => {
@@ -56,7 +60,7 @@ export function useTokenEditor(rest, initialValues, onVersionChange) {
 			}));
 
 			try {
-				await saveTokenLeaf(rest.namespace, tokenId, buildTokenLeaf(type, nextValue), DEFAULT_TOKEN_SET_SLUG);
+				await saveTokenLeaf(rest.namespace, tokenId, buildTokenLeaf(type, nextValue), slug);
 
 				await refreshValues();
 
@@ -77,7 +81,7 @@ export function useTokenEditor(rest, initialValues, onVersionChange) {
 				return { ok: false, error: message };
 			}
 		},
-		[rest, refreshValues]
+		[rest, refreshValues, slug]
 	);
 
 	const getFieldState = useCallback(

--- a/src/style-book/hooks/use-user-primitive-editor.js
+++ b/src/style-book/hooks/use-user-primitive-editor.js
@@ -1,0 +1,132 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	createUserPrimitive,
+	deleteUserPrimitive,
+	fetchUserPrimitiveReferences,
+	renameUserPrimitive,
+} from '../api/client';
+
+const HTTP_CONFLICT = 409;
+
+/**
+ * Manage user-primitive mutations (create, delete, rename) and version tracking.
+ *
+ * @since TBD
+ *
+ * @param {string} initialVersion Feed version string from the localized payload.
+ * @param {string} slug           Token set slug.
+ * @return {{ version: string, isPending: boolean, fetchPreview: Function, createPrimitive: Function, deletePrimitive: Function, renamePrimitive: Function }}
+ */
+export function useUserPrimitiveEditor(initialVersion, slug) {
+	const [version, setVersion] = useState(initialVersion);
+	const [isPending, setIsPending] = useState(false);
+
+	const fetchPreview = useCallback(
+		async (id) => {
+			try {
+				const data = await fetchUserPrimitiveReferences(slug, id);
+				return { ok: true, data };
+			} catch (error) {
+				return { ok: false, error: error?.message ?? 'Preview failed.' };
+			}
+		},
+		[slug]
+	);
+
+	const createPrimitive = useCallback(
+		async (payload) => {
+			setIsPending(true);
+
+			try {
+				const data = await createUserPrimitive(slug, { ...payload, version });
+
+				if (data?.version) {
+					setVersion(data.version);
+				}
+
+				return { ok: true, data };
+			} catch (error) {
+				const isConflict = error?.data?.status === HTTP_CONFLICT;
+
+				return {
+					ok: false,
+					isConflict,
+					error: error?.message ?? 'Create failed.',
+				};
+			} finally {
+				setIsPending(false);
+			}
+		},
+		[slug, version]
+	);
+
+	const deletePrimitive = useCallback(
+		async (id, previewVersion) => {
+			setIsPending(true);
+
+			try {
+				const data = await deleteUserPrimitive(slug, id, previewVersion);
+
+				if (data?.version) {
+					setVersion(data.version);
+				}
+
+				return { ok: true, data };
+			} catch (error) {
+				const isConflict = error?.data?.status === HTTP_CONFLICT;
+
+				return {
+					ok: false,
+					isConflict,
+					error: error?.message ?? 'Delete failed.',
+				};
+			} finally {
+				setIsPending(false);
+			}
+		},
+		[slug]
+	);
+
+	const renamePrimitive = useCallback(
+		async (id, payload) => {
+			setIsPending(true);
+
+			try {
+				const data = await renameUserPrimitive(slug, id, { ...payload, version });
+
+				if (data?.version) {
+					setVersion(data.version);
+				}
+
+				return { ok: true, data };
+			} catch (error) {
+				const isConflict = error?.data?.status === HTTP_CONFLICT;
+
+				return {
+					ok: false,
+					isConflict,
+					error: error?.message ?? 'Rename failed.',
+				};
+			} finally {
+				setIsPending(false);
+			}
+		},
+		[slug, version]
+	);
+
+	return {
+		version,
+		isPending,
+		fetchPreview,
+		createPrimitive,
+		deletePrimitive,
+		renamePrimitive,
+	};
+}

--- a/src/style-book/hooks/use-user-primitive-editor.js
+++ b/src/style-book/hooks/use-user-primitive-editor.js
@@ -16,16 +16,22 @@ import {
 const HTTP_CONFLICT = 409;
 
 /**
- * Manage user-primitive mutations (create, delete, rename) and version tracking.
+ * Manage user-primitive mutations (create, delete, rename).
+ *
+ * `version` is a controlled value owned by the caller rather than local state: the document
+ * version also changes from writes made outside this hook (e.g. a semantic-token edit), so a
+ * copy tracked only from this hook's own responses can go stale and trip the write guard with a
+ * false-positive conflict. `onVersionChange` reports this hook's own successful writes back to
+ * that shared value.
  *
  * @since TBD
  *
- * @param {string} initialVersion Feed version string from the localized payload.
- * @param {string} slug           Token set slug.
- * @return {{ version: string, isPending: boolean, fetchPreview: Function, createPrimitive: Function, deletePrimitive: Function, renamePrimitive: Function }}
+ * @param {string}   version          Current document version, from the shared version state.
+ * @param {string}   slug             Token set slug.
+ * @param {Function} onVersionChange  Called with the latest document version after a successful write.
+ * @return {{ isPending: boolean, fetchPreview: Function, createPrimitive: Function, deletePrimitive: Function, renamePrimitive: Function }}
  */
-export function useUserPrimitiveEditor(initialVersion, slug) {
-	const [version, setVersion] = useState(initialVersion);
+export function useUserPrimitiveEditor(version, slug, onVersionChange) {
 	const [isPending, setIsPending] = useState(false);
 
 	const fetchPreview = useCallback(
@@ -48,7 +54,7 @@ export function useUserPrimitiveEditor(initialVersion, slug) {
 				const data = await createUserPrimitive(slug, { ...payload, version });
 
 				if (data?.version) {
-					setVersion(data.version);
+					onVersionChange?.(data.version);
 				}
 
 				return { ok: true, data };
@@ -64,7 +70,7 @@ export function useUserPrimitiveEditor(initialVersion, slug) {
 				setIsPending(false);
 			}
 		},
-		[slug, version]
+		[slug, version, onVersionChange]
 	);
 
 	const deletePrimitive = useCallback(
@@ -75,7 +81,7 @@ export function useUserPrimitiveEditor(initialVersion, slug) {
 				const data = await deleteUserPrimitive(slug, id, previewVersion);
 
 				if (data?.version) {
-					setVersion(data.version);
+					onVersionChange?.(data.version);
 				}
 
 				return { ok: true, data };
@@ -91,7 +97,7 @@ export function useUserPrimitiveEditor(initialVersion, slug) {
 				setIsPending(false);
 			}
 		},
-		[slug]
+		[slug, onVersionChange]
 	);
 
 	const renamePrimitive = useCallback(
@@ -102,7 +108,7 @@ export function useUserPrimitiveEditor(initialVersion, slug) {
 				const data = await renameUserPrimitive(slug, id, { ...payload, version });
 
 				if (data?.version) {
-					setVersion(data.version);
+					onVersionChange?.(data.version);
 				}
 
 				return { ok: true, data };
@@ -118,11 +124,10 @@ export function useUserPrimitiveEditor(initialVersion, slug) {
 				setIsPending(false);
 			}
 		},
-		[slug, version]
+		[slug, version, onVersionChange]
 	);
 
 	return {
-		version,
 		isPending,
 		fetchPreview,
 		createPrimitive,

--- a/tests/snapshot/Resources/Design_Tokens/Admin/Feed/Builder_SnapshotTest.php
+++ b/tests/snapshot/Resources/Design_Tokens/Admin/Feed/Builder_SnapshotTest.php
@@ -82,7 +82,7 @@ final class Builder_SnapshotTest extends SnapshotTestCase {
 			'nonce'     => 'test-nonce',
 		];
 
-		$feed = ( new Builder( $this->registry ) )->build( $values, true, $variants, $rest, 'v7' );
+		$feed = ( new Builder( $this->registry ) )->build( $values, true, $variants, $rest, 'v7', 'default' );
 
 		// Structural assertions that must always hold regardless of snapshot content.
 		$this->assertTrue( $feed['active'] );

--- a/tests/snapshot/Resources/Design_Tokens/Admin/Feed/__snapshots__/Builder_SnapshotTest__testFullPayloadMatchesSnapshot__1.txt
+++ b/tests/snapshot/Resources/Design_Tokens/Admin/Feed/__snapshots__/Builder_SnapshotTest__testFullPayloadMatchesSnapshot__1.txt
@@ -2,6 +2,7 @@
     "active": true,
     "resolved": true,
     "version": "v7",
+    "slug": "default",
     "schema": {
         "groups": {
             "Brand": [

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/BuilderTest.php
@@ -40,11 +40,12 @@ final class BuilderTest extends TestCase {
 		$values   = [ 'semantic.color.button-bg' => '#3182CE' ];
 		$variants = [ 'kadence/advancedbtn' => [ 'default' => 'primary' ] ];
 
-		$feed = ( new Builder( $this->registry ) )->build( $values, true, $variants, $this->rest(), 'v7' );
+		$feed = ( new Builder( $this->registry ) )->build( $values, true, $variants, $this->rest(), 'v7', 'default' );
 
 		$this->assertTrue( $feed['active'] );
 		$this->assertTrue( $feed['resolved'] );
 		$this->assertSame( 'v7', $feed['version'] );
+		$this->assertSame( 'default', $feed['slug'] );
 		$this->assertSame( $this->registry->to_ui_schema(), $feed['schema'] );
 		$this->assertSame( $values, $feed['values'] );
 		$this->assertSame( $variants, $feed['variants'] );
@@ -52,7 +53,7 @@ final class BuilderTest extends TestCase {
 	}
 
 	public function testResolvedFalseKeepsStructureButEmptyValues(): void {
-		$feed = ( new Builder( $this->registry ) )->build( [], false, [], $this->rest(), 'v7' );
+		$feed = ( new Builder( $this->registry ) )->build( [], false, [], $this->rest(), 'v7', 'default' );
 
 		$this->assertTrue( $feed['active'] );
 		$this->assertFalse( $feed['resolved'] );
@@ -61,7 +62,7 @@ final class BuilderTest extends TestCase {
 	}
 
 	public function testResolvedTrueWithEmptyValuesPassesThroughUnchanged(): void {
-		$feed = ( new Builder( $this->registry ) )->build( [], true, [], $this->rest(), 'v7' );
+		$feed = ( new Builder( $this->registry ) )->build( [], true, [], $this->rest(), 'v7', 'default' );
 
 		$this->assertTrue( $feed['active'] );
 		$this->assertTrue( $feed['resolved'] );
@@ -77,7 +78,8 @@ final class BuilderTest extends TestCase {
 			true,
 			[ 'kadence/advancedbtn' => [] ],
 			$this->rest(),
-			'v7'
+			'v7',
+			'default'
 		);
 
 		$this->assertFalse( $feed['active'] );
@@ -85,8 +87,18 @@ final class BuilderTest extends TestCase {
 		$this->assertSame( [ 'groups' => [] ], $feed['schema'] );
 		$this->assertSame( [], $feed['values'] );
 		$this->assertSame( [], $feed['variants'] );
-		// The REST descriptor and version are still present so the React app can wire even when hidden.
+		// The REST descriptor, version and slug are still present so the React app can wire even when hidden.
 		$this->assertSame( $this->rest(), $feed['rest'] );
 		$this->assertSame( 'v7', $feed['version'] );
+		$this->assertSame( 'default', $feed['slug'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSlugPassesThroughRegardlessOfActiveState(): void {
+		$feed = ( new Builder( $this->registry ) )->build( [], true, [], $this->rest(), 'v7', 'brand-b' );
+
+		$this->assertSame( 'brand-b', $feed['slug'] );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
@@ -8,6 +8,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Variants;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Style_Book\Asset_Loader;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\User_Primitive_Registrar;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Css_Renderer;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
@@ -208,5 +209,62 @@ final class LocalizerTest extends TestCase {
 	public function testTheModuleWiresTheLocalizerOntoAdminHead(): void {
 		$this->assertInstanceOf( Localizer::class, $this->container->get( Localizer::class ) );
 		$this->assertNotFalse( has_action( 'admin_head' ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testUserPrimitivesReachTheLocalizedSchemaWithUserCreatedFlag(): void {
+		$store = $this->container->get( Token_Store::class );
+
+		$doc = (string) wp_json_encode(
+			[
+				'primitive'   => [
+					'color' => [
+						'custom' => [
+							'brand-blue' => [
+								'$type'  => 'color',
+								'$value' => '#1a56db',
+							],
+						],
+					],
+				],
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'userPrimitives' => [
+							'primitive.color.custom.brand-blue' => [ 'label' => 'Brand Blue' ],
+						],
+					],
+				],
+			]
+		);
+
+		$store->save_document( $doc );
+
+		/** @var User_Primitive_Registrar $registrar */
+		$registrar = $this->container->get( User_Primitive_Registrar::class );
+		$registrar->sync();
+
+		$this->enqueue_dashboard();
+		$this->localizer()->localize();
+
+		$feed = $this->attached_feed();
+		$this->assertNotNull( $feed );
+		$this->assertTrue( $feed['active'] );
+
+		$found = null;
+
+		foreach ( $feed['schema']['groups'] as $entries ) {
+			foreach ( $entries as $entry ) {
+				if ( ( $entry['id'] ?? '' ) === 'primitive.color.custom.brand-blue' ) {
+					$found = $entry;
+					break 2;
+				}
+			}
+		}
+
+		$this->assertNotNull( $found, 'User primitive must appear in the localized schema.' );
+		$this->assertTrue( $found['userCreated'], 'User primitive must carry userCreated: true.' );
+		$this->assertSame( 'Brand Blue', $found['label'] );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
@@ -6,6 +6,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Localizer;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Variants;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Style_Book\Asset_Loader;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\User_Primitive_Registrar;
@@ -110,6 +111,7 @@ final class LocalizerTest extends TestCase {
 
 		$this->assertTrue( $feed['active'] );
 		$this->assertTrue( $feed['resolved'] );
+		$this->assertSame( Token_Store::default_slug(), $feed['slug'] );
 
 		// Structure: the shipped button-bg token reaches the schema.
 		$ids = [];
@@ -177,6 +179,7 @@ final class LocalizerTest extends TestCase {
 		$localizer = new Localizer(
 			$cyclic,
 			$this->container->get( Token_Store::class ),
+			$this->container->get( Active_Set_Store::class ),
 			$this->container->get( Variants::class ),
 			$this->container->get( Builder::class )
 		);
@@ -266,5 +269,67 @@ final class LocalizerTest extends TestCase {
 		$this->assertNotNull( $found, 'User primitive must appear in the localized schema.' );
 		$this->assertTrue( $found['userCreated'], 'User primitive must carry userCreated: true.' );
 		$this->assertSame( 'Brand Blue', $found['label'] );
+	}
+
+	/**
+	 * The dashboard must read (and, via the REST descriptor's slug, write) whichever set is active —
+	 * not always the default one — so it stays consistent with the registry's user primitives and every
+	 * projector, all of which already resolve against Active_Set_Store::get().
+	 *
+	 * @return void
+	 */
+	public function testFeedFollowsTheActiveSetRatherThanAlwaysTheDefaultSet(): void {
+		$store  = $this->container->get( Token_Store::class );
+		$active = $this->container->get( Active_Set_Store::class );
+
+		$doc = (string) wp_json_encode(
+			[
+				'primitive'   => [
+					'color' => [
+						'custom' => [
+							'brand-green' => [
+								'$type'  => 'color',
+								'$value' => '#0f7a3d',
+							],
+						],
+					],
+				],
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'userPrimitives' => [
+							'primitive.color.custom.brand-green' => [ 'label' => 'Brand Green' ],
+						],
+					],
+				],
+			]
+		);
+
+		$store->save_document( $doc, 'brand-b' );
+		$active->set( 'brand-b' );
+
+		/** @var User_Primitive_Registrar $registrar */
+		$registrar = $this->container->get( User_Primitive_Registrar::class );
+		$registrar->sync();
+
+		$this->enqueue_dashboard();
+		$this->localizer()->localize();
+
+		$feed = $this->attached_feed();
+		$this->assertNotNull( $feed );
+		$this->assertSame( 'brand-b', $feed['slug'] );
+		$this->assertSame( '#0f7a3d', $feed['values']['primitive.color.custom.brand-green'] );
+
+		$found = null;
+
+		foreach ( $feed['schema']['groups'] as $entries ) {
+			foreach ( $entries as $entry ) {
+				if ( ( $entry['id'] ?? '' ) === 'primitive.color.custom.brand-green' ) {
+					$found = $entry;
+					break 2;
+				}
+			}
+		}
+
+		$this->assertNotNull( $found, 'The active set\'s user primitive must appear in the localized schema.' );
 	}
 }


### PR DESCRIPTION
## Summary
- Extends the Style Book (from the `SOFT-3407` token-catalog stack) with add/delete/rename controls for user-created color primitives: `AddPrimitiveDialog`, `DeletePrimitiveDialog`, `RenamePrimitiveDialog`, and the REST client/path helpers and `useUserPrimitiveEditor` hook that back them.
- `DeletePrimitiveDialog` fetches the references preview on open and disables confirmation while any unsupported reference exists, mirroring the backend's block-on-unsupported-reference behavior. `RenamePrimitiveDialog` intentionally makes no equivalent safety claim, since the backend's rename only rewrites direct semantic-layer aliases and does not scan for unsupported references (a limitation called out in the phase-10 PR).
- Fixes a reachability bug found during review: `FoundationPage` always rendered the token list in its flat (non-grouped) mode, which never mounted the `TokenGroup` component holding the add/rename/delete controls — so the mutation UI shipped in this phase's original commit was unreachable through the app regardless of custom-color count. The ungrouped path now routes through `TokenGroup` (with its heading suppressed, since the page already shows one), scoped to the Custom Colors section only. The Custom Colors section is also now always present in the sidebar, even before any custom color exists, so there's a way to create the first one.
- Fixes a version-conflict (409) UX gap: `AddPrimitiveDialog` previously had no conflict handling (a stale version would silently retry-and-fail forever); `RenamePrimitiveDialog` mislabeled a conflict as an ID collision. Both now prompt a reload. `DeletePrimitiveDialog`'s existing silent preview-refresh-on-conflict now surfaces an interim notice.
- Also adds a PHP `Localizer` test proving a user primitive's `userCreated`/`label` metadata survives `User_Primitive_Registrar::sync()` into the localized feed the UI consumes, and a `test` script in `package.json`.

## Test plan
- [x] Added `navigation.test.js` covering that the Custom Colors section is always present (including with zero user-created tokens) and correctly flagged `isUserCreated`.
- [x] `use-user-primitive-editor.test.js`, `tokens.test.js`, `paths.test.js` (existing) plus the new test all pass via `bun run test`.
- [x] `LocalizerTest` (PHP) passes.
- [x] ESLint clean on all touched JS.
- [x] cspell clean.
- [x] Full wpunit/acceptance/snapshot suites pass (pre-push CI-equivalent hook).