### PR TITLE
feat(design-tokens): follow palette switching in the variant projection

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Variant/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Variant/Css_Builder.php
@@ -3,6 +3,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Variant;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Css_Builder as Token_Css_Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Identifier;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Value;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Scope;
@@ -13,7 +14,8 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
 use RuntimeException;
 
 /**
- * Builds the scoped CSS for selectable block variants — Kadence blocks and core/button alike.
+ * Builds the scoped CSS for selectable block variants — Kadence blocks and core/button alike — across
+ * every token set at once, so a variant follows palette switching the same way the raw token layer does.
  *
  * A selected variant reaches output purely through the cascade: the editor adds a "kb-variant--<name>"
  * class to the block, and this builder emits, per (block, variant), a rule that retargets the --global-*
@@ -22,19 +24,22 @@ use RuntimeException;
  * companion stylesheet (Native\Styles\Button), so one retarget path re-skins both with zero changes to a
  * block's markup. The selector is block-aware: core/button resolves to ".wp-block-button".
  *
- * Three declaration blocks are emitted:
+ * The emission mirrors the raw-token (Css_Var) projection so a variant var is just another token in the
+ * same multi-set graph:
  *
- *   1. A global --kb-token--variant--<block>--<variant>--<property> definition for every bound value, so
- *      a variant's values surface as named token vars in the same graph as every other token. The value
- *      preserves alias indirection (Variant_Resolver::resolve): a binding that aliases a token reads
- *      var(--kb-token--<target>) so the variant var chains to the semantic/primitive it points at and
- *      follows a token edit live; a literal binding emits the literal.
- *   2. Per (block, variant) scoped rules — ".wp-block-<block>.kb-variant--<variant>" — pointing each
- *      --global-<slot> at its variant var. The var is always co-emitted in (1) in the same stylesheet,
- *      so the reference resolves without a literal fallback.
- *   3. A class-less ".wp-block-<block>" rule pointing each --global-<slot> at the $default variant's var,
- *      so a block with no variant selected still shows its preset (the $default look) — the Kadence
- *      analogue of the block preset, for color slots that have no attribute to seed.
+ *   1. One namespaced variant-var block per set —
+ *      --kb-token--<set>--variant--<block>--<variant>--<property>: <value-or-var> — where an aliased
+ *      binding reads var(--kb-token--<set>--<target>), so the variant chains to that set's namespaced
+ *      token and a set's chain stays inside the set; a literal binding emits the literal.
+ *   2. An active-set alias layer pointing each canonical variant var at the active set's namespaced one
+ *      (--kb-token--variant--…: var(--kb-token--<active>--variant--…)).
+ *   3. One [data-kb-token-set="<set>"] switch selector per set re-pointing the canonical variant vars at
+ *      that set, so a body class / container attribute swaps the variant palette client-side — the scoped
+ *      rules below read the canonical variant var on the block element, so they follow it for their subtree.
+ *   4. Per (block, variant) scoped rules — ".wp-block-<block>.kb-variant--<variant>" — pointing each
+ *      --global-<slot> at the canonical variant var, plus a class-less ".wp-block-<block>" rule for the
+ *      $default variant so a block with no variant selected still shows its preset. These are the coercive
+ *      surface, built from the active set only.
  *
  * Scoping is per (block, variant): the same variant name on two blocks ("ghost" on a Button and a Row)
  * gets its own block-qualified rule, so values never collide. Both named variants and the "$default"
@@ -42,6 +47,8 @@ use RuntimeException;
  *
  * Nothing here is !important and the scope carries ordinary class specificity, so a per-instance inline
  * style still wins over a variant. Values are sanitized defensively before they reach a declaration.
+ *
+ * Pure: no WordPress calls beyond the object cache in css_for_version(). The hooks live in Projector.
  *
  * @since TBD
  */
@@ -51,7 +58,8 @@ final class Css_Builder {
 	use Sanitizes_Css_Value;
 
 	/**
-	 * The variant var namespace, appended after the shared --kb-token-- prefix.
+	 * The variant var namespace, appended after the shared --kb-token-- prefix (and after any set
+	 * namespace).
 	 *
 	 * @since TBD
 	 *
@@ -100,14 +108,24 @@ final class Css_Builder {
 	private Variant_Resolver $variants;
 
 	/**
-	 * Per-request memo keyed on slug + store version, so repeated builds within a request are free and a
-	 * write (which bumps the version) invalidates it without an explicit purge.
+	 * Per-request memo of built CSS, keyed on each cached fragment's object-cache key and the full-assembly
+	 * signature, so a write (which bumps a set's version) invalidates the affected entries on its own.
 	 *
 	 * @since TBD
 	 *
 	 * @var array<string, string>
 	 */
 	private array $memo = [];
+
+	/**
+	 * Per-request memo of the collected variant structure, keyed on the set slug, so the registry/resolver
+	 * walk runs once per set even when several layers read it.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string, array<string, array{selector:string, default:string, variants:array<string, array<string, array{slot:string, value:string}>>}>>
+	 */
+	private array $collected = [];
 
 	/**
 	 * @since TBD
@@ -121,19 +139,172 @@ final class Css_Builder {
 	}
 
 	/**
-	 * Build the full variant CSS for a token set: the global variant-var block, the per (block, variant)
-	 * scoped rules, and a class-less $default rule per block. Empty when no registered block contributes a
-	 * slot-targeted value.
+	 * Build the full multi-set variant CSS: a namespaced variant-var block plus switch selector per set, the
+	 * active-set alias layer, and the active set's scoped rules. The pure, uncached assembler (its cached
+	 * counterpart is css_for_version()).
 	 *
 	 * @since TBD
 	 *
-	 * @param string $slug The token set whose resolved values the variant aliases resolve against.
+	 * @param string[] $slugs       Every token set slug to emit, in order.
+	 * @param string   $active_slug The active set's slug — the set the canonical alias layer points at.
 	 *
-	 * @return string The CSS, or an empty string when there is nothing to project.
+	 * @return string The CSS, or an empty string when no block contributes a slot-targeted value.
 	 */
-	public function css( string $slug = 'default' ): string {
-		$globals = '';
-		$scoped  = '';
+	public function css( array $slugs, string $active_slug ): string {
+		$css = '';
+		foreach ( $slugs as $slug ) {
+			$css .= $this->build_set_fragment( (string) $slug );
+		}
+
+		return $css . $this->build_active_fragment( $active_slug );
+	}
+
+	/**
+	 * Cached variant of css(): assembles the per-set fragments and the active fragment from the object cache
+	 * at fragment granularity, with a per-request memo. Editing one set busts only that set's fragment;
+	 * switching the active set reuses every per-set fragment and rebuilds only the active one.
+	 *
+	 * The plugin version is folded into each fragment's cache key alongside the store version, so the cache
+	 * also busts on a plugin build (shipped variant definitions and the baseline can change with it).
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, string> $versions    Each token set slug => the store version it was built from.
+	 * @param string                $active_slug The active set's slug.
+	 *
+	 * @return string
+	 */
+	public function css_for_version( array $versions, string $active_slug ): string {
+		$signature = 'assembly:' . $active_slug;
+		foreach ( $versions as $slug => $version ) {
+			$signature .= '|' . (string) $slug . ':' . $version;
+		}
+
+		if ( isset( $this->memo[ $signature ] ) ) {
+			return $this->memo[ $signature ];
+		}
+
+		$css = '';
+		foreach ( $versions as $slug => $version ) {
+			$css .= $this->set_fragment( (string) $slug, $version );
+		}
+
+		$css .= $this->active_fragment( $active_slug, (string) ( $versions[ $active_slug ] ?? '' ) );
+
+		return $this->memo[ $signature ] = $css;
+	}
+
+	/**
+	 * A set's per-set fragment — its namespaced variant-var block plus its switch selector — served from /
+	 * stored in the object cache. Active-independent: it depends only on this set's resolved variants.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug    The set slug.
+	 * @param string $version The store version the set was built from.
+	 *
+	 * @return string
+	 */
+	public function set_fragment( string $slug, string $version ): string {
+		$cache_key = 'variant_css_set_' . KADENCE_BLOCKS_VERSION . '_' . $slug . '_' . $version;
+
+		if ( isset( $this->memo[ $cache_key ] ) ) {
+			return $this->memo[ $cache_key ];
+		}
+
+		$cached = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
+
+		if ( $found && is_string( $cached ) ) {
+			return $this->memo[ $cache_key ] = $cached;
+		}
+
+		$css = $this->build_set_fragment( $slug );
+
+		wp_cache_set( $cache_key, $css, self::CACHE_GROUP, DAY_IN_SECONDS );
+
+		return $this->memo[ $cache_key ] = $css;
+	}
+
+	/**
+	 * The active fragment — the canonical alias layer plus the coercive scoped rules — served from / stored
+	 * in the object cache. Depends only on the active set, so a switch rebuilds just this.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $active_slug The active set slug.
+	 * @param string $version     The store version the active set was built from.
+	 *
+	 * @return string
+	 */
+	public function active_fragment( string $active_slug, string $version ): string {
+		$cache_key = 'variant_css_active_' . KADENCE_BLOCKS_VERSION . '_' . $active_slug . '_' . $version;
+
+		if ( isset( $this->memo[ $cache_key ] ) ) {
+			return $this->memo[ $cache_key ];
+		}
+
+		$cached = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
+
+		if ( $found && is_string( $cached ) ) {
+			return $this->memo[ $cache_key ] = $cached;
+		}
+
+		$css = $this->build_active_fragment( $active_slug );
+
+		wp_cache_set( $cache_key, $css, self::CACHE_GROUP, DAY_IN_SECONDS );
+
+		return $this->memo[ $cache_key ] = $css;
+	}
+
+	/**
+	 * Build (uncached) a set's per-set fragment: its namespaced variant-var block followed by its switch
+	 * selector. The single assembly definition shared by css() and the cached set_fragment().
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The set slug.
+	 *
+	 * @return string
+	 */
+	private function build_set_fragment( string $slug ): string {
+		$collected = $this->collect( $slug );
+
+		return $this->namespaced_block( $collected, $slug ) . $this->switch_block( $collected, $slug );
+	}
+
+	/**
+	 * Build (uncached) the active fragment: the canonical alias layer plus the coercive scoped rules. The
+	 * single assembly definition shared by css() and the cached active_fragment().
+	 *
+	 * @since TBD
+	 *
+	 * @param string $active_slug The active set slug.
+	 *
+	 * @return string
+	 */
+	private function build_active_fragment( string $active_slug ): string {
+		$collected = $this->collect( $active_slug );
+
+		return $this->alias_block( $collected, $active_slug ) . $this->scoped_block( $collected );
+	}
+
+	/**
+	 * Walk every (block, variant, property) that resolves to a slot-targeted value for a set, into a
+	 * structure the layers below build from. The projected value namespaces its var() target to the set, so
+	 * an aliased variant chains to that set's namespaced token. Memoized per slug for the request.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The set slug to resolve against (and namespace the values to).
+	 *
+	 * @return array<string, array{selector:string, default:string, variants:array<string, array<string, array{slot:string, value:string}>>}>
+	 */
+	private function collect( string $slug ): array {
+		if ( isset( $this->collected[ $slug ] ) ) {
+			return $this->collected[ $slug ];
+		}
+
+		$out = [];
 
 		foreach ( $this->registry->variant_blocks() as $block ) {
 			$set = $this->registry->for_block( $block );
@@ -150,19 +321,16 @@ final class Css_Builder {
 				continue;
 			}
 
-			$selector = $this->block_selector( $block );
-
-			// Keep each variant's slot declarations so the $default's can be re-emitted, class-less, below.
-			$variant_declarations = [];
+			$variants = [];
 
 			foreach ( $names as $variant ) {
 				try {
-					$values = $this->variants->resolve( $block, $variant, $slug );
+					$values = $this->variants->resolve( $block, $variant, $slug, $slug );
 				} catch ( RuntimeException $e ) {
 					continue;
 				}
 
-				$declarations = '';
+				$properties = [];
 
 				foreach ( $values as $property => $value ) {
 					$binding = $set->binding( $property );
@@ -177,16 +345,159 @@ final class Css_Builder {
 						continue;
 					}
 
-					$var       = $this->variant_var( $block, $variant, $property );
-					$projected = $this->sanitize_value( $value );
+					$properties[ $property ] = [
+						'slot'  => $slot,
+						'value' => $value,
+					];
+				}
 
-					$globals      .= $var . ':' . $projected . ';';
-					$declarations .= '--global-' . $slot . ':var(' . $var . ');';
+				if ( $properties !== [] ) {
+					$variants[ $variant ] = $properties;
+				}
+			}
+
+			if ( $variants === [] ) {
+				continue;
+			}
+
+			try {
+				$default = $this->variants->default_variant( $block );
+			} catch ( RuntimeException $e ) {
+				$default = '';
+			}
+
+			$out[ $block ] = [
+				'selector' => $this->block_selector( $block ),
+				'default'  => $default,
+				'variants' => $variants,
+			];
+		}
+
+		return $this->collected[ $slug ] = $out;
+	}
+
+	/**
+	 * Emit a set's `--kb-token--<set>--variant--*` definitions from its collected variants. The value
+	 * preserves alias indirection namespaced to the set, so the variant chains to that set's token.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{slot:string, value:string}>>}> $collected The set's collected variants.
+	 * @param string                                                                                                                          $slug      The set slug to namespace the var names under.
+	 *
+	 * @return string
+	 */
+	private function namespaced_block( array $collected, string $slug ): string {
+		$declarations = '';
+
+		foreach ( $collected as $block => $data ) {
+			foreach ( $data['variants'] as $variant => $properties ) {
+				foreach ( $properties as $property => $info ) {
+					$declarations .= $this->variant_var( $block, $variant, $property, $slug ) . ':' . $this->sanitize_value( $info['value'] ) . ';';
+				}
+			}
+		}
+
+		return $declarations === '' ? '' : Scope::root() . '{' . $declarations . '}';
+	}
+
+	/**
+	 * Emit the active-set alias layer: each canonical variant var pointed at the active set's namespaced
+	 * variant var, so the scoped rules (which read the canonical var) follow the active set.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{slot:string, value:string}>>}> $collected   The active set's collected variants.
+	 * @param string                                                                                                                          $active_slug The active set slug.
+	 *
+	 * @return string
+	 */
+	private function alias_block( array $collected, string $active_slug ): string {
+		$declarations = $this->point_canonical_at_set( $collected, $active_slug );
+
+		return $declarations === '' ? '' : Scope::root() . '{' . $declarations . '}';
+	}
+
+	/**
+	 * Emit a set's switch selector: under `[data-kb-token-set="<set>"]`, re-point every canonical variant
+	 * var at that set's namespaced variant var for the matched element's subtree, so a body class /
+	 * container attribute swaps the variant palette client-side (the scoped --global-<slot> rules read the
+	 * canonical variant var on the block element, so they follow it there).
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{slot:string, value:string}>>}> $collected The set's collected variants.
+	 * @param string                                                                                                                          $slug      The set slug.
+	 *
+	 * @return string
+	 */
+	private function switch_block( array $collected, string $slug ): string {
+		$declarations = $this->point_canonical_at_set( $collected, $slug );
+
+		if ( $declarations === '' ) {
+			return '';
+		}
+
+		return '[' . Token_Css_Builder::get_switch_attribute() . '="' . self::sanitize_identifier( $slug ) . '"]{' . $declarations . '}';
+	}
+
+	/**
+	 * Build the `--kb-token--variant--…: var(--kb-token--<slug>--variant--…);` declarations that point every
+	 * canonical variant var at its namespaced counterpart in $slug. Both names derive from variant_var(), so
+	 * the reference always matches the namespaced block's defined var.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{slot:string, value:string}>>}> $collected The collected variants whose ids drive the layer.
+	 * @param string                                                                                                                          $slug      The set slug the canonical names are pointed at.
+	 *
+	 * @return string
+	 */
+	private function point_canonical_at_set( array $collected, string $slug ): string {
+		$declarations = '';
+
+		foreach ( $collected as $block => $data ) {
+			foreach ( $data['variants'] as $variant => $properties ) {
+				foreach ( $properties as $property => $info ) {
+					$declarations .= $this->variant_var( $block, $variant, $property ) . ':var(' . $this->variant_var( $block, $variant, $property, $slug ) . ');';
+				}
+			}
+		}
+
+		return $declarations;
+	}
+
+	/**
+	 * Emit the coercive scoped rules from the active set's collected variants: per (block, variant) a
+	 * ".wp-block-<block>.kb-variant--<variant>" rule pointing each --global-<slot> at the canonical variant
+	 * var, plus a class-less ".wp-block-<block>" rule re-emitting the $default variant's declarations so an
+	 * unselected block still shows its preset.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{slot:string, value:string}>>}> $collected The active set's collected variants.
+	 *
+	 * @return string
+	 */
+	private function scoped_block( array $collected ): string {
+		$css = '';
+
+		foreach ( $collected as $block => $data ) {
+			$selector = $data['selector'];
+
+			// Keep each variant's slot declarations so the $default's can be re-emitted, class-less, below.
+			$variant_declarations = [];
+
+			foreach ( $data['variants'] as $variant => $properties ) {
+				$declarations = '';
+
+				foreach ( $properties as $property => $info ) {
+					$declarations .= '--global-' . $info['slot'] . ':var(' . $this->variant_var( $block, $variant, $property ) . ');';
 				}
 
 				if ( $declarations !== '' ) {
 					$variant_declarations[ $variant ] = $declarations;
-					$scoped                          .= $selector . '.' . Style::variant_class( $variant ) . '{' . $declarations . '}';
+					$css                             .= $selector . '.' . Style::variant_class( $variant ) . '{' . $declarations . '}';
 				}
 			}
 
@@ -196,53 +507,14 @@ final class Css_Builder {
 			 * the kb-variant-- rules above (a selected variant) and to a per-instance edit, so it only fills
 			 * the gap.
 			 */
-			try {
-				$default = $this->variants->default_variant( $block );
-			} catch ( RuntimeException $e ) {
-				$default = '';
-			}
+			$default = $data['default'];
 
 			if ( $default !== '' && isset( $variant_declarations[ $default ] ) ) {
-				$scoped .= $selector . '{' . $variant_declarations[ $default ] . '}';
+				$css .= $selector . '{' . $variant_declarations[ $default ] . '}';
 			}
 		}
 
-		$css = $globals === '' ? '' : Scope::root() . '{' . $globals . '}';
-
-		return $css . $scoped;
-	}
-
-	/**
-	 * Cached variant of css(): memoized per request and persisted in the object cache keyed on the store
-	 * version, so a token write (which bumps the version) invalidates it automatically. The plugin version
-	 * is folded in too, since variant CSS also depends on shipped declarations and the baseline.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $version The store version the resolved set was built from.
-	 * @param string $slug    The token set slug.
-	 *
-	 * @return string
-	 */
-	public function css_for_version( string $version, string $slug = 'default' ): string {
-		$memo_key = $slug . '|' . $version;
-
-		if ( isset( $this->memo[ $memo_key ] ) ) {
-			return $this->memo[ $memo_key ];
-		}
-
-		$cache_key = 'variant_css_' . KADENCE_BLOCKS_VERSION . '_' . $slug . '_' . $version;
-		$cached    = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
-
-		if ( $found && is_string( $cached ) ) {
-			return $this->memo[ $memo_key ] = $cached;
-		}
-
-		$css = $this->css( $slug );
-
-		wp_cache_set( $cache_key, $css, self::CACHE_GROUP, DAY_IN_SECONDS );
-
-		return $this->memo[ $memo_key ] = $css;
+		return $css;
 	}
 
 	/**
@@ -297,19 +569,24 @@ final class Css_Builder {
 	}
 
 	/**
-	 * The variant var name for a (block, variant, property): "--kb-token--variant--<block>--<variant>--
-	 * <property>", e.g. --kb-token--variant--kadence-advancedbtn--ghost--button-bg.
+	 * The variant var name for a (block, variant, property), optionally namespaced to a token set:
+	 * "--kb-token--[<set>--]variant--<block>--<variant>--<property>", e.g.
+	 * --kb-token--dark--variant--kadence-advancedbtn--ghost--button-bg.
 	 *
 	 * @since TBD
 	 *
-	 * @param string $block    The block name.
-	 * @param string $variant  The variant slug.
-	 * @param string $property The block property.
+	 * @param string $block     The block name.
+	 * @param string $variant   The variant slug.
+	 * @param string $property  The block property.
+	 * @param string $namespace Optional token-set slug to namespace the variable under. Empty yields the
+	 *                          canonical (un-namespaced) name.
 	 *
 	 * @return string
 	 */
-	private function variant_var( string $block, string $variant, string $property ): string {
-		return Css_Var::get_prefix() . self::VARIANT_SEGMENT
+	private function variant_var( string $block, string $variant, string $property, string $namespace = '' ): string {
+		return Css_Var::get_prefix()
+			. ( $namespace === '' ? '' : self::sanitize_identifier( $namespace ) . '--' )
+			. self::VARIANT_SEGMENT
 			. self::sanitize_identifier( str_replace( '/', '-', $block ) ) . '--'
 			. self::sanitize_identifier( $variant ) . '--'
 			. self::sanitize_identifier( $property );

--- a/includes/resources/Design_Tokens/Projection/Variant/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Variant/Projector.php
@@ -112,10 +112,12 @@ final class Projector {
 	}
 
 	/**
-	 * Build the variant CSS for the current set, via the builder's version-keyed cache.
+	 * Build the variant CSS for every token set at once, via the builder's fragment cache.
 	 *
-	 * Returns an empty string when the store version cannot be read or a variant cannot be resolved (e.g.
-	 * an alias cycle from a direct DB write that bypassed the REST gate), so the page never crashes — the
+	 * Each set's variants are emitted as namespaced --kb-token--<set>--variant--* vars plus a switch
+	 * selector; the active set additionally drives the canonical alias layer and the coercive scoped rules.
+	 * Returns an empty string when the store version cannot be read or a variant cannot be resolved (e.g. an
+	 * alias cycle from a direct DB write that bypassed the REST gate), so the page never crashes — the
 	 * inline style is simply omitted and KB falls back to its $default look.
 	 *
 	 * @since TBD
@@ -123,14 +125,36 @@ final class Projector {
 	 * @return string
 	 */
 	private function build_css(): string {
-		$slug = $this->active->get();
-
 		try {
-			$version = $this->store->get_version( $slug );
+			$active   = $this->active->get();
+			$versions = [];
+
+			foreach ( $this->set_slugs() as $slug ) {
+				$versions[ $slug ] = $this->store->get_version( $slug );
+			}
+
+			return $this->css_builder->css_for_version( $versions, $active );
 		} catch ( Throwable $e ) {
 			return '';
 		}
+	}
 
-		return $this->css_builder->css_for_version( $version, $slug );
+	/**
+	 * Every token set slug to emit: the stored sets plus the always-addressable default, which renders from
+	 * baseline even with no row. Mirrors the REST collection's default-inclusive listing, and always
+	 * includes the active set (the active-set pointer only ever resolves to default or a stored set).
+	 *
+	 * @since TBD
+	 *
+	 * @return string[]
+	 */
+	private function set_slugs(): array {
+		$slugs = array_column( $this->store->list_stores(), 'slug' );
+
+		if ( ! in_array( Token_Store::default_slug(), $slugs, true ) ) {
+			array_unshift( $slugs, Token_Store::default_slug() );
+		}
+
+		return $slugs;
 	}
 }

--- a/includes/resources/Design_Tokens/Resolver/Variant_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Variant_Resolver.php
@@ -77,15 +77,18 @@ final class Variant_Resolver {
 	 *
 	 * @since TBD
 	 *
-	 * @param string $block   The block name, e.g. "kadence/advancedbtn".
-	 * @param string $variant The variant slug, e.g. "ghost".
-	 * @param string $slug    The token set whose resolved values aliases resolve against.
+	 * @param string $block     The block name, e.g. "kadence/advancedbtn".
+	 * @param string $variant   The variant slug, e.g. "ghost".
+	 * @param string $slug      The token set whose resolved values aliases resolve against.
+	 * @param string $namespace Css-var namespace for the var() target ('' for the canonical name). When set,
+	 *                          an alias becomes var(--kb-token--<namespace>--<target>), so a namespaced
+	 *                          variant var chains to that set's namespaced token and stays inside the set.
 	 *
 	 * @throws Unknown_Variant_Exception When the block or variant is not defined.
 	 *
 	 * @return array<string, string> property => var()-preserving CSS value.
 	 */
-	public function resolve( string $block, string $variant, string $slug = 'default' ): array {
+	public function resolve( string $block, string $variant, string $slug = 'default', string $namespace = '' ): array {
 		$tokens   = $this->variant_tokens( $block, $variant );
 		$resolved = $this->resolver->resolve( $slug );
 
@@ -96,7 +99,7 @@ final class Variant_Resolver {
 				continue;
 			}
 
-			$values[ $property ] = $this->project( $value );
+			$values[ $property ] = $this->project( $value, $namespace );
 		}
 
 		return $values;
@@ -305,13 +308,14 @@ final class Variant_Resolver {
 	 *
 	 * @since TBD
 	 *
-	 * @param mixed $value The raw binding value (alias string or literal).
+	 * @param mixed  $value     The raw binding value (alias string or literal).
+	 * @param string $namespace Css-var namespace for the var() target ('' for the canonical name).
 	 *
 	 * @return string
 	 */
-	private function project( $value ): string {
+	private function project( $value, string $namespace = '' ): string {
 		if ( is_string( $value ) && Alias::is_alias( $value ) ) {
-			return 'var(' . Css_Var::from_id( Alias::path_of( $value ) ) . ')';
+			return 'var(' . Css_Var::from_id( Alias::path_of( $value ), $namespace ) . ')';
 		}
 
 		return Cast::to_string( $value );

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Variant/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Variant/Css_BuilderTest.php
@@ -12,7 +12,8 @@ use Tests\Support\Classes\TestCase;
 /**
  * Exercises the selectable-variant CSS builder against the real shipped Button variant set, so these
  * assertions also guard the Button wiring: the button-specific --global-palette-btn-* slot retargeting,
- * the variant-var indirection, and the class-less $default rule.
+ * the per-set namespaced variant-var indirection, the active-alias layer, the client-side switch selector,
+ * and the class-less $default rule.
  */
 final class Css_BuilderTest extends TestCase {
 
@@ -48,29 +49,77 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
-	 * Each variant's value lives as a co-emitted global token var that preserves the alias indirection:
-	 * the variant var reads var(--kb-token--<semantic>) rather than a flattened hex, so a token edit flows
-	 * through the chain live.
+	 * Each variant's value lives as a per-set namespaced token var that preserves the alias indirection
+	 * inside the set (var(--kb-token--<set>--<semantic>)), and the canonical variant var is pointed at the
+	 * active set's namespaced one by the alias layer — so a token edit flows through the chain live and the
+	 * variant follows the active set.
 	 *
 	 * @return void
 	 */
-	public function testItDefinesTheVariantVars(): void {
-		$css = $this->builder( $this->registry )->css();
+	public function testItDefinesTheVariantVarsNamespacedWithAnAliasLayer(): void {
+		$css = $this->builder( $this->registry )->css( [ 'default' ], 'default' );
 
-		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--semantic--color--button-primary-bg);', $css );
-		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--primary--button-bg-hover:var(--kb-token--semantic--color--button-primary-bg-hover);', $css );
-		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--secondary--button-bg:var(--kb-token--semantic--color--button-secondary-bg);', $css );
-		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--secondary--button-bg-hover:var(--kb-token--semantic--color--button-secondary-bg-hover);', $css );
+		// The namespaced variant var chains to that set's namespaced semantic.
+		$this->assertStringContainsString( '--kb-token--default--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--default--semantic--color--button-primary-bg);', $css );
+		$this->assertStringContainsString( '--kb-token--default--variant--kadence-singlebtn--secondary--button-bg:var(--kb-token--default--semantic--color--button-secondary-bg);', $css );
+
+		// The canonical variant var is pointed at the active set's namespaced variant var (the alias layer).
+		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--default--variant--kadence-singlebtn--primary--button-bg);', $css );
+	}
+
+	/**
+	 * Every set is emitted simultaneously: both namespaces carry their variant vars, and each set has a
+	 * [data-kb-token-set] switch selector re-pointing the canonical variant var, so a body class swaps the
+	 * variant palette client-side.
+	 *
+	 * @return void
+	 */
+	public function testItEmitsEverySetNamespacedWithASwitchSelector(): void {
+		$css = $this->builder( $this->registry )->css( [ 'default', 'dark' ], 'default' );
+
+		// Both sets' namespaced variant vars are present (dark resolves from baseline here, namespaced).
+		$this->assertStringContainsString( '--kb-token--default--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--default--semantic--color--button-primary-bg);', $css );
+		$this->assertStringContainsString( '--kb-token--dark--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--dark--semantic--color--button-primary-bg);', $css );
+
+		// The dark switch selector re-points the canonical variant var at the dark namespace.
+		$this->assertStringContainsString(
+			'[data-kb-token-set="dark"]{',
+			$css
+		);
+		$this->assertStringContainsString(
+			'--kb-token--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--dark--variant--kadence-singlebtn--primary--button-bg);',
+			$css
+		);
+	}
+
+	/**
+	 * The :root alias layer targets the active set: the active set's canonical re-point appears twice (the
+	 * :root alias plus its own switch selector), a non-active set's only once (its switch selector).
+	 *
+	 * @return void
+	 */
+	public function testItPointsTheAliasLayerAtTheActiveSet(): void {
+		$css = $this->builder( $this->registry )->css( [ 'default', 'dark' ], 'dark' );
+
+		$this->assertSame(
+			2,
+			substr_count( $css, '--kb-token--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--dark--variant--kadence-singlebtn--primary--button-bg);' )
+		);
+		$this->assertSame(
+			1,
+			substr_count( $css, '--kb-token--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--default--variant--kadence-singlebtn--primary--button-bg);' )
+		);
 	}
 
 	/**
 	 * A named variant retargets the button's own --global-palette-btn-* slots (the vars the button render
-	 * path consumes), not the numbered palette, at the co-emitted variant var.
+	 * path consumes), not the numbered palette, at the canonical variant var — so it follows the alias /
+	 * switch layers.
 	 *
 	 * @return void
 	 */
 	public function testItRetargetsButtonSlotsForANamedVariant(): void {
-		$css = $this->builder( $this->registry )->css();
+		$css = $this->builder( $this->registry )->css( [ 'default' ], 'default' );
 
 		$this->assertStringContainsString(
 			'.wp-block-kadence-singlebtn.kb-variant--secondary{'
@@ -89,7 +138,7 @@ final class Css_BuilderTest extends TestCase {
 	 * @return void
 	 */
 	public function testItRetargetsButtonSlotsForANativeBlock(): void {
-		$css = $this->builder( $this->registry )->css();
+		$css = $this->builder( $this->registry )->css( [ 'default' ], 'default' );
 
 		$this->assertStringContainsString(
 			'.wp-block-button.kb-variant--secondary{'
@@ -106,7 +155,7 @@ final class Css_BuilderTest extends TestCase {
 	 * @return void
 	 */
 	public function testItEmitsTheDefaultPresetOnTheBareSelector(): void {
-		$css = $this->builder( $this->registry )->css();
+		$css = $this->builder( $this->registry )->css( [ 'default' ], 'default' );
 
 		$this->assertStringContainsString(
 			'.wp-block-kadence-singlebtn{'
@@ -119,12 +168,13 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
-	 * button-radius is bound css_var only (no slot), so it never reaches a --global-* declaration.
+	 * button-radius is bound css_var only (no slot), so it never reaches a --global-* declaration or a
+	 * variant var (a property bound to no slot is dropped before emission).
 	 *
 	 * @return void
 	 */
 	public function testItSkipsAPropertyBoundToNoSlot(): void {
-		$css = $this->builder( $this->registry )->css();
+		$css = $this->builder( $this->registry )->css( [ 'default' ], 'default' );
 
 		$this->assertStringNotContainsString( 'button-radius', $css );
 	}
@@ -133,7 +183,7 @@ final class Css_BuilderTest extends TestCase {
 	 * @return void
 	 */
 	public function testItIsEmptyWhenNoVariantSetsAreRegistered(): void {
-		$this->assertSame( '', $this->builder( new Token_Registry() )->css() );
+		$this->assertSame( '', $this->builder( new Token_Registry() )->css( [ 'default' ], 'default' ) );
 	}
 
 	/**
@@ -151,7 +201,7 @@ final class Css_BuilderTest extends TestCase {
 			]
 		);
 
-		$this->assertSame( '', $this->builder( $registry )->css() );
+		$this->assertSame( '', $this->builder( $registry )->css( [ 'default' ], 'default' ) );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_ResolverTest.php
@@ -69,6 +69,20 @@ final class Variant_ResolverTest extends TestCase {
 	}
 
 	/**
+	 * A namespace argument namespaces the var() target to that set, so a per-set variant var chains to the
+	 * set's namespaced token and the chain stays inside the set (the basis for client-side palette switching
+	 * of variants).
+	 *
+	 * @return void
+	 */
+	public function testResolveNamespacesTheVarTarget(): void {
+		$projected = $this->resolver->resolve( self::BUTTON, 'primary', 'dark', 'dark' );
+
+		$this->assertSame( 'var(--kb-token--dark--semantic--color--button-primary-bg)', $projected['button-bg'] );
+		$this->assertSame( 'var(--kb-token--dark--semantic--radius--control)', $projected['button-radius'] );
+	}
+
+	/**
 	 * resolve() and resolve_literal() cover exactly the same properties — only the value form differs.
 	 *
 	 * @return void


### PR DESCRIPTION
🎫 [SOFT-3587](https://linear.app/nexcess/issue/SOFT-3587/simultaneous-multi-set-emission-active-alias-layer)

📹 https://www.loom.com/share/b367269167694d2fb17386b695609880

> Depends on #1094; merge that first.

Mirrors the raw-token active-alias switch layer in the variant layer, so variant-styled blocks (buttons) follow palette switching the same way tokens do. For every set the variant builder emits:

- each set's variant vars under its own namespace,
- an active-set alias layer over the canonical variant vars, and
- a per-set `[data-kb-token-set="<set>"]` switch selector, reusing the token builder's switch attribute (`Token_Css_Builder::get_switch_attribute()`) so the variant and token layers switch together under one attribute.

`Variant_Resolver` resolves a set's variant bindings with namespaced css-var names while keeping each alias inside the set; the coercive scoped / `$default` rules are unchanged.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
