### PR TITLE
Multi-axis Variants [2/4]: variant projection — CSS classes + dynamic-block render

### DIFF
--- a/includes/blocks/class-kadence-blocks-singlebtn-block.php
+++ b/includes/blocks/class-kadence-blocks-singlebtn-block.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Identifier;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Variant\Renders_Variant_Classes;
 use KadenceWP\KadenceBlocks\Utils\Cast;
 
 /**
@@ -22,6 +23,7 @@ use KadenceWP\KadenceBlocks\Utils\Cast;
  */
 class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 	use Sanitizes_Css_Identifier;
+	use Renders_Variant_Classes;
 
 	/**
 	 * Instance of this class
@@ -367,15 +369,10 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$classes[] = ! empty( $attributes['text'] ) ? 'kt-btn-has-text-true' : 'kt-btn-has-text-false';
 		$classes[] = ! empty( $attributes['icon'] ) ? 'kt-btn-has-svg-true' : 'kt-btn-has-svg-false';
 		$classes[] = ! empty( $attributes['iconReveal'] ) && ! empty( $attributes['icon'] ) ? 'icon-reveal' : '';
-		if ( ! empty( $attributes['kbVariant'] ) ) {
-			/**
-			 * The selected design-token variant outputs a kb-variant--<slug> class the Design Tokens variant
-			 * projector's scoped CSS hooks. This is a dynamic block, so the class is added here rather than by
-			 * the editor save filter; the shared Sanitizes_Css_Identifier sanitizer keeps the slug matching the
-			 * selector the projected CSS targets.
-			 */
-			$classes[] = 'kb-variant--' . self::sanitize_identifier( Cast::to_string( $attributes['kbVariant'] ) );
-		}
+		// Each selected design-token variant outputs a kb-variant--<group>--<slug> class (one per variant
+		// set/axis) the Design Tokens variant projector's scoped CSS hooks. This is a dynamic block, so the
+		// classes are added here rather than by the editor save filter.
+		$classes = array_merge( $classes, $this->variant_classes( $attributes['kbVariants'] ?? [] ) );
 
 		if ( ! empty( $attributes['target'] ) && 'video' === $attributes['target'] ) {
 			$classes[] = 'ktblocksvideopop';

--- a/includes/resources/Design_Tokens/Admin/Feed/Variants.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Variants.php
@@ -3,20 +3,22 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Variant_Set;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Unknown_Variant_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
 
 /**
- * Builds the admin UI feed's "variants" section: for every block that registered a variant set, its
- * default, variant names, bound properties, per-property bindings (structure) and resolved preview
- * values.
+ * Builds the admin UI feed's "variants" section: for every variant SET a block registers — keyed by block
+ * then by set group slug — its default, variant names, per-property bindings (structure) and resolved
+ * preview values.
  *
  * Structure comes from the registry ({@see \KadenceWP\KadenceBlocks\Design_Tokens\Registry\Variant_Set::to_ui_schema()});
- * the variant list and resolved values come from the {@see Variant_Resolver} against the live store. A
- * block registered but absent from the document (Unknown_Variant_Exception) is skipped, and a single
- * variant that fails to resolve is omitted, so one malformed block never breaks the whole feed. The
- * corrupt-store case (the Token_Resolver throwing an alias-cycle / dangling-alias RuntimeException from
- * inside resolve()) is NOT swallowed here — it is the Localizer's fail-open boundary.
+ * the variant list and resolved values come from the {@see Variant_Resolver} against the live store. A set
+ * registered but absent from the document (Unknown_Variant_Exception) is skipped, and a single variant that
+ * fails to resolve is omitted, so one malformed set never breaks the whole feed. The corrupt-store case (the
+ * Token_Resolver throwing an alias-cycle / dangling-alias RuntimeException from inside resolve()) is NOT
+ * swallowed here — it is the Localizer's fail-open boundary. A preset / default-variant set (the implicit
+ * group, no picker) surfaces with an empty group slug.
  *
  * @since TBD
  */
@@ -52,46 +54,56 @@ final class Variants {
 	}
 
 	/**
-	 * The variants section, keyed by block name.
+	 * The variants section, keyed by block name then by set group slug.
 	 *
 	 * @since TBD
 	 *
 	 * @param string $slug The token set whose values variant aliases resolve against.
 	 *
-	 * @return array<string, mixed> block => { bindings, default, names, properties, values }.
+	 * @return array<string, array<string, mixed>> block => group => { bindings, group, default, names,
+	 *                                             properties, values, label? }.
 	 */
 	public function all( string $slug = 'default' ): array {
 		$out = [];
 
-		foreach ( $this->registry->variant_sets() as $block => $set ) {
-			try {
-				$names      = $this->variants->names( $block, $slug );
-				$default    = $this->variants->default_variant( $block, $slug );
-				$properties = $this->variants->value_properties( $block, $slug );
-			} catch ( Unknown_Variant_Exception $e ) {
-				continue; // Block registered but not defined in the document — skip, fail soft.
-			}
-
-			$values = [];
-
-			foreach ( $names as $variant ) {
+		foreach ( $this->registry->variant_sets() as $block => $sets ) {
+			foreach ( $sets as $group => $set ) {
 				try {
-					// Literal values: the editor renders each as a swatch, which a var() chain can't paint.
-					$values[ $variant ] = $this->variants->resolve_literal( $block, $variant, $slug );
+					$names   = $this->variants->names( $block, $slug, $group );
+					$default = $this->variants->default_variant( $block, $slug, $group );
 				} catch ( Unknown_Variant_Exception $e ) {
-					continue; // Omit a single unresolvable variant; keep the rest.
+					continue; // Set registered but not defined in the document — skip, fail soft.
 				}
-			}
 
-			$out[ $block ] = array_merge(
-				$set->to_ui_schema(),
-				[
-					'default'    => $default,
-					'names'      => $names,
-					'properties' => $properties,
-					'values'     => $values,
-				]
-			);
+				$values = [];
+
+				foreach ( $names as $variant ) {
+					try {
+						// Literal values: the editor renders each as a swatch, which a var() chain can't paint.
+						$values[ $variant ] = $this->variants->resolve_literal( $block, $variant, $slug, $group );
+					} catch ( Unknown_Variant_Exception $e ) {
+						continue; // Omit a single unresolvable variant; keep the rest.
+					}
+				}
+
+				$entry = array_merge(
+					$set->to_ui_schema(),
+					[
+						// A preset (implicit) set carries no picker slug; the editor keys off the empty group.
+						'group'      => $group === Variant_Set::get_implicit_group_key() ? '' : $group,
+						'default'    => $default,
+						'names'      => $names,
+						'properties' => array_keys( $set->bindings ),
+						'values'     => $values,
+					]
+				);
+
+				if ( $set->label !== null ) {
+					$entry['label'] = $set->label;
+				}
+
+				$out[ $block ][ $group ] = $entry;
+			}
 		}
 
 		return $out;

--- a/includes/resources/Design_Tokens/Editor/Variant_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Variant_Catalog.php
@@ -5,6 +5,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Editor;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Variant_Set;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Variants;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Unknown_Variant_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
@@ -13,12 +14,14 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
  * Builds the per-set variant catalog the block editor's variant picker and "save as new variant" form read.
  *
  * Keyed by token set so the picker can show the variants for whichever set a block is on (its `kbTokenSet`,
- * or the active set), not just the active one: `{ active: <slug>, sets: { <slug>: { <block>: {…} } } }`. Per
- * block it carries the `$default` slug, the named variants as { slug, label, userCreated }, the picker
- * control label, and the controllable surface as { key, kind, token } per bound property so the form can
- * render one input per property. It carries no resolved token values, so it cannot raise the alias-cycle
- * errors the admin feed must guard; a block registered but absent from a set (Unknown_Variant_Exception) is
- * skipped, so one undefined block never empties the catalog.
+ * or the active set), not just the active one, then by block and by variant SET (axis):
+ * `{ active: <slug>, sets: { <slug>: { <block>: { <group>: {…} } } } }`. Per variant set it carries the
+ * `$default` slug, the named variants as { slug, label, userCreated }, the picker control label, and the
+ * controllable surface as { key, kind, token } per bound property so the form can render one input per
+ * property. Only NAMED (picker-driven) sets appear; a block's preset / default-variant set (the implicit
+ * group) has no picker and is omitted. It carries no resolved token values, so it cannot raise the
+ * alias-cycle errors the admin feed must guard; a set registered but absent from a token set
+ * (Unknown_Variant_Exception) is skipped, so one undefined set never empties the catalog.
  *
  * @since TBD
  */
@@ -113,75 +116,75 @@ final class Variant_Catalog {
 	}
 
 	/**
-	 * The per-block catalog for one set.
+	 * The per-block, per-variant-set catalog for one token set. Only NAMED (picker-driven) sets are
+	 * surfaced; a block's preset / default-variant set (the implicit group) has no picker, so it is skipped.
 	 *
 	 * @since TBD
 	 *
 	 * @param string $slug The token set slug.
 	 *
-	 * @return array<string, mixed> block => { default, variants, properties, label? }.
+	 * @return array<string, array<string, mixed>> block => group => { group, default, variants, properties, label? }.
 	 */
 	private function for_set( string $slug ): array {
 		$out = [];
 
 		foreach ( $this->registry->variant_blocks() as $block ) {
-			try {
-				$names   = $this->variants->names( $block, $slug );
-				$default = $this->variants->default_variant( $block, $slug );
-			} catch ( Unknown_Variant_Exception $e ) {
-				continue; // Block registered but not defined in this set — skip, fail soft.
-			}
+			foreach ( $this->registry->sets_for_block( $block ) as $group => $set ) {
+				if ( $group === Variant_Set::get_implicit_group_key() ) {
+					continue; // A preset / default-variant set shows no picker, so it is not offered here.
+				}
 
-			$user_created = $this->effective->user_created( $block, $slug );
+				try {
+					$names   = $this->variants->names( $block, $slug, $group );
+					$default = $this->variants->default_variant( $block, $slug, $group );
+				} catch ( Unknown_Variant_Exception $e ) {
+					continue; // Set registered but not defined in this token set — skip, fail soft.
+				}
 
-			$variants = [];
+				$user_created = $this->effective->user_created( $block, $slug, $group );
 
-			foreach ( $names as $name ) {
-				$variants[] = [
-					'slug'        => $name,
-					'label'       => $this->variants->label( $block, $name, $slug ) ?? $name,
-					'userCreated' => in_array( $name, $user_created, true ),
+				$variants = [];
+
+				foreach ( $names as $name ) {
+					$variants[] = [
+						'slug'        => $name,
+						'label'       => $this->variants->label( $block, $name, $slug, $group ) ?? $name,
+						'userCreated' => in_array( $name, $user_created, true ),
+					];
+				}
+
+				$entry = [
+					'group'      => $group,
+					'default'    => $default,
+					'variants'   => $variants,
+					'properties' => $this->properties_for( $set ),
 				];
+
+				// The picker's control label (the set's axis), declared on the variant set. Omitted when the
+				// set declares none, so the editor falls back to its default label.
+				if ( $set->label !== null ) {
+					$entry['label'] = $set->label;
+				}
+
+				$out[ $block ][ $group ] = $entry;
 			}
-
-			$entry = [
-				'default'    => $default,
-				'variants'   => $variants,
-				'properties' => $this->properties_for( $block ),
-			];
-
-			// The picker's control label (the variant axis), declared on the variant set. Omitted when the
-			// block declares none, so the editor falls back to its default label.
-			$set = $this->registry->for_block( $block );
-
-			if ( $set !== null && $set->label !== null ) {
-				$entry['label'] = $set->label;
-			}
-
-			$out[ $block ] = $entry;
 		}
 
 		return $out;
 	}
 
 	/**
-	 * The controllable surface for a block: one { key, kind, token } entry per bound property, in binding
-	 * order, so the editor form renders an input per property. Set-independent structure read from the
-	 * registry's bindings.
+	 * The controllable surface for a variant set: one { key, kind, token } entry per bound property, in
+	 * binding order, so the editor form renders an input per property. Set-structure read from the set's
+	 * bindings.
 	 *
 	 * @since TBD
 	 *
-	 * @param string $block The block name.
+	 * @param Variant_Set $set The variant set.
 	 *
 	 * @return array<int, array{key: string, kind: string, token: string|null}>
 	 */
-	private function properties_for( string $block ): array {
-		$set = $this->registry->for_block( $block );
-
-		if ( $set === null ) {
-			return [];
-		}
-
+	private function properties_for( Variant_Set $set ): array {
 		$properties = [];
 
 		foreach ( $set->bindings as $property => $binding ) {

--- a/includes/resources/Design_Tokens/Projection/Variant/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Variant/Css_Builder.php
@@ -10,6 +10,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Scope;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Binding;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Variant_Set;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
 use RuntimeException;
 
@@ -24,26 +25,34 @@ use RuntimeException;
  * companion stylesheet (Native\Styles\Button), so one retarget path re-skins both with zero changes to a
  * block's markup. The selector is block-aware: core/button resolves to ".wp-block-button".
  *
+ * A block's variants may be organized into named GROUPS (independent single-select axes). The build
+ * iterates each block's groups and emits, per (block, group, variant), the same layers below. A grouped
+ * selection folds the group into both the class ("kb-variant--<group>--<variant>") and the variant var
+ * name; a flat block's single implicit group omits the group segment, so its output is identical to an
+ * ungrouped block. When two groups retarget the same --global-<slot>, their selected-variant rules carry
+ * equal specificity, so source order decides: groups are emitted in document order, so the later group
+ * wins for a shared slot.
+ *
  * The emission mirrors the raw-token (Css_Var) projection so a variant var is just another token in the
  * same multi-set graph:
  *
  *   1. One namespaced variant-var block per set —
- *      --kb-token--<set>--variant--<block>--<variant>--<property>: <value-or-var> — where an aliased
- *      binding reads var(--kb-token--<set>--<target>), so the variant chains to that set's namespaced
- *      token and a set's chain stays inside the set; a literal binding emits the literal.
+ *      --kb-token--<set>--variant--<block>--[<group>--]<variant>--<property>: <value-or-var> — where an
+ *      aliased binding reads var(--kb-token--<set>--<target>), so the variant chains to that set's
+ *      namespaced token and a set's chain stays inside the set; a literal binding emits the literal.
  *   2. An active-set alias layer pointing each canonical variant var at the active set's namespaced one
  *      (--kb-token--variant--…: var(--kb-token--<active>--variant--…)).
  *   3. One [data-kb-token-set="<set>"] switch selector per set re-pointing the canonical variant vars at
  *      that set, so a body class / container attribute swaps the variant palette client-side — the scoped
  *      rules below read the canonical variant var on the block element, so they follow it for their subtree.
- *   4. Per (block, variant) scoped rules — ".wp-block-<block>.kb-variant--<variant>" — pointing each
- *      --global-<slot> at the canonical variant var, plus a class-less ".wp-block-<block>" rule for the
- *      $default variant so a block with no variant selected still shows its preset. These are the coercive
- *      surface, built from the active set only.
+ *   4. Per (block, group, variant) scoped rules — ".wp-block-<block>.kb-variant--[<group>--]<variant>" —
+ *      pointing each --global-<slot> at the canonical variant var, plus a class-less ".wp-block-<block>"
+ *      rule per group for its $default variant so a block with no variant selected still shows its preset.
+ *      These are the coercive surface, built from the active set only.
  *
- * Scoping is per (block, variant): the same variant name on two blocks ("ghost" on a Button and a Row)
- * gets its own block-qualified rule, so values never collide. Both named variants and the "$default"
- * preset carry ordinary class/element specificity, so a per-instance edit still wins.
+ * Scoping is per (block, group, variant): the same variant name on two blocks ("ghost" on a Button and a
+ * Row), or on two groups, gets its own qualified rule, so values never collide. Both named variants and
+ * the "$default" preset carry ordinary class/element specificity, so a per-instance edit still wins.
  *
  * Nothing here is !important and the scope carries ordinary class specificity, so a per-instance inline
  * style still wins over a variant. Values are sanitized defensively before they reach a declaration.
@@ -123,7 +132,7 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @var array<string, array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}>>
+	 * @var array<string, array<string, array{selector:string, groups:array<string, array{default:string, variants:array<string, array<string, array{target:string, value:string}>>}>}>>
 	 */
 	private array $collected = [];
 
@@ -289,7 +298,7 @@ final class Css_Builder {
 	}
 
 	/**
-	 * Walk every (block, variant, property) that resolves to a slot-targeted value for a set, into a
+	 * Walk every (block, group, variant, property) that resolves to a slot-targeted value for a set, into a
 	 * structure the layers below build from. The projected value namespaces its var() target to the set, so
 	 * an aliased variant chains to that set's namespaced token. Memoized per slug for the request.
 	 *
@@ -297,7 +306,7 @@ final class Css_Builder {
 	 *
 	 * @param string $slug The set slug to resolve against (and namespace the values to).
 	 *
-	 * @return array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}>
+	 * @return array<string, array{selector:string, groups:array<string, array{default:string, variants:array<string, array<string, array{target:string, value:string}>>}>}>
 	 */
 	private function collect( string $slug ): array {
 		if ( isset( $this->collected[ $slug ] ) ) {
@@ -307,69 +316,92 @@ final class Css_Builder {
 		$out = [];
 
 		foreach ( $this->registry->variant_blocks() as $block ) {
-			$set = $this->registry->for_block( $block );
-
-			if ( $set === null ) {
-				continue;
-			}
-
 			try {
 				// A block may carry registered bindings before the document defines its variants; that is not
 				// an error, it simply contributes nothing yet, so skip it rather than fail the whole build.
-				$names = $this->variants->names( $block, $slug );
+				$groups = $this->variants->groups( $block, $slug );
 			} catch ( RuntimeException $e ) {
 				continue;
 			}
 
-			$variants = [];
+			$group_data = [];
 
-			foreach ( $names as $variant ) {
+			// Groups are collected in document order: when two groups share a --global-<slot>, equal
+			// specificity means the later group's scoped rule wins by source order.
+			foreach ( $groups as $group ) {
+				// Each set (axis) owns its bindings, so look them up per group — the button's "style" set, a
+				// preset block's implicit set. A group the document defines but the registry never declared a
+				// set for contributes nothing (no bindings), so skip it.
+				$set = $this->registry->for_variant_set( $block, $group );
+
+				if ( $set === null ) {
+					continue;
+				}
+
 				try {
-					$values = $this->variants->resolve( $block, $variant, $slug, $slug );
+					$names = $this->variants->names( $block, $slug, $group );
 				} catch ( RuntimeException $e ) {
 					continue;
 				}
 
-				$properties = [];
+				$variants = [];
 
-				foreach ( $values as $property => $value ) {
-					$binding = $set->binding( $property );
-
-					if ( $binding === null ) {
+				foreach ( $names as $variant ) {
+					try {
+						$values = $this->variants->resolve( $block, $variant, $slug, $slug, $group );
+					} catch ( RuntimeException $e ) {
 						continue;
 					}
 
-					$target = $this->target_var( $binding );
+					$properties = [];
 
-					if ( $target === null ) {
-						continue;
+					foreach ( $values as $property => $value ) {
+						$binding = $set->binding( $property );
+
+						if ( $binding === null ) {
+							continue;
+						}
+
+						$target = $this->target_var( $binding );
+
+						if ( $target === null ) {
+							continue;
+						}
+
+						$properties[ $property ] = [
+							'target' => $target,
+							'value'  => $value,
+						];
 					}
 
-					$properties[ $property ] = [
-						'target' => $target,
-						'value'  => $value,
-					];
+					if ( $properties !== [] ) {
+						$variants[ $variant ] = $properties;
+					}
 				}
 
-				if ( $properties !== [] ) {
-					$variants[ $variant ] = $properties;
+				if ( $variants === [] ) {
+					continue;
 				}
+
+				try {
+					$default = $this->variants->default_variant( $block, $slug, $group );
+				} catch ( RuntimeException $e ) {
+					$default = '';
+				}
+
+				$group_data[ $group ] = [
+					'default'  => $default,
+					'variants' => $variants,
+				];
 			}
 
-			if ( $variants === [] ) {
+			if ( $group_data === [] ) {
 				continue;
-			}
-
-			try {
-				$default = $this->variants->default_variant( $block, $slug );
-			} catch ( RuntimeException $e ) {
-				$default = '';
 			}
 
 			$out[ $block ] = [
 				'selector' => $this->block_selector( $block ),
-				'default'  => $default,
-				'variants' => $variants,
+				'groups'   => $group_data,
 			];
 		}
 
@@ -382,8 +414,8 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}> $collected The set's collected variants.
-	 * @param string                                                                                                                          $slug      The set slug to namespace the var names under.
+	 * @param array<string, array{selector:string, groups:array<string, array{default:string, variants:array<string, array<string, array{target:string, value:string}>>}>}> $collected The set's collected variants.
+	 * @param string                                                                                                                                                       $slug      The set slug to namespace the var names under.
 	 *
 	 * @return string
 	 */
@@ -391,9 +423,11 @@ final class Css_Builder {
 		$declarations = '';
 
 		foreach ( $collected as $block => $data ) {
-			foreach ( $data['variants'] as $variant => $properties ) {
-				foreach ( $properties as $property => $info ) {
-					$declarations .= $this->variant_var( $block, $variant, $property, $slug ) . ':' . $this->sanitize_value( $info['value'] ) . ';';
+			foreach ( $data['groups'] as $group => $group_data ) {
+				foreach ( $group_data['variants'] as $variant => $properties ) {
+					foreach ( $properties as $property => $info ) {
+						$declarations .= $this->variant_var( $block, $group, $variant, $property, $slug ) . ':' . $this->sanitize_value( $info['value'] ) . ';';
+					}
 				}
 			}
 		}
@@ -407,8 +441,8 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}> $collected   The active set's collected variants.
-	 * @param string                                                                                                                          $active_slug The active set slug.
+	 * @param array<string, array{selector:string, groups:array<string, array{default:string, variants:array<string, array<string, array{target:string, value:string}>>}>}> $collected   The active set's collected variants.
+	 * @param string                                                                                                                                                       $active_slug The active set slug.
 	 *
 	 * @return string
 	 */
@@ -426,8 +460,8 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}> $collected The set's collected variants.
-	 * @param string                                                                                                                          $slug      The set slug.
+	 * @param array<string, array{selector:string, groups:array<string, array{default:string, variants:array<string, array<string, array{target:string, value:string}>>}>}> $collected The set's collected variants.
+	 * @param string                                                                                                                                                       $slug      The set slug.
 	 *
 	 * @return string
 	 */
@@ -448,8 +482,8 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}> $collected The collected variants whose ids drive the layer.
-	 * @param string                                                                                                                          $slug      The set slug the canonical names are pointed at.
+	 * @param array<string, array{selector:string, groups:array<string, array{default:string, variants:array<string, array<string, array{target:string, value:string}>>}>}> $collected The collected variants whose ids drive the layer.
+	 * @param string                                                                                                                                                       $slug      The set slug the canonical names are pointed at.
 	 *
 	 * @return string
 	 */
@@ -457,9 +491,11 @@ final class Css_Builder {
 		$declarations = '';
 
 		foreach ( $collected as $block => $data ) {
-			foreach ( $data['variants'] as $variant => $properties ) {
-				foreach ( $properties as $property => $info ) {
-					$declarations .= $this->variant_var( $block, $variant, $property ) . ':var(' . $this->variant_var( $block, $variant, $property, $slug ) . ');';
+			foreach ( $data['groups'] as $group => $group_data ) {
+				foreach ( $group_data['variants'] as $variant => $properties ) {
+					foreach ( $properties as $property => $info ) {
+						$declarations .= $this->variant_var( $block, $group, $variant, $property ) . ':var(' . $this->variant_var( $block, $group, $variant, $property, $slug ) . ');';
+					}
 				}
 			}
 		}
@@ -468,14 +504,14 @@ final class Css_Builder {
 	}
 
 	/**
-	 * Emit the coercive scoped rules from the active set's collected variants: per (block, variant) a
-	 * ".wp-block-<block>.kb-variant--<variant>" rule pointing each --global-<slot> at the canonical variant
-	 * var, plus a class-less ".wp-block-<block>" rule re-emitting the $default variant's declarations so an
-	 * unselected block still shows its preset.
+	 * Emit the coercive scoped rules from the active set's collected variants: per (block, group, variant) a
+	 * ".wp-block-<block>.kb-variant--[<group>--]<variant>" rule pointing each --global-<slot> at the
+	 * canonical variant var, plus a class-less ".wp-block-<block>" rule per group re-emitting that group's
+	 * $default variant's declarations so an unselected block still shows its preset.
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}> $collected The active set's collected variants.
+	 * @param array<string, array{selector:string, groups:array<string, array{default:string, variants:array<string, array<string, array{target:string, value:string}>>}>}> $collected The active set's collected variants.
 	 *
 	 * @return string
 	 */
@@ -485,32 +521,34 @@ final class Css_Builder {
 		foreach ( $collected as $block => $data ) {
 			$selector = $data['selector'];
 
-			// Keep each variant's slot declarations so the $default's can be re-emitted, class-less, below.
-			$variant_declarations = [];
+			foreach ( $data['groups'] as $group => $group_data ) {
+				// Keep each variant's slot declarations so the group's $default can be re-emitted, class-less, below.
+				$variant_declarations = [];
 
-			foreach ( $data['variants'] as $variant => $properties ) {
-				$declarations = '';
+				foreach ( $group_data['variants'] as $variant => $properties ) {
+					$declarations = '';
 
-				foreach ( $properties as $property => $info ) {
-					$declarations .= $info['target'] . ':var(' . $this->variant_var( $block, $variant, $property ) . ');';
+					foreach ( $properties as $property => $info ) {
+						$declarations .= $info['target'] . ':var(' . $this->variant_var( $block, $group, $variant, $property ) . ');';
+					}
+
+					if ( $declarations !== '' ) {
+						$variant_declarations[ $variant ] = $declarations;
+						$css                             .= $selector . '.' . $this->variant_class( $group, $variant ) . '{' . $declarations . '}';
+					}
 				}
 
-				if ( $declarations !== '' ) {
-					$variant_declarations[ $variant ] = $declarations;
-					$css                             .= $selector . '.' . Style::variant_class( $variant ) . '{' . $declarations . '}';
+				/**
+				 * The group's $default look: a block with no variant selected for this group still shows its
+				 * preset. Point the same slots at the group's $default variant's var on the class-less block
+				 * selector. Its lower specificity yields to the kb-variant-- rules above (a selected variant)
+				 * and to a per-instance edit, so it only fills the gap.
+				 */
+				$default = $group_data['default'];
+
+				if ( $default !== '' && isset( $variant_declarations[ $default ] ) ) {
+					$css .= $selector . '{' . $variant_declarations[ $default ] . '}';
 				}
-			}
-
-			/**
-			 * The $default look: a block with no variant selected still shows its preset. Point the same slots
-			 * at the $default variant's var on the class-less block selector. Its lower specificity yields to
-			 * the kb-variant-- rules above (a selected variant) and to a per-instance edit, so it only fills
-			 * the gap.
-			 */
-			$default = $data['default'];
-
-			if ( $default !== '' && isset( $variant_declarations[ $default ] ) ) {
-				$css .= $selector . '{' . $variant_declarations[ $default ] . '}';
 			}
 		}
 
@@ -599,13 +637,33 @@ final class Css_Builder {
 	}
 
 	/**
-	 * The variant var name for a (block, variant, property), optionally namespaced to a token set:
-	 * "--kb-token--[<set>--]variant--<block>--<variant>--<property>", e.g.
-	 * --kb-token--dark--variant--kadence-advancedbtn--ghost--button-bg.
+	 * The variant class for a (group, variant): the flat "kb-variant--<variant>" for a block's implicit
+	 * single group, or the grouped "kb-variant--<group>--<variant>" for an explicit group. Delegates to
+	 * {@see Style} so the class shape matches the editor's and never drifts.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $group   The variant group (the implicit-group sentinel for a flat block).
+	 * @param string $variant The variant slug.
+	 *
+	 * @return string
+	 */
+	private function variant_class( string $group, string $variant ): string {
+		return $group === Variant_Set::get_implicit_group_key()
+			? Style::variant_class( $variant )
+			: Style::group_variant_class( $group, $variant );
+	}
+
+	/**
+	 * The variant var name for a (block, group, variant, property), optionally namespaced to a token set:
+	 * "--kb-token--[<set>--]variant--<block>--[<group>--]<variant>--<property>", e.g.
+	 * --kb-token--dark--variant--kadence-advancedbtn--emphasis--ghost--button-bg. A block's implicit single
+	 * group omits the "<group>--" segment, so a flat block keeps the ungrouped var shape unchanged.
 	 *
 	 * @since TBD
 	 *
 	 * @param string $block     The block name.
+	 * @param string $group     The variant group (the implicit-group sentinel for a flat block).
 	 * @param string $variant   The variant slug.
 	 * @param string $property  The block property.
 	 * @param string $namespace Optional token-set slug to namespace the variable under. Empty yields the
@@ -613,11 +671,12 @@ final class Css_Builder {
 	 *
 	 * @return string
 	 */
-	private function variant_var( string $block, string $variant, string $property, string $namespace = '' ): string {
+	private function variant_var( string $block, string $group, string $variant, string $property, string $namespace = '' ): string {
 		return Css_Var::get_prefix()
 			. ( $namespace === '' ? '' : self::sanitize_identifier( $namespace ) . '--' )
 			. self::VARIANT_SEGMENT
 			. self::sanitize_identifier( str_replace( '/', '-', $block ) ) . '--'
+			. ( $group === Variant_Set::get_implicit_group_key() ? '' : self::sanitize_identifier( $group ) . '--' )
 			. self::sanitize_identifier( $variant ) . '--'
 			. self::sanitize_identifier( $property );
 	}

--- a/includes/resources/Design_Tokens/Projection/Variant/Renders_Variant_Classes.php
+++ b/includes/resources/Design_Tokens/Projection/Variant/Renders_Variant_Classes.php
@@ -1,0 +1,51 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Variant;
+
+/**
+ * Shared helper for a dynamic (PHP-rendered) block that adds its selected design-token variant classes to
+ * its own markup. A static (save.js) block gets these classes from the editor save filter instead, but a
+ * dynamic block builds its class list in PHP, so it composes this trait and merges {@see self::variant_classes()}
+ * into that list.
+ *
+ * The classes are the same `kb-variant--<group>--<variant>` shape the projector's scoped CSS targets and the
+ * editor's preview/save filters emit — one per variant set (axis) the block's `kbVariants` attribute selects.
+ * The shape itself has a single source, {@see Style::group_variant_class()}; this trait is only the "read the
+ * attribute map, produce the list" seam so every block does it identically.
+ *
+ * @since TBD
+ */
+trait Renders_Variant_Classes {
+
+	/**
+	 * The `kb-variant--<group>--<variant>` classes a block's `kbVariants` attribute selects — one per variant
+	 * set (axis) with a non-empty selection. A non-array attribute, or an entry with an empty group or
+	 * variant, yields nothing, so a block can pass the raw attribute straight through.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $kb_variants The block's `kbVariants` attribute (variant-set group slug => variant slug map).
+	 *
+	 * @return string[]
+	 */
+	protected function variant_classes( $kb_variants ): array {
+		if ( ! is_array( $kb_variants ) ) {
+			return [];
+		}
+
+		$classes = [];
+
+		foreach ( $kb_variants as $group => $variant ) {
+			$group   = (string) $group;
+			$variant = is_string( $variant ) ? $variant : '';
+
+			if ( $group === '' || $variant === '' ) {
+				continue;
+			}
+
+			$classes[] = Style::group_variant_class( $group, $variant );
+		}
+
+		return $classes;
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Variant/Style.php
+++ b/includes/resources/Design_Tokens/Projection/Variant/Style.php
@@ -14,6 +14,11 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Identi
  * "is-style-outline" and "kb-variant--secondary" at once. The editor adds the class via the shared kbVariant
  * save/preview filters (see src/early-filters.js), mirroring the same sanitizer used here.
  *
+ * A variant may belong to a named GROUP (axis). A grouped selection carries the group in the class —
+ * "kb-variant--<group>--<variant>" — so two independently chosen axes (e.g. a color and an emphasis)
+ * compose as two classes on one block. A flat block's implicit single group omits the group segment and
+ * keeps the "kb-variant--<variant>" shape, so stored documents are unaffected.
+ *
  * @since TBD
  */
 final class Style {
@@ -41,5 +46,22 @@ final class Style {
 	 */
 	public static function variant_class( string $variant ): string {
 		return self::CLASS_PREFIX . self::sanitize_identifier( $variant );
+	}
+
+	/**
+	 * The class a grouped variant selection outputs, e.g. ("emphasis", "outline") =>
+	 * "kb-variant--emphasis--outline". Each segment is sanitized independently so the group and variant
+	 * slugs cannot merge across the "--" delimiter, mirroring the JS kbVariantsClassNames() sanitizer so the
+	 * class always matches the selector the projected CSS targets.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $group   The variant group (axis) slug.
+	 * @param string $variant The variant slug.
+	 *
+	 * @return string
+	 */
+	public static function group_variant_class( string $group, string $variant ): string {
+		return self::CLASS_PREFIX . self::sanitize_identifier( $group ) . '--' . self::sanitize_identifier( $variant );
 	}
 }

--- a/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
@@ -6,6 +6,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Variant_Set;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Variants;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
@@ -122,6 +123,15 @@ final class Variants_Controller extends Controller {
 	 * @var string
 	 */
 	private const SET_PARAM = 'set';
+
+	/**
+	 * The request parameter that carries the variant set (axis) group slug a read/write targets.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const VARIANT_SET_PARAM = 'variant_set';
 
 	/**
 	 * The block vendor path segment. A slug-safe class with no slash; the block name is the second segment.
@@ -395,14 +405,17 @@ final class Variants_Controller extends Controller {
 		$section = $this->variants->section( $slug );
 		$blocks  = [];
 
-		foreach ( $this->registry->variant_blocks() as $block ) {
-			$node = isset( $section[ $block ] ) && is_array( $section[ $block ] ) ? $section[ $block ] : [];
+		foreach ( $this->registry->variant_sets() as $block => $sets ) {
+			foreach ( $sets as $group => $set ) {
+				$node = $this->set_node( $section, $block, $group );
 
-			$blocks[] = [
-				'block'   => $block,
-				'default' => $this->default_of( $node ),
-				'names'   => $this->variant_names( $node ),
-			];
+				$blocks[] = [
+					'block'   => $block,
+					'group'   => $group === Variant_Set::get_implicit_group_key() ? '' : $group,
+					'default' => $this->default_of( $node ),
+					'names'   => $this->variant_names( $node ),
+				];
+			}
 		}
 
 		return new WP_REST_Response( [ 'blocks' => $blocks ], WP_Http::OK );
@@ -419,13 +432,14 @@ final class Variants_Controller extends Controller {
 	 */
 	public function get_item( $request ) {
 		$block = $this->block_from( $request );
+		$group = $this->group_from( $request, $block );
 		$error = $this->guard_block( $block );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
 		}
 
-		return new WP_REST_Response( $this->prepare_item( $block, $this->slug( $request ) ), WP_Http::OK );
+		return new WP_REST_Response( $this->prepare_item( $block, $group, $this->slug( $request ) ), WP_Http::OK );
 	}
 
 	/**
@@ -442,6 +456,7 @@ final class Variants_Controller extends Controller {
 	 */
 	public function create_item( $request ) {
 		$block = $this->block_from( $request );
+		$group = $this->group_from( $request, $block );
 		$error = $this->guard_block( $block );
 
 		if ( $error instanceof WP_Error ) {
@@ -477,9 +492,9 @@ final class Variants_Controller extends Controller {
 
 		$slug       = $this->slug( $request );
 		$block_node = $this->normalize_block_node( $block_node, $slug );
-		$candidate  = $this->mutator->merge( $this->stored_document( $slug ), $this->partial( $block, $block_node ) );
+		$candidate  = $this->mutator->merge( $this->stored_document( $slug ), $this->partial( $block, $group, $block_node ) );
 
-		$error = $this->guard_surface( $candidate, $block_node, $block );
+		$error = $this->guard_surface( $candidate, $block_node, $block, $group );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
@@ -491,7 +506,7 @@ final class Variants_Controller extends Controller {
 			return $error;
 		}
 
-		return $this->validate_and_save( $candidate, $block, $slug );
+		return $this->validate_and_save( $candidate, $block, $group, $slug );
 	}
 
 	/**
@@ -508,6 +523,7 @@ final class Variants_Controller extends Controller {
 	 */
 	public function update_item( $request ) {
 		$block = $this->block_from( $request );
+		$group = $this->group_from( $request, $block );
 		$error = $this->guard_block( $block );
 
 		if ( $error instanceof WP_Error ) {
@@ -539,16 +555,16 @@ final class Variants_Controller extends Controller {
 		$block_node = $this->normalize_block_node( $block_node, $slug );
 
 		// Replace, not merge: drop the stored block node first so a variant the body omits does not survive.
-		$stored    = $this->unset_block( $this->stored_document( $slug ), $block );
-		$candidate = $this->mutator->merge( $stored, $this->partial( $block, $block_node ) );
+		$stored    = $this->unset_block( $this->stored_document( $slug ), $block, $group );
+		$candidate = $this->mutator->merge( $stored, $this->partial( $block, $group, $block_node ) );
 
-		$error = $this->guard_default_present( $candidate, $block );
+		$error = $this->guard_default_present( $candidate, $block, $group );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
 		}
 
-		$error = $this->guard_surface( $candidate, $block_node, $block );
+		$error = $this->guard_surface( $candidate, $block_node, $block, $group );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
@@ -560,7 +576,7 @@ final class Variants_Controller extends Controller {
 			return $error;
 		}
 
-		return $this->validate_and_save( $candidate, $block, $slug );
+		return $this->validate_and_save( $candidate, $block, $group, $slug );
 	}
 
 	/**
@@ -577,6 +593,7 @@ final class Variants_Controller extends Controller {
 	 */
 	public function delete_item( $request ) {
 		$block = $this->block_from( $request );
+		$group = $this->group_from( $request, $block );
 		$error = $this->guard_block( $block );
 
 		if ( $error instanceof WP_Error ) {
@@ -585,13 +602,13 @@ final class Variants_Controller extends Controller {
 
 		$slug      = $this->slug( $request );
 		$stored    = $this->stored_document( $slug );
-		$candidate = $this->unset_block( $stored, $block );
+		$candidate = $this->unset_block( $stored, $block, $group );
 
 		if ( $candidate === $stored ) {
-			return new WP_REST_Response( $this->prepare_item( $block, $slug ), WP_Http::OK );
+			return new WP_REST_Response( $this->prepare_item( $block, $group, $slug ), WP_Http::OK );
 		}
 
-		return $this->validate_and_save( $candidate, $block, $slug );
+		return $this->validate_and_save( $candidate, $block, $group, $slug );
 	}
 
 	/**
@@ -610,6 +627,7 @@ final class Variants_Controller extends Controller {
 	 */
 	public function delete_variant( $request ) {
 		$block = $this->block_from( $request );
+		$group = $this->group_from( $request, $block );
 		$error = $this->guard_block( $block );
 
 		if ( $error instanceof WP_Error ) {
@@ -631,19 +649,19 @@ final class Variants_Controller extends Controller {
 
 		$slug      = $this->slug( $request );
 		$stored    = $this->stored_document( $slug );
-		$candidate = $this->unset_variant( $stored, $block, $variant );
+		$candidate = $this->unset_variant( $stored, $block, $group, $variant );
 
 		if ( $candidate === $stored ) {
-			return new WP_REST_Response( $this->prepare_item( $block, $slug ), WP_Http::OK );
+			return new WP_REST_Response( $this->prepare_item( $block, $group, $slug ), WP_Http::OK );
 		}
 
-		$error = $this->guard_default_present( $candidate, $block );
+		$error = $this->guard_default_present( $candidate, $block, $group );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
 		}
 
-		return $this->validate_and_save( $candidate, $block, $slug );
+		return $this->validate_and_save( $candidate, $block, $group, $slug );
 	}
 
 	/**
@@ -657,17 +675,19 @@ final class Variants_Controller extends Controller {
 	 */
 	public function get_default( $request ) {
 		$block = $this->block_from( $request );
+		$group = $this->group_from( $request, $block );
 		$error = $this->guard_block( $block );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
 		}
 
-		$node = $this->variants->block( $block, $this->slug( $request ) ) ?? [];
+		$node = $this->set_node( $this->variants->section( $this->slug( $request ) ), $block, $group );
 
 		return new WP_REST_Response(
 			[
 				'block'   => $block,
+				'group'   => $group === Variant_Set::get_implicit_group_key() ? '' : $group,
 				'default' => $this->default_of( $node ),
 			],
 			WP_Http::OK
@@ -688,6 +708,7 @@ final class Variants_Controller extends Controller {
 	 */
 	public function set_default( $request ) {
 		$block = $this->block_from( $request );
+		$group = $this->group_from( $request, $block );
 		$error = $this->guard_block( $block );
 
 		if ( $error instanceof WP_Error ) {
@@ -699,16 +720,16 @@ final class Variants_Controller extends Controller {
 		$slug      = $this->slug( $request );
 		$candidate = $this->mutator->merge(
 			$this->stored_document( $slug ),
-			$this->partial( $block, [ Extensions::get_default_key() => $default ] )
+			$this->partial( $block, $group, [ Extensions::get_default_key() => $default ] )
 		);
 
-		$error = $this->guard_default_present( $candidate, $block );
+		$error = $this->guard_default_present( $candidate, $block, $group );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
 		}
 
-		return $this->validate_and_save( $candidate, $block, $slug );
+		return $this->validate_and_save( $candidate, $block, $group, $slug );
 	}
 
 	/**
@@ -804,16 +825,17 @@ final class Variants_Controller extends Controller {
 	 *
 	 * @param array<string, mixed> $candidate The full candidate overrides document to validate and store.
 	 * @param string               $block     The block being written, for error context.
+	 * @param string               $group     The variant set group (the implicit sentinel for a preset set).
 	 * @param string               $slug      The token set slug being written.
 	 *
 	 * @return WP_REST_Response|WP_Error
 	 */
-	private function validate_and_save( array $candidate, string $block, string $slug ) {
+	private function validate_and_save( array $candidate, string $block, string $group, string $slug ) {
 		// A brand-new set has no version yet; report 201 Created rather than 200 OK on first write.
 		$status = $this->store->get_version( $slug ) !== '' ? WP_Http::OK : WP_Http::CREATED;
 
 		if ( $candidate === [] ) {
-			return $this->persist( '', $block, $status, $slug );
+			return $this->persist( '', $block, $group, $status, $slug );
 		}
 
 		$result = $this->validator->validate( $candidate, Dtcg_Validator::get_context_overrides() );
@@ -857,7 +879,7 @@ final class Variants_Controller extends Controller {
 			);
 		}
 
-		return $this->persist( $encoded, $block, $status, $slug );
+		return $this->persist( $encoded, $block, $group, $status, $slug );
 	}
 
 	/**
@@ -867,12 +889,13 @@ final class Variants_Controller extends Controller {
 	 *
 	 * @param string $document The raw overrides-only DTCG JSON (empty string clears the set).
 	 * @param string $block    The block being written.
+	 * @param string $group    The variant set group (the implicit sentinel for a preset set).
 	 * @param int    $status   The success status code.
 	 * @param string $slug     The token set slug being written.
 	 *
 	 * @return WP_REST_Response|WP_Error
 	 */
-	private function persist( string $document, string $block, int $status, string $slug ) {
+	private function persist( string $document, string $block, string $group, int $status, string $slug ) {
 		try {
 			$this->store->save_document( $document, $slug );
 		} catch ( DatabaseQueryException $e ) {
@@ -886,7 +909,7 @@ final class Variants_Controller extends Controller {
 			);
 		}
 
-		return new WP_REST_Response( $this->prepare_item( $block, $slug ), $status );
+		return new WP_REST_Response( $this->prepare_item( $block, $group, $slug ), $status );
 	}
 
 	/**
@@ -899,7 +922,7 @@ final class Variants_Controller extends Controller {
 	 * @return WP_Error|null A WP_Error when the block accepts no variants, null otherwise.
 	 */
 	private function guard_block( string $block ): ?WP_Error {
-		if ( $this->registry->for_block( $block ) !== null ) {
+		if ( $this->registry->sets_for_block( $block ) !== [] ) {
 			return null;
 		}
 
@@ -1013,14 +1036,15 @@ final class Variants_Controller extends Controller {
 	 *
 	 * @param array<string, mixed> $candidate The candidate overrides document.
 	 * @param string               $block     The block name.
+	 * @param string               $group     The variant set group (the implicit sentinel for a preset set).
 	 *
 	 * @return WP_Error|null A WP_Error when the default is dangling, null otherwise.
 	 */
-	private function guard_default_present( array $candidate, string $block ): ?WP_Error {
-		$node    = $this->variants->for_overrides( $candidate )[ $block ] ?? [];
-		$default = $this->default_of( is_array( $node ) ? $node : [] );
+	private function guard_default_present( array $candidate, string $block, string $group ): ?WP_Error {
+		$node    = $this->set_node( $this->variants->for_overrides( $candidate ), $block, $group );
+		$default = $this->default_of( $node );
 
-		if ( $default === '' || in_array( $default, $this->variant_names( is_array( $node ) ? $node : [] ), true ) ) {
+		if ( $default === '' || in_array( $default, $this->variant_names( $node ), true ) ) {
 			return null;
 		}
 
@@ -1048,20 +1072,20 @@ final class Variants_Controller extends Controller {
 	 * @since TBD
 	 *
 	 * @param array<string, mixed> $candidate  The post-merge candidate overrides document.
-	 * @param array<string, mixed> $block_node The block's variant node from the request.
+	 * @param array<string, mixed> $block_node The set's variant node from the request.
 	 * @param string               $block      The block name.
+	 * @param string               $group      The variant set group (the implicit sentinel for a preset set).
 	 *
 	 * @return WP_Error|null A WP_Error when a written variant's surface is wrong, null otherwise.
 	 */
-	private function guard_surface( array $candidate, array $block_node, string $block ): ?WP_Error {
-		$set = $this->registry->for_block( $block );
+	private function guard_surface( array $candidate, array $block_node, string $block, string $group ): ?WP_Error {
+		$set = $this->registry->for_variant_set( $block, $group );
 
 		if ( $set === null ) {
 			return null;
 		}
 
-		$node       = $this->variants->for_overrides( $candidate )[ $block ] ?? [];
-		$effective  = is_array( $node ) ? $node : [];
+		$effective  = $this->set_node( $this->variants->for_overrides( $candidate ), $block, $group );
 		$tokens_key = Extensions::get_tokens_key();
 
 		foreach ( array_keys( $block_node ) as $slug ) {
@@ -1190,15 +1214,17 @@ final class Variants_Controller extends Controller {
 	 * @since TBD
 	 *
 	 * @param string $block The block name.
+	 * @param string $group The variant set group (the implicit sentinel for a preset set).
 	 * @param string $slug  The token set slug being read.
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function prepare_item( string $block, string $slug ): array {
-		$node = $this->variants->block( $block, $slug ) ?? [];
+	private function prepare_item( string $block, string $group, string $slug ): array {
+		$node = $this->set_node( $this->variants->section( $slug ), $block, $group );
 
 		return [
 			'block'    => $block,
+			'group'    => $group === Variant_Set::get_implicit_group_key() ? '' : $group,
 			'slug'     => $slug,
 			'version'  => $this->store->get_version( $slug ),
 			'default'  => $this->default_of( $node ),
@@ -1232,21 +1258,25 @@ final class Variants_Controller extends Controller {
 	}
 
 	/**
-	 * Build a partial overrides document carrying only the given variant node for one block.
+	 * Build a partial overrides document carrying only the given variant node for one block's set.
 	 *
 	 * @since TBD
 	 *
 	 * @param string               $block      The block name.
-	 * @param array<string, mixed> $block_node The block's variant node.
+	 * @param string               $group      The variant set group (the implicit sentinel for a preset set).
+	 * @param array<string, mixed> $block_node The set's variant node.
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function partial( string $block, array $block_node ): array {
+	private function partial( string $block, string $group, array $block_node ): array {
+		// A named set nests its variants under the set slug; a preset (implicit) set sits directly on the block.
+		$node = $group === Variant_Set::get_implicit_group_key() ? $block_node : [ $group => $block_node ];
+
 		return [
 			Extensions::get_extensions_key() => [
 				Extensions::get_namespace() => [
 					Extensions::get_section_variants() => [
-						$block => $block_node,
+						$block => $node,
 					],
 				],
 			],
@@ -1254,32 +1284,36 @@ final class Variants_Controller extends Controller {
 	}
 
 	/**
-	 * Remove the stored `variants.<block>` node, pruning any ancestor emptied by the removal.
+	 * Remove the stored variant-set node (`variants.<block>[.<group>]`), pruning any ancestor emptied by the
+	 * removal.
 	 *
 	 * @since TBD
 	 *
 	 * @param array<string, mixed> $document The stored overrides document.
 	 * @param string               $block    The block name.
+	 * @param string               $group    The variant set group (the implicit sentinel for a preset set).
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function unset_block( array $document, string $block ): array {
-		return $this->mutator->remove_by_keys( $document, array_merge( $this->variants_path(), [ $block ] ) );
+	private function unset_block( array $document, string $block, string $group ): array {
+		return $this->mutator->remove_by_keys( $document, $this->node_path( $block, $group ) );
 	}
 
 	/**
-	 * Remove the stored `variants.<block>.<variant>` node, pruning any ancestor emptied by the removal.
+	 * Remove one stored variant (`variants.<block>[.<group>].<variant>`), pruning any ancestor emptied by the
+	 * removal.
 	 *
 	 * @since TBD
 	 *
 	 * @param array<string, mixed> $document The stored overrides document.
 	 * @param string               $block    The block name.
+	 * @param string               $group    The variant set group (the implicit sentinel for a preset set).
 	 * @param string               $variant  The variant slug.
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function unset_variant( array $document, string $block, string $variant ): array {
-		return $this->mutator->remove_by_keys( $document, array_merge( $this->variants_path(), [ $block, $variant ] ) );
+	private function unset_variant( array $document, string $block, string $group, string $variant ): array {
+		return $this->mutator->remove_by_keys( $document, array_merge( $this->node_path( $block, $group ), [ $variant ] ) );
 	}
 
 	/**
@@ -1291,6 +1325,81 @@ final class Variants_Controller extends Controller {
 	 */
 	private function variants_path(): array {
 		return Extensions::get_variants_path();
+	}
+
+	/**
+	 * The document key-path to a variant set's node: `variants.<block>` for a preset (implicit) set, or
+	 * `variants.<block>.<group>` for a named set.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block The block name.
+	 * @param string $group The variant set group (the implicit sentinel for a preset set).
+	 *
+	 * @return string[]
+	 */
+	private function node_path( string $block, string $group ): array {
+		$path = array_merge( $this->variants_path(), [ $block ] );
+
+		if ( $group !== Variant_Set::get_implicit_group_key() ) {
+			$path[] = $group;
+		}
+
+		return $path;
+	}
+
+	/**
+	 * The variant-bearing node for a (block, group) within a variants section: the block node itself for a
+	 * preset (implicit) set, or its `<group>` sub-map for a named set. Absent block/group yields an empty array.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $section The variants section.
+	 * @param string               $block   The block name.
+	 * @param string               $group   The variant set group.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function set_node( array $section, string $block, string $group ): array {
+		$node = isset( $section[ $block ] ) && is_array( $section[ $block ] ) ? $section[ $block ] : [];
+
+		if ( $group === Variant_Set::get_implicit_group_key() ) {
+			return $node;
+		}
+
+		return isset( $node[ $group ] ) && is_array( $node[ $group ] ) ? $node[ $group ] : [];
+	}
+
+	/**
+	 * The variant set (axis) a request targets: the `variant_set` parameter when it names a set the block
+	 * registers, otherwise the block's sole named set, else its preset (implicit) set. So a button request
+	 * defaults to its "style" set without the caller naming it, while a preset block resolves to the implicit set.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @param string          $block   The block name.
+	 *
+	 * @return string
+	 */
+	private function group_from( WP_REST_Request $request, string $block ): string {
+		$group = Cast::to_string( $request->get_param( self::VARIANT_SET_PARAM ) );
+
+		if ( $group !== '' && $this->registry->for_variant_set( $block, $group ) !== null ) {
+			return $group;
+		}
+
+		$named = array_keys(
+			array_filter(
+				$this->registry->sets_for_block( $block ),
+				static function ( string $slug ): bool {
+					return $slug !== Variant_Set::get_implicit_group_key();
+				},
+				ARRAY_FILTER_USE_KEY
+			)
+		);
+
+		return count( $named ) === 1 ? (string) $named[0] : Variant_Set::get_implicit_group_key();
 	}
 
 	/**
@@ -1441,7 +1550,8 @@ final class Variants_Controller extends Controller {
 				'pattern'           => '^[a-z0-9][a-z0-9-]*$',
 				'sanitize_callback' => 'sanitize_key',
 			],
-			self::SET_PARAM        => $this->set_param(),
+			self::SET_PARAM         => $this->set_param(),
+			self::VARIANT_SET_PARAM => $this->variant_set_param(),
 		];
 	}
 
@@ -1456,6 +1566,24 @@ final class Variants_Controller extends Controller {
 	private function set_param(): array {
 		return [
 			'description'       => __( 'Optional token set slug to target; defaults to the active set.', 'kadence-blocks' ),
+			'type'              => 'string',
+			'required'          => false,
+			'pattern'           => '^[\w-]+$',
+			'sanitize_callback' => 'sanitize_key',
+		];
+	}
+
+	/**
+	 * The optional variant-set argument: names the variant set (axis) a read/write targets, defaulting to the
+	 * block's sole named set (or its preset set) when absent.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function variant_set_param(): array {
+		return [
+			'description'       => __( 'Optional variant set (axis) group slug.', 'kadence-blocks' ),
 			'type'              => 'string',
 			'required'          => false,
 			'pattern'           => '^[\w-]+$',

--- a/src/blocks/singlebtn/block.json
+++ b/src/blocks/singlebtn/block.json
@@ -754,9 +754,9 @@
 			"type": "boolean",
 			"default": false
 		},
-		"kbVariant": {
-			"type": "string",
-			"default": ""
+		"kbVariants": {
+			"type": "object",
+			"default": {}
 		},
 		"kbTokenSet": {
 			"type": "string",

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -48,7 +48,7 @@ import {
 	SubsectionWrap,
 } from '@kadence/components';
 import classnames from 'classnames';
-import { times, filter, map, uniqueId } from 'lodash';
+import { times, filter, map, uniqueId, get } from 'lodash';
 
 import metadata from './block.json';
 /**
@@ -84,7 +84,7 @@ import {
 } from '@wordpress/components';
 import { addFilter, applyFilters, doAction } from '@wordpress/hooks';
 import BackendStyles from './components/backend-styles';
-import { VariantPicker, blockVariants, activeSet } from '../../extension/variant-picker';
+import { VariantPicker, blockVariants, activeSet, blockSetGroup } from '../../extension/variant-picker';
 import { VariantActions } from '../../extension/variant-picker/VariantActions';
 import { TokenSetPicker, selectableSets } from '../../extension/token-set-picker';
 
@@ -846,22 +846,36 @@ export default function KadenceButtonEdit(props) {
 												/>
 											</SubsectionWrap>
 										)}
-										{blockVariants(name, attributes.kbTokenSet || activeSet()).length > 0 && (
-											<SubsectionWrap label={__('Design Variants', 'kadence-blocks')}>
-												<VariantPicker
-													name={name}
-													set={attributes.kbTokenSet || activeSet()}
-													value={attributes.kbVariant || ''}
-													onChange={(value) => setAttributes({ kbVariant: value })}
-												/>
-												<VariantActions
-													blockName={name}
-													set={attributes.kbTokenSet || activeSet()}
-													selected={attributes.kbVariant || ''}
-													onSelect={(slug) => setAttributes({ kbVariant: slug })}
-												/>
-											</SubsectionWrap>
-										)}
+										{blockVariants(name, attributes.kbTokenSet || activeSet()).length > 0 &&
+											(() => {
+												const set = attributes.kbTokenSet || activeSet();
+												const group = blockSetGroup(name, set);
+												const selected = get(attributes, ['kbVariants', group], '');
+												const selectVariant = (value) =>
+													setAttributes({
+														kbVariants: {
+															...get(attributes, 'kbVariants', {}),
+															[group]: value,
+														},
+													});
+
+												return (
+													<SubsectionWrap label={__('Design Variants', 'kadence-blocks')}>
+														<VariantPicker
+															name={name}
+															set={set}
+															value={selected}
+															onChange={selectVariant}
+														/>
+														<VariantActions
+															blockName={name}
+															set={set}
+															selected={selected}
+															onSelect={selectVariant}
+														/>
+													</SubsectionWrap>
+												);
+											})()}
 									</KadencePanelBody>
 								)}
 								{showSettings('colorSettings', 'kadence/advancedbtn') && (

--- a/src/early-filters.js
+++ b/src/early-filters.js
@@ -13,7 +13,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { useDispatch, select } from '@wordpress/data';
-import { VariantPicker, blockVariants, activeSet } from './extension/variant-picker';
+import { VariantPicker, blockVariants, activeSet, blockSetGroup } from './extension/variant-picker';
 import { VariantActions } from './extension/variant-picker/VariantActions';
 import { TokenSetPicker, selectableSets } from './extension/token-set-picker';
 
@@ -99,26 +99,26 @@ export function enableNativeBlockVariants(settings, name) {
 addFilter('blocks.registerBlockType', 'kadence/kb-variant-native-support', enableNativeBlockVariants);
 
 /**
- * Add the kbVariant and kbTokenSet attributes to any block that opts in via the `kbVariant` block support.
+ * Add the kbVariants and kbTokenSet attributes to any block that opts in via the `kbVariant` block support.
  *
- * kbVariant holds the slug of the selected design-token variant (e.g. "ghost"); empty means the block
- * keeps its $default look (the block preset). kbTokenSet holds the slug of a per-block token-set override
- * (e.g. "dark"); empty means the block follows the active set. The scoped CSS that re-skins the block for a
- * selected variant and the switch selectors a set override re-points through are both emitted server-side
- * by the Design Tokens projector.
+ * kbVariants is a map of group slug => selected variant slug (e.g. { style: "ghost" }); an absent or empty
+ * entry means the block keeps that group's $default look (the block preset). kbTokenSet holds the slug of a
+ * per-block token-set override (e.g. "dark"); empty means the block follows the active set. The scoped CSS
+ * that re-skins the block for a selected variant and the switch selectors a set override re-points through
+ * are both emitted server-side by the Design Tokens projector.
  *
  * @param {Object} settings The block settings.
  *
  * @since TBD
  *
- * @return {Object} The block settings with the kbVariant and kbTokenSet attributes added.
+ * @return {Object} The block settings with the kbVariants and kbTokenSet attributes added.
  */
 export function blockVariantAttribute(settings) {
 	if (hasBlockSupport(settings, 'kbVariant')) {
 		settings.attributes = assign(settings.attributes, {
-			kbVariant: {
-				type: 'string',
-				default: '',
+			kbVariants: {
+				type: 'object',
+				default: {},
 			},
 			kbTokenSet: {
 				type: 'string',
@@ -149,18 +149,31 @@ function sanitizeTokenIdentifier(slug) {
 }
 
 /**
- * The class a selected variant outputs, or an empty string when none is selected.
+ * The classes a block's selected variants output: one `kb-variant--<group>--<slug>` per variant set with a
+ * non-empty selection in the `kbVariants` map. Each segment is sanitized independently so the group and
+ * variant slugs cannot merge across the "--" delimiter, mirroring the projector's PHP
+ * Style::group_variant_class().
  *
- * @param {string} kbVariant The selected variant slug.
+ * @param {Object} kbVariants The kbVariants map (variant-set group slug => selected variant slug).
  *
  * @since TBD
  *
- * @return {string} The `kb-variant--<slug>` class, or an empty string.
+ * @return {string} The space-joined variant classes, or an empty string.
  */
-function kbVariantClassName(kbVariant) {
-	const slug = sanitizeTokenIdentifier(kbVariant);
+function kbVariantsClassNames(kbVariants) {
+	if (!kbVariants || typeof kbVariants !== 'object') {
+		return '';
+	}
 
-	return slug ? `kb-variant--${slug}` : '';
+	return Object.keys(kbVariants)
+		.map((group) => {
+			const groupSlug = sanitizeTokenIdentifier(group);
+			const variantSlug = sanitizeTokenIdentifier(kbVariants[group]);
+
+			return groupSlug && variantSlug ? `kb-variant--${groupSlug}--${variantSlug}` : '';
+		})
+		.filter(Boolean)
+		.join(' ');
 }
 
 /**
@@ -180,7 +193,7 @@ export function blockVariantSaveClass(props, blockType, attributes) {
 		return props;
 	}
 
-	const variantClass = kbVariantClassName(get(attributes, 'kbVariant', ''));
+	const variantClass = kbVariantsClassNames(get(attributes, 'kbVariants', {}));
 
 	if (variantClass) {
 		props.className = props.className ? `${props.className} ${variantClass}` : variantClass;
@@ -232,7 +245,7 @@ const withBlockVariantClass = createHigherOrderComponent((BlockListBlock) => {
 			return <BlockListBlock {...props} />;
 		}
 
-		const variantClass = kbVariantClassName(get(attributes, 'kbVariant', ''));
+		const variantClass = kbVariantsClassNames(get(attributes, 'kbVariants', {}));
 
 		if (!variantClass) {
 			return <BlockListBlock {...props} />;
@@ -278,10 +291,10 @@ addFilter('editor.BlockListBlock', 'kadence/kb-token-set-attr', withBlockTokenSe
  * "Design Tokens" panel: a "Token Set" subsection (the per-block set override) above a "Design Variants"
  * subsection (the variant picker). Selecting a set writes the kbTokenSet attribute, which the save/preview
  * filters turn into the data-kb-token-set attribute the projector's switch selectors re-point through;
- * selecting a variant writes the kbVariant attribute, which the save/preview filters turn into the
- * kb-variant--<slug> class the projector's scoped CSS hooks. An empty set follows the active set; an empty
- * variant selects the block's $default preset look. Each subsection is shown only when it has something to
- * offer (two or more sets / any variants), and the panel is skipped when neither does.
+ * selecting a variant writes its group's entry in the kbVariants map, which the save/preview filters turn
+ * into the kb-variant--<group>--<slug> class the projector's scoped CSS hooks. An empty set follows the
+ * active set; an empty variant selects the block's $default preset look. Each subsection is shown only when
+ * it has something to offer (two or more sets / any variants), and the panel is skipped when neither does.
  *
  * A block whose `kbVariant` support requests `inlinePicker` renders the pickers itself (e.g. a Kadence
  * block placing them under its own Style tab), so this generic sidebar panel skips it to avoid a duplicate.
@@ -303,12 +316,17 @@ const withVariantPicker = createHigherOrderComponent((BlockEdit) => {
 		}
 
 		const set = get(attributes, 'kbTokenSet', '') || activeSet();
+		const group = blockSetGroup(name, set);
 		const hasVariants = blockVariants(name, set).length > 0;
 		const hasSets = selectableSets().length >= 2;
 
 		if (!hasVariants && !hasSets) {
 			return <BlockEdit {...props} />;
 		}
+
+		const selected = get(attributes, ['kbVariants', group], '');
+		const selectVariant = (value) =>
+			setAttributes({ kbVariants: { ...get(attributes, 'kbVariants', {}), [group]: value } });
 
 		return (
 			<>
@@ -327,17 +345,12 @@ const withVariantPicker = createHigherOrderComponent((BlockEdit) => {
 							)}
 							{hasVariants && (
 								<SubsectionWrap label={__('Design Variants', 'kadence-blocks')}>
-									<VariantPicker
-										name={name}
-										set={set}
-										value={get(attributes, 'kbVariant', '')}
-										onChange={(value) => setAttributes({ kbVariant: value })}
-									/>
+									<VariantPicker name={name} set={set} value={selected} onChange={selectVariant} />
 									<VariantActions
 										blockName={name}
 										set={set}
-										selected={get(attributes, 'kbVariant', '')}
-										onSelect={(slug) => setAttributes({ kbVariant: slug })}
+										selected={selected}
+										onSelect={selectVariant}
 									/>
 								</SubsectionWrap>
 							)}

--- a/src/extension/variant-picker/SaveVariantModal.js
+++ b/src/extension/variant-picker/SaveVariantModal.js
@@ -12,7 +12,7 @@ import { Modal, TextControl, SelectControl, Button, Notice, Spinner } from '@wor
 import { useState, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { get } from 'lodash';
-import { blockProperties, appendVariant } from './index';
+import { blockProperties, appendVariant, blockSetGroup } from './index';
 import { getBlockVariants, createVariant } from '../variants/api/client';
 import { refreshProjectedCss } from '../design-tokens/live-css';
 import { deriveSlug, dedupeSlug } from '../variants/slug';
@@ -59,6 +59,7 @@ function seedValues(properties, tokens) {
  */
 export function SaveVariantModal({ blockName, set, source, editSlug = '', onClose, onSaved }) {
 	const properties = blockProperties(blockName, set);
+	const variantSet = blockSetGroup(blockName, set);
 	const isEdit = editSlug !== '';
 
 	const [status, setStatus] = useState('loading');
@@ -73,7 +74,7 @@ export function SaveVariantModal({ blockName, set, source, editSlug = '', onClos
 	useEffect(() => {
 		let cancelled = false;
 
-		getBlockVariants(blockName, set)
+		getBlockVariants(blockName, set, variantSet)
 			.then((payload) => {
 				if (cancelled) {
 					return;
@@ -133,7 +134,7 @@ export function SaveVariantModal({ blockName, set, source, editSlug = '', onClos
 		setStatus('saving');
 		setError('');
 
-		createVariant(blockName, { variant: slug, label: label.trim(), tokens: values }, set)
+		createVariant(blockName, { variant: slug, label: label.trim(), tokens: values }, set, variantSet)
 			.then(() => {
 				appendVariant(blockName, set, { slug, label: label.trim(), userCreated: true });
 				refreshProjectedCss();

--- a/src/extension/variant-picker/VariantActions.js
+++ b/src/extension/variant-picker/VariantActions.js
@@ -11,7 +11,7 @@ import { Button, Notice } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { SaveVariantModal } from './SaveVariantModal';
-import { blockVariants, blockDefaultVariant, isUserVariant, removeVariant } from './index';
+import { blockVariants, blockDefaultVariant, isUserVariant, removeVariant, blockSetGroup } from './index';
 import { deleteVariant, setVariantDefault } from '../variants/api/client';
 import { hasDesignTokensRest } from '../design-tokens/rest';
 import { refreshProjectedCss } from '../design-tokens/live-css';
@@ -48,15 +48,17 @@ export function VariantActions({ blockName, set, selected, onSelect }) {
 		setBusy(true);
 		setError('');
 
+		const variantSet = blockSetGroup(blockName, set);
 		const isDefault = blockDefaultVariant(blockName, set) === selected;
 		const fallback = blockVariants(blockName, set)
 			.map((variant) => variant.slug)
 			.find((slug) => slug !== selected);
 
-		const reassign = isDefault && fallback ? setVariantDefault(blockName, fallback, set) : Promise.resolve();
+		const reassign =
+			isDefault && fallback ? setVariantDefault(blockName, fallback, set, variantSet) : Promise.resolve();
 
 		reassign
-			.then(() => deleteVariant(blockName, selected, set))
+			.then(() => deleteVariant(blockName, selected, set, variantSet))
 			.then(() => {
 				removeVariant(blockName, set, selected);
 				refreshProjectedCss();

--- a/src/extension/variant-picker/index.js
+++ b/src/extension/variant-picker/index.js
@@ -2,11 +2,13 @@
  * Shared design-token color-variant picker.
  *
  * The catalog is printed by the server-side editor localizer to `window.kadenceDesignTokensVariants`,
- * keyed by token set: `{ active, sets: { <slug>: { <block>: { default, variants, properties, label? } } } }`.
- * Reads take the set a block is on (its `kbTokenSet`, or the active set) so the picker shows that set's
- * variants. Both the generic inspector picker (src/early-filters.js) and a block that renders the picker
- * inline in its own Style tab (e.g. kadence/singlebtn) use this so the control stays identical wherever it
- * surfaces.
+ * keyed by token set then by block then by variant SET (axis):
+ * `{ active, sets: { <slug>: { <block>: { <group>: { group, default, variants, properties, label? } } } } }`.
+ * Reads take the token set a block is on (its `kbTokenSet`, or the active set). A picker-driven block
+ * registers one named variant set (e.g. the button's "style"); these readers resolve that sole set, and its
+ * selection lives in the `kbVariants` map keyed by the set's group. Both the generic inspector picker
+ * (src/early-filters.js) and a block that renders the picker inline in its own Style tab (e.g.
+ * kadence/singlebtn) use this so the control stays identical wherever it surfaces.
  */
 import { get } from 'lodash';
 import { KadenceRadioButtons } from '@kadence/components';
@@ -32,62 +34,100 @@ export function activeSet() {
 }
 
 /**
- * The per-block catalog for a set, defaulting to the active set.
+ * The per-block catalog for a token set, defaulting to the active set.
  *
  * @param {string} [set] The token set slug.
- * @return {Object} The per-block catalog for the set.
+ * @return {Object} The per-block catalog for the set (block => { group => entry }).
  */
 function setBlocks(set) {
 	return get(variantCatalog(), ['sets', set || activeSet()], {}) || {};
 }
 
 /**
- * The variants defined for a block in a set, or an empty array when it has none.
+ * A block's variant sets (axes) for a token set, keyed by group slug.
+ *
+ * @param {string} name  The block name.
+ * @param {string} [set] The token set slug; defaults to the active set.
+ * @return {Object} The block's sets ({ group => entry }).
+ */
+function blockSets(name, set) {
+	return get(setBlocks(set), [name], {}) || {};
+}
+
+/**
+ * The group slug of a block's variant set (its picker axis) for a token set — a picker-driven block
+ * registers one, so this is that sole set's group. Empty when the block offers no set.
+ *
+ * @param {string} name  The block name.
+ * @param {string} [set] The token set slug; defaults to the active set.
+ * @return {string} The variant-set group slug, or an empty string.
+ */
+export function blockSetGroup(name, set) {
+	const groups = Object.keys(blockSets(name, set));
+
+	return groups.length ? groups[0] : '';
+}
+
+/**
+ * The catalog entry for a block's sole variant set in a token set, or null when it offers none.
+ *
+ * @param {string} name  The block name.
+ * @param {string} [set] The token set slug; defaults to the active set.
+ * @return {Object|null} The set entry ({ group, default, variants, properties, label? }).
+ */
+function soleSet(name, set) {
+	const group = blockSetGroup(name, set);
+
+	return group ? blockSets(name, set)[group] : null;
+}
+
+/**
+ * The variants defined for a block's set, or an empty array when it has none.
  *
  * @param {string} name  The block name.
  * @param {string} [set] The token set slug; defaults to the active set.
  * @return {Array} The block's variants ([{ slug, label, userCreated }]).
  */
 export function blockVariants(name, set) {
-	return get(setBlocks(set), [name, 'variants'], []);
+	return get(soleSet(name, set), 'variants', []);
 }
 
 /**
- * The picker control label a block declares for its variant axis (the variant set's `label` in
- * declarations.php), or an empty string when it declares none.
+ * The picker control label a block declares for its variant set (the set's `label` in declarations.php),
+ * or an empty string when it declares none.
  *
  * @param {string} name  The block name.
  * @param {string} [set] The token set slug; defaults to the active set.
  * @return {string} The control label, or an empty string.
  */
 export function blockVariantLabel(name, set) {
-	return get(setBlocks(set), [name, 'label'], '');
+	return get(soleSet(name, set), 'label', '');
 }
 
 /**
- * The controllable surface for a block: one { key, kind, token } entry per bound property.
+ * The controllable surface for a block's set: one { key, kind, token } entry per bound property.
  *
  * @param {string} name  The block name.
  * @param {string} [set] The token set slug; defaults to the active set.
  * @return {Array} The block's surface ([{ key, kind, token }]).
  */
 export function blockProperties(name, set) {
-	return get(setBlocks(set), [name, 'properties'], []);
+	return get(soleSet(name, set), 'properties', []);
 }
 
 /**
- * The block's default variant slug in a set.
+ * The block set's default variant slug in a token set.
  *
  * @param {string} name  The block name.
  * @param {string} [set] The token set slug; defaults to the active set.
  * @return {string} The default variant slug, or an empty string.
  */
 export function blockDefaultVariant(name, set) {
-	return get(setBlocks(set), [name, 'default'], '');
+	return get(soleSet(name, set), 'default', '');
 }
 
 /**
- * Whether a variant slug is a user-created one for a block in a set (editable and deletable). A baseline
+ * Whether a variant slug is a user-created one for a block's set (editable and deletable). A baseline
  * variant, or one that only shadows a baseline variant, is not.
  *
  * @param {string} name The block name.
@@ -100,8 +140,8 @@ export function isUserVariant(name, set, slug) {
 }
 
 /**
- * Append a user-created variant to the in-memory catalog for a set, so the picker offers it without a page
- * reload. A no-op when the block has no catalog entry for the set.
+ * Append a user-created variant to the in-memory catalog for a block's set, so the picker offers it without
+ * a page reload. A no-op when the block has no set for the token set.
  *
  * @param {string} name    The block name.
  * @param {string} set     The token set slug.
@@ -109,19 +149,20 @@ export function isUserVariant(name, set, slug) {
  * @return {void}
  */
 export function appendVariant(name, set, variant) {
-	const block = get(variantCatalog(), ['sets', set || activeSet(), name]);
+	const entry = soleSet(name, set);
 
-	if (!block || !Array.isArray(block.variants)) {
+	if (!entry || !Array.isArray(entry.variants)) {
 		return;
 	}
 
-	if (!block.variants.some((existing) => existing.slug === variant.slug)) {
-		block.variants.push(variant);
+	if (!entry.variants.some((existing) => existing.slug === variant.slug)) {
+		entry.variants.push(variant);
 	}
 }
 
 /**
- * Remove a variant from the in-memory catalog for a set, so the picker drops it without a page reload.
+ * Remove a variant from the in-memory catalog for a block's set, so the picker drops it without a page
+ * reload.
  *
  * @param {string} name The block name.
  * @param {string} set  The token set slug.
@@ -129,19 +170,19 @@ export function appendVariant(name, set, variant) {
  * @return {void}
  */
 export function removeVariant(name, set, slug) {
-	const block = get(variantCatalog(), ['sets', set || activeSet(), name]);
+	const entry = soleSet(name, set);
 
-	if (!block || !Array.isArray(block.variants)) {
+	if (!entry || !Array.isArray(entry.variants)) {
 		return;
 	}
 
-	block.variants = block.variants.filter((existing) => existing.slug !== slug);
+	entry.variants = entry.variants.filter((existing) => existing.slug !== slug);
 }
 
 /**
  * The color-variant picker for a block. Renders nothing when the block has no variants in the set.
- * Selecting an option writes the kbVariant attribute (via onChange); an empty value selects the block's
- * $default look.
+ * Selecting an option calls onChange with the chosen variant slug (the caller writes it into the block's
+ * kbVariants map under this control's group); an empty value selects the block's $default look.
  *
  * @param {Object}   props             The component props.
  * @param {string}   props.name        The block name, used to read its variants from the catalog.

--- a/src/extension/variants/api/client.js
+++ b/src/extension/variants/api/client.js
@@ -3,8 +3,9 @@
  *
  * Uses the editor's already-configured `@wordpress/api-fetch` (root + nonce), reading only the REST
  * namespace from the shared design-tokens descriptor. Every call targets a specific token set via the `set`
- * parameter (query for reads/deletes, body for writes); an absent set lets the server fall back to the
- * active set.
+ * parameter and a specific variant set (axis) via the `variant_set` parameter (query for reads/deletes,
+ * body for writes); an absent `set` falls back to the active token set, and an absent `variant_set` to the
+ * block's sole named set.
  */
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
@@ -12,15 +13,30 @@ import { designTokensNamespace } from '../../design-tokens/rest';
 import { variantsBlockPath, variantItemPath, variantDefaultPath } from './paths';
 
 /**
+ * The optional { set, variant_set } params, omitting each when empty so the server applies its defaults.
+ *
+ * @param {string} [set]        The token set slug.
+ * @param {string} [variantSet] The variant set (axis) group slug.
+ * @return {Object} The params object.
+ */
+function targetParams(set, variantSet) {
+	return {
+		...(set ? { set } : {}),
+		...(variantSet ? { variant_set: variantSet } : {}),
+	};
+}
+
+/**
  * Read a block's effective variant set for a token set.
  *
- * @param {string} block The block name.
- * @param {string} [set] The token set slug; omitted targets the active set.
- * @return {Promise<Object>} The variant set payload ({ block, slug, version, default, variants }).
+ * @param {string} block        The block name.
+ * @param {string} [set]        The token set slug; omitted targets the active set.
+ * @param {string} [variantSet] The variant set (axis) group slug; omitted targets the sole named set.
+ * @return {Promise<Object>} The variant set payload ({ block, group, slug, version, default, variants }).
  */
-export function getBlockVariants(block, set) {
+export function getBlockVariants(block, set, variantSet) {
 	return apiFetch({
-		path: addQueryArgs(variantsBlockPath(designTokensNamespace(), block), set ? { set } : {}),
+		path: addQueryArgs(variantsBlockPath(designTokensNamespace(), block), targetParams(set, variantSet)),
 	});
 }
 
@@ -33,43 +49,46 @@ export function getBlockVariants(block, set) {
  * @param {string} [variant.label]     The variant label.
  * @param {Object} [variant.tokens]    The property => value token map.
  * @param {string} [set]               The token set slug; omitted targets the active set.
+ * @param {string} [variantSet]        The variant set (axis) group slug; omitted targets the sole named set.
  * @return {Promise<Object>} The updated variant set payload.
  */
-export function createVariant(block, { variant, label, tokens }, set) {
+export function createVariant(block, { variant, label, tokens }, set, variantSet) {
 	return apiFetch({
 		path: variantsBlockPath(designTokensNamespace(), block),
 		method: 'POST',
-		data: { variant, label, tokens, ...(set ? { set } : {}) },
+		data: { variant, label, tokens, ...targetParams(set, variantSet) },
 	});
 }
 
 /**
- * Set a block's default variant.
+ * Set a block set's default variant.
  *
  * @param {string} block          The block name.
  * @param {string} defaultVariant The variant slug to make default.
  * @param {string} [set]          The token set slug; omitted targets the active set.
+ * @param {string} [variantSet]   The variant set (axis) group slug; omitted targets the sole named set.
  * @return {Promise<Object>} The updated variant set payload.
  */
-export function setVariantDefault(block, defaultVariant, set) {
+export function setVariantDefault(block, defaultVariant, set, variantSet) {
 	return apiFetch({
 		path: variantDefaultPath(designTokensNamespace(), block),
 		method: 'PUT',
-		data: { default: defaultVariant, ...(set ? { set } : {}) },
+		data: { default: defaultVariant, ...targetParams(set, variantSet) },
 	});
 }
 
 /**
  * Delete a single variant from a block's set.
  *
- * @param {string} block   The block name.
- * @param {string} variant The variant slug.
- * @param {string} [set]   The token set slug; omitted targets the active set.
+ * @param {string} block        The block name.
+ * @param {string} variant      The variant slug.
+ * @param {string} [set]        The token set slug; omitted targets the active set.
+ * @param {string} [variantSet] The variant set (axis) group slug; omitted targets the sole named set.
  * @return {Promise<Object>} The updated variant set payload.
  */
-export function deleteVariant(block, variant, set) {
+export function deleteVariant(block, variant, set, variantSet) {
 	return apiFetch({
-		path: addQueryArgs(variantItemPath(designTokensNamespace(), block, variant), set ? { set } : {}),
+		path: addQueryArgs(variantItemPath(designTokensNamespace(), block, variant), targetParams(set, variantSet)),
 		method: 'DELETE',
 	});
 }

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/VariantsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/VariantsTest.php
@@ -32,8 +32,10 @@ final class VariantsTest extends TestCase {
 
 		$this->assertArrayHasKey( self::BUTTON, $variants );
 
-		$button = $variants[ self::BUTTON ];
+		// The button's variants live under its named "style" set (block => group => entry).
+		$button = $variants[ self::BUTTON ]['style'];
 
+		$this->assertSame( 'style', $button['group'] );
 		$this->assertSame( 'primary', $button['default'] );
 		$this->assertSame( [ 'primary', 'secondary' ], $button['names'] );
 		$this->assertContains( 'button-bg', $button['properties'] );

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Variant_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Variant_CatalogTest.php
@@ -51,8 +51,9 @@ final class Variant_CatalogTest extends TestCase {
 		$this->assertSame( Token_Store::default_slug(), $catalog['active'] );
 		$this->assertArrayHasKey( self::BUTTON, $catalog['sets'][ Token_Store::default_slug() ] );
 
-		$button = $catalog['sets'][ Token_Store::default_slug() ][ self::BUTTON ];
+		$button = $catalog['sets'][ Token_Store::default_slug() ][ self::BUTTON ]['style'];
 
+		$this->assertSame( 'style', $button['group'] );
 		$this->assertSame( 'primary', $button['default'] );
 		// The picker's control label, declared on the variant set in declarations.php.
 		$this->assertSame( 'Style', $button['label'] );
@@ -80,7 +81,7 @@ final class Variant_CatalogTest extends TestCase {
 	 * @return void
 	 */
 	public function testItExposesTheControllableSurface(): void {
-		$properties = $this->catalog->all()['sets'][ Token_Store::default_slug() ][ self::BUTTON ]['properties'];
+		$properties = $this->catalog->all()['sets'][ Token_Store::default_slug() ][ self::BUTTON ]['style']['properties'];
 
 		$kinds = wp_list_pluck( $properties, 'kind', 'key' );
 
@@ -95,11 +96,11 @@ final class Variant_CatalogTest extends TestCase {
 	 */
 	public function testItFlagsUserCreatedVariants(): void {
 		$this->store->save_document(
-			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{'
-			. '"accent":{"label":"Accent","tokens":{"button-bg":"#ff0000"}}}}}}}'
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{"style":{'
+			. '"accent":{"label":"Accent","tokens":{"button-bg":"#ff0000"}}}}}}}}'
 		);
 
-		$variants = $this->catalog->all()['sets'][ Token_Store::default_slug() ][ self::BUTTON ]['variants'];
+		$variants = $this->catalog->all()['sets'][ Token_Store::default_slug() ][ self::BUTTON ]['style']['variants'];
 		$flags    = wp_list_pluck( $variants, 'userCreated', 'slug' );
 
 		$this->assertTrue( $flags['accent'] );

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Preset/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Preset/ProjectorTest.php
@@ -4,27 +4,59 @@
 namespace Tests\wpunit\Resources\Design_Tokens\Projection\Block_Preset;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Preset\Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Variants;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
+use Tests\Support\Classes\Fake_Baseline_Document;
 use Tests\Support\Classes\TestCase;
 
 /**
- * Exercises the block-preset projector against the real shipped Button variants, with a synthetic variant
- * set supplying the `block_attr` bindings the shipped declarations do not carry yet (those arrive with the
- * Button wiring, SOFT-3406). Values come from the baseline; this proves the property -> attribute mapping
- * and the overlay semantics.
+ * Exercises the block-preset projector against a flat preset variant set — the no-picker "default variant"
+ * case the projector serves. A controllable fixture baseline supplies a single `$default` variant of literal
+ * values, and a synthetic variant set supplies the `block_attr` bindings; together they prove the
+ * property -> attribute mapping and the overlay semantics.
  */
 final class ProjectorTest extends TestCase {
 
-	private const BUTTON = 'kadence/singlebtn';
+	private const BUTTON = 'kadence/preset-btn';
 
 	private Variant_Resolver $resolver;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->resolver = $this->container->get( Variant_Resolver::class );
+		// A flat preset block: one $default variant of literal values, so resolve_default() is deterministic.
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'variants' => [
+						self::BUTTON => [
+							'$default' => 'primary',
+							'primary'  => [
+								'label'  => 'Primary',
+								'tokens' => [
+									'button-bg'     => '#3633e1',
+									'button-text'   => '#ffffff',
+									'button-radius' => '0.5rem',
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$variants = new Effective_Variants(
+			new Fake_Baseline_Document( $document ),
+			$this->container->get( Token_Store::class ),
+			$this->container->get( Mutator::class )
+		);
+
+		$this->resolver = new Variant_Resolver( $variants, $this->container->get( Token_Resolver::class ) );
 	}
 
 	public function testItMapsThePresetValuesOntoTheBoundBlockAttributes(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Variant/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Variant/Css_BuilderTest.php
@@ -3,10 +3,15 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Projection\Variant;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Variant\Css_Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Variants;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
 use ReflectionProperty;
+use Tests\Support\Classes\Fake_Baseline_Document;
 use Tests\Support\Classes\TestCase;
 
 /**
@@ -14,6 +19,11 @@ use Tests\Support\Classes\TestCase;
  * assertions also guard the Button wiring: the button-specific --global-palette-btn-* slot retargeting,
  * the per-set namespaced variant-var indirection, the active-alias layer, the client-side switch selector,
  * and the class-less $default rule.
+ *
+ * The grouped (multi-axis) cases run against a controllable baseline fixture — a button with two orthogonal
+ * axes, "color" (base fill slots) and "hover" (hover slots) — so they guard the grouped class/var shape and
+ * the per-group $default for axes that compose cleanly. A separate, deliberately misconfigured fixture (two
+ * axes on one slot) guards the source-order tie-break. Literal token values keep that CSS deterministic.
  */
 final class Css_BuilderTest extends TestCase {
 
@@ -60,11 +70,11 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $this->registry )->css( [ 'default' ], 'default' );
 
 		// The namespaced variant var chains to that set's namespaced semantic.
-		$this->assertStringContainsString( '--kb-token--default--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--default--semantic--color--button-primary-bg);', $css );
-		$this->assertStringContainsString( '--kb-token--default--variant--kadence-singlebtn--secondary--button-bg:var(--kb-token--default--semantic--color--button-secondary-bg);', $css );
+		$this->assertStringContainsString( '--kb-token--default--variant--kadence-singlebtn--style--primary--button-bg:var(--kb-token--default--semantic--color--button-primary-bg);', $css );
+		$this->assertStringContainsString( '--kb-token--default--variant--kadence-singlebtn--style--secondary--button-bg:var(--kb-token--default--semantic--color--button-secondary-bg);', $css );
 
 		// The canonical variant var is pointed at the active set's namespaced variant var (the alias layer).
-		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--default--variant--kadence-singlebtn--primary--button-bg);', $css );
+		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--style--primary--button-bg:var(--kb-token--default--variant--kadence-singlebtn--style--primary--button-bg);', $css );
 	}
 
 	/**
@@ -78,8 +88,8 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $this->registry )->css( [ 'default', 'dark' ], 'default' );
 
 		// Both sets' namespaced variant vars are present (dark resolves from baseline here, namespaced).
-		$this->assertStringContainsString( '--kb-token--default--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--default--semantic--color--button-primary-bg);', $css );
-		$this->assertStringContainsString( '--kb-token--dark--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--dark--semantic--color--button-primary-bg);', $css );
+		$this->assertStringContainsString( '--kb-token--default--variant--kadence-singlebtn--style--primary--button-bg:var(--kb-token--default--semantic--color--button-primary-bg);', $css );
+		$this->assertStringContainsString( '--kb-token--dark--variant--kadence-singlebtn--style--primary--button-bg:var(--kb-token--dark--semantic--color--button-primary-bg);', $css );
 
 		// The dark switch selector re-points the canonical variant var at the dark namespace.
 		$this->assertStringContainsString(
@@ -87,7 +97,7 @@ final class Css_BuilderTest extends TestCase {
 			$css
 		);
 		$this->assertStringContainsString(
-			'--kb-token--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--dark--variant--kadence-singlebtn--primary--button-bg);',
+			'--kb-token--variant--kadence-singlebtn--style--primary--button-bg:var(--kb-token--dark--variant--kadence-singlebtn--style--primary--button-bg);',
 			$css
 		);
 	}
@@ -103,11 +113,11 @@ final class Css_BuilderTest extends TestCase {
 
 		$this->assertSame(
 			2,
-			substr_count( $css, '--kb-token--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--dark--variant--kadence-singlebtn--primary--button-bg);' )
+			substr_count( $css, '--kb-token--variant--kadence-singlebtn--style--primary--button-bg:var(--kb-token--dark--variant--kadence-singlebtn--style--primary--button-bg);' )
 		);
 		$this->assertSame(
 			1,
-			substr_count( $css, '--kb-token--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--default--variant--kadence-singlebtn--primary--button-bg);' )
+			substr_count( $css, '--kb-token--variant--kadence-singlebtn--style--primary--button-bg:var(--kb-token--default--variant--kadence-singlebtn--style--primary--button-bg);' )
 		);
 	}
 
@@ -122,12 +132,12 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $this->registry )->css( [ 'default' ], 'default' );
 
 		$this->assertStringContainsString(
-			'.wp-block-kadence-singlebtn.kb-variant--secondary{'
-				. '--global-palette-btn-bg:var(--kb-token--variant--kadence-singlebtn--secondary--button-bg);'
-				. '--global-palette-btn:var(--kb-token--variant--kadence-singlebtn--secondary--button-text);'
-				. '--global-palette-btn-bg-hover:var(--kb-token--variant--kadence-singlebtn--secondary--button-bg-hover);'
-				. '--global-palette-btn-hover:var(--kb-token--variant--kadence-singlebtn--secondary--button-text-hover);'
-				. '--kb-btn-radius:var(--kb-token--variant--kadence-singlebtn--secondary--button-radius);}',
+			'.wp-block-kadence-singlebtn.kb-variant--style--secondary{'
+				. '--global-palette-btn-bg:var(--kb-token--variant--kadence-singlebtn--style--secondary--button-bg);'
+				. '--global-palette-btn:var(--kb-token--variant--kadence-singlebtn--style--secondary--button-text);'
+				. '--global-palette-btn-bg-hover:var(--kb-token--variant--kadence-singlebtn--style--secondary--button-bg-hover);'
+				. '--global-palette-btn-hover:var(--kb-token--variant--kadence-singlebtn--style--secondary--button-text-hover);'
+				. '--kb-btn-radius:var(--kb-token--variant--kadence-singlebtn--style--secondary--button-radius);}',
 			$css
 		);
 	}
@@ -142,8 +152,8 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $this->registry )->css( [ 'default' ], 'default' );
 
 		$this->assertStringContainsString(
-			'.wp-block-button.kb-variant--secondary{'
-				. '--global-palette-btn-bg:var(--kb-token--variant--core-button--secondary--button-bg);',
+			'.wp-block-button.kb-variant--style--secondary{'
+				. '--global-palette-btn-bg:var(--kb-token--variant--core-button--style--secondary--button-bg);',
 			$css
 		);
 		$this->assertStringNotContainsString( '.wp-block-core-button', $css );
@@ -160,11 +170,11 @@ final class Css_BuilderTest extends TestCase {
 
 		$this->assertStringContainsString(
 			'.wp-block-kadence-singlebtn{'
-				. '--global-palette-btn-bg:var(--kb-token--variant--kadence-singlebtn--primary--button-bg);'
-				. '--global-palette-btn:var(--kb-token--variant--kadence-singlebtn--primary--button-text);'
-				. '--global-palette-btn-bg-hover:var(--kb-token--variant--kadence-singlebtn--primary--button-bg-hover);'
-				. '--global-palette-btn-hover:var(--kb-token--variant--kadence-singlebtn--primary--button-text-hover);'
-				. '--kb-btn-radius:var(--kb-token--variant--kadence-singlebtn--primary--button-radius);}',
+				. '--global-palette-btn-bg:var(--kb-token--variant--kadence-singlebtn--style--primary--button-bg);'
+				. '--global-palette-btn:var(--kb-token--variant--kadence-singlebtn--style--primary--button-text);'
+				. '--global-palette-btn-bg-hover:var(--kb-token--variant--kadence-singlebtn--style--primary--button-bg-hover);'
+				. '--global-palette-btn-hover:var(--kb-token--variant--kadence-singlebtn--style--primary--button-text-hover);'
+				. '--kb-btn-radius:var(--kb-token--variant--kadence-singlebtn--style--primary--button-radius);}',
 			$css
 		);
 	}
@@ -181,12 +191,12 @@ final class Css_BuilderTest extends TestCase {
 
 		// The scoped rule points --kb-btn-radius at the per-variant var.
 		$this->assertStringContainsString(
-			'--kb-btn-radius:var(--kb-token--variant--kadence-singlebtn--secondary--button-radius);',
+			'--kb-btn-radius:var(--kb-token--variant--kadence-singlebtn--style--secondary--button-radius);',
 			$css
 		);
 		// The namespaced block defines that per-variant var for the set.
 		$this->assertStringContainsString(
-			'--kb-token--default--variant--kadence-singlebtn--secondary--button-radius:',
+			'--kb-token--default--variant--kadence-singlebtn--style--secondary--button-radius:',
 			$css
 		);
 	}
@@ -225,5 +235,332 @@ final class Css_BuilderTest extends TestCase {
 	 */
 	private function builder( Token_Registry $registry ): Css_Builder {
 		return new Css_Builder( $registry, $this->resolver );
+	}
+
+	/**
+	 * Each (group, variant) value lives as a per-set namespaced token var whose name folds in the group, so
+	 * two axes never collide on a shared property.
+	 *
+	 * @return void
+	 */
+	public function testItFoldsTheGroupIntoTheVariantVar(): void {
+		$css = $this->grouped_builder()->css( [ 'default' ], 'default' );
+
+		$this->assertStringContainsString( '--kb-token--default--variant--kadence-grouped-btn--color--secondary--button-bg:#111111;', $css );
+		$this->assertStringContainsString( '--kb-token--default--variant--kadence-grouped-btn--hover--bold--button-bg-hover:#000000;', $css );
+	}
+
+	/**
+	 * A grouped selection scopes to a "kb-variant--<group>--<variant>" class, so two independently chosen
+	 * axes compose as two classes on one block.
+	 *
+	 * @return void
+	 */
+	public function testItScopesEachGroupedVariantToItsGroupClass(): void {
+		$css = $this->grouped_builder()->css( [ 'default' ], 'default' );
+
+		$this->assertStringContainsString(
+			'.wp-block-kadence-grouped-btn.kb-variant--color--secondary{'
+				. '--global-palette-btn-bg:var(--kb-token--variant--kadence-grouped-btn--color--secondary--button-bg);'
+				. '--global-palette-btn:var(--kb-token--variant--kadence-grouped-btn--color--secondary--button-text);}',
+			$css
+		);
+
+		$this->assertStringContainsString(
+			'.wp-block-kadence-grouped-btn.kb-variant--hover--bold{'
+				. '--global-palette-btn-bg-hover:var(--kb-token--variant--kadence-grouped-btn--hover--bold--button-bg-hover);'
+				. '--global-palette-btn-hover:var(--kb-token--variant--kadence-grouped-btn--hover--bold--button-text-hover);}',
+			$css
+		);
+	}
+
+	/**
+	 * Each group re-emits its own $default on the class-less block selector, so a block with no selection
+	 * still shows every axis's preset.
+	 *
+	 * @return void
+	 */
+	public function testItEmitsAClassLessDefaultPerGroup(): void {
+		$css = $this->grouped_builder()->css( [ 'default' ], 'default' );
+
+		// color $default is "primary".
+		$this->assertStringContainsString(
+			'.wp-block-kadence-grouped-btn{--global-palette-btn-bg:var(--kb-token--variant--kadence-grouped-btn--color--primary--button-bg);',
+			$css
+		);
+		// hover $default is "subtle".
+		$this->assertStringContainsString(
+			'.wp-block-kadence-grouped-btn{--global-palette-btn-bg-hover:var(--kb-token--variant--kadence-grouped-btn--hover--subtle--button-bg-hover);',
+			$css
+		);
+	}
+
+	/**
+	 * Orthogonal axes never share a slot, but should two groups be configured to retarget the same
+	 * --global-<slot>, their selected-variant rules carry equal specificity, so source order breaks the
+	 * tie: groups are emitted in document order, so the later group wins deterministically.
+	 *
+	 * @return void
+	 */
+	public function testTheLaterGroupWinsForASharedSlot(): void {
+		$css = $this->overlapping_builder()->css( [ 'default' ], 'default' );
+
+		$first  = strpos( $css, '--kb-token--variant--kadence-overlap-btn--first--one--button-bg)' );
+		$second = strpos( $css, '--kb-token--variant--kadence-overlap-btn--second--two--button-bg)' );
+
+		$this->assertNotFalse( $first );
+		$this->assertNotFalse( $second );
+		$this->assertGreaterThan( $first, $second, 'The later group must follow the earlier one in source order.' );
+	}
+
+	/**
+	 * Two variant sets (groups) on one block reuse the SAME variant slug ("primary") and are active
+	 * alongside each other — each emitting its own "kb-variant--<set>--primary" class. Each set sets its own
+	 * property (Fill's "fill-color", Type's "type-color") on the block's shared bindings, so the shared slug
+	 * resolves through each set's own binding to a different --global-<slot>. Every Fill variant maps through
+	 * Fill's binding, every Type variant through Type's.
+	 *
+	 * @return void
+	 */
+	public function testTwoVariantSetsShareASlugWithTheirOwnBindings(): void {
+		$css = $this->dual_set_builder()->css( [ 'default' ], 'default' );
+
+		$this->assertStringContainsString(
+			'.wp-block-kadence-dual-btn.kb-variant--fill--primary{'
+				. '--global-palette-btn-bg:var(--kb-token--variant--kadence-dual-btn--fill--primary--fill-color);}',
+			$css
+		);
+		$this->assertStringContainsString(
+			'.wp-block-kadence-dual-btn.kb-variant--type--primary{'
+				. '--global-palette-btn:var(--kb-token--variant--kadence-dual-btn--type--primary--type-color);}',
+			$css
+		);
+
+		// The two same-slug vars are distinct and carry each set's own value.
+		$this->assertStringContainsString( '--kb-token--default--variant--kadence-dual-btn--fill--primary--fill-color:#111111;', $css );
+		$this->assertStringContainsString( '--kb-token--default--variant--kadence-dual-btn--type--primary--type-color:#222222;', $css );
+	}
+
+	/**
+	 * Build the CSS builder over a controllable grouped baseline fixture and a registry that binds each
+	 * axis's slots. The two axes are ORTHOGONAL — "color" retargets the base fill slots (palette-btn-bg /
+	 * palette-btn), "hover" retargets the hover slots (palette-btn-bg-hover / palette-btn-hover) — so one
+	 * selection per axis composes cleanly without either overwriting the other.
+	 *
+	 * @return Css_Builder
+	 */
+	private function grouped_builder(): Css_Builder {
+		$block = 'kadence/grouped-btn';
+
+		$registry = new Token_Registry();
+		$registry->register_variant_set(
+			[
+				'block'    => $block,
+				'group'    => 'color',
+				'label'    => 'Color',
+				'bindings' => [
+					'button-bg'   => [ 'kadence_slot' => 'palette-btn-bg' ],
+					'button-text' => [ 'kadence_slot' => 'palette-btn' ],
+				],
+			]
+		);
+		$registry->register_variant_set(
+			[
+				'block'    => $block,
+				'group'    => 'hover',
+				'label'    => 'Hover',
+				'bindings' => [
+					'button-bg-hover'   => [ 'kadence_slot' => 'palette-btn-bg-hover' ],
+					'button-text-hover' => [ 'kadence_slot' => 'palette-btn-hover' ],
+				],
+			]
+		);
+
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'variants' => [
+						$block => [
+							'color' => [
+								'$default'  => 'primary',
+								'primary'   => [
+									'label'  => 'Primary',
+									'tokens' => [
+										'button-bg'   => '#3633e1',
+										'button-text' => '#ffffff',
+									],
+								],
+								'secondary' => [
+									'label'  => 'Secondary',
+									'tokens' => [
+										'button-bg'   => '#111111',
+										'button-text' => '#ffffff',
+									],
+								],
+							],
+							'hover' => [
+								'$default' => 'subtle',
+								'subtle'   => [
+									'label'  => 'Subtle',
+									'tokens' => [
+										'button-bg-hover'   => '#2f2ffc',
+										'button-text-hover' => '#ffffff',
+									],
+								],
+								'bold'     => [
+									'label'  => 'Bold',
+									'tokens' => [
+										'button-bg-hover'   => '#000000',
+										'button-text-hover' => '#ffffff',
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		return new Css_Builder( $registry, $this->fixture_resolver( $document ) );
+	}
+
+	/**
+	 * Build the CSS builder over a deliberately MISCONFIGURED fixture: two axes that both retarget the same
+	 * slot (palette-btn-bg). Orthogonal axes never share a slot, but the projector must still resolve a
+	 * conflict deterministically, which is the source-order tie-break this exercises.
+	 *
+	 * @return Css_Builder
+	 */
+	private function overlapping_builder(): Css_Builder {
+		$block = 'kadence/overlap-btn';
+
+		$registry = new Token_Registry();
+		$registry->register_variant_set(
+			[
+				'block'    => $block,
+				'group'    => 'first',
+				'label'    => 'First',
+				'bindings' => [ 'button-bg' => [ 'kadence_slot' => 'palette-btn-bg' ] ],
+			]
+		);
+		$registry->register_variant_set(
+			[
+				'block'    => $block,
+				'group'    => 'second',
+				'label'    => 'Second',
+				'bindings' => [ 'button-bg' => [ 'kadence_slot' => 'palette-btn-bg' ] ],
+			]
+		);
+
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'variants' => [
+						$block => [
+							'first'  => [
+								'$default' => 'one',
+								'one'      => [
+									'label'  => 'One',
+									'tokens' => [ 'button-bg' => '#111111' ],
+								],
+							],
+							'second' => [
+								'$default' => 'two',
+								'two'      => [
+									'label'  => 'Two',
+									'tokens' => [ 'button-bg' => '#222222' ],
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		return new Css_Builder( $registry, $this->fixture_resolver( $document ) );
+	}
+
+	/**
+	 * Build the CSS builder over a block with two variant sets (fill, type) that each define a "primary"
+	 * variant. The block's one bindings map holds each axis's own property (fill-color, type-color) bound to
+	 * a different slot, so the shared "primary" slug resolves through each set's own binding — no per-group
+	 * binding table is needed.
+	 *
+	 * @return Css_Builder
+	 */
+	private function dual_set_builder(): Css_Builder {
+		$block = 'kadence/dual-btn';
+
+		$registry = new Token_Registry();
+		$registry->register_variant_set(
+			[
+				'block'    => $block,
+				'group'    => 'fill',
+				'label'    => 'Fill',
+				'bindings' => [ 'fill-color' => [ 'kadence_slot' => 'palette-btn-bg' ] ],
+			]
+		);
+		$registry->register_variant_set(
+			[
+				'block'    => $block,
+				'group'    => 'type',
+				'label'    => 'Type',
+				'bindings' => [ 'type-color' => [ 'kadence_slot' => 'palette-btn' ] ],
+			]
+		);
+
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'variants' => [
+						$block => [
+							'fill' => [
+								'$default'  => 'primary',
+								'primary'   => [
+									'label'  => 'Primary',
+									'tokens' => [ 'fill-color' => '#111111' ],
+								],
+								'secondary' => [
+									'label'  => 'Secondary',
+									'tokens' => [ 'fill-color' => '#1a1a1a' ],
+								],
+							],
+							'type' => [
+								'$default' => 'primary',
+								'primary'  => [
+									'label'  => 'Primary',
+									'tokens' => [ 'type-color' => '#222222' ],
+								],
+								'bold'     => [
+									'label'  => 'Bold',
+									'tokens' => [ 'type-color' => '#2a2a2a' ],
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		return new Css_Builder( $registry, $this->fixture_resolver( $document ) );
+	}
+
+	/**
+	 * Build a Variant_Resolver over a controllable baseline fixture document, through a real
+	 * Effective_Variants (no stored overrides for the fixture blocks). The fixture's literal values never
+	 * reach the Token_Resolver.
+	 *
+	 * @param array<string, mixed> $document The fake baseline document.
+	 *
+	 * @return Variant_Resolver
+	 */
+	private function fixture_resolver( array $document ): Variant_Resolver {
+		$variants = new Effective_Variants(
+			new Fake_Baseline_Document( $document ),
+			$this->container->get( Token_Store::class ),
+			$this->container->get( Mutator::class )
+		);
+
+		return new Variant_Resolver( $variants, $this->container->get( Token_Resolver::class ) );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Variant/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Variant/ProjectorTest.php
@@ -63,8 +63,8 @@ final class ProjectorTest extends TestCase {
 
 		$css = implode( '', (array) wp_styles()->get_data( 'kadence-blocks-global-variables', 'after' ) );
 
-		$this->assertStringContainsString( '.wp-block-kadence-singlebtn.kb-variant--primary{', $css );
-		$this->assertStringContainsString( '--global-palette1:var(--kb-token--variant--kadence-singlebtn--primary--button-bg', $css );
+		$this->assertStringContainsString( '.wp-block-kadence-singlebtn.kb-variant--style--primary{', $css );
+		$this->assertStringContainsString( '--global-palette1:var(--kb-token--variant--kadence-singlebtn--style--primary--button-bg', $css );
 	}
 
 	public function testItIsANoopWhenTheRegistryIsDeactivated(): void {
@@ -99,6 +99,7 @@ final class ProjectorTest extends TestCase {
 		$registry->register_variant_set(
 			[
 				'block'    => self::BUTTON,
+				'group'    => 'style',
 				'bindings' => [
 					'button-bg'   => [ 'kadence_slot' => 'palette1' ],
 					'button-text' => [ 'kadence_slot' => 'palette9' ],

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Variant/StyleTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Variant/StyleTest.php
@@ -1,0 +1,64 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Projection\Variant;
+
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Variant\Style;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Guards the variant class shapes the editor adds and the projector targets, so the flat single-axis class
+ * and the grouped multi-axis class can never drift from the selector the CSS hooks.
+ */
+final class StyleTest extends TestCase {
+
+	/**
+	 * A flat block's variant keeps the single-segment "kb-variant--<variant>" shape.
+	 *
+	 * @return void
+	 */
+	public function testFlatVariantClass(): void {
+		$this->assertSame( 'kb-variant--secondary', Style::variant_class( 'secondary' ) );
+	}
+
+	/**
+	 * A grouped selection carries the group: "kb-variant--<group>--<variant>".
+	 *
+	 * @return void
+	 */
+	public function testGroupedVariantClass(): void {
+		$this->assertSame( 'kb-variant--emphasis--outline', Style::group_variant_class( 'emphasis', 'outline' ) );
+	}
+
+	/**
+	 * Each segment is sanitized independently, so a stray character in the group or variant cannot merge the
+	 * two across the "--" delimiter.
+	 *
+	 * @dataProvider unsafeSegmentProvider
+	 *
+	 * @param string $group    The raw group slug.
+	 * @param string $variant  The raw variant slug.
+	 * @param string $expected The sanitized class.
+	 *
+	 * @return void
+	 */
+	public function testItSanitizesEachSegmentIndependently( string $group, string $variant, string $expected ): void {
+		$this->assertSame( $expected, Style::group_variant_class( $group, $variant ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function unsafeSegmentProvider(): Generator {
+		yield 'space in variant' => [
+			'group'    => 'color',
+			'variant'  => 'sea green',
+			'expected' => 'kb-variant--color--sea-green',
+		];
+		yield 'slash in group' => [
+			'group'    => 'a/b',
+			'variant'  => 'x',
+			'expected' => 'kb-variant--a-b--x',
+		];
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Projected_Css_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Projected_Css_ControllerTest.php
@@ -61,7 +61,7 @@ final class Projected_Css_ControllerTest extends TestCase {
 		$css = $this->css();
 
 		$this->assertStringContainsString( '--kb-token--', $css, 'The token vars layer should be present.' );
-		$this->assertStringContainsString( 'kb-variant--accent', $css, 'The stored variant scoped rule should be present.' );
+		$this->assertStringContainsString( 'kb-variant--style--accent', $css, 'The stored variant scoped rule should be present.' );
 	}
 
 	/**
@@ -135,14 +135,16 @@ final class Projected_Css_ControllerTest extends TestCase {
 				'com.kadence.designTokens' => [
 					'variants' => [
 						self::BUTTON => [
-							$variant => [
-								'label'  => 'Accent',
-								'tokens' => [
-									'button-bg'         => '#ff0000',
-									'button-text'       => '#ffffff',
-									'button-bg-hover'   => '#cc0000',
-									'button-text-hover' => '#ffffff',
-									'button-radius'     => '1rem',
+							'style' => [
+								$variant => [
+									'label'  => 'Accent',
+									'tokens' => [
+										'button-bg'         => '#ff0000',
+										'button-text'       => '#ffffff',
+										'button-bg-hover'   => '#cc0000',
+										'button-text-hover' => '#ffffff',
+										'button-radius'     => '1rem',
+									],
 								],
 							],
 						],

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
@@ -136,8 +136,8 @@ final class VariantsControllerTest extends TestCase {
 	 */
 	public function testGetItemReflectsAStoredOverride(): void {
 		$this->store->save_document(
-			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{'
-			. '"outline":{"label":"Outline","tokens":{"button-bg":"transparent"}}}}}}}'
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{"style":{'
+			. '"outline":{"label":"Outline","tokens":{"button-bg":"transparent"}}}}}}}}'
 		);
 
 		$data = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) )->get_data();
@@ -349,8 +349,8 @@ final class VariantsControllerTest extends TestCase {
 	 */
 	public function testDeleteVariantIsAnIdempotentNoOpWhenAbsent(): void {
 		$this->store->save_document(
-			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{'
-			. '"outline":{"tokens":{"button-bg":"transparent"}}}}}}}'
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{"style":{'
+			. '"outline":{"tokens":{"button-bg":"transparent"}}}}}}}}'
 		);
 
 		$version_before = $this->store->get_version( Token_Store::default_slug() );
@@ -624,8 +624,8 @@ final class VariantsControllerTest extends TestCase {
 	 */
 	public function testAWriteBumpsTheVersion(): void {
 		$this->store->save_document(
-			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{'
-			. '"outline":{"tokens":{"button-bg":"transparent"}}}}}}}'
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{"style":{'
+			. '"outline":{"tokens":{"button-bg":"transparent"}}}}}}}}'
 		);
 
 		$version_before = $this->store->get_version( Token_Store::default_slug() );


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3577

**Stacked PR 2 of 4.** Base: `soft-3577/pr1-variant-model`.

Projects a selected grouped variant into CSS classes and `var()`s, and gives dynamic (PHP-rendered) blocks a reusable way to emit those classes.

- `Style` is the single source of the `kb-variant--<group>--<variant>` class shape.
- `Css_Builder` projects each set by `(block, group)` via `for_variant_set()`, emitting the namespaced vars and scoped rules for the button's `style` set.
- `Renders_Variant_Classes` is a trait a dynamic block composes to turn its `kbVariants` attribute into those classes; the singlebtn block uses it.

### Why CI is red on this PR

This is expected for this layer of the stack, not a defect. This PR updates the projector and its tests, but the REST controller, editor catalog, and admin feed that also read the model's new registry shape — and their tests — land in **#1122**. In isolation this branch therefore shows:

- **PHPStan** — `Admin/Feed/Variants.php:87` reads the new nested shape (that file is updated in **#1122**).
- **wpunit** — the REST/catalog/feed tests still assert the pre-flip shape until they are updated in **#1122**.

Both checks are fully green as of **#1122**, and the tip of the stack (**#1123**) is green end to end. Review this PR as the second layer; CI reflects the completed stack.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
