### PR TITLE
Design Tokens scale bridges [1/3]: Tokenize the fluid font-size scale

### DIFF
--- a/includes/class-kadence-blocks-editor-assets.php
+++ b/includes/class-kadence-blocks-editor-assets.php
@@ -303,14 +303,10 @@ class Editor_Assets {
 			];
 		}
 		$global_colors = apply_filters( 'kadence_blocks_pattern_global_colors', $global_colors );
-		$font_sizes    = [
-			'sm'   => 'clamp(0.8rem, 0.73rem + 0.217vw, 0.9rem)',
-			'md'   => 'clamp(1.1rem, 0.995rem + 0.326vw, 1.25rem)',
-			'lg'   => 'clamp(1.75rem, 1.576rem + 0.543vw, 2rem)',
-			'xl'   => 'clamp(2.25rem, 1.728rem + 1.63vw, 3rem)',
-			'xxl'  => 'clamp(2.5rem, 1.456rem + 3.26vw, 4rem)',
-			'xxxl' => 'clamp(2.75rem, 0.489rem + 7.065vw, 6rem)',
-		];
+		// The fluid font-size scale is owned by the design-tokens baseline; retrieve it so the shipped
+		// clamp() values are not duplicated here. Empty when token projection is unavailable.
+		$font_sizes = kadence_blocks_variable_font_size_scale();
+
 		$pro_data      = $this->get_pro_data();
 		$is_authorized = ! kadence_blocks_is_ai_disabled() && kadence_blocks_is_legacy_license_authorized();
 		$font_sizes       = apply_filters( 'kadence_blocks_variable_font_sizes', $font_sizes );

--- a/includes/init.php
+++ b/includes/init.php
@@ -6,6 +6,8 @@
  * @package Kadence Blocks
  */
 
+// cspell:ignore editorwidth yourtheme iconset wpmlcore getresponse lotte Sashicons .
+
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/includes/init.php
+++ b/includes/init.php
@@ -98,14 +98,9 @@ function kadence_blocks_post_block_get_excerpt_length() {
  */
 function kadence_blocks_add_global_gutenberg_inline_styles() {
 	global $content_width;
-	$font_sizes = array(
-		'sm' => 'clamp(0.8rem, 0.73rem + 0.217vw, 0.9rem)',
-		'md' => 'clamp(1.1rem, 0.995rem + 0.326vw, 1.25rem)',
-		'lg' => 'clamp(1.75rem, 1.576rem + 0.543vw, 2rem)',
-		'xl' => 'clamp(2.25rem, 1.728rem + 1.63vw, 3rem)',
-		'xxl' => 'clamp(2.5rem, 1.456rem + 3.26vw, 4rem)',
-		'xxxl' => 'clamp(2.75rem, 0.489rem + 7.065vw, 6rem)',
-	);
+	// The fluid font-size scale is owned by the design-tokens baseline; retrieve it so the shipped clamp()
+	// values are not duplicated here. Empty when token projection is unavailable, leaving the filter intact.
+	$font_sizes = kadence_blocks_variable_font_size_scale();
 	$font_sizes = apply_filters( 'kadence_blocks_variable_font_sizes', $font_sizes );
 	$css = ':root {';
 	foreach ( $font_sizes as $key => $value ) {
@@ -217,14 +212,9 @@ add_action( 'admin_init', 'kadence_blocks_update_global_gutenberg_inline_styles_
  * Add global styles into the frontend.
  */
 function kadence_blocks_add_global_gutenberg_styles_frontend() {
-	$font_sizes = array(
-		'sm' => 'clamp(0.8rem, 0.73rem + 0.217vw, 0.9rem)',
-		'md' => 'clamp(1.1rem, 0.995rem + 0.326vw, 1.25rem)',
-		'lg' => 'clamp(1.75rem, 1.576rem + 0.543vw, 2rem)',
-		'xl' => 'clamp(2.25rem, 1.728rem + 1.63vw, 3rem)',
-		'xxl' => 'clamp(2.5rem, 1.456rem + 3.26vw, 4rem)',
-		'xxxl' => 'clamp(2.75rem, 0.489rem + 7.065vw, 6rem)',
-	);
+	// The fluid font-size scale is owned by the design-tokens baseline; retrieve it so the shipped clamp()
+	// values are not duplicated here. Empty when token projection is unavailable, leaving the filter intact.
+	$font_sizes = kadence_blocks_variable_font_size_scale();
 	$font_sizes = apply_filters( 'kadence_blocks_variable_font_sizes', $font_sizes );
 	$css = ':root {';
 	foreach ( $font_sizes as $key => $value ) {

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Css_Builder.php
@@ -3,6 +3,7 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot\Contracts\Target;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot\Font_Size_Target;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot\Gap_Target;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot\Spacing_Target;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Identifier;
@@ -287,7 +288,8 @@ final class Css_Builder {
 	private function build_active_fragment( Resolved_Tokens $active, string $active_slug ): string {
 		return $this->alias_block( $active, $active_slug )
 			. $this->slot_block( $active, Spacing_Target::class )
-			. $this->slot_block( $active, Gap_Target::class );
+			. $this->slot_block( $active, Gap_Target::class )
+			. $this->slot_block( $active, Font_Size_Target::class );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Legacy_Filter_Bridge.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Legacy_Filter_Bridge.php
@@ -9,45 +9,24 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use RuntimeException;
 
 /**
- * Feeds resolved token values into KB's legacy variable families so existing blocks inherit tokens
- * without per-block changes.
+ * Feeds resolved token values into KB's legacy color palette so existing blocks inherit tokens without
+ * per-block changes.
  *
- * Two filter families are supported:
- *
- *   - kadence_blocks_pattern_global_colors  — tokens declaring a kadence_slot of palette[1-9]
- *     override that --global-paletteN entry.
- *   - kadence_blocks_variable_font_sizes    — tokens declaring a font-size slot key override
- *     that key's clamp() value.
- *
- * Each callback is a transform of the incoming array: a token-claimed slot is rewritten to
- * "var(--kb-token--…, <resolved literal>)" so legacy blocks react to variant overrides of
+ * kadence_blocks_pattern_global_colors — tokens declaring a kadence_slot of palette[1-9] override that
+ * --global-paletteN entry. The callback is a transform of the incoming array: a token-claimed slot is
+ * rewritten to "var(--kb-token--…, <resolved literal>)" so legacy blocks react to variant overrides of
  * --kb-token--* with the resolved literal as a fallback for contexts that lack the token definitions
  * (e.g. prebuilt-library preview iframes). Everything else passes through untouched.
  *
- * The color half is a no-op when the Kadence theme owns the palette. Activation is gated upstream
- * by Hooks (it only calls these methods when Token_Registry::is_active()).
+ * The font-size scale is delivered separately, through the --global-kb-font-size-<slug> slot bridge
+ * (Font_Size_Target) in Css_Builder, not this filter.
+ *
+ * A no-op when the Kadence theme owns the palette. Activation is gated upstream by the Projector (it
+ * only calls this when Token_Registry::is_active()).
  *
  * @since TBD
  */
 final class Legacy_Filter_Bridge {
-
-	/**
-	 * The projection key a token uses to claim a Kadence slot.
-	 *
-	 * @since TBD
-	 *
-	 * @var string
-	 */
-	private const SLOT = 'kadence_slot';
-
-	/**
-	 * The font-size keys KB ships; a slot matching one of these feeds the font-size filter.
-	 *
-	 * @since TBD
-	 *
-	 * @var string[]
-	 */
-	private const FONT_SIZE_KEYS = [ 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl' ];
 
 	/**
 	 * @var Token_Registry
@@ -113,40 +92,5 @@ final class Legacy_Filter_Bridge {
 		}
 
 		return $colors;
-	}
-
-	/**
-	 * Filter callback for kadence_blocks_variable_font_sizes.
-	 *
-	 * @since TBD
-	 *
-	 * @param array<string,string> $sizes The current size-key => clamp() map.
-	 *
-	 * @return array<string,string>
-	 */
-	public function font_sizes( array $sizes ): array {
-		try {
-			$resolved = $this->resolver->resolve();
-		} catch ( RuntimeException $e ) {
-			return $sizes;
-		}
-
-		foreach ( $this->registry->by_projection( self::SLOT ) as $id => $token ) {
-			$slot = $token->projections[ self::SLOT ] ?? null;
-			if ( ! is_string( $slot ) || ! in_array( $slot, self::FONT_SIZE_KEYS, true ) ) {
-				continue;
-			}
-
-			$value = $resolved->value( $id );
-			if ( $value === null ) {
-				continue;
-			}
-
-			// Same indirection + literal fallback as global_colors(): reactive where the token vars
-			// exist, falling back to the resolved clamp/length in iframes that lack them.
-			$sizes[ $slot ] = sprintf( 'var(%s, %s)', $token->css_var, $value );
-		}
-
-		return $sizes;
 	}
 }

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
@@ -164,21 +164,6 @@ final class Projector implements Css_Projector {
 	}
 
 	/**
-	 * @since TBD
-	 *
-	 * @param array<string,string> $sizes
-	 *
-	 * @return array<string,string>
-	 */
-	public function filter_font_sizes( array $sizes ): array {
-		if ( ! $this->is_active() ) {
-			return $sizes;
-		}
-
-		return $this->bridge->font_sizes( $sizes );
-	}
-
-	/**
 	 * Build the projected CSS for every token set at once, using the per-request memo and object cache
 	 * so repeated calls within the same request are free.
 	 *

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Provider.php
@@ -21,7 +21,7 @@ final class Provider extends Provider_Contract {
 	public function register(): void {
 		$this->container->singleton( Css_Builder::class );
 		$this->container->singleton( Legacy_Filter_Bridge::class );
-		$this->container->singleton( Scale_Reader::class );
+		$this->container->singleton( Slot_Target_Reader::class );
 		$this->container->singleton( Projector::class );
 
 		// Contribute this projector's editor CSS to the combined projected-CSS endpoint.

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Provider.php
@@ -21,6 +21,7 @@ final class Provider extends Provider_Contract {
 	public function register(): void {
 		$this->container->singleton( Css_Builder::class );
 		$this->container->singleton( Legacy_Filter_Bridge::class );
+		$this->container->singleton( Scale_Reader::class );
 		$this->container->singleton( Projector::class );
 
 		// Contribute this projector's editor CSS to the combined projected-CSS endpoint.
@@ -38,9 +39,9 @@ final class Provider extends Provider_Contract {
 		// exists and keeps that dependency, which is what gives editor-iframe coverage for free.
 		add_action( 'admin_init', $this->container->callback( Projector::class, 'enqueue_editor' ), 5 );
 
-		// Legacy variable families (init.php applies these in both editor and front-end functions).
+		// Legacy color palette (init.php applies this filter in both editor and front-end functions).
 		// Merge semantics: the bridge overrides only token-claimed slots; everything else passes through.
+		// The font-size scale is delivered by the --global-kb-font-size-<slug> slot bridge in Css_Builder.
 		add_filter( 'kadence_blocks_pattern_global_colors', $this->container->callback( Projector::class, 'filter_global_colors' ), 20 );
-		add_filter( 'kadence_blocks_variable_font_sizes', $this->container->callback( Projector::class, 'filter_font_sizes' ), 20 );
 	}
 }

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Scale_Reader.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Scale_Reader.php
@@ -1,0 +1,101 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot\Contracts\Target;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use Throwable;
+
+/**
+ * Resolves a slot family's shipped scale to a slug => value map, so Kadence Blocks' legacy
+ * `--global-kb-<family>-*` variable families can be fed from the design tokens instead of a hardcoded
+ * copy (see includes/init.php and class-kadence-blocks-editor-assets.php).
+ *
+ * The single source of a scale is the baseline: each slug's value comes from resolving the primitive that
+ * backs it (Target::get_primitive_id()), so the shipped literals live once. For spacing/gap that primitive
+ * is the projection-holding token itself; for font-size it is the primitive the semantic aliases, so the
+ * value is the fluid clamp() rather than the semantic's flat base.
+ *
+ * Fails open to an empty array when the registry is inactive or a stored document cannot be resolved, so a
+ * caller keeps its own fallback and a broken token store never suppresses KB's own scale.
+ *
+ * @since TBD
+ */
+final class Scale_Reader {
+
+	/**
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * @var Token_Resolver
+	 */
+	private Token_Resolver $resolver;
+
+	/**
+	 * Owns the active-set pointer, so the scale follows the active set (e.g. a switched palette) the same
+	 * way the projected CSS does.
+	 *
+	 * @since TBD
+	 *
+	 * @var Active_Set_Store
+	 */
+	private Active_Set_Store $active;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry   $registry
+	 * @param Token_Resolver   $resolver
+	 * @param Active_Set_Store $active
+	 */
+	public function __construct( Token_Registry $registry, Token_Resolver $resolver, Active_Set_Store $active ) {
+		$this->registry = $registry;
+		$this->resolver = $resolver;
+		$this->active   = $active;
+	}
+
+	/**
+	 * The resolved scale for a slot family as a slug => value map.
+	 *
+	 * @since TBD
+	 *
+	 * @param class-string<Target> $target_class The slot target defining the family's projection key,
+	 *                                           shipped slugs and backing primitive ids.
+	 *
+	 * @return array<string,string> Slug => resolved scale value (a length, or a clamp() string for a fluid
+	 *                              family).
+	 */
+	public function scale( string $target_class ): array {
+		if ( ! $this->registry->is_active() ) {
+			return [];
+		}
+
+		try {
+			// Resolve the active set (not just the default) so the scale follows a switched set, matching
+			// how the projected slot overrides resolve.
+			$resolved = $this->resolver->resolve( $this->active->get() );
+		} catch ( Throwable $e ) {
+			return [];
+		}
+
+		$scale = [];
+
+		foreach ( $this->registry->by_projection( $target_class::get_projection_key() ) as $token ) {
+			$target = $target_class::from_token( $token );
+			if ( $target === null ) {
+				continue;
+			}
+
+			$value = $resolved->value( $target_class::get_primitive_id( $target->slot() ) );
+			if ( is_string( $value ) && $value !== '' ) {
+				$scale[ $target->slot() ] = $value;
+			}
+		}
+
+		return $scale;
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Slot/Contracts/Abstract_Target.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Slot/Contracts/Abstract_Target.php
@@ -48,6 +48,16 @@ abstract class Abstract_Target implements Target {
 	protected const SLOTS = [];
 
 	/**
+	 * The dot-path prefix of the primitive dimension token backing a slug in this family, e.g.
+	 * "primitive.dimension.spacing.". Concrete families override.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	protected const PRIMITIVE_PREFIX = '';
+
+	/**
 	 * The claimed slug, e.g. "lg".
 	 *
 	 * @since TBD
@@ -101,5 +111,23 @@ abstract class Abstract_Target implements Target {
 	 */
 	final public function css_property(): string {
 		return static::VAR_PREFIX . $this->slot;
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @since TBD
+	 */
+	final public function slot(): string {
+		return $this->slot;
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @since TBD
+	 */
+	final public static function get_primitive_id( string $slug ): string {
+		return static::PRIMITIVE_PREFIX . $slug;
 	}
 }

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Slot/Contracts/Target.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Slot/Contracts/Target.php
@@ -48,4 +48,27 @@ interface Target {
 	 * @return string
 	 */
 	public function css_property(): string;
+
+	/**
+	 * The claimed slug, e.g. "lg".
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function slot(): string;
+
+	/**
+	 * The id of the primitive dimension token backing a slug in this family, e.g.
+	 * "primitive.dimension.spacing.lg". For spacing/gap this is the projection-holding token itself; for
+	 * font-size it is the primitive the projection-holding semantic aliases. Used to resolve a slug's
+	 * scale value.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The claimed slug, e.g. "lg".
+	 *
+	 * @return string
+	 */
+	public static function get_primitive_id( string $slug ): string;
 }

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Slot/Font_Size_Target.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Slot/Font_Size_Target.php
@@ -1,0 +1,63 @@
+<?php declare( strict_types=1 );
+// cspell:ignore xxl xxxl .
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot\Contracts\Abstract_Target;
+
+/**
+ * Normalizes a token's "kb_font_size_slot" projection into one of Kadence Blocks' fixed font-size slugs.
+ *
+ * Kadence Blocks renders font-size attributes that hold a preset slug (sm/md/lg/…) as
+ * `var(--global-kb-font-size-<slug>, <literal>)`, and emits those slugs' fluid `clamp()` values through
+ * the `kadence_blocks_variable_font_sizes` filter. The `primitive.dimension.font-size.<slug>` token claims
+ * that slug with `'kb_font_size_slot' => 'lg'`; the Css_Var builder then redefines `--global-kb-font-size-lg`
+ * as the token variable, so every block already storing that slug follows the token with no block change —
+ * the same slug-on-the-primitive shape spacing and gap use (the button's per-instance default font size is a
+ * separate token, semantic.font-size.control, not a scale step).
+ *
+ * The slug is validated against the set Kadence Blocks ships, so a typo never emits a dead override.
+ *
+ * @since TBD
+ */
+final class Font_Size_Target extends Abstract_Target {
+
+	/**
+	 * The projection key a token declares to claim a font-size slug.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	protected const PROJECTION = 'kb_font_size_slot';
+
+	/**
+	 * The custom-property prefix Kadence Blocks emits each font-size slug under.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	protected const VAR_PREFIX = '--global-kb-font-size-';
+
+	/**
+	 * The font-size slugs Kadence Blocks defines (see includes/init.php / class-kadence-blocks-css.php).
+	 * A claim on any other slug is ignored so the override can never point at a slug no block reads.
+	 *
+	 * @since TBD
+	 *
+	 * @var string[]
+	 */
+	protected const SLOTS = [ 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl' ];
+
+	/**
+	 * The primitive dimension tokens that back the font-size slugs; the slug is claimed on the primitive
+	 * itself, so this prefix plus the slug is the projection-holding token's own id (and resolves to its
+	 * fluid clamp()).
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	protected const PRIMITIVE_PREFIX = 'primitive.dimension.font-size.';
+}

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Slot/Gap_Target.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Slot/Gap_Target.php
@@ -50,4 +50,14 @@ final class Gap_Target extends Abstract_Target {
 	 * @var string[]
 	 */
 	protected const SLOTS = [ 'none', 'xs', 'sm', 'md', 'lg' ];
+
+	/**
+	 * The primitive dimension tokens that back the gap slugs; the slug is claimed on the primitive itself,
+	 * so this prefix plus the slug is the projection-holding token's own id.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	protected const PRIMITIVE_PREFIX = 'primitive.dimension.gap.';
 }

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Slot/Spacing_Target.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Slot/Spacing_Target.php
@@ -46,4 +46,14 @@ final class Spacing_Target extends Abstract_Target {
 	 * @var string[]
 	 */
 	protected const SLOTS = [ 'ss-auto', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ];
+
+	/**
+	 * The primitive dimension tokens that back the spacing slugs; the slug is claimed on the primitive
+	 * itself, so this prefix plus the slug is the projection-holding token's own id.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	protected const PRIMITIVE_PREFIX = 'primitive.dimension.spacing.';
 }

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Slot_Target_Reader.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Slot_Target_Reader.php
@@ -23,7 +23,7 @@ use Throwable;
  *
  * @since TBD
  */
-final class Scale_Reader {
+final class Slot_Target_Reader {
 
 	/**
 	 * @var Token_Registry
@@ -69,7 +69,7 @@ final class Scale_Reader {
 	 * @return array<string,string> Slug => resolved scale value (a length, or a clamp() string for a fluid
 	 *                              family).
 	 */
-	public function scale( string $target_class ): array {
+	public function read( string $target_class ): array {
 		if ( ! $this->registry->is_active() ) {
 			return [];
 		}

--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -136,6 +136,86 @@
 					"$value": "4rem"
 				}
 			},
+			"font-size": {
+				"sm": {
+					"$type": "dimension",
+					"$value": "0.9rem",
+					"$extensions": {
+						"com.kadence.designTokens": {
+							"clamp": {
+								"min": "0.8rem",
+								"preferred": "0.73rem + 0.217vw",
+								"max": "0.9rem"
+							}
+						}
+					}
+				},
+				"md": {
+					"$type": "dimension",
+					"$value": "1.25rem",
+					"$extensions": {
+						"com.kadence.designTokens": {
+							"clamp": {
+								"min": "1.1rem",
+								"preferred": "0.995rem + 0.326vw",
+								"max": "1.25rem"
+							}
+						}
+					}
+				},
+				"lg": {
+					"$type": "dimension",
+					"$value": "2rem",
+					"$extensions": {
+						"com.kadence.designTokens": {
+							"clamp": {
+								"min": "1.75rem",
+								"preferred": "1.576rem + 0.543vw",
+								"max": "2rem"
+							}
+						}
+					}
+				},
+				"xl": {
+					"$type": "dimension",
+					"$value": "3rem",
+					"$extensions": {
+						"com.kadence.designTokens": {
+							"clamp": {
+								"min": "2.25rem",
+								"preferred": "1.728rem + 1.63vw",
+								"max": "3rem"
+							}
+						}
+					}
+				},
+				"xxl": {
+					"$type": "dimension",
+					"$value": "4rem",
+					"$extensions": {
+						"com.kadence.designTokens": {
+							"clamp": {
+								"min": "2.5rem",
+								"preferred": "1.456rem + 3.26vw",
+								"max": "4rem"
+							}
+						}
+					}
+				},
+				"xxxl": {
+					"$type": "dimension",
+					"$value": "6rem",
+					"$extensions": {
+						"com.kadence.designTokens": {
+							"clamp": {
+								"min": "2.75rem",
+								"preferred": "0.489rem + 7.065vw",
+								"max": "6rem"
+							}
+						}
+					}
+				}
+			},
 			"radius": {
 				"none": {
 					"$type": "dimension",

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -1,5 +1,5 @@
 <?php declare( strict_types=1 );
-// cspell:ignore advancedbtn xxs xxl .
+// cspell:ignore advancedbtn xxs xxl xxxl .
 // The single declaration point. Adding an entry here automatically reaches every projector and the
 // admin UI. Returned as data (rather than calling the global helper) so the Provider can register it
 // directly against the container. The shipped baseline must contain an entry for every token registered
@@ -42,6 +42,27 @@ $gap_tokens = array_map(
 		];
 	},
 	$gap_slugs
+);
+
+// The fluid font-size scale steps are primitives (the slug IS a scale step), each holding the shipped
+// clamp() value from includes/init.php and claiming the Kadence Blocks font-size slug it backs
+// (class-kadence-blocks-css.php): the Css_Var builder redefines --global-kb-font-size-<slug> as the
+// primitive token, so a block already storing that slug follows it — mirroring spacing/gap. Defaults match
+// KB's own values, so registering them changes nothing until overridden. The button's per-instance default
+// font size is a separate token, semantic.font-size.control -- not a scale step.
+$font_size_slugs = [ 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl' ];
+
+$font_size_primitive_tokens = array_map(
+	static function ( string $slug ): array {
+		return [
+			'id'          => 'primitive.dimension.font-size.' . $slug,
+			'type'        => 'dimension',
+			'label'       => strtoupper( $slug ),
+			'group'       => __( 'Font Size', 'kadence-blocks' ),
+			'projections' => [ 'kb_font_size_slot' => $slug ],
+		];
+	},
+	$font_size_slugs
 );
 
 /**
@@ -218,7 +239,8 @@ return [
 		$button_color_tokens,
 		$palette_tokens,
 		$spacing_tokens,
-		$gap_tokens
+		$gap_tokens,
+		$font_size_primitive_tokens
 	),
 	/**
 	 * Variant set for the Button block: that it accepts variants, plus the per-property bindings (a

--- a/includes/resources/Design_Tokens/functions.php
+++ b/includes/resources/Design_Tokens/functions.php
@@ -3,6 +3,8 @@
 use KadenceWP\KadenceBlocks\Design_Tokens\Foundation_Presets\Catalog;
 use KadenceWP\KadenceBlocks\Design_Tokens\Foundation_Presets\Selector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts\Adapter_Interface;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Scale_Reader;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot\Font_Size_Target;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 
 if ( ! function_exists( 'kadence_blocks_register_design_token' ) ) {
@@ -104,5 +106,29 @@ if ( ! function_exists( 'kadence_blocks_apply_design_foundation_preset' ) ) {
 		/** @var Selector $selector */
 		$selector = kadence_blocks()->get( Selector::class );
 		$selector->apply( $group, $choice );
+	}
+}
+
+if ( ! function_exists( 'kadence_blocks_variable_font_size_scale' ) ) {
+	/**
+	 * The token-driven fluid font-size scale as a slug => value map, used to seed the base of KB's
+	 * `kadence_blocks_variable_font_sizes` filter (includes/init.php and
+	 * class-kadence-blocks-editor-assets.php) so the shipped clamp() values live once, in the baseline,
+	 * rather than being copied into each emission site. Returns an empty array when token projection is
+	 * unavailable or inactive, so callers keep their own fallback. Thin accessor over the Scale_Reader.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string,string> Slug => resolved font-size value (a clamp() string by default).
+	 */
+	function kadence_blocks_variable_font_size_scale(): array {
+		try {
+			/** @var Scale_Reader $reader */
+			$reader = kadence_blocks()->get( Scale_Reader::class );
+		} catch ( \Throwable $e ) {
+			return [];
+		}
+
+		return $reader->scale( Font_Size_Target::class );
 	}
 }

--- a/includes/resources/Design_Tokens/functions.php
+++ b/includes/resources/Design_Tokens/functions.php
@@ -3,7 +3,7 @@
 use KadenceWP\KadenceBlocks\Design_Tokens\Foundation_Presets\Catalog;
 use KadenceWP\KadenceBlocks\Design_Tokens\Foundation_Presets\Selector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts\Adapter_Interface;
-use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Scale_Reader;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot_Target_Reader;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot\Font_Size_Target;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 
@@ -115,7 +115,7 @@ if ( ! function_exists( 'kadence_blocks_variable_font_size_scale' ) ) {
 	 * `kadence_blocks_variable_font_sizes` filter (includes/init.php and
 	 * class-kadence-blocks-editor-assets.php) so the shipped clamp() values live once, in the baseline,
 	 * rather than being copied into each emission site. Returns an empty array when token projection is
-	 * unavailable or inactive, so callers keep their own fallback. Thin accessor over the Scale_Reader.
+	 * unavailable or inactive, so callers keep their own fallback. Thin accessor over the Slot_Target_Reader.
 	 *
 	 * @since TBD
 	 *
@@ -123,12 +123,12 @@ if ( ! function_exists( 'kadence_blocks_variable_font_size_scale' ) ) {
 	 */
 	function kadence_blocks_variable_font_size_scale(): array {
 		try {
-			/** @var Scale_Reader $reader */
-			$reader = kadence_blocks()->get( Scale_Reader::class );
+			/** @var Slot_Target_Reader $reader */
+			$reader = kadence_blocks()->get( Slot_Target_Reader::class );
 		} catch ( \Throwable $e ) {
 			return [];
 		}
 
-		return $reader->scale( Font_Size_Target::class );
+		return $reader->read( Font_Size_Target::class );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Css_BuilderTest.php
@@ -1,5 +1,5 @@
 <?php declare( strict_types=1 );
-// cspell:ignore palette Fghi redbodycolor xxs xxl .
+// cspell:ignore palette Fghi redbodycolor xxs xxl xxxl .
 
 namespace Tests\wpunit\Resources\Design_Tokens\Projection\Css_Var;
 
@@ -332,14 +332,37 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
-	 * Built from the real registry and resolver, the shipped declarations emit a slot override for every
-	 * spacing and gap step Kadence Blocks ships, so each --global-kb-spacing-* / --global-kb-gap-* slug
-	 * follows its token. The default resolves from baseline (no overrides), so each override carries the
-	 * canonical token var with KB's own length as the literal fallback.
+	 * A font-size token that claims a shipped slug redefines --global-kb-font-size-<slug> as the canonical
+	 * token var, with the resolved length as a literal fallback, so a block storing that named size follows it.
 	 *
 	 * @return void
 	 */
-	public function testTheShippedDeclarationsEmitEverySpacingAndGapSlot(): void {
+	public function testItEmitsFontSizeOverrideForAClaimedSlot(): void {
+		$id = 'primitive.dimension.font-size.lg';
+
+		$this->registry->register(
+			[
+				'id'          => $id,
+				'type'        => 'dimension',
+				'label'       => 'LG',
+				'projections' => [ 'kb_font_size_slot' => 'lg' ],
+			]
+		);
+
+		$css = $this->css_default( $this->set( [ $id => '2rem' ], [ Css_Var::from_id( $id, 'default' ) => '2rem' ] ) );
+
+		$this->assertStringContainsString( '--global-kb-font-size-lg:var(' . Css_Var::from_id( $id ) . ',2rem);', $css );
+	}
+
+	/**
+	 * Built from the real registry and resolver, the shipped declarations emit a slot override for every
+	 * spacing, gap and font-size step Kadence Blocks ships, so each --global-kb-spacing-* / --global-kb-gap-* /
+	 * --global-kb-font-size-* slug follows its token. The default resolves from baseline (no overrides), so
+	 * each override carries the canonical token var with KB's own length as the literal fallback.
+	 *
+	 * @return void
+	 */
+	public function testTheShippedDeclarationsEmitEverySpacingGapAndFontSizeSlot(): void {
 		$registry = $this->container->get( Token_Registry::class );
 		$resolved = $this->container->get( Token_Resolver::class )->resolve_namespaced( 'default' );
 
@@ -351,6 +374,10 @@ final class Css_BuilderTest extends TestCase {
 
 		foreach ( [ 'none', 'xs', 'sm', 'md', 'lg' ] as $slug ) {
 			$this->assertStringContainsString( '--global-kb-gap-' . $slug . ':var(', $css );
+		}
+
+		foreach ( [ 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl' ] as $slug ) {
+			$this->assertStringContainsString( '--global-kb-font-size-' . $slug . ':var(', $css );
 		}
 	}
 

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Legacy_Filter_BridgeTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Legacy_Filter_BridgeTest.php
@@ -34,20 +34,6 @@ final class Legacy_Filter_BridgeTest extends TestCase {
 		'--global-palette9' => '#ffffff',
 	];
 
-	/**
-	 * The default font-size map included in `includes/init.php` — keys and values must stay in lockstep.
-	 *
-	 * @var array<string,string>
-	 */
-	private array $default_font_sizes = [
-		'sm'   => 'clamp(0.8rem, 0.73rem + 0.217vw, 0.9rem)',
-		'md'   => 'clamp(1.1rem, 0.995rem + 0.326vw, 1.25rem)',
-		'lg'   => 'clamp(1.75rem, 1.576rem + 0.543vw, 2rem)',
-		'xl'   => 'clamp(2.25rem, 1.728rem + 1.63vw, 3rem)',
-		'xxl'  => 'clamp(2.5rem, 1.456rem + 3.26vw, 4rem)',
-		'xxxl' => 'clamp(2.75rem, 0.489rem + 7.065vw, 6rem)',
-	];
-
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -176,109 +162,6 @@ final class Legacy_Filter_BridgeTest extends TestCase {
 		$this->assertSame( $this->default_colors['--global-palette2'], $result['--global-palette2'] );
 	}
 
-	// ---- font_sizes() -------------------------------------------------------------------------------
-
-	public function testFontSizeTokenOverridesItsKeyAndLeavesOthersIntact(): void {
-		$id  = 'semantic.dimension.font-sm';
-		$var = Css_Var::from_id( $id );
-
-		$this->registry->register(
-			[
-				'id'          => $id,
-				'type'        => 'dimension',
-				'label'       => 'Font Small',
-				'projections' => [ 'kadence_slot' => 'sm' ],
-			]
-		);
-
-		$baseline = [
-			'semantic' => [
-				'dimension' => [
-					'font-sm' => [
-						'$type'  => 'dimension',
-						'$value' => '0.875rem',
-					],
-				],
-			],
-		];
-		$bridge   = $this->bridge_for( $baseline );
-		$result   = $bridge->font_sizes( $this->default_font_sizes );
-
-		$this->assertSame( 'var(' . $var . ', 0.875rem)', $result['sm'] );
-
-		foreach ( $this->default_font_sizes as $key => $original ) {
-			if ( $key === 'sm' ) {
-				continue;
-			}
-			$this->assertSame( $original, $result[ $key ], "Key {$key} should be unchanged." );
-		}
-	}
-
-	public function testFontSizeValueIncludesBothVarAndLiteralFallback(): void {
-		$id  = 'semantic.dimension.font-md';
-		$var = Css_Var::from_id( $id );
-
-		$this->registry->register(
-			[
-				'id'          => $id,
-				'type'        => 'dimension',
-				'label'       => 'Font Medium',
-				'projections' => [ 'kadence_slot' => 'md' ],
-			]
-		);
-
-		$baseline = [
-			'semantic' => [
-				'dimension' => [
-					'font-md' => [
-						'$type'  => 'dimension',
-						'$value' => '1rem',
-					],
-				],
-			],
-		];
-		$bridge   = $this->bridge_for( $baseline );
-		$result   = $bridge->font_sizes( $this->default_font_sizes );
-		$value    = $result['md'];
-
-		$this->assertStringContainsString( $var, $value );
-		$this->assertStringContainsString( '1rem', $value );
-	}
-
-	public function testPaletteSlotIsIgnoredByFontSizes(): void {
-		$id = 'semantic.color.button-bg';
-
-		$this->registry->register(
-			[
-				'id'          => $id,
-				'type'        => 'color',
-				'label'       => 'Button Background',
-				'projections' => [ 'kadence_slot' => 'palette1' ],
-			]
-		);
-
-		$bridge = $this->bridge_for( $this->color_baseline( $id, '#3182CE' ) );
-		$result = $bridge->font_sizes( $this->default_font_sizes );
-
-		$this->assertSame( $this->default_font_sizes, $result );
-	}
-
-	public function testFontSizeTokenWithNoResolvedValueLeavesMapUnchanged(): void {
-		$this->registry->register(
-			[
-				'id'          => 'semantic.dimension.font-lg',
-				'type'        => 'dimension',
-				'label'       => 'Font Large',
-				'projections' => [ 'kadence_slot' => 'lg' ],
-			]
-		);
-
-		$bridge = $this->bridge_for( [] );
-		$result = $bridge->font_sizes( $this->default_font_sizes );
-
-		$this->assertSame( $this->default_font_sizes['lg'], $result['lg'] );
-	}
-
 	// ---- Theme guard (must run last — defines Kadence\Theme stub) ----------------------------------------
 
 	public function testGlobalColorsIsNoOpWhenKadenceThemeIsActive(): void {
@@ -304,35 +187,5 @@ final class Legacy_Filter_BridgeTest extends TestCase {
 		$result = $bridge->global_colors( $this->default_colors );
 
 		$this->assertSame( $this->default_colors, $result );
-	}
-
-	public function testFontSizesIsUnaffectedByKadenceTheme(): void {
-		$id = 'semantic.dimension.font-sm';
-
-		$this->registry->register(
-			[
-				'id'          => $id,
-				'type'        => 'dimension',
-				'label'       => 'Font Small',
-				'projections' => [ 'kadence_slot' => 'sm' ],
-			]
-		);
-
-		$baseline = [
-			'semantic' => [
-				'dimension' => [
-					'font-sm' => [
-						'$type'  => 'dimension',
-						'$value' => '0.875rem',
-					],
-				],
-			],
-		];
-		$bridge   = $this->bridge_for( $baseline );
-
-		// Kadence\Theme may or may not be defined — font_sizes() never checks for it.
-		$result = $bridge->font_sizes( $this->default_font_sizes );
-
-		$this->assertStringContainsString( '0.875rem', $result['sm'] );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/ProjectorTest.php
@@ -1,5 +1,5 @@
 <?php declare( strict_types=1 );
-// cspell:ignore palette pagenow .
+// cspell:ignore palette pagenow xxl xxxl .
 
 namespace Tests\wpunit\Resources\Design_Tokens\Projection\Css_Var;
 
@@ -15,9 +15,10 @@ use Tests\Support\Classes\TestCase;
 
 /**
  * Covers the CSS-variable projector: it appends the resolved --kb-token--* declarations to KB's front-end
- * and editor style handles, routes the legacy color/font-size filters through the bridge, is a no-op when
- * the registry is deactivated, and honors the active set — the declarations carry the active set's resolved
- * values, so pointing the active-set pointer at another set changes what is projected to the front end.
+ * and editor style handles, routes the legacy color filter through the bridge, feeds KB's font-size scale
+ * from the tokens, is a no-op when the registry is deactivated, and honors the active set — the declarations
+ * carry the active set's resolved values, so pointing the active-set pointer at another set changes what is
+ * projected to the front end.
  */
 final class ProjectorTest extends TestCase {
 
@@ -160,15 +161,30 @@ final class ProjectorTest extends TestCase {
 		$this->assertArrayHasKey( '--global-palette2', $result );
 	}
 
+	// ---- Font-size slot bridge -----------------------------------------------------------------------
+
 	/**
+	 * The front-end projection redefines each --global-kb-font-size-<slug> slot as its primitive token var
+	 * (the slug is claimed on the primitive, like spacing/gap), and that primitive carries the shipped
+	 * clamp(), so a block storing a named size follows the token.
+	 *
 	 * @return void
 	 */
-	public function testFilterFontSizesPassesThroughWhenNoFontSizeTokensRegistered(): void {
-		$input  = [ 'sm' => 'clamp(0.8rem, 0.73rem + 0.217vw, 0.9rem)' ];
-		$result = $this->projector->filter_font_sizes( $input );
+	public function testFrontEndCssRedefinesGlobalFontSizeSlots(): void {
+		$this->projector->enqueue_front_end();
 
-		// Shipped tokens have no kadence_slot font-size entries, so input passes through unchanged.
-		$this->assertSame( $input, $result );
+		$css        = implode( '', (array) wp_styles()->get_data( 'kadence-blocks-global-variables', 'after' ) );
+		$canonical  = Css_Var::from_id( 'primitive.dimension.font-size.lg' );
+		$namespaced = Css_Var::from_id( 'primitive.dimension.font-size.lg', 'default' );
+
+		// The slot points --global-kb-font-size-lg at the primitive token var.
+		$this->assertStringContainsString( '--global-kb-font-size-lg:var(' . $canonical . ',', $css );
+
+		// And that primitive carries the shipped fluid clamp() value.
+		$this->assertStringContainsString(
+			$namespaced . ':clamp(1.75rem, 1.576rem + 0.543vw, 2rem)',
+			$css
+		);
 	}
 
 	// ---- Deactivated registry (fail-closed) ----------------------------------------------------------
@@ -190,16 +206,17 @@ final class ProjectorTest extends TestCase {
 	}
 
 	/**
+	 * A deactivated registry leaves the legacy color filter's input untouched, so KB's own palette survives
+	 * when token projection is off.
+	 *
 	 * @return void
 	 */
-	public function testFiltersReturnInputUnchangedWhenRegistryIsDeactivated(): void {
+	public function testDeactivatedRegistryLeavesColorFilterUnchanged(): void {
 		$this->registry->deactivate();
 
 		$colors = [ '--global-palette1' => '#3182CE' ];
-		$sizes  = [ 'sm' => 'clamp(0.8rem, 0.73rem + 0.217vw, 0.9rem)' ];
 
 		$this->assertSame( $colors, $this->projector->filter_global_colors( $colors ) );
-		$this->assertSame( $sizes, $this->projector->filter_font_sizes( $sizes ) );
 	}
 
 	// ---- Active set ----------------------------------------------------------------------------------

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Scale_ReaderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Scale_ReaderTest.php
@@ -1,0 +1,132 @@
+<?php declare( strict_types=1 );
+// cspell:ignore xxs xxl xxxl .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Projection\Css_Var;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Scale_Reader;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot\Font_Size_Target;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot\Gap_Target;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot\Spacing_Target;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use ReflectionProperty;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Covers the shared scale reader: for each slot family it resolves the shipped scale from the baseline as a
+ * slug => value map (the source of truth KB's legacy --global-kb-* families are fed from), and returns an
+ * empty map when the registry is deactivated so callers keep their own fallback.
+ */
+final class Scale_ReaderTest extends TestCase {
+
+	/**
+	 * @var Scale_Reader
+	 */
+	private Scale_Reader $reader;
+
+	/**
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->reader   = $this->container->get( Scale_Reader::class );
+		$this->registry = $this->container->get( Token_Registry::class );
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		// Re-activate the registry in case a test called deactivate() on the singleton.
+		$this->registry->activate();
+
+		// Clear the Token_Resolver singleton's in-memory memo so calls to resolve() made during these
+		// tests do not short-circuit object-cache checks in later test classes.
+		$resolver      = $this->container->get( Token_Resolver::class );
+		$memo_property = new ReflectionProperty( Token_Resolver::class, 'memo' );
+		$memo_property->setAccessible( true );
+		$memo_property->setValue( $resolver, [] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The font-size family resolves every shipped slug to its primitive's fluid clamp() value.
+	 *
+	 * @return void
+	 */
+	public function testItReadsTheFontSizeScaleAsTheShippedClamps(): void {
+		$this->assertEquals(
+			[
+				'sm'   => 'clamp(0.8rem, 0.73rem + 0.217vw, 0.9rem)',
+				'md'   => 'clamp(1.1rem, 0.995rem + 0.326vw, 1.25rem)',
+				'lg'   => 'clamp(1.75rem, 1.576rem + 0.543vw, 2rem)',
+				'xl'   => 'clamp(2.25rem, 1.728rem + 1.63vw, 3rem)',
+				'xxl'  => 'clamp(2.5rem, 1.456rem + 3.26vw, 4rem)',
+				'xxxl' => 'clamp(2.75rem, 0.489rem + 7.065vw, 6rem)',
+			],
+			$this->reader->scale( Font_Size_Target::class )
+		);
+	}
+
+	/**
+	 * The spacing family resolves every shipped step to its primitive length, matching KB's own scale.
+	 *
+	 * @return void
+	 */
+	public function testItReadsTheSpacingScaleAsTheShippedLengths(): void {
+		$this->assertEquals(
+			[
+				'xxs' => '0.5rem',
+				'xs'  => '1rem',
+				'sm'  => '1.5rem',
+				'md'  => '2rem',
+				'lg'  => '3rem',
+				'xl'  => '4rem',
+				'xxl' => '5rem',
+				'3xl' => '6.5rem',
+				'4xl' => '8rem',
+				'5xl' => '10rem',
+			],
+			$this->reader->scale( Spacing_Target::class )
+		);
+	}
+
+	/**
+	 * The gap family resolves every shipped step to its primitive length, matching KB's own gap scale.
+	 *
+	 * @return void
+	 */
+	public function testItReadsTheGapScaleAsTheShippedLengths(): void {
+		$this->assertEquals(
+			[
+				'none' => '0rem',
+				'xs'   => '0.5rem',
+				'sm'   => '1rem',
+				'md'   => '2rem',
+				'lg'   => '4rem',
+			],
+			$this->reader->scale( Gap_Target::class )
+		);
+	}
+
+	/**
+	 * A deactivated registry yields an empty map for every family, so KB's own defaults survive when token
+	 * projection is off.
+	 *
+	 * @return void
+	 */
+	public function testItReturnsAnEmptyMapWhenTheRegistryIsDeactivated(): void {
+		$this->registry->deactivate();
+
+		$this->assertSame( [], $this->reader->scale( Font_Size_Target::class ) );
+		$this->assertSame( [], $this->reader->scale( Spacing_Target::class ) );
+		$this->assertSame( [], $this->reader->scale( Gap_Target::class ) );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Slot/Font_Size_TargetTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Slot/Font_Size_TargetTest.php
@@ -1,0 +1,112 @@
+<?php declare( strict_types=1 );
+// cspell:ignore xxl xxxl .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Projection\Css_Var\Slot;
+
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot\Font_Size_Target;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Definition;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Covers the font-size-slot target: it normalizes a token's `kb_font_size_slot` projection to one of KB's
+ * fixed font-size slugs and the custom property that slug is emitted under, rejecting absent or unknown
+ * slugs so the Css_Var override never points at a slug no block reads.
+ */
+final class Font_Size_TargetTest extends TestCase {
+
+	/**
+	 * A known font-size slug resolves to a target carrying that slug and its --global-kb-font-size-* property.
+	 *
+	 * @return void
+	 */
+	public function testItResolvesAKnownFontSizeSlug(): void {
+		$target = Font_Size_Target::from_token( $this->token( 'lg' ) );
+
+		$this->assertNotNull( $target );
+		$this->assertSame( 'lg', $target->slot );
+		$this->assertSame( '--global-kb-font-size-lg', $target->css_property() );
+	}
+
+	/**
+	 * The largest slug, xxxl, resolves to the --global-kb-font-size-xxxl property the button's 3xl preset reads.
+	 *
+	 * @return void
+	 */
+	public function testItResolvesTheLargestSlug(): void {
+		$target = Font_Size_Target::from_token( $this->token( 'xxxl' ) );
+
+		$this->assertNotNull( $target );
+		$this->assertSame( '--global-kb-font-size-xxxl', $target->css_property() );
+	}
+
+	/**
+	 * A slug KB does not ship, or non-string config, produces no target so no dead override is emitted.
+	 *
+	 * @dataProvider unusableSlotProvider
+	 *
+	 * @param mixed $slot The declared kb_font_size_slot value.
+	 *
+	 * @return void
+	 */
+	public function testItRejectsAnUnusableSlot( $slot ): void {
+		$this->assertNull( Font_Size_Target::from_token( $this->token( $slot ) ) );
+	}
+
+	/**
+	 * A token that declares no kb_font_size_slot projection is not a font-size target.
+	 *
+	 * @return void
+	 */
+	public function testItIsNullWhenTheTokenDeclaresNoFontSizeSlot(): void {
+		$token = Token_Definition::from_array(
+			[
+				'id'    => 'primitive.dimension.font-size.lg',
+				'type'  => 'dimension',
+				'label' => 'LG',
+			]
+		);
+
+		$this->assertNull( Font_Size_Target::from_token( $token ) );
+	}
+
+	/**
+	 * The target exposes the projection key a token uses to claim a font-size slug.
+	 *
+	 * @return void
+	 */
+	public function testItExposesItsProjectionKey(): void {
+		$this->assertSame( 'kb_font_size_slot', Font_Size_Target::get_projection_key() );
+	}
+
+	/**
+	 * Slugs that must not produce a target: one KB does not ship, the spacing-only 3xl, and non-string config.
+	 *
+	 * @return Generator
+	 */
+	public function unusableSlotProvider(): Generator {
+		yield 'unknown slug'      => [ 'slot' => 'enormous' ];
+		yield 'spacing-only slug' => [ 'slot' => '3xl' ];
+		yield 'empty string'      => [ 'slot' => '' ];
+		yield 'non-string'        => [ 'slot' => 123 ];
+		yield 'boolean true'      => [ 'slot' => true ];
+	}
+
+	/**
+	 * A token declaring the given kb_font_size_slot projection value.
+	 *
+	 * @param mixed $slot The kb_font_size_slot projection value.
+	 *
+	 * @return Token_Definition
+	 */
+	private function token( $slot ): Token_Definition {
+		return Token_Definition::from_array(
+			[
+				'id'          => 'semantic.font-size.lg',
+				'type'        => 'dimension',
+				'label'       => 'LG',
+				'projections' => [ 'kb_font_size_slot' => $slot ],
+			]
+		);
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Slot_Target_ReaderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Slot_Target_ReaderTest.php
@@ -3,7 +3,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Projection\Css_Var;
 
-use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Scale_Reader;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot_Target_Reader;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot\Font_Size_Target;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot\Gap_Target;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot\Spacing_Target;
@@ -17,12 +17,12 @@ use Tests\Support\Classes\TestCase;
  * slug => value map (the source of truth KB's legacy --global-kb-* families are fed from), and returns an
  * empty map when the registry is deactivated so callers keep their own fallback.
  */
-final class Scale_ReaderTest extends TestCase {
+final class Slot_Target_ReaderTest extends TestCase {
 
 	/**
-	 * @var Scale_Reader
+	 * @var Slot_Target_Reader
 	 */
-	private Scale_Reader $reader;
+	private Slot_Target_Reader $reader;
 
 	/**
 	 * @var Token_Registry
@@ -35,7 +35,7 @@ final class Scale_ReaderTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->reader   = $this->container->get( Scale_Reader::class );
+		$this->reader   = $this->container->get( Slot_Target_Reader::class );
 		$this->registry = $this->container->get( Token_Registry::class );
 	}
 
@@ -71,7 +71,7 @@ final class Scale_ReaderTest extends TestCase {
 				'xxl'  => 'clamp(2.5rem, 1.456rem + 3.26vw, 4rem)',
 				'xxxl' => 'clamp(2.75rem, 0.489rem + 7.065vw, 6rem)',
 			],
-			$this->reader->scale( Font_Size_Target::class )
+			$this->reader->read( Font_Size_Target::class )
 		);
 	}
 
@@ -94,7 +94,7 @@ final class Scale_ReaderTest extends TestCase {
 				'4xl' => '8rem',
 				'5xl' => '10rem',
 			],
-			$this->reader->scale( Spacing_Target::class )
+			$this->reader->read( Spacing_Target::class )
 		);
 	}
 
@@ -112,7 +112,7 @@ final class Scale_ReaderTest extends TestCase {
 				'md'   => '2rem',
 				'lg'   => '4rem',
 			],
-			$this->reader->scale( Gap_Target::class )
+			$this->reader->read( Gap_Target::class )
 		);
 	}
 
@@ -125,8 +125,8 @@ final class Scale_ReaderTest extends TestCase {
 	public function testItReturnsAnEmptyMapWhenTheRegistryIsDeactivated(): void {
 		$this->registry->deactivate();
 
-		$this->assertSame( [], $this->reader->scale( Font_Size_Target::class ) );
-		$this->assertSame( [], $this->reader->scale( Spacing_Target::class ) );
-		$this->assertSame( [], $this->reader->scale( Gap_Target::class ) );
+		$this->assertSame( [], $this->reader->read( Font_Size_Target::class ) );
+		$this->assertSame( [], $this->reader->read( Spacing_Target::class ) );
+		$this->assertSame( [], $this->reader->read( Gap_Target::class ) );
 	}
 }


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3869/tokenize-the-fluid-font-size-scale-as-primitives-match-the-spacing
:video_camera: https://www.loom.com/share/2a6b602906b843f0b0e2c860dda22b05

Tokenizes the global fluid font-size scale so a named font size ("Small/Medium/Large/…") resolves to a design token instead of KB's hardcoded `clamp()` value. Each `primitive.dimension.font-size.<slug>` claims a dedicated `kb_font_size_slot` on the primitive, and the Css_Var builder redefines `--global-kb-font-size-<slug>` as `var(--kb-token--…, <clamp>)` — the same slot-on-the-primitive bridge `spacing`/`gap` already use, so a block already storing the slug follows the token with no block change.

**Why the dedicated `kb_font_size_slot` path (not the old `kadence_slot` filter).** `Legacy_Filter_Bridge` shipped a dormant `font_sizes()` callback that read the overloaded `kadence_slot` projection — the *same* key the palette uses — against a hardcoded `FONT_SIZE_KEYS` list. No font-size token ever declared it, so it was dead code. Giving font-size its own `kb_font_size_slot` (mirroring `kb_spacing_slot` / `kb_gap_slot`) validates the slug against the set KB ships, stops one projection key doing double duty across colors and sizes, and makes the `slot_block` bridge the single delivery path. The dead `font_sizes()` / `FONT_SIZE_KEYS` branch and its filter hook are removed.

**Why `Slot_Target_Reader`.** KB's `kadence_blocks_variable_font_sizes` base was a hardcoded `clamp()` map duplicated in three spots (`init.php` ×2 + the editor `wp_localize_script`). Rather than adding a fourth copy in the token baseline, that base is now sourced from the tokens via a small resolver-backed `Slot_Target_Reader`, so the shipped clamp values live once, in `baseline.json`. `Slot_Target_Reader::read( Font_Size_Target::class )` resolves the backing primitive for the slot family the target defines and follows the active token set; it is generic (keyed by the slot `*_Target`) so the spacing PR reuses it, and it fails open to an empty array when projection is unavailable so KB's own fallbacks still apply. It lives in its own class rather than on the side-effecting projector, keeping the read path pure and unit-testable.

First of a 3-PR stack (Design Tokens scale bridges [1/3]).

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
