### PR TITLE
[DTM] SOFT-3902 [1/2]: PHP pickable-tokens catalog + editor pool global

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -108,6 +108,7 @@
         "phar",
         "phpcs",
         "phpstan",
+        "pickable",
         "postfields",
         "progressbar",
         "puprc",

--- a/includes/resources/Design_Tokens/Editor/Localizer.php
+++ b/includes/resources/Design_Tokens/Editor/Localizer.php
@@ -8,12 +8,13 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
 /**
  * Attaches the editor catalogs to the block editor's early-filters bundle.
  *
- * On enqueue_block_editor_assets (after the editor-assets class has enqueued the script) it attaches four
+ * On enqueue_block_editor_assets (after the editor-assets class has enqueued the script) it attaches five
  * globals to the existing 'kadence-blocks-early-filters-js' handle: window.kadenceDesignTokensVariants (the
  * per-set variant catalog the variant picker and the "save as new variant" form read),
  * window.kadenceDesignTokensSets (the token-set catalog the per-block set-override picker reads),
  * window.kadenceDesignTokensPresetDefaults (the per-block attribute-default catalog the block-registration
- * filter reads), and window.kadenceDesignTokensRest (the REST descriptor the variant writes POST to).
+ * filter reads), window.kadenceDesignTokensRest (the REST descriptor the variant writes POST to), and
+ * window.kadenceDesignTokensPickable (the pickable-token pool the editor token picker's accessor reads).
  * Guarded on wp_script_is( …, 'enqueued' ) so it runs only where that bundle loads, and skipped entirely
  * when the registry is fail-closed (a deactivated registry projects nothing, so the pickers offer nothing).
  *
@@ -70,6 +71,15 @@ final class Localizer {
 	private const REST_OBJECT = 'kadenceDesignTokensRest';
 
 	/**
+	 * The JS global the editor token picker's accessor reads (the pickable-token pool).
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const PICKABLE_OBJECT = 'kadenceDesignTokensPickable';
+
+	/**
 	 * The token registry, for the fail-closed gate.
 	 *
 	 * @since TBD
@@ -106,23 +116,35 @@ final class Localizer {
 	private Block_Preset_Catalog $preset_defaults;
 
 	/**
+	 * The pickable-token pool builder.
+	 *
 	 * @since TBD
 	 *
-	 * @param Token_Registry       $registry        The token registry.
-	 * @param Variant_Catalog      $variant_catalog The variant catalog builder.
-	 * @param Set_Catalog          $set_catalog     The token-set catalog builder.
-	 * @param Block_Preset_Catalog $preset_defaults The per-block attribute-default catalog builder.
+	 * @var Pickable_Tokens_Catalog
+	 */
+	private Pickable_Tokens_Catalog $pickable;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry          $registry        The token registry.
+	 * @param Variant_Catalog         $variant_catalog The variant catalog builder.
+	 * @param Set_Catalog             $set_catalog     The token-set catalog builder.
+	 * @param Block_Preset_Catalog    $preset_defaults The per-block attribute-default catalog builder.
+	 * @param Pickable_Tokens_Catalog $pickable        The pickable-token pool builder.
 	 */
 	public function __construct(
 		Token_Registry $registry,
 		Variant_Catalog $variant_catalog,
 		Set_Catalog $set_catalog,
-		Block_Preset_Catalog $preset_defaults
+		Block_Preset_Catalog $preset_defaults,
+		Pickable_Tokens_Catalog $pickable
 	) {
 		$this->registry        = $registry;
 		$this->variant_catalog = $variant_catalog;
 		$this->set_catalog     = $set_catalog;
 		$this->preset_defaults = $preset_defaults;
+		$this->pickable        = $pickable;
 	}
 
 	/**
@@ -145,6 +167,7 @@ final class Localizer {
 		$this->attach( self::SETS_OBJECT, $this->set_catalog->all() );
 		$this->attach( self::PRESET_DEFAULTS_OBJECT, $this->preset_defaults->all() );
 		$this->attach( self::REST_OBJECT, $this->rest() );
+		$this->attach( self::PICKABLE_OBJECT, $this->pickable->all() );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Editor/Pickable_Tokens_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Pickable_Tokens_Catalog.php
@@ -1,0 +1,165 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Editor;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Layers;
+
+/**
+ * Builds the pickable-token pool the block editor's token picker reads.
+ *
+ * Two sections: `tokens` is the set-independent STRUCTURE — one { id, alias, label, type, layer }
+ * entry per registered token, in registry order, where `alias` is the {id} string a pick will later
+ * write to a block attribute and `layer` (semantic | primitive) is derived from the id's first
+ * dot-segment so the picker can rank semantic tokens before primitives. `values` is the per-set
+ * resolved literal map (set slug => ( id => literal )) used ONLY for the picker's preview
+ * swatch/number — a pick writes the alias, never the literal. A set whose stored document cannot be
+ * resolved (alias cycle / dangling alias from a raw DB write) is skipped, so one corrupt set never
+ * empties the pool; structure is registry-driven and always ships.
+ *
+ * @since TBD
+ */
+final class Pickable_Tokens_Catalog {
+
+	/**
+	 * The token registry, source of the registered token structure.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * The token resolver, source of each set's resolved literal values (by id).
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Resolver
+	 */
+	private Token_Resolver $resolver;
+
+	/**
+	 * The persistence gateway, source of the stored set slugs.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry $registry The token registry.
+	 * @param Token_Resolver $resolver The token resolver.
+	 * @param Token_Store    $store    The persistence gateway.
+	 */
+	public function __construct( Token_Registry $registry, Token_Resolver $resolver, Token_Store $store ) {
+		$this->registry = $registry;
+		$this->resolver = $resolver;
+		$this->store    = $store;
+	}
+
+	/**
+	 * The pool: the pickable token structure plus the per-set resolved preview values.
+	 *
+	 * @since TBD
+	 *
+	 * @return array{tokens: array<int, array<string, string>>, values: array<string, array<string, string>>}
+	 */
+	public function all(): array {
+		return [
+			'tokens' => $this->tokens(),
+			'values' => $this->values(),
+		];
+	}
+
+	/**
+	 * The pickable token structure: one { id, alias, label, type, layer } entry per registered token,
+	 * in registry insertion order. Set-independent — values live in values().
+	 *
+	 * @since TBD
+	 *
+	 * @return array<int, array{id: string, alias: string, label: string, type: string, layer: string}>
+	 */
+	private function tokens(): array {
+		$tokens = [];
+
+		foreach ( $this->registry->all() as $token ) {
+			$tokens[] = [
+				'id'    => $token->id,
+				'alias' => Alias::wrap( $token->id ),
+				'label' => $token->label,
+				'type'  => $token->type,
+				'layer' => $this->layer_of( $token->id ),
+			];
+		}
+
+		return $tokens;
+	}
+
+	/**
+	 * The layer a token id lives in, derived from its first dot-segment: `semantic` for a semantic-layer
+	 * id, `primitive` otherwise. Derivation, not lookup — the registry keeps no per-layer index, and the
+	 * layer is by construction the id's leading segment (the document walk registers ids under their
+	 * top-level layer key).
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id The token id (a dot-path).
+	 *
+	 * @return string The layer name (semantic | primitive).
+	 */
+	private function layer_of( string $id ): string {
+		$first = explode( '.', $id )[0];
+
+		return $first === Layers::get_semantic() ? Layers::get_semantic() : Layers::get_primitive();
+	}
+
+	/**
+	 * The per-set resolved preview values: `set slug => ( token id => literal CSS value )`, for every
+	 * stored set plus the always-present default. Used only for the picker's swatch/number preview — a
+	 * pick writes the alias, so a stale or missing value is cosmetic. A set whose stored document cannot
+	 * be resolved is skipped, so one corrupt set never empties the map.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, array<string, string>> set slug => ( id => literal value ).
+	 */
+	private function values(): array {
+		$values = [];
+
+		foreach ( $this->set_slugs() as $slug ) {
+			try {
+				$values[ $slug ] = $this->resolver->resolve( $slug )->by_id();
+			} catch ( Alias_Cycle_Exception | Dangling_Alias_Exception $e ) {
+				continue; // Corrupt stored document — skip this set, fail soft.
+			}
+		}
+
+		return $values;
+	}
+
+	/**
+	 * The set slugs to resolve values for: every stored set plus the always-present default.
+	 *
+	 * @since TBD
+	 *
+	 * @return string[]
+	 */
+	private function set_slugs(): array {
+		$slugs = array_map( 'strval', array_column( $this->store->list_stores(), 'slug' ) );
+
+		if ( ! in_array( Token_Store::default_slug(), $slugs, true ) ) {
+			array_unshift( $slugs, Token_Store::default_slug() );
+		}
+
+		return $slugs;
+	}
+}

--- a/includes/resources/Design_Tokens/Editor/Provider.php
+++ b/includes/resources/Design_Tokens/Editor/Provider.php
@@ -5,11 +5,12 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Editor;
 use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
 
 /**
- * Registers the block-editor catalogs: binds the variant, token-set and preset-default catalog builders
- * and the localizer as singletons, then hooks the localizer onto enqueue_block_editor_assets so the
- * early-filters bundle receives window.kadenceDesignTokensVariants (variant picker),
- * window.kadenceDesignTokensSets (per-block set-override picker) and
- * window.kadenceDesignTokensPresetDefaults (block-registration attribute-default filter).
+ * Registers the block-editor catalogs: binds the variant, token-set, preset-default and pickable-token
+ * catalog builders and the localizer as singletons, then hooks the localizer onto
+ * enqueue_block_editor_assets so the early-filters bundle receives window.kadenceDesignTokensVariants
+ * (variant picker), window.kadenceDesignTokensSets (per-block set-override picker),
+ * window.kadenceDesignTokensPresetDefaults (block-registration attribute-default filter) and
+ * window.kadenceDesignTokensPickable (the editor token picker's accessor).
  *
  * @since TBD
  */
@@ -24,6 +25,7 @@ final class Provider extends Provider_Contract {
 		$this->container->singleton( Variant_Catalog::class );
 		$this->container->singleton( Set_Catalog::class );
 		$this->container->singleton( Block_Preset_Catalog::class );
+		$this->container->singleton( Pickable_Tokens_Catalog::class );
 		$this->container->singleton( Localizer::class );
 
 		/**

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Layers.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Layers.php
@@ -65,4 +65,15 @@ final class Layers {
 	public static function get_semantic(): string {
 		return self::SEMANTIC;
 	}
+
+	/**
+	 * The "primitive" layer name — the raw, context-free layer a semantic token typically aliases into.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_primitive(): string {
+		return self::PRIMITIVE;
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Pickable_Tokens_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Pickable_Tokens_CatalogTest.php
@@ -1,0 +1,200 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Editor;
+
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Editor\Pickable_Tokens_Catalog;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Exercises the pickable-token pool against the real shipped baseline, so these assertions also guard
+ * the token surface the editor token picker offers.
+ */
+final class Pickable_Tokens_CatalogTest extends TestCase {
+
+	/**
+	 * @var Pickable_Tokens_Catalog
+	 */
+	private Pickable_Tokens_Catalog $catalog;
+
+	/**
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * Resolves the catalog and the store from the container so each test exercises the real shipped
+	 * baseline and registered collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->catalog = $this->container->get( Pickable_Tokens_Catalog::class );
+		$this->store   = $this->container->get( Token_Store::class );
+	}
+
+	/**
+	 * Every token entry carries the full pickable shape and wraps its own id as the alias.
+	 *
+	 * @return void
+	 */
+	public function testEveryTokenEntryWrapsItsIdAsTheAlias(): void {
+		$tokens = $this->catalog->all()['tokens'];
+
+		$this->assertNotEmpty( $tokens );
+
+		foreach ( $tokens as $token ) {
+			$this->assertSame( [ 'id', 'alias', 'label', 'type', 'layer' ], array_keys( $token ) );
+			$this->assertSame( '{' . $token['id'] . '}', $token['alias'] );
+			$this->assertNotSame( '', $token['label'] );
+		}
+	}
+
+	/**
+	 * A token's layer is derived from its id's first dot-segment, so every token under a layer prefix
+	 * reports that layer.
+	 *
+	 * @dataProvider layerProvider
+	 *
+	 * @param string $prefix   The id prefix selecting the tokens under one layer.
+	 * @param string $expected The layer every matching token must report.
+	 *
+	 * @return void
+	 */
+	public function testLayerIsDerivedFromTheIdFirstSegment( string $prefix, string $expected ): void {
+		$matching = array_filter(
+			$this->catalog->all()['tokens'],
+			static fn( array $token ): bool => strpos( $token['id'], $prefix ) === 0
+		);
+
+		// The shipped baseline registers tokens in both layers; an empty match means the fixture broke.
+		$this->assertNotEmpty( $matching );
+
+		foreach ( $matching as $token ) {
+			$this->assertSame( $expected, $token['layer'] );
+		}
+	}
+
+	/**
+	 * The values map is keyed by set slug and resolves each token to a literal: a color token to a
+	 * color literal (hex / rgb) and a dimension token to a CSS length, never an alias or a var() chain.
+	 *
+	 * @return void
+	 */
+	public function testValuesResolveToLiteralsPerSet(): void {
+		$pool   = $this->catalog->all();
+		$values = $pool['values'];
+
+		$this->assertArrayHasKey( Token_Store::default_slug(), $values );
+
+		$defaults = $values[ Token_Store::default_slug() ];
+
+		// Not just the first color entry — the baseline also registers keyword literals (e.g.
+		// "transparent"), so pick the first one that resolves to a hex/rgb/hsl literal to exercise the
+		// intended assertion.
+		$color = $this->first_matching(
+			$pool['tokens'],
+			'color',
+			static fn( string $value ): bool => (bool) preg_match( '/^(#|rgb|hsl)/i', $value ),
+			$defaults
+		);
+
+		$dimension = $this->first_of_type( $pool['tokens'], 'dimension' );
+
+		$this->assertMatchesRegularExpression( '/^(#|rgb|hsl)/i', $defaults[ $color['id'] ] );
+		$this->assertMatchesRegularExpression( '/^-?[\d.]+[a-z%]*$/i', $defaults[ $dimension['id'] ] );
+
+		// Preview values are literals, never unresolved references.
+		$this->assertStringNotContainsString( '{', $defaults[ $color['id'] ] );
+		$this->assertStringNotContainsString( 'var(', $defaults[ $color['id'] ] );
+	}
+
+	/**
+	 * A set whose stored document cannot be resolved is skipped from the values map while its siblings
+	 * (the default set) survive, so one corrupt set never empties the pool.
+	 *
+	 * @return void
+	 */
+	public function testACorruptSetIsSkippedFromValues(): void {
+		// Raw store write (bypasses the REST validation gate that would reject a dangling alias),
+		// mirroring the raw-DB-write scenario the resolver's fail-soft guards exist for.
+		$this->store->save_document(
+			wp_json_encode(
+				[
+					'semantic' => [
+						'color' => [
+							'border' => [
+								'$type'  => 'color',
+								'$value' => '{primitive.color.does-not-exist}',
+							],
+						],
+					],
+				]
+			),
+			'broken'
+		);
+
+		$values = $this->container->get( Pickable_Tokens_Catalog::class )->all()['values'];
+
+		$this->assertArrayHasKey( Token_Store::default_slug(), $values );
+		$this->assertArrayNotHasKey( 'broken', $values );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function layerProvider(): Generator {
+		yield 'semantic tokens' => [
+			'prefix'   => 'semantic.',
+			'expected' => 'semantic',
+		];
+
+		yield 'primitive tokens' => [
+			'prefix'   => 'primitive.',
+			'expected' => 'primitive',
+		];
+	}
+
+	/**
+	 * The first token entry of a given type, failing the test when the baseline registers none.
+	 *
+	 * @param array<int, array<string, string>> $tokens The pool's token entries.
+	 * @param string                            $type   The DTCG type to find.
+	 *
+	 * @return array<string, string> The first matching token entry.
+	 */
+	private function first_of_type( array $tokens, string $type ): array {
+		foreach ( $tokens as $token ) {
+			if ( $token['type'] === $type ) {
+				return $token;
+			}
+		}
+
+		$this->fail( sprintf( 'No token of type "%s" in the pool.', $type ) );
+	}
+
+	/**
+	 * The first token entry of a given type whose resolved default-set value satisfies a predicate,
+	 * failing the test when the baseline has no such token (e.g. every entry of that type resolves to a
+	 * keyword literal instead of a hex/rgb/hsl one).
+	 *
+	 * @param array<int, array<string, string>> $tokens    The pool's token entries.
+	 * @param string                            $type      The DTCG type to find.
+	 * @param callable                          $predicate Receives the resolved literal, returns whether it matches.
+	 * @param array<string, string>             $defaults  The default set's resolved values, keyed by id.
+	 *
+	 * @return array<string, string> The first matching token entry.
+	 */
+	private function first_matching( array $tokens, string $type, callable $predicate, array $defaults ): array {
+		foreach ( $tokens as $token ) {
+			if ( $token['type'] === $type && isset( $defaults[ $token['id'] ] ) && $predicate( $defaults[ $token['id'] ] ) ) {
+				return $token;
+			}
+		}
+
+		$this->fail( sprintf( 'No token of type "%s" with a matching resolved value in the pool.', $type ) );
+	}
+}


### PR DESCRIPTION
## Summary

Adds the editor-side **pickable-token pool feed** — the data surface the token picker (SOFT-3908) reads. A new `Pickable_Tokens_Catalog` builds `{ tokens, values }`: per-token structure (`id`, `alias`, `label`, `type`, `layer`) plus per-set resolved literal preview values. It ships as a 5th editor global, `window.kadenceDesignTokensPickable`, behind the existing enqueued + registry-active guards.

## Changes

- **New `Editor/Pickable_Tokens_Catalog`** (mirrors `Variant_Catalog`): `all()` returns `{ tokens, values }`. `alias` is minted via `Alias::wrap()`; `layer` is derived from the token id's first dot-segment; per-set `values` come from `Token_Resolver::resolve( $slug )->by_id()`, fail-soft skipping a set whose stored document cannot be resolved.
- **`Layers::get_primitive()`** accessor (mirrors the existing `get_semantic()`), so the catalog never hardcodes the layer name.
- **`Editor/Localizer`** attaches the 5th global `window.kadenceDesignTokensPickable`.
- **`Editor/Provider`** registers the catalog as a singleton.
- **wpunit `Pickable_Tokens_CatalogTest`**: alias wrapping, layer derivation, per-set literal resolution, corrupt-set skip.

The `value` field is preview-only — a pick will write the `alias`, never the literal. No `declarations.php` / `baseline.json` change, so no baseline-cache flush is needed.

## Test plan

- `vendor/bin/phpstan analyse` (level max) green; `phpstan-baseline.neon` untouched.
- `slic run wpunit Resources/Design_Tokens/Editor/Pickable_Tokens_CatalogTest` green (5 tests, 210 assertions).
