### PR TITLE
[DTM] SOFT-3849 [4/5]: picker highlight-edits + reset-all

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,33 @@ the team enforces in review; follow them exactly.
   `kadence/single-icon`'s `color`) — that shape fits the low-specificity `Block_Default_Css`
   binding directly, with no adapter and no unit conversion needed.
 
+## JavaScript coding conventions
+
+### Docblocks
+
+- **`@since TBD` on every new JS function, hook, component, and exported helper.** Just like PHP,
+  new JavaScript gets a `@since TBD` tag in its JSDoc block. This applies to functions, React
+  components, custom hooks, store selectors/actions/reducers, and exported helpers the change adds.
+  Only tag the code the change introduces — do not retrofit pre-existing functions in a file you are
+  only partially touching.
+
+- **Placement differs from PHP.** In this repo's JS, the `@since TBD` line goes **after** the
+  `@param` block and **before** `@return`, with a blank ` *` line on each side (not before `@param`
+  the way PHP puts it before `@var`). Match `src/early-filters.js` exactly. A function with no
+  params puts `@since TBD` between the description and `@return`.
+
+  ```js
+  /**
+   * Description.
+   *
+   * @param {Object} settings The block settings.
+   *
+   * @since TBD
+   *
+   * @return {Object} The updated settings.
+   */
+  ```
+
 ## Tests
 
 - **Data providers use `Generator`, not arrays.** A provider `yield`s each case; the return

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -873,6 +873,8 @@ export default function KadenceButtonEdit(props) {
 															set={set}
 															selected={selected}
 															onSelect={selectVariant}
+															attributes={attributes}
+															setAttributes={setAttributes}
 														/>
 													</SubsectionWrap>
 												);

--- a/src/early-filters.js
+++ b/src/early-filters.js
@@ -371,6 +371,8 @@ const withVariantPicker = createHigherOrderComponent((BlockEdit) => {
 										set={set}
 										selected={selected}
 										onSelect={selectVariant}
+										attributes={attributes}
+										setAttributes={setAttributes}
 									/>
 								</SubsectionWrap>
 							)}

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -44,6 +44,9 @@ function unitAttrFor(kind, attr) {
  *
  * @param {string} blockName The block name.
  * @param {string} [set]     The token set slug; defaults to the active set.
+ *
+ * @since TBD
+ *
  * @return {Array} The mapped attributes ([{ attr, kind }]).
  */
 export function mappedAttrsFor(blockName, set) {
@@ -123,6 +126,9 @@ export function useVariantBinding(blockName, attributes) {
  *
  * @param {string} attr The primary attribute name.
  * @param {string} kind The property kind, so a dimension also clears its companions.
+ *
+ * @since TBD
+ *
  * @return {Object} The attribute patch to pass to `setAttributes`.
  */
 export function resetAttrPatch(attr, kind) {

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -48,6 +48,21 @@ function defaultVariantFor(values) {
 }
 
 /**
+ * The mapped control attributes for a block's set, as `[{ attr, kind }]` — the surface reset-all clears.
+ * Skips properties with no control attribute. Independent of the selected variant (reset-all clears every
+ * mapped override regardless of which variant is active).
+ *
+ * @param {string} blockName The block name.
+ * @param {string} [set]     The token set slug; defaults to the active set.
+ * @return {Array} The mapped attributes ([{ attr, kind }]).
+ */
+export function mappedAttrsFor(blockName, set) {
+	return blockProperties(blockName, set || activeSet())
+		.filter((property) => !!property.control_attr)
+		.map((property) => ({ attr: property.control_attr, kind: property.kind }));
+}
+
+/**
  * The design-token binding state for a block's mapped controls, keyed by the control's attribute name.
  *
  * @param {string} blockName  The block name (e.g. 'kadence/singlebtn').

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -103,14 +103,40 @@ export function useVariantBinding(blockName, attributes) {
 }
 
 /**
- * Clear a mapped control's attribute(s) so the block falls back to the existing variant-scoped CSS (the
- * `.wp-block-*.kb-variant--<variant>` retarget) or the preset default — no new render path. A `color`/
- * `text` control clears its single attribute to `''`. A `dimension` control (e.g. `borderRadius`) also
- * clears its unit companion and its `tablet*`/`mobile*` companions by convention; the primary and
- * companion array attributes reset to the block's declared default shape — a 4-side
- * `['', '', '', '']` array, per `block.json` (e.g. `borderRadius`, `tabletBorderRadius`,
- * `mobileBorderRadius`) — not a bare `''`, and the unit resets to `'px'` (`borderRadiusUnit`'s declared
- * default), not `''`.
+ * The `setAttributes` patch that clears a mapped control's attribute(s) back to their block.json default
+ * shape, so the block falls back to the existing variant-scoped CSS (the `.wp-block-*.kb-variant--<variant>`
+ * retarget) or the preset default — no new render path. A `color`/`text` control clears its single
+ * attribute to `''`. A `dimension` control (e.g. `borderRadius`) also clears its unit companion and its
+ * `tablet*`/`mobile*` companions by convention; the primary and companion array attributes reset to the
+ * block's declared default shape — a 4-side `['', '', '', '']` array, per `block.json` (e.g. `borderRadius`,
+ * `tabletBorderRadius`, `mobileBorderRadius`) — not a bare `''`, and the unit resets to `'px'`
+ * (`borderRadiusUnit`'s declared default), not `''`.
+ *
+ * Shared by the per-control reset (`resetAttr`) and the picker's reset-all, so their clearing convention
+ * cannot drift.
+ *
+ * @param {string} attr The primary attribute name.
+ * @param {string} kind The property kind, so a dimension also clears its companions.
+ * @return {Object} The attribute patch to pass to `setAttributes`.
+ */
+export function resetAttrPatch(attr, kind) {
+	if (kind !== 'dimension') {
+		return { [attr]: '' };
+	}
+
+	const capitalized = attr.charAt(0).toUpperCase() + attr.slice(1);
+	const emptySides = ['', '', '', ''];
+
+	return {
+		[attr]: emptySides,
+		[`${attr}Unit`]: 'px',
+		[`tablet${capitalized}`]: emptySides,
+		[`mobile${capitalized}`]: emptySides,
+	};
+}
+
+/**
+ * Clear a mapped control's attribute(s) back to their block.json default shape (see `resetAttrPatch`).
  *
  * @param {string}   attr          The primary attribute name.
  * @param {Function} setAttributes The block's setAttributes.
@@ -118,19 +144,5 @@ export function useVariantBinding(blockName, attributes) {
  * @return {void}
  */
 export function resetAttr(attr, setAttributes, kind) {
-	if (kind !== 'dimension') {
-		setAttributes({ [attr]: '' });
-
-		return;
-	}
-
-	const capitalized = attr.charAt(0).toUpperCase() + attr.slice(1);
-	const emptySides = ['', '', '', ''];
-
-	setAttributes({
-		[attr]: emptySides,
-		[`${attr}Unit`]: 'px',
-		[`tablet${capitalized}`]: emptySides,
-		[`mobile${capitalized}`]: emptySides,
-	});
+	setAttributes(resetAttrPatch(attr, kind));
 }

--- a/src/extension/variant-picker/VariantActions.js
+++ b/src/extension/variant-picker/VariantActions.js
@@ -1,5 +1,6 @@
 /**
- * Create / edit / delete controls for a block's design-token variants.
+ * Create / edit / delete controls for a block's design-token variants, plus the design-system actions:
+ * a highlight-edits toggle and a reset-all that clears every mapped override for the block.
  *
  * Renders a "Create new variant" button for every block, and, when the selected variant is a user-created
  * one, "Edit" and "Delete" buttons. Deleting the variant the set currently defaults to first reassigns the
@@ -7,37 +8,70 @@
  * inspector panel and a block's inline picker so the controls stay identical wherever they surface. Renders
  * nothing when the editor lacks the REST descriptor.
  */
-import { Button, Notice } from '@wordpress/components';
+import { Button, Notice, ToggleControl } from '@wordpress/components';
 import { useState } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { SaveVariantModal } from './SaveVariantModal';
 import { blockVariants, blockDefaultVariant, isUserVariant, removeVariant } from './index';
 import { deleteVariant, setVariantDefault } from '../variants/api/client';
 import { hasDesignTokensRest } from '../design-tokens/rest';
 import { refreshProjectedCss } from '../design-tokens/live-css';
+import { TOKEN_INDICATORS_STORE } from '../token-indicators/store';
+import { mappedAttrsFor } from '../token-indicators';
 
 /**
- * The variant create/edit/delete controls.
+ * The variant create/edit/delete controls, plus the design-system actions: a highlight-edits toggle and a
+ * reset-all that clears every mapped override for the block.
  *
- * @param {Object}   props           The component props.
- * @param {string}   props.blockName The block name.
- * @param {string}   props.set       The token set the block is on.
- * @param {string}   props.selected  The block's currently selected variant slug ('' for the default look).
- * @param {Function} props.onSelect  Called with a variant slug to select it on the block.
+ * @param {Object}   props               The component props.
+ * @param {string}   props.blockName     The block name.
+ * @param {string}   props.set           The token set the block is on.
+ * @param {string}   props.selected      The block's currently selected variant slug ('' for the default look).
+ * @param {Function} props.onSelect      Called with a variant slug to select it on the block.
+ * @param {Object}   props.attributes    The block's current attributes (for reset-all).
+ * @param {Function} props.setAttributes The block's setAttributes (for reset-all).
  *
  * @return {Object|null} The controls, or null when the variants REST API is unavailable.
  */
-export function VariantActions({ blockName, set, selected, onSelect }) {
+export function VariantActions({ blockName, set, selected, onSelect, attributes, setAttributes }) {
 	const [mode, setMode] = useState('none');
 	const [confirming, setConfirming] = useState(false);
 	const [busy, setBusy] = useState(false);
 	const [error, setError] = useState('');
+
+	const highlighting = useSelect((select) => select(TOKEN_INDICATORS_STORE).isHighlightingEdits(), []);
+	const { setHighlightEdits } = useDispatch(TOKEN_INDICATORS_STORE);
 
 	if (!hasDesignTokensRest()) {
 		return null;
 	}
 
 	const canManage = selected !== '' && isUserVariant(blockName, set, selected);
+
+	/**
+	 * Clear every mapped override for the block, so all mapped controls fall back to the selected
+	 * variant's values (served by the existing scoped CSS), then refresh the live preview.
+	 *
+	 * @return {void}
+	 */
+	const onResetAll = () => {
+		const patch = {};
+
+		mappedAttrsFor(blockName, set).forEach(({ attr, kind }) => {
+			patch[attr] = '';
+
+			if (kind === 'dimension') {
+				const capitalized = attr.charAt(0).toUpperCase() + attr.slice(1);
+				patch[`${attr}Unit`] = '';
+				patch[`tablet${capitalized}`] = '';
+				patch[`mobile${capitalized}`] = '';
+			}
+		});
+
+		setAttributes(patch);
+		refreshProjectedCss();
+	};
 
 	/**
 	 * Delete the selected user variant, first moving the default off it when it is the current default.
@@ -110,6 +144,17 @@ export function VariantActions({ blockName, set, selected, onSelect }) {
 					</Button>
 				</>
 			)}
+
+			<ToggleControl
+				label={__('Highlight edits', 'kadence-blocks')}
+				help={__('Emphasize controls that override the selected variant.', 'kadence-blocks')}
+				checked={highlighting}
+				onChange={(on) => setHighlightEdits(on)}
+			/>
+
+			<Button variant="tertiary" onClick={onResetAll}>
+				{__('Reset all to variant', 'kadence-blocks')}
+			</Button>
 
 			{mode !== 'none' && (
 				<SaveVariantModal

--- a/src/extension/variant-picker/VariantActions.js
+++ b/src/extension/variant-picker/VariantActions.js
@@ -53,6 +53,8 @@ export function VariantActions({ blockName, set, selected, onSelect, attributes,
 	 * Clear every mapped override for the block, so all mapped controls fall back to the selected
 	 * variant's values (served by the existing scoped CSS), then refresh the live preview.
 	 *
+	 * @since TBD
+	 *
 	 * @return {void}
 	 */
 	const onResetAll = () => {

--- a/src/extension/variant-picker/VariantActions.js
+++ b/src/extension/variant-picker/VariantActions.js
@@ -18,7 +18,7 @@ import { deleteVariant, setVariantDefault } from '../variants/api/client';
 import { hasDesignTokensRest } from '../design-tokens/rest';
 import { refreshProjectedCss } from '../design-tokens/live-css';
 import { TOKEN_INDICATORS_STORE } from '../token-indicators/store';
-import { mappedAttrsFor } from '../token-indicators';
+import { mappedAttrsFor, resetAttrPatch } from '../token-indicators';
 
 /**
  * The variant create/edit/delete controls, plus the design-system actions: a highlight-edits toggle and a
@@ -56,18 +56,10 @@ export function VariantActions({ blockName, set, selected, onSelect, attributes,
 	 * @return {void}
 	 */
 	const onResetAll = () => {
-		const patch = {};
-
-		mappedAttrsFor(blockName, set).forEach(({ attr, kind }) => {
-			patch[attr] = '';
-
-			if (kind === 'dimension') {
-				const capitalized = attr.charAt(0).toUpperCase() + attr.slice(1);
-				patch[`${attr}Unit`] = '';
-				patch[`tablet${capitalized}`] = '';
-				patch[`mobile${capitalized}`] = '';
-			}
-		});
+		const patch = mappedAttrsFor(blockName, set).reduce(
+			(acc, { attr, kind }) => Object.assign(acc, resetAttrPatch(attr, kind)),
+			{}
+		);
 
 		setAttributes(patch);
 		refreshProjectedCss();


### PR DESCRIPTION
🎫 https://linear.app/nexcess/issue/SOFT-3849/design-system-control-mapping-and-indicators-button-first

Phase 4 of 4 (stacked). Base: `SOFT-3849/phase-3-indicator-labels`.

## Summary

Adds the two variant-picker actions from the design. The single-slug variant dropdown and the save-as-new-variant flow already exist, so this only adds:

- **Highlight-edits toggle** in `VariantActions.js` — flips the Phase 3 highlight-edits store, so overridden controls highlight across the block.
- **Reset-all** — clears every mapped override for the block back to the selected variant, via `mappedAttrsFor()` + a single batched `setAttributes`, then refreshes the projected CSS.

The existing create / edit / delete / save-as-new behavior is untouched; the two new controls are inserted between the delete-confirmation block and the save-as-new modal.

## Test plan

- `npm run lint-js` (eslint) and cspell green on all changed files.
- Production `npm run build` compiles.
- Editor check (after the chain merges + baseline flush): toggle highlight-edits and confirm overridden controls highlight; use reset-all and confirm every mapped override clears and the live preview updates.
