### PR TITLE
SOFT-3529 [3/3] Wire kadence/singlebtn typography to a control token

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Adapter/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Adapter/Provider.php
@@ -7,29 +7,53 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
 
 /**
- * Registers the per-block adapter projector and wires it into KB's render path.
+ * Registers the per-block adapters and wires them into KB's render path, across two seams:
  *
- * KB emits `kadence_blocks_block_default_attributes` while assembling a block's attributes (passing the
- * block name), the same seam the block-preset projector uses. Running the adapter there — after the
- * preset overlay (priority 20 vs 10) — lets it rewrite the values a block's attributes cannot express
- * as a clean token/variable reference. The projector looks the adapter up by block at render time, so a
- * block with no adapter is a no-op.
+ *   1. Registration-default adapters (self::ADAPTERS). KB emits `kadence_blocks_block_default_attributes`
+ *      while assembling a block's *registration* defaults (passing the block name), the same seam the
+ *      block-preset projector uses. Running an adapter there — after the preset overlay (priority 20 vs
+ *      10) — lets it overlay a value a block's attributes cannot express as a clean token/variable
+ *      reference, while a genuinely-customized instance still wins via merge_attributes_with_defaults.
+ *      The Projector looks the adapter up by block at render time, so a block with no adapter is a no-op.
+ *      This suits a scalar attribute with a concrete default (an icon's `size`): the default is what gets
+ *      overlaid, so the seam must run before merge.
+ *   2. Render-instance adapters (self::RENDER_ADAPTERS). KB emits
+ *      `kadence_blocks_<block>_render_block_attributes` with a block's *already-merged instance*
+ *      attributes at render time. An adapter there sees the concrete per-instance values, so it can fill
+ *      a whole-object attribute (a button's `typography[0]` bundle) field by field, leaving any field the
+ *      instance set untouched — "local wins" at field granularity, impossible on the registration seam
+ *      because a stored object arrives whole. Each is hooked directly on its block's filter and gates /
+ *      fails soft itself, so it never needs the Registry's by-block lookup.
  *
  * @since TBD
  */
 final class Provider extends Provider_Contract {
 
 	/**
-	 * The adapter classes registered against the Token Registry, resolved from the container so an adapter
-	 * can take the Registry or Resolver as a dependency. A Kadence Blocks block whose attributes cannot be
-	 * expressed as a clean token/variable reference lists its adapter here.
+	 * Adapters that overlay a block's *registration defaults*, registered against the Token Registry and
+	 * dispatched by the Projector on `kadence_blocks_block_default_attributes` (before instance merge).
+	 * Resolved from the container so an adapter can take the Registry or Resolver as a dependency.
 	 *
 	 * @since TBD
 	 *
 	 * @var class-string<Adapter_Interface>[]
 	 */
-	private const ADAPTERS = [
+	private const DEFAULT_ATTRIBUTE_ADAPTERS = [
 		Icon_Size_Adapter::class,
+	];
+
+	/**
+	 * Adapters that fill a block's *merged instance attributes* at render time. Each is hooked on its
+	 * block's `kadence_blocks_<block>_render_block_attributes` filter (the block read from the adapter's
+	 * own get_block()) so it can fill a whole-object attribute from a token with field-level "local wins".
+	 * Resolved from the container so an adapter can take the Registry or Resolver as a dependency.
+	 *
+	 * @since TBD
+	 *
+	 * @var class-string<Adapter_Interface>[]
+	 */
+	private const RENDER_INSTANCE_ADAPTERS = [
+		Singlebtn_Typography_Adapter::class,
 	];
 
 	/**
@@ -52,10 +76,13 @@ final class Provider extends Provider_Contract {
 			20,
 			2
 		);
+
+		// Hook the render-instance adapters on init at the same priority — see register_render_instance_adapters().
+		add_action( 'init', [ $this, 'register_render_instance_adapters' ], 10 );
 	}
 
 	/**
-	 * Register the declared adapters against the Token Registry.
+	 * Register the declared registration-default adapters against the Token Registry.
 	 *
 	 * @since TBD
 	 *
@@ -65,10 +92,45 @@ final class Provider extends Provider_Contract {
 		/** @var Token_Registry $registry */
 		$registry = $this->container->get( Token_Registry::class );
 
-		foreach ( self::ADAPTERS as $adapter ) {
+		foreach ( self::DEFAULT_ATTRIBUTE_ADAPTERS as $adapter ) {
 			/** @var Adapter_Interface $instance */
 			$instance = $this->container->get( $adapter );
 			$registry->register_adapter( $instance );
 		}
+	}
+
+	/**
+	 * Hook each render-instance adapter on its block's `kadence_blocks_<block>_render_block_attributes`
+	 * filter, deriving the block from the adapter's get_block(). Runs on init so the container can resolve
+	 * an adapter's Registry/Resolver dependencies, and before any block renders.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register_render_instance_adapters(): void {
+		foreach ( self::RENDER_INSTANCE_ADAPTERS as $adapter ) {
+			/** @var Adapter_Interface $instance */
+			$instance = $this->container->get( $adapter );
+			$block    = str_replace( '-', '_', $this->block_slug( $instance->get_block() ) );
+
+			add_filter( "kadence_blocks_{$block}_render_block_attributes", [ $instance, 'apply' ], 10, 1 );
+		}
+	}
+
+	/**
+	 * The Kadence Blocks block slug (the segment after the namespace) an adapter is keyed to, e.g.
+	 * "kadence/singlebtn" => "singlebtn" — the infix KB builds its per-instance render filter name from.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block The fully-qualified block name.
+	 *
+	 * @return string
+	 */
+	private function block_slug( string $block ): string {
+		$slash = strpos( $block, '/' );
+
+		return $slash === false ? $block : substr( $block, $slash + 1 );
 	}
 }

--- a/includes/resources/Design_Tokens/Projection/Adapter/Singlebtn_Typography_Adapter.php
+++ b/includes/resources/Design_Tokens/Projection/Adapter/Singlebtn_Typography_Adapter.php
@@ -1,0 +1,257 @@
+<?php declare( strict_types=1 );
+// cspell:ignore singlebtn advancedbtn .
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts\Abstract_Adapter;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use KadenceWP\KadenceBlocks\Utils\Cast;
+use Throwable;
+
+/**
+ * Fills a kadence/singlebtn instance's `typography[0]` bundle from the resolved
+ * `semantic.typography.control` token, so a button follows the design system's on-brand typography with
+ * no per-instance edit while any locally-set field still wins.
+ *
+ * Unlike {@see Icon_Size_Adapter} — which overlays a block's *registration* defaults on
+ * `kadence_blocks_block_default_attributes` — a button's `typography` attribute is stored as a whole
+ * object (a partially-customized button saves every field), so a registration-default overlay would be
+ * all-or-nothing. This adapter instead runs on the per-instance `kadence_blocks_singlebtn_render_block_attributes`
+ * filter, which fires with the block's already-merged attributes at render time. That lets it fill each
+ * `typography[0]` field only when the instance left it blank, so a button that set (say) only its weight
+ * keeps that weight and still picks up the token family — field-level "local wins", not object-level.
+ * `Kadence_Blocks_CSS::render_typography()` then emits the CSS exactly as it does for a hand-set value,
+ * so nothing in the button's render path or stylesheet changes.
+ *
+ * The token drives only the sub-fields it declares (the shipped baseline seeds just `fontFamily`), so a
+ * field the token omits is left to inherit — activation changes only the on-brand font family until a
+ * site owner overrides the token to add weight/size/style/etc.
+ *
+ * An {@see Adapter_Interface} like {@see Icon_Size_Adapter}, but {@see Provider} hooks it on the
+ * per-instance render filter keyed by {@see get_block()} rather than dispatching it through the Token
+ * Registry (whose lookup only feeds the registration-default filter this adapter must not use). It is a
+ * no-op when projection is fail-closed, when the token is absent, or when it throws, so it is safe on
+ * every button render.
+ *
+ * @since TBD
+ */
+final class Singlebtn_Typography_Adapter extends Abstract_Adapter {
+
+	/**
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	protected const BLOCK = 'kadence/singlebtn';
+
+	/**
+	 * The resolved-token dot-path this adapter reads.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const TOKEN = 'semantic.typography.control';
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Token_Resolver
+	 */
+	private Token_Resolver $resolver;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry $registry The token registry (for the fail-closed guard).
+	 * @param Token_Resolver $resolver The token resolver.
+	 */
+	public function __construct( Token_Registry $registry, Token_Resolver $resolver ) {
+		$this->registry = $registry;
+		$this->resolver = $resolver;
+	}
+
+	/**
+	 * Fill the button's `typography[0]` bundle from the control token, returning the transformed
+	 * attributes. A no-op when projection is fail-closed, the token is absent, or a failure occurs.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $attributes The button's already-merged instance attributes.
+	 *
+	 * @return array<string, mixed> The transformed attributes.
+	 */
+	public function apply( array $attributes ): array {
+		// Respect the fail-closed guard: fall back to stock KB behavior rather than half-applying tokens.
+		if ( ! $this->registry->is_active() ) {
+			return $attributes;
+		}
+
+		try {
+			$bundle = $this->resolver->resolve()->composite( self::TOKEN );
+
+			if ( $bundle === null ) {
+				return $attributes;
+			}
+
+			return $this->fill( $attributes, $bundle );
+		} catch ( Throwable $e ) {
+			// This runs in the render path: a faulty resolve must never fatal a page, so fail soft.
+			return $attributes;
+		}
+	}
+
+	/**
+	 * Fill each blank `typography[0]` field from the resolved token bundle, leaving locally-set fields
+	 * untouched.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $attributes The button's instance attributes.
+	 * @param array<string, mixed> $bundle     The resolved control-token sub-fields (field => literal).
+	 *
+	 * @return array<string, mixed> The transformed attributes.
+	 */
+	private function fill( array $attributes, array $bundle ): array {
+		$instances  = isset( $attributes['typography'] ) && is_array( $attributes['typography'] ) ? $attributes['typography'] : [];
+		$typography = ( isset( $instances[0] ) && is_array( $instances[0] ) ) ? $instances[0] : [];
+
+		if ( isset( $bundle['fontFamily'] ) && $this->is_blank( $typography['family'] ?? '' ) ) {
+			$typography['family'] = $this->font_family( $bundle['fontFamily'] );
+		}
+
+		if ( isset( $bundle['fontWeight'] ) && $this->is_blank( $typography['weight'] ?? '' ) ) {
+			$typography['weight'] = Cast::to_string( $bundle['fontWeight'] );
+		}
+
+		if ( isset( $bundle['fontStyle'] ) && $this->is_blank( $typography['style'] ?? '' ) ) {
+			$typography['style'] = Cast::to_string( $bundle['fontStyle'] );
+		}
+
+		if ( isset( $bundle['textTransform'] ) && $this->is_blank( $typography['textTransform'] ?? '' ) ) {
+			$typography['textTransform'] = Cast::to_string( $bundle['textTransform'] );
+		}
+
+		$this->fill_length( $typography, 'size', 'sizeType', $bundle['fontSize'] ?? null );
+		$this->fill_length( $typography, 'lineHeight', 'lineType', $bundle['lineHeight'] ?? null );
+		$this->fill_length( $typography, 'letterSpacing', 'letterType', $bundle['letterSpacing'] ?? null );
+
+		$instances[0]            = $typography;
+		$attributes['typography'] = $instances;
+
+		return $attributes;
+	}
+
+	/**
+	 * Fill a responsive-length `typography[0]` field (size/lineHeight/letterSpacing) and its unit key from
+	 * a resolved token value, only when the instance left the desktop slot blank. The number lands in the
+	 * desktop slot and the parsed unit in the unit key; a unit-less value (e.g. a raw line-height) leaves
+	 * the unit key untouched.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $typography The button's typography[0] bundle, by reference.
+	 * @param string               $value_key  The responsive value key (e.g. "size").
+	 * @param string               $unit_key   The unit key (e.g. "sizeType").
+	 * @param mixed                $resolved   The resolved token value, or null when the token omits it.
+	 *
+	 * @return void
+	 */
+	private function fill_length( array &$typography, string $value_key, string $unit_key, $resolved ): void {
+		if ( $resolved === null ) {
+			return;
+		}
+
+		$current = $typography[ $value_key ] ?? [ '', '', '' ];
+		$desktop = is_array( $current ) ? ( $current[0] ?? '' ) : $current;
+
+		if ( ! $this->is_blank( $desktop ) ) {
+			return;
+		}
+
+		[ $number, $unit ] = $this->split_length( Cast::to_string( $resolved ) );
+
+		if ( $number === '' ) {
+			return;
+		}
+
+		$responsive      = is_array( $current ) ? $current : [ '', '', '' ];
+		$responsive[0]   = $number;
+		$typography[ $value_key ] = $responsive;
+
+		if ( $unit !== '' ) {
+			$typography[ $unit_key ] = $unit;
+		}
+	}
+
+	/**
+	 * Split a CSS length into its numeric portion and unit, e.g. "1.5rem" => ["1.5", "rem"] and a
+	 * unit-less "1.5" => ["1.5", ""]. A value with no leading number (e.g. "normal") yields ["", ""], so
+	 * the caller skips it.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $length The CSS length.
+	 *
+	 * @return array{0:string, 1:string} The [number, unit] pair.
+	 */
+	private function split_length( string $length ): array {
+		if ( preg_match( '/^(-?(?:\d+\.?\d*|\.\d+))([a-z%]*)$/i', trim( $length ), $matches ) !== 1 ) {
+			return [ '', '' ];
+		}
+
+		return [ $matches[1], $matches[2] ];
+	}
+
+	/**
+	 * Render a resolved fontFamily (a list of family names, or a single string) to the CSS family stack
+	 * the `family` attribute stores, quoting any name that contains whitespace.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $family The resolved fontFamily value.
+	 *
+	 * @return string
+	 */
+	private function font_family( $family ): string {
+		if ( ! is_array( $family ) ) {
+			return Cast::to_string( $family );
+		}
+
+		$names = array_map(
+			static function ( $name ): string {
+				// Strip any surrounding quotes an authored family already carries before re-quoting, so a
+				// name that needs quoting because it contains a space (e.g. an already-quoted "Segoe UI")
+				// is not double-wrapped into a broken `""Segoe UI""`.
+				$name = trim( Cast::to_string( $name ) );
+				$name = trim( $name, "\"'" );
+
+				return strpos( $name, ' ' ) !== false ? '"' . $name . '"' : $name;
+			},
+			$family
+		);
+
+		return implode( ', ', $names );
+	}
+
+	/**
+	 * Whether a stored typography value counts as blank (unset by the instance), so the token may fill it.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $value The stored value.
+	 *
+	 * @return bool
+	 */
+	private function is_blank( $value ): bool {
+		return $value === '' || $value === null;
+	}
+}

--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -385,6 +385,12 @@
 					"fontWeight": 400,
 					"lineHeight": 1.6
 				}
+			},
+			"control": {
+				"$type": "typography",
+				"$value": {
+					"fontFamily": "{primitive.fontFamily.sans}"
+				}
 			}
 		},
 		"shadow": {

--- a/includes/resources/Design_Tokens/Resolver/Variant_Value_Normalizer.php
+++ b/includes/resources/Design_Tokens/Resolver/Variant_Value_Normalizer.php
@@ -109,7 +109,17 @@ final class Variant_Value_Normalizer {
 				continue;
 			}
 
-			$index[ $this->normalize_value( $value ) ][] = (string) $id;
+			$normalized = $this->normalize_value( $value );
+
+			// An empty resolved value is not a useful match target: a semantic that renders to nothing
+			// (e.g. a typography token carrying only a family, whose `font` shorthand needs a size and so
+			// renders empty) would otherwise let an invalid empty literal alias onto it. Skipping empties
+			// keeps an empty captured value a literal, which the DTCG grammar then rejects as it should.
+			if ( $normalized === '' ) {
+				continue;
+			}
+
+			$index[ $normalized ][] = (string) $id;
 		}
 
 		return $index;

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Adapter/Singlebtn_Typography_AdapterTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Adapter/Singlebtn_Typography_AdapterTest.php
@@ -1,0 +1,207 @@
+<?php declare( strict_types=1 );
+// cspell:ignore singlebtn .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Projection\Adapter;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Singlebtn_Typography_Adapter;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Css_Renderer;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use Tests\Support\Classes\Fake_Baseline_Document;
+use Tests\Support\Classes\TestCase;
+
+final class Singlebtn_Typography_AdapterTest extends TestCase {
+
+	/**
+	 * Build the adapter over an active registry and a resolver whose `semantic.typography.control` leaf
+	 * holds the given composite `$value`.
+	 *
+	 * @param array<string, mixed> $value The control token's `$value` (its sub-field map).
+	 *
+	 * @return Singlebtn_Typography_Adapter
+	 */
+	private function adapter_with_control( array $value ): Singlebtn_Typography_Adapter {
+		return new Singlebtn_Typography_Adapter(
+			new Token_Registry(),
+			$this->resolver_for(
+				[
+					'semantic' => [
+						'typography' => [
+							'control' => [
+								'$type'  => 'typography',
+								'$value' => $value,
+							],
+						],
+					],
+				]
+			)
+		);
+	}
+
+	/**
+	 * Build a resolver over a fully-controlled baseline.
+	 *
+	 * @param array<string, mixed> $baseline The baseline document.
+	 *
+	 * @return Token_Resolver
+	 */
+	private function resolver_for( array $baseline ): Token_Resolver {
+		return new Token_Resolver(
+			$this->container->get( Token_Store::class ),
+			new Effective_Document( new Fake_Baseline_Document( $baseline ) ),
+			new Css_Renderer()
+		);
+	}
+
+	/**
+	 * A button with no typography set has its family filled from the control token's font-family stack,
+	 * joined into the string the `family` attribute stores.
+	 *
+	 * @return void
+	 */
+	public function testAMissingFamilyIsFilledFromTheToken(): void {
+		$adapter = $this->adapter_with_control( [ 'fontFamily' => [ 'Inter', 'system-ui', 'sans-serif' ] ] );
+
+		$attributes = $adapter->apply( [ 'typography' => [ [ 'family' => '' ] ] ] );
+
+		$this->assertSame( 'Inter, system-ui, sans-serif', $attributes['typography'][0]['family'] );
+	}
+
+	/**
+	 * A family stack whose members contain spaces is quoted once, and a member that already carries
+	 * surrounding quotes is not double-wrapped into a broken `""Segoe UI""`.
+	 *
+	 * @return void
+	 */
+	public function testAFamilyStackIsQuotedOnceWithoutDoubleWrapping(): void {
+		$adapter = $this->adapter_with_control(
+			[ 'fontFamily' => [ '-apple-system', '"Segoe UI"', 'Helvetica Neue', 'sans-serif' ] ]
+		);
+
+		$attributes = $adapter->apply( [ 'typography' => [ [ 'family' => '' ] ] ] );
+
+		$this->assertSame(
+			'-apple-system, "Segoe UI", "Helvetica Neue", sans-serif',
+			$attributes['typography'][0]['family']
+		);
+	}
+
+	/**
+	 * A family the instance already set wins over the token — the adapter fills only blank fields.
+	 *
+	 * @return void
+	 */
+	public function testALocallySetFamilyWins(): void {
+		$adapter = $this->adapter_with_control( [ 'fontFamily' => [ 'Inter', 'sans-serif' ] ] );
+
+		$attributes = $adapter->apply( [ 'typography' => [ [ 'family' => 'Georgia' ] ] ] );
+
+		$this->assertSame( 'Georgia', $attributes['typography'][0]['family'] );
+	}
+
+	/**
+	 * Local-wins is field-level: an instance that set only its weight keeps that weight and still picks up
+	 * the token family and size.
+	 *
+	 * @return void
+	 */
+	public function testFillIsFieldLevelSoASetFieldSurvivesWhileBlanksFill(): void {
+		$adapter = $this->adapter_with_control(
+			[
+				'fontFamily' => [ 'Inter', 'sans-serif' ],
+				'fontWeight' => 400,
+				'fontSize'   => '1rem',
+			]
+		);
+
+		$attributes = $adapter->apply( [ 'typography' => [ [ 'family' => '', 'weight' => '700', 'size' => [ '', '', '' ] ] ] ] );
+
+		$typography = $attributes['typography'][0];
+		$this->assertSame( '700', $typography['weight'] );
+		$this->assertSame( 'Inter, sans-serif', $typography['family'] );
+		$this->assertSame( [ '1', '', '' ], $typography['size'] );
+		$this->assertSame( 'rem', $typography['sizeType'] );
+	}
+
+	/**
+	 * A resolved dimension with no unit (a "0" letter-spacing) fills the desktop slot and leaves the unit
+	 * key untouched.
+	 *
+	 * @return void
+	 */
+	public function testAUnitlessLengthFillsTheValueWithoutAUnit(): void {
+		$adapter = $this->adapter_with_control(
+			[
+				'fontFamily'    => [ 'Inter' ],
+				'letterSpacing' => '0',
+			]
+		);
+
+		$attributes = $adapter->apply( [ 'typography' => [ [ 'family' => '' ] ] ] );
+
+		$this->assertSame( [ '0', '', '' ], $attributes['typography'][0]['letterSpacing'] );
+		$this->assertArrayNotHasKey( 'letterType', $attributes['typography'][0] );
+	}
+
+	/**
+	 * When projection is fail-closed the adapter is a no-op, leaving the attributes exactly as KB stored
+	 * them.
+	 *
+	 * @return void
+	 */
+	public function testAnInactiveRegistryLeavesAttributesUnchanged(): void {
+		$registry = new Token_Registry();
+		$registry->deactivate();
+
+		$adapter    = new Singlebtn_Typography_Adapter(
+			$registry,
+			$this->resolver_for(
+				[
+					'semantic' => [
+						'typography' => [
+							'control' => [
+								'$type'  => 'typography',
+								'$value' => [ 'fontFamily' => [ 'Inter' ] ],
+							],
+						],
+					],
+				]
+			)
+		);
+		$attributes = [ 'typography' => [ [ 'family' => '' ] ] ];
+
+		$this->assertSame( $attributes, $adapter->apply( $attributes ) );
+	}
+
+	/**
+	 * With no `semantic.typography.control` leaf in the baseline the token is absent, so the adapter leaves
+	 * the attributes untouched.
+	 *
+	 * @return void
+	 */
+	public function testAnAbsentTokenLeavesAttributesUnchanged(): void {
+		$adapter    = new Singlebtn_Typography_Adapter( new Token_Registry(), $this->resolver_for( [] ) );
+		$attributes = [ 'typography' => [ [ 'family' => '' ] ] ];
+
+		$this->assertSame( $attributes, $adapter->apply( $attributes ) );
+	}
+
+	/**
+	 * The adapter is registered on the real `kadence_blocks_singlebtn_render_block_attributes` filter and
+	 * fills a blank family from the shipped baseline's `semantic.typography.control` (the sans stack),
+	 * proving the wiring in `Adapter\Provider`, not just the adapter class in isolation.
+	 *
+	 * @return void
+	 */
+	public function testTheRegisteredAdapterFillsFamilyThroughTheRealFilterChain(): void {
+		$attributes = apply_filters(
+			'kadence_blocks_singlebtn_render_block_attributes',
+			[ 'typography' => [ [ 'family' => '' ] ] ],
+			null
+		);
+
+		$this->assertSame( 'Inter, system-ui, sans-serif', $attributes['typography'][0]['family'] );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_Value_NormalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_Value_NormalizerTest.php
@@ -105,4 +105,17 @@ final class Variant_Value_NormalizerTest extends TestCase {
 			'The hover property should prefer a hover-role semantic.'
 		);
 	}
+
+	/**
+	 * An empty captured literal is never aliased onto a semantic that resolves to an empty value (such as the
+	 * family-only semantic.typography.control, whose `font` shorthand renders empty). It stays an empty
+	 * literal so the DTCG grammar rejects it downstream.
+	 *
+	 * @return void
+	 */
+	public function testItDoesNotAliasAnEmptyLiteralToAnEmptyResolvingSemantic(): void {
+		$result = $this->normalizer->normalize( [ 'button-bg' => '' ], self::SET );
+
+		$this->assertSame( '', $result['button-bg'] );
+	}
 }


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3529/button-typography-token-wiring-kadenceadvancedbtn-singlebtn

Wires `kadence/singlebtn` typography to a new `semantic.typography.control` token, seeded to the on-brand font family. A render-instance adapter fills the button's `typography[0]` bundle from the resolved token with field-level local-wins on the per-instance render filter, so an uncustomized button follows the token while any per-button value still wins — with no change to the button's render path or stylesheet. Also adds a render-instance adapter category alongside the existing registration-default one, and guards the variant value normalizer against aliasing a value onto an empty-resolving semantic.

### Checklist
- [ ] I have performed a self-review.
- [ ] No unrelated files are modified.
- [ ] No debugging statements exist (Ex: console.log, error_log).
- [ ] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
