### PR TITLE
Custom Variant Creation [5/11]: reserve the "default" variant slug on write

### DIFF
--- a/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
@@ -469,6 +469,12 @@ final class Variants_Controller extends Controller {
 			return $error;
 		}
 
+		$error = $this->guard_reserved_slugs( $block_node, $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
 		$slug       = $this->slug( $request );
 		$block_node = $this->normalize_block_node( $block_node, $slug );
 		$candidate  = $this->mutator->merge( $this->stored_document( $slug ), $this->partial( $block, $block_node ) );
@@ -518,6 +524,12 @@ final class Variants_Controller extends Controller {
 		}
 
 		$error = $this->guard_variant_shape( $block_node, $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$error = $this->guard_reserved_slugs( $block_node, $block );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
@@ -944,6 +956,41 @@ final class Variants_Controller extends Controller {
 				return new WP_Error(
 					'rest_design_tokens_invalid',
 					__( 'Each variant must be an object with an optional string label and a token map.', 'kadence-blocks' ),
+					[
+						'status'  => WP_Http::UNPROCESSABLE_ENTITY,
+						'block'   => $block,
+						'variant' => (string) $slug,
+					]
+				);
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Reject a variant whose slug is reserved. "default" is the literal used by the block's `/default`
+	 * sub-route and by `delete_variant`, so a variant named "default" could never be deleted or set through
+	 * the dedicated route; refuse to create one.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $block_node The block's variant node being written.
+	 * @param string               $block      The block name, for error context.
+	 *
+	 * @return WP_Error|null A WP_Error when a reserved slug is used, null otherwise.
+	 */
+	private function guard_reserved_slugs( array $block_node, string $block ): ?WP_Error {
+		foreach ( array_keys( $block_node ) as $slug ) {
+			// $default and any other "$"-prefixed metadata key is not a named variant.
+			if ( is_string( $slug ) && strpos( $slug, '$' ) === 0 ) {
+				continue;
+			}
+
+			if ( (string) $slug === self::DEFAULT_ROUTE ) {
+				return new WP_Error(
+					'rest_design_tokens_reserved_slug',
+					__( 'The variant slug "default" is reserved.', 'kadence-blocks' ),
 					[
 						'status'  => WP_Http::UNPROCESSABLE_ENTITY,
 						'block'   => $block,

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
@@ -548,6 +548,29 @@ final class VariantsControllerTest extends TestCase {
 	}
 
 	/**
+	 * Creating a variant named "default" is rejected: the slug is reserved for the block's default sub-route
+	 * and could never be deleted or set through the dedicated route.
+	 *
+	 * @return void
+	 */
+	public function testCreatingAVariantNamedDefaultIsRejected(): void {
+		$result = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'variant' => 'default',
+					'tokens'  => $this->button_tokens(),
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_reserved_slug', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testAMalformedVariantShapeReturns422(): void {


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked PR — #1100 must be merged first.

🎫  https://linear.app/nexcess/issue/SOFT-3575/user-created-variants-clone-an-existing-variants-surface-no-token

The literal `default` is the block's `/default` sub-route segment and the slug `delete_variant` refuses, so a variant named `default` could never be deleted or set through the dedicated route. `guard_reserved_slugs` rejects creating or replacing one with `rest_design_tokens_reserved_slug` on both the create and replace paths.

The editor-side slug derivation (kebab from the user's label) and collision de-duplication against the catalog's known names land with the Save-as-variant UI.

Stacks on the alias normalization work.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.