### PR TITLE
[DTM] SOFT-3849 [2/5]: token-indicators binding/override state

### DIFF
--- a/src/extension/token-indicators/__tests__/normalize.test.js
+++ b/src/extension/token-indicators/__tests__/normalize.test.js
@@ -1,0 +1,113 @@
+/* eslint-env jest */
+import { isEmptyValue, matchesVariant, normalizeColor, normalizeDimension } from '../normalize';
+
+describe('normalizeColor', () => {
+	beforeEach(() => {
+		window.kadence_blocks_params = {
+			global_colors: {
+				'--global-palette1': '#3182CE',
+				'--global-palette3': '#1A202C',
+			},
+		};
+	});
+
+	afterEach(() => {
+		delete window.kadence_blocks_params;
+	});
+
+	it('resolves a paletteN slug to its mapped literal, lower-cased', () => {
+		expect(normalizeColor('palette1')).toBe('#3182ce');
+	});
+
+	it('passes a literal through, lower-cased', () => {
+		expect(normalizeColor('#3182CE')).toBe('#3182ce');
+	});
+
+	it('passes an unresolved slug through as itself (degrade safe)', () => {
+		expect(normalizeColor('palette9')).toBe('palette9');
+	});
+
+	it('returns an empty string for an empty value', () => {
+		expect(normalizeColor('')).toBe('');
+	});
+});
+
+describe('matchesVariant color', () => {
+	beforeEach(() => {
+		window.kadence_blocks_params = {
+			global_colors: { '--global-palette3': '#3182CE' },
+		};
+	});
+
+	afterEach(() => {
+		delete window.kadence_blocks_params;
+	});
+
+	it('matches when a stored palette slug resolves to the variant literal', () => {
+		expect(matchesVariant('color', 'palette3', '', '#3182ce')).toBe(true);
+	});
+
+	it('does not match when the stored literal differs from the variant literal', () => {
+		expect(matchesVariant('color', '#ffffff', '', '#3182ce')).toBe(false);
+	});
+});
+
+describe('matchesVariant dimension', () => {
+	it('matches a uniform 4-side array against the variant value + unit', () => {
+		expect(matchesVariant('dimension', ['8', '8', '8', '8'], 'px', '8px')).toBe(true);
+	});
+
+	it('matches a scalar value against the variant value + unit', () => {
+		expect(matchesVariant('dimension', '8', 'px', '8px')).toBe(true);
+	});
+
+	it('does not match a per-corner override where one side differs', () => {
+		expect(matchesVariant('dimension', ['8', '8', '8', '4'], 'px', '8px')).toBe(false);
+	});
+
+	it('does not match when the value matches but the unit differs', () => {
+		expect(matchesVariant('dimension', ['8', '8', '8', '8'], 'rem', '8px')).toBe(false);
+	});
+
+	it('does not match a different value with the same unit', () => {
+		expect(matchesVariant('dimension', ['8', '8', '8', '8'], 'px', '1.5rem')).toBe(false);
+	});
+});
+
+describe('matchesVariant text', () => {
+	it('matches trimmed equal strings', () => {
+		expect(matchesVariant('text', ' bold ', '', 'bold')).toBe(true);
+	});
+
+	it('does not match differing strings', () => {
+		expect(matchesVariant('text', 'bold', '', 'normal')).toBe(false);
+	});
+});
+
+describe('isEmptyValue', () => {
+	it('treats an empty color string as empty', () => {
+		expect(isEmptyValue('color', '')).toBe(true);
+	});
+
+	it('treats an all-empty 4-side dimension array as empty', () => {
+		expect(isEmptyValue('dimension', ['', '', '', ''])).toBe(true);
+	});
+
+	it('treats a populated dimension side as not empty', () => {
+		expect(isEmptyValue('dimension', ['8', '', '', ''])).toBe(false);
+	});
+
+	it('treats a populated color as not empty', () => {
+		expect(isEmptyValue('color', 'palette3')).toBe(false);
+	});
+});
+
+describe('normalizeDimension', () => {
+	it('returns an empty marker for an all-empty array', () => {
+		expect(normalizeDimension(['', '', '', ''], 'px')).toEqual({ value: '', unit: '' });
+	});
+
+	it('pairs the first populated side with its unit', () => {
+		expect(normalizeDimension(['8', '8', '8', '8'], 'px')).toEqual({ value: '8', unit: 'px' });
+	});
+});

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -1,0 +1,126 @@
+/**
+ * Editor binding/override state for design-token-mapped controls.
+ *
+ * `useVariantBinding` computes, for the block's currently selected variant, a per-attribute map the
+ * indicator layer reads: whether each mapped control is bound to the active variant and whether it has
+ * been overridden away from it, plus the variant's resolved value so a reset knows what to restore to.
+ *
+ * Detection matches how a block is bound. Buttons bind via CSS retarget, so a bound-but-untouched
+ * attribute stays EMPTY — there `empty => bound`, `non-empty && value != variantValue => overridden`.
+ * (A block that binds by seeding a block attribute — image's borderRadius — is never empty; there the
+ * test is a pure value-compare. This module keeps `variantValue` as the primary signal so that path is a
+ * one-line change when a seeded block is wired later. See the Phase 3 recipe caveat.)
+ */
+
+import { get } from 'lodash';
+import { activeSet, blockProperties, blockVariantValues } from '../variant-picker';
+import { isEmptyValue, matchesVariant } from './normalize';
+
+/**
+ * The companion unit attribute for a dimension control, by convention `${attr}Unit` (e.g. `borderRadius`
+ * -> `borderRadiusUnit`). Returns '' for non-dimension kinds.
+ *
+ * @param {string} kind The property kind.
+ * @param {string} attr The primary attribute name.
+ * @return {string} The unit attribute name, or ''.
+ */
+function unitAttrFor(kind, attr) {
+	return kind === 'dimension' ? `${attr}Unit` : '';
+}
+
+/**
+ * The default variant slug to fall back to when the block has no explicit `kbVariant`: the first variant
+ * present in the resolved-values map (the catalog lists them in default-first order). '' when none.
+ *
+ * @param {Object} values The per-variant value map.
+ * @return {string} The fallback variant slug, or ''.
+ */
+function defaultVariantFor(values) {
+	const slugs = Object.keys(values || {});
+
+	return slugs.length ? slugs[0] : '';
+}
+
+/**
+ * The design-token binding state for a block's mapped controls, keyed by the control's attribute name.
+ *
+ * @param {string} blockName  The block name (e.g. 'kadence/singlebtn').
+ * @param {Object} attributes The block's current attributes.
+ * @return {Object} attrName => { property, token, kind, variantValue, bound, overridden }.
+ */
+export function useVariantBinding(blockName, attributes) {
+	const set = get(attributes, 'kbTokenSet', '') || activeSet();
+	const selected = get(attributes, 'kbVariant', '');
+	const properties = blockProperties(blockName, set);
+	const values = blockVariantValues(blockName, set);
+
+	// The variant whose surface drives the indicators: the explicit selection, or the block's default
+	// look when none is chosen. When neither resolves, no control is bound.
+	const activeVariant = selected || defaultVariantFor(values);
+	const variantValues = get(values, activeVariant, {});
+
+	const state = {};
+
+	properties.forEach((property) => {
+		const attr = property.control_attr;
+
+		// A property with no mapped control attribute, or one the active variant does not define, is not
+		// surfaced — only a property the selected variant sets is "bound" (the variant-set collapse
+		// interlock: the per-variant surface, not just the block's full property list, gates binding).
+		if (!attr || !(property.key in variantValues)) {
+			return;
+		}
+
+		const kind = property.kind;
+		const variantValue = variantValues[property.key];
+		const value = get(attributes, attr, '');
+		const unit = unitAttrFor(kind, attr) ? get(attributes, unitAttrFor(kind, attr), '') : '';
+
+		const empty = isEmptyValue(kind, value);
+		const overridden = !empty && !matchesVariant(kind, value, unit, variantValue);
+
+		state[attr] = {
+			property: property.key,
+			token: property.token,
+			kind,
+			variantValue,
+			bound: true,
+			overridden,
+		};
+	});
+
+	return state;
+}
+
+/**
+ * Clear a mapped control's attribute(s) so the block falls back to the existing variant-scoped CSS (the
+ * `.wp-block-*.kb-variant--<variant>` retarget) or the preset default — no new render path. A `color`/
+ * `text` control clears its single attribute to `''`. A `dimension` control (e.g. `borderRadius`) also
+ * clears its unit companion and its `tablet*`/`mobile*` companions by convention; the primary and
+ * companion array attributes reset to the block's declared default shape — a 4-side
+ * `['', '', '', '']` array, per `block.json` (e.g. `borderRadius`, `tabletBorderRadius`,
+ * `mobileBorderRadius`) — not a bare `''`, and the unit resets to `'px'` (`borderRadiusUnit`'s declared
+ * default), not `''`.
+ *
+ * @param {string}   attr          The primary attribute name.
+ * @param {Function} setAttributes The block's setAttributes.
+ * @param {string}   kind          The property kind, so a dimension also clears its companions.
+ * @return {void}
+ */
+export function resetAttr(attr, setAttributes, kind) {
+	if (kind !== 'dimension') {
+		setAttributes({ [attr]: '' });
+
+		return;
+	}
+
+	const capitalized = attr.charAt(0).toUpperCase() + attr.slice(1);
+	const emptySides = ['', '', '', ''];
+
+	setAttributes({
+		[attr]: emptySides,
+		[`${attr}Unit`]: 'px',
+		[`tablet${capitalized}`]: emptySides,
+		[`mobile${capitalized}`]: emptySides,
+	});
+}

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -13,7 +13,7 @@
  */
 
 import { get } from 'lodash';
-import { activeSet, blockProperties, blockVariantValues } from '../variant-picker';
+import { activeSet, blockDefaultVariant, blockProperties, blockVariantValues } from '../variant-picker';
 import { isEmptyValue, matchesVariant } from './normalize';
 
 /**
@@ -29,19 +29,6 @@ function unitAttrFor(kind, attr) {
 }
 
 /**
- * The default variant slug to fall back to when the block has no explicit `kbVariant`: the first variant
- * present in the resolved-values map (the catalog lists them in default-first order). '' when none.
- *
- * @param {Object} values The per-variant value map.
- * @return {string} The fallback variant slug, or ''.
- */
-function defaultVariantFor(values) {
-	const slugs = Object.keys(values || {});
-
-	return slugs.length ? slugs[0] : '';
-}
-
-/**
  * The design-token binding state for a block's mapped controls, keyed by the control's attribute name.
  *
  * @param {string} blockName  The block name (e.g. 'kadence/singlebtn').
@@ -54,9 +41,11 @@ export function useVariantBinding(blockName, attributes) {
 	const properties = blockProperties(blockName, set);
 	const values = blockVariantValues(blockName, set);
 
-	// The variant whose surface drives the indicators: the explicit selection, or the block's default
-	// look when none is chosen. When neither resolves, no control is bound.
-	const activeVariant = selected || defaultVariantFor(values);
+	// The variant whose surface drives the indicators: the explicit selection, or the set's authoritative
+	// default variant when none is chosen (kbVariant is '' on every freshly inserted block, so this
+	// fallback runs constantly and must use the catalog's declared default, not JSON key order). When
+	// neither resolves, no control is bound.
+	const activeVariant = selected || blockDefaultVariant(blockName, set);
 	const variantValues = get(values, activeVariant, {});
 
 	const state = {};

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -22,6 +22,9 @@ import { isEmptyValue, matchesVariant } from './normalize';
  *
  * @param {string} kind The property kind.
  * @param {string} attr The primary attribute name.
+ *
+ * @since TBD
+ *
  * @return {string} The unit attribute name, or ''.
  */
 function unitAttrFor(kind, attr) {
@@ -33,6 +36,9 @@ function unitAttrFor(kind, attr) {
  *
  * @param {string} blockName  The block name (e.g. 'kadence/singlebtn').
  * @param {Object} attributes The block's current attributes.
+ *
+ * @since TBD
+ *
  * @return {Object} attrName => { property, token, kind, variantValue, bound, overridden }.
  */
 export function useVariantBinding(blockName, attributes) {
@@ -94,6 +100,9 @@ export function useVariantBinding(blockName, attributes) {
  * @param {string}   attr          The primary attribute name.
  * @param {Function} setAttributes The block's setAttributes.
  * @param {string}   kind          The property kind, so a dimension also clears its companions.
+ *
+ * @since TBD
+ *
  * @return {void}
  */
 export function resetAttr(attr, setAttributes, kind) {

--- a/src/extension/token-indicators/normalize.js
+++ b/src/extension/token-indicators/normalize.js
@@ -1,0 +1,150 @@
+/**
+ * Kind-aware value normalization for the design-token indicator's bound-vs-overridden compare.
+ *
+ * A control's stored attribute value and the selected variant's resolved value are compared after being
+ * reduced to a canonical form per `kind`:
+ *   - `color`      — a Kadence palette slug (`palette3`) is resolved to its literal via the global
+ *                    palette map, then lower-cased; a literal (`#3182CE`, `rgb(...)`) is lower-cased.
+ *   - `dimension`  — the numeric value is paired with its unit (`{ value, unit }`), tolerant of the
+ *                    4-side array shape a measurement control writes.
+ *   - `text`       — trimmed string compare.
+ */
+
+import { get } from 'lodash';
+
+/**
+ * The editor's global color palette map (`paletteN -> literal color`). Kadence localizes the theme
+ * palette as `window.kadence_blocks_params.global_colors`, keyed by CSS custom-property name
+ * (`--global-palette1`..`--global-palette9`); this reader strips the `--global-` prefix so the map keys
+ * line up with the bare `paletteN` slug a color control writes into a block attribute (confirmed against
+ * `SinglePopColorControl`, the swatch component behind `PopColorControl`). Empty when the params are
+ * absent, so an unresolved slug simply compares as itself — the degrade-safe fallback.
+ *
+ * @return {Object} slug ('paletteN') => color literal.
+ */
+function paletteMap() {
+	const colors = get(window, ['kadence_blocks_params', 'global_colors'], {}) || {};
+
+	return Object.keys(colors).reduce((map, cssVar) => {
+		const slug = cssVar.replace(/^--global-/, '');
+
+		map[slug] = colors[cssVar];
+
+		return map;
+	}, {});
+}
+
+/**
+ * Resolve a color attribute value to a comparable literal: a `paletteN` slug becomes its mapped color;
+ * anything else passes through. Lower-cased so `#3182CE` and `#3182ce` compare equal. An unresolved slug
+ * (palette map missing the key) passes through as the slug itself, which degrades safe — it never
+ * produces a false match, at worst a false override.
+ *
+ * @param {*} value The stored color value (slug or literal), possibly empty.
+ * @return {string} The comparable literal, or '' when empty.
+ */
+export function normalizeColor(value) {
+	if (value === undefined || value === null || value === '') {
+		return '';
+	}
+
+	const literal = paletteMap()[value] || value;
+
+	return String(literal).trim().toLowerCase();
+}
+
+/**
+ * Normalize a dimension attribute to `{ value, unit }`. A measurement control writes a 4-side array
+ * (`[top, right, bottom, left]`); a uniform value is taken from the first defined side. An empty value
+ * yields an empty marker so "no override" is detectable.
+ *
+ * @param {*}      value The stored dimension value (number, string, or 4-side array).
+ * @param {string} unit  The companion unit attribute (e.g. `borderRadiusUnit`).
+ * @return {{ value: string, unit: string }} The canonical dimension, `value: ''` when empty.
+ */
+export function normalizeDimension(value, unit) {
+	let scalar = value;
+
+	if (Array.isArray(value)) {
+		scalar = value.find((side) => side !== '' && side !== undefined && side !== null);
+	}
+
+	if (scalar === undefined || scalar === null || scalar === '') {
+		return { value: '', unit: '' };
+	}
+
+	return { value: String(scalar).trim(), unit: String(unit || '').trim() };
+}
+
+/**
+ * Normalize a text attribute for compare.
+ *
+ * @param {*} value The stored value.
+ * @return {string} The trimmed string, or '' when empty.
+ */
+export function normalizeText(value) {
+	if (value === undefined || value === null) {
+		return '';
+	}
+
+	return String(value).trim();
+}
+
+/**
+ * Whether a stored attribute value is "empty" (untouched) for its kind — the signal a retarget-bound
+ * control uses for `empty => bound`.
+ *
+ * @param {string} kind  The property kind ('color' | 'dimension' | 'text').
+ * @param {*}      value The stored primary attribute value.
+ * @return {boolean} True when the value is unset/empty.
+ */
+export function isEmptyValue(kind, value) {
+	if (kind === 'dimension') {
+		return normalizeDimension(value, '').value === '';
+	}
+
+	return normalizeColor(value) === '' && normalizeText(value) === '';
+}
+
+/**
+ * Split a resolved dimension literal (`"1.5rem"`, `"8px"`, `"0"`) into `{ value, unit }` so it compares
+ * against the control's separate value/unit attributes.
+ *
+ * @param {string} literal The resolved dimension literal.
+ * @return {{ value: string, unit: string }} The parsed value and unit.
+ */
+function parseDimensionLiteral(literal) {
+	const match = String(literal || '')
+		.trim()
+		.match(/^(-?[\d.]+)\s*([a-z%]*)$/i);
+
+	if (!match) {
+		return { value: String(literal || '').trim(), unit: '' };
+	}
+
+	return { value: match[1], unit: match[2] };
+}
+
+/**
+ * Whether a stored value equals the selected variant's resolved value, normalized per kind.
+ *
+ * @param {string} kind         The property kind.
+ * @param {*}      value        The stored primary attribute value.
+ * @param {string} unit         The companion unit (dimension only; '' otherwise).
+ * @param {string} variantValue The variant's resolved literal for this property.
+ * @return {boolean} True when the stored value matches the variant value.
+ */
+export function matchesVariant(kind, value, unit, variantValue) {
+	if (kind === 'dimension') {
+		const stored = normalizeDimension(value, unit);
+		const variant = parseDimensionLiteral(variantValue);
+
+		return stored.value === variant.value && (stored.unit === variant.unit || variant.unit === '');
+	}
+
+	if (kind === 'color') {
+		return normalizeColor(value) === normalizeColor(variantValue);
+	}
+
+	return normalizeText(value) === normalizeText(variantValue);
+}

--- a/src/extension/token-indicators/normalize.js
+++ b/src/extension/token-indicators/normalize.js
@@ -20,6 +20,8 @@ import { get } from 'lodash';
  * `SinglePopColorControl`, the swatch component behind `PopColorControl`). Empty when the params are
  * absent, so an unresolved slug simply compares as itself — the degrade-safe fallback.
  *
+ * @since TBD
+ *
  * @return {Object} slug ('paletteN') => color literal.
  */
 function paletteMap() {
@@ -41,6 +43,9 @@ function paletteMap() {
  * produces a false match, at worst a false override.
  *
  * @param {*} value The stored color value (slug or literal), possibly empty.
+ *
+ * @since TBD
+ *
  * @return {string} The comparable literal, or '' when empty.
  */
 export function normalizeColor(value) {
@@ -60,6 +65,9 @@ export function normalizeColor(value) {
  * override yields one entry per touched side — the shape a side-aware compare needs.
  *
  * @param {*} value The stored dimension value (number, string, or 4-side array).
+ *
+ * @since TBD
+ *
  * @return {string[]} The populated sides as trimmed strings; empty array when nothing is set.
  */
 function dimensionSides(value) {
@@ -77,6 +85,9 @@ function dimensionSides(value) {
  *
  * @param {*}      value The stored dimension value (number, string, or 4-side array).
  * @param {string} unit  The companion unit attribute (e.g. `borderRadiusUnit`).
+ *
+ * @since TBD
+ *
  * @return {{ value: string, unit: string }} The canonical dimension, `value: ''` when empty.
  */
 export function normalizeDimension(value, unit) {
@@ -93,6 +104,9 @@ export function normalizeDimension(value, unit) {
  * Normalize a text attribute for compare.
  *
  * @param {*} value The stored value.
+ *
+ * @since TBD
+ *
  * @return {string} The trimmed string, or '' when empty.
  */
 export function normalizeText(value) {
@@ -109,6 +123,9 @@ export function normalizeText(value) {
  *
  * @param {string} kind  The property kind ('color' | 'dimension' | 'text').
  * @param {*}      value The stored primary attribute value.
+ *
+ * @since TBD
+ *
  * @return {boolean} True when the value is unset/empty.
  */
 export function isEmptyValue(kind, value) {
@@ -124,6 +141,9 @@ export function isEmptyValue(kind, value) {
  * against the control's separate value/unit attributes.
  *
  * @param {string} literal The resolved dimension literal.
+ *
+ * @since TBD
+ *
  * @return {{ value: string, unit: string }} The parsed value and unit.
  */
 function parseDimensionLiteral(literal) {
@@ -145,6 +165,9 @@ function parseDimensionLiteral(literal) {
  * @param {*}      value        The stored primary attribute value.
  * @param {string} unit         The companion unit (dimension only; '' otherwise).
  * @param {string} variantValue The variant's resolved literal for this property.
+ *
+ * @since TBD
+ *
  * @return {boolean} True when the stored value matches the variant value.
  */
 export function matchesVariant(kind, value, unit, variantValue) {

--- a/src/extension/token-indicators/normalize.js
+++ b/src/extension/token-indicators/normalize.js
@@ -54,26 +54,39 @@ export function normalizeColor(value) {
 }
 
 /**
+ * The populated sides of a stored dimension value, each trimmed to a string. A measurement control writes
+ * a 4-side array (`[top, right, bottom, left]`) where an untouched side is `''`; a scalar value is a
+ * single side. Empty/undefined sides are dropped, so an all-empty value yields `[]` and a per-corner
+ * override yields one entry per touched side — the shape a side-aware compare needs.
+ *
+ * @param {*} value The stored dimension value (number, string, or 4-side array).
+ * @return {string[]} The populated sides as trimmed strings; empty array when nothing is set.
+ */
+function dimensionSides(value) {
+	const raw = Array.isArray(value) ? value : [value];
+
+	return raw.filter((side) => side !== '' && side !== undefined && side !== null).map((side) => String(side).trim());
+}
+
+/**
  * Normalize a dimension attribute to `{ value, unit }`. A measurement control writes a 4-side array
- * (`[top, right, bottom, left]`); a uniform value is taken from the first defined side. An empty value
- * yields an empty marker so "no override" is detectable.
+ * (`[top, right, bottom, left]`); the representative value is the first populated side. An empty value
+ * yields an empty marker so "no override" is detectable. This is the scalar view used for empty
+ * detection and the single-value path; the bound-vs-overridden compare uses the side-aware `matchesVariant`
+ * so a per-corner override is not masked by a matching first side.
  *
  * @param {*}      value The stored dimension value (number, string, or 4-side array).
  * @param {string} unit  The companion unit attribute (e.g. `borderRadiusUnit`).
  * @return {{ value: string, unit: string }} The canonical dimension, `value: ''` when empty.
  */
 export function normalizeDimension(value, unit) {
-	let scalar = value;
+	const sides = dimensionSides(value);
 
-	if (Array.isArray(value)) {
-		scalar = value.find((side) => side !== '' && side !== undefined && side !== null);
-	}
-
-	if (scalar === undefined || scalar === null || scalar === '') {
+	if (!sides.length) {
 		return { value: '', unit: '' };
 	}
 
-	return { value: String(scalar).trim(), unit: String(unit || '').trim() };
+	return { value: sides[0], unit: String(unit || '').trim() };
 }
 
 /**
@@ -136,10 +149,20 @@ function parseDimensionLiteral(literal) {
  */
 export function matchesVariant(kind, value, unit, variantValue) {
 	if (kind === 'dimension') {
-		const stored = normalizeDimension(value, unit);
+		const sides = dimensionSides(value);
+		const storedUnit = String(unit || '').trim();
 		const variant = parseDimensionLiteral(variantValue);
 
-		return stored.value === variant.value && (stored.unit === variant.unit || variant.unit === '');
+		if (!sides.length) {
+			return false;
+		}
+
+		const unitMatches = variant.unit === '' || storedUnit === variant.unit;
+
+		// Side-aware: a stored dimension matches only when EVERY populated side equals the variant value.
+		// A per-corner override (e.g. `['8','8','8','4']` vs `8px`) leaves one side differing and so reads
+		// as overridden, not still-bound.
+		return unitMatches && sides.every((side) => side === variant.value);
 	}
 
 	if (kind === 'color') {

--- a/src/extension/variant-picker/index.js
+++ b/src/extension/variant-picker/index.js
@@ -77,14 +77,28 @@ export function blockVariantLabel(name, set) {
 }
 
 /**
- * The controllable surface for a block's set: one { key, kind, token } entry per bound property.
+ * The controllable surface for a block's set: one { key, kind, token, control_attr } entry per bound
+ * property.
  *
  * @param {string} name  The block name.
  * @param {string} [set] The token set slug; defaults to the active set.
- * @return {Array} The block's surface ([{ key, kind, token }]).
+ * @return {Array} The block's surface ([{ key, kind, token, control_attr }]).
  */
 export function blockProperties(name, set) {
 	return get(blockEntry(name, set), 'properties', []);
+}
+
+/**
+ * The per-variant resolved values for a block's set: `{ <variantSlug>: { <property>: literalValue } }`.
+ * Empty object when the block offers none. Used by the token-indicators hook to compare a control's
+ * current value against the selected variant's value.
+ *
+ * @param {string} name  The block name.
+ * @param {string} [set] The token set slug; defaults to the active set.
+ * @return {Object} The per-variant value map.
+ */
+export function blockVariantValues(name, set) {
+	return get(blockEntry(name, set), 'values', {}) || {};
 }
 
 /**

--- a/src/extension/variant-picker/index.js
+++ b/src/extension/variant-picker/index.js
@@ -95,6 +95,9 @@ export function blockProperties(name, set) {
  *
  * @param {string} name  The block name.
  * @param {string} [set] The token set slug; defaults to the active set.
+ *
+ * @since TBD
+ *
  * @return {Object} The per-variant value map.
  */
 export function blockVariantValues(name, set) {


### PR DESCRIPTION
🎫 https://linear.app/nexcess/issue/SOFT-3849/design-system-control-mapping-and-indicators-button-first

Phase 2 of 4 (stacked). Base: `SOFT-3849/phase-1-php-control-attr-and-catalog`.

## Summary

The editor-side binding/override state, as a new module `src/extension/token-indicators/`.

- **`useVariantBinding(blockName, attributes)`** — reads the selected `kbVariant` slug and the flat catalog on `window.kadenceDesignTokensVariants`, resolves the selected variant's property surface, and returns `attrName => { property, token, kind, variantValue, bound, overridden }`.
- **`resetAttr(attr, setAttributes, kind)`** — clears a mapped attribute (and its unit / responsive companions) back to its empty default, so the block falls back to the existing variant-scoped CSS. No new render path.
- **Kind-aware detection** — buttons bind via CSS retarget, so a bound-but-untouched attribute is empty: `empty ⇒ bound`, `non-empty && value ≠ variantValue ⇒ overridden`. Color comparison resolves both sides to a literal first (an attribute may hold a `paletteN` slug while the variant value is a literal); unresolved slugs degrade safe to "override". The seeded-attribute branch (for future `block_attr`-bound blocks like image) is documented in comments but not implemented.
- **`blockVariantValues()` catalog reader** for the per-variant `values` shape added in Phase 1.

## Test plan

- `npm run lint-js` (eslint) and cspell green on the new module.
- Production `npm run build` compiles.
- Behavioral verification lands with Phase 3 (the UI that consumes this hook).
