### PR TITLE
Custom Variant Creation [10/11]: apply design-token changes live in the editor

### DIFF
--- a/src/extension/design-tokens/live-css.js
+++ b/src/extension/design-tokens/live-css.js
@@ -1,0 +1,71 @@
+/**
+ * Live re-injection of the design-token editor CSS into the block-editor canvas.
+ *
+ * The projectors emit the token/variant CSS server-side only at page load, so a change made in the editor
+ * (creating/editing/deleting a variant, or a future token-value edit) is not reflected until a reload. These
+ * helpers fetch the combined projected CSS and write it into a dedicated `<style>` in the canvas document, so
+ * the change applies immediately. Generic on purpose — any design-token change can call `refreshProjectedCss`.
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { designTokensNamespace } from './rest';
+
+/**
+ * The id of the runtime `<style>` element, so it is found-and-replaced rather than duplicated.
+ */
+const STYLE_ID = 'kadence-blocks-design-tokens-live';
+
+/**
+ * Fetch the combined design-token editor CSS for live re-injection into the canvas.
+ *
+ * @return {Promise<{ css: string }>} The projected CSS payload.
+ */
+export function fetchProjectedCss() {
+	return apiFetch({ path: `/${designTokensNamespace()}/projected-css` });
+}
+
+/**
+ * The block-editor canvas document. Modern Gutenberg puts the canvas in an iframe; the `|| document`
+ * fallback covers the case where it is not.
+ *
+ * @return {Document} The canvas document, or the top document when the canvas is not in an iframe.
+ */
+function canvasDocument() {
+	return document.querySelector('iframe[name="editor-canvas"]')?.contentWindow?.document || document;
+}
+
+/**
+ * Write the given CSS into the canvas's dedicated runtime `<style>`, creating it on first use. A full replace
+ * keeps it idempotent, so it reflects the latest state for create, edit, and delete alike.
+ *
+ * @param {string} css The design-token editor CSS to apply.
+ * @return {void}
+ */
+export function applyProjectedCss(css) {
+	const doc = canvasDocument();
+
+	if (!doc?.head) {
+		return;
+	}
+
+	let style = doc.getElementById(STYLE_ID);
+
+	if (!style) {
+		style = doc.createElement('style');
+		style.id = STYLE_ID;
+		doc.head.appendChild(style);
+	}
+
+	style.textContent = css || '';
+}
+
+/**
+ * Fetch the current projected CSS and apply it to the canvas. Fetch failures are swallowed — the change is
+ * already saved server-side, so the worst case is that it shows after a reload.
+ *
+ * @return {Promise<void>}
+ */
+export function refreshProjectedCss() {
+	return fetchProjectedCss()
+		.then((payload) => applyProjectedCss(payload?.css || ''))
+		.catch(() => {});
+}

--- a/src/extension/design-tokens/rest.js
+++ b/src/extension/design-tokens/rest.js
@@ -1,0 +1,34 @@
+/**
+ * Shared access to the design-tokens REST descriptor the editor localizer prints
+ * (`window.kadenceDesignTokensRest`). Every design-token editor client reads the namespace and presence
+ * from here rather than re-implementing it; `@wordpress/api-fetch` supplies the root + nonce in the editor.
+ */
+import { get } from 'lodash';
+
+/**
+ * The localized design-tokens REST descriptor, or an empty object when the registry is inactive.
+ *
+ * @return {Object} The descriptor ({ root, namespace, nonce }).
+ */
+function descriptor() {
+	return get(window, 'kadenceDesignTokensRest', {}) || {};
+}
+
+/**
+ * The REST namespace the design-token routes register under.
+ *
+ * @return {string} The namespace, e.g. "kb-design-tokens/v1".
+ */
+export function designTokensNamespace() {
+	return descriptor().namespace || 'kb-design-tokens/v1';
+}
+
+/**
+ * Whether the editor has the descriptor needed to talk to the design-tokens REST API. When false, the
+ * design-token editor controls are hidden.
+ *
+ * @return {boolean} True when the descriptor is present.
+ */
+export function hasDesignTokensRest() {
+	return Boolean(descriptor().namespace);
+}

--- a/src/extension/variant-picker/SaveVariantModal.js
+++ b/src/extension/variant-picker/SaveVariantModal.js
@@ -14,6 +14,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { get } from 'lodash';
 import { blockProperties, appendVariant } from './index';
 import { getBlockVariants, createVariant } from '../variants/api/client';
+import { refreshProjectedCss } from '../design-tokens/live-css';
 import { deriveSlug, dedupeSlug } from '../variants/slug';
 
 /**
@@ -135,6 +136,7 @@ export function SaveVariantModal({ blockName, set, source, editSlug = '', onClos
 		createVariant(blockName, { variant: slug, label: label.trim(), tokens: values }, set)
 			.then(() => {
 				appendVariant(blockName, set, { slug, label: label.trim(), userCreated: true });
+				refreshProjectedCss();
 				onSaved(slug);
 				onClose();
 			})

--- a/src/extension/variant-picker/VariantActions.js
+++ b/src/extension/variant-picker/VariantActions.js
@@ -12,7 +12,9 @@ import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { SaveVariantModal } from './SaveVariantModal';
 import { blockVariants, blockDefaultVariant, isUserVariant, removeVariant } from './index';
-import { hasVariantsRest, deleteVariant, setVariantDefault } from '../variants/api/client';
+import { deleteVariant, setVariantDefault } from '../variants/api/client';
+import { hasDesignTokensRest } from '../design-tokens/rest';
+import { refreshProjectedCss } from '../design-tokens/live-css';
 
 /**
  * The variant create/edit/delete controls.
@@ -31,7 +33,7 @@ export function VariantActions({ blockName, set, selected, onSelect }) {
 	const [busy, setBusy] = useState(false);
 	const [error, setError] = useState('');
 
-	if (!hasVariantsRest()) {
+	if (!hasDesignTokensRest()) {
 		return null;
 	}
 
@@ -57,6 +59,7 @@ export function VariantActions({ blockName, set, selected, onSelect }) {
 			.then(() => deleteVariant(blockName, selected, set))
 			.then(() => {
 				removeVariant(blockName, set, selected);
+				refreshProjectedCss();
 				onSelect('');
 				setConfirming(false);
 				setBusy(false);

--- a/src/extension/variants/api/client.js
+++ b/src/extension/variants/api/client.js
@@ -2,42 +2,14 @@
  * REST client for the Design Tokens variants resource.
  *
  * Uses the editor's already-configured `@wordpress/api-fetch` (root + nonce), reading only the REST
- * namespace from the localized descriptor `window.kadenceDesignTokensRest`. Every call targets a specific
- * token set via the `set` parameter (query for reads/deletes, body for writes); an absent set lets the
- * server fall back to the active set.
+ * namespace from the shared design-tokens descriptor. Every call targets a specific token set via the `set`
+ * parameter (query for reads/deletes, body for writes); an absent set lets the server fall back to the
+ * active set.
  */
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
-import { get } from 'lodash';
+import { designTokensNamespace } from '../../design-tokens/rest';
 import { variantsBlockPath, variantItemPath, variantDefaultPath } from './paths';
-
-/**
- * The localized REST descriptor, or an empty object when the design-token registry is inactive.
- *
- * @return {Object} The descriptor ({ root, namespace, nonce }).
- */
-function descriptor() {
-	return get(window, 'kadenceDesignTokensRest', {}) || {};
-}
-
-/**
- * The REST namespace the variant routes register under.
- *
- * @return {string} The namespace, e.g. "kb-design-tokens/v1".
- */
-export function variantsNamespace() {
-	return descriptor().namespace || 'kb-design-tokens/v1';
-}
-
-/**
- * Whether the editor has the REST descriptor needed to talk to the variants API. When false, the
- * "save as new variant" affordance is hidden.
- *
- * @return {boolean} True when the descriptor is present.
- */
-export function hasVariantsRest() {
-	return Boolean(descriptor().namespace);
-}
 
 /**
  * Read a block's effective variant set for a token set.
@@ -48,7 +20,7 @@ export function hasVariantsRest() {
  */
 export function getBlockVariants(block, set) {
 	return apiFetch({
-		path: addQueryArgs(variantsBlockPath(variantsNamespace(), block), set ? { set } : {}),
+		path: addQueryArgs(variantsBlockPath(designTokensNamespace(), block), set ? { set } : {}),
 	});
 }
 
@@ -65,7 +37,7 @@ export function getBlockVariants(block, set) {
  */
 export function createVariant(block, { variant, label, tokens }, set) {
 	return apiFetch({
-		path: variantsBlockPath(variantsNamespace(), block),
+		path: variantsBlockPath(designTokensNamespace(), block),
 		method: 'POST',
 		data: { variant, label, tokens, ...(set ? { set } : {}) },
 	});
@@ -81,7 +53,7 @@ export function createVariant(block, { variant, label, tokens }, set) {
  */
 export function setVariantDefault(block, defaultVariant, set) {
 	return apiFetch({
-		path: variantDefaultPath(variantsNamespace(), block),
+		path: variantDefaultPath(designTokensNamespace(), block),
 		method: 'PUT',
 		data: { default: defaultVariant, ...(set ? { set } : {}) },
 	});
@@ -97,7 +69,7 @@ export function setVariantDefault(block, defaultVariant, set) {
  */
 export function deleteVariant(block, variant, set) {
 	return apiFetch({
-		path: addQueryArgs(variantItemPath(variantsNamespace(), block, variant), set ? { set } : {}),
+		path: addQueryArgs(variantItemPath(designTokensNamespace(), block, variant), set ? { set } : {}),
 		method: 'DELETE',
 	});
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked PR — #1114 must be merged first.

🎫  https://linear.app/nexcess/issue/SOFT-3575/user-created-variants-clone-an-existing-variants-surface-no-token

🎥  https://www.loom.com/share/3ae3db5d20dd434db698ed13f9f7b126

Makes a variant change apply in the editor immediately, without a page reload.

After a variant is created, edited, or deleted, the editor fetches the combined design-token editor CSS from `GET /projected-css` (added in the previous PR) and writes it into a dedicated `<style>` in the block-editor canvas document, so the block restyles right away. The `kb-variant--<slug>` class is already applied live in the canvas, so once the CSS is present it takes effect.

The fetch + injection and the REST descriptor/namespace are design-token-general (nothing variant-specific), so they live in a new shared `src/extension/design-tokens` module (`rest.js` + `live-css.js`) that the variants client and pickers consume. A future in-editor token editor can reuse `refreshProjectedCss` the same way. As part of this, the shared namespace/`hasDesignTokensRest` helpers moved out of the variants client into the shared module.

Known limitation: the injected `<style>` lives on the current canvas document, so a device-preview switch or canvas remount drops it until the next change or a reload (after which PHP serves it) — a `useRefEffect`-based re-assert is possible later hardening.

Verified with `wp-scripts lint-js` and a full `wp-scripts build` (the repo has no JS test harness).

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.