### PR TITLE
[DTM] SOFT-3849 [3/5]: indicator UI + singlebtn wiring

### DIFF
--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -87,6 +87,9 @@ import BackendStyles from './components/backend-styles';
 import { VariantPicker, blockVariants, activeSet } from '../../extension/variant-picker';
 import { VariantActions } from '../../extension/variant-picker/VariantActions';
 import { TokenSetPicker, selectableSets } from '../../extension/token-set-picker';
+import { useVariantBinding, resetAttr } from '../../extension/token-indicators';
+import { TokenLabel } from '../../extension/token-indicators/components/TokenLabel';
+import { TokenControlRow } from '../../extension/token-indicators/components/TokenControlRow';
 
 export default function KadenceButtonEdit(props) {
 	const { attributes, setAttributes, isSelected, context, clientId, name } = props;
@@ -263,6 +266,11 @@ export default function KadenceButtonEdit(props) {
 	);
 	const marginMouseOver = mouseOverVisualizer();
 	const paddingMouseOver = mouseOverVisualizer();
+
+	// Design-token indicators: the per-attribute bound/overridden state for the selected variant, plus a
+	// reset that clears the mapped attribute back to the variant value (served by the existing scoped CSS).
+	const tokenBinding = useVariantBinding('kadence/singlebtn', attributes);
+	const resetToken = (attr) => resetAttr(attr, setAttributes, tokenBinding[attr]?.kind);
 
 	useEffect(() => {
 		setAttributes({ inQueryBlock: getInQueryBlock(context, inQueryBlock) });
@@ -903,15 +911,23 @@ export default function KadenceButtonEdit(props) {
 															/>
 														)}
 														{'normal' === textBackgroundHoverType && (
-															<PopColorControl
-																key={'btncolorhover'}
-																label={__('Color Hover', 'kadence-blocks')}
-																value={colorHover ? colorHover : ''}
-																default={''}
-																onChange={(value) =>
-																	setAttributes({ colorHover: value })
-																}
-															/>
+															// TODO: confirm exact placement vs Figma node 160-12291
+															<TokenControlRow
+																heading={__('Color Hover', 'kadence-blocks')}
+																attr="colorHover"
+																binding={tokenBinding}
+																onReset={resetToken}
+															>
+																<PopColorControl
+																	key={'btncolorhover'}
+																	label={__('Color Hover', 'kadence-blocks')}
+																	value={colorHover ? colorHover : ''}
+																	default={''}
+																	onChange={(value) =>
+																		setAttributes({ colorHover: value })
+																	}
+																/>
+															</TokenControlRow>
 														)}
 														<BackgroundTypeControl
 															label={__('Background Hover Type', 'kadence-blocks')}
@@ -931,15 +947,23 @@ export default function KadenceButtonEdit(props) {
 															/>
 														)}
 														{'normal' === backgroundHoverType && (
-															<PopColorControl
-																key={'btnbghover'}
-																label={__('Background Color', 'kadence-blocks')}
-																value={backgroundHover ? backgroundHover : ''}
-																default={''}
-																onChange={(value) =>
-																	setAttributes({ backgroundHover: value })
-																}
-															/>
+															// TODO: confirm exact placement vs Figma node 160-12291
+															<TokenControlRow
+																heading={__('Background Color', 'kadence-blocks')}
+																attr="backgroundHover"
+																binding={tokenBinding}
+																onReset={resetToken}
+															>
+																<PopColorControl
+																	key={'btnbghover'}
+																	label={__('Background Color', 'kadence-blocks')}
+																	value={backgroundHover ? backgroundHover : ''}
+																	default={''}
+																	onChange={(value) =>
+																		setAttributes({ backgroundHover: value })
+																	}
+																/>
+															</TokenControlRow>
 														)}
 														<ResponsiveBorderControl
 															label={__('Border', 'kadence-blocks')}
@@ -1100,13 +1124,23 @@ export default function KadenceButtonEdit(props) {
 															/>
 														)}
 														{'normal' === textBackgroundType && (
-															<PopColorControl
-																key={'btncolor'}
-																label={__('Color', 'kadence-blocks')}
-																value={color ? color : ''}
-																default={''}
-																onChange={(value) => setAttributes({ color: value })}
-															/>
+															// TODO: confirm exact placement vs Figma node 160-12291
+															<TokenControlRow
+																heading={__('Color', 'kadence-blocks')}
+																attr="color"
+																binding={tokenBinding}
+																onReset={resetToken}
+															>
+																<PopColorControl
+																	key={'btncolor'}
+																	label={__('Color', 'kadence-blocks')}
+																	value={color ? color : ''}
+																	default={''}
+																	onChange={(value) =>
+																		setAttributes({ color: value })
+																	}
+																/>
+															</TokenControlRow>
 														)}
 														<BackgroundTypeControl
 															label={__('Background Type', 'kadence-blocks')}
@@ -1124,15 +1158,23 @@ export default function KadenceButtonEdit(props) {
 															/>
 														)}
 														{'normal' === backgroundType && (
-															<PopColorControl
-																key={'btnbg'}
-																label={__('Background Color', 'kadence-blocks')}
-																value={background ? background : ''}
-																default={''}
-																onChange={(value) =>
-																	setAttributes({ background: value })
-																}
-															/>
+															// TODO: confirm exact placement vs Figma node 160-12291
+															<TokenControlRow
+																heading={__('Background Color', 'kadence-blocks')}
+																attr="background"
+																binding={tokenBinding}
+																onReset={resetToken}
+															>
+																<PopColorControl
+																	key={'btnbg'}
+																	label={__('Background Color', 'kadence-blocks')}
+																	value={background ? background : ''}
+																	default={''}
+																	onChange={(value) =>
+																		setAttributes({ background: value })
+																	}
+																/>
+															</TokenControlRow>
 														)}
 														<ResponsiveBorderControl
 															label={__('Border', 'kadence-blocks')}
@@ -1148,7 +1190,14 @@ export default function KadenceButtonEdit(props) {
 															}
 														/>
 														<ResponsiveMeasurementControls
-															label={__('Border Radius', 'kadence-blocks')}
+															label={
+																<TokenLabel
+																	text={__('Border Radius', 'kadence-blocks')}
+																	attr="borderRadius"
+																	binding={tokenBinding}
+																	onReset={resetToken}
+																/>
+															}
 															value={borderRadius}
 															tabletValue={tabletBorderRadius}
 															mobileValue={mobileBorderRadius}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -920,7 +920,7 @@ export default function KadenceButtonEdit(props) {
 															>
 																<PopColorControl
 																	key={'btncolorhover'}
-																	label={__('Color Hover', 'kadence-blocks')}
+																	swatchLabel={__('Color Hover', 'kadence-blocks')}
 																	value={colorHover ? colorHover : ''}
 																	default={''}
 																	onChange={(value) =>
@@ -956,7 +956,10 @@ export default function KadenceButtonEdit(props) {
 															>
 																<PopColorControl
 																	key={'btnbghover'}
-																	label={__('Background Color', 'kadence-blocks')}
+																	swatchLabel={__(
+																		'Background Color',
+																		'kadence-blocks'
+																	)}
 																	value={backgroundHover ? backgroundHover : ''}
 																	default={''}
 																	onChange={(value) =>
@@ -1133,7 +1136,7 @@ export default function KadenceButtonEdit(props) {
 															>
 																<PopColorControl
 																	key={'btncolor'}
-																	label={__('Color', 'kadence-blocks')}
+																	swatchLabel={__('Color', 'kadence-blocks')}
 																	value={color ? color : ''}
 																	default={''}
 																	onChange={(value) =>
@@ -1167,7 +1170,10 @@ export default function KadenceButtonEdit(props) {
 															>
 																<PopColorControl
 																	key={'btnbg'}
-																	label={__('Background Color', 'kadence-blocks')}
+																	swatchLabel={__(
+																		'Background Color',
+																		'kadence-blocks'
+																	)}
 																	value={background ? background : ''}
 																	default={''}
 																	onChange={(value) =>

--- a/src/extension/token-indicators/components/TokenControlRow.js
+++ b/src/extension/token-indicators/components/TokenControlRow.js
@@ -1,0 +1,34 @@
+/**
+ * A row wrapper that places the design-system indicator BESIDE a control whose `label` prop is not
+ * rendered as visible content (e.g. `PopColorControl`, which forwards `label` to a Button tooltip). The
+ * wrapped control is passed through as children with all its own props intact; only an adjacent indicator
+ * (and an optional heading) is added. Renders just the children when the attribute is not mapped for the
+ * selected variant, so an unmapped control looks identical to today.
+ */
+
+import { TokenIndicator } from './TokenIndicator';
+
+/**
+ * A control wrapped with an adjacent design-token indicator.
+ *
+ * @param {Object}   props           The component props.
+ * @param {string}   [props.heading] Optional heading text shown next to the indicator, above the control.
+ * @param {string}   props.attr      The attribute the wrapped control writes (the indicator's key).
+ * @param {Object}   props.binding   The block's binding map from useVariantBinding.
+ * @param {Function} props.onReset   Called with `attr` to reset that control's override.
+ * @param {Object}   props.children  The wrapped control element, rendered untouched.
+ * @return {Object} The wrapped control with its adjacent indicator.
+ */
+export function TokenControlRow({ heading, attr, binding, onReset, children }) {
+	const state = binding ? binding[attr] : undefined;
+
+	return (
+		<div className="kb-token-control-row">
+			<div className="kb-token-control-row__header">
+				{heading ? <span className="kb-token-control-row__heading">{heading}</span> : null}
+				<TokenIndicator state={state} onReset={() => onReset(attr)} />
+			</div>
+			{children}
+		</div>
+	);
+}

--- a/src/extension/token-indicators/components/TokenControlRow.js
+++ b/src/extension/token-indicators/components/TokenControlRow.js
@@ -17,6 +17,9 @@ import { TokenIndicator } from './TokenIndicator';
  * @param {Object}   props.binding   The block's binding map from useVariantBinding.
  * @param {Function} props.onReset   Called with `attr` to reset that control's override.
  * @param {Object}   props.children  The wrapped control element, rendered untouched.
+ *
+ * @since TBD
+ *
  * @return {Object} The wrapped control with its adjacent indicator.
  */
 export function TokenControlRow({ heading, attr, binding, onReset, children }) {

--- a/src/extension/token-indicators/components/TokenControlRow.js
+++ b/src/extension/token-indicators/components/TokenControlRow.js
@@ -1,9 +1,9 @@
 /**
  * A row wrapper that places the design-system indicator BESIDE a control whose `label` prop is not
  * rendered as visible content (e.g. `PopColorControl`, which forwards `label` to a Button tooltip). The
- * wrapped control is passed through as children with all its own props intact; only an adjacent indicator
- * (and an optional heading) is added. Renders just the children when the attribute is not mapped for the
- * selected variant, so an unmapped control looks identical to today.
+ * wrapped control is passed through as children with all its own props intact; a header row (an optional
+ * heading plus the indicator) is added above them. The indicator renders only when the attribute is mapped
+ * for the selected variant, so an unmapped control shows just its heading with no indicator.
  */
 
 import { TokenIndicator } from './TokenIndicator';

--- a/src/extension/token-indicators/components/TokenIndicator.js
+++ b/src/extension/token-indicators/components/TokenIndicator.js
@@ -29,7 +29,11 @@ export function TokenIndicator({ state, onReset }) {
 	if (!state.overridden) {
 		return (
 			<Tooltip text={__('Bound to the selected design variant', 'kadence-blocks')}>
-				<span className="kb-token-indicator kb-token-indicator--bound" aria-hidden="true" />
+				<span
+					className="kb-token-indicator kb-token-indicator--bound"
+					role="img"
+					aria-label={__('Bound to the selected design variant', 'kadence-blocks')}
+				/>
 			</Tooltip>
 		);
 	}

--- a/src/extension/token-indicators/components/TokenIndicator.js
+++ b/src/extension/token-indicators/components/TokenIndicator.js
@@ -17,6 +17,9 @@ import { TOKEN_INDICATORS_STORE } from '../store';
  * @param {Object}   [props.state] The attribute's binding state from useVariantBinding, or undefined when
  *                                 the control is not mapped for the selected variant.
  * @param {Function} props.onReset Called to clear the control's override back to the variant value.
+ *
+ * @since TBD
+ *
  * @return {Object|null} The indicator element, or null when the control is not bound.
  */
 export function TokenIndicator({ state, onReset }) {

--- a/src/extension/token-indicators/components/TokenIndicator.js
+++ b/src/extension/token-indicators/components/TokenIndicator.js
@@ -1,0 +1,57 @@
+/**
+ * The per-control design-system indicator: a design-system icon when the control is bound to the active
+ * variant, an override dot plus a reset affordance when the control has diverged from it, and nothing when
+ * the control is not mapped for the selected variant. Purely additive — it renders inside a control's
+ * label node and never touches the control's value.
+ */
+
+import { Button, Tooltip } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { TOKEN_INDICATORS_STORE } from '../store';
+
+/**
+ * The design-system indicator for one mapped control.
+ *
+ * @param {Object}   props         The component props.
+ * @param {Object}   [props.state] The attribute's binding state from useVariantBinding, or undefined when
+ *                                 the control is not mapped for the selected variant.
+ * @param {Function} props.onReset Called to clear the control's override back to the variant value.
+ * @return {Object|null} The indicator element, or null when the control is not bound.
+ */
+export function TokenIndicator({ state, onReset }) {
+	const highlighting = useSelect((select) => select(TOKEN_INDICATORS_STORE).isHighlightingEdits(), []);
+
+	if (!state || !state.bound) {
+		return null;
+	}
+
+	if (!state.overridden) {
+		return (
+			<Tooltip text={__('Bound to the selected design variant', 'kadence-blocks')}>
+				<span className="kb-token-indicator kb-token-indicator--bound" aria-hidden="true" />
+			</Tooltip>
+		);
+	}
+
+	const className =
+		'kb-token-indicator kb-token-indicator--overridden' + (highlighting ? ' kb-token-indicator--highlight' : '');
+
+	return (
+		<span className={className}>
+			<Tooltip text={__('Overrides the selected design variant', 'kadence-blocks')}>
+				<span className="kb-token-indicator__dot" aria-hidden="true" />
+			</Tooltip>
+			<Button
+				className="kb-token-indicator__reset"
+				variant="tertiary"
+				isSmall
+				onClick={onReset}
+				label={__('Reset to variant value', 'kadence-blocks')}
+				showTooltip
+			>
+				{__('Reset', 'kadence-blocks')}
+			</Button>
+		</span>
+	);
+}

--- a/src/extension/token-indicators/components/TokenLabel.js
+++ b/src/extension/token-indicators/components/TokenLabel.js
@@ -1,0 +1,29 @@
+/**
+ * A control label that carries the design-system indicator. Renders the plain label text with a
+ * `<TokenIndicator>` appended, so a Kadence control's `label` prop (which accepts a React node) shows the
+ * bound / overridden state for the attribute the control writes. When the attribute is not mapped for the
+ * selected variant, only the text renders — identical to today's control.
+ */
+
+import { TokenIndicator } from './TokenIndicator';
+
+/**
+ * A control label wrapped with the design-token indicator.
+ *
+ * @param {Object}   props         The component props.
+ * @param {string}   props.text    The label text.
+ * @param {string}   props.attr    The attribute the control writes (the indicator's key).
+ * @param {Object}   props.binding The block's binding map from useVariantBinding.
+ * @param {Function} props.onReset Called with `attr` to reset that control's override.
+ * @return {Object} The label node.
+ */
+export function TokenLabel({ text, attr, binding, onReset }) {
+	const state = binding ? binding[attr] : undefined;
+
+	return (
+		<span className="kb-token-label">
+			<span className="kb-token-label__text">{text}</span>
+			<TokenIndicator state={state} onReset={() => onReset(attr)} />
+		</span>
+	);
+}

--- a/src/extension/token-indicators/components/TokenLabel.js
+++ b/src/extension/token-indicators/components/TokenLabel.js
@@ -15,6 +15,9 @@ import { TokenIndicator } from './TokenIndicator';
  * @param {string}   props.attr    The attribute the control writes (the indicator's key).
  * @param {Object}   props.binding The block's binding map from useVariantBinding.
  * @param {Function} props.onReset Called with `attr` to reset that control's override.
+ *
+ * @since TBD
+ *
  * @return {Object} The label node.
  */
 export function TokenLabel({ text, attr, binding, onReset }) {

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -15,6 +15,12 @@
 import { get } from 'lodash';
 import { activeSet, blockProperties, blockVariantValues } from '../variant-picker';
 import { isEmptyValue, matchesVariant } from './normalize';
+import './token-indicators.scss';
+
+export { TOKEN_INDICATORS_STORE } from './store';
+export { TokenIndicator } from './components/TokenIndicator';
+export { TokenLabel } from './components/TokenLabel';
+export { TokenControlRow } from './components/TokenControlRow';
 
 /**
  * The companion unit attribute for a dimension control, by convention `${attr}Unit` (e.g. `borderRadius`

--- a/src/extension/token-indicators/store.js
+++ b/src/extension/token-indicators/store.js
@@ -1,0 +1,56 @@
+/**
+ * A tiny @wordpress/data store holding the editor-wide "highlight edits" flag: when on, controls that
+ * have overridden their variant value are visually emphasized. Toggled from the variant picker's
+ * actions (Part D) and read by the token indicators (Part C). Editor-session state only — never persisted.
+ */
+
+import { createReduxStore, register } from '@wordpress/data';
+
+const STORE_NAME = 'kadence/token-indicators';
+
+const DEFAULT_STATE = { highlightEdits: false };
+
+const actions = {
+	/**
+	 * Set the highlight-edits flag.
+	 *
+	 * @param {boolean} on Whether to highlight overridden controls.
+	 * @return {Object} The action.
+	 */
+	setHighlightEdits(on) {
+		return { type: 'SET_HIGHLIGHT_EDITS', on: !!on };
+	},
+};
+
+const selectors = {
+	/**
+	 * Whether highlight-edits is on.
+	 *
+	 * @param {Object} state The store state.
+	 * @return {boolean} True when overridden controls should be highlighted.
+	 */
+	isHighlightingEdits(state) {
+		return state.highlightEdits;
+	},
+};
+
+/**
+ * The highlight-edits reducer.
+ *
+ * @param {Object} state  The current state.
+ * @param {Object} action The dispatched action.
+ * @return {Object} The next state.
+ */
+function reducer(state = DEFAULT_STATE, action) {
+	if (action.type === 'SET_HIGHLIGHT_EDITS') {
+		return { ...state, highlightEdits: action.on };
+	}
+
+	return state;
+}
+
+const store = createReduxStore(STORE_NAME, { reducer, actions, selectors });
+
+register(store);
+
+export const TOKEN_INDICATORS_STORE = STORE_NAME;

--- a/src/extension/token-indicators/store.js
+++ b/src/extension/token-indicators/store.js
@@ -15,6 +15,9 @@ const actions = {
 	 * Set the highlight-edits flag.
 	 *
 	 * @param {boolean} on Whether to highlight overridden controls.
+	 *
+	 * @since TBD
+	 *
 	 * @return {Object} The action.
 	 */
 	setHighlightEdits(on) {
@@ -27,6 +30,9 @@ const selectors = {
 	 * Whether highlight-edits is on.
 	 *
 	 * @param {Object} state The store state.
+	 *
+	 * @since TBD
+	 *
 	 * @return {boolean} True when overridden controls should be highlighted.
 	 */
 	isHighlightingEdits(state) {
@@ -39,6 +45,9 @@ const selectors = {
  *
  * @param {Object} state  The current state.
  * @param {Object} action The dispatched action.
+ *
+ * @since TBD
+ *
  * @return {Object} The next state.
  */
 function reducer(state = DEFAULT_STATE, action) {

--- a/src/extension/token-indicators/token-indicators.scss
+++ b/src/extension/token-indicators/token-indicators.scss
@@ -1,0 +1,70 @@
+/**
+ * Design-system control indicators.
+ *
+ * Styling for the bound / overridden indicator that mounts beside (or inside the label of) a
+ * design-token-mapped control. Matches the block editor's existing control-label type scale so the
+ * indicator reads as part of the control, not a new UI.
+ */
+
+.kb-token-indicator {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	margin-left: 4px;
+	vertical-align: middle;
+}
+
+.kb-token-indicator--bound {
+	display: inline-block;
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	background: #007cba;
+}
+
+.kb-token-indicator__dot {
+	display: inline-block;
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	background: #d67635;
+}
+
+.kb-token-indicator--highlight {
+	.kb-token-indicator__dot {
+		box-shadow: 0 0 0 2px rgba(214, 118, 53, 0.35);
+	}
+}
+
+.kb-token-indicator__reset {
+	height: auto;
+	min-height: 0;
+	padding: 0 4px;
+	font-size: 11px;
+	line-height: 1.4;
+}
+
+.kb-token-label {
+	display: inline-flex;
+	align-items: center;
+}
+
+.kb-token-label__text {
+	display: inline-block;
+}
+
+.kb-token-control-row {
+	.kb-token-control-row__header {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		margin-bottom: 4px;
+	}
+
+	.kb-token-control-row__heading {
+		font-size: 11px;
+		font-weight: 500;
+		text-transform: uppercase;
+		color: #1e1e1e;
+	}
+}


### PR DESCRIPTION
🎫 https://linear.app/nexcess/issue/SOFT-3849/design-system-control-mapping-and-indicators-button-first

Phase 3 of 4 (stacked). Base: `SOFT-3849/phase-2-editor-binding-state`.

## Summary

The indicator UI and its wiring into the Single Button controls.

- **Components** (`src/extension/token-indicators/components/`): `TokenIndicator` (design-system icon when bound; override dot + reset affordance when overridden; nothing when unmapped), `TokenLabel` (label text + indicator as a React node), `TokenControlRow` (renders the indicator adjacent to a control).
- **Highlight-edits store** (`src/extension/token-indicators/store.js`) — a small `@wordpress/data` store; `TokenIndicator` highlights overridden controls when it is on. (The toggle that flips it ships in Phase 4.)
- **Two wiring mechanisms, by control type.** `ResponsiveMeasurementControls` (Border Radius) renders its `label` prop as content, so the indicator is injected as a `TokenLabel` node. `PopColorControl` (the color swatches) forwards `label` to a `Button` **tooltip**, not content — so a node there would not render and would corrupt the aria label. The 4 color swatches instead get a `TokenControlRow` sibling, leaving each swatch's own `label`/`value`/`onChange` untouched.
- **Single Button wiring** (`src/blocks/singlebtn/edit.js`): `borderRadius` via `TokenLabel`; `color`, `background`, `colorHover`, `backgroundHover` via `TokenControlRow`. The unmapped hover-radius control is deliberately left alone.

`// TODO: confirm exact placement vs Figma node 160-12291` markers sit at each swatch wiring site — the adjacent-placement default is implemented; the exact visual is to be confirmed against the Figma.

## Test plan

- `npm run lint-js` (eslint) and cspell green on all changed files.
- Production `npm run build` compiles; the new `kb-token-*` classes are present in `dist/blocks-singlebtn.css`.
- Editor check (after the chain merges + baseline flush): select a variant on a Single Button and confirm the design-system icon appears on the 5 bound controls; override one and confirm it flips to the override state and reset returns it to the variant value.
