### PR TITLE
Multi-axis Variants [4/4]: editor picker writes the per-group variant map

### DIFF
--- a/src/blocks/singlebtn/block.json
+++ b/src/blocks/singlebtn/block.json
@@ -754,9 +754,9 @@
 			"type": "boolean",
 			"default": false
 		},
-		"kbVariant": {
-			"type": "string",
-			"default": ""
+		"kbVariants": {
+			"type": "object",
+			"default": {}
 		},
 		"kbTokenSet": {
 			"type": "string",

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -48,7 +48,7 @@ import {
 	SubsectionWrap,
 } from '@kadence/components';
 import classnames from 'classnames';
-import { times, filter, map, uniqueId } from 'lodash';
+import { times, filter, map, uniqueId, get } from 'lodash';
 
 import metadata from './block.json';
 /**
@@ -84,7 +84,7 @@ import {
 } from '@wordpress/components';
 import { addFilter, applyFilters, doAction } from '@wordpress/hooks';
 import BackendStyles from './components/backend-styles';
-import { VariantPicker, blockVariants, activeSet } from '../../extension/variant-picker';
+import { VariantPicker, blockVariants, activeSet, blockSetGroup } from '../../extension/variant-picker';
 import { VariantActions } from '../../extension/variant-picker/VariantActions';
 import { TokenSetPicker, selectableSets } from '../../extension/token-set-picker';
 
@@ -846,22 +846,36 @@ export default function KadenceButtonEdit(props) {
 												/>
 											</SubsectionWrap>
 										)}
-										{blockVariants(name, attributes.kbTokenSet || activeSet()).length > 0 && (
-											<SubsectionWrap label={__('Design Variants', 'kadence-blocks')}>
-												<VariantPicker
-													name={name}
-													set={attributes.kbTokenSet || activeSet()}
-													value={attributes.kbVariant || ''}
-													onChange={(value) => setAttributes({ kbVariant: value })}
-												/>
-												<VariantActions
-													blockName={name}
-													set={attributes.kbTokenSet || activeSet()}
-													selected={attributes.kbVariant || ''}
-													onSelect={(slug) => setAttributes({ kbVariant: slug })}
-												/>
-											</SubsectionWrap>
-										)}
+										{blockVariants(name, attributes.kbTokenSet || activeSet()).length > 0 &&
+											(() => {
+												const set = attributes.kbTokenSet || activeSet();
+												const group = blockSetGroup(name, set);
+												const selected = get(attributes, ['kbVariants', group], '');
+												const selectVariant = (value) =>
+													setAttributes({
+														kbVariants: {
+															...get(attributes, 'kbVariants', {}),
+															[group]: value,
+														},
+													});
+
+												return (
+													<SubsectionWrap label={__('Design Variants', 'kadence-blocks')}>
+														<VariantPicker
+															name={name}
+															set={set}
+															value={selected}
+															onChange={selectVariant}
+														/>
+														<VariantActions
+															blockName={name}
+															set={set}
+															selected={selected}
+															onSelect={selectVariant}
+														/>
+													</SubsectionWrap>
+												);
+											})()}
 									</KadencePanelBody>
 								)}
 								{showSettings('colorSettings', 'kadence/advancedbtn') && (

--- a/src/early-filters.js
+++ b/src/early-filters.js
@@ -13,7 +13,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { useDispatch, select } from '@wordpress/data';
-import { VariantPicker, blockVariants, activeSet } from './extension/variant-picker';
+import { VariantPicker, blockVariants, activeSet, blockSetGroup } from './extension/variant-picker';
 import { VariantActions } from './extension/variant-picker/VariantActions';
 import { TokenSetPicker, selectableSets } from './extension/token-set-picker';
 
@@ -99,26 +99,26 @@ export function enableNativeBlockVariants(settings, name) {
 addFilter('blocks.registerBlockType', 'kadence/kb-variant-native-support', enableNativeBlockVariants);
 
 /**
- * Add the kbVariant and kbTokenSet attributes to any block that opts in via the `kbVariant` block support.
+ * Add the kbVariants and kbTokenSet attributes to any block that opts in via the `kbVariant` block support.
  *
- * kbVariant holds the slug of the selected design-token variant (e.g. "ghost"); empty means the block
- * keeps its $default look (the block preset). kbTokenSet holds the slug of a per-block token-set override
- * (e.g. "dark"); empty means the block follows the active set. The scoped CSS that re-skins the block for a
- * selected variant and the switch selectors a set override re-points through are both emitted server-side
- * by the Design Tokens projector.
+ * kbVariants is a map of group slug => selected variant slug (e.g. { style: "ghost" }); an absent or empty
+ * entry means the block keeps that group's $default look (the block preset). kbTokenSet holds the slug of a
+ * per-block token-set override (e.g. "dark"); empty means the block follows the active set. The scoped CSS
+ * that re-skins the block for a selected variant and the switch selectors a set override re-points through
+ * are both emitted server-side by the Design Tokens projector.
  *
  * @param {Object} settings The block settings.
  *
  * @since TBD
  *
- * @return {Object} The block settings with the kbVariant and kbTokenSet attributes added.
+ * @return {Object} The block settings with the kbVariants and kbTokenSet attributes added.
  */
 export function blockVariantAttribute(settings) {
 	if (hasBlockSupport(settings, 'kbVariant')) {
 		settings.attributes = assign(settings.attributes, {
-			kbVariant: {
-				type: 'string',
-				default: '',
+			kbVariants: {
+				type: 'object',
+				default: {},
 			},
 			kbTokenSet: {
 				type: 'string',
@@ -149,18 +149,31 @@ function sanitizeTokenIdentifier(slug) {
 }
 
 /**
- * The class a selected variant outputs, or an empty string when none is selected.
+ * The classes a block's selected variants output: one `kb-variant--<group>--<slug>` per variant set with a
+ * non-empty selection in the `kbVariants` map. Each segment is sanitized independently so the group and
+ * variant slugs cannot merge across the "--" delimiter, mirroring the projector's PHP
+ * Style::group_variant_class().
  *
- * @param {string} kbVariant The selected variant slug.
+ * @param {Object} kbVariants The kbVariants map (variant-set group slug => selected variant slug).
  *
  * @since TBD
  *
- * @return {string} The `kb-variant--<slug>` class, or an empty string.
+ * @return {string} The space-joined variant classes, or an empty string.
  */
-function kbVariantClassName(kbVariant) {
-	const slug = sanitizeTokenIdentifier(kbVariant);
+function kbVariantsClassNames(kbVariants) {
+	if (!kbVariants || typeof kbVariants !== 'object') {
+		return '';
+	}
 
-	return slug ? `kb-variant--${slug}` : '';
+	return Object.keys(kbVariants)
+		.map((group) => {
+			const groupSlug = sanitizeTokenIdentifier(group);
+			const variantSlug = sanitizeTokenIdentifier(kbVariants[group]);
+
+			return groupSlug && variantSlug ? `kb-variant--${groupSlug}--${variantSlug}` : '';
+		})
+		.filter(Boolean)
+		.join(' ');
 }
 
 /**
@@ -180,7 +193,7 @@ export function blockVariantSaveClass(props, blockType, attributes) {
 		return props;
 	}
 
-	const variantClass = kbVariantClassName(get(attributes, 'kbVariant', ''));
+	const variantClass = kbVariantsClassNames(get(attributes, 'kbVariants', {}));
 
 	if (variantClass) {
 		props.className = props.className ? `${props.className} ${variantClass}` : variantClass;
@@ -232,7 +245,7 @@ const withBlockVariantClass = createHigherOrderComponent((BlockListBlock) => {
 			return <BlockListBlock {...props} />;
 		}
 
-		const variantClass = kbVariantClassName(get(attributes, 'kbVariant', ''));
+		const variantClass = kbVariantsClassNames(get(attributes, 'kbVariants', {}));
 
 		if (!variantClass) {
 			return <BlockListBlock {...props} />;
@@ -278,10 +291,10 @@ addFilter('editor.BlockListBlock', 'kadence/kb-token-set-attr', withBlockTokenSe
  * "Design Tokens" panel: a "Token Set" subsection (the per-block set override) above a "Design Variants"
  * subsection (the variant picker). Selecting a set writes the kbTokenSet attribute, which the save/preview
  * filters turn into the data-kb-token-set attribute the projector's switch selectors re-point through;
- * selecting a variant writes the kbVariant attribute, which the save/preview filters turn into the
- * kb-variant--<slug> class the projector's scoped CSS hooks. An empty set follows the active set; an empty
- * variant selects the block's $default preset look. Each subsection is shown only when it has something to
- * offer (two or more sets / any variants), and the panel is skipped when neither does.
+ * selecting a variant writes its group's entry in the kbVariants map, which the save/preview filters turn
+ * into the kb-variant--<group>--<slug> class the projector's scoped CSS hooks. An empty set follows the
+ * active set; an empty variant selects the block's $default preset look. Each subsection is shown only when
+ * it has something to offer (two or more sets / any variants), and the panel is skipped when neither does.
  *
  * A block whose `kbVariant` support requests `inlinePicker` renders the pickers itself (e.g. a Kadence
  * block placing them under its own Style tab), so this generic sidebar panel skips it to avoid a duplicate.
@@ -303,12 +316,17 @@ const withVariantPicker = createHigherOrderComponent((BlockEdit) => {
 		}
 
 		const set = get(attributes, 'kbTokenSet', '') || activeSet();
+		const group = blockSetGroup(name, set);
 		const hasVariants = blockVariants(name, set).length > 0;
 		const hasSets = selectableSets().length >= 2;
 
 		if (!hasVariants && !hasSets) {
 			return <BlockEdit {...props} />;
 		}
+
+		const selected = get(attributes, ['kbVariants', group], '');
+		const selectVariant = (value) =>
+			setAttributes({ kbVariants: { ...get(attributes, 'kbVariants', {}), [group]: value } });
 
 		return (
 			<>
@@ -327,17 +345,12 @@ const withVariantPicker = createHigherOrderComponent((BlockEdit) => {
 							)}
 							{hasVariants && (
 								<SubsectionWrap label={__('Design Variants', 'kadence-blocks')}>
-									<VariantPicker
-										name={name}
-										set={set}
-										value={get(attributes, 'kbVariant', '')}
-										onChange={(value) => setAttributes({ kbVariant: value })}
-									/>
+									<VariantPicker name={name} set={set} value={selected} onChange={selectVariant} />
 									<VariantActions
 										blockName={name}
 										set={set}
-										selected={get(attributes, 'kbVariant', '')}
-										onSelect={(slug) => setAttributes({ kbVariant: slug })}
+										selected={selected}
+										onSelect={selectVariant}
 									/>
 								</SubsectionWrap>
 							)}

--- a/src/extension/variant-picker/SaveVariantModal.js
+++ b/src/extension/variant-picker/SaveVariantModal.js
@@ -12,7 +12,7 @@ import { Modal, TextControl, SelectControl, Button, Notice, Spinner } from '@wor
 import { useState, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { get } from 'lodash';
-import { blockProperties, appendVariant } from './index';
+import { blockProperties, appendVariant, blockSetGroup } from './index';
 import { getBlockVariants, createVariant } from '../variants/api/client';
 import { refreshProjectedCss } from '../design-tokens/live-css';
 import { deriveSlug, dedupeSlug } from '../variants/slug';
@@ -59,6 +59,7 @@ function seedValues(properties, tokens) {
  */
 export function SaveVariantModal({ blockName, set, source, editSlug = '', onClose, onSaved }) {
 	const properties = blockProperties(blockName, set);
+	const variantSet = blockSetGroup(blockName, set);
 	const isEdit = editSlug !== '';
 
 	const [status, setStatus] = useState('loading');
@@ -73,7 +74,7 @@ export function SaveVariantModal({ blockName, set, source, editSlug = '', onClos
 	useEffect(() => {
 		let cancelled = false;
 
-		getBlockVariants(blockName, set)
+		getBlockVariants(blockName, set, variantSet)
 			.then((payload) => {
 				if (cancelled) {
 					return;
@@ -133,7 +134,7 @@ export function SaveVariantModal({ blockName, set, source, editSlug = '', onClos
 		setStatus('saving');
 		setError('');
 
-		createVariant(blockName, { variant: slug, label: label.trim(), tokens: values }, set)
+		createVariant(blockName, { variant: slug, label: label.trim(), tokens: values }, set, variantSet)
 			.then(() => {
 				appendVariant(blockName, set, { slug, label: label.trim(), userCreated: true });
 				refreshProjectedCss();

--- a/src/extension/variant-picker/VariantActions.js
+++ b/src/extension/variant-picker/VariantActions.js
@@ -11,7 +11,7 @@ import { Button, Notice } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { SaveVariantModal } from './SaveVariantModal';
-import { blockVariants, blockDefaultVariant, isUserVariant, removeVariant } from './index';
+import { blockVariants, blockDefaultVariant, isUserVariant, removeVariant, blockSetGroup } from './index';
 import { deleteVariant, setVariantDefault } from '../variants/api/client';
 import { hasDesignTokensRest } from '../design-tokens/rest';
 import { refreshProjectedCss } from '../design-tokens/live-css';
@@ -48,15 +48,17 @@ export function VariantActions({ blockName, set, selected, onSelect }) {
 		setBusy(true);
 		setError('');
 
+		const variantSet = blockSetGroup(blockName, set);
 		const isDefault = blockDefaultVariant(blockName, set) === selected;
 		const fallback = blockVariants(blockName, set)
 			.map((variant) => variant.slug)
 			.find((slug) => slug !== selected);
 
-		const reassign = isDefault && fallback ? setVariantDefault(blockName, fallback, set) : Promise.resolve();
+		const reassign =
+			isDefault && fallback ? setVariantDefault(blockName, fallback, set, variantSet) : Promise.resolve();
 
 		reassign
-			.then(() => deleteVariant(blockName, selected, set))
+			.then(() => deleteVariant(blockName, selected, set, variantSet))
 			.then(() => {
 				removeVariant(blockName, set, selected);
 				refreshProjectedCss();

--- a/src/extension/variant-picker/index.js
+++ b/src/extension/variant-picker/index.js
@@ -2,11 +2,13 @@
  * Shared design-token color-variant picker.
  *
  * The catalog is printed by the server-side editor localizer to `window.kadenceDesignTokensVariants`,
- * keyed by token set: `{ active, sets: { <slug>: { <block>: { default, variants, properties, label? } } } }`.
- * Reads take the set a block is on (its `kbTokenSet`, or the active set) so the picker shows that set's
- * variants. Both the generic inspector picker (src/early-filters.js) and a block that renders the picker
- * inline in its own Style tab (e.g. kadence/singlebtn) use this so the control stays identical wherever it
- * surfaces.
+ * keyed by token set then by block then by variant SET (axis):
+ * `{ active, sets: { <slug>: { <block>: { <group>: { group, default, variants, properties, label? } } } } }`.
+ * Reads take the token set a block is on (its `kbTokenSet`, or the active set). A picker-driven block
+ * registers one named variant set (e.g. the button's "style"); these readers resolve that sole set, and its
+ * selection lives in the `kbVariants` map keyed by the set's group. Both the generic inspector picker
+ * (src/early-filters.js) and a block that renders the picker inline in its own Style tab (e.g.
+ * kadence/singlebtn) use this so the control stays identical wherever it surfaces.
  */
 import { get } from 'lodash';
 import { KadenceRadioButtons } from '@kadence/components';
@@ -32,62 +34,100 @@ export function activeSet() {
 }
 
 /**
- * The per-block catalog for a set, defaulting to the active set.
+ * The per-block catalog for a token set, defaulting to the active set.
  *
  * @param {string} [set] The token set slug.
- * @return {Object} The per-block catalog for the set.
+ * @return {Object} The per-block catalog for the set (block => { group => entry }).
  */
 function setBlocks(set) {
 	return get(variantCatalog(), ['sets', set || activeSet()], {}) || {};
 }
 
 /**
- * The variants defined for a block in a set, or an empty array when it has none.
+ * A block's variant sets (axes) for a token set, keyed by group slug.
+ *
+ * @param {string} name  The block name.
+ * @param {string} [set] The token set slug; defaults to the active set.
+ * @return {Object} The block's sets ({ group => entry }).
+ */
+function blockSets(name, set) {
+	return get(setBlocks(set), [name], {}) || {};
+}
+
+/**
+ * The group slug of a block's variant set (its picker axis) for a token set — a picker-driven block
+ * registers one, so this is that sole set's group. Empty when the block offers no set.
+ *
+ * @param {string} name  The block name.
+ * @param {string} [set] The token set slug; defaults to the active set.
+ * @return {string} The variant-set group slug, or an empty string.
+ */
+export function blockSetGroup(name, set) {
+	const groups = Object.keys(blockSets(name, set));
+
+	return groups.length ? groups[0] : '';
+}
+
+/**
+ * The catalog entry for a block's sole variant set in a token set, or null when it offers none.
+ *
+ * @param {string} name  The block name.
+ * @param {string} [set] The token set slug; defaults to the active set.
+ * @return {Object|null} The set entry ({ group, default, variants, properties, label? }).
+ */
+function soleSet(name, set) {
+	const group = blockSetGroup(name, set);
+
+	return group ? blockSets(name, set)[group] : null;
+}
+
+/**
+ * The variants defined for a block's set, or an empty array when it has none.
  *
  * @param {string} name  The block name.
  * @param {string} [set] The token set slug; defaults to the active set.
  * @return {Array} The block's variants ([{ slug, label, userCreated }]).
  */
 export function blockVariants(name, set) {
-	return get(setBlocks(set), [name, 'variants'], []);
+	return get(soleSet(name, set), 'variants', []);
 }
 
 /**
- * The picker control label a block declares for its variant axis (the variant set's `label` in
- * declarations.php), or an empty string when it declares none.
+ * The picker control label a block declares for its variant set (the set's `label` in declarations.php),
+ * or an empty string when it declares none.
  *
  * @param {string} name  The block name.
  * @param {string} [set] The token set slug; defaults to the active set.
  * @return {string} The control label, or an empty string.
  */
 export function blockVariantLabel(name, set) {
-	return get(setBlocks(set), [name, 'label'], '');
+	return get(soleSet(name, set), 'label', '');
 }
 
 /**
- * The controllable surface for a block: one { key, kind, token } entry per bound property.
+ * The controllable surface for a block's set: one { key, kind, token } entry per bound property.
  *
  * @param {string} name  The block name.
  * @param {string} [set] The token set slug; defaults to the active set.
  * @return {Array} The block's surface ([{ key, kind, token }]).
  */
 export function blockProperties(name, set) {
-	return get(setBlocks(set), [name, 'properties'], []);
+	return get(soleSet(name, set), 'properties', []);
 }
 
 /**
- * The block's default variant slug in a set.
+ * The block set's default variant slug in a token set.
  *
  * @param {string} name  The block name.
  * @param {string} [set] The token set slug; defaults to the active set.
  * @return {string} The default variant slug, or an empty string.
  */
 export function blockDefaultVariant(name, set) {
-	return get(setBlocks(set), [name, 'default'], '');
+	return get(soleSet(name, set), 'default', '');
 }
 
 /**
- * Whether a variant slug is a user-created one for a block in a set (editable and deletable). A baseline
+ * Whether a variant slug is a user-created one for a block's set (editable and deletable). A baseline
  * variant, or one that only shadows a baseline variant, is not.
  *
  * @param {string} name The block name.
@@ -100,8 +140,8 @@ export function isUserVariant(name, set, slug) {
 }
 
 /**
- * Append a user-created variant to the in-memory catalog for a set, so the picker offers it without a page
- * reload. A no-op when the block has no catalog entry for the set.
+ * Append a user-created variant to the in-memory catalog for a block's set, so the picker offers it without
+ * a page reload. A no-op when the block has no set for the token set.
  *
  * @param {string} name    The block name.
  * @param {string} set     The token set slug.
@@ -109,19 +149,20 @@ export function isUserVariant(name, set, slug) {
  * @return {void}
  */
 export function appendVariant(name, set, variant) {
-	const block = get(variantCatalog(), ['sets', set || activeSet(), name]);
+	const entry = soleSet(name, set);
 
-	if (!block || !Array.isArray(block.variants)) {
+	if (!entry || !Array.isArray(entry.variants)) {
 		return;
 	}
 
-	if (!block.variants.some((existing) => existing.slug === variant.slug)) {
-		block.variants.push(variant);
+	if (!entry.variants.some((existing) => existing.slug === variant.slug)) {
+		entry.variants.push(variant);
 	}
 }
 
 /**
- * Remove a variant from the in-memory catalog for a set, so the picker drops it without a page reload.
+ * Remove a variant from the in-memory catalog for a block's set, so the picker drops it without a page
+ * reload.
  *
  * @param {string} name The block name.
  * @param {string} set  The token set slug.
@@ -129,19 +170,19 @@ export function appendVariant(name, set, variant) {
  * @return {void}
  */
 export function removeVariant(name, set, slug) {
-	const block = get(variantCatalog(), ['sets', set || activeSet(), name]);
+	const entry = soleSet(name, set);
 
-	if (!block || !Array.isArray(block.variants)) {
+	if (!entry || !Array.isArray(entry.variants)) {
 		return;
 	}
 
-	block.variants = block.variants.filter((existing) => existing.slug !== slug);
+	entry.variants = entry.variants.filter((existing) => existing.slug !== slug);
 }
 
 /**
  * The color-variant picker for a block. Renders nothing when the block has no variants in the set.
- * Selecting an option writes the kbVariant attribute (via onChange); an empty value selects the block's
- * $default look.
+ * Selecting an option calls onChange with the chosen variant slug (the caller writes it into the block's
+ * kbVariants map under this control's group); an empty value selects the block's $default look.
  *
  * @param {Object}   props             The component props.
  * @param {string}   props.name        The block name, used to read its variants from the catalog.

--- a/src/extension/variants/api/client.js
+++ b/src/extension/variants/api/client.js
@@ -3,8 +3,9 @@
  *
  * Uses the editor's already-configured `@wordpress/api-fetch` (root + nonce), reading only the REST
  * namespace from the shared design-tokens descriptor. Every call targets a specific token set via the `set`
- * parameter (query for reads/deletes, body for writes); an absent set lets the server fall back to the
- * active set.
+ * parameter and a specific variant set (axis) via the `variant_set` parameter (query for reads/deletes,
+ * body for writes); an absent `set` falls back to the active token set, and an absent `variant_set` to the
+ * block's sole named set.
  */
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
@@ -12,15 +13,30 @@ import { designTokensNamespace } from '../../design-tokens/rest';
 import { variantsBlockPath, variantItemPath, variantDefaultPath } from './paths';
 
 /**
+ * The optional { set, variant_set } params, omitting each when empty so the server applies its defaults.
+ *
+ * @param {string} [set]        The token set slug.
+ * @param {string} [variantSet] The variant set (axis) group slug.
+ * @return {Object} The params object.
+ */
+function targetParams(set, variantSet) {
+	return {
+		...(set ? { set } : {}),
+		...(variantSet ? { variant_set: variantSet } : {}),
+	};
+}
+
+/**
  * Read a block's effective variant set for a token set.
  *
- * @param {string} block The block name.
- * @param {string} [set] The token set slug; omitted targets the active set.
- * @return {Promise<Object>} The variant set payload ({ block, slug, version, default, variants }).
+ * @param {string} block        The block name.
+ * @param {string} [set]        The token set slug; omitted targets the active set.
+ * @param {string} [variantSet] The variant set (axis) group slug; omitted targets the sole named set.
+ * @return {Promise<Object>} The variant set payload ({ block, group, slug, version, default, variants }).
  */
-export function getBlockVariants(block, set) {
+export function getBlockVariants(block, set, variantSet) {
 	return apiFetch({
-		path: addQueryArgs(variantsBlockPath(designTokensNamespace(), block), set ? { set } : {}),
+		path: addQueryArgs(variantsBlockPath(designTokensNamespace(), block), targetParams(set, variantSet)),
 	});
 }
 
@@ -33,43 +49,46 @@ export function getBlockVariants(block, set) {
  * @param {string} [variant.label]     The variant label.
  * @param {Object} [variant.tokens]    The property => value token map.
  * @param {string} [set]               The token set slug; omitted targets the active set.
+ * @param {string} [variantSet]        The variant set (axis) group slug; omitted targets the sole named set.
  * @return {Promise<Object>} The updated variant set payload.
  */
-export function createVariant(block, { variant, label, tokens }, set) {
+export function createVariant(block, { variant, label, tokens }, set, variantSet) {
 	return apiFetch({
 		path: variantsBlockPath(designTokensNamespace(), block),
 		method: 'POST',
-		data: { variant, label, tokens, ...(set ? { set } : {}) },
+		data: { variant, label, tokens, ...targetParams(set, variantSet) },
 	});
 }
 
 /**
- * Set a block's default variant.
+ * Set a block set's default variant.
  *
  * @param {string} block          The block name.
  * @param {string} defaultVariant The variant slug to make default.
  * @param {string} [set]          The token set slug; omitted targets the active set.
+ * @param {string} [variantSet]   The variant set (axis) group slug; omitted targets the sole named set.
  * @return {Promise<Object>} The updated variant set payload.
  */
-export function setVariantDefault(block, defaultVariant, set) {
+export function setVariantDefault(block, defaultVariant, set, variantSet) {
 	return apiFetch({
 		path: variantDefaultPath(designTokensNamespace(), block),
 		method: 'PUT',
-		data: { default: defaultVariant, ...(set ? { set } : {}) },
+		data: { default: defaultVariant, ...targetParams(set, variantSet) },
 	});
 }
 
 /**
  * Delete a single variant from a block's set.
  *
- * @param {string} block   The block name.
- * @param {string} variant The variant slug.
- * @param {string} [set]   The token set slug; omitted targets the active set.
+ * @param {string} block        The block name.
+ * @param {string} variant      The variant slug.
+ * @param {string} [set]        The token set slug; omitted targets the active set.
+ * @param {string} [variantSet] The variant set (axis) group slug; omitted targets the sole named set.
  * @return {Promise<Object>} The updated variant set payload.
  */
-export function deleteVariant(block, variant, set) {
+export function deleteVariant(block, variant, set, variantSet) {
 	return apiFetch({
-		path: addQueryArgs(variantItemPath(designTokensNamespace(), block, variant), set ? { set } : {}),
+		path: addQueryArgs(variantItemPath(designTokensNamespace(), block, variant), targetParams(set, variantSet)),
 		method: 'DELETE',
 	});
 }


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3577

**Stacked PR 4 of 4.** Base: `soft-3577/pr3-variant-rest`.

The editor UI for grouped variants.

- The block's variant selection is an object attribute (`kbVariants`) mapping a set's group slug to the chosen variant slug; the flat single-string attribute is retired for the button.
- The picker HOC resolves each block's named set and reads/writes `kbVariants[group]`; the save/preview filters emit `kb-variant--<group>--<slug>`.
- The REST client addresses a set with a `variant_set` param.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
