### PR TITLE
[DTM] SOFT-3405 [1/4]: Icon color token binding

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -546,7 +546,7 @@
 						}
 					}
 				},
-				"kadence/icon": {
+				"kadence/single-icon": {
 					"$default": "default",
 					"default": {
 						"label": "Default",

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -323,5 +323,36 @@ return [
 				],
 			],
 		],
+		[
+			// Icon color: the $default binds color to the brand icon-color token. The block-default-CSS
+			// projector emits a low-specificity `.wp-block-kadence-single-icon *.kb-svg-icon-wrap
+			// { color: var(...) }` rule, so a fresh icon follows the token while any color the user sets
+			// still wins (equal specificity, later source order). The binding lives on `single-icon` (the
+			// 3.0 child block that actually owns `color`/`size`), not the legacy `kadence/icon` container,
+			// which has no top-level color/size attribute of its own to bind.
+			//
+			// The leading `*` is load-bearing, not decorative: Css_Builder::selector_suffix() treats a
+			// selector starting with `.` as an already-attached compound (the same element as the block root,
+			// e.g. `.is-style-rounded`), not a descendant — a bare `.kb-svg-icon-wrap` would produce
+			// `.wp-block-kadence-single-icon.kb-svg-icon-wrap`, which never matches because the wrap span is a
+			// descendant of the block root, not the root itself (and isn't always a direct child either — it
+			// sits inside an `<a>` when the icon is linked — so a `>` child combinator would also be wrong).
+			// Prefixing with `*` keeps the selector's first character outside selector_suffix()'s
+			// attach-verbatim set, so it gets the normal descendant-space treatment; the universal selector
+			// contributes no specificity, so this is identical in effect to a hand-written
+			// `.wp-block-kadence-single-icon .kb-svg-icon-wrap` descendant rule.
+			//
+			// `size` is deliberately NOT bound here: it is rendered two incompatible ways (an SVG prop in
+			// the editor, a `font-size` CSS rule on the front end) and is never empty, so it cannot use this
+			// low-specificity-CSS-default mechanism at all.
+			'block'    => 'kadence/single-icon',
+			'bindings' => [
+				'color' => [
+					'token'        => 'semantic.color.icon',
+					'css_prop'     => 'color',
+					'css_selector' => '*.kb-svg-icon-wrap',
+				],
+			],
+		],
 	],
 ];

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -81,6 +81,7 @@ final class Css_BuilderTest extends TestCase {
 			'.wp-block-kadence-single-icon *.kb-svg-icon-wrap{color:var(' . Css_Var::from_id( 'semantic.color.icon' ),
 			$css
 		);
+		$this->assertStringNotContainsString( '.wp-block-kadence-icon ', $css );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -48,20 +48,39 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
+	 * Build from the real registry (declarations loaded on init). Image radius and icon color are the
+	 * css_prop-bound cases that fit this projector: each attribute is empty by default and rendered as CSS
+	 * in both editor and front end. Button radius (own 3px default) and icon size (rendered as inline SVG
+	 * width/height, never empty) do not fit it, so the shipped declarations bind neither and emit no rule
+	 * for them.
+	 *
 	 * @return void
 	 */
 	public function testTheShippedDeclarationsEmitTheImageRadiusRule(): void {
-		// Build from the real registry (declarations loaded on init). Image radius is the css_prop-bound case
-		// that fits this projector: the attribute is empty by default and rendered as CSS in both editor and
-		// front end. Button radius (own 3px default) and icon size (rendered as inline SVG width/height, never
-		// empty) do not fit it, so the shipped declarations bind only the image and emit no rule for them.
 		$registry = $this->container->get( Token_Registry::class );
 
 		$css = $this->builder( $registry )->css();
 
 		$this->assertStringContainsString( '.wp-block-kadence-image img{border-radius:var(', $css );
 		$this->assertStringNotContainsString( '.wp-block-kadence-advancedbtn', $css );
-		$this->assertStringNotContainsString( '.wp-block-kadence-icon', $css );
+	}
+
+	/**
+	 * The icon color binding registered for `kadence/single-icon` emits a low-specificity rule pointing the
+	 * `.kb-svg-icon-wrap` descendant's `color` at the brand icon-color token, while the legacy `kadence/icon`
+	 * container (which has no top-level color/size attribute to bind) emits nothing.
+	 *
+	 * @return void
+	 */
+	public function testTheShippedDeclarationsEmitTheSingleIconColorRule(): void {
+		$registry = $this->container->get( Token_Registry::class );
+
+		$css = $this->builder( $registry )->css();
+
+		$this->assertStringContainsString(
+			'.wp-block-kadence-single-icon *.kb-svg-icon-wrap{color:var(' . Css_Var::from_id( 'semantic.color.icon' ),
+			$css
+		);
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Icon_Size_ResolutionTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Icon_Size_ResolutionTest.php
@@ -1,0 +1,133 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Resolver;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Css_Renderer;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use Tests\Support\Classes\Fake_Baseline_Document;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Confirms that `semantic.icon-size.default` and `semantic.color.icon` resolve through the existing
+ * dimension/color alias pass-through in the Resolver with zero bespoke renderer code: `icon-size` is a
+ * plain `dimension` token, the same family as spacing/radius, and `semantic.color.icon` is a plain `color`
+ * token like every other semantic color alias.
+ */
+final class Icon_Size_ResolutionTest extends TestCase {
+
+	/**
+	 * Build a resolver over a fully-controlled baseline, mirroring Token_ResolverTest's own helper so the
+	 * resolution path exercised here is identical to the one every other token type already relies on.
+	 *
+	 * @param array<string, mixed> $baseline
+	 *
+	 * @return Token_Resolver
+	 */
+	private function resolver_for( array $baseline ): Token_Resolver {
+		return new Token_Resolver(
+			$this->container->get( Token_Store::class ),
+			new Effective_Document( new Fake_Baseline_Document( $baseline ) ),
+			new Css_Renderer()
+		);
+	}
+
+	/**
+	 * `semantic.icon-size.default` is a `dimension` alias to `primitive.dimension.icon-size.md`, resolving
+	 * to a plain CSS length with no icon-specific renderer involved — the same alias-flattening every other
+	 * dimension token (radius, spacing) already goes through.
+	 *
+	 * @return void
+	 */
+	public function testIconSizeDefaultResolvesThroughTheDimensionAliasChain(): void {
+		$resolver = $this->resolver_for(
+			[
+				'primitive' => [
+					'dimension' => [
+						'icon-size' => [
+							'md' => [
+								'$type'  => 'dimension',
+								'$value' => '1.5rem',
+							],
+						],
+					],
+				],
+				'semantic'  => [
+					'icon-size' => [
+						'default' => [
+							'$type'  => 'dimension',
+							'$value' => '{primitive.dimension.icon-size.md}',
+						],
+					],
+				],
+			]
+		);
+
+		$resolved = $resolver->resolve_overrides( [] );
+
+		$this->assertSame( '1.5rem', $resolved->value( 'semantic.icon-size.default' ) );
+		$this->assertSame( 'primitive.dimension.icon-size.md', $resolved->target( 'semantic.icon-size.default' ) );
+		$this->assertSame(
+			'var(' . Css_Var::from_id( 'primitive.dimension.icon-size.md' ) . ')',
+			$resolved->projected_vars()[ Css_Var::from_id( 'semantic.icon-size.default' ) ]
+		);
+	}
+
+	/**
+	 * `semantic.color.icon` is a `color` alias to `primitive.color.brand.primary`, resolving to a plain hex
+	 * string through the same alias-flattening every other semantic color already goes through.
+	 *
+	 * @return void
+	 */
+	public function testSemanticColorIconResolvesThroughTheColorAliasChain(): void {
+		$resolver = $this->resolver_for(
+			[
+				'primitive' => [
+					'color' => [
+						'brand' => [
+							'primary' => [
+								'$type'  => 'color',
+								'$value' => '#3182CE',
+							],
+						],
+					],
+				],
+				'semantic'  => [
+					'color' => [
+						'icon' => [
+							'$type'  => 'color',
+							'$value' => '{primitive.color.brand.primary}',
+						],
+					],
+				],
+			]
+		);
+
+		$resolved = $resolver->resolve_overrides( [] );
+
+		$this->assertSame( '#3182CE', $resolved->value( 'semantic.color.icon' ) );
+		$this->assertSame( 'primitive.color.brand.primary', $resolved->target( 'semantic.color.icon' ) );
+		$this->assertSame(
+			'var(' . Css_Var::from_id( 'primitive.color.brand.primary' ) . ')',
+			$resolved->projected_vars()[ Css_Var::from_id( 'semantic.color.icon' ) ]
+		);
+	}
+
+	/**
+	 * Both icon tokens resolve identically against the real shipped baseline (not a fake one), proving the
+	 * pass-through this test exercises in isolation is exactly what production wiring already resolves.
+	 *
+	 * @return void
+	 */
+	public function testBothIconTokensResolveAgainstTheShippedBaseline(): void {
+		/** @var Token_Resolver $resolver */
+		$resolver = $this->container->get( Token_Resolver::class );
+
+		$resolved = $resolver->resolve();
+
+		$this->assertSame( '1.5rem', $resolved->value( 'semantic.icon-size.default' ) );
+		$this->assertSame( '#3182CE', $resolved->value( 'semantic.color.icon' ) );
+	}
+}


### PR DESCRIPTION
Moves the icon token binding from the legacy `kadence/icon` container to `kadence/single-icon`, the 3.0 child block that actually owns the `color`/`size` attributes, and wires `color` to the design-token system.

- The baseline's `$default` icon variant entry moves from `kadence/icon` to `kadence/single-icon`.
- A new `variant_sets` entry on `kadence/single-icon` binds `color` to `semantic.color.icon` via the existing `Block_Default_Css` low-specificity mechanism — the same one `kadence/image`'s `borderRadius` already uses — emitting a `.wp-block-kadence-single-icon *.kb-svg-icon-wrap { color: var(...) }` rule that a fresh icon follows while any user-set color still wins.
- `size` is deliberately left unbound here: it renders two incompatible ways (an SVG prop in the editor, a `font-size` rule on the front end) and is never empty, so it needs different machinery than the low-specificity-CSS-default mechanism. That's covered by a later PR in this stack.
- Adds `Icon_Size_ResolutionTest`, confirming `semantic.icon-size.default` and `semantic.color.icon` resolve through the existing dimension/color alias pass-through with no bespoke renderer code.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.