### PR TITLE
SOFT-3857 [7/8] Per-breakpoint token editor in the Style Book

### DIFF
--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Literals.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Literals.php
@@ -448,6 +448,15 @@ final class Literals {
 	 * would also match, but a DTCG $value is a single token — that concatenation is not a shape this
 	 * module is meant to police, and parsing it would belong in a real CSS parser.
 	 *
+	 * An empty argument IS rejected, though: no CSS <length>/<color> function is valid with a missing
+	 * argument, and that is the shape an incomplete clamp()/var()/calc() takes when a slot is left blank
+	 * (e.g. the token editor's fluid helper before every slot is filled). This catches the whole call
+	 * being empty (func(), clamp(, , )) AND an empty leading or interior positional argument at any depth
+	 * (clamp(, a, b), clamp(1rem, , 2rem), foo(bar(, x))). A TRAILING empty is left alone, because
+	 * var(--x,) is a valid empty custom-property fallback. It stays a shape gate — argument count and type
+	 * are not checked, so e.g. clamp(1rem) (too few args) still passes; that grammar belongs in a real CSS
+	 * parser.
+	 *
 	 * @since TBD
 	 *
 	 * @param string $value The candidate function string.
@@ -455,6 +464,20 @@ final class Literals {
 	 * @return bool
 	 */
 	private static function is_function( string $value ): bool {
-		return (bool) preg_match( '/^[a-z][a-z0-9-]*\(.*\)$/i', $value );
+		if ( ! preg_match( '/^[a-z][a-z0-9-]*\((.*)\)$/i', $value, $matches ) ) {
+			return false;
+		}
+
+		$args = $matches[1];
+
+		// No real arguments at all: func(), clamp(, , ), var(  ).
+		if ( trim( $args, " \t\n\r\0\x0B," ) === '' ) {
+			return false;
+		}
+
+		// An empty leading or interior positional argument: a comma at the start or right after an open
+		// paren, or two commas with nothing between them. A trailing empty (var(--x,)) is intentionally
+		// not matched.
+		return ! (bool) preg_match( '/(?:^|\()\s*,|,\s*,/', $args );
 	}
 }

--- a/src/style-book/__tests__/tokens.test.js
+++ b/src/style-book/__tests__/tokens.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { flattenSchemaTokens } from '../helpers/tokens';
+import { buildTokenLeaf, flattenSchemaTokens, isResponsiveType } from '../helpers/tokens';
 
 describe('flattenSchemaTokens', () => {
 	it('returns empty array when schema has no groups', () => {
@@ -57,5 +57,81 @@ describe('flattenSchemaTokens', () => {
 		};
 
 		expect(flattenSchemaTokens(schema)).toHaveLength(3);
+	});
+});
+
+describe('isResponsiveType', () => {
+	it('is true only for dimension and lineHeight', () => {
+		expect(isResponsiveType('dimension')).toBe(true);
+		expect(isResponsiveType('lineHeight')).toBe(true);
+		expect(isResponsiveType('color')).toBe(false);
+		expect(isResponsiveType('fontFamily')).toBe(false);
+	});
+});
+
+describe('buildTokenLeaf', () => {
+	it('builds a flat leaf from a plain string', () => {
+		expect(buildTokenLeaf('dimension', ' 1.125rem ')).toEqual({
+			$type: 'dimension',
+			$value: '1.125rem',
+		});
+	});
+
+	it('serializes a stepped responsive shape under $extensions', () => {
+		const leaf = buildTokenLeaf('dimension', {
+			base: '1.125rem',
+			responsive: { tablet: '1.0625rem', mobile: '1rem' },
+		});
+
+		expect(leaf).toEqual({
+			$type: 'dimension',
+			$value: '1.125rem',
+			$extensions: {
+				'com.kadence.designTokens': {
+					responsive: { tablet: '1.0625rem', mobile: '1rem' },
+				},
+			},
+		});
+	});
+
+	it('omits empty breakpoint steps and drops $extensions when all are empty', () => {
+		const leaf = buildTokenLeaf('dimension', {
+			base: '1.125rem',
+			responsive: { tablet: '', mobile: '  ' },
+		});
+
+		expect(leaf).toEqual({ $type: 'dimension', $value: '1.125rem' });
+		expect(leaf.$extensions).toBeUndefined();
+	});
+
+	it('keeps only the populated breakpoint step', () => {
+		const leaf = buildTokenLeaf('dimension', {
+			base: '1.125rem',
+			responsive: { tablet: '', mobile: '1rem' },
+		});
+
+		expect(leaf.$extensions['com.kadence.designTokens'].responsive).toEqual({ mobile: '1rem' });
+	});
+
+	it('serializes a structured clamp shape', () => {
+		const leaf = buildTokenLeaf('dimension', {
+			base: 'clamp(1.1rem, 0.995rem + 0.326vw, 1.25rem)',
+			clamp: { min: '1.1rem', preferred: '0.995rem + 0.326vw', max: '1.25rem' },
+		});
+
+		expect(leaf.$extensions['com.kadence.designTokens'].clamp).toEqual({
+			min: '1.1rem',
+			preferred: '0.995rem + 0.326vw',
+			max: '1.25rem',
+		});
+	});
+
+	it('drops an incomplete clamp shape', () => {
+		const leaf = buildTokenLeaf('dimension', {
+			base: '1.1rem',
+			clamp: { min: '1.1rem', preferred: '', max: '1.25rem' },
+		});
+
+		expect(leaf.$extensions).toBeUndefined();
 	});
 });

--- a/src/style-book/api/client.js
+++ b/src/style-book/api/client.js
@@ -39,7 +39,7 @@ export function configureRestClient(rest) {
  *
  * @param {string} namespace REST namespace.
  * @param {string} slug      Token set slug.
- * @return {Promise<{ by_id: Record<string, string>, version: string }>} Resolved payload.
+ * @return {Promise<{ by_id: Record<string, string>, responsive: Record<string, object>, version: string }>} Resolved payload.
  */
 export function fetchResolvedTokens(namespace, slug) {
 	return apiFetch({ path: resolvedPath(namespace, slug) });

--- a/src/style-book/components/molecules/ResponsiveTokenField.js
+++ b/src/style-book/components/molecules/ResponsiveTokenField.js
@@ -17,6 +17,8 @@ import './token-field.scss';
  * The stepped device tabs, in cascade order. Desktop is the base ($value); tablet / mobile are the
  * max-width overrides stored under the responsive shape.
  *
+ * @since TBD
+ *
  * @type {{ key: string, label: string }[]}
  */
 const DEVICES = [
@@ -27,6 +29,8 @@ const DEVICES = [
 
 /**
  * Derive the initial editor state from the authored shape (when present) or the flat resolved value.
+ *
+ * @since TBD
  *
  * @param {string}                 value      Flat resolved value (desktop fallback).
  * @param {object|undefined}       responsive Authored shape: { base, responsive?: {...} } or { base, clamp?: {...} }.
@@ -61,6 +65,8 @@ function hydrate(value, responsive) {
 /**
  * Assemble the structured value the save path serializes into a DTCG leaf ($value + $extensions).
  *
+ * @since TBD
+ *
  * @param {{ mode: string, desktop: string, tablet: string, mobile: string, clamp: object }} state Editor state.
  * @return {{ base: string, responsive?: object, clamp?: object }} Structured value: base plus the stepped
  *         responsive map, or base plus the clamp slots in fluid mode.
@@ -86,6 +92,8 @@ function toStructuredValue(state) {
  * mobile) editor with an optional fluid clamp() helper. Desktop is the base value; tablet / mobile and the
  * clamp slots are stored under the token's responsive $extensions. Device state is local to the field so
  * the Style Book admin app needs no block-editor preview store.
+ *
+ * @since TBD
  *
  * @param {object}   props            Component props.
  * @param {object}   props.token      Token definition from the schema.
@@ -115,8 +123,14 @@ export function ResponsiveTokenField({ token, value, responsive, onSave, fieldSt
 	const setClampSlot = (slot, next) =>
 		setState((current) => ({ ...current, clamp: { ...current.clamp, [slot]: next } }));
 
+	// In fluid mode every clamp slot must be filled — otherwise the base would assemble to an invalid
+	// `clamp(, , )` value. Block the save (and disable the button) until the curve is complete.
+	const clampIncomplete =
+		state.mode === 'fluid' &&
+		[state.clamp.min, state.clamp.preferred, state.clamp.max].some((slot) => slot.trim() === '');
+
 	const handleSave = async () => {
-		if (!isDirty || isSaving) {
+		if (!isDirty || isSaving || clampIncomplete) {
 			return;
 		}
 
@@ -193,7 +207,17 @@ export function ResponsiveTokenField({ token, value, responsive, onSave, fieldSt
 					</div>
 				)}
 
-				<Button variant="secondary" onClick={handleSave} disabled={!isDirty || isSaving} isBusy={isSaving}>
+				{clampIncomplete && (
+					<p className="kadence-blocks-style-book__token-hint">
+						{__('Enter all three clamp values (min, preferred, max) to save.', 'kadence-blocks')}
+					</p>
+				)}
+				<Button
+					variant="secondary"
+					onClick={handleSave}
+					disabled={!isDirty || isSaving || clampIncomplete}
+					isBusy={isSaving}
+				>
 					{__('Save', 'kadence-blocks')}
 				</Button>
 				<SaveStatus status={fieldState.status} error={fieldState.error} />

--- a/src/style-book/components/molecules/ResponsiveTokenField.js
+++ b/src/style-book/components/molecules/ResponsiveTokenField.js
@@ -1,0 +1,202 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useMemo, useState } from '@wordpress/element';
+import { Button, ButtonGroup, TextControl, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { SaveStatus } from '../atoms/SaveStatus';
+import { TokenSwatch } from '../atoms/TokenSwatch';
+import { TokenTypeBadge } from '../atoms/TokenTypeBadge';
+import './token-field.scss';
+
+/**
+ * The stepped device tabs, in cascade order. Desktop is the base ($value); tablet / mobile are the
+ * max-width overrides stored under the responsive shape.
+ *
+ * @type {{ key: string, label: string }[]}
+ */
+const DEVICES = [
+	{ key: 'desktop', label: __('Desktop', 'kadence-blocks') },
+	{ key: 'tablet', label: __('Tablet', 'kadence-blocks') },
+	{ key: 'mobile', label: __('Mobile', 'kadence-blocks') },
+];
+
+/**
+ * Derive the initial editor state from the authored shape (when present) or the flat resolved value.
+ *
+ * @param {string}                 value      Flat resolved value (desktop fallback).
+ * @param {object|undefined}       responsive Authored shape: { base, responsive?: {...} } or { base, clamp?: {...} }.
+ * @return {{ mode: string, desktop: string, tablet: string, mobile: string, clamp: { min: string, preferred: string, max: string } }}
+ */
+function hydrate(value, responsive) {
+	const base = responsive?.base ?? value ?? '';
+
+	if (responsive?.clamp) {
+		return {
+			mode: 'fluid',
+			desktop: base,
+			tablet: '',
+			mobile: '',
+			clamp: {
+				min: responsive.clamp.min ?? '',
+				preferred: responsive.clamp.preferred ?? '',
+				max: responsive.clamp.max ?? '',
+			},
+		};
+	}
+
+	return {
+		mode: 'stepped',
+		desktop: base,
+		tablet: responsive?.responsive?.tablet ?? '',
+		mobile: responsive?.responsive?.mobile ?? '',
+		clamp: { min: '', preferred: '', max: '' },
+	};
+}
+
+/**
+ * Assemble the structured value the save path serializes into a DTCG leaf ($value + $extensions).
+ *
+ * @param {{ mode: string, desktop: string, tablet: string, mobile: string, clamp: object }} state Editor state.
+ * @return {string|{ base: string, responsive?: object, clamp?: object }} Structured value (or a plain string when flat).
+ */
+function toStructuredValue(state) {
+	if (state.mode === 'fluid') {
+		const { min, preferred, max } = state.clamp;
+
+		return {
+			base: `clamp(${min}, ${preferred}, ${max})`,
+			clamp: { min, preferred, max },
+		};
+	}
+
+	return {
+		base: state.desktop,
+		responsive: { tablet: state.tablet, mobile: state.mobile },
+	};
+}
+
+/**
+ * Responsive-aware token row for the dimension / lineHeight types: a per-breakpoint (desktop / tablet /
+ * mobile) editor with an optional fluid clamp() helper. Desktop is the base value; tablet / mobile and the
+ * clamp slots are stored under the token's responsive $extensions. Device state is local to the field so
+ * the Style Book admin app needs no block-editor preview store.
+ *
+ * @param {object}   props            Component props.
+ * @param {object}   props.token      Token definition from the schema.
+ * @param {string}   props.value      Current flat resolved value (desktop fallback).
+ * @param {object}   [props.responsive] Authored responsive / clamp shape for hydration.
+ * @param {Function} props.onSave     Async save handler (tokenId, type, structuredValue).
+ * @param {object}   props.fieldState Save status for this field.
+ * @return {JSX.Element} Token field row.
+ */
+export function ResponsiveTokenField({ token, value, responsive, onSave, fieldState }) {
+	const initial = useMemo(() => hydrate(value, responsive), [value, responsive]);
+	const [device, setDevice] = useState('desktop');
+	const [state, setState] = useState(initial);
+
+	const isSaving = fieldState.status === 'saving';
+
+	useEffect(() => {
+		setState(initial);
+	}, [initial]);
+
+	const isDirty = useMemo(
+		() => JSON.stringify(toStructuredValue(state)) !== JSON.stringify(toStructuredValue(initial)),
+		[state, initial]
+	);
+
+	const setField = (key, next) => setState((current) => ({ ...current, [key]: next }));
+	const setClampSlot = (slot, next) =>
+		setState((current) => ({ ...current, clamp: { ...current.clamp, [slot]: next } }));
+
+	const handleSave = async () => {
+		if (!isDirty || isSaving) {
+			return;
+		}
+
+		await onSave(token.id, token.type, toStructuredValue(state));
+	};
+
+	const previewValue = state.mode === 'fluid' ? state.clamp.preferred : state[device] || state.desktop;
+
+	return (
+		<div className="kadence-blocks-style-book__token-field">
+			<div className="kadence-blocks-style-book__token-field-meta">
+				<TokenSwatch type={token.type} value={previewValue} />
+				<div className="kadence-blocks-style-book__token-field-labels">
+					<strong className="kadence-blocks-style-book__token-label">{token.label}</strong>
+					<code className="kadence-blocks-style-book__token-id">{token.id}</code>
+				</div>
+				<TokenTypeBadge type={token.type} />
+			</div>
+
+			<div className="kadence-blocks-style-book__token-field-controls">
+				<ToggleControl
+					className="kadence-blocks-style-book__token-fluid-toggle"
+					label={__('Fluid (clamp)', 'kadence-blocks')}
+					checked={state.mode === 'fluid'}
+					disabled={isSaving}
+					onChange={(checked) => setField('mode', checked ? 'fluid' : 'stepped')}
+				/>
+
+				{state.mode === 'stepped' ? (
+					<>
+						<ButtonGroup className="kadence-blocks-style-book__token-devices">
+							{DEVICES.map(({ key, label }) => (
+								<Button
+									key={key}
+									size="small"
+									variant={device === key ? 'primary' : 'secondary'}
+									onClick={() => setDevice(key)}
+								>
+									{label}
+								</Button>
+							))}
+						</ButtonGroup>
+
+						<TextControl
+							className="kadence-blocks-style-book__token-input"
+							value={state[device]}
+							onChange={(next) => setField(device, next)}
+							disabled={isSaving}
+							placeholder={device === 'desktop' ? '' : __('Inherits desktop', 'kadence-blocks')}
+							help={device === 'desktop' ? token.cssVar : undefined}
+						/>
+					</>
+				) : (
+					<div className="kadence-blocks-style-book__token-clamp">
+						<TextControl
+							label={__('Min', 'kadence-blocks')}
+							value={state.clamp.min}
+							onChange={(next) => setClampSlot('min', next)}
+							disabled={isSaving}
+						/>
+						<TextControl
+							label={__('Preferred', 'kadence-blocks')}
+							value={state.clamp.preferred}
+							onChange={(next) => setClampSlot('preferred', next)}
+							disabled={isSaving}
+							help={__('A fluid expression, e.g. 0.995rem + 0.326vw', 'kadence-blocks')}
+						/>
+						<TextControl
+							label={__('Max', 'kadence-blocks')}
+							value={state.clamp.max}
+							onChange={(next) => setClampSlot('max', next)}
+							disabled={isSaving}
+						/>
+					</div>
+				)}
+
+				<Button variant="secondary" onClick={handleSave} disabled={!isDirty || isSaving} isBusy={isSaving}>
+					{__('Save', 'kadence-blocks')}
+				</Button>
+				<SaveStatus status={fieldState.status} error={fieldState.error} />
+			</div>
+		</div>
+	);
+}

--- a/src/style-book/components/molecules/ResponsiveTokenField.js
+++ b/src/style-book/components/molecules/ResponsiveTokenField.js
@@ -62,7 +62,8 @@ function hydrate(value, responsive) {
  * Assemble the structured value the save path serializes into a DTCG leaf ($value + $extensions).
  *
  * @param {{ mode: string, desktop: string, tablet: string, mobile: string, clamp: object }} state Editor state.
- * @return {string|{ base: string, responsive?: object, clamp?: object }} Structured value (or a plain string when flat).
+ * @return {{ base: string, responsive?: object, clamp?: object }} Structured value: base plus the stepped
+ *         responsive map, or base plus the clamp slots in fluid mode.
  */
 function toStructuredValue(state) {
 	if (state.mode === 'fluid') {

--- a/src/style-book/components/molecules/TokenField.js
+++ b/src/style-book/components/molecules/TokenField.js
@@ -1,9 +1,10 @@
 /**
  * Internal dependencies
  */
-import { isColorType } from '../../helpers/tokens';
+import { isColorType, isResponsiveType } from '../../helpers/tokens';
 import { ColorTokenField } from './ColorTokenField';
 import { GenericTokenField } from './GenericTokenField';
+import { ResponsiveTokenField } from './ResponsiveTokenField';
 
 /**
  * Route a token row to the appropriate field editor for its type.
@@ -14,6 +15,10 @@ import { GenericTokenField } from './GenericTokenField';
 export function TokenField(props) {
 	if (isColorType(props.token.type)) {
 		return <ColorTokenField {...props} />;
+	}
+
+	if (isResponsiveType(props.token.type)) {
+		return <ResponsiveTokenField {...props} />;
 	}
 
 	return <GenericTokenField {...props} />;

--- a/src/style-book/components/organisms/TokenGroup.js
+++ b/src/style-book/components/organisms/TokenGroup.js
@@ -27,6 +27,7 @@ import './token-group.scss';
  * @param {string}   props.groupName            Display name for the group.
  * @param {object[]} props.tokens               Tokens belonging to this group.
  * @param {Record<string, string>} props.values Resolved values keyed by token id.
+ * @param {Record<string, object>} [props.responsive] Authored responsive / clamp shapes keyed by token id.
  * @param {Function} props.onSave               Save handler passed to each field.
  * @param {Function} props.getFieldState        Field state accessor.
  * @param {boolean}  [props.isUserCreatedGroup] Whether this is the Custom Colors group.
@@ -41,6 +42,7 @@ export function TokenGroup({
 	groupName,
 	tokens,
 	values,
+	responsive,
 	onSave,
 	getFieldState,
 	isUserCreatedGroup = false,
@@ -83,6 +85,7 @@ export function TokenGroup({
 						<TokenField
 							token={token}
 							value={values[token.id] ?? ''}
+							responsive={responsive?.[token.id]}
 							onSave={onSave}
 							fieldState={getFieldState(token.id)}
 						/>

--- a/src/style-book/components/pages/FoundationPage.js
+++ b/src/style-book/components/pages/FoundationPage.js
@@ -12,6 +12,7 @@ import { TokenList } from '../templates/TokenList';
  * @param {object[]} props.sections             Built navigation sections.
  * @param {object[]} props.tokens               Flat token list.
  * @param {Record<string, string>} props.values Resolved values.
+ * @param {Record<string, object>} [props.responsive] Authored responsive / clamp shapes by token id.
  * @param {boolean}  props.isReady              Whether the feed loaded.
  * @param {boolean}  props.isActive             Whether design tokens are active.
  * @param {boolean}  props.isResolved           Whether values resolved successfully.
@@ -29,6 +30,7 @@ export function FoundationPage({
 	sections,
 	tokens,
 	values,
+	responsive,
 	isReady,
 	isActive,
 	isResolved,
@@ -59,6 +61,7 @@ export function FoundationPage({
 			<TokenList
 				tokens={filtered}
 				values={values}
+				responsive={responsive}
 				isReady={isReady}
 				isActive={isActive}
 				isResolved={isResolved}

--- a/src/style-book/components/pages/TokensPage.js
+++ b/src/style-book/components/pages/TokensPage.js
@@ -52,7 +52,7 @@ export function TokensPage() {
 		isActive,
 		isResolved,
 		values: feedValues,
-		responsive,
+		responsive: initialResponsive,
 		rest,
 		version: initialVersion,
 		slug,
@@ -64,7 +64,13 @@ export function TokensPage() {
 	// tripping a false-positive conflict when one surface's write is followed by another's.
 	const [version, setVersion] = useState(initialVersion);
 
-	const { values, saveToken, getFieldState, refreshValues } = useTokenEditor(rest, feedValues, setVersion, slug);
+	const { values, responsive, saveToken, getFieldState, refreshValues } = useTokenEditor(
+		rest,
+		feedValues,
+		initialResponsive,
+		setVersion,
+		slug
+	);
 
 	const [localTokens, setLocalTokens] = useState(null);
 	const tokens = localTokens ?? feedTokens;

--- a/src/style-book/components/pages/TokensPage.js
+++ b/src/style-book/components/pages/TokensPage.js
@@ -52,6 +52,7 @@ export function TokensPage() {
 		isActive,
 		isResolved,
 		values: feedValues,
+		responsive,
 		rest,
 		version: initialVersion,
 		slug,
@@ -104,6 +105,7 @@ export function TokensPage() {
 	const sharedListProps = {
 		tokens,
 		values,
+		responsive,
 		isReady,
 		isActive,
 		isResolved,

--- a/src/style-book/components/templates/TokenList.js
+++ b/src/style-book/components/templates/TokenList.js
@@ -37,6 +37,7 @@ function groupTokens(tokens) {
  * @param {object}   props                      Component props.
  * @param {object[]} props.tokens               Flat token definitions.
  * @param {Record<string, string>} props.values Resolved values.
+ * @param {Record<string, object>} [props.responsive] Authored responsive / clamp shapes by token id.
  * @param {boolean}  props.isReady              Whether the feed loaded.
  * @param {boolean}  props.isActive             Whether design tokens are active.
  * @param {boolean}  props.isResolved           Whether values resolved successfully.
@@ -54,6 +55,7 @@ function groupTokens(tokens) {
 export function TokenList({
 	tokens,
 	values,
+	responsive,
 	isReady,
 	isActive,
 	isResolved,
@@ -110,6 +112,7 @@ export function TokenList({
 							groupName={groupName}
 							tokens={groupTokensList}
 							values={values}
+							responsive={responsive}
 							onSave={onSave}
 							getFieldState={getFieldState}
 							isUserCreatedGroup={hasUserCreated}
@@ -129,6 +132,7 @@ export function TokenList({
 					groupName=""
 					tokens={tokens}
 					values={values}
+					responsive={responsive}
 					onSave={onSave}
 					getFieldState={getFieldState}
 					isUserCreatedGroup={Boolean(onCreatePrimitive)}

--- a/src/style-book/helpers/tokens.js
+++ b/src/style-book/helpers/tokens.js
@@ -38,17 +38,91 @@ export function flattenSchemaTokens(schema) {
 }
 
 /**
+ * The vendor-extension namespace the module owns (mirrors Schema\Vocabulary\Extensions::NAMESPACE).
+ *
+ * @type {string}
+ */
+export const KADENCE_TOKEN_NAMESPACE = 'com.kadence.designTokens';
+
+/**
+ * The stepped responsive breakpoint keys, in cascade order (mirrors Schema\Vocabulary\Responsive).
+ *
+ * @type {string[]}
+ */
+export const RESPONSIVE_BREAKPOINTS = ['tablet', 'mobile'];
+
+/**
  * Build a DTCG leaf payload for a token value update.
  *
+ * Accepts either a plain string (a flat token) or a structured value carrying a base plus a per-breakpoint
+ * `responsive` map or a `clamp` map. The responsive / clamp shape is serialized under the leaf's
+ * `$extensions`, and is omitted entirely when it holds no non-empty values, so a desktop-only edit
+ * round-trips as a clean flat leaf (never a degenerate `responsive: {}`).
+ *
  * @param {string} type  Token type from the schema (color, dimension, etc.).
- * @param {string} value Raw value string.
- * @return {{ $type: string, $value: string }} DTCG leaf.
+ * @param {string|{ base?: string, responsive?: Record<string, string>, clamp?: Record<string, string> }} value
+ *                       Raw value string, or a structured responsive / clamp value.
+ * @return {{ $type: string, $value: string, $extensions?: object }} DTCG leaf.
  */
 export function buildTokenLeaf(type, value) {
-	return {
+	if (typeof value === 'string') {
+		return {
+			$type: type,
+			$value: value.trim(),
+		};
+	}
+
+	const leaf = {
 		$type: type,
-		$value: value.trim(),
+		$value: String(value?.base ?? '').trim(),
 	};
+
+	const extension = buildResponsiveExtension(value);
+
+	if (extension) {
+		leaf.$extensions = { [KADENCE_TOKEN_NAMESPACE]: extension };
+	}
+
+	return leaf;
+}
+
+/**
+ * Build the `com.kadence.designTokens` extension body for a structured value, or null when it carries no
+ * non-empty responsive / clamp values.
+ *
+ * @param {{ responsive?: Record<string, string>, clamp?: Record<string, string> }} value Structured value.
+ * @return {{ responsive: object }|{ clamp: object }|null} Extension body, or null.
+ */
+function buildResponsiveExtension(value) {
+	if (value?.clamp) {
+		const min = String(value.clamp.min ?? '').trim();
+		const preferred = String(value.clamp.preferred ?? '').trim();
+		const max = String(value.clamp.max ?? '').trim();
+
+		if (min !== '' && preferred !== '' && max !== '') {
+			return { clamp: { min, preferred, max } };
+		}
+
+		return null;
+	}
+
+	if (value?.responsive) {
+		const responsive = {};
+
+		RESPONSIVE_BREAKPOINTS.forEach((breakpoint) => {
+			const step = String(value.responsive[breakpoint] ?? '').trim();
+
+			if (step !== '') {
+				responsive[breakpoint] = step;
+			}
+		});
+
+		if (Object.keys(responsive).length > 0) {
+			return { responsive };
+		}
+	}
+
+	return null;
 }
 
 /**
@@ -59,6 +133,17 @@ export function buildTokenLeaf(type, value) {
  */
 export function isColorType(type) {
 	return type === 'color';
+}
+
+/**
+ * Whether a token type is responsive-capable (mirrors Schema\Vocabulary\Responsive::is_responsive_capable):
+ * only dimension and lineHeight may carry a per-breakpoint / clamp shape.
+ *
+ * @param {string} type Token type from the schema.
+ * @return {boolean}
+ */
+export function isResponsiveType(type) {
+	return type === 'dimension' || type === 'lineHeight';
 }
 
 /**

--- a/src/style-book/helpers/tokens.js
+++ b/src/style-book/helpers/tokens.js
@@ -40,12 +40,16 @@ export function flattenSchemaTokens(schema) {
 /**
  * The vendor-extension namespace the module owns (mirrors Schema\Vocabulary\Extensions::NAMESPACE).
  *
+ * @since TBD
+ *
  * @type {string}
  */
 export const KADENCE_TOKEN_NAMESPACE = 'com.kadence.designTokens';
 
 /**
  * The stepped responsive breakpoint keys, in cascade order (mirrors Schema\Vocabulary\Responsive).
+ *
+ * @since TBD
  *
  * @type {string[]}
  */
@@ -89,6 +93,8 @@ export function buildTokenLeaf(type, value) {
 /**
  * Build the `com.kadence.designTokens` extension body for a structured value, or null when it carries no
  * non-empty responsive / clamp values.
+ *
+ * @since TBD
  *
  * @param {{ responsive?: Record<string, string>, clamp?: Record<string, string> }} value Structured value.
  * @return {{ responsive: object }|{ clamp: object }|null} Extension body, or null.
@@ -138,6 +144,8 @@ export function isColorType(type) {
 /**
  * Whether a token type is responsive-capable (mirrors Schema\Vocabulary\Responsive::is_responsive_capable):
  * only dimension and lineHeight may carry a per-breakpoint / clamp shape.
+ *
+ * @since TBD
  *
  * @param {string} type Token type from the schema.
  * @return {boolean}

--- a/src/style-book/hooks/use-design-tokens-feed.js
+++ b/src/style-book/hooks/use-design-tokens-feed.js
@@ -36,6 +36,7 @@ export function useDesignTokensFeed() {
 		isActive: Boolean(feed?.active),
 		isResolved: Boolean(feed?.resolved),
 		values: feed?.values ?? {},
+		responsive: feed?.responsive ?? {},
 		rest: feed?.rest ?? null,
 		version: feed?.version ?? '',
 		slug: feed?.slug ?? DEFAULT_TOKEN_SET_SLUG,

--- a/src/style-book/hooks/use-design-tokens-feed.js
+++ b/src/style-book/hooks/use-design-tokens-feed.js
@@ -17,7 +17,7 @@ import { DEFAULT_TOKEN_SET_SLUG } from '../constants';
  * active set, not necessarily the default one (see `Admin\Feed\Localizer`). Every write this page
  * makes must target that same slug, or an edit lands in a document other than the one being shown.
  *
- * @return {{ feed: object|null, tokens: object[], isReady: boolean, isActive: boolean, isResolved: boolean, values: Record<string, string>, rest: object|null, version: string, slug: string }}
+ * @return {{ feed: object|null, tokens: object[], isReady: boolean, isActive: boolean, isResolved: boolean, values: Record<string, string>, responsive: Record<string, object>, rest: object|null, version: string, slug: string }}
  */
 export function useDesignTokensFeed() {
 	const feed = useMemo(() => getDesignTokensFeed(), []);

--- a/src/style-book/hooks/use-token-editor.js
+++ b/src/style-book/hooks/use-token-editor.js
@@ -21,19 +21,30 @@ import { buildTokenLeaf } from '../helpers/tokens';
  * `useDesignTokensFeed`) — writing to a different slug than the one being displayed would silently
  * save into a document the page never reads back.
  *
- * @param {{ namespace: string }|null} rest             REST descriptor from the feed.
- * @param {Record<string, string>}     initialValues    Resolved values keyed by token id.
+ * `refreshValues` re-reads both the flat resolved values AND the authored responsive / clamp shape, so a
+ * responsive field hydrates from the same source the write went to. Refreshing only the flat values would
+ * leave the responsive read-model on its page-load bootstrap, and a responsive field re-deriving from that
+ * stale shape after a save would drop the just-saved per-breakpoint steps.
+ *
+ * @param {{ namespace: string }|null} rest              REST descriptor from the feed.
+ * @param {Record<string, string>}     initialValues     Resolved values keyed by token id.
+ * @param {Record<string, object>}     initialResponsive Authored responsive / clamp shape keyed by token id.
  * @param {Function}                   [onVersionChange] Called with the latest document version.
- * @param {string}                     slug             Token set slug.
- * @return {{ values: Record<string, string>, saveToken: Function, getFieldState: Function, refreshValues: Function }}
+ * @param {string}                     slug              Token set slug.
+ * @return {{ values: Record<string, string>, responsive: Record<string, object>, saveToken: Function, getFieldState: Function, refreshValues: Function }}
  */
-export function useTokenEditor(rest, initialValues, onVersionChange, slug) {
+export function useTokenEditor(rest, initialValues, initialResponsive, onVersionChange, slug) {
 	const [values, setValues] = useState(initialValues);
+	const [responsive, setResponsive] = useState(initialResponsive);
 	const [fieldState, setFieldState] = useState({});
 
 	useEffect(() => {
 		setValues(initialValues);
 	}, [initialValues]);
+
+	useEffect(() => {
+		setResponsive(initialResponsive);
+	}, [initialResponsive]);
 
 	const refreshValues = useCallback(async () => {
 		if (!rest?.namespace) {
@@ -42,6 +53,7 @@ export function useTokenEditor(rest, initialValues, onVersionChange, slug) {
 
 		const resolved = await fetchResolvedTokens(rest.namespace, slug);
 		setValues(resolved?.by_id ?? {});
+		setResponsive(resolved?.responsive ?? {});
 
 		if (resolved?.version) {
 			onVersionChange?.(resolved.version);
@@ -91,6 +103,7 @@ export function useTokenEditor(rest, initialValues, onVersionChange, slug) {
 
 	return {
 		values,
+		responsive,
 		saveToken,
 		getFieldState,
 		refreshValues,

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/LiteralsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/LiteralsTest.php
@@ -48,6 +48,14 @@ final class LiteralsTest extends TestCase {
 			'value'    => 'var(--x)',
 			'expected' => true,
 		];
+		yield 'empty color function' => [
+			'value'    => 'rgb()',
+			'expected' => false,
+		];
+		yield 'empty interior color arg' => [
+			'value'    => 'rgb(0, , 0)',
+			'expected' => false,
+		];
 		yield 'named' => [
 			'value'    => 'rebeccapurple',
 			'expected' => true,
@@ -120,6 +128,30 @@ final class LiteralsTest extends TestCase {
 		];
 		yield 'calc()' => [
 			'value'    => 'calc(100% - 8px)',
+			'expected' => true,
+		];
+		yield 'empty clamp' => [
+			'value'    => 'clamp(, , )',
+			'expected' => false,
+		];
+		yield 'empty function' => [
+			'value'    => 'calc()',
+			'expected' => false,
+		];
+		yield 'empty interior clamp arg' => [
+			'value'    => 'clamp(1rem, , 2rem)',
+			'expected' => false,
+		];
+		yield 'empty leading clamp arg' => [
+			'value'    => 'clamp(, 1rem, 2rem)',
+			'expected' => false,
+		];
+		yield 'empty nested arg' => [
+			'value'    => 'max(1rem, min(, 2rem))',
+			'expected' => false,
+		];
+		yield 'var empty fallback allowed' => [
+			'value'    => 'var(--x,)',
 			'expected' => true,
 		];
 		yield 'unitless num' => [


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3857/responsive-per-breakpoint-fluid-clamp-values-for-dimensiontypography
:video_camera: https://www.loom.com/share/0ebee5dc556b4afa8d54923a7c2b4ab0

Part of the SOFT-3857 stack (7/8) — stacked on 6/8.

Adds a responsive-aware token field to the Style Book: per-breakpoint (desktop/tablet/mobile) inputs plus an optional fluid clamp helper. `buildTokenLeaf` serializes the `$extensions` shape and omits it entirely when empty, so a desktop-only edit round-trips as a clean flat leaf.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


