### PR TITLE
SOFT-3857 [5/8] Redeclare token vars per breakpoint + seed responsive font-size

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Css_Var/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Css_Builder.php
@@ -122,17 +122,20 @@ final class Css_Builder {
 	 *                                                         (from Token_Resolver::resolve_namespaced()).
 	 * @param string                        $active_slug      The active set's slug — the set the canonical
 	 *                                                         alias layer points at.
+	 * @param array<string,string>          $breakpoints      Breakpoint => media-query string (e.g.
+	 *                                                         "tablet" => "(max-width: 1024px)"), for the
+	 *                                                         per-breakpoint responsive var redeclaration.
 	 *
 	 * @return string The CSS, or an empty string when there is nothing to project.
 	 */
-	public function css( array $resolved_by_slug, string $active_slug ): string {
+	public function css( array $resolved_by_slug, string $active_slug, array $breakpoints = [] ): string {
 		if ( ! isset( $resolved_by_slug[ $active_slug ] ) ) {
 			return '';
 		}
 
 		$css = '';
 		foreach ( $resolved_by_slug as $slug => $resolved ) {
-			$css .= $this->build_set_fragment( $resolved, (string) $slug );
+			$css .= $this->build_set_fragment( $resolved, (string) $slug, $breakpoints );
 		}
 
 		return $css . $this->build_active_fragment( $resolved_by_slug[ $active_slug ], $active_slug );
@@ -152,15 +155,18 @@ final class Css_Builder {
 	 * @param array<string,Resolved_Tokens> $resolved_by_slug Each set slug => its namespaced resolved maps.
 	 * @param array<string,string>          $versions         Each set slug => the store version it was built from.
 	 * @param string                        $active_slug      The active set's slug.
+	 * @param array<string,string>          $breakpoints      Breakpoint => media-query string, for the
+	 *                                                         per-breakpoint responsive var redeclaration.
 	 *
 	 * @return string
 	 */
-	public function css_for_version( array $resolved_by_slug, array $versions, string $active_slug ): string {
+	public function css_for_version( array $resolved_by_slug, array $versions, string $active_slug, array $breakpoints = [] ): string {
 		if ( ! isset( $resolved_by_slug[ $active_slug ] ) ) {
 			return '';
 		}
 
-		$signature = 'assembly:' . $active_slug;
+		$breakpoint_signature = $this->breakpoint_signature( $breakpoints );
+		$signature            = 'assembly:' . $active_slug . '@' . $breakpoint_signature;
 		foreach ( $resolved_by_slug as $slug => $resolved ) {
 			$signature .= '|' . (string) $slug . ':' . ( $versions[ $slug ] ?? '' );
 		}
@@ -172,7 +178,7 @@ final class Css_Builder {
 		$css = '';
 		foreach ( $resolved_by_slug as $slug => $resolved ) {
 			$slug = (string) $slug;
-			$css .= $this->set_fragment( $resolved, $slug, (string) ( $versions[ $slug ] ?? '' ) );
+			$css .= $this->set_fragment( $resolved, $slug, (string) ( $versions[ $slug ] ?? '' ), $breakpoints );
 		}
 
 		$css .= $this->active_fragment(
@@ -191,14 +197,16 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param Resolved_Tokens $resolved The set's namespaced resolved maps.
-	 * @param string          $slug     The set slug.
-	 * @param string          $version  The store version the set was built from.
+	 * @param Resolved_Tokens      $resolved    The set's namespaced resolved maps.
+	 * @param string               $slug        The set slug.
+	 * @param string               $version     The store version the set was built from.
+	 * @param array<string,string> $breakpoints Breakpoint => media-query string, folded into the cache key
+	 *                                           because the emitted CSS depends on the active breakpoints.
 	 *
 	 * @return string
 	 */
-	public function set_fragment( Resolved_Tokens $resolved, string $slug, string $version ): string {
-		$cache_key = 'projected_css_set_' . KADENCE_BLOCKS_VERSION . '_' . $slug . '_' . $version;
+	public function set_fragment( Resolved_Tokens $resolved, string $slug, string $version, array $breakpoints = [] ): string {
+		$cache_key = 'projected_css_set_' . KADENCE_BLOCKS_VERSION . '_' . $slug . '_' . $version . '_' . $this->breakpoint_signature( $breakpoints );
 
 		if ( isset( $this->memo[ $cache_key ] ) ) {
 			return $this->memo[ $cache_key ];
@@ -210,7 +218,7 @@ final class Css_Builder {
 			return $this->memo[ $cache_key ] = $cached;
 		}
 
-		$css = $this->build_set_fragment( $resolved, $slug );
+		$css = $this->build_set_fragment( $resolved, $slug, $breakpoints );
 
 		wp_cache_set( $cache_key, $css, self::CACHE_GROUP, DAY_IN_SECONDS );
 
@@ -255,13 +263,14 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param Resolved_Tokens $resolved The set's namespaced resolved maps.
-	 * @param string          $slug     The set slug.
+	 * @param Resolved_Tokens      $resolved    The set's namespaced resolved maps.
+	 * @param string               $slug        The set slug.
+	 * @param array<string,string> $breakpoints Breakpoint => media-query string.
 	 *
 	 * @return string
 	 */
-	private function build_set_fragment( Resolved_Tokens $resolved, string $slug ): string {
-		return $this->namespaced_block( $resolved ) . $this->switch_block( $resolved, $slug );
+	private function build_set_fragment( Resolved_Tokens $resolved, string $slug, array $breakpoints = [] ): string {
+		return $this->namespaced_block( $resolved, $breakpoints ) . $this->switch_block( $resolved, $slug );
 	}
 
 	/**
@@ -294,11 +303,13 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param Resolved_Tokens $resolved The set's namespaced resolved maps.
+	 * @param Resolved_Tokens      $resolved    The set's namespaced resolved maps.
+	 * @param array<string,string> $breakpoints Breakpoint => media-query string, for the responsive
+	 *                                           redeclaration blocks appended after the base declarations.
 	 *
 	 * @return string
 	 */
-	private function namespaced_block( Resolved_Tokens $resolved ): string {
+	private function namespaced_block( Resolved_Tokens $resolved, array $breakpoints = [] ): string {
 		$projected = $resolved->projected_vars();
 		if ( $projected === [] ) {
 			return '';
@@ -309,7 +320,71 @@ final class Css_Builder {
 			$declarations .= $var . ':' . $this->sanitize_value( $value ) . ';';
 		}
 
-		return Scope::root() . '{' . $declarations . '}';
+		return Scope::root() . '{' . $declarations . '}' . $this->responsive_blocks( $resolved->projected_responsive(), $breakpoints );
+	}
+
+	/**
+	 * Emit the per-breakpoint responsive redeclarations: for each breakpoint that has overrides, redeclare
+	 * the affected `--kb-token--<set>--*` vars inside that breakpoint's `@media` block, at the same :root
+	 * scope, so a value declared once at :root is overridden within the query and every consuming token /
+	 * block follows for free. Breakpoints are emitted in the given order (tablet before mobile), so the
+	 * narrower max-width override wins by source order. A document with no responsive tokens emits nothing,
+	 * keeping flat output byte-for-byte unchanged.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string,array<string,string>> $responsive  css-var => [ breakpoint => value ] overrides.
+	 * @param array<string,string>               $breakpoints Breakpoint => media-query string.
+	 *
+	 * @return string
+	 */
+	private function responsive_blocks( array $responsive, array $breakpoints ): string {
+		if ( $responsive === [] ) {
+			return '';
+		}
+
+		$css = '';
+		foreach ( $breakpoints as $breakpoint => $query ) {
+			if ( $query === '' ) {
+				continue;
+			}
+
+			$declarations = '';
+			foreach ( $responsive as $var => $by_breakpoint ) {
+				if ( ! isset( $by_breakpoint[ $breakpoint ] ) ) {
+					continue;
+				}
+
+				$declarations .= $var . ':' . $this->sanitize_value( $by_breakpoint[ $breakpoint ] ) . ';';
+			}
+
+			if ( $declarations === '' ) {
+				continue;
+			}
+
+			$css .= '@media all and ' . $query . '{' . Scope::root() . '{' . $declarations . '}}';
+		}
+
+		return $css;
+	}
+
+	/**
+	 * A short, stable signature of the active breakpoint media-query strings, folded into fragment cache
+	 * keys so a change to the filterable breakpoints busts the projected-CSS cache. serialize() keeps this
+	 * dependency-free (the builder stays WordPress-agnostic).
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string,string> $breakpoints Breakpoint => media-query string.
+	 *
+	 * @return string
+	 */
+	private function breakpoint_signature( array $breakpoints ): string {
+		if ( $breakpoints === [] ) {
+			return 'none';
+		}
+
+		return substr( md5( serialize( $breakpoints ) ), 0, 12 );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
@@ -7,6 +7,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts\Css_Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Responsive;
 use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Location;
 use Throwable;
 
@@ -215,7 +216,26 @@ final class Projector implements Css_Projector {
 			}
 		}
 
-		return $this->css_builder->css_for_version( $resolved_by_slug, $versions, $active );
+		return $this->css_builder->css_for_version( $resolved_by_slug, $versions, $active, $this->breakpoints() );
+	}
+
+	/**
+	 * The breakpoint => media-query string map for the per-breakpoint responsive redeclaration, resolved at
+	 * emit time so the filterable KB breakpoints are final. Keyed to match the resolver's breakpoint keys;
+	 * defaults mirror Kadence_Blocks_CSS::get_media_queries(). Desktop is the base (:root), so only the
+	 * tablet / mobile max-width overrides are needed here.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string,string>
+	 */
+	private function breakpoints(): array {
+		return [
+			/** This filter is documented in includes/class-kadence-blocks-css.php */
+			Responsive::get_tablet_key() => (string) apply_filters( 'kadence_tablet_media_query', '(max-width: 1024px)' ),
+			/** This filter is documented in includes/class-kadence-blocks-css.php */
+			Responsive::get_mobile_key() => (string) apply_filters( 'kadence_mobile_media_query', '(max-width: 767px)' ),
+		];
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -376,7 +376,15 @@
 		"font-size": {
 			"control": {
 				"$type": "dimension",
-				"$value": "1.125rem"
+				"$value": "1.125rem",
+				"$extensions": {
+					"com.kadence.designTokens": {
+						"responsive": {
+							"tablet": "1.0625rem",
+							"mobile": "1rem"
+						}
+					}
+				}
 			}
 		},
 		"font-weight": {

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Css_BuilderTest.php
@@ -442,8 +442,9 @@ final class Css_BuilderTest extends TestCase {
 		$default = $this->set( [ $id => '#111' ], [ Css_Var::from_id( $id, 'default' ) => '#111' ] );
 		$dark    = $this->set( [ $id => '#eee' ], [ Css_Var::from_id( $id, 'dark' ) => '#eee' ] );
 
-		// Seed the dark per-set fragment with a sentinel.
-		$dark_key = 'projected_css_set_' . KADENCE_BLOCKS_VERSION . '_dark_v1';
+		// Seed the dark per-set fragment with a sentinel. The cache key carries the breakpoint signature,
+		// "none" here because css_for_version() is called with no breakpoints.
+		$dark_key = 'projected_css_set_' . KADENCE_BLOCKS_VERSION . '_dark_v1_none';
 		wp_cache_set( $dark_key, '--dark-fragment-sentinel:1;', 'kb_design_tokens', DAY_IN_SECONDS );
 
 		$builder  = $this->builder();
@@ -458,5 +459,61 @@ final class Css_BuilderTest extends TestCase {
 
 		$this->assertStringContainsString( '--dark-fragment-sentinel:1;', $with_dark_active );
 		$this->assertStringContainsString( '--dark-fragment-sentinel:1;', $with_default_active );
+	}
+
+	/**
+	 * A responsive set redeclares each affected `--kb-token--<set>--*` var inside the tablet and mobile
+	 * media queries (at :root, tablet before mobile), on top of the base :root declaration, so a consuming
+	 * block inherits the per-breakpoint value with no block change.
+	 *
+	 * @return void
+	 */
+	public function testItRedeclaresResponsiveVarsInsideMediaQueries(): void {
+		$id  = 'semantic.font-size.control';
+		$var = Css_Var::from_id( $id, 'default' );
+
+		$resolved = new Resolved_Tokens(
+			[ $id => '1.125rem' ],
+			[],
+			[ $var => '1.125rem' ],
+			[],
+			[ $var => [ 'tablet' => '1rem', 'mobile' => '0.9rem' ] ]
+		);
+
+		$breakpoints = [
+			'tablet' => '(max-width: 1024px)',
+			'mobile' => '(max-width: 767px)',
+		];
+
+		$css = $this->builder()->css_for_version( [ 'default' => $resolved ], [ 'default' => 'v1' ], 'default', $breakpoints );
+
+		$this->assertStringContainsString( $var . ':1.125rem;', $css );
+		$this->assertStringContainsString( '@media all and (max-width: 1024px){' . Scope::root() . '{' . $var . ':1rem;}}', $css );
+		$this->assertStringContainsString( '@media all and (max-width: 767px){' . Scope::root() . '{' . $var . ':0.9rem;}}', $css );
+		$this->assertLessThan(
+			(int) strpos( $css, '(max-width: 767px)' ),
+			(int) strpos( $css, '(max-width: 1024px)' ),
+			'The tablet override must precede the mobile override so the narrower max-width wins by source order.'
+		);
+	}
+
+	/**
+	 * A flat set (no responsive overrides) emits no media queries, so responsive support never perturbs the
+	 * projected CSS of a flat document.
+	 *
+	 * @return void
+	 */
+	public function testAFlatSetEmitsNoMediaQueries(): void {
+		$id       = 'semantic.color.text';
+		$resolved = $this->set( [ $id => '#111' ], [ Css_Var::from_id( $id, 'default' ) => '#111' ] );
+
+		$css = $this->builder()->css_for_version(
+			[ 'default' => $resolved ],
+			[ 'default' => 'v1' ],
+			'default',
+			[ 'tablet' => '(max-width: 1024px)', 'mobile' => '(max-width: 767px)' ]
+		);
+
+		$this->assertStringNotContainsString( '@media', $css );
 	}
 }


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3857/responsive-per-breakpoint-fluid-clamp-values-for-dimensiontypography
:video_camera: https://www.loom.com/share/0ebee5dc556b4afa8d54923a7c2b4ab0

Part of the SOFT-3857 stack (5/8) — stacked on 4/8.

Redeclares each `--kb-token--*` var inside filterable tablet/mobile `@media` blocks so a consuming block inherits per-breakpoint values with no block change, and seeds `semantic.font-size.control` with a responsive default. Breakpoints resolve from the `kadence_{tablet,mobile}_media_query` filters; flat tokens emit identical CSS. (Exact seeded values are design-gated.)

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


