### PR TITLE
SOFT-3529 [2/2] Wire kadence/singlebtn typography to discrete tokens

### DIFF
--- a/dev_scripts/src/Design_Tokens/Schema/Dtcg_Schema_Generator.php
+++ b/dev_scripts/src/Design_Tokens/Schema/Dtcg_Schema_Generator.php
@@ -207,12 +207,18 @@ final class Dtcg_Schema_Generator {
 			return $this->composite_shape( $type );
 		}
 
-		// color, dimension: a literal string (hex/function/keyword/length). PHP Literals enforces grammar.
+		// fontWeight (400 / "bold") and lineHeight (1.5 / "1.5rem") accept a number as well as a string.
+		if ( $type === Token_Type::get_type_font_weight() || $type === Token_Type::get_type_line_height() ) {
+			return [ 'type' => [ 'string', 'number' ] ];
+		}
+
+		// color, dimension, fontStyle, textTransform: a literal string. PHP Literals enforces grammar.
 		return [ 'type' => 'string' ];
 	}
 
 	/**
-	 * The object shape for a composite type: every sub-field required, each "alias OR kind shape".
+	 * The object shape for a composite type: every sub-field required, each "alias OR the sub-field's own
+	 * $type shape".
 	 *
 	 * @since TBD
 	 *
@@ -224,11 +230,11 @@ final class Dtcg_Schema_Generator {
 		$fields     = Token_Type::composite_fields( $type );
 		$properties = [];
 
-		foreach ( $fields as $field => $kind ) {
+		foreach ( $fields as $field => $field_type ) {
 			$properties[ $field ] = [
 				'anyOf' => [
 					[ '$ref' => '#/definitions/alias' ],
-					$this->kind_shape( $kind ),
+					$this->literal_shape( $field_type ),
 				],
 			];
 		}
@@ -239,29 +245,6 @@ final class Dtcg_Schema_Generator {
 			'properties'           => $properties,
 			'additionalProperties' => false,
 		];
-	}
-
-	/**
-	 * The permissive non-alias shape for a composite sub-field kind.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $kind A $type or KIND_* constant.
-	 *
-	 * @return array<string, mixed>
-	 */
-	private function kind_shape( string $kind ): array {
-		switch ( $kind ) {
-			case Token_Type::get_type_font_family():
-				return [
-					'type'     => 'array',
-					'items'    => [ 'type' => 'string' ],
-					'minItems' => 1,
-				];
-			default:
-				// color, dimension.
-				return [ 'type' => 'string' ];
-		}
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -367,6 +367,48 @@
 				"$value": "{primitive.dimension.icon-size.md}"
 			}
 		},
+		"font-family": {
+			"control": {
+				"$type": "fontFamily",
+				"$value": "{primitive.fontFamily.sans}"
+			}
+		},
+		"font-size": {
+			"control": {
+				"$type": "dimension",
+				"$value": "1.125rem"
+			}
+		},
+		"font-weight": {
+			"control": {
+				"$type": "fontWeight",
+				"$value": "normal"
+			}
+		},
+		"line-height": {
+			"control": {
+				"$type": "lineHeight",
+				"$value": "normal"
+			}
+		},
+		"font-style": {
+			"control": {
+				"$type": "fontStyle",
+				"$value": "normal"
+			}
+		},
+		"text-transform": {
+			"control": {
+				"$type": "textTransform",
+				"$value": "none"
+			}
+		},
+		"letter-spacing": {
+			"control": {
+				"$type": "dimension",
+				"$value": "0"
+			}
+		},
 		"shadow": {
 			"card": {
 				"$type": "shadow",

--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -7,7 +7,11 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Contracts\Value_Vali
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Color_Value;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Dimension_Value;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Font_Family_Value;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Font_Style_Value;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Font_Weight_Value;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Line_Height_Value;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Shadow_Value;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Text_Transform_Value;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Sentinels;
@@ -75,10 +79,14 @@ final class Dtcg_Validator {
 	 */
 	public function __construct() {
 		$this->validators = [
-			Token_Type::get_type_color()       => new Color_Value(),
-			Token_Type::get_type_dimension()   => new Dimension_Value(),
-			Token_Type::get_type_font_family() => new Font_Family_Value(),
-			Token_Type::get_type_shadow()      => new Shadow_Value(),
+			Token_Type::get_type_color()          => new Color_Value(),
+			Token_Type::get_type_dimension()      => new Dimension_Value(),
+			Token_Type::get_type_font_family()    => new Font_Family_Value(),
+			Token_Type::get_type_font_weight()    => new Font_Weight_Value(),
+			Token_Type::get_type_line_height()    => new Line_Height_Value(),
+			Token_Type::get_type_font_style()     => new Font_Style_Value(),
+			Token_Type::get_type_text_transform() => new Text_Transform_Value(),
+			Token_Type::get_type_shadow()         => new Shadow_Value(),
 		];
 	}
 

--- a/includes/resources/Design_Tokens/Schema/Validation/Kind.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Kind.php
@@ -10,8 +10,9 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
  * The shared "alias OR literal-of-kind" decision, single-sourced so a leaf $value and a composite
  * sub-field that share a kind reach the exact same verdict — and the exact same error code.
  *
- * A "kind" is a v1 $type (color, dimension, fontFamily, …), whether it is a leaf token's own $type or
- * the $type of a composite sub-field. validate() makes a three-way decision in a fixed order:
+ * A "kind" is a v1 $type (color, dimension, fontFamily, fontWeight, …), whether it is a leaf token's
+ * own $type or the $type of a composite sub-field. validate() makes a three-way decision in a fixed
+ * order:
  *
  *   1. a well-formed alias        → valid (the Resolver flattens it later; "alias anywhere" lives here).
  *   2. a malformed alias attempt  → CODE_ALIAS_MALFORMED (a value that reaches for a "{…}" but is not
@@ -83,6 +84,14 @@ final class Kind {
 				return Literals::is_dimension( $value );
 			case Token_Type::get_type_font_family():
 				return Literals::is_font_family( $value );
+			case Token_Type::get_type_font_weight():
+				return Literals::is_font_weight( $value );
+			case Token_Type::get_type_line_height():
+				return Literals::is_line_height( $value );
+			case Token_Type::get_type_font_style():
+				return Literals::is_font_style( $value );
+			case Token_Type::get_type_text_transform():
+				return Literals::is_text_transform( $value );
 			default:
 				return false;
 		}

--- a/includes/resources/Design_Tokens/Schema/Validation/Values/Font_Style_Value.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Values/Font_Style_Value.php
@@ -1,0 +1,30 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Contracts\Value_Validator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Kind;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Validation_Error;
+
+/**
+ * Validates a fontStyle $value: an alias or a fontStyle literal.
+ *
+ * @since TBD
+ */
+final class Font_Style_Value implements Value_Validator {
+
+	/**
+	 * Validate a fontStyle $value.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed  $value The decoded $value.
+	 * @param string $path  Dot-path to the value, for error reporting.
+	 *
+	 * @return Validation_Error[] Empty when valid.
+	 */
+	public function validate( $value, string $path ): array {
+		return Kind::validate( Token_Type::get_type_font_style(), $value, $path );
+	}
+}

--- a/includes/resources/Design_Tokens/Schema/Validation/Values/Font_Weight_Value.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Values/Font_Weight_Value.php
@@ -1,0 +1,30 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Contracts\Value_Validator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Kind;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Validation_Error;
+
+/**
+ * Validates a fontWeight $value: an alias or a fontWeight literal.
+ *
+ * @since TBD
+ */
+final class Font_Weight_Value implements Value_Validator {
+
+	/**
+	 * Validate a fontWeight $value.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed  $value The decoded $value.
+	 * @param string $path  Dot-path to the value, for error reporting.
+	 *
+	 * @return Validation_Error[] Empty when valid.
+	 */
+	public function validate( $value, string $path ): array {
+		return Kind::validate( Token_Type::get_type_font_weight(), $value, $path );
+	}
+}

--- a/includes/resources/Design_Tokens/Schema/Validation/Values/Line_Height_Value.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Values/Line_Height_Value.php
@@ -1,0 +1,30 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Contracts\Value_Validator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Kind;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Validation_Error;
+
+/**
+ * Validates a lineHeight $value: an alias or a lineHeight literal.
+ *
+ * @since TBD
+ */
+final class Line_Height_Value implements Value_Validator {
+
+	/**
+	 * Validate a lineHeight $value.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed  $value The decoded $value.
+	 * @param string $path  Dot-path to the value, for error reporting.
+	 *
+	 * @return Validation_Error[] Empty when valid.
+	 */
+	public function validate( $value, string $path ): array {
+		return Kind::validate( Token_Type::get_type_line_height(), $value, $path );
+	}
+}

--- a/includes/resources/Design_Tokens/Schema/Validation/Values/Text_Transform_Value.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Values/Text_Transform_Value.php
@@ -1,0 +1,30 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Contracts\Value_Validator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Kind;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Validation_Error;
+
+/**
+ * Validates a textTransform $value: an alias or a textTransform literal.
+ *
+ * @since TBD
+ */
+final class Text_Transform_Value implements Value_Validator {
+
+	/**
+	 * Validate a textTransform $value.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed  $value The decoded $value.
+	 * @param string $path  Dot-path to the value, for error reporting.
+	 *
+	 * @return Validation_Error[] Empty when valid.
+	 */
+	public function validate( $value, string $path ): array {
+		return Kind::validate( Token_Type::get_type_text_transform(), $value, $path );
+	}
+}

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Literals.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Literals.php
@@ -55,6 +55,36 @@ final class Literals {
 	];
 
 	/**
+	 * The CSS font-style keywords accepted as a fontStyle literal. "oblique <angle>" is intentionally
+	 * not modeled — the keyword forms cover the design-system need.
+	 *
+	 * @since TBD
+	 *
+	 * @var string[]
+	 */
+	private const FONT_STYLE_KEYWORDS = [
+		'normal',
+		'italic',
+		'oblique',
+	];
+
+	/**
+	 * The CSS text-transform keywords accepted as a textTransform literal.
+	 *
+	 * @since TBD
+	 *
+	 * @var string[]
+	 */
+	private const TEXT_TRANSFORM_KEYWORDS = [
+		'none',
+		'capitalize',
+		'uppercase',
+		'lowercase',
+		'full-width',
+		'full-size-kana',
+	];
+
+	/**
 	 * The CSS named colors (CSS Color Module Level 4 extended set, lower-cased). A curated allowlist is
 	 * what lets "not-a-color" be rejected while "rebeccapurple" is accepted.
 	 *
@@ -352,6 +382,32 @@ final class Literals {
 		}
 
 		return self::is_dimension( $value );
+	}
+
+	/**
+	 * Whether the value is a valid fontStyle literal: one of the CSS font-style keywords.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $value The candidate fontStyle.
+	 *
+	 * @return bool
+	 */
+	public static function is_font_style( $value ): bool {
+		return is_string( $value ) && in_array( strtolower( $value ), self::FONT_STYLE_KEYWORDS, true );
+	}
+
+	/**
+	 * Whether the value is a valid textTransform literal: one of the CSS text-transform keywords.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $value The candidate textTransform.
+	 *
+	 * @return bool
+	 */
+	public static function is_text_transform( $value ): bool {
+		return is_string( $value ) && in_array( strtolower( $value ), self::TEXT_TRANSFORM_KEYWORDS, true );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Token_Type.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Token_Type.php
@@ -10,8 +10,11 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary;
  * no native enums, so the vocabulary is modelled as class constants plus static lookup maps.
  *
  * The shadow composite type holds an object $value whose sub-fields each validate as another $type
- * (color, dimension); composite_fields() returns that field => $type map as DATA so a future shape
- * extends the map rather than rewriting the walker.
+ * (color, dimension); composite_fields() returns the field => $type map as DATA so a future shape
+ * extends the map rather than rewriting the walker. Text-style properties (fontWeight, lineHeight,
+ * fontStyle, textTransform) are plain scalar $types a block binds one discrete token per property —
+ * there is no bundled typography composite, because a block that sets each property individually can
+ * never consume a single `font` shorthand.
  *
  * @since TBD
  */
@@ -27,7 +30,7 @@ final class Token_Type {
 	private const COLOR = 'color';
 
 	/**
-	 * The dimension $type (covers spacing, radius, border-width, icon-size).
+	 * The dimension $type (covers spacing, radius, border-width, icon-size, font-size, letter-spacing).
 	 *
 	 * @since TBD
 	 *
@@ -43,6 +46,42 @@ final class Token_Type {
 	 * @var string
 	 */
 	private const FONT_FAMILY = 'fontFamily';
+
+	/**
+	 * The fontWeight $type (a numeric weight 1-1000 or a CSS weight keyword).
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const FONT_WEIGHT = 'fontWeight';
+
+	/**
+	 * The lineHeight $type (a unit-less number, a dimension, or "normal").
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const LINE_HEIGHT = 'lineHeight';
+
+	/**
+	 * The fontStyle $type (an enum literal: normal/italic/oblique).
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const FONT_STYLE = 'fontStyle';
+
+	/**
+	 * The textTransform $type (an enum literal: none/uppercase/…).
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const TEXT_TRANSFORM = 'textTransform';
 
 	/**
 	 * The shadow $type (a composite object $value).
@@ -74,13 +113,17 @@ final class Token_Type {
 		self::COLOR,
 		self::DIMENSION,
 		self::FONT_FAMILY,
+		self::FONT_WEIGHT,
+		self::LINE_HEIGHT,
+		self::FONT_STYLE,
+		self::TEXT_TRANSFORM,
 		self::SHADOW,
 	];
 
 	/**
-	 * The composite types and their sub-field => kind maps. A field absent from the document is a
-	 * missing-field error; a field present but not listed here is an unknown-field error. Every kind is
-	 * validated "alias OR literal-of-kind", so an alias is accepted in any sub-field.
+	 * The composite types and their sub-field => $type maps. A field absent from the document is a
+	 * missing-field error; a field present but not listed here is an unknown-field error. Every field is
+	 * validated "alias OR literal-of-$type", so an alias is accepted in any sub-field.
 	 *
 	 * @var array<string, array<string, string>>
 	 *
@@ -134,13 +177,13 @@ final class Token_Type {
 	}
 
 	/**
-	 * The sub-field => kind map for a composite $type, or an empty array for a non-composite type.
+	 * The sub-field => $type map for a composite $type, or an empty array for a non-composite type.
 	 *
 	 * @since TBD
 	 *
 	 * @param string $type The composite $type.
 	 *
-	 * @return array<string, string> Field name => kind (a $type or a KIND_* constant).
+	 * @return array<string, string> Field name => the sub-field's $type.
 	 */
 	public static function composite_fields( string $type ): array {
 		return self::COMPOSITE_FIELDS[ $type ] ?? [];
@@ -188,6 +231,50 @@ final class Token_Type {
 	 */
 	public static function get_type_font_family(): string {
 		return self::FONT_FAMILY;
+	}
+
+	/**
+	 * The fontWeight $type.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_type_font_weight(): string {
+		return self::FONT_WEIGHT;
+	}
+
+	/**
+	 * The lineHeight $type.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_type_line_height(): string {
+		return self::LINE_HEIGHT;
+	}
+
+	/**
+	 * The fontStyle $type.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_type_font_style(): string {
+		return self::FONT_STYLE;
+	}
+
+	/**
+	 * The textTransform $type.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_type_text_transform(): string {
+		return self::TEXT_TRANSFORM;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Schema/dtcg.schema.json
+++ b/includes/resources/Design_Tokens/Schema/dtcg.schema.json
@@ -64,6 +64,10 @@
                         "color",
                         "dimension",
                         "fontFamily",
+                        "fontWeight",
+                        "lineHeight",
+                        "fontStyle",
+                        "textTransform",
                         "shadow"
                     ]
                 },
@@ -121,6 +125,62 @@
                 {
                     "properties": {
                         "$type": {
+                            "const": "fontWeight"
+                        },
+                        "$value": {
+                            "$ref": "#/definitions/fontWeightValue"
+                        }
+                    },
+                    "required": [
+                        "$type",
+                        "$value"
+                    ]
+                },
+                {
+                    "properties": {
+                        "$type": {
+                            "const": "lineHeight"
+                        },
+                        "$value": {
+                            "$ref": "#/definitions/lineHeightValue"
+                        }
+                    },
+                    "required": [
+                        "$type",
+                        "$value"
+                    ]
+                },
+                {
+                    "properties": {
+                        "$type": {
+                            "const": "fontStyle"
+                        },
+                        "$value": {
+                            "$ref": "#/definitions/fontStyleValue"
+                        }
+                    },
+                    "required": [
+                        "$type",
+                        "$value"
+                    ]
+                },
+                {
+                    "properties": {
+                        "$type": {
+                            "const": "textTransform"
+                        },
+                        "$value": {
+                            "$ref": "#/definitions/textTransformValue"
+                        }
+                    },
+                    "required": [
+                        "$type",
+                        "$value"
+                    ]
+                },
+                {
+                    "properties": {
+                        "$type": {
                             "const": "shadow"
                         },
                         "$value": {
@@ -166,6 +226,52 @@
                         "type": "string"
                     },
                     "minItems": 1
+                }
+            ]
+        },
+        "fontWeightValue": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/alias"
+                },
+                {
+                    "type": [
+                        "string",
+                        "number"
+                    ]
+                }
+            ]
+        },
+        "lineHeightValue": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/alias"
+                },
+                {
+                    "type": [
+                        "string",
+                        "number"
+                    ]
+                }
+            ]
+        },
+        "fontStyleValue": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/alias"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        "textTransformValue": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/alias"
+                },
+                {
+                    "type": "string"
                 }
             ]
         },

--- a/src/blocks/advancedbtn/editor.scss
+++ b/src/blocks/advancedbtn/editor.scss
@@ -218,7 +218,15 @@
 .kt-button:not(.kb-btn-global-inherit) {
 	padding: 0.4em 1em;
 	cursor: pointer;
-	font-size: 1.125rem;
+	// Mirror of style.scss: the button follows the semantic.*.control typography tokens so the editor
+	// preview matches the front end. See the note there.
+	font-family: var(--kb-token--semantic--font-family--control, inherit);
+	font-size: var(--kb-token--semantic--font-size--control, 1.125rem);
+	font-weight: var(--kb-token--semantic--font-weight--control);
+	font-style: var(--kb-token--semantic--font-style--control);
+	line-height: var(--kb-token--semantic--line-height--control);
+	letter-spacing: var(--kb-token--semantic--letter-spacing--control);
+	text-transform: var(--kb-token--semantic--text-transform--control);
 	border-radius: var(--kb-btn-radius, var(--kb-token--semantic--radius--control, 3px));
 	transition: all 0.3s ease-in-out;
 	box-shadow: none;

--- a/src/blocks/advancedbtn/style.scss
+++ b/src/blocks/advancedbtn/style.scss
@@ -37,7 +37,16 @@
 	border: 0 solid transparent;
 	padding: 0.4em 1em;
 	cursor: pointer;
-	font-size: 1.125rem;
+	// Typography follows the semantic.*.control design tokens, one custom property per property, so a
+	// button follows the design system in the editor and on the front end. Each is a low-specificity
+	// default: a per-button typography value renders at the higher `.kb-btn<uid>` specificity and wins.
+	font-family: var(--kb-token--semantic--font-family--control, inherit);
+	font-size: var(--kb-token--semantic--font-size--control, 1.125rem);
+	font-weight: var(--kb-token--semantic--font-weight--control);
+	font-style: var(--kb-token--semantic--font-style--control);
+	line-height: var(--kb-token--semantic--line-height--control);
+	letter-spacing: var(--kb-token--semantic--letter-spacing--control);
+	text-transform: var(--kb-token--semantic--text-transform--control);
 	border-radius: var(--kb-btn-radius, var(--kb-token--semantic--radius--control, 3px));
 	transition: all 0.3s ease-in-out;
 	box-shadow: none;

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Values/Value_ValidatorsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Values/Value_ValidatorsTest.php
@@ -6,7 +6,11 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Validation_Error;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Color_Value;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Dimension_Value;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Font_Family_Value;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Font_Style_Value;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Font_Weight_Value;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Line_Height_Value;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Shadow_Value;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Text_Transform_Value;
 use Tests\Support\Classes\TestCase;
 
 final class Value_ValidatorsTest extends TestCase {
@@ -144,6 +148,63 @@ final class Value_ValidatorsTest extends TestCase {
 	public function testShadowRejectsNonObjectLiteral(): void {
 		$errors = ( new Shadow_Value() )->validate( 5, 's.$value' );
 
+		$this->assertCount( 1, $errors );
+		$this->assertSame( Validation_Error::get_code_value_invalid(), $errors[0]->code );
+	}
+
+	/**
+	 * A fontWeight value accepts a numeric weight, a keyword, or an alias, and rejects an out-of-range or
+	 * bogus literal.
+	 *
+	 * @return void
+	 */
+	public function testFontWeightAcceptsWeightsAndRejectsBogus(): void {
+		$this->assertSame( [], ( new Font_Weight_Value() )->validate( 700, 'p.$value' ) );
+		$this->assertSame( [], ( new Font_Weight_Value() )->validate( 'bold', 'p.$value' ) );
+		$this->assertSame( [], ( new Font_Weight_Value() )->validate( '{semantic.font-weight.control}', 'p.$value' ) );
+
+		$errors = ( new Font_Weight_Value() )->validate( 'heavy', 'p.$value' );
+		$this->assertCount( 1, $errors );
+		$this->assertSame( Validation_Error::get_code_value_invalid(), $errors[0]->code );
+	}
+
+	/**
+	 * A lineHeight value accepts a unit-less number, "normal", a dimension, or an alias.
+	 *
+	 * @return void
+	 */
+	public function testLineHeightAcceptsNumbersAndKeyword(): void {
+		$this->assertSame( [], ( new Line_Height_Value() )->validate( 1.5, 'p.$value' ) );
+		$this->assertSame( [], ( new Line_Height_Value() )->validate( 'normal', 'p.$value' ) );
+		$this->assertSame( [], ( new Line_Height_Value() )->validate( '1.5rem', 'p.$value' ) );
+
+		$errors = ( new Line_Height_Value() )->validate( 'tall', 'p.$value' );
+		$this->assertCount( 1, $errors );
+		$this->assertSame( Validation_Error::get_code_value_invalid(), $errors[0]->code );
+	}
+
+	/**
+	 * A fontStyle value accepts the CSS keywords and rejects anything else.
+	 *
+	 * @return void
+	 */
+	public function testFontStyleAcceptsKeywords(): void {
+		$this->assertSame( [], ( new Font_Style_Value() )->validate( 'italic', 'p.$value' ) );
+
+		$errors = ( new Font_Style_Value() )->validate( 'slanted', 'p.$value' );
+		$this->assertCount( 1, $errors );
+		$this->assertSame( Validation_Error::get_code_value_invalid(), $errors[0]->code );
+	}
+
+	/**
+	 * A textTransform value accepts the CSS keywords and rejects anything else.
+	 *
+	 * @return void
+	 */
+	public function testTextTransformAcceptsKeywords(): void {
+		$this->assertSame( [], ( new Text_Transform_Value() )->validate( 'uppercase', 'p.$value' ) );
+
+		$errors = ( new Text_Transform_Value() )->validate( 'bogus', 'p.$value' );
 		$this->assertCount( 1, $errors );
 		$this->assertSame( Validation_Error::get_code_value_invalid(), $errors[0]->code );
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/LiteralsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/LiteralsTest.php
@@ -281,4 +281,85 @@ final class LiteralsTest extends TestCase {
 			'expected' => false,
 		];
 	}
+
+	/**
+	 * A fontStyle literal is one of the CSS font-style keywords (case-insensitive); anything else is not.
+	 *
+	 * @dataProvider fontStyleProvider
+	 *
+	 * @param mixed $value    The candidate value.
+	 * @param bool  $expected Whether it is a valid fontStyle.
+	 *
+	 * @return void
+	 */
+	public function testFontStyles( $value, bool $expected ): void {
+		$this->assertSame( $expected, Literals::is_font_style( $value ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function fontStyleProvider(): Generator {
+		yield 'normal' => [
+			'value'    => 'normal',
+			'expected' => true,
+		];
+		yield 'italic' => [
+			'value'    => 'italic',
+			'expected' => true,
+		];
+		yield 'mixed case' => [
+			'value'    => 'Italic',
+			'expected' => true,
+		];
+		yield 'unknown word' => [
+			'value'    => 'slanted',
+			'expected' => false,
+		];
+		yield 'number' => [
+			'value'    => 400,
+			'expected' => false,
+		];
+	}
+
+	/**
+	 * A textTransform literal is one of the CSS text-transform keywords (case-insensitive); anything else
+	 * is not.
+	 *
+	 * @dataProvider textTransformProvider
+	 *
+	 * @param mixed $value    The candidate value.
+	 * @param bool  $expected Whether it is a valid textTransform.
+	 *
+	 * @return void
+	 */
+	public function testTextTransforms( $value, bool $expected ): void {
+		$this->assertSame( $expected, Literals::is_text_transform( $value ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function textTransformProvider(): Generator {
+		yield 'none' => [
+			'value'    => 'none',
+			'expected' => true,
+		];
+		yield 'uppercase' => [
+			'value'    => 'uppercase',
+			'expected' => true,
+		];
+		yield 'full-width' => [
+			'value'    => 'full-width',
+			'expected' => true,
+		];
+		yield 'unknown word' => [
+			'value'    => 'bogus',
+			'expected' => false,
+		];
+		yield 'empty' => [
+			'value'    => '',
+			'expected' => false,
+		];
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/Token_TypeTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/Token_TypeTest.php
@@ -9,13 +9,14 @@ use Tests\Support\Classes\TestCase;
 final class Token_TypeTest extends TestCase {
 
 	/**
-	 * The v1 $type vocabulary is the scalar types plus the shadow composite; there is no typography type.
+	 * The v1 $type vocabulary is the scalar types (color, dimension, fontFamily and the text-style
+	 * scalars) plus the shadow composite — there is no typography composite.
 	 *
 	 * @return void
 	 */
 	public function testItListsTheV1Types(): void {
 		$this->assertSame(
-			[ 'color', 'dimension', 'fontFamily', 'shadow' ],
+			[ 'color', 'dimension', 'fontFamily', 'fontWeight', 'lineHeight', 'fontStyle', 'textTransform', 'shadow' ],
 			Token_Type::all()
 		);
 	}
@@ -38,6 +39,10 @@ final class Token_TypeTest extends TestCase {
 		yield 'color' => [ 'type' => 'color' ];
 		yield 'dimension' => [ 'type' => 'dimension' ];
 		yield 'fontFamily' => [ 'type' => 'fontFamily' ];
+		yield 'fontWeight' => [ 'type' => 'fontWeight' ];
+		yield 'lineHeight' => [ 'type' => 'lineHeight' ];
+		yield 'fontStyle' => [ 'type' => 'fontStyle' ];
+		yield 'textTransform' => [ 'type' => 'textTransform' ];
 		yield 'shadow' => [ 'type' => 'shadow' ];
 	}
 
@@ -64,6 +69,8 @@ final class Token_TypeTest extends TestCase {
 	}
 
 	/**
+	 * Shadow is the only composite type; every scalar type (including the text-style scalars) is not.
+	 *
 	 * @return void
 	 */
 	public function testOnlyCompositeTypesReportComposite(): void {
@@ -71,6 +78,8 @@ final class Token_TypeTest extends TestCase {
 		$this->assertFalse( Token_Type::is_composite( Token_Type::get_type_color() ) );
 		$this->assertFalse( Token_Type::is_composite( Token_Type::get_type_dimension() ) );
 		$this->assertFalse( Token_Type::is_composite( Token_Type::get_type_font_family() ) );
+		$this->assertFalse( Token_Type::is_composite( Token_Type::get_type_font_weight() ) );
+		$this->assertFalse( Token_Type::is_composite( Token_Type::get_type_text_transform() ) );
 	}
 
 	/**
@@ -90,9 +99,12 @@ final class Token_TypeTest extends TestCase {
 	}
 
 	/**
+	 * A scalar type has no composite sub-fields.
+	 *
 	 * @return void
 	 */
 	public function testNonCompositeTypesHaveNoFields(): void {
 		$this->assertSame( [], Token_Type::composite_fields( Token_Type::get_type_color() ) );
+		$this->assertSame( [], Token_Type::composite_fields( Token_Type::get_type_font_weight() ) );
 	}
 }


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3529/button-typography-token-wiring-kadenceadvancedbtn-singlebtn

Wires `kadence/singlebtn` typography to the design system through discrete CSS variables, so a button follows its tokens in the editor and on the front end, a per-button value still wins by specificity, and nothing is written to saved content (no freezing).

Promotes `fontWeight`/`lineHeight` and adds `fontStyle`/`textTransform` as first-class scalar `$types` (each with a value-validator), then adds seven `semantic.<prop>.control` tokens (family/size/weight/style/line-height/letter-spacing). Each projects a normal `--kb-token--semantic--<prop>--control` custom property through the standard pipeline, and the Button's `style.scss`/`editor.scss` read one per property. Only the font family is seeded on-brand, so nothing else changes until a token is overridden; the wiring already carries the rest.

### Breakpoints / responsive defaults are out of scope here

The token defaults are single (flat) values. The block's Typography panel exposes per-breakpoint (desktop/tablet/mobile) controls for font-size, line-height, and letter-spacing, and a per-instance responsive value still wins by specificity — so this is not a regression (the flat defaults match the block's prior flat defaults). Making the *token defaults themselves* per-breakpoint (stepped) or fluid (`clamp()`) is deliberately out of scope and tracked in SOFT-3857, which will add that shape onto these discrete `dimension`/`line-height` tokens: https://linear.app/nexcess/issue/SOFT-3857/responsive-per-breakpoint-fluid-clamp-values-for-dimensiontypography

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

