### PR TITLE
refactor(design-tokens): resolve token aliases via the @kadence/helpers hooks seam

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,5 +1,8 @@
 {
     "version": "0.2",
+    "ignoreRegExpList": [
+        "github:[\\w.@/#-]+"
+    ],
     "ignorePaths": [
         "AGENTS.md",
         "package-lock.json",

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@floating-ui/react": "^0.27.12",
         "@hcaptcha/react-hcaptcha": "^1.8.1",
         "@kadence/components": "github:stellarwp/kadence-components#1.1.9",
-        "@kadence/helpers": "github:stellarwp/kadence-helpers#1.1.0",
+        "@kadence/helpers": "github:stellarwp/kadence-helpers#soft-3903-js-resolvetokenalias-alias-aware-kadencehelpers-output",
         "@kadence/icons": "github:stellarwp/kadence-icons#1.1.4",
         "@lottiefiles/dotlottie-react": "^0.15.2",
         "@react-google-maps/api": "^2.12.0",
@@ -649,11 +649,11 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@kadence/components": ["@kadence/components@github:stellarwp/kadence-components#da6ab6f", { "dependencies": { "@floating-ui/react": "^0.26.16", "@wordpress/icons": "^9.49.0", "classnames": "^2.2.6", "colord": "^2.9.3", "react-color": "^2.18.0", "react-select": "^5.10.2" }, "peerDependencies": { "@kadence/helpers": "*", "@kadence/icons": "*", "react": ">=17 <19", "react-dom": ">=17 <19" }, "optionalPeers": ["@kadence/helpers", "@kadence/icons"] }, "stellarwp-kadence-components-da6ab6f", "sha512-Ei/wOwF1Yh1PunwprGDxaVpTQcY4Rn6SdO/BZ9sbI7R3tA0H9zOqIBrXX3o9dcI6oK1WTEVb8Pjj15XHs49Vig=="],
+    "@kadence/components": ["@kadence/components@github:stellarwp/kadence-components#da6ab6f", { "dependencies": { "@floating-ui/react": "^0.26.16", "@wordpress/icons": "^9.49.0", "classnames": "^2.2.6", "colord": "^2.9.3", "react-color": "^2.18.0", "react-select": "^5.10.2" }, "peerDependencies": { "@kadence/helpers": "*", "@kadence/icons": "*", "react": ">=17 <19", "react-dom": ">=17 <19" }, "optionalPeers": ["@kadence/helpers", "@kadence/icons"] }, "stellarwp-kadence-components-da6ab6f"],
 
-    "@kadence/helpers": ["@kadence/helpers@github:stellarwp/kadence-helpers#64f9b4f", { "dependencies": { "@kadence/icons": "git+https://github.com/stellarwp/kadence-icons.git#package" }, "peerDependencies": { "react": ">=17 <19", "react-dom": ">=17 <19" } }, "stellarwp-kadence-helpers-64f9b4f", "sha512-NOyNNQXGhvizVt842l7/I1YlZeb4AYLsYVuVAJ7Oyo8TTtDC+h1Ye7Z1NG8SEMoRK9lZQOK8FtYR4IBbSBM29g=="],
+    "@kadence/helpers": ["@kadence/helpers@github:stellarwp/kadence-helpers#bdceb76", { "dependencies": { "@kadence/icons": "git+https://github.com/stellarwp/kadence-icons.git#1.1.0" }, "peerDependencies": { "@wordpress/hooks": ">=4 <5", "react": ">=17 <19", "react-dom": ">=17 <19" } }, "stellarwp-kadence-helpers-bdceb76"],
 
-    "@kadence/icons": ["@kadence/icons@github:stellarwp/kadence-icons#568e2a9", { "peerDependencies": { "react": ">=17 <19", "react-dom": ">=17 <19" } }, "stellarwp-kadence-icons-568e2a9", "sha512-GM0rSCwxilq9STIBjxHccjPurQAwkKlhgfkV2mc62HTEM3zzW3vk5Vu8tF31OSt3v8Zc6ipISs69OV9kjr2f6Q=="],
+    "@kadence/icons": ["@kadence/icons@github:stellarwp/kadence-icons#568e2a9", { "peerDependencies": { "react": ">=17 <19", "react-dom": ">=17 <19" } }, "stellarwp-kadence-icons-568e2a9"],
 
     "@keyv/bigmap": ["@keyv/bigmap@1.3.1", "", { "dependencies": { "hashery": "^1.4.0", "hookified": "^1.15.0" }, "peerDependencies": { "keyv": "^5.6.0" } }, "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ=="],
 
@@ -3421,7 +3421,7 @@
 
     "@kadence/components/@wordpress/icons": ["@wordpress/icons@9.49.0", "", { "dependencies": { "@babel/runtime": "^7.16.0", "@wordpress/element": "^5.35.0", "@wordpress/primitives": "^3.56.0" } }, "sha512-Z8F+ledkfkcKDuS1c/RkM0dEWdfv2AXs6bCgey89p0atJSscf7qYbMJR9zE5rZ5aqXyFfV0DAFKJEgayNqneNQ=="],
 
-    "@kadence/helpers/@kadence/icons": ["@kadence/icons@github:stellarwp/kadence-icons#71383e2", { "peerDependencies": { "react": ">=17 <19", "react-dom": ">=17 <19" } }, "stellarwp-kadence-icons-71383e2", "sha512-HSFk/BhXV7AEMtUc4kave8zoY+B25tm5lvAsm9xFFQ/lUimee4j8MnmVoXZL8EJxXLNBBclhmGEpbCPPh/6+gA=="],
+    "@kadence/helpers/@kadence/icons": ["@kadence/icons@github:stellarwp/kadence-icons#f056b8b", { "peerDependencies": { "react": ">=17 <19", "react-dom": ">=17 <19" } }, "stellarwp-kadence-icons-f056b8b"],
 
     "@keyv/bigmap/keyv": ["keyv@5.6.0", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -651,7 +651,7 @@
 
     "@kadence/components": ["@kadence/components@github:stellarwp/kadence-components#da6ab6f", { "dependencies": { "@floating-ui/react": "^0.26.16", "@wordpress/icons": "^9.49.0", "classnames": "^2.2.6", "colord": "^2.9.3", "react-color": "^2.18.0", "react-select": "^5.10.2" }, "peerDependencies": { "@kadence/helpers": "*", "@kadence/icons": "*", "react": ">=17 <19", "react-dom": ">=17 <19" }, "optionalPeers": ["@kadence/helpers", "@kadence/icons"] }, "stellarwp-kadence-components-da6ab6f"],
 
-    "@kadence/helpers": ["@kadence/helpers@github:stellarwp/kadence-helpers#bdceb76", { "dependencies": { "@kadence/icons": "git+https://github.com/stellarwp/kadence-icons.git#1.1.0" }, "peerDependencies": { "@wordpress/hooks": ">=4 <5", "react": ">=17 <19", "react-dom": ">=17 <19" } }, "stellarwp-kadence-helpers-bdceb76"],
+    "@kadence/helpers": ["@kadence/helpers@github:stellarwp/kadence-helpers#eb43c57", { "dependencies": { "@kadence/icons": "git+https://github.com/stellarwp/kadence-icons.git#1.1.0" }, "peerDependencies": { "@wordpress/hooks": ">=4 <5", "react": ">=17 <19", "react-dom": ">=17 <19" } }, "stellarwp-kadence-helpers-eb43c57"],
 
     "@kadence/icons": ["@kadence/icons@github:stellarwp/kadence-icons#568e2a9", { "peerDependencies": { "react": ">=17 <19", "react-dom": ">=17 <19" } }, "stellarwp-kadence-icons-568e2a9"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@floating-ui/react": "^0.27.12",
         "@hcaptcha/react-hcaptcha": "^1.8.1",
         "@kadence/components": "github:stellarwp/kadence-components#1.1.9",
-        "@kadence/helpers": "github:stellarwp/kadence-helpers#soft-3903-js-resolvetokenalias-alias-aware-kadencehelpers-output",
+        "@kadence/helpers": "github:stellarwp/kadence-helpers#feature/design-tokens-module",
         "@kadence/icons": "github:stellarwp/kadence-icons#1.1.4",
         "@lottiefiles/dotlottie-react": "^0.15.2",
         "@react-google-maps/api": "^2.12.0",
@@ -651,7 +651,7 @@
 
     "@kadence/components": ["@kadence/components@github:stellarwp/kadence-components#da6ab6f", { "dependencies": { "@floating-ui/react": "^0.26.16", "@wordpress/icons": "^9.49.0", "classnames": "^2.2.6", "colord": "^2.9.3", "react-color": "^2.18.0", "react-select": "^5.10.2" }, "peerDependencies": { "@kadence/helpers": "*", "@kadence/icons": "*", "react": ">=17 <19", "react-dom": ">=17 <19" }, "optionalPeers": ["@kadence/helpers", "@kadence/icons"] }, "stellarwp-kadence-components-da6ab6f"],
 
-    "@kadence/helpers": ["@kadence/helpers@github:stellarwp/kadence-helpers#5801b7a", { "dependencies": { "@kadence/icons": "git+https://github.com/stellarwp/kadence-icons.git#1.1.0" }, "peerDependencies": { "@wordpress/hooks": ">=4 <5", "react": ">=17 <19", "react-dom": ">=17 <19" } }, "stellarwp-kadence-helpers-5801b7a"],
+    "@kadence/helpers": ["@kadence/helpers@github:stellarwp/kadence-helpers#e192350", { "dependencies": { "@kadence/icons": "git+https://github.com/stellarwp/kadence-icons.git#1.1.0" }, "peerDependencies": { "@wordpress/hooks": ">=4 <5", "react": ">=17 <19", "react-dom": ">=17 <19" } }, "stellarwp-kadence-helpers-e192350"],
 
     "@kadence/icons": ["@kadence/icons@github:stellarwp/kadence-icons#568e2a9", { "peerDependencies": { "react": ">=17 <19", "react-dom": ">=17 <19" } }, "stellarwp-kadence-icons-568e2a9"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -651,7 +651,7 @@
 
     "@kadence/components": ["@kadence/components@github:stellarwp/kadence-components#da6ab6f", { "dependencies": { "@floating-ui/react": "^0.26.16", "@wordpress/icons": "^9.49.0", "classnames": "^2.2.6", "colord": "^2.9.3", "react-color": "^2.18.0", "react-select": "^5.10.2" }, "peerDependencies": { "@kadence/helpers": "*", "@kadence/icons": "*", "react": ">=17 <19", "react-dom": ">=17 <19" }, "optionalPeers": ["@kadence/helpers", "@kadence/icons"] }, "stellarwp-kadence-components-da6ab6f"],
 
-    "@kadence/helpers": ["@kadence/helpers@github:stellarwp/kadence-helpers#eb43c57", { "dependencies": { "@kadence/icons": "git+https://github.com/stellarwp/kadence-icons.git#1.1.0" }, "peerDependencies": { "@wordpress/hooks": ">=4 <5", "react": ">=17 <19", "react-dom": ">=17 <19" } }, "stellarwp-kadence-helpers-eb43c57"],
+    "@kadence/helpers": ["@kadence/helpers@github:stellarwp/kadence-helpers#5801b7a", { "dependencies": { "@kadence/icons": "git+https://github.com/stellarwp/kadence-icons.git#1.1.0" }, "peerDependencies": { "@wordpress/hooks": ">=4 <5", "react": ">=17 <19", "react-dom": ">=17 <19" } }, "stellarwp-kadence-helpers-5801b7a"],
 
     "@kadence/icons": ["@kadence/icons@github:stellarwp/kadence-icons#568e2a9", { "peerDependencies": { "react": ">=17 <19", "react-dom": ">=17 <19" } }, "stellarwp-kadence-icons-568e2a9"],
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,24 @@
+/**
+ * Jest configuration for unit tests.
+ *
+ * Extends the @wordpress/scripts default and forces a single `@wordpress/hooks` instance. In
+ * production `@wordpress/hooks` is externalized to the one `wp.hooks` global, so the filter registry
+ * is shared between this plugin and the bundled `@kadence/helpers` copy. Under jest, node resolution
+ * would otherwise load a nested `@wordpress/hooks` from `node_modules/@kadence/helpers/node_modules`,
+ * splitting the registry so helper `applyFilters` calls never see filters this plugin registered.
+ * Mapping every `@wordpress/hooks` import to the top-level copy mirrors the production single-instance
+ * behavior.
+ */
+const path = require('path');
+const baseConfig = require('@wordpress/scripts/config/jest-unit.config.js');
+
+module.exports = {
+	...baseConfig,
+	moduleNameMapper: {
+		...(baseConfig.moduleNameMapper || {}),
+		'^@wordpress/hooks$': path.join(
+			path.dirname(require.resolve('@wordpress/hooks/package.json')),
+			'build/index.cjs'
+		),
+	},
+};

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"@floating-ui/react": "^0.27.12",
 		"@hcaptcha/react-hcaptcha": "^1.8.1",
 		"@kadence/components": "github:stellarwp/kadence-components#1.1.9",
-		"@kadence/helpers": "github:stellarwp/kadence-helpers#1.1.0",
+		"@kadence/helpers": "github:stellarwp/kadence-helpers#soft-3903-js-resolvetokenalias-alias-aware-kadencehelpers-output",
 		"@kadence/icons": "github:stellarwp/kadence-icons#1.1.4",
 		"@lottiefiles/dotlottie-react": "^0.15.2",
 		"@react-google-maps/api": "^2.12.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"@floating-ui/react": "^0.27.12",
 		"@hcaptcha/react-hcaptcha": "^1.8.1",
 		"@kadence/components": "github:stellarwp/kadence-components#1.1.9",
-		"@kadence/helpers": "github:stellarwp/kadence-helpers#soft-3903-js-resolvetokenalias-alias-aware-kadencehelpers-output",
+		"@kadence/helpers": "github:stellarwp/kadence-helpers#feature/design-tokens-module",
 		"@kadence/icons": "github:stellarwp/kadence-icons#1.1.4",
 		"@lottiefiles/dotlottie-react": "^0.15.2",
 		"@react-google-maps/api": "^2.12.0",

--- a/src/blocks/spacer/__tests__/save-markup.test.js
+++ b/src/blocks/spacer/__tests__/save-markup.test.js
@@ -45,10 +45,7 @@ const { renderToStaticMarkup } = require('react-dom/server');
 // KadenceColorOutput module directly to exercise the real helper (and its `@wordpress/hooks` seam)
 // without the barrel. `@kadence/helpers/package.json` is exposed by the package `exports` map.
 const helpersRoot = path.dirname(require.resolve('@kadence/helpers/package.json'));
-const KadenceColorOutput = require(path.join(
-	helpersRoot,
-	'dist/cjs/kadence-color-output/index.js'
-)).default;
+const KadenceColorOutput = require(path.join(helpersRoot, 'dist/cjs/kadence-color-output/index.js')).default;
 
 // SvgPattern reads `wp.element.Component` at module load, so provide the global before requiring it.
 global.wp = { element: require('@wordpress/element') };

--- a/src/blocks/spacer/__tests__/save-markup.test.js
+++ b/src/blocks/spacer/__tests__/save-markup.test.js
@@ -1,16 +1,30 @@
 /* eslint-env jest */
 /**
- * Spacer save-markup coupling for design-token aliases.
+ * Spacer stripe-divider: a design-token alias must survive into the SAVED block markup.
  *
- * The audit (SOFT-3899) flagged that `kadence/spacer` renders `dividerColor` through
- * `KadenceColorOutput` into an SVG `stroke=` attribute in the SAVED markup
- * (save.js -> svg-pattern.js). Now that `KadenceColorOutput` is alias-aware, an aliased
- * `dividerColor` must serialize into that markup as a valid `var(--kb-token--<id>)` string, and a
- * non-alias color must remain byte-identical (the change is strictly additive).
+ * Most Kadence blocks deliver their design values as CSS injected out-of-band in a `<style>` tag, so
+ * aliasing them is invisible to block validation. `kadence/spacer` is the exception this test guards:
+ * its stripe divider passes `dividerColor` through `KadenceColorOutput` and writes the result directly
+ * into the SVG `stroke=` presentation attribute of the block's serialized `save.js` output
+ * (save.js -> svg-pattern.js). That means the color is baked into stored post content, not just
+ * injected CSS — so whatever `KadenceColorOutput` returns for an aliased `dividerColor` is exactly
+ * what gets persisted and later re-validated by Gutenberg.
  *
- * A full Gutenberg registerBlockType/serialize/parse round-trip is not exercised here because
- * `@wordpress/blocks` is externalized (provided by WP core) and not resolvable in this test harness;
- * this asserts the exact static-markup line the audit called out.
+ * The library helper is design-token-agnostic; alias resolution only happens because this plugin
+ * registers a listener on the helper's `@wordpress/hooks` seam (`registerTokenAliasFilters`). So this
+ * exercises the full path with that filter active and asserts three things about the serialized SVG:
+ *   1. an aliased `dividerColor` becomes a valid `var(--kb-token--<id>)` in the `stroke` attribute
+ *      (a resolvable CSS var, not a raw `{dot.alias}` brace string that would render nothing);
+ *   2. a hex color is emitted verbatim; and
+ *   3. a palette slug still becomes `var(--global-paletteN)`.
+ * (2) and (3) are the regression guard: because the change is strictly additive, existing saved
+ * spacers and newly-aliased ones both serialize the same shape they always have, so block validation
+ * does not trip on unexpected content.
+ *
+ * This renders the real save-markup component directly rather than doing a full
+ * registerBlockType -> serialize -> parse round-trip: `@wordpress/blocks` is externalized (provided by
+ * WordPress core) and unresolvable in this jest harness, so the SVG string produced here IS the
+ * markup line that would be persisted.
  */
 import { TextEncoder, TextDecoder } from 'util';
 import path from 'path';

--- a/src/blocks/spacer/__tests__/save-markup.test.js
+++ b/src/blocks/spacer/__tests__/save-markup.test.js
@@ -26,9 +26,10 @@
  * value is not parsed as a CSS declaration), so a token — OR a palette — color delivered this way may
  * not actually paint in the browser. That is a pre-existing limitation of the stripe divider's
  * `stroke=` delivery, not something introduced here; making a token (or palette) stripe truly render
- * means moving the color into a CSS context, which is out of scope for this ticket (residual JS seam)
- * and is why the spacer `dividerColor` is held out of the initial alias picker scope. What this test
- * locks in is that the seam is additive and deterministic at the save-markup boundary.
+ * means moving the color into a CSS context — out of scope here and tracked in SOFT-3909 (residual JS
+ * seam / per-block rollout), which is why the spacer `dividerColor` is held out of the initial alias
+ * picker scope. What this test locks in is that the seam is additive and deterministic at the
+ * save-markup boundary.
  *
  * This renders the real save-markup component directly rather than doing a full
  * registerBlockType -> serialize -> parse round-trip: `@wordpress/blocks` is externalized (provided by

--- a/src/blocks/spacer/__tests__/save-markup.test.js
+++ b/src/blocks/spacer/__tests__/save-markup.test.js
@@ -1,0 +1,89 @@
+/* eslint-env jest */
+/**
+ * Spacer save-markup coupling for design-token aliases.
+ *
+ * The audit (SOFT-3899) flagged that `kadence/spacer` renders `dividerColor` through
+ * `KadenceColorOutput` into an SVG `stroke=` attribute in the SAVED markup
+ * (save.js -> svg-pattern.js). Now that `KadenceColorOutput` is alias-aware, an aliased
+ * `dividerColor` must serialize into that markup as a valid `var(--kb-token--<id>)` string, and a
+ * non-alias color must remain byte-identical (the change is strictly additive).
+ *
+ * A full Gutenberg registerBlockType/serialize/parse round-trip is not exercised here because
+ * `@wordpress/blocks` is externalized (provided by WP core) and not resolvable in this test harness;
+ * this asserts the exact static-markup line the audit called out.
+ */
+import { TextEncoder, TextDecoder } from 'util';
+import path from 'path';
+import { createElement } from '@wordpress/element';
+
+// jsdom does not define TextEncoder/TextDecoder, which react-dom/server needs at import; polyfill
+// them before requiring it (require, not import, so this runs first).
+if (typeof global.TextEncoder === 'undefined') {
+	global.TextEncoder = TextEncoder;
+	global.TextDecoder = TextDecoder;
+}
+const { renderToStaticMarkup } = require('react-dom/server');
+
+// The `@kadence/helpers` barrel eagerly pulls in sibling helpers whose deps are externalized by the
+// plugin's webpack build (and so are unresolvable under jest). Load the single compiled
+// KadenceColorOutput module directly — it has no external deps — to exercise the real alias-aware
+// helper without the barrel. `@kadence/helpers/package.json` is exposed by the package `exports` map.
+const helpersRoot = path.dirname(require.resolve('@kadence/helpers/package.json'));
+const KadenceColorOutput = require(path.join(
+	helpersRoot,
+	'dist/cjs/kadence-color-output/index.js'
+)).default;
+
+// SvgPattern reads `wp.element.Component` at module load, so provide the global before requiring it.
+global.wp = { element: require('@wordpress/element') };
+const SvgPattern = require('../svg-pattern').default;
+
+/**
+ * Render the spacer stripe-divider SVG for a given divider color, exactly as save.js does.
+ *
+ * @param {string} dividerColor The block's `dividerColor` attribute (literal, palette slug, or alias).
+ * @return {string} The static SVG markup.
+ */
+function renderDivider(dividerColor) {
+	return renderToStaticMarkup(
+		createElement(SvgPattern, {
+			uniqueID: 'test',
+			color: KadenceColorOutput(dividerColor),
+			opacity: 100,
+			rotate: 40,
+			strokeWidth: 9,
+			strokeGap: 9,
+		})
+	);
+}
+
+describe('spacer stripe divider save markup', () => {
+	// SvgPattern renders the hyphenated SVG DOM prop `stroke-width` (its real, unchanged saved-markup
+	// shape), which React warns about once. That warning predates and is unrelated to aliasing, so
+	// swallow console.error here (@wordpress/jest-console would otherwise fail the test on it).
+	let errorSpy;
+	beforeEach(() => {
+		errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+	});
+	afterEach(() => {
+		errorSpy.mockRestore();
+	});
+
+	it('serializes an aliased dividerColor into the SVG stroke as a token var', () => {
+		const markup = renderDivider('{semantic.color.divider}');
+
+		expect(markup).toContain('stroke="var(--kb-token--semantic--color--divider)"');
+	});
+
+	it('serializes a hex dividerColor unchanged (additive: no regression)', () => {
+		const markup = renderDivider('#eeeeee');
+
+		expect(markup).toContain('stroke="#eeeeee"');
+	});
+
+	it('serializes a palette dividerColor as a global var (additive: no regression)', () => {
+		const markup = renderDivider('palette3');
+
+		expect(markup).toContain('stroke="var(--global-palette3)"');
+	});
+});

--- a/src/blocks/spacer/__tests__/save-markup.test.js
+++ b/src/blocks/spacer/__tests__/save-markup.test.js
@@ -15,6 +15,8 @@
 import { TextEncoder, TextDecoder } from 'util';
 import path from 'path';
 import { createElement } from '@wordpress/element';
+import { removeFilter } from '@wordpress/hooks';
+import { registerTokenAliasFilters } from '../../../extension/design-tokens/register-filters';
 
 // jsdom does not define TextEncoder/TextDecoder, which react-dom/server needs at import; polyfill
 // them before requiring it (require, not import, so this runs first).
@@ -26,8 +28,8 @@ const { renderToStaticMarkup } = require('react-dom/server');
 
 // The `@kadence/helpers` barrel eagerly pulls in sibling helpers whose deps are externalized by the
 // plugin's webpack build (and so are unresolvable under jest). Load the single compiled
-// KadenceColorOutput module directly — it has no external deps — to exercise the real alias-aware
-// helper without the barrel. `@kadence/helpers/package.json` is exposed by the package `exports` map.
+// KadenceColorOutput module directly to exercise the real helper (and its `@wordpress/hooks` seam)
+// without the barrel. `@kadence/helpers/package.json` is exposed by the package `exports` map.
 const helpersRoot = path.dirname(require.resolve('@kadence/helpers/package.json'));
 const KadenceColorOutput = require(path.join(
 	helpersRoot,
@@ -63,9 +65,14 @@ describe('spacer stripe divider save markup', () => {
 	// swallow console.error here (@wordpress/jest-console would otherwise fail the test on it).
 	let errorSpy;
 	beforeEach(() => {
+		// The plugin registers alias resolution on the helper's filter seam; an aliased dividerColor
+		// only resolves to a token var because this listener is active.
+		registerTokenAliasFilters();
 		errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 	});
 	afterEach(() => {
+		removeFilter('kadence.helpers.colorValue', 'kadence-blocks/token-alias');
+		removeFilter('kadence.helpers.dimensionValue', 'kadence-blocks/token-alias');
 		errorSpy.mockRestore();
 	});
 

--- a/src/blocks/spacer/__tests__/save-markup.test.js
+++ b/src/blocks/spacer/__tests__/save-markup.test.js
@@ -12,14 +12,23 @@
  *
  * The library helper is design-token-agnostic; alias resolution only happens because this plugin
  * registers a listener on the helper's `@wordpress/hooks` seam (`registerTokenAliasFilters`). So this
- * exercises the full path with that filter active and asserts three things about the serialized SVG:
- *   1. an aliased `dividerColor` becomes a valid `var(--kb-token--<id>)` in the `stroke` attribute
- *      (a resolvable CSS var, not a raw `{dot.alias}` brace string that would render nothing);
+ * exercises the full path with that filter active and asserts what gets SERIALIZED into the SVG:
+ *   1. an aliased `dividerColor` becomes `var(--kb-token--<id>)` in the `stroke` attribute — the same
+ *      var *shape* a palette slug already produces (`var(--global-paletteN)`), just for a token;
  *   2. a hex color is emitted verbatim; and
  *   3. a palette slug still becomes `var(--global-paletteN)`.
  * (2) and (3) are the regression guard: because the change is strictly additive, existing saved
- * spacers and newly-aliased ones both serialize the same shape they always have, so block validation
- * does not trip on unexpected content.
+ * spacers and newly-aliased ones serialize the same shape they always have, so block validation does
+ * not trip on unexpected content.
+ *
+ * IMPORTANT — this asserts *serialization*, not rendering. `var()` is generally NOT substituted inside
+ * an SVG presentation attribute like `stroke=` (it is a CSS-value function; a presentation-attribute
+ * value is not parsed as a CSS declaration), so a token — OR a palette — color delivered this way may
+ * not actually paint in the browser. That is a pre-existing limitation of the stripe divider's
+ * `stroke=` delivery, not something introduced here; making a token (or palette) stripe truly render
+ * means moving the color into a CSS context, which is out of scope for this ticket (residual JS seam)
+ * and is why the spacer `dividerColor` is held out of the initial alias picker scope. What this test
+ * locks in is that the seam is additive and deterministic at the save-markup boundary.
  *
  * This renders the real save-markup component directly rather than doing a full
  * registerBlockType -> serialize -> parse round-trip: `@wordpress/blocks` is externalized (provided by
@@ -40,10 +49,13 @@ if (typeof global.TextEncoder === 'undefined') {
 }
 const { renderToStaticMarkup } = require('react-dom/server');
 
-// The `@kadence/helpers` barrel eagerly pulls in sibling helpers whose deps are externalized by the
-// plugin's webpack build (and so are unresolvable under jest). Load the single compiled
-// KadenceColorOutput module directly to exercise the real helper (and its `@wordpress/hooks` seam)
-// without the barrel. `@kadence/helpers/package.json` is exposed by the package `exports` map.
+// Import just the compiled KadenceColorOutput leaf module, not the `@kadence/helpers` barrel.
+// Evaluating the barrel would load every sibling helper, and several import WordPress packages the
+// plugin externalizes to `wp.*` globals at build time (e.g. `@wordpress/api-fetch`, `@wordpress/data`)
+// and never installs in node_modules — so the barrel throws "Cannot find module" under jest. The leaf
+// module pulls only its own minimal deps while still exercising the real helper (and its
+// `@wordpress/hooks` seam). The package `exports` map only exposes `.` and `./package.json`, so we
+// resolve the package root via package.json and join the compiled file path.
 const helpersRoot = path.dirname(require.resolve('@kadence/helpers/package.json'));
 const KadenceColorOutput = require(path.join(helpersRoot, 'dist/cjs/kadence-color-output/index.js')).default;
 

--- a/src/early-filters.js
+++ b/src/early-filters.js
@@ -16,6 +16,11 @@ import { useDispatch, select } from '@wordpress/data';
 import { VariantPicker, blockVariants, activeSet } from './extension/variant-picker';
 import { VariantActions } from './extension/variant-picker/VariantActions';
 import { TokenSetPicker, selectableSets } from './extension/token-set-picker';
+import { registerTokenAliasFilters } from './extension/design-tokens/register-filters';
+
+// Make the @kadence/helpers output helpers design-token aware by resolving `{dot.alias}` values to
+// their `var(--kb-token--<id>)` reference through the library's filter seam.
+registerTokenAliasFilters();
 
 /**
  * Add animation attributes

--- a/src/extension/design-tokens/__tests__/alias-css-output.test.js
+++ b/src/extension/design-tokens/__tests__/alias-css-output.test.js
@@ -1,0 +1,105 @@
+/* eslint-env jest */
+/**
+ * Blocks-side integration: the alias-aware CSS builder as the plugin consumes it.
+ *
+ * Nearly every Kadence block generates its injected `<style>` through `KadenceBlocksCSS`
+ * (`@kadence/helpers`). These tests load the COMPILED package the plugin actually ships (not the
+ * source) and assert that a `{dot.alias}` design value resolves to a bare `var(--kb-token--<id>)`
+ * across the dimension / border-radius / shadow paths, while every literal stays byte-identical (the
+ * change is strictly additive).
+ *
+ * Loaded via the package `exports`-exposed `package.json` + a direct path to the compiled module,
+ * because the `@kadence/helpers` barrel eagerly pulls in siblings whose deps are webpack-externalized
+ * and unresolvable under jest.
+ */
+import path from 'path';
+
+const helpersRoot = path.dirname(require.resolve('@kadence/helpers/package.json'));
+const KadenceBlocksCSS = require(path.join(helpersRoot, 'dist/cjs/css/index.js')).default;
+
+const ALIAS = '{semantic.radius.media}';
+const ALIAS_VAR = 'var(--kb-token--semantic--radius--media)';
+
+describe('KadenceBlocksCSS render_measure_output (padding/margin/border-radius/border-width)', () => {
+	it('emits a single aliased corner as a bare var and literal corners with their unit', () => {
+		const css = new KadenceBlocksCSS();
+		css.render_measure_output([ALIAS, 8, '', ''], null, null, 'Desktop', 'border-radius', 'px', {}, true);
+
+		expect(css._css).toContain(`border-top-left-radius:${ALIAS_VAR};`);
+		expect(css._css).toContain('border-top-right-radius:8px;');
+	});
+
+	it('emits every corner as a var when all four sides are aliases', () => {
+		const css = new KadenceBlocksCSS();
+		css.render_measure_output([ALIAS, ALIAS, ALIAS, ALIAS], null, null, 'Desktop', 'border-radius', 'px', {}, true);
+
+		// border-radius is a "special" property that also emits vendor-prefixed variants; assert the
+		// standard corner longhands each resolve to the token var.
+		expect(css._css).toContain(`border-top-left-radius:${ALIAS_VAR};`);
+		expect(css._css).toContain(`border-top-right-radius:${ALIAS_VAR};`);
+		expect(css._css).toContain(`border-bottom-right-radius:${ALIAS_VAR};`);
+		expect(css._css).toContain(`border-bottom-left-radius:${ALIAS_VAR};`);
+	});
+
+	it('is byte-identical for a plain numeric padding array (no regression)', () => {
+		const css = new KadenceBlocksCSS();
+		css.render_measure_output([10, 20, 30, 40], null, null, 'Desktop', 'padding', 'px', {}, true);
+
+		expect(css._css).toBe(
+			'padding-top:10px;padding-right:20px;padding-bottom:30px;padding-left:40px;'
+		);
+	});
+
+	it('resolves an aliased border-width side to a var (no unit appended)', () => {
+		const css = new KadenceBlocksCSS();
+		css.render_measure_output([ALIAS, '', '', ''], null, null, 'Desktop', 'border-width', 'px', {}, true);
+
+		expect(css._css).toContain(`border-top-width:${ALIAS_VAR};`);
+	});
+});
+
+describe('KadenceBlocksCSS render_size / render_half_size', () => {
+	it('render_size resolves an alias to a bare var and a literal to value+unit', () => {
+		const css = new KadenceBlocksCSS();
+
+		expect(css.render_size(ALIAS, 'px')).toBe(ALIAS_VAR);
+		expect(css.render_size(24, 'px')).toBe('24px');
+	});
+
+	it('render_half_size resolves an alias to a bare var and a literal to calc()', () => {
+		const css = new KadenceBlocksCSS();
+
+		expect(css.render_half_size(ALIAS, 'px')).toBe(ALIAS_VAR);
+		expect(css.render_half_size(12, 'px')).toBe('calc(12px / 2)');
+	});
+});
+
+describe('KadenceBlocksCSS render_shadow', () => {
+	it('resolves an aliased shadow color while keeping numeric offsets literal', () => {
+		const css = new KadenceBlocksCSS();
+		const shadow = css.render_shadow({
+			inset: false,
+			hOffset: 0,
+			vOffset: 4,
+			blur: 12,
+			spread: 0,
+			color: '{semantic.color.shadow}',
+		});
+
+		expect(shadow).toBe('0px 4px 12px 0px var(--kb-token--semantic--color--shadow)');
+	});
+
+	it('is byte-identical for a literal-colored shadow (no regression)', () => {
+		const css = new KadenceBlocksCSS();
+		const shadow = css.render_shadow({
+			inset: false,
+			hOffset: 0,
+			vOffset: 4,
+			blur: 12,
+			spread: 0,
+			color: '#000000',
+		});
+
+		expect(shadow).toBe('0px 4px 12px 0px #000000');
+	});
+});

--- a/src/extension/design-tokens/__tests__/alias-css-output.test.js
+++ b/src/extension/design-tokens/__tests__/alias-css-output.test.js
@@ -46,7 +46,7 @@ describe('KadenceBlocksCSS render_measure_output (padding/margin/border-radius/b
 		css.render_measure_output([ALIAS, ALIAS, ALIAS, ALIAS], null, null, 'Desktop', 'border-radius', 'px', {}, true);
 
 		// border-radius is a "special" property that also emits vendor-prefixed variants; assert the
-		// standard corner longhands each resolve to the token var.
+		// four standard corner properties each resolve to the token var.
 		expect(css._css).toContain(`border-top-left-radius:${ALIAS_VAR};`);
 		expect(css._css).toContain(`border-top-right-radius:${ALIAS_VAR};`);
 		expect(css._css).toContain(`border-bottom-right-radius:${ALIAS_VAR};`);
@@ -57,9 +57,7 @@ describe('KadenceBlocksCSS render_measure_output (padding/margin/border-radius/b
 		const css = new KadenceBlocksCSS();
 		css.render_measure_output([10, 20, 30, 40], null, null, 'Desktop', 'padding', 'px', {}, true);
 
-		expect(css._css).toBe(
-			'padding-top:10px;padding-right:20px;padding-bottom:30px;padding-left:40px;'
-		);
+		expect(css._css).toBe('padding-top:10px;padding-right:20px;padding-bottom:30px;padding-left:40px;');
 	});
 
 	it('resolves an aliased border-width side to a var (no unit appended)', () => {

--- a/src/extension/design-tokens/__tests__/alias-css-output.test.js
+++ b/src/extension/design-tokens/__tests__/alias-css-output.test.js
@@ -1,24 +1,36 @@
 /* eslint-env jest */
 /**
- * Blocks-side integration: the alias-aware CSS builder as the plugin consumes it.
+ * Blocks-side integration: the alias-aware CSS builder as the plugin consumes it, end to end.
  *
  * Nearly every Kadence block generates its injected `<style>` through `KadenceBlocksCSS`
- * (`@kadence/helpers`). These tests load the COMPILED package the plugin actually ships (not the
- * source) and assert that a `{dot.alias}` design value resolves to a bare `var(--kb-token--<id>)`
- * across the dimension / border-radius / shadow paths, while every literal stays byte-identical (the
- * change is strictly additive).
+ * (`@kadence/helpers`). The library is token-agnostic — it exposes a `@wordpress/hooks` seam — so this
+ * loads the COMPILED package the plugin actually ships, registers the plugin's real alias filter
+ * (`registerTokenAliasFilters`), and asserts a `{dot.alias}` design value resolves to a bare
+ * `var(--kb-token--<id>)` across the dimension / border-radius paths, while every literal stays
+ * byte-identical. Both sides of the seam are exercised: the compiled helper's `applyFilters` and the
+ * plugin's `addFilter` share the one `wp.hooks` registry.
  *
- * Loaded via the package `exports`-exposed `package.json` + a direct path to the compiled module,
- * because the `@kadence/helpers` barrel eagerly pulls in siblings whose deps are webpack-externalized
- * and unresolvable under jest.
+ * The compiled module is loaded via a direct path (the `@kadence/helpers` barrel eagerly pulls in
+ * siblings whose deps are webpack-externalized and unresolvable under jest).
  */
 import path from 'path';
+import { removeFilter } from '@wordpress/hooks';
+import { registerTokenAliasFilters } from '../register-filters';
 
 const helpersRoot = path.dirname(require.resolve('@kadence/helpers/package.json'));
 const KadenceBlocksCSS = require(path.join(helpersRoot, 'dist/cjs/css/index.js')).default;
 
 const ALIAS = '{semantic.radius.media}';
 const ALIAS_VAR = 'var(--kb-token--semantic--radius--media)';
+
+beforeEach(() => {
+	registerTokenAliasFilters();
+});
+
+afterEach(() => {
+	removeFilter('kadence.helpers.colorValue', 'kadence-blocks/token-alias');
+	removeFilter('kadence.helpers.dimensionValue', 'kadence-blocks/token-alias');
+});
 
 describe('KadenceBlocksCSS render_measure_output (padding/margin/border-radius/border-width)', () => {
 	it('emits a single aliased corner as a bare var and literal corners with their unit', () => {
@@ -101,5 +113,16 @@ describe('KadenceBlocksCSS render_shadow', () => {
 		});
 
 		expect(shadow).toBe('0px 4px 12px 0px #000000');
+	});
+});
+
+describe('the seam is what resolves the alias', () => {
+	it('leaves an alias unresolved when the plugin filter is not registered', () => {
+		removeFilter('kadence.helpers.colorValue', 'kadence-blocks/token-alias');
+		removeFilter('kadence.helpers.dimensionValue', 'kadence-blocks/token-alias');
+
+		// With no listener, the agnostic helper cannot recognize the alias: render_size falls through
+		// its numeric/variable branches and does not emit the token var.
+		expect(new KadenceBlocksCSS().render_size(ALIAS, 'px')).not.toBe(ALIAS_VAR);
 	});
 });

--- a/src/extension/design-tokens/__tests__/alias.test.js
+++ b/src/extension/design-tokens/__tests__/alias.test.js
@@ -1,10 +1,20 @@
 /* eslint-env jest */
 /**
- * Design-token alias primitives + PHP/JS conformance.
+ * Design-token alias primitives, and their byte-for-byte parity with the PHP side.
  *
- * These guard byte-for-byte parity with the PHP transform (`Alias` + `Css_Var::from_id`) via a shared
- * fixture (seeding SOFT-3904), plus the recognition edge cases. The primitives live in this plugin
- * (not `@kadence/helpers`) so the shared library stays token-agnostic.
+ * A block control stores a design-token reference as a whole-string alias, `{dot.alias}`. That same
+ * value is resolved twice: in PHP for the front end (`Alias::path_of` + `Css_Var::from_id`) and in
+ * this JS for the editor preview. If the two ever disagree by a single character, an authored token
+ * would render one way in the editor and another on the front end. These tests lock the JS side to
+ * the PHP output:
+ *   - `isTokenAlias` recognizes exactly what PHP's `Alias::is_alias` recognizes (well-formed braces
+ *     only; non-strings and malformed/partial braces rejected);
+ *   - `resolveTokenAlias` produces the exact `var(--kb-token--<id>)` string PHP emits (dots -> `--`,
+ *     no fallback literal), and passes any non-alias through untouched.
+ *
+ * The expected pairs are kept in a JSON fixture that is intended to be shared with a PHP test so both
+ * languages assert against one source of truth. The primitives live in this plugin (not
+ * `@kadence/helpers`) so the shared library carries no design-token knowledge.
  */
 import { isTokenAlias, resolveTokenAlias, TOKEN_VAR_PREFIX } from '../alias';
 import conformance from './fixtures/token-alias-conformance.json';
@@ -18,12 +28,9 @@ describe('isTokenAlias', () => {
 		expect(isTokenAlias(value)).toBe(false);
 	});
 
-	it.each([null, undefined, 5, 0, true, false, ['{a.b}'], { a: 1 }])(
-		'rejects the non-string %p',
-		(value) => {
-			expect(isTokenAlias(value)).toBe(false);
-		}
-	);
+	it.each([null, undefined, 5, 0, true, false, ['{a.b}'], { a: 1 }])('rejects the non-string %p', (value) => {
+		expect(isTokenAlias(value)).toBe(false);
+	});
 
 	it('rejects an alias with a trailing newline (strict, unlike PHP)', () => {
 		expect(isTokenAlias('{a.b}\n')).toBe(false);
@@ -31,12 +38,9 @@ describe('isTokenAlias', () => {
 });
 
 describe('resolveTokenAlias', () => {
-	it.each(conformance.aliases.map(({ alias, cssVar }) => [alias, cssVar]))(
-		'resolves %s to %s',
-		(alias, cssVar) => {
-			expect(resolveTokenAlias(alias)).toBe(cssVar);
-		}
-	);
+	it.each(conformance.aliases.map(({ alias, cssVar }) => [alias, cssVar]))('resolves %s to %s', (alias, cssVar) => {
+		expect(resolveTokenAlias(alias)).toBe(cssVar);
+	});
 
 	it('builds the var from the TOKEN_VAR_PREFIX constant, with no fallback literal', () => {
 		expect(TOKEN_VAR_PREFIX).toBe('--kb-token--');

--- a/src/extension/design-tokens/__tests__/alias.test.js
+++ b/src/extension/design-tokens/__tests__/alias.test.js
@@ -1,0 +1,54 @@
+/* eslint-env jest */
+/**
+ * Design-token alias primitives + PHP/JS conformance.
+ *
+ * These guard byte-for-byte parity with the PHP transform (`Alias` + `Css_Var::from_id`) via a shared
+ * fixture (seeding SOFT-3904), plus the recognition edge cases. The primitives live in this plugin
+ * (not `@kadence/helpers`) so the shared library stays token-agnostic.
+ */
+import { isTokenAlias, resolveTokenAlias, TOKEN_VAR_PREFIX } from '../alias';
+import conformance from './fixtures/token-alias-conformance.json';
+
+describe('isTokenAlias', () => {
+	it.each(conformance.aliases.map(({ alias }) => alias))('recognizes %s as an alias', (alias) => {
+		expect(isTokenAlias(alias)).toBe(true);
+	});
+
+	it.each(conformance.nonAliases)('rejects the non-alias %p', (value) => {
+		expect(isTokenAlias(value)).toBe(false);
+	});
+
+	it.each([null, undefined, 5, 0, true, false, ['{a.b}'], { a: 1 }])(
+		'rejects the non-string %p',
+		(value) => {
+			expect(isTokenAlias(value)).toBe(false);
+		}
+	);
+
+	it('rejects an alias with a trailing newline (strict, unlike PHP)', () => {
+		expect(isTokenAlias('{a.b}\n')).toBe(false);
+	});
+});
+
+describe('resolveTokenAlias', () => {
+	it.each(conformance.aliases.map(({ alias, cssVar }) => [alias, cssVar]))(
+		'resolves %s to %s',
+		(alias, cssVar) => {
+			expect(resolveTokenAlias(alias)).toBe(cssVar);
+		}
+	);
+
+	it('builds the var from the TOKEN_VAR_PREFIX constant, with no fallback literal', () => {
+		expect(TOKEN_VAR_PREFIX).toBe('--kb-token--');
+		expect(resolveTokenAlias('{a.b}')).toBe(`var(${TOKEN_VAR_PREFIX}a--b)`);
+		expect(resolveTokenAlias('{semantic.radius.media}')).not.toContain(',');
+	});
+
+	it.each(conformance.nonAliases)('passes the non-alias %p through unchanged', (value) => {
+		expect(resolveTokenAlias(value)).toBe(value);
+	});
+
+	it.each([null, undefined, 5, ['{a.b}']])('passes the non-string %p through unchanged', (value) => {
+		expect(resolveTokenAlias(value)).toBe(value);
+	});
+});

--- a/src/extension/design-tokens/__tests__/fixtures/token-alias-conformance.json
+++ b/src/extension/design-tokens/__tests__/fixtures/token-alias-conformance.json
@@ -1,5 +1,5 @@
 {
-	"_comment": "Shared PHP<->JS conformance fixture for the {dot.alias} -> var(--kb-token--<id>) transform. The JS side asserts resolveTokenAlias(alias) === cssVar and isTokenAlias(alias) === true; the PHP side (Alias::path_of + Css_Var::from_id) must produce byte-identical output. Inputs are canonical and carry no trailing whitespace. Seeds SOFT-3904 next to the PHP transform.",
+	"_comment": "One source of truth for the {dot.alias} -> var(--kb-token--<id>) transform, shared so the JS and PHP implementations can assert against the same pairs and cannot drift. The JS side asserts resolveTokenAlias(alias) === cssVar and isTokenAlias(alias) === true; the PHP side (Alias::path_of + Css_Var::from_id) must produce byte-identical output for each. 'nonAliases' must be rejected by both. Inputs are canonical and carry no trailing whitespace.",
 	"aliases": [
 		{ "alias": "{semantic.radius.media}", "cssVar": "var(--kb-token--semantic--radius--media)" },
 		{ "alias": "{primitive.color.brand.primary}", "cssVar": "var(--kb-token--primitive--color--brand--primary)" },

--- a/src/extension/design-tokens/__tests__/fixtures/token-alias-conformance.json
+++ b/src/extension/design-tokens/__tests__/fixtures/token-alias-conformance.json
@@ -1,0 +1,23 @@
+{
+	"_comment": "Shared PHP<->JS conformance fixture for the {dot.alias} -> var(--kb-token--<id>) transform. The JS side asserts resolveTokenAlias(alias) === cssVar and isTokenAlias(alias) === true; the PHP side (Alias::path_of + Css_Var::from_id) must produce byte-identical output. Inputs are canonical and carry no trailing whitespace. Seeds SOFT-3904 next to the PHP transform.",
+	"aliases": [
+		{ "alias": "{semantic.radius.media}", "cssVar": "var(--kb-token--semantic--radius--media)" },
+		{ "alias": "{primitive.color.brand.primary}", "cssVar": "var(--kb-token--primitive--color--brand--primary)" },
+		{ "alias": "{semantic.color.button-primary-bg}", "cssVar": "var(--kb-token--semantic--color--button-primary-bg)" },
+		{ "alias": "{primitive.spacing.md}", "cssVar": "var(--kb-token--primitive--spacing--md)" },
+		{ "alias": "{a}", "cssVar": "var(--kb-token--a)" }
+	],
+	"nonAliases": [
+		"palette1",
+		"#3182CE",
+		"1px solid red",
+		"1px solid {semantic.color.brand}",
+		"{bad path}",
+		"{unclosed",
+		"unopened}",
+		"{}",
+		"16px",
+		"10",
+		""
+	]
+}

--- a/src/extension/design-tokens/alias.js
+++ b/src/extension/design-tokens/alias.js
@@ -1,0 +1,60 @@
+/**
+ * Design-token alias primitives (JS peer of the PHP `Alias` + `Css_Var`).
+ *
+ * A block control can store a design-token reference as a whole-string alias, `{dot.alias}`, instead
+ * of a frozen literal. These pure, data-free helpers recognize such a value and transform it to its
+ * CSS custom-property reference, byte-for-byte identical to the PHP side so the editor preview and the
+ * frontend never drift. The `--kb-token--*` var is injected into the editor canvas by the projector,
+ * so no localized token data is needed here.
+ *
+ * These are registered as `@kadence/helpers` output-filter listeners (see `registerTokenAliasFilters`
+ * in `early-filters.js`) so the shared helper library stays token-agnostic — the token knowledge lives
+ * only in this plugin.
+ */
+
+/**
+ * The CSS custom-property namespace for Kadence design tokens. Mirrors PHP `Css_Var::get_prefix()`.
+ */
+export const TOKEN_VAR_PREFIX = '--kb-token--';
+
+/**
+ * Whole-string alias pattern. Mirrors the PHP `Alias::PATTERN` (`^\{[\w.-]+\}$`) exactly: a "{", a
+ * dot-path of word characters, dots and dashes, then a "}", anchored end to end. `\w` is ASCII on
+ * both sides (no unicode flag), so the two implementations agree. Block-attribute values never carry
+ * a trailing newline, so the strict `$` (unlike PHP's newline-tolerant `$`) is intentional.
+ */
+const TOKEN_ALIAS_PATTERN = /^\{[\w.-]+\}$/;
+
+/**
+ * Whether the given value is a whole-string design-token alias, e.g. `{semantic.radius.media}`.
+ *
+ * Only strings can be aliases; any non-string returns false so callers can short-circuit
+ * "alias OR literal" cleanly. Mirrors PHP `Alias::is_alias()`.
+ *
+ * @param {*} value The value to test.
+ * @return {boolean} True when the value is a well-formed alias string.
+ */
+export function isTokenAlias( value ) {
+	return typeof value === 'string' && TOKEN_ALIAS_PATTERN.test( value );
+}
+
+/**
+ * Resolve a design-token alias string to its CSS custom-property reference.
+ *
+ * Mirrors the PHP Resolver primitive (`'var(' . Css_Var::from_id( Alias::path_of( $value ) ) . ')'`)
+ * byte-for-byte: strip the braces, replace every "." with "--" behind the `--kb-token--` prefix, and
+ * emit a BARE `var(--kb-token--<id>)` with no fallback literal. Non-aliases fall through untouched, so
+ * callers can pipe any value through it unconditionally.
+ *
+ * @param {*} value A value that may be an alias string, e.g. `{semantic.radius.media}`.
+ * @return {*} `var(--kb-token--<id>)` when the value is an alias; otherwise the value unchanged.
+ */
+export function resolveTokenAlias( value ) {
+	if ( ! isTokenAlias( value ) ) {
+		return value;
+	}
+
+	const id = value.slice( 1, -1 ).replace( /\./g, '--' );
+
+	return 'var(' + TOKEN_VAR_PREFIX + id + ')';
+}

--- a/src/extension/design-tokens/alias.js
+++ b/src/extension/design-tokens/alias.js
@@ -34,8 +34,8 @@ const TOKEN_ALIAS_PATTERN = /^\{[\w.-]+\}$/;
  * @param {*} value The value to test.
  * @return {boolean} True when the value is a well-formed alias string.
  */
-export function isTokenAlias( value ) {
-	return typeof value === 'string' && TOKEN_ALIAS_PATTERN.test( value );
+export function isTokenAlias(value) {
+	return typeof value === 'string' && TOKEN_ALIAS_PATTERN.test(value);
 }
 
 /**
@@ -49,12 +49,12 @@ export function isTokenAlias( value ) {
  * @param {*} value A value that may be an alias string, e.g. `{semantic.radius.media}`.
  * @return {*} `var(--kb-token--<id>)` when the value is an alias; otherwise the value unchanged.
  */
-export function resolveTokenAlias( value ) {
-	if ( ! isTokenAlias( value ) ) {
+export function resolveTokenAlias(value) {
+	if (!isTokenAlias(value)) {
 		return value;
 	}
 
-	const id = value.slice( 1, -1 ).replace( /\./g, '--' );
+	const id = value.slice(1, -1).replace(/\./g, '--');
 
 	return 'var(' + TOKEN_VAR_PREFIX + id + ')';
 }

--- a/src/extension/design-tokens/register-filters.js
+++ b/src/extension/design-tokens/register-filters.js
@@ -1,0 +1,39 @@
+/**
+ * Wire design-token alias resolution into the `@kadence/helpers` output-filter seam.
+ *
+ * The shared helper library is token-agnostic: `KadenceColorOutput`, the border/dimension helpers and
+ * `KadenceBlocksCSS` run their value through `kadence.helpers.colorValue` / `kadence.helpers.dimensionValue`
+ * filters. Here Kadence Blocks registers a listener on both that resolves a `{dot.alias}` to its
+ * `var(--kb-token--<id>)` reference and passes every other value through untouched — so the token
+ * knowledge lives only in this plugin, and the change is strictly additive.
+ */
+import { addFilter, removeFilter } from '@wordpress/hooks';
+import { isTokenAlias, resolveTokenAlias } from './alias';
+
+const NAMESPACE = 'kadence-blocks/token-alias';
+const HOOKS = [ 'kadence.helpers.colorValue', 'kadence.helpers.dimensionValue' ];
+
+/**
+ * Resolve a helper value: a design-token alias becomes its CSS var, anything else is unchanged.
+ *
+ * @param {*} value The raw value the helper received.
+ * @return {*} The resolved value.
+ */
+function resolveAlias( value ) {
+	return isTokenAlias( value ) ? resolveTokenAlias( value ) : value;
+}
+
+/**
+ * Register the alias-resolution listeners on the helper output filters.
+ *
+ * Idempotent: it removes any prior listener under this namespace before adding, so it is safe to call
+ * more than once (e.g. editor init plus a test's setup).
+ *
+ * @return {void}
+ */
+export function registerTokenAliasFilters() {
+	HOOKS.forEach( ( hook ) => {
+		removeFilter( hook, NAMESPACE );
+		addFilter( hook, NAMESPACE, resolveAlias );
+	} );
+}

--- a/src/extension/design-tokens/register-filters.js
+++ b/src/extension/design-tokens/register-filters.js
@@ -11,7 +11,7 @@ import { addFilter, removeFilter } from '@wordpress/hooks';
 import { isTokenAlias, resolveTokenAlias } from './alias';
 
 const NAMESPACE = 'kadence-blocks/token-alias';
-const HOOKS = [ 'kadence.helpers.colorValue', 'kadence.helpers.dimensionValue' ];
+const HOOKS = ['kadence.helpers.colorValue', 'kadence.helpers.dimensionValue'];
 
 /**
  * Resolve a helper value: a design-token alias becomes its CSS var, anything else is unchanged.
@@ -19,8 +19,8 @@ const HOOKS = [ 'kadence.helpers.colorValue', 'kadence.helpers.dimensionValue' ]
  * @param {*} value The raw value the helper received.
  * @return {*} The resolved value.
  */
-function resolveAlias( value ) {
-	return isTokenAlias( value ) ? resolveTokenAlias( value ) : value;
+function resolveAlias(value) {
+	return isTokenAlias(value) ? resolveTokenAlias(value) : value;
 }
 
 /**
@@ -32,8 +32,8 @@ function resolveAlias( value ) {
  * @return {void}
  */
 export function registerTokenAliasFilters() {
-	HOOKS.forEach( ( hook ) => {
-		removeFilter( hook, NAMESPACE );
-		addFilter( hook, NAMESPACE, resolveAlias );
-	} );
+	HOOKS.forEach((hook) => {
+		removeFilter(hook, NAMESPACE);
+		addFilter(hook, NAMESPACE, resolveAlias);
+	});
 }


### PR DESCRIPTION
:ticket: https://linear.app/nexcess/issue/SOFT-3903/js-resolvetokenalias-alias-aware-kadencehelpers-output
:video_camera: https://www.loom.com/share/ad701c7c95084c849f6d013140f35ffa

**Paired helpers PR:** stellarwp/kadence-helpers#6 (must merge first — this branch pins that helpers branch).

Makes block controls able to store a design-token reference (`{dot.alias}`) that resolves live in the editor, without baking token logic into the shared `@kadence/helpers` library.

`@kadence/helpers` exposes a `@wordpress/hooks` seam on its output helpers (stellarwp/kadence-helpers#6); this plugin registers a listener that resolves `{dot.alias}` to `var(--kb-token--<id>)`:

- `src/extension/design-tokens/alias.js` — `isTokenAlias` / `resolveTokenAlias` / `TOKEN_VAR_PREFIX`, the byte-exact JS peer of the PHP `Alias` + `Css_Var` transform (bare `var()`, no fallback).
- `registerTokenAliasFilters` (in `early-filters.js`) — registers the resolver on `kadence.helpers.colorValue` / `kadence.helpers.dimensionValue`. Strictly additive: a non-alias value renders byte-identically to today.
- Repins `@kadence/helpers` to the seam branch.

Tests: primitives + a PHP/JS conformance fixture (seeds SOFT-3904); the spacer save-markup and `KadenceBlocksCSS` integration tests register the real filter and assert an aliased value resolves through the seam end to end (and is inert without it).

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
