### PR TITLE
Custom Variant Creation [7/11]: add the save-as-new-variant editor UI

### DIFF
--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -84,7 +84,9 @@ import {
 } from '@wordpress/components';
 import { addFilter, applyFilters, doAction } from '@wordpress/hooks';
 import BackendStyles from './components/backend-styles';
-import { VariantPicker, blockVariants } from '../../extension/variant-picker';
+import { VariantPicker, blockVariants, activeSet } from '../../extension/variant-picker';
+import { SaveVariantModal } from '../../extension/variant-picker/SaveVariantModal';
+import { hasVariantsRest } from '../../extension/variants/api/client';
 import { TokenSetPicker, selectableSets } from '../../extension/token-set-picker';
 
 export default function KadenceButtonEdit(props) {
@@ -275,6 +277,7 @@ export default function KadenceButtonEdit(props) {
 
 	const [activeTab, setActiveTab] = useState('general');
 	const [isEditingURL, setIsEditingURL] = useState(false);
+	const [savingVariant, setSavingVariant] = useState(false);
 	useEffect(() => {
 		if (!isSelected) {
 			setIsEditingURL(false);
@@ -829,7 +832,8 @@ export default function KadenceButtonEdit(props) {
 
 						{activeTab === 'style' && (
 							<>
-								{(blockVariants(name).length > 0 || selectableSets().length >= 2) && (
+								{(blockVariants(name, attributes.kbTokenSet || activeSet()).length > 0 ||
+									selectableSets().length >= 2) && (
 									<KadencePanelBody
 										title={__('Design Tokens', 'kadence-blocks')}
 										initialOpen={true}
@@ -844,16 +848,31 @@ export default function KadenceButtonEdit(props) {
 												/>
 											</SubsectionWrap>
 										)}
-										{blockVariants(name).length > 0 && (
+										{blockVariants(name, attributes.kbTokenSet || activeSet()).length > 0 && (
 											<SubsectionWrap label={__('Design Variants', 'kadence-blocks')}>
 												<VariantPicker
 													name={name}
+													set={attributes.kbTokenSet || activeSet()}
 													value={attributes.kbVariant || ''}
 													onChange={(value) => setAttributes({ kbVariant: value })}
 												/>
+												{hasVariantsRest() && (
+													<Button variant="secondary" onClick={() => setSavingVariant(true)}>
+														{__('Save as new variant', 'kadence-blocks')}
+													</Button>
+												)}
 											</SubsectionWrap>
 										)}
 									</KadencePanelBody>
+								)}
+								{savingVariant && (
+									<SaveVariantModal
+										blockName={name}
+										set={attributes.kbTokenSet || activeSet()}
+										source={attributes.kbVariant || ''}
+										onClose={() => setSavingVariant(false)}
+										onCreated={(slug) => setAttributes({ kbVariant: slug })}
+									/>
 								)}
 								{showSettings('colorSettings', 'kadence/advancedbtn') && (
 									<>

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -858,7 +858,7 @@ export default function KadenceButtonEdit(props) {
 												/>
 												{hasVariantsRest() && (
 													<Button variant="secondary" onClick={() => setSavingVariant(true)}>
-														{__('Save as new variant', 'kadence-blocks')}
+														{__('Create new variant', 'kadence-blocks')}
 													</Button>
 												)}
 											</SubsectionWrap>

--- a/src/early-filters.js
+++ b/src/early-filters.js
@@ -338,7 +338,7 @@ const withVariantPicker = createHigherOrderComponent((BlockEdit) => {
 									/>
 									{hasVariantsRest() && (
 										<Button variant="secondary" onClick={() => setSaving(true)}>
-											{__('Save as new variant', 'kadence-blocks')}
+											{__('Create new variant', 'kadence-blocks')}
 										</Button>
 									)}
 								</SubsectionWrap>

--- a/src/early-filters.js
+++ b/src/early-filters.js
@@ -13,7 +13,9 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { useDispatch, select } from '@wordpress/data';
-import { VariantPicker, blockVariants } from './extension/variant-picker';
+import { VariantPicker, blockVariants, activeSet } from './extension/variant-picker';
+import { SaveVariantModal } from './extension/variant-picker/SaveVariantModal';
+import { hasVariantsRest } from './extension/variants/api/client';
 import { TokenSetPicker, selectableSets } from './extension/token-set-picker';
 
 /**
@@ -291,6 +293,8 @@ const withVariantPicker = createHigherOrderComponent((BlockEdit) => {
 	return (props) => {
 		const { name, attributes, setAttributes, isSelected } = props;
 
+		const [saving, setSaving] = useState(false);
+
 		if (!hasBlockSupport(name, 'kbVariant')) {
 			return <BlockEdit {...props} />;
 		}
@@ -301,7 +305,8 @@ const withVariantPicker = createHigherOrderComponent((BlockEdit) => {
 			return <BlockEdit {...props} />;
 		}
 
-		const hasVariants = blockVariants(name).length > 0;
+		const set = get(attributes, 'kbTokenSet', '') || activeSet();
+		const hasVariants = blockVariants(name, set).length > 0;
 		const hasSets = selectableSets().length >= 2;
 
 		if (!hasVariants && !hasSets) {
@@ -327,13 +332,28 @@ const withVariantPicker = createHigherOrderComponent((BlockEdit) => {
 								<SubsectionWrap label={__('Design Variants', 'kadence-blocks')}>
 									<VariantPicker
 										name={name}
+										set={set}
 										value={get(attributes, 'kbVariant', '')}
 										onChange={(value) => setAttributes({ kbVariant: value })}
 									/>
+									{hasVariantsRest() && (
+										<Button variant="secondary" onClick={() => setSaving(true)}>
+											{__('Save as new variant', 'kadence-blocks')}
+										</Button>
+									)}
 								</SubsectionWrap>
 							)}
 						</PanelBody>
 					</InspectorControls>
+				)}
+				{saving && (
+					<SaveVariantModal
+						blockName={name}
+						set={set}
+						source={get(attributes, 'kbVariant', '')}
+						onClose={() => setSaving(false)}
+						onCreated={(slug) => setAttributes({ kbVariant: slug })}
+					/>
 				)}
 			</>
 		);

--- a/src/extension/variant-picker/SaveVariantModal.js
+++ b/src/extension/variant-picker/SaveVariantModal.js
@@ -1,5 +1,5 @@
 /**
- * "Save as new variant" modal.
+ * "Create new variant" modal.
  *
  * Clones an existing variant's surface for a block: the user picks a variant to clone from, edits the value
  * of each bound property, names the variant, and saves. The new variant is written through the variants REST
@@ -43,7 +43,7 @@ function seedValues(properties, tokens) {
 }
 
 /**
- * The save-as-new-variant modal.
+ * The create-new-variant modal.
  *
  * @param {Object}   props           The component props.
  * @param {string}   props.blockName The block name, e.g. "kadence/advancedbtn".
@@ -134,7 +134,7 @@ export function SaveVariantModal({ blockName, set, source, onClose, onCreated })
 
 	return (
 		<Modal
-			title={__('Save as new variant', 'kadence-blocks')}
+			title={__('Create new variant', 'kadence-blocks')}
 			onRequestClose={onClose}
 			className="kb-save-variant-modal"
 		>

--- a/src/extension/variant-picker/SaveVariantModal.js
+++ b/src/extension/variant-picker/SaveVariantModal.js
@@ -1,0 +1,217 @@
+/**
+ * "Save as new variant" modal.
+ *
+ * Clones an existing variant's surface for a block: the user picks a variant to clone from, edits the value
+ * of each bound property, names the variant, and saves. The new variant is written through the variants REST
+ * endpoint (which aliases matching literals, validates the full surface, and rejects dangling aliases), then
+ * appended to the in-memory catalog and selected on the block. Works for any block that registers a variant
+ * set — it seeds from an existing variant's values, so it needs no per-block knowledge.
+ */
+import { Modal, TextControl, SelectControl, Button, Notice, Spinner } from '@wordpress/components';
+import { useState, useEffect } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { get } from 'lodash';
+import { blockProperties, appendVariant } from './index';
+import { getBlockVariants, createVariant } from '../variants/api/client';
+import { deriveSlug, dedupeSlug } from '../variants/slug';
+
+/**
+ * Whether a value can render as a color swatch (a concrete hex/rgb, not an alias or empty).
+ *
+ * @param {*} value The value to test.
+ * @return {boolean} True when it looks like a color a swatch can render.
+ */
+function isColorValue(value) {
+	return typeof value === 'string' && /^(#|rgb|hsl)/i.test(value.trim());
+}
+
+/**
+ * Build the initial property => value map for a source variant's tokens across the block's surface.
+ *
+ * @param {Array}  properties The block's surface ([{ key }]).
+ * @param {Object} tokens     The source variant's property => value token map.
+ * @return {Object} The seeded values keyed by property.
+ */
+function seedValues(properties, tokens) {
+	const values = {};
+
+	properties.forEach((property) => {
+		values[property.key] = get(tokens, property.key, '');
+	});
+
+	return values;
+}
+
+/**
+ * The save-as-new-variant modal.
+ *
+ * @param {Object}   props           The component props.
+ * @param {string}   props.blockName The block name, e.g. "kadence/advancedbtn".
+ * @param {string}   props.set       The token set the block is on.
+ * @param {string}   [props.source]  The variant slug to clone from initially.
+ * @param {Function} props.onClose   Called to dismiss the modal.
+ * @param {Function} props.onCreated Called with the new variant slug after a successful save.
+ *
+ * @return {Object} The modal element.
+ */
+export function SaveVariantModal({ blockName, set, source, onClose, onCreated }) {
+	const properties = blockProperties(blockName, set);
+
+	const [status, setStatus] = useState('loading');
+	const [error, setError] = useState('');
+	const [variants, setVariants] = useState({});
+	const [sourceSlug, setSourceSlug] = useState(source || '');
+	const [label, setLabel] = useState('');
+	const [values, setValues] = useState({});
+
+	// Load the block's variants for the set, then seed the form from the chosen (or default) source variant.
+	useEffect(() => {
+		let cancelled = false;
+
+		getBlockVariants(blockName, set)
+			.then((payload) => {
+				if (cancelled) {
+					return;
+				}
+
+				const map = get(payload, 'variants', {}) || {};
+				const initialSource =
+					source && map[source] ? source : get(payload, 'default', Object.keys(map)[0] || '');
+
+				setVariants(map);
+				setSourceSlug(initialSource);
+				setValues(seedValues(properties, get(map, [initialSource, 'tokens'], {})));
+				setStatus('ready');
+			})
+			.catch((caught) => {
+				if (!cancelled) {
+					setError(caught?.message || __('Could not load the block variants.', 'kadence-blocks'));
+					setStatus('error');
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [blockName, set]);
+
+	const existingSlugs = Object.keys(variants);
+	const slug = dedupeSlug(deriveSlug(label), existingSlugs);
+	const canSave = status !== 'saving' && label.trim() !== '' && properties.length > 0;
+
+	/**
+	 * Reseed the form values when the user chooses a different variant to clone from.
+	 *
+	 * @param {string} next The newly chosen source variant slug.
+	 * @return {void}
+	 */
+	const onChooseSource = (next) => {
+		setSourceSlug(next);
+		setValues(seedValues(properties, get(variants, [next, 'tokens'], {})));
+	};
+
+	/**
+	 * Write the new variant, then append it to the catalog and select it on the block.
+	 *
+	 * @return {void}
+	 */
+	const onSave = () => {
+		setStatus('saving');
+		setError('');
+
+		createVariant(blockName, { variant: slug, label: label.trim(), tokens: values }, set)
+			.then(() => {
+				appendVariant(blockName, set, { slug, label: label.trim(), userCreated: true });
+				onCreated(slug);
+				onClose();
+			})
+			.catch((caught) => {
+				setError(caught?.message || __('Could not save the variant.', 'kadence-blocks'));
+				setStatus('ready');
+			});
+	};
+
+	return (
+		<Modal
+			title={__('Save as new variant', 'kadence-blocks')}
+			onRequestClose={onClose}
+			className="kb-save-variant-modal"
+		>
+			{status === 'loading' && <Spinner />}
+
+			{status === 'error' && (
+				<Notice status="error" isDismissible={false}>
+					{error}
+				</Notice>
+			)}
+
+			{(status === 'ready' || status === 'saving') && (
+				<>
+					{error !== '' && (
+						<Notice status="error" onRemove={() => setError('')}>
+							{error}
+						</Notice>
+					)}
+
+					<TextControl
+						label={__('Variant name', 'kadence-blocks')}
+						value={label}
+						onChange={setLabel}
+						help={
+							label.trim() !== ''
+								? sprintf(/* translators: %s: variant slug. */ __('Slug: %s', 'kadence-blocks'), slug)
+								: ''
+						}
+					/>
+
+					{existingSlugs.length > 0 && (
+						<SelectControl
+							label={__('Clone values from', 'kadence-blocks')}
+							value={sourceSlug}
+							options={existingSlugs.map((existing) => ({
+								label: get(variants, [existing, 'label'], existing),
+								value: existing,
+							}))}
+							onChange={onChooseSource}
+						/>
+					)}
+
+					{properties.map((property) => (
+						<div key={property.key} className="kb-save-variant-modal__field">
+							<TextControl
+								label={property.key}
+								value={values[property.key] || ''}
+								onChange={(next) => setValues({ ...values, [property.key]: next })}
+							/>
+							{property.kind === 'color' && isColorValue(values[property.key]) && (
+								<span
+									className="kb-save-variant-modal__swatch"
+									style={{
+										backgroundColor: values[property.key],
+										display: 'inline-block',
+										width: '20px',
+										height: '20px',
+										borderRadius: '3px',
+										border: '1px solid rgba(0, 0, 0, 0.2)',
+										verticalAlign: 'middle',
+									}}
+									aria-hidden="true"
+								/>
+							)}
+						</div>
+					))}
+
+					<div className="kb-save-variant-modal__actions">
+						<Button variant="tertiary" onClick={onClose} disabled={status === 'saving'}>
+							{__('Cancel', 'kadence-blocks')}
+						</Button>
+						<Button variant="primary" onClick={onSave} isBusy={status === 'saving'} disabled={!canSave}>
+							{__('Create variant', 'kadence-blocks')}
+						</Button>
+					</div>
+				</>
+			)}
+		</Modal>
+	);
+}

--- a/src/extension/variant-picker/index.js
+++ b/src/extension/variant-picker/index.js
@@ -1,64 +1,147 @@
 /**
  * Shared design-token color-variant picker.
  *
- * The catalog (block name -> { default, variants }) is printed by the server-side editor localizer to
- * `window.kadenceDesignTokensVariants`. Both the generic inspector picker (src/early-filters.js) and a
- * block that renders the picker inline in its own Style tab (e.g. kadence/singlebtn) use this so the
- * control stays identical wherever it surfaces.
+ * The catalog is printed by the server-side editor localizer to `window.kadenceDesignTokensVariants`,
+ * keyed by token set: `{ active, sets: { <slug>: { <block>: { default, variants, properties, label? } } } }`.
+ * Reads take the set a block is on (its `kbTokenSet`, or the active set) so the picker shows that set's
+ * variants. Both the generic inspector picker (src/early-filters.js) and a block that renders the picker
+ * inline in its own Style tab (e.g. kadence/singlebtn) use this so the control stays identical wherever it
+ * surfaces.
  */
 import { get } from 'lodash';
 import { KadenceRadioButtons } from '@kadence/components';
 import { __ } from '@wordpress/i18n';
 
 /**
- * The design-token variant catalog the editor localizer prints, or an empty object when the token
+ * The whole design-token variant catalog the editor localizer prints, or an empty object when the token
  * registry is inactive (no variants offered).
  *
- * @return {Object} The catalog keyed by block name.
+ * @return {Object} The catalog ({ active, sets }).
  */
 function variantCatalog() {
 	return get(window, 'kadenceDesignTokensVariants', {}) || {};
 }
 
 /**
- * The variants defined for a block in the design-token document, or an empty array when it has none.
+ * The active token set slug, defaulting to "default".
  *
- * @param {string} name The block name.
- *
- * @return {Array} The block's variants ([{ slug, label }]).
+ * @return {string} The active set slug.
  */
-export function blockVariants(name) {
-	return get(variantCatalog(), [name, 'variants'], []);
+export function activeSet() {
+	return get(variantCatalog(), 'active', 'default') || 'default';
+}
+
+/**
+ * The per-block catalog for a set, defaulting to the active set.
+ *
+ * @param {string} [set] The token set slug.
+ * @return {Object} The per-block catalog for the set.
+ */
+function setBlocks(set) {
+	return get(variantCatalog(), ['sets', set || activeSet()], {}) || {};
+}
+
+/**
+ * The variants defined for a block in a set, or an empty array when it has none.
+ *
+ * @param {string} name  The block name.
+ * @param {string} [set] The token set slug; defaults to the active set.
+ * @return {Array} The block's variants ([{ slug, label, userCreated }]).
+ */
+export function blockVariants(name, set) {
+	return get(setBlocks(set), [name, 'variants'], []);
 }
 
 /**
  * The picker control label a block declares for its variant axis (the variant set's `label` in
  * declarations.php), or an empty string when it declares none.
  *
- * @param {string} name The block name.
- *
+ * @param {string} name  The block name.
+ * @param {string} [set] The token set slug; defaults to the active set.
  * @return {string} The control label, or an empty string.
  */
-export function blockVariantLabel(name) {
-	return get(variantCatalog(), [name, 'label'], '');
+export function blockVariantLabel(name, set) {
+	return get(setBlocks(set), [name, 'label'], '');
 }
 
 /**
- * The color-variant picker for a block. Renders nothing when the block has no variants in the document.
+ * The controllable surface for a block: one { key, kind, token } entry per bound property.
+ *
+ * @param {string} name  The block name.
+ * @param {string} [set] The token set slug; defaults to the active set.
+ * @return {Array} The block's surface ([{ key, kind, token }]).
+ */
+export function blockProperties(name, set) {
+	return get(setBlocks(set), [name, 'properties'], []);
+}
+
+/**
+ * The block's default variant slug in a set.
+ *
+ * @param {string} name  The block name.
+ * @param {string} [set] The token set slug; defaults to the active set.
+ * @return {string} The default variant slug, or an empty string.
+ */
+export function blockDefaultVariant(name, set) {
+	return get(setBlocks(set), [name, 'default'], '');
+}
+
+/**
+ * Append a user-created variant to the in-memory catalog for a set, so the picker offers it without a page
+ * reload. A no-op when the block has no catalog entry for the set.
+ *
+ * @param {string} name    The block name.
+ * @param {string} set     The token set slug.
+ * @param {Object} variant The variant to append ({ slug, label, userCreated }).
+ * @return {void}
+ */
+export function appendVariant(name, set, variant) {
+	const block = get(variantCatalog(), ['sets', set || activeSet(), name]);
+
+	if (!block || !Array.isArray(block.variants)) {
+		return;
+	}
+
+	if (!block.variants.some((existing) => existing.slug === variant.slug)) {
+		block.variants.push(variant);
+	}
+}
+
+/**
+ * Remove a variant from the in-memory catalog for a set, so the picker drops it without a page reload.
+ *
+ * @param {string} name The block name.
+ * @param {string} set  The token set slug.
+ * @param {string} slug The variant slug to remove.
+ * @return {void}
+ */
+export function removeVariant(name, set, slug) {
+	const block = get(variantCatalog(), ['sets', set || activeSet(), name]);
+
+	if (!block || !Array.isArray(block.variants)) {
+		return;
+	}
+
+	block.variants = block.variants.filter((existing) => existing.slug !== slug);
+}
+
+/**
+ * The color-variant picker for a block. Renders nothing when the block has no variants in the set.
  * Selecting an option writes the kbVariant attribute (via onChange); an empty value selects the block's
  * $default look.
  *
- * @param {Object}   props           The component props.
- * @param {string}   props.name      The block name, used to read its variants from the catalog.
- * @param {string}   props.value     The currently selected variant slug.
- * @param {Function} props.onChange  Called with the selected slug.
- * @param {string}   [props.label]   The control label; defaults to the block's declared label, then a generic fallback.
+ * @param {Object}   props             The component props.
+ * @param {string}   props.name        The block name, used to read its variants from the catalog.
+ * @param {string}   props.value       The currently selected variant slug.
+ * @param {Function} props.onChange    Called with the selected slug.
+ * @param {string}   [props.set]       The token set the block is on; defaults to the active set.
+ * @param {string}   [props.label]     The control label; defaults to the block's declared label, then a generic fallback.
  * @param {string}   [props.className] The control class.
  *
  * @return {Object|null} The picker element, or null when the block has no variants.
  */
-export function VariantPicker({ name, value, onChange, label, className }) {
-	const variants = blockVariants(name);
+export function VariantPicker({ name, value, onChange, set, label, className }) {
+	const variants = blockVariants(name, set);
 
 	if (!variants.length) {
 		return null;
@@ -71,7 +154,7 @@ export function VariantPicker({ name, value, onChange, label, className }) {
 
 	return (
 		<KadenceRadioButtons
-			label={label || blockVariantLabel(name) || __('Variant', 'kadence-blocks')}
+			label={label || blockVariantLabel(name, set) || __('Variant', 'kadence-blocks')}
 			className={className || 'kb-variant-picker'}
 			value={value || ''}
 			options={options}

--- a/src/extension/variants/api/client.js
+++ b/src/extension/variants/api/client.js
@@ -1,0 +1,103 @@
+/**
+ * REST client for the Design Tokens variants resource.
+ *
+ * Uses the editor's already-configured `@wordpress/api-fetch` (root + nonce), reading only the REST
+ * namespace from the localized descriptor `window.kadenceDesignTokensRest`. Every call targets a specific
+ * token set via the `set` parameter (query for reads/deletes, body for writes); an absent set lets the
+ * server fall back to the active set.
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import { get } from 'lodash';
+import { variantsBlockPath, variantItemPath, variantDefaultPath } from './paths';
+
+/**
+ * The localized REST descriptor, or an empty object when the design-token registry is inactive.
+ *
+ * @return {Object} The descriptor ({ root, namespace, nonce }).
+ */
+function descriptor() {
+	return get(window, 'kadenceDesignTokensRest', {}) || {};
+}
+
+/**
+ * The REST namespace the variant routes register under.
+ *
+ * @return {string} The namespace, e.g. "kb-design-tokens/v1".
+ */
+export function variantsNamespace() {
+	return descriptor().namespace || 'kb-design-tokens/v1';
+}
+
+/**
+ * Whether the editor has the REST descriptor needed to talk to the variants API. When false, the
+ * "save as new variant" affordance is hidden.
+ *
+ * @return {boolean} True when the descriptor is present.
+ */
+export function hasVariantsRest() {
+	return Boolean(descriptor().namespace);
+}
+
+/**
+ * Read a block's effective variant set for a token set.
+ *
+ * @param {string} block The block name.
+ * @param {string} [set] The token set slug; omitted targets the active set.
+ * @return {Promise<Object>} The variant set payload ({ block, slug, version, default, variants }).
+ */
+export function getBlockVariants(block, set) {
+	return apiFetch({
+		path: addQueryArgs(variantsBlockPath(variantsNamespace(), block), set ? { set } : {}),
+	});
+}
+
+/**
+ * Create or merge a single variant into a block's set.
+ *
+ * @param {string} block               The block name.
+ * @param {Object} variant             The variant definition.
+ * @param {string} variant.variant     The variant slug.
+ * @param {string} [variant.label]     The variant label.
+ * @param {Object} [variant.tokens]    The property => value token map.
+ * @param {string} [set]               The token set slug; omitted targets the active set.
+ * @return {Promise<Object>} The updated variant set payload.
+ */
+export function createVariant(block, { variant, label, tokens }, set) {
+	return apiFetch({
+		path: variantsBlockPath(variantsNamespace(), block),
+		method: 'POST',
+		data: { variant, label, tokens, ...(set ? { set } : {}) },
+	});
+}
+
+/**
+ * Set a block's default variant.
+ *
+ * @param {string} block          The block name.
+ * @param {string} defaultVariant The variant slug to make default.
+ * @param {string} [set]          The token set slug; omitted targets the active set.
+ * @return {Promise<Object>} The updated variant set payload.
+ */
+export function setVariantDefault(block, defaultVariant, set) {
+	return apiFetch({
+		path: variantDefaultPath(variantsNamespace(), block),
+		method: 'PUT',
+		data: { default: defaultVariant, ...(set ? { set } : {}) },
+	});
+}
+
+/**
+ * Delete a single variant from a block's set.
+ *
+ * @param {string} block   The block name.
+ * @param {string} variant The variant slug.
+ * @param {string} [set]   The token set slug; omitted targets the active set.
+ * @return {Promise<Object>} The updated variant set payload.
+ */
+export function deleteVariant(block, variant, set) {
+	return apiFetch({
+		path: addQueryArgs(variantItemPath(variantsNamespace(), block, variant), set ? { set } : {}),
+		method: 'DELETE',
+	});
+}

--- a/src/extension/variants/api/paths.js
+++ b/src/extension/variants/api/paths.js
@@ -1,0 +1,40 @@
+/**
+ * REST path builders for the Design Tokens variants resource.
+ *
+ * The block name carries a slash ("kadence/advancedbtn") and is routed as two path segments, so it is
+ * interpolated verbatim into the path.
+ */
+
+/**
+ * The path for a block's variant set (GET list / POST create-or-merge / PUT replace / DELETE reset).
+ *
+ * @param {string} namespace The REST namespace, e.g. "kb-design-tokens/v1".
+ * @param {string} block     The block name, e.g. "kadence/advancedbtn".
+ * @return {string} The REST path relative to the wp-json root.
+ */
+export function variantsBlockPath(namespace, block) {
+	return `/${namespace}/variants/${block}`;
+}
+
+/**
+ * The path for a single variant (DELETE one variant).
+ *
+ * @param {string} namespace The REST namespace.
+ * @param {string} block     The block name.
+ * @param {string} variant   The variant slug.
+ * @return {string} The REST path relative to the wp-json root.
+ */
+export function variantItemPath(namespace, block, variant) {
+	return `/${namespace}/variants/${block}/${variant}`;
+}
+
+/**
+ * The path for a block's default variant sub-route (GET / PUT the default).
+ *
+ * @param {string} namespace The REST namespace.
+ * @param {string} block     The block name.
+ * @return {string} The REST path relative to the wp-json root.
+ */
+export function variantDefaultPath(namespace, block) {
+	return `/${namespace}/variants/${block}/default`;
+}

--- a/src/extension/variants/slug.js
+++ b/src/extension/variants/slug.js
@@ -1,0 +1,45 @@
+/**
+ * Slug helpers for user-created variants: derive a kebab slug from a user's label, and de-duplicate it
+ * against the slugs a block already uses (baseline + user), mirroring the server's slug pattern.
+ */
+
+/**
+ * Derive a kebab-case slug from a label: lowercase, non-alphanumeric runs collapsed to a single dash, and
+ * leading/trailing dashes trimmed.
+ *
+ * @param {string} label The user-supplied label.
+ * @return {string} The derived slug, possibly empty when the label has no alphanumerics.
+ */
+export function deriveSlug(label) {
+	return String(label || '')
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '');
+}
+
+/**
+ * De-duplicate a slug against a set of taken slugs by appending "-2", "-3", … until it is free. The
+ * reserved slug "default" is always treated as taken.
+ *
+ * @param {string}   slug  The candidate slug.
+ * @param {string[]} taken The slugs already in use for the block.
+ * @return {string} A slug not present in `taken`.
+ */
+export function dedupeSlug(slug, taken) {
+	const used = new Set([...(taken || []), 'default']);
+
+	if (slug !== '' && !used.has(slug)) {
+		return slug;
+	}
+
+	const base = slug === '' ? 'variant' : slug;
+	let candidate = base;
+	let suffix = 2;
+
+	while (used.has(candidate)) {
+		candidate = `${base}-${suffix}`;
+		suffix += 1;
+	}
+
+	return candidate;
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked PR — #1102 must be merged first.

🎫  https://linear.app/nexcess/issue/SOFT-3575/user-created-variants-clone-an-existing-variants-surface-no-token

The editor affordance for user-created variants.

A new `SaveVariantModal` clones an existing variant's surface: the user picks a variant to clone from, edits the value of each bound property (rendered by its `kind`), names the variant, and saves through `POST /variants/{block}?set=`. Because it seeds from an existing variant's values it needs no per-block knowledge, so it works for every block that registers a variant set. The server aliases matching literals, enforces the full surface, and rejects dangling aliases; on success the new variant is appended to the in-memory catalog and selected on the block.

A small variants REST client (`src/extension/variants`) wraps the block routes over the editor's `apiFetch`, and `src/extension/variants/slug.js` derives a kebab slug from the label and de-duplicates it against the block's existing slugs (the reserved `default` included).

The variant picker is now set-aware: it reads the per-set catalog and shows the variants for whichever set the block is on (its `kbTokenSet`, or the active set). The "Save as new variant" affordance is wired into the generic Design Tokens inspector panel and the singlebtn inline panel, gated on the REST descriptor being present.

Verified with `wp-scripts lint-js` and a full `wp-scripts build` (the repo has no JS test harness).

Stacks on the per-set catalog work.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.