### PR TITLE
SOFT-3834 [2/2]: Collapse variant sets — editor

### DIFF
--- a/src/blocks/singlebtn/block.json
+++ b/src/blocks/singlebtn/block.json
@@ -754,9 +754,9 @@
 			"type": "boolean",
 			"default": false
 		},
-		"kbVariants": {
-			"type": "object",
-			"default": {}
+		"kbVariant": {
+			"type": "string",
+			"default": ""
 		},
 		"kbTokenSet": {
 			"type": "string",

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -84,7 +84,7 @@ import {
 } from '@wordpress/components';
 import { addFilter, applyFilters, doAction } from '@wordpress/hooks';
 import BackendStyles from './components/backend-styles';
-import { VariantPicker, blockVariants, activeSet, blockSetGroup } from '../../extension/variant-picker';
+import { VariantPicker, blockVariants, activeSet } from '../../extension/variant-picker';
 import { VariantActions } from '../../extension/variant-picker/VariantActions';
 import { TokenSetPicker, selectableSets } from '../../extension/token-set-picker';
 
@@ -849,15 +849,8 @@ export default function KadenceButtonEdit(props) {
 										{blockVariants(name, attributes.kbTokenSet || activeSet()).length > 0 &&
 											(() => {
 												const set = attributes.kbTokenSet || activeSet();
-												const group = blockSetGroup(name, set);
-												const selected = get(attributes, ['kbVariants', group], '');
-												const selectVariant = (value) =>
-													setAttributes({
-														kbVariants: {
-															...get(attributes, 'kbVariants', {}),
-															[group]: value,
-														},
-													});
+												const selected = get(attributes, 'kbVariant', '');
+												const selectVariant = (value) => setAttributes({ kbVariant: value });
 
 												return (
 													<SubsectionWrap label={__('Design Variants', 'kadence-blocks')}>

--- a/src/early-filters.js
+++ b/src/early-filters.js
@@ -13,7 +13,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { useDispatch, select } from '@wordpress/data';
-import { VariantPicker, blockVariants, activeSet, blockSetGroup } from './extension/variant-picker';
+import { VariantPicker, blockVariants, activeSet } from './extension/variant-picker';
 import { VariantActions } from './extension/variant-picker/VariantActions';
 import { TokenSetPicker, selectableSets } from './extension/token-set-picker';
 
@@ -99,26 +99,26 @@ export function enableNativeBlockVariants(settings, name) {
 addFilter('blocks.registerBlockType', 'kadence/kb-variant-native-support', enableNativeBlockVariants);
 
 /**
- * Add the kbVariants and kbTokenSet attributes to any block that opts in via the `kbVariant` block support.
+ * Add the kbVariant and kbTokenSet attributes to any block that opts in via the `kbVariant` block support.
  *
- * kbVariants is a map of group slug => selected variant slug (e.g. { style: "ghost" }); an absent or empty
- * entry means the block keeps that group's $default look (the block preset). kbTokenSet holds the slug of a
- * per-block token-set override (e.g. "dark"); empty means the block follows the active set. The scoped CSS
- * that re-skins the block for a selected variant and the switch selectors a set override re-points through
- * are both emitted server-side by the Design Tokens projector.
+ * kbVariant is the selected variant slug (e.g. "ghost"); an empty value means the block keeps its $default
+ * look (the block preset). kbTokenSet holds the slug of a per-block token-set override (e.g. "dark"); empty
+ * means the block follows the active set. The scoped CSS that re-skins the block for a selected variant and
+ * the switch selectors a set override re-points through are both emitted server-side by the Design Tokens
+ * projector.
  *
  * @param {Object} settings The block settings.
  *
  * @since TBD
  *
- * @return {Object} The block settings with the kbVariants and kbTokenSet attributes added.
+ * @return {Object} The block settings with the kbVariant and kbTokenSet attributes added.
  */
 export function blockVariantAttribute(settings) {
 	if (hasBlockSupport(settings, 'kbVariant')) {
 		settings.attributes = assign(settings.attributes, {
-			kbVariants: {
-				type: 'object',
-				default: {},
+			kbVariant: {
+				type: 'string',
+				default: '',
 			},
 			kbTokenSet: {
 				type: 'string',
@@ -183,31 +183,19 @@ function sanitizeTokenIdentifier(slug) {
 }
 
 /**
- * The classes a block's selected variants output: one `kb-variant--<group>--<slug>` per variant set with a
- * non-empty selection in the `kbVariants` map. Each segment is sanitized independently so the group and
- * variant slugs cannot merge across the "--" delimiter, mirroring the projector's PHP
- * Style::group_variant_class().
+ * The class a block's selected variant outputs: `kb-variant--<slug>`. The slug is sanitized, mirroring the
+ * projector's PHP Style::variant_class(). Empty when nothing is selected.
  *
- * @param {Object} kbVariants The kbVariants map (variant-set group slug => selected variant slug).
+ * @param {string} kbVariant The kbVariant attribute (the selected variant slug).
  *
  * @since TBD
  *
- * @return {string} The space-joined variant classes, or an empty string.
+ * @return {string} The variant class, or an empty string.
  */
-function kbVariantsClassNames(kbVariants) {
-	if (!kbVariants || typeof kbVariants !== 'object') {
-		return '';
-	}
+function kbVariantClassName(kbVariant) {
+	const slug = sanitizeTokenIdentifier(typeof kbVariant === 'string' ? kbVariant : '');
 
-	return Object.keys(kbVariants)
-		.map((group) => {
-			const groupSlug = sanitizeTokenIdentifier(group);
-			const variantSlug = sanitizeTokenIdentifier(kbVariants[group]);
-
-			return groupSlug && variantSlug ? `kb-variant--${groupSlug}--${variantSlug}` : '';
-		})
-		.filter(Boolean)
-		.join(' ');
+	return slug ? `kb-variant--${slug}` : '';
 }
 
 /**
@@ -227,7 +215,7 @@ export function blockVariantSaveClass(props, blockType, attributes) {
 		return props;
 	}
 
-	const variantClass = kbVariantsClassNames(get(attributes, 'kbVariants', {}));
+	const variantClass = kbVariantClassName(get(attributes, 'kbVariant', ''));
 
 	if (variantClass) {
 		props.className = props.className ? `${props.className} ${variantClass}` : variantClass;
@@ -279,7 +267,7 @@ const withBlockVariantClass = createHigherOrderComponent((BlockListBlock) => {
 			return <BlockListBlock {...props} />;
 		}
 
-		const variantClass = kbVariantsClassNames(get(attributes, 'kbVariants', {}));
+		const variantClass = kbVariantClassName(get(attributes, 'kbVariant', ''));
 
 		if (!variantClass) {
 			return <BlockListBlock {...props} />;
@@ -325,8 +313,8 @@ addFilter('editor.BlockListBlock', 'kadence/kb-token-set-attr', withBlockTokenSe
  * "Design Tokens" panel: a "Token Set" subsection (the per-block set override) above a "Design Variants"
  * subsection (the variant picker). Selecting a set writes the kbTokenSet attribute, which the save/preview
  * filters turn into the data-kb-token-set attribute the projector's switch selectors re-point through;
- * selecting a variant writes its group's entry in the kbVariants map, which the save/preview filters turn
- * into the kb-variant--<group>--<slug> class the projector's scoped CSS hooks. An empty set follows the
+ * selecting a variant writes the kbVariant attribute, which the save/preview filters turn into the
+ * kb-variant--<slug> class the projector's scoped CSS hooks. An empty set follows the
  * active set; an empty variant selects the block's $default preset look. Each subsection is shown only when
  * it has something to offer (two or more sets / any variants), and the panel is skipped when neither does.
  *
@@ -350,7 +338,6 @@ const withVariantPicker = createHigherOrderComponent((BlockEdit) => {
 		}
 
 		const set = get(attributes, 'kbTokenSet', '') || activeSet();
-		const group = blockSetGroup(name, set);
 		const hasVariants = blockVariants(name, set).length > 0;
 		const hasSets = selectableSets().length >= 2;
 
@@ -358,9 +345,8 @@ const withVariantPicker = createHigherOrderComponent((BlockEdit) => {
 			return <BlockEdit {...props} />;
 		}
 
-		const selected = get(attributes, ['kbVariants', group], '');
-		const selectVariant = (value) =>
-			setAttributes({ kbVariants: { ...get(attributes, 'kbVariants', {}), [group]: value } });
+		const selected = get(attributes, 'kbVariant', '');
+		const selectVariant = (value) => setAttributes({ kbVariant: value });
 
 		return (
 			<>

--- a/src/extension/variant-picker/SaveVariantModal.js
+++ b/src/extension/variant-picker/SaveVariantModal.js
@@ -1,18 +1,20 @@
 /**
  * "Create new variant" / "Edit variant" modal.
  *
- * Create mode clones an existing variant's surface for a block: the user picks a variant to clone from,
- * edits the value of each bound property, names the variant, and saves a new one. Edit mode pre-fills from an
- * existing user variant and saves back under the same slug. Either way the write goes through the variants
- * REST endpoint (which aliases matching literals, validates the full surface, and rejects dangling aliases),
- * then the in-memory catalog is updated and the variant selected on the block. It seeds from an existing
- * variant's values, so it needs no per-block knowledge and works for any block that registers a variant set.
+ * Create mode captures the full bound surface for a block: the modal shows every bound property, seeded from
+ * the currently-selected variant's resolved token values (a complete snapshot, not a delta from a previous
+ * selection); the user edits any value, names the variant, and saves the whole surface as the new variant's
+ * tokens. Edit mode pre-fills from an existing user variant and saves back under the same slug. Either way
+ * the write goes through the variants REST endpoint (which aliases matching literals and rejects dangling
+ * aliases; a subset of the surface is accepted, an unbound property is not), then the in-memory catalog is
+ * updated and the variant selected on the block. It seeds from an existing variant's values, so it needs no
+ * per-block knowledge and works for any block that registers a variant set.
  */
 import { Modal, TextControl, SelectControl, Button, Notice, Spinner } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { get } from 'lodash';
-import { blockProperties, appendVariant, blockSetGroup } from './index';
+import { blockProperties, appendVariant } from './index';
 import { getBlockVariants, createVariant } from '../variants/api/client';
 import { refreshProjectedCss } from '../design-tokens/live-css';
 import { deriveSlug, dedupeSlug } from '../variants/slug';
@@ -59,7 +61,6 @@ function seedValues(properties, tokens) {
  */
 export function SaveVariantModal({ blockName, set, source, editSlug = '', onClose, onSaved }) {
 	const properties = blockProperties(blockName, set);
-	const variantSet = blockSetGroup(blockName, set);
 	const isEdit = editSlug !== '';
 
 	const [status, setStatus] = useState('loading');
@@ -74,7 +75,7 @@ export function SaveVariantModal({ blockName, set, source, editSlug = '', onClos
 	useEffect(() => {
 		let cancelled = false;
 
-		getBlockVariants(blockName, set, variantSet)
+		getBlockVariants(blockName, set)
 			.then((payload) => {
 				if (cancelled) {
 					return;
@@ -134,7 +135,7 @@ export function SaveVariantModal({ blockName, set, source, editSlug = '', onClos
 		setStatus('saving');
 		setError('');
 
-		createVariant(blockName, { variant: slug, label: label.trim(), tokens: values }, set, variantSet)
+		createVariant(blockName, { variant: slug, label: label.trim(), tokens: values }, set)
 			.then(() => {
 				appendVariant(blockName, set, { slug, label: label.trim(), userCreated: true });
 				refreshProjectedCss();

--- a/src/extension/variant-picker/VariantActions.js
+++ b/src/extension/variant-picker/VariantActions.js
@@ -11,7 +11,7 @@ import { Button, Notice } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { SaveVariantModal } from './SaveVariantModal';
-import { blockVariants, blockDefaultVariant, isUserVariant, removeVariant, blockSetGroup } from './index';
+import { blockVariants, blockDefaultVariant, isUserVariant, removeVariant } from './index';
 import { deleteVariant, setVariantDefault } from '../variants/api/client';
 import { hasDesignTokensRest } from '../design-tokens/rest';
 import { refreshProjectedCss } from '../design-tokens/live-css';
@@ -48,17 +48,15 @@ export function VariantActions({ blockName, set, selected, onSelect }) {
 		setBusy(true);
 		setError('');
 
-		const variantSet = blockSetGroup(blockName, set);
 		const isDefault = blockDefaultVariant(blockName, set) === selected;
 		const fallback = blockVariants(blockName, set)
 			.map((variant) => variant.slug)
 			.find((slug) => slug !== selected);
 
-		const reassign =
-			isDefault && fallback ? setVariantDefault(blockName, fallback, set, variantSet) : Promise.resolve();
+		const reassign = isDefault && fallback ? setVariantDefault(blockName, fallback, set) : Promise.resolve();
 
 		reassign
-			.then(() => deleteVariant(blockName, selected, set, variantSet))
+			.then(() => deleteVariant(blockName, selected, set))
 			.then(() => {
 				removeVariant(blockName, set, selected);
 				refreshProjectedCss();

--- a/src/extension/variant-picker/index.js
+++ b/src/extension/variant-picker/index.js
@@ -1,14 +1,13 @@
 /**
- * Shared design-token color-variant picker.
+ * Shared design-token variant picker.
  *
  * The catalog is printed by the server-side editor localizer to `window.kadenceDesignTokensVariants`,
- * keyed by token set then by block then by variant SET (axis):
- * `{ active, sets: { <slug>: { <block>: { <group>: { group, default, variants, properties, label? } } } } }`.
+ * keyed by token set then by block:
+ * `{ active, sets: { <slug>: { <block>: { default, variants, properties, label } } } }`.
  * Reads take the token set a block is on (its `kbTokenSet`, or the active set). A picker-driven block
- * registers one named variant set (e.g. the button's "style"); these readers resolve that sole set, and its
- * selection lives in the `kbVariants` map keyed by the set's group. Both the generic inspector picker
- * (src/early-filters.js) and a block that renders the picker inline in its own Style tab (e.g.
- * kadence/singlebtn) use this so the control stays identical wherever it surfaces.
+ * declares one variant set; its selection lives in the block's `kbVariant` string attribute. Both the
+ * generic inspector picker (src/early-filters.js) and a block that renders the picker inline in its own
+ * Style tab (e.g. kadence/singlebtn) use this so the control stays identical wherever it surfaces.
  */
 import { get } from 'lodash';
 import { KadenceRadioButtons } from '@kadence/components';
@@ -37,48 +36,21 @@ export function activeSet() {
  * The per-block catalog for a token set, defaulting to the active set.
  *
  * @param {string} [set] The token set slug.
- * @return {Object} The per-block catalog for the set (block => { group => entry }).
+ * @return {Object} The per-block catalog for the set (block => entry).
  */
 function setBlocks(set) {
 	return get(variantCatalog(), ['sets', set || activeSet()], {}) || {};
 }
 
 /**
- * A block's variant sets (axes) for a token set, keyed by group slug.
+ * The catalog entry for a block's variant set in a token set, or null when it offers none.
  *
  * @param {string} name  The block name.
  * @param {string} [set] The token set slug; defaults to the active set.
- * @return {Object} The block's sets ({ group => entry }).
+ * @return {Object|null} The set entry ({ default, variants, properties, label }).
  */
-function blockSets(name, set) {
-	return get(setBlocks(set), [name], {}) || {};
-}
-
-/**
- * The group slug of a block's variant set (its picker axis) for a token set — a picker-driven block
- * registers one, so this is that sole set's group. Empty when the block offers no set.
- *
- * @param {string} name  The block name.
- * @param {string} [set] The token set slug; defaults to the active set.
- * @return {string} The variant-set group slug, or an empty string.
- */
-export function blockSetGroup(name, set) {
-	const groups = Object.keys(blockSets(name, set));
-
-	return groups.length ? groups[0] : '';
-}
-
-/**
- * The catalog entry for a block's sole variant set in a token set, or null when it offers none.
- *
- * @param {string} name  The block name.
- * @param {string} [set] The token set slug; defaults to the active set.
- * @return {Object|null} The set entry ({ group, default, variants, properties, label? }).
- */
-function soleSet(name, set) {
-	const group = blockSetGroup(name, set);
-
-	return group ? blockSets(name, set)[group] : null;
+function blockEntry(name, set) {
+	return get(setBlocks(set), [name], null) || null;
 }
 
 /**
@@ -89,7 +61,7 @@ function soleSet(name, set) {
  * @return {Array} The block's variants ([{ slug, label, userCreated }]).
  */
 export function blockVariants(name, set) {
-	return get(soleSet(name, set), 'variants', []);
+	return get(blockEntry(name, set), 'variants', []);
 }
 
 /**
@@ -101,7 +73,7 @@ export function blockVariants(name, set) {
  * @return {string} The control label, or an empty string.
  */
 export function blockVariantLabel(name, set) {
-	return get(soleSet(name, set), 'label', '');
+	return get(blockEntry(name, set), 'label', '');
 }
 
 /**
@@ -112,7 +84,7 @@ export function blockVariantLabel(name, set) {
  * @return {Array} The block's surface ([{ key, kind, token }]).
  */
 export function blockProperties(name, set) {
-	return get(soleSet(name, set), 'properties', []);
+	return get(blockEntry(name, set), 'properties', []);
 }
 
 /**
@@ -123,7 +95,7 @@ export function blockProperties(name, set) {
  * @return {string} The default variant slug, or an empty string.
  */
 export function blockDefaultVariant(name, set) {
-	return get(soleSet(name, set), 'default', '');
+	return get(blockEntry(name, set), 'default', '');
 }
 
 /**
@@ -149,7 +121,7 @@ export function isUserVariant(name, set, slug) {
  * @return {void}
  */
 export function appendVariant(name, set, variant) {
-	const entry = soleSet(name, set);
+	const entry = blockEntry(name, set);
 
 	if (!entry || !Array.isArray(entry.variants)) {
 		return;
@@ -170,7 +142,7 @@ export function appendVariant(name, set, variant) {
  * @return {void}
  */
 export function removeVariant(name, set, slug) {
-	const entry = soleSet(name, set);
+	const entry = blockEntry(name, set);
 
 	if (!entry || !Array.isArray(entry.variants)) {
 		return;
@@ -180,9 +152,9 @@ export function removeVariant(name, set, slug) {
 }
 
 /**
- * The color-variant picker for a block. Renders nothing when the block has no variants in the set.
+ * The variant picker for a block. Renders nothing when the block has no variants in the set.
  * Selecting an option calls onChange with the chosen variant slug (the caller writes it into the block's
- * kbVariants map under this control's group); an empty value selects the block's $default look.
+ * kbVariant attribute); an empty value selects the block's $default look.
  *
  * @param {Object}   props             The component props.
  * @param {string}   props.name        The block name, used to read its variants from the catalog.

--- a/src/extension/variants/api/client.js
+++ b/src/extension/variants/api/client.js
@@ -3,9 +3,7 @@
  *
  * Uses the editor's already-configured `@wordpress/api-fetch` (root + nonce), reading only the REST
  * namespace from the shared design-tokens descriptor. Every call targets a specific token set via the `set`
- * parameter and a specific variant set (axis) via the `variant_set` parameter (query for reads/deletes,
- * body for writes); an absent `set` falls back to the active token set, and an absent `variant_set` to the
- * block's sole named set.
+ * parameter (query for reads/deletes, body for writes); an absent `set` falls back to the active token set.
  */
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
@@ -13,50 +11,46 @@ import { designTokensNamespace } from '../../design-tokens/rest';
 import { variantsBlockPath, variantItemPath, variantDefaultPath } from './paths';
 
 /**
- * The optional { set, variant_set } params, omitting each when empty so the server applies its defaults.
+ * The optional { set } param, omitted when empty so the server applies its default (the active set).
  *
- * @param {string} [set]        The token set slug.
- * @param {string} [variantSet] The variant set (axis) group slug.
+ * @param {string} [set] The token set slug.
  * @return {Object} The params object.
  */
-function targetParams(set, variantSet) {
+function targetParams(set) {
 	return {
 		...(set ? { set } : {}),
-		...(variantSet ? { variant_set: variantSet } : {}),
 	};
 }
 
 /**
  * Read a block's effective variant set for a token set.
  *
- * @param {string} block        The block name.
- * @param {string} [set]        The token set slug; omitted targets the active set.
- * @param {string} [variantSet] The variant set (axis) group slug; omitted targets the sole named set.
- * @return {Promise<Object>} The variant set payload ({ block, group, slug, version, default, variants }).
+ * @param {string} block The block name.
+ * @param {string} [set] The token set slug; omitted targets the active set.
+ * @return {Promise<Object>} The variant set payload ({ block, slug, version, default, variants }).
  */
-export function getBlockVariants(block, set, variantSet) {
+export function getBlockVariants(block, set) {
 	return apiFetch({
-		path: addQueryArgs(variantsBlockPath(designTokensNamespace(), block), targetParams(set, variantSet)),
+		path: addQueryArgs(variantsBlockPath(designTokensNamespace(), block), targetParams(set)),
 	});
 }
 
 /**
  * Create or merge a single variant into a block's set.
  *
- * @param {string} block               The block name.
- * @param {Object} variant             The variant definition.
- * @param {string} variant.variant     The variant slug.
- * @param {string} [variant.label]     The variant label.
- * @param {Object} [variant.tokens]    The property => value token map.
- * @param {string} [set]               The token set slug; omitted targets the active set.
- * @param {string} [variantSet]        The variant set (axis) group slug; omitted targets the sole named set.
+ * @param {string} block            The block name.
+ * @param {Object} variant          The variant definition.
+ * @param {string} variant.variant  The variant slug.
+ * @param {string} [variant.label]  The variant label.
+ * @param {Object} [variant.tokens] The property => value token map.
+ * @param {string} [set]            The token set slug; omitted targets the active set.
  * @return {Promise<Object>} The updated variant set payload.
  */
-export function createVariant(block, { variant, label, tokens }, set, variantSet) {
+export function createVariant(block, { variant, label, tokens }, set) {
 	return apiFetch({
 		path: variantsBlockPath(designTokensNamespace(), block),
 		method: 'POST',
-		data: { variant, label, tokens, ...targetParams(set, variantSet) },
+		data: { variant, label, tokens, ...targetParams(set) },
 	});
 }
 
@@ -66,29 +60,27 @@ export function createVariant(block, { variant, label, tokens }, set, variantSet
  * @param {string} block          The block name.
  * @param {string} defaultVariant The variant slug to make default.
  * @param {string} [set]          The token set slug; omitted targets the active set.
- * @param {string} [variantSet]   The variant set (axis) group slug; omitted targets the sole named set.
  * @return {Promise<Object>} The updated variant set payload.
  */
-export function setVariantDefault(block, defaultVariant, set, variantSet) {
+export function setVariantDefault(block, defaultVariant, set) {
 	return apiFetch({
 		path: variantDefaultPath(designTokensNamespace(), block),
 		method: 'PUT',
-		data: { default: defaultVariant, ...targetParams(set, variantSet) },
+		data: { default: defaultVariant, ...targetParams(set) },
 	});
 }
 
 /**
  * Delete a single variant from a block's set.
  *
- * @param {string} block        The block name.
- * @param {string} variant      The variant slug.
- * @param {string} [set]        The token set slug; omitted targets the active set.
- * @param {string} [variantSet] The variant set (axis) group slug; omitted targets the sole named set.
+ * @param {string} block   The block name.
+ * @param {string} variant The variant slug.
+ * @param {string} [set]   The token set slug; omitted targets the active set.
  * @return {Promise<Object>} The updated variant set payload.
  */
-export function deleteVariant(block, variant, set, variantSet) {
+export function deleteVariant(block, variant, set) {
 	return apiFetch({
-		path: addQueryArgs(variantItemPath(designTokensNamespace(), block, variant), targetParams(set, variantSet)),
+		path: addQueryArgs(variantItemPath(designTokensNamespace(), block, variant), targetParams(set)),
 		method: 'DELETE',
 	});
 }


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3834/collapse-variant-sets-into-a-single-per-block-variant-list-per-variant

Editor half of the variant-set collapse. Stacked on #1129 (base is `soft-3834/pr1-backend`); review after it.

- The `kbVariants` group => variant map attribute becomes a single `kbVariant` slug; the emitted class collapses to `kb-variant--<variant>`.
- The variant picker, actions, save-as-new-variant modal and REST client drop the group / `variant_set` indirection and read the flat catalog shape.
- `singlebtn` block.json switches to the `kbVariant` attribute.

`wp-scripts` build, eslint and cspell are green.

### Checklist
- [ ] I have performed a self-review.
- [ ] No unrelated files are modified.
- [ ] No debugging statements exist (Ex: console.log, error_log).
- [ ] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
