### PR TITLE
feat(design-tokens): per-block token-set override

### DIFF
--- a/includes/blocks/class-kadence-blocks-singlebtn-block.php
+++ b/includes/blocks/class-kadence-blocks-singlebtn-block.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Identifier;
 use KadenceWP\KadenceBlocks\Utils\Cast;
 
 /**
@@ -20,6 +21,8 @@ use KadenceWP\KadenceBlocks\Utils\Cast;
  * @category class
  */
 class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
+	use Sanitizes_Css_Identifier;
+
 	/**
 	 * Instance of this class
 	 *
@@ -363,9 +366,10 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 			/**
 			 * The selected design-token variant outputs a kb-variant--<slug> class the Design Tokens variant
 			 * projector's scoped CSS hooks. This is a dynamic block, so the class is added here rather than by
-			 * the editor save filter; the sanitizer mirrors the projector's so the class matches the selector.
+			 * the editor save filter; the shared Sanitizes_Css_Identifier sanitizer keeps the slug matching the
+			 * selector the projected CSS targets.
 			 */
-			$classes[] = 'kb-variant--' . preg_replace( '/[^A-Za-z0-9_-]+/', '-', Cast::to_string( $attributes['kbVariant'] ) );
+			$classes[] = 'kb-variant--' . self::sanitize_identifier( Cast::to_string( $attributes['kbVariant'] ) );
 		}
 
 		if ( ! empty( $attributes['target'] ) && 'video' === $attributes['target'] ) {
@@ -382,9 +386,9 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 			 * A per-block token-set override outputs a data-kb-token-set="<slug>" attribute the Design Tokens
 			 * projector's [data-kb-token-set] switch selectors re-point the block's canonical token vars
 			 * through. This is a dynamic block, so the attribute is added here rather than by the editor save
-			 * filter; the sanitizer mirrors the projector's so the value matches the selector.
+			 * filter; the shared Sanitizes_Css_Identifier sanitizer keeps the slug matching the switch selector.
 			 */
-			$wrapper_args['data-kb-token-set'] = Cast::to_string( preg_replace( '/[^A-Za-z0-9_-]+/', '-', Cast::to_string( $attributes['kbTokenSet'] ) ) );
+			$wrapper_args['data-kb-token-set'] = self::sanitize_identifier( Cast::to_string( $attributes['kbTokenSet'] ) );
 		}
 		if ( ! empty( $attributes['anchor'] ) ) {
 			$wrapper_args['id'] = Cast::to_string( $attributes['anchor'] );

--- a/includes/blocks/class-kadence-blocks-singlebtn-block.php
+++ b/includes/blocks/class-kadence-blocks-singlebtn-block.php
@@ -377,6 +377,15 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$wrapper_args = [
 			'class' => implode( ' ', $classes ),
 		];
+		if ( ! empty( $attributes['kbTokenSet'] ) ) {
+			/**
+			 * A per-block token-set override outputs a data-kb-token-set="<slug>" attribute the Design Tokens
+			 * projector's [data-kb-token-set] switch selectors re-point the block's canonical token vars
+			 * through. This is a dynamic block, so the attribute is added here rather than by the editor save
+			 * filter; the sanitizer mirrors the projector's so the value matches the selector.
+			 */
+			$wrapper_args['data-kb-token-set'] = Cast::to_string( preg_replace( '/[^A-Za-z0-9_-]+/', '-', Cast::to_string( $attributes['kbTokenSet'] ) ) );
+		}
 		if ( ! empty( $attributes['anchor'] ) ) {
 			$wrapper_args['id'] = Cast::to_string( $attributes['anchor'] );
 		}

--- a/includes/resources/Design_Tokens/Editor/Localizer.php
+++ b/includes/resources/Design_Tokens/Editor/Localizer.php
@@ -5,13 +5,14 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Editor;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 
 /**
- * Attaches the variant catalog to the block editor's early-filters bundle.
+ * Attaches the editor catalogs to the block editor's early-filters bundle.
  *
  * On enqueue_block_editor_assets (after the editor-assets class has enqueued the script) it attaches
- * the catalog to the existing 'kadence-blocks-early-filters-js' handle as
- * window.kadenceDesignTokensVariants, which the variant picker reads. Guarded on
- * wp_script_is( …, 'enqueued' ) so it runs only where that bundle loads, and skipped entirely when the
- * registry is fail-closed (a deactivated registry projects nothing, so the picker offers no variants).
+ * two globals to the existing 'kadence-blocks-early-filters-js' handle: window.kadenceDesignTokensVariants
+ * (the variant catalog the variant picker reads) and window.kadenceDesignTokensSets (the token-set catalog
+ * the per-block set-override picker reads). Guarded on wp_script_is( …, 'enqueued' ) so it runs only where
+ * that bundle loads, and skipped entirely when the registry is fail-closed (a deactivated registry projects
+ * nothing, so the pickers offer nothing).
  *
  * Emitted with wp_add_inline_script + wp_json_encode; the JSON_HEX_* flags make the payload safe to
  * inline inside a <script> (no </script> breakout, no & ambiguity) without further escaping.
@@ -21,7 +22,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 final class Localizer {
 
 	/**
-	 * The editor script handle the catalog is attached to (enqueued in class-kadence-blocks-editor-assets).
+	 * The editor script handle the catalogs are attached to (enqueued in class-kadence-blocks-editor-assets).
 	 *
 	 * @since TBD
 	 *
@@ -36,7 +37,16 @@ final class Localizer {
 	 *
 	 * @var string
 	 */
-	private const OBJECT = 'kadenceDesignTokensVariants';
+	private const VARIANTS_OBJECT = 'kadenceDesignTokensVariants';
+
+	/**
+	 * The JS global the per-block set-override picker reads.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const SETS_OBJECT = 'kadenceDesignTokensSets';
 
 	/**
 	 * The token registry, for the fail-closed gate.
@@ -57,18 +67,29 @@ final class Localizer {
 	private Variant_Catalog $variant_catalog;
 
 	/**
+	 * The token-set catalog builder.
+	 *
+	 * @since TBD
+	 *
+	 * @var Set_Catalog
+	 */
+	private Set_Catalog $set_catalog;
+
+	/**
 	 * @since TBD
 	 *
 	 * @param Token_Registry  $registry        The token registry.
 	 * @param Variant_Catalog $variant_catalog The variant catalog builder.
+	 * @param Set_Catalog     $set_catalog     The token-set catalog builder.
 	 */
-	public function __construct( Token_Registry $registry, Variant_Catalog $variant_catalog ) {
+	public function __construct( Token_Registry $registry, Variant_Catalog $variant_catalog, Set_Catalog $set_catalog ) {
 		$this->registry        = $registry;
 		$this->variant_catalog = $variant_catalog;
+		$this->set_catalog     = $set_catalog;
 	}
 
 	/**
-	 * Attach the catalog to the editor bundle, when that bundle is on the page and the registry is active.
+	 * Attach the catalogs to the editor bundle, when that bundle is on the page and the registry is active.
 	 *
 	 * @since TBD
 	 *
@@ -80,11 +101,27 @@ final class Localizer {
 		}
 
 		if ( ! $this->registry->is_active() ) {
-			return; // Fail-closed: no projection, so offer no variants.
+			return; // Fail-closed: no projection, so offer nothing.
 		}
 
+		$this->attach( self::VARIANTS_OBJECT, $this->variant_catalog->all() );
+		$this->attach( self::SETS_OBJECT, $this->set_catalog->all() );
+	}
+
+	/**
+	 * Encode a catalog and attach it to the editor bundle as a window global. A catalog that cannot be
+	 * serialized is skipped rather than injected as malformed JS.
+	 *
+	 * @since TBD
+	 *
+	 * @param string              $global_name The window global name to assign.
+	 * @param array<string,mixed> $catalog     The catalog payload to encode.
+	 *
+	 * @return void
+	 */
+	private function attach( string $global_name, array $catalog ): void {
 		$json = wp_json_encode(
-			$this->variant_catalog->all(),
+			$catalog,
 			JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
 		);
 
@@ -94,7 +131,7 @@ final class Localizer {
 
 		wp_add_inline_script(
 			self::HANDLE,
-			'window.' . self::OBJECT . ' = ' . $json . ';',
+			'window.' . $global_name . ' = ' . $json . ';',
 			'before'
 		);
 	}

--- a/includes/resources/Design_Tokens/Editor/Provider.php
+++ b/includes/resources/Design_Tokens/Editor/Provider.php
@@ -5,9 +5,10 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Editor;
 use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
 
 /**
- * Registers the block-editor variant catalog: binds the catalog builder and localizer as singletons,
- * then hooks the localizer onto enqueue_block_editor_assets so the early-filters bundle receives
- * window.kadenceDesignTokensVariants for the variant picker.
+ * Registers the block-editor catalogs: binds the variant and token-set catalog builders and the localizer
+ * as singletons, then hooks the localizer onto enqueue_block_editor_assets so the early-filters bundle
+ * receives window.kadenceDesignTokensVariants (variant picker) and window.kadenceDesignTokensSets (per-block
+ * set-override picker).
  *
  * @since TBD
  */
@@ -20,6 +21,7 @@ final class Provider extends Provider_Contract {
 	 */
 	public function register(): void {
 		$this->container->singleton( Variant_Catalog::class );
+		$this->container->singleton( Set_Catalog::class );
 		$this->container->singleton( Localizer::class );
 
 		/**

--- a/includes/resources/Design_Tokens/Editor/Set_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Set_Catalog.php
@@ -1,0 +1,108 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Editor;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+
+/**
+ * Builds the compact token-set catalog the block editor's per-block set-override picker reads.
+ *
+ * Only the data the picker needs — which set is active and the selectable sets as { slug, label } —
+ * so it carries no resolved token values and cannot raise the alias-cycle errors the projection must
+ * guard. The listing is default-inclusive: the always-addressable default set appears even when it has
+ * no stored row, mirroring the projection's set listing so the picker never offers a set the projection
+ * cannot resolve, and never omits one it can.
+ *
+ * @since TBD
+ */
+final class Set_Catalog {
+
+	/**
+	 * The token store, source of the stored sets and their titles.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * The active-set pointer, source of the active slug.
+	 *
+	 * @since TBD
+	 *
+	 * @var Active_Set_Store
+	 */
+	private Active_Set_Store $active;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Store      $store  The token store.
+	 * @param Active_Set_Store $active The active-set pointer.
+	 */
+	public function __construct( Token_Store $store, Active_Set_Store $active ) {
+		$this->store  = $store;
+		$this->active = $active;
+	}
+
+	/**
+	 * The catalog: the active slug plus every selectable set as { slug, label }.
+	 *
+	 * The always-addressable default set is listed first, ahead of the stored sets (which follow the store's
+	 * slug order), and is synthesized from baseline when it has no row — so the picker can offer default as
+	 * the first concrete option regardless of where its slug would otherwise sort.
+	 *
+	 * @since TBD
+	 *
+	 * @return array{active: string, sets: array<int, array{slug: string, label: string}>}
+	 */
+	public function all(): array {
+		$sets = [];
+
+		foreach ( $this->store->list_stores() as $row ) {
+			$slug = $row['slug'];
+
+			$sets[ $slug ] = [
+				'slug'  => $slug,
+				'label' => $this->label( $slug, $row['title'] ),
+			];
+		}
+
+		$default = $sets[ Token_Store::default_slug() ] ?? [
+			'slug'  => Token_Store::default_slug(),
+			'label' => $this->label( Token_Store::default_slug(), '' ),
+		];
+		unset( $sets[ Token_Store::default_slug() ] );
+
+		return [
+			'active' => $this->active->get(),
+			'sets'   => array_values( [ Token_Store::default_slug() => $default ] + $sets ),
+		];
+	}
+
+	/**
+	 * The display label for a set: its stored title when it has one, otherwise a friendly name for the
+	 * default set and the bare slug for any other set with no title. Display-only — the slug is the value
+	 * the picker writes to the block attribute.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug  The set slug.
+	 * @param string $title The stored title, possibly empty.
+	 *
+	 * @return string
+	 */
+	private function label( string $slug, string $title ): string {
+		if ( $title !== '' ) {
+			return $title;
+		}
+
+		if ( $slug === Token_Store::default_slug() ) {
+			return __( 'Default', 'kadence-blocks' );
+		}
+
+		return $slug;
+	}
+}

--- a/src/blocks/singlebtn/block.json
+++ b/src/blocks/singlebtn/block.json
@@ -757,6 +757,10 @@
 		"kbVariant": {
 			"type": "string",
 			"default": ""
+		},
+		"kbTokenSet": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"supports": {

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -45,6 +45,7 @@ import {
 	DynamicTextControl,
 	DynamicInlineReplaceControl,
 	Tooltip,
+	SubsectionWrap,
 } from '@kadence/components';
 import classnames from 'classnames';
 import { times, filter, map, uniqueId } from 'lodash';
@@ -84,6 +85,7 @@ import {
 import { addFilter, applyFilters, doAction } from '@wordpress/hooks';
 import BackendStyles from './components/backend-styles';
 import { VariantPicker, blockVariants } from '../../extension/variant-picker';
+import { TokenSetPicker, selectableSets } from '../../extension/token-set-picker';
 
 export default function KadenceButtonEdit(props) {
 	const { attributes, setAttributes, isSelected, context, clientId, name } = props;
@@ -827,17 +829,30 @@ export default function KadenceButtonEdit(props) {
 
 						{activeTab === 'style' && (
 							<>
-								{blockVariants(name).length > 0 && (
+								{(blockVariants(name).length > 0 || selectableSets().length >= 2) && (
 									<KadencePanelBody
-										title={__('Design Variant', 'kadence-blocks')}
+										title={__('Design Tokens', 'kadence-blocks')}
 										initialOpen={true}
 										panelName={'kb-adv-single-btn-variant'}
 									>
-										<VariantPicker
-											name={name}
-											value={attributes.kbVariant || ''}
-											onChange={(value) => setAttributes({ kbVariant: value })}
-										/>
+										{selectableSets().length >= 2 && (
+											<SubsectionWrap label={__('Token Set', 'kadence-blocks')}>
+												<TokenSetPicker
+													value={attributes.kbTokenSet || ''}
+													onChange={(value) => setAttributes({ kbTokenSet: value })}
+													label=""
+												/>
+											</SubsectionWrap>
+										)}
+										{blockVariants(name).length > 0 && (
+											<SubsectionWrap label={__('Design Variants', 'kadence-blocks')}>
+												<VariantPicker
+													name={name}
+													value={attributes.kbVariant || ''}
+													onChange={(value) => setAttributes({ kbVariant: value })}
+												/>
+											</SubsectionWrap>
+										)}
 									</KadencePanelBody>
 								)}
 								{showSettings('colorSettings', 'kadence/advancedbtn') && (

--- a/src/early-filters.js
+++ b/src/early-filters.js
@@ -8,11 +8,13 @@ import { assign, get } from 'lodash';
 import { Button, Modal, PanelBody } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 import { blockExists } from '@kadence/helpers';
+import { SubsectionWrap } from '@kadence/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { useDispatch, select } from '@wordpress/data';
 import { VariantPicker, blockVariants } from './extension/variant-picker';
+import { TokenSetPicker, selectableSets } from './extension/token-set-picker';
 
 /**
  * Add animation attributes
@@ -96,22 +98,28 @@ export function enableNativeBlockVariants(settings, name) {
 addFilter('blocks.registerBlockType', 'kadence/kb-variant-native-support', enableNativeBlockVariants);
 
 /**
- * Add the kbVariant attribute to any block that opts in via the `kbVariant` block support.
+ * Add the kbVariant and kbTokenSet attributes to any block that opts in via the `kbVariant` block support.
  *
- * The attribute holds the slug of the selected design-token variant (e.g. "ghost"); empty means the
- * block keeps its $default look (the block preset). The scoped CSS that re-skins the block for a
- * selected variant is emitted server-side by the Design Tokens variant projector.
+ * kbVariant holds the slug of the selected design-token variant (e.g. "ghost"); empty means the block
+ * keeps its $default look (the block preset). kbTokenSet holds the slug of a per-block token-set override
+ * (e.g. "dark"); empty means the block follows the active set. The scoped CSS that re-skins the block for a
+ * selected variant and the switch selectors a set override re-points through are both emitted server-side
+ * by the Design Tokens projector.
  *
  * @param {Object} settings The block settings.
  *
  * @since TBD
  *
- * @return {Object} The block settings with the kbVariant attribute added.
+ * @return {Object} The block settings with the kbVariant and kbTokenSet attributes added.
  */
 export function blockVariantAttribute(settings) {
 	if (hasBlockSupport(settings, 'kbVariant')) {
 		settings.attributes = assign(settings.attributes, {
 			kbVariant: {
+				type: 'string',
+				default: '',
+			},
+			kbTokenSet: {
 				type: 'string',
 				default: '',
 			},
@@ -123,6 +131,23 @@ export function blockVariantAttribute(settings) {
 addFilter('blocks.registerBlockType', 'kadence/kb-variant-attribute', blockVariantAttribute);
 
 /**
+ * Sanitize a design-token slug to the identifier form the projector emits.
+ *
+ * Mirrors the projector's PHP Css_Builder::sanitize_identifier() sanitizer, so a slug written to a class
+ * or a data attribute always matches the scoped selector / switch selector the projector emits even if it
+ * carries an unexpected character.
+ *
+ * @param {string} slug The raw slug.
+ *
+ * @since TBD
+ *
+ * @return {string} The sanitized slug.
+ */
+function sanitizeTokenIdentifier(slug) {
+	return (slug || '').replace(/[^A-Za-z0-9_-]+/g, '-');
+}
+
+/**
  * The class a selected variant outputs, or an empty string when none is selected.
  *
  * @param {string} kbVariant The selected variant slug.
@@ -132,9 +157,7 @@ addFilter('blocks.registerBlockType', 'kadence/kb-variant-attribute', blockVaria
  * @return {string} The `kb-variant--<slug>` class, or an empty string.
  */
 function kbVariantClassName(kbVariant) {
-	// Mirror the projector's PHP Css_Builder::sanitize_identifier() sanitizer, so the output class always
-	// matches the scoped selector the projector emits even if a slug carries an unexpected character.
-	const slug = (kbVariant || '').replace(/[^A-Za-z0-9_-]+/g, '-');
+	const slug = sanitizeTokenIdentifier(kbVariant);
 
 	return slug ? `kb-variant--${slug}` : '';
 }
@@ -167,6 +190,34 @@ export function blockVariantSaveClass(props, blockType, attributes) {
 addFilter('blocks.getSaveContent.extraProps', 'kadence/kb-variant-save-class', blockVariantSaveClass);
 
 /**
+ * Append the data-kb-token-set="<slug>" attribute to a block's saved markup when it is pinned to a token
+ * set, so the projector's `[data-kb-token-set]` switch selectors re-point the block's canonical token vars
+ * at that set on the front end. A no-op for blocks that do not opt in or follow the active set.
+ *
+ * @param {Object} props      The save element props.
+ * @param {Object} blockType  The block type.
+ * @param {Object} attributes The block attributes.
+ *
+ * @since TBD
+ *
+ * @return {Object} The props, with the data attribute appended when a set is pinned.
+ */
+export function blockTokenSetSaveAttr(props, blockType, attributes) {
+	if (!hasBlockSupport(blockType, 'kbVariant')) {
+		return props;
+	}
+
+	const slug = sanitizeTokenIdentifier(get(attributes, 'kbTokenSet', ''));
+
+	if (slug) {
+		props['data-kb-token-set'] = slug;
+	}
+
+	return props;
+}
+addFilter('blocks.getSaveContent.extraProps', 'kadence/kb-token-set-save-attr', blockTokenSetSaveAttr);
+
+/**
  * Mirror the kb-variant--<name> class onto the block in the editor canvas, so a selected variant previews
  * live with the same scoped overrides the front end uses.
  *
@@ -194,13 +245,45 @@ const withBlockVariantClass = createHigherOrderComponent((BlockListBlock) => {
 addFilter('editor.BlockListBlock', 'kadence/kb-variant-class', withBlockVariantClass);
 
 /**
- * Add a "Design Variant" picker to the inspector of any block that opts into kbVariant support and has
- * variants defined in the design-token document. Selecting an option writes the kbVariant attribute,
- * which the save/preview filters turn into the kb-variant--<slug> class the projector's scoped CSS hooks.
- * An empty value selects the block's $default preset look.
+ * Mirror the data-kb-token-set="<slug>" attribute onto the block in the editor canvas, so a pinned set
+ * previews live with the same switch-selector re-pointing the front end uses. Added via wrapperProps so it
+ * lands on the same block wrapper the variant class and scoped rules target.
  *
- * A block whose `kbVariant` support requests `inlinePicker` renders the picker itself (e.g. a Kadence
- * block placing it under its own Style tab), so this generic sidebar panel skips it to avoid a duplicate.
+ * @since TBD
+ */
+const withBlockTokenSetAttr = createHigherOrderComponent((BlockListBlock) => {
+	return (props) => {
+		const { name, attributes } = props;
+
+		if (!hasBlockSupport(name, 'kbVariant')) {
+			return <BlockListBlock {...props} />;
+		}
+
+		const slug = sanitizeTokenIdentifier(get(attributes, 'kbTokenSet', ''));
+
+		if (!slug) {
+			return <BlockListBlock {...props} />;
+		}
+
+		const wrapperProps = { ...(props.wrapperProps || {}), 'data-kb-token-set': slug };
+
+		return <BlockListBlock {...props} wrapperProps={wrapperProps} />;
+	};
+}, 'withBlockTokenSetAttr');
+addFilter('editor.BlockListBlock', 'kadence/kb-token-set-attr', withBlockTokenSetAttr);
+
+/**
+ * Add the design-token pickers to the inspector of any block that opts into kbVariant support, under a
+ * "Design Tokens" panel: a "Token Set" subsection (the per-block set override) above a "Design Variants"
+ * subsection (the variant picker). Selecting a set writes the kbTokenSet attribute, which the save/preview
+ * filters turn into the data-kb-token-set attribute the projector's switch selectors re-point through;
+ * selecting a variant writes the kbVariant attribute, which the save/preview filters turn into the
+ * kb-variant--<slug> class the projector's scoped CSS hooks. An empty set follows the active set; an empty
+ * variant selects the block's $default preset look. Each subsection is shown only when it has something to
+ * offer (two or more sets / any variants), and the panel is skipped when neither does.
+ *
+ * A block whose `kbVariant` support requests `inlinePicker` renders the pickers itself (e.g. a Kadence
+ * block placing them under its own Style tab), so this generic sidebar panel skips it to avoid a duplicate.
  *
  * @since TBD
  */
@@ -218,7 +301,10 @@ const withVariantPicker = createHigherOrderComponent((BlockEdit) => {
 			return <BlockEdit {...props} />;
 		}
 
-		if (!blockVariants(name).length) {
+		const hasVariants = blockVariants(name).length > 0;
+		const hasSets = selectableSets().length >= 2;
+
+		if (!hasVariants && !hasSets) {
 			return <BlockEdit {...props} />;
 		}
 
@@ -227,12 +313,25 @@ const withVariantPicker = createHigherOrderComponent((BlockEdit) => {
 				<BlockEdit {...props} />
 				{isSelected && (
 					<InspectorControls group="styles">
-						<PanelBody title={__('Design Variant', 'kadence-blocks')} initialOpen={false}>
-							<VariantPicker
-								name={name}
-								value={get(attributes, 'kbVariant', '')}
-								onChange={(value) => setAttributes({ kbVariant: value })}
-							/>
+						<PanelBody title={__('Design Tokens', 'kadence-blocks')} initialOpen={false}>
+							{hasSets && (
+								<SubsectionWrap label={__('Token Set', 'kadence-blocks')}>
+									<TokenSetPicker
+										value={get(attributes, 'kbTokenSet', '')}
+										onChange={(value) => setAttributes({ kbTokenSet: value })}
+										label=""
+									/>
+								</SubsectionWrap>
+							)}
+							{hasVariants && (
+								<SubsectionWrap label={__('Design Variants', 'kadence-blocks')}>
+									<VariantPicker
+										name={name}
+										value={get(attributes, 'kbVariant', '')}
+										onChange={(value) => setAttributes({ kbVariant: value })}
+									/>
+								</SubsectionWrap>
+							)}
 						</PanelBody>
 					</InspectorControls>
 				)}

--- a/src/extension/token-set-picker/index.js
+++ b/src/extension/token-set-picker/index.js
@@ -1,0 +1,86 @@
+/**
+ * Shared per-block token-set override picker.
+ *
+ * The catalog ({ active, sets: [{ slug, label }] }) is printed by the server-side editor localizer to
+ * `window.kadenceDesignTokensSets`. Both the generic inspector picker (src/early-filters.js) and a block
+ * that renders the picker inline in its own Style tab (e.g. kadence/singlebtn) use this so the control
+ * stays identical wherever it surfaces.
+ *
+ * Selecting a set writes its slug to the kbVariant-companion `kbTokenSet` attribute, which the save/preview
+ * filters turn into a `data-kb-token-set` attribute on the block. That re-points the block's canonical
+ * `--kb-token--*` vars at the chosen set's namespaced vars via the projector's switch selectors. An empty
+ * value (the default) leaves the attribute unset, so the block follows the active set.
+ */
+import { get } from 'lodash';
+import { KadenceRadioButtons } from '@kadence/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * The token-set catalog the editor localizer prints, or an empty catalog when the token registry is
+ * inactive (no sets offered).
+ *
+ * @return {Object} The catalog ({ active, sets }).
+ */
+function tokenSetCatalog() {
+	return get(window, 'kadenceDesignTokensSets', {}) || {};
+}
+
+/**
+ * The selectable token sets ([{ slug, label }]), or an empty array when none are printed.
+ *
+ * @return {Array} The token sets.
+ */
+export function selectableSets() {
+	return get(tokenSetCatalog(), 'sets', []);
+}
+
+/**
+ * The per-block token-set override picker. Renders nothing when fewer than two sets exist (there is
+ * nothing to override to). Selecting an option writes the kbTokenSet attribute (via onChange); an empty
+ * value follows the active set.
+ *
+ * The currently active set is annotated "(active)" so it reads as a concrete set that happens to be active
+ * right now, distinct from "Follow active set" which tracks whichever set is active over time.
+ *
+ * @param {Object}   props             The component props.
+ * @param {string}   props.value       The currently selected set slug.
+ * @param {Function} props.onChange    Called with the selected slug.
+ * @param {string}   [props.label]     The control label; defaults to "Token Set". Pass "" to omit it when a
+ *                                     section heading already supplies the label.
+ * @param {string}   [props.className] The control class.
+ *
+ * @return {Object|null} The picker element, or null when there is nothing to override to.
+ */
+export function TokenSetPicker({ value, onChange, label = __('Token Set', 'kadence-blocks'), className }) {
+	const catalog = tokenSetCatalog();
+	const sets = get(catalog, 'sets', []);
+
+	if (sets.length < 2) {
+		return null;
+	}
+
+	const active = get(catalog, 'active', '');
+
+	const options = [
+		{ label: __('Follow active set', 'kadence-blocks'), value: '' },
+		...sets.map((set) => ({
+			label:
+				set.slug === active
+					? // translators: %s is the token set name.
+						sprintf(__('%s (active)', 'kadence-blocks'), set.label)
+					: set.label,
+			value: set.slug,
+		})),
+	];
+
+	return (
+		<KadenceRadioButtons
+			label={label}
+			className={className || 'kb-token-set-picker'}
+			value={value || ''}
+			options={options}
+			wrap={true}
+			onChange={onChange}
+		/>
+	);
+}

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Set_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Set_CatalogTest.php
@@ -1,0 +1,168 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Editor;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Editor\Set_Catalog;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Exercises the editor token-set catalog the per-block set-override picker reads: the default-inclusive
+ * listing, its display labels, and the active-set pointer.
+ */
+final class Set_CatalogTest extends TestCase {
+
+	/**
+	 * @var Active_Set_Store
+	 */
+	private Active_Set_Store $active;
+
+	/**
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->active = $this->container->get( Active_Set_Store::class );
+		$this->store  = $this->container->get( Token_Store::class );
+	}
+
+	/**
+	 * With no stored sets the catalog still offers the always-addressable default, labeled and active.
+	 *
+	 * @return void
+	 */
+	public function testItListsOnlyTheDefaultSetWhenNothingIsStored(): void {
+		$catalog = $this->catalog();
+
+		$this->assertSame( Token_Store::default_slug(), $catalog['active'] );
+		$this->assertSame(
+			[
+				[
+					'slug'  => Token_Store::default_slug(),
+					'label' => 'Default',
+				],
+			],
+			$catalog['sets']
+		);
+	}
+
+	/**
+	 * Stored sets appear with their titles as labels, the default is synthesized at the front, and the
+	 * listing follows the store's slug order.
+	 *
+	 * @return void
+	 */
+	public function testItListsStoredSetsWithTitlesAndSynthesizesTheDefault(): void {
+		$this->store->save_document( '{}', 'brand-b', 'Brand B' );
+		$this->store->save_document( '{}', 'dark', 'Dark' );
+
+		$catalog = $this->catalog();
+
+		$this->assertSame( Token_Store::default_slug(), $catalog['active'] );
+		$this->assertSame(
+			[
+				[
+					'slug'  => Token_Store::default_slug(),
+					'label' => 'Default',
+				],
+				[
+					'slug'  => 'brand-b',
+					'label' => 'Brand B',
+				],
+				[
+					'slug'  => 'dark',
+					'label' => 'Dark',
+				],
+			],
+			$catalog['sets']
+		);
+	}
+
+	/**
+	 * A non-default set with no title falls back to its slug for the label.
+	 *
+	 * @return void
+	 */
+	public function testItLabelsASetWithoutATitleUsingItsSlug(): void {
+		$this->store->save_document( '{}', 'brand-b' );
+
+		$sets = $this->indexBySlug( $this->catalog()['sets'] );
+
+		$this->assertSame( 'brand-b', $sets['brand-b']['label'] );
+	}
+
+	/**
+	 * A stored default row's title wins over the synthesized "Default" label.
+	 *
+	 * @return void
+	 */
+	public function testItUsesTheStoredTitleForTheDefaultSet(): void {
+		$this->store->save_document( '{}', Token_Store::default_slug(), 'House Palette' );
+
+		$sets = $this->indexBySlug( $this->catalog()['sets'] );
+
+		$this->assertSame( 'House Palette', $sets[ Token_Store::default_slug() ]['label'] );
+		// The default is not duplicated when it has a real row.
+		$this->assertCount( 1, $this->catalog()['sets'] );
+	}
+
+	/**
+	 * The default set is listed first even when a stored set's slug sorts ahead of it alphabetically.
+	 *
+	 * @return void
+	 */
+	public function testItPlacesTheDefaultSetFirstRegardlessOfSlugOrder(): void {
+		// 'brand-a' sorts before 'default' in the store's slug-ASC listing.
+		$this->store->save_document( '{}', 'brand-a', 'Brand A' );
+		$this->store->save_document( '{}', Token_Store::default_slug(), 'House Palette' );
+
+		$slugs = array_column( $this->catalog()['sets'], 'slug' );
+
+		$this->assertSame( [ Token_Store::default_slug(), 'brand-a' ], $slugs );
+	}
+
+	/**
+	 * The catalog reports the active-set pointer.
+	 *
+	 * @return void
+	 */
+	public function testItReflectsTheActivePointer(): void {
+		$this->store->save_document( '{}', 'brand-b', 'Brand B' );
+		$this->active->set( 'brand-b' );
+
+		$this->assertSame( 'brand-b', $this->catalog()['active'] );
+	}
+
+	/**
+	 * Build the catalog under test from the container-resolved stores.
+	 *
+	 * @return array{active: string, sets: array<int, array{slug: string, label: string}>}
+	 */
+	private function catalog(): array {
+		return ( new Set_Catalog( $this->store, $this->active ) )->all();
+	}
+
+	/**
+	 * Re-key a catalog's set list by slug, for assertions that target a single set.
+	 *
+	 * @param array<int, array{slug: string, label: string}> $sets The set list.
+	 *
+	 * @return array<string, array{slug: string, label: string}>
+	 */
+	private function indexBySlug( array $sets ): array {
+		$indexed = [];
+
+		foreach ( $sets as $set ) {
+			$indexed[ $set['slug'] ] = $set;
+		}
+
+		return $indexed;
+	}
+}


### PR DESCRIPTION
🎫 https://linear.app/nexcess/issue/SOFT-3588/per-block-token-set-override

📹 https://www.loom.com/share/6478cb2cf85c4e72a26484998a407a09

Lets a single block render against a non-active token set. A `kbTokenSet` attribute writes a `data-kb-token-set="<slug>"` on the block, and the projector's existing per-set switch selectors re-point that subtree's canonical token vars at the chosen set, while the rest of the page follows the active set. Adds an editor "Token Set" picker (above the variant picker) fed by a new `Set_Catalog` localized to the editor.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
