### PR TITLE
SOFT-3529 [3/3] Wire kadence/singlebtn typography via per-property CSS vars

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Css_Var/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Css_Builder.php
@@ -11,6 +11,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Scope;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Resolved_Tokens;
+use KadenceWP\KadenceBlocks\Utils\Cast;
 
 /**
  * Builds the CSS custom-property output for every token set at once — the CSS-variable backbone, in the
@@ -62,6 +63,28 @@ final class Css_Builder {
 	 * @var string
 	 */
 	private const CACHE_GROUP = 'kb_design_tokens';
+
+	/**
+	 * A typography composite's sub-field => the CSS property a block reads it as. A composite token can
+	 * only be consumed through a single `font` shorthand var, which is useless to a block that sets its
+	 * properties individually (and renders empty unless the token carries both a size and a family); so
+	 * every typography token is ALSO projected as one custom property per sub-field, named
+	 * `--kb-token--<id>--<css-prop>`, that a block's CSS reads directly (e.g. the Button's `font-family`).
+	 * A composite whose fields are not in this map (a shadow) contributes nothing here.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string, string>
+	 */
+	private const TYPOGRAPHY_FIELD_CSS_PROPS = [
+		'fontFamily'    => 'font-family',
+		'fontSize'      => 'font-size',
+		'fontWeight'    => 'font-weight',
+		'lineHeight'    => 'line-height',
+		'fontStyle'     => 'font-style',
+		'textTransform' => 'text-transform',
+		'letterSpacing' => 'letter-spacing',
+	];
 
 	/**
 	 * The HTML attribute a body class / container sets to switch the active token set client-side. Its
@@ -278,7 +301,79 @@ final class Css_Builder {
 	private function build_active_fragment( Resolved_Tokens $active, string $active_slug ): string {
 		return $this->alias_block( $active, $active_slug )
 			. $this->slot_block( $active, Spacing_Target::class )
-			. $this->slot_block( $active, Gap_Target::class );
+			. $this->slot_block( $active, Gap_Target::class )
+			. $this->typography_field_block( $active );
+	}
+
+	/**
+	 * Emit one custom property per typography sub-field — `--kb-token--<id>--<css-prop>: <value>;` — for
+	 * every typography composite in the active set, so a block reads each property (font-family, weight,
+	 * …) directly instead of the single, block-useless `font` shorthand. A field the token omits is not
+	 * emitted, so the block's `var(--…--<prop>)` falls back to its own default; a field the token sets is
+	 * emitted and wins. Resolved to the active set's literals (aliases already flattened); a write
+	 * re-projects, so an override propagates. Non-typography composites (shadow) contribute nothing.
+	 *
+	 * @since TBD
+	 *
+	 * @param Resolved_Tokens $active The active set's resolved maps.
+	 *
+	 * @return string
+	 */
+	private function typography_field_block( Resolved_Tokens $active ): string {
+		$declarations = '';
+
+		foreach ( $active->composite_ids() as $id ) {
+			$fields = $active->composite( $id );
+
+			if ( $fields === null ) {
+				continue;
+			}
+
+			$prefix = Css_Var::from_id( $id );
+
+			foreach ( self::TYPOGRAPHY_FIELD_CSS_PROPS as $field => $css_prop ) {
+				if ( ! array_key_exists( $field, $fields ) ) {
+					continue;
+				}
+
+				$value = $this->render_field( $fields[ $field ] );
+
+				if ( $value === '' ) {
+					continue;
+				}
+
+				$declarations .= $prefix . '--' . $css_prop . ':' . $this->sanitize_value( $value ) . ';';
+			}
+		}
+
+		return $declarations === '' ? '' : Scope::root() . '{' . $declarations . '}';
+	}
+
+	/**
+	 * Render a resolved typography sub-field to its CSS string: a fontFamily list becomes a comma-joined
+	 * family stack (each space-bearing name quoted); any other field is cast to string.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $value The resolved sub-field value.
+	 *
+	 * @return string
+	 */
+	private function render_field( $value ): string {
+		if ( is_array( $value ) ) {
+			$families = array_map(
+				static function ( $family ): string {
+					$name = trim( Cast::to_string( $family ), " \t\n\r\0\x0B\"'" );
+
+					return strpos( $name, ' ' ) !== false ? '"' . $name . '"' : $name;
+				},
+				$value
+			);
+
+			return implode( ', ', $families );
+		}
+
+		return Cast::to_string( $value );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -385,6 +385,12 @@
 					"fontWeight": 400,
 					"lineHeight": 1.6
 				}
+			},
+			"control": {
+				"$type": "typography",
+				"$value": {
+					"fontFamily": "{primitive.fontFamily.sans}"
+				}
 			}
 		},
 		"shadow": {

--- a/includes/resources/Design_Tokens/Resolver/Resolved_Tokens.php
+++ b/includes/resources/Design_Tokens/Resolver/Resolved_Tokens.php
@@ -155,4 +155,16 @@ final class Resolved_Tokens {
 	public function composite( string $id ): ?array {
 		return $this->by_id_composite[ $id ] ?? null;
 	}
+
+	/**
+	 * The ids of every composite token in this resolution, for a consumer that walks them (e.g. the
+	 * per-sub-field css-var projection).
+	 *
+	 * @since TBD
+	 *
+	 * @return string[]
+	 */
+	public function composite_ids(): array {
+		return array_keys( $this->by_id_composite );
+	}
 }

--- a/includes/resources/Design_Tokens/Resolver/Variant_Value_Normalizer.php
+++ b/includes/resources/Design_Tokens/Resolver/Variant_Value_Normalizer.php
@@ -109,7 +109,17 @@ final class Variant_Value_Normalizer {
 				continue;
 			}
 
-			$index[ $this->normalize_value( $value ) ][] = (string) $id;
+			$normalized = $this->normalize_value( $value );
+
+			// An empty resolved value is not a useful match target: a semantic that renders to nothing
+			// (e.g. a typography token carrying only a family, whose `font` shorthand needs a size and so
+			// renders empty) would otherwise let an invalid empty literal alias onto it. Skipping empties
+			// keeps an empty captured value a literal, which the DTCG grammar then rejects as it should.
+			if ( $normalized === '' ) {
+				continue;
+			}
+
+			$index[ $normalized ][] = (string) $id;
 		}
 
 		return $index;

--- a/src/blocks/advancedbtn/editor.scss
+++ b/src/blocks/advancedbtn/editor.scss
@@ -218,7 +218,15 @@
 .kt-button:not(.kb-btn-global-inherit) {
 	padding: 0.4em 1em;
 	cursor: pointer;
-	font-size: 1.125rem;
+	// Mirror of style.scss: the button follows the semantic.typography.control token per sub-field so the
+	// editor preview matches the front end. See the note there.
+	font-family: var(--kb-token--semantic--typography--control--font-family, inherit);
+	font-size: var(--kb-token--semantic--typography--control--font-size, 1.125rem);
+	font-weight: var(--kb-token--semantic--typography--control--font-weight);
+	font-style: var(--kb-token--semantic--typography--control--font-style);
+	line-height: var(--kb-token--semantic--typography--control--line-height);
+	letter-spacing: var(--kb-token--semantic--typography--control--letter-spacing);
+	text-transform: var(--kb-token--semantic--typography--control--text-transform);
 	border-radius: var(--kb-btn-radius, var(--kb-token--semantic--radius--control, 3px));
 	transition: all 0.3s ease-in-out;
 	box-shadow: none;

--- a/src/blocks/advancedbtn/style.scss
+++ b/src/blocks/advancedbtn/style.scss
@@ -37,7 +37,17 @@
 	border: 0 solid transparent;
 	padding: 0.4em 1em;
 	cursor: pointer;
-	font-size: 1.125rem;
+	// Typography follows the semantic.typography.control token, one custom property per sub-field, so a
+	// button follows the design system in the editor and on the front end. Each is a low-specificity
+	// default: a per-button typography value renders at the higher `.kb-btn<uid>` specificity and wins,
+	// and a sub-field the token does not set leaves the property to inherit (its current behavior).
+	font-family: var(--kb-token--semantic--typography--control--font-family, inherit);
+	font-size: var(--kb-token--semantic--typography--control--font-size, 1.125rem);
+	font-weight: var(--kb-token--semantic--typography--control--font-weight);
+	font-style: var(--kb-token--semantic--typography--control--font-style);
+	line-height: var(--kb-token--semantic--typography--control--line-height);
+	letter-spacing: var(--kb-token--semantic--typography--control--letter-spacing);
+	text-transform: var(--kb-token--semantic--typography--control--text-transform);
 	border-radius: var(--kb-btn-radius, var(--kb-token--semantic--radius--control, 3px));
 	transition: all 0.3s ease-in-out;
 	box-shadow: none;

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Css_BuilderTest.php
@@ -1,5 +1,5 @@
 <?php declare( strict_types=1 );
-// cspell:ignore palette Fghi redbodycolor xxs xxl .
+// cspell:ignore palette Fghi redbodycolor xxs xxl Segoe Helvetica .
 
 namespace Tests\wpunit\Resources\Design_Tokens\Projection\Css_Var;
 
@@ -458,5 +458,73 @@ final class Css_BuilderTest extends TestCase {
 
 		$this->assertStringContainsString( '--dark-fragment-sentinel:1;', $with_dark_active );
 		$this->assertStringContainsString( '--dark-fragment-sentinel:1;', $with_default_active );
+	}
+
+	// ---- Typography composite per-sub-field vars ----------------------------------------------------
+
+	/**
+	 * A typography composite is projected as one custom property per sub-field it carries, named
+	 * --kb-token--<id>--<css-prop>, so a block reads each property directly. A field the token omits
+	 * is not emitted, so the block's own default (or inheritance) stands.
+	 *
+	 * @return void
+	 */
+	public function testItProjectsTypographyCompositeSubFieldsAsPerPropertyVars(): void {
+		$id       = 'semantic.typography.control';
+		$resolved = new Resolved_Tokens(
+			[ $id => '' ],
+			[],
+			[ Css_Var::from_id( $id, 'default' ) => '' ],
+			[],
+			[ $id => [ 'fontFamily' => [ 'Inter', 'system-ui', 'sans-serif' ], 'fontWeight' => 500 ] ]
+		);
+
+		$css = $this->css_default( $resolved );
+
+		$this->assertStringContainsString( '--kb-token--semantic--typography--control--font-family:Inter, system-ui, sans-serif;', $css );
+		$this->assertStringContainsString( '--kb-token--semantic--typography--control--font-weight:500;', $css );
+		$this->assertStringNotContainsString( '--kb-token--semantic--typography--control--font-size', $css );
+	}
+
+	/**
+	 * A family stack member that already carries surrounding quotes is not double-wrapped when re-quoted
+	 * for containing a space, and a bare space-bearing member is quoted once.
+	 *
+	 * @return void
+	 */
+	public function testItQuotesFamilyStackMembersOnceWithoutDoubleWrapping(): void {
+		$id       = 'semantic.typography.control';
+		$resolved = new Resolved_Tokens(
+			[ $id => '' ],
+			[],
+			[ Css_Var::from_id( $id, 'default' ) => '' ],
+			[],
+			[ $id => [ 'fontFamily' => [ '"Segoe UI"', 'Helvetica Neue', 'sans-serif' ] ] ]
+		);
+
+		$css = $this->css_default( $resolved );
+
+		$this->assertStringContainsString( '--kb-token--semantic--typography--control--font-family:"Segoe UI", "Helvetica Neue", sans-serif;', $css );
+	}
+
+	/**
+	 * A shadow composite contributes no per-property typography vars — its fields are not typography
+	 * properties, so the projection skips them.
+	 *
+	 * @return void
+	 */
+	public function testItDoesNotProjectSubFieldVarsForANonTypographyComposite(): void {
+		$id       = 'semantic.shadow.card';
+		$resolved = new Resolved_Tokens(
+			[ $id => '0 2px 8px #000' ],
+			[],
+			[ Css_Var::from_id( $id, 'default' ) => '0 2px 8px #000' ],
+			[],
+			[ $id => [ 'color' => '#000', 'offsetX' => '0px', 'offsetY' => '2px', 'blur' => '8px', 'spread' => '0px' ] ]
+		);
+
+		$css = $this->css_default( $resolved );
+
+		$this->assertStringNotContainsString( '--kb-token--semantic--shadow--card--', $css );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_Value_NormalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_Value_NormalizerTest.php
@@ -105,4 +105,17 @@ final class Variant_Value_NormalizerTest extends TestCase {
 			'The hover property should prefer a hover-role semantic.'
 		);
 	}
+
+	/**
+	 * An empty captured literal is never aliased onto a semantic that resolves to an empty value (such as
+	 * the family-only semantic.typography.control, whose `font` shorthand renders empty). It stays an
+	 * empty literal so the DTCG grammar rejects it downstream.
+	 *
+	 * @return void
+	 */
+	public function testItDoesNotAliasAnEmptyLiteralToAnEmptyResolvingSemantic(): void {
+		$result = $this->normalizer->normalize( [ 'button-bg' => '' ], self::SET );
+
+		$this->assertSame( '', $result['button-bg'] );
+	}
 }


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3529/button-typography-token-wiring-kadenceadvancedbtn-singlebtn

Wires `kadence/singlebtn` typography to the design system through CSS variables, so a button follows the token in the editor and on the front end, a per-button value still wins by specificity, and nothing is written to saved content (no freezing).

Each typography composite is projected as one custom property per sub-field (`--kb-token--<id>--<css-prop>`) — the single `font` shorthand is useless to a block that sets properties individually — and the Button's `style.scss`/`editor.scss` read those vars (`font-family`, `font-weight`, `font-style`, `text-transform`, `font-size`, `line-height`, `letter-spacing`). The shipped `semantic.typography.control` token seeds only the on-brand font family, so nothing but the family changes until a field is set; the wiring already carries the rest. The variant value normalizer is guarded against aliasing an empty literal onto an empty-resolving semantic.

### Checklist
- [ ] I have performed a self-review.
- [ ] No unrelated files are modified.
- [ ] No debugging statements exist (Ex: console.log, error_log).
- [ ] There are no warnings or notices in the wordpress error log.
- [ ] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
