### PR TITLE
feat(design-tokens): namespaced css-var naming and resolution (foundation)

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Css_Var.php
+++ b/includes/resources/Design_Tokens/Registry/Css_Var.php
@@ -2,6 +2,8 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Identifier;
+
 /**
  * Derives the canonical CSS custom-property name from a token id.
  *
@@ -17,6 +19,8 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry;
  * @since TBD
  */
 final class Css_Var {
+
+	use Sanitizes_Css_Identifier;
 
 	private const PREFIX = '--kb-token--';
 
@@ -51,6 +55,10 @@ final class Css_Var {
 	public static function from_id( string $id, string $namespace = '' ): string {
 		$name = str_replace( '.', '--', $id );
 
-		return self::PREFIX . ( $namespace === '' ? '' : $namespace . '--' ) . $name;
+		if ( $namespace !== '' ) {
+			$namespace = self::sanitize_identifier( $namespace ) . '--';
+		}
+
+		return self::PREFIX . $namespace . $name;
 	}
 }

--- a/includes/resources/Design_Tokens/Registry/Css_Var.php
+++ b/includes/resources/Design_Tokens/Registry/Css_Var.php
@@ -32,15 +32,25 @@ final class Css_Var {
 	}
 
 	/**
-	 * Derive the canonical CSS custom-property name from a token id.
+	 * Derive the CSS custom-property name from a token id, optionally namespaced to a token set.
+	 *
+	 * With no namespace the canonical name is produced (`semantic.color.text` →
+	 * `--kb-token--semantic--color--text`). With a namespace the set slug is inserted as a leading
+	 * segment after the prefix (`semantic.color.text`, `dark` →
+	 * `--kb-token--dark--semantic--color--text`), so every set's tokens occupy their own namespace while
+	 * sharing the one derivation rule — names and ids cannot drift, namespaced or not.
 	 *
 	 * @since TBD
 	 *
-	 * @param string $id The DTCG dot-path id.
+	 * @param string $id        The DTCG dot-path id.
+	 * @param string $namespace Optional token-set slug to namespace the variable under. Empty yields the
+	 *                          canonical (un-namespaced) name.
 	 *
 	 * @return string The derived CSS custom-property name.
 	 */
-	public static function from_id( string $id ): string {
-		return self::PREFIX . str_replace( '.', '--', $id );
+	public static function from_id( string $id, string $namespace = '' ): string {
+		$name = str_replace( '.', '--', $id );
+
+		return self::PREFIX . ( $namespace === '' ? '' : $namespace . '--' ) . $name;
 	}
 }

--- a/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
@@ -45,7 +45,8 @@ final class Token_Resolver {
 	/**
 	 * Per-request memo of resolved results, keyed on the same cache key load() uses for the object cache:
 	 * the cache prefix (which distinguishes the canonical "resolved_tokens_{slug}" and namespaced
-	 * "resolved_tokens_ns_{slug}" forms) followed by the store version, e.g. "resolved_tokens_default_v3".
+	 * "resolved_tokens_namespaced_{slug}" forms) followed by the store version, e.g.
+	 * "resolved_tokens_default_v3".
 	 *
 	 * @var array<string,Resolved_Tokens>
 	 */
@@ -108,7 +109,7 @@ final class Token_Resolver {
 	 * @throws Dangling_Alias_Exception When a stored alias references a path with no token leaf.
 	 */
 	public function resolve_namespaced( string $slug ): Resolved_Tokens {
-		return $this->load( $slug, $slug, 'resolved_tokens_ns_' . $slug );
+		return $this->load( $slug, $slug, 'resolved_tokens_namespaced_' . $slug );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
@@ -43,7 +43,9 @@ final class Token_Resolver {
 	private Css_Renderer $renderer;
 
 	/**
-	 * Per-request memo of resolved results, keyed on "{slug}:{store-version}".
+	 * Per-request memo of resolved results, keyed on the same cache key load() uses for the object cache:
+	 * the cache prefix (which distinguishes the canonical "resolved_tokens_{slug}" and namespaced
+	 * "resolved_tokens_ns_{slug}" forms) followed by the store version, e.g. "resolved_tokens_default_v3".
 	 *
 	 * @var array<string,Resolved_Tokens>
 	 */
@@ -83,19 +85,60 @@ final class Token_Resolver {
 	 *                                  Writes are gated by resolve_overrides(), so a clean store never hits this.
 	 */
 	public function resolve( string $slug = 'default' ): Resolved_Tokens {
-		$version = $this->store->get_version( $slug );
-		$key     = $slug . ':' . $version;
+		return $this->load( $slug, '', 'resolved_tokens_' . $slug );
+	}
 
-		if ( isset( $this->memo[ $key ] ) ) {
-			return $this->memo[ $key ];
+	/**
+	 * Resolve a stored token set with its css-var names namespaced to the set's own slug
+	 * (`--kb-token--<slug>--*`), for simultaneous multi-set emission. Same cache shape as resolve(),
+	 * under its own key, so the canonical and namespaced forms never collide.
+	 *
+	 * The returned object's projected map carries the namespaced var names and namespaced alias/composite
+	 * targets, so a set's alias chain stays inside the set. The literal id map (by_id) is keyed on the
+	 * canonical dot-path and its values are literals, so it is identical to the canonical resolve — host
+	 * surfaces and the canonical token-id list read it unchanged.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token set slug to resolve and namespace under.
+	 *
+	 * @return Resolved_Tokens
+	 *
+	 * @throws Alias_Cycle_Exception    When a stored alias forms an unresolvable cycle.
+	 * @throws Dangling_Alias_Exception When a stored alias references a path with no token leaf.
+	 */
+	public function resolve_namespaced( string $slug ): Resolved_Tokens {
+		return $this->load( $slug, $slug, 'resolved_tokens_ns_' . $slug );
+	}
+
+	/**
+	 * Shared resolve path for the canonical and namespaced forms: per-request memo over a persistent
+	 * object-cache entry, both keyed on the store version (bumped on every write, so they self-invalidate).
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug         The token set slug to resolve.
+	 * @param string $namespace    Css-var namespace to apply ('' for the canonical names).
+	 * @param string $cache_prefix Cache-key prefix that distinguishes the canonical and namespaced forms.
+	 *
+	 * @return Resolved_Tokens
+	 *
+	 * @throws Alias_Cycle_Exception    When a stored alias forms an unresolvable cycle.
+	 * @throws Dangling_Alias_Exception When a stored alias references a path with no token leaf.
+	 */
+	private function load( string $slug, string $namespace, string $cache_prefix ): Resolved_Tokens {
+		$version   = $this->store->get_version( $slug );
+		$cache_key = $cache_prefix . '_' . $version;
+
+		if ( isset( $this->memo[ $cache_key ] ) ) {
+			return $this->memo[ $cache_key ];
 		}
 
 		// L2: persistent object cache (requires a drop-in such as Memcached or Redis) — survives across requests, keyed on the store version.
-		$cache_key = 'resolved_tokens_' . $slug . '_' . $version;
-		$cached    = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
+		$cached = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
 
 		if ( $found && $cached instanceof Resolved_Tokens ) {
-			$this->memo[ $key ] = $cached;
+			$this->memo[ $cache_key ] = $cached;
 
 			return $cached;
 		}
@@ -105,10 +148,10 @@ final class Token_Resolver {
 		$over     = is_array( $decoded ) ? $decoded : [];
 		$document = $this->effective->build( $over );
 
-		$result = $this->resolve_document( $document );
+		$result = $this->resolve_document( $document, $namespace );
 
 		wp_cache_set( $cache_key, $result, self::CACHE_GROUP, DAY_IN_SECONDS );
-		$this->memo[ $key ] = $result;
+		$this->memo[ $cache_key ] = $result;
 
 		return $result;
 	}
@@ -135,8 +178,9 @@ final class Token_Resolver {
 	 * @since TBD
 	 *
 	 * @param array<string,mixed> $document
+	 * @param string              $namespace Css-var namespace to apply to projected names ('' for canonical).
 	 */
-	private function resolve_document( array $document ): Resolved_Tokens {
+	private function resolve_document( array $document, string $namespace = '' ): Resolved_Tokens {
 		$by_id            = [];
 		$by_var           = [];
 		$by_var_projected = [];
@@ -144,7 +188,7 @@ final class Token_Resolver {
 
 		foreach ( Layers::token_layers() as $layer ) {
 			if ( isset( $document[ $layer ] ) && is_array( $document[ $layer ] ) ) {
-				$this->walk( $document[ $layer ], $layer, $document, $by_id, $by_var, $by_var_projected, $by_id_target );
+				$this->walk( $document[ $layer ], $layer, $document, $by_id, $by_var, $by_var_projected, $by_id_target, $namespace );
 			}
 		}
 
@@ -163,10 +207,11 @@ final class Token_Resolver {
 	 * @param array<string,string> $by_var           By-reference css-var => literal CSS value map.
 	 * @param array<string,string> $by_var_projected By-reference css-var => var()-preserving CSS value map.
 	 * @param array<string,string> $by_id_target     By-reference id => target id map (whole-$value aliases only).
+	 * @param string               $namespace        Css-var namespace to apply to projected names ('' for canonical).
 	 *
 	 * @return void
 	 */
-	private function walk( array $node, string $prefix, array $document, array &$by_id, array &$by_var, array &$by_var_projected, array &$by_id_target ): void {
+	private function walk( array $node, string $prefix, array $document, array &$by_id, array &$by_var, array &$by_var_projected, array &$by_id_target, string $namespace = '' ): void {
 		foreach ( $node as $key => $child ) {
 			if ( is_string( $key ) && strpos( $key, '$' ) === 0 ) {
 				continue; // DTCG metadata key.
@@ -182,7 +227,7 @@ final class Token_Resolver {
 				$type  = (string) ( $child[ Token_Type::get_type_key() ] ?? '' );
 				$value = $this->resolve_value( $raw, $document, [] );
 				$css   = $this->renderer->render( $type, $value );
-				$var   = Css_Var::from_id( $path );
+				$var   = Css_Var::from_id( $path, $namespace );
 
 				$by_id[ $path ] = $css;
 				$by_var[ $var ] = $css;
@@ -193,21 +238,21 @@ final class Token_Resolver {
 					// indirection survives into CSS and dependents follow live. resolve_value() has
 					// already validated the alias (no cycle, not dangling), so the target is a real leaf
 					// this same walk emits a --kb-token--* var for. The literal above still feeds host
-					// surfaces.
+					// surfaces. Under a namespace the target name is namespaced too, so the chain stays in-set.
 					$target_id                = Alias::path_of( $raw );
 					$by_id_target[ $path ]    = $target_id;
-					$by_var_projected[ $var ] = 'var(' . Css_Var::from_id( $target_id ) . ')';
+					$by_var_projected[ $var ] = 'var(' . Css_Var::from_id( $target_id, $namespace ) . ')';
 				} else {
 					// A composite (shadow/typography) may alias individual fields; project those to
 					// var() references and render the shorthand around them. Scalars and lists carry no
 					// alias and render identically to the literal.
-					$by_var_projected[ $var ] = $this->renderer->render( $type, $this->project_value( $raw ) );
+					$by_var_projected[ $var ] = $this->renderer->render( $type, $this->project_value( $raw, $namespace ) );
 				}
 
 				continue;
 			}
 
-			$this->walk( $child, $path, $document, $by_id, $by_var, $by_var_projected, $by_id_target );
+			$this->walk( $child, $path, $document, $by_id, $by_var, $by_var_projected, $by_id_target, $namespace );
 		}
 	}
 
@@ -222,19 +267,20 @@ final class Token_Resolver {
 	 *
 	 * @since TBD
 	 *
-	 * @param mixed $value
+	 * @param mixed  $value
+	 * @param string $namespace Css-var namespace to apply to the var() targets ('' for canonical).
 	 *
 	 * @return mixed The value with aliases replaced by var() references.
 	 */
-	private function project_value( $value ) {
+	private function project_value( $value, string $namespace = '' ) {
 		if ( is_string( $value ) && Alias::is_alias( $value ) ) {
-			return 'var(' . Css_Var::from_id( Alias::path_of( $value ) ) . ')';
+			return 'var(' . Css_Var::from_id( Alias::path_of( $value ), $namespace ) . ')';
 		}
 
 		if ( is_array( $value ) && ! $this->is_list( $value ) ) {
 			$projected = [];
 			foreach ( $value as $field => $sub ) {
-				$projected[ $field ] = $this->project_value( $sub );
+				$projected[ $field ] = $this->project_value( $sub, $namespace );
 			}
 
 			return $projected;

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Css_VarTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Css_VarTest.php
@@ -31,4 +31,29 @@ final class Css_VarTest extends TestCase {
 			Css_Var::from_id( 'semantic.color.button-bg' )
 		);
 	}
+
+	/**
+	 * A non-empty namespace is inserted as a leading segment after the prefix, so each set's tokens get
+	 * their own --kb-token--<set>--* namespace.
+	 *
+	 * @return void
+	 */
+	public function testItNamespacesUnderASet(): void {
+		$this->assertSame(
+			'--kb-token--dark--semantic--color--button-bg',
+			Css_Var::from_id( 'semantic.color.button-bg', 'dark' )
+		);
+	}
+
+	/**
+	 * An empty namespace yields the canonical name, identical to the single-argument call.
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyNamespaceYieldsTheCanonicalName(): void {
+		$this->assertSame(
+			Css_Var::from_id( 'semantic.color.button-bg' ),
+			Css_Var::from_id( 'semantic.color.button-bg', '' )
+		);
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Css_VarTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Css_VarTest.php
@@ -7,6 +7,12 @@ use Tests\Support\Classes\TestCase;
 
 final class Css_VarTest extends TestCase {
 
+	/**
+	 * The worked example from the derivation rule: a dot-path id gains the prefix and each dot becomes a
+	 * double hyphen.
+	 *
+	 * @return void
+	 */
 	public function testItMatchesTheWorkedExample(): void {
 		$this->assertSame(
 			'--kb-token--semantic--color--button-bg',
@@ -14,10 +20,20 @@ final class Css_VarTest extends TestCase {
 		);
 	}
 
+	/**
+	 * A single-segment id (no dots) is simply prefixed, with nothing to replace.
+	 *
+	 * @return void
+	 */
 	public function testItPrefixesASingleSegmentId(): void {
 		$this->assertSame( '--kb-token--brand', Css_Var::from_id( 'brand' ) );
 	}
 
+	/**
+	 * Every dot in an arbitrarily deep id is replaced, so the rule is not limited to a fixed segment count.
+	 *
+	 * @return void
+	 */
 	public function testItHandlesArbitraryDepth(): void {
 		$this->assertSame(
 			'--kb-token--a--b--c--d--e',
@@ -25,6 +41,11 @@ final class Css_VarTest extends TestCase {
 		);
 	}
 
+	/**
+	 * The same id always derives the same name, since the rule is pure with no hidden state.
+	 *
+	 * @return void
+	 */
 	public function testItIsDeterministicAcrossCalls(): void {
 		$this->assertSame(
 			Css_Var::from_id( 'semantic.color.button-bg' ),
@@ -54,6 +75,19 @@ final class Css_VarTest extends TestCase {
 		$this->assertSame(
 			Css_Var::from_id( 'semantic.color.button-bg' ),
 			Css_Var::from_id( 'semantic.color.button-bg', '' )
+		);
+	}
+
+	/**
+	 * A namespace is reduced to a CSS-identifier-safe segment so it cannot break out of the variable name;
+	 * unsafe characters collapse to a single hyphen.
+	 *
+	 * @return void
+	 */
+	public function testItSanitizesTheNamespaceSegment(): void {
+		$this->assertSame(
+			'--kb-token--dark-theme--semantic--color--button-bg',
+			Css_Var::from_id( 'semantic.color.button-bg', 'dark/theme' )
 		);
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
@@ -757,7 +757,7 @@ final class Token_ResolverTest extends TestCase {
 	}
 
 	/**
-	 * The namespaced form caches under its own key (resolved_tokens_ns_<slug>_<version>), distinct from the
+	 * The namespaced form caches under its own key (resolved_tokens_namespaced_<slug>_<version>), distinct from the
 	 * canonical resolve() key, so the two never collide.
 	 *
 	 * @return void
@@ -773,7 +773,7 @@ final class Token_ResolverTest extends TestCase {
 		);
 
 		$version   = $store->get_version();
-		$cache_key = 'resolved_tokens_ns_default_' . $version;
+		$cache_key = 'resolved_tokens_namespaced_default_' . $version;
 
 		wp_cache_delete( $cache_key, 'kb_design_tokens' );
 

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
@@ -629,6 +629,164 @@ final class Token_ResolverTest extends TestCase {
 		$this->assertSame( '#FF0000', $after->value( 'semantic.color.button-bg' ) );
 	}
 
+	/**
+	 * resolve_namespaced() namespaces every projected css-var name under the set slug, and keeps a set's
+	 * alias chain inside the set: a reference reads var(--kb-token--<slug>--<target>), not the canonical
+	 * target, so switching the active set never leaks one set's primitive into another.
+	 *
+	 * @return void
+	 */
+	public function testResolveNamespacedNamespacesTheProjectedNamesAndKeepsTheChainInSet(): void {
+		$resolver = $this->resolver_for(
+			[
+				'primitive' => [
+					'color' => [
+						'brand' => [
+							'primary' => [
+								'$type'  => 'color',
+								'$value' => '#3182CE',
+							],
+						],
+					],
+				],
+				'semantic'  => [
+					'color' => [
+						'button-bg' => [
+							'$type'  => 'color',
+							'$value' => '{primitive.color.brand.primary}',
+						],
+					],
+				],
+			]
+		);
+
+		// A slug with no stored row resolves the baseline directly, namespaced under that slug.
+		$projected = $resolver->resolve_namespaced( 'dark' )->projected_vars();
+
+		// The leaf primitive carries the literal under its namespaced name.
+		$this->assertSame( '#3182CE', $projected[ Css_Var::from_id( 'primitive.color.brand.primary', 'dark' ) ] );
+
+		// The semantic alias points at the namespaced primitive, so the chain stays inside the set.
+		$this->assertSame(
+			'var(' . Css_Var::from_id( 'primitive.color.brand.primary', 'dark' ) . ')',
+			$projected[ Css_Var::from_id( 'semantic.color.button-bg', 'dark' ) ]
+		);
+
+		// The canonical (un-namespaced) names are absent from a namespaced projection.
+		$this->assertArrayNotHasKey( Css_Var::from_id( 'semantic.color.button-bg' ), $projected );
+	}
+
+	/**
+	 * A composite's embedded var() reference is namespaced too, field by field, so a namespaced shadow's
+	 * aliased color follows that set's primitive.
+	 *
+	 * @return void
+	 */
+	public function testResolveNamespacedNamespacesACompositeEmbeddedVar(): void {
+		$resolver = $this->resolver_for(
+			[
+				'primitive' => [
+					'color' => [
+						'ink' => [
+							'$type'  => 'color',
+							'$value' => '#1A202C',
+						],
+					],
+				],
+				'semantic'  => [
+					'shadow' => [
+						'card' => [
+							'$type'  => 'shadow',
+							'$value' => [
+								'color'   => '{primitive.color.ink}',
+								'offsetX' => '0px',
+								'offsetY' => '2px',
+								'blur'    => '8px',
+								'spread'  => '0px',
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$projected = $resolver->resolve_namespaced( 'dark' )->projected_vars();
+
+		$this->assertSame(
+			'0px 2px 8px 0px var(' . Css_Var::from_id( 'primitive.color.ink', 'dark' ) . ')',
+			$projected[ Css_Var::from_id( 'semantic.shadow.card', 'dark' ) ]
+		);
+	}
+
+	/**
+	 * The id-keyed literal map is namespace-invariant: by_id() keys stay canonical dot-paths and its
+	 * values stay the flattened literals, so host surfaces and the canonical token-id list read it
+	 * unchanged whether resolved canonically or namespaced.
+	 *
+	 * @return void
+	 */
+	public function testResolveNamespacedLeavesByIdCanonicalAndLiteral(): void {
+		$resolver = $this->resolver_for(
+			[
+				'primitive' => [
+					'color' => [
+						'brand' => [
+							'primary' => [
+								'$type'  => 'color',
+								'$value' => '#3182CE',
+							],
+						],
+					],
+				],
+				'semantic'  => [
+					'color' => [
+						'button-bg' => [
+							'$type'  => 'color',
+							'$value' => '{primitive.color.brand.primary}',
+						],
+					],
+				],
+			]
+		);
+
+		$by_id = $resolver->resolve_namespaced( 'dark' )->by_id();
+
+		// Keyed on the canonical dot-path, with the flattened literal — identical to a canonical resolve.
+		$this->assertArrayHasKey( 'semantic.color.button-bg', $by_id );
+		$this->assertSame( '#3182CE', $by_id['semantic.color.button-bg'] );
+	}
+
+	/**
+	 * The namespaced form caches under its own key (resolved_tokens_ns_<slug>_<version>), distinct from the
+	 * canonical resolve() key, so the two never collide.
+	 *
+	 * @return void
+	 */
+	public function testResolveNamespacedPopulatesItsOwnObjectCacheKey(): void {
+		/** @var Token_Store $store */
+		$store = $this->container->get( Token_Store::class );
+		// Fresh instance so the L1 memo is empty — the container singleton may already be warm.
+		$resolver = new Token_Resolver(
+			$store,
+			$this->container->get( Effective_Document::class ),
+			$this->container->get( Css_Renderer::class )
+		);
+
+		$version   = $store->get_version();
+		$cache_key = 'resolved_tokens_ns_default_' . $version;
+
+		wp_cache_delete( $cache_key, 'kb_design_tokens' );
+
+		$result = $resolver->resolve_namespaced( 'default' );
+
+		$this->assertInstanceOf( Resolved_Tokens::class, $result );
+
+		$cached = wp_cache_get( $cache_key, 'kb_design_tokens', false, $found );
+
+		$this->assertTrue( $found );
+		$this->assertInstanceOf( Resolved_Tokens::class, $cached );
+	}
+
 	public function testResolveReadsTheStoredOverridesAndInvalidatesOnVersionBump(): void {
 		/** @var Token_Resolver $resolver */
 		$resolver = $this->container->get( Token_Resolver::class );


### PR DESCRIPTION
🎫 [SOFT-3587](https://linear.app/nexcess/issue/SOFT-3587/simultaneous-multi-set-emission-active-alias-layer)

📹 https://www.loom.com/share/b367269167694d2fb17386b695609880

> Depends on #1077 (SOFT-3586); merge that first.

Foundation for simultaneous multi-set emission: a set-namespaced mode for css-var naming and token resolution, with no projection wiring yet.

- `Css_Var::from_id()` gains an optional `$namespace` that inserts the set slug as a leading segment after the `--kb-token--` prefix, so each set's tokens occupy their own namespace while sharing the one derivation rule. `from_id('semantic.color.text')` still yields `--kb-token--semantic--color--text`; `from_id('semantic.color.text', 'dark')` yields `--kb-token--dark--semantic--color--text`.
- `Token_Resolver::resolve_namespaced($slug)` mirrors `resolve()` but returns the set's resolved maps with every css-var name namespaced to `$slug`. A semantic that aliases a primitive points at that primitive's namespaced var in the same set (`--kb-token--dark--semantic--color--button-bg: var(--kb-token--dark--primitive--color--brand)`), so the alias indirection survives into CSS and each set's chain stays self-contained -- no cross-set references. A shared `load()` path memoizes the canonical and namespaced forms separately under version-qualified cache keys, so a store write self-invalidates both.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
