### PR TITLE
[DTM] SOFT-3398 [2/5]: Value translator

### DIFF
--- a/includes/resources/Design_Tokens/Global_Styles/Default_Value_Translator.php
+++ b/includes/resources/Design_Tokens/Global_Styles/Default_Value_Translator.php
@@ -92,6 +92,11 @@ final class Default_Value_Translator implements Value_Translator {
 	 * (Schema\Validation\Values\Font_Family_Value), so a plain family name is wrapped, and a
 	 * comma-separated stack is split into its elements.
 	 *
+	 * Each element also has its surrounding quotes stripped (e.g. `"Segoe UI"` -> `Segoe UI`):
+	 * Css_Renderer::font_family() re-wraps any element containing a space in quotes when
+	 * rendering back to CSS, so a literal that already arrived quoted would otherwise come out
+	 * double-quoted (`""Segoe UI""`).
+	 *
 	 * @since TBD
 	 *
 	 * @param string $value The font family value to translate.
@@ -103,7 +108,10 @@ final class Default_Value_Translator implements Value_Translator {
 	private function font_family( string $value ): array {
 		$families = array_values(
 			array_filter(
-				array_map( 'trim', explode( ',', $value ) ),
+				array_map(
+					static fn( string $family ): string => trim( $family, " \t\n\r\0\x0B\"'" ),
+					explode( ',', $value )
+				),
 				static fn( string $family ): bool => $family !== ''
 			)
 		);

--- a/includes/resources/Design_Tokens/Global_Styles/Default_Value_Translator.php
+++ b/includes/resources/Design_Tokens/Global_Styles/Default_Value_Translator.php
@@ -1,0 +1,120 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Global_Styles;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
+
+/**
+ * Default Value_Translator: color, spacing (dimension), font-family only.
+ *
+ * @since TBD
+ */
+final class Default_Value_Translator implements Value_Translator {
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @since TBD
+	 *
+	 * @param string $category       The wp_preset category ("color", "spacing", "font-family").
+	 * @param string $literal_value  The literal value read from the Global Styles preset entry.
+	 *
+	 * @return array<string, mixed>
+	 *
+	 * @throws Untranslatable_Value_Exception When the category is unsupported or the value is malformed.
+	 */
+	public function translate( string $category, string $literal_value ): array {
+		switch ( $category ) {
+			case 'color':
+				return $this->color( $literal_value );
+			case 'spacing':
+				return $this->dimension( $literal_value );
+			case 'font-family':
+				return $this->font_family( $literal_value );
+			default:
+				throw new Untranslatable_Value_Exception(
+					sprintf( 'No Value_Translator for wp_preset category "%s".', $category )
+				);
+		}
+	}
+
+	/**
+	 * Translate a color literal: hex, rgb()/rgba(), hsl()/hsla(). Passed through as-is — the
+	 * write pipeline's own Dtcg_Validator (Schema\Validation\Values\Color_Value) re-validates it
+	 * before commit, so this only needs to reject the obviously-empty case.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $value The color value to translate.
+	 *
+	 * @return array<string, mixed>
+	 *
+	 * @throws Untranslatable_Value_Exception When the value is empty.
+	 */
+	private function color( string $value ): array {
+		$value = trim( $value );
+		if ( $value === '' ) {
+			throw new Untranslatable_Value_Exception( 'Color value cannot be empty.' );
+		}
+
+		return [
+			'$type'  => Token_Type::get_type_color(),
+			'$value' => $value,
+		];
+	}
+
+	/**
+	 * Translate a spacing literal to a "dimension" leaf. The theme.json spacingSizes "size" field
+	 * is already a CSS length string (e.g. "1rem", "8px", "clamp(...)"); passed through unchanged.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $value The dimension value to translate.
+	 *
+	 * @return array<string, mixed>
+	 *
+	 * @throws Untranslatable_Value_Exception When the value is empty.
+	 */
+	private function dimension( string $value ): array {
+		$value = trim( $value );
+		if ( $value === '' ) {
+			throw new Untranslatable_Value_Exception( 'Dimension value cannot be empty.' );
+		}
+
+		return [
+			'$type'  => Token_Type::get_type_dimension(),
+			'$value' => $value,
+		];
+	}
+
+	/**
+	 * Translate a font-family literal to a "fontFamily" leaf: DTCG requires an array $value
+	 * (Schema\Validation\Values\Font_Family_Value), so a plain family name is wrapped, and a
+	 * comma-separated stack is split into its elements.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $value The font family value to translate.
+	 *
+	 * @return array<string, mixed>
+	 *
+	 * @throws Untranslatable_Value_Exception When the value is empty or contains only whitespace.
+	 */
+	private function font_family( string $value ): array {
+		$families = array_values(
+			array_filter(
+				array_map( 'trim', explode( ',', $value ) ),
+				static fn( string $family ): bool => $family !== ''
+			)
+		);
+
+		if ( $families === [] ) {
+			throw new Untranslatable_Value_Exception( 'Font family value cannot be empty.' );
+		}
+
+		return [
+			'$type'  => Token_Type::get_type_font_family(),
+			'$value' => $families,
+		];
+	}
+}

--- a/includes/resources/Design_Tokens/Global_Styles/Untranslatable_Value_Exception.php
+++ b/includes/resources/Design_Tokens/Global_Styles/Untranslatable_Value_Exception.php
@@ -6,8 +6,8 @@ use Exception;
 
 /**
  * Thrown when a Site Editor preset value cannot be translated to a DTCG leaf — an unsupported
- * category (e.g. "shadow") or a malformed literal (empty, or a color that matches neither hex nor
- * a CSS color function).
+ * category (e.g. "shadow") or a malformed literal (an empty color/dimension/font-family value, or
+ * a font-family stack that is only commas).
  *
  * @since TBD
  */

--- a/includes/resources/Design_Tokens/Global_Styles/Untranslatable_Value_Exception.php
+++ b/includes/resources/Design_Tokens/Global_Styles/Untranslatable_Value_Exception.php
@@ -1,0 +1,15 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Global_Styles;
+
+use Exception;
+
+/**
+ * Thrown when a Site Editor preset value cannot be translated to a DTCG leaf — an unsupported
+ * category (e.g. "shadow") or a malformed literal (empty, or a color that matches neither hex nor
+ * a CSS color function).
+ *
+ * @since TBD
+ */
+final class Untranslatable_Value_Exception extends Exception {
+}

--- a/includes/resources/Design_Tokens/Global_Styles/Value_Translator.php
+++ b/includes/resources/Design_Tokens/Global_Styles/Value_Translator.php
@@ -1,0 +1,32 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Global_Styles;
+
+/**
+ * Translates a literal Site Editor preset value into a DTCG leaf for the categories
+ * Theme_Json\Preset_Bucket actually injects: color, spacing (dimension), font-family.
+ *
+ * Deliberately does NOT handle "shadow": the Site Editor's shadow preset value is a CSS shorthand
+ * string, while the DTCG shadow $type is a structured, alias-able composite object
+ * (Schema\Vocabulary\Token_Type). Translating shorthand -> structured correctly is out of scope
+ * for this ticket; a changed shadow preset is skipped upstream (Global_Styles_Sync_Listener) and
+ * reported, not guessed at.
+ *
+ * @since TBD
+ */
+interface Value_Translator {
+
+	/**
+	 * Translate a literal preset value to a DTCG leaf for the given wp_preset category.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $category       The wp_preset category ("color", "spacing", "font-family").
+	 * @param string $literal_value  The literal value read from the Global Styles preset entry.
+	 *
+	 * @return array<string, mixed> A DTCG leaf: ['$type' => ..., '$value' => ...].
+	 *
+	 * @throws Untranslatable_Value_Exception When the category is unsupported or the value is malformed.
+	 */
+	public function translate( string $category, string $literal_value ): array;
+}

--- a/tests/wpunit/Resources/Design_Tokens/Global_Styles/Default_Value_TranslatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Global_Styles/Default_Value_TranslatorTest.php
@@ -140,6 +140,30 @@ final class Default_Value_TranslatorTest extends TestCase {
 	}
 
 	/**
+	 * A quoted family name (e.g. from `-apple-system, "Segoe UI", Roboto`) has its surrounding
+	 * quotes stripped, so Css_Renderer::font_family() re-wrapping it in quotes on render doesn't
+	 * double them up into `""Segoe UI""`.
+	 *
+	 * @return void
+	 */
+	public function testFontFamilyStripsSurroundingQuotes(): void {
+		$result = $this->translator->translate( 'font-family', '-apple-system, "Segoe UI", Roboto' );
+
+		$this->assertSame( [ '-apple-system', 'Segoe UI', 'Roboto' ], $result['$value'] );
+	}
+
+	/**
+	 * A single-quoted family name has its surrounding quotes stripped too.
+	 *
+	 * @return void
+	 */
+	public function testFontFamilyStripsSingleQuotes(): void {
+		$result = $this->translator->translate( 'font-family', "'Segoe UI', Roboto" );
+
+		$this->assertSame( [ 'Segoe UI', 'Roboto' ], $result['$value'] );
+	}
+
+	/**
 	 * An empty font family value throws.
 	 *
 	 * @return void

--- a/tests/wpunit/Resources/Design_Tokens/Global_Styles/Default_Value_TranslatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Global_Styles/Default_Value_TranslatorTest.php
@@ -1,0 +1,189 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Global_Styles;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Global_Styles\Default_Value_Translator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Global_Styles\Untranslatable_Value_Exception;
+use Tests\Support\Classes\TestCase;
+
+final class Default_Value_TranslatorTest extends TestCase {
+
+	private Default_Value_Translator $translator;
+
+	/**
+	 * Set up test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->translator = new Default_Value_Translator();
+	}
+
+	/**
+	 * A hex color is passed through unchanged.
+	 *
+	 * @return void
+	 */
+	public function testColorPassesHexThrough(): void {
+		$result = $this->translator->translate( 'color', '#3182CE' );
+
+		$this->assertSame( 'color', $result['$type'] );
+		$this->assertSame( '#3182CE', $result['$value'] );
+	}
+
+	/**
+	 * An rgb() color is passed through unchanged.
+	 *
+	 * @return void
+	 */
+	public function testColorPassesRgbThrough(): void {
+		$result = $this->translator->translate( 'color', 'rgb(49, 130, 206)' );
+
+		$this->assertSame( 'color', $result['$type'] );
+		$this->assertSame( 'rgb(49, 130, 206)', $result['$value'] );
+	}
+
+	/**
+	 * An empty color value throws.
+	 *
+	 * @return void
+	 */
+	public function testColorThrowsOnEmpty(): void {
+		$this->expectException( Untranslatable_Value_Exception::class );
+		$this->expectExceptionMessage( 'Color value cannot be empty.' );
+
+		$this->translator->translate( 'color', '' );
+	}
+
+	/**
+	 * A spacing dimension like "8px" is passed through unchanged.
+	 *
+	 * @return void
+	 */
+	public function testDimensionPassesPxThrough(): void {
+		$result = $this->translator->translate( 'spacing', '8px' );
+
+		$this->assertSame( 'dimension', $result['$type'] );
+		$this->assertSame( '8px', $result['$value'] );
+	}
+
+	/**
+	 * A spacing dimension like "1rem" is passed through unchanged.
+	 *
+	 * @return void
+	 */
+	public function testDimensionPassesRemThrough(): void {
+		$result = $this->translator->translate( 'spacing', '1rem' );
+
+		$this->assertSame( 'dimension', $result['$type'] );
+		$this->assertSame( '1rem', $result['$value'] );
+	}
+
+	/**
+	 * A spacing dimension like "clamp(...)" is passed through unchanged.
+	 *
+	 * @return void
+	 */
+	public function testDimensionPassesClampThrough(): void {
+		$result = $this->translator->translate( 'spacing', 'clamp(1rem, 2vw, 2rem)' );
+
+		$this->assertSame( 'dimension', $result['$type'] );
+		$this->assertSame( 'clamp(1rem, 2vw, 2rem)', $result['$value'] );
+	}
+
+	/**
+	 * An empty spacing dimension throws.
+	 *
+	 * @return void
+	 */
+	public function testDimensionThrowsOnEmpty(): void {
+		$this->expectException( Untranslatable_Value_Exception::class );
+		$this->expectExceptionMessage( 'Dimension value cannot be empty.' );
+
+		$this->translator->translate( 'spacing', '' );
+	}
+
+	/**
+	 * A single font family is wrapped in an array.
+	 *
+	 * @return void
+	 */
+	public function testFontFamilyWrapsSingleName(): void {
+		$result = $this->translator->translate( 'font-family', 'Georgia' );
+
+		$this->assertSame( 'fontFamily', $result['$type'] );
+		$this->assertSame( [ 'Georgia' ], $result['$value'] );
+	}
+
+	/**
+	 * A comma-separated font family stack is split and trimmed.
+	 *
+	 * @return void
+	 */
+	public function testFontFamilySplitsCommaStack(): void {
+		$result = $this->translator->translate( 'font-family', 'Georgia, serif' );
+
+		$this->assertSame( 'fontFamily', $result['$type'] );
+		$this->assertSame( [ 'Georgia', 'serif' ], $result['$value'] );
+	}
+
+	/**
+	 * Font family values with leading/trailing whitespace are trimmed.
+	 *
+	 * @return void
+	 */
+	public function testFontFamilyTrimsWhitespace(): void {
+		$result = $this->translator->translate( 'font-family', '  Georgia  ,  serif  ' );
+
+		$this->assertSame( [ 'Georgia', 'serif' ], $result['$value'] );
+	}
+
+	/**
+	 * An empty font family value throws.
+	 *
+	 * @return void
+	 */
+	public function testFontFamilyThrowsOnEmpty(): void {
+		$this->expectException( Untranslatable_Value_Exception::class );
+		$this->expectExceptionMessage( 'Font family value cannot be empty.' );
+
+		$this->translator->translate( 'font-family', '' );
+	}
+
+	/**
+	 * A font family that is only commas throws.
+	 *
+	 * @return void
+	 */
+	public function testFontFamilyThrowsOnAllCommas(): void {
+		$this->expectException( Untranslatable_Value_Exception::class );
+		$this->expectExceptionMessage( 'Font family value cannot be empty.' );
+
+		$this->translator->translate( 'font-family', ',,,' );
+	}
+
+	/**
+	 * Translating a shadow category throws (out of scope).
+	 *
+	 * @return void
+	 */
+	public function testTranslateShadowThrows(): void {
+		$this->expectException( Untranslatable_Value_Exception::class );
+		$this->expectExceptionMessage( 'No Value_Translator for wp_preset category "shadow".' );
+
+		$this->translator->translate( 'shadow', '0 0 4px rgba(0, 0, 0, 0.25)' );
+	}
+
+	/**
+	 * Translating an unknown category throws.
+	 *
+	 * @return void
+	 */
+	public function testTranslateUnknownCategoryThrows(): void {
+		$this->expectException( Untranslatable_Value_Exception::class );
+		$this->expectExceptionMessage( 'No Value_Translator for wp_preset category "unknown-category".' );
+
+		$this->translator->translate( 'unknown-category', 'some-value' );
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `Value_Translator` for converting Site Editor (Global Styles) preset values into DTCG token leaves.

- `Value_Translator` interface: translates a literal preset value for a given `wp_preset` category (`color`, `spacing`, `font-family`) into a `['\$type' => ..., '\$value' => ...]` DTCG leaf. Deliberately excludes `shadow` — the Site Editor's shadow preset is a CSS shorthand string, while the DTCG `shadow` `\$type` is a structured, alias-able composite; that conversion is out of scope here and is skipped upstream by the sync listener instead of being guessed at.
- `Default_Value_Translator`: the default implementation.
  - `color` — passed through unchanged (hex, `rgb()`/`rgba()`, `hsl()`/`hsla()`); the write pipeline's own DTCG validator re-validates it before commit, so this only rejects an empty value.
  - `spacing` — passed through unchanged as a `dimension` leaf; theme.json `spacingSizes` values are already valid CSS length strings.
  - `font-family` — wrapped into the array form the DTCG `fontFamily` `\$type` requires; a comma-separated stack is split and trimmed into its individual families.
  - Any other category, or an empty/malformed literal, throws `Untranslatable_Value_Exception`.
- `Untranslatable_Value_Exception`: thrown for an unsupported category or a malformed literal (empty value, or all-comma font-family list).

## Test plan

- [x] `Default_Value_TranslatorTest` covers color (hex, `rgb()`, empty), spacing (`px`, `rem`, `clamp()`, empty), font-family (single name, comma stack, whitespace trimming, empty, all-commas), and the unsupported-category cases (`shadow`, an arbitrary unknown category).
