### PR TITLE
Custom Variant Creation [8/11]: edit and delete user-created variants in the editor

### DIFF
--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -85,8 +85,7 @@ import {
 import { addFilter, applyFilters, doAction } from '@wordpress/hooks';
 import BackendStyles from './components/backend-styles';
 import { VariantPicker, blockVariants, activeSet } from '../../extension/variant-picker';
-import { SaveVariantModal } from '../../extension/variant-picker/SaveVariantModal';
-import { hasVariantsRest } from '../../extension/variants/api/client';
+import { VariantActions } from '../../extension/variant-picker/VariantActions';
 import { TokenSetPicker, selectableSets } from '../../extension/token-set-picker';
 
 export default function KadenceButtonEdit(props) {
@@ -277,7 +276,6 @@ export default function KadenceButtonEdit(props) {
 
 	const [activeTab, setActiveTab] = useState('general');
 	const [isEditingURL, setIsEditingURL] = useState(false);
-	const [savingVariant, setSavingVariant] = useState(false);
 	useEffect(() => {
 		if (!isSelected) {
 			setIsEditingURL(false);
@@ -856,23 +854,15 @@ export default function KadenceButtonEdit(props) {
 													value={attributes.kbVariant || ''}
 													onChange={(value) => setAttributes({ kbVariant: value })}
 												/>
-												{hasVariantsRest() && (
-													<Button variant="secondary" onClick={() => setSavingVariant(true)}>
-														{__('Save as new variant', 'kadence-blocks')}
-													</Button>
-												)}
+												<VariantActions
+													blockName={name}
+													set={attributes.kbTokenSet || activeSet()}
+													selected={attributes.kbVariant || ''}
+													onSelect={(slug) => setAttributes({ kbVariant: slug })}
+												/>
 											</SubsectionWrap>
 										)}
 									</KadencePanelBody>
-								)}
-								{savingVariant && (
-									<SaveVariantModal
-										blockName={name}
-										set={attributes.kbTokenSet || activeSet()}
-										source={attributes.kbVariant || ''}
-										onClose={() => setSavingVariant(false)}
-										onCreated={(slug) => setAttributes({ kbVariant: slug })}
-									/>
 								)}
 								{showSettings('colorSettings', 'kadence/advancedbtn') && (
 									<>

--- a/src/early-filters.js
+++ b/src/early-filters.js
@@ -14,8 +14,7 @@ import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { useDispatch, select } from '@wordpress/data';
 import { VariantPicker, blockVariants, activeSet } from './extension/variant-picker';
-import { SaveVariantModal } from './extension/variant-picker/SaveVariantModal';
-import { hasVariantsRest } from './extension/variants/api/client';
+import { VariantActions } from './extension/variant-picker/VariantActions';
 import { TokenSetPicker, selectableSets } from './extension/token-set-picker';
 
 /**
@@ -293,8 +292,6 @@ const withVariantPicker = createHigherOrderComponent((BlockEdit) => {
 	return (props) => {
 		const { name, attributes, setAttributes, isSelected } = props;
 
-		const [saving, setSaving] = useState(false);
-
 		if (!hasBlockSupport(name, 'kbVariant')) {
 			return <BlockEdit {...props} />;
 		}
@@ -336,24 +333,16 @@ const withVariantPicker = createHigherOrderComponent((BlockEdit) => {
 										value={get(attributes, 'kbVariant', '')}
 										onChange={(value) => setAttributes({ kbVariant: value })}
 									/>
-									{hasVariantsRest() && (
-										<Button variant="secondary" onClick={() => setSaving(true)}>
-											{__('Save as new variant', 'kadence-blocks')}
-										</Button>
-									)}
+									<VariantActions
+										blockName={name}
+										set={set}
+										selected={get(attributes, 'kbVariant', '')}
+										onSelect={(slug) => setAttributes({ kbVariant: slug })}
+									/>
 								</SubsectionWrap>
 							)}
 						</PanelBody>
 					</InspectorControls>
-				)}
-				{saving && (
-					<SaveVariantModal
-						blockName={name}
-						set={set}
-						source={get(attributes, 'kbVariant', '')}
-						onClose={() => setSaving(false)}
-						onCreated={(slug) => setAttributes({ kbVariant: slug })}
-					/>
 				)}
 			</>
 		);

--- a/src/extension/variant-picker/SaveVariantModal.js
+++ b/src/extension/variant-picker/SaveVariantModal.js
@@ -1,11 +1,12 @@
 /**
- * "Save as new variant" modal.
+ * "Save as new variant" / "Edit variant" modal.
  *
- * Clones an existing variant's surface for a block: the user picks a variant to clone from, edits the value
- * of each bound property, names the variant, and saves. The new variant is written through the variants REST
- * endpoint (which aliases matching literals, validates the full surface, and rejects dangling aliases), then
- * appended to the in-memory catalog and selected on the block. Works for any block that registers a variant
- * set — it seeds from an existing variant's values, so it needs no per-block knowledge.
+ * Create mode clones an existing variant's surface for a block: the user picks a variant to clone from,
+ * edits the value of each bound property, names the variant, and saves a new one. Edit mode pre-fills from an
+ * existing user variant and saves back under the same slug. Either way the write goes through the variants
+ * REST endpoint (which aliases matching literals, validates the full surface, and rejects dangling aliases),
+ * then the in-memory catalog is updated and the variant selected on the block. It seeds from an existing
+ * variant's values, so it needs no per-block knowledge and works for any block that registers a variant set.
  */
 import { Modal, TextControl, SelectControl, Button, Notice, Spinner } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
@@ -43,19 +44,21 @@ function seedValues(properties, tokens) {
 }
 
 /**
- * The save-as-new-variant modal.
+ * The save/edit variant modal.
  *
  * @param {Object}   props           The component props.
  * @param {string}   props.blockName The block name, e.g. "kadence/advancedbtn".
  * @param {string}   props.set       The token set the block is on.
- * @param {string}   [props.source]  The variant slug to clone from initially.
+ * @param {string}   [props.source]  The variant slug to clone from initially (create mode).
+ * @param {string}   [props.editSlug] When set, edit this existing variant in place instead of creating one.
  * @param {Function} props.onClose   Called to dismiss the modal.
- * @param {Function} props.onCreated Called with the new variant slug after a successful save.
+ * @param {Function} props.onSaved   Called with the variant slug after a successful save.
  *
  * @return {Object} The modal element.
  */
-export function SaveVariantModal({ blockName, set, source, onClose, onCreated }) {
+export function SaveVariantModal({ blockName, set, source, editSlug = '', onClose, onSaved }) {
 	const properties = blockProperties(blockName, set);
+	const isEdit = editSlug !== '';
 
 	const [status, setStatus] = useState('loading');
 	const [error, setError] = useState('');
@@ -64,7 +67,8 @@ export function SaveVariantModal({ blockName, set, source, onClose, onCreated })
 	const [label, setLabel] = useState('');
 	const [values, setValues] = useState({});
 
-	// Load the block's variants for the set, then seed the form from the chosen (or default) source variant.
+	// Load the block's variants for the set, then seed the form: from the edited variant in edit mode, or
+	// from the chosen (or default) source variant in create mode.
 	useEffect(() => {
 		let cancelled = false;
 
@@ -75,12 +79,20 @@ export function SaveVariantModal({ blockName, set, source, onClose, onCreated })
 				}
 
 				const map = get(payload, 'variants', {}) || {};
-				const initialSource =
-					source && map[source] ? source : get(payload, 'default', Object.keys(map)[0] || '');
+				const seedSlug = isEdit
+					? editSlug
+					: source && map[source]
+						? source
+						: get(payload, 'default', Object.keys(map)[0] || '');
 
 				setVariants(map);
-				setSourceSlug(initialSource);
-				setValues(seedValues(properties, get(map, [initialSource, 'tokens'], {})));
+				setSourceSlug(seedSlug);
+				setValues(seedValues(properties, get(map, [seedSlug, 'tokens'], {})));
+
+				if (isEdit) {
+					setLabel(get(map, [editSlug, 'label'], editSlug));
+				}
+
 				setStatus('ready');
 			})
 			.catch((caught) => {
@@ -94,14 +106,14 @@ export function SaveVariantModal({ blockName, set, source, onClose, onCreated })
 			cancelled = true;
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [blockName, set]);
+	}, [blockName, set, editSlug]);
 
 	const existingSlugs = Object.keys(variants);
-	const slug = dedupeSlug(deriveSlug(label), existingSlugs);
+	const slug = isEdit ? editSlug : dedupeSlug(deriveSlug(label), existingSlugs);
 	const canSave = status !== 'saving' && label.trim() !== '' && properties.length > 0;
 
 	/**
-	 * Reseed the form values when the user chooses a different variant to clone from.
+	 * Reseed the form values when the user chooses a different variant to clone from (create mode).
 	 *
 	 * @param {string} next The newly chosen source variant slug.
 	 * @return {void}
@@ -112,7 +124,7 @@ export function SaveVariantModal({ blockName, set, source, onClose, onCreated })
 	};
 
 	/**
-	 * Write the new variant, then append it to the catalog and select it on the block.
+	 * Write the variant, then update the catalog and select it on the block.
 	 *
 	 * @return {void}
 	 */
@@ -123,7 +135,7 @@ export function SaveVariantModal({ blockName, set, source, onClose, onCreated })
 		createVariant(blockName, { variant: slug, label: label.trim(), tokens: values }, set)
 			.then(() => {
 				appendVariant(blockName, set, { slug, label: label.trim(), userCreated: true });
-				onCreated(slug);
+				onSaved(slug);
 				onClose();
 			})
 			.catch((caught) => {
@@ -134,7 +146,7 @@ export function SaveVariantModal({ blockName, set, source, onClose, onCreated })
 
 	return (
 		<Modal
-			title={__('Save as new variant', 'kadence-blocks')}
+			title={isEdit ? __('Edit variant', 'kadence-blocks') : __('Save as new variant', 'kadence-blocks')}
 			onRequestClose={onClose}
 			className="kb-save-variant-modal"
 		>
@@ -159,13 +171,13 @@ export function SaveVariantModal({ blockName, set, source, onClose, onCreated })
 						value={label}
 						onChange={setLabel}
 						help={
-							label.trim() !== ''
+							!isEdit && label.trim() !== ''
 								? sprintf(/* translators: %s: variant slug. */ __('Slug: %s', 'kadence-blocks'), slug)
 								: ''
 						}
 					/>
 
-					{existingSlugs.length > 0 && (
+					{!isEdit && existingSlugs.length > 0 && (
 						<SelectControl
 							label={__('Clone values from', 'kadence-blocks')}
 							value={sourceSlug}
@@ -207,7 +219,7 @@ export function SaveVariantModal({ blockName, set, source, onClose, onCreated })
 							{__('Cancel', 'kadence-blocks')}
 						</Button>
 						<Button variant="primary" onClick={onSave} isBusy={status === 'saving'} disabled={!canSave}>
-							{__('Create variant', 'kadence-blocks')}
+							{isEdit ? __('Save changes', 'kadence-blocks') : __('Create variant', 'kadence-blocks')}
 						</Button>
 					</div>
 				</>

--- a/src/extension/variant-picker/VariantActions.js
+++ b/src/extension/variant-picker/VariantActions.js
@@ -1,0 +1,123 @@
+/**
+ * Create / edit / delete controls for a block's design-token variants.
+ *
+ * Renders a "Save as new variant" button for every block, and, when the selected variant is a user-created
+ * one, "Edit" and "Delete" buttons. Deleting the variant the set currently defaults to first reassigns the
+ * default to another variant (so the default is never left dangling), then removes it. Shared by the generic
+ * inspector panel and a block's inline picker so the controls stay identical wherever they surface. Renders
+ * nothing when the editor lacks the REST descriptor.
+ */
+import { Button, Notice } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { SaveVariantModal } from './SaveVariantModal';
+import { blockVariants, blockDefaultVariant, isUserVariant, removeVariant } from './index';
+import { hasVariantsRest, deleteVariant, setVariantDefault } from '../variants/api/client';
+
+/**
+ * The variant create/edit/delete controls.
+ *
+ * @param {Object}   props           The component props.
+ * @param {string}   props.blockName The block name.
+ * @param {string}   props.set       The token set the block is on.
+ * @param {string}   props.selected  The block's currently selected variant slug ('' for the default look).
+ * @param {Function} props.onSelect  Called with a variant slug to select it on the block.
+ *
+ * @return {Object|null} The controls, or null when the variants REST API is unavailable.
+ */
+export function VariantActions({ blockName, set, selected, onSelect }) {
+	const [mode, setMode] = useState('none');
+	const [confirming, setConfirming] = useState(false);
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState('');
+
+	if (!hasVariantsRest()) {
+		return null;
+	}
+
+	const canManage = selected !== '' && isUserVariant(blockName, set, selected);
+
+	/**
+	 * Delete the selected user variant, first moving the default off it when it is the current default.
+	 *
+	 * @return {void}
+	 */
+	const onDelete = () => {
+		setBusy(true);
+		setError('');
+
+		const isDefault = blockDefaultVariant(blockName, set) === selected;
+		const fallback = blockVariants(blockName, set)
+			.map((variant) => variant.slug)
+			.find((slug) => slug !== selected);
+
+		const reassign = isDefault && fallback ? setVariantDefault(blockName, fallback, set) : Promise.resolve();
+
+		reassign
+			.then(() => deleteVariant(blockName, selected, set))
+			.then(() => {
+				removeVariant(blockName, set, selected);
+				onSelect('');
+				setConfirming(false);
+				setBusy(false);
+			})
+			.catch((caught) => {
+				setError(caught?.message || __('Could not delete the variant.', 'kadence-blocks'));
+				setBusy(false);
+			});
+	};
+
+	return (
+		<>
+			{error !== '' && (
+				<Notice status="error" onRemove={() => setError('')}>
+					{error}
+				</Notice>
+			)}
+
+			<Button variant="secondary" onClick={() => setMode('create')}>
+				{__('Save as new variant', 'kadence-blocks')}
+			</Button>
+
+			{canManage && !confirming && (
+				<>
+					<Button variant="tertiary" onClick={() => setMode('edit')}>
+						{__('Edit variant', 'kadence-blocks')}
+					</Button>
+					<Button variant="tertiary" isDestructive onClick={() => setConfirming(true)}>
+						{__('Delete variant', 'kadence-blocks')}
+					</Button>
+				</>
+			)}
+
+			{canManage && confirming && (
+				<>
+					<p>
+						{sprintf(
+							/* translators: %s: variant slug. */
+							__('Delete the "%s" variant? This cannot be undone.', 'kadence-blocks'),
+							selected
+						)}
+					</p>
+					<Button variant="tertiary" onClick={() => setConfirming(false)} disabled={busy}>
+						{__('Cancel', 'kadence-blocks')}
+					</Button>
+					<Button variant="primary" isDestructive isBusy={busy} onClick={onDelete}>
+						{__('Delete', 'kadence-blocks')}
+					</Button>
+				</>
+			)}
+
+			{mode !== 'none' && (
+				<SaveVariantModal
+					blockName={blockName}
+					set={set}
+					source={selected}
+					editSlug={mode === 'edit' ? selected : ''}
+					onClose={() => setMode('none')}
+					onSaved={(slug) => onSelect(slug)}
+				/>
+			)}
+		</>
+	);
+}

--- a/src/extension/variant-picker/VariantActions.js
+++ b/src/extension/variant-picker/VariantActions.js
@@ -1,7 +1,7 @@
 /**
  * Create / edit / delete controls for a block's design-token variants.
  *
- * Renders a "Save as new variant" button for every block, and, when the selected variant is a user-created
+ * Renders a "Create new variant" button for every block, and, when the selected variant is a user-created
  * one, "Edit" and "Delete" buttons. Deleting the variant the set currently defaults to first reassigns the
  * default to another variant (so the default is never left dangling), then removes it. Shared by the generic
  * inspector panel and a block's inline picker so the controls stay identical wherever they surface. Renders
@@ -76,7 +76,7 @@ export function VariantActions({ blockName, set, selected, onSelect }) {
 			)}
 
 			<Button variant="secondary" onClick={() => setMode('create')}>
-				{__('Save as new variant', 'kadence-blocks')}
+				{__('Create new variant', 'kadence-blocks')}
 			</Button>
 
 			{canManage && !confirming && (

--- a/src/extension/variant-picker/index.js
+++ b/src/extension/variant-picker/index.js
@@ -87,6 +87,19 @@ export function blockDefaultVariant(name, set) {
 }
 
 /**
+ * Whether a variant slug is a user-created one for a block in a set (editable and deletable). A baseline
+ * variant, or one that only shadows a baseline variant, is not.
+ *
+ * @param {string} name The block name.
+ * @param {string} set  The token set slug.
+ * @param {string} slug The variant slug.
+ * @return {boolean} True when the variant is user-created.
+ */
+export function isUserVariant(name, set, slug) {
+	return blockVariants(name, set).some((variant) => variant.slug === slug && variant.userCreated);
+}
+
+/**
  * Append a user-created variant to the in-memory catalog for a set, so the picker offers it without a page
  * reload. A no-op when the block has no catalog entry for the set.
  *


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked PR — #1103 must be merged first.

🎫  https://linear.app/nexcess/issue/SOFT-3575/user-created-variants-clone-an-existing-variants-surface-no-token

Editing and deleting user-created variants from the editor.

A shared `VariantActions` component now renders the save / edit / delete controls for a block's variants, replacing the inline save button in both the generic Design Tokens panel and the singlebtn inline panel. Edit and Delete surface only for a user-created variant (`userCreated` in the catalog); baseline and shadowing variants stay read-only.

- **Edit** reopens the modal pre-filled from the variant's stored tokens and saves back under the same slug (the modal gained an edit mode).
- **Delete** removes the variant, first reassigning the default to another variant when the target is the current default — so the block's default is never left dangling (the server also rejects deleting the current default) — then drops it from the in-memory catalog and clears the block's selection. A confirmation step guards the delete.

Verified with `wp-scripts lint-js` and a full `wp-scripts build`.

Stacks on the save-as-new-variant UI.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.