### PR TITLE
Design Tokens scale bridges [2/3]: Token-driven spacing scale

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -128,17 +128,14 @@ function kadence_blocks_add_global_gutenberg_inline_styles() {
 		}';
 		$css .= '.kb-header-container { --global-content-width: var(--wp--style--global--wide-size, var(--wp--style--global--content-size)) }';
 	}
-	$css .= ':root {
-		--global-kb-spacing-xxs: 0.5rem;
-		--global-kb-spacing-xs: 1rem;
-		--global-kb-spacing-sm: 1.5rem;
-		--global-kb-spacing-md: 2rem;
-		--global-kb-spacing-lg: 3rem;
-		--global-kb-spacing-xl: 4rem;
-		--global-kb-spacing-xxl: 5rem;
-		--global-kb-spacing-3xl: 6.5rem;
-		--global-kb-spacing-4xl: 8rem;
-		--global-kb-spacing-5xl: 10rem;
+	// The spacing scale is owned by the design-tokens baseline; retrieve it so the shipped literals are not
+	// duplicated here. Empty when token projection is unavailable, leaving blocks on their own
+	// var(--global-kb-spacing-*, <rem>) fallbacks.
+	$spacing_css = '';
+	foreach ( kadence_blocks_variable_spacing_scale() as $spacing_slug => $spacing_value ) {
+		$spacing_css .= '--global-kb-spacing-' . $spacing_slug . ':' . $spacing_value . ';';
+	}
+	$css .= ':root {' . $spacing_css . '
 		--global-row-edge-sm: 15px;
 		--global-row-edge-theme: var(--global-content-edge-padding);
 		--global-kb-gutter-sm: 1rem;

--- a/includes/resources/Design_Tokens/functions.php
+++ b/includes/resources/Design_Tokens/functions.php
@@ -5,6 +5,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Foundation_Presets\Selector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Adapter\Contracts\Adapter_Interface;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Scale_Reader;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot\Font_Size_Target;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Slot\Spacing_Target;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 
 if ( ! function_exists( 'kadence_blocks_register_design_token' ) ) {
@@ -130,5 +131,29 @@ if ( ! function_exists( 'kadence_blocks_variable_font_size_scale' ) ) {
 		}
 
 		return $reader->scale( Font_Size_Target::class );
+	}
+}
+
+if ( ! function_exists( 'kadence_blocks_variable_spacing_scale' ) ) {
+	/**
+	 * The token-driven spacing scale as a slug => value map, used to seed the base of KB's
+	 * `--global-kb-spacing-*` emission (includes/init.php) so the shipped spacing literals live once, in
+	 * the baseline, rather than being copied into the emission. Returns an empty array when token
+	 * projection is unavailable or inactive, so callers keep their own fallback. Thin accessor over the
+	 * Scale_Reader.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string,string> Slug => resolved spacing length.
+	 */
+	function kadence_blocks_variable_spacing_scale(): array {
+		try {
+			/** @var Scale_Reader $reader */
+			$reader = kadence_blocks()->get( Scale_Reader::class );
+		} catch ( \Throwable $e ) {
+			return [];
+		}
+
+		return $reader->scale( Spacing_Target::class );
 	}
 }

--- a/includes/resources/Design_Tokens/functions.php
+++ b/includes/resources/Design_Tokens/functions.php
@@ -140,7 +140,7 @@ if ( ! function_exists( 'kadence_blocks_variable_spacing_scale' ) ) {
 	 * `--global-kb-spacing-*` emission (includes/init.php) so the shipped spacing literals live once, in
 	 * the baseline, rather than being copied into the emission. Returns an empty array when token
 	 * projection is unavailable or inactive, so callers keep their own fallback. Thin accessor over the
-	 * Scale_Reader.
+	 * Slot_Target_Reader.
 	 *
 	 * @since TBD
 	 *
@@ -148,12 +148,12 @@ if ( ! function_exists( 'kadence_blocks_variable_spacing_scale' ) ) {
 	 */
 	function kadence_blocks_variable_spacing_scale(): array {
 		try {
-			/** @var Scale_Reader $reader */
-			$reader = kadence_blocks()->get( Scale_Reader::class );
+			/** @var Slot_Target_Reader $reader */
+			$reader = kadence_blocks()->get( Slot_Target_Reader::class );
 		} catch ( \Throwable $e ) {
 			return [];
 		}
 
-		return $reader->scale( Spacing_Target::class );
+		return $reader->read( Spacing_Target::class );
 	}
 }


### PR DESCRIPTION
Design Tokens scale bridges [2/3] · stacked on #1156
:video_camera: https://www.loom.com/share/2a6b602906b843f0b0e2c860dda22b05

Reuses the shared `Slot_Target_Reader` to source init.php's editor spacing emission from `primitive.dimension.spacing.*` instead of hardcoded literals, so the shipped spacing values live once in the baseline. Adds `kadence_blocks_variable_spacing_scale()`; when token projection is unavailable the emission is skipped and blocks fall back to their own `var(--global-kb-spacing-*, <rem>)` defaults, so nothing changes.

Stacked follow-up (no separate ticket) — targets #1156's branch.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
