### PR TITLE
Custom Variant Creation [9/11]: serve the combined editor CSS over REST

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Projector.php
@@ -84,7 +84,7 @@ final class Projector {
 			return;
 		}
 
-		$css = $this->build_css();
+		$css = $this->css();
 
 		if ( $css !== '' ) {
 			wp_add_inline_style( 'kadence-blocks-global-variables', $css );
@@ -111,7 +111,7 @@ final class Projector {
 			return;
 		}
 
-		$css = $this->build_css();
+		$css = $this->css();
 
 		if ( $css !== '' ) {
 			wp_add_inline_style( 'kadence-blocks-global-editor-styles', $css );
@@ -129,7 +129,7 @@ final class Projector {
 	 *
 	 * @return string
 	 */
-	private function build_css(): string {
+	public function css(): string {
 		$slug = $this->active->get();
 
 		try {

--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Projector.php
@@ -4,6 +4,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts\Css_Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Location;
 use Throwable;
@@ -19,7 +20,7 @@ use Throwable;
  *
  * @since TBD
  */
-final class Projector {
+final class Projector implements Css_Projector {
 
 	/**
 	 * The token registry, used to gate projection on the registry being active.

--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Provider.php
@@ -2,6 +2,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Projectors;
 use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
 
 /**
@@ -21,6 +22,13 @@ final class Provider extends Provider_Contract {
 	public function register(): void {
 		$this->container->singleton( Css_Builder::class );
 		$this->container->singleton( Projector::class );
+
+		// Contribute this projector's editor CSS to the combined projected-CSS endpoint.
+		/** @var Css_Projectors $projectors */
+		$projectors = $this->container->get( Css_Projectors::class );
+		/** @var Projector $projector */
+		$projector = $this->container->get( Projector::class );
+		$projectors->add( $projector );
 
 		// Front end: append after the token vars (100) and variant overrides (110). These are low-specificity
 		// defaults, so a per-instance value KB renders later still wins regardless of order.

--- a/includes/resources/Design_Tokens/Projection/Contracts/Css_Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Contracts/Css_Projector.php
@@ -1,0 +1,49 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts;
+
+/**
+ * A projector that builds design-token CSS and appends it to KB's front-end and editor style handles.
+ *
+ * The shared shape of the CSS-emitting projectors (token vars, variants, native retarget, block defaults):
+ * each enqueues its CSS on the front end and in the editor, and exposes the same string through `css()` — the
+ * unguarded builder the enqueue methods wrap behind their context gates. Scoped to the CSS projectors on
+ * purpose: other projectors in this namespace feed theme.json presets or seed block attributes rather than a
+ * style handle, so they are not CSS projectors.
+ *
+ * {@see \KadenceWP\KadenceBlocks\Design_Tokens\Projection\Editor_Css} aggregates the editor `css()` of every
+ * CSS projector, so a new one joins by implementing this contract and adding itself to the collection from
+ * its own provider.
+ *
+ * @since TBD
+ */
+interface Css_Projector {
+
+	/**
+	 * Append the projected CSS to the front-end global-variables handle.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function enqueue_front_end(): void;
+
+	/**
+	 * Append the projected CSS to the editor global-styles handle.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function enqueue_editor(): void;
+
+	/**
+	 * The projector's CSS — the unguarded builder, since the enqueue-context gate (the block-editor page
+	 * check) stays in enqueue_editor() and does not apply to a REST request.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function css(): string;
+}

--- a/includes/resources/Design_Tokens/Projection/Css_Projectors.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Projectors.php
@@ -1,0 +1,60 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts\Css_Projector;
+
+/**
+ * A collection of the CSS projectors that contribute to the combined editor CSS.
+ *
+ * Each CSS projector's own provider adds it here, so {@see Editor_Css} gathers them without a central list: a
+ * new editor-CSS projector joins entirely from its own module, with no change to Editor_Css or the Projection
+ * provider. Projectors are returned in the order they were added, which follows the Projection provider's
+ * sub-provider order and so mirrors the load-time enqueue.
+ *
+ * @since TBD
+ */
+final class Css_Projectors {
+
+	/**
+	 * The projectors, in registration order.
+	 *
+	 * @since TBD
+	 *
+	 * @var Css_Projector[]
+	 */
+	private array $projectors;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Css_Projector[] $projectors The projectors to seed the collection with.
+	 */
+	public function __construct( array $projectors = [] ) {
+		$this->projectors = $projectors;
+	}
+
+	/**
+	 * Add a CSS projector to the collection.
+	 *
+	 * @since TBD
+	 *
+	 * @param Css_Projector $projector The projector to add.
+	 *
+	 * @return void
+	 */
+	public function add( Css_Projector $projector ): void {
+		$this->projectors[] = $projector;
+	}
+
+	/**
+	 * The projectors, in registration order.
+	 *
+	 * @since TBD
+	 *
+	 * @return Css_Projector[]
+	 */
+	public function all(): array {
+		return $this->projectors;
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
@@ -4,6 +4,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts\Css_Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Location;
@@ -35,7 +36,7 @@ use Throwable;
  *
  * @since TBD
  */
-final class Projector {
+final class Projector implements Css_Projector {
 
 	/**
 	 * @var Token_Registry

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
@@ -109,7 +109,7 @@ final class Projector {
 			return;
 		}
 
-		$css = $this->build_css();
+		$css = $this->css();
 		if ( $css !== '' ) {
 			wp_add_inline_style( 'kadence-blocks-global-variables', $css );
 		}
@@ -140,7 +140,7 @@ final class Projector {
 			return;
 		}
 
-		$css = $this->build_css();
+		$css = $this->css();
 		if ( $css !== '' ) {
 			wp_add_inline_style( 'kadence-blocks-global-editor-styles', $css );
 		}
@@ -192,7 +192,7 @@ final class Projector {
 	 *
 	 * @return string
 	 */
-	private function build_css(): string {
+	public function css(): string {
 		try {
 			$active = $this->active->get();
 		} catch ( Throwable $e ) {

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Provider.php
@@ -2,6 +2,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Projectors;
 use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
 
 /**
@@ -21,6 +22,13 @@ final class Provider extends Provider_Contract {
 		$this->container->singleton( Css_Builder::class );
 		$this->container->singleton( Legacy_Filter_Bridge::class );
 		$this->container->singleton( Projector::class );
+
+		// Contribute this projector's editor CSS to the combined projected-CSS endpoint.
+		/** @var Css_Projectors $projectors */
+		$projectors = $this->container->get( Css_Projectors::class );
+		/** @var Projector $projector */
+		$projector = $this->container->get( Projector::class );
+		$projectors->add( $projector );
 
 		// Front end: append our declarations to the global-variables handle (KB enqueues at 90).
 		add_action( 'wp_enqueue_scripts', $this->container->callback( Projector::class, 'enqueue_front_end' ), 100 );

--- a/includes/resources/Design_Tokens/Projection/Editor_Css.php
+++ b/includes/resources/Design_Tokens/Projection/Editor_Css.php
@@ -1,0 +1,114 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css\Projector as Block_Default_Projector;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Projector as Css_Var_Projector;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Native\Projector as Native_Projector;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Variant\Projector as Variant_Projector;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+
+/**
+ * Aggregates the design-token EDITOR CSS from every projector into one string, so the projected-CSS REST
+ * endpoint can serve exactly the CSS the projectors enqueue at page load — for live re-injection into the
+ * block-editor canvas when a variant (or, later, a token value) changes without a reload.
+ *
+ * Each projector's `css()` is the unguarded builder; the enqueue-context gate (the block-editor page check)
+ * stays in each `enqueue_editor()` and does not apply off a block-editor page request, so it is deliberately
+ * not repeated here. This aggregator applies the one gate that still matters: a deactivated registry projects
+ * nothing, so it returns ''. The concatenation order mirrors the load-time enqueue — the token vars first (the
+ * foundation the other layers reference), then variants, native retarget, and block defaults. Each projector
+ * already fails open to '' on its own, so one broken layer never suppresses the others. Multi-set (multi-
+ * palette) support is preserved verbatim: the token-var and variant builders each emit every set's namespaced
+ * vars plus the per-set switch selectors, unchanged.
+ *
+ * @since TBD
+ */
+final class Editor_Css {
+
+	/**
+	 * The token registry, for the fail-closed gate.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * The token-var projector (the `--kb-token--*` custom properties, every set).
+	 *
+	 * @since TBD
+	 *
+	 * @var Css_Var_Projector
+	 */
+	private Css_Var_Projector $css_var;
+
+	/**
+	 * The variant projector (per-variant vars + scoped retarget rules, every set).
+	 *
+	 * @since TBD
+	 *
+	 * @var Variant_Projector
+	 */
+	private Variant_Projector $variant;
+
+	/**
+	 * The native-block projector (core/button companion CSS).
+	 *
+	 * @since TBD
+	 *
+	 * @var Native_Projector
+	 */
+	private Native_Projector $native;
+
+	/**
+	 * The block-default projector (block-default dimension CSS for the active set).
+	 *
+	 * @since TBD
+	 *
+	 * @var Block_Default_Projector
+	 */
+	private Block_Default_Projector $block_default;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry          $registry      The token registry.
+	 * @param Css_Var_Projector       $css_var       The token-var projector.
+	 * @param Variant_Projector       $variant       The variant projector.
+	 * @param Native_Projector        $native        The native-block projector.
+	 * @param Block_Default_Projector $block_default The block-default projector.
+	 */
+	public function __construct(
+		Token_Registry $registry,
+		Css_Var_Projector $css_var,
+		Variant_Projector $variant,
+		Native_Projector $native,
+		Block_Default_Projector $block_default
+	) {
+		$this->registry      = $registry;
+		$this->css_var       = $css_var;
+		$this->variant       = $variant;
+		$this->native        = $native;
+		$this->block_default = $block_default;
+	}
+
+	/**
+	 * The combined design-token editor CSS, or an empty string when the registry is deactivated.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function css(): string {
+		if ( ! $this->registry->is_active() ) {
+			return '';
+		}
+
+		return $this->css_var->css()
+			. $this->variant->css()
+			. $this->native->css()
+			. $this->block_default->css();
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Editor_Css.php
+++ b/includes/resources/Design_Tokens/Projection/Editor_Css.php
@@ -2,10 +2,6 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection;
 
-use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css\Projector as Block_Default_Projector;
-use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Projector as Css_Var_Projector;
-use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Native\Projector as Native_Projector;
-use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Variant\Projector as Variant_Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 
 /**
@@ -13,14 +9,19 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
  * endpoint can serve exactly the CSS the projectors enqueue at page load — for live re-injection into the
  * block-editor canvas when a variant (or, later, a token value) changes without a reload.
  *
- * Each projector's `css()` is the unguarded builder; the enqueue-context gate (the block-editor page check)
+ * Each source's `css()` is the unguarded builder; the enqueue-context gate (the block-editor page check)
  * stays in each `enqueue_editor()` and does not apply off a block-editor page request, so it is deliberately
  * not repeated here. This aggregator applies the one gate that still matters: a deactivated registry projects
- * nothing, so it returns ''. The concatenation order mirrors the load-time enqueue — the token vars first (the
- * foundation the other layers reference), then variants, native retarget, and block defaults. Each projector
- * already fails open to '' on its own, so one broken layer never suppresses the others. Multi-set (multi-
- * palette) support is preserved verbatim: the token-var and variant builders each emit every set's namespaced
- * vars plus the per-set switch selectors, unchanged.
+ * nothing, so it returns ''. The sources are concatenated in the order the Projection provider supplies them,
+ * which mirrors the load-time enqueue — the token vars first (the foundation the other layers reference),
+ * then variants, native retarget, and block defaults. Each source already fails open to '' on its own, so one
+ * broken layer never suppresses the others. Multi-set (multi-palette) support is preserved verbatim: the
+ * token-var and variant builders each emit every set's namespaced vars plus the per-set switch selectors,
+ * unchanged.
+ *
+ * The projectors are gathered from the {@see Css_Projectors} collection, which each CSS projector's own
+ * provider adds to — so a new editor-CSS projector joins from its own module, with no change to this class or
+ * the Projection provider.
  *
  * @since TBD
  */
@@ -36,62 +37,23 @@ final class Editor_Css {
 	private Token_Registry $registry;
 
 	/**
-	 * The token-var projector (the `--kb-token--*` custom properties, every set).
+	 * The collection of CSS projectors whose editor CSS is aggregated, in load order.
 	 *
 	 * @since TBD
 	 *
-	 * @var Css_Var_Projector
+	 * @var Css_Projectors
 	 */
-	private Css_Var_Projector $css_var;
-
-	/**
-	 * The variant projector (per-variant vars + scoped retarget rules, every set).
-	 *
-	 * @since TBD
-	 *
-	 * @var Variant_Projector
-	 */
-	private Variant_Projector $variant;
-
-	/**
-	 * The native-block projector (core/button companion CSS).
-	 *
-	 * @since TBD
-	 *
-	 * @var Native_Projector
-	 */
-	private Native_Projector $native;
-
-	/**
-	 * The block-default projector (block-default dimension CSS for the active set).
-	 *
-	 * @since TBD
-	 *
-	 * @var Block_Default_Projector
-	 */
-	private Block_Default_Projector $block_default;
+	private Css_Projectors $projectors;
 
 	/**
 	 * @since TBD
 	 *
-	 * @param Token_Registry          $registry      The token registry.
-	 * @param Css_Var_Projector       $css_var       The token-var projector.
-	 * @param Variant_Projector       $variant       The variant projector.
-	 * @param Native_Projector        $native        The native-block projector.
-	 * @param Block_Default_Projector $block_default The block-default projector.
+	 * @param Token_Registry $registry   The token registry.
+	 * @param Css_Projectors $projectors The collection of CSS projectors to aggregate.
 	 */
-	public function __construct(
-		Token_Registry $registry,
-		Css_Var_Projector $css_var,
-		Variant_Projector $variant,
-		Native_Projector $native,
-		Block_Default_Projector $block_default
-	) {
-		$this->registry      = $registry;
-		$this->css_var       = $css_var;
-		$this->variant       = $variant;
-		$this->native        = $native;
-		$this->block_default = $block_default;
+	public function __construct( Token_Registry $registry, Css_Projectors $projectors ) {
+		$this->registry   = $registry;
+		$this->projectors = $projectors;
 	}
 
 	/**
@@ -106,9 +68,12 @@ final class Editor_Css {
 			return '';
 		}
 
-		return $this->css_var->css()
-			. $this->variant->css()
-			. $this->native->css()
-			. $this->block_default->css();
+		$css = '';
+
+		foreach ( $this->projectors->all() as $projector ) {
+			$css .= $projector->css();
+		}
+
+		return $css;
 	}
 }

--- a/includes/resources/Design_Tokens/Projection/Native/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Native/Projector.php
@@ -2,6 +2,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Native;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts\Css_Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Native\Styles\Contracts\Styles;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Location;
@@ -31,7 +32,7 @@ use KadenceWP\KadenceBlocks\Utils\Cast;
  *
  * @since TBD
  */
-final class Projector {
+final class Projector implements Css_Projector {
 
 	/**
 	 * @var Token_Registry

--- a/includes/resources/Design_Tokens/Projection/Native/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Native/Projector.php
@@ -109,7 +109,7 @@ final class Projector {
 	 *
 	 * @return string
 	 */
-	private function css(): string {
+	public function css(): string {
 		$owns_default = $this->design_system_owns_defaults();
 		$css          = '';
 

--- a/includes/resources/Design_Tokens/Projection/Native/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Native/Provider.php
@@ -2,6 +2,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Native;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Projectors;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Native\Styles\Button;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
@@ -43,6 +44,13 @@ final class Provider extends Provider_Contract {
 				return new Projector( $registry, [ $button ] );
 			}
 		);
+
+		// Contribute this projector's editor CSS to the combined projected-CSS endpoint.
+		/** @var Css_Projectors $projectors */
+		$projectors = $this->container->get( Css_Projectors::class );
+		/** @var Projector $projector */
+		$projector = $this->container->get( Projector::class );
+		$projectors->add( $projector );
 
 		// Companion CSS, appended after the base token vars and the kbVariant retarget so it follows them in
 		// source order (front end: Css_Var at 100, Variant at 110; editor: Css_Var at 5, Variant at 10).

--- a/includes/resources/Design_Tokens/Projection/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Provider.php
@@ -41,5 +41,9 @@ final class Provider extends Provider_Contract {
 		foreach ( self::PROVIDERS as $provider ) {
 			$this->container->register( $provider );
 		}
+
+		// Aggregates every projector's editor CSS for the projected-CSS REST endpoint. Registered after the
+		// sub-providers so the projectors it depends on are already bound.
+		$this->container->singleton( Editor_Css::class );
 	}
 }

--- a/includes/resources/Design_Tokens/Projection/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Provider.php
@@ -38,12 +38,16 @@ final class Provider extends Provider_Contract {
 	 * @since TBD
 	 */
 	public function register(): void {
+		// The shared collection each CSS projector's provider adds itself to; bound before the sub-providers so
+		// they can add to it as they register.
+		$this->container->singleton( Css_Projectors::class );
+
 		foreach ( self::PROVIDERS as $provider ) {
 			$this->container->register( $provider );
 		}
 
-		// Aggregates every projector's editor CSS for the projected-CSS REST endpoint. Registered after the
-		// sub-providers so the projectors it depends on are already bound.
+		// Aggregates every CSS projector's editor CSS (from the collection above) for the projected-CSS REST
+		// endpoint. Autowired — a new editor-CSS projector joins from its own provider, not here.
 		$this->container->singleton( Editor_Css::class );
 	}
 }

--- a/includes/resources/Design_Tokens/Projection/Variant/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Variant/Projector.php
@@ -77,7 +77,7 @@ final class Projector {
 			return;
 		}
 
-		$css = $this->build_css();
+		$css = $this->css();
 
 		if ( $css !== '' ) {
 			wp_add_inline_style( 'kadence-blocks-global-variables', $css );
@@ -104,7 +104,7 @@ final class Projector {
 			return;
 		}
 
-		$css = $this->build_css();
+		$css = $this->css();
 
 		if ( $css !== '' ) {
 			wp_add_inline_style( 'kadence-blocks-global-editor-styles', $css );
@@ -124,7 +124,7 @@ final class Projector {
 	 *
 	 * @return string
 	 */
-	private function build_css(): string {
+	public function css(): string {
 		try {
 			$active   = $this->active->get();
 			$versions = [];

--- a/includes/resources/Design_Tokens/Projection/Variant/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Variant/Projector.php
@@ -4,6 +4,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Variant;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts\Css_Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Location;
 use Throwable;
@@ -18,7 +19,7 @@ use Throwable;
  *
  * @since TBD
  */
-final class Projector {
+final class Projector implements Css_Projector {
 
 	/**
 	 * @var Token_Registry

--- a/includes/resources/Design_Tokens/Projection/Variant/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Variant/Provider.php
@@ -2,6 +2,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Variant;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Projectors;
 use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
 
 /**
@@ -21,6 +22,13 @@ final class Provider extends Provider_Contract {
 	public function register(): void {
 		$this->container->singleton( Css_Builder::class );
 		$this->container->singleton( Projector::class );
+
+		// Contribute this projector's editor CSS to the combined projected-CSS endpoint.
+		/** @var Css_Projectors $projectors */
+		$projectors = $this->container->get( Css_Projectors::class );
+		/** @var Projector $projector */
+		$projector = $this->container->get( Projector::class );
+		$projectors->add( $projector );
 
 		// Front end: append after the token vars (KB enqueues the handle at 90; the Css_Var projector at 100),
 		// so a variant override always follows the base token vars in source order and wins by cascade.

--- a/includes/resources/Design_Tokens/Rest/V1/Projected_Css_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Projected_Css_Controller.php
@@ -1,0 +1,119 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Editor_Css;
+use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
+use WP_Http;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * REST controller that serves the combined design-token editor CSS.
+ *
+ * A single read-only resource returning the exact CSS the projectors enqueue into the block editor at page
+ * load — every projector's output aggregated ({@see Editor_Css}): the `--kb-token--*` token vars, the variant
+ * vars + scoped retarget rules, the native-block companion CSS, and the block-default dimension CSS, for every
+ * token set including the per-set switch layer. The editor fetches this after a variant (or, later, a token
+ * value) change and re-injects it into the canvas, so the change applies live without a page reload.
+ *
+ * Read-only and gated by the shared design-tokens capability; a deactivated registry yields an empty string.
+ *
+ * @since TBD
+ */
+final class Projected_Css_Controller extends Controller {
+
+	/**
+	 * Aggregates every projector's editor CSS into one string.
+	 *
+	 * @since TBD
+	 *
+	 * @var Editor_Css
+	 */
+	private Editor_Css $editor_css;
+
+	/**
+	 * Memoised item schema for this request. Null until first built.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string, mixed>|null
+	 */
+	private ?array $item_schema = null;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Editor_Css $editor_css Aggregates every projector's editor CSS.
+	 */
+	public function __construct( Editor_Css $editor_css ) {
+		$this->editor_css = $editor_css;
+		$this->rest_base  = 'projected-css';
+	}
+
+	/**
+	 * Register the read route for the projected editor CSS.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			"/$this->rest_base",
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_item' ],
+					'permission_callback' => [ $this, 'get_item_permissions_check' ],
+					'args'                => [],
+				],
+				'schema' => [ $this, 'get_item_schema' ],
+			]
+		);
+	}
+
+	/**
+	 * Read the combined design-token editor CSS.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		return new WP_REST_Response( [ 'css' => $this->editor_css->css() ], WP_Http::OK );
+	}
+
+	/**
+	 * The JSON Schema for the projected-CSS resource.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_item_schema(): array {
+		if ( $this->item_schema !== null ) {
+			return $this->add_additional_fields_schema( $this->item_schema );
+		}
+
+		$this->item_schema = [
+			'$schema'    => 'http://json-schema.org/draft-07/schema#',
+			'title'      => 'design-token-projected-css',
+			'type'       => 'object',
+			'properties' => [
+				'css' => [
+					'description' => __( 'The combined design-token editor CSS for every token set.', 'kadence-blocks' ),
+					'type'        => 'string',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+			],
+		];
+
+		return $this->add_additional_fields_schema( $this->item_schema );
+	}
+}

--- a/includes/resources/Design_Tokens/Rest/V1/Provider.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Provider.php
@@ -28,6 +28,7 @@ final class Provider extends Provider_Contract {
 		Schema_Controller::class,
 		Variants_Controller::class,
 		Active_Set_Controller::class,
+		Projected_Css_Controller::class,
 	];
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Projected_Css_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Projected_Css_ControllerTest.php
@@ -1,0 +1,156 @@
+<?php declare( strict_types=1 );
+// cspell:ignore singlebtn .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Rest\V1;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Projected_Css_Controller;
+use Tests\Support\Classes\TestCase;
+use WP_Error;
+use WP_Http;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Covers the projected-CSS controller: it aggregates every design-token editor projector into one CSS string
+ * for the editor to re-inject live, keeps multi-set (multi-palette) support intact, and is capability-gated.
+ */
+final class Projected_Css_ControllerTest extends TestCase {
+
+	private const BUTTON = 'kadence/singlebtn';
+
+	/**
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @var Projected_Css_Controller
+	 */
+	private Projected_Css_Controller $controller;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->store      = $this->container->get( Token_Store::class );
+		$this->controller = $this->container->get( Projected_Css_Controller::class );
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The aggregated CSS contains both the token vars and a stored variant's scoped retarget rule, proving it
+	 * composes the token-var and variant projectors (not just one layer).
+	 *
+	 * @return void
+	 */
+	public function testItAggregatesTokenVarsAndAVariantsScopedRule(): void {
+		$this->seedVariant( Token_Store::default_slug(), 'accent' );
+
+		$css = $this->css();
+
+		$this->assertStringContainsString( '--kb-token--', $css, 'The token vars layer should be present.' );
+		$this->assertStringContainsString( 'kb-variant--accent', $css, 'The stored variant scoped rule should be present.' );
+	}
+
+	/**
+	 * A second, non-default token set is emitted with its own namespaced vars and a per-set switch selector,
+	 * proving multi-set (multi-palette) support survives the aggregation.
+	 *
+	 * @return void
+	 */
+	public function testItEmitsEveryTokenSetWithItsSwitchLayer(): void {
+		$this->seedVariant( Token_Store::default_slug(), 'accent' );
+		$this->seedVariant( 'dark', 'accent' );
+
+		$css = $this->css();
+
+		$this->assertStringContainsString( '--kb-token--dark--', $css, 'The non-default set should emit namespaced vars.' );
+		$this->assertStringContainsString( 'data-kb-token-set', $css, 'The non-default set should emit a switch selector.' );
+	}
+
+	/**
+	 * The read route is gated by the design-tokens capability: denied for a user without it, allowed for an
+	 * administrator.
+	 *
+	 * @return void
+	 */
+	public function testTheRouteIsCapabilityGated(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'subscriber' ] ) );
+		$this->assertInstanceOf( WP_Error::class, $this->controller->get_item_permissions_check( $request ) );
+
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->assertTrue( $this->controller->get_item_permissions_check( $request ) );
+	}
+
+	/**
+	 * With nothing stored the endpoint still returns a string (the baseline token vars), never an error, so a
+	 * fetch failure never blocks the editor.
+	 *
+	 * @return void
+	 */
+	public function testItReturnsAStringWithAnEmptyStore(): void {
+		$response = $this->controller->get_item( new WP_REST_Request( WP_REST_Server::READABLE ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertIsString( $response->get_data()['css'] );
+	}
+
+	/**
+	 * The CSS string from a read of the resource.
+	 *
+	 * @return string
+	 */
+	private function css(): string {
+		$response = $this->controller->get_item( new WP_REST_Request( WP_REST_Server::READABLE ) );
+
+		return $response->get_data()['css'];
+	}
+
+	/**
+	 * Persist a full-surface button variant into a token set's overrides document.
+	 *
+	 * @param string $slug    The token set slug to write into.
+	 * @param string $variant The variant slug.
+	 *
+	 * @return void
+	 */
+	private function seedVariant( string $slug, string $variant ): void {
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'variants' => [
+						self::BUTTON => [
+							$variant => [
+								'label'  => 'Accent',
+								'tokens' => [
+									'button-bg'         => '#ff0000',
+									'button-text'       => '#ffffff',
+									'button-bg-hover'   => '#cc0000',
+									'button-text-hover' => '#ffffff',
+									'button-radius'     => '1rem',
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$this->store->save_document( (string) wp_json_encode( $document ), $slug );
+	}
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked PR — #1104 must be merged first.

🎫  https://linear.app/nexcess/issue/SOFT-3575/user-created-variants-clone-an-existing-variants-surface-no-token

🎥  https://www.loom.com/share/3ae3db5d20dd434db698ed13f9f7b126

Groundwork for applying a newly-created variant live in the editor (no reload). Today the design-token editor CSS is emitted server-side only at page load, so a just-created variant's rule isn't in the canvas until a reload.

This exposes a read-only `GET /projected-css` returning `{ css }` — the exact combined editor CSS the projectors enqueue — so the editor can fetch and re-inject it after a change (PR 10 wires that up). It's deliberately general (not variant-specific), so a future in-editor token-value editor can reuse the same endpoint.

- Each editor projector (`Css_Var`, `Variant`, `Native`, `Block_Default_Css`) implements a new `Css_Projector` contract exposing a public `css()` — the builder that was previously private to `enqueue_editor()`; the enqueue-context gates stay in `enqueue_editor()`.
- A new `Editor_Css` aggregator concatenates them in load order (token vars, variants, native, block-default) behind the registry active gate. It gathers the projectors from a `Css_Projectors` collection that each projector's own provider adds itself to, so adding another editor-CSS projector touches only its own module — not the aggregator or the Projection provider.
- `Projected_Css_Controller` serves the result, gated by the shared design-tokens capability.

Multi-set (SOFT-3582) is preserved by construction: the `css()` methods are verbatim, so the token-var and variant builders still emit every set's namespaced `--kb-token--<set>--…` vars and the per-set `[data-kb-token-set]` switch selectors — the test asserts a non-default set's vars and switch selector survive the aggregation.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.