### PR TITLE
Custom Variant Creation [11/11]: let a button variant set its own border-radius

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Variant/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Variant/Css_Builder.php
@@ -123,7 +123,7 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @var array<string, array<string, array{selector:string, default:string, variants:array<string, array<string, array{slot:string, value:string}>>}>>
+	 * @var array<string, array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}>>
 	 */
 	private array $collected = [];
 
@@ -297,7 +297,7 @@ final class Css_Builder {
 	 *
 	 * @param string $slug The set slug to resolve against (and namespace the values to).
 	 *
-	 * @return array<string, array{selector:string, default:string, variants:array<string, array<string, array{slot:string, value:string}>>}>
+	 * @return array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}>
 	 */
 	private function collect( string $slug ): array {
 		if ( isset( $this->collected[ $slug ] ) ) {
@@ -339,15 +339,15 @@ final class Css_Builder {
 						continue;
 					}
 
-					$slot = $this->global_slot( $binding );
+					$target = $this->target_var( $binding );
 
-					if ( $slot === null ) {
+					if ( $target === null ) {
 						continue;
 					}
 
 					$properties[ $property ] = [
-						'slot'  => $slot,
-						'value' => $value,
+						'target' => $target,
+						'value'  => $value,
 					];
 				}
 
@@ -382,7 +382,7 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{slot:string, value:string}>>}> $collected The set's collected variants.
+	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}> $collected The set's collected variants.
 	 * @param string                                                                                                                          $slug      The set slug to namespace the var names under.
 	 *
 	 * @return string
@@ -407,7 +407,7 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{slot:string, value:string}>>}> $collected   The active set's collected variants.
+	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}> $collected   The active set's collected variants.
 	 * @param string                                                                                                                          $active_slug The active set slug.
 	 *
 	 * @return string
@@ -426,7 +426,7 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{slot:string, value:string}>>}> $collected The set's collected variants.
+	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}> $collected The set's collected variants.
 	 * @param string                                                                                                                          $slug      The set slug.
 	 *
 	 * @return string
@@ -448,7 +448,7 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{slot:string, value:string}>>}> $collected The collected variants whose ids drive the layer.
+	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}> $collected The collected variants whose ids drive the layer.
 	 * @param string                                                                                                                          $slug      The set slug the canonical names are pointed at.
 	 *
 	 * @return string
@@ -475,7 +475,7 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{slot:string, value:string}>>}> $collected The active set's collected variants.
+	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}> $collected The active set's collected variants.
 	 *
 	 * @return string
 	 */
@@ -492,7 +492,7 @@ final class Css_Builder {
 				$declarations = '';
 
 				foreach ( $properties as $property => $info ) {
-					$declarations .= '--global-' . $info['slot'] . ':var(' . $this->variant_var( $block, $variant, $property ) . ');';
+					$declarations .= $info['target'] . ':var(' . $this->variant_var( $block, $variant, $property ) . ');';
 				}
 
 				if ( $declarations !== '' ) {
@@ -515,6 +515,36 @@ final class Css_Builder {
 		}
 
 		return $css;
+	}
+
+	/**
+	 * The CSS custom property a selected variant sets for a binding, or null when the binding drives none.
+	 *
+	 * A binding that targets a Kadence palette slot resolves to `--global-<slot>` (the color path); a binding
+	 * that declares a `css_var` resolves to `--<css_var>` (e.g. `--kb-btn-radius` for border-radius, which has
+	 * no palette slot). The variant's scoped rule sets this property to the per-variant value, so it can vary
+	 * per variant while the block reads the same variable.
+	 *
+	 * @since TBD
+	 *
+	 * @param Binding $binding The variant binding.
+	 *
+	 * @return string|null The full custom-property name (e.g. "--global-palette-btn-bg", "--kb-btn-radius"), or null.
+	 */
+	private function target_var( Binding $binding ): ?string {
+		$slot = $this->global_slot( $binding );
+
+		if ( $slot !== null ) {
+			return '--global-' . $slot;
+		}
+
+		$css_var = $binding->css_var();
+
+		if ( $css_var !== null ) {
+			return '--' . $css_var;
+		}
+
+		return null;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Registry/Binding.php
+++ b/includes/resources/Design_Tokens/Registry/Binding.php
@@ -66,8 +66,10 @@ final class Binding {
 	private const BLOCK_ATTR = 'block_attr';
 
 	/**
-	 * Inline target (boolean flag): the property surfaces only as its `--kb-token--*` var, with no
-	 * preset/slot bucket (e.g. border-radius, which WordPress has no preset category for).
+	 * Inline target: a KB-owned CSS custom property this property drives, named without the leading `--`
+	 * (e.g. "kb-btn-radius" → `--kb-btn-radius`). For a property with no Kadence palette slot or WordPress
+	 * preset bucket (e.g. border-radius): the block reads `var(--<css_var>, <token fallback>)`, and a selected
+	 * variant sets `--<css_var>` on its scope so the value can vary per variant.
 	 *
 	 * @since TBD
 	 *
@@ -108,7 +110,7 @@ final class Binding {
 	 *
 	 * @var string[]
 	 */
-	private const STRING_TARGETS = [ self::KADENCE_SLOT, self::WP_PRESET, self::BLOCK_ATTR, self::CSS_PROP, self::CSS_SELECTOR ];
+	private const STRING_TARGETS = [ self::KADENCE_SLOT, self::WP_PRESET, self::BLOCK_ATTR, self::CSS_PROP, self::CSS_SELECTOR, self::CSS_VAR ];
 
 	/**
 	 * The block property this binding drives, e.g. "button-bg". Carried for error messages and so a
@@ -259,6 +261,21 @@ final class Binding {
 	}
 
 	/**
+	 * The KB-owned CSS custom property this binding drives (named without the leading `--`, e.g.
+	 * "kb-btn-radius"), or null when it declares none. Read by the variant projector to set that variable on a
+	 * selected variant's scope so the value can vary per variant. Inline only.
+	 *
+	 * @since TBD
+	 *
+	 * @return string|null
+	 */
+	public function css_var(): ?string {
+		$name = $this->projections[ self::CSS_VAR ] ?? null;
+
+		return is_string( $name ) ? $name : null;
+	}
+
+	/**
 	 * Extract and validate the inline projection targets from a binding declaration.
 	 *
 	 * @since TBD
@@ -285,16 +302,6 @@ final class Binding {
 			}
 
 			$inline[ $key ] = $spec[ $key ];
-		}
-
-		if ( array_key_exists( self::CSS_VAR, $spec ) ) {
-			if ( $spec[ self::CSS_VAR ] !== true ) {
-				throw new InvalidArgumentException(
-					sprintf( 'Binding "%s" target "%s" must be true when present.', $property, self::CSS_VAR )
-				);
-			}
-
-			$inline[ self::CSS_VAR ] = true;
 		}
 
 		return $inline;

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -240,7 +240,7 @@ return [
 				'button-text'       => [ 'kadence_slot' => 'palette-btn' ],
 				'button-bg-hover'   => [ 'kadence_slot' => 'palette-btn-bg-hover' ],
 				'button-text-hover' => [ 'kadence_slot' => 'palette-btn-hover' ],
-				'button-radius'     => [ 'css_var' => true ], // token-var only (no preset bucket).
+				'button-radius'     => [ 'css_var' => 'kb-btn-radius' ], // drives --kb-btn-radius so a variant can vary the radius.
 			],
 		],
 		[

--- a/src/blocks/advanced-form/fields/submit/editor.scss
+++ b/src/blocks/advanced-form/fields/submit/editor.scss
@@ -11,7 +11,7 @@
 	justify-content: flex-start;
 }
 // NEW CSS.
-.kt-button {
+.wp-block-kadence-advanced-form-submit .kt-button {
 	z-index: 1;
 	position: relative;
 	overflow: hidden;
@@ -21,7 +21,7 @@
 	align-items: center;
 	justify-content: center;
 }
-.kt-button:not(.kb-btn-global-inherit) {
+.wp-block-kadence-advanced-form-submit .kt-button:not(.kb-btn-global-inherit) {
 	padding: 0.4em 1em;
 	cursor: pointer;
 	font-size: 1.125rem;
@@ -29,7 +29,7 @@
 	transition: all 0.3s ease-in-out;
 	box-shadow: none;
 }
-.kt-button.kb-btn-global-fill {
+.wp-block-kadence-advanced-form-submit .kt-button.kb-btn-global-fill {
 	border: 0px solid transparent;
 	border-radius: 3px;
 	background: var(--global-palette-btn-bg, #3633e1);
@@ -38,7 +38,7 @@
 		color: var(--global-palette-btn-hover, #ffffff);
 	}
 }
-.kt-button.kb-btn-global-outline {
+.wp-block-kadence-advanced-form-submit .kt-button.kb-btn-global-outline {
 	border: 2px solid var(--global-palette-btn-bg, #3633e1);
 	background: transparent;
 	padding: calc(0.4em - 2px) calc(1em - 2px);
@@ -49,7 +49,7 @@
 		color: var(--global-palette-btn-bg-hover, #2f2ffc);
 	}
 }
-.kt-button::before {
+.wp-block-kadence-advanced-form-submit .kt-button::before {
 	position: absolute;
 	content: "";
 	top: 0;
@@ -61,16 +61,16 @@
 	background: transparent;
 	transition: all 0.3s ease-in-out;
 }
-.kt-button.kb-btn-global-fill::before {
+.wp-block-kadence-advanced-form-submit .kt-button.kb-btn-global-fill::before {
 	background: var(--global-palette-btn-bg-hover, #2f2ffc);
 }
 .editor-styles-wrapper .wp-block-kadence-advanced-form-submit .kt-button:not(.kb-btn-global-inherit):hover {
 	box-shadow: none;
 }
-.kt-button:hover::before {
+.wp-block-kadence-advanced-form-submit .kt-button:hover::before {
 	opacity: 1;
 }
-.kt-btn-width-type-fixed .kt-button {
+.wp-block-kadence-advanced-form-submit .kt-btn-width-type-fixed .kt-button {
 	width: 100%;
 }
 .editor-styles-wrapper .wp-block-kadence-advanced-form-submit .kt-button.kt-btn-size-small {
@@ -82,14 +82,14 @@
 .editor-styles-wrapper .wp-block-kadence-advanced-form-submit .kt-button.kt-btn-size-xlarge {
 	font-size: 1.65rem;
 }
-.kt-button.kb-btn-global-outline.kt-btn-size-xlarge {
+.wp-block-kadence-advanced-form-submit .kt-button.kb-btn-global-outline.kt-btn-size-xlarge {
 	border-width: 4px;
 }
-.kt-button.kb-btn-global-outline.kt-btn-size-large {
+.wp-block-kadence-advanced-form-submit .kt-button.kb-btn-global-outline.kt-btn-size-large {
 	border-width: 3px;
 	padding: calc(0.4em - 3px) calc(1em - 3px);
 }
-.kt-button.kb-btn-global-outline.kt-btn-size-small {
+.wp-block-kadence-advanced-form-submit .kt-button.kb-btn-global-outline.kt-btn-size-small {
 	border-width: 1px;
 	padding: calc(0.4em - 1px) calc(1em - 1px);
 }

--- a/src/blocks/advancedbtn/editor.scss
+++ b/src/blocks/advancedbtn/editor.scss
@@ -219,13 +219,13 @@
 	padding: 0.4em 1em;
 	cursor: pointer;
 	font-size: 1.125rem;
-	border-radius: var(--kb-token--semantic--radius--control, 3px);
+	border-radius: var(--kb-btn-radius, var(--kb-token--semantic--radius--control, 3px));
 	transition: all 0.3s ease-in-out;
 	box-shadow: none;
 }
 .kt-button.kb-btn-global-fill {
 	border: 0px solid transparent;
-	border-radius: var(--kb-token--semantic--radius--control, 3px);
+	border-radius: var(--kb-btn-radius, var(--kb-token--semantic--radius--control, 3px));
 	background: var(--global-palette-btn-bg, #3633e1);
 	color: var(--global-palette-btn, #ffffff);
 	&:hover {

--- a/src/blocks/advancedbtn/style.scss
+++ b/src/blocks/advancedbtn/style.scss
@@ -38,7 +38,7 @@
 	padding: 0.4em 1em;
 	cursor: pointer;
 	font-size: 1.125rem;
-	border-radius: var(--kb-token--semantic--radius--control, 3px);
+	border-radius: var(--kb-btn-radius, var(--kb-token--semantic--radius--control, 3px));
 	transition: all 0.3s ease-in-out;
 	box-shadow: none;
 	&:hover {
@@ -47,7 +47,7 @@
 }
 .kb-button.kb-btn-global-fill {
 	border: 0px solid transparent;
-	border-radius: var(--kb-token--semantic--radius--control, 3px);
+	border-radius: var(--kb-btn-radius, var(--kb-token--semantic--radius--control, 3px));
 	background: var(--global-palette-btn-bg, #3633e1);
 	color: var(--global-palette-btn, #ffffff);
 	&:hover {

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Preset/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Preset/ProjectorTest.php
@@ -125,7 +125,7 @@ final class ProjectorTest extends TestCase {
 						'token'      => 'semantic.color.button-text',
 						'block_attr' => 'color',
 					],
-					'button-radius' => [ 'css_var' => true ], // no block_attr -> skipped.
+					'button-radius' => [ 'css_var' => 'kb-btn-radius' ], // no block_attr -> skipped.
 				],
 			]
 		);

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Variant/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Variant/Css_BuilderTest.php
@@ -126,7 +126,8 @@ final class Css_BuilderTest extends TestCase {
 				. '--global-palette-btn-bg:var(--kb-token--variant--kadence-singlebtn--secondary--button-bg);'
 				. '--global-palette-btn:var(--kb-token--variant--kadence-singlebtn--secondary--button-text);'
 				. '--global-palette-btn-bg-hover:var(--kb-token--variant--kadence-singlebtn--secondary--button-bg-hover);'
-				. '--global-palette-btn-hover:var(--kb-token--variant--kadence-singlebtn--secondary--button-text-hover);}',
+				. '--global-palette-btn-hover:var(--kb-token--variant--kadence-singlebtn--secondary--button-text-hover);'
+				. '--kb-btn-radius:var(--kb-token--variant--kadence-singlebtn--secondary--button-radius);}',
 			$css
 		);
 	}
@@ -162,21 +163,32 @@ final class Css_BuilderTest extends TestCase {
 				. '--global-palette-btn-bg:var(--kb-token--variant--kadence-singlebtn--primary--button-bg);'
 				. '--global-palette-btn:var(--kb-token--variant--kadence-singlebtn--primary--button-text);'
 				. '--global-palette-btn-bg-hover:var(--kb-token--variant--kadence-singlebtn--primary--button-bg-hover);'
-				. '--global-palette-btn-hover:var(--kb-token--variant--kadence-singlebtn--primary--button-text-hover);}',
+				. '--global-palette-btn-hover:var(--kb-token--variant--kadence-singlebtn--primary--button-text-hover);'
+				. '--kb-btn-radius:var(--kb-token--variant--kadence-singlebtn--primary--button-radius);}',
 			$css
 		);
 	}
 
 	/**
-	 * button-radius is bound css_var only (no slot), so it never reaches a --global-* declaration or a
-	 * variant var (a property bound to no slot is dropped before emission).
+	 * button-radius is bound with a css_var (no palette slot), so a selected variant sets the --kb-btn-radius
+	 * variable the button's border-radius reads — via the scoped rule and a per-variant var in the namespaced
+	 * block — so the radius can vary per variant rather than being dropped.
 	 *
 	 * @return void
 	 */
-	public function testItSkipsAPropertyBoundToNoSlot(): void {
+	public function testItProjectsACssVarBindingToItsVariable(): void {
 		$css = $this->builder( $this->registry )->css( [ 'default' ], 'default' );
 
-		$this->assertStringNotContainsString( 'button-radius', $css );
+		// The scoped rule points --kb-btn-radius at the per-variant var.
+		$this->assertStringContainsString(
+			'--kb-btn-radius:var(--kb-token--variant--kadence-singlebtn--secondary--button-radius);',
+			$css
+		);
+		// The namespaced block defines that per-variant var for the set.
+		$this->assertStringContainsString(
+			'--kb-token--default--variant--kadence-singlebtn--secondary--button-radius:',
+			$css
+		);
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Registry/BindingTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/BindingTest.php
@@ -65,7 +65,7 @@ final class BindingTest extends TestCase {
 		$this->assertSame( 'background', $bound->block_attr() );
 
 		// A binding with no block_attr target has no attribute to seed.
-		$unbound = Binding::from_array( 'button-radius', [ 'css_var' => true ] );
+		$unbound = Binding::from_array( 'button-radius', [ 'css_var' => 'kb-btn-radius' ] );
 		$this->assertNull( $unbound->block_attr() );
 	}
 
@@ -91,7 +91,7 @@ final class BindingTest extends TestCase {
 	 */
 	public function testCssPropAndSelectorReturnNullWhenAbsent(): void {
 		// A binding with no css_prop/css_selector feeds no block-default rule.
-		$binding = Binding::from_array( 'button-radius', [ 'css_var' => true ] );
+		$binding = Binding::from_array( 'button-radius', [ 'css_var' => 'kb-btn-radius' ] );
 
 		$this->assertNull( $binding->css_prop() );
 		$this->assertNull( $binding->css_selector() );
@@ -109,10 +109,11 @@ final class BindingTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testItAcceptsTheCssVarFlag(): void {
-		$binding = Binding::from_array( 'button-radius', [ 'css_var' => true ] );
+	public function testItAcceptsACssVarTarget(): void {
+		$binding = Binding::from_array( 'button-radius', [ 'css_var' => 'kb-btn-radius' ] );
 
-		$this->assertSame( [ 'css_var' => true ], $binding->projections );
+		$this->assertSame( 'kb-btn-radius', $binding->css_var() );
+		$this->assertSame( [ 'css_var' => 'kb-btn-radius' ], $binding->projections );
 	}
 
 	/**
@@ -178,7 +179,7 @@ final class BindingTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testItThrowsWhenCssVarIsNotTrue(): void {
+	public function testItThrowsWhenCssVarIsNotAString(): void {
 		$this->expectException( InvalidArgumentException::class );
 
 		Binding::from_array( 'button-radius', [ 'css_var' => false ] );


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked PR — #1115 must be merged first.

🎫  https://linear.app/nexcess/issue/SOFT-3575/user-created-variants-clone-an-existing-variants-surface-no-token

🎥  https://www.loom.com/share/ad75b63e1b624659983ffbcb2d753a3b

Makes a button variant able to set its own border-radius, and fixes an editor-only leak that was masking it. Two commits.

**1. `fix(advanced-form)`: scope the submit field's editor button styles.** The submit field's editor stylesheet styled bare, unscoped `.kt-button`, so its hardcoded `border-radius: 3px` leaked onto every Kadence button in the editor iframe and overrode the design-token radius at equal specificity + later source order (colors survived only because those rules token-reference the palette vars). Scoped the bare `.kt-button` rules to `.wp-block-kadence-advanced-form-submit`, matching the already-scoped rules in the same file and the front-end's dedicated class.

**2. `feat(design-tokens)`: per-variant button border-radius.** Border-radius was a single shared token across all variants — the variant CSS builder only projected `kadence_slot` (color) bindings, so the `button-radius` `css_var` binding was dropped and a per-variant radius never rendered. Now:
- the `css_var` binding carries the target variable name (`button-radius` drives `--kb-btn-radius`), with a `Binding::css_var()` accessor;
- the variant builder projects `css_var` bindings: a selected variant emits `.kb-variant--<slug>{ --kb-btn-radius: var(<per-variant var>) }` plus the per-variant value in the namespaced block;
- the button reads `border-radius: var(--kb-btn-radius, var(--kb-token--semantic--radius--control, 3px))`, so with no variant it falls through to the shared token exactly as before (no circularity, no regression), and a variant overrides only its own buttons.

Verified on a live site: a variant's radius now emits `--kb-btn-radius:var(--kb-token--variant--kadence-singlebtn--<variant>--button-radius)` and applies live in the editor via the projected-CSS re-injection. wpunit updated (Css_Builder + Binding) and green; PHPStan clean.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.