### PR TITLE
[DTM] SOFT-3405 [2/4]: Icon size adapter

### DIFF
--- a/includes/blocks/class-kadence-blocks-abstract-block.php
+++ b/includes/blocks/class-kadence-blocks-abstract-block.php
@@ -96,6 +96,7 @@ class Kadence_Blocks_Abstract_Block {
 		'accept',
 		'captcha',
 		'submit',
+		'single-icon',
 	];
 
 	/**

--- a/includes/resources/Design_Tokens/Projection/Adapter/Icon_Size_Adapter.php
+++ b/includes/resources/Design_Tokens/Projection/Adapter/Icon_Size_Adapter.php
@@ -1,0 +1,113 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts\Abstract_Adapter;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+
+/**
+ * Gap-fills kadence/single-icon's `size` attribute with the resolved semantic.icon-size.default
+ * token value, converted to the raw pixel number the attribute stores, when the stored attributes
+ * genuinely omit `size`. Because `size` has no `source` key and defaults to `50`, the block
+ * serializer omits it from saved content whenever it was never customized — so this fires for the
+ * large majority of currently-published icon blocks, not a narrow legacy case. Intentional: this
+ * mirrors the retroactive re-skin behavior kadence/image's borderRadius token already has in
+ * production.
+ *
+ * The rem/em-to-px conversion assumes a 16px root font size — the same assumption an unstyled
+ * `rem` makes in a browser. Nothing in this module tracks a site's actual root font size, so this
+ * is a known, accepted simplification rather than a silent guess.
+ *
+ * Does NOT affect a freshly inserted icon block: `single-icon` is a static (client-rendered) block,
+ * so a fresh insert's `size` comes from block.json's JS default at insert time, before this
+ * render-path filter ever runs. See Phase 3 (the editor-default catalog) for that case.
+ *
+ * @since TBD
+ */
+final class Icon_Size_Adapter extends Abstract_Adapter {
+
+	/**
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	protected const BLOCK = 'kadence/single-icon';
+
+	/**
+	 * The resolved-token dot-path this adapter reads.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const TOKEN = 'semantic.icon-size.default';
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Token_Resolver
+	 */
+	private Token_Resolver $resolver;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Resolver $resolver The token resolver.
+	 */
+	public function __construct( Token_Resolver $resolver ) {
+		$this->resolver = $resolver;
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $attributes The block's attributes.
+	 *
+	 * @return array<string, mixed> The transformed attributes.
+	 */
+	public function apply( array $attributes ): array {
+		if ( isset( $attributes['size'] ) ) {
+			return $attributes; // A stored value (including 0) always wins.
+		}
+
+		$length = $this->resolver->resolve()->value( self::TOKEN );
+
+		if ( $length === null ) {
+			return $attributes;
+		}
+
+		$px = $this->to_px( $length );
+
+		if ( $px === null ) {
+			return $attributes;
+		}
+
+		$attributes['size'] = $px;
+
+		return $attributes;
+	}
+
+	/**
+	 * Convert a resolved CSS length to a raw pixel number, assuming the browser/CSS default root
+	 * font size (16px) for `rem`/`em` — the only units this token family's baseline values use.
+	 * Returns null for a value this adapter cannot safely convert (already px, or an unrecognized
+	 * unit), so the caller can leave the attribute as WordPress's own default rather than guess.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $length A resolved CSS length, e.g. "1.5rem", "24px".
+	 *
+	 * @return float|null The pixel value, or null when the unit is not rem/em/px.
+	 */
+	private function to_px( string $length ): ?float {
+		if ( ! preg_match( '/^(-?[0-9.]+)(px|rem|em)$/', trim( $length ), $matches ) ) {
+			return null;
+		}
+
+		$number = (float) $matches[1];
+
+		return $matches[2] === 'px' ? $number : $number * 16.0;
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Adapter/Icon_Size_Adapter.php
+++ b/includes/resources/Design_Tokens/Projection/Adapter/Icon_Size_Adapter.php
@@ -6,13 +6,16 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts\Abstract_
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 
 /**
- * Gap-fills kadence/single-icon's `size` attribute with the resolved semantic.icon-size.default
- * token value, converted to the raw pixel number the attribute stores, when the stored attributes
- * genuinely omit `size`. Because `size` has no `source` key and defaults to `50`, the block
- * serializer omits it from saved content whenever it was never customized — so this fires for the
- * large majority of currently-published icon blocks, not a narrow legacy case. Intentional: this
- * mirrors the retroactive re-skin behavior kadence/image's borderRadius token already has in
- * production.
+ * Overlays kadence/single-icon's `size` registration default (block.json hardcodes `50`) with the
+ * resolved `semantic.icon-size.default` token value, converted to the raw pixel number the
+ * attribute stores. This runs on `kadence_blocks_block_default_attributes`, which fires with the
+ * block's *registration* defaults, not its stored instance attributes — so overwriting `size` here
+ * is safe: `Kadence_Blocks_Abstract_Block::merge_attributes_with_defaults()` still lets a genuinely
+ * customized instance value win afterward. Because `size` has no `source` key and defaults to `50`,
+ * the block serializer omits it from saved content whenever it was never customized, so an instance
+ * with no stored `size` ends up with this token-resolved default — which covers the large majority
+ * of currently-published icon blocks, not a narrow legacy case. Intentional: this mirrors the
+ * retroactive re-skin behavior kadence/image's borderRadius token already has in production.
  *
  * The rem/em-to-px conversion assumes a 16px root font size — the same assumption an unstyled
  * `rem` makes in a browser. Nothing in this module tracks a site's actual root font size, so this
@@ -63,15 +66,11 @@ final class Icon_Size_Adapter extends Abstract_Adapter {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, mixed> $attributes The block's attributes.
+	 * @param array<string, mixed> $attributes The block's registration default attributes.
 	 *
-	 * @return array<string, mixed> The transformed attributes.
+	 * @return array<string, mixed> The transformed default attributes.
 	 */
 	public function apply( array $attributes ): array {
-		if ( isset( $attributes['size'] ) ) {
-			return $attributes; // A stored value (including 0) always wins.
-		}
-
 		$length = $this->resolver->resolve()->value( self::TOKEN );
 
 		if ( $length === null ) {

--- a/includes/resources/Design_Tokens/Projection/Adapter/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Adapter/Provider.php
@@ -28,7 +28,9 @@ final class Provider extends Provider_Contract {
 	 *
 	 * @var class-string<Adapter_Interface>[]
 	 */
-	private const ADAPTERS = [];
+	private const ADAPTERS = [
+		Icon_Size_Adapter::class,
+	];
 
 	/**
 	 * @inheritDoc
@@ -63,7 +65,7 @@ final class Provider extends Provider_Contract {
 		/** @var Token_Registry $registry */
 		$registry = $this->container->get( Token_Registry::class );
 
-		foreach ( self::ADAPTERS as $adapter ) { // @phpstan-ignore foreach.emptyArray (Remove once ADAPTERS lists an adapter.)
+		foreach ( self::ADAPTERS as $adapter ) {
 			/** @var Adapter_Interface $instance */
 			$instance = $this->container->get( $adapter );
 			$registry->register_adapter( $instance );

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Adapter/Icon_Size_AdapterTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Adapter/Icon_Size_AdapterTest.php
@@ -1,0 +1,175 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Projection\Adapter;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Icon_Size_Adapter;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Projector;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Css_Renderer;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use Tests\Support\Classes\Fake_Baseline_Document;
+use Tests\Support\Classes\TestCase;
+
+final class Icon_Size_AdapterTest extends TestCase {
+
+	/**
+	 * A baseline whose `semantic.icon-size.default` resolves to the given dimension value, mirroring
+	 * Icon_Size_ResolutionTest's own helper so the resolver behind this adapter is built the same way
+	 * every other icon-size test already builds it.
+	 *
+	 * @param string $value The `$value` the `semantic.icon-size.default` leaf resolves to.
+	 *
+	 * @return Token_Resolver
+	 */
+	private function resolver_resolving_to( string $value ): Token_Resolver {
+		return $this->resolver_for(
+			[
+				'semantic' => [
+					'icon-size' => [
+						'default' => [
+							'$type'  => 'dimension',
+							'$value' => $value,
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * A resolver over a baseline with no `semantic.icon-size.default` leaf at all, so the token is
+	 * genuinely unresolved rather than resolved to an unrecognized value.
+	 *
+	 * @return Token_Resolver
+	 */
+	private function resolver_with_no_icon_size_token(): Token_Resolver {
+		return $this->resolver_for( [] );
+	}
+
+	/**
+	 * Build a resolver over a fully-controlled baseline.
+	 *
+	 * @param array<string, mixed> $baseline
+	 *
+	 * @return Token_Resolver
+	 */
+	private function resolver_for( array $baseline ): Token_Resolver {
+		return new Token_Resolver(
+			$this->container->get( Token_Store::class ),
+			new Effective_Document( new Fake_Baseline_Document( $baseline ) ),
+			new Css_Renderer()
+		);
+	}
+
+	/**
+	 * A stored `size` of any value, including `0`, always wins over the token-resolved default.
+	 *
+	 * @return void
+	 */
+	public function testStoredSizeIsNeverOverwritten(): void {
+		$adapter = new Icon_Size_Adapter( $this->resolver_resolving_to( '1.5rem' ) );
+
+		$attributes = $adapter->apply( [ 'size' => 0 ] );
+
+		$this->assertSame( [ 'size' => 0 ], $attributes );
+	}
+
+	/**
+	 * A missing `size` is filled from a `rem` token value, converted to px on the 16px root-size
+	 * assumption.
+	 *
+	 * @return void
+	 */
+	public function testMissingSizeIsFilledFromARemToken(): void {
+		$adapter = new Icon_Size_Adapter( $this->resolver_resolving_to( '1.5rem' ) );
+
+		$attributes = $adapter->apply( [] );
+
+		$this->assertSame( [ 'size' => 24.0 ], $attributes );
+	}
+
+	/**
+	 * A missing `size` is filled from a `px` token value, passed through as a bare number.
+	 *
+	 * @return void
+	 */
+	public function testMissingSizeIsFilledFromAPxToken(): void {
+		$adapter = new Icon_Size_Adapter( $this->resolver_resolving_to( '24px' ) );
+
+		$attributes = $adapter->apply( [] );
+
+		$this->assertSame( [ 'size' => 24.0 ], $attributes );
+	}
+
+	/**
+	 * A token value in a unit this adapter cannot safely convert leaves the attributes untouched
+	 * rather than guessing.
+	 *
+	 * @return void
+	 */
+	public function testUnrecognizedUnitLeavesAttributesUnchanged(): void {
+		$adapter = new Icon_Size_Adapter( $this->resolver_resolving_to( '2vw' ) );
+
+		$attributes = $adapter->apply( [] );
+
+		$this->assertSame( [], $attributes );
+	}
+
+	/**
+	 * An unresolved token (no `semantic.icon-size.default` leaf in the baseline) leaves the
+	 * attributes untouched rather than guessing.
+	 *
+	 * @return void
+	 */
+	public function testUnresolvedTokenLeavesAttributesUnchanged(): void {
+		$adapter = new Icon_Size_Adapter( $this->resolver_with_no_icon_size_token() );
+
+		$attributes = $adapter->apply( [] );
+
+		$this->assertSame( [], $attributes );
+	}
+
+	/**
+	 * `Icon_Size_Adapter` is registered against the real Token Registry on boot, so the real
+	 * `Adapter\Projector` finds it for `kadence/single-icon` and fills a missing `size` with the
+	 * shipped baseline's `semantic.icon-size.default` (1.5rem, i.e. 24px) — proving the wiring in
+	 * `Adapter\Provider::ADAPTERS`, not just the adapter class in isolation.
+	 *
+	 * @return void
+	 */
+	public function testTheRegisteredAdapterFillsSizeThroughTheRealProjector(): void {
+		/** @var Token_Registry $registry */
+		$registry = $this->container->get( Token_Registry::class );
+
+		$attributes = ( new Projector( $registry ) )->apply( [], 'kadence/single-icon' );
+
+		$this->assertSame( [ 'size' => 24.0 ], $attributes );
+	}
+
+	/**
+	 * The same fill happens through the real `kadence_blocks_block_default_attributes` filter chain,
+	 * proving `Adapter\Provider::register()` wired the projector into that hook, not just that the
+	 * standalone `Projector` object works.
+	 *
+	 * @return void
+	 */
+	public function testTheRegisteredAdapterFillsSizeThroughTheRealFilterChain(): void {
+		$attributes = apply_filters( 'kadence_blocks_block_default_attributes', [], 'kadence/single-icon' );
+
+		$this->assertSame( [ 'size' => 24.0 ], $attributes );
+	}
+
+	/**
+	 * A stored `size` survives the real filter chain untouched, confirming the adapter's "never
+	 * overwrite a stored value" guarantee holds end-to-end, not just in the isolated unit tests above.
+	 *
+	 * @return void
+	 */
+	public function testAStoredSizeSurvivesTheRealFilterChain(): void {
+		$attributes = apply_filters( 'kadence_blocks_block_default_attributes', [ 'size' => 12 ], 'kadence/single-icon' );
+
+		$this->assertSame( [ 'size' => 12 ], $attributes );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Adapter/Icon_Size_AdapterTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Adapter/Icon_Size_AdapterTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Projection\Adapter;
 
+use Kadence_Blocks_CSS;
+use Kadence_Blocks_Single_Icon_Block;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Icon_Size_Adapter;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Projector;
@@ -9,6 +11,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Css_Renderer;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use Tests\helpers\CSSTestHelper;
 use Tests\Support\Classes\Fake_Baseline_Document;
 use Tests\Support\Classes\TestCase;
 
@@ -64,16 +67,19 @@ final class Icon_Size_AdapterTest extends TestCase {
 	}
 
 	/**
-	 * A stored `size` of any value, including `0`, always wins over the token-resolved default.
+	 * The adapter runs on the block's registration defaults, not its stored instance attributes, so
+	 * a `size` already present in the given array (e.g. block.json's own hardcoded `50`) is
+	 * overwritten with the resolved token — `Kadence_Blocks_Abstract_Block::merge_attributes_with_defaults()`
+	 * is what lets a genuinely customized instance value win afterward, not a guard in this adapter.
 	 *
 	 * @return void
 	 */
-	public function testStoredSizeIsNeverOverwritten(): void {
+	public function testAnExistingDefaultIsOverwrittenWithTheResolvedToken(): void {
 		$adapter = new Icon_Size_Adapter( $this->resolver_resolving_to( '1.5rem' ) );
 
-		$attributes = $adapter->apply( [ 'size' => 0 ] );
+		$attributes = $adapter->apply( [ 'size' => 50 ] );
 
-		$this->assertSame( [ 'size' => 0 ], $attributes );
+		$this->assertSame( [ 'size' => 24.0 ], $attributes );
 	}
 
 	/**
@@ -162,14 +168,83 @@ final class Icon_Size_AdapterTest extends TestCase {
 	}
 
 	/**
-	 * A stored `size` survives the real filter chain untouched, confirming the adapter's "never
-	 * overwrite a stored value" guarantee holds end-to-end, not just in the isolated unit tests above.
+	 * The real filter chain overwrites `kadence/single-icon`'s registration default (block.json's
+	 * hardcoded `50`) with the resolved token, confirming the fix for the bug that let the adapter's
+	 * own registration default mask the token end-to-end, not just in the isolated unit test above.
 	 *
 	 * @return void
 	 */
-	public function testAStoredSizeSurvivesTheRealFilterChain(): void {
-		$attributes = apply_filters( 'kadence_blocks_block_default_attributes', [ 'size' => 12 ], 'kadence/single-icon' );
+	public function testTheRealFilterChainOverwritesTheBlockJsonDefaultWithTheResolvedToken(): void {
+		$attributes = apply_filters( 'kadence_blocks_block_default_attributes', [ 'size' => 50 ], 'kadence/single-icon' );
 
-		$this->assertSame( [ 'size' => 12 ], $attributes );
+		$this->assertSame( [ 'size' => 24.0 ], $attributes );
+	}
+
+	/**
+	 * A genuinely customized instance `size` still wins over the token-resolved default when a real
+	 * `kadence/single-icon` block renders through `render_css()` itself — the block's registered
+	 * `render_callback`, and the only entry point that actually gates `get_attributes_with_defaults()`
+	 * behind `Kadence_Blocks_Abstract_Block::$supports_merged_defaults`. Calling
+	 * `get_attributes_with_defaults()` directly (as the isolated tests above do) would pass even with
+	 * `single-icon` missing from that allowlist, since the gate lives in the caller, not the method.
+	 *
+	 * `render_css()` only inline-embeds its built CSS into the returned content for a classic theme (a block
+	 * theme's per-block CSS reaches the page through a separate, unrelated mechanism, and the wpunit
+	 * suite runs on a block theme), so this reads the CSS `build_css()` registered into
+	 * `Kadence_Blocks_CSS::$styles` — a side effect of `render_css()` that happens regardless of the
+	 * active theme — rather than the returned `$content`.
+	 *
+	 * @return void
+	 */
+	public function testACustomizedInstanceSizeWinsThroughTheRealRenderPath(): void {
+		$block      = new Kadence_Blocks_Single_Icon_Block();
+		$unique_id  = 'icon-size-adapter-customized';
+		$attributes = [
+			'size'     => 80,
+			'uniqueID' => $unique_id,
+		];
+
+		$block->render_css( $attributes, '<span class="kb-svg-icon-wrap"></span>', null );
+
+		$css_helper = new CSSTestHelper( Kadence_Blocks_CSS::$styles[ 'kb-single-icon' . $unique_id ] ?? '' );
+
+		$this->assertTrue(
+			$css_helper->assertCSSPropertiesEqual(
+				'.kt-svg-item-' . $unique_id . ' .kb-svg-icon-wrap, .kt-svg-style-stacked.kt-svg-item-' . $unique_id . ' .kb-svg-icon-wrap',
+				[ 'font-size' => '80px' ]
+			)
+		);
+	}
+
+	/**
+	 * An instance with no stored `size` renders with the token-resolved size when a real
+	 * `kadence/single-icon` block renders through `render_css()` itself — the block's registered
+	 * `render_callback` (see `Kadence_Blocks_Abstract_Block::on_init()`), which is the only entry
+	 * point that actually gates `get_attributes_with_defaults()` behind
+	 * `$supports_merged_defaults`. This is the path a real page render uses, and it is only reachable
+	 * because `single-icon` is registered in that allowlist.
+	 *
+	 * Reads `Kadence_Blocks_CSS::$styles` rather than the returned content; see the note on the
+	 * previous test for why.
+	 *
+	 * @return void
+	 */
+	public function testAMissingInstanceSizeIsFilledWithTheResolvedTokenThroughTheRealRenderPath(): void {
+		$block      = new Kadence_Blocks_Single_Icon_Block();
+		$unique_id  = 'icon-size-adapter-missing';
+		$attributes = [
+			'uniqueID' => $unique_id,
+		];
+
+		$block->render_css( $attributes, '<span class="kb-svg-icon-wrap"></span>', null );
+
+		$css_helper = new CSSTestHelper( Kadence_Blocks_CSS::$styles[ 'kb-single-icon' . $unique_id ] ?? '' );
+
+		$this->assertTrue(
+			$css_helper->assertCSSPropertiesEqual(
+				'.kt-svg-item-' . $unique_id . ' .kb-svg-icon-wrap, .kt-svg-style-stacked.kt-svg-item-' . $unique_id . ' .kb-svg-icon-wrap',
+				[ 'font-size' => '24px' ]
+			)
+		);
 	}
 }


### PR DESCRIPTION
## Summary

Adds the first concrete `Adapter_Interface`/`Abstract_Adapter` implementation in this module, `Icon_Size_Adapter`, which gap-fills `kadence/single-icon`'s `size` attribute from the resolved `semantic.icon-size.default` token.

- `Design_Tokens\Projection\Adapter\Icon_Size_Adapter` resolves `semantic.icon-size.default`, converts the resulting CSS length (e.g. `"1.5rem"`) to the raw pixel number `size` stores, and applies it only when the stored attributes genuinely omit `size` — an explicit value, including `0`, always wins.
- Registered in `Adapter\Provider::ADAPTERS` alongside the module's other adapters.
- Because `size` has no `source` key and defaults to `50`, WordPress's block serializer omits it from saved content for any block that was never customized away from the default — so this fires for the large majority of currently-published icon blocks, not a narrow legacy-content edge case. This affects the render-path/CSS-build gap-filling case broadly.
- Does not cover a freshly inserted `single-icon` block: that's a static (client-rendered) block, so a fresh insert's `size` comes from `block.json`'s JS default at insert time, before this render-path filter ever runs. A later PR in this stack closes that complementary "freshly inserted block" gap on the editor JS side.

## Test plan

- [x] `Icon_Size_AdapterTest` covers gap-filling when `size` is absent, leaving an explicit stored value (including `0`) untouched, unit conversion (`px`/`rem`/`em`), and the null/unresolvable-token fallback.
