### PR TITLE
[DTM] SOFT-3403: Advanced Text (advancedheading) token bindings

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -397,6 +397,10 @@
 			"image-bg": {
 				"$type": "color",
 				"$value": "{primitive.color.transparent}"
+			},
+			"heading-bg": {
+				"$type": "color",
+				"$value": "{primitive.color.transparent}"
 			}
 		},
 		"spacing": {
@@ -415,6 +419,10 @@
 			"media-padding": {
 				"$type": "dimension",
 				"$value": "{primitive.dimension.spacing.none}"
+			},
+			"heading-padding": {
+				"$type": "dimension",
+				"$value": "{primitive.dimension.spacing.none}"
 			}
 		},
 		"radius": {
@@ -431,6 +439,10 @@
 				"$value": "{primitive.dimension.radius.none}"
 			},
 			"column": {
+				"$type": "dimension",
+				"$value": "{primitive.dimension.radius.none}"
+			},
+			"heading": {
 				"$type": "dimension",
 				"$value": "{primitive.dimension.radius.none}"
 			}
@@ -465,18 +477,30 @@
 						}
 					}
 				}
+			},
+			"heading": {
+				"$type": "dimension",
+				"$value": "2rem"
 			}
 		},
 		"font-weight": {
 			"control": {
 				"$type": "fontWeight",
 				"$value": "normal"
+			},
+			"heading": {
+				"$type": "fontWeight",
+				"$value": "700"
 			}
 		},
 		"line-height": {
 			"control": {
 				"$type": "lineHeight",
 				"$value": "normal"
+			},
+			"heading": {
+				"$type": "lineHeight",
+				"$value": "1.2"
 			}
 		},
 		"font-style": {
@@ -671,6 +695,26 @@
 						"tokens": {
 							"color": "{semantic.color.icon}",
 							"size": "{semantic.icon-size.default}"
+						}
+					}
+				},
+				"kadence/advancedheading": {
+					"$default": "default",
+					"default": {
+						"label": "Default",
+						"tokens": {
+							"color": "{semantic.color.text}",
+							"background": "{semantic.color.heading-bg}",
+							"typography": "{semantic.font-family.control}",
+							"fontSize": "{semantic.font-size.heading}",
+							"fontHeight": "{semantic.line-height.heading}",
+							"fontWeight": "{semantic.font-weight.heading}",
+							"letterSpacing": "{semantic.letter-spacing.control}",
+							"textTransform": "{semantic.text-transform.control}",
+							"padding": "{semantic.spacing.heading-padding}",
+							"borderColor": "{semantic.color.border}",
+							"borderWidth": "{semantic.border-width.default}",
+							"borderRadius": "{semantic.radius.heading}"
 						}
 					}
 				}

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -409,5 +409,68 @@ return [
 				],
 			],
 		],
+		[
+			// Advanced Text (heading) core design properties + typography set: low-specificity
+			// block-default-CSS rules on the block root (`.wp-block-kadence-advancedheading`), where every
+			// bound attribute is empty by default in block.json — build_css() emits nothing for any of them
+			// until a value is set, so the whole 12-property set fits this mechanism directly with no
+			// per-block adapter and no build_css()/SCSS/editor-JS change. Color, font-family, and the
+			// letter-spacing/text-transform pair reuse the shared `.control` semantics already wired for the
+			// button; font-size/line-height/font-weight are the heading's own re-skin seeds. The rule also
+			// overrides a theme's per-tag element styles (h1/h2/p, specificity 0,0,1), which is what lets the
+			// design-system defaults "re-skin" an unset heading. A per-instance value renders at higher
+			// specificity (the `.kt-adv-heading<uid>` instance selector) and still wins.
+			'block'    => 'kadence/advancedheading',
+			'bindings' => [
+				'color'         => [
+					'token'    => 'semantic.color.text',
+					'css_prop' => 'color',
+				],
+				'background'    => [
+					'token'    => 'semantic.color.heading-bg',
+					'css_prop' => 'background-color',
+				],
+				'typography'    => [
+					'token'    => 'semantic.font-family.control',
+					'css_prop' => 'font-family',
+				],
+				'fontSize'      => [
+					'token'    => 'semantic.font-size.heading',
+					'css_prop' => 'font-size',
+				],
+				'fontHeight'    => [
+					'token'    => 'semantic.line-height.heading',
+					'css_prop' => 'line-height',
+				],
+				'fontWeight'    => [
+					'token'    => 'semantic.font-weight.heading',
+					'css_prop' => 'font-weight',
+				],
+				'letterSpacing' => [
+					'token'    => 'semantic.letter-spacing.control',
+					'css_prop' => 'letter-spacing',
+				],
+				'textTransform' => [
+					'token'    => 'semantic.text-transform.control',
+					'css_prop' => 'text-transform',
+				],
+				'padding'       => [
+					'token'    => 'semantic.spacing.heading-padding',
+					'css_prop' => 'padding',
+				],
+				'borderColor'   => [
+					'token'    => 'semantic.color.border',
+					'css_prop' => 'border-color',
+				],
+				'borderWidth'   => [
+					'token'    => 'semantic.border-width.default',
+					'css_prop' => 'border-width',
+				],
+				'borderRadius'  => [
+					'token'    => 'semantic.radius.heading',
+					'css_prop' => 'border-radius',
+				],
+			],
+		],
 	],
 ];

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -166,6 +166,42 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
+	 * The shipped Advanced Text (heading) declarations emit all 12 bound core-design and typography
+	 * properties as one grouped, low-specificity rule on the block root, each pointing its css_prop at the
+	 * matching token var with the resolved default as the fallback — including the font-family fallback
+	 * stringified to a comma-joined list.
+	 *
+	 * @return void
+	 */
+	public function testTheShippedDeclarationsEmitTheAdvancedHeadingSurfaceRule(): void {
+		$registry = $this->container->get( Token_Registry::class );
+
+		$css = $this->builder( $registry )->css();
+
+		$this->assertStringContainsString(
+			'.wp-block-kadence-advancedheading{color:var(' . Css_Var::from_id( 'semantic.color.text' ) . ',#1A202C);',
+			$css
+		);
+		$this->assertStringContainsString(
+			'background-color:var(' . Css_Var::from_id( 'semantic.color.heading-bg' ) . ',transparent);',
+			$css
+		);
+		$this->assertStringContainsString(
+			'font-family:var(' . Css_Var::from_id( 'semantic.font-family.control' ) . ',Inter, system-ui, sans-serif);',
+			$css
+		);
+		$this->assertStringContainsString( 'font-size:var(' . Css_Var::from_id( 'semantic.font-size.heading' ) . ',2rem);', $css );
+		$this->assertStringContainsString( 'line-height:var(' . Css_Var::from_id( 'semantic.line-height.heading' ) . ',1.2);', $css );
+		$this->assertStringContainsString( 'font-weight:var(' . Css_Var::from_id( 'semantic.font-weight.heading' ) . ',700);', $css );
+		$this->assertStringContainsString( 'letter-spacing:var(' . Css_Var::from_id( 'semantic.letter-spacing.control' ) . ',0);', $css );
+		$this->assertStringContainsString( 'text-transform:var(' . Css_Var::from_id( 'semantic.text-transform.control' ) . ',none);', $css );
+		$this->assertStringContainsString( 'padding:var(' . Css_Var::from_id( 'semantic.spacing.heading-padding' ) . ',0);', $css );
+		$this->assertStringContainsString( 'border-color:var(' . Css_Var::from_id( 'semantic.color.border' ) . ',#E2E8F0);', $css );
+		$this->assertStringContainsString( 'border-width:var(' . Css_Var::from_id( 'semantic.border-width.default' ) . ',1px);', $css );
+		$this->assertStringContainsString( 'border-radius:var(' . Css_Var::from_id( 'semantic.radius.heading' ) . ',0);}', $css );
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testItContributesNothingForABindingWithoutACssProp(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Variant_ResolverTest.php
@@ -167,6 +167,40 @@ final class Variant_ResolverTest extends TestCase {
 		);
 	}
 
+	/**
+	 * The Advanced Text (heading) variant set is registered at boot and its $default resolves the full
+	 * 12-property core-design and typography surface to the shipped baseline's literal values.
+	 *
+	 * @return void
+	 */
+	public function testTheShippedAdvancedHeadingSetIsRegisteredAndResolvesTheDefault(): void {
+		/** @var Token_Registry $registry */
+		$registry = $this->container->get( Token_Registry::class );
+
+		$this->assertNotNull(
+			$registry->for_block( 'kadence/advancedheading' ),
+			'The Advanced Text variant set should be registered at boot.'
+		);
+
+		$this->assertSame(
+			[
+				'color'         => '#1A202C',
+				'background'    => 'transparent',
+				'typography'    => 'Inter, system-ui, sans-serif',
+				'fontSize'      => '2rem',
+				'fontHeight'    => '1.2',
+				'fontWeight'    => '700',
+				'letterSpacing' => '0',
+				'textTransform' => 'none',
+				'padding'       => '0',
+				'borderColor'   => '#E2E8F0',
+				'borderWidth'   => '1px',
+				'borderRadius'  => '0',
+			],
+			$this->resolver->resolve_default( 'kadence/advancedheading' )
+		);
+	}
+
 	public function testItThrowsForAnUnknownBlock(): void {
 		$this->expectException( Unknown_Variant_Exception::class );
 

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/VariantsControllerTest.php
@@ -150,8 +150,8 @@ final class VariantsControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testGetItemReturns404ForABlockThatAcceptsNoVariants(): void {
-		// The baseline ships variant data for advancedheading, but no variant set is registered for it.
-		$result = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, 'kadence/advancedheading' ) );
+		// kadence/spacer has no baseline variant data and no variant set registered for it.
+		$result = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, 'kadence/spacer' ) );
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'rest_design_tokens_not_found', $result->get_error_code() );


### PR DESCRIPTION
## Summary

Wires the Advanced Text block (`kadence/advancedheading`) to the design-tokens system, so a fresh block follows the site's tokens for its core design properties while any per-instance value the user sets still wins.

Every bound attribute is empty-by-default in the block, so all of them flow through the existing low-specificity `Block_Default_Css` projector — the same mechanism already used for `kadence/image` and `kadence/single-icon` color. The per-block mapping spike found **no deviation**, so there is **no adapter, no `build_css()` change, no SCSS change, and no editor-JS change**. (The button block delivers the same tokens through SCSS `var()` fallbacks because its stylesheet loads on the front end; this block's does not — all its front-end CSS comes from PHP — so it uses the PHP projector to get the identical low-specificity-default semantics.)

## What changed

- **`baseline.json`** — 6 new `semantic.*` leaves: `color.heading-bg` (transparent), `font-size.heading` (`2rem`), `line-height.heading` (`1.2`), `font-weight.heading` (`700`), `spacing.heading-padding` (0), `radius.heading` (0). Plus a `kadence/advancedheading` `$default` variant entry mapping the 12 bound properties to their tokens.
- **`declarations.php`** — a `kadence/advancedheading` `variant_sets` entry with 12 `token` + `css_prop` bindings (no `css_selector`, no picker `label`).
- Reuses existing leaves for color, font-family, letter-spacing, text-transform, border color, and border width — no duplication.
- **No `tokens` registration** for any of these (the `:root` vars emit from the baseline document regardless, and overrides work without it — matching the `single-icon` color and button-typography precedents). Admin-UI editability + `Baseline_Guard` coverage is a deliberate follow-up.

## Scope

Bound: text color, background color, font-family, font-size, line-height, font-weight, letter-spacing, text-transform, padding, and border color/width/radius (12 properties).

Out of scope (deliberate follow-up): margin (would strip theme heading spacing) and the compound sub-features — highlight/mark, link colors, icon color/size/padding, inline image, and text-shadow.

## Behavior on activation (intentional re-skin)

Only `color`, `font-family`, `font-size`, `line-height`, and `font-weight` are visibly affected — an unset Advanced Text block adopts the design-system defaults (neutral.900 / Inter / 2rem / 1.2 / 700), the same trade-off accepted for the button font. Background, padding, border, letter-spacing, and text-transform resolve to inert values, so they change nothing. A per-instance value still wins by specificity.

## ⚑ For reviewer confirmation

`font-size.heading` (`2rem`), `line-height.heading` (`1.2`), and `font-weight.heading` (`700`) are the only properties that force **every** Advanced Text block — including body-text uses of the block — to one value, overriding a theme's per-tag (h1/h2/p) styling. Please confirm these exact numbers, or whether `font-size` in particular should be inert instead of a fixed default.

## Test plan

- New `Css_BuilderTest` case asserts all 12 declarations emit in the grouped `.wp-block-kadence-advancedheading{...}` rule with the right var names and resolved fallbacks (including the font-family stack `Inter, system-ui, sans-serif`).
- New `Variant_ResolverTest` case asserts the variant set is registered and `resolve_default()` returns all 12 property/value pairs.
- Repointed `VariantsControllerTest`'s "block that accepts no variants" 404 case off `advancedheading` (now registered) onto `kadence/spacer`.
- Full `Resources/Design_Tokens` wpunit suite: 950 tests, 0 failures. `phpstan` clean (`phpstan-baseline.neon` untouched); `cspell` clean.

---

This PR targets `SOFT-3403/base`; the roll-up into `feature/design-tokens-module` is a separate integration-base PR.
