### PR TITLE
Custom Variant Creation [1/11]: resolve variants from the effective per-set document

### DIFF
--- a/includes/resources/Design_Tokens/Admin/Feed/Variants.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Variants.php
@@ -65,9 +65,9 @@ final class Variants {
 
 		foreach ( $this->registry->variant_sets() as $block => $set ) {
 			try {
-				$names      = $this->variants->names( $block );
-				$default    = $this->variants->default_variant( $block );
-				$properties = $this->variants->value_properties( $block );
+				$names      = $this->variants->names( $block, $slug );
+				$default    = $this->variants->default_variant( $block, $slug );
+				$properties = $this->variants->value_properties( $block, $slug );
 			} catch ( Unknown_Variant_Exception $e ) {
 				continue; // Block registered but not defined in the document — skip, fail soft.
 			}

--- a/includes/resources/Design_Tokens/Editor/Variant_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Variant_Catalog.php
@@ -48,19 +48,21 @@ final class Variant_Catalog {
 	}
 
 	/**
-	 * The catalog, keyed by block name.
+	 * The catalog for a token set, keyed by block name.
 	 *
 	 * @since TBD
 	 *
+	 * @param string $slug The token set whose effective variants are read.
+	 *
 	 * @return array<string, array{default: string, variants: array<int, array{slug: string, label: string}>}>
 	 */
-	public function all(): array {
+	public function all( string $slug = 'default' ): array {
 		$out = [];
 
 		foreach ( $this->registry->variant_blocks() as $block ) {
 			try {
-				$names   = $this->variants->names( $block );
-				$default = $this->variants->default_variant( $block );
+				$names   = $this->variants->names( $block, $slug );
+				$default = $this->variants->default_variant( $block, $slug );
 			} catch ( Unknown_Variant_Exception $e ) {
 				continue; // Block registered but not defined in the document — skip, fail soft.
 			}
@@ -70,7 +72,7 @@ final class Variant_Catalog {
 			foreach ( $names as $name ) {
 				$variants[] = [
 					'slug'  => $name,
-					'label' => $this->variants->label( $block, $name ) ?? $name,
+					'label' => $this->variants->label( $block, $name, $slug ) ?? $name,
 				];
 			}
 

--- a/includes/resources/Design_Tokens/Projection/Variant/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Variant/Css_Builder.php
@@ -316,7 +316,7 @@ final class Css_Builder {
 			try {
 				// A block may carry registered bindings before the document defines its variants; that is not
 				// an error, it simply contributes nothing yet, so skip it rather than fail the whole build.
-				$names = $this->variants->names( $block );
+				$names = $this->variants->names( $block, $slug );
 			} catch ( RuntimeException $e ) {
 				continue;
 			}
@@ -361,7 +361,7 @@ final class Css_Builder {
 			}
 
 			try {
-				$default = $this->variants->default_variant( $block );
+				$default = $this->variants->default_variant( $block, $slug );
 			} catch ( RuntimeException $e ) {
 				$default = '';
 			}

--- a/includes/resources/Design_Tokens/Resolver/Variant_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Variant_Resolver.php
@@ -38,7 +38,7 @@ use KadenceWP\KadenceBlocks\Utils\Cast;
 final class Variant_Resolver {
 
 	/**
-	 * @var Effective_Variants The per-set effective (baseline ⊕ overrides) variant definitions are read from.
+	 * @var Effective_Variants The per-set effective variant definitions (the baseline deep-merged with the set's stored overrides) are read from.
 	 *
 	 * @since TBD
 	 */
@@ -176,9 +176,9 @@ final class Variant_Resolver {
 	}
 
 	/**
-	 * The variant slugs a block declares for a set, in document order — the effective set (baseline ⊕ the
-	 * set's stored overrides) being the source of truth, so a user-added variant in the store appears here
-	 * alongside the baseline ones.
+	 * The variant slugs a block declares for a set, in document order — the effective set (the baseline
+	 * deep-merged with the set's stored overrides) being the source of truth, so a user-added variant in the
+	 * store appears here alongside the baseline ones.
 	 *
 	 * @since TBD
 	 *
@@ -402,8 +402,8 @@ final class Variant_Resolver {
 	}
 
 	/**
-	 * The whole effective variants section for a set (baseline ⊕ the set's stored overrides), or an empty
-	 * array when absent.
+	 * The whole effective variants section for a set (the baseline deep-merged with the set's stored
+	 * overrides), or an empty array when absent.
 	 *
 	 * @since TBD
 	 *

--- a/includes/resources/Design_Tokens/Resolver/Variant_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Variant_Resolver.php
@@ -2,7 +2,6 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Resolver;
 
-use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Unknown_Variant_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
@@ -29,19 +28,21 @@ use KadenceWP\KadenceBlocks\Utils\Cast;
  * surfaces that cannot consume a var() chain (block-attribute presets, the dimension-default fallback,
  * the editor variant-catalog feed).
  *
- * Variant definitions are read from the shipped baseline. The core Resolver's Effective_Document
- * deliberately strips `$extensions`, so variants are resolved here rather than through that deep-merge.
+ * Variant definitions are read per token set through {@see Effective_Variants}: the shipped baseline's
+ * variants deep-merged with that set's stored overrides, so a variant a user authored through the store
+ * is resolved alongside the baseline ones. The core Resolver's Effective_Document deliberately strips
+ * `$extensions`, so variants are resolved here rather than through that deep-merge.
  *
  * @since TBD
  */
 final class Variant_Resolver {
 
 	/**
-	 * @var Baseline_Document The shipped baseline the variant definitions are read from.
+	 * @var Effective_Variants The per-set effective (baseline ⊕ overrides) variant definitions are read from.
 	 *
 	 * @since TBD
 	 */
-	private Baseline_Document $baseline;
+	private Effective_Variants $variants;
 
 	/**
 	 * @var Token_Resolver The token resolver whose flattened id map variant aliases are looked up in.
@@ -53,11 +54,11 @@ final class Variant_Resolver {
 	/**
 	 * @since TBD
 	 *
-	 * @param Baseline_Document $baseline The shipped baseline document.
-	 * @param Token_Resolver    $resolver The token resolver.
+	 * @param Effective_Variants $variants The per-set effective variant definitions.
+	 * @param Token_Resolver     $resolver The token resolver.
 	 */
-	public function __construct( Baseline_Document $baseline, Token_Resolver $resolver ) {
-		$this->baseline = $baseline;
+	public function __construct( Effective_Variants $variants, Token_Resolver $resolver ) {
+		$this->variants = $variants;
 		$this->resolver = $resolver;
 	}
 
@@ -79,7 +80,7 @@ final class Variant_Resolver {
 	 *
 	 * @param string $block     The block name, e.g. "kadence/advancedbtn".
 	 * @param string $variant   The variant slug, e.g. "ghost".
-	 * @param string $slug      The token set whose resolved values aliases resolve against.
+	 * @param string $slug      The token set whose effective variants and resolved values are read.
 	 * @param string $namespace Css-var namespace for the var() target ('' for the canonical name). When set,
 	 *                          an alias becomes var(--kb-token--<namespace>--<target>), so a namespaced
 	 *                          variant var chains to that set's namespaced token and stays inside the set.
@@ -89,7 +90,7 @@ final class Variant_Resolver {
 	 * @return array<string, string> property => var()-preserving CSS value.
 	 */
 	public function resolve( string $block, string $variant, string $slug = 'default', string $namespace = '' ): array {
-		$tokens   = $this->variant_tokens( $block, $variant );
+		$tokens   = $this->variant_tokens( $block, $variant, $slug );
 		$resolved = $this->resolver->resolve( $slug );
 
 		$values = [];
@@ -128,14 +129,14 @@ final class Variant_Resolver {
 	 *
 	 * @param string $block   The block name, e.g. "kadence/advancedbtn".
 	 * @param string $variant The variant slug, e.g. "ghost".
-	 * @param string $slug    The token set whose resolved values aliases resolve against.
+	 * @param string $slug    The token set whose effective variants and resolved values are read.
 	 *
 	 * @throws Unknown_Variant_Exception When the block or variant is not defined.
 	 *
 	 * @return array<string, string> property => flattened literal CSS value.
 	 */
 	public function resolve_literal( string $block, string $variant, string $slug = 'default' ): array {
-		$tokens   = $this->variant_tokens( $block, $variant );
+		$tokens   = $this->variant_tokens( $block, $variant, $slug );
 		$resolved = $this->resolver->resolve( $slug );
 
 		$values = [];
@@ -164,33 +165,34 @@ final class Variant_Resolver {
 	 * @since TBD
 	 *
 	 * @param string $block The block name.
-	 * @param string $slug  The token set aliases resolve against.
+	 * @param string $slug  The token set whose effective variants and resolved values are read.
 	 *
 	 * @throws Unknown_Variant_Exception When the block is not defined or declares no default.
 	 *
 	 * @return array<string, string> property => flattened literal CSS value.
 	 */
 	public function resolve_default( string $block, string $slug = 'default' ): array {
-		return $this->resolve_literal( $block, $this->default_variant( $block ), $slug );
+		return $this->resolve_literal( $block, $this->default_variant( $block, $slug ), $slug );
 	}
 
 	/**
-	 * The variant slugs a block declares, in document order — the document being the single source of
-	 * truth for the variant list (a user-added variant in the store would appear here once override
-	 * merging lands).
+	 * The variant slugs a block declares for a set, in document order — the effective set (baseline ⊕ the
+	 * set's stored overrides) being the source of truth, so a user-added variant in the store appears here
+	 * alongside the baseline ones.
 	 *
 	 * @since TBD
 	 *
 	 * @param string $block The block name.
+	 * @param string $slug  The token set whose effective variants are read.
 	 *
 	 * @throws Unknown_Variant_Exception When the block defines no variants.
 	 *
 	 * @return string[]
 	 */
-	public function names( string $block ): array {
+	public function names( string $block, string $slug = 'default' ): array {
 		$names = [];
 
-		foreach ( array_keys( $this->block_variants( $block ) ) as $key ) {
+		foreach ( array_keys( $this->block_variants( $block, $slug ) ) as $key ) {
 			// Skip `$default` and any other DTCG metadata key; only named variants are slugs.
 			if ( is_string( $key ) && strpos( $key, '$' ) === 0 ) {
 				continue;
@@ -203,39 +205,41 @@ final class Variant_Resolver {
 	}
 
 	/**
-	 * Whether a block declares the given variant. False for an unknown block (no throw), so callers can
-	 * validate a selection without first checking the block exists.
+	 * Whether a block declares the given variant in a set. False for an unknown block (no throw), so callers
+	 * can validate a selection without first checking the block exists.
 	 *
 	 * @since TBD
 	 *
 	 * @param string $block The block name.
 	 * @param string $name  The variant slug.
+	 * @param string $slug  The token set whose effective variants are read.
 	 *
 	 * @return bool
 	 */
-	public function has_variant( string $block, string $name ): bool {
-		$section = $this->variants_section();
+	public function has_variant( string $block, string $name, string $slug = 'default' ): bool {
+		$section = $this->variants_section( $slug );
 
 		if ( ! isset( $section[ $block ] ) || ! is_array( $section[ $block ] ) ) {
 			return false;
 		}
 
-		return in_array( $name, $this->names( $block ), true );
+		return in_array( $name, $this->names( $block, $slug ), true );
 	}
 
 	/**
-	 * The human-readable label a block's variant declares in the document, or null when the block, the
-	 * variant, or its label is absent. A lookup convenience that never throws, mirroring has_variant().
+	 * The human-readable label a block's variant declares in a set, or null when the block, the variant, or
+	 * its label is absent. A lookup convenience that never throws, mirroring has_variant().
 	 *
 	 * @since TBD
 	 *
 	 * @param string $block   The block name.
 	 * @param string $variant The variant slug.
+	 * @param string $slug    The token set whose effective variants are read.
 	 *
 	 * @return string|null
 	 */
-	public function label( string $block, string $variant ): ?string {
-		$block_node = $this->variants_section()[ $block ] ?? null;
+	public function label( string $block, string $variant, string $slug = 'default' ): ?string {
+		$block_node = $this->variants_section( $slug )[ $block ] ?? null;
 
 		if ( ! is_array( $block_node ) ) {
 			return null;
@@ -253,28 +257,52 @@ final class Variant_Resolver {
 	}
 
 	/**
-	 * The union of every property the block's variants set a value for — what a {@see
+	 * The union of every property the block's variants set a value for in a set — what a {@see
 	 * \KadenceWP\KadenceBlocks\Design_Tokens\Registry\Variant_Set::consistency()} check compares the
 	 * bindings against, and what a block preset iterates.
 	 *
 	 * @since TBD
 	 *
 	 * @param string $block The block name.
+	 * @param string $slug  The token set whose effective variants are read.
 	 *
 	 * @throws Unknown_Variant_Exception When the block defines no variants.
 	 *
 	 * @return string[]
 	 */
-	public function value_properties( string $block ): array {
+	public function value_properties( string $block, string $slug = 'default' ): array {
 		$properties = [];
 
-		foreach ( $this->names( $block ) as $variant ) {
-			foreach ( array_keys( $this->variant_tokens( $block, $variant ) ) as $property ) {
+		foreach ( $this->names( $block, $slug ) as $variant ) {
+			foreach ( array_keys( $this->variant_tokens( $block, $variant, $slug ) ) as $property ) {
 				$properties[ $property ] = true;
 			}
 		}
 
 		return array_keys( $properties );
+	}
+
+	/**
+	 * The block's default variant slug for a set, read from the effective set's `$default` — the single
+	 * source of truth for the default (no registry mirror to drift from).
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block The block name.
+	 * @param string $slug  The token set whose effective variants are read.
+	 *
+	 * @throws Unknown_Variant_Exception When the block is not defined or declares no default.
+	 *
+	 * @return string
+	 */
+	public function default_variant( string $block, string $slug = 'default' ): string {
+		$default = $this->block_variants( $block, $slug )[ Extensions::get_default_key() ] ?? '';
+
+		if ( ! is_string( $default ) || $default === '' ) {
+			throw Unknown_Variant_Exception::no_default( $block );
+		}
+
+		return $default;
 	}
 
 	/**
@@ -322,7 +350,7 @@ final class Variant_Resolver {
 	}
 
 	/**
-	 * The property => value map for a variant, or throw when the block/variant is undefined.
+	 * The property => value map for a variant in a set, or throw when the block/variant is undefined.
 	 *
 	 * A variant that exists but carries no `tokens` map — or a non-array one — resolves to an empty map,
 	 * not an error: a variant may legitimately set no values (it then contributes nothing downstream).
@@ -333,13 +361,14 @@ final class Variant_Resolver {
 	 *
 	 * @param string $block   The block name.
 	 * @param string $variant The variant slug.
+	 * @param string $slug    The token set whose effective variants are read.
 	 *
 	 * @throws Unknown_Variant_Exception When the block or variant is not defined.
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function variant_tokens( string $block, string $variant ): array {
-		$block_variants = $this->block_variants( $block );
+	private function variant_tokens( string $block, string $variant, string $slug = 'default' ): array {
+		$block_variants = $this->block_variants( $block, $slug );
 
 		if ( ! isset( $block_variants[ $variant ] ) || ! is_array( $block_variants[ $variant ] ) ) {
 			throw Unknown_Variant_Exception::for_variant( $block, $variant );
@@ -351,40 +380,19 @@ final class Variant_Resolver {
 	}
 
 	/**
-	 * The block's default variant slug, read from the document's `$default` — the single source of truth
-	 * for the default (no registry mirror to drift from).
+	 * The variants node for a block in a set (its `$default` plus named variants), or throw when undefined.
 	 *
 	 * @since TBD
 	 *
 	 * @param string $block The block name.
-	 *
-	 * @throws Unknown_Variant_Exception When the block is not defined or declares no default.
-	 *
-	 * @return string
-	 */
-	public function default_variant( string $block ): string {
-		$default = $this->block_variants( $block )[ Extensions::get_default_key() ] ?? '';
-
-		if ( ! is_string( $default ) || $default === '' ) {
-			throw Unknown_Variant_Exception::no_default( $block );
-		}
-
-		return $default;
-	}
-
-	/**
-	 * The variants node for a block (its `$default` plus named variants), or throw when undefined.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $block The block name.
+	 * @param string $slug  The token set whose effective variants are read.
 	 *
 	 * @throws Unknown_Variant_Exception When the block defines no variants.
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function block_variants( string $block ): array {
-		$variants = $this->variants_section();
+	private function block_variants( string $block, string $slug = 'default' ): array {
+		$variants = $this->variants_section( $slug );
 
 		if ( ! isset( $variants[ $block ] ) || ! is_array( $variants[ $block ] ) ) {
 			throw Unknown_Variant_Exception::for_block( $block );
@@ -394,25 +402,16 @@ final class Variant_Resolver {
 	}
 
 	/**
-	 * The whole variants section from the baseline, or an empty array when absent.
+	 * The whole effective variants section for a set (baseline ⊕ the set's stored overrides), or an empty
+	 * array when absent.
 	 *
 	 * @since TBD
 	 *
+	 * @param string $slug The token set whose effective variants are read.
+	 *
 	 * @return array<string, mixed>
 	 */
-	private function variants_section(): array {
-		$node = $this->baseline->document();
-
-		$path = Extensions::get_variants_path();
-
-		foreach ( $path as $key ) {
-			if ( ! is_array( $node ) || ! isset( $node[ $key ] ) ) {
-				return [];
-			}
-
-			$node = $node[ $key ];
-		}
-
-		return is_array( $node ) ? $node : [];
+	private function variants_section( string $slug = 'default' ): array {
+		return $this->variants->section( $slug );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_ResolverTest.php
@@ -3,6 +3,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Resolver;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Binding;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Unknown_Variant_Exception;
@@ -176,5 +177,115 @@ final class Variant_ResolverTest extends TestCase {
 		$this->expectException( Unknown_Variant_Exception::class );
 
 		$this->resolver->resolve( self::BUTTON, 'not-a-variant' );
+	}
+
+	/**
+	 * A variant authored into the store (not the baseline) is resolved alongside the baseline variants: it
+	 * appears in the name list, and its values resolve, because definitions are now read through the
+	 * effective (baseline deep-merged with stored overrides) set.
+	 *
+	 * @return void
+	 */
+	public function testItResolvesAVariantAuthoredIntoTheStore(): void {
+		$this->seedVariant(
+			Token_Store::default_slug(),
+			'accent',
+			'Accent',
+			[
+				'button-bg'         => '#ff0000',
+				'button-text'       => '#ffffff',
+				'button-bg-hover'   => '#cc0000',
+				'button-text-hover' => '#ffffff',
+				'button-radius'     => '1rem',
+			]
+		);
+
+		$this->assertSame( [ 'primary', 'secondary', 'accent' ], $this->resolver->names( self::BUTTON ) );
+		$this->assertTrue( $this->resolver->has_variant( self::BUTTON, 'accent' ) );
+		$this->assertSame( 'Accent', $this->resolver->label( self::BUTTON, 'accent' ) );
+
+		$values = $this->resolver->resolve_literal( self::BUTTON, 'accent' );
+		$this->assertSame( '#ff0000', $values['button-bg'] );
+		$this->assertSame( '1rem', $values['button-radius'] );
+
+		// A stored literal has no alias, so the projected form passes it through unchanged.
+		$this->assertSame( '#ff0000', $this->resolver->resolve( self::BUTTON, 'accent' )['button-bg'] );
+	}
+
+	/**
+	 * A stored override for an existing baseline variant wins over the baseline value for that property,
+	 * while the variant's other properties keep their baseline values.
+	 *
+	 * @return void
+	 */
+	public function testAStoredOverrideWinsOverTheBaselineVariantValue(): void {
+		$this->seedVariant( Token_Store::default_slug(), 'secondary', 'Secondary', [ 'button-bg' => '#000000' ] );
+
+		$values = $this->resolver->resolve_literal( self::BUTTON, 'secondary' );
+
+		// The overridden property takes the stored value.
+		$this->assertSame( '#000000', $values['button-bg'] );
+		// A property the override does not touch still resolves from the baseline alias.
+		$this->assertSame( '#ffffff', $values['button-text'] );
+	}
+
+	/**
+	 * Variant definitions are per token set: a variant authored into one set is visible only for that set,
+	 * and the default set is left untouched.
+	 *
+	 * @return void
+	 */
+	public function testStoredVariantsAreScopedToTheirSet(): void {
+		$this->seedVariant(
+			'dark',
+			'accent',
+			'Accent',
+			[
+				'button-bg'         => '#ff0000',
+				'button-text'       => '#ffffff',
+				'button-bg-hover'   => '#cc0000',
+				'button-text-hover' => '#ffffff',
+				'button-radius'     => '1rem',
+			]
+		);
+
+		$this->assertTrue( $this->resolver->has_variant( self::BUTTON, 'accent', 'dark' ) );
+		$this->assertContains( 'accent', $this->resolver->names( self::BUTTON, 'dark' ) );
+
+		// The default set never saw the write.
+		$this->assertFalse( $this->resolver->has_variant( self::BUTTON, 'accent' ) );
+		$this->assertSame( [ 'primary', 'secondary' ], $this->resolver->names( self::BUTTON ) );
+	}
+
+	/**
+	 * Persist a single button variant into a token set's overrides document.
+	 *
+	 * @param string                $slug    The token set slug to write into.
+	 * @param string                $variant The variant slug.
+	 * @param string                $label   The variant label.
+	 * @param array<string, string> $tokens  The property => value map for the variant.
+	 *
+	 * @return void
+	 */
+	private function seedVariant( string $slug, string $variant, string $label, array $tokens ): void {
+		/** @var Token_Store $store */
+		$store = $this->container->get( Token_Store::class );
+
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'variants' => [
+						self::BUTTON => [
+							$variant => [
+								'label'  => $label,
+								'tokens' => $tokens,
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$store->save_document( (string) wp_json_encode( $document ), $slug );
 	}
 }


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3575/user-created-variants-clone-an-existing-variants-surface-no-token

`Variant_Resolver` read variant definitions from the shipped baseline only, so a variant authored into a token set's overrides persisted but never resolved, projected, or showed up in any variant feed. This sources definitions from `Effective_Variants` (baseline deep-merged with a set's stored overrides) and threads the set slug through every definition-reading method (`names`, `has_variant`, `label`, `value_properties`, `default_variant`, `variant_tokens`, `block_variants`, `variants_section`). Value resolution is unchanged.

The variant `Css_Builder` and the admin feed now read the variant list/default/labels for the same set they resolve values against. New params default to `default`, so behavior is unchanged when there are no overrides.

First step of the user-created variants work; nothing yet writes user variants — later steps add the authoring surface.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.