### PR TITLE
SOFT-3857 [6/8] Surface authored responsive shapes in the admin feed

### DIFF
--- a/includes/resources/Design_Tokens/Admin/Feed/Builder.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Builder.php
@@ -42,27 +42,30 @@ final class Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, string>                                 $values   id => resolved value (by_id), or [] when unresolved.
-	 * @param bool                                                  $resolved Whether resolution succeeded.
-	 * @param array<string, mixed>                                  $variants Per-block variant structure + values.
-	 * @param array{root: string, namespace: string, nonce: string} $rest     REST root, namespace and nonce.
-	 * @param string                                                $version  Store version hash ('' from baseline).
-	 * @param string                                                $slug     The token set slug the values/version/schema were resolved against.
+	 * @param array<string, string>                                 $values     id => resolved value (by_id), or [] when unresolved.
+	 * @param bool                                                  $resolved   Whether resolution succeeded.
+	 * @param array<string, mixed>                                  $variants   Per-block variant structure + values.
+	 * @param array{root: string, namespace: string, nonce: string} $rest       REST root, namespace and nonce.
+	 * @param string                                                $version    Store version hash ('' from baseline).
+	 * @param string                                                $slug       The token set slug the values/version/schema were resolved against.
+	 * @param array<string, array<string, mixed>>                   $responsive id => raw authored responsive / clamp shape, for
+	 *                                                                          tokens that carry one (for editor hydration).
 	 *
 	 * @return array<string, mixed> The localized payload.
 	 */
-	public function build( array $values, bool $resolved, array $variants, array $rest, string $version, string $slug ): array {
+	public function build( array $values, bool $resolved, array $variants, array $rest, string $version, string $slug, array $responsive = [] ): array {
 		$active = $this->registry->is_active();
 
 		return [
-			'active'   => $active,
-			'resolved' => $active && $resolved,
-			'version'  => $version,
-			'slug'     => $slug,
-			'schema'   => $active ? $this->registry->to_ui_schema() : [ 'groups' => [] ],
-			'values'   => $active ? $values : [],
-			'variants' => $active ? $variants : [],
-			'rest'     => $rest,
+			'active'     => $active,
+			'resolved'   => $active && $resolved,
+			'version'    => $version,
+			'slug'       => $slug,
+			'schema'     => $active ? $this->registry->to_ui_schema() : [ 'groups' => [] ],
+			'values'     => $active ? $values : [],
+			'variants'   => $active ? $variants : [],
+			'responsive' => $active ? $responsive : [],
+			'rest'       => $rest,
 		];
 	}
 }

--- a/includes/resources/Design_Tokens/Admin/Feed/Localizer.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Localizer.php
@@ -6,6 +6,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Style_Book\Asset_Loader;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
@@ -111,26 +112,50 @@ final class Localizer {
 	private Builder $builder;
 
 	/**
+	 * Builds the baseline-merged effective document the responsive feed is extracted from.
+	 *
 	 * @since TBD
 	 *
-	 * @param Token_Resolver   $resolver     The token resolver.
-	 * @param Token_Store      $store        The token store.
-	 * @param Active_Set_Store $active       The active-set pointer.
-	 * @param Variants         $variant_feed The variants section builder.
-	 * @param Builder          $builder      The pure payload assembler.
+	 * @var Effective_Document
+	 */
+	private Effective_Document $effective;
+
+	/**
+	 * Extracts the raw authored responsive / clamp shapes for the editor to hydrate from.
+	 *
+	 * @since TBD
+	 *
+	 * @var Responsive_Feed
+	 */
+	private Responsive_Feed $responsive_feed;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Resolver     $resolver        The token resolver.
+	 * @param Token_Store        $store           The token store.
+	 * @param Active_Set_Store   $active          The active-set pointer.
+	 * @param Variants           $variant_feed    The variants section builder.
+	 * @param Builder            $builder         The pure payload assembler.
+	 * @param Effective_Document $effective       The effective-document builder.
+	 * @param Responsive_Feed    $responsive_feed The responsive / clamp shape extractor.
 	 */
 	public function __construct(
 		Token_Resolver $resolver,
 		Token_Store $store,
 		Active_Set_Store $active,
 		Variants $variant_feed,
-		Builder $builder
+		Builder $builder,
+		Effective_Document $effective,
+		Responsive_Feed $responsive_feed
 	) {
-		$this->resolver     = $resolver;
-		$this->store        = $store;
-		$this->active       = $active;
-		$this->variant_feed = $variant_feed;
-		$this->builder      = $builder;
+		$this->resolver        = $resolver;
+		$this->store           = $store;
+		$this->active          = $active;
+		$this->variant_feed    = $variant_feed;
+		$this->builder         = $builder;
+		$this->effective       = $effective;
+		$this->responsive_feed = $responsive_feed;
 	}
 
 	/**
@@ -154,19 +179,21 @@ final class Localizer {
 		$slug    = $this->active->get();
 		$version = $this->store->get_version( $slug );
 
-		$values   = [];
-		$variants = [];
-		$resolved = false;
+		$values     = [];
+		$variants   = [];
+		$responsive = [];
+		$resolved   = false;
 
 		try {
-			$values   = $this->resolver->resolve( $slug )->by_id();
-			$variants = $this->variant_feed->all( $slug );
-			$resolved = true;
+			$values     = $this->resolver->resolve( $slug )->by_id();
+			$variants   = $this->variant_feed->all( $slug );
+			$responsive = $this->responsive_feed->from_document( $this->effective->build( $this->overrides( $slug ) ) );
+			$resolved   = true;
 		} catch ( Alias_Cycle_Exception | Dangling_Alias_Exception $e ) {
 			$resolved = false; // Corrupt stored document. Fail open: ship structure only.
 		}
 
-		$feed = $this->builder->build( $values, $resolved, $variants, $this->rest(), $version, $slug );
+		$feed = $this->builder->build( $values, $resolved, $variants, $this->rest(), $version, $slug, $responsive );
 		$json = wp_json_encode(
 			$feed,
 			JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
@@ -181,6 +208,27 @@ final class Localizer {
 			'window.' . self::OBJECT . ' = ' . $json . ';',
 			'before'
 		);
+	}
+
+	/**
+	 * The decoded stored overrides for a set, or an empty array when the set has no stored document.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token set slug.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function overrides( string $slug ): array {
+		$raw = $this->store->get_document( $slug );
+
+		if ( $raw === '' ) {
+			return [];
+		}
+
+		$decoded = json_decode( $raw, true );
+
+		return is_array( $decoded ) ? $decoded : [];
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Admin/Feed/Localizer.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Localizer.php
@@ -6,7 +6,6 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Style_Book\Asset_Loader;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
-use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
@@ -112,15 +111,6 @@ final class Localizer {
 	private Builder $builder;
 
 	/**
-	 * Builds the baseline-merged effective document the responsive feed is extracted from.
-	 *
-	 * @since TBD
-	 *
-	 * @var Effective_Document
-	 */
-	private Effective_Document $effective;
-
-	/**
 	 * Extracts the raw authored responsive / clamp shapes for the editor to hydrate from.
 	 *
 	 * @since TBD
@@ -132,13 +122,12 @@ final class Localizer {
 	/**
 	 * @since TBD
 	 *
-	 * @param Token_Resolver     $resolver        The token resolver.
-	 * @param Token_Store        $store           The token store.
-	 * @param Active_Set_Store   $active          The active-set pointer.
-	 * @param Variants           $variant_feed    The variants section builder.
-	 * @param Builder            $builder         The pure payload assembler.
-	 * @param Effective_Document $effective       The effective-document builder.
-	 * @param Responsive_Feed    $responsive_feed The responsive / clamp shape extractor.
+	 * @param Token_Resolver   $resolver        The token resolver.
+	 * @param Token_Store      $store           The token store.
+	 * @param Active_Set_Store $active          The active-set pointer.
+	 * @param Variants         $variant_feed    The variants section builder.
+	 * @param Builder          $builder         The pure payload assembler.
+	 * @param Responsive_Feed  $responsive_feed The responsive / clamp shape extractor.
 	 */
 	public function __construct(
 		Token_Resolver $resolver,
@@ -146,7 +135,6 @@ final class Localizer {
 		Active_Set_Store $active,
 		Variants $variant_feed,
 		Builder $builder,
-		Effective_Document $effective,
 		Responsive_Feed $responsive_feed
 	) {
 		$this->resolver        = $resolver;
@@ -154,7 +142,6 @@ final class Localizer {
 		$this->active          = $active;
 		$this->variant_feed    = $variant_feed;
 		$this->builder         = $builder;
-		$this->effective       = $effective;
 		$this->responsive_feed = $responsive_feed;
 	}
 
@@ -187,7 +174,7 @@ final class Localizer {
 		try {
 			$values     = $this->resolver->resolve( $slug )->by_id();
 			$variants   = $this->variant_feed->all( $slug );
-			$responsive = $this->responsive_feed->from_document( $this->effective->build( $this->overrides( $slug ) ) );
+			$responsive = $this->responsive_feed->from_document( $this->resolver->effective_document( $slug ) );
 			$resolved   = true;
 		} catch ( Alias_Cycle_Exception | Dangling_Alias_Exception $e ) {
 			$resolved = false; // Corrupt stored document. Fail open: ship structure only.
@@ -208,27 +195,6 @@ final class Localizer {
 			'window.' . self::OBJECT . ' = ' . $json . ';',
 			'before'
 		);
-	}
-
-	/**
-	 * The decoded stored overrides for a set, or an empty array when the set has no stored document.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $slug The token set slug.
-	 *
-	 * @return array<string,mixed>
-	 */
-	private function overrides( string $slug ): array {
-		$raw = $this->store->get_document( $slug );
-
-		if ( $raw === '' ) {
-			return [];
-		}
-
-		$decoded = json_decode( $raw, true );
-
-		return is_array( $decoded ) ? $decoded : [];
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Admin/Feed/Responsive_Feed.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Responsive_Feed.php
@@ -1,0 +1,122 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Responsive;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Sentinels;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
+
+/**
+ * Extracts the raw authored responsive / clamp shape for every responsive-capable leaf in an effective
+ * document, so the Style Book token editor can hydrate its per-breakpoint (and clamp) inputs exactly as
+ * authored rather than from the flat resolved value (which loses the tablet / mobile steps and the clamp
+ * slots).
+ *
+ * The feed's `values` map already carries the flat resolved value per token for a flat editor; this adds a
+ * parallel `responsive` map keyed by token id, present ONLY for tokens that actually carry a shape:
+ *
+ *   "semantic.font-size.control" => { "base": "1.125rem", "responsive": { "tablet": "…", "mobile": "…" } }
+ *   "semantic.font-size.control" => { "base": "clamp(…)",  "clamp": { "min": "…", "preferred": "…", "max": "…" } }
+ *
+ * A flat token is absent, so the editor falls back to the flat value for its desktop input. Values are the
+ * raw authored strings (an alias slot stays a "{dot.path}" reference); the editor shows what was authored.
+ * Pure: no WordPress calls, no globals, no I/O.
+ *
+ * @since TBD
+ */
+final class Responsive_Feed {
+
+	/**
+	 * Build the id => authored-shape map for every responsive-capable leaf that carries a responsive or
+	 * clamp shape.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string,mixed> $document The effective (baseline-merged) DTCG document.
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	public function from_document( array $document ): array {
+		$out = [];
+		$this->walk( $document, '', $out );
+
+		return $out;
+	}
+
+	/**
+	 * Depth-first walk collecting the authored shape of each responsive-capable leaf.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string,mixed>               $node   The current node.
+	 * @param string                            $prefix The dot-path accumulated so far.
+	 * @param array<string,array<string,mixed>> $out    By-reference id => authored-shape map.
+	 *
+	 * @return void
+	 */
+	private function walk( array $node, string $prefix, array &$out ): void {
+		foreach ( $node as $key => $child ) {
+			if ( ! is_string( $key ) || strncmp( $key, '$', 1 ) === 0 || ! is_array( $child ) ) {
+				continue;
+			}
+
+			$path = $prefix === '' ? $key : $prefix . '.' . $key;
+
+			if ( ! array_key_exists( Sentinels::get_value_key(), $child ) ) {
+				$this->walk( $child, $path, $out );
+
+				continue;
+			}
+
+			$type = $child[ Token_Type::get_type_key() ] ?? '';
+
+			if ( ! is_string( $type ) || ! Responsive::is_responsive_capable( $type ) ) {
+				continue;
+			}
+
+			$entry = $this->authored_shape( $child );
+
+			if ( $entry !== [] ) {
+				$out[ $path ] = $entry;
+			}
+		}
+	}
+
+	/**
+	 * The authored responsive / clamp shape for a leaf, or an empty array when it is flat. Base is the raw
+	 * scalar $value; responsive and clamp are the raw authored maps.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string,mixed> $leaf The decoded leaf.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function authored_shape( array $leaf ): array {
+		$base = $leaf[ Sentinels::get_value_key() ] ?? null;
+
+		if ( Responsive::has_responsive( $leaf ) ) {
+			$responsive = Responsive::responsive_of( $leaf );
+
+			if ( is_array( $responsive ) ) {
+				return [
+					'base'       => $base,
+					'responsive' => $responsive,
+				];
+			}
+		}
+
+		if ( Responsive::has_clamp( $leaf ) ) {
+			$clamp = Responsive::clamp_of( $leaf );
+
+			if ( is_array( $clamp ) ) {
+				return [
+					'base'  => $base,
+					'clamp' => $clamp,
+				];
+			}
+		}
+
+		return [];
+	}
+}

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -473,7 +473,9 @@ final class Documents_Controller extends Controller {
 				'version'    => $this->store->get_version( $slug ),
 				'by_id'      => $resolved->by_id(),
 				'by_var'     => $resolved->by_var(),
-				'responsive' => $responsive,
+				// An empty PHP array JSON-encodes as [] rather than {}; cast the empty case to an object so
+				// the responsive map keeps a stable object wire type whether or not a token carries the shape.
+				'responsive' => empty( $responsive ) ? (object) [] : $responsive,
 			],
 			WP_Http::OK
 		);

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -465,7 +465,7 @@ final class Documents_Controller extends Controller {
 			);
 		}
 
-		$responsive = $this->responsive_feed->from_document( $this->effective->build( $this->read_stored_document( $slug ) ) );
+		$responsive = $this->responsive_feed->from_document( $this->resolver->effective_document( $slug ) );
 
 		return new WP_REST_Response(
 			[

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -2,9 +2,9 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Responsive_Feed;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Document_Path;
-use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Responsive_Feed;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Reserved_Namespace;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Reference_Policy;
@@ -821,23 +821,23 @@ final class Documents_Controller extends Controller {
 			'title'      => 'design-token-resolved-map',
 			'type'       => 'object',
 			'properties' => [
-				'slug'    => [
+				'slug'       => [
 					'description' => __( 'The token set slug.', 'kadence-blocks' ),
 					'type'        => 'string',
 					'context'     => [ 'view' ],
 					'readonly'    => true,
 				],
-				'version' => [
+				'version'    => [
 					'description' => __( 'The cache-busting version hash for the set, empty when it renders from baseline.', 'kadence-blocks' ),
 					'type'        => 'string',
 					'context'     => [ 'view' ],
 					'readonly'    => true,
 				],
-				'by_id'   => array_merge(
+				'by_id'      => array_merge(
 					[ 'description' => __( 'Resolved CSS values keyed by token dot-path id.', 'kadence-blocks' ) ],
 					$css_value_map
 				),
-				'by_var'  => array_merge(
+				'by_var'     => array_merge(
 					[ 'description' => __( 'Resolved CSS values keyed by CSS custom-property name.', 'kadence-blocks' ) ],
 					$css_value_map
 				),

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -4,6 +4,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Document_Path;
+use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Responsive_Feed;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Reserved_Namespace;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Reference_Policy;
@@ -196,6 +197,16 @@ final class Documents_Controller extends Controller {
 	private Token_Reference_Policy $reference_policy;
 
 	/**
+	 * Extracts the authored responsive / clamp shape per token, so a read of the resolved map can carry the
+	 * per-breakpoint steps the flat by_id map flattens away.
+	 *
+	 * @since TBD
+	 *
+	 * @var Responsive_Feed
+	 */
+	private Responsive_Feed $responsive_feed;
+
+	/**
 	 * Memoised item schema for this request. Null until first built.
 	 *
 	 * @since TBD
@@ -224,6 +235,7 @@ final class Documents_Controller extends Controller {
 	 * @param User_Primitive_Index              $user_primitive_index  Inspects documents for user-created primitives.
 	 * @param User_Primitive_Document_Validator $user_primitive_validator Enforces the user-primitive document invariant.
 	 * @param Token_Reference_Policy            $reference_policy      Scans for alias references to a user primitive.
+	 * @param Responsive_Feed                   $responsive_feed       Extracts the authored responsive / clamp shape per token.
 	 */
 	public function __construct(
 		Token_Store $store,
@@ -233,7 +245,8 @@ final class Documents_Controller extends Controller {
 		Effective_Document $effective,
 		User_Primitive_Index $user_primitive_index,
 		User_Primitive_Document_Validator $user_primitive_validator,
-		Token_Reference_Policy $reference_policy
+		Token_Reference_Policy $reference_policy,
+		Responsive_Feed $responsive_feed
 	) {
 		$this->store                    = $store;
 		$this->resolver                 = $resolver;
@@ -243,6 +256,7 @@ final class Documents_Controller extends Controller {
 		$this->user_primitive_index     = $user_primitive_index;
 		$this->user_primitive_validator = $user_primitive_validator;
 		$this->reference_policy         = $reference_policy;
+		$this->responsive_feed          = $responsive_feed;
 		$this->rest_base                = 'documents';
 	}
 
@@ -420,6 +434,11 @@ final class Documents_Controller extends Controller {
 	 * to its CSS value; a stored set carrying an alias cycle or a dangling alias cannot be flattened, so it
 	 * is surfaced as HTTP 422 rather than a fatal.
 	 *
+	 * Alongside the flat by_id / by_var maps, the response carries the authored responsive / clamp shape per
+	 * token (empty for a set with no responsive tokens). The flat maps lose the per-breakpoint steps, so a
+	 * client that re-reads this endpoint after a write — the Style Book token editor does, to keep its
+	 * per-breakpoint inputs fresh — would otherwise fall back to a stale bootstrap of the responsive shape.
+	 *
 	 * @since TBD
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
@@ -446,12 +465,15 @@ final class Documents_Controller extends Controller {
 			);
 		}
 
+		$responsive = $this->responsive_feed->from_document( $this->effective->build( $this->read_stored_document( $slug ) ) );
+
 		return new WP_REST_Response(
 			[
-				'slug'    => $slug,
-				'version' => $this->store->get_version( $slug ),
-				'by_id'   => $resolved->by_id(),
-				'by_var'  => $resolved->by_var(),
+				'slug'       => $slug,
+				'version'    => $this->store->get_version( $slug ),
+				'by_id'      => $resolved->by_id(),
+				'by_var'     => $resolved->by_var(),
+				'responsive' => $responsive,
 			],
 			WP_Http::OK
 		);
@@ -819,6 +841,13 @@ final class Documents_Controller extends Controller {
 					[ 'description' => __( 'Resolved CSS values keyed by CSS custom-property name.', 'kadence-blocks' ) ],
 					$css_value_map
 				),
+				'responsive' => [
+					'description'          => __( 'Authored responsive / clamp shape keyed by token dot-path id; present only for tokens that carry a shape.', 'kadence-blocks' ),
+					'type'                 => 'object',
+					'context'              => [ 'view' ],
+					'readonly'             => true,
+					'additionalProperties' => [ 'type' => 'object' ],
+				],
 			],
 		];
 

--- a/tests/snapshot/Resources/Design_Tokens/Admin/Feed/__snapshots__/Builder_SnapshotTest__testFullPayloadMatchesSnapshot__1.txt
+++ b/tests/snapshot/Resources/Design_Tokens/Admin/Feed/__snapshots__/Builder_SnapshotTest__testFullPayloadMatchesSnapshot__1.txt
@@ -68,6 +68,7 @@
             }
         }
     },
+    "responsive": [],
     "rest": {
         "root": "https:\/\/example.test\/wp-json\/",
         "namespace": "kb-design-tokens\/v1",

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
@@ -4,6 +4,7 @@ namespace Tests\wpunit\Resources\Design_Tokens\Admin\Feed;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Localizer;
+use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Responsive_Feed;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Variants;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Style_Book\Asset_Loader;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
@@ -181,7 +182,9 @@ final class LocalizerTest extends TestCase {
 			$this->container->get( Token_Store::class ),
 			$this->container->get( Active_Set_Store::class ),
 			$this->container->get( Variants::class ),
-			$this->container->get( Builder::class )
+			$this->container->get( Builder::class ),
+			$this->container->get( Effective_Document::class ),
+			$this->container->get( Responsive_Feed::class )
 		);
 
 		$localizer->localize();

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
@@ -183,7 +183,6 @@ final class LocalizerTest extends TestCase {
 			$this->container->get( Active_Set_Store::class ),
 			$this->container->get( Variants::class ),
 			$this->container->get( Builder::class ),
-			$this->container->get( Effective_Document::class ),
 			$this->container->get( Responsive_Feed::class )
 		);
 

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Responsive_FeedTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Responsive_FeedTest.php
@@ -1,0 +1,116 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Admin\Feed;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Responsive_Feed;
+use Tests\Support\Classes\TestCase;
+
+final class Responsive_FeedTest extends TestCase {
+
+	private Responsive_Feed $feed;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->feed = new Responsive_Feed();
+	}
+
+	/**
+	 * A stepped responsive leaf is surfaced with its base value and its raw per-breakpoint map, keyed by
+	 * token id, so the editor hydrates the desktop / tablet / mobile inputs exactly as authored.
+	 *
+	 * @return void
+	 */
+	public function testItSurfacesASteppedResponsiveShape(): void {
+		$document = [
+			'semantic' => [
+				'font-size' => [
+					'control' => [
+						'$type'       => 'dimension',
+						'$value'      => '1.125rem',
+						'$extensions' => [
+							'com.kadence.designTokens' => [
+								'responsive' => [
+									'tablet' => '1.0625rem',
+									'mobile' => '1rem',
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$this->assertSame(
+			[
+				'semantic.font-size.control' => [
+					'base'       => '1.125rem',
+					'responsive' => [
+						'tablet' => '1.0625rem',
+						'mobile' => '1rem',
+					],
+				],
+			],
+			$this->feed->from_document( $document )
+		);
+	}
+
+	/**
+	 * A clamp leaf is surfaced with its base value and its raw min / preferred / max slots.
+	 *
+	 * @return void
+	 */
+	public function testItSurfacesAClampShape(): void {
+		$document = [
+			'semantic' => [
+				'font-size' => [
+					'control' => [
+						'$type'       => 'dimension',
+						'$value'      => 'clamp(1.1rem, 0.995rem + 0.326vw, 1.25rem)',
+						'$extensions' => [
+							'com.kadence.designTokens' => [
+								'clamp' => [
+									'min'       => '1.1rem',
+									'preferred' => '0.995rem + 0.326vw',
+									'max'       => '1.25rem',
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$shape = $this->feed->from_document( $document );
+
+		$this->assertArrayHasKey( 'semantic.font-size.control', $shape );
+		$this->assertSame( '0.995rem + 0.326vw', $shape['semantic.font-size.control']['clamp']['preferred'] );
+	}
+
+	/**
+	 * A flat responsive-capable leaf and a non-responsive-capable type are both absent from the map, so the
+	 * editor falls back to the flat resolved value for them.
+	 *
+	 * @return void
+	 */
+	public function testItOmitsFlatAndNonCapableTokens(): void {
+		$document = [
+			'semantic' => [
+				'font-size'   => [
+					'control' => [
+						'$type'  => 'dimension',
+						'$value' => '1.125rem',
+					],
+				],
+				'font-family' => [
+					'control' => [
+						'$type'  => 'fontFamily',
+						'$value' => [ 'Inter', 'sans-serif' ],
+					],
+				],
+			],
+		];
+
+		$this->assertSame( [], $this->feed->from_document( $document ) );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerTest.php
@@ -181,6 +181,36 @@ final class DocumentsControllerTest extends TestCase {
 	}
 
 	/**
+	 * The resolved read carries the authored responsive shape per token alongside the flat maps, so a client
+	 * re-reading after a write sees the per-breakpoint steps the flat by_id map flattens away.
+	 *
+	 * @return void
+	 */
+	public function testItReturnsTheAuthoredResponsiveShapeAlongsideTheFlatMaps(): void {
+		$this->store->save_document(
+			'{"semantic":{"font-size":{"probe":{"$type":"dimension","$value":"1.125rem",'
+			. '"$extensions":{"com.kadence.designTokens":{"responsive":{"tablet":"1.0625rem","mobile":"1rem"}}}}}}}'
+		);
+
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', Token_Store::default_slug() );
+
+		$data = $this->controller->get_resolved( $request )->get_data();
+
+		$this->assertArrayHasKey( 'responsive', $data );
+		$this->assertSame(
+			[
+				'base'       => '1.125rem',
+				'responsive' => [
+					'tablet' => '1.0625rem',
+					'mobile' => '1rem',
+				],
+			],
+			$data['responsive']['semantic.font-size.probe']
+		);
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testItReturns422WhenAStoredDocumentHasAnAliasCycle(): void {


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3857/responsive-per-breakpoint-fluid-clamp-values-for-dimensiontypography
:video_camera: https://www.loom.com/share/0ebee5dc556b4afa8d54923a7c2b4ab0

Part of the SOFT-3857 stack (6/8) — stacked on 5/8.

Surfaces each token's raw authored responsive/clamp shape in the admin feed (`Responsive_Feed` + `Localizer`/`Builder`) so the Style Book editor can hydrate its per-breakpoint inputs exactly as authored rather than from the flat resolved value.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


