### PR TITLE
feat(design-tokens): resolve token aliases in Kadence_Blocks_CSS render gates

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -120,6 +120,7 @@
         "retargeted",
         "retargets",
         "returntransfer",
+        "Ritner",
         "rowlayout",
         "scroller",
         "shivammathur",

--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -1037,7 +1037,7 @@ class Kadence_Blocks_CSS {
 	 *
 	 * @return string|null The var() reference, or null when the value is not an alias.
 	 */
-	public function get_token_reference( $value ): ?string {
+	private function get_token_reference( $value ): ?string {
 		if ( ! is_string( $value ) || ! Alias::is_alias( $value ) ) {
 			return null;
 		}

--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -11,6 +11,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
+
 /**
  * Class to create a minified css output.
  */
@@ -838,22 +841,39 @@ class Kadence_Blocks_CSS {
 		if ( isset( $font['size'] ) && isset( $font['size'][0] ) && ! empty( $font['size'][0] ) ) {
 			$this->add_property( 'font-size', $this->get_font_size( $font['size'][0], $size_type ) );
 		}
-		if ( isset( $font['lineHeight'] ) && isset( $font['lineHeight']['desktop'] ) && ! empty( $font['lineHeight']['desktop'] ) ) {
+		$line_height_desktop_reference = $this->get_token_reference( $font['lineHeight']['desktop'] ?? null );
+		if ( null !== $line_height_desktop_reference ) {
+			$this->add_property( 'line-height', $line_height_desktop_reference );
+		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight']['desktop'] ) && ! empty( $font['lineHeight']['desktop'] ) ) {
 			$this->add_property( 'line-height', $font['lineHeight']['desktop'] . $line_type );
 		}
 		// Numeric array.
-		if ( isset( $font['lineHeight'] ) && isset( $font['lineHeight'][0] ) && ! empty( $font['lineHeight'][0] ) ) {
+		$line_height_reference = $this->get_token_reference( $font['lineHeight'][0] ?? null );
+		if ( null !== $line_height_reference ) {
+			$this->add_property( 'line-height', $line_height_reference );
+		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight'][0] ) && ! empty( $font['lineHeight'][0] ) ) {
 			$this->add_property( 'line-height', $font['lineHeight'][0] . $line_type );
 		}
 		if ( isset( $font['letterSpacing'] ) && is_array( $font['letterSpacing'] ) ) {
-			if ( isset( $font['letterSpacing']['desktop'] ) && is_numeric( $font['letterSpacing']['desktop'] ) ) {
+			$letter_spacing_desktop_reference = $this->get_token_reference( $font['letterSpacing']['desktop'] ?? null );
+			if ( null !== $letter_spacing_desktop_reference ) {
+				$this->add_property( 'letter-spacing', $letter_spacing_desktop_reference );
+			} elseif ( isset( $font['letterSpacing']['desktop'] ) && is_numeric( $font['letterSpacing']['desktop'] ) ) {
 				$this->add_property( 'letter-spacing', $font['letterSpacing']['desktop'] . $letter_type );
 			}
-			if ( isset( $font['letterSpacing'][0] ) && is_numeric( $font['letterSpacing'][0] ) ) {
+			$letter_spacing_reference = $this->get_token_reference( $font['letterSpacing'][0] ?? null );
+			if ( null !== $letter_spacing_reference ) {
+				$this->add_property( 'letter-spacing', $letter_spacing_reference );
+			} elseif ( isset( $font['letterSpacing'][0] ) && is_numeric( $font['letterSpacing'][0] ) ) {
 				$this->add_property( 'letter-spacing', $font['letterSpacing'][0] . $letter_type );
 			}
-		} elseif ( isset( $font['letterSpacing'] ) && is_numeric( $font['letterSpacing'] ) ) {
-			$this->add_property( 'letter-spacing', $font['letterSpacing'] . $letter_type );
+		} else {
+			$letter_spacing_scalar_reference = $this->get_token_reference( $font['letterSpacing'] ?? null );
+			if ( null !== $letter_spacing_scalar_reference ) {
+				$this->add_property( 'letter-spacing', $letter_spacing_scalar_reference );
+			} elseif ( isset( $font['letterSpacing'] ) && is_numeric( $font['letterSpacing'] ) ) {
+				$this->add_property( 'letter-spacing', $font['letterSpacing'] . $letter_type );
+			}
 		}
 		$family = ( isset( $font['family'] ) && ! empty( $font['family'] ) && 'inherit' !== $font['family'] ? $font['family'] : '' );
 		$is_google = false;
@@ -879,16 +899,28 @@ class Kadence_Blocks_CSS {
 		if ( isset( $font['size'] ) && isset( $font['size'][1] ) && ! empty( $font['size'][1] ) ) {
 			$this->add_property( 'font-size', $this->get_font_size( $font['size'][1], $size_type ) );
 		}
-		if ( isset( $font['lineHeight'] ) && isset( $font['lineHeight']['tablet'] ) && ! empty( $font['lineHeight']['tablet'] ) ) {
+		$line_height_tablet_key_reference = $this->get_token_reference( $font['lineHeight']['tablet'] ?? null );
+		if ( null !== $line_height_tablet_key_reference ) {
+			$this->add_property( 'line-height', $line_height_tablet_key_reference );
+		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight']['tablet'] ) && ! empty( $font['lineHeight']['tablet'] ) ) {
 			$this->add_property( 'line-height', $font['lineHeight']['tablet'] . $line_type );
 		}
-		if ( isset( $font['lineHeight'] ) && isset( $font['lineHeight'][1] ) && ! empty( $font['lineHeight'][1] ) ) {
+		$line_height_tablet_reference = $this->get_token_reference( $font['lineHeight'][1] ?? null );
+		if ( null !== $line_height_tablet_reference ) {
+			$this->add_property( 'line-height', $line_height_tablet_reference );
+		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight'][1] ) && ! empty( $font['lineHeight'][1] ) ) {
 			$this->add_property( 'line-height', $font['lineHeight'][1] . $line_type );
 		}
-		if ( isset( $font['letterSpacing'] ) && isset( $font['letterSpacing']['tablet'] ) && is_numeric( $font['letterSpacing']['tablet'] ) ) {
+		$letter_spacing_tablet_key_reference = $this->get_token_reference( $font['letterSpacing']['tablet'] ?? null );
+		if ( null !== $letter_spacing_tablet_key_reference ) {
+			$this->add_property( 'letter-spacing', $letter_spacing_tablet_key_reference );
+		} elseif ( isset( $font['letterSpacing'] ) && isset( $font['letterSpacing']['tablet'] ) && is_numeric( $font['letterSpacing']['tablet'] ) ) {
 			$this->add_property( 'letter-spacing', $font['letterSpacing']['tablet'] . $letter_type );
 		}
-		if ( isset( $font['letterSpacing'] ) && isset( $font['letterSpacing'][1] ) && is_numeric( $font['letterSpacing'][1] ) ) {
+		$letter_spacing_tablet_reference = $this->get_token_reference( $font['letterSpacing'][1] ?? null );
+		if ( null !== $letter_spacing_tablet_reference ) {
+			$this->add_property( 'letter-spacing', $letter_spacing_tablet_reference );
+		} elseif ( isset( $font['letterSpacing'] ) && isset( $font['letterSpacing'][1] ) && is_numeric( $font['letterSpacing'][1] ) ) {
 			$this->add_property( 'letter-spacing', $font['letterSpacing'][1] . $letter_type );
 		}
 		// Mobile.
@@ -896,16 +928,28 @@ class Kadence_Blocks_CSS {
 		if ( isset( $font['size'] ) && isset( $font['size'][2] ) && ! empty( $font['size'][2] ) ) {
 			$this->add_property( 'font-size', $this->get_font_size( $font['size'][2], $size_type ) );
 		}
-		if ( isset( $font['lineHeight'] ) && isset( $font['lineHeight']['mobile'] ) && ! empty( $font['lineHeight']['mobile'] ) ) {
+		$line_height_mobile_key_reference = $this->get_token_reference( $font['lineHeight']['mobile'] ?? null );
+		if ( null !== $line_height_mobile_key_reference ) {
+			$this->add_property( 'line-height', $line_height_mobile_key_reference );
+		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight']['mobile'] ) && ! empty( $font['lineHeight']['mobile'] ) ) {
 			$this->add_property( 'line-height', $font['lineHeight']['mobile'] . $line_type );
 		}
-		if ( isset( $font['lineHeight'] ) && isset( $font['lineHeight'][2] ) && ! empty( $font['lineHeight'][2] ) ) {
+		$line_height_mobile_reference = $this->get_token_reference( $font['lineHeight'][2] ?? null );
+		if ( null !== $line_height_mobile_reference ) {
+			$this->add_property( 'line-height', $line_height_mobile_reference );
+		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight'][2] ) && ! empty( $font['lineHeight'][2] ) ) {
 			$this->add_property( 'line-height', $font['lineHeight'][2] . $line_type );
 		}
-		if ( isset( $font['letterSpacing'] ) && isset( $font['letterSpacing']['mobile'] ) && is_numeric( $font['letterSpacing']['mobile'] ) ) {
+		$letter_spacing_mobile_key_reference = $this->get_token_reference( $font['letterSpacing']['mobile'] ?? null );
+		if ( null !== $letter_spacing_mobile_key_reference ) {
+			$this->add_property( 'letter-spacing', $letter_spacing_mobile_key_reference );
+		} elseif ( isset( $font['letterSpacing'] ) && isset( $font['letterSpacing']['mobile'] ) && is_numeric( $font['letterSpacing']['mobile'] ) ) {
 			$this->add_property( 'letter-spacing', $font['letterSpacing']['mobile'] . $letter_type );
 		}
-		if ( isset( $font['letterSpacing'] ) && isset( $font['letterSpacing'][2] ) && is_numeric( $font['letterSpacing'][2] ) ) {
+		$letter_spacing_mobile_reference = $this->get_token_reference( $font['letterSpacing'][2] ?? null );
+		if ( null !== $letter_spacing_mobile_reference ) {
+			$this->add_property( 'letter-spacing', $letter_spacing_mobile_reference );
+		} elseif ( isset( $font['letterSpacing'] ) && isset( $font['letterSpacing'][2] ) && is_numeric( $font['letterSpacing'][2] ) ) {
 			$this->add_property( 'letter-spacing', $font['letterSpacing'][2] . $letter_type );
 		}
 		$this->set_media_state( 'desktop' );
@@ -979,6 +1023,26 @@ class Kadence_Blocks_CSS {
 		return $string;
 	}
 	/**
+	 * Resolve a design-token alias reference to its CSS custom-property var().
+	 *
+	 * A value matching the strict {dot.alias} form resolves to a bare
+	 * var(--kb-token--<id>) with no fallback literal; anything else returns null so
+	 * the caller falls through to its existing numeric/palette handling.
+	 *
+	 * @param mixed $value The raw attribute value.
+	 *
+	 * @since TBD
+	 *
+	 * @return string|null The var() reference, or null when the value is not an alias.
+	 */
+	public function get_token_reference( $value ): ?string {
+		if ( ! is_string( $value ) || ! Alias::is_alias( $value ) ) {
+			return null;
+		}
+
+		return 'var(' . Css_Var::from_id( Alias::path_of( $value ) ) . ')';
+	}
+	/**
 	 * Outputs a string if set.
 	 *
 	 * @param array  $number a string setting.
@@ -986,6 +1050,10 @@ class Kadence_Blocks_CSS {
 	 * @return string
 	 */
 	public function render_number( $number = null, $unit = null ) {
+		$token_reference = $this->get_token_reference( $number );
+		if ( null !== $token_reference ) {
+			return $token_reference;
+		}
 		if ( ! is_numeric( $number ) ) {
 			return false;
 		}
@@ -1002,6 +1070,10 @@ class Kadence_Blocks_CSS {
 	public function render_color( $color, $opacity = null ) {
 		if ( empty( $color ) ) {
 			return false;
+		}
+		$token_reference = $this->get_token_reference( $color );
+		if ( null !== $token_reference ) {
+			return $token_reference;
 		}
 		if ( ! is_array( $color ) && strpos( $color, 'palette' ) === 0 ) {
 			switch ( $color ) {
@@ -1048,6 +1120,10 @@ class Kadence_Blocks_CSS {
 	public function sanitize_color( $color, $opacity = null ) {
 		if ( empty( $color ) ) {
 			return false;
+		}
+		$token_reference = $this->get_token_reference( $color );
+		if ( null !== $token_reference ) {
+			return $token_reference;
 		}
 		if ( ! is_array( $color ) && strpos( $color, 'palette' ) === 0 ) {
 			switch ( $color ) {
@@ -1152,16 +1228,21 @@ class Kadence_Blocks_CSS {
 		if ( ! isset( $attributes[ $name ] ) ) {
 			return false;
 		}
-		if ( $render_zero ) {
-			if ( ! is_numeric( $attributes[ $name ] ) ) {
-				return false;
-			}
+		$token_reference = $this->get_token_reference( $attributes[ $name ] );
+		if ( null !== $token_reference ) {
+			$this->add_property( $property, $token_reference );
 		} else {
-			if ( empty( $attributes[ $name ] ) ) {
-				return false;
+			if ( $render_zero ) {
+				if ( ! is_numeric( $attributes[ $name ] ) ) {
+					return false;
+				}
+			} else {
+				if ( empty( $attributes[ $name ] ) ) {
+					return false;
+				}
 			}
+			$this->add_property( $property, $attributes[ $name ] . $unit );
 		}
-		$this->add_property( $property, $attributes[ $name ] . $unit );
 	}
 	/**
 	 * Generates the measure range output.
@@ -1228,22 +1309,34 @@ class Kadence_Blocks_CSS {
 		$args = wp_parse_args( $args, $defaults );
 		$unit = ! empty( $attributes[ $args['unit_key'] ] ) ? $attributes[ $args['unit_key'] ] : $unit;
 		if ( isset( $attributes[ $name ] ) && is_array( $attributes[ $name ] ) ) {
-			if ( $render_zero && is_numeric( $attributes[ $name ][0] ) ) {
+			$first_reference = $this->get_token_reference( $attributes[ $name ][0] ?? null );
+			if ( null !== $first_reference ) {
+				$this->add_property( $args['first_prop'], $first_reference );
+			} else if ( $render_zero && is_numeric( $attributes[ $name ][0] ) ) {
 				$this->add_property( $args['first_prop'], $attributes[ $name ][0] . $unit );
 			} else if ( ! $render_zero && ! empty( $attributes[ $name ][0] ) ) {
 				$this->add_property( $args['first_prop'], $attributes[ $name ][0] . $unit );
 			}
-			if ( $render_zero && is_numeric( $attributes[ $name ][1] ) ) {
+			$second_reference = $this->get_token_reference( $attributes[ $name ][1] ?? null );
+			if ( null !== $second_reference ) {
+				$this->add_property( $args['second_prop'], $second_reference );
+			} else if ( $render_zero && is_numeric( $attributes[ $name ][1] ) ) {
 				$this->add_property( $args['second_prop'], $attributes[ $name ][1] . $unit );
 			} else if ( ! $render_zero && ! empty( $attributes[ $name ][1] ) ) {
 				$this->add_property( $args['second_prop'], $attributes[ $name ][1] . $unit );
 			}
-			if ( $render_zero && is_numeric( $attributes[ $name ][2] ) ) {
+			$third_reference = $this->get_token_reference( $attributes[ $name ][2] ?? null );
+			if ( null !== $third_reference ) {
+				$this->add_property( $args['third_prop'], $third_reference );
+			} else if ( $render_zero && is_numeric( $attributes[ $name ][2] ) ) {
 				$this->add_property( $args['third_prop'], $attributes[ $name ][2] . $unit );
 			} else if ( ! $render_zero && ! empty( $attributes[ $name ][2] ) ) {
 				$this->add_property( $args['third_prop'], $attributes[ $name ][2] . $unit );
 			}
-			if ( $render_zero && is_numeric( $attributes[ $name ][3] ) ) {
+			$fourth_reference = $this->get_token_reference( $attributes[ $name ][3] ?? null );
+			if ( null !== $fourth_reference ) {
+				$this->add_property( $args['fourth_prop'], $fourth_reference );
+			} else if ( $render_zero && is_numeric( $attributes[ $name ][3] ) ) {
 				$this->add_property( $args['fourth_prop'], $attributes[ $name ][3] . $unit );
 			} else if ( ! $render_zero && ! empty( $attributes[ $name ][3] ) ) {
 				$this->add_property( $args['fourth_prop'], $attributes[ $name ][3] . $unit );
@@ -1494,10 +1587,19 @@ class Kadence_Blocks_CSS {
 		if ( ! isset( $shadow['inset'] ) ) {
 			return false;
 		}
+		$h_offset_reference = $this->get_token_reference( $shadow['hOffset'] );
+		$h_offset           = null !== $h_offset_reference ? $h_offset_reference : ( ( ! empty( $shadow['hOffset'] ) ? $shadow['hOffset'] : '0' ) . 'px' );
+		$v_offset_reference = $this->get_token_reference( $shadow['vOffset'] );
+		$v_offset           = null !== $v_offset_reference ? $v_offset_reference : ( ( ! empty( $shadow['vOffset'] ) ? $shadow['vOffset'] : '0' ) . 'px' );
+		$blur_reference     = $this->get_token_reference( $shadow['blur'] );
+		$blur               = null !== $blur_reference ? $blur_reference : ( ( ! empty( $shadow['blur'] ) ? $shadow['blur'] : '0' ) . 'px' );
+		$spread_reference   = $this->get_token_reference( $shadow['spread'] );
+		$spread             = null !== $spread_reference ? $spread_reference : ( ( ! empty( $shadow['spread'] ) ? $shadow['spread'] : '0' ) . 'px' );
+		$color              = ! empty( $shadow['color'] ) ? $this->render_color( $shadow['color'], $shadow['opacity'] ) : $this->render_color( '#000000', $shadow['opacity'] );
 		if ( $shadow['inset'] ) {
-			$shadow_string = 'inset ' . ( ! empty( $shadow['hOffset'] ) ? $shadow['hOffset'] : '0' ) . 'px ' . ( ! empty( $shadow['vOffset'] ) ? $shadow['vOffset'] : '0' ) . 'px ' . ( ! empty( $shadow['blur'] ) ? $shadow['blur'] : '0' ) . 'px ' . ( ! empty( $shadow['spread'] ) ? $shadow['spread'] : '0' ) . 'px ' . ( ! empty( $shadow['color'] ) ? $this->render_color( $shadow['color'], $shadow['opacity'] ) : $this->render_color( '#000000', $shadow['opacity'] ) );
+			$shadow_string = 'inset ' . $h_offset . ' ' . $v_offset . ' ' . $blur . ' ' . $spread . ' ' . $color;
 		} else {
-			$shadow_string =  ( ! empty( $shadow['hOffset'] ) ? $shadow['hOffset'] : '0' ) . 'px ' . ( ! empty( $shadow['vOffset'] ) ? $shadow['vOffset'] : '0' ) . 'px ' . ( ! empty( $shadow['blur'] ) ? $shadow['blur'] : '0' ) . 'px ' . ( ! empty( $shadow['spread'] ) ? $shadow['spread'] : '0' ) . 'px ' . ( ! empty( $shadow['color'] ) ? $this->render_color( $shadow['color'], $shadow['opacity'] ) : $this->render_color( '#000000', $shadow['opacity'] ) );
+			$shadow_string = $h_offset . ' ' . $v_offset . ' ' . $blur . ' ' . $spread . ' ' . $color;
 		}
 
 		return $shadow_string;
@@ -1519,16 +1621,28 @@ class Kadence_Blocks_CSS {
 			return false;
 		}
 		if ( isset( $attributes[ $name ] ) && is_array( $attributes[ $name ] ) ) {
-			if ( isset( $attributes[ $name ][0] ) && is_numeric( $attributes[ $name ][0] ) ) {
+			$top_left_reference = $this->get_token_reference( $attributes[ $name ][0] ?? null );
+			if ( null !== $top_left_reference ) {
+				$this->add_property( 'border-top-left-radius', $top_left_reference );
+			} else if ( isset( $attributes[ $name ][0] ) && is_numeric( $attributes[ $name ][0] ) ) {
 				$this->add_property( 'border-top-left-radius', $attributes[ $name ][0] . $unit );
 			}
-			if ( isset( $attributes[ $name ][1] ) && is_numeric( $attributes[ $name ][1] ) ) {
+			$top_right_reference = $this->get_token_reference( $attributes[ $name ][1] ?? null );
+			if ( null !== $top_right_reference ) {
+				$this->add_property( 'border-top-right-radius', $top_right_reference );
+			} else if ( isset( $attributes[ $name ][1] ) && is_numeric( $attributes[ $name ][1] ) ) {
 				$this->add_property( 'border-top-right-radius', $attributes[ $name ][1] . $unit );
 			}
-			if ( isset( $attributes[ $name ][2] ) && is_numeric( $attributes[ $name ][2] ) ) {
+			$bottom_right_reference = $this->get_token_reference( $attributes[ $name ][2] ?? null );
+			if ( null !== $bottom_right_reference ) {
+				$this->add_property( 'border-bottom-right-radius', $bottom_right_reference );
+			} else if ( isset( $attributes[ $name ][2] ) && is_numeric( $attributes[ $name ][2] ) ) {
 				$this->add_property( 'border-bottom-right-radius', $attributes[ $name ][2] . $unit );
 			}
-			if ( isset( $attributes[ $name ][3] ) && is_numeric( $attributes[ $name ][3] ) ) {
+			$bottom_left_reference = $this->get_token_reference( $attributes[ $name ][3] ?? null );
+			if ( null !== $bottom_left_reference ) {
+				$this->add_property( 'border-bottom-left-radius', $bottom_left_reference );
+			} else if ( isset( $attributes[ $name ][3] ) && is_numeric( $attributes[ $name ][3] ) ) {
 				$this->add_property( 'border-bottom-left-radius', $attributes[ $name ][3] . $unit );
 			}
 		}
@@ -1705,14 +1819,25 @@ class Kadence_Blocks_CSS {
 		}
 		$unit = ! empty( $attributes[ $unit ] ) ? $attributes[ $unit ] : 'px';
 		if ( isset( $attributes[ $name ] ) && is_array( $attributes[ $name ] ) ) {
-			if ( isset( $attributes[ $name ][0] ) && is_numeric( $attributes[ $name ][0] ) ) {
+			$desktop_reference = $this->get_token_reference( $attributes[ $name ][0] ?? null );
+			if ( null !== $desktop_reference ) {
+				$this->add_property( $property, $desktop_reference );
+			} else if ( isset( $attributes[ $name ][0] ) && is_numeric( $attributes[ $name ][0] ) ) {
 				$this->add_property( $property, $attributes[ $name ][0] . $unit );
 			}
-			if ( isset( $attributes[ $name ][1] ) && is_numeric( $attributes[ $name ][1] ) ){
+			$tablet_reference = $this->get_token_reference( $attributes[ $name ][1] ?? null );
+			if ( null !== $tablet_reference ) {
+				$this->set_media_state( 'tablet' );
+				$this->add_property( $property, $tablet_reference );
+			} else if ( isset( $attributes[ $name ][1] ) && is_numeric( $attributes[ $name ][1] ) ){
 				$this->set_media_state( 'tablet' );
 				$this->add_property( $property, $attributes[ $name ][1] . $unit );
 			}
-			if ( isset( $attributes[ $name ][2] ) && is_numeric( $attributes[ $name ][2] ) ) {
+			$mobile_reference = $this->get_token_reference( $attributes[ $name ][2] ?? null );
+			if ( null !== $mobile_reference ) {
+				$this->set_media_state( 'mobile' );
+				$this->add_property( $property, $mobile_reference );
+			} else if ( isset( $attributes[ $name ][2] ) && is_numeric( $attributes[ $name ][2] ) ) {
 				$this->set_media_state( 'mobile' );
 				$this->add_property( $property, $attributes[ $name ][2] . $unit );
 			}
@@ -1742,19 +1867,28 @@ class Kadence_Blocks_CSS {
 		$unit = ! empty( $attributes[ $unit ] ) ? $attributes[ $unit ] : 'px';
 
 		$this->set_media_state( 'desktop' );
-		if ( isset( $attributes[ $name[0] ] ) && '' !== $attributes[ $name[0] ] ) {
+		$desktop_reference = $this->get_token_reference( $attributes[ $name[0] ] ?? null );
+		if ( null !== $desktop_reference ) {
+			$this->add_property( $property, $desktop_reference );
+		} else if ( isset( $attributes[ $name[0] ] ) && '' !== $attributes[ $name[0] ] ) {
 			$this->add_property( $property, $attributes[ $name[0] ] . $unit );
 		} else if ( $defaults[0] ) {
 			$this->add_property( $property, $defaults[0] . $unit );
 		}
 		$this->set_media_state( 'tablet' );
-		if ( isset( $attributes[ $name[1] ] ) && '' !== $attributes[ $name[1] ] ) {
+		$tablet_reference = $this->get_token_reference( $attributes[ $name[1] ] ?? null );
+		if ( null !== $tablet_reference ) {
+			$this->add_property( $property, $tablet_reference );
+		} else if ( isset( $attributes[ $name[1] ] ) && '' !== $attributes[ $name[1] ] ) {
 			$this->add_property( $property, $attributes[ $name[1] ] . $unit );
 		} else if ( $defaults[1] ) {
 			$this->add_property( $property, $defaults[1] . $unit );
 		}
 		$this->set_media_state( 'mobile' );
-		if ( isset( $attributes[ $name[2] ] ) && '' !== $attributes[ $name[2] ] ) {
+		$mobile_reference = $this->get_token_reference( $attributes[ $name[2] ] ?? null );
+		if ( null !== $mobile_reference ) {
+			$this->add_property( $property, $mobile_reference );
+		} else if ( isset( $attributes[ $name[2] ] ) && '' !== $attributes[ $name[2] ] ) {
 			$this->add_property( $property, $attributes[ $name[2] ] . $unit );
 		} else if ( $defaults[2] ) {
 			$this->add_property( $property, $defaults[2] . $unit );
@@ -2096,7 +2230,12 @@ class Kadence_Blocks_CSS {
 			$return_value = $this->sanitize_color($return_value);
 		}
 		if( $given_value == 'width') {
-			$return_value = $this->is_number($return_value) ? $return_value . $return_unit : '';
+			$width_reference = $this->get_token_reference( $return_value );
+			if ( null !== $width_reference ) {
+				$return_value = $width_reference;
+			} else {
+				$return_value = $this->is_number($return_value) ? $return_value . $return_unit : '';
+			}
 		}
 
 		return $return_value;
@@ -2378,10 +2517,17 @@ class Kadence_Blocks_CSS {
 		if ( ! isset( $measure[0] ) ) {
 			return false;
 		}
-		if ( ! is_numeric( $measure[0] ) && ! is_numeric( $measure[1] ) && ! is_numeric( $measure[2] ) && ! is_numeric( $measure[3] ) ) {
+		$references = array(
+			$this->get_token_reference( $measure[0] ),
+			$this->get_token_reference( $measure[1] ?? null ),
+			$this->get_token_reference( $measure[2] ?? null ),
+			$this->get_token_reference( $measure[3] ?? null ),
+		);
+		$has_alias  = null !== $references[0] || null !== $references[1] || null !== $references[2] || null !== $references[3];
+		if ( ! $has_alias && ! is_numeric( $measure[0] ) && ! is_numeric( $measure[1] ) && ! is_numeric( $measure[2] ) && ! is_numeric( $measure[3] ) ) {
 			return false;
 		}
-		$size_string = ( is_numeric( $measure[0] ) ? $measure[0] : '0' ) . $unit . ' ' . ( is_numeric( $measure[1] ) ? $measure[1] : '0' ) . $unit . ' ' . ( is_numeric( $measure[2] ) ? $measure[2] : '0' ) . $unit . ' ' . ( is_numeric( $measure[3] ) ? $measure[3] : '0' ) . $unit;
+		$size_string = ( null !== $references[0] ? $references[0] : ( is_numeric( $measure[0] ) ? $measure[0] : '0' ) . $unit ) . ' ' . ( null !== $references[1] ? $references[1] : ( is_numeric( $measure[1] ) ? $measure[1] : '0' ) . $unit ) . ' ' . ( null !== $references[2] ? $references[2] : ( is_numeric( $measure[2] ) ? $measure[2] : '0' ) . $unit ) . ' ' . ( null !== $references[3] ? $references[3] : ( is_numeric( $measure[3] ) ? $measure[3] : '0' ) . $unit );
 		return $size_string;
 	}
 	/**

--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -7,6 +7,8 @@
  * @version  1.9
  */
 
+// cSpell:ignore dglobal fontvariants fontsubsets attribtues .
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -138,7 +140,7 @@ class Kadence_Blocks_CSS {
 	protected $_media_state = 'desktop';
 
 	/**
-	 * Stores a list of css properties that require more formating
+	 * Stores a list of css properties that require more formatting
 	 *
 	 * @access private
 	 * @var array
@@ -305,7 +307,7 @@ class Kadence_Blocks_CSS {
 		if ( empty( $style_id ) ) {
 			return;
 		}
-		// Render the css in the output string everytime the style_id changes.
+		// Render the css in the output string every time the style_id changes.
 		if ( ! isset( self::$styles[ $style_id ] ) ) {
 			self::$styles[ $style_id ] = '';
 		}
@@ -359,7 +361,7 @@ class Kadence_Blocks_CSS {
 	 * @return $this
 	 */
 	public function set_selector( $selector = '' ) {
-		// Render the css in the output string everytime the selector changes.
+		// Render the css in the output string every time the selector changes.
 		if ( '' !== $this->_selector ) {
 			$this->add_selector_rules_to_output();
 		}
@@ -580,7 +582,7 @@ class Kadence_Blocks_CSS {
 	 *
 	 * @param  string $property - the css property
 	 * @param  mixed  $value - the value to be placed with the property
-	 * @param  mixed  $check_empty - the value to be checkd if empty
+	 * @param  mixed  $check_empty - the value to be checked if empty
 	 * @return $this
 	 */
 	public function add_property( $property, $value = null, $check_empty = null ) {
@@ -1029,9 +1031,9 @@ class Kadence_Blocks_CSS {
 	 * var(--kb-token--<id>) with no fallback literal; anything else returns null so
 	 * the caller falls through to its existing numeric/palette handling.
 	 *
-	 * @param mixed $value The raw attribute value.
-	 *
 	 * @since TBD
+	 *
+	 * @param mixed $value The raw attribute value.
 	 *
 	 * @return string|null The var() reference, or null when the value is not an alias.
 	 */
@@ -1605,7 +1607,7 @@ class Kadence_Blocks_CSS {
 		return $shadow_string;
 	}
 
-	
+
 	/**
 	 * Generates the border radius color output.
 	 *
@@ -2139,7 +2141,7 @@ class Kadence_Blocks_CSS {
 	 * @param array  $args an array of settings.
 	 * @param string $given_side the side to retrieve a value for (desktop, tablet, mobile).
 	 * @param string $given_size the size to retrieve a value for (top, right, bottom, left).
-	 * @param string $given_value the name of the value to retreive (color, style, width).
+	 * @param string $given_value the name of the value to retrieve (color, style, width).
 	 * @param string $single_styles if this value is being calculated to be output alone.
 	 * @return string
 	 */
@@ -2349,7 +2351,7 @@ class Kadence_Blocks_CSS {
 	 *
 	 * @param array  $attributes an array of attributes.
 	 * @param string $name a string of the block attribute name.
-	 * @param string $property a string of the css propery name.
+	 * @param string $property a string of the css property name.
 	 * @param array  $args an array of settings.
 	 * @return string
 	 */

--- a/tests/wpunit/KadenceBlocksCssTest.php
+++ b/tests/wpunit/KadenceBlocksCssTest.php
@@ -521,13 +521,28 @@ class KadenceBlocksCssTest extends WPTestCase {
 	 * @return void
 	 */
 	public function testGetTokenReference( $value, ?string $expected ): void {
-		$this->assertSame( $expected, $this->css->get_token_reference( $value ),
+		$this->assertSame( $expected, $this->invokeGetTokenReference( $value ),
 			'Alias recognizer must match the JS resolveTokenAlias output byte-for-byte' );
 
 		if ( null !== $expected ) {
 			$this->assertStringNotContainsString( ',', $expected,
 				'A resolved token reference is a bare var() with no fallback literal' );
 		}
+	}
+
+	/**
+	 * Invokes the private get_token_reference() recognizer via reflection so the direct
+	 * conformance assertions can exercise it without widening its visibility.
+	 *
+	 * @param mixed $value The raw attribute value.
+	 *
+	 * @return string|null The resolved reference, or null when the value is not an alias.
+	 */
+	private function invokeGetTokenReference( $value ): ?string {
+		$method = new \ReflectionMethod( Kadence_Blocks_CSS::class, 'get_token_reference' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $this->css, $value );
 	}
 
 	/**

--- a/tests/wpunit/KadenceBlocksCssTest.php
+++ b/tests/wpunit/KadenceBlocksCssTest.php
@@ -3,6 +3,7 @@
 namespace Tests\wpunit;
 
 use Codeception\TestCase\WPTestCase;
+use Generator;
 use Kadence_Blocks_CSS;
 
 class KadenceBlocksCssTest extends WPTestCase {
@@ -505,6 +506,371 @@ class KadenceBlocksCssTest extends WPTestCase {
 			$this->css->get_media_queries('mobile'),
 			'Mobile media query should match expected value'
 		);
+	}
+
+	/**
+	 * A strict {dot.alias} value resolves to a bare var(--kb-token--<id>) with no
+	 * fallback literal, and every non-alias value (including a malformed brace-string)
+	 * returns null so the caller falls through to its existing numeric/palette handling.
+	 *
+	 * @dataProvider tokenReferenceProvider
+	 *
+	 * @param mixed       $value    The raw attribute value.
+	 * @param string|null $expected The expected resolved reference, or null.
+	 *
+	 * @return void
+	 */
+	public function testGetTokenReference( $value, ?string $expected ): void {
+		$this->assertSame( $expected, $this->css->get_token_reference( $value ),
+			'Alias recognizer must match the JS resolveTokenAlias output byte-for-byte' );
+
+		if ( null !== $expected ) {
+			$this->assertStringNotContainsString( ',', $expected,
+				'A resolved token reference is a bare var() with no fallback literal' );
+		}
+	}
+
+	/**
+	 * Provides alias and non-alias values for the recognizer, mirroring the shared
+	 * token-alias conformance cases the JS side asserts.
+	 *
+	 * @return Generator
+	 */
+	public static function tokenReferenceProvider(): Generator {
+		yield 'semantic radius alias' => [
+			'value'    => '{semantic.radius.media}',
+			'expected' => 'var(--kb-token--semantic--radius--media)',
+		];
+		yield 'single segment alias' => [
+			'value'    => '{a}',
+			'expected' => 'var(--kb-token--a)',
+		];
+		yield 'namespaced path alias' => [
+			'value'    => '{dark.primitive.color.brand.primary}',
+			'expected' => 'var(--kb-token--dark--primitive--color--brand--primary)',
+		];
+		yield 'palette slug is not an alias' => [
+			'value'    => 'palette1',
+			'expected' => null,
+		];
+		yield 'hex is not an alias' => [
+			'value'    => '#3182CE',
+			'expected' => null,
+		];
+		yield 'literal shorthand is not an alias' => [
+			'value'    => '1px solid red',
+			'expected' => null,
+		];
+		yield 'partial interpolation is not an alias' => [
+			'value'    => '1px solid {semantic.color.brand}',
+			'expected' => null,
+		];
+		yield 'malformed alias with a space fails open' => [
+			'value'    => '{bad path}',
+			'expected' => null,
+		];
+		yield 'unclosed brace fails open' => [
+			'value'    => '{unclosed',
+			'expected' => null,
+		];
+		yield 'empty braces fail open' => [
+			'value'    => '{}',
+			'expected' => null,
+		];
+		yield 'pixel literal is not an alias' => [
+			'value'    => '16px',
+			'expected' => null,
+		];
+		yield 'bare number string is not an alias' => [
+			'value'    => '10',
+			'expected' => null,
+		];
+		yield 'empty string is not an alias' => [
+			'value'    => '',
+			'expected' => null,
+		];
+		yield 'integer is not an alias' => [
+			'value'    => 10,
+			'expected' => null,
+		];
+		yield 'null is not an alias' => [
+			'value'    => null,
+			'expected' => null,
+		];
+		yield 'array is not an alias' => [
+			'value'    => [ '{semantic.radius.media}' ],
+			'expected' => null,
+		];
+	}
+
+	/**
+	 * render_color emits the token var for an alias, leaves a malformed brace-string
+	 * untouched (fail open), and renders literals and palette slugs exactly as before.
+	 *
+	 * @return void
+	 */
+	public function testRenderColorResolvesTokenAlias(): void {
+		$this->assertSame(
+			'var(--kb-token--dark--primitive--color--brand--primary)',
+			$this->css->render_color( '{dark.primitive.color.brand.primary}' ),
+			'A color alias resolves to the bare token var'
+		);
+		$this->assertSame(
+			'var(--kb-token--dark--primitive--color--brand--primary)',
+			$this->css->sanitize_color( '{dark.primitive.color.brand.primary}' ),
+			'sanitize_color resolves a color alias the same way'
+		);
+		$this->assertSame(
+			'{bad path}',
+			$this->css->render_color( '{bad path}' ),
+			'A malformed alias fails open and is left untouched'
+		);
+		$this->assertSame(
+			'#123456',
+			$this->css->render_color( '#123456' ),
+			'A literal hex color is unchanged'
+		);
+		$this->assertSame(
+			'var(--global-palette1, #3182CE)',
+			$this->css->render_color( 'palette1' ),
+			'A palette slug still resolves to the global palette var'
+		);
+	}
+
+	/**
+	 * render_border_radius emits a token var (with no unit) for an aliased corner,
+	 * emits nothing for a malformed alias, and keeps numeric corners byte-identical.
+	 *
+	 * @return void
+	 */
+	public function testRenderBorderRadiusResolvesTokenAlias(): void {
+		$this->css->render_border_radius( [ 'borderRadius' => [ '{semantic.radius.media}', 10, '{bad path}', '' ] ] );
+		$output = $this->css->css_output();
+
+		$this->assertStringContainsString( 'border-top-left-radius:var(--kb-token--semantic--radius--media)', $output,
+			'An aliased corner emits the token var with no unit' );
+		$this->assertStringContainsString( 'border-top-right-radius:10px', $output,
+			'A numeric corner is still rendered with its unit' );
+		$this->assertStringNotContainsString( 'border-bottom-right-radius', $output,
+			'A malformed alias corner fails open and emits nothing' );
+	}
+
+	/**
+	 * render_measure_range (border-width) emits a token var without a unit for an
+	 * aliased side while leaving numeric sides unchanged.
+	 *
+	 * @return void
+	 */
+	public function testRenderMeasureRangeResolvesTokenAlias(): void {
+		$this->css->render_measure_range(
+			[ 'borderWidth' => [ '{semantic.border.width}', 2, 2, 2 ] ],
+			'borderWidth',
+			'border-width'
+		);
+		$output = $this->css->css_output();
+
+		$this->assertStringContainsString( 'border-top-width:var(--kb-token--semantic--border--width)', $output,
+			'An aliased side emits the token var with no unit' );
+		$this->assertStringContainsString( 'border-right-width:2px', $output,
+			'A numeric side is still rendered with its unit' );
+	}
+
+	/**
+	 * render_range emits a token var without a unit for an aliased value and keeps a
+	 * numeric value byte-identical.
+	 *
+	 * @return void
+	 */
+	public function testRenderRangeResolvesTokenAlias(): void {
+		$this->css->render_range( [ 'width' => '{semantic.size.width}' ], 'width', 'width' );
+		$this->assertStringContainsString( 'width:var(--kb-token--semantic--size--width)', $this->css->css_output(),
+			'An aliased range value emits the token var with no unit' );
+
+		$numeric = new Kadence_Blocks_CSS();
+		$numeric->render_range( [ 'width' => 10 ], 'width', 'width' );
+		$this->assertStringContainsString( 'width:10px', $numeric->css_output(),
+			'A numeric range value is still rendered with its unit' );
+	}
+
+	/**
+	 * render_responsive_range emits a token var per breakpoint for aliased values and
+	 * keeps numeric breakpoints byte-identical.
+	 *
+	 * @return void
+	 */
+	public function testRenderResponsiveRangeResolvesTokenAlias(): void {
+		$this->css->render_responsive_range(
+			[ 'spacing' => [ '{semantic.space.md}', 20, '{semantic.space.sm}' ], 'spacingType' => 'px' ],
+			'spacing',
+			'margin'
+		);
+		$output = $this->css->css_output();
+
+		$this->assertStringContainsString( 'margin:var(--kb-token--semantic--space--md)', $output,
+			'An aliased desktop value emits the token var with no unit' );
+		$this->assertStringContainsString( 'margin:20px', $output,
+			'A numeric tablet value is still rendered with its unit' );
+		$this->assertStringContainsString( 'margin:var(--kb-token--semantic--space--sm)', $output,
+			'An aliased mobile value emits the token var with no unit' );
+	}
+
+	/**
+	 * render_responsive_size resolves an aliased value to the token var without a unit
+	 * even though its gate is an empty-string check rather than is_numeric.
+	 *
+	 * @return void
+	 */
+	public function testRenderResponsiveSizeResolvesTokenAlias(): void {
+		$this->css->render_responsive_size(
+			[ 'width' => '{semantic.size.width}', 'tabletWidth' => '20', 'mobileWidth' => '' ],
+			[ 'width', 'tabletWidth', 'mobileWidth' ],
+			'width'
+		);
+		$output = $this->css->css_output();
+
+		$this->assertStringContainsString( 'width:var(--kb-token--semantic--size--width)', $output,
+			'An aliased desktop value emits the token var with no unit' );
+		$this->assertStringContainsString( 'width:20px', $output,
+			'A literal tablet value is still rendered with its unit' );
+	}
+
+	/**
+	 * render_measure resolves an aliased side to the token var (no unit) within the
+	 * shorthand while numeric sides keep their unit.
+	 *
+	 * @return void
+	 */
+	public function testRenderMeasureResolvesTokenAlias(): void {
+		$this->assertSame(
+			'var(--kb-token--semantic--space--md) 20px 0px 40px',
+			$this->css->render_measure( [ '{semantic.space.md}', 20, '', 40 ] ),
+			'An aliased side is a bare var and non-numeric siblings fall back to 0 with the unit'
+		);
+		$this->assertSame(
+			'10px 20px 30px 40px',
+			$this->css->render_measure( [ 10, 20, 30, 40 ] ),
+			'A fully numeric measure is byte-identical to the pre-alias output'
+		);
+	}
+
+	/**
+	 * render_number returns the token var for an alias, keeps numeric values unchanged,
+	 * and returns false for a malformed brace-string.
+	 *
+	 * @return void
+	 */
+	public function testRenderNumberResolvesTokenAlias(): void {
+		$this->assertSame(
+			'var(--kb-token--semantic--size--icon)',
+			$this->css->render_number( '{semantic.size.icon}', 'px' ),
+			'An alias returns the bare token var with no unit'
+		);
+		$this->assertSame(
+			'10px',
+			$this->css->render_number( 10, 'px' ),
+			'A numeric value is still rendered with its unit'
+		);
+		$this->assertFalse(
+			$this->css->render_number( '{bad path}', 'px' ),
+			'A malformed alias fails open and returns false'
+		);
+	}
+
+	/**
+	 * render_shadow resolves an aliased offset to the token var while numeric pieces
+	 * keep their unit, and a fully numeric shadow stays byte-identical.
+	 *
+	 * @return void
+	 */
+	public function testRenderShadowResolvesTokenAlias(): void {
+		$this->assertSame(
+			'var(--kb-token--semantic--shadow--x) 1px 4px 2px rgba(0, 0, 0, 0.5)',
+			$this->css->render_shadow( [
+				'color'   => '#000000',
+				'opacity' => 0.5,
+				'spread'  => 2,
+				'blur'    => 4,
+				'hOffset' => '{semantic.shadow.x}',
+				'vOffset' => 1,
+				'inset'   => false,
+			] ),
+			'An aliased offset is a bare var while numeric pieces keep their px unit'
+		);
+		$this->assertSame(
+			'1px 1px 4px 2px rgba(0, 0, 0, 0.5)',
+			$this->css->render_shadow( [
+				'color'   => '#000000',
+				'opacity' => 0.5,
+				'spread'  => 2,
+				'blur'    => 4,
+				'hOffset' => 1,
+				'vOffset' => 1,
+				'inset'   => false,
+			] ),
+			'A fully numeric shadow is byte-identical to the pre-alias output'
+		);
+	}
+
+	/**
+	 * render_border_styles emits a token var for an aliased width so the width branch
+	 * still fires, while numeric widths remain byte-identical.
+	 *
+	 * @return void
+	 */
+	public function testRenderBorderStylesResolvesTokenWidth(): void {
+		$this->css->render_border_styles( [
+			'borderStyle' => [
+				[
+					'top'    => [ '#000000', 'solid', '{semantic.border.width}' ],
+					'right'  => [ '#000000', 'solid', 1 ],
+					'bottom' => [ '#000000', 'solid', 1 ],
+					'left'   => [ '#000000', 'solid', 1 ],
+					'unit'   => 'px',
+				],
+			],
+		] );
+		$output = $this->css->css_output();
+
+		$this->assertStringContainsString( 'border-top:var(--kb-token--semantic--border--width) solid #000000', $output,
+			'An aliased width resolves to the token var and the width branch still fires' );
+		$this->assertStringContainsString( 'border-right:1px solid #000000', $output,
+			'A numeric width is still rendered with its unit' );
+	}
+
+	/**
+	 * render_typography resolves aliased line-height and letter-spacing values to token
+	 * vars (no unit), and keeps numeric typography values byte-identical.
+	 *
+	 * @return void
+	 */
+	public function testRenderTypographyResolvesTokenAlias(): void {
+		$this->css->render_typography( [
+			'typography' => [
+				'lineHeight'    => [ '{semantic.line-height.tight}', '', '' ],
+				'letterSpacing' => [ '{semantic.letter-spacing.wide}', '', '' ],
+			],
+		] );
+		$output = $this->css->css_output();
+
+		$this->assertStringContainsString( 'line-height:var(--kb-token--semantic--line-height--tight)', $output,
+			'An aliased line-height resolves to the token var with no unit' );
+		$this->assertStringContainsString( 'letter-spacing:var(--kb-token--semantic--letter-spacing--wide)', $output,
+			'An aliased letter-spacing resolves to the token var with no unit' );
+
+		$numeric = new Kadence_Blocks_CSS();
+		$numeric->render_typography( [
+			'typography' => [
+				'lineType'      => 'px',
+				'lineHeight'    => [ 1.5, '', '' ],
+				'letterSpacing' => [ 2, '', '' ],
+			],
+		] );
+		$numeric_output = $numeric->css_output();
+
+		$this->assertStringContainsString( 'line-height:1.5px', $numeric_output,
+			'A numeric line-height is still rendered with its unit' );
+		$this->assertStringContainsString( 'letter-spacing:2px', $numeric_output,
+			'A numeric letter-spacing is still rendered with its unit' );
 	}
 
 	protected function _before() {


### PR DESCRIPTION
🎫 https://linear.app/nexcess/issue/SOFT-3900/php-render-token-reference-relax-is-numeric-gates-in-kadence-blocks

:video_camera: https://www.loom.com/share/92b2c54d02da481b8a7298c1b2c7776a

Adds a shared `get_token_reference()` recognizer to `Kadence_Blocks_CSS` and relaxes the render gates so a `{dot.alias}` block attribute resolves to a bare `var(--kb-token--<id>)` on the front end, mirroring the editor's `resolveTokenAlias`. The recognizer runs before each numeric/palette gate, emits no fallback and no unit, and returns `null` for anything that is not a strict alias -- so a malformed brace-string fails open and literal/palette output stays byte-for-byte identical.

Relaxed gates: color (`render_color`/`sanitize_color`), `render_number`, `render_range`, `render_measure_range`, `render_border_radius`, `render_responsive_range`/`render_responsive_size`, `render_measure`, `render_shadow`, border width (`get_border_value`), and line-height/letter-spacing in `render_typography`.

Tests cover the recognizer (conformance cases shared with the JS side), per-gate alias emission, fail-open, and byte-identical literal output.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
