### PR TITLE
Custom Variant Creation [4/11]: alias captured variant literals and guard variant aliases

### DIFF
--- a/includes/resources/Design_Tokens/Resolver/Provider.php
+++ b/includes/resources/Design_Tokens/Resolver/Provider.php
@@ -21,6 +21,7 @@ final class Provider extends Provider_Contract {
 		$this->container->singleton( Css_Renderer::class );
 		$this->container->singleton( Token_Resolver::class );
 		$this->container->singleton( Variant_Resolver::class );
+		$this->container->singleton( Variant_Value_Normalizer::class );
 		$this->container->singleton( Effective_Variants::class );
 	}
 }

--- a/includes/resources/Design_Tokens/Resolver/Variant_Value_Normalizer.php
+++ b/includes/resources/Design_Tokens/Resolver/Variant_Value_Normalizer.php
@@ -70,9 +70,9 @@ final class Variant_Value_Normalizer {
 	 *
 	 * @since TBD
 	 *
-	 * @param string                     $property The property the value is set on, used to break ties.
-	 * @param mixed                      $value    The captured value (alias string or literal).
-	 * @param array<string, string[]>    $index    The normalized-value => semantic-ids map.
+	 * @param string                  $property The property the value is set on, used to break ties.
+	 * @param mixed                   $value    The captured value (alias string or literal).
+	 * @param array<string, string[]> $index    The normalized-value => semantic-ids map.
 	 *
 	 * @return mixed The alias string when matched, otherwise the original value.
 	 */

--- a/includes/resources/Design_Tokens/Resolver/Variant_Value_Normalizer.php
+++ b/includes/resources/Design_Tokens/Resolver/Variant_Value_Normalizer.php
@@ -1,0 +1,186 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Resolver;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Layers;
+
+/**
+ * Rewrites a variant's captured literal values into semantic aliases, so a value captured off a block
+ * instance re-joins the theming cascade instead of freezing as a literal.
+ *
+ * The editor captures concrete values (a hex, a length) from a block and sends them as literals. For each
+ * value this normalizer looks for a semantic token whose resolved value matches it in the target set; when
+ * one is found the literal is replaced with that token's alias (`{semantic.color.button-primary-bg}`), so a
+ * later edit to the semantic (or the primitive it points at) still cascades into the variant. A value that
+ * is already an alias is left untouched, and a value with no matching semantic stays a literal.
+ *
+ * The match is deterministic: candidates are the semantic-layer entries of the set's resolved token map, in
+ * document order; when several share a value the one whose id best matches the property's role wins (e.g.
+ * `button-bg` prefers a semantic id containing "button" and "bg"), tie-broken by document order. Matching is
+ * done PHP-side on write because the Resolver is the only authority that can guarantee the chosen alias
+ * resolves, and it keeps the whole semantic value map off the editor page.
+ *
+ * @since TBD
+ */
+final class Variant_Value_Normalizer {
+
+	/**
+	 * @var Token_Resolver The resolver whose flattened semantic values captured literals are matched against.
+	 *
+	 * @since TBD
+	 */
+	private Token_Resolver $resolver;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Resolver $resolver The token resolver.
+	 */
+	public function __construct( Token_Resolver $resolver ) {
+		$this->resolver = $resolver;
+	}
+
+	/**
+	 * Rewrite a property => value token map, replacing each literal with a matching semantic alias where one
+	 * exists in the given set.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $tokens The variant's property => alias-or-literal token map.
+	 * @param string               $slug   The token set the values are matched against.
+	 *
+	 * @return array<string, mixed> The token map with literals aliased where a semantic matches.
+	 */
+	public function normalize( array $tokens, string $slug ): array {
+		$index = $this->semantic_index( $slug );
+
+		$out = [];
+
+		foreach ( $tokens as $property => $value ) {
+			$out[ $property ] = $this->alias_for( (string) $property, $value, $index );
+		}
+
+		return $out;
+	}
+
+	/**
+	 * The semantic alias for a captured value, or the value unchanged when it is already an alias, is not a
+	 * string, or matches no semantic.
+	 *
+	 * @since TBD
+	 *
+	 * @param string                     $property The property the value is set on, used to break ties.
+	 * @param mixed                      $value    The captured value (alias string or literal).
+	 * @param array<string, string[]>    $index    The normalized-value => semantic-ids map.
+	 *
+	 * @return mixed The alias string when matched, otherwise the original value.
+	 */
+	private function alias_for( string $property, $value, array $index ) {
+		if ( ! is_string( $value ) || Alias::is_alias( $value ) ) {
+			return $value;
+		}
+
+		$candidates = $index[ $this->normalize_value( $value ) ] ?? [];
+
+		if ( $candidates === [] ) {
+			return $value;
+		}
+
+		return Alias::wrap( $this->pick( $property, $candidates ) );
+	}
+
+	/**
+	 * Build the normalized-value => semantic-ids index for a set: every semantic-layer entry of the resolved
+	 * token map, keyed by its normalized value, preserving document order within each bucket.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token set to resolve.
+	 *
+	 * @return array<string, string[]>
+	 */
+	private function semantic_index( string $slug ): array {
+		$prefix = Layers::get_semantic() . '.';
+		$index  = [];
+
+		foreach ( $this->resolver->resolve( $slug )->by_id() as $id => $value ) {
+			if ( strpos( (string) $id, $prefix ) !== 0 || ! is_string( $value ) ) {
+				continue;
+			}
+
+			$index[ $this->normalize_value( $value ) ][] = (string) $id;
+		}
+
+		return $index;
+	}
+
+	/**
+	 * Pick the semantic id whose name best matches the property's role, tie-broken by document order.
+	 *
+	 * @since TBD
+	 *
+	 * @param string   $property   The property the value is set on, e.g. "button-bg".
+	 * @param string[] $candidates The semantic ids sharing the value, in document order.
+	 *
+	 * @return string
+	 */
+	private function pick( string $property, array $candidates ): string {
+		$parts = array_filter( explode( '-', $property ) );
+		$best  = $candidates[0];
+		$score = $this->score( $best, $parts );
+
+		foreach ( $candidates as $id ) {
+			$candidate_score = $this->score( $id, $parts );
+
+			if ( $candidate_score > $score ) {
+				$best  = $id;
+				$score = $candidate_score;
+			}
+		}
+
+		return $best;
+	}
+
+	/**
+	 * How many of the property's role parts appear in a semantic id.
+	 *
+	 * @since TBD
+	 *
+	 * @param string   $id    The semantic id.
+	 * @param string[] $parts The property's hyphen-separated role parts.
+	 *
+	 * @return int
+	 */
+	private function score( string $id, array $parts ): int {
+		$score = 0;
+
+		foreach ( $parts as $part ) {
+			if ( $part !== '' && strpos( $id, $part ) !== false ) {
+				++$score;
+			}
+		}
+
+		return $score;
+	}
+
+	/**
+	 * Normalize a literal for equality: lowercase and trim, and expand a 3-digit hex to its 6-digit form so
+	 * "#ABC" matches "#aabbcc". Non-color literals compare on their trimmed, lowercased form; no unit math.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $value The literal value.
+	 *
+	 * @return string
+	 */
+	private function normalize_value( string $value ): string {
+		$value = strtolower( trim( $value ) );
+
+		if ( preg_match( '/^#([0-9a-f])([0-9a-f])([0-9a-f])$/', $value, $matches ) ) {
+			return '#' . $matches[1] . $matches[1] . $matches[2] . $matches[2] . $matches[3] . $matches[3];
+		}
+
+		return $value;
+	}
+}

--- a/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
@@ -10,8 +10,10 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Variants;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Value_Normalizer;
 use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Dtcg_Validator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
 use KadenceWP\KadenceBlocks\Utils\Cast;
 use KadenceWP\KadenceBlocks\StellarWP\DB\Database\Exceptions\DatabaseQueryException;
@@ -231,6 +233,15 @@ final class Variants_Controller extends Controller {
 	private Active_Set_Store $active;
 
 	/**
+	 * Rewrites captured literal variant values into semantic aliases where one matches.
+	 *
+	 * @since TBD
+	 *
+	 * @var Variant_Value_Normalizer
+	 */
+	private Variant_Value_Normalizer $normalizer;
+
+	/**
 	 * Memoised item schema for this request. Null until first built.
 	 *
 	 * @since TBD
@@ -246,9 +257,10 @@ final class Variants_Controller extends Controller {
 	 * @param Mutator            $mutator   Assembles the candidate overrides document.
 	 * @param Token_Resolver     $resolver  Dry-runs a candidate's token layers before commit.
 	 * @param Dtcg_Validator     $validator Validates the DTCG grammar of a candidate document.
-	 * @param Effective_Variants $variants  Reads the baseline-merged variants section.
-	 * @param Token_Registry     $registry  Declares which blocks accept variants.
-	 * @param Active_Set_Store   $active    Resolves the active set when a request names none.
+	 * @param Effective_Variants       $variants   Reads the baseline-merged variants section.
+	 * @param Token_Registry           $registry   Declares which blocks accept variants.
+	 * @param Active_Set_Store         $active     Resolves the active set when a request names none.
+	 * @param Variant_Value_Normalizer $normalizer Rewrites captured literals into semantic aliases.
 	 */
 	public function __construct(
 		Token_Store $store,
@@ -257,16 +269,18 @@ final class Variants_Controller extends Controller {
 		Dtcg_Validator $validator,
 		Effective_Variants $variants,
 		Token_Registry $registry,
-		Active_Set_Store $active
+		Active_Set_Store $active,
+		Variant_Value_Normalizer $normalizer
 	) {
-		$this->store     = $store;
-		$this->mutator   = $mutator;
-		$this->resolver  = $resolver;
-		$this->validator = $validator;
-		$this->variants  = $variants;
-		$this->registry  = $registry;
-		$this->active    = $active;
-		$this->rest_base = 'variants';
+		$this->store      = $store;
+		$this->mutator    = $mutator;
+		$this->resolver   = $resolver;
+		$this->validator  = $validator;
+		$this->variants   = $variants;
+		$this->registry   = $registry;
+		$this->active     = $active;
+		$this->normalizer = $normalizer;
+		$this->rest_base  = 'variants';
 	}
 
 	/**
@@ -455,10 +469,17 @@ final class Variants_Controller extends Controller {
 			return $error;
 		}
 
-		$slug      = $this->slug( $request );
-		$candidate = $this->mutator->merge( $this->stored_document( $slug ), $this->partial( $block, $block_node ) );
+		$slug       = $this->slug( $request );
+		$block_node = $this->normalize_block_node( $block_node, $slug );
+		$candidate  = $this->mutator->merge( $this->stored_document( $slug ), $this->partial( $block, $block_node ) );
 
 		$error = $this->guard_surface( $candidate, $block_node, $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$error = $this->guard_aliases_resolve( $block_node, $block, $slug );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
@@ -502,7 +523,8 @@ final class Variants_Controller extends Controller {
 			return $error;
 		}
 
-		$slug = $this->slug( $request );
+		$slug       = $this->slug( $request );
+		$block_node = $this->normalize_block_node( $block_node, $slug );
 
 		// Replace, not merge: drop the stored block node first so a variant the body omits does not survive.
 		$stored    = $this->unset_block( $this->stored_document( $slug ), $block );
@@ -515,6 +537,12 @@ final class Variants_Controller extends Controller {
 		}
 
 		$error = $this->guard_surface( $candidate, $block_node, $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$error = $this->guard_aliases_resolve( $block_node, $block, $slug );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
@@ -1021,6 +1049,86 @@ final class Variants_Controller extends Controller {
 						'block'      => $block,
 						'variant'    => (string) $slug,
 						'properties' => $report['unvalued'],
+					]
+				);
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Rewrite each named variant's captured literal values into semantic aliases where one matches the set,
+	 * so a value captured off a block instance re-joins the theming cascade rather than freezing as a literal.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $block_node The block's variant node from the request.
+	 * @param string               $slug       The token set the values are matched against.
+	 *
+	 * @return array<string, mixed> The variant node with literals aliased where a semantic matches.
+	 */
+	private function normalize_block_node( array $block_node, string $slug ): array {
+		$tokens_key = Extensions::get_tokens_key();
+
+		foreach ( $block_node as $variant_slug => $variant ) {
+			// $default and any other "$"-prefixed metadata key carries no token map to normalize.
+			if ( is_string( $variant_slug ) && strpos( $variant_slug, '$' ) === 0 ) {
+				continue;
+			}
+
+			if ( ! is_array( $variant ) || ! isset( $variant[ $tokens_key ] ) || ! is_array( $variant[ $tokens_key ] ) ) {
+				continue;
+			}
+
+			$variant[ $tokens_key ]      = $this->normalizer->normalize( $variant[ $tokens_key ], $slug );
+			$block_node[ $variant_slug ] = $variant;
+		}
+
+		return $block_node;
+	}
+
+	/**
+	 * Reject a written variant whose token map carries an alias that does not resolve in the target set.
+	 *
+	 * Variant token values live under `$extensions`, which the Resolver's dry-run (which walks only the token
+	 * layers) never sees, so a dangling variant alias would otherwise slip past validation and fail silently
+	 * at projection. Normalizer-minted aliases resolve by construction; this only catches a hand-supplied or
+	 * stale alias. Only the aliases the request carries are checked.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $block_node The block's variant node from the request.
+	 * @param string               $block      The block name, for error context.
+	 * @param string               $slug       The token set the aliases resolve against.
+	 *
+	 * @return WP_Error|null A WP_Error when an alias does not resolve, null otherwise.
+	 */
+	private function guard_aliases_resolve( array $block_node, string $block, string $slug ): ?WP_Error {
+		$resolved   = $this->resolver->resolve( $slug );
+		$tokens_key = Extensions::get_tokens_key();
+
+		foreach ( $block_node as $variant_slug => $variant ) {
+			if ( is_string( $variant_slug ) && strpos( $variant_slug, '$' ) === 0 ) {
+				continue;
+			}
+
+			$tokens = is_array( $variant ) && isset( $variant[ $tokens_key ] ) && is_array( $variant[ $tokens_key ] ) ? $variant[ $tokens_key ] : [];
+
+			foreach ( $tokens as $property => $value ) {
+				if ( ! Alias::is_alias( $value ) || $resolved->value( Alias::path_of( $value ) ) !== null ) {
+					continue;
+				}
+
+				return new WP_Error(
+					'rest_design_tokens_unresolvable',
+					__( 'A variant alias does not resolve to a token.', 'kadence-blocks' ),
+					[
+						'status'   => WP_Http::UNPROCESSABLE_ENTITY,
+						'block'    => $block,
+						'variant'  => (string) $variant_slug,
+						'property' => (string) $property,
+						'alias'    => $value,
 					]
 				);
 			}

--- a/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
@@ -253,10 +253,10 @@ final class Variants_Controller extends Controller {
 	/**
 	 * @since TBD
 	 *
-	 * @param Token_Store        $store     The sole gateway to the kb_design_tokens table.
-	 * @param Mutator            $mutator   Assembles the candidate overrides document.
-	 * @param Token_Resolver     $resolver  Dry-runs a candidate's token layers before commit.
-	 * @param Dtcg_Validator     $validator Validates the DTCG grammar of a candidate document.
+	 * @param Token_Store              $store     The sole gateway to the kb_design_tokens table.
+	 * @param Mutator                  $mutator   Assembles the candidate overrides document.
+	 * @param Token_Resolver           $resolver  Dry-runs a candidate's token layers before commit.
+	 * @param Dtcg_Validator           $validator Validates the DTCG grammar of a candidate document.
 	 * @param Effective_Variants       $variants   Reads the baseline-merged variants section.
 	 * @param Token_Registry           $registry   Declares which blocks accept variants.
 	 * @param Active_Set_Store         $active     Resolves the active set when a request names none.

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Alias.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Alias.php
@@ -93,4 +93,18 @@ final class Alias {
 
 		return substr( $value, 1, -1 );
 	}
+
+	/**
+	 * Wrap a dot-path into an alias string. The inverse of path_of(), so callers that mint an alias (e.g.
+	 * the variant value normalizer) do not hard-code the brace delimiters.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id A dot-path into the document, e.g. "semantic.color.button-primary-bg".
+	 *
+	 * @return string The alias string, e.g. "{semantic.color.button-primary-bg}".
+	 */
+	public static function wrap( string $id ): string {
+		return '{' . $id . '}';
+	}
 }

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Layers.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Layers.php
@@ -54,4 +54,15 @@ final class Layers {
 	public static function token_layers(): array {
 		return self::TOKEN_LAYERS;
 	}
+
+	/**
+	 * The "semantic" layer name — the role-based layer a variant value aliases into.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_semantic(): string {
+		return self::SEMANTIC;
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_Value_NormalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_Value_NormalizerTest.php
@@ -1,0 +1,108 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Resolver;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Value_Normalizer;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Covers the variant value normalizer against the real shipped baseline: matching a captured literal to a
+ * semantic alias, leaving unmatched literals and existing aliases alone, and the deterministic role-affinity
+ * pick when several semantics share a value.
+ */
+final class Variant_Value_NormalizerTest extends TestCase {
+
+	private const SET = 'default';
+
+	/**
+	 * @var Variant_Value_Normalizer
+	 */
+	private Variant_Value_Normalizer $normalizer;
+
+	/**
+	 * @var Token_Resolver
+	 */
+	private Token_Resolver $resolver;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->normalizer = $this->container->get( Variant_Value_Normalizer::class );
+		$this->resolver   = $this->container->get( Token_Resolver::class );
+	}
+
+	/**
+	 * A literal that equals a semantic's resolved value is rewritten to that semantic's alias, and the alias
+	 * resolves back to the original value so the chain is intact.
+	 *
+	 * @return void
+	 */
+	public function testItAliasesALiteralThatMatchesASemantic(): void {
+		// #3633e1 is the resolved value of the primary button background semantic.
+		$result = $this->normalizer->normalize( [ 'button-bg' => '#3633e1' ], self::SET );
+
+		$this->assertTrue( Alias::is_alias( $result['button-bg'] ), 'A matched literal should become an alias.' );
+		$this->assertSame(
+			'#3633e1',
+			$this->resolver->resolve( self::SET )->value( Alias::path_of( $result['button-bg'] ) ),
+			'The chosen alias should resolve back to the captured value.'
+		);
+	}
+
+	/**
+	 * A three-digit hex is matched against its expanded six-digit form, so "#FFF" still aliases the semantic
+	 * whose resolved value is "#ffffff".
+	 *
+	 * @return void
+	 */
+	public function testItMatchesAThreeDigitHexCaseInsensitively(): void {
+		$result = $this->normalizer->normalize( [ 'button-text' => '#FFF' ], self::SET );
+
+		$this->assertTrue( Alias::is_alias( $result['button-text'] ) );
+		$this->assertSame( '#ffffff', $this->resolver->resolve( self::SET )->value( Alias::path_of( $result['button-text'] ) ) );
+	}
+
+	/**
+	 * A literal that matches no semantic is left as a literal.
+	 *
+	 * @return void
+	 */
+	public function testItLeavesAnUnmatchedLiteralAsIs(): void {
+		$result = $this->normalizer->normalize( [ 'button-bg' => 'rgba(1,2,3,0.42)' ], self::SET );
+
+		$this->assertSame( 'rgba(1,2,3,0.42)', $result['button-bg'] );
+	}
+
+	/**
+	 * A value that is already an alias is passed through untouched.
+	 *
+	 * @return void
+	 */
+	public function testItLeavesAnExistingAliasUnchanged(): void {
+		$result = $this->normalizer->normalize( [ 'button-bg' => '{semantic.color.button-primary-bg}' ], self::SET );
+
+		$this->assertSame( '{semantic.color.button-primary-bg}', $result['button-bg'] );
+	}
+
+	/**
+	 * When several semantics share a value, the one whose id best matches the property's role wins: #ffffff is
+	 * shared by the plain and hover button-text semantics, and the hover property picks the hover semantic.
+	 *
+	 * @return void
+	 */
+	public function testItPrefersASemanticMatchingThePropertyRole(): void {
+		$result = $this->normalizer->normalize( [ 'button-text-hover' => '#ffffff' ], self::SET );
+
+		$this->assertTrue( Alias::is_alias( $result['button-text-hover'] ) );
+		$this->assertStringContainsString(
+			'hover',
+			Alias::path_of( $result['button-text-hover'] ),
+			'The hover property should prefer a hover-role semantic.'
+		);
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
@@ -511,7 +511,12 @@ final class VariantsControllerTest extends TestCase {
 				[
 					'variant' => 'accent',
 					// #3633e1 matches the primary button background semantic; the rgba value matches nothing.
-					'tokens'  => $this->button_tokens( [ 'button-bg' => '#3633e1', 'button-text' => 'rgba(1,2,3,0.42)' ] ),
+					'tokens'  => $this->button_tokens(
+						[
+							'button-bg'   => '#3633e1',
+							'button-text' => 'rgba(1,2,3,0.42)',
+						] 
+					),
 				]
 			)
 		);

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\wpunit\Resources\Design_Tokens\Rest\V1;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Variants_Controller;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
 use ReflectionClass;
 use ReflectionProperty;
 use Tests\Support\Classes\TestCase;
@@ -494,6 +495,56 @@ final class VariantsControllerTest extends TestCase {
 		$this->assertSame( 'rest_design_tokens_incomplete_surface', $result->get_error_code() );
 		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
 		$this->assertContains( 'button-radius', $result->get_error_data()['properties'] );
+	}
+
+	/**
+	 * A captured literal that matches a semantic is stored as that semantic's alias, so the variant re-joins
+	 * the theming cascade, while a literal with no match is stored as-is.
+	 *
+	 * @return void
+	 */
+	public function testCreateAliasesAMatchingLiteral(): void {
+		$response = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'variant' => 'accent',
+					// #3633e1 matches the primary button background semantic; the rgba value matches nothing.
+					'tokens'  => $this->button_tokens( [ 'button-bg' => '#3633e1', 'button-text' => 'rgba(1,2,3,0.42)' ] ),
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+
+		$tokens = $response->get_data()['variants']['accent']['tokens'];
+
+		$this->assertTrue( Alias::is_alias( $tokens['button-bg'] ) );
+		$this->assertSame( 'rgba(1,2,3,0.42)', $tokens['button-text'] );
+	}
+
+	/**
+	 * A hand-supplied variant alias that does not resolve to a token is rejected before commit, since a
+	 * dangling variant alias lives under $extensions where the token dry-run never sees it.
+	 *
+	 * @return void
+	 */
+	public function testADanglingVariantAliasIsRejected(): void {
+		$result = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'variant' => 'accent',
+					'tokens'  => $this->button_tokens( [ 'button-bg' => '{semantic.color.does-not-exist}' ] ),
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_unresolvable', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
 	}
 
 	/**


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked PR — #1099 must be merged first.

🎫  https://linear.app/nexcess/issue/SOFT-3575/user-created-variants-clone-an-existing-variants-surface-no-token

Two write-time concerns for user variants, handled server-side.

**Alias normalization.** The editor captures concrete values off a block instance and sends them as literals. `Variant_Value_Normalizer` rewrites each literal to a semantic alias whose resolved value matches it in the target set, so the value re-joins the theming cascade instead of freezing. Matching is deterministic: candidates are the semantic-layer entries of the set's resolved map in document order; when several share a value, the one whose id best matches the property role wins (e.g. `button-text-hover` prefers a hover-role semantic), tie-broken by document order. A value already an alias, or one with no match, is left unchanged. Colors match case-insensitively with 3-digit hex expansion. Done in PHP because the Resolver is the only authority that can guarantee the chosen alias resolves.

**Dangling alias guard.** Variant token values live under `$extensions`, which the Resolver's token-layer dry-run never walks, so `guard_aliases_resolve` rejects (422 `rest_design_tokens_unresolvable`) any alias a written variant carries that does not resolve in the target set.

Adds `Layers::get_semantic()` and `Alias::wrap()` as the seams these use.

Stacks on the full-surface guard.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.