### PR TITLE
[DTM] SOFT-3902 [2/2]: JS token-picker accessor

### DIFF
--- a/src/extension/token-picker/__tests__/index.test.js
+++ b/src/extension/token-picker/__tests__/index.test.js
@@ -1,0 +1,208 @@
+/* eslint-env jest */
+
+// `../index` pulls in `../../variant-picker`, which imports `@kadence/components` (an untransformed
+// ESM module) for its `VariantPicker` component. This module never renders it, so stub it out.
+jest.mock('@kadence/components', () => ({}));
+
+import { pickableTokenPool, pickableTokensFor, pickableTokensForControl } from '../index';
+
+/**
+ * The fixture pickable-token pool: layers are interleaved on purpose to prove the semantic-first
+ * rank re-orders rather than merely preserving input order.
+ */
+const POOL = {
+	tokens: [
+		{
+			id: 'primitive.color.blue-500',
+			alias: '{primitive.color.blue-500}',
+			label: 'Blue 500',
+			type: 'color',
+			layer: 'primitive',
+		},
+		{
+			id: 'semantic.color.button-primary-bg',
+			alias: '{semantic.color.button-primary-bg}',
+			label: 'Button Primary Background',
+			type: 'color',
+			layer: 'semantic',
+		},
+		{
+			id: 'primitive.dimension.radius.sm',
+			alias: '{primitive.dimension.radius.sm}',
+			label: 'Radius SM',
+			type: 'dimension',
+			layer: 'primitive',
+		},
+		{
+			id: 'semantic.radius.button',
+			alias: '{semantic.radius.button}',
+			label: 'Button Radius',
+			type: 'dimension',
+			layer: 'semantic',
+		},
+		{
+			id: 'primitive.font-weight.bold',
+			alias: '{primitive.font-weight.bold}',
+			label: 'Bold',
+			type: 'fontWeight',
+			layer: 'primitive',
+		},
+	],
+	values: {
+		default: {
+			'primitive.color.blue-500': '#3182ce',
+			'semantic.color.button-primary-bg': '#2b6cb0',
+			'primitive.dimension.radius.sm': '4px',
+			'semantic.radius.button': '0.5rem',
+			'primitive.font-weight.bold': '700',
+		},
+		brand: { 'semantic.color.button-primary-bg': '#000000' },
+	},
+};
+
+/**
+ * The fixture variant catalog: enough for `activeSet()` and `blockProperties()` to resolve a single
+ * mapped control (`borderRadius` -> `dimension`) for `kadence/singlebtn`.
+ */
+const VARIANTS = {
+	active: 'default',
+	sets: {
+		default: {
+			'kadence/singlebtn': {
+				properties: [{ key: 'button-radius', kind: 'dimension', token: null, control_attr: 'borderRadius' }],
+			},
+		},
+	},
+};
+
+describe('pickableTokenPool', () => {
+	beforeEach(() => {
+		window.kadenceDesignTokensPickable = POOL;
+		window.kadenceDesignTokensVariants = VARIANTS;
+	});
+
+	afterEach(() => {
+		delete window.kadenceDesignTokensPickable;
+		delete window.kadenceDesignTokensVariants;
+	});
+
+	it('returns the seeded pool', () => {
+		expect(pickableTokenPool()).toBe(POOL);
+	});
+
+	it('returns an empty object when the global is absent', () => {
+		delete window.kadenceDesignTokensPickable;
+
+		expect(pickableTokenPool()).toEqual({});
+	});
+});
+
+describe('pickableTokensFor', () => {
+	beforeEach(() => {
+		window.kadenceDesignTokensPickable = POOL;
+		window.kadenceDesignTokensVariants = VARIANTS;
+	});
+
+	afterEach(() => {
+		delete window.kadenceDesignTokensPickable;
+		delete window.kadenceDesignTokensVariants;
+	});
+
+	it('returns only color tokens, semantic first, with no dimension or fontWeight leakage', () => {
+		const result = pickableTokensFor('color');
+
+		expect(result).toEqual([
+			{
+				id: 'semantic.color.button-primary-bg',
+				alias: '{semantic.color.button-primary-bg}',
+				label: 'Button Primary Background',
+				value: '#2b6cb0',
+				type: 'color',
+			},
+			{
+				id: 'primitive.color.blue-500',
+				alias: '{primitive.color.blue-500}',
+				label: 'Blue 500',
+				value: '#3182ce',
+				type: 'color',
+			},
+		]);
+	});
+
+	it('returns only dimension tokens, semantic first, with resolved values', () => {
+		const result = pickableTokensFor('dimension');
+
+		expect(result.map((token) => token.id)).toEqual(['semantic.radius.button', 'primitive.dimension.radius.sm']);
+		expect(result.map((token) => token.value)).toEqual(['0.5rem', '4px']);
+	});
+
+	it('returns only the fontWeight token for the text kind', () => {
+		const result = pickableTokensFor('text');
+
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe('primitive.font-weight.bold');
+	});
+
+	it('fails closed on an unknown kind', () => {
+		expect(pickableTokensFor('nope')).toEqual([]);
+	});
+
+	it('reads the requested set, leaving a missing entry blank', () => {
+		const result = pickableTokensFor('color', 'brand');
+
+		expect(result).toEqual([
+			{
+				id: 'semantic.color.button-primary-bg',
+				alias: '{semantic.color.button-primary-bg}',
+				label: 'Button Primary Background',
+				value: '#000000',
+				type: 'color',
+			},
+			{
+				id: 'primitive.color.blue-500',
+				alias: '{primitive.color.blue-500}',
+				label: 'Blue 500',
+				value: '',
+				type: 'color',
+			},
+		]);
+	});
+
+	it('falls back to the active set values for an unknown set slug', () => {
+		const result = pickableTokensFor('color', 'nonexistent-set');
+
+		expect(result.find((token) => token.id === 'semantic.color.button-primary-bg').value).toBe('#2b6cb0');
+	});
+
+	it('fails soft when the pool is missing, returning empty results without throwing', () => {
+		delete window.kadenceDesignTokensPickable;
+
+		expect(() => pickableTokensFor('color')).not.toThrow();
+		expect(pickableTokensFor('color')).toEqual([]);
+		expect(pickableTokensFor('dimension')).toEqual([]);
+	});
+});
+
+describe('pickableTokensForControl', () => {
+	beforeEach(() => {
+		window.kadenceDesignTokensPickable = POOL;
+		window.kadenceDesignTokensVariants = VARIANTS;
+	});
+
+	afterEach(() => {
+		delete window.kadenceDesignTokensPickable;
+		delete window.kadenceDesignTokensVariants;
+	});
+
+	it('resolves the mapped control kind and delegates to pickableTokensFor', () => {
+		expect(pickableTokensForControl('kadence/singlebtn', 'borderRadius')).toEqual(pickableTokensFor('dimension'));
+	});
+
+	it('returns an empty array for an unmapped attribute', () => {
+		expect(pickableTokensForControl('kadence/singlebtn', 'padding')).toEqual([]);
+	});
+
+	it('returns an empty array for an unknown block', () => {
+		expect(pickableTokensForControl('kadence/does-not-exist', 'borderRadius')).toEqual([]);
+	});
+});

--- a/src/extension/token-picker/index.js
+++ b/src/extension/token-picker/index.js
@@ -21,6 +21,8 @@ import { activeSet, blockProperties } from '../variant-picker';
  * kinds; values are DTCG $type lists. `shadow` is inert until a shadow control kind exists — it is
  * mapped now so a future shadow control lights up with no change here. An unknown kind yields no
  * types, so the filter fails closed.
+ *
+ * @since TBD
  */
 const KIND_TYPES = {
 	color: ['color'],

--- a/src/extension/token-picker/index.js
+++ b/src/extension/token-picker/index.js
@@ -1,0 +1,118 @@
+/**
+ * Pickable-token accessor for the editor token picker.
+ *
+ * The pool is printed by the server-side editor localizer to `window.kadenceDesignTokensPickable`:
+ * `{ tokens: [{ id, alias, label, type, layer }], values: { <setSlug>: { <id>: literal } } }`.
+ * This module turns it into the per-control PICKABLE list — hard type filter by the control's kind
+ * (a radius control never lists color or font tokens), semantic-layer tokens ranked before
+ * primitives, and each entry carrying the resolved literal `value` for the preview swatch/number.
+ * A pick writes the `alias` (the `{id}` string) — never the `value`; consumers of this module build
+ * the picker UI and the attribute write, neither of which lives here.
+ *
+ * The `value` field reflects page-load resolution; a token override written through the REST API
+ * refreshes the projected CSS but not this pool, so a preview swatch can go stale until reload.
+ * That is cosmetic (the alias never goes stale) and live refresh is the picker UI's concern.
+ */
+import { get } from 'lodash';
+import { activeSet, blockProperties } from '../variant-picker';
+
+/**
+ * Token $types compatible with each control kind. Keys are the variant catalog's coarse control
+ * kinds; values are DTCG $type lists. `shadow` is inert until a shadow control kind exists — it is
+ * mapped now so a future shadow control lights up with no change here. An unknown kind yields no
+ * types, so the filter fails closed.
+ */
+const KIND_TYPES = {
+	color: ['color'],
+	dimension: ['dimension'],
+	text: ['fontFamily', 'fontWeight', 'lineHeight', 'fontStyle', 'textTransform'],
+	shadow: ['shadow'],
+};
+
+/**
+ * The whole pickable-token pool the editor localizer prints, or an empty pool when the token
+ * registry is inactive (nothing pickable).
+ *
+ * @since TBD
+ *
+ * @return {Object} The pool ({ tokens, values }).
+ */
+export function pickableTokenPool() {
+	return get(window, 'kadenceDesignTokensPickable', {}) || {};
+}
+
+/**
+ * The resolved literal values for a token set, falling back to the active set when the requested
+ * set is omitted or absent from the pool.
+ *
+ * @param {string} [set] The token set slug.
+ *
+ * @since TBD
+ *
+ * @return {Object} id => literal value.
+ */
+function valuesFor(set) {
+	const values = get(pickableTokenPool(), 'values', {}) || {};
+	const slug = set || activeSet();
+
+	return get(values, [slug], null) || get(values, [activeSet()], {}) || {};
+}
+
+/**
+ * The pickable tokens for a control kind: only type-compatible tokens (the hard filter), semantic-
+ * layer tokens ranked before primitives (stable order within each layer, i.e. registry order), each
+ * with its resolved literal `value` from the requested set for the preview swatch/number.
+ *
+ * @param {string} kind  The control kind ('color' | 'dimension' | 'text' | 'shadow').
+ * @param {string} [set] The token set slug; defaults to the active set.
+ *
+ * @since TBD
+ *
+ * @return {Array} The pickable list ([{ id, alias, label, value, type }]).
+ */
+export function pickableTokensFor(kind, set) {
+	const types = KIND_TYPES[kind] || [];
+	const tokens = get(pickableTokenPool(), 'tokens', []) || [];
+	const values = valuesFor(set);
+
+	const compatible = tokens.filter((token) => types.includes(token.type));
+
+	// Semantic first, primitives as the fallback pool; filter() preserves registry order per group.
+	const ranked = [
+		...compatible.filter((token) => token.layer === 'semantic'),
+		...compatible.filter((token) => token.layer !== 'semantic'),
+	];
+
+	return ranked.map((token) => ({
+		id: token.id,
+		alias: token.alias,
+		label: token.label,
+		value: get(values, [token.id], ''),
+		type: token.type,
+	}));
+}
+
+/**
+ * The pickable tokens for one block control, keyed by the attribute the control writes: resolves
+ * the control's kind from the variant catalog's { key, kind, token, control_attr } surface, then
+ * filters and ranks the pool for that kind. Empty when the block maps no such control in the set —
+ * an unmapped control offers no tokens, which is the "selectable only where it makes sense"
+ * guarantee at the per-control call site.
+ *
+ * @param {string} blockName   The block name (e.g. 'kadence/singlebtn').
+ * @param {string} controlAttr The attribute the control writes (e.g. 'borderRadius').
+ * @param {string} [set]       The token set slug; defaults to the active set.
+ *
+ * @since TBD
+ *
+ * @return {Array} The pickable list ([{ id, alias, label, value, type }]), empty when unmapped.
+ */
+export function pickableTokensForControl(blockName, controlAttr, set) {
+	const property = blockProperties(blockName, set).find((entry) => entry.control_attr === controlAttr);
+
+	if (!property || !property.kind) {
+		return [];
+	}
+
+	return pickableTokensFor(property.kind, set);
+}


### PR DESCRIPTION
## Summary

Adds the JS accessor half of the pickable-token surface: a new `src/extension/token-picker/` module. Pure functions that turn the `window.kadenceDesignTokensPickable` pool (from #1163) into a per-control pickable list — a hard type filter by control kind, semantic-layer tokens ranked before primitives, each entry carrying a resolved preview `value`. No UI and no attribute writes (those belong to the picker ticket).

Stacked on #1163 — review/merge that first.

## Changes

- `pickableTokenPool()` — reads the pool global, fail-soft on a missing/partial payload.
- `pickableTokensFor(kind, set)` — kind-to-type hard filter (a radius control never lists color or font tokens), semantic-before-primitive stable rank, and each entry's `value` resolved from the requested set with an active-set fallback. Returns `[{ id, alias, label, value, type }]`.
- `pickableTokensForControl(blockName, controlAttr, set)` — resolves the control kind from the variant-catalog surface and delegates; the entry point the picker UI will call.
- jest tests: per-kind filtering with no cross-type leakage, semantic-first ordering, fail-closed on an unknown kind, set override + active-set fallback, and fail-soft on a missing pool.

`value` is preview-only; a pick will write the `alias`. Precise per-control narrowing within `dimension` (radius vs spacing) and role-pinning are a documented follow-up — this surface ranks semantic before primitive.

## Test plan

- `bun run test src/extension/token-picker` green (12 tests).
- `bun run lint-js src/extension/token-picker` clean.
