### PR TITLE
SOFT-3834 [1/2]: Collapse variant sets — PHP backend

### DIFF
--- a/includes/blocks/class-kadence-blocks-singlebtn-block.php
+++ b/includes/blocks/class-kadence-blocks-singlebtn-block.php
@@ -369,10 +369,10 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$classes[] = ! empty( $attributes['text'] ) ? 'kt-btn-has-text-true' : 'kt-btn-has-text-false';
 		$classes[] = ! empty( $attributes['icon'] ) ? 'kt-btn-has-svg-true' : 'kt-btn-has-svg-false';
 		$classes[] = ! empty( $attributes['iconReveal'] ) && ! empty( $attributes['icon'] ) ? 'icon-reveal' : '';
-		// Each selected design-token variant outputs a kb-variant--<group>--<slug> class (one per variant
-		// set/axis) the Design Tokens variant projector's scoped CSS hooks. This is a dynamic block, so the
-		// classes are added here rather than by the editor save filter.
-		$classes = array_merge( $classes, $this->variant_classes( $attributes['kbVariants'] ?? [] ) );
+		// A selected design-token variant outputs a kb-variant--<slug> class the Design Tokens variant
+		// projector's scoped CSS hooks. This is a dynamic block, so the class is added here rather than by
+		// the editor save filter.
+		$classes = array_merge( $classes, $this->variant_classes( $attributes['kbVariant'] ?? '' ) );
 
 		if ( ! empty( $attributes['target'] ) && 'video' === $attributes['target'] ) {
 			$classes[] = 'ktblocksvideopop';

--- a/includes/resources/Design_Tokens/Admin/Feed/Variants.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Variants.php
@@ -3,22 +3,20 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
-use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Variant_Set;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Unknown_Variant_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
 
 /**
- * Builds the admin UI feed's "variants" section: for every variant SET a block registers — keyed by block
- * then by set group slug — its default, variant names, per-property bindings (structure) and resolved
- * preview values.
+ * Builds the admin UI feed's "variants" section: for every variant set a block registers — keyed by block —
+ * its default, variant names, per-property bindings (structure) and resolved preview values.
  *
  * Structure comes from the registry ({@see \KadenceWP\KadenceBlocks\Design_Tokens\Registry\Variant_Set::to_ui_schema()});
  * the variant list and resolved values come from the {@see Variant_Resolver} against the live store. A set
  * registered but absent from the document (Unknown_Variant_Exception) is skipped, and a single variant that
  * fails to resolve is omitted, so one malformed set never breaks the whole feed. The corrupt-store case (the
  * Token_Resolver throwing an alias-cycle / dangling-alias RuntimeException from inside resolve()) is NOT
- * swallowed here — it is the Localizer's fail-open boundary. A preset / default-variant set (the implicit
- * group, no picker) surfaces with an empty group slug.
+ * swallowed here — it is the Localizer's fail-open boundary. A preset / default-variant set (one with no
+ * picker) surfaces the same way, without a `label`.
  *
  * @since TBD
  */
@@ -54,56 +52,52 @@ final class Variants {
 	}
 
 	/**
-	 * The variants section, keyed by block name then by set group slug.
+	 * The variants section, keyed by block name.
 	 *
 	 * @since TBD
 	 *
 	 * @param string $slug The token set whose values variant aliases resolve against.
 	 *
-	 * @return array<string, array<string, mixed>> block => group => { bindings, group, default, names,
-	 *                                             properties, values, label? }.
+	 * @return array<string, array<string, mixed>> block => { bindings, default, names, properties, values,
+	 *                                             label? }.
 	 */
 	public function all( string $slug = 'default' ): array {
 		$out = [];
 
-		foreach ( $this->registry->variant_sets() as $block => $sets ) {
-			foreach ( $sets as $group => $set ) {
-				try {
-					$names   = $this->variants->names( $block, $slug, $group );
-					$default = $this->variants->default_variant( $block, $slug, $group );
-				} catch ( Unknown_Variant_Exception $e ) {
-					continue; // Set registered but not defined in the document — skip, fail soft.
-				}
-
-				$values = [];
-
-				foreach ( $names as $variant ) {
-					try {
-						// Literal values: the editor renders each as a swatch, which a var() chain can't paint.
-						$values[ $variant ] = $this->variants->resolve_literal( $block, $variant, $slug, $group );
-					} catch ( Unknown_Variant_Exception $e ) {
-						continue; // Omit a single unresolvable variant; keep the rest.
-					}
-				}
-
-				$entry = array_merge(
-					$set->to_ui_schema(),
-					[
-						// A preset (implicit) set carries no picker slug; the editor keys off the empty group.
-						'group'      => $group === Variant_Set::get_implicit_group_key() ? '' : $group,
-						'default'    => $default,
-						'names'      => $names,
-						'properties' => array_keys( $set->bindings ),
-						'values'     => $values,
-					]
-				);
-
-				if ( $set->label !== null ) {
-					$entry['label'] = $set->label;
-				}
-
-				$out[ $block ][ $group ] = $entry;
+		foreach ( $this->registry->variant_sets() as $block => $set ) {
+			try {
+				$names   = $this->variants->names( $block, $slug );
+				$default = $this->variants->default_variant( $block, $slug );
+			} catch ( Unknown_Variant_Exception $e ) {
+				continue; // Set registered but not defined in the document — skip, fail soft.
 			}
+
+			$values = [];
+
+			foreach ( $names as $variant ) {
+				try {
+					// Literal values: the editor renders each as a swatch, which a var() chain can't paint.
+					$values[ $variant ] = $this->variants->resolve_literal( $block, $variant, $slug );
+				} catch ( Unknown_Variant_Exception $e ) {
+					continue; // Omit a single unresolvable variant; keep the rest.
+				}
+			}
+
+			$entry = array_merge(
+				$set->to_ui_schema(),
+				[
+					'default'    => $default,
+					'names'      => $names,
+					'properties' => array_keys( $set->bindings ),
+					'values'     => $values,
+				]
+			);
+
+			if ( $set->label !== null ) {
+				$entry['label'] = $set->label;
+			}
+
+			$out[ $block ] = $entry;
 		}
 
 		return $out;

--- a/includes/resources/Design_Tokens/Editor/Variant_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Variant_Catalog.php
@@ -14,14 +14,14 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
  * Builds the per-set variant catalog the block editor's variant picker and "save as new variant" form read.
  *
  * Keyed by token set so the picker can show the variants for whichever set a block is on (its `kbTokenSet`,
- * or the active set), not just the active one, then by block and by variant SET (axis):
- * `{ active: <slug>, sets: { <slug>: { <block>: { <group>: {…} } } } }`. Per variant set it carries the
- * `$default` slug, the named variants as { slug, label, userCreated }, the picker control label, and the
- * controllable surface as { key, kind, token } per bound property so the form can render one input per
- * property. Only NAMED (picker-driven) sets appear; a block's preset / default-variant set (the implicit
- * group) has no picker and is omitted. It carries no resolved token values, so it cannot raise the
- * alias-cycle errors the admin feed must guard; a set registered but absent from a token set
- * (Unknown_Variant_Exception) is skipped, so one undefined set never empties the catalog.
+ * or the active set), not just the active one, then by block:
+ * `{ active: <slug>, sets: { <slug>: { <block>: {…} } } }`. Per block it carries the `$default` slug, the
+ * named variants as { slug, label, userCreated }, the picker control label, and the controllable surface as
+ * { key, kind, token } per bound property so the form can render one input per property. Only PICKER sets
+ * appear (a set that declares a `label`); a block's preset / default-variant set (no label) has no picker
+ * and is omitted. It carries no resolved token values, so it cannot raise the alias-cycle errors the admin
+ * feed must guard; a set registered but absent from a token set (Unknown_Variant_Exception) is skipped, so
+ * one undefined set never empties the catalog.
  *
  * @since TBD
  */
@@ -116,58 +116,51 @@ final class Variant_Catalog {
 	}
 
 	/**
-	 * The per-block, per-variant-set catalog for one token set. Only NAMED (picker-driven) sets are
-	 * surfaced; a block's preset / default-variant set (the implicit group) has no picker, so it is skipped.
+	 * The per-block catalog for one token set. Only PICKER sets are surfaced; a block's preset /
+	 * default-variant set (one with no `label`) has no picker, so it is skipped.
 	 *
 	 * @since TBD
 	 *
 	 * @param string $slug The token set slug.
 	 *
-	 * @return array<string, array<string, mixed>> block => group => { group, default, variants, properties, label? }.
+	 * @return array<string, array<string, mixed>> block => { default, variants, properties, label }.
 	 */
 	private function for_set( string $slug ): array {
 		$out = [];
 
 		foreach ( $this->registry->variant_blocks() as $block ) {
-			foreach ( $this->registry->sets_for_block( $block ) as $group => $set ) {
-				if ( $group === Variant_Set::get_implicit_group_key() ) {
-					continue; // A preset / default-variant set shows no picker, so it is not offered here.
-				}
+			$set = $this->registry->for_block( $block );
 
-				try {
-					$names   = $this->variants->names( $block, $slug, $group );
-					$default = $this->variants->default_variant( $block, $slug, $group );
-				} catch ( Unknown_Variant_Exception $e ) {
-					continue; // Set registered but not defined in this token set — skip, fail soft.
-				}
-
-				$user_created = $this->effective->user_created( $block, $slug, $group );
-
-				$variants = [];
-
-				foreach ( $names as $name ) {
-					$variants[] = [
-						'slug'        => $name,
-						'label'       => $this->variants->label( $block, $name, $slug, $group ) ?? $name,
-						'userCreated' => in_array( $name, $user_created, true ),
-					];
-				}
-
-				$entry = [
-					'group'      => $group,
-					'default'    => $default,
-					'variants'   => $variants,
-					'properties' => $this->properties_for( $set ),
-				];
-
-				// The picker's control label (the set's axis), declared on the variant set. Omitted when the
-				// set declares none, so the editor falls back to its default label.
-				if ( $set->label !== null ) {
-					$entry['label'] = $set->label;
-				}
-
-				$out[ $block ][ $group ] = $entry;
+			// A preset / default-variant set (no label) shows no picker, so it is not offered here.
+			if ( $set === null || $set->label === null ) {
+				continue;
 			}
+
+			try {
+				$names   = $this->variants->names( $block, $slug );
+				$default = $this->variants->default_variant( $block, $slug );
+			} catch ( Unknown_Variant_Exception $e ) {
+				continue; // Set registered but not defined in this token set — skip, fail soft.
+			}
+
+			$user_created = $this->effective->user_created( $block, $slug );
+
+			$variants = [];
+
+			foreach ( $names as $name ) {
+				$variants[] = [
+					'slug'        => $name,
+					'label'       => $this->variants->label( $block, $name, $slug ) ?? $name,
+					'userCreated' => in_array( $name, $user_created, true ),
+				];
+			}
+
+			$out[ $block ] = [
+				'default'    => $default,
+				'variants'   => $variants,
+				'properties' => $this->properties_for( $set ),
+				'label'      => $set->label,
+			];
 		}
 
 		return $out;

--- a/includes/resources/Design_Tokens/Projection/Variant/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Variant/Css_Builder.php
@@ -10,7 +10,6 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Scope;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Binding;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
-use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Variant_Set;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
 use RuntimeException;
 
@@ -25,34 +24,33 @@ use RuntimeException;
  * companion stylesheet (Native\Styles\Button), so one retarget path re-skins both with zero changes to a
  * block's markup. The selector is block-aware: core/button resolves to ".wp-block-button".
  *
- * A block's variants may be organized into named GROUPS (independent single-select axes). The build
- * iterates each block's groups and emits, per (block, group, variant), the same layers below. A grouped
- * selection folds the group into both the class ("kb-variant--<group>--<variant>") and the variant var
- * name; a flat block's single implicit group omits the group segment, so its output is identical to an
- * ungrouped block. When two groups retarget the same --global-<slot>, their selected-variant rules carry
- * equal specificity, so source order decides: groups are emitted in document order, so the later group
- * wins for a shared slot.
+ * A block declares one flat variant list, and each variant may define a different subset of the block's
+ * bound surface; the build emits, per variant, exactly the properties that variant resolves. Two variants
+ * that both retarget the same --global-<slot> carry equal specificity, so the selected-variant rule wins
+ * over the class-less $default rule by higher specificity, and a per-instance edit wins over both.
  *
  * The emission mirrors the raw-token (Css_Var) projection so a variant var is just another token in the
  * same multi-set graph:
  *
  *   1. One namespaced variant-var block per set —
- *      --kb-token--<set>--variant--<block>--[<group>--]<variant>--<property>: <value-or-var> — where an
- *      aliased binding reads var(--kb-token--<set>--<target>), so the variant chains to that set's
- *      namespaced token and a set's chain stays inside the set; a literal binding emits the literal.
+ *      --kb-token--<set>--variant--<block>--<variant>--<property>: <value-or-var> — where an aliased
+ *      binding reads var(--kb-token--<set>--<target>), so the variant chains to that set's namespaced token
+ *      and a set's chain stays inside the set; a literal binding emits the literal.
  *   2. An active-set alias layer pointing each canonical variant var at the active set's namespaced one
  *      (--kb-token--variant--…: var(--kb-token--<active>--variant--…)).
  *   3. One [data-kb-token-set="<set>"] switch selector per set re-pointing the canonical variant vars at
  *      that set, so a body class / container attribute swaps the variant palette client-side — the scoped
  *      rules below read the canonical variant var on the block element, so they follow it for their subtree.
- *   4. Per (block, group, variant) scoped rules — ".wp-block-<block>.kb-variant--[<group>--]<variant>" —
- *      pointing each --global-<slot> at the canonical variant var, plus a class-less ".wp-block-<block>"
- *      rule per group for its $default variant so a block with no variant selected still shows its preset.
- *      These are the coercive surface, built from the active set only.
+ *   4. Per (block, variant) scoped rules — ".wp-block-<block>.kb-variant--<variant>" — pointing each
+ *      --global-<slot> at the canonical variant var. These read the canonical var (which the switch
+ *      selectors re-point per set), so a rule is set-independent and is emitted from every set's fragment —
+ *      a variant that exists only in a non-active set (e.g. a user-created variant on the "dark" set) still
+ *      gets its retarget rule. A class-less ".wp-block-<block>" rule for the active set's $default variant
+ *      is emitted alongside the active fragment, so a block with no variant selected still shows its preset.
  *
- * Scoping is per (block, group, variant): the same variant name on two blocks ("ghost" on a Button and a
- * Row), or on two groups, gets its own qualified rule, so values never collide. Both named variants and
- * the "$default" preset carry ordinary class/element specificity, so a per-instance edit still wins.
+ * Scoping is per (block, variant): the same variant name on two blocks ("ghost" on a Button and a Row) gets
+ * its own qualified rule, so values never collide. Both named variants and the "$default" preset carry
+ * ordinary class/element specificity, so a per-instance edit still wins.
  *
  * Nothing here is !important and the scope carries ordinary class specificity, so a per-instance inline
  * style still wins over a variant. Values are sanitized defensively before they reach a declaration.
@@ -132,7 +130,7 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @var array<string, array<string, array{selector:string, groups:array<string, array{default:string, variants:array<string, array<string, array{target:string, value:string}>>}>}>>
+	 * @var array<string, array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}>>
 	 */
 	private array $collected = [];
 
@@ -266,8 +264,11 @@ final class Css_Builder {
 	}
 
 	/**
-	 * Build (uncached) a set's per-set fragment: its namespaced variant-var block followed by its switch
-	 * selector. The single assembly definition shared by css() and the cached set_fragment().
+	 * Build (uncached) a set's per-set fragment: its namespaced variant-var block, its switch selector, and
+	 * its per-variant scoped retarget rules. The scoped rules read the canonical variant var (which the
+	 * switch selectors re-point per set), so emitting them from every set's fragment — not just the active
+	 * one — is what lets a variant that exists only in a non-active set still retarget its slots when a block
+	 * is placed on that set. A rule shared across sets is byte-identical, so the duplication is inert.
 	 *
 	 * @since TBD
 	 *
@@ -278,11 +279,13 @@ final class Css_Builder {
 	private function build_set_fragment( string $slug ): string {
 		$collected = $this->collect( $slug );
 
-		return $this->namespaced_block( $collected, $slug ) . $this->switch_block( $collected, $slug );
+		return $this->namespaced_block( $collected, $slug )
+			. $this->switch_block( $collected, $slug )
+			. $this->scoped_variants( $collected );
 	}
 
 	/**
-	 * Build (uncached) the active fragment: the canonical alias layer plus the coercive scoped rules. The
+	 * Build (uncached) the active fragment: the canonical alias layer plus the class-less $default rules. The
 	 * single assembly definition shared by css() and the cached active_fragment().
 	 *
 	 * @since TBD
@@ -294,11 +297,11 @@ final class Css_Builder {
 	private function build_active_fragment( string $active_slug ): string {
 		$collected = $this->collect( $active_slug );
 
-		return $this->alias_block( $collected, $active_slug ) . $this->scoped_block( $collected );
+		return $this->alias_block( $collected, $active_slug ) . $this->scoped_default( $collected );
 	}
 
 	/**
-	 * Walk every (block, group, variant, property) that resolves to a slot-targeted value for a set, into a
+	 * Walk every (block, variant, property) that resolves to a slot-targeted value for a set, into a
 	 * structure the layers below build from. The projected value namespaces its var() target to the set, so
 	 * an aliased variant chains to that set's namespaced token. Memoized per slug for the request.
 	 *
@@ -306,7 +309,7 @@ final class Css_Builder {
 	 *
 	 * @param string $slug The set slug to resolve against (and namespace the values to).
 	 *
-	 * @return array<string, array{selector:string, groups:array<string, array{default:string, variants:array<string, array<string, array{target:string, value:string}>>}>}>
+	 * @return array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}>
 	 */
 	private function collect( string $slug ): array {
 		if ( isset( $this->collected[ $slug ] ) ) {
@@ -316,92 +319,69 @@ final class Css_Builder {
 		$out = [];
 
 		foreach ( $this->registry->variant_blocks() as $block ) {
+			// A block may carry registered bindings before the document defines its variants; that is not an
+			// error, it simply contributes nothing yet, so skip a block whose set the registry never declared.
+			$set = $this->registry->for_block( $block );
+
+			if ( $set === null ) {
+				continue;
+			}
+
 			try {
-				// A block may carry registered bindings before the document defines its variants; that is not
-				// an error, it simply contributes nothing yet, so skip it rather than fail the whole build.
-				$groups = $this->variants->groups( $block, $slug );
+				$names = $this->variants->names( $block, $slug );
 			} catch ( RuntimeException $e ) {
 				continue;
 			}
 
-			$group_data = [];
+			$variants = [];
 
-			// Groups are collected in document order: when two groups share a --global-<slot>, equal
-			// specificity means the later group's scoped rule wins by source order.
-			foreach ( $groups as $group ) {
-				// Each set (axis) owns its bindings, so look them up per group — the button's "style" set, a
-				// preset block's implicit set. A group the document defines but the registry never declared a
-				// set for contributes nothing (no bindings), so skip it.
-				$set = $this->registry->for_variant_set( $block, $group );
-
-				if ( $set === null ) {
-					continue;
-				}
-
+			foreach ( $names as $variant ) {
 				try {
-					$names = $this->variants->names( $block, $slug, $group );
+					$values = $this->variants->resolve( $block, $variant, $slug, $slug );
 				} catch ( RuntimeException $e ) {
 					continue;
 				}
 
-				$variants = [];
+				$properties = [];
 
-				foreach ( $names as $variant ) {
-					try {
-						$values = $this->variants->resolve( $block, $variant, $slug, $slug, $group );
-					} catch ( RuntimeException $e ) {
+				foreach ( $values as $property => $value ) {
+					$binding = $set->binding( $property );
+
+					if ( $binding === null ) {
 						continue;
 					}
 
-					$properties = [];
+					$target = $this->target_var( $binding );
 
-					foreach ( $values as $property => $value ) {
-						$binding = $set->binding( $property );
-
-						if ( $binding === null ) {
-							continue;
-						}
-
-						$target = $this->target_var( $binding );
-
-						if ( $target === null ) {
-							continue;
-						}
-
-						$properties[ $property ] = [
-							'target' => $target,
-							'value'  => $value,
-						];
+					if ( $target === null ) {
+						continue;
 					}
 
-					if ( $properties !== [] ) {
-						$variants[ $variant ] = $properties;
-					}
+					$properties[ $property ] = [
+						'target' => $target,
+						'value'  => $value,
+					];
 				}
 
-				if ( $variants === [] ) {
-					continue;
+				if ( $properties !== [] ) {
+					$variants[ $variant ] = $properties;
 				}
-
-				try {
-					$default = $this->variants->default_variant( $block, $slug, $group );
-				} catch ( RuntimeException $e ) {
-					$default = '';
-				}
-
-				$group_data[ $group ] = [
-					'default'  => $default,
-					'variants' => $variants,
-				];
 			}
 
-			if ( $group_data === [] ) {
+			if ( $variants === [] ) {
 				continue;
+			}
+
+			try {
+				$default = $this->variants->default_variant( $block, $slug );
+			} catch ( RuntimeException $e ) {
+				$default = '';
 			}
 
 			$out[ $block ] = [
 				'selector' => $this->block_selector( $block ),
-				'groups'   => $group_data,
+				'default'  => $default,
+				'variants' => $variants,
 			];
 		}
 
@@ -414,8 +394,8 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, groups:array<string, array{default:string, variants:array<string, array<string, array{target:string, value:string}>>}>}> $collected The set's collected variants.
-	 * @param string                                                                                                                                                       $slug      The set slug to namespace the var names under.
+	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}> $collected The set's collected variants.
+	 * @param string                                                                                                                            $slug      The set slug to namespace the var names under.
 	 *
 	 * @return string
 	 */
@@ -423,11 +403,9 @@ final class Css_Builder {
 		$declarations = '';
 
 		foreach ( $collected as $block => $data ) {
-			foreach ( $data['groups'] as $group => $group_data ) {
-				foreach ( $group_data['variants'] as $variant => $properties ) {
-					foreach ( $properties as $property => $info ) {
-						$declarations .= $this->variant_var( $block, $group, $variant, $property, $slug ) . ':' . $this->sanitize_value( $info['value'] ) . ';';
-					}
+			foreach ( $data['variants'] as $variant => $properties ) {
+				foreach ( $properties as $property => $info ) {
+					$declarations .= $this->variant_var( $block, $variant, $property, $slug ) . ':' . $this->sanitize_value( $info['value'] ) . ';';
 				}
 			}
 		}
@@ -441,8 +419,8 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, groups:array<string, array{default:string, variants:array<string, array<string, array{target:string, value:string}>>}>}> $collected   The active set's collected variants.
-	 * @param string                                                                                                                                                       $active_slug The active set slug.
+	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}> $collected   The active set's collected variants.
+	 * @param string                                                                                                                            $active_slug The active set slug.
 	 *
 	 * @return string
 	 */
@@ -460,8 +438,8 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, groups:array<string, array{default:string, variants:array<string, array<string, array{target:string, value:string}>>}>}> $collected The set's collected variants.
-	 * @param string                                                                                                                                                       $slug      The set slug.
+	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}> $collected The set's collected variants.
+	 * @param string                                                                                                                            $slug      The set slug.
 	 *
 	 * @return string
 	 */
@@ -482,8 +460,8 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, groups:array<string, array{default:string, variants:array<string, array<string, array{target:string, value:string}>>}>}> $collected The collected variants whose ids drive the layer.
-	 * @param string                                                                                                                                                       $slug      The set slug the canonical names are pointed at.
+	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}> $collected The collected variants whose ids drive the layer.
+	 * @param string                                                                                                                            $slug      The set slug the canonical names are pointed at.
 	 *
 	 * @return string
 	 */
@@ -491,11 +469,9 @@ final class Css_Builder {
 		$declarations = '';
 
 		foreach ( $collected as $block => $data ) {
-			foreach ( $data['groups'] as $group => $group_data ) {
-				foreach ( $group_data['variants'] as $variant => $properties ) {
-					foreach ( $properties as $property => $info ) {
-						$declarations .= $this->variant_var( $block, $group, $variant, $property ) . ':var(' . $this->variant_var( $block, $group, $variant, $property, $slug ) . ');';
-					}
+			foreach ( $data['variants'] as $variant => $properties ) {
+				foreach ( $properties as $property => $info ) {
+					$declarations .= $this->variant_var( $block, $variant, $property ) . ':var(' . $this->variant_var( $block, $variant, $property, $slug ) . ');';
 				}
 			}
 		}
@@ -504,55 +480,86 @@ final class Css_Builder {
 	}
 
 	/**
-	 * Emit the coercive scoped rules from the active set's collected variants: per (block, group, variant) a
-	 * ".wp-block-<block>.kb-variant--[<group>--]<variant>" rule pointing each --global-<slot> at the
-	 * canonical variant var, plus a class-less ".wp-block-<block>" rule per group re-emitting that group's
-	 * $default variant's declarations so an unselected block still shows its preset.
+	 * Emit the per-variant scoped rules from a set's collected variants: per (block, variant) a
+	 * ".wp-block-<block>.kb-variant--<variant>" rule pointing each --global-<slot> at the canonical variant
+	 * var. Called for every set (not just the active one), so a variant that exists only in a non-active set
+	 * still gets its retarget rule; the rule body is set-independent (it reads the canonical var the switch
+	 * selectors re-point), so a rule shared across sets is byte-identical.
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, groups:array<string, array{default:string, variants:array<string, array<string, array{target:string, value:string}>>}>}> $collected The active set's collected variants.
+	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}> $collected The set's collected variants.
 	 *
 	 * @return string
 	 */
-	private function scoped_block( array $collected ): string {
+	private function scoped_variants( array $collected ): string {
 		$css = '';
 
 		foreach ( $collected as $block => $data ) {
-			$selector = $data['selector'];
+			foreach ( $data['variants'] as $variant => $properties ) {
+				$declarations = $this->slot_declarations( $block, $variant, $properties );
 
-			foreach ( $data['groups'] as $group => $group_data ) {
-				// Keep each variant's slot declarations so the group's $default can be re-emitted, class-less, below.
-				$variant_declarations = [];
-
-				foreach ( $group_data['variants'] as $variant => $properties ) {
-					$declarations = '';
-
-					foreach ( $properties as $property => $info ) {
-						$declarations .= $info['target'] . ':var(' . $this->variant_var( $block, $group, $variant, $property ) . ');';
-					}
-
-					if ( $declarations !== '' ) {
-						$variant_declarations[ $variant ] = $declarations;
-						$css                             .= $selector . '.' . $this->variant_class( $group, $variant ) . '{' . $declarations . '}';
-					}
-				}
-
-				/**
-				 * The group's $default look: a block with no variant selected for this group still shows its
-				 * preset. Point the same slots at the group's $default variant's var on the class-less block
-				 * selector. Its lower specificity yields to the kb-variant-- rules above (a selected variant)
-				 * and to a per-instance edit, so it only fills the gap.
-				 */
-				$default = $group_data['default'];
-
-				if ( $default !== '' && isset( $variant_declarations[ $default ] ) ) {
-					$css .= $selector . '{' . $variant_declarations[ $default ] . '}';
+				if ( $declarations !== '' ) {
+					$css .= $data['selector'] . '.' . Style::variant_class( $variant ) . '{' . $declarations . '}';
 				}
 			}
 		}
 
 		return $css;
+	}
+
+	/**
+	 * Emit the class-less $default rules from the active set's collected variants: per block a
+	 * ".wp-block-<block>" rule re-emitting the $default variant's declarations so a block with no variant
+	 * selected still shows its preset. Its lower specificity yields to the kb-variant-- rules (a selected
+	 * variant) and to a per-instance edit, so it only fills the gap. Built from the active set — the preset a
+	 * block shows when it follows the active set with no selection.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, array{selector:string, default:string, variants:array<string, array<string, array{target:string, value:string}>>}> $collected The active set's collected variants.
+	 *
+	 * @return string
+	 */
+	private function scoped_default( array $collected ): string {
+		$css = '';
+
+		foreach ( $collected as $block => $data ) {
+			$default = $data['default'];
+
+			if ( $default === '' || ! isset( $data['variants'][ $default ] ) ) {
+				continue;
+			}
+
+			$declarations = $this->slot_declarations( $block, $default, $data['variants'][ $default ] );
+
+			if ( $declarations !== '' ) {
+				$css .= $data['selector'] . '{' . $declarations . '}';
+			}
+		}
+
+		return $css;
+	}
+
+	/**
+	 * Build the `--global-<slot>:var(<canonical variant var>);` declarations for one variant's properties.
+	 *
+	 * @since TBD
+	 *
+	 * @param string                                                     $block      The block name.
+	 * @param string                                                     $variant    The variant slug.
+	 * @param array<string, array{target:string, value:string}>         $properties The variant's collected properties.
+	 *
+	 * @return string
+	 */
+	private function slot_declarations( string $block, string $variant, array $properties ): string {
+		$declarations = '';
+
+		foreach ( $properties as $property => $info ) {
+			$declarations .= $info['target'] . ':var(' . $this->variant_var( $block, $variant, $property ) . ');';
+		}
+
+		return $declarations;
 	}
 
 	/**
@@ -637,33 +644,13 @@ final class Css_Builder {
 	}
 
 	/**
-	 * The variant class for a (group, variant): the flat "kb-variant--<variant>" for a block's implicit
-	 * single group, or the grouped "kb-variant--<group>--<variant>" for an explicit group. Delegates to
-	 * {@see Style} so the class shape matches the editor's and never drifts.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $group   The variant group (the implicit-group sentinel for a flat block).
-	 * @param string $variant The variant slug.
-	 *
-	 * @return string
-	 */
-	private function variant_class( string $group, string $variant ): string {
-		return $group === Variant_Set::get_implicit_group_key()
-			? Style::variant_class( $variant )
-			: Style::group_variant_class( $group, $variant );
-	}
-
-	/**
-	 * The variant var name for a (block, group, variant, property), optionally namespaced to a token set:
-	 * "--kb-token--[<set>--]variant--<block>--[<group>--]<variant>--<property>", e.g.
-	 * --kb-token--dark--variant--kadence-advancedbtn--emphasis--ghost--button-bg. A block's implicit single
-	 * group omits the "<group>--" segment, so a flat block keeps the ungrouped var shape unchanged.
+	 * The variant var name for a (block, variant, property), optionally namespaced to a token set:
+	 * "--kb-token--[<set>--]variant--<block>--<variant>--<property>", e.g.
+	 * --kb-token--dark--variant--kadence-singlebtn--secondary--button-bg.
 	 *
 	 * @since TBD
 	 *
 	 * @param string $block     The block name.
-	 * @param string $group     The variant group (the implicit-group sentinel for a flat block).
 	 * @param string $variant   The variant slug.
 	 * @param string $property  The block property.
 	 * @param string $namespace Optional token-set slug to namespace the variable under. Empty yields the
@@ -671,12 +658,11 @@ final class Css_Builder {
 	 *
 	 * @return string
 	 */
-	private function variant_var( string $block, string $group, string $variant, string $property, string $namespace = '' ): string {
+	private function variant_var( string $block, string $variant, string $property, string $namespace = '' ): string {
 		return Css_Var::get_prefix()
 			. ( $namespace === '' ? '' : self::sanitize_identifier( $namespace ) . '--' )
 			. self::VARIANT_SEGMENT
 			. self::sanitize_identifier( str_replace( '/', '-', $block ) ) . '--'
-			. ( $group === Variant_Set::get_implicit_group_key() ? '' : self::sanitize_identifier( $group ) . '--' )
 			. self::sanitize_identifier( $variant ) . '--'
 			. self::sanitize_identifier( $property );
 	}

--- a/includes/resources/Design_Tokens/Projection/Variant/Renders_Variant_Classes.php
+++ b/includes/resources/Design_Tokens/Projection/Variant/Renders_Variant_Classes.php
@@ -3,49 +3,38 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Variant;
 
 /**
- * Shared helper for a dynamic (PHP-rendered) block that adds its selected design-token variant classes to
- * its own markup. A static (save.js) block gets these classes from the editor save filter instead, but a
+ * Shared helper for a dynamic (PHP-rendered) block that adds its selected design-token variant class to
+ * its own markup. A static (save.js) block gets this class from the editor save filter instead, but a
  * dynamic block builds its class list in PHP, so it composes this trait and merges {@see self::variant_classes()}
  * into that list.
  *
- * The classes are the same `kb-variant--<group>--<variant>` shape the projector's scoped CSS targets and the
- * editor's preview/save filters emit — one per variant set (axis) the block's `kbVariants` attribute selects.
- * The shape itself has a single source, {@see Style::group_variant_class()}; this trait is only the "read the
- * attribute map, produce the list" seam so every block does it identically.
+ * The class is the same `kb-variant--<variant>` shape the projector's scoped CSS targets and the editor's
+ * preview/save filters emit for the block's `kbVariant` selection. The shape itself has a single source,
+ * {@see Style::variant_class()}; this trait is only the "read the attribute, produce the list" seam so every
+ * block does it identically.
  *
  * @since TBD
  */
 trait Renders_Variant_Classes {
 
 	/**
-	 * The `kb-variant--<group>--<variant>` classes a block's `kbVariants` attribute selects — one per variant
-	 * set (axis) with a non-empty selection. A non-array attribute, or an entry with an empty group or
-	 * variant, yields nothing, so a block can pass the raw attribute straight through.
+	 * The `kb-variant--<variant>` class a block's `kbVariant` selection outputs, as a single-element list (or
+	 * an empty list when nothing is selected). A non-string or empty selection yields nothing, so a block can
+	 * pass the raw attribute straight through.
 	 *
 	 * @since TBD
 	 *
-	 * @param mixed $kb_variants The block's `kbVariants` attribute (variant-set group slug => variant slug map).
+	 * @param mixed $kb_variant The block's `kbVariant` attribute (the selected variant slug).
 	 *
 	 * @return string[]
 	 */
-	protected function variant_classes( $kb_variants ): array {
-		if ( ! is_array( $kb_variants ) ) {
+	protected function variant_classes( $kb_variant ): array {
+		$variant = is_string( $kb_variant ) ? $kb_variant : '';
+
+		if ( $variant === '' ) {
 			return [];
 		}
 
-		$classes = [];
-
-		foreach ( $kb_variants as $group => $variant ) {
-			$group   = (string) $group;
-			$variant = is_string( $variant ) ? $variant : '';
-
-			if ( $group === '' || $variant === '' ) {
-				continue;
-			}
-
-			$classes[] = Style::group_variant_class( $group, $variant );
-		}
-
-		return $classes;
+		return [ Style::variant_class( $variant ) ];
 	}
 }

--- a/includes/resources/Design_Tokens/Projection/Variant/Style.php
+++ b/includes/resources/Design_Tokens/Projection/Variant/Style.php
@@ -9,15 +9,10 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Identi
  * adds and the class the projected CSS targets can never drift apart — and so a Kadence block and a native
  * block (core/button) share one class shape for the color axis.
  *
- * A block's color variant is an ADDITIVE class (not a register_block_style() block style), so it composes
+ * A block's variant is an ADDITIVE class (not a register_block_style() block style), so it composes
  * with WordPress's own single-select block styles (e.g. the built-in "Outline"): a button can carry
  * "is-style-outline" and "kb-variant--secondary" at once. The editor adds the class via the shared kbVariant
  * save/preview filters (see src/early-filters.js), mirroring the same sanitizer used here.
- *
- * A variant may belong to a named GROUP (axis). A grouped selection carries the group in the class —
- * "kb-variant--<group>--<variant>" — so two independently chosen axes (e.g. a color and an emphasis)
- * compose as two classes on one block. A flat block's implicit single group omits the group segment and
- * keeps the "kb-variant--<variant>" shape, so stored documents are unaffected.
  *
  * @since TBD
  */
@@ -46,22 +41,5 @@ final class Style {
 	 */
 	public static function variant_class( string $variant ): string {
 		return self::CLASS_PREFIX . self::sanitize_identifier( $variant );
-	}
-
-	/**
-	 * The class a grouped variant selection outputs, e.g. ("emphasis", "outline") =>
-	 * "kb-variant--emphasis--outline". Each segment is sanitized independently so the group and variant
-	 * slugs cannot merge across the "--" delimiter, mirroring the JS kbVariantsClassNames() sanitizer so the
-	 * class always matches the selector the projected CSS targets.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $group   The variant group (axis) slug.
-	 * @param string $variant The variant slug.
-	 *
-	 * @return string
-	 */
-	public static function group_variant_class( string $group, string $variant ): string {
-		return self::CLASS_PREFIX . self::sanitize_identifier( $group ) . '--' . self::sanitize_identifier( $variant );
 	}
 }

--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -540,27 +540,25 @@
 					}
 				},
 				"kadence/singlebtn": {
-					"style": {
-						"$default": "primary",
-						"primary": {
-							"label": "Primary",
-							"tokens": {
-								"button-bg": "{semantic.color.button-primary-bg}",
-								"button-text": "{semantic.color.button-primary-text}",
-								"button-bg-hover": "{semantic.color.button-primary-bg-hover}",
-								"button-text-hover": "{semantic.color.button-primary-text-hover}",
-								"button-radius": "{semantic.radius.control}"
-							}
-						},
-						"secondary": {
-							"label": "Secondary",
-							"tokens": {
-								"button-bg": "{semantic.color.button-secondary-bg}",
-								"button-text": "{semantic.color.button-secondary-text}",
-								"button-bg-hover": "{semantic.color.button-secondary-bg-hover}",
-								"button-text-hover": "{semantic.color.button-secondary-text-hover}",
-								"button-radius": "{semantic.radius.control}"
-							}
+					"$default": "primary",
+					"primary": {
+						"label": "Primary",
+						"tokens": {
+							"button-bg": "{semantic.color.button-primary-bg}",
+							"button-text": "{semantic.color.button-primary-text}",
+							"button-bg-hover": "{semantic.color.button-primary-bg-hover}",
+							"button-text-hover": "{semantic.color.button-primary-text-hover}",
+							"button-radius": "{semantic.radius.control}"
+						}
+					},
+					"secondary": {
+						"label": "Secondary",
+						"tokens": {
+							"button-bg": "{semantic.color.button-secondary-bg}",
+							"button-text": "{semantic.color.button-secondary-text}",
+							"button-bg-hover": "{semantic.color.button-secondary-bg-hover}",
+							"button-text-hover": "{semantic.color.button-secondary-text-hover}",
+							"button-radius": "{semantic.radius.control}"
 						}
 					}
 				},
@@ -585,25 +583,23 @@
 					}
 				},
 				"core/button": {
-					"style": {
-						"$default": "primary",
-						"primary": {
-							"label": "Primary",
-							"tokens": {
-								"button-bg": "{semantic.color.button-primary-bg}",
-								"button-text": "{semantic.color.button-primary-text}",
-								"button-bg-hover": "{semantic.color.button-primary-bg-hover}",
-								"button-text-hover": "{semantic.color.button-primary-text-hover}"
-							}
-						},
-						"secondary": {
-							"label": "Secondary",
-							"tokens": {
-								"button-bg": "{semantic.color.button-secondary-bg}",
-								"button-text": "{semantic.color.button-secondary-text}",
-								"button-bg-hover": "{semantic.color.button-secondary-bg-hover}",
-								"button-text-hover": "{semantic.color.button-secondary-text-hover}"
-							}
+					"$default": "primary",
+					"primary": {
+						"label": "Primary",
+						"tokens": {
+							"button-bg": "{semantic.color.button-primary-bg}",
+							"button-text": "{semantic.color.button-primary-text}",
+							"button-bg-hover": "{semantic.color.button-primary-bg-hover}",
+							"button-text-hover": "{semantic.color.button-primary-text-hover}"
+						}
+					},
+					"secondary": {
+						"label": "Secondary",
+						"tokens": {
+							"button-bg": "{semantic.color.button-secondary-bg}",
+							"button-text": "{semantic.color.button-secondary-text}",
+							"button-bg-hover": "{semantic.color.button-secondary-bg-hover}",
+							"button-text-hover": "{semantic.color.button-secondary-text-hover}"
 						}
 					}
 				}

--- a/includes/resources/Design_Tokens/Registry/Token_Registry.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Registry.php
@@ -24,7 +24,7 @@ final class Token_Registry {
 	/** @var array<string, Token_Definition> Keyed by token id, insertion-ordered. */
 	private array $tokens = [];
 
-	/** @var array<string, array<string, Variant_Set>> Keyed by block name, then by set group slug. */
+	/** @var array<string, Variant_Set> The one set a block accepts, keyed by block name. */
 	private array $variant_sets = [];
 
 	/** @var array<string, Adapter_Interface> Keyed by block name. */
@@ -107,8 +107,8 @@ final class Token_Registry {
 	}
 
 	/**
-	 * Register a block's variant set — the variants it accepts, its default, and the per-property
-	 * bindings.
+	 * Register a block's variant set — its bindable surface and picker label. One set per block; a later
+	 * registration for the same block replaces the earlier one.
 	 *
 	 * @since TBD
 	 *
@@ -119,7 +119,7 @@ final class Token_Registry {
 	public function register_variant_set( array $set ): void {
 		$variant_set = Variant_Set::from_array( $set );
 
-		$this->variant_sets[ $variant_set->block ][ $variant_set->group ] = $variant_set;
+		$this->variant_sets[ $variant_set->block ] = $variant_set;
 	}
 
 	/**
@@ -222,10 +222,9 @@ final class Token_Registry {
 	}
 
 	/**
-	 * The block's preset / default-variant set (the one declared without an explicit group — see
-	 * {@see Variant_Set::get_implicit_group_key()}), or null. This is the no-picker set the block-preset and
-	 * block-default-CSS projectors consume; a block that only registers named (picker-driven) sets returns
-	 * null here. Use {@see self::for_variant_set()} to address a named set.
+	 * The one variant set a block registers, or null when it registers none. Both the picker-driven and the
+	 * preset (no-picker) projectors read this; distinguish the two by the set's `label` (a picker set
+	 * declares one, a preset set does not).
 	 *
 	 * @since TBD
 	 *
@@ -234,47 +233,16 @@ final class Token_Registry {
 	 * @return Variant_Set|null
 	 */
 	public function for_block( string $block ): ?Variant_Set {
-		return $this->variant_sets[ $block ][ Variant_Set::get_implicit_group_key() ] ?? null;
+		return $this->variant_sets[ $block ] ?? null;
 	}
 
 	/**
-	 * A specific variant set of a block by its group slug, or null when the block registers none under that
-	 * slug. Pass {@see Variant_Set::get_implicit_group_key()} for the preset set, or a named slug (e.g. "style") for a
-	 * picker-driven set. This is the per-set lookup the variant projector uses.
+	 * All registered variant sets, keyed by block name, in registration order. The admin UI feed iterates
+	 * this to render per-block variant editors; mirrors all() for tokens.
 	 *
 	 * @since TBD
-	 *
-	 * @param string $block The block name.
-	 * @param string $group The set group slug.
-	 *
-	 * @return Variant_Set|null
-	 */
-	public function for_variant_set( string $block, string $group ): ?Variant_Set {
-		return $this->variant_sets[ $block ][ $group ] ?? null;
-	}
-
-	/**
-	 * Every variant set a block registers, keyed by group slug (in registration order), or an empty array
-	 * when the block registers none. The "does this block accept variants" guard and the editor read this to
-	 * see all of a block's sets — preset and named alike.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $block The block name.
 	 *
 	 * @return array<string, Variant_Set>
-	 */
-	public function sets_for_block( string $block ): array {
-		return $this->variant_sets[ $block ] ?? [];
-	}
-
-	/**
-	 * All registered variant sets, keyed by block name then by set group slug, in registration order. The
-	 * admin UI feed iterates this to render per-block, per-set variant editors; mirrors all() for tokens.
-	 *
-	 * @since TBD
-	 *
-	 * @return array<string, array<string, Variant_Set>>
 	 */
 	public function variant_sets(): array {
 		return $this->variant_sets;

--- a/includes/resources/Design_Tokens/Registry/Variant_Set.php
+++ b/includes/resources/Design_Tokens/Registry/Variant_Set.php
@@ -5,51 +5,34 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry;
 use InvalidArgumentException;
 
 /**
- * Immutable registration of one block variant SET — a named axis of mutually-exclusive variants, plus its
- * per-property bindings. The *structure* half of the variant model, and the only part that cannot live in
- * the document.
+ * Immutable registration of the ONE variant set a block accepts — the block's full bindable surface: the
+ * per-property bindings any of its variants may draw from. The *structure* half of the variant model, and
+ * the only part that cannot live in the document.
  *
- * A block can register more than one set (e.g. a button's "style" axis alongside some other axis); each is
- * its own Variant_Set with its own bindings and picker label, keyed in the registry by (block, group).
- * Because each set owns its bindings, two sets on one block can reuse the same property name (each binds it
- * to its own output) and the same variant slug.
+ * A block declares exactly one set. Its `bindings` are the union of every property any variant may control;
+ * a given variant in the document may define any subset of them (and different variants may define
+ * different subsets), inheriting the rest from the block `$default` through the cascade.
  *
- * Two kinds of set exist:
- *
- *   - **Named set** (a `group` is declared, e.g. "style"): a picker-driven axis. The editor renders a
- *     control for it and the variant projector emits `kb-variant--<group>--<variant>` rules.
- *   - **Preset / default-variant set** (no `group`, so `group` is {@see self::IMPLICIT_GROUP_KEY}): the block's
- *     default look, with NO picker. It seeds block attributes / low-specificity CSS through
- *     {@see \KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Preset\Projector} and
- *     {@see \KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css\Css_Builder}, not the picker.
+ * A set with a `label` is picker-driven: the editor renders a Design Variants control for it and the
+ * variant projector emits `kb-variant--<variant>` rules. A set with no `label` is a preset / default look
+ * with NO picker: it seeds block attributes / low-specificity CSS through
+ * {@see \KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Preset\Projector} and
+ * {@see \KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css\Css_Builder} instead.
  *
  * It deliberately holds NO variant names, default or values, and no per-variant labels: those are document
- * data (`$extensions.com.kadence.designTokens.variants.<block>[.<group>]` — the `$default`, the variant
- * keys, and each variant's `tokens`), read through the Variant_Resolver. Keeping them out of the registry
- * means a single source of truth for the variant list (so a user-added variant in the store is honoured)
- * and no drift between a declaration and the document. The `label` is the one exception — it names the
- * editor picker CONTROL for the set (the axis), not a variant, so it is structural editor config declared
- * here.
+ * data (`$extensions.com.kadence.designTokens.variants.<block>` — the `$default`, the variant keys, and
+ * each variant's `tokens`), read through the Variant_Resolver. Keeping them out of the registry means a
+ * single source of truth for the variant list (so a user-added variant in the store is honoured) and no
+ * drift between a declaration and the document. The `label` is the one exception — it names the editor
+ * picker CONTROL, not a variant, so it is structural editor config declared here.
  *
- * Bindings are keyed by property (e.g. "button-bg" => {@see Binding}); every variant in the set shares
- * them, since "the button's background" maps to the same output slot whichever variant is active — only
- * the value changes.
+ * Bindings are keyed by property (e.g. "button-bg" => {@see Binding}); every variant shares them, since
+ * "the button's background" maps to the same output slot whichever variant is active — only the value
+ * changes.
  *
  * @since TBD
  */
 final class Variant_Set {
-
-	/**
-	 * The group slug of a preset / default-variant set — a set declared without an explicit `group`. It is
-	 * `$`-prefixed so it can never collide with a real (kebab-case) set slug, and is the key such a set is
-	 * stored under in the registry and returned as by the resolver's implicit-group reads. A named
-	 * (picker-driven) set declares its own group instead.
-	 *
-	 * @since TBD
-	 *
-	 * @var string
-	 */
-	private const IMPLICIT_GROUP_KEY = '$single';
 
 	/**
 	 * The block name, e.g. "kadence/advancedbtn".
@@ -61,17 +44,8 @@ final class Variant_Set {
 	public string $block;
 
 	/**
-	 * The set's group slug (the axis name, e.g. "style"), or {@see self::IMPLICIT_GROUP_KEY} for a preset /
-	 * default-variant set that shows no picker.
-	 *
-	 * @since TBD
-	 *
-	 * @var string
-	 */
-	public string $group;
-
-	/**
-	 * Per-property bindings for this set, keyed by property name. Shared by every variant in the set.
+	 * The block's bindable surface, keyed by property name — the union of properties any variant may
+	 * control. Shared by every variant; a variant defines values for any subset of these.
 	 *
 	 * @since TBD
 	 *
@@ -80,8 +54,8 @@ final class Variant_Set {
 	public array $bindings;
 
 	/**
-	 * The editor picker's control label for this set's axis (e.g. "Style"), or null to fall back to the
-	 * editor's default label. Names the CONTROL, not a variant. Unused for a preset set (it has no picker).
+	 * The editor picker's control label (e.g. "Style"), or null for a preset set that shows no picker.
+	 * Names the CONTROL, not a variant.
 	 *
 	 * @since TBD
 	 *
@@ -93,28 +67,13 @@ final class Variant_Set {
 	 * @since TBD
 	 *
 	 * @param string                 $block    The block name.
-	 * @param string                 $group    The set's group slug, or {@see self::IMPLICIT_GROUP_KEY} for a preset set.
-	 * @param array<string, Binding> $bindings Per-property bindings.
-	 * @param string|null            $label    The picker control label, or null for the editor default.
+	 * @param array<string, Binding> $bindings The block's bindable surface, keyed by property.
+	 * @param string|null            $label    The picker control label, or null for a preset set.
 	 */
-	private function __construct( string $block, string $group, array $bindings, ?string $label ) {
+	private function __construct( string $block, array $bindings, ?string $label ) {
 		$this->block    = $block;
-		$this->group    = $group;
 		$this->bindings = $bindings;
 		$this->label    = $label;
-	}
-
-	/**
-	 * The group slug of a preset / default-variant set — the sentinel a set declared without an explicit
-	 * `group` is stored under and returned as. Exposed for callers that branch on the implicit group (the
-	 * resolver, projector, REST controller and admin feed).
-	 *
-	 * @since TBD
-	 *
-	 * @return string
-	 */
-	public static function get_implicit_group_key(): string {
-		return self::IMPLICIT_GROUP_KEY;
 	}
 
 	/**
@@ -122,11 +81,10 @@ final class Variant_Set {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, mixed> $set The declaration: "block", optional "group" (the set/axis slug; omit
-	 *                                  for a preset / default-variant set), optional "bindings" (property =>
+	 * @param array<string, mixed> $set The declaration: "block", optional "bindings" (property =>
 	 *                                  {@see Binding::from_array()}) and optional "label" (the picker control
-	 *                                  label). Variant names, default and values are document data, not
-	 *                                  declared here.
+	 *                                  label; omit for a preset set with no picker). Variant names, default
+	 *                                  and values are document data, not declared here.
 	 *
 	 * @throws InvalidArgumentException When "block" is missing or a binding is malformed.
 	 *
@@ -139,14 +97,8 @@ final class Variant_Set {
 			throw new InvalidArgumentException( 'Variant-set declaration is missing required string "block".' );
 		}
 
-		// A non-empty "group" names a picker-driven set; its absence marks a preset / default-variant set.
-		$group = isset( $set['group'] ) && is_string( $set['group'] ) && $set['group'] !== ''
-			? $set['group']
-			: self::IMPLICIT_GROUP_KEY;
-
 		return new self(
 			$set['block'],
-			$group,
 			self::bindings( $set['block'], $set['bindings'] ?? [] ),
 			isset( $set['label'] ) && is_string( $set['label'] ) ? $set['label'] : null
 		);

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -272,8 +272,7 @@ return [
 			 * zero changes to its render path; a fresh button follows the $default.
 			 */
 			'block'    => 'kadence/singlebtn',
-			'group'    => 'style', // a named, picker-driven set (the button's Style axis), keyed variants.<block>.style.
-			'label'    => __( 'Style', 'kadence-blocks' ), // the editor picker's control label for the variant axis.
+			'label'    => __( 'Style', 'kadence-blocks' ), // a picker-driven set; this is the editor control's label.
 			'bindings' => [
 				'button-bg'         => [ 'kadence_slot' => 'palette-btn-bg' ],
 				'button-text'       => [ 'kadence_slot' => 'palette-btn' ],
@@ -295,8 +294,7 @@ return [
 			 * in the baseline document.
 			 */
 			'block'    => 'core/button',
-			'group'    => 'style', // a named, picker-driven set (the button's Style axis), keyed variants.<block>.style.
-			'label'    => __( 'Style', 'kadence-blocks' ), // the editor picker's control label for the variant axis.
+			'label'    => __( 'Style', 'kadence-blocks' ), // a picker-driven set; this is the editor control's label.
 			'bindings' => [
 				'button-bg'         => [ 'kadence_slot' => 'palette-btn-bg' ],
 				'button-text'       => [ 'kadence_slot' => 'palette-btn' ],

--- a/includes/resources/Design_Tokens/Resolver/Effective_Variants.php
+++ b/includes/resources/Design_Tokens/Resolver/Effective_Variants.php
@@ -5,7 +5,6 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
-use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Variant_Set;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
 
 /**
@@ -112,16 +111,14 @@ final class Effective_Variants {
 	 *
 	 * @since TBD
 	 *
-	 * @param string      $block The block name, e.g. "kadence/advancedbtn".
-	 * @param string      $slug  The token set slug.
-	 * @param string|null $group The variant set (axis) to read; null / the implicit sentinel reads the
-	 *                           block's flat preset set. A named button set passes its group (e.g. "style").
+	 * @param string $block The block name, e.g. "kadence/advancedbtn".
+	 * @param string $slug  The token set slug.
 	 *
 	 * @return string[]
 	 */
-	public function user_created( string $block, string $slug = 'default', ?string $group = null ): array {
-		$baseline_block  = $this->group_node( $this->variants_of( $this->baseline->document() ), $block, $group );
-		$effective_block = $this->group_node( $this->section( $slug ), $block, $group );
+	public function user_created( string $block, string $slug = 'default' ): array {
+		$baseline_block  = $this->block_node( $this->variants_of( $this->baseline->document() ), $block );
+		$effective_block = $this->block_node( $this->section( $slug ), $block );
 
 		$baseline_names  = $this->named_of( $baseline_block );
 		$effective_names = $this->named_of( $effective_block );
@@ -130,26 +127,18 @@ final class Effective_Variants {
 	}
 
 	/**
-	 * The variant-bearing node for a (block, group) within a variants section: the block node itself for a
-	 * flat preset set (a null or implicit-sentinel group), or the block's `<group>` sub-map for a named set.
-	 * An absent block or group yields an empty array, so the callers above fail soft.
+	 * The variant-bearing node for a block within a variants section — its `{ $default, <variant> }` map —
+	 * or an empty array when absent, so the callers above fail soft.
 	 *
 	 * @since TBD
 	 *
 	 * @param array<string, mixed> $section The variants section (baseline or effective).
 	 * @param string               $block   The block name.
-	 * @param string|null          $group   The variant set group, or null / the implicit sentinel.
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function group_node( array $section, string $block, ?string $group ): array {
-		$node = isset( $section[ $block ] ) && is_array( $section[ $block ] ) ? $section[ $block ] : [];
-
-		if ( $group === null || $group === Variant_Set::get_implicit_group_key() ) {
-			return $node;
-		}
-
-		return isset( $node[ $group ] ) && is_array( $node[ $group ] ) ? $node[ $group ] : [];
+	private function block_node( array $section, string $block ): array {
+		return isset( $section[ $block ] ) && is_array( $section[ $block ] ) ? $section[ $block ] : [];
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Resolver/Exception/Unknown_Variant_Exception.php
+++ b/includes/resources/Design_Tokens/Resolver/Exception/Unknown_Variant_Exception.php
@@ -51,19 +51,4 @@ final class Unknown_Variant_Exception extends RuntimeException {
 	public static function no_default( string $block ): self {
 		return new self( sprintf( 'Block "%s" has no default variant.', $block ) );
 	}
-
-	/**
-	 * The block has no variant group by the requested name (or an implicit-group lookup was asked of a
-	 * grouped block, or an explicit-group lookup of a flat one).
-	 *
-	 * @since TBD
-	 *
-	 * @param string $block The block name.
-	 * @param string $group The requested group slug.
-	 *
-	 * @return self
-	 */
-	public static function for_group( string $block, string $group ): self {
-		return new self( sprintf( 'Unknown variant group "%s" for block "%s".', $group, $block ) );
-	}
 }

--- a/includes/resources/Design_Tokens/Resolver/Variant_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Variant_Resolver.php
@@ -3,7 +3,6 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Resolver;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
-use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Variant_Set;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Unknown_Variant_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
@@ -29,14 +28,11 @@ use KadenceWP\KadenceBlocks\Utils\Cast;
  * surfaces that cannot consume a var() chain (block-attribute presets, the dimension-default fallback,
  * the editor variant-catalog feed).
  *
- * A block's variants can be organized as named variant SETS (picker-driven axes, e.g. a button's "style"
- * set): the document then nests `variants.<block>.<group>.{ $default, <variant> }`, and each set resolves
- * independently. A block may instead ship a single flat PRESET set (`variants.<block>.{ $default,
- * <variant> }`) — its default look, with no picker — which is read through the
- * {@see \KadenceWP\KadenceBlocks\Design_Tokens\Registry\Variant_Set::get_implicit_group_key()} sentinel. So every
- * accessor takes an optional `$group`: a null argument resolves to that single implicit preset set, while a
- * named set is addressed by its slug. A user-authored variant (added through the store) is a variant within
- * its set, so it sits underneath the per-set override merge unchanged.
+ * A block declares one flat variant list: the document nests `variants.<block>.{ $default, <variant> }`,
+ * where `$default` names the default variant and each named key is a variant. Different variants may
+ * define different subsets of the block's bound surface — a property a variant omits simply does not
+ * resolve for it, inherited from the block `$default` through the cascade. A user-authored variant (added
+ * through the store) is a variant in the same list, so it sits underneath the override merge unchanged.
  *
  * Variant definitions are read per token set through {@see Effective_Variants}: the shipped baseline's
  * variants deep-merged with that set's stored overrides, so a variant a user authored through the store
@@ -73,60 +69,6 @@ final class Variant_Resolver {
 	}
 
 	/**
-	 * The variant groups (axes) a block declares for a set, in document order. A grouped block returns its
-	 * explicit group slugs; a flat block returns a single-element list naming the {@see Variant_Set::get_implicit_group_key()}
-	 * sentinel, so callers can iterate axes uniformly whether or not the block is grouped.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $block The block name.
-	 * @param string $slug  The token set whose effective variants are read.
-	 *
-	 * @throws Unknown_Variant_Exception When the block defines no variants.
-	 *
-	 * @return string[]
-	 */
-	public function groups( string $block, string $slug = 'default' ): array {
-		$node = $this->block_variants( $block, $slug );
-
-		if ( ! $this->node_is_grouped( $node ) ) {
-			return [ Variant_Set::get_implicit_group_key() ];
-		}
-
-		$groups = [];
-
-		foreach ( array_keys( $node ) as $key ) {
-			// Skip `$default` and any other DTCG metadata key; only named groups are axes.
-			if ( is_string( $key ) && strpos( $key, '$' ) === 0 ) {
-				continue;
-			}
-
-			$groups[] = (string) $key;
-		}
-
-		return $groups;
-	}
-
-	/**
-	 * Whether the block organizes its variants into explicit named groups (multi-axis), as opposed to the
-	 * flat single-axis shape read as one implicit group. False for an unknown block (no throw).
-	 *
-	 * @since TBD
-	 *
-	 * @param string $block The block name.
-	 * @param string $slug  The token set whose effective variants are read.
-	 *
-	 * @return bool
-	 */
-	public function is_grouped( string $block, string $slug = 'default' ): bool {
-		try {
-			return $this->node_is_grouped( $this->block_variants( $block, $slug ) );
-		} catch ( Unknown_Variant_Exception $e ) {
-			return false;
-		}
-	}
-
-	/**
 	 * Resolve a variant's bindings to a `property => value` map for the css-var projection, preserving
 	 * alias indirection: an alias binding becomes a `var(--kb-token--<target>)` reference (so the variant
 	 * var chains to the semantic/primitive it points at and follows a token edit live) while a literal
@@ -142,20 +84,19 @@ final class Variant_Resolver {
 	 *
 	 * @since TBD
 	 *
-	 * @param string      $block         The block name, e.g. "kadence/advancedbtn".
-	 * @param string      $variant       The variant slug, e.g. "ghost".
-	 * @param string      $slug          The token set whose effective variants and resolved values are read.
-	 * @param string      $css_namespace Css-var namespace for the var() target ('' for the canonical name). When set,
-	 *                                   an alias becomes var(--kb-token--<namespace>--<target>), so a namespaced
-	 *                                   variant var chains to that set's namespaced token and stays inside the set.
-	 * @param string|null $group         The variant group, or null for a flat block's implicit group.
+	 * @param string $block         The block name, e.g. "kadence/advancedbtn".
+	 * @param string $variant       The variant slug, e.g. "ghost".
+	 * @param string $slug          The token set whose effective variants and resolved values are read.
+	 * @param string $css_namespace Css-var namespace for the var() target ('' for the canonical name). When set,
+	 *                              an alias becomes var(--kb-token--<namespace>--<target>), so a namespaced
+	 *                              variant var chains to that set's namespaced token and stays inside the set.
 	 *
-	 * @throws Unknown_Variant_Exception When the block, group or variant is not defined.
+	 * @throws Unknown_Variant_Exception When the block or variant is not defined.
 	 *
 	 * @return array<string, string> property => var()-preserving CSS value.
 	 */
-	public function resolve( string $block, string $variant, string $slug = 'default', string $css_namespace = '', ?string $group = null ): array {
-		$tokens   = $this->variant_tokens( $block, $variant, $slug, $group );
+	public function resolve( string $block, string $variant, string $slug = 'default', string $css_namespace = '' ): array {
+		$tokens   = $this->variant_tokens( $block, $variant, $slug );
 		$resolved = $this->resolver->resolve( $slug );
 
 		$values = [];
@@ -192,17 +133,16 @@ final class Variant_Resolver {
 	 *
 	 * @since TBD
 	 *
-	 * @param string      $block   The block name, e.g. "kadence/advancedbtn".
-	 * @param string      $variant The variant slug, e.g. "ghost".
-	 * @param string      $slug    The token set whose effective variants and resolved values are read.
-	 * @param string|null $group   The variant group, or null for a flat block's implicit group.
+	 * @param string $block   The block name, e.g. "kadence/advancedbtn".
+	 * @param string $variant The variant slug, e.g. "ghost".
+	 * @param string $slug    The token set whose effective variants and resolved values are read.
 	 *
-	 * @throws Unknown_Variant_Exception When the block, group or variant is not defined.
+	 * @throws Unknown_Variant_Exception When the block or variant is not defined.
 	 *
 	 * @return array<string, string> property => flattened literal CSS value.
 	 */
-	public function resolve_literal( string $block, string $variant, string $slug = 'default', ?string $group = null ): array {
-		$tokens   = $this->variant_tokens( $block, $variant, $slug, $group );
+	public function resolve_literal( string $block, string $variant, string $slug = 'default' ): array {
+		$tokens   = $this->variant_tokens( $block, $variant, $slug );
 		$resolved = $this->resolver->resolve( $slug );
 
 		$values = [];
@@ -219,7 +159,7 @@ final class Variant_Resolver {
 	}
 
 	/**
-	 * Resolve a group's default ("preset") variant to flattened LITERALS.
+	 * Resolve a block's default ("preset") variant to flattened LITERALS.
 	 *
 	 * Returns literals — it delegates to resolve_literal(), not resolve() — because its only callers are
 	 * concrete-value surfaces: Block_Preset seeds the value into a block attribute default an editor
@@ -230,37 +170,35 @@ final class Variant_Resolver {
 	 *
 	 * @since TBD
 	 *
-	 * @param string      $block The block name.
-	 * @param string      $slug  The token set whose effective variants and resolved values are read.
-	 * @param string|null $group The variant group, or null for a flat block's implicit group.
+	 * @param string $block The block name.
+	 * @param string $slug  The token set whose effective variants and resolved values are read.
 	 *
-	 * @throws Unknown_Variant_Exception When the block is not defined or the group declares no default.
+	 * @throws Unknown_Variant_Exception When the block is not defined or declares no default.
 	 *
 	 * @return array<string, string> property => flattened literal CSS value.
 	 */
-	public function resolve_default( string $block, string $slug = 'default', ?string $group = null ): array {
-		return $this->resolve_literal( $block, $this->default_variant( $block, $slug, $group ), $slug, $group );
+	public function resolve_default( string $block, string $slug = 'default' ): array {
+		return $this->resolve_literal( $block, $this->default_variant( $block, $slug ), $slug );
 	}
 
 	/**
-	 * The variant slugs a group declares for a set, in document order — the effective set (the baseline
+	 * The variant slugs a block declares for a set, in document order — the effective set (the baseline
 	 * deep-merged with the set's stored overrides) being the source of truth, so a user-added variant in the
 	 * store appears here alongside the baseline ones.
 	 *
 	 * @since TBD
 	 *
-	 * @param string      $block The block name.
-	 * @param string      $slug  The token set whose effective variants are read.
-	 * @param string|null $group The variant group, or null for a flat block's implicit group.
+	 * @param string $block The block name.
+	 * @param string $slug  The token set whose effective variants are read.
 	 *
-	 * @throws Unknown_Variant_Exception When the block or group defines no variants.
+	 * @throws Unknown_Variant_Exception When the block defines no variants.
 	 *
 	 * @return string[]
 	 */
-	public function names( string $block, string $slug = 'default', ?string $group = null ): array {
+	public function names( string $block, string $slug = 'default' ): array {
 		$names = [];
 
-		foreach ( array_keys( $this->group_node( $block, $slug, $group ) ) as $key ) {
+		foreach ( array_keys( $this->block_variants( $block, $slug ) ) as $key ) {
 			// Skip `$default` and any other DTCG metadata key; only named variants are slugs.
 			if ( is_string( $key ) && strpos( $key, '$' ) === 0 ) {
 				continue;
@@ -273,47 +211,45 @@ final class Variant_Resolver {
 	}
 
 	/**
-	 * Whether a block's group declares the given variant in a set. False for an unknown block or group (no
-	 * throw), so callers can validate a selection without first checking the block exists.
+	 * Whether a block declares the given variant in a set. False for an unknown block (no throw), so callers
+	 * can validate a selection without first checking the block exists.
 	 *
 	 * @since TBD
 	 *
-	 * @param string      $block The block name.
-	 * @param string      $name  The variant slug.
-	 * @param string      $slug  The token set whose effective variants are read.
-	 * @param string|null $group The variant group, or null for a flat block's implicit group.
+	 * @param string $block The block name.
+	 * @param string $name  The variant slug.
+	 * @param string $slug  The token set whose effective variants are read.
 	 *
 	 * @return bool
 	 */
-	public function has_variant( string $block, string $name, string $slug = 'default', ?string $group = null ): bool {
+	public function has_variant( string $block, string $name, string $slug = 'default' ): bool {
 		try {
-			return in_array( $name, $this->names( $block, $slug, $group ), true );
+			return in_array( $name, $this->names( $block, $slug ), true );
 		} catch ( Unknown_Variant_Exception $e ) {
 			return false;
 		}
 	}
 
 	/**
-	 * The human-readable label a block's variant declares in a set, or null when the block, the group, the
-	 * variant, or its label is absent. A lookup convenience that never throws, mirroring has_variant().
+	 * The human-readable label a block's variant declares in a set, or null when the block, the variant, or
+	 * its label is absent. A lookup convenience that never throws, mirroring has_variant().
 	 *
 	 * @since TBD
 	 *
-	 * @param string      $block   The block name.
-	 * @param string      $variant The variant slug.
-	 * @param string      $slug    The token set whose effective variants are read.
-	 * @param string|null $group   The variant group, or null for a flat block's implicit group.
+	 * @param string $block   The block name.
+	 * @param string $variant The variant slug.
+	 * @param string $slug    The token set whose effective variants are read.
 	 *
 	 * @return string|null
 	 */
-	public function label( string $block, string $variant, string $slug = 'default', ?string $group = null ): ?string {
+	public function label( string $block, string $variant, string $slug = 'default' ): ?string {
 		try {
-			$group_node = $this->group_node( $block, $slug, $group );
+			$node = $this->block_variants( $block, $slug );
 		} catch ( Unknown_Variant_Exception $e ) {
 			return null;
 		}
 
-		$variant_node = $group_node[ $variant ] ?? null;
+		$variant_node = $node[ $variant ] ?? null;
 
 		if ( ! is_array( $variant_node ) ) {
 			return null;
@@ -325,9 +261,9 @@ final class Variant_Resolver {
 	}
 
 	/**
-	 * The union of every property the block's variants set a value for in a set, across all of its groups —
-	 * what a {@see \KadenceWP\KadenceBlocks\Design_Tokens\Registry\Variant_Set::consistency()} check compares
-	 * the (per-block) bindings against, and what a block preset iterates.
+	 * The union of every property the block's variants set a value for in a set — what a
+	 * {@see \KadenceWP\KadenceBlocks\Design_Tokens\Registry\Variant_Set::consistency()} check compares the
+	 * block's bindings against, and what a block preset iterates.
 	 *
 	 * @since TBD
 	 *
@@ -341,11 +277,9 @@ final class Variant_Resolver {
 	public function value_properties( string $block, string $slug = 'default' ): array {
 		$properties = [];
 
-		foreach ( $this->groups( $block, $slug ) as $group ) {
-			foreach ( $this->names( $block, $slug, $group ) as $variant ) {
-				foreach ( array_keys( $this->variant_tokens( $block, $variant, $slug, $group ) ) as $property ) {
-					$properties[ $property ] = true;
-				}
+		foreach ( $this->names( $block, $slug ) as $variant ) {
+			foreach ( array_keys( $this->variant_tokens( $block, $variant, $slug ) ) as $property ) {
+				$properties[ $property ] = true;
 			}
 		}
 
@@ -353,21 +287,20 @@ final class Variant_Resolver {
 	}
 
 	/**
-	 * A group's default variant slug for a set, read from the effective set's `$default` — the single
+	 * A block's default variant slug for a set, read from the effective set's `$default` — the single
 	 * source of truth for the default (no registry mirror to drift from).
 	 *
 	 * @since TBD
 	 *
-	 * @param string      $block The block name.
-	 * @param string      $slug  The token set whose effective variants are read.
-	 * @param string|null $group The variant group, or null for a flat block's implicit group.
+	 * @param string $block The block name.
+	 * @param string $slug  The token set whose effective variants are read.
 	 *
-	 * @throws Unknown_Variant_Exception When the block is not defined or the group declares no default.
+	 * @throws Unknown_Variant_Exception When the block is not defined or declares no default.
 	 *
 	 * @return string
 	 */
-	public function default_variant( string $block, string $slug = 'default', ?string $group = null ): string {
-		$default = $this->group_node( $block, $slug, $group )[ Extensions::get_default_key() ] ?? '';
+	public function default_variant( string $block, string $slug = 'default' ): string {
+		$default = $this->block_variants( $block, $slug )[ Extensions::get_default_key() ] ?? '';
 
 		if ( ! is_string( $default ) || $default === '' ) {
 			throw Unknown_Variant_Exception::no_default( $block );
@@ -407,7 +340,7 @@ final class Variant_Resolver {
 	 *
 	 * @since TBD
 	 *
-	 * @param mixed  $value     The raw binding value (alias string or literal).
+	 * @param mixed  $value         The raw binding value (alias string or literal).
 	 * @param string $css_namespace Css-var namespace for the var() target ('' for the canonical name).
 	 *
 	 * @return string
@@ -421,74 +354,38 @@ final class Variant_Resolver {
 	}
 
 	/**
-	 * The property => value map for a variant in a set, or throw when the block/group/variant is undefined.
+	 * The property => value map for a variant in a set, or throw when the block/variant is undefined.
 	 *
 	 * A variant that exists but carries no `tokens` map — or a non-array one — resolves to an empty map,
 	 * not an error: a variant may legitimately set no values (it then contributes nothing downstream).
-	 * Only an undefined block, group or variant is an error; a malformed-but-present `tokens` fails soft,
-	 * in line with the resolver's other lookups.
+	 * Only an undefined block or variant is an error; a malformed-but-present `tokens` fails soft, in line
+	 * with the resolver's other lookups.
 	 *
 	 * @since TBD
 	 *
-	 * @param string      $block   The block name.
-	 * @param string      $variant The variant slug.
-	 * @param string      $slug    The token set whose effective variants are read.
-	 * @param string|null $group   The variant group, or null for a flat block's implicit group.
+	 * @param string $block   The block name.
+	 * @param string $variant The variant slug.
+	 * @param string $slug    The token set whose effective variants are read.
 	 *
-	 * @throws Unknown_Variant_Exception When the block, group or variant is not defined.
+	 * @throws Unknown_Variant_Exception When the block or variant is not defined.
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function variant_tokens( string $block, string $variant, string $slug = 'default', ?string $group = null ): array {
-		$group_node = $this->group_node( $block, $slug, $group );
+	private function variant_tokens( string $block, string $variant, string $slug = 'default' ): array {
+		$node = $this->block_variants( $block, $slug );
 
-		if ( ! isset( $group_node[ $variant ] ) || ! is_array( $group_node[ $variant ] ) ) {
+		if ( ! isset( $node[ $variant ] ) || ! is_array( $node[ $variant ] ) ) {
 			throw Unknown_Variant_Exception::for_variant( $block, $variant );
 		}
 
-		$tokens = $group_node[ $variant ][ Extensions::get_tokens_key() ] ?? [];
+		$tokens = $node[ $variant ][ Extensions::get_tokens_key() ] ?? [];
 
 		return is_array( $tokens ) ? $tokens : [];
 	}
 
 	/**
-	 * The variant-bearing node for a (block, group) in a set: the `$default` plus named variants the rest
-	 * of the resolver reads. For a flat block the block node itself is the single implicit group, so a null
-	 * or implicit-sentinel `$group` returns it; an explicit group name then walks one level deeper. A group
-	 * mismatch (an explicit name on a flat block, or a null/implicit lookup on a grouped block) throws.
-	 *
-	 * @since TBD
-	 *
-	 * @param string      $block The block name.
-	 * @param string      $slug  The token set whose effective variants are read.
-	 * @param string|null $group The variant group, or null for a flat block's implicit group.
-	 *
-	 * @throws Unknown_Variant_Exception When the block defines no variants or the group is unknown.
-	 *
-	 * @return array<string, mixed>
-	 */
-	private function group_node( string $block, string $slug, ?string $group ): array {
-		$node        = $this->block_variants( $block, $slug );
-		$is_implicit = $group === null || $group === Variant_Set::get_implicit_group_key();
-
-		if ( ! $this->node_is_grouped( $node ) ) {
-			if ( $is_implicit ) {
-				return $node;
-			}
-
-			throw Unknown_Variant_Exception::for_group( $block, (string) $group );
-		}
-
-		if ( $is_implicit || ! isset( $node[ $group ] ) || ! is_array( $node[ $group ] ) ) {
-			throw Unknown_Variant_Exception::for_group( $block, (string) $group );
-		}
-
-		return $node[ $group ];
-	}
-
-	/**
-	 * The raw variants node for a block in a set — either a flat `{ $default, <variant> }` map or a grouped
-	 * `{ <group>: { $default, <variant> } }` map — or throw when the block is undefined.
+	 * The variant-bearing node for a block in a set: the `$default` plus named variants the rest of the
+	 * resolver reads — or throw when the block is undefined.
 	 *
 	 * @since TBD
 	 *
@@ -507,31 +404,6 @@ final class Variant_Resolver {
 		}
 
 		return $variants[ $block ];
-	}
-
-	/**
-	 * Whether a block node nests named groups rather than variants directly. A variant always carries a
-	 * `tokens` key; a group node does not (it holds `$default` and nested variants). So the block is
-	 * grouped when its first named (non-`$`) child is an array with no `tokens` key. A block is uniformly
-	 * flat or grouped — pinned by the baseline shape test.
-	 *
-	 * @since TBD
-	 *
-	 * @param array<string, mixed> $node The raw block variants node.
-	 *
-	 * @return bool
-	 */
-	private function node_is_grouped( array $node ): bool {
-		foreach ( $node as $key => $child ) {
-			// Skip `$default` and any other DTCG metadata key; only named children disambiguate the shape.
-			if ( is_string( $key ) && strpos( $key, '$' ) === 0 ) {
-				continue;
-			}
-
-			return is_array( $child ) && ! array_key_exists( Extensions::get_tokens_key(), $child );
-		}
-
-		return false;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Variants_Controller.php
@@ -6,7 +6,6 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
-use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Variant_Set;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Variants;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
@@ -123,15 +122,6 @@ final class Variants_Controller extends Controller {
 	 * @var string
 	 */
 	private const SET_PARAM = 'set';
-
-	/**
-	 * The request parameter that carries the variant set (axis) group slug a read/write targets.
-	 *
-	 * @since TBD
-	 *
-	 * @var string
-	 */
-	private const VARIANT_SET_PARAM = 'variant_set';
 
 	/**
 	 * The block vendor path segment. A slug-safe class with no slash; the block name is the second segment.
@@ -405,17 +395,14 @@ final class Variants_Controller extends Controller {
 		$section = $this->variants->section( $slug );
 		$blocks  = [];
 
-		foreach ( $this->registry->variant_sets() as $block => $sets ) {
-			foreach ( $sets as $group => $set ) {
-				$node = $this->set_node( $section, $block, $group );
+		foreach ( array_keys( $this->registry->variant_sets() ) as $block ) {
+			$node = $this->set_node( $section, $block );
 
-				$blocks[] = [
-					'block'   => $block,
-					'group'   => $group === Variant_Set::get_implicit_group_key() ? '' : $group,
-					'default' => $this->default_of( $node ),
-					'names'   => $this->variant_names( $node ),
-				];
-			}
+			$blocks[] = [
+				'block'   => $block,
+				'default' => $this->default_of( $node ),
+				'names'   => $this->variant_names( $node ),
+			];
 		}
 
 		return new WP_REST_Response( [ 'blocks' => $blocks ], WP_Http::OK );
@@ -432,14 +419,13 @@ final class Variants_Controller extends Controller {
 	 */
 	public function get_item( $request ) {
 		$block = $this->block_from( $request );
-		$group = $this->group_from( $request, $block );
 		$error = $this->guard_block( $block );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
 		}
 
-		return new WP_REST_Response( $this->prepare_item( $block, $group, $this->slug( $request ) ), WP_Http::OK );
+		return new WP_REST_Response( $this->prepare_item( $block, $this->slug( $request ) ), WP_Http::OK );
 	}
 
 	/**
@@ -456,7 +442,6 @@ final class Variants_Controller extends Controller {
 	 */
 	public function create_item( $request ) {
 		$block = $this->block_from( $request );
-		$group = $this->group_from( $request, $block );
 		$error = $this->guard_block( $block );
 
 		if ( $error instanceof WP_Error ) {
@@ -492,9 +477,9 @@ final class Variants_Controller extends Controller {
 
 		$slug       = $this->slug( $request );
 		$block_node = $this->normalize_block_node( $block_node, $slug );
-		$candidate  = $this->mutator->merge( $this->stored_document( $slug ), $this->partial( $block, $group, $block_node ) );
+		$candidate  = $this->mutator->merge( $this->stored_document( $slug ), $this->partial( $block, $block_node ) );
 
-		$error = $this->guard_surface( $candidate, $block_node, $block, $group );
+		$error = $this->guard_surface( $candidate, $block_node, $block );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
@@ -506,7 +491,7 @@ final class Variants_Controller extends Controller {
 			return $error;
 		}
 
-		return $this->validate_and_save( $candidate, $block, $group, $slug );
+		return $this->validate_and_save( $candidate, $block, $slug );
 	}
 
 	/**
@@ -523,7 +508,6 @@ final class Variants_Controller extends Controller {
 	 */
 	public function update_item( $request ) {
 		$block = $this->block_from( $request );
-		$group = $this->group_from( $request, $block );
 		$error = $this->guard_block( $block );
 
 		if ( $error instanceof WP_Error ) {
@@ -555,16 +539,16 @@ final class Variants_Controller extends Controller {
 		$block_node = $this->normalize_block_node( $block_node, $slug );
 
 		// Replace, not merge: drop the stored block node first so a variant the body omits does not survive.
-		$stored    = $this->unset_block( $this->stored_document( $slug ), $block, $group );
-		$candidate = $this->mutator->merge( $stored, $this->partial( $block, $group, $block_node ) );
+		$stored    = $this->unset_block( $this->stored_document( $slug ), $block );
+		$candidate = $this->mutator->merge( $stored, $this->partial( $block, $block_node ) );
 
-		$error = $this->guard_default_present( $candidate, $block, $group );
+		$error = $this->guard_default_present( $candidate, $block );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
 		}
 
-		$error = $this->guard_surface( $candidate, $block_node, $block, $group );
+		$error = $this->guard_surface( $candidate, $block_node, $block );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
@@ -576,7 +560,7 @@ final class Variants_Controller extends Controller {
 			return $error;
 		}
 
-		return $this->validate_and_save( $candidate, $block, $group, $slug );
+		return $this->validate_and_save( $candidate, $block, $slug );
 	}
 
 	/**
@@ -593,7 +577,6 @@ final class Variants_Controller extends Controller {
 	 */
 	public function delete_item( $request ) {
 		$block = $this->block_from( $request );
-		$group = $this->group_from( $request, $block );
 		$error = $this->guard_block( $block );
 
 		if ( $error instanceof WP_Error ) {
@@ -602,13 +585,13 @@ final class Variants_Controller extends Controller {
 
 		$slug      = $this->slug( $request );
 		$stored    = $this->stored_document( $slug );
-		$candidate = $this->unset_block( $stored, $block, $group );
+		$candidate = $this->unset_block( $stored, $block );
 
 		if ( $candidate === $stored ) {
-			return new WP_REST_Response( $this->prepare_item( $block, $group, $slug ), WP_Http::OK );
+			return new WP_REST_Response( $this->prepare_item( $block, $slug ), WP_Http::OK );
 		}
 
-		return $this->validate_and_save( $candidate, $block, $group, $slug );
+		return $this->validate_and_save( $candidate, $block, $slug );
 	}
 
 	/**
@@ -627,7 +610,6 @@ final class Variants_Controller extends Controller {
 	 */
 	public function delete_variant( $request ) {
 		$block = $this->block_from( $request );
-		$group = $this->group_from( $request, $block );
 		$error = $this->guard_block( $block );
 
 		if ( $error instanceof WP_Error ) {
@@ -649,19 +631,19 @@ final class Variants_Controller extends Controller {
 
 		$slug      = $this->slug( $request );
 		$stored    = $this->stored_document( $slug );
-		$candidate = $this->unset_variant( $stored, $block, $group, $variant );
+		$candidate = $this->unset_variant( $stored, $block, $variant );
 
 		if ( $candidate === $stored ) {
-			return new WP_REST_Response( $this->prepare_item( $block, $group, $slug ), WP_Http::OK );
+			return new WP_REST_Response( $this->prepare_item( $block, $slug ), WP_Http::OK );
 		}
 
-		$error = $this->guard_default_present( $candidate, $block, $group );
+		$error = $this->guard_default_present( $candidate, $block );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
 		}
 
-		return $this->validate_and_save( $candidate, $block, $group, $slug );
+		return $this->validate_and_save( $candidate, $block, $slug );
 	}
 
 	/**
@@ -675,19 +657,17 @@ final class Variants_Controller extends Controller {
 	 */
 	public function get_default( $request ) {
 		$block = $this->block_from( $request );
-		$group = $this->group_from( $request, $block );
 		$error = $this->guard_block( $block );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
 		}
 
-		$node = $this->set_node( $this->variants->section( $this->slug( $request ) ), $block, $group );
+		$node = $this->set_node( $this->variants->section( $this->slug( $request ) ), $block );
 
 		return new WP_REST_Response(
 			[
 				'block'   => $block,
-				'group'   => $group === Variant_Set::get_implicit_group_key() ? '' : $group,
 				'default' => $this->default_of( $node ),
 			],
 			WP_Http::OK
@@ -708,7 +688,6 @@ final class Variants_Controller extends Controller {
 	 */
 	public function set_default( $request ) {
 		$block = $this->block_from( $request );
-		$group = $this->group_from( $request, $block );
 		$error = $this->guard_block( $block );
 
 		if ( $error instanceof WP_Error ) {
@@ -720,16 +699,16 @@ final class Variants_Controller extends Controller {
 		$slug      = $this->slug( $request );
 		$candidate = $this->mutator->merge(
 			$this->stored_document( $slug ),
-			$this->partial( $block, $group, [ Extensions::get_default_key() => $default ] )
+			$this->partial( $block, [ Extensions::get_default_key() => $default ] )
 		);
 
-		$error = $this->guard_default_present( $candidate, $block, $group );
+		$error = $this->guard_default_present( $candidate, $block );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
 		}
 
-		return $this->validate_and_save( $candidate, $block, $group, $slug );
+		return $this->validate_and_save( $candidate, $block, $slug );
 	}
 
 	/**
@@ -825,17 +804,16 @@ final class Variants_Controller extends Controller {
 	 *
 	 * @param array<string, mixed> $candidate The full candidate overrides document to validate and store.
 	 * @param string               $block     The block being written, for error context.
-	 * @param string               $group     The variant set group (the implicit sentinel for a preset set).
 	 * @param string               $slug      The token set slug being written.
 	 *
 	 * @return WP_REST_Response|WP_Error
 	 */
-	private function validate_and_save( array $candidate, string $block, string $group, string $slug ) {
+	private function validate_and_save( array $candidate, string $block, string $slug ) {
 		// A brand-new set has no version yet; report 201 Created rather than 200 OK on first write.
 		$status = $this->store->get_version( $slug ) !== '' ? WP_Http::OK : WP_Http::CREATED;
 
 		if ( $candidate === [] ) {
-			return $this->persist( '', $block, $group, $status, $slug );
+			return $this->persist( '', $block, $status, $slug );
 		}
 
 		$result = $this->validator->validate( $candidate, Dtcg_Validator::get_context_overrides() );
@@ -879,7 +857,7 @@ final class Variants_Controller extends Controller {
 			);
 		}
 
-		return $this->persist( $encoded, $block, $group, $status, $slug );
+		return $this->persist( $encoded, $block, $status, $slug );
 	}
 
 	/**
@@ -889,13 +867,12 @@ final class Variants_Controller extends Controller {
 	 *
 	 * @param string $document The raw overrides-only DTCG JSON (empty string clears the set).
 	 * @param string $block    The block being written.
-	 * @param string $group    The variant set group (the implicit sentinel for a preset set).
 	 * @param int    $status   The success status code.
 	 * @param string $slug     The token set slug being written.
 	 *
 	 * @return WP_REST_Response|WP_Error
 	 */
-	private function persist( string $document, string $block, string $group, int $status, string $slug ) {
+	private function persist( string $document, string $block, int $status, string $slug ) {
 		try {
 			$this->store->save_document( $document, $slug );
 		} catch ( DatabaseQueryException $e ) {
@@ -909,7 +886,7 @@ final class Variants_Controller extends Controller {
 			);
 		}
 
-		return new WP_REST_Response( $this->prepare_item( $block, $group, $slug ), $status );
+		return new WP_REST_Response( $this->prepare_item( $block, $slug ), $status );
 	}
 
 	/**
@@ -922,7 +899,7 @@ final class Variants_Controller extends Controller {
 	 * @return WP_Error|null A WP_Error when the block accepts no variants, null otherwise.
 	 */
 	private function guard_block( string $block ): ?WP_Error {
-		if ( $this->registry->sets_for_block( $block ) !== [] ) {
+		if ( $this->registry->for_block( $block ) !== null ) {
 			return null;
 		}
 
@@ -1036,12 +1013,11 @@ final class Variants_Controller extends Controller {
 	 *
 	 * @param array<string, mixed> $candidate The candidate overrides document.
 	 * @param string               $block     The block name.
-	 * @param string               $group     The variant set group (the implicit sentinel for a preset set).
 	 *
 	 * @return WP_Error|null A WP_Error when the default is dangling, null otherwise.
 	 */
-	private function guard_default_present( array $candidate, string $block, string $group ): ?WP_Error {
-		$node    = $this->set_node( $this->variants->for_overrides( $candidate ), $block, $group );
+	private function guard_default_present( array $candidate, string $block ): ?WP_Error {
+		$node    = $this->set_node( $this->variants->for_overrides( $candidate ), $block );
 		$default = $this->default_of( $node );
 
 		if ( $default === '' || in_array( $default, $this->variant_names( $node ), true ) ) {
@@ -1060,32 +1036,30 @@ final class Variants_Controller extends Controller {
 	}
 
 	/**
-	 * Reject a written variant that does not set exactly the block's bound surface.
+	 * Reject a written variant that sets a property the block does not bind.
 	 *
-	 * A user variant clones the surface an existing variant controls: it supplies values for the block's
-	 * bound properties and nothing else. So a property with no binding (unbound) is rejected — it could
-	 * never project — and a bound property the variant leaves unset is rejected too, since a variant must
-	 * value the full surface. Only the variants carried by the request are checked, each against its
-	 * post-merge token set, so a partial edit that would drop a bound property is caught while the baseline
-	 * variants are left alone.
+	 * A variant may define any subset of the block's bound surface — different variants may define
+	 * different subsets, and a property a variant omits is inherited from the block `$default` through the
+	 * cascade — so an incomplete surface is allowed. But a property with no binding (unbound) is still
+	 * rejected: it could never project. Only the variants carried by the request are checked, each against
+	 * its post-merge token set, so a partial edit is validated while the baseline variants are left alone.
 	 *
 	 * @since TBD
 	 *
 	 * @param array<string, mixed> $candidate  The post-merge candidate overrides document.
 	 * @param array<string, mixed> $block_node The set's variant node from the request.
 	 * @param string               $block      The block name.
-	 * @param string               $group      The variant set group (the implicit sentinel for a preset set).
 	 *
-	 * @return WP_Error|null A WP_Error when a written variant's surface is wrong, null otherwise.
+	 * @return WP_Error|null A WP_Error when a written variant sets an unbound property, null otherwise.
 	 */
-	private function guard_surface( array $candidate, array $block_node, string $block, string $group ): ?WP_Error {
-		$set = $this->registry->for_variant_set( $block, $group );
+	private function guard_surface( array $candidate, array $block_node, string $block ): ?WP_Error {
+		$set = $this->registry->for_block( $block );
 
 		if ( $set === null ) {
 			return null;
 		}
 
-		$effective  = $this->set_node( $this->variants->for_overrides( $candidate ), $block, $group );
+		$effective  = $this->set_node( $this->variants->for_overrides( $candidate ), $block );
 		$tokens_key = Extensions::get_tokens_key();
 
 		foreach ( array_keys( $block_node ) as $slug ) {
@@ -1107,19 +1081,6 @@ final class Variants_Controller extends Controller {
 						'block'      => $block,
 						'variant'    => (string) $slug,
 						'properties' => $report['unbound'],
-					]
-				);
-			}
-
-			if ( $report['unvalued'] !== [] ) {
-				return new WP_Error(
-					'rest_design_tokens_incomplete_surface',
-					__( 'A variant must set every property the block binds.', 'kadence-blocks' ),
-					[
-						'status'     => WP_Http::UNPROCESSABLE_ENTITY,
-						'block'      => $block,
-						'variant'    => (string) $slug,
-						'properties' => $report['unvalued'],
 					]
 				);
 			}
@@ -1214,17 +1175,15 @@ final class Variants_Controller extends Controller {
 	 * @since TBD
 	 *
 	 * @param string $block The block name.
-	 * @param string $group The variant set group (the implicit sentinel for a preset set).
 	 * @param string $slug  The token set slug being read.
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function prepare_item( string $block, string $group, string $slug ): array {
-		$node = $this->set_node( $this->variants->section( $slug ), $block, $group );
+	private function prepare_item( string $block, string $slug ): array {
+		$node = $this->set_node( $this->variants->section( $slug ), $block );
 
 		return [
 			'block'    => $block,
-			'group'    => $group === Variant_Set::get_implicit_group_key() ? '' : $group,
 			'slug'     => $slug,
 			'version'  => $this->store->get_version( $slug ),
 			'default'  => $this->default_of( $node ),
@@ -1263,20 +1222,16 @@ final class Variants_Controller extends Controller {
 	 * @since TBD
 	 *
 	 * @param string               $block      The block name.
-	 * @param string               $group      The variant set group (the implicit sentinel for a preset set).
-	 * @param array<string, mixed> $block_node The set's variant node.
+	 * @param array<string, mixed> $block_node The block's variant node.
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function partial( string $block, string $group, array $block_node ): array {
-		// A named set nests its variants under the set slug; a preset (implicit) set sits directly on the block.
-		$node = $group === Variant_Set::get_implicit_group_key() ? $block_node : [ $group => $block_node ];
-
+	private function partial( string $block, array $block_node ): array {
 		return [
 			Extensions::get_extensions_key() => [
 				Extensions::get_namespace() => [
 					Extensions::get_section_variants() => [
-						$block => $node,
+						$block => $block_node,
 					],
 				],
 			],
@@ -1284,36 +1239,32 @@ final class Variants_Controller extends Controller {
 	}
 
 	/**
-	 * Remove the stored variant-set node (`variants.<block>[.<group>]`), pruning any ancestor emptied by the
-	 * removal.
+	 * Remove the stored variant-set node (`variants.<block>`), pruning any ancestor emptied by the removal.
 	 *
 	 * @since TBD
 	 *
 	 * @param array<string, mixed> $document The stored overrides document.
 	 * @param string               $block    The block name.
-	 * @param string               $group    The variant set group (the implicit sentinel for a preset set).
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function unset_block( array $document, string $block, string $group ): array {
-		return $this->mutator->remove_by_keys( $document, $this->node_path( $block, $group ) );
+	private function unset_block( array $document, string $block ): array {
+		return $this->mutator->remove_by_keys( $document, $this->node_path( $block ) );
 	}
 
 	/**
-	 * Remove one stored variant (`variants.<block>[.<group>].<variant>`), pruning any ancestor emptied by the
-	 * removal.
+	 * Remove one stored variant (`variants.<block>.<variant>`), pruning any ancestor emptied by the removal.
 	 *
 	 * @since TBD
 	 *
 	 * @param array<string, mixed> $document The stored overrides document.
 	 * @param string               $block    The block name.
-	 * @param string               $group    The variant set group (the implicit sentinel for a preset set).
 	 * @param string               $variant  The variant slug.
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function unset_variant( array $document, string $block, string $group, string $variant ): array {
-		return $this->mutator->remove_by_keys( $document, array_merge( $this->node_path( $block, $group ), [ $variant ] ) );
+	private function unset_variant( array $document, string $block, string $variant ): array {
+		return $this->mutator->remove_by_keys( $document, array_merge( $this->node_path( $block ), [ $variant ] ) );
 	}
 
 	/**
@@ -1328,78 +1279,31 @@ final class Variants_Controller extends Controller {
 	}
 
 	/**
-	 * The document key-path to a variant set's node: `variants.<block>` for a preset (implicit) set, or
-	 * `variants.<block>.<group>` for a named set.
+	 * The document key-path to a block's variant node: `variants.<block>`.
 	 *
 	 * @since TBD
 	 *
 	 * @param string $block The block name.
-	 * @param string $group The variant set group (the implicit sentinel for a preset set).
 	 *
 	 * @return string[]
 	 */
-	private function node_path( string $block, string $group ): array {
-		$path = array_merge( $this->variants_path(), [ $block ] );
-
-		if ( $group !== Variant_Set::get_implicit_group_key() ) {
-			$path[] = $group;
-		}
-
-		return $path;
+	private function node_path( string $block ): array {
+		return array_merge( $this->variants_path(), [ $block ] );
 	}
 
 	/**
-	 * The variant-bearing node for a (block, group) within a variants section: the block node itself for a
-	 * preset (implicit) set, or its `<group>` sub-map for a named set. Absent block/group yields an empty array.
+	 * The variant-bearing node for a block within a variants section — its `{ $default, <variant> }` map — or
+	 * an empty array when absent.
 	 *
 	 * @since TBD
 	 *
 	 * @param array<string, mixed> $section The variants section.
 	 * @param string               $block   The block name.
-	 * @param string               $group   The variant set group.
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function set_node( array $section, string $block, string $group ): array {
-		$node = isset( $section[ $block ] ) && is_array( $section[ $block ] ) ? $section[ $block ] : [];
-
-		if ( $group === Variant_Set::get_implicit_group_key() ) {
-			return $node;
-		}
-
-		return isset( $node[ $group ] ) && is_array( $node[ $group ] ) ? $node[ $group ] : [];
-	}
-
-	/**
-	 * The variant set (axis) a request targets: the `variant_set` parameter when it names a set the block
-	 * registers, otherwise the block's sole named set, else its preset (implicit) set. So a button request
-	 * defaults to its "style" set without the caller naming it, while a preset block resolves to the implicit set.
-	 *
-	 * @since TBD
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @param string          $block   The block name.
-	 *
-	 * @return string
-	 */
-	private function group_from( WP_REST_Request $request, string $block ): string {
-		$group = Cast::to_string( $request->get_param( self::VARIANT_SET_PARAM ) );
-
-		if ( $group !== '' && $this->registry->for_variant_set( $block, $group ) !== null ) {
-			return $group;
-		}
-
-		$named = array_keys(
-			array_filter(
-				$this->registry->sets_for_block( $block ),
-				static function ( string $slug ): bool {
-					return $slug !== Variant_Set::get_implicit_group_key();
-				},
-				ARRAY_FILTER_USE_KEY
-			)
-		);
-
-		return count( $named ) === 1 ? (string) $named[0] : Variant_Set::get_implicit_group_key();
+	private function set_node( array $section, string $block ): array {
+		return isset( $section[ $block ] ) && is_array( $section[ $block ] ) ? $section[ $block ] : [];
 	}
 
 	/**
@@ -1551,7 +1455,6 @@ final class Variants_Controller extends Controller {
 				'sanitize_callback' => 'sanitize_key',
 			],
 			self::SET_PARAM         => $this->set_param(),
-			self::VARIANT_SET_PARAM => $this->variant_set_param(),
 		];
 	}
 
@@ -1566,24 +1469,6 @@ final class Variants_Controller extends Controller {
 	private function set_param(): array {
 		return [
 			'description'       => __( 'Optional token set slug to target; defaults to the active set.', 'kadence-blocks' ),
-			'type'              => 'string',
-			'required'          => false,
-			'pattern'           => '^[\w-]+$',
-			'sanitize_callback' => 'sanitize_key',
-		];
-	}
-
-	/**
-	 * The optional variant-set argument: names the variant set (axis) a read/write targets, defaulting to the
-	 * block's sole named set (or its preset set) when absent.
-	 *
-	 * @since TBD
-	 *
-	 * @return array<string, mixed>
-	 */
-	private function variant_set_param(): array {
-		return [
-			'description'       => __( 'Optional variant set (axis) group slug.', 'kadence-blocks' ),
 			'type'              => 'string',
 			'required'          => false,
 			'pattern'           => '^[\w-]+$',

--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -322,10 +322,9 @@ final class Dtcg_Validator {
 	 * and any non-Kadence extension namespace is passed through untouched.
 	 *
 	 * Each owned section is walked without assuming a fixed depth: a `tokens` map can sit at varying depths — a
-	 * foundation preset and a flat variant nest it two levels under the section (group/preset → tokens,
-	 * block/variant → tokens), while a grouped (multi-axis) variant nests it three levels down
-	 * (block → group → variant → tokens). The walk descends every array branch and validates each `tokens`
-	 * map it finds, so all of these are covered by the same logic.
+	 * foundation preset and a variant nest it two levels under the section (preset → tokens, block/variant →
+	 * tokens). The walk descends every array branch and validates each `tokens` map it finds, so all of these
+	 * are covered by the same logic.
 	 *
 	 * @since TBD
 	 *

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/VariantsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/VariantsTest.php
@@ -32,10 +32,10 @@ final class VariantsTest extends TestCase {
 
 		$this->assertArrayHasKey( self::BUTTON, $variants );
 
-		// The button's variants live under its named "style" set (block => group => entry).
-		$button = $variants[ self::BUTTON ]['style'];
+		// The button's variants live directly under the block (one flat set per block).
+		$button = $variants[ self::BUTTON ];
 
-		$this->assertSame( 'style', $button['group'] );
+		$this->assertSame( 'Style', $button['label'] );
 		$this->assertSame( 'primary', $button['default'] );
 		$this->assertSame( [ 'primary', 'secondary' ], $button['names'] );
 		$this->assertContains( 'button-bg', $button['properties'] );

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Variant_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Variant_CatalogTest.php
@@ -51,9 +51,8 @@ final class Variant_CatalogTest extends TestCase {
 		$this->assertSame( Token_Store::default_slug(), $catalog['active'] );
 		$this->assertArrayHasKey( self::BUTTON, $catalog['sets'][ Token_Store::default_slug() ] );
 
-		$button = $catalog['sets'][ Token_Store::default_slug() ][ self::BUTTON ]['style'];
+		$button = $catalog['sets'][ Token_Store::default_slug() ][ self::BUTTON ];
 
-		$this->assertSame( 'style', $button['group'] );
 		$this->assertSame( 'primary', $button['default'] );
 		// The picker's control label, declared on the variant set in declarations.php.
 		$this->assertSame( 'Style', $button['label'] );
@@ -81,7 +80,7 @@ final class Variant_CatalogTest extends TestCase {
 	 * @return void
 	 */
 	public function testItExposesTheControllableSurface(): void {
-		$properties = $this->catalog->all()['sets'][ Token_Store::default_slug() ][ self::BUTTON ]['style']['properties'];
+		$properties = $this->catalog->all()['sets'][ Token_Store::default_slug() ][ self::BUTTON ]['properties'];
 
 		$kinds = wp_list_pluck( $properties, 'kind', 'key' );
 
@@ -96,11 +95,11 @@ final class Variant_CatalogTest extends TestCase {
 	 */
 	public function testItFlagsUserCreatedVariants(): void {
 		$this->store->save_document(
-			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{"style":{'
-			. '"accent":{"label":"Accent","tokens":{"button-bg":"#ff0000"}}}}}}}}'
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{'
+			. '"accent":{"label":"Accent","tokens":{"button-bg":"#ff0000"}}}}}}}'
 		);
 
-		$variants = $this->catalog->all()['sets'][ Token_Store::default_slug() ][ self::BUTTON ]['style']['variants'];
+		$variants = $this->catalog->all()['sets'][ Token_Store::default_slug() ][ self::BUTTON ]['variants'];
 		$flags    = wp_list_pluck( $variants, 'userCreated', 'slug' );
 
 		$this->assertTrue( $flags['accent'] );
@@ -113,8 +112,10 @@ final class Variant_CatalogTest extends TestCase {
 	 * @return void
 	 */
 	public function testItSkipsABlockAbsentFromTheDocument(): void {
+		// A picker set (it declares a label) whose block has no variants in the baseline — the names() lookup
+		// throws Unknown_Variant_Exception and the block is skipped rather than emitted empty.
 		$registry = new Token_Registry();
-		$registry->register_variant_set( [ 'block' => 'kadence/not-a-real-block' ] );
+		$registry->register_variant_set( [ 'block' => 'kadence/not-a-real-block', 'label' => 'Style' ] );
 
 		$catalog = ( new Variant_Catalog(
 			$registry,

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Variant_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Variant_CatalogTest.php
@@ -115,7 +115,12 @@ final class Variant_CatalogTest extends TestCase {
 		// A picker set (it declares a label) whose block has no variants in the baseline — the names() lookup
 		// throws Unknown_Variant_Exception and the block is skipped rather than emitted empty.
 		$registry = new Token_Registry();
-		$registry->register_variant_set( [ 'block' => 'kadence/not-a-real-block', 'label' => 'Style' ] );
+		$registry->register_variant_set(
+			[
+				'block' => 'kadence/not-a-real-block',
+				'label' => 'Style',
+			]
+		);
 
 		$catalog = ( new Variant_Catalog(
 			$registry,

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Variant/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Variant/Css_BuilderTest.php
@@ -4,14 +4,10 @@
 namespace Tests\wpunit\Resources\Design_Tokens\Projection\Variant;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
-use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Variant\Css_Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
-use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Variants;
-use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
 use ReflectionProperty;
-use Tests\Support\Classes\Fake_Baseline_Document;
 use Tests\Support\Classes\TestCase;
 
 /**
@@ -19,11 +15,6 @@ use Tests\Support\Classes\TestCase;
  * assertions also guard the Button wiring: the button-specific --global-palette-btn-* slot retargeting,
  * the per-set namespaced variant-var indirection, the active-alias layer, the client-side switch selector,
  * and the class-less $default rule.
- *
- * The grouped (multi-axis) cases run against a controllable baseline fixture — a button with two orthogonal
- * axes, "color" (base fill slots) and "hover" (hover slots) — so they guard the grouped class/var shape and
- * the per-group $default for axes that compose cleanly. A separate, deliberately misconfigured fixture (two
- * axes on one slot) guards the source-order tie-break. Literal token values keep that CSS deterministic.
  */
 final class Css_BuilderTest extends TestCase {
 
@@ -70,11 +61,11 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $this->registry )->css( [ 'default' ], 'default' );
 
 		// The namespaced variant var chains to that set's namespaced semantic.
-		$this->assertStringContainsString( '--kb-token--default--variant--kadence-singlebtn--style--primary--button-bg:var(--kb-token--default--semantic--color--button-primary-bg);', $css );
-		$this->assertStringContainsString( '--kb-token--default--variant--kadence-singlebtn--style--secondary--button-bg:var(--kb-token--default--semantic--color--button-secondary-bg);', $css );
+		$this->assertStringContainsString( '--kb-token--default--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--default--semantic--color--button-primary-bg);', $css );
+		$this->assertStringContainsString( '--kb-token--default--variant--kadence-singlebtn--secondary--button-bg:var(--kb-token--default--semantic--color--button-secondary-bg);', $css );
 
 		// The canonical variant var is pointed at the active set's namespaced variant var (the alias layer).
-		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--style--primary--button-bg:var(--kb-token--default--variant--kadence-singlebtn--style--primary--button-bg);', $css );
+		$this->assertStringContainsString( '--kb-token--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--default--variant--kadence-singlebtn--primary--button-bg);', $css );
 	}
 
 	/**
@@ -88,8 +79,8 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $this->registry )->css( [ 'default', 'dark' ], 'default' );
 
 		// Both sets' namespaced variant vars are present (dark resolves from baseline here, namespaced).
-		$this->assertStringContainsString( '--kb-token--default--variant--kadence-singlebtn--style--primary--button-bg:var(--kb-token--default--semantic--color--button-primary-bg);', $css );
-		$this->assertStringContainsString( '--kb-token--dark--variant--kadence-singlebtn--style--primary--button-bg:var(--kb-token--dark--semantic--color--button-primary-bg);', $css );
+		$this->assertStringContainsString( '--kb-token--default--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--default--semantic--color--button-primary-bg);', $css );
+		$this->assertStringContainsString( '--kb-token--dark--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--dark--semantic--color--button-primary-bg);', $css );
 
 		// The dark switch selector re-points the canonical variant var at the dark namespace.
 		$this->assertStringContainsString(
@@ -97,7 +88,7 @@ final class Css_BuilderTest extends TestCase {
 			$css
 		);
 		$this->assertStringContainsString(
-			'--kb-token--variant--kadence-singlebtn--style--primary--button-bg:var(--kb-token--dark--variant--kadence-singlebtn--style--primary--button-bg);',
+			'--kb-token--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--dark--variant--kadence-singlebtn--primary--button-bg);',
 			$css
 		);
 	}
@@ -113,11 +104,11 @@ final class Css_BuilderTest extends TestCase {
 
 		$this->assertSame(
 			2,
-			substr_count( $css, '--kb-token--variant--kadence-singlebtn--style--primary--button-bg:var(--kb-token--dark--variant--kadence-singlebtn--style--primary--button-bg);' )
+			substr_count( $css, '--kb-token--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--dark--variant--kadence-singlebtn--primary--button-bg);' )
 		);
 		$this->assertSame(
 			1,
-			substr_count( $css, '--kb-token--variant--kadence-singlebtn--style--primary--button-bg:var(--kb-token--default--variant--kadence-singlebtn--style--primary--button-bg);' )
+			substr_count( $css, '--kb-token--variant--kadence-singlebtn--primary--button-bg:var(--kb-token--default--variant--kadence-singlebtn--primary--button-bg);' )
 		);
 	}
 
@@ -132,12 +123,12 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $this->registry )->css( [ 'default' ], 'default' );
 
 		$this->assertStringContainsString(
-			'.wp-block-kadence-singlebtn.kb-variant--style--secondary{'
-				. '--global-palette-btn-bg:var(--kb-token--variant--kadence-singlebtn--style--secondary--button-bg);'
-				. '--global-palette-btn:var(--kb-token--variant--kadence-singlebtn--style--secondary--button-text);'
-				. '--global-palette-btn-bg-hover:var(--kb-token--variant--kadence-singlebtn--style--secondary--button-bg-hover);'
-				. '--global-palette-btn-hover:var(--kb-token--variant--kadence-singlebtn--style--secondary--button-text-hover);'
-				. '--kb-btn-radius:var(--kb-token--variant--kadence-singlebtn--style--secondary--button-radius);}',
+			'.wp-block-kadence-singlebtn.kb-variant--secondary{'
+				. '--global-palette-btn-bg:var(--kb-token--variant--kadence-singlebtn--secondary--button-bg);'
+				. '--global-palette-btn:var(--kb-token--variant--kadence-singlebtn--secondary--button-text);'
+				. '--global-palette-btn-bg-hover:var(--kb-token--variant--kadence-singlebtn--secondary--button-bg-hover);'
+				. '--global-palette-btn-hover:var(--kb-token--variant--kadence-singlebtn--secondary--button-text-hover);'
+				. '--kb-btn-radius:var(--kb-token--variant--kadence-singlebtn--secondary--button-radius);}',
 			$css
 		);
 	}
@@ -152,8 +143,8 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $this->registry )->css( [ 'default' ], 'default' );
 
 		$this->assertStringContainsString(
-			'.wp-block-button.kb-variant--style--secondary{'
-				. '--global-palette-btn-bg:var(--kb-token--variant--core-button--style--secondary--button-bg);',
+			'.wp-block-button.kb-variant--secondary{'
+				. '--global-palette-btn-bg:var(--kb-token--variant--core-button--secondary--button-bg);',
 			$css
 		);
 		$this->assertStringNotContainsString( '.wp-block-core-button', $css );
@@ -170,11 +161,11 @@ final class Css_BuilderTest extends TestCase {
 
 		$this->assertStringContainsString(
 			'.wp-block-kadence-singlebtn{'
-				. '--global-palette-btn-bg:var(--kb-token--variant--kadence-singlebtn--style--primary--button-bg);'
-				. '--global-palette-btn:var(--kb-token--variant--kadence-singlebtn--style--primary--button-text);'
-				. '--global-palette-btn-bg-hover:var(--kb-token--variant--kadence-singlebtn--style--primary--button-bg-hover);'
-				. '--global-palette-btn-hover:var(--kb-token--variant--kadence-singlebtn--style--primary--button-text-hover);'
-				. '--kb-btn-radius:var(--kb-token--variant--kadence-singlebtn--style--primary--button-radius);}',
+				. '--global-palette-btn-bg:var(--kb-token--variant--kadence-singlebtn--primary--button-bg);'
+				. '--global-palette-btn:var(--kb-token--variant--kadence-singlebtn--primary--button-text);'
+				. '--global-palette-btn-bg-hover:var(--kb-token--variant--kadence-singlebtn--primary--button-bg-hover);'
+				. '--global-palette-btn-hover:var(--kb-token--variant--kadence-singlebtn--primary--button-text-hover);'
+				. '--kb-btn-radius:var(--kb-token--variant--kadence-singlebtn--primary--button-radius);}',
 			$css
 		);
 	}
@@ -191,12 +182,42 @@ final class Css_BuilderTest extends TestCase {
 
 		// The scoped rule points --kb-btn-radius at the per-variant var.
 		$this->assertStringContainsString(
-			'--kb-btn-radius:var(--kb-token--variant--kadence-singlebtn--style--secondary--button-radius);',
+			'--kb-btn-radius:var(--kb-token--variant--kadence-singlebtn--secondary--button-radius);',
 			$css
 		);
 		// The namespaced block defines that per-variant var for the set.
 		$this->assertStringContainsString(
-			'--kb-token--default--variant--kadence-singlebtn--style--secondary--button-radius:',
+			'--kb-token--default--variant--kadence-singlebtn--secondary--button-radius:',
+			$css
+		);
+	}
+
+	/**
+	 * A variant that exists only in a NON-active set (a user-created variant on the "dark" set, absent from
+	 * the active "default" set) still gets its scoped ".kb-variant--<slug>" retarget rule, so a block placed
+	 * on that set applies the variant. The rule is emitted from the dark set's fragment — the active set has
+	 * no such variant — while the dark switch selector re-points the canonical var at the dark value.
+	 *
+	 * @return void
+	 */
+	public function testItEmitsTheScopedRuleForAVariantOnlyInANonActiveSet(): void {
+		$this->seedDarkVariant();
+
+		// Building only the default (active) set never sees the dark-only variant, so no rule is emitted.
+		$default_only = $this->builder( $this->registry )->css( [ 'default' ], 'default' );
+		$this->assertStringNotContainsString( '.kb-variant--midnight{', $default_only );
+
+		// Building both sets with default active: the scoped retarget rule comes from the dark fragment.
+		$css = $this->builder( $this->registry )->css( [ 'default', 'dark' ], 'default' );
+
+		$this->assertStringContainsString(
+			'.wp-block-kadence-singlebtn.kb-variant--midnight{'
+				. '--global-palette-btn-bg:var(--kb-token--variant--kadence-singlebtn--midnight--button-bg);',
+			$css
+		);
+		// The dark switch selector re-points the canonical midnight var at the dark namespace.
+		$this->assertStringContainsString(
+			'--kb-token--variant--kadence-singlebtn--midnight--button-bg:var(--kb-token--dark--variant--kadence-singlebtn--midnight--button-bg);',
 			$css
 		);
 	}
@@ -238,181 +259,28 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
-	 * Each (group, variant) value lives as a per-set namespaced token var whose name folds in the group, so
-	 * two axes never collide on a shared property.
+	 * Persist a user-created "midnight" button variant into the "dark" token set only, so it is absent from
+	 * the active "default" set.
 	 *
 	 * @return void
 	 */
-	public function testItFoldsTheGroupIntoTheVariantVar(): void {
-		$css = $this->grouped_builder()->css( [ 'default' ], 'default' );
-
-		$this->assertStringContainsString( '--kb-token--default--variant--kadence-grouped-btn--color--secondary--button-bg:#111111;', $css );
-		$this->assertStringContainsString( '--kb-token--default--variant--kadence-grouped-btn--hover--bold--button-bg-hover:#000000;', $css );
-	}
-
-	/**
-	 * A grouped selection scopes to a "kb-variant--<group>--<variant>" class, so two independently chosen
-	 * axes compose as two classes on one block.
-	 *
-	 * @return void
-	 */
-	public function testItScopesEachGroupedVariantToItsGroupClass(): void {
-		$css = $this->grouped_builder()->css( [ 'default' ], 'default' );
-
-		$this->assertStringContainsString(
-			'.wp-block-kadence-grouped-btn.kb-variant--color--secondary{'
-				. '--global-palette-btn-bg:var(--kb-token--variant--kadence-grouped-btn--color--secondary--button-bg);'
-				. '--global-palette-btn:var(--kb-token--variant--kadence-grouped-btn--color--secondary--button-text);}',
-			$css
-		);
-
-		$this->assertStringContainsString(
-			'.wp-block-kadence-grouped-btn.kb-variant--hover--bold{'
-				. '--global-palette-btn-bg-hover:var(--kb-token--variant--kadence-grouped-btn--hover--bold--button-bg-hover);'
-				. '--global-palette-btn-hover:var(--kb-token--variant--kadence-grouped-btn--hover--bold--button-text-hover);}',
-			$css
-		);
-	}
-
-	/**
-	 * Each group re-emits its own $default on the class-less block selector, so a block with no selection
-	 * still shows every axis's preset.
-	 *
-	 * @return void
-	 */
-	public function testItEmitsAClassLessDefaultPerGroup(): void {
-		$css = $this->grouped_builder()->css( [ 'default' ], 'default' );
-
-		// color $default is "primary".
-		$this->assertStringContainsString(
-			'.wp-block-kadence-grouped-btn{--global-palette-btn-bg:var(--kb-token--variant--kadence-grouped-btn--color--primary--button-bg);',
-			$css
-		);
-		// hover $default is "subtle".
-		$this->assertStringContainsString(
-			'.wp-block-kadence-grouped-btn{--global-palette-btn-bg-hover:var(--kb-token--variant--kadence-grouped-btn--hover--subtle--button-bg-hover);',
-			$css
-		);
-	}
-
-	/**
-	 * Orthogonal axes never share a slot, but should two groups be configured to retarget the same
-	 * --global-<slot>, their selected-variant rules carry equal specificity, so source order breaks the
-	 * tie: groups are emitted in document order, so the later group wins deterministically.
-	 *
-	 * @return void
-	 */
-	public function testTheLaterGroupWinsForASharedSlot(): void {
-		$css = $this->overlapping_builder()->css( [ 'default' ], 'default' );
-
-		$first  = strpos( $css, '--kb-token--variant--kadence-overlap-btn--first--one--button-bg)' );
-		$second = strpos( $css, '--kb-token--variant--kadence-overlap-btn--second--two--button-bg)' );
-
-		$this->assertNotFalse( $first );
-		$this->assertNotFalse( $second );
-		$this->assertGreaterThan( $first, $second, 'The later group must follow the earlier one in source order.' );
-	}
-
-	/**
-	 * Two variant sets (groups) on one block reuse the SAME variant slug ("primary") and are active
-	 * alongside each other — each emitting its own "kb-variant--<set>--primary" class. Each set sets its own
-	 * property (Fill's "fill-color", Type's "type-color") on the block's shared bindings, so the shared slug
-	 * resolves through each set's own binding to a different --global-<slot>. Every Fill variant maps through
-	 * Fill's binding, every Type variant through Type's.
-	 *
-	 * @return void
-	 */
-	public function testTwoVariantSetsShareASlugWithTheirOwnBindings(): void {
-		$css = $this->dual_set_builder()->css( [ 'default' ], 'default' );
-
-		$this->assertStringContainsString(
-			'.wp-block-kadence-dual-btn.kb-variant--fill--primary{'
-				. '--global-palette-btn-bg:var(--kb-token--variant--kadence-dual-btn--fill--primary--fill-color);}',
-			$css
-		);
-		$this->assertStringContainsString(
-			'.wp-block-kadence-dual-btn.kb-variant--type--primary{'
-				. '--global-palette-btn:var(--kb-token--variant--kadence-dual-btn--type--primary--type-color);}',
-			$css
-		);
-
-		// The two same-slug vars are distinct and carry each set's own value.
-		$this->assertStringContainsString( '--kb-token--default--variant--kadence-dual-btn--fill--primary--fill-color:#111111;', $css );
-		$this->assertStringContainsString( '--kb-token--default--variant--kadence-dual-btn--type--primary--type-color:#222222;', $css );
-	}
-
-	/**
-	 * Build the CSS builder over a controllable grouped baseline fixture and a registry that binds each
-	 * axis's slots. The two axes are ORTHOGONAL — "color" retargets the base fill slots (palette-btn-bg /
-	 * palette-btn), "hover" retargets the hover slots (palette-btn-bg-hover / palette-btn-hover) — so one
-	 * selection per axis composes cleanly without either overwriting the other.
-	 *
-	 * @return Css_Builder
-	 */
-	private function grouped_builder(): Css_Builder {
-		$block = 'kadence/grouped-btn';
-
-		$registry = new Token_Registry();
-		$registry->register_variant_set(
-			[
-				'block'    => $block,
-				'group'    => 'color',
-				'label'    => 'Color',
-				'bindings' => [
-					'button-bg'   => [ 'kadence_slot' => 'palette-btn-bg' ],
-					'button-text' => [ 'kadence_slot' => 'palette-btn' ],
-				],
-			]
-		);
-		$registry->register_variant_set(
-			[
-				'block'    => $block,
-				'group'    => 'hover',
-				'label'    => 'Hover',
-				'bindings' => [
-					'button-bg-hover'   => [ 'kadence_slot' => 'palette-btn-bg-hover' ],
-					'button-text-hover' => [ 'kadence_slot' => 'palette-btn-hover' ],
-				],
-			]
-		);
+	private function seedDarkVariant(): void {
+		/** @var Token_Store $store */
+		$store = $this->container->get( Token_Store::class );
 
 		$document = [
 			'$extensions' => [
 				'com.kadence.designTokens' => [
 					'variants' => [
-						$block => [
-							'color' => [
-								'$default'  => 'primary',
-								'primary'   => [
-									'label'  => 'Primary',
-									'tokens' => [
-										'button-bg'   => '#3633e1',
-										'button-text' => '#ffffff',
-									],
-								],
-								'secondary' => [
-									'label'  => 'Secondary',
-									'tokens' => [
-										'button-bg'   => '#111111',
-										'button-text' => '#ffffff',
-									],
-								],
-							],
-							'hover' => [
-								'$default' => 'subtle',
-								'subtle'   => [
-									'label'  => 'Subtle',
-									'tokens' => [
-										'button-bg-hover'   => '#2f2ffc',
-										'button-text-hover' => '#ffffff',
-									],
-								],
-								'bold'     => [
-									'label'  => 'Bold',
-									'tokens' => [
-										'button-bg-hover'   => '#000000',
-										'button-text-hover' => '#ffffff',
-									],
+						'kadence/singlebtn' => [
+							'midnight' => [
+								'label'  => 'Midnight',
+								'tokens' => [
+									'button-bg'         => '#0b1020',
+									'button-text'       => '#ffffff',
+									'button-bg-hover'   => '#1a2540',
+									'button-text-hover' => '#ffffff',
+									'button-radius'     => '0.5rem',
 								],
 							],
 						],
@@ -421,146 +289,6 @@ final class Css_BuilderTest extends TestCase {
 			],
 		];
 
-		return new Css_Builder( $registry, $this->fixture_resolver( $document ) );
-	}
-
-	/**
-	 * Build the CSS builder over a deliberately MISCONFIGURED fixture: two axes that both retarget the same
-	 * slot (palette-btn-bg). Orthogonal axes never share a slot, but the projector must still resolve a
-	 * conflict deterministically, which is the source-order tie-break this exercises.
-	 *
-	 * @return Css_Builder
-	 */
-	private function overlapping_builder(): Css_Builder {
-		$block = 'kadence/overlap-btn';
-
-		$registry = new Token_Registry();
-		$registry->register_variant_set(
-			[
-				'block'    => $block,
-				'group'    => 'first',
-				'label'    => 'First',
-				'bindings' => [ 'button-bg' => [ 'kadence_slot' => 'palette-btn-bg' ] ],
-			]
-		);
-		$registry->register_variant_set(
-			[
-				'block'    => $block,
-				'group'    => 'second',
-				'label'    => 'Second',
-				'bindings' => [ 'button-bg' => [ 'kadence_slot' => 'palette-btn-bg' ] ],
-			]
-		);
-
-		$document = [
-			'$extensions' => [
-				'com.kadence.designTokens' => [
-					'variants' => [
-						$block => [
-							'first'  => [
-								'$default' => 'one',
-								'one'      => [
-									'label'  => 'One',
-									'tokens' => [ 'button-bg' => '#111111' ],
-								],
-							],
-							'second' => [
-								'$default' => 'two',
-								'two'      => [
-									'label'  => 'Two',
-									'tokens' => [ 'button-bg' => '#222222' ],
-								],
-							],
-						],
-					],
-				],
-			],
-		];
-
-		return new Css_Builder( $registry, $this->fixture_resolver( $document ) );
-	}
-
-	/**
-	 * Build the CSS builder over a block with two variant sets (fill, type) that each define a "primary"
-	 * variant. The block's one bindings map holds each axis's own property (fill-color, type-color) bound to
-	 * a different slot, so the shared "primary" slug resolves through each set's own binding — no per-group
-	 * binding table is needed.
-	 *
-	 * @return Css_Builder
-	 */
-	private function dual_set_builder(): Css_Builder {
-		$block = 'kadence/dual-btn';
-
-		$registry = new Token_Registry();
-		$registry->register_variant_set(
-			[
-				'block'    => $block,
-				'group'    => 'fill',
-				'label'    => 'Fill',
-				'bindings' => [ 'fill-color' => [ 'kadence_slot' => 'palette-btn-bg' ] ],
-			]
-		);
-		$registry->register_variant_set(
-			[
-				'block'    => $block,
-				'group'    => 'type',
-				'label'    => 'Type',
-				'bindings' => [ 'type-color' => [ 'kadence_slot' => 'palette-btn' ] ],
-			]
-		);
-
-		$document = [
-			'$extensions' => [
-				'com.kadence.designTokens' => [
-					'variants' => [
-						$block => [
-							'fill' => [
-								'$default'  => 'primary',
-								'primary'   => [
-									'label'  => 'Primary',
-									'tokens' => [ 'fill-color' => '#111111' ],
-								],
-								'secondary' => [
-									'label'  => 'Secondary',
-									'tokens' => [ 'fill-color' => '#1a1a1a' ],
-								],
-							],
-							'type' => [
-								'$default' => 'primary',
-								'primary'  => [
-									'label'  => 'Primary',
-									'tokens' => [ 'type-color' => '#222222' ],
-								],
-								'bold'     => [
-									'label'  => 'Bold',
-									'tokens' => [ 'type-color' => '#2a2a2a' ],
-								],
-							],
-						],
-					],
-				],
-			],
-		];
-
-		return new Css_Builder( $registry, $this->fixture_resolver( $document ) );
-	}
-
-	/**
-	 * Build a Variant_Resolver over a controllable baseline fixture document, through a real
-	 * Effective_Variants (no stored overrides for the fixture blocks). The fixture's literal values never
-	 * reach the Token_Resolver.
-	 *
-	 * @param array<string, mixed> $document The fake baseline document.
-	 *
-	 * @return Variant_Resolver
-	 */
-	private function fixture_resolver( array $document ): Variant_Resolver {
-		$variants = new Effective_Variants(
-			new Fake_Baseline_Document( $document ),
-			$this->container->get( Token_Store::class ),
-			$this->container->get( Mutator::class )
-		);
-
-		return new Variant_Resolver( $variants, $this->container->get( Token_Resolver::class ) );
+		$store->save_document( (string) wp_json_encode( $document ), 'dark' );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Variant/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Variant/ProjectorTest.php
@@ -63,8 +63,8 @@ final class ProjectorTest extends TestCase {
 
 		$css = implode( '', (array) wp_styles()->get_data( 'kadence-blocks-global-variables', 'after' ) );
 
-		$this->assertStringContainsString( '.wp-block-kadence-singlebtn.kb-variant--style--primary{', $css );
-		$this->assertStringContainsString( '--global-palette1:var(--kb-token--variant--kadence-singlebtn--style--primary--button-bg', $css );
+		$this->assertStringContainsString( '.wp-block-kadence-singlebtn.kb-variant--primary{', $css );
+		$this->assertStringContainsString( '--global-palette1:var(--kb-token--variant--kadence-singlebtn--primary--button-bg', $css );
 	}
 
 	public function testItIsANoopWhenTheRegistryIsDeactivated(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Variant/StyleTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Variant/StyleTest.php
@@ -7,43 +7,32 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Variant\Style;
 use Tests\Support\Classes\TestCase;
 
 /**
- * Guards the variant class shapes the editor adds and the projector targets, so the flat single-axis class
- * and the grouped multi-axis class can never drift from the selector the CSS hooks.
+ * Guards the variant class shape the editor adds and the projector targets, so the "kb-variant--<variant>"
+ * class can never drift from the selector the CSS hooks.
  */
 final class StyleTest extends TestCase {
 
 	/**
-	 * A flat block's variant keeps the single-segment "kb-variant--<variant>" shape.
+	 * A variant keeps the "kb-variant--<variant>" shape.
 	 *
 	 * @return void
 	 */
-	public function testFlatVariantClass(): void {
+	public function testVariantClass(): void {
 		$this->assertSame( 'kb-variant--secondary', Style::variant_class( 'secondary' ) );
 	}
 
 	/**
-	 * A grouped selection carries the group: "kb-variant--<group>--<variant>".
-	 *
-	 * @return void
-	 */
-	public function testGroupedVariantClass(): void {
-		$this->assertSame( 'kb-variant--emphasis--outline', Style::group_variant_class( 'emphasis', 'outline' ) );
-	}
-
-	/**
-	 * Each segment is sanitized independently, so a stray character in the group or variant cannot merge the
-	 * two across the "--" delimiter.
+	 * The variant slug is sanitized, so a stray character cannot break the class shape.
 	 *
 	 * @dataProvider unsafeSegmentProvider
 	 *
-	 * @param string $group    The raw group slug.
 	 * @param string $variant  The raw variant slug.
 	 * @param string $expected The sanitized class.
 	 *
 	 * @return void
 	 */
-	public function testItSanitizesEachSegmentIndependently( string $group, string $variant, string $expected ): void {
-		$this->assertSame( $expected, Style::group_variant_class( $group, $variant ) );
+	public function testItSanitizesTheVariantSlug( string $variant, string $expected ): void {
+		$this->assertSame( $expected, Style::variant_class( $variant ) );
 	}
 
 	/**
@@ -51,14 +40,12 @@ final class StyleTest extends TestCase {
 	 */
 	public function unsafeSegmentProvider(): Generator {
 		yield 'space in variant' => [
-			'group'    => 'color',
 			'variant'  => 'sea green',
-			'expected' => 'kb-variant--color--sea-green',
+			'expected' => 'kb-variant--sea-green',
 		];
-		yield 'slash in group' => [
-			'group'    => 'a/b',
-			'variant'  => 'x',
-			'expected' => 'kb-variant--a-b--x',
+		yield 'slash in variant' => [
+			'variant'  => 'a/b',
+			'expected' => 'kb-variant--a-b',
 		];
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Registry/RegistrationHelperTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/RegistrationHelperTest.php
@@ -56,12 +56,12 @@ final class RegistrationHelperTest extends TestCase {
 	}
 
 	public function testDeclarationsFileRegisteredTheButtonVariantSet(): void {
-		// The button registers a named "style" set (its picker axis), not a preset/implicit set.
-		$set = $this->registry->for_variant_set( 'kadence/singlebtn', 'style' );
+		// The button registers a picker set (it declares a "Style" control label).
+		$set = $this->registry->for_block( 'kadence/singlebtn' );
 
 		$this->assertNotNull( $set );
 		$this->assertSame( 'kadence/singlebtn', $set->block );
-		$this->assertSame( 'style', $set->group );
+		$this->assertSame( 'Style', $set->label );
 		$this->assertNotNull( $set->binding( 'button-bg' ) );
 	}
 

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
@@ -5,7 +5,6 @@ namespace Tests\wpunit\Resources\Design_Tokens\Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Definition;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
-use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Variant_Set;
 use RuntimeException;
 use Tests\Support\Classes\TestCase;
 
@@ -156,9 +155,9 @@ final class Token_RegistryTest extends TestCase {
 			[ 'kadence/advancedbtn', 'kadence/advancedheading' ],
 			array_keys( $sets )
 		);
-		// Each block maps to its sets keyed by group slug; these register no group, so the preset (implicit) key.
-		$this->assertSame( 'kadence/advancedbtn', $sets['kadence/advancedbtn'][ Variant_Set::get_implicit_group_key() ]->block );
-		$this->assertSame( 'kadence/advancedheading', $sets['kadence/advancedheading'][ Variant_Set::get_implicit_group_key() ]->block );
+		// Each block maps to its single set.
+		$this->assertSame( 'kadence/advancedbtn', $sets['kadence/advancedbtn']->block );
+		$this->assertSame( 'kadence/advancedheading', $sets['kadence/advancedheading']->block );
 	}
 
 	public function testIsActiveByDefaultAndDeactivates(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_VariantsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_VariantsTest.php
@@ -39,7 +39,7 @@ final class Effective_VariantsTest extends TestCase {
 	 * @return void
 	 */
 	public function testItReturnsTheBaselineVariantsWhenNothingIsStored(): void {
-		$node = $this->variants->block( self::BUTTON )['style'];
+		$node = $this->variants->block( self::BUTTON );
 
 		$this->assertIsArray( $node );
 		$this->assertSame( 'primary', $node['$default'] );
@@ -52,11 +52,11 @@ final class Effective_VariantsTest extends TestCase {
 	 */
 	public function testAStoredOverrideAddsAVariantAlongsideTheBaselineOnes(): void {
 		$this->store->save_document(
-			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{"style":{'
-			. '"outline":{"label":"Outline","tokens":{"button-bg":"transparent"}}}}}}}}'
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{'
+			. '"outline":{"label":"Outline","tokens":{"button-bg":"transparent"}}}}}}}'
 		);
 
-		$node = $this->variants->block( self::BUTTON )['style'];
+		$node = $this->variants->block( self::BUTTON );
 
 		$this->assertIsArray( $node );
 		// The override-only variant appears next to the baseline ones.
@@ -72,11 +72,11 @@ final class Effective_VariantsTest extends TestCase {
 	public function testAStoredOverrideMergesIntoAVariantsTokensPerProperty(): void {
 		// Override just one property of the baseline "secondary" variant.
 		$this->store->save_document(
-			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{"style":{'
-			. '"secondary":{"tokens":{"button-bg":"#000000"}}}}}}}}'
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{'
+			. '"secondary":{"tokens":{"button-bg":"#000000"}}}}}}}'
 		);
 
-		$secondary = $this->variants->block( self::BUTTON )['style']['secondary'];
+		$secondary = $this->variants->block( self::BUTTON )['secondary'];
 
 		// The overridden property wins; the variant's other baseline tokens and its label survive.
 		$this->assertSame( '#000000', $secondary['tokens']['button-bg'] );
@@ -93,9 +93,7 @@ final class Effective_VariantsTest extends TestCase {
 				'com.kadence.designTokens' => [
 					'variants' => [
 						self::BUTTON => [
-							'style' => [
-								'outline' => [ 'tokens' => [ 'button-bg' => 'transparent' ] ],
-							],
+							'outline' => [ 'tokens' => [ 'button-bg' => 'transparent' ] ],
 						],
 					],
 				],
@@ -104,8 +102,8 @@ final class Effective_VariantsTest extends TestCase {
 
 		$section = $this->variants->for_overrides( $candidate );
 
-		$this->assertArrayHasKey( 'outline', $section[ self::BUTTON ]['style'] );
-		$this->assertArrayHasKey( 'primary', $section[ self::BUTTON ]['style'] );
+		$this->assertArrayHasKey( 'outline', $section[ self::BUTTON ] );
+		$this->assertArrayHasKey( 'primary', $section[ self::BUTTON ] );
 		// The store was never written.
 		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
 	}
@@ -126,12 +124,12 @@ final class Effective_VariantsTest extends TestCase {
 	 */
 	public function testUserCreatedReportsOverrideOnlyVariants(): void {
 		$this->store->save_document(
-			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{"style":{'
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{'
 			. '"outline":{"label":"Outline","tokens":{"button-bg":"transparent"}},'
-			. '"secondary":{"tokens":{"button-bg":"#000000"}}}}}}}}'
+			. '"secondary":{"tokens":{"button-bg":"#000000"}}}}}}}'
 		);
 
-		$user_created = $this->variants->user_created( self::BUTTON, 'default', 'style' );
+		$user_created = $this->variants->user_created( self::BUTTON, 'default' );
 
 		$this->assertContains( 'outline', $user_created );
 		$this->assertNotContains( 'primary', $user_created );

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_ResolverTest.php
@@ -221,7 +221,15 @@ final class Variant_ResolverTest extends TestCase {
 	 */
 	public function testAVariantMayDefineASubsetOfTheSurface(): void {
 		// Only two of the five bound properties.
-		$this->seedVariant( Token_Store::default_slug(), 'accent', 'Accent', [ 'button-bg' => '#ff0000', 'button-text' => '#ffffff' ] );
+		$this->seedVariant(
+			Token_Store::default_slug(),
+			'accent',
+			'Accent',
+			[
+				'button-bg'   => '#ff0000',
+				'button-text' => '#ffffff',
+			]
+		);
 
 		$values = $this->resolver->resolve_literal( self::BUTTON, 'accent' );
 

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_ResolverTest.php
@@ -4,33 +4,20 @@
 namespace Tests\wpunit\Resources\Design_Tokens\Resolver;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
-use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Binding;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
-use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Variant_Set;
-use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Variants;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Unknown_Variant_Exception;
-use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
-use Tests\Support\Classes\Fake_Baseline_Document;
 use Tests\Support\Classes\TestCase;
 
 /**
  * Resolves the Button variants against the real shipped baseline, so these assertions also guard the
- * baseline's variant definitions.
- *
- * The grouped (multi-axis) cases run against a controllable baseline fixture — a grouped block with two
- * orthogonal axes alongside a flat block — so the same accessors are asserted for both shapes. That
- * fixture uses literal token values, so resolution is deterministic without leaning on the token graph.
+ * baseline's variant definitions. A block declares one flat variant list, so every accessor is read without
+ * a group argument.
  */
 final class Variant_ResolverTest extends TestCase {
 
 	private const BUTTON = 'kadence/singlebtn';
-
-	/**
-	 * The button's picker-driven variant set (its Style axis); the button's variants nest under this group.
-	 */
-	private const STYLE = 'style';
 
 	private Variant_Resolver $resolver;
 
@@ -41,7 +28,7 @@ final class Variant_ResolverTest extends TestCase {
 	}
 
 	public function testItResolvesAliasBindingsForSecondary(): void {
-		$values = $this->resolver->resolve_literal( self::BUTTON, 'secondary', 'default', self::STYLE );
+		$values = $this->resolver->resolve_literal( self::BUTTON, 'secondary' );
 
 		// Aliases flatten through the token graph. Secondary is the dark/charcoal identity.
 		$this->assertSame( '#1A202C', $values['button-bg'] );           // {semantic.color.button-secondary-bg} -> neutral.900
@@ -52,7 +39,7 @@ final class Variant_ResolverTest extends TestCase {
 	}
 
 	public function testItFlattensMultiHopAliasesForThePrimaryVariant(): void {
-		$values = $this->resolver->resolve_literal( self::BUTTON, 'primary', 'default', self::STYLE );
+		$values = $this->resolver->resolve_literal( self::BUTTON, 'primary' );
 
 		// button-bg -> {semantic.color.button-primary-bg} -> {primitive.color.brand.button} -> #3633e1
 		$this->assertSame( '#3633e1', $values['button-bg'] );
@@ -72,7 +59,7 @@ final class Variant_ResolverTest extends TestCase {
 	 * @return void
 	 */
 	public function testResolvePreservesAliasIndirection(): void {
-		$projected = $this->resolver->resolve( self::BUTTON, 'primary', 'default', '', self::STYLE );
+		$projected = $this->resolver->resolve( self::BUTTON, 'primary' );
 
 		$this->assertSame( 'var(--kb-token--semantic--color--button-primary-bg)', $projected['button-bg'] );
 		$this->assertSame( 'var(--kb-token--semantic--color--button-primary-text)', $projected['button-text'] );
@@ -80,7 +67,7 @@ final class Variant_ResolverTest extends TestCase {
 		$this->assertSame( 'var(--kb-token--semantic--radius--control)', $projected['button-radius'] );
 
 		// The literal form is still available for the concrete-value surfaces — both forms are exposed.
-		$this->assertSame( '#3633e1', $this->resolver->resolve_literal( self::BUTTON, 'primary', 'default', self::STYLE )['button-bg'] );
+		$this->assertSame( '#3633e1', $this->resolver->resolve_literal( self::BUTTON, 'primary' )['button-bg'] );
 	}
 
 	/**
@@ -91,7 +78,7 @@ final class Variant_ResolverTest extends TestCase {
 	 * @return void
 	 */
 	public function testResolveNamespacesTheVarTarget(): void {
-		$projected = $this->resolver->resolve( self::BUTTON, 'primary', 'dark', 'dark', self::STYLE );
+		$projected = $this->resolver->resolve( self::BUTTON, 'primary', 'dark', 'dark' );
 
 		$this->assertSame( 'var(--kb-token--dark--semantic--color--button-primary-bg)', $projected['button-bg'] );
 		$this->assertSame( 'var(--kb-token--dark--semantic--radius--control)', $projected['button-radius'] );
@@ -104,43 +91,43 @@ final class Variant_ResolverTest extends TestCase {
 	 */
 	public function testResolveAndResolveLiteralShareTheInclusionSet(): void {
 		$this->assertSame(
-			array_keys( $this->resolver->resolve_literal( self::BUTTON, 'secondary', 'default', self::STYLE ) ),
-			array_keys( $this->resolver->resolve( self::BUTTON, 'secondary', 'default', '', self::STYLE ) )
+			array_keys( $this->resolver->resolve_literal( self::BUTTON, 'secondary' ) ),
+			array_keys( $this->resolver->resolve( self::BUTTON, 'secondary' ) )
 		);
 	}
 
 	public function testResolveDefaultUsesTheDeclaredDefault(): void {
 		// The baseline's $default for the button is "primary"; resolve_default() returns literals.
 		$this->assertSame(
-			$this->resolver->resolve_literal( self::BUTTON, 'primary', 'default', self::STYLE ),
-			$this->resolver->resolve_default( self::BUTTON, 'default', self::STYLE )
+			$this->resolver->resolve_literal( self::BUTTON, 'primary' ),
+			$this->resolver->resolve_default( self::BUTTON )
 		);
 	}
 
 	public function testItListsTheDocumentsVariantNames(): void {
-		$this->assertSame( [ 'primary', 'secondary' ], $this->resolver->names( self::BUTTON, 'default', self::STYLE ) );
+		$this->assertSame( [ 'primary', 'secondary' ], $this->resolver->names( self::BUTTON ) );
 	}
 
 	public function testDefaultVariantReadsTheDollarDefault(): void {
-		$this->assertSame( 'primary', $this->resolver->default_variant( self::BUTTON, 'default', self::STYLE ) );
+		$this->assertSame( 'primary', $this->resolver->default_variant( self::BUTTON ) );
 	}
 
 	public function testHasVariant(): void {
-		$this->assertTrue( $this->resolver->has_variant( self::BUTTON, 'secondary', 'default', self::STYLE ) );
+		$this->assertTrue( $this->resolver->has_variant( self::BUTTON, 'secondary' ) );
 		// "ghost" is not a V1 Button variant (the native Outline style covers it).
-		$this->assertFalse( $this->resolver->has_variant( self::BUTTON, 'ghost', 'default', self::STYLE ) );
+		$this->assertFalse( $this->resolver->has_variant( self::BUTTON, 'ghost' ) );
 		// Unknown block is false, not an error.
 		$this->assertFalse( $this->resolver->has_variant( 'kadence/nope', 'primary' ) );
 	}
 
 	public function testItReadsAVariantLabelFromTheDocument(): void {
-		$this->assertSame( 'Secondary', $this->resolver->label( self::BUTTON, 'secondary', 'default', self::STYLE ) );
-		$this->assertSame( 'Primary', $this->resolver->label( self::BUTTON, 'primary', 'default', self::STYLE ) );
+		$this->assertSame( 'Secondary', $this->resolver->label( self::BUTTON, 'secondary' ) );
+		$this->assertSame( 'Primary', $this->resolver->label( self::BUTTON, 'primary' ) );
 	}
 
 	public function testLabelIsNullForAnUnknownVariantOrBlock(): void {
 		// A non-throwing lookup, mirroring has_variant().
-		$this->assertNull( $this->resolver->label( self::BUTTON, 'ghost', 'default', self::STYLE ) );
+		$this->assertNull( $this->resolver->label( self::BUTTON, 'ghost' ) );
 		$this->assertNull( $this->resolver->label( 'kadence/nope', 'primary' ) );
 	}
 
@@ -157,15 +144,14 @@ final class Variant_ResolverTest extends TestCase {
 	public function testTheShippedButtonSetIsConsistent(): void {
 		/** @var Token_Registry $registry */
 		$registry = $this->container->get( Token_Registry::class );
-		$set      = $registry->for_variant_set( self::BUTTON, self::STYLE );
+		$set      = $registry->for_block( self::BUTTON );
 
 		$this->assertNotNull( $set, 'The Button variant set should be registered at boot.' );
 
-		// Every property the variants value has a binding, and every binding is valued somewhere.
+		// Every property the variants value has a binding.
 		$report = $set->consistency( $this->resolver->value_properties( self::BUTTON ) );
 
 		$this->assertSame( [], $report['unbound'], 'Valued properties with no binding.' );
-		$this->assertSame( [], $report['unvalued'], 'Bindings no variant ever sets.' );
 
 		/**
 		 * The Kadence button bindings retarget a global slot directly — the per-variant VALUE comes from
@@ -214,16 +200,33 @@ final class Variant_ResolverTest extends TestCase {
 			]
 		);
 
-		$this->assertSame( [ 'primary', 'secondary', 'accent' ], $this->resolver->names( self::BUTTON, 'default', self::STYLE ) );
-		$this->assertTrue( $this->resolver->has_variant( self::BUTTON, 'accent', 'default', self::STYLE ) );
-		$this->assertSame( 'Accent', $this->resolver->label( self::BUTTON, 'accent', 'default', self::STYLE ) );
+		$this->assertSame( [ 'primary', 'secondary', 'accent' ], $this->resolver->names( self::BUTTON ) );
+		$this->assertTrue( $this->resolver->has_variant( self::BUTTON, 'accent' ) );
+		$this->assertSame( 'Accent', $this->resolver->label( self::BUTTON, 'accent' ) );
 
-		$values = $this->resolver->resolve_literal( self::BUTTON, 'accent', 'default', self::STYLE );
+		$values = $this->resolver->resolve_literal( self::BUTTON, 'accent' );
 		$this->assertSame( '#ff0000', $values['button-bg'] );
 		$this->assertSame( '1rem', $values['button-radius'] );
 
 		// A stored literal has no alias, so the projected form passes it through unchanged.
-		$this->assertSame( '#ff0000', $this->resolver->resolve( self::BUTTON, 'accent', 'default', '', self::STYLE )['button-bg'] );
+		$this->assertSame( '#ff0000', $this->resolver->resolve( self::BUTTON, 'accent' )['button-bg'] );
+	}
+
+	/**
+	 * A variant may define a SUBSET of the block's bound surface — the properties it omits simply do not
+	 * resolve for it, inherited from the block $default through the cascade rather than forced onto the
+	 * variant.
+	 *
+	 * @return void
+	 */
+	public function testAVariantMayDefineASubsetOfTheSurface(): void {
+		// Only two of the five bound properties.
+		$this->seedVariant( Token_Store::default_slug(), 'accent', 'Accent', [ 'button-bg' => '#ff0000', 'button-text' => '#ffffff' ] );
+
+		$values = $this->resolver->resolve_literal( self::BUTTON, 'accent' );
+
+		$this->assertSame( [ 'button-bg', 'button-text' ], array_keys( $values ) );
+		$this->assertSame( '#ff0000', $values['button-bg'] );
 	}
 
 	/**
@@ -235,7 +238,7 @@ final class Variant_ResolverTest extends TestCase {
 	public function testAStoredOverrideWinsOverTheBaselineVariantValue(): void {
 		$this->seedVariant( Token_Store::default_slug(), 'secondary', 'Secondary', [ 'button-bg' => '#000000' ] );
 
-		$values = $this->resolver->resolve_literal( self::BUTTON, 'secondary', 'default', self::STYLE );
+		$values = $this->resolver->resolve_literal( self::BUTTON, 'secondary' );
 
 		// The overridden property takes the stored value.
 		$this->assertSame( '#000000', $values['button-bg'] );
@@ -263,12 +266,12 @@ final class Variant_ResolverTest extends TestCase {
 			]
 		);
 
-		$this->assertTrue( $this->resolver->has_variant( self::BUTTON, 'accent', 'dark', self::STYLE ) );
-		$this->assertContains( 'accent', $this->resolver->names( self::BUTTON, 'dark', self::STYLE ) );
+		$this->assertTrue( $this->resolver->has_variant( self::BUTTON, 'accent', 'dark' ) );
+		$this->assertContains( 'accent', $this->resolver->names( self::BUTTON, 'dark' ) );
 
 		// The default set never saw the write.
-		$this->assertFalse( $this->resolver->has_variant( self::BUTTON, 'accent', 'default', self::STYLE ) );
-		$this->assertSame( [ 'primary', 'secondary' ], $this->resolver->names( self::BUTTON, 'default', self::STYLE ) );
+		$this->assertFalse( $this->resolver->has_variant( self::BUTTON, 'accent', 'default' ) );
+		$this->assertSame( [ 'primary', 'secondary' ], $this->resolver->names( self::BUTTON, 'default' ) );
 	}
 
 	/**
@@ -290,11 +293,9 @@ final class Variant_ResolverTest extends TestCase {
 				'com.kadence.designTokens' => [
 					'variants' => [
 						self::BUTTON => [
-							self::STYLE => [
-								$variant => [
-									'label'  => $label,
-									'tokens' => $tokens,
-								],
+							$variant => [
+								'label'  => $label,
+								'tokens' => $tokens,
 							],
 						],
 					],
@@ -303,178 +304,5 @@ final class Variant_ResolverTest extends TestCase {
 		];
 
 		$store->save_document( (string) wp_json_encode( $document ), $slug );
-	}
-
-	/**
-	 * A grouped block reports its explicit axes in document order; a flat block reports the single implicit
-	 * group sentinel.
-	 *
-	 * @return void
-	 */
-	public function testItReportsTheGroupsForEachShape(): void {
-		$resolver = $this->grouped_resolver();
-
-		$this->assertSame( [ 'color', 'hover' ], $resolver->groups( 'kadence/grouped-btn' ) );
-		$this->assertSame( [ Variant_Set::get_implicit_group_key() ], $resolver->groups( 'kadence/flat-btn' ) );
-	}
-
-	/**
-	 * is_grouped distinguishes a multi-axis block from a flat one, and never throws for an unknown block.
-	 *
-	 * @return void
-	 */
-	public function testItDetectsWhetherABlockIsGrouped(): void {
-		$resolver = $this->grouped_resolver();
-
-		$this->assertTrue( $resolver->is_grouped( 'kadence/grouped-btn' ) );
-		$this->assertFalse( $resolver->is_grouped( 'kadence/flat-btn' ) );
-		$this->assertFalse( $resolver->is_grouped( 'kadence/nope' ) );
-	}
-
-	/**
-	 * Names, default and resolved values are read per group for a grouped block.
-	 *
-	 * @return void
-	 */
-	public function testItReadsEachGroupIndependently(): void {
-		$resolver = $this->grouped_resolver();
-
-		$this->assertSame( [ 'primary', 'secondary' ], $resolver->names( 'kadence/grouped-btn', 'default', 'color' ) );
-		$this->assertSame( [ 'subtle', 'bold' ], $resolver->names( 'kadence/grouped-btn', 'default', 'hover' ) );
-
-		$this->assertSame( 'primary', $resolver->default_variant( 'kadence/grouped-btn', 'default', 'color' ) );
-		$this->assertSame( 'subtle', $resolver->default_variant( 'kadence/grouped-btn', 'default', 'hover' ) );
-
-		$this->assertSame( '#111111', $resolver->resolve_literal( 'kadence/grouped-btn', 'secondary', 'default', 'color' )['button-bg'] );
-		$this->assertSame( '#000000', $resolver->resolve_literal( 'kadence/grouped-btn', 'bold', 'default', 'hover' )['button-bg-hover'] );
-	}
-
-	/**
-	 * A flat block resolves through its single implicit group with no group argument, exactly as an
-	 * ungrouped block always has.
-	 *
-	 * @return void
-	 */
-	public function testAFlatBlockResolvesThroughTheImplicitGroup(): void {
-		$resolver = $this->grouped_resolver();
-
-		$this->assertSame( [ 'primary', 'secondary' ], $resolver->names( 'kadence/flat-btn' ) );
-		$this->assertSame( 'primary', $resolver->default_variant( 'kadence/flat-btn' ) );
-		$this->assertSame( '#111111', $resolver->resolve_literal( 'kadence/flat-btn', 'secondary' )['button-bg'] );
-	}
-
-	/**
-	 * has_variant and label are scoped to the named group; a variant in one group is not seen in another.
-	 *
-	 * @return void
-	 */
-	public function testHasVariantAndLabelAreGroupScoped(): void {
-		$resolver = $this->grouped_resolver();
-
-		$this->assertTrue( $resolver->has_variant( 'kadence/grouped-btn', 'primary', 'default', 'color' ) );
-		$this->assertFalse( $resolver->has_variant( 'kadence/grouped-btn', 'primary', 'default', 'hover' ) );
-
-		$this->assertSame( 'Bold', $resolver->label( 'kadence/grouped-btn', 'bold', 'default', 'hover' ) );
-		$this->assertNull( $resolver->label( 'kadence/grouped-btn', 'bold', 'default', 'color' ) );
-	}
-
-	/**
-	 * value_properties unions every property across all of a grouped block's axes.
-	 *
-	 * @return void
-	 */
-	public function testValuePropertiesUnionsAcrossGroups(): void {
-		$this->assertSame(
-			[ 'button-bg', 'button-text', 'button-bg-hover', 'button-text-hover' ],
-			$this->grouped_resolver()->value_properties( 'kadence/grouped-btn' )
-		);
-	}
-
-	/**
-	 * Addressing a grouped block's implicit group (a null/sentinel group) is a group mismatch and throws,
-	 * so a caller cannot silently read the wrong axis.
-	 *
-	 * @return void
-	 */
-	public function testAGroupMismatchThrows(): void {
-		$this->expectException( Unknown_Variant_Exception::class );
-
-		$this->grouped_resolver()->names( 'kadence/grouped-btn' );
-	}
-
-	/**
-	 * Build a Variant_Resolver over a controllable grouped/flat baseline fixture. The grouped block carries
-	 * two ORTHOGONAL axes — "color" sets the base fill (button-bg / button-text), "hover" sets the hover
-	 * treatment (button-bg-hover / button-text-hover) — so one selection per axis composes cleanly without
-	 * either overwriting the other. Definitions are read through a real Effective_Variants over a fake
-	 * baseline (no stored overrides for these blocks), and the fixture's literal values never reach the
-	 * Token_Resolver.
-	 *
-	 * @return Variant_Resolver
-	 */
-	private function grouped_resolver(): Variant_Resolver {
-		$document = [
-			'$extensions' => [
-				'com.kadence.designTokens' => [
-					'variants' => [
-						'kadence/grouped-btn' => [
-							'color' => [
-								'$default'  => 'primary',
-								'primary'   => [
-									'label'  => 'Primary',
-									'tokens' => [
-										'button-bg'   => '#3633e1',
-										'button-text' => '#ffffff',
-									],
-								],
-								'secondary' => [
-									'label'  => 'Secondary',
-									'tokens' => [
-										'button-bg'   => '#111111',
-										'button-text' => '#ffffff',
-									],
-								],
-							],
-							'hover' => [
-								'$default' => 'subtle',
-								'subtle'   => [
-									'label'  => 'Subtle',
-									'tokens' => [
-										'button-bg-hover' => '#2f2ffc',
-										'button-text-hover' => '#ffffff',
-									],
-								],
-								'bold'     => [
-									'label'  => 'Bold',
-									'tokens' => [
-										'button-bg-hover' => '#000000',
-										'button-text-hover' => '#ffffff',
-									],
-								],
-							],
-						],
-						'kadence/flat-btn'    => [
-							'$default'  => 'primary',
-							'primary'   => [
-								'label'  => 'Primary',
-								'tokens' => [ 'button-bg' => '#3633e1' ],
-							],
-							'secondary' => [
-								'label'  => 'Secondary',
-								'tokens' => [ 'button-bg' => '#111111' ],
-							],
-						],
-					],
-				],
-			],
-		];
-
-		$variants = new Effective_Variants(
-			new Fake_Baseline_Document( $document ),
-			$this->container->get( Token_Store::class ),
-			$this->container->get( Mutator::class )
-		);
-
-		return new Variant_Resolver( $variants, $this->container->get( Token_Resolver::class ) );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Projected_Css_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Projected_Css_ControllerTest.php
@@ -61,7 +61,7 @@ final class Projected_Css_ControllerTest extends TestCase {
 		$css = $this->css();
 
 		$this->assertStringContainsString( '--kb-token--', $css, 'The token vars layer should be present.' );
-		$this->assertStringContainsString( 'kb-variant--style--accent', $css, 'The stored variant scoped rule should be present.' );
+		$this->assertStringContainsString( 'kb-variant--accent', $css, 'The stored variant scoped rule should be present.' );
 	}
 
 	/**
@@ -135,16 +135,14 @@ final class Projected_Css_ControllerTest extends TestCase {
 				'com.kadence.designTokens' => [
 					'variants' => [
 						self::BUTTON => [
-							'style' => [
-								$variant => [
-									'label'  => 'Accent',
-									'tokens' => [
-										'button-bg'         => '#ff0000',
-										'button-text'       => '#ffffff',
-										'button-bg-hover'   => '#cc0000',
-										'button-text-hover' => '#ffffff',
-										'button-radius'     => '1rem',
-									],
+							$variant => [
+								'label'  => 'Accent',
+								'tokens' => [
+									'button-bg'         => '#ff0000',
+									'button-text'       => '#ffffff',
+									'button-bg-hover'   => '#cc0000',
+									'button-text-hover' => '#ffffff',
+									'button-radius'     => '1rem',
 								],
 							],
 						],

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
@@ -136,8 +136,8 @@ final class VariantsControllerTest extends TestCase {
 	 */
 	public function testGetItemReflectsAStoredOverride(): void {
 		$this->store->save_document(
-			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{"style":{'
-			. '"outline":{"label":"Outline","tokens":{"button-bg":"transparent"}}}}}}}}'
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{'
+			. '"outline":{"label":"Outline","tokens":{"button-bg":"transparent"}}}}}}}'
 		);
 
 		$data = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) )->get_data();
@@ -349,8 +349,8 @@ final class VariantsControllerTest extends TestCase {
 	 */
 	public function testDeleteVariantIsAnIdempotentNoOpWhenAbsent(): void {
 		$this->store->save_document(
-			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{"style":{'
-			. '"outline":{"tokens":{"button-bg":"transparent"}}}}}}}}'
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{'
+			. '"outline":{"tokens":{"button-bg":"transparent"}}}}}}}'
 		);
 
 		$version_before = $this->store->get_version( Token_Store::default_slug() );
@@ -471,16 +471,17 @@ final class VariantsControllerTest extends TestCase {
 	}
 
 	/**
-	 * A variant that leaves a bound property unset is rejected: a variant must value the block's full bound
-	 * surface. The post-merge token set is evaluated, so a partial replace is caught too.
+	 * A variant may define a SUBSET of the block's bound surface: a variant that leaves a bound property
+	 * unset is accepted and stored with exactly the properties it defines. The property it omits is inherited
+	 * from the block $default through the cascade rather than being required here.
 	 *
 	 * @return void
 	 */
-	public function testAnIncompleteSurfaceIsRejected(): void {
+	public function testAnIncompleteSurfaceIsAccepted(): void {
 		$tokens = $this->button_tokens();
 		unset( $tokens['button-radius'] );
 
-		$result = $this->controller->create_item(
+		$response = $this->controller->create_item(
 			$this->block_request(
 				WP_REST_Server::CREATABLE,
 				self::BUTTON,
@@ -491,10 +492,13 @@ final class VariantsControllerTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'rest_design_tokens_incomplete_surface', $result->get_error_code() );
-		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
-		$this->assertContains( 'button-radius', $result->get_error_data()['properties'] );
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::CREATED, $response->get_status() );
+
+		// The variant is stored with only the properties it defined; button-radius is absent.
+		$stored = $response->get_data()['variants']['accent']['tokens'];
+		$this->assertArrayHasKey( 'button-bg', $stored );
+		$this->assertArrayNotHasKey( 'button-radius', $stored );
 	}
 
 	/**
@@ -624,8 +628,8 @@ final class VariantsControllerTest extends TestCase {
 	 */
 	public function testAWriteBumpsTheVersion(): void {
 		$this->store->save_document(
-			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{"style":{'
-			. '"outline":{"tokens":{"button-bg":"transparent"}}}}}}}}'
+			'{"$extensions":{"com.kadence.designTokens":{"variants":{"kadence/singlebtn":{'
+			. '"outline":{"tokens":{"button-bg":"transparent"}}}}}}}'
 		);
 
 		$version_before = $this->store->get_version( Token_Store::default_slug() );


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3834/collapse-variant-sets-into-a-single-per-block-variant-list-per-variant

Primarily reverses the recently-shipped grouped / multi-axis variant work (SOFT-3533, SOFT-3577), collapsing the design-token variant model from multiple combinable axes (grouped sets keyed by block + group) back to one flat variant list per block. Backend half.

- Registry: one `Variant_Set` per block (the block's full bindable surface); the `group` concept and the `$single` sentinel are removed.
- Resolvers, projection, REST, catalog and admin feed drop all group branching. The emitted class collapses to `kb-variant--<variant>` and the CSS var to `--variant--<block>--<variant>--<property>`.
- A variant may define any subset of the block's bound properties; an unbound property is still rejected. The `variant_set` REST param is gone.
- `baseline.json` / `declarations.php` migrated off the grouped `.style.` shape.

Also fixes a **pre-existing** bug (present before this ticket, unrelated to the collapse): the per-variant scoped retarget rules were built from the active token set only, so a variant defined solely on a non-active set (e.g. a user-created variant on `dark`) never applied in the editor or on the front end. They are now emitted from every set's fragment.

PHPStan (level max) and the design-tokens wpunit suite are green.

### Checklist
- [ ] I have performed a self-review.
- [ ] No unrelated files are modified.
- [ ] No debugging statements exist (Ex: console.log, error_log).
- [ ] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
