### PR TITLE
SOFT-3529 [2/3] Resolver composite sub-field accessor

### DIFF
--- a/includes/resources/Design_Tokens/Resolver/Resolved_Tokens.php
+++ b/includes/resources/Design_Tokens/Resolver/Resolved_Tokens.php
@@ -38,22 +38,36 @@ final class Resolved_Tokens {
 	private array $by_id_target;
 
 	/**
+	 * Resolved composite sub-field map per composite token, token-id => (field => resolved literal). Each
+	 * field holds its alias-flattened literal (a fontFamily as its list, other fields as scalars), the raw
+	 * shape a consumer that needs the individual properties (rather than the rendered `font` shorthand in
+	 * by_id) reads. Only composite tokens (shadow, typography) appear here.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string,array<string,mixed>>
+	 */
+	private array $by_id_composite;
+
+	/**
 	 * Build the resolved maps. The projection defaults to the literal var map when omitted, so a
 	 * caller with no aliases to preserve constructs with just the two literal maps.
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string,string> $by_id            token-id => literal CSS value.
-	 * @param array<string,string> $by_var           css-var => literal CSS value.
-	 * @param array<string,string> $by_var_projected css-var => var()-preserving CSS value; defaults to
-	 *                                                the literal map when omitted (no aliases to preserve).
-	 * @param array<string,string> $by_id_target     token-id => immediate target token-id.
+	 * @param array<string,string>              $by_id            token-id => literal CSS value.
+	 * @param array<string,string>              $by_var           css-var => literal CSS value.
+	 * @param array<string,string>              $by_var_projected css-var => var()-preserving CSS value;
+	 *                                                            defaults to the literal map when omitted.
+	 * @param array<string,string>              $by_id_target     token-id => immediate target token-id.
+	 * @param array<string,array<string,mixed>> $by_id_composite  token-id => resolved composite sub-field map.
 	 */
-	public function __construct( array $by_id, array $by_var, array $by_var_projected = [], array $by_id_target = [] ) {
+	public function __construct( array $by_id, array $by_var, array $by_var_projected = [], array $by_id_target = [], array $by_id_composite = [] ) {
 		$this->by_id            = $by_id;
 		$this->by_var           = $by_var;
 		$this->by_var_projected = $by_var_projected === [] ? $by_var : $by_var_projected;
 		$this->by_id_target     = $by_id_target;
+		$this->by_id_composite  = $by_id_composite;
 	}
 
 	/**
@@ -124,5 +138,21 @@ final class Resolved_Tokens {
 	 */
 	public function target( string $id ): ?string {
 		return $this->by_id_target[ $id ] ?? null;
+	}
+
+	/**
+	 * The resolved composite sub-field map for a composite token (field => resolved literal), or null when
+	 * the token is unknown or not a composite. A fontFamily field holds its list; other fields hold their
+	 * resolved scalar. Consumers that need the individual properties read this rather than the rendered
+	 * `font` shorthand in {@see value()}.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id The token id.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	public function composite( string $id ): ?array {
+		return $this->by_id_composite[ $id ] ?? null;
 	}
 }

--- a/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
@@ -187,14 +187,15 @@ final class Token_Resolver {
 		$by_var           = [];
 		$by_var_projected = [];
 		$by_id_target     = [];
+		$by_id_composite  = [];
 
 		foreach ( Layers::token_layers() as $layer ) {
 			if ( isset( $document[ $layer ] ) && is_array( $document[ $layer ] ) ) {
-				$this->walk( $document[ $layer ], $layer, $document, $by_id, $by_var, $by_var_projected, $by_id_target, $css_namespace );
+				$this->walk( $document[ $layer ], $layer, $document, $by_id, $by_var, $by_var_projected, $by_id_target, $by_id_composite, $css_namespace );
 			}
 		}
 
-		return new Resolved_Tokens( $by_id, $by_var, $by_var_projected, $by_id_target );
+		return new Resolved_Tokens( $by_id, $by_var, $by_var_projected, $by_id_target, $by_id_composite );
 	}
 
 	/**
@@ -208,12 +209,13 @@ final class Token_Resolver {
 	 * @param array<string,string> $by_id            By-reference id => literal CSS value map.
 	 * @param array<string,string> $by_var           By-reference css-var => literal CSS value map.
 	 * @param array<string,string> $by_var_projected By-reference css-var => var()-preserving CSS value map.
-	 * @param array<string,string> $by_id_target     By-reference id => target id map (whole-$value aliases only).
-	 * @param string               $css_namespace        Css-var namespace to apply to projected names ('' for canonical).
+	 * @param array<string,string>              $by_id_target     By-reference id => target id map (whole-$value aliases only).
+	 * @param array<string,array<string,mixed>> $by_id_composite  By-reference id => resolved composite sub-field map.
+	 * @param string                            $css_namespace    Css-var namespace to apply to projected names ('' for canonical).
 	 *
 	 * @return void
 	 */
-	private function walk( array $node, string $prefix, array $document, array &$by_id, array &$by_var, array &$by_var_projected, array &$by_id_target, string $css_namespace = '' ): void {
+	private function walk( array $node, string $prefix, array $document, array &$by_id, array &$by_var, array &$by_var_projected, array &$by_id_target, array &$by_id_composite, string $css_namespace = '' ): void {
 		foreach ( $node as $key => $child ) {
 			if ( is_string( $key ) && strpos( $key, '$' ) === 0 ) {
 				continue; // DTCG metadata key.
@@ -233,6 +235,12 @@ final class Token_Resolver {
 
 				$by_id[ $path ] = $css;
 				$by_var[ $var ] = $css;
+
+				// A composite token also carries its resolved sub-field map, for consumers that need the
+				// individual properties (e.g. a per-block adapter) rather than the rendered shorthand.
+				if ( Token_Type::is_composite( $type ) && is_array( $value ) ) {
+					$by_id_composite[ $path ] = $value;
+				}
 
 				if ( is_string( $raw ) && Alias::is_alias( $raw ) ) {
 					// Whole-$value alias: the token's variable points straight at its immediate
@@ -254,7 +262,7 @@ final class Token_Resolver {
 				continue;
 			}
 
-			$this->walk( $child, $path, $document, $by_id, $by_var, $by_var_projected, $by_id_target, $css_namespace );
+			$this->walk( $child, $path, $document, $by_id, $by_var, $by_var_projected, $by_id_target, $by_id_composite, $css_namespace );
 		}
 	}
 

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Resolved_TokensTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Resolved_TokensTest.php
@@ -78,4 +78,25 @@ final class Resolved_TokensTest extends TestCase {
 
 		$this->assertNull( $resolved->target( 'primitive.color.brand.primary' ) );
 	}
+
+	/**
+	 * composite() returns the resolved sub-field map for a composite token and null for a token absent
+	 * from that map (a scalar token, or an unknown id).
+	 *
+	 * @return void
+	 */
+	public function testCompositeReturnsTheSubFieldMapOrNull(): void {
+		$bundle   = [ 'fontFamily' => [ 'Inter', 'sans-serif' ], 'fontWeight' => 400 ];
+		$resolved = new Resolved_Tokens(
+			[ 'semantic.typography.control' => '', 'semantic.color.text' => '#111' ],
+			[],
+			[],
+			[],
+			[ 'semantic.typography.control' => $bundle ]
+		);
+
+		$this->assertSame( $bundle, $resolved->composite( 'semantic.typography.control' ) );
+		$this->assertNull( $resolved->composite( 'semantic.color.text' ) );
+		$this->assertNull( $resolved->composite( 'nope.not.here' ) );
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
@@ -247,6 +247,46 @@ final class Token_ResolverTest extends TestCase {
 	}
 
 	/**
+	 * composite() exposes a composite token's resolved sub-field map with aliases flattened field by field
+	 * — a typography token whose fontFamily aliases a primitive resolves to that primitive's family list.
+	 *
+	 * @return void
+	 */
+	public function testCompositeExposesTheResolvedSubFieldMapWithAliasesFlattened(): void {
+		$resolver = $this->resolver_for(
+			[
+				'primitive' => [
+					'fontFamily' => [
+						'sans' => [
+							'$type'  => 'fontFamily',
+							'$value' => [ 'Inter', 'system-ui', 'sans-serif' ],
+						],
+					],
+				],
+				'semantic'   => [
+					'typography' => [
+						'control' => [
+							'$type'  => 'typography',
+							'$value' => [
+								'fontFamily' => '{primitive.fontFamily.sans}',
+								'fontWeight' => 400,
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$this->assertSame(
+			[
+				'fontFamily' => [ 'Inter', 'system-ui', 'sans-serif' ],
+				'fontWeight' => 400,
+			],
+			$resolver->resolve()->composite( 'semantic.typography.control' )
+		);
+	}
+
+	/**
 	 * A baseline alias overridden to a literal is "explicitly set": its effective $value is no longer an
 	 * alias, so it exposes no target and emits the literal — the indirection only applies when unset.
 	 *


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3529/button-typography-token-wiring-kadenceadvancedbtn-singlebtn

Adds `Resolved_Tokens::composite()`, returning a composite token's alias-flattened sub-field map (recorded as the resolver walks each composite leaf), for a consumer that needs the individual properties rather than the rendered shorthand.

### Checklist
- [ ] I have performed a self-review.
- [ ] No unrelated files are modified.
- [ ] No debugging statements exist (Ex: console.log, error_log).
- [ ] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
