### PR TITLE
SOFT-3857 [8/8] Responsive block-attribute write-back seam

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Adapter/Responsive_Attribute_Writer.php
+++ b/includes/resources/Design_Tokens/Projection/Adapter/Responsive_Attribute_Writer.php
@@ -1,0 +1,87 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Resolved_Tokens;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Responsive;
+
+/**
+ * Fans a breakpoint-keyed resolved token value into the two block-attribute shapes Kadence Blocks renders
+ * responsive values with, so a future per-block Adapter can seed a responsive token default into a block
+ * whose attribute is a raw value (no CSS-var indirection):
+ *
+ *   - INDEXED [desktop, tablet, mobile] — what Kadence_Blocks_CSS::render_typography() reads for a
+ *     typography sub-value (size / lineHeight / letterSpacing are each a 3-element array).
+ *   - SUFFIXED siblings — `<attr>` / `tablet<Attr>` / `mobile<Attr>`, the shape render_measure_output()
+ *     and similar sibling-attribute renderers read.
+ *
+ * A breakpoint with no override is left empty rather than back-filled with the desktop value, so the
+ * block's own renderer skips it and the desktop value cascades — the same "absent = inherit base"
+ * semantics the css-var projection uses.
+ *
+ * This is the write-back mechanism the discrete responsive tokens need for a block that consumes a raw
+ * attribute instead of a css-var. No shipped block declares such a binding today — kadence/singlebtn
+ * reads the `--kb-token--*` vars directly and is responsive through the per-media-query redeclaration
+ * with no write-back — so this is intentionally not wired into any Adapter yet; it exists so the first
+ * block that adopts a responsive raw-attribute binding has a tested seam to build on. Pure: no
+ * WordPress calls, no globals.
+ *
+ * @since TBD
+ */
+final class Responsive_Attribute_Writer {
+
+	/**
+	 * The resolved token maps a value and its per-breakpoint overrides are read from.
+	 *
+	 * @since TBD
+	 *
+	 * @var Resolved_Tokens
+	 */
+	private Resolved_Tokens $resolved;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Resolved_Tokens $resolved The resolved token maps.
+	 */
+	public function __construct( Resolved_Tokens $resolved ) {
+		$this->resolved = $resolved;
+	}
+
+	/**
+	 * The indexed [desktop, tablet, mobile] array for a token, for a render_typography sub-value. An absent
+	 * breakpoint override is an empty string so the block renderer inherits the desktop value there.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id The token id.
+	 *
+	 * @return array{0: string, 1: string, 2: string}
+	 */
+	public function indexed( string $id ): array {
+		return [
+			(string) ( $this->resolved->value( $id ) ?? '' ),
+			(string) ( $this->resolved->value_at( $id, Responsive::get_tablet_key() ) ?? '' ),
+			(string) ( $this->resolved->value_at( $id, Responsive::get_mobile_key() ) ?? '' ),
+		];
+	}
+
+	/**
+	 * The suffixed sibling attributes for a token: the desktop attribute plus its tablet / mobile siblings
+	 * (`<attr>`, `tablet<Attr>`, `mobile<Attr>`). An absent breakpoint override is an empty string.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id        The token id.
+	 * @param string $attribute The desktop attribute name (e.g. "padding").
+	 *
+	 * @return array<string,string> Attribute name => value, ready to array_merge into a block's attributes.
+	 */
+	public function siblings( string $id, string $attribute ): array {
+		return [
+			$attribute                        => (string) ( $this->resolved->value( $id ) ?? '' ),
+			'tablet' . ucfirst( $attribute )  => (string) ( $this->resolved->value_at( $id, Responsive::get_tablet_key() ) ?? '' ),
+			'mobile' . ucfirst( $attribute )  => (string) ( $this->resolved->value_at( $id, Responsive::get_mobile_key() ) ?? '' ),
+		];
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Adapter/Responsive_Attribute_Writer.php
+++ b/includes/resources/Design_Tokens/Projection/Adapter/Responsive_Attribute_Writer.php
@@ -79,9 +79,9 @@ final class Responsive_Attribute_Writer {
 	 */
 	public function siblings( string $id, string $attribute ): array {
 		return [
-			$attribute                        => (string) ( $this->resolved->value( $id ) ?? '' ),
-			'tablet' . ucfirst( $attribute )  => (string) ( $this->resolved->value_at( $id, Responsive::get_tablet_key() ) ?? '' ),
-			'mobile' . ucfirst( $attribute )  => (string) ( $this->resolved->value_at( $id, Responsive::get_mobile_key() ) ?? '' ),
+			$attribute                       => (string) ( $this->resolved->value( $id ) ?? '' ),
+			'tablet' . ucfirst( $attribute ) => (string) ( $this->resolved->value_at( $id, Responsive::get_tablet_key() ) ?? '' ),
+			'mobile' . ucfirst( $attribute ) => (string) ( $this->resolved->value_at( $id, Responsive::get_mobile_key() ) ?? '' ),
 		];
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Adapter/Responsive_Attribute_WriterTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Adapter/Responsive_Attribute_WriterTest.php
@@ -1,0 +1,90 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Projection\Adapter;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Responsive_Attribute_Writer;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Resolved_Tokens;
+use Tests\Support\Classes\TestCase;
+
+final class Responsive_Attribute_WriterTest extends TestCase {
+
+	/**
+	 * A responsive token fans into the indexed [desktop, tablet, mobile] array render_typography reads.
+	 *
+	 * @return void
+	 */
+	public function testItFansAResponsiveTokenIntoAnIndexedArray(): void {
+		$writer = new Responsive_Attribute_Writer( $this->resolved() );
+
+		$this->assertSame( [ '1.125rem', '1.0625rem', '1rem' ], $writer->indexed( 'semantic.font-size.control' ) );
+	}
+
+	/**
+	 * A responsive token fans into the desktop / tablet<Attr> / mobile<Attr> sibling attributes
+	 * render_measure_output reads.
+	 *
+	 * @return void
+	 */
+	public function testItFansAResponsiveTokenIntoSuffixedSiblings(): void {
+		$writer = new Responsive_Attribute_Writer( $this->resolved() );
+
+		$this->assertSame(
+			[
+				'padding'       => '1.125rem',
+				'tabletPadding' => '1.0625rem',
+				'mobilePadding' => '1rem',
+			],
+			$writer->siblings( 'semantic.font-size.control', 'padding' )
+		);
+	}
+
+	/**
+	 * A breakpoint with no override is left empty (not back-filled with desktop) so the block renderer
+	 * inherits the desktop value there.
+	 *
+	 * @return void
+	 */
+	public function testAnAbsentBreakpointIsEmpty(): void {
+		$resolved = new Resolved_Tokens(
+			[ 'semantic.font-size.control' => '1.125rem' ],
+			[],
+			[],
+			[],
+			[],
+			[ 'semantic.font-size.control' => [ 'mobile' => '1rem' ] ]
+		);
+
+		$writer = new Responsive_Attribute_Writer( $resolved );
+
+		$this->assertSame( [ '1.125rem', '', '1rem' ], $writer->indexed( 'semantic.font-size.control' ) );
+	}
+
+	/**
+	 * A flat token (no responsive overrides) fans into the desktop value with empty tablet / mobile slots.
+	 *
+	 * @return void
+	 */
+	public function testAFlatTokenHasEmptyBreakpoints(): void {
+		$resolved = new Resolved_Tokens( [ 'semantic.radius.control' => '3px' ], [] );
+
+		$writer = new Responsive_Attribute_Writer( $resolved );
+
+		$this->assertSame( [ '3px', '', '' ], $writer->indexed( 'semantic.radius.control' ) );
+	}
+
+	/**
+	 * A resolved-tokens fixture carrying a base value plus tablet / mobile literal overrides.
+	 *
+	 * @return Resolved_Tokens
+	 */
+	private function resolved(): Resolved_Tokens {
+		return new Resolved_Tokens(
+			[ 'semantic.font-size.control' => '1.125rem' ],
+			[],
+			[],
+			[],
+			[],
+			[ 'semantic.font-size.control' => [ 'tablet' => '1.0625rem', 'mobile' => '1rem' ] ]
+		);
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Adapter/Responsive_Attribute_WriterTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Adapter/Responsive_Attribute_WriterTest.php
@@ -84,7 +84,12 @@ final class Responsive_Attribute_WriterTest extends TestCase {
 			[],
 			[],
 			[],
-			[ 'semantic.font-size.control' => [ 'tablet' => '1.0625rem', 'mobile' => '1rem' ] ]
+			[
+				'semantic.font-size.control' => [
+					'tablet' => '1.0625rem',
+					'mobile' => '1rem',
+				],
+			]
 		);
 	}
 }


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3857/responsive-per-breakpoint-fluid-clamp-values-for-dimensiontypography
:video_camera: https://www.loom.com/share/0ebee5dc556b4afa8d54923a7c2b4ab0

Part of the SOFT-3857 stack (8/8) — stacked on 7/8.

Adds `Responsive_Attribute_Writer`, the mechanism that fans a breakpoint-keyed resolved value into a block's indexed `[desktop, tablet, mobile]` array or suffixed `padding`/`tabletPadding`/`mobilePadding` attributes. Forward-looking and intentionally unwired — no shipped block has a responsive raw-attribute binding yet.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


