### PR TITLE
SOFT-3529 [1/3] Optional typography composite fields

### DIFF
--- a/dev_scripts/src/Design_Tokens/Schema/Dtcg_Schema_Generator.php
+++ b/dev_scripts/src/Design_Tokens/Schema/Dtcg_Schema_Generator.php
@@ -212,7 +212,8 @@ final class Dtcg_Schema_Generator {
 	}
 
 	/**
-	 * The object shape for a composite type: every sub-field required, each "alias OR kind shape".
+	 * The object shape for a composite type: required sub-fields listed in `required`, optional sub-fields
+	 * present in `properties` but not required; each sub-field is "alias OR kind shape".
 	 *
 	 * @since TBD
 	 *
@@ -221,10 +222,11 @@ final class Dtcg_Schema_Generator {
 	 * @return array<string, mixed>
 	 */
 	private function composite_shape( string $type ): array {
-		$fields     = Token_Type::composite_fields( $type );
+		$required   = Token_Type::composite_fields( $type );
+		$optional   = Token_Type::optional_composite_fields( $type );
 		$properties = [];
 
-		foreach ( $fields as $field => $kind ) {
+		foreach ( $required + $optional as $field => $kind ) {
 			$properties[ $field ] = [
 				'anyOf' => [
 					[ '$ref' => '#/definitions/alias' ],
@@ -235,7 +237,7 @@ final class Dtcg_Schema_Generator {
 
 		return [
 			'type'                 => 'object',
-			'required'             => array_keys( $fields ),
+			'required'             => array_keys( $required ),
 			'properties'           => $properties,
 			'additionalProperties' => false,
 		];

--- a/includes/resources/Design_Tokens/Schema/Validation/Kind.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Kind.php
@@ -87,6 +87,10 @@ final class Kind {
 				return Literals::is_font_weight( $value );
 			case Token_Type::get_kind_line_height():
 				return Literals::is_line_height( $value );
+			case Token_Type::get_kind_font_style():
+				return Literals::is_font_style( $value );
+			case Token_Type::get_kind_text_transform():
+				return Literals::is_text_transform( $value );
 			default:
 				return false;
 		}

--- a/includes/resources/Design_Tokens/Schema/Validation/Values/Composite_Value.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Values/Composite_Value.php
@@ -10,10 +10,13 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Validation_Error;
 
 /**
  * Shared walk for a composite $value (shadow, typography): an alias for the whole value, or an object
- * whose every declared sub-field validates "alias OR literal-of-kind" via Kind.
+ * whose required sub-fields are all present and every declared sub-field validates "alias OR
+ * literal-of-kind" via Kind. Optional sub-fields (Token_Type::optional_composite_fields()) may be
+ * omitted, but validate against their kind when present.
  *
- * The field => kind map comes from Token_Type::composite_fields(), so adding or reshaping a composite
- * is a data edit there, not a change here. Subclasses only name their $type.
+ * The field => kind maps come from Token_Type::composite_fields() / optional_composite_fields(), so
+ * adding or reshaping a composite is a data edit there, not a change here. Subclasses only name their
+ * $type.
  *
  * @since TBD
  */
@@ -65,11 +68,13 @@ abstract class Composite_Value implements Value_Validator {
 			];
 		}
 
-		$fields = Token_Type::composite_fields( $this->type() );
-		$errors = [];
+		$required = Token_Type::composite_fields( $this->type() );
+		$optional = Token_Type::optional_composite_fields( $this->type() );
+		$known    = $required + $optional;
+		$errors   = [];
 
-		// Every declared sub-field must be present and valid for its kind.
-		foreach ( $fields as $field => $kind ) {
+		// Every required sub-field must be present and valid for its kind.
+		foreach ( $required as $field => $kind ) {
 			if ( ! array_key_exists( $field, $value ) ) {
 				$errors[] = new Validation_Error(
 					$path . '.' . $field,
@@ -83,9 +88,16 @@ abstract class Composite_Value implements Value_Validator {
 			$errors = array_merge( $errors, Kind::validate( $kind, $value[ $field ], $path . '.' . $field ) );
 		}
 
-		// Any sub-field not in the map (and not a "$"-prefixed extension) is unknown.
+		// Optional sub-fields may be omitted, but validate against their kind when present.
+		foreach ( $optional as $field => $kind ) {
+			if ( array_key_exists( $field, $value ) ) {
+				$errors = array_merge( $errors, Kind::validate( $kind, $value[ $field ], $path . '.' . $field ) );
+			}
+		}
+
+		// Any sub-field in neither map (and not a "$"-prefixed extension) is unknown.
 		foreach ( array_keys( $value ) as $field ) {
-			if ( isset( $fields[ $field ] ) || ( is_string( $field ) && strncmp( $field, '$', 1 ) === 0 ) ) {
+			if ( isset( $known[ $field ] ) || ( is_string( $field ) && strncmp( $field, '$', 1 ) === 0 ) ) {
 				continue;
 			}
 

--- a/includes/resources/Design_Tokens/Schema/Validation/Values/Typography_Value.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Values/Typography_Value.php
@@ -5,8 +5,11 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
 
 /**
- * Validates a typography $value: an alias, or an object of { fontFamily, fontSize, fontWeight,
- * lineHeight } where each sub-field is itself an alias or its literal kind.
+ * Validates a typography $value: an alias, or an object carrying the required fontFamily plus any of the
+ * optional text-style fields (fontSize, fontWeight, lineHeight, fontStyle, textTransform,
+ * letterSpacing), where each sub-field is itself an alias or its literal kind. The field set is data on
+ * Token_Type, so a typography token drives exactly the properties it declares and leaves the rest to
+ * inherit.
  *
  * Extension seam for future responsive / clamp() typography: it lands by overriding validate() here to
  * branch on the structured shape before delegating the scalar object to the parent walk.

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Literals.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Literals.php
@@ -55,6 +55,36 @@ final class Literals {
 	];
 
 	/**
+	 * The CSS font-style keywords accepted as a fontStyle literal. "oblique <angle>" is intentionally
+	 * not modeled — the keyword forms cover the design-system need.
+	 *
+	 * @since TBD
+	 *
+	 * @var string[]
+	 */
+	private const FONT_STYLE_KEYWORDS = [
+		'normal',
+		'italic',
+		'oblique',
+	];
+
+	/**
+	 * The CSS text-transform keywords accepted as a textTransform literal.
+	 *
+	 * @since TBD
+	 *
+	 * @var string[]
+	 */
+	private const TEXT_TRANSFORM_KEYWORDS = [
+		'none',
+		'capitalize',
+		'uppercase',
+		'lowercase',
+		'full-width',
+		'full-size-kana',
+	];
+
+	/**
 	 * The CSS named colors (CSS Color Module Level 4 extended set, lower-cased). A curated allowlist is
 	 * what lets "not-a-color" be rejected while "rebeccapurple" is accepted.
 	 *
@@ -352,6 +382,32 @@ final class Literals {
 		}
 
 		return self::is_dimension( $value );
+	}
+
+	/**
+	 * Whether the value is a valid fontStyle literal: one of the CSS font-style keywords.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $value The candidate fontStyle.
+	 *
+	 * @return bool
+	 */
+	public static function is_font_style( $value ): bool {
+		return is_string( $value ) && in_array( strtolower( $value ), self::FONT_STYLE_KEYWORDS, true );
+	}
+
+	/**
+	 * Whether the value is a valid textTransform literal: one of the CSS text-transform keywords.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $value The candidate textTransform.
+	 *
+	 * @return bool
+	 */
+	public static function is_text_transform( $value ): bool {
+		return is_string( $value ) && in_array( strtolower( $value ), self::TEXT_TRANSFORM_KEYWORDS, true );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Token_Type.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Token_Type.php
@@ -10,10 +10,12 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary;
  * no native enums, so the vocabulary is modelled as class constants plus static lookup maps.
  *
  * Composite types (shadow, typography) hold an object $value whose sub-fields each validate as a
- * "kind" — usually another $type (color, dimension, fontFamily), and for typography two scale kinds
- * (fontWeight, lineHeight) that are not themselves registrable $types. composite_fields() returns that
- * field => kind map as DATA so a future responsive/clamp shape extends the map rather than
- * rewriting the walker.
+ * "kind" — usually another $type (color, dimension, fontFamily), and for typography four scale kinds
+ * (fontWeight, lineHeight, fontStyle, textTransform) that are not themselves registrable $types.
+ * composite_fields() returns the required field => kind map as DATA so a future responsive/clamp shape
+ * extends the map rather than rewriting the walker; optional_composite_fields() returns the sub-fields
+ * a composite may carry but need not (e.g. a typography token's fontStyle/textTransform/letterSpacing),
+ * so a token that omits them still validates.
  *
  * @since TBD
  */
@@ -94,6 +96,26 @@ final class Token_Type {
 	private const KIND_LINE_HEIGHT = 'lineHeight';
 
 	/**
+	 * The fontStyle composite sub-field kind (an enum literal: normal/italic/oblique). Not a registrable
+	 * $type (see KIND_FONT_WEIGHT).
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const KIND_FONT_STYLE = 'fontStyle';
+
+	/**
+	 * The textTransform composite sub-field kind (an enum literal: none/uppercase/…). Not a registrable
+	 * $type (see KIND_FONT_WEIGHT).
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const KIND_TEXT_TRANSFORM = 'textTransform';
+
+	/**
 	 * Every v1 $type, in declaration order.
 	 *
 	 * @var string[]
@@ -109,9 +131,10 @@ final class Token_Type {
 	];
 
 	/**
-	 * The composite types and their sub-field => kind maps. A field absent from the document is a
-	 * missing-field error; a field present but not listed here is an unknown-field error. Every kind is
-	 * validated "alias OR literal-of-kind", so an alias is accepted in any sub-field.
+	 * The composite types and their required sub-field => kind maps. A required field absent from the
+	 * document is a missing-field error; a field present but listed in neither this map nor
+	 * COMPOSITE_OPTIONAL_FIELDS is an unknown-field error. Every kind is validated "alias OR
+	 * literal-of-kind", so an alias is accepted in any sub-field.
 	 *
 	 * @var array<string, array<string, string>>
 	 *
@@ -127,9 +150,32 @@ final class Token_Type {
 		],
 		self::TYPOGRAPHY => [
 			'fontFamily' => self::FONT_FAMILY,
-			'fontSize'   => self::DIMENSION,
-			'fontWeight' => self::KIND_FONT_WEIGHT,
-			'lineHeight' => self::KIND_LINE_HEIGHT,
+		],
+	];
+
+	/**
+	 * The composite types and their optional sub-field => kind maps. An optional field may be omitted (so
+	 * a token carrying only the required fields still validates), but when present it must satisfy its
+	 * kind.
+	 *
+	 * Typography keeps only fontFamily required; every other text-style property is optional so a
+	 * typography token drives exactly the properties it declares and leaves the rest to inherit. That
+	 * mirrors how a Kadence per-instance typography bundle inherits any field left blank, and lets a
+	 * design-system typography token seed (say) only the family without forcing a weight/size/line-height
+	 * onto every block that consumes it.
+	 *
+	 * @var array<string, array<string, string>>
+	 *
+	 * @since TBD
+	 */
+	private const COMPOSITE_OPTIONAL_FIELDS = [
+		self::TYPOGRAPHY => [
+			'fontSize'      => self::DIMENSION,
+			'fontWeight'    => self::KIND_FONT_WEIGHT,
+			'lineHeight'    => self::KIND_LINE_HEIGHT,
+			'fontStyle'     => self::KIND_FONT_STYLE,
+			'textTransform' => self::KIND_TEXT_TRANSFORM,
+			'letterSpacing' => self::DIMENSION,
 		],
 	];
 
@@ -171,7 +217,8 @@ final class Token_Type {
 	}
 
 	/**
-	 * The sub-field => kind map for a composite $type, or an empty array for a non-composite type.
+	 * The required sub-field => kind map for a composite $type, or an empty array for a non-composite
+	 * type.
 	 *
 	 * @since TBD
 	 *
@@ -181,6 +228,20 @@ final class Token_Type {
 	 */
 	public static function composite_fields( string $type ): array {
 		return self::COMPOSITE_FIELDS[ $type ] ?? [];
+	}
+
+	/**
+	 * The optional sub-field => kind map for a composite $type, or an empty array when the type has none.
+	 * These sub-fields may be omitted from a token, but validate against their kind when present.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $type The composite $type.
+	 *
+	 * @return array<string, string> Field name => kind (a $type or a KIND_* constant).
+	 */
+	public static function optional_composite_fields( string $type ): array {
+		return self::COMPOSITE_OPTIONAL_FIELDS[ $type ] ?? [];
 	}
 
 	/**
@@ -269,5 +330,27 @@ final class Token_Type {
 	 */
 	public static function get_kind_line_height(): string {
 		return self::KIND_LINE_HEIGHT;
+	}
+
+	/**
+	 * The fontStyle composite sub-field kind.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_kind_font_style(): string {
+		return self::KIND_FONT_STYLE;
+	}
+
+	/**
+	 * The textTransform composite sub-field kind.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_kind_text_transform(): string {
+		return self::KIND_TEXT_TRANSFORM;
 	}
 }

--- a/includes/resources/Design_Tokens/Schema/dtcg.schema.json
+++ b/includes/resources/Design_Tokens/Schema/dtcg.schema.json
@@ -262,10 +262,7 @@
                 {
                     "type": "object",
                     "required": [
-                        "fontFamily",
-                        "fontSize",
-                        "fontWeight",
-                        "lineHeight"
+                        "fontFamily"
                     ],
                     "properties": {
                         "fontFamily": {
@@ -315,6 +312,36 @@
                                         "string",
                                         "number"
                                     ]
+                                }
+                            ]
+                        },
+                        "fontStyle": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/definitions/alias"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        "textTransform": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/definitions/alias"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        "letterSpacing": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/definitions/alias"
+                                },
+                                {
+                                    "type": "string"
                                 }
                             ]
                         }

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Values/Value_ValidatorsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Values/Value_ValidatorsTest.php
@@ -180,4 +180,57 @@ final class Value_ValidatorsTest extends TestCase {
 		$this->assertSame( 't.$value.fontWeight', $errors[0]->path );
 		$this->assertSame( Validation_Error::get_code_value_invalid(), $errors[0]->code );
 	}
+
+	/**
+	 * A typography token carrying only the required fontFamily is valid — the optional text-style fields
+	 * may all be omitted (the shipped semantic.typography.control shape).
+	 *
+	 * @return void
+	 */
+	public function testTypographyAcceptsFontFamilyOnly(): void {
+		$value = [ 'fontFamily' => '{primitive.fontFamily.sans}' ];
+
+		$this->assertSame( [], ( new Typography_Value() )->validate( $value, 't.$value' ) );
+	}
+
+	/**
+	 * A missing fontFamily is reported as a missing required sub-field.
+	 *
+	 * @return void
+	 */
+	public function testTypographyReportsMissingFontFamily(): void {
+		$errors = ( new Typography_Value() )->validate( [ 'fontWeight' => 400 ], 't.$value' );
+
+		$this->assertCount( 1, $errors );
+		$this->assertSame( 't.$value.fontFamily', $errors[0]->path );
+		$this->assertSame( Validation_Error::get_code_composite_field_missing(), $errors[0]->code );
+	}
+
+	/**
+	 * The optional fontStyle/textTransform/letterSpacing fields validate against their kinds when present:
+	 * valid keywords/lengths pass and a bogus fontStyle is rejected.
+	 *
+	 * @return void
+	 */
+	public function testTypographyValidatesOptionalTextStyleFields(): void {
+		$valid = [
+			'fontFamily'    => '{primitive.fontFamily.sans}',
+			'fontStyle'     => 'italic',
+			'textTransform' => 'uppercase',
+			'letterSpacing' => '-0.01em',
+		];
+		$this->assertSame( [], ( new Typography_Value() )->validate( $valid, 't.$value' ) );
+
+		$errors = ( new Typography_Value() )->validate(
+			[
+				'fontFamily' => '{primitive.fontFamily.sans}',
+				'fontStyle'  => 'slanted',
+			],
+			't.$value'
+		);
+
+		$this->assertCount( 1, $errors );
+		$this->assertSame( 't.$value.fontStyle', $errors[0]->path );
+		$this->assertSame( Validation_Error::get_code_value_invalid(), $errors[0]->code );
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/LiteralsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/LiteralsTest.php
@@ -281,4 +281,93 @@ final class LiteralsTest extends TestCase {
 			'expected' => false,
 		];
 	}
+
+	/**
+	 * A fontStyle literal is one of the CSS font-style keywords (case-insensitive); anything else is not.
+	 *
+	 * @dataProvider fontStyleProvider
+	 *
+	 * @param mixed $value    The candidate value.
+	 * @param bool  $expected Whether it is a valid fontStyle.
+	 *
+	 * @return void
+	 */
+	public function testFontStyles( $value, bool $expected ): void {
+		$this->assertSame( $expected, Literals::is_font_style( $value ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function fontStyleProvider(): Generator {
+		yield 'normal' => [
+			'value'    => 'normal',
+			'expected' => true,
+		];
+		yield 'italic' => [
+			'value'    => 'italic',
+			'expected' => true,
+		];
+		yield 'oblique' => [
+			'value'    => 'oblique',
+			'expected' => true,
+		];
+		yield 'mixed case' => [
+			'value'    => 'Italic',
+			'expected' => true,
+		];
+		yield 'unknown word' => [
+			'value'    => 'slanted',
+			'expected' => false,
+		];
+		yield 'number' => [
+			'value'    => 400,
+			'expected' => false,
+		];
+	}
+
+	/**
+	 * A textTransform literal is one of the CSS text-transform keywords (case-insensitive); anything else
+	 * is not.
+	 *
+	 * @dataProvider textTransformProvider
+	 *
+	 * @param mixed $value    The candidate value.
+	 * @param bool  $expected Whether it is a valid textTransform.
+	 *
+	 * @return void
+	 */
+	public function testTextTransforms( $value, bool $expected ): void {
+		$this->assertSame( $expected, Literals::is_text_transform( $value ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function textTransformProvider(): Generator {
+		yield 'none' => [
+			'value'    => 'none',
+			'expected' => true,
+		];
+		yield 'uppercase' => [
+			'value'    => 'uppercase',
+			'expected' => true,
+		];
+		yield 'capitalize' => [
+			'value'    => 'capitalize',
+			'expected' => true,
+		];
+		yield 'full-width' => [
+			'value'    => 'full-width',
+			'expected' => true,
+		];
+		yield 'unknown word' => [
+			'value'    => 'bogus',
+			'expected' => false,
+		];
+		yield 'empty' => [
+			'value'    => '',
+			'expected' => false,
+		];
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/Token_TypeTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/Token_TypeTest.php
@@ -90,24 +90,45 @@ final class Token_TypeTest extends TestCase {
 	}
 
 	/**
+	 * Typography requires only fontFamily; the other text-style properties are optional.
+	 *
 	 * @return void
 	 */
 	public function testTypographyFieldsMapToTheirKinds(): void {
 		$this->assertSame(
 			[
 				'fontFamily' => 'fontFamily',
-				'fontSize'   => 'dimension',
-				'fontWeight' => 'fontWeight',
-				'lineHeight' => 'lineHeight',
 			],
 			Token_Type::composite_fields( Token_Type::get_type_typography() )
 		);
 	}
 
 	/**
+	 * Typography's optional sub-fields map to their kinds so a token may carry any of them.
+	 *
+	 * @return void
+	 */
+	public function testTypographyOptionalFieldsMapToTheirKinds(): void {
+		$this->assertSame(
+			[
+				'fontSize'      => 'dimension',
+				'fontWeight'    => 'fontWeight',
+				'lineHeight'    => 'lineHeight',
+				'fontStyle'     => 'fontStyle',
+				'textTransform' => 'textTransform',
+				'letterSpacing' => 'dimension',
+			],
+			Token_Type::optional_composite_fields( Token_Type::get_type_typography() )
+		);
+	}
+
+	/**
+	 * A non-composite type has no required and no optional sub-fields.
+	 *
 	 * @return void
 	 */
 	public function testNonCompositeTypesHaveNoFields(): void {
 		$this->assertSame( [], Token_Type::composite_fields( Token_Type::get_type_color() ) );
+		$this->assertSame( [], Token_Type::optional_composite_fields( Token_Type::get_type_color() ) );
 	}
 }


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3529/button-typography-token-wiring-kadenceadvancedbtn-singlebtn

Makes the DTCG `typography` composite carry only `fontFamily` as required; `fontSize`, `fontWeight`, `lineHeight`, `fontStyle`, `textTransform` and `letterSpacing` become optional, so a typography token declares only the properties it drives. Adds `fontStyle`/`textTransform` literal grammar and regenerates the committed `dtcg.schema.json`. Existing `heading`/`body` tokens are unaffected.

### Checklist
- [ ] I have performed a self-review.
- [ ] No unrelated files are modified.
- [ ] No debugging statements exist (Ex: console.log, error_log).
- [ ] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
