### PR TITLE
Seed button border radius from the control-radius token via the preset catalog

### DIFF
--- a/includes/resources/Design_Tokens/Editor/Block_Preset_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Block_Preset_Catalog.php
@@ -10,11 +10,12 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
  * early-filters.js reads to seed a freshly inserted block's attribute default from a resolved
  * token, instead of the hardcoded static default in block.json.
  *
- * Scoped to kadence/single-icon's `size` today — the only block/attribute pair this ticket needs.
- * Not a general "any block, any attribute" registry: extend the ENTRIES map (or promote to a
- * declarations-driven shape) only when a second real consumer needs it, matching this module's
- * existing preference for composable-but-not-speculative catalogs (see Variant_Catalog, which
- * itself started scoped to what the variant picker needed).
+ * Covers kadence/single-icon's `size` (a scalar pixel default) and kadence/singlebtn's
+ * `borderRadius` (a 4-corner pixel default) — the anticipated second consumer this module's
+ * composable-but-not-speculative preference (see Variant_Catalog) was waiting on before
+ * generalizing. Not a general "any block, any attribute" registry: keep extending the ENTRIES
+ * map (or promote to a declarations-driven shape) only when a further real consumer needs it,
+ * rather than opening it up ahead of demand.
  *
  * @since TBD
  */
@@ -23,17 +24,47 @@ final class Block_Preset_Catalog {
 	use Converts_Length_To_Px;
 
 	/**
-	 * Block => attribute => resolved-token dot-path. Each entry's value is looked up via the
-	 * resolver and, when present, exposed to JS as a raw number (this catalog only supports
-	 * numeric attribute defaults today — the one case this ticket has).
+	 * Scalar shape: the resolved token is exposed to JS as a bare float, matching a numeric
+	 * attribute default (e.g. kadence/single-icon's `size`).
 	 *
 	 * @since TBD
 	 *
-	 * @var array<string, array<string, string>>
+	 * @var string
+	 */
+	private const SHAPE_SCALAR = 'scalar';
+
+	/**
+	 * Corners shape: the resolved token is exposed to JS as a 4-element float array — the same
+	 * resolved value repeated across the top/right/bottom/left corners, matching a corner-array
+	 * attribute default (e.g. kadence/singlebtn's `borderRadius`).
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const SHAPE_CORNERS = 'corners';
+
+	/**
+	 * Block => attribute => { token dot-path, output shape }. Each entry's token is looked up
+	 * via the resolver and, when present, converted to a pixel value and emitted to JS in the
+	 * entry's shape — a bare float for `scalar`, a 4-element float array for `corners`.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string, array<string, array{token: string, shape: string}>>
 	 */
 	private const ENTRIES = [
 		'kadence/single-icon' => [
-			'size' => 'semantic.icon-size.default',
+			'size' => [
+				'token' => 'semantic.icon-size.default',
+				'shape' => self::SHAPE_SCALAR,
+			],
+		],
+		'kadence/singlebtn'   => [
+			'borderRadius' => [
+				'token' => 'semantic.radius.control',
+				'shape' => self::SHAPE_CORNERS,
+			],
 		],
 	];
 
@@ -54,22 +85,23 @@ final class Block_Preset_Catalog {
 	}
 
 	/**
-	 * The catalog, keyed by block name then attribute name, each value the resolved numeric
-	 * default. A block/attribute whose token does not resolve, or whose resolved value is not a
-	 * convertible numeric length, is omitted — the editor filter falls back to block.json's own
-	 * default for it.
+	 * The catalog, keyed by block name then attribute name, each value the resolved pixel
+	 * default in the entry's shape — a bare float for `scalar`, a 4-element float array (the
+	 * value repeated per corner) for `corners`. A block/attribute whose token does not resolve,
+	 * or whose resolved value is not a convertible numeric length, is omitted — the editor
+	 * filter falls back to block.json's own default for it.
 	 *
 	 * @since TBD
 	 *
-	 * @return array<string, array<string, float>>
+	 * @return array<string, array<string, float|array<int, float>>>
 	 */
 	public function all(): array {
 		$resolved = $this->resolver->resolve();
 		$out      = [];
 
 		foreach ( self::ENTRIES as $block => $attributes ) {
-			foreach ( $attributes as $attribute => $token_id ) {
-				$value = $resolved->value( $token_id );
+			foreach ( $attributes as $attribute => $spec ) {
+				$value = $resolved->value( $spec['token'] );
 
 				if ( $value === null ) {
 					continue;
@@ -81,7 +113,9 @@ final class Block_Preset_Catalog {
 					continue;
 				}
 
-				$out[ $block ][ $attribute ] = $px;
+				$out[ $block ][ $attribute ] = $spec['shape'] === self::SHAPE_CORNERS
+					? [ $px, $px, $px, $px ]
+					: $px;
 			}
 		}
 

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Block_Preset_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Block_Preset_CatalogTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Editor;
 
+use Generator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Editor\Block_Preset_Catalog;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Css_Renderer;
@@ -12,88 +13,134 @@ use Tests\Support\Classes\TestCase;
 
 /**
  * Exercises the editor per-block attribute-default catalog the block-registration filter in
- * early-filters.js reads: a resolved token converts and appears in the catalog, an unresolved
- * token is omitted, and a resolved value this catalog cannot convert is omitted too.
+ * early-filters.js reads: a resolved token converts to px and appears under its block/attribute
+ * path in the entry's shape — a bare float for the scalar icon-size entry, a 4-corner float
+ * array for the corner-shaped button border-radius entry — while an unresolved or unconvertible
+ * token is omitted so the filter falls back to block.json's own default.
  */
 final class Block_Preset_CatalogTest extends TestCase {
 
 	/**
-	 * A resolved `rem` token converts to px and appears under its block/attribute path.
+	 * A resolved token is emitted under its block/attribute path in the entry's shape: a bare
+	 * float for the icon-size scalar entry and a 4-corner float array (the value repeated) for
+	 * the button border-radius corner entry; entries whose token does not resolve or does not
+	 * convert to a pixel length are omitted.
+	 *
+	 * @dataProvider catalogProvider
+	 *
+	 * @param string|null                                    $icon_value   The `$value` the `semantic.icon-size.default` leaf resolves to, or null to omit the leaf.
+	 * @param string|null                                    $radius_value The `$value` the `semantic.radius.control` leaf resolves to, or null to omit the leaf.
+	 * @param array<string, array<string, float|array<int, float>>> $expected     The expected catalog.
 	 *
 	 * @return void
 	 */
-	public function testResolvedRemTokenAppearsConvertedToPx(): void {
-		$catalog = $this->catalog_resolving_to( '1.5rem' );
+	public function testCatalogEmitsEachEntryInItsShape( ?string $icon_value, ?string $radius_value, array $expected ): void {
+		$catalog = $this->catalog_resolving( $icon_value, $radius_value );
 
-		$this->assertSame( [ 'kadence/single-icon' => [ 'size' => 24.0 ] ], $catalog->all() );
-	}
-
-	/**
-	 * A resolved `px` token appears as a bare number, unconverted.
-	 *
-	 * @return void
-	 */
-	public function testResolvedPxTokenAppearsAsIs(): void {
-		$catalog = $this->catalog_resolving_to( '24px' );
-
-		$this->assertSame( [ 'kadence/single-icon' => [ 'size' => 24.0 ] ], $catalog->all() );
-	}
-
-	/**
-	 * A token with no baseline leaf at all is omitted from the catalog rather than guessed.
-	 *
-	 * @return void
-	 */
-	public function testUnresolvedTokenIsOmitted(): void {
-		$catalog = $this->catalog_for( [] );
-
-		$this->assertSame( [], $catalog->all() );
-	}
-
-	/**
-	 * A resolved value in a unit this catalog cannot safely convert is omitted rather than guessed.
-	 *
-	 * @return void
-	 */
-	public function testUnconvertibleResolvedValueIsOmitted(): void {
-		$catalog = $this->catalog_resolving_to( '2vw' );
-
-		$this->assertSame( [], $catalog->all() );
+		$this->assertSame( $expected, $catalog->all() );
 	}
 
 	/**
 	 * `Block_Preset_Catalog` is registered against the real Token Registry on boot, so the real
 	 * container resolves it with the shipped baseline's `semantic.icon-size.default` (1.5rem, i.e.
-	 * 24px) — proving the wiring, not just the catalog class in isolation.
+	 * 24px) and `semantic.radius.control` (0.5rem, i.e. 8px in all four corners) — proving the
+	 * wiring, not just the catalog class in isolation.
 	 *
 	 * @return void
 	 */
 	public function testTheRegisteredCatalogResolvesThroughTheRealContainer(): void {
 		$catalog = $this->container->get( Block_Preset_Catalog::class );
 
-		$this->assertSame( [ 'kadence/single-icon' => [ 'size' => 24.0 ] ], $catalog->all() );
+		$this->assertSame(
+			[
+				'kadence/single-icon' => [ 'size' => 24.0 ],
+				'kadence/singlebtn'   => [ 'borderRadius' => [ 8.0, 8.0, 8.0, 8.0 ] ],
+			],
+			$catalog->all()
+		);
 	}
 
 	/**
-	 * Build a catalog whose `semantic.icon-size.default` leaf resolves to the given dimension value.
+	 * Cases covering both entry shapes: rem conversion, px pass-through, each entry in isolation,
+	 * and the omission fallbacks (no leaf, unconvertible unit).
 	 *
-	 * @param string $value The `$value` the `semantic.icon-size.default` leaf resolves to.
+	 * @return Generator
+	 */
+	public function catalogProvider(): Generator {
+		yield 'both tokens resolve, rem converts to px per shape' => [
+			'icon_value'   => '1.5rem',
+			'radius_value' => '0.5rem',
+			'expected'     => [
+				'kadence/single-icon' => [ 'size' => 24.0 ],
+				'kadence/singlebtn'   => [ 'borderRadius' => [ 8.0, 8.0, 8.0, 8.0 ] ],
+			],
+		];
+
+		yield 'both tokens resolve, px passes through per shape' => [
+			'icon_value'   => '24px',
+			'radius_value' => '8px',
+			'expected'     => [
+				'kadence/single-icon' => [ 'size' => 24.0 ],
+				'kadence/singlebtn'   => [ 'borderRadius' => [ 8.0, 8.0, 8.0, 8.0 ] ],
+			],
+		];
+
+		yield 'only icon-size resolves emits just the scalar entry' => [
+			'icon_value'   => '24px',
+			'radius_value' => null,
+			'expected'     => [ 'kadence/single-icon' => [ 'size' => 24.0 ] ],
+		];
+
+		yield 'only control radius resolves emits just the corner entry' => [
+			'icon_value'   => null,
+			'radius_value' => '8px',
+			'expected'     => [ 'kadence/singlebtn' => [ 'borderRadius' => [ 8.0, 8.0, 8.0, 8.0 ] ] ],
+		];
+
+		yield 'no tokens resolve yields an empty catalog' => [
+			'icon_value'   => null,
+			'radius_value' => null,
+			'expected'     => [],
+		];
+
+		yield 'unconvertible units omit both entries' => [
+			'icon_value'   => '2vw',
+			'radius_value' => '3vh',
+			'expected'     => [],
+		];
+	}
+
+	/**
+	 * Build a catalog whose `semantic.icon-size.default` and `semantic.radius.control` leaves
+	 * resolve to the given dimension values; a null value omits that leaf from the baseline.
+	 *
+	 * @param string|null $icon_value   The `$value` the `semantic.icon-size.default` leaf resolves to, or null to omit it.
+	 * @param string|null $radius_value The `$value` the `semantic.radius.control` leaf resolves to, or null to omit it.
 	 *
 	 * @return Block_Preset_Catalog
 	 */
-	private function catalog_resolving_to( string $value ): Block_Preset_Catalog {
-		return $this->catalog_for(
-			[
-				'semantic' => [
-					'icon-size' => [
-						'default' => [
-							'$type'  => 'dimension',
-							'$value' => $value,
-						],
-					],
+	private function catalog_resolving( ?string $icon_value, ?string $radius_value ): Block_Preset_Catalog {
+		$semantic = [];
+
+		if ( $icon_value !== null ) {
+			$semantic['icon-size'] = [
+				'default' => [
+					'$type'  => 'dimension',
+					'$value' => $icon_value,
 				],
-			]
-		);
+			];
+		}
+
+		if ( $radius_value !== null ) {
+			$semantic['radius'] = [
+				'control' => [
+					'$type'  => 'dimension',
+					'$value' => $radius_value,
+				],
+			];
+		}
+
+		return $this->catalog_for( $semantic === [] ? [] : [ 'semantic' => $semantic ] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Follow-up to the review question on PR #1112 (`discussion_r3539263596`): can the Kadence button's **Border Radius** seed its editor default from a design token via the new `Block_Preset_Catalog`, the same way `kadence/single-icon`'s `size` does?

Yes. This generalizes the catalog from scalar-only to per-entry **shape** and wires the button's `borderRadius` to `semantic.radius.control`.

## What changed

- **`Block_Preset_Catalog`** grows a per-entry `shape` (`SHAPE_SCALAR` / `SHAPE_CORNERS`, both private consts with accessors per convention). `all()` now emits either a bare float (icon size — unchanged output) or a 4-element float array for corner attributes.
- New entry: `kadence/singlebtn` → `borderRadius` → `semantic.radius.control` (corners shape). In the shipped baseline this resolves to `radius.md` = 0.5rem = 8px, so a freshly-inserted button seeds `[8, 8, 8, 8]`.
- Class docblock updated to record the button as the anticipated second consumer.

## Deliberately out of scope

- `tabletBorderRadius` / `mobileBorderRadius` — left empty; the block already inherits desktop when a breakpoint value is empty.
- `borderHoverRadius` / `borderTransparentRadius` / `borderStickyRadius` — the review question was about the base Border Radius, not hover/transparent/sticky states.
- `borderRadiusUnit` — untouched; the resolved value is already px, matching its own default.

## JS

No change to `src/early-filters.js`. `blockPresetAttributeDefault()` assigns the catalog value verbatim into the attribute default, so an array works unmodified.

## Testing

- `Block_Preset_CatalogTest` rewritten to a `Generator`-based provider covering both shapes: rem→px and px pass-through, each entry in isolation (scalar float vs. corner array), empty baseline, and unconvertible units. The real-container test asserts both the icon-size scalar (`24.0`) and the button corners (`[8, 8, 8, 8]`).
- PHPStan (level max): clean.
- slic wpunit `Block_Preset_CatalogTest`: `OK (7 tests, 7 assertions)`.
- cspell on changed files: clean.

## Base branch

Branched off `SOFT-3405/phase-3-editor-default-catalog` (PR #1112), which is the intended integration point.
