### PR TITLE
[DTM] SOFT-3849 [5/5]: indicator design alignment (Figma)

### DIFF
--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -913,7 +913,6 @@ export default function KadenceButtonEdit(props) {
 															/>
 														)}
 														{'normal' === textBackgroundHoverType && (
-															// TODO: confirm exact placement vs Figma node 160-12291
 															<TokenControlRow
 																heading={__('Color Hover', 'kadence-blocks')}
 																attr="colorHover"
@@ -949,7 +948,6 @@ export default function KadenceButtonEdit(props) {
 															/>
 														)}
 														{'normal' === backgroundHoverType && (
-															// TODO: confirm exact placement vs Figma node 160-12291
 															<TokenControlRow
 																heading={__('Background Color', 'kadence-blocks')}
 																attr="backgroundHover"
@@ -1126,7 +1124,6 @@ export default function KadenceButtonEdit(props) {
 															/>
 														)}
 														{'normal' === textBackgroundType && (
-															// TODO: confirm exact placement vs Figma node 160-12291
 															<TokenControlRow
 																heading={__('Color', 'kadence-blocks')}
 																attr="color"
@@ -1160,7 +1157,6 @@ export default function KadenceButtonEdit(props) {
 															/>
 														)}
 														{'normal' === backgroundType && (
-															// TODO: confirm exact placement vs Figma node 160-12291
 															<TokenControlRow
 																heading={__('Background Color', 'kadence-blocks')}
 																attr="background"

--- a/src/extension/token-indicators/components/TokenControlRow.js
+++ b/src/extension/token-indicators/components/TokenControlRow.js
@@ -4,6 +4,9 @@
  * wrapped control is passed through as children with all its own props intact; only an adjacent indicator
  * (and an optional heading) is added. Renders just the children when the attribute is not mapped for the
  * selected variant, so an unmapped control looks identical to today.
+ *
+ * Per the Figma reference, the indicator sits right-aligned at the end of the control's row (the heading
+ * on the left, the indicator on the right) — see `.kb-token-control-row__header` in `token-indicators.scss`.
  */
 
 import { TokenIndicator } from './TokenIndicator';

--- a/src/extension/token-indicators/components/TokenIndicator.js
+++ b/src/extension/token-indicators/components/TokenIndicator.js
@@ -1,13 +1,18 @@
 /**
  * The per-control design-system indicator: a design-system icon when the control is bound to the active
- * variant, an override dot plus a reset affordance when the control has diverged from it, and nothing when
- * the control is not mapped for the selected variant. Purely additive — it renders inside a control's
- * label node and never touches the control's value.
+ * variant, that same icon with a small override dot plus an undo-arrow reset button when the control has
+ * diverged from it, and nothing when the control is not mapped for the selected variant. Purely additive —
+ * it renders inside a control's label node (or a sibling row) and never touches the control's value.
+ *
+ * The bound icon reuses `@wordpress/icons`' `styles` glyph — the same mark the block editor uses for
+ * Global Styles — as a stand-in design-system/token mark. Swap for the exact Figma glyph (node
+ * 160-12291) once design provides that asset as an SVG.
  */
 
-import { Button, Tooltip } from '@wordpress/components';
+import { Button, Icon, Tooltip } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { styles as designSystemIcon, undo as undoIcon } from '@wordpress/icons';
 import { TOKEN_INDICATORS_STORE } from '../store';
 
 /**
@@ -36,7 +41,9 @@ export function TokenIndicator({ state, onReset }) {
 					className="kb-token-indicator kb-token-indicator--bound"
 					role="img"
 					aria-label={__('Bound to the selected design variant', 'kadence-blocks')}
-				/>
+				>
+					<Icon icon={designSystemIcon} size={14} />
+				</span>
 			</Tooltip>
 		);
 	}
@@ -47,18 +54,21 @@ export function TokenIndicator({ state, onReset }) {
 	return (
 		<span className={className}>
 			<Tooltip text={__('Overrides the selected design variant', 'kadence-blocks')}>
-				<span className="kb-token-indicator__dot" aria-hidden="true" />
+				<span className="kb-token-indicator__icon-wrap" role="img" aria-hidden="true">
+					<Icon icon={designSystemIcon} size={14} />
+					<span className="kb-token-indicator__dot" />
+				</span>
 			</Tooltip>
 			<Button
 				className="kb-token-indicator__reset"
+				icon={undoIcon}
+				iconSize={14}
 				variant="tertiary"
 				isSmall
 				onClick={onReset}
 				label={__('Reset to variant value', 'kadence-blocks')}
 				showTooltip
-			>
-				{__('Reset', 'kadence-blocks')}
-			</Button>
+			/>
 		</span>
 	);
 }

--- a/src/extension/token-indicators/components/TokenIndicator.js
+++ b/src/extension/token-indicators/components/TokenIndicator.js
@@ -54,7 +54,11 @@ export function TokenIndicator({ state, onReset }) {
 	return (
 		<span className={className}>
 			<Tooltip text={__('Overrides the selected design variant', 'kadence-blocks')}>
-				<span className="kb-token-indicator__icon-wrap" role="img" aria-hidden="true">
+				<span
+					className="kb-token-indicator__icon-wrap"
+					role="img"
+					aria-label={__('Overridden — differs from the selected variant', 'kadence-blocks')}
+				>
 					<Icon icon={designSystemIcon} size={14} />
 					<span className="kb-token-indicator__dot" />
 				</span>

--- a/src/extension/token-indicators/token-indicators.scss
+++ b/src/extension/token-indicators/token-indicators.scss
@@ -4,44 +4,57 @@
  * Styling for the bound / overridden indicator that mounts beside (or inside the label of) a
  * design-token-mapped control. Matches the block editor's existing control-label type scale so the
  * indicator reads as part of the control, not a new UI.
+ *
+ * Per the Figma reference, a bound control shows a small design-system icon right-aligned at the end of
+ * the control's row; an overridden control keeps that icon but adds a small red dot plus an undo-arrow
+ * reset button.
  */
 
 .kb-token-indicator {
 	display: inline-flex;
 	align-items: center;
-	gap: 4px;
+	gap: 2px;
 	margin-left: 4px;
 	vertical-align: middle;
 }
 
 .kb-token-indicator--bound {
-	display: inline-block;
-	width: 8px;
-	height: 8px;
-	border-radius: 50%;
-	background: #007cba;
+	display: inline-flex;
+	align-items: center;
+	color: #6647c1;
+}
+
+.kb-token-indicator__icon-wrap {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	color: #6647c1;
 }
 
 .kb-token-indicator__dot {
+	position: absolute;
+	top: -2px;
+	right: -2px;
 	display: inline-block;
-	width: 8px;
-	height: 8px;
+	width: 6px;
+	height: 6px;
 	border-radius: 50%;
-	background: #d67635;
+	background: #cc1818;
+	border: 1px solid #fff;
 }
 
 .kb-token-indicator--highlight {
 	.kb-token-indicator__dot {
-		box-shadow: 0 0 0 2px rgba(214, 118, 53, 0.35);
+		box-shadow: 0 0 0 2px rgba(204, 24, 24, 0.35);
 	}
 }
 
 .kb-token-indicator__reset {
-	height: auto;
+	height: 20px;
 	min-height: 0;
-	padding: 0 4px;
-	font-size: 11px;
-	line-height: 1.4;
+	width: 20px;
+	padding: 0;
+	color: #cc1818;
 }
 
 .kb-token-label {
@@ -57,6 +70,7 @@
 	.kb-token-control-row__header {
 		display: flex;
 		align-items: center;
+		justify-content: space-between;
 		gap: 4px;
 		margin-bottom: 4px;
 	}
@@ -66,5 +80,9 @@
 		font-weight: 500;
 		text-transform: uppercase;
 		color: #1e1e1e;
+	}
+
+	.kb-token-indicator {
+		margin-left: 0;
 	}
 }


### PR DESCRIPTION
🎫 https://linear.app/nexcess/issue/SOFT-3849/design-system-control-mapping-and-indicators-button-first

Phase 5 of 5 (stacked). Base: `SOFT-3849/phase-4-picker-actions`.

## Summary

Presentation-only refinement that aligns the token indicators with the Figma design reference (node `160-12291`) and resolves the swatch-placement TODOs left in Phase 3. No detection/logic changes — it reuses the Phase 2 `useVariantBinding` hook unchanged.

- **Bound state** now renders a small design-system **icon** (right-aligned at the end of each control row) instead of a colored dot next to the section label — matching how the Figma places the indicator on every bound control.
- **Overridden state** keeps the icon with a small **red corner dot**, and the reset affordance is an icon-only **undo-arrow** button instead of a "Reset" text link.
- Right-alignment is handled in CSS (`justify-content: space-between` on the control-row header); `TokenControlRow` markup is unchanged.
- Removed the 4 `// TODO: confirm exact placement vs Figma` markers in `singlebtn/edit.js`.

**Icon choice:** the bound state uses `@wordpress/icons`' `styles` glyph (WordPress's own Global Styles mark) as a design-system stand-in, and `undo` for reset — both noted in code as swappable once design exports the exact Figma asset.

**Deliberately deferred** (documented in the phase plan, not built here): a per-section override **count badge** (the block's panels don't map 1:1 to the Figma sub-sections, and only 5 controls are mapped this pass); the `Stylebook`/`Custom` control dropdowns; showing the variant's value-name inside controls; the top-of-card variant selector; and the "Variant" → "Preset" wording (a product-copy decision).

## Test plan

- `npm run lint-js` (eslint) + cspell green on all changed files.
- Production `npm run build` compiles and regenerates `dist/blocks-singlebtn.*`.
- Editor check: select a variant on a Single Button and confirm the design-system icon sits right-aligned on each bound control; override one and confirm the red dot + undo-arrow reset appear and reset works.
