### PR TITLE
SOFT-3857 [4/8] Resolve and render responsive/clamp token values

### DIFF
--- a/includes/resources/Design_Tokens/Resolver/Css_Renderer.php
+++ b/includes/resources/Design_Tokens/Resolver/Css_Renderer.php
@@ -30,6 +30,23 @@ final class Css_Renderer {
 	}
 
 	/**
+	 * Render a structured clamp to "clamp(<min>, <preferred>, <max>)" from already-rendered slot strings.
+	 * The resolver flattens each slot (following any alias, or preserving it as a var() reference for the
+	 * projection form) before handing the strings here.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $min       The rendered minimum-bound slot.
+	 * @param string $preferred The rendered preferred (fluid) slot.
+	 * @param string $max       The rendered maximum-bound slot.
+	 *
+	 * @return string
+	 */
+	public function clamp( string $min, string $preferred, string $max ): string {
+		return sprintf( 'clamp(%s, %s, %s)', $min, $preferred, $max );
+	}
+
+	/**
 	 * @param mixed $value string[] of family names, or a single string.
 	 */
 	private function font_family( $value ): string {

--- a/includes/resources/Design_Tokens/Resolver/Resolved_Tokens.php
+++ b/includes/resources/Design_Tokens/Resolver/Resolved_Tokens.php
@@ -38,22 +38,55 @@ final class Resolved_Tokens {
 	private array $by_id_target;
 
 	/**
+	 * Per-breakpoint css-var overrides, css-var => [ breakpoint => var()-preserving CSS value ], for the
+	 * per-media-query redeclaration the css-var projection emits. Only responsive (stepped) tokens with an
+	 * override at a breakpoint appear; a flat token is absent, so a flat token projects exactly as before.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string,array<string,string>>
+	 */
+	private array $by_var_responsive;
+
+	/**
+	 * Per-breakpoint literal overrides, token-id => [ breakpoint => literal CSS value ], for host surfaces
+	 * and the write-back adapters that fan a breakpoint value into a block's indexed / suffixed attributes.
+	 * Mirrors by_var_responsive keyed by id, with literals rather than var() references.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string,array<string,string>>
+	 */
+	private array $by_id_responsive;
+
+	/**
 	 * Build the resolved maps. The projection defaults to the literal var map when omitted, so a
 	 * caller with no aliases to preserve constructs with just the two literal maps.
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string,string> $by_id            token-id => literal CSS value.
-	 * @param array<string,string> $by_var           css-var => literal CSS value.
-	 * @param array<string,string> $by_var_projected css-var => var()-preserving CSS value; defaults to
-	 *                                                the literal map when omitted (no aliases to preserve).
-	 * @param array<string,string> $by_id_target     token-id => immediate target token-id.
+	 * @param array<string,string>               $by_id             token-id => literal CSS value.
+	 * @param array<string,string>               $by_var            css-var => literal CSS value.
+	 * @param array<string,string>               $by_var_projected  css-var => var()-preserving CSS value;
+	 *                                                               defaults to the literal map when omitted.
+	 * @param array<string,string>               $by_id_target      token-id => immediate target token-id.
+	 * @param array<string,array<string,string>> $by_var_responsive css-var => [ breakpoint => projected value ].
+	 * @param array<string,array<string,string>> $by_id_responsive  token-id => [ breakpoint => literal value ].
 	 */
-	public function __construct( array $by_id, array $by_var, array $by_var_projected = [], array $by_id_target = [] ) {
-		$this->by_id            = $by_id;
-		$this->by_var           = $by_var;
-		$this->by_var_projected = $by_var_projected === [] ? $by_var : $by_var_projected;
-		$this->by_id_target     = $by_id_target;
+	public function __construct(
+		array $by_id,
+		array $by_var,
+		array $by_var_projected = [],
+		array $by_id_target = [],
+		array $by_var_responsive = [],
+		array $by_id_responsive = []
+	) {
+		$this->by_id             = $by_id;
+		$this->by_var            = $by_var;
+		$this->by_var_projected  = $by_var_projected === [] ? $by_var : $by_var_projected;
+		$this->by_id_target      = $by_id_target;
+		$this->by_var_responsive = $by_var_responsive;
+		$this->by_id_responsive  = $by_id_responsive;
 	}
 
 	/**
@@ -124,5 +157,33 @@ final class Resolved_Tokens {
 	 */
 	public function target( string $id ): ?string {
 		return $this->by_id_target[ $id ] ?? null;
+	}
+
+	/**
+	 * The per-breakpoint css-var projection overrides, css-var => [ breakpoint => var()-preserving value ].
+	 * The css-var projection redeclares each of these inside the matching media query. Empty for a document
+	 * with no responsive tokens, so flat projection is byte-for-byte unchanged.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string,array<string,string>>
+	 */
+	public function projected_responsive(): array {
+		return $this->by_var_responsive;
+	}
+
+	/**
+	 * The literal CSS value for a token at a breakpoint, or null when the token has no override there. A
+	 * token with no responsive shape returns null for every breakpoint (its base value is read via value()).
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id         The token id.
+	 * @param string $breakpoint The breakpoint key (e.g. "tablet", "mobile").
+	 *
+	 * @return string|null
+	 */
+	public function value_at( string $id, string $breakpoint ): ?string {
+		return $this->by_id_responsive[ $id ][ $breakpoint ] ?? null;
 	}
 }

--- a/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
@@ -9,6 +9,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Excepti
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Layers;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Responsive;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
 
 /**
@@ -183,18 +184,20 @@ final class Token_Resolver {
 	 * @param string              $css_namespace Css-var namespace to apply to projected names ('' for canonical).
 	 */
 	private function resolve_document( array $document, string $css_namespace = '' ): Resolved_Tokens {
-		$by_id            = [];
-		$by_var           = [];
-		$by_var_projected = [];
-		$by_id_target     = [];
+		$by_id             = [];
+		$by_var            = [];
+		$by_var_projected  = [];
+		$by_id_target      = [];
+		$by_var_responsive = [];
+		$by_id_responsive  = [];
 
 		foreach ( Layers::token_layers() as $layer ) {
 			if ( isset( $document[ $layer ] ) && is_array( $document[ $layer ] ) ) {
-				$this->walk( $document[ $layer ], $layer, $document, $by_id, $by_var, $by_var_projected, $by_id_target, $css_namespace );
+				$this->walk( $document[ $layer ], $layer, $document, $by_id, $by_var, $by_var_projected, $by_id_target, $by_var_responsive, $by_id_responsive, $css_namespace );
 			}
 		}
 
-		return new Resolved_Tokens( $by_id, $by_var, $by_var_projected, $by_id_target );
+		return new Resolved_Tokens( $by_id, $by_var, $by_var_projected, $by_id_target, $by_var_responsive, $by_id_responsive );
 	}
 
 	/**
@@ -205,15 +208,17 @@ final class Token_Resolver {
 	 * @param array<string,mixed>  $node             The current group node.
 	 * @param string               $prefix           The dot-path accumulated so far.
 	 * @param array<string,mixed>  $document         Full effective doc, for alias lookups.
-	 * @param array<string,string> $by_id            By-reference id => literal CSS value map.
-	 * @param array<string,string> $by_var           By-reference css-var => literal CSS value map.
-	 * @param array<string,string> $by_var_projected By-reference css-var => var()-preserving CSS value map.
-	 * @param array<string,string> $by_id_target     By-reference id => target id map (whole-$value aliases only).
-	 * @param string               $css_namespace        Css-var namespace to apply to projected names ('' for canonical).
+	 * @param array<string,string>               $by_id             By-reference id => literal CSS value map.
+	 * @param array<string,string>               $by_var            By-reference css-var => literal CSS value map.
+	 * @param array<string,string>               $by_var_projected  By-reference css-var => var()-preserving CSS value map.
+	 * @param array<string,string>               $by_id_target      By-reference id => target id map (whole-$value aliases only).
+	 * @param array<string,array<string,string>> $by_var_responsive By-reference css-var => [ breakpoint => projected value ].
+	 * @param array<string,array<string,string>> $by_id_responsive  By-reference id => [ breakpoint => literal value ].
+	 * @param string                             $css_namespace     Css-var namespace to apply to projected names ('' for canonical).
 	 *
 	 * @return void
 	 */
-	private function walk( array $node, string $prefix, array $document, array &$by_id, array &$by_var, array &$by_var_projected, array &$by_id_target, string $css_namespace = '' ): void {
+	private function walk( array $node, string $prefix, array $document, array &$by_id, array &$by_var, array &$by_var_projected, array &$by_id_target, array &$by_var_responsive, array &$by_id_responsive, string $css_namespace = '' ): void {
 		foreach ( $node as $key => $child ) {
 			if ( is_string( $key ) && strpos( $key, '$' ) === 0 ) {
 				continue; // DTCG metadata key.
@@ -225,11 +230,28 @@ final class Token_Resolver {
 			$path = $prefix . '.' . $key;
 
 			if ( array_key_exists( '$value', $child ) ) {
-				$raw   = $child['$value'];
-				$type  = (string) ( $child[ Token_Type::get_type_key() ] ?? '' );
+				$raw  = $child['$value'];
+				$type = (string) ( $child[ Token_Type::get_type_key() ] ?? '' );
+				$var  = Css_Var::from_id( $path, $css_namespace );
+
+				// A structured clamp is authoritative: it renders to clamp(min, preferred, max) for both the
+				// literal (host) and var()-preserving (projection) forms, overriding whatever the flat base
+				// $value holds (a literal clamp there is treated as a stale cache of this).
+				if ( Responsive::has_clamp( $child ) ) {
+					$clamp = Responsive::clamp_of( $child );
+
+					if ( is_array( $clamp ) ) {
+						$literal                  = $this->render_clamp( $clamp, $type, $document, $css_namespace, false );
+						$by_id[ $path ]           = $literal;
+						$by_var[ $var ]           = $literal;
+						$by_var_projected[ $var ] = $this->render_clamp( $clamp, $type, $document, $css_namespace, true );
+
+						continue;
+					}
+				}
+
 				$value = $this->resolve_value( $raw, $document, [] );
 				$css   = $this->renderer->render( $type, $value );
-				$var   = Css_Var::from_id( $path, $css_namespace );
 
 				$by_id[ $path ] = $css;
 				$by_var[ $var ] = $css;
@@ -251,11 +273,62 @@ final class Token_Resolver {
 					$by_var_projected[ $var ] = $this->renderer->render( $type, $this->project_value( $raw, $css_namespace ) );
 				}
 
+				// A stepped responsive shape keeps the flat base above and adds a per-breakpoint override the
+				// css-var projection redeclares inside the matching media query; each slot may itself alias.
+				if ( Responsive::has_responsive( $child ) ) {
+					$responsive = Responsive::responsive_of( $child );
+
+					if ( is_array( $responsive ) ) {
+						foreach ( Responsive::get_breakpoint_keys() as $breakpoint ) {
+							if ( ! array_key_exists( $breakpoint, $responsive ) ) {
+								continue;
+							}
+
+							$slot = $responsive[ $breakpoint ];
+
+							$by_id_responsive[ $path ][ $breakpoint ]  = $this->renderer->render( $type, $this->resolve_value( $slot, $document, [] ) );
+							$by_var_responsive[ $var ][ $breakpoint ] = $this->renderer->render( $type, $this->project_value( $slot, $css_namespace ) );
+						}
+					}
+				}
+
 				continue;
 			}
 
-			$this->walk( $child, $path, $document, $by_id, $by_var, $by_var_projected, $by_id_target, $css_namespace );
+			$this->walk( $child, $path, $document, $by_id, $by_var, $by_var_projected, $by_id_target, $by_var_responsive, $by_id_responsive, $css_namespace );
 		}
+	}
+
+	/**
+	 * Render a structured clamp map to a clamp(min, preferred, max) string. Each min / max slot is flattened
+	 * against the leaf's $type; the preferred slot is a calc-style expression rendered as-is. When $projected
+	 * is true, alias slots are preserved as var() references (for the css-var projection); otherwise they are
+	 * flattened to literals (for host surfaces).
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string,mixed> $clamp         The decoded clamp map.
+	 * @param string              $type          The leaf's $type.
+	 * @param array<string,mixed> $document      Full effective doc, for alias lookups.
+	 * @param string              $css_namespace Css-var namespace to apply to var() targets ('' for canonical).
+	 * @param bool                $projected     Whether to preserve aliases as var() references.
+	 *
+	 * @return string
+	 */
+	private function render_clamp( array $clamp, string $type, array $document, string $css_namespace, bool $projected ): string {
+		$slot = function ( $value ) use ( $type, $document, $css_namespace, $projected ): string {
+			$flattened = $projected
+				? $this->project_value( $value, $css_namespace )
+				: $this->resolve_value( $value, $document, [] );
+
+			return $this->renderer->render( $type, $flattened );
+		};
+
+		return $this->renderer->clamp(
+			$slot( $clamp[ Responsive::get_clamp_min_key() ] ?? '' ),
+			$slot( $clamp[ Responsive::get_clamp_preferred_key() ] ?? '' ),
+			$slot( $clamp[ Responsive::get_clamp_max_key() ] ?? '' )
+		);
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
@@ -326,10 +326,11 @@ final class Token_Resolver {
 	}
 
 	/**
-	 * Render a structured clamp map to a clamp(min, preferred, max) string. Each min / max slot is flattened
-	 * against the leaf's $type; the preferred slot is a calc-style expression rendered as-is. When $projected
-	 * is true, alias slots are preserved as var() references (for the css-var projection); otherwise they are
-	 * flattened to literals (for host surfaces).
+	 * Render a structured clamp map to a clamp(min, preferred, max) string. Every slot — min, preferred and
+	 * max alike — is flattened against the leaf's $type: an alias slot resolves to its target, a literal
+	 * passes through, and the calc-style fluid expression the preferred slot typically holds renders
+	 * verbatim. When $projected is true, alias slots are preserved as var() references (for the css-var
+	 * projection); otherwise they are flattened to literals (for host surfaces).
 	 *
 	 * @since TBD
 	 *

--- a/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
@@ -205,9 +205,9 @@ final class Token_Resolver {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string,mixed>  $node             The current group node.
-	 * @param string               $prefix           The dot-path accumulated so far.
-	 * @param array<string,mixed>  $document         Full effective doc, for alias lookups.
+	 * @param array<string,mixed>                $node             The current group node.
+	 * @param string                             $prefix           The dot-path accumulated so far.
+	 * @param array<string,mixed>                $document         Full effective doc, for alias lookups.
 	 * @param array<string,string>               $by_id             By-reference id => literal CSS value map.
 	 * @param array<string,string>               $by_var            By-reference css-var => literal CSS value map.
 	 * @param array<string,string>               $by_var_projected  By-reference css-var => var()-preserving CSS value map.
@@ -275,27 +275,53 @@ final class Token_Resolver {
 
 				// A stepped responsive shape keeps the flat base above and adds a per-breakpoint override the
 				// css-var projection redeclares inside the matching media query; each slot may itself alias.
-				if ( Responsive::has_responsive( $child ) ) {
-					$responsive = Responsive::responsive_of( $child );
-
-					if ( is_array( $responsive ) ) {
-						foreach ( Responsive::get_breakpoint_keys() as $breakpoint ) {
-							if ( ! array_key_exists( $breakpoint, $responsive ) ) {
-								continue;
-							}
-
-							$slot = $responsive[ $breakpoint ];
-
-							$by_id_responsive[ $path ][ $breakpoint ]  = $this->renderer->render( $type, $this->resolve_value( $slot, $document, [] ) );
-							$by_var_responsive[ $var ][ $breakpoint ] = $this->renderer->render( $type, $this->project_value( $slot, $css_namespace ) );
-						}
-					}
-				}
+				$this->collect_responsive_overrides( $child, $type, $path, $var, $document, $css_namespace, $by_id_responsive, $by_var_responsive );
 
 				continue;
 			}
 
 			$this->walk( $child, $path, $document, $by_id, $by_var, $by_var_projected, $by_id_target, $by_var_responsive, $by_id_responsive, $css_namespace );
+		}
+	}
+
+	/**
+	 * Collect a leaf's per-breakpoint responsive overrides into the by-id (literal) and by-var (var()-preserving)
+	 * maps. A no-op when the leaf has no responsive shape. Each slot may itself be an alias, flattened for the
+	 * literal form and preserved as a var() reference for the projection form.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string,mixed>                $child             The leaf node.
+	 * @param string                             $type              The leaf's $type.
+	 * @param string                             $path              The token dot-path.
+	 * @param string                             $css_var           The token's css-var name.
+	 * @param array<string,mixed>                $document          Full effective doc, for alias lookups.
+	 * @param string                             $css_namespace     Css-var namespace to apply ('' for canonical).
+	 * @param array<string,array<string,string>> $by_id_responsive  By-reference id => [ breakpoint => literal value ].
+	 * @param array<string,array<string,string>> $by_var_responsive By-reference css-var => [ breakpoint => projected value ].
+	 *
+	 * @return void
+	 */
+	private function collect_responsive_overrides( array $child, string $type, string $path, string $css_var, array $document, string $css_namespace, array &$by_id_responsive, array &$by_var_responsive ): void {
+		if ( ! Responsive::has_responsive( $child ) ) {
+			return;
+		}
+
+		$responsive = Responsive::responsive_of( $child );
+
+		if ( ! is_array( $responsive ) ) {
+			return;
+		}
+
+		foreach ( Responsive::get_breakpoint_keys() as $breakpoint ) {
+			if ( ! array_key_exists( $breakpoint, $responsive ) ) {
+				continue;
+			}
+
+			$slot = $responsive[ $breakpoint ];
+
+			$by_id_responsive[ $path ][ $breakpoint ]     = $this->renderer->render( $type, $this->resolve_value( $slot, $document, [] ) );
+			$by_var_responsive[ $css_var ][ $breakpoint ] = $this->renderer->render( $type, $this->project_value( $slot, $css_namespace ) );
 		}
 	}
 

--- a/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
@@ -55,6 +55,17 @@ final class Token_Resolver {
 	private array $memo = [];
 
 	/**
+	 * Per-request memo of effective (baseline-merged) documents, keyed on the slug and store version, so the
+	 * stored document is decoded and merged once per version no matter how many callers need the authored
+	 * view — the resolve path itself, the responsive feed, and the REST resolved read all share one build.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string,array<string,mixed>>
+	 */
+	private array $effective_memo = [];
+
+	/**
 	 * Wire the token store, effective-document builder, and value renderer.
 	 *
 	 * @since TBD
@@ -146,10 +157,7 @@ final class Token_Resolver {
 			return $cached;
 		}
 
-		$raw      = $this->store->get_document( $slug );
-		$decoded  = $raw === '' ? [] : json_decode( $raw, true );
-		$over     = is_array( $decoded ) ? $decoded : [];
-		$document = $this->effective->build( $over );
+		$document = $this->effective_document( $slug );
 
 		$result = $this->resolve_document( $document, $css_namespace );
 
@@ -173,6 +181,35 @@ final class Token_Resolver {
 	 */
 	public function resolve_overrides( array $overrides ): Resolved_Tokens {
 		return $this->resolve_document( $this->effective->build( $overrides ) );
+	}
+
+	/**
+	 * The baseline-merged effective document for a stored set, with $extensions intact — the authored view
+	 * the resolved maps flatten away. This is the source the responsive feed and the REST resolved read need
+	 * to recover a token's authored responsive / clamp shape (aliases preserved, unrendered), which the flat
+	 * by_id / by_var maps have already dropped. Memoised per request on the store version like resolve(), so
+	 * the stored document is decoded and merged once rather than rebuilt by every caller.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token set slug.
+	 *
+	 * @return array<string,mixed> The effective document.
+	 */
+	public function effective_document( string $slug = 'default' ): array {
+		$cache_key = $slug . '_' . $this->store->get_version( $slug );
+
+		if ( isset( $this->effective_memo[ $cache_key ] ) ) {
+			return $this->effective_memo[ $cache_key ];
+		}
+
+		$raw     = $this->store->get_document( $slug );
+		$decoded = $raw === '' ? [] : json_decode( $raw, true );
+		$over    = is_array( $decoded ) ? $decoded : [];
+
+		$this->effective_memo[ $cache_key ] = $this->effective->build( $over );
+
+		return $this->effective_memo[ $cache_key ];
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Css_RendererTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Css_RendererTest.php
@@ -69,4 +69,16 @@ final class Css_RendererTest extends TestCase {
 	public function testNonScalarScalarTypeReturnsEmptyString(): void {
 		$this->assertSame( '', $this->renderer->render( 'color', [ 'unexpected' => 'array' ] ) );
 	}
+
+	/**
+	 * A structured clamp is assembled into a clamp(min, preferred, max) string from its slot strings.
+	 *
+	 * @return void
+	 */
+	public function testClampAssemblesTheThreeSlots(): void {
+		$this->assertSame(
+			'clamp(1.1rem, 0.995rem + 0.326vw, 1.25rem)',
+			$this->renderer->clamp( '1.1rem', '0.995rem + 0.326vw', '1.25rem' )
+		);
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Resolved_TokensTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Resolved_TokensTest.php
@@ -86,8 +86,18 @@ final class Resolved_TokensTest extends TestCase {
 	 * @return void
 	 */
 	public function testItExposesThePerBreakpointResponsiveMaps(): void {
-		$by_var_responsive = [ '--kb-token--semantic--font-size--control' => [ 'tablet' => '1rem', 'mobile' => '0.9rem' ] ];
-		$by_id_responsive  = [ 'semantic.font-size.control' => [ 'tablet' => '1rem', 'mobile' => '0.9rem' ] ];
+		$by_var_responsive = [
+			'--kb-token--semantic--font-size--control' => [
+				'tablet' => '1rem',
+				'mobile' => '0.9rem',
+			],
+		];
+		$by_id_responsive  = [
+			'semantic.font-size.control' => [
+				'tablet' => '1rem',
+				'mobile' => '0.9rem',
+			],
+		];
 
 		$resolved = new Resolved_Tokens(
 			[ 'semantic.font-size.control' => '1.125rem' ],

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Resolved_TokensTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Resolved_TokensTest.php
@@ -78,4 +78,41 @@ final class Resolved_TokensTest extends TestCase {
 
 		$this->assertNull( $resolved->target( 'primitive.color.brand.primary' ) );
 	}
+
+	/**
+	 * The per-breakpoint maps round-trip: projected_responsive() exposes the css-var override map and
+	 * value_at() reads the literal override for a token at a breakpoint.
+	 *
+	 * @return void
+	 */
+	public function testItExposesThePerBreakpointResponsiveMaps(): void {
+		$by_var_responsive = [ '--kb-token--semantic--font-size--control' => [ 'tablet' => '1rem', 'mobile' => '0.9rem' ] ];
+		$by_id_responsive  = [ 'semantic.font-size.control' => [ 'tablet' => '1rem', 'mobile' => '0.9rem' ] ];
+
+		$resolved = new Resolved_Tokens(
+			[ 'semantic.font-size.control' => '1.125rem' ],
+			[ '--kb-token--semantic--font-size--control' => '1.125rem' ],
+			[],
+			[],
+			$by_var_responsive,
+			$by_id_responsive
+		);
+
+		$this->assertSame( $by_var_responsive, $resolved->projected_responsive() );
+		$this->assertSame( '1rem', $resolved->value_at( 'semantic.font-size.control', 'tablet' ) );
+		$this->assertSame( '0.9rem', $resolved->value_at( 'semantic.font-size.control', 'mobile' ) );
+	}
+
+	/**
+	 * A construction with no responsive maps exposes an empty projection and null value_at() everywhere, so a
+	 * flat document behaves exactly as before.
+	 *
+	 * @return void
+	 */
+	public function testTheResponsiveMapsDefaultToEmpty(): void {
+		$resolved = new Resolved_Tokens( [ 'semantic.font-size.control' => '1.125rem' ], [] );
+
+		$this->assertSame( [], $resolved->projected_responsive() );
+		$this->assertNull( $resolved->value_at( 'semantic.font-size.control', 'tablet' ) );
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
@@ -816,4 +816,209 @@ final class Token_ResolverTest extends TestCase {
 
 		$this->assertSame( '#000000', $resolver->resolve()->value( 'semantic.color.button-primary-bg' ) );
 	}
+
+	/**
+	 * A stepped responsive dimension keeps its flat base value and adds a per-breakpoint override that the
+	 * projection redeclares: the base is in by_id / by_var, and each breakpoint override is exposed both as a
+	 * projected var map and as a literal via value_at().
+	 *
+	 * @return void
+	 */
+	public function testItExposesPerBreakpointResponsiveOverrides(): void {
+		$resolver = $this->resolver_for(
+			[
+				'semantic' => [
+					'font-size' => [
+						'control' => [
+							'$type'       => 'dimension',
+							'$value'      => '1.125rem',
+							'$extensions' => [
+								'com.kadence.designTokens' => [
+									'responsive' => [
+										'tablet' => '1rem',
+										'mobile' => '0.9rem',
+									],
+								],
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$resolved = $resolver->resolve_overrides( [] );
+		$var      = Css_Var::from_id( 'semantic.font-size.control' );
+
+		$this->assertSame( '1.125rem', $resolved->value( 'semantic.font-size.control' ) );
+		$this->assertSame( '1.125rem', $resolved->projected_vars()[ $var ] );
+		$this->assertSame(
+			[
+				'tablet' => '1rem',
+				'mobile' => '0.9rem',
+			],
+			$resolved->projected_responsive()[ $var ]
+		);
+		$this->assertSame( '1rem', $resolved->value_at( 'semantic.font-size.control', 'tablet' ) );
+		$this->assertSame( '0.9rem', $resolved->value_at( 'semantic.font-size.control', 'mobile' ) );
+	}
+
+	/**
+	 * A responsive breakpoint slot may itself be an alias: the literal per-breakpoint value flattens to the
+	 * referenced token's value, while the projected form preserves the indirection as a var() reference.
+	 *
+	 * @return void
+	 */
+	public function testAResponsiveSlotCanAlias(): void {
+		$resolver = $this->resolver_for(
+			[
+				'primitive' => [
+					'dimension' => [
+						'font-size' => [
+							'mobile' => [
+								'$type'  => 'dimension',
+								'$value' => '0.875rem',
+							],
+						],
+					],
+				],
+				'semantic'  => [
+					'font-size' => [
+						'control' => [
+							'$type'       => 'dimension',
+							'$value'      => '1.125rem',
+							'$extensions' => [
+								'com.kadence.designTokens' => [
+									'responsive' => [
+										'mobile' => '{primitive.dimension.font-size.mobile}',
+									],
+								],
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$resolved = $resolver->resolve_overrides( [] );
+		$var      = Css_Var::from_id( 'semantic.font-size.control' );
+
+		$this->assertSame( '0.875rem', $resolved->value_at( 'semantic.font-size.control', 'mobile' ) );
+		$this->assertSame(
+			'var(' . Css_Var::from_id( 'primitive.dimension.font-size.mobile' ) . ')',
+			$resolved->projected_responsive()[ $var ]['mobile']
+		);
+	}
+
+	/**
+	 * A structured clamp renders to a clamp(min, preferred, max) string for both the literal and projected
+	 * forms, overriding the flat base $value, and produces no per-breakpoint media-query overrides.
+	 *
+	 * @return void
+	 */
+	public function testItRendersAStructuredClampIntoTheValue(): void {
+		$resolver = $this->resolver_for(
+			[
+				'semantic' => [
+					'font-size' => [
+						'control' => [
+							'$type'       => 'dimension',
+							'$value'      => '1.125rem',
+							'$extensions' => [
+								'com.kadence.designTokens' => [
+									'clamp' => [
+										'min'       => '1.1rem',
+										'preferred' => '0.995rem + 0.326vw',
+										'max'       => '1.25rem',
+									],
+								],
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$resolved = $resolver->resolve_overrides( [] );
+		$var      = Css_Var::from_id( 'semantic.font-size.control' );
+
+		$this->assertSame( 'clamp(1.1rem, 0.995rem + 0.326vw, 1.25rem)', $resolved->value( 'semantic.font-size.control' ) );
+		$this->assertSame( 'clamp(1.1rem, 0.995rem + 0.326vw, 1.25rem)', $resolved->projected_vars()[ $var ] );
+		$this->assertSame( [], $resolved->projected_responsive() );
+	}
+
+	/**
+	 * A clamp bound slot may itself be an alias: the literal clamp flattens the slot to the referenced value,
+	 * while the projected clamp preserves the indirection as a var() reference.
+	 *
+	 * @return void
+	 */
+	public function testAClampSlotCanAlias(): void {
+		$resolver = $this->resolver_for(
+			[
+				'primitive' => [
+					'dimension' => [
+						'font-size' => [
+							'min' => [
+								'$type'  => 'dimension',
+								'$value' => '1.1rem',
+							],
+						],
+					],
+				],
+				'semantic'  => [
+					'font-size' => [
+						'control' => [
+							'$type'       => 'dimension',
+							'$value'      => '1.125rem',
+							'$extensions' => [
+								'com.kadence.designTokens' => [
+									'clamp' => [
+										'min'       => '{primitive.dimension.font-size.min}',
+										'preferred' => '0.995rem + 0.326vw',
+										'max'       => '1.25rem',
+									],
+								],
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$resolved = $resolver->resolve_overrides( [] );
+		$var      = Css_Var::from_id( 'semantic.font-size.control' );
+
+		$this->assertSame( 'clamp(1.1rem, 0.995rem + 0.326vw, 1.25rem)', $resolved->value( 'semantic.font-size.control' ) );
+		$this->assertSame(
+			'clamp(var(' . Css_Var::from_id( 'primitive.dimension.font-size.min' ) . '), 0.995rem + 0.326vw, 1.25rem)',
+			$resolved->projected_vars()[ $var ]
+		);
+	}
+
+	/**
+	 * A flat token (no responsive / clamp shape) resolves exactly as before: no per-breakpoint overrides and
+	 * null value_at() at every breakpoint, so enabling responsive elsewhere never perturbs a flat token.
+	 *
+	 * @return void
+	 */
+	public function testAFlatTokenHasNoResponsiveProjection(): void {
+		$resolver = $this->resolver_for(
+			[
+				'semantic' => [
+					'font-size' => [
+						'control' => [
+							'$type'  => 'dimension',
+							'$value' => '1.125rem',
+						],
+					],
+				],
+			]
+		);
+
+		$resolved = $resolver->resolve_overrides( [] );
+
+		$this->assertSame( '1.125rem', $resolved->value( 'semantic.font-size.control' ) );
+		$this->assertSame( [], $resolved->projected_responsive() );
+		$this->assertNull( $resolved->value_at( 'semantic.font-size.control', 'tablet' ) );
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
@@ -59,6 +59,44 @@ final class Token_ResolverTest extends TestCase {
 		$this->assertSame( '#3182CE', $by_id['primitive.color.brand.primary'] );
 	}
 
+	/**
+	 * effective_document() returns the baseline-merged document with a stored leaf's authored $extensions
+	 * intact, so the responsive feed and the REST resolved read can recover the authored responsive / clamp
+	 * shape the flat resolved maps drop.
+	 *
+	 * @return void
+	 */
+	public function testEffectiveDocumentPreservesAStoredLeafsAuthoredExtensions(): void {
+		$resolver = $this->resolver_for(
+			[
+				'semantic' => [
+					'font-size' => [
+						'control' => [
+							'$type'  => 'dimension',
+							'$value' => '1rem',
+						],
+					],
+				],
+			]
+		);
+
+		$this->container->get( Token_Store::class )->save_document(
+			'{"semantic":{"font-size":{"control":{"$type":"dimension","$value":"1.125rem",'
+			. '"$extensions":{"com.kadence.designTokens":{"responsive":{"tablet":"1.0625rem","mobile":"1rem"}}}}}}}'
+		);
+
+		$leaf = $resolver->effective_document( Token_Store::default_slug() )['semantic']['font-size']['control'];
+
+		$this->assertSame( '1.125rem', $leaf['$value'] );
+		$this->assertSame(
+			[
+				'tablet' => '1.0625rem',
+				'mobile' => '1rem',
+			],
+			$leaf['$extensions']['com.kadence.designTokens']['responsive']
+		);
+	}
+
 	public function testItCollapsesAMultiHopAliasChain(): void {
 		$resolver = $this->resolver_for(
 			[


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3857/responsive-per-breakpoint-fluid-clamp-values-for-dimensiontypography
:video_camera: https://www.loom.com/share/0ebee5dc556b4afa8d54923a7c2b4ab0

Part of the SOFT-3857 stack (4/8) — stacked on 3/8.

Teaches the Resolver to flatten aliases inside the responsive/clamp slots, render a structured clamp to `clamp(min, preferred, max)` (structured wins over any literal), and expose breakpoint-keyed accessors (`projected_responsive()`, `value_at()`). A flat token resolves exactly as before.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


