### PR TITLE
SOFT-3857 [2/8] Validate the responsive/clamp leaf-extension shape

### DIFF
--- a/includes/resources/Design_Tokens/Rest/V1/Provider.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Provider.php
@@ -16,8 +16,8 @@ final class Provider extends Provider_Contract {
 	 * Concrete v1 REST controllers registered on rest_api_init.
 	 *
 	 * Each entry is resolved from the container and has its routes registered.
-	 * Endpoint controllers are added here as the read, write, variant, and
-	 * Design MD surfaces land.
+	 * Endpoint controllers are added here as the read, write, and variant
+	 * surfaces land.
 	 *
 	 * @since TBD
 	 *

--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -497,23 +497,27 @@ final class Dtcg_Validator {
 		}
 
 		if ( array_key_exists( $preferred, $clamp ) ) {
-			$errors = array_merge( $errors, $this->validate_clamp_preferred( $clamp[ $preferred ], $path . '.' . $preferred ) );
+			$errors = array_merge( $errors, $this->validate_clamp_preferred( $clamp[ $preferred ], $type, $path . '.' . $preferred ) );
 		}
 
 		return $errors;
 	}
 
 	/**
-	 * Validate a clamp preferred slot: an alias, or a calc-style expression / dimension literal.
+	 * Validate a clamp preferred slot: an alias, a literal of the leaf's own $type, or a bare calc-style
+	 * fluid expression. The $type check is what lets a lineHeight clamp carry a unitless preferred (e.g.
+	 * "1.2") exactly as its min / max slots do; the calc-style branch accepts what a plain type literal
+	 * rejects — a clamp() preferred takes a <calc-sum> like "0.995rem + 0.326vw" without a calc() wrapper.
 	 *
 	 * @since TBD
 	 *
 	 * @param mixed  $value The decoded preferred slot.
+	 * @param string $type  The leaf's $type.
 	 * @param string $path  Dot-path to the slot.
 	 *
 	 * @return Validation_Error[]
 	 */
-	private function validate_clamp_preferred( $value, string $path ): array {
+	private function validate_clamp_preferred( $value, string $type, string $path ): array {
 		if ( Alias::is_alias( $value ) ) {
 			return [];
 		}
@@ -528,6 +532,13 @@ final class Dtcg_Validator {
 			];
 		}
 
+		// A literal of the leaf's own type — a bare dimension, or a unitless lineHeight — is a valid
+		// preferred, mirroring how the min / max slots validate against $this->validators[ $type ].
+		if ( $this->validators[ $type ]->validate( $value, $path ) === [] ) {
+			return [];
+		}
+
+		// A bare calc-style fluid expression, which a plain type literal rejects.
 		if ( Literals::is_clamp_preferred( $value ) ) {
 			return [];
 		}
@@ -536,7 +547,7 @@ final class Dtcg_Validator {
 			new Validation_Error(
 				$path,
 				Validation_Error::get_code_value_invalid(),
-				'The clamp preferred slot must be an alias, a dimension, or a calc-style expression.'
+				'The clamp preferred slot must be an alias, a literal of the token type, or a calc-style expression.'
 			),
 		];
 	}

--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -14,6 +14,8 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Shadow_Value;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Text_Transform_Value;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Literals;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Responsive;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Sentinels;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
 
@@ -36,9 +38,12 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
  *                         (remove the token) sentinels; outside of those, an override leaf without a
  *                         $type is rejected as $type_unknown.
  *
- * Leaf-level "$"-extensions are passed through without validation and reserved for future responsive /
- * clamp work. The $extensions layer is validated only as far as this ticket's scope: variant / preset
- * `tokens` map values must be alias-or-literal; richer variant semantics are out of scope here.
+ * Leaf-level "$"-extensions carry the responsive / clamp shape (see validate_leaf_extensions): a
+ * dimension / lineHeight leaf may declare a per-breakpoint `responsive` map or a structured `clamp` map
+ * (mutually exclusive) whose slots are validated as alias-or-literal of the leaf's own $type; any other
+ * leaf "$"-extension is passed through untouched. The document-level $extensions layer is validated only
+ * as far as this ticket's scope: variant / preset `tokens` map values must be alias-or-literal; richer
+ * variant semantics are out of scope here.
  *
  * @since TBD
  */
@@ -290,11 +295,10 @@ final class Dtcg_Validator {
 	 * @return Validation_Error[]
 	 */
 	private function validate_typed_leaf( array $leaf, string $path ): array {
-		$errors   = [];
-		$type     = $leaf[ Token_Type::get_type_key() ] ?? null;
-		$has_type = is_string( $type ) && Token_Type::is_valid( $type );
+		$errors = [];
+		$type   = $leaf[ Token_Type::get_type_key() ] ?? null;
 
-		if ( ! $has_type ) {
+		if ( ! is_string( $type ) || ! Token_Type::is_valid( $type ) ) {
 			$errors[] = new Validation_Error(
 				$path . '.$type',
 				Validation_Error::get_code_type_unknown(),
@@ -310,16 +314,231 @@ final class Dtcg_Validator {
 				Validation_Error::get_code_missing_value(),
 				'Token is missing a $value.'
 			);
-
-			return $errors;
-		}
-
-		// Without a known type there is no validator to dispatch the value to.
-		if ( $has_type ) {
+		} elseif ( is_string( $type ) && Token_Type::is_valid( $type ) ) {
+			// Without a known type there is no validator to dispatch the value to.
 			$errors = array_merge( $errors, $this->validators[ $type ]->validate( $leaf['$value'], $path . '.$value' ) );
 		}
 
+		// The responsive / clamp leaf-extension shape is validated against the leaf's own $type, so it can
+		// only run once the type is known; it is independent of whether $value itself validated.
+		if ( is_string( $type ) && Token_Type::is_valid( $type ) ) {
+			$errors = array_merge( $errors, $this->validate_leaf_extensions( $leaf, $type, $path ) );
+		}
+
 		return $errors;
+	}
+
+	/**
+	 * Validate a concrete leaf's responsive / clamp extension shape, when present. A flat leaf (no shape)
+	 * validates trivially, so enabling responsive on a previously-flat token is safe against already-stored
+	 * data. The shape is rejected on non-responsive-capable types, `responsive` and `clamp` are mutually
+	 * exclusive, and each present slot is validated as an alias-or-literal of the leaf's own $type (the
+	 * clamp preferred slot additionally accepts a bare calc-style expression).
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $leaf The decoded leaf.
+	 * @param string               $type The leaf's validated $type.
+	 * @param string               $path Dot-path to the leaf.
+	 *
+	 * @return Validation_Error[]
+	 */
+	private function validate_leaf_extensions( array $leaf, string $type, string $path ): array {
+		$has_responsive = Responsive::has_responsive( $leaf );
+		$has_clamp      = Responsive::has_clamp( $leaf );
+
+		if ( ! $has_responsive && ! $has_clamp ) {
+			return [];
+		}
+
+		$base = $path . '.' . Extensions::get_extensions_key() . '.' . Extensions::get_namespace();
+
+		if ( ! Responsive::is_responsive_capable( $type ) ) {
+			return [
+				new Validation_Error(
+					$base,
+					Validation_Error::get_code_responsive_not_allowed(),
+					sprintf(
+						'The responsive / clamp shape is not allowed on a "%s" token; only dimension and lineHeight are responsive-capable.',
+						$type
+					)
+				),
+			];
+		}
+
+		if ( $has_responsive && $has_clamp ) {
+			return [
+				new Validation_Error(
+					$base,
+					Validation_Error::get_code_responsive_clamp_conflict(),
+					'A token may carry either a responsive or a clamp shape, not both.'
+				),
+			];
+		}
+
+		if ( $has_responsive ) {
+			return $this->validate_responsive_shape(
+				Responsive::responsive_of( $leaf ),
+				$type,
+				$base . '.' . Responsive::get_responsive_key()
+			);
+		}
+
+		return $this->validate_clamp_shape(
+			Responsive::clamp_of( $leaf ),
+			$type,
+			$base . '.' . Responsive::get_clamp_key()
+		);
+	}
+
+	/**
+	 * Validate a per-breakpoint `responsive` map: a non-empty object whose keys are known breakpoints and
+	 * whose values are each an alias-or-literal of the leaf's $type.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed  $responsive The decoded responsive map.
+	 * @param string $type       The leaf's $type.
+	 * @param string $path       Dot-path to the responsive map.
+	 *
+	 * @return Validation_Error[]
+	 */
+	private function validate_responsive_shape( $responsive, string $type, string $path ): array {
+		if ( ! is_array( $responsive ) || $responsive === [] ) {
+			return [
+				new Validation_Error(
+					$path,
+					Validation_Error::get_code_value_invalid(),
+					'The responsive shape must be a non-empty object of breakpoint overrides.'
+				),
+			];
+		}
+
+		$allowed = Responsive::get_breakpoint_keys();
+		$errors  = [];
+
+		foreach ( $responsive as $breakpoint => $value ) {
+			if ( ! in_array( $breakpoint, $allowed, true ) ) {
+				$errors[] = new Validation_Error(
+					$path . '.' . $breakpoint,
+					Validation_Error::get_code_composite_field_unknown(),
+					sprintf(
+						'Unknown responsive breakpoint "%s"; expected one of: %s.',
+						(string) $breakpoint,
+						implode( ', ', $allowed )
+					)
+				);
+
+				continue;
+			}
+
+			$errors = array_merge( $errors, $this->validators[ $type ]->validate( $value, $path . '.' . $breakpoint ) );
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Validate a structured `clamp` map: an object carrying exactly the min / preferred / max slots. min and
+	 * max are alias-or-literal of the leaf's $type; preferred additionally accepts a bare calc-style
+	 * expression (a clamp() argument is a <calc-sum>, which a plain dimension literal rejects).
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed  $clamp The decoded clamp map.
+	 * @param string $type  The leaf's $type.
+	 * @param string $path  Dot-path to the clamp map.
+	 *
+	 * @return Validation_Error[]
+	 */
+	private function validate_clamp_shape( $clamp, string $type, string $path ): array {
+		if ( ! is_array( $clamp ) ) {
+			return [
+				new Validation_Error(
+					$path,
+					Validation_Error::get_code_value_invalid(),
+					'The clamp shape must be an object with min, preferred and max slots.'
+				),
+			];
+		}
+
+		$min       = Responsive::get_clamp_min_key();
+		$preferred = Responsive::get_clamp_preferred_key();
+		$max       = Responsive::get_clamp_max_key();
+		$required  = [ $min, $preferred, $max ];
+		$errors    = [];
+
+		foreach ( array_keys( $clamp ) as $key ) {
+			if ( ! in_array( $key, $required, true ) ) {
+				$errors[] = new Validation_Error(
+					$path . '.' . $key,
+					Validation_Error::get_code_composite_field_unknown(),
+					sprintf( 'Unknown clamp slot "%s"; expected min, preferred and max.', (string) $key )
+				);
+			}
+		}
+
+		foreach ( $required as $slot ) {
+			if ( ! array_key_exists( $slot, $clamp ) ) {
+				$errors[] = new Validation_Error(
+					$path . '.' . $slot,
+					Validation_Error::get_code_composite_field_missing(),
+					sprintf( 'The clamp shape is missing its required "%s" slot.', $slot )
+				);
+			}
+		}
+
+		if ( array_key_exists( $min, $clamp ) ) {
+			$errors = array_merge( $errors, $this->validators[ $type ]->validate( $clamp[ $min ], $path . '.' . $min ) );
+		}
+
+		if ( array_key_exists( $max, $clamp ) ) {
+			$errors = array_merge( $errors, $this->validators[ $type ]->validate( $clamp[ $max ], $path . '.' . $max ) );
+		}
+
+		if ( array_key_exists( $preferred, $clamp ) ) {
+			$errors = array_merge( $errors, $this->validate_clamp_preferred( $clamp[ $preferred ], $path . '.' . $preferred ) );
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Validate a clamp preferred slot: an alias, or a calc-style expression / dimension literal.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed  $value The decoded preferred slot.
+	 * @param string $path  Dot-path to the slot.
+	 *
+	 * @return Validation_Error[]
+	 */
+	private function validate_clamp_preferred( $value, string $path ): array {
+		if ( Alias::is_alias( $value ) ) {
+			return [];
+		}
+
+		if ( Alias::looks_like_alias( $value ) ) {
+			return [
+				new Validation_Error(
+					$path,
+					Validation_Error::get_code_alias_malformed(),
+					'The clamp preferred slot looks like an alias but is not a whole-string "{dot.path}" reference.'
+				),
+			];
+		}
+
+		if ( Literals::is_clamp_preferred( $value ) ) {
+			return [];
+		}
+
+		return [
+			new Validation_Error(
+				$path,
+				Validation_Error::get_code_value_invalid(),
+				'The clamp preferred slot must be an alias, a dimension, or a calc-style expression.'
+			),
+		];
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Schema/Validation/Validation_Error.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Validation_Error.php
@@ -105,6 +105,24 @@ final class Validation_Error {
 	private const CODE_LEAF_FIELD_UNKNOWN = 'leaf_field_unknown';
 
 	/**
+	 * A leaf carries the responsive / clamp extension shape on a $type that is not responsive-capable.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const CODE_RESPONSIVE_NOT_ALLOWED = 'responsive_not_allowed';
+
+	/**
+	 * A leaf carries both the responsive and the clamp extension shapes, which are mutually exclusive.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const CODE_RESPONSIVE_CLAMP_CONFLICT = 'responsive_clamp_conflict';
+
+	/**
 	 * DTCG dot-path to the offending node.
 	 *
 	 * @since TBD
@@ -267,5 +285,27 @@ final class Validation_Error {
 	 */
 	public static function get_code_leaf_field_unknown(): string {
 		return self::CODE_LEAF_FIELD_UNKNOWN;
+	}
+
+	/**
+	 * Code: a leaf carries the responsive / clamp shape on a $type that is not responsive-capable.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_code_responsive_not_allowed(): string {
+		return self::CODE_RESPONSIVE_NOT_ALLOWED;
+	}
+
+	/**
+	 * Code: a leaf carries both the responsive and clamp shapes, which are mutually exclusive.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_code_responsive_clamp_conflict(): string {
+		return self::CODE_RESPONSIVE_CLAMP_CONFLICT;
 	}
 }

--- a/includes/resources/Design_Tokens/Schema/Validation/Values/Dimension_Value.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Values/Dimension_Value.php
@@ -10,9 +10,10 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Validation_Error;
 /**
  * Validates a dimension $value: an alias or a length literal ("0", number+unit, or a CSS function).
  *
- * Extension seam for future responsive / clamp() work: when those dimension shapes land, an additional branch
- * for the structured shape goes here, BEFORE delegating the scalar case to Kind, so the scalar path is
- * untouched.
+ * The $value stays a plain scalar even for a responsive / clamp token — that shape lives in the leaf's
+ * $extensions (validated by Dtcg_Validator::validate_leaf_extensions), which reuses this validator to
+ * check each per-breakpoint / clamp slot. So this validator only ever sees the flat base value and needs
+ * no responsive branch of its own.
  *
  * @since TBD
  */

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
@@ -445,6 +445,38 @@ final class Dtcg_ValidatorTest extends TestCase {
 	}
 
 	/**
+	 * A lineHeight leaf carrying a structured clamp with a unitless preferred validates: the preferred slot
+	 * is checked against the leaf's own $type, so a bare "1.35" is accepted exactly as its min / max slots.
+	 *
+	 * @return void
+	 */
+	public function testALineHeightClampWithUnitlessPreferredValidates(): void {
+		$document = [
+			'semantic' => [
+				'line-height' => [
+					'control' => [
+						'$type'       => 'lineHeight',
+						'$value'      => 'clamp(1.2, 1.35, 1.5)',
+						'$extensions' => [
+							'com.kadence.designTokens' => [
+								'clamp' => [
+									'min'       => '1.2',
+									'preferred' => '1.35',
+									'max'       => '1.5',
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$result = $this->validator->validate( $document, Dtcg_Validator::get_context_baseline() );
+
+		$this->assertTrue( $result->is_valid(), $this->describe( $result->errors() ) );
+	}
+
+	/**
 	 * A flat dimension leaf with no responsive / clamp extension still validates, so enabling responsive
 	 * on a previously-flat token is safe against already-stored flat overrides.
 	 *

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
@@ -219,6 +219,250 @@ final class Dtcg_ValidatorTest extends TestCase {
 			'code'     => Validation_Error::get_code_value_invalid(),
 			'path'     => '$extensions.com.kadence.designTokens.variants.kadence/x.emphasis.solid.tokens.bg',
 		];
+		yield 'responsive on non-capable type' => [
+			'document' => [
+				'semantic' => [
+					'x' => [
+						'$type'       => 'fontWeight',
+						'$value'      => 'normal',
+						'$extensions' => [
+							'com.kadence.designTokens' => [
+								'responsive' => [ 'tablet' => 'bold' ],
+							],
+						],
+					],
+				],
+			],
+			'context'  => Dtcg_Validator::get_context_baseline(),
+			'code'     => Validation_Error::get_code_responsive_not_allowed(),
+			'path'     => 'semantic.x.$extensions.com.kadence.designTokens',
+		];
+		yield 'responsive and clamp conflict' => [
+			'document' => [
+				'semantic' => [
+					'x' => [
+						'$type'       => 'dimension',
+						'$value'      => '1rem',
+						'$extensions' => [
+							'com.kadence.designTokens' => [
+								'responsive' => [ 'tablet' => '0.9rem' ],
+								'clamp'      => [
+									'min'       => '1rem',
+									'preferred' => '1vw',
+									'max'       => '2rem',
+								],
+							],
+						],
+					],
+				],
+			],
+			'context'  => Dtcg_Validator::get_context_baseline(),
+			'code'     => Validation_Error::get_code_responsive_clamp_conflict(),
+			'path'     => 'semantic.x.$extensions.com.kadence.designTokens',
+		];
+		yield 'unknown breakpoint' => [
+			'document' => [
+				'semantic' => [
+					'x' => [
+						'$type'       => 'dimension',
+						'$value'      => '1rem',
+						'$extensions' => [
+							'com.kadence.designTokens' => [
+								'responsive' => [ 'desktop' => '1rem' ],
+							],
+						],
+					],
+				],
+			],
+			'context'  => Dtcg_Validator::get_context_baseline(),
+			'code'     => Validation_Error::get_code_composite_field_unknown(),
+			'path'     => 'semantic.x.$extensions.com.kadence.designTokens.responsive.desktop',
+		];
+		yield 'bad breakpoint value' => [
+			'document' => [
+				'semantic' => [
+					'x' => [
+						'$type'       => 'dimension',
+						'$value'      => '1rem',
+						'$extensions' => [
+							'com.kadence.designTokens' => [
+								'responsive' => [ 'tablet' => 'red' ],
+							],
+						],
+					],
+				],
+			],
+			'context'  => Dtcg_Validator::get_context_baseline(),
+			'code'     => Validation_Error::get_code_value_invalid(),
+			'path'     => 'semantic.x.$extensions.com.kadence.designTokens.responsive.tablet',
+		];
+		yield 'responsive not an object' => [
+			'document' => [
+				'semantic' => [
+					'x' => [
+						'$type'       => 'dimension',
+						'$value'      => '1rem',
+						'$extensions' => [
+							'com.kadence.designTokens' => [
+								'responsive' => '0.9rem',
+							],
+						],
+					],
+				],
+			],
+			'context'  => Dtcg_Validator::get_context_baseline(),
+			'code'     => Validation_Error::get_code_value_invalid(),
+			'path'     => 'semantic.x.$extensions.com.kadence.designTokens.responsive',
+		];
+		yield 'clamp missing a slot' => [
+			'document' => [
+				'semantic' => [
+					'x' => [
+						'$type'       => 'dimension',
+						'$value'      => '1rem',
+						'$extensions' => [
+							'com.kadence.designTokens' => [
+								'clamp' => [
+									'min' => '1rem',
+									'max' => '2rem',
+								],
+							],
+						],
+					],
+				],
+			],
+			'context'  => Dtcg_Validator::get_context_baseline(),
+			'code'     => Validation_Error::get_code_composite_field_missing(),
+			'path'     => 'semantic.x.$extensions.com.kadence.designTokens.clamp.preferred',
+		];
+		yield 'unknown clamp slot' => [
+			'document' => [
+				'semantic' => [
+					'x' => [
+						'$type'       => 'dimension',
+						'$value'      => '1rem',
+						'$extensions' => [
+							'com.kadence.designTokens' => [
+								'clamp' => [
+									'min'       => '1rem',
+									'preferred' => '1vw',
+									'max'       => '2rem',
+									'ideal'     => '1.5rem',
+								],
+							],
+						],
+					],
+				],
+			],
+			'context'  => Dtcg_Validator::get_context_baseline(),
+			'code'     => Validation_Error::get_code_composite_field_unknown(),
+			'path'     => 'semantic.x.$extensions.com.kadence.designTokens.clamp.ideal',
+		];
+		yield 'bad clamp preferred' => [
+			'document' => [
+				'semantic' => [
+					'x' => [
+						'$type'       => 'dimension',
+						'$value'      => '1rem',
+						'$extensions' => [
+							'com.kadence.designTokens' => [
+								'clamp' => [
+									'min'       => '1rem',
+									'preferred' => 'fluid',
+									'max'       => '2rem',
+								],
+							],
+						],
+					],
+				],
+			],
+			'context'  => Dtcg_Validator::get_context_baseline(),
+			'code'     => Validation_Error::get_code_value_invalid(),
+			'path'     => 'semantic.x.$extensions.com.kadence.designTokens.clamp.preferred',
+		];
+	}
+
+	/**
+	 * A dimension leaf carrying a well-formed per-breakpoint responsive map (literal and alias slots)
+	 * validates.
+	 *
+	 * @return void
+	 */
+	public function testAValidResponsiveShapeValidates(): void {
+		$document = [
+			'semantic' => [
+				'font-size' => [
+					'control' => [
+						'$type'       => 'dimension',
+						'$value'      => '1.125rem',
+						'$extensions' => [
+							'com.kadence.designTokens' => [
+								'responsive' => [
+									'tablet' => '1rem',
+									'mobile' => '{primitive.dimension.font-size.mobile}',
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$result = $this->validator->validate( $document, Dtcg_Validator::get_context_baseline() );
+
+		$this->assertTrue( $result->is_valid(), $this->describe( $result->errors() ) );
+	}
+
+	/**
+	 * A dimension leaf carrying a structured clamp (bare calc-style preferred, alias min) validates.
+	 *
+	 * @return void
+	 */
+	public function testAValidClampShapeValidates(): void {
+		$document = [
+			'semantic' => [
+				'font-size' => [
+					'control' => [
+						'$type'       => 'dimension',
+						'$value'      => 'clamp(1.1rem, 0.995rem + 0.326vw, 1.25rem)',
+						'$extensions' => [
+							'com.kadence.designTokens' => [
+								'clamp' => [
+									'min'       => '{primitive.dimension.font-size.min}',
+									'preferred' => '0.995rem + 0.326vw',
+									'max'       => '1.25rem',
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$result = $this->validator->validate( $document, Dtcg_Validator::get_context_baseline() );
+
+		$this->assertTrue( $result->is_valid(), $this->describe( $result->errors() ) );
+	}
+
+	/**
+	 * A flat dimension leaf with no responsive / clamp extension still validates, so enabling responsive
+	 * on a previously-flat token is safe against already-stored flat overrides.
+	 *
+	 * @return void
+	 */
+	public function testAFlatResponsiveCapableLeafRemainsValid(): void {
+		$document = [
+			'semantic' => [
+				'font-size' => [
+					'control' => [
+						'$type'  => 'dimension',
+						'$value' => '1.125rem',
+					],
+				],
+			],
+		];
+
+		$this->assertTrue( $this->validator->validate( $document, Dtcg_Validator::get_context_baseline() )->is_valid() );
 	}
 
 	/**


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3857/responsive-per-breakpoint-fluid-clamp-values-for-dimensiontypography
:video_camera: https://www.loom.com/share/0ebee5dc556b4afa8d54923a7c2b4ab0

Part of the SOFT-3857 stack (2/8) — stacked on 1/8.

Validates the responsive/clamp leaf-extension shape in `Dtcg_Validator`: rejects it on non-responsive-capable types, enforces `responsive` XOR `clamp`, and reuses the existing per-type value validators for each breakpoint and clamp slot. Also corrects the now-inaccurate `Dimension_Value` seam docblock and removes the dropped Design MD reference.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


