### PR TITLE
[DTM] SOFT-3849 [1/5]: PHP control_attr field + catalog surface

### DIFF
--- a/includes/resources/Design_Tokens/Editor/Variant_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Variant_Catalog.php
@@ -16,12 +16,14 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Variant_Resolver;
  * Keyed by token set so the picker can show the variants for whichever set a block is on (its `kbTokenSet`,
  * or the active set), not just the active one, then by block:
  * `{ active: <slug>, sets: { <slug>: { <block>: {…} } } }`. Per block it carries the `$default` slug, the
- * named variants as { slug, label, userCreated }, the picker control label, and the controllable surface as
- * { key, kind, token } per bound property so the form can render one input per property. Only PICKER sets
- * appear (a set that declares a `label`); a block's preset / default-variant set (no label) has no picker
- * and is omitted. It carries no resolved token values, so it cannot raise the alias-cycle errors the admin
- * feed must guard; a set registered but absent from a token set (Unknown_Variant_Exception) is skipped, so
- * one undefined set never empties the catalog.
+ * named variants as { slug, label, userCreated }, the picker control label, the controllable surface as
+ * { key, kind, token, control_attr } per bound property so the form can render one input per property, and
+ * a per-variant resolved-value map ({ variant slug => { property => literal } }) so a control can compare
+ * its current value against the selected variant's value. Only PICKER sets appear (a set that declares a
+ * `label`); a block's preset / default-variant set (no label) has no picker and is omitted. It carries no
+ * resolved token values beyond those per-variant literals, so it cannot raise the alias-cycle errors the
+ * admin feed must guard; a set registered but absent from a token set (Unknown_Variant_Exception) is
+ * skipped, so one undefined set never empties the catalog.
  *
  * @since TBD
  */
@@ -123,7 +125,7 @@ final class Variant_Catalog {
 	 *
 	 * @param string $slug The token set slug.
 	 *
-	 * @return array<string, array<string, mixed>> block => { default, variants, properties, label }.
+	 * @return array<string, array<string, mixed>> block => { default, variants, properties, values, label }.
 	 */
 	private function for_set( string $slug ): array {
 		$out = [];
@@ -159,6 +161,7 @@ final class Variant_Catalog {
 				'default'    => $default,
 				'variants'   => $variants,
 				'properties' => $this->properties_for( $set ),
+				'values'     => $this->values_for( $block, $slug, $names ),
 				'label'      => $set->label,
 			];
 		}
@@ -167,28 +170,58 @@ final class Variant_Catalog {
 	}
 
 	/**
-	 * The controllable surface for a variant set: one { key, kind, token } entry per bound property, in
-	 * binding order, so the editor form renders an input per property. Set-structure read from the set's
-	 * bindings.
+	 * The controllable surface for a variant set: one { key, kind, token, control_attr } entry per bound
+	 * property, in binding order, so the editor form renders an input per property and the indicator layer
+	 * can key an override signal to the control attribute. Set-structure read from the set's bindings.
 	 *
 	 * @since TBD
 	 *
 	 * @param Variant_Set $set The variant set.
 	 *
-	 * @return array<int, array{key: string, kind: string, token: string|null}>
+	 * @return array<int, array{key: string, kind: string, token: string|null, control_attr: string|null}>
 	 */
 	private function properties_for( Variant_Set $set ): array {
 		$properties = [];
 
 		foreach ( $set->bindings as $property => $binding ) {
 			$properties[] = [
-				'key'   => (string) $property,
-				'kind'  => $set->kind( (string) $property ),
-				'token' => $binding->token,
+				'key'          => (string) $property,
+				'kind'         => $set->kind( (string) $property ),
+				'token'        => $binding->token,
+				'control_attr' => $binding->control_attr(),
 			];
 		}
 
 		return $properties;
+	}
+
+	/**
+	 * The per-variant resolved values for a block's set: `variant slug => ( property => literal CSS value )`,
+	 * so the editor can compare a control's current value against the selected variant's value to decide
+	 * bound-vs-overridden. Values are flattened literals (hex / length), matching the swatch feed — a control
+	 * cannot compare against a `var()` chain. A variant whose resolution fails (undefined in this set) is
+	 * skipped, so one bad variant never empties the map.
+	 *
+	 * @since TBD
+	 *
+	 * @param string   $block The block name.
+	 * @param string   $slug  The token set slug.
+	 * @param string[] $names The variant slugs to resolve, in catalog order.
+	 *
+	 * @return array<string, array<string, string>> variant slug => ( property => literal value ).
+	 */
+	private function values_for( string $block, string $slug, array $names ): array {
+		$values = [];
+
+		foreach ( $names as $name ) {
+			try {
+				$values[ $name ] = $this->variants->resolve_literal( $block, $name, $slug );
+			} catch ( Unknown_Variant_Exception $e ) {
+				continue; // Variant undefined in this set — skip, fail soft.
+			}
+		}
+
+		return $values;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Registry/Binding.php
+++ b/includes/resources/Design_Tokens/Registry/Binding.php
@@ -25,6 +25,9 @@ use InvalidArgumentException;
  * one tokens use, with three additions — `block_attr`, `css_prop`, and `css_selector`, which tokens
  * never carry.
  *
+ * A binding may also declare `control_attr`, editor-only metadata kept out of the projection set — see
+ * {@see Binding::control_attr()}.
+ *
  * @since TBD
  */
 final class Binding {
@@ -104,6 +107,19 @@ final class Binding {
 	private const CSS_SELECTOR = 'css_selector';
 
 	/**
+	 * Editor-only target: the block attribute the editor control for this property writes, so the
+	 * indicator layer can tell whether a control is bound to the active variant or has been overridden.
+	 * Deliberately NOT a projection target — it is excluded from STRING_TARGETS / inline_targets(), so it
+	 * never enters $projections and effective_projections() never emits it. That is what keeps a bound but
+	 * untouched attribute EMPTY (nothing is seeded), which the editor's "empty = bound" detection relies on.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const CONTROL_ATTR = 'control_attr';
+
+	/**
 	 * The inline string targets and their validation: each, when present, must be a non-empty string.
 	 *
 	 * @since TBD
@@ -141,16 +157,28 @@ final class Binding {
 	public array $projections;
 
 	/**
+	 * The block attribute the editor control for this property writes, or null when the binding declares
+	 * none. Editor-only metadata; kept out of $projections on purpose so no projector seeds it.
+	 *
 	 * @since TBD
 	 *
-	 * @param string               $property    The block property this binding drives.
-	 * @param string|null          $token       Referenced token id, or null when inline.
-	 * @param array<string, mixed> $projections Inline projection targets, empty when a token reference.
+	 * @var string|null
 	 */
-	private function __construct( string $property, ?string $token, array $projections ) {
-		$this->property    = $property;
-		$this->token       = $token;
-		$this->projections = $projections;
+	public ?string $control_attr;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param string               $property     The block property this binding drives.
+	 * @param string|null          $token        Referenced token id, or null when inline.
+	 * @param array<string, mixed> $projections  Inline projection targets, empty when a token reference.
+	 * @param string|null          $control_attr The editor control attribute, or null when none declared.
+	 */
+	private function __construct( string $property, ?string $token, array $projections, ?string $control_attr ) {
+		$this->property     = $property;
+		$this->token        = $token;
+		$this->projections  = $projections;
+		$this->control_attr = $control_attr;
 	}
 
 	/**
@@ -189,7 +217,7 @@ final class Binding {
 			);
 		}
 
-		return new self( $property, $token, $inline );
+		return new self( $property, $token, $inline, self::control_attr_of( $property, $spec ) );
 	}
 
 	/**
@@ -228,6 +256,19 @@ final class Binding {
 		$attribute = $this->projections[ self::BLOCK_ATTR ] ?? null;
 
 		return is_string( $attribute ) ? $attribute : null;
+	}
+
+	/**
+	 * The block attribute the editor control for this property writes, or null when the binding declares
+	 * none. Editor-only: read by the variant catalog so the indicator layer can key an override signal to a
+	 * control. Unlike block_attr(), this is NOT a projection target and never seeds an attribute default.
+	 *
+	 * @since TBD
+	 *
+	 * @return string|null
+	 */
+	public function control_attr(): ?string {
+		return $this->control_attr;
 	}
 
 	/**
@@ -305,5 +346,35 @@ final class Binding {
 		}
 
 		return $inline;
+	}
+
+	/**
+	 * Extract and validate the editor-only control attribute from a binding declaration. Kept separate from
+	 * inline_targets() on purpose: control_attr is NOT a projection target, so it must never reach
+	 * $projections (and hence effective_projections()).
+	 *
+	 * @since TBD
+	 *
+	 * @param string               $property The block property, for error messages.
+	 * @param array<string, mixed> $spec     The binding declaration.
+	 *
+	 * @throws InvalidArgumentException When the control attribute is present but not a non-empty string.
+	 *
+	 * @return string|null The control attribute, or null when the declaration omits it.
+	 */
+	private static function control_attr_of( string $property, array $spec ): ?string {
+		if ( ! array_key_exists( self::CONTROL_ATTR, $spec ) ) {
+			return null;
+		}
+
+		$value = $spec[ self::CONTROL_ATTR ];
+
+		if ( ! is_string( $value ) || $value === '' ) {
+			throw new InvalidArgumentException(
+				sprintf( 'Binding "%s" target "%s" must be a non-empty string.', $property, self::CONTROL_ATTR )
+			);
+		}
+
+		return $value;
 	}
 }

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -274,11 +274,26 @@ return [
 			'block'    => 'kadence/singlebtn',
 			'label'    => __( 'Style', 'kadence-blocks' ), // a picker-driven set; this is the editor control's label.
 			'bindings' => [
-				'button-bg'         => [ 'kadence_slot' => 'palette-btn-bg' ],
-				'button-text'       => [ 'kadence_slot' => 'palette-btn' ],
-				'button-bg-hover'   => [ 'kadence_slot' => 'palette-btn-bg-hover' ],
-				'button-text-hover' => [ 'kadence_slot' => 'palette-btn-hover' ],
-				'button-radius'     => [ 'css_var' => 'kb-btn-radius' ], // drives --kb-btn-radius so a variant can vary the radius.
+				'button-bg'         => [
+					'kadence_slot' => 'palette-btn-bg',
+					'control_attr' => 'background',
+				],
+				'button-text'       => [
+					'kadence_slot' => 'palette-btn',
+					'control_attr' => 'color',
+				],
+				'button-bg-hover'   => [
+					'kadence_slot' => 'palette-btn-bg-hover',
+					'control_attr' => 'backgroundHover',
+				],
+				'button-text-hover' => [
+					'kadence_slot' => 'palette-btn-hover',
+					'control_attr' => 'colorHover',
+				],
+				'button-radius'     => [
+					'css_var'      => 'kb-btn-radius', // drives --kb-btn-radius so a variant can vary the radius.
+					'control_attr' => 'borderRadius',
+				],
 			],
 		],
 		[

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Variant_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Variant_CatalogTest.php
@@ -132,4 +132,31 @@ final class Variant_CatalogTest extends TestCase {
 
 		$this->assertSame( [], $catalog['sets'][ Token_Store::default_slug() ] );
 	}
+
+	/**
+	 * The Button catalog surfaces each bound property's control attribute and a per-variant resolved-value
+	 * map, so the editor can key an override indicator to a control and compare against the variant value.
+	 *
+	 * @return void
+	 */
+	public function testItSurfacesControlAttrAndPerVariantValues(): void {
+		$button = $this->catalog->all()['sets'][ Token_Store::default_slug() ][ self::BUTTON ];
+
+		$by_key = [];
+		foreach ( $button['properties'] as $property ) {
+			$by_key[ $property['key'] ] = $property;
+		}
+
+		$this->assertSame( 'background', $by_key['button-bg']['control_attr'] );
+		$this->assertSame( 'color', $by_key['button-text']['control_attr'] );
+		$this->assertSame( 'backgroundHover', $by_key['button-bg-hover']['control_attr'] );
+		$this->assertSame( 'colorHover', $by_key['button-text-hover']['control_attr'] );
+		$this->assertSame( 'borderRadius', $by_key['button-radius']['control_attr'] );
+
+		// Per-variant resolved values, keyed by variant slug then property id.
+		$this->assertArrayHasKey( 'primary', $button['values'] );
+		$this->assertArrayHasKey( 'secondary', $button['values'] );
+		$this->assertArrayHasKey( 'button-bg', $button['values']['primary'] );
+		$this->assertNotSame( '', $button['values']['primary']['button-bg'] );
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Registry/BindingTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/BindingTest.php
@@ -184,4 +184,52 @@ final class BindingTest extends TestCase {
 
 		Binding::from_array( 'button-radius', [ 'css_var' => false ] );
 	}
+
+	/**
+	 * A binding parses control_attr into its own field, exposed via control_attr(), separate from the
+	 * projection targets.
+	 *
+	 * @return void
+	 */
+	public function testItParsesTheControlAttrField(): void {
+		$binding = Binding::from_array(
+			'button-bg',
+			[
+				'kadence_slot' => 'palette-btn-bg',
+				'control_attr' => 'background',
+			]
+		);
+
+		$this->assertSame( 'background', $binding->control_attr() );
+		// control_attr is editor-only metadata and must not leak into the projection targets.
+		$this->assertArrayNotHasKey( 'control_attr', $binding->projections );
+	}
+
+	/**
+	 * A binding with no control_attr declaration exposes null.
+	 *
+	 * @return void
+	 */
+	public function testControlAttrIsNullWhenAbsent(): void {
+		$binding = Binding::from_array( 'button-bg', [ 'kadence_slot' => 'palette-btn-bg' ] );
+
+		$this->assertNull( $binding->control_attr() );
+	}
+
+	/**
+	 * An empty-string control_attr is rejected, matching the inline-target validation.
+	 *
+	 * @return void
+	 */
+	public function testItRejectsAnEmptyControlAttr(): void {
+		$this->expectException( InvalidArgumentException::class );
+
+		Binding::from_array(
+			'button-bg',
+			[
+				'kadence_slot' => 'palette-btn-bg',
+				'control_attr' => '',
+			]
+		);
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Token_Registry_VariantsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Token_Registry_VariantsTest.php
@@ -32,11 +32,15 @@ final class Token_Registry_VariantsTest extends TestCase {
 			[
 				'block'    => 'kadence/advancedbtn',
 				'bindings' => [
-					'button-bg'      => [ 'token' => 'semantic.color.button-bg' ],
-					'button-border'  => [ 'kadence_slot' => 'palette3' ],
-					'button-bg-attr' => [
+					'button-bg'         => [ 'token' => 'semantic.color.button-bg' ],
+					'button-border'     => [ 'kadence_slot' => 'palette3' ],
+					'button-bg-attr'    => [
 						'token'      => 'semantic.color.button-bg',
 						'block_attr' => 'background',
+					],
+					'button-bg-control' => [
+						'token'        => 'semantic.color.button-bg',
+						'control_attr' => 'background',
 					],
 				],
 			]
@@ -105,5 +109,30 @@ final class Token_Registry_VariantsTest extends TestCase {
 		$binding = $registry->for_block( 'kadence/advancedbtn' )->binding( 'button-bg' );
 
 		$this->assertSame( [], $registry->effective_projections( $binding ) );
+	}
+
+	/**
+	 * A binding's control_attr never appears in its effective projections, so no projector (including the
+	 * block-preset seeder) ever sees it and nothing is seeded from it — the guarantee the editor's
+	 * "empty = bound" detection depends on.
+	 *
+	 * @return void
+	 */
+	public function testEffectiveProjectionsExcludeControlAttr(): void {
+		$registry = $this->registry();
+		$binding  = $registry->for_block( 'kadence/advancedbtn' )->binding( 'button-bg-control' );
+
+		$this->assertSame( 'background', $binding->control_attr() );
+
+		$projections = $registry->effective_projections( $binding );
+
+		$this->assertSame(
+			[
+				'kadence_slot' => 'palette1',
+				'wp_preset'    => 'color',
+			],
+			$projections
+		);
+		$this->assertArrayNotHasKey( 'control_attr', $projections );
 	}
 }


### PR DESCRIPTION
🎫 https://linear.app/nexcess/issue/SOFT-3849/design-system-control-mapping-and-indicators-button-first

Phase 1 of 4 (stacked). Base: `SOFT-3849/base`.

## Summary

Adds the property → editor-control map that the indicator layer (later phases) reads, without disturbing any projection.

- **New editor-only `control_attr` field on `Binding`** — a private const + `control_attr()` accessor, parsed in `from_array()`. It is deliberately **excluded** from the projection vocabulary (`STRING_TARGETS` / `inline_targets()` / `$projections`), so `Token_Registry::effective_projections()` never emits it and `Block_Preset\Projector` never seeds a block attribute from it. This is the interlock the whole feature rests on: because nothing seeds these attributes, a bound-but-untouched button control keeps its attribute **empty**, which the editor's "empty = bound" detection depends on. (Reusing the existing `block_attr` projection slot would have seeded the attribute and broken that detection.)
- **Declares `control_attr` on the `kadence/singlebtn` bindings** — `button-bg` → `background`, `button-text` → `color`, `button-bg-hover` → `backgroundHover`, `button-text-hover` → `colorHover`, `button-radius` → `borderRadius`. No `block_attr` is added. `core/button` is intentionally untouched (follow-up).
- **Surfaces the map to the editor** — `Variant_Catalog::properties_for()` now carries `control_attr` per property, and a new `values_for()` helper (called from `for_set()`) adds each variant's resolved literal values keyed by property, so the editor can compare a control's value against the selected variant's value.

## Test plan

- `vendor/bin/phpstan analyse` (level max) green; `phpstan-baseline.neon` untouched.
- wpunit (via slic): `Resources/Design_Tokens/Registry/BindingTest`, `Resources/Design_Tokens/Registry/Token_Registry_VariantsTest` (incl. the guardrail asserting `control_attr` never appears in `effective_projections()`), `Resources/Design_Tokens/Editor/Variant_CatalogTest`.
- After merge, flush the baseline cache (`redis-cli flushall`) and confirm a freshly inserted Single Button has **empty** `background` / `color` / `borderRadius` attributes.
