### PR TITLE
Custom Variant Creation [6/11]: expose a per-set variant catalog with surface and provenance

### DIFF
--- a/includes/resources/Design_Tokens/Editor/Localizer.php
+++ b/includes/resources/Design_Tokens/Editor/Localizer.php
@@ -3,16 +3,18 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Editor;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
 
 /**
  * Attaches the editor catalogs to the block editor's early-filters bundle.
  *
- * On enqueue_block_editor_assets (after the editor-assets class has enqueued the script) it attaches
- * two globals to the existing 'kadence-blocks-early-filters-js' handle: window.kadenceDesignTokensVariants
- * (the variant catalog the variant picker reads) and window.kadenceDesignTokensSets (the token-set catalog
- * the per-block set-override picker reads). Guarded on wp_script_is( …, 'enqueued' ) so it runs only where
- * that bundle loads, and skipped entirely when the registry is fail-closed (a deactivated registry projects
- * nothing, so the pickers offer nothing).
+ * On enqueue_block_editor_assets (after the editor-assets class has enqueued the script) it attaches three
+ * globals to the existing 'kadence-blocks-early-filters-js' handle: window.kadenceDesignTokensVariants (the
+ * per-set variant catalog the variant picker and the "save as new variant" form read),
+ * window.kadenceDesignTokensSets (the token-set catalog the per-block set-override picker reads), and
+ * window.kadenceDesignTokensRest (the REST descriptor the variant writes POST to). Guarded on
+ * wp_script_is( …, 'enqueued' ) so it runs only where that bundle loads, and skipped entirely when the
+ * registry is fail-closed (a deactivated registry projects nothing, so the pickers offer nothing).
  *
  * Emitted with wp_add_inline_script + wp_json_encode; the JSON_HEX_* flags make the payload safe to
  * inline inside a <script> (no </script> breakout, no & ambiguity) without further escaping.
@@ -47,6 +49,15 @@ final class Localizer {
 	 * @var string
 	 */
 	private const SETS_OBJECT = 'kadenceDesignTokensSets';
+
+	/**
+	 * The JS global the variant writes read for the REST root, namespace and nonce.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const REST_OBJECT = 'kadenceDesignTokensRest';
 
 	/**
 	 * The token registry, for the fail-closed gate.
@@ -106,6 +117,23 @@ final class Localizer {
 
 		$this->attach( self::VARIANTS_OBJECT, $this->variant_catalog->all() );
 		$this->attach( self::SETS_OBJECT, $this->set_catalog->all() );
+		$this->attach( self::REST_OBJECT, $this->rest() );
+	}
+
+	/**
+	 * The REST descriptor the editor's variant writes POST to: the wp-json root, the v1 namespace, and a
+	 * nonce. Mirrors the admin feed's descriptor so the editor's variants client reuses the same middleware.
+	 *
+	 * @since TBD
+	 *
+	 * @return array{root: string, namespace: string, nonce: string}
+	 */
+	private function rest(): array {
+		return [
+			'root'      => esc_url_raw( rest_url() ),
+			'namespace' => Controller::namespace(),
+			'nonce'     => wp_create_nonce( 'wp_rest' ),
+		];
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Editor/Variant_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Variant_Catalog.php
@@ -72,10 +72,10 @@ final class Variant_Catalog {
 	/**
 	 * @since TBD
 	 *
-	 * @param Token_Registry    $registry  The token registry.
-	 * @param Variant_Resolver  $variants  The variant resolver.
-	 * @param Token_Store       $store     The persistence gateway.
-	 * @param Active_Set_Store  $active    The active-set pointer.
+	 * @param Token_Registry     $registry  The token registry.
+	 * @param Variant_Resolver   $variants  The variant resolver.
+	 * @param Token_Store        $store     The persistence gateway.
+	 * @param Active_Set_Store   $active    The active-set pointer.
 	 * @param Effective_Variants $effective The effective-variants reader.
 	 */
 	public function __construct(

--- a/includes/resources/Design_Tokens/Editor/Variant_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Variant_Catalog.php
@@ -2,24 +2,30 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Editor;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Variants;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Unknown_Variant_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
 
 /**
- * Builds the compact per-block variant catalog the block editor's variant picker reads.
+ * Builds the per-set variant catalog the block editor's variant picker and "save as new variant" form read.
  *
- * Only the data the variant picker needs — each block's `$default` slug and its named variants as
- * { slug, label } — so it carries no resolved token values and cannot raise the alias-cycle errors
- * the admin feed must guard. A block registered but absent from the document
- * (Unknown_Variant_Exception) is skipped, so one undefined block never empties the whole catalog.
+ * Keyed by token set so the picker can show the variants for whichever set a block is on (its `kbTokenSet`,
+ * or the active set), not just the active one: `{ active: <slug>, sets: { <slug>: { <block>: {…} } } }`. Per
+ * block it carries the `$default` slug, the named variants as { slug, label, userCreated }, the picker
+ * control label, and the controllable surface as { key, kind, token } per bound property so the form can
+ * render one input per property. It carries no resolved token values, so it cannot raise the alias-cycle
+ * errors the admin feed must guard; a block registered but absent from a set (Unknown_Variant_Exception) is
+ * skipped, so one undefined block never empties the catalog.
  *
  * @since TBD
  */
 final class Variant_Catalog {
 
 	/**
-	 * The token registry, source of the registered variant-set blocks.
+	 * The token registry, source of the registered variant-set blocks and their bindings.
 	 *
 	 * @since TBD
 	 *
@@ -28,7 +34,7 @@ final class Variant_Catalog {
 	private Token_Registry $registry;
 
 	/**
-	 * The variant resolver, source of each block's default, names and labels.
+	 * The variant resolver, source of each block's default, names and labels per set.
 	 *
 	 * @since TBD
 	 *
@@ -37,26 +43,85 @@ final class Variant_Catalog {
 	private Variant_Resolver $variants;
 
 	/**
+	 * The persistence gateway, source of the stored set slugs.
+	 *
 	 * @since TBD
 	 *
-	 * @param Token_Registry   $registry The token registry.
-	 * @param Variant_Resolver $variants The variant resolver.
+	 * @var Token_Store
 	 */
-	public function __construct( Token_Registry $registry, Variant_Resolver $variants ) {
-		$this->registry = $registry;
-		$this->variants = $variants;
+	private Token_Store $store;
+
+	/**
+	 * The active-set pointer, so the catalog can report which set the editor renders by default.
+	 *
+	 * @since TBD
+	 *
+	 * @var Active_Set_Store
+	 */
+	private Active_Set_Store $active;
+
+	/**
+	 * The effective-variants reader, source of each variant's user-created provenance per set.
+	 *
+	 * @since TBD
+	 *
+	 * @var Effective_Variants
+	 */
+	private Effective_Variants $effective;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry    $registry  The token registry.
+	 * @param Variant_Resolver  $variants  The variant resolver.
+	 * @param Token_Store       $store     The persistence gateway.
+	 * @param Active_Set_Store  $active    The active-set pointer.
+	 * @param Effective_Variants $effective The effective-variants reader.
+	 */
+	public function __construct(
+		Token_Registry $registry,
+		Variant_Resolver $variants,
+		Token_Store $store,
+		Active_Set_Store $active,
+		Effective_Variants $effective
+	) {
+		$this->registry  = $registry;
+		$this->variants  = $variants;
+		$this->store     = $store;
+		$this->active    = $active;
+		$this->effective = $effective;
 	}
 
 	/**
-	 * The catalog for a token set, keyed by block name.
+	 * The catalog: the active set slug plus the per-block catalog for every set.
 	 *
 	 * @since TBD
 	 *
-	 * @param string $slug The token set whose effective variants are read.
-	 *
-	 * @return array<string, array{default: string, variants: array<int, array{slug: string, label: string}>}>
+	 * @return array{active: string, sets: array<string, array<string, mixed>>}
 	 */
-	public function all( string $slug = 'default' ): array {
+	public function all(): array {
+		$sets = [];
+
+		foreach ( $this->set_slugs() as $slug ) {
+			$sets[ $slug ] = $this->for_set( $slug );
+		}
+
+		return [
+			'active' => $this->active->get(),
+			'sets'   => $sets,
+		];
+	}
+
+	/**
+	 * The per-block catalog for one set.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token set slug.
+	 *
+	 * @return array<string, mixed> block => { default, variants, properties, label? }.
+	 */
+	private function for_set( string $slug ): array {
 		$out = [];
 
 		foreach ( $this->registry->variant_blocks() as $block ) {
@@ -64,21 +129,25 @@ final class Variant_Catalog {
 				$names   = $this->variants->names( $block, $slug );
 				$default = $this->variants->default_variant( $block, $slug );
 			} catch ( Unknown_Variant_Exception $e ) {
-				continue; // Block registered but not defined in the document — skip, fail soft.
+				continue; // Block registered but not defined in this set — skip, fail soft.
 			}
+
+			$user_created = $this->effective->user_created( $block, $slug );
 
 			$variants = [];
 
 			foreach ( $names as $name ) {
 				$variants[] = [
-					'slug'  => $name,
-					'label' => $this->variants->label( $block, $name, $slug ) ?? $name,
+					'slug'        => $name,
+					'label'       => $this->variants->label( $block, $name, $slug ) ?? $name,
+					'userCreated' => in_array( $name, $user_created, true ),
 				];
 			}
 
 			$entry = [
-				'default'  => $default,
-				'variants' => $variants,
+				'default'    => $default,
+				'variants'   => $variants,
+				'properties' => $this->properties_for( $block ),
 			];
 
 			// The picker's control label (the variant axis), declared on the variant set. Omitted when the
@@ -93,5 +162,53 @@ final class Variant_Catalog {
 		}
 
 		return $out;
+	}
+
+	/**
+	 * The controllable surface for a block: one { key, kind, token } entry per bound property, in binding
+	 * order, so the editor form renders an input per property. Set-independent structure read from the
+	 * registry's bindings.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block The block name.
+	 *
+	 * @return array<int, array{key: string, kind: string, token: string|null}>
+	 */
+	private function properties_for( string $block ): array {
+		$set = $this->registry->for_block( $block );
+
+		if ( $set === null ) {
+			return [];
+		}
+
+		$properties = [];
+
+		foreach ( $set->bindings as $property => $binding ) {
+			$properties[] = [
+				'key'   => (string) $property,
+				'kind'  => $set->kind( (string) $property ),
+				'token' => $binding->token,
+			];
+		}
+
+		return $properties;
+	}
+
+	/**
+	 * The set slugs to build the catalog for: every stored set plus the always-present default.
+	 *
+	 * @since TBD
+	 *
+	 * @return string[]
+	 */
+	private function set_slugs(): array {
+		$slugs = array_map( 'strval', array_column( $this->store->list_stores(), 'slug' ) );
+
+		if ( ! in_array( Token_Store::default_slug(), $slugs, true ) ) {
+			array_unshift( $slugs, Token_Store::default_slug() );
+		}
+
+		return $slugs;
 	}
 }

--- a/includes/resources/Design_Tokens/Registry/Variant_Set.php
+++ b/includes/resources/Design_Tokens/Registry/Variant_Set.php
@@ -153,6 +153,35 @@ final class Variant_Set {
 	}
 
 	/**
+	 * A coarse input kind for a bound property — "color", "dimension" or "text" — so the editor's variant
+	 * form can render the right control per property. Read from the referenced token's group segment when the
+	 * binding is a token reference (e.g. `semantic.radius.media` => "dimension"), otherwise inferred from the
+	 * property name (e.g. `button-bg` => "color", `button-radius` => "dimension"). Falls back to "text".
+	 *
+	 * @since TBD
+	 *
+	 * @param string $property The bound property, e.g. "button-bg".
+	 *
+	 * @return string One of "color", "dimension" or "text".
+	 */
+	public function kind( string $property ): string {
+		$binding = $this->binding( $property );
+
+		if ( $binding !== null && $binding->token !== null ) {
+			$segments = explode( '.', $binding->token );
+			$group    = self::classify( $segments[1] ?? '' );
+
+			if ( $group !== '' ) {
+				return $group;
+			}
+		}
+
+		$by_name = self::classify( $property );
+
+		return $by_name !== '' ? $by_name : 'text';
+	}
+
+	/**
 	 * Build the property => Binding map from a declaration's "bindings".
 	 *
 	 * @since TBD
@@ -185,5 +214,34 @@ final class Variant_Set {
 		}
 
 		return $bindings;
+	}
+
+	/**
+	 * Classify a term (a token group segment or a property name) into a coarse input kind, or "" when it
+	 * matches neither a dimension nor a color. Dimension terms are checked first so "borderRadius" resolves to
+	 * "dimension" rather than matching the "border" color term.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $term The term to classify.
+	 *
+	 * @return string "color", "dimension" or "".
+	 */
+	private static function classify( string $term ): string {
+		$term = strtolower( $term );
+
+		foreach ( [ 'radius', 'width', 'gap', 'spacing', 'space', 'size', 'height', 'dimension' ] as $needle ) {
+			if ( strpos( $term, $needle ) !== false ) {
+				return 'dimension';
+			}
+		}
+
+		foreach ( [ 'color', 'bg', 'background', 'text', 'border', 'fill', 'stroke' ] as $needle ) {
+			if ( strpos( $term, $needle ) !== false ) {
+				return 'color';
+			}
+		}
+
+		return '';
 	}
 }

--- a/includes/resources/Design_Tokens/Resolver/Effective_Variants.php
+++ b/includes/resources/Design_Tokens/Resolver/Effective_Variants.php
@@ -105,6 +105,51 @@ final class Effective_Variants {
 	}
 
 	/**
+	 * The named variant slugs a set defines for a block that are NOT in the baseline — i.e. the user-created
+	 * ones. A slug that shadows a baseline variant is excluded, since deleting it reverts to baseline rather
+	 * than removing it.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block The block name, e.g. "kadence/advancedbtn".
+	 * @param string $slug  The token set slug.
+	 *
+	 * @return string[]
+	 */
+	public function user_created( string $block, string $slug = 'default' ): array {
+		$baseline_block  = $this->variants_of( $this->baseline->document() )[ $block ] ?? [];
+		$effective_block = $this->section( $slug )[ $block ] ?? [];
+
+		$baseline_names  = $this->named_of( is_array( $baseline_block ) ? $baseline_block : [] );
+		$effective_names = $this->named_of( is_array( $effective_block ) ? $effective_block : [] );
+
+		return array_values( array_diff( $effective_names, $baseline_names ) );
+	}
+
+	/**
+	 * The named variant slugs of a block variant node, skipping "$"-prefixed metadata keys.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $node The block's variant node.
+	 *
+	 * @return string[]
+	 */
+	private function named_of( array $node ): array {
+		$names = [];
+
+		foreach ( array_keys( $node ) as $key ) {
+			if ( is_string( $key ) && strpos( $key, '$' ) === 0 ) {
+				continue;
+			}
+
+			$names[] = (string) $key;
+		}
+
+		return $names;
+	}
+
+	/**
 	 * Decode a set's stored overrides document, tolerating an absent/empty/malformed row as "no overrides".
 	 *
 	 * The single decode seam for the stored overrides: callers that need the raw decoded document, rather than

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Variant_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Variant_CatalogTest.php
@@ -3,8 +3,11 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Editor;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Editor\Variant_Catalog;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Variants;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
 use Tests\Support\Classes\TestCase;
 
@@ -16,7 +19,15 @@ final class Variant_CatalogTest extends TestCase {
 
 	private const BUTTON = 'kadence/singlebtn';
 
-	private Variant_Resolver $resolver;
+	/**
+	 * @var Variant_Catalog
+	 */
+	private Variant_Catalog $catalog;
+
+	/**
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
 
 	/**
 	 * @return void
@@ -24,23 +35,23 @@ final class Variant_CatalogTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->resolver = $this->container->get( Variant_Resolver::class );
+		$this->catalog = $this->container->get( Variant_Catalog::class );
+		$this->store   = $this->container->get( Token_Store::class );
 	}
 
 	/**
-	 * The shipped Button reports its default and its named variants as { slug, label } for the picker.
+	 * The catalog reports the active set and, per set, the shipped Button's default and its named variants as
+	 * { slug, label, userCreated }, plus the picker control label and the controllable surface.
 	 *
 	 * @return void
 	 */
-	public function testItBuildsTheButtonCatalog(): void {
-		/** @var Token_Registry $registry */
-		$registry = $this->container->get( Token_Registry::class );
+	public function testItBuildsTheButtonCatalogForTheDefaultSet(): void {
+		$catalog = $this->catalog->all();
 
-		$catalog = ( new Variant_Catalog( $registry, $this->resolver ) )->all();
+		$this->assertSame( Token_Store::default_slug(), $catalog['active'] );
+		$this->assertArrayHasKey( self::BUTTON, $catalog['sets'][ Token_Store::default_slug() ] );
 
-		$this->assertArrayHasKey( self::BUTTON, $catalog );
-
-		$button = $catalog[ self::BUTTON ];
+		$button = $catalog['sets'][ Token_Store::default_slug() ][ self::BUTTON ];
 
 		$this->assertSame( 'primary', $button['default'] );
 		// The picker's control label, declared on the variant set in declarations.php.
@@ -48,12 +59,14 @@ final class Variant_CatalogTest extends TestCase {
 		$this->assertSame(
 			[
 				[
-					'slug'  => 'primary',
-					'label' => 'Primary',
+					'slug'        => 'primary',
+					'label'       => 'Primary',
+					'userCreated' => false,
 				],
 				[
-					'slug'  => 'secondary',
-					'label' => 'Secondary',
+					'slug'        => 'secondary',
+					'label'       => 'Secondary',
+					'userCreated' => false,
 				],
 			],
 			$button['variants']
@@ -61,7 +74,40 @@ final class Variant_CatalogTest extends TestCase {
 	}
 
 	/**
-	 * A block registered but absent from the document is skipped rather than emitted empty.
+	 * The per-block surface lists every bound property with its coarse input kind, so a color property reads
+	 * as "color" and the radius property as "dimension".
+	 *
+	 * @return void
+	 */
+	public function testItExposesTheControllableSurface(): void {
+		$properties = $this->catalog->all()['sets'][ Token_Store::default_slug() ][ self::BUTTON ]['properties'];
+
+		$kinds = wp_list_pluck( $properties, 'kind', 'key' );
+
+		$this->assertSame( 'color', $kinds['button-bg'] );
+		$this->assertSame( 'dimension', $kinds['button-radius'] );
+	}
+
+	/**
+	 * A variant authored into a set is flagged userCreated, while the baseline variants are not.
+	 *
+	 * @return void
+	 */
+	public function testItFlagsUserCreatedVariants(): void {
+		$this->store->save_document(
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{'
+			. '"accent":{"label":"Accent","tokens":{"button-bg":"#ff0000"}}}}}}}'
+		);
+
+		$variants = $this->catalog->all()['sets'][ Token_Store::default_slug() ][ self::BUTTON ]['variants'];
+		$flags    = wp_list_pluck( $variants, 'userCreated', 'slug' );
+
+		$this->assertTrue( $flags['accent'] );
+		$this->assertFalse( $flags['primary'] );
+	}
+
+	/**
+	 * A block registered but absent from a set is skipped rather than emitted empty.
 	 *
 	 * @return void
 	 */
@@ -69,8 +115,14 @@ final class Variant_CatalogTest extends TestCase {
 		$registry = new Token_Registry();
 		$registry->register_variant_set( [ 'block' => 'kadence/not-a-real-block' ] );
 
-		$catalog = ( new Variant_Catalog( $registry, $this->resolver ) )->all();
+		$catalog = ( new Variant_Catalog(
+			$registry,
+			$this->container->get( Variant_Resolver::class ),
+			$this->store,
+			$this->container->get( Active_Set_Store::class ),
+			$this->container->get( Effective_Variants::class )
+		) )->all();
 
-		$this->assertSame( [], $catalog );
+		$this->assertSame( [], $catalog['sets'][ Token_Store::default_slug() ] );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_VariantsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_VariantsTest.php
@@ -114,4 +114,26 @@ final class Effective_VariantsTest extends TestCase {
 	public function testItReturnsNullForABlockWithNoVariants(): void {
 		$this->assertNull( $this->variants->block( 'kadence/not-a-block' ) );
 	}
+
+	/**
+	 * user_created() reports the override-only variant slugs: a baseline variant is excluded, an override-only
+	 * one is included, and a slug that shadows a baseline variant is excluded (deleting it reverts to
+	 * baseline rather than removing it).
+	 *
+	 * @return void
+	 */
+	public function testUserCreatedReportsOverrideOnlyVariants(): void {
+		$this->store->save_document(
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{'
+			. '"outline":{"label":"Outline","tokens":{"button-bg":"transparent"}},'
+			. '"secondary":{"tokens":{"button-bg":"#000000"}}}}}}}'
+		);
+
+		$user_created = $this->variants->user_created( self::BUTTON );
+
+		$this->assertContains( 'outline', $user_created );
+		$this->assertNotContains( 'primary', $user_created );
+		// "secondary" shadows a baseline variant, so it is not user-created.
+		$this->assertNotContains( 'secondary', $user_created );
+	}
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked PR — #1101 must be merged first.

🎫  https://linear.app/nexcess/issue/SOFT-3575/user-created-variants-clone-an-existing-variants-surface-no-token

Prepares the editor-facing data for user-created variants.

The variant catalog is rebuilt keyed by token set, so the picker can show the variants for whichever set a block is on (its `kbTokenSet`, or the active set), not just the active one:

```
{ active: <slug>, sets: { <slug>: { <block>: { default, variants, properties, label? } } } }
```

- each variant carries a `userCreated` flag (in the set's effective variants but not the baseline), via new `Effective_Variants::user_created()`, so the editor can gate edit/delete affordances;
- each block carries its controllable surface as `{ key, kind, token }` per bound property, so the save-as-variant form renders one input per property. `Variant_Set::kind()` classifies a bound property as `color` / `dimension` / `text` (from the referenced token's group segment, else the property name).

The editor Localizer also prints `window.kadenceDesignTokensRest` (root, namespace, nonce) so the editor's variant writes can reach the REST API, mirroring the admin feed descriptor.

The picker/consumer changes that read this new shape land with the save-as-variant UI.

Stacks on the reserved-slug guard.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.