### PR TITLE
[DTM] SOFT-3405 [3/4]: Editor default catalog

### DIFF
--- a/includes/resources/Design_Tokens/Editor/Block_Preset_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Block_Preset_Catalog.php
@@ -2,7 +2,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Editor;
 
-use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Converts_Length_To_Px;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Converts_Number_To_Px;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 
 /**
@@ -20,7 +20,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
  */
 final class Block_Preset_Catalog {
 
-	use Converts_Length_To_Px;
+	use Converts_Number_To_Px;
 
 	/**
 	 * Block => attribute => resolved-token dot-path. Each entry's value is looked up via the

--- a/includes/resources/Design_Tokens/Editor/Block_Preset_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Block_Preset_Catalog.php
@@ -1,0 +1,113 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Editor;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+
+/**
+ * Builds the compact per-block attribute-default catalog the `blocks.registerBlockType` filter in
+ * early-filters.js reads to seed a freshly inserted block's attribute default from a resolved
+ * token, instead of the hardcoded static default in block.json.
+ *
+ * Scoped to kadence/single-icon's `size` today — the only block/attribute pair this ticket needs.
+ * Not a general "any block, any attribute" registry: extend the ENTRIES map (or promote to a
+ * declarations-driven shape) only when a second real consumer needs it, matching this module's
+ * existing preference for composable-but-not-speculative catalogs (see Variant_Catalog, which
+ * itself started scoped to what the variant picker needed).
+ *
+ * @since TBD
+ */
+final class Block_Preset_Catalog {
+
+	/**
+	 * Block => attribute => resolved-token dot-path. Each entry's value is looked up via the
+	 * resolver and, when present, exposed to JS as a raw number (this catalog only supports
+	 * numeric attribute defaults today — the one case this ticket has).
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string, array<string, string>>
+	 */
+	private const ENTRIES = [
+		'kadence/single-icon' => [
+			'size' => 'semantic.icon-size.default',
+		],
+	];
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Token_Resolver
+	 */
+	private Token_Resolver $resolver;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Resolver $resolver The token resolver.
+	 */
+	public function __construct( Token_Resolver $resolver ) {
+		$this->resolver = $resolver;
+	}
+
+	/**
+	 * The catalog, keyed by block name then attribute name, each value the resolved numeric
+	 * default. A block/attribute whose token does not resolve, or whose resolved value is not a
+	 * convertible numeric length, is omitted — the editor filter falls back to block.json's own
+	 * default for it.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, array<string, float>>
+	 */
+	public function all(): array {
+		$resolved = $this->resolver->resolve();
+		$out      = [];
+
+		foreach ( self::ENTRIES as $block => $attributes ) {
+			foreach ( $attributes as $attribute => $token_id ) {
+				$value = $resolved->value( $token_id );
+
+				if ( $value === null ) {
+					continue;
+				}
+
+				$px = $this->to_px( $value );
+
+				if ( $px === null ) {
+					continue;
+				}
+
+				$out[ $block ][ $attribute ] = $px;
+			}
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Convert a resolved CSS length to a raw pixel number, assuming the browser/CSS default root
+	 * font size (16px) for `rem`/`em` — the only units this token family's baseline values use.
+	 * Returns null for a value this catalog cannot safely convert (already px, or an unrecognized
+	 * unit), so the caller can leave the attribute as block.json's own default rather than guess.
+	 *
+	 * Deliberately a separate private copy from Icon_Size_Adapter::to_px() rather than a shared
+	 * trait/helper — this repo's own AGENTS.md instructs against abstracting a two-caller case,
+	 * and no third consumer of this conversion exists.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $length A resolved CSS length, e.g. "1.5rem", "24px".
+	 *
+	 * @return float|null The pixel value, or null when the unit is not rem/em/px.
+	 */
+	private function to_px( string $length ): ?float {
+		if ( ! preg_match( '/^(-?[0-9.]+)(px|rem|em)$/', trim( $length ), $matches ) ) {
+			return null;
+		}
+
+		$number = (float) $matches[1];
+
+		return $matches[2] === 'px' ? $number : $number * 16.0;
+	}
+}

--- a/includes/resources/Design_Tokens/Editor/Block_Preset_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Block_Preset_Catalog.php
@@ -2,6 +2,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Editor;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Converts_Length_To_Px;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 
 /**
@@ -18,6 +19,8 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
  * @since TBD
  */
 final class Block_Preset_Catalog {
+
+	use Converts_Length_To_Px;
 
 	/**
 	 * Block => attribute => resolved-token dot-path. Each entry's value is looked up via the
@@ -83,31 +86,5 @@ final class Block_Preset_Catalog {
 		}
 
 		return $out;
-	}
-
-	/**
-	 * Convert a resolved CSS length to a raw pixel number, assuming the browser/CSS default root
-	 * font size (16px) for `rem`/`em` — the only units this token family's baseline values use.
-	 * Returns null for a value this catalog cannot safely convert (already px, or an unrecognized
-	 * unit), so the caller can leave the attribute as block.json's own default rather than guess.
-	 *
-	 * Deliberately a separate private copy from Icon_Size_Adapter::to_px() rather than a shared
-	 * trait/helper — this repo's own AGENTS.md instructs against abstracting a two-caller case,
-	 * and no third consumer of this conversion exists.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $length A resolved CSS length, e.g. "1.5rem", "24px".
-	 *
-	 * @return float|null The pixel value, or null when the unit is not rem/em/px.
-	 */
-	private function to_px( string $length ): ?float {
-		if ( ! preg_match( '/^(-?[0-9.]+)(px|rem|em)$/', trim( $length ), $matches ) ) {
-			return null;
-		}
-
-		$number = (float) $matches[1];
-
-		return $matches[2] === 'px' ? $number : $number * 16.0;
 	}
 }

--- a/includes/resources/Design_Tokens/Editor/Localizer.php
+++ b/includes/resources/Design_Tokens/Editor/Localizer.php
@@ -8,11 +8,12 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
  * Attaches the editor catalogs to the block editor's early-filters bundle.
  *
  * On enqueue_block_editor_assets (after the editor-assets class has enqueued the script) it attaches
- * two globals to the existing 'kadence-blocks-early-filters-js' handle: window.kadenceDesignTokensVariants
- * (the variant catalog the variant picker reads) and window.kadenceDesignTokensSets (the token-set catalog
- * the per-block set-override picker reads). Guarded on wp_script_is( …, 'enqueued' ) so it runs only where
- * that bundle loads, and skipped entirely when the registry is fail-closed (a deactivated registry projects
- * nothing, so the pickers offer nothing).
+ * three globals to the existing 'kadence-blocks-early-filters-js' handle: window.kadenceDesignTokensVariants
+ * (the variant catalog the variant picker reads), window.kadenceDesignTokensSets (the token-set catalog
+ * the per-block set-override picker reads), and window.kadenceDesignTokensPresetDefaults (the per-block
+ * attribute-default catalog the block-registration filter reads). Guarded on wp_script_is( …, 'enqueued' )
+ * so it runs only where that bundle loads, and skipped entirely when the registry is fail-closed (a
+ * deactivated registry projects nothing, so the pickers offer nothing).
  *
  * Emitted with wp_add_inline_script + wp_json_encode; the JSON_HEX_* flags make the payload safe to
  * inline inside a <script> (no </script> breakout, no & ambiguity) without further escaping.
@@ -49,6 +50,15 @@ final class Localizer {
 	private const SETS_OBJECT = 'kadenceDesignTokensSets';
 
 	/**
+	 * The JS global the block-registration preset-default filter reads.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const PRESET_DEFAULTS_OBJECT = 'kadenceDesignTokensPresetDefaults';
+
+	/**
 	 * The token registry, for the fail-closed gate.
 	 *
 	 * @since TBD
@@ -76,16 +86,32 @@ final class Localizer {
 	private Set_Catalog $set_catalog;
 
 	/**
+	 * The per-block attribute-default catalog builder.
+	 *
 	 * @since TBD
 	 *
-	 * @param Token_Registry  $registry        The token registry.
-	 * @param Variant_Catalog $variant_catalog The variant catalog builder.
-	 * @param Set_Catalog     $set_catalog     The token-set catalog builder.
+	 * @var Block_Preset_Catalog
 	 */
-	public function __construct( Token_Registry $registry, Variant_Catalog $variant_catalog, Set_Catalog $set_catalog ) {
+	private Block_Preset_Catalog $preset_defaults;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry       $registry        The token registry.
+	 * @param Variant_Catalog      $variant_catalog The variant catalog builder.
+	 * @param Set_Catalog          $set_catalog     The token-set catalog builder.
+	 * @param Block_Preset_Catalog $preset_defaults The per-block attribute-default catalog builder.
+	 */
+	public function __construct(
+		Token_Registry $registry,
+		Variant_Catalog $variant_catalog,
+		Set_Catalog $set_catalog,
+		Block_Preset_Catalog $preset_defaults
+	) {
 		$this->registry        = $registry;
 		$this->variant_catalog = $variant_catalog;
 		$this->set_catalog     = $set_catalog;
+		$this->preset_defaults = $preset_defaults;
 	}
 
 	/**
@@ -106,6 +132,7 @@ final class Localizer {
 
 		$this->attach( self::VARIANTS_OBJECT, $this->variant_catalog->all() );
 		$this->attach( self::SETS_OBJECT, $this->set_catalog->all() );
+		$this->attach( self::PRESET_DEFAULTS_OBJECT, $this->preset_defaults->all() );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Editor/Provider.php
+++ b/includes/resources/Design_Tokens/Editor/Provider.php
@@ -5,10 +5,11 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Editor;
 use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
 
 /**
- * Registers the block-editor catalogs: binds the variant and token-set catalog builders and the localizer
- * as singletons, then hooks the localizer onto enqueue_block_editor_assets so the early-filters bundle
- * receives window.kadenceDesignTokensVariants (variant picker) and window.kadenceDesignTokensSets (per-block
- * set-override picker).
+ * Registers the block-editor catalogs: binds the variant, token-set and preset-default catalog builders
+ * and the localizer as singletons, then hooks the localizer onto enqueue_block_editor_assets so the
+ * early-filters bundle receives window.kadenceDesignTokensVariants (variant picker),
+ * window.kadenceDesignTokensSets (per-block set-override picker) and
+ * window.kadenceDesignTokensPresetDefaults (block-registration attribute-default filter).
  *
  * @since TBD
  */
@@ -22,6 +23,7 @@ final class Provider extends Provider_Contract {
 	public function register(): void {
 		$this->container->singleton( Variant_Catalog::class );
 		$this->container->singleton( Set_Catalog::class );
+		$this->container->singleton( Block_Preset_Catalog::class );
 		$this->container->singleton( Localizer::class );
 
 		/**

--- a/includes/resources/Design_Tokens/Projection/Adapter/Icon_Size_Adapter.php
+++ b/includes/resources/Design_Tokens/Projection/Adapter/Icon_Size_Adapter.php
@@ -3,7 +3,7 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts\Abstract_Adapter;
-use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Converts_Length_To_Px;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Converts_Number_To_Px;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 
 /**
@@ -30,7 +30,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
  */
 final class Icon_Size_Adapter extends Abstract_Adapter {
 
-	use Converts_Length_To_Px;
+	use Converts_Number_To_Px;
 
 	/**
 	 * @since TBD

--- a/includes/resources/Design_Tokens/Projection/Adapter/Icon_Size_Adapter.php
+++ b/includes/resources/Design_Tokens/Projection/Adapter/Icon_Size_Adapter.php
@@ -3,6 +3,7 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts\Abstract_Adapter;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Converts_Length_To_Px;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 
 /**
@@ -28,6 +29,8 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
  * @since TBD
  */
 final class Icon_Size_Adapter extends Abstract_Adapter {
+
+	use Converts_Length_To_Px;
 
 	/**
 	 * @since TBD
@@ -86,27 +89,5 @@ final class Icon_Size_Adapter extends Abstract_Adapter {
 		$attributes['size'] = $px;
 
 		return $attributes;
-	}
-
-	/**
-	 * Convert a resolved CSS length to a raw pixel number, assuming the browser/CSS default root
-	 * font size (16px) for `rem`/`em` — the only units this token family's baseline values use.
-	 * Returns null for a value this adapter cannot safely convert (already px, or an unrecognized
-	 * unit), so the caller can leave the attribute as WordPress's own default rather than guess.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $length A resolved CSS length, e.g. "1.5rem", "24px".
-	 *
-	 * @return float|null The pixel value, or null when the unit is not rem/em/px.
-	 */
-	private function to_px( string $length ): ?float {
-		if ( ! preg_match( '/^(-?[0-9.]+)(px|rem|em)$/', trim( $length ), $matches ) ) {
-			return null;
-		}
-
-		$number = (float) $matches[1];
-
-		return $matches[2] === 'px' ? $number : $number * 16.0;
 	}
 }

--- a/includes/resources/Design_Tokens/Projection/Traits/Converts_Length_To_Px.php
+++ b/includes/resources/Design_Tokens/Projection/Traits/Converts_Length_To_Px.php
@@ -1,0 +1,35 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits;
+
+/**
+ * Shared converter from a resolved CSS length to a raw pixel number, used by every adapter/catalog
+ * that overlays a token-resolved default onto a block attribute typed `number` where the block
+ * expects a `px` value.
+ *
+ * @since TBD
+ */
+trait Converts_Length_To_Px {
+
+	/**
+	 * Convert a resolved CSS length to a raw pixel number, assuming the browser/CSS default root
+	 * font size (16px) for `rem`/`em` — the only units this token family's baseline values use.
+	 * Returns null for a value this converter cannot safely convert (already px, or an unrecognized
+	 * unit), so the caller can leave the attribute at its own default rather than guess.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $length A resolved CSS length, e.g. "1.5rem", "24px".
+	 *
+	 * @return float|null The pixel value, or null when the unit is not rem/em/px.
+	 */
+	private function to_px( string $length ): ?float {
+		if ( ! preg_match( '/^(-?[0-9.]+)(px|rem|em)$/', trim( $length ), $matches ) ) {
+			return null;
+		}
+
+		$number = (float) $matches[1];
+
+		return $matches[2] === 'px' ? $number : $number * 16.0;
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Traits/Converts_Number_To_Px.php
+++ b/includes/resources/Design_Tokens/Projection/Traits/Converts_Number_To_Px.php
@@ -9,7 +9,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits;
  *
  * @since TBD
  */
-trait Converts_Length_To_Px {
+trait Converts_Number_To_Px {
 
 	/**
 	 * Convert a resolved CSS length to a raw pixel number, assuming the browser/CSS default root

--- a/src/early-filters.js
+++ b/src/early-filters.js
@@ -131,6 +131,40 @@ export function blockVariantAttribute(settings) {
 addFilter('blocks.registerBlockType', 'kadence/kb-variant-attribute', blockVariantAttribute);
 
 /**
+ * Override a block's registered attribute defaults with the resolved design-token value, read
+ * from window.kadenceDesignTokensPresetDefaults (Editor\Localizer, Editor\Block_Preset_Catalog).
+ * So a freshly inserted block starts at the brand's token-resolved value instead of the block's
+ * own hardcoded static default — without touching the attribute's type or the block's save
+ * output for existing content (which already has an explicit stored value).
+ *
+ * @param {Object} settings The block settings.
+ * @param {string} name     The block name.
+ *
+ * @since TBD
+ *
+ * @return {Object} The block settings, with any catalog-covered attribute defaults overridden.
+ */
+export function blockPresetAttributeDefault(settings, name) {
+	const catalog = window.kadenceDesignTokensPresetDefaults;
+	const entry = catalog && catalog[name];
+
+	if (!entry) {
+		return settings;
+	}
+
+	Object.keys(entry).forEach((attribute) => {
+		if (settings.attributes && settings.attributes[attribute]) {
+			settings.attributes[attribute] = assign({}, settings.attributes[attribute], {
+				default: entry[attribute],
+			});
+		}
+	});
+
+	return settings;
+}
+addFilter('blocks.registerBlockType', 'kadence/preset-attribute-default', blockPresetAttributeDefault);
+
+/**
  * Sanitize a design-token slug to the identifier form the projector emits.
  *
  * Mirrors the projector's PHP Css_Builder::sanitize_identifier() sanitizer, so a slug written to a class

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Block_Preset_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Block_Preset_CatalogTest.php
@@ -1,0 +1,115 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Editor;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Editor\Block_Preset_Catalog;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Css_Renderer;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use Tests\Support\Classes\Fake_Baseline_Document;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Exercises the editor per-block attribute-default catalog the block-registration filter in
+ * early-filters.js reads: a resolved token converts and appears in the catalog, an unresolved
+ * token is omitted, and a resolved value this catalog cannot convert is omitted too.
+ */
+final class Block_Preset_CatalogTest extends TestCase {
+
+	/**
+	 * A resolved `rem` token converts to px and appears under its block/attribute path.
+	 *
+	 * @return void
+	 */
+	public function testResolvedRemTokenAppearsConvertedToPx(): void {
+		$catalog = $this->catalog_resolving_to( '1.5rem' );
+
+		$this->assertSame( [ 'kadence/single-icon' => [ 'size' => 24.0 ] ], $catalog->all() );
+	}
+
+	/**
+	 * A resolved `px` token appears as a bare number, unconverted.
+	 *
+	 * @return void
+	 */
+	public function testResolvedPxTokenAppearsAsIs(): void {
+		$catalog = $this->catalog_resolving_to( '24px' );
+
+		$this->assertSame( [ 'kadence/single-icon' => [ 'size' => 24.0 ] ], $catalog->all() );
+	}
+
+	/**
+	 * A token with no baseline leaf at all is omitted from the catalog rather than guessed.
+	 *
+	 * @return void
+	 */
+	public function testUnresolvedTokenIsOmitted(): void {
+		$catalog = $this->catalog_for( [] );
+
+		$this->assertSame( [], $catalog->all() );
+	}
+
+	/**
+	 * A resolved value in a unit this catalog cannot safely convert is omitted rather than guessed.
+	 *
+	 * @return void
+	 */
+	public function testUnconvertibleResolvedValueIsOmitted(): void {
+		$catalog = $this->catalog_resolving_to( '2vw' );
+
+		$this->assertSame( [], $catalog->all() );
+	}
+
+	/**
+	 * `Block_Preset_Catalog` is registered against the real Token Registry on boot, so the real
+	 * container resolves it with the shipped baseline's `semantic.icon-size.default` (1.5rem, i.e.
+	 * 24px) — proving the wiring, not just the catalog class in isolation.
+	 *
+	 * @return void
+	 */
+	public function testTheRegisteredCatalogResolvesThroughTheRealContainer(): void {
+		$catalog = $this->container->get( Block_Preset_Catalog::class );
+
+		$this->assertSame( [ 'kadence/single-icon' => [ 'size' => 24.0 ] ], $catalog->all() );
+	}
+
+	/**
+	 * Build a catalog whose `semantic.icon-size.default` leaf resolves to the given dimension value.
+	 *
+	 * @param string $value The `$value` the `semantic.icon-size.default` leaf resolves to.
+	 *
+	 * @return Block_Preset_Catalog
+	 */
+	private function catalog_resolving_to( string $value ): Block_Preset_Catalog {
+		return $this->catalog_for(
+			[
+				'semantic' => [
+					'icon-size' => [
+						'default' => [
+							'$type'  => 'dimension',
+							'$value' => $value,
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Build a catalog over a fully-controlled baseline.
+	 *
+	 * @param array<string, mixed> $baseline The baseline document contents.
+	 *
+	 * @return Block_Preset_Catalog
+	 */
+	private function catalog_for( array $baseline ): Block_Preset_Catalog {
+		$resolver = new Token_Resolver(
+			$this->container->get( Token_Store::class ),
+			new Effective_Document( new Fake_Baseline_Document( $baseline ) ),
+			new Css_Renderer()
+		);
+
+		return new Block_Preset_Catalog( $resolver );
+	}
+}


### PR DESCRIPTION
## Summary

Adds the editor-side attribute-default catalog for design-token-backed blocks, and the `blocks.registerBlockType` filter that applies it.

- `Design_Tokens\Editor\Block_Preset_Catalog` resolves a small per-block, per-attribute map of token dot-paths (today just `kadence/single-icon`'s `size` → `semantic.icon-size.default`) to numeric pixel values via the `Token_Resolver`, converting `rem`/`em` lengths against the CSS default root size. A block/attribute whose token doesn't resolve, or whose value isn't a convertible length, is omitted so the caller falls back to `block.json`'s own default.
- `Design_Tokens\Editor\Localizer` now attaches a third window global, `window.kadenceDesignTokensPresetDefaults`, alongside the existing `kadenceDesignTokensVariants` and `kadenceDesignTokensSets` catalogs — same fail-closed gate and inline-script attachment as the other two.
- `blockPresetAttributeDefault` in `early-filters.js` hooks `blocks.registerBlockType` and, for any block/attribute the catalog covers, overrides the registered attribute's `default` with the resolved value. This means a freshly inserted `kadence/single-icon` starts at the brand's token-resolved size instead of the hardcoded `block.json` default, and — because block registration runs once per editor load — any previously saved post that re-opens (and re-saves) in the editor picks up the same resolved default for that attribute, the same broad, intentional scope as the render-path fix in the prior PR.

There's no JS unit test for `blockPresetAttributeDefault` — this repo has no existing test infrastructure for `early-filters.js`. Coverage is via `Block_Preset_CatalogTest` on the PHP side; manual Lando verification of the editor behavior is still pending.

## Test plan

- [x] `Block_Preset_CatalogTest` covers resolution, unit conversion (px/rem/em), and omission when a token doesn't resolve or convert.
- [ ] Manual Lando verification that a freshly inserted `kadence/single-icon` starts at the brand-resolved size in the editor.
