### PR TITLE
docs: document the JS `@since TBD` JSDoc convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,33 @@ the team enforces in review; follow them exactly.
   `kadence/single-icon`'s `color`) — that shape fits the low-specificity `Block_Default_Css`
   binding directly, with no adapter and no unit conversion needed.
 
+## JavaScript coding conventions
+
+### Docblocks
+
+- **`@since TBD` on every new JS function, hook, component, and exported helper.** Just like PHP,
+  new JavaScript gets a `@since TBD` tag in its JSDoc block. This applies to functions, React
+  components, custom hooks, store selectors/actions/reducers, and exported helpers the change adds.
+  Only tag the code the change introduces — do not retrofit pre-existing functions in a file you are
+  only partially touching.
+
+- **Placement differs from PHP.** In this repo's JS, the `@since TBD` line goes **after** the
+  `@param` block and **before** `@return`, with a blank ` *` line on each side (not before `@param`
+  the way PHP puts it before `@var`). Match `src/early-filters.js` exactly. A function with no
+  params puts `@since TBD` between the description and `@return`.
+
+  ```js
+  /**
+   * Description.
+   *
+   * @param {Object} settings The block settings.
+   *
+   * @since TBD
+   *
+   * @return {Object} The updated settings.
+   */
+  ```
+
 ## Tests
 
 - **Data providers use `Generator`, not arrays.** A provider `yield`s each case; the return


### PR DESCRIPTION
Documents the JavaScript `@since TBD` JSDoc convention in `AGENTS.md` (surfaced as `CLAUDE.md`), so it is enforced in review the same way the PHP rule already is.

## Why

`AGENTS.md` spelled out `@since TBD` only for PHP, even though the repo's JS already uses it (`src/early-filters.js`, `src/style-book/*`). New JS could silently miss the tag. This adds a **JavaScript coding conventions → Docblocks** section that:

- requires `@since TBD` on every new JS function, hook, component, store selector/action/reducer, and exported helper (only the code a change introduces, not pre-existing functions);
- documents the repo-specific placement: the `@since TBD` line goes **after** the `@param` block and **before** `@return` (unlike PHP, which puts it before `@var`), matching `src/early-filters.js`.

Docs only — no code changes.
