### PR TITLE
SOFT-3857 [1/8] Responsive/clamp token vocabulary + clamp grammar

### DIFF
--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Literals.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Literals.php
@@ -385,6 +385,35 @@ final class Literals {
 	}
 
 	/**
+	 * Whether the value is a valid clamp preferred (fluid) slot: a plain dimension, a CSS function form,
+	 * or a bare calc-style expression combining number/length/percentage/viewport terms with the math
+	 * operators + - * / (e.g. "0.995rem + 0.326vw", "100% - 20px"). The bare-expression form is what a
+	 * dimension literal rejects — a clamp() argument accepts a <calc-sum> without a calc() wrapper, so the
+	 * preferred slot must too. This is a shape gate, not a full CSS math validator.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $value The candidate clamp preferred slot.
+	 *
+	 * @return bool
+	 */
+	public static function is_clamp_preferred( $value ): bool {
+		if ( ! is_string( $value ) || trim( $value ) === '' ) {
+			return false;
+		}
+
+		// A single length / "0" / function form (var()/calc()/clamp()/min()/max()) is already a dimension.
+		if ( self::is_dimension( $value ) ) {
+			return true;
+		}
+
+		// A bare calc-style sum: number(+unit) terms joined by + - * / (spaces optional in this shape gate).
+		$term = '-?(?:\d+\.?\d*|\.\d+)(?:' . self::LENGTH_UNITS . ')?';
+
+		return (bool) preg_match( '/^' . $term . '(?:\s*[-+*\/]\s*' . $term . ')+$/i', $value );
+	}
+
+	/**
 	 * Whether the value is a valid fontStyle literal: one of the CSS font-style keywords.
 	 *
 	 * @since TBD

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Responsive.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Responsive.php
@@ -193,28 +193,6 @@ final class Responsive {
 	}
 
 	/**
-	 * The module's leaf-extension map ($extensions.com.kadence.designTokens) for a leaf, or an empty
-	 * array when the leaf carries no such extension. The single seam for reading the shape.
-	 *
-	 * @since TBD
-	 *
-	 * @param array<string, mixed> $leaf The decoded token leaf.
-	 *
-	 * @return array<string, mixed>
-	 */
-	public static function extension_of( array $leaf ): array {
-		$extensions = $leaf[ Extensions::get_extensions_key() ] ?? null;
-
-		if ( ! is_array( $extensions ) ) {
-			return [];
-		}
-
-		$namespace = $extensions[ Extensions::get_namespace() ] ?? null;
-
-		return is_array( $namespace ) ? $namespace : [];
-	}
-
-	/**
 	 * The responsive (stepped) override map for a leaf, or null when absent. A present-but-non-array
 	 * shape returns the raw value so the validator can reject it; readers should treat non-array as
 	 * "no overrides".
@@ -271,5 +249,28 @@ final class Responsive {
 	 */
 	public static function has_clamp( array $leaf ): bool {
 		return array_key_exists( self::CLAMP_KEY, self::extension_of( $leaf ) );
+	}
+
+	/**
+	 * The module's leaf-extension map ($extensions.com.kadence.designTokens) for a leaf, or an empty array
+	 * when the leaf carries no such extension. The shared internal accessor behind the responsive_of() /
+	 * clamp_of() / has_responsive() / has_clamp() readers, which are the seam every consumer goes through.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $leaf The decoded token leaf.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function extension_of( array $leaf ): array {
+		$extensions = $leaf[ Extensions::get_extensions_key() ] ?? null;
+
+		if ( ! is_array( $extensions ) ) {
+			return [];
+		}
+
+		$namespace = $extensions[ Extensions::get_namespace() ] ?? null;
+
+		return is_array( $namespace ) ? $namespace : [];
 	}
 }

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Responsive.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Responsive.php
@@ -1,0 +1,275 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary;
+
+/**
+ * The responsive / fluid-clamp leaf-extension vocabulary this module owns, single-sourced so the
+ * validator, the Resolver, the write-back adapters and the JSON Schema generator agree on the exact
+ * spelling of every key and on which $types may carry the shape.
+ *
+ * A responsive-capable dimension / lineHeight leaf keeps a plain scalar $value (the desktop / base
+ * value, so flat DTCG consumers still work) and carries the per-breakpoint or fluid shape under its
+ * own $extensions:
+ *
+ *   "$extensions": { "com.kadence.designTokens": {
+ *       "responsive": { "tablet": "1.5rem", "mobile": "1rem" }   // OR
+ *       "clamp":      { "min": "1.1rem", "preferred": "0.995rem + 0.326vw", "max": "1.25rem" }
+ *   } }
+ *
+ * "responsive" and "clamp" are mutually exclusive on one leaf. Both are optional: a leaf with neither
+ * (or with no $extensions at all) is a flat token — indistinguishable from a pre-responsive override.
+ * The responsive_of() / clamp_of() readers are the single seam every consumer goes through, so old and
+ * new leaf shapes are interpreted identically in one place.
+ *
+ * @since TBD
+ */
+final class Responsive {
+
+	/**
+	 * The key carrying the per-breakpoint (stepped) override map.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const RESPONSIVE_KEY = 'responsive';
+
+	/**
+	 * The tablet (max-width) breakpoint override key inside the responsive map.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const TABLET_KEY = 'tablet';
+
+	/**
+	 * The mobile (max-width) breakpoint override key inside the responsive map.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const MOBILE_KEY = 'mobile';
+
+	/**
+	 * The key carrying the structured fluid-clamp shape.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const CLAMP_KEY = 'clamp';
+
+	/**
+	 * The clamp minimum-bound slot key.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const CLAMP_MIN_KEY = 'min';
+
+	/**
+	 * The clamp preferred (fluid) slot key; carries a calc-style expression.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const CLAMP_PREFERRED_KEY = 'preferred';
+
+	/**
+	 * The clamp maximum-bound slot key.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const CLAMP_MAX_KEY = 'max';
+
+	/**
+	 * The key carrying the per-breakpoint override map.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_responsive_key(): string {
+		return self::RESPONSIVE_KEY;
+	}
+
+	/**
+	 * The tablet breakpoint override key.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_tablet_key(): string {
+		return self::TABLET_KEY;
+	}
+
+	/**
+	 * The mobile breakpoint override key.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_mobile_key(): string {
+		return self::MOBILE_KEY;
+	}
+
+	/**
+	 * The breakpoint override keys, in cascade order (tablet, then mobile).
+	 *
+	 * @since TBD
+	 *
+	 * @return string[]
+	 */
+	public static function get_breakpoint_keys(): array {
+		return [ self::TABLET_KEY, self::MOBILE_KEY ];
+	}
+
+	/**
+	 * The key carrying the structured fluid-clamp shape.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_clamp_key(): string {
+		return self::CLAMP_KEY;
+	}
+
+	/**
+	 * The clamp minimum-bound slot key.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_clamp_min_key(): string {
+		return self::CLAMP_MIN_KEY;
+	}
+
+	/**
+	 * The clamp preferred (fluid) slot key.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_clamp_preferred_key(): string {
+		return self::CLAMP_PREFERRED_KEY;
+	}
+
+	/**
+	 * The clamp maximum-bound slot key.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_clamp_max_key(): string {
+		return self::CLAMP_MAX_KEY;
+	}
+
+	/**
+	 * Whether a $type may carry the responsive / clamp shape. Only the dimension and lineHeight scalar
+	 * types are responsive-capable; single-value types (fontFamily / fontWeight / fontStyle /
+	 * textTransform) and composites are not.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $type The token $type.
+	 *
+	 * @return bool
+	 */
+	public static function is_responsive_capable( string $type ): bool {
+		return $type === Token_Type::get_type_dimension()
+			|| $type === Token_Type::get_type_line_height();
+	}
+
+	/**
+	 * The module's leaf-extension map ($extensions.com.kadence.designTokens) for a leaf, or an empty
+	 * array when the leaf carries no such extension. The single seam for reading the shape.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $leaf The decoded token leaf.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function extension_of( array $leaf ): array {
+		$extensions = $leaf[ Extensions::get_extensions_key() ] ?? null;
+
+		if ( ! is_array( $extensions ) ) {
+			return [];
+		}
+
+		$namespace = $extensions[ Extensions::get_namespace() ] ?? null;
+
+		return is_array( $namespace ) ? $namespace : [];
+	}
+
+	/**
+	 * The responsive (stepped) override map for a leaf, or null when absent. A present-but-non-array
+	 * shape returns the raw value so the validator can reject it; readers should treat non-array as
+	 * "no overrides".
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $leaf The decoded token leaf.
+	 *
+	 * @return mixed The responsive map, or null when the key is absent.
+	 */
+	public static function responsive_of( array $leaf ) {
+		$extension = self::extension_of( $leaf );
+
+		return $extension[ self::RESPONSIVE_KEY ] ?? null;
+	}
+
+	/**
+	 * The structured clamp map for a leaf, or null when absent. A present-but-non-array shape returns
+	 * the raw value so the validator can reject it.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $leaf The decoded token leaf.
+	 *
+	 * @return mixed The clamp map, or null when the key is absent.
+	 */
+	public static function clamp_of( array $leaf ) {
+		$extension = self::extension_of( $leaf );
+
+		return $extension[ self::CLAMP_KEY ] ?? null;
+	}
+
+	/**
+	 * Whether the leaf declares a responsive (stepped) shape.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $leaf The decoded token leaf.
+	 *
+	 * @return bool
+	 */
+	public static function has_responsive( array $leaf ): bool {
+		return array_key_exists( self::RESPONSIVE_KEY, self::extension_of( $leaf ) );
+	}
+
+	/**
+	 * Whether the leaf declares a structured clamp shape.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $leaf The decoded token leaf.
+	 *
+	 * @return bool
+	 */
+	public static function has_clamp( array $leaf ): bool {
+		return array_key_exists( self::CLAMP_KEY, self::extension_of( $leaf ) );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/LiteralsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/LiteralsTest.php
@@ -362,4 +362,70 @@ final class LiteralsTest extends TestCase {
 			'expected' => false,
 		];
 	}
+
+	/**
+	 * A clamp preferred slot accepts a plain dimension, a CSS function form, or a bare calc-style
+	 * expression combining length / percentage / viewport terms; a lone unitless number, a bare word, or
+	 * an unbalanced expression is not.
+	 *
+	 * @dataProvider clampPreferredProvider
+	 *
+	 * @param mixed $value    The candidate preferred slot.
+	 * @param bool  $expected Whether it is a valid clamp preferred slot.
+	 *
+	 * @return void
+	 */
+	public function testClampPreferred( $value, bool $expected ): void {
+		$this->assertSame( $expected, Literals::is_clamp_preferred( $value ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function clampPreferredProvider(): Generator {
+		yield 'rem + vw' => [
+			'value'    => '0.995rem + 0.326vw',
+			'expected' => true,
+		];
+		yield 'percent minus px' => [
+			'value'    => '100% - 20px',
+			'expected' => true,
+		];
+		yield 'vw times scalar' => [
+			'value'    => '2vw * 1.5',
+			'expected' => true,
+		];
+		yield 'plain dimension' => [
+			'value'    => '1.25rem',
+			'expected' => true,
+		];
+		yield 'calc()' => [
+			'value'    => 'calc(0.995rem + 0.326vw)',
+			'expected' => true,
+		];
+		yield 'lone viewport unit' => [
+			'value'    => '0.326vw',
+			'expected' => true,
+		];
+		yield 'unitless number' => [
+			'value'    => '12',
+			'expected' => false,
+		];
+		yield 'word' => [
+			'value'    => 'fluid',
+			'expected' => false,
+		];
+		yield 'trailing operator' => [
+			'value'    => '1rem +',
+			'expected' => false,
+		];
+		yield 'empty' => [
+			'value'    => '',
+			'expected' => false,
+		];
+		yield 'non-string' => [
+			'value'    => 3,
+			'expected' => false,
+		];
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/ResponsiveTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/ResponsiveTest.php
@@ -3,6 +3,7 @@
 namespace Tests\wpunit\Resources\Design_Tokens\Schema\Vocabulary;
 
 use Generator;
+use ReflectionMethod;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Responsive;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
 use Tests\Support\Classes\TestCase;
@@ -126,7 +127,7 @@ final class ResponsiveTest extends TestCase {
 		$this->assertFalse( Responsive::has_clamp( $leaf ) );
 		$this->assertNull( Responsive::responsive_of( $leaf ) );
 		$this->assertNull( Responsive::clamp_of( $leaf ) );
-		$this->assertSame( [], Responsive::extension_of( $leaf ) );
+		$this->assertSame( [], $this->extensionOf( $leaf ) );
 	}
 
 	/**
@@ -144,7 +145,7 @@ final class ResponsiveTest extends TestCase {
 		];
 
 		$this->assertFalse( Responsive::has_responsive( $leaf ) );
-		$this->assertSame( [], Responsive::extension_of( $leaf ) );
+		$this->assertSame( [], $this->extensionOf( $leaf ) );
 	}
 
 	/**
@@ -154,5 +155,20 @@ final class ResponsiveTest extends TestCase {
 	 */
 	public function testTheBreakpointKeys(): void {
 		$this->assertSame( [ 'tablet', 'mobile' ], Responsive::get_breakpoint_keys() );
+	}
+
+	/**
+	 * Invoke the private Responsive::extension_of() via reflection, so its behavior stays directly covered
+	 * even though it is no longer part of the public reader seam.
+	 *
+	 * @param array<string, mixed> $leaf The decoded token leaf.
+	 *
+	 * @return array<string, mixed> The module leaf-extension map.
+	 */
+	private function extensionOf( array $leaf ): array {
+		$method = new ReflectionMethod( Responsive::class, 'extension_of' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null, $leaf );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/ResponsiveTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/ResponsiveTest.php
@@ -1,0 +1,158 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Schema\Vocabulary;
+
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Responsive;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
+use Tests\Support\Classes\TestCase;
+
+final class ResponsiveTest extends TestCase {
+
+	/**
+	 * Only the dimension and lineHeight scalar types are responsive-capable; single-value and composite
+	 * types are not.
+	 *
+	 * @dataProvider capableProvider
+	 *
+	 * @param string $type     The token $type.
+	 * @param bool   $expected Whether the type may carry the responsive / clamp shape.
+	 *
+	 * @return void
+	 */
+	public function testIsResponsiveCapable( string $type, bool $expected ): void {
+		$this->assertSame( $expected, Responsive::is_responsive_capable( $type ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function capableProvider(): Generator {
+		yield 'dimension' => [
+			'type'     => Token_Type::get_type_dimension(),
+			'expected' => true,
+		];
+		yield 'lineHeight' => [
+			'type'     => Token_Type::get_type_line_height(),
+			'expected' => true,
+		];
+		yield 'fontFamily' => [
+			'type'     => Token_Type::get_type_font_family(),
+			'expected' => false,
+		];
+		yield 'fontWeight' => [
+			'type'     => Token_Type::get_type_font_weight(),
+			'expected' => false,
+		];
+		yield 'color' => [
+			'type'     => Token_Type::get_type_color(),
+			'expected' => false,
+		];
+		yield 'shadow' => [
+			'type'     => Token_Type::get_type_shadow(),
+			'expected' => false,
+		];
+	}
+
+	/**
+	 * The extension readers return the responsive / clamp maps from a leaf, and report their presence.
+	 *
+	 * @return void
+	 */
+	public function testItReadsTheResponsiveShapeFromALeaf(): void {
+		$leaf = [
+			'$type'       => 'dimension',
+			'$value'      => '1.125rem',
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'responsive' => [
+						'tablet' => '1rem',
+						'mobile' => '0.9rem',
+					],
+				],
+			],
+		];
+
+		$this->assertTrue( Responsive::has_responsive( $leaf ) );
+		$this->assertFalse( Responsive::has_clamp( $leaf ) );
+		$this->assertSame(
+			[
+				'tablet' => '1rem',
+				'mobile' => '0.9rem',
+			],
+			Responsive::responsive_of( $leaf )
+		);
+		$this->assertNull( Responsive::clamp_of( $leaf ) );
+	}
+
+	/**
+	 * The clamp reader returns the structured clamp map from a leaf.
+	 *
+	 * @return void
+	 */
+	public function testItReadsTheClampShapeFromALeaf(): void {
+		$leaf = [
+			'$type'       => 'dimension',
+			'$value'      => 'clamp(1.1rem, 0.995rem + 0.326vw, 1.25rem)',
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'clamp' => [
+						'min'       => '1.1rem',
+						'preferred' => '0.995rem + 0.326vw',
+						'max'       => '1.25rem',
+					],
+				],
+			],
+		];
+
+		$this->assertTrue( Responsive::has_clamp( $leaf ) );
+		$this->assertFalse( Responsive::has_responsive( $leaf ) );
+		$this->assertSame( '0.995rem + 0.326vw', Responsive::clamp_of( $leaf )[ Responsive::get_clamp_preferred_key() ] );
+	}
+
+	/**
+	 * A flat leaf (no $extensions) reports no responsive / clamp shape and yields null readers, so it is
+	 * interpreted identically to a leaf that predates responsive support.
+	 *
+	 * @return void
+	 */
+	public function testAFlatLeafHasNoShape(): void {
+		$leaf = [
+			'$type'  => 'dimension',
+			'$value' => '1.125rem',
+		];
+
+		$this->assertFalse( Responsive::has_responsive( $leaf ) );
+		$this->assertFalse( Responsive::has_clamp( $leaf ) );
+		$this->assertNull( Responsive::responsive_of( $leaf ) );
+		$this->assertNull( Responsive::clamp_of( $leaf ) );
+		$this->assertSame( [], Responsive::extension_of( $leaf ) );
+	}
+
+	/**
+	 * A leaf whose only extension is a foreign vendor namespace is not read as a responsive / clamp shape.
+	 *
+	 * @return void
+	 */
+	public function testAForeignNamespaceIsIgnored(): void {
+		$leaf = [
+			'$type'       => 'dimension',
+			'$value'      => '1rem',
+			'$extensions' => [
+				'com.example.other' => [ 'responsive' => [ 'tablet' => '0.9rem' ] ],
+			],
+		];
+
+		$this->assertFalse( Responsive::has_responsive( $leaf ) );
+		$this->assertSame( [], Responsive::extension_of( $leaf ) );
+	}
+
+	/**
+	 * The breakpoint keys are tablet then mobile, in cascade order.
+	 *
+	 * @return void
+	 */
+	public function testTheBreakpointKeys(): void {
+		$this->assertSame( [ 'tablet', 'mobile' ], Responsive::get_breakpoint_keys() );
+	}
+}


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3857/responsive-per-breakpoint-fluid-clamp-values-for-dimensiontypography
:video_camera: https://www.loom.com/share/0ebee5dc556b4afa8d54923a7c2b4ab0

Part of the SOFT-3857 stack (1/8) — stacked on the SOFT-3529 branch.

Adds the `Responsive` vocabulary that single-sources the responsive/clamp `$extensions` keys, the responsive-capable type check, and the leaf-shape readers, plus a `Literals::is_clamp_preferred()` grammar rule that accepts bare calc-style clamp expressions (e.g. `0.995rem + 0.326vw`). Pure additions with no behavior change yet.

**On the `clamp` (fluid) shape:** it has no shipped consumer in this stack — the discrete control tokens (e.g. the button's `semantic.font-size.control`) use the stepped `responsive` shape. Clamp is delivered here for **SOFT-3869** (https://linear.app/nexcess/issue/SOFT-3869/tokenize-the-fluid-font-size-scale-as-primitives-match-the-spacing), which tokenizes the fluid font-size scale as primitives (the analog of the already-tokenized spacing scale) and authors those `clamp()` values through this shape + the editor's min/preferred/max helper.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


