### PR TITLE
[DTM] SOFT-3403 [2/2]: Block_Default_Css editor parity

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
@@ -128,6 +128,39 @@ final class Css_Builder {
 	}
 
 	/**
+	 * Cached variant of css(): memoized per request and persisted in the object cache keyed on the store
+	 * version (and plugin version), so a token write (which bumps the store version) and a plugin upgrade
+	 * both invalidate it automatically.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $version The store version the resolved set was built from.
+	 * @param string $slug    The token set slug.
+	 *
+	 * @return string
+	 */
+	public function css_for_version( string $version, string $slug ): string {
+		return $this->for_version( $version, $slug, false );
+	}
+
+	/**
+	 * Cached variant of editor_css(): same memo/object-cache mechanics as {@see self::css_for_version()}, but
+	 * keyed under a distinct `editor:` context so the editor-scoped string (which differs from the front-end
+	 * one for any block declaring an `editor_selector`) never collides with, or gets served in place of, the
+	 * front-end cache entry.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $version The store version the resolved set was built from.
+	 * @param string $slug    The token set slug.
+	 *
+	 * @return string
+	 */
+	public function editor_css_for_version( string $version, string $slug ): string {
+		return $this->for_version( $version, $slug, true );
+	}
+
+	/**
 	 * Shared build for both {@see self::css()} and {@see self::editor_css()}; only the selector base differs
 	 * per block, per the presence of an `editor_selector` declaration.
 	 *
@@ -192,39 +225,6 @@ final class Css_Builder {
 		}
 
 		return $css;
-	}
-
-	/**
-	 * Cached variant of css(): memoized per request and persisted in the object cache keyed on the store
-	 * version (and plugin version), so a token write (which bumps the store version) and a plugin upgrade
-	 * both invalidate it automatically.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $version The store version the resolved set was built from.
-	 * @param string $slug    The token set slug.
-	 *
-	 * @return string
-	 */
-	public function css_for_version( string $version, string $slug ): string {
-		return $this->for_version( $version, $slug, false );
-	}
-
-	/**
-	 * Cached variant of editor_css(): same memo/object-cache mechanics as {@see self::css_for_version()}, but
-	 * keyed under a distinct `editor:` context so the editor-scoped string (which differs from the front-end
-	 * one for any block declaring an `editor_selector`) never collides with, or gets served in place of, the
-	 * front-end cache entry.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $version The store version the resolved set was built from.
-	 * @param string $slug    The token set slug.
-	 *
-	 * @return string
-	 */
-	public function editor_css_for_version( string $version, string $slug ): string {
-		return $this->for_version( $version, $slug, true );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
@@ -246,13 +246,14 @@ final class Css_Builder {
 	 */
 	private function for_version( string $version, string $slug, bool $editor ): string {
 		$context  = $editor ? 'editor' : 'front';
-		$memo_key = $context . ':' . $version . ':' . $slug;
+		$suffix   = $version . ':' . $slug;
+		$memo_key = $context . ':' . $suffix;
 
 		if ( isset( $this->memo[ $memo_key ] ) ) {
 			return $this->memo[ $memo_key ];
 		}
 
-		$cache_key = 'block_default_css_' . $context . '_' . KADENCE_BLOCKS_VERSION . '_' . $version . ':' . $slug;
+		$cache_key = 'block_default_css_' . $context . '_' . KADENCE_BLOCKS_VERSION . '_' . $suffix;
 		$cached    = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
 
 		if ( $found && is_string( $cached ) ) {

--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
@@ -35,8 +35,11 @@ use RuntimeException;
  *   - attribute set to any value → the block's higher-specificity rule wins, including an explicit `0`.
  *
  * And because the Projector enqueues this onto KB's editor style handle as well as the front-end one,
- * the editor canvas gets the same default for free — the reason this CSS approach is preferred over an
- * attribute/slug/control approach for these families. Nothing here is `!important`.
+ * the editor canvas gets the same token default — for most blocks the identical rule, and for a block
+ * whose editor markup renders the binding on a different element (one declaring an `editor_selector`,
+ * currently Advanced Heading) a rule re-scoped to that element so the default still lands. This
+ * editor-canvas parity is the reason this CSS approach is preferred over an attribute/slug/control
+ * approach for these families. Nothing here is `!important`.
  *
  * Only a binding that declares a `css_prop` and references a token contributes, and only the block's
  * `$default` variant is read (named variants are the selectable-variant projector's job). Pure: no
@@ -76,8 +79,9 @@ final class Css_Builder {
 	private Variant_Resolver $variants;
 
 	/**
-	 * Per-request memo keyed on slug + store version, so repeated builds within a request are free and a
-	 * write (which bumps the version) invalidates it without an explicit purge.
+	 * Per-request memo keyed on context (front end / editor) + store version + slug, so repeated builds
+	 * within a request are free and a write (which bumps the version) invalidates it without an explicit
+	 * purge. The context is part of the key because the editor build can differ from the front-end one.
 	 *
 	 * @since TBD
 	 *

--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
@@ -107,6 +107,38 @@ final class Css_Builder {
 	 * @return string The CSS, or an empty string when there is nothing to project.
 	 */
 	public function css( string $slug = 'default' ): string {
+		return $this->build( $slug, false );
+	}
+
+	/**
+	 * Build the EDITOR-scoped variant of the block-default CSS for a token set. Identical to {@see self::css()}
+	 * for every block that declares no `editor_selector` (e.g. Image, Single Icon, Row Layout, Column) — the
+	 * front-end `.wp-block-*` selector is reused verbatim. For a block that declares one (currently Advanced
+	 * Heading), the rule targets `.editor-styles-wrapper <editor_selector>` instead, so the default lands on
+	 * the element the editor actually renders the bindings against rather than the `useBlockProps()` wrapper.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token set whose resolved values the `$default` aliases resolve against.
+	 *
+	 * @return string The CSS, or an empty string when there is nothing to project.
+	 */
+	public function editor_css( string $slug = 'default' ): string {
+		return $this->build( $slug, true );
+	}
+
+	/**
+	 * Shared build for both {@see self::css()} and {@see self::editor_css()}; only the selector base differs
+	 * per block, per the presence of an `editor_selector` declaration.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug   The token set whose resolved values the `$default` aliases resolve against.
+	 * @param bool   $editor Whether to build the editor-scoped variant.
+	 *
+	 * @return string The CSS, or an empty string when there is nothing to project.
+	 */
+	private function build( string $slug, bool $editor ): string {
 		$css = '';
 
 		foreach ( $this->registry->variant_blocks() as $block ) {
@@ -124,7 +156,9 @@ final class Css_Builder {
 				continue;
 			}
 
-			$selector = '.wp-block-' . str_replace( '/', '-', $block );
+			$selector = $editor && $set->editor_selector !== null
+				? '.editor-styles-wrapper ' . $set->editor_selector
+				: '.wp-block-' . str_replace( '/', '-', $block );
 
 			// Group declarations by selector suffix so a block with several dimension props on the same
 			// element emits one rule, and props on a descendant (e.g. " img") get their own.
@@ -173,20 +207,55 @@ final class Css_Builder {
 	 * @return string
 	 */
 	public function css_for_version( string $version, string $slug ): string {
-		$memo_key = $version . ':' . $slug;
+		return $this->for_version( $version, $slug, false );
+	}
+
+	/**
+	 * Cached variant of editor_css(): same memo/object-cache mechanics as {@see self::css_for_version()}, but
+	 * keyed under a distinct `editor:` context so the editor-scoped string (which differs from the front-end
+	 * one for any block declaring an `editor_selector`) never collides with, or gets served in place of, the
+	 * front-end cache entry.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $version The store version the resolved set was built from.
+	 * @param string $slug    The token set slug.
+	 *
+	 * @return string
+	 */
+	public function editor_css_for_version( string $version, string $slug ): string {
+		return $this->for_version( $version, $slug, true );
+	}
+
+	/**
+	 * Shared cache/memo plumbing for {@see self::css_for_version()} and {@see self::editor_css_for_version()}.
+	 * The context (front end vs editor) is folded into both the per-request memo key and the object-cache key
+	 * so the two builds never share a cache slot.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $version The store version the resolved set was built from.
+	 * @param string $slug    The token set slug.
+	 * @param bool   $editor  Whether to build the editor-scoped variant.
+	 *
+	 * @return string
+	 */
+	private function for_version( string $version, string $slug, bool $editor ): string {
+		$context  = $editor ? 'editor' : 'front';
+		$memo_key = $context . ':' . $version . ':' . $slug;
 
 		if ( isset( $this->memo[ $memo_key ] ) ) {
 			return $this->memo[ $memo_key ];
 		}
 
-		$cache_key = 'block_default_css_' . KADENCE_BLOCKS_VERSION . '_' . $memo_key;
+		$cache_key = 'block_default_css_' . $context . '_' . KADENCE_BLOCKS_VERSION . '_' . $version . ':' . $slug;
 		$cached    = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
 
 		if ( $found && is_string( $cached ) ) {
 			return $this->memo[ $memo_key ] = $cached;
 		}
 
-		$css = $this->css( $slug );
+		$css = $editor ? $this->editor_css( $slug ) : $this->css( $slug );
 
 		wp_cache_set( $cache_key, $css, self::CACHE_GROUP, DAY_IN_SECONDS );
 

--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Projector.php
@@ -4,7 +4,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
-use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts\Css_Projector;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts\Abstract_Css_Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Location;
 use Throwable;
@@ -20,7 +20,7 @@ use Throwable;
  *
  * @since TBD
  */
-final class Projector implements Css_Projector {
+final class Projector extends Abstract_Css_Projector {
 
 	/**
 	 * The token registry, used to gate projection on the registry being active.

--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Projector.php
@@ -112,7 +112,7 @@ final class Projector implements Css_Projector {
 			return;
 		}
 
-		$css = $this->css();
+		$css = $this->editor_css();
 
 		if ( $css !== '' ) {
 			wp_add_inline_style( 'kadence-blocks-global-editor-styles', $css );
@@ -120,7 +120,7 @@ final class Projector implements Css_Projector {
 	}
 
 	/**
-	 * Build the block-default CSS for the current set, via the builder's version-keyed cache.
+	 * Build the FRONT-END block-default CSS for the current set, via the builder's version-keyed cache.
 	 *
 	 * Returns an empty string when the store version cannot be read or a block cannot be resolved (e.g. an
 	 * alias cycle from a direct DB write that bypassed the REST gate), so the page never crashes — the
@@ -140,5 +140,29 @@ final class Projector implements Css_Projector {
 		}
 
 		return $this->css_builder->css_for_version( $version, $slug );
+	}
+
+	/**
+	 * Build the EDITOR-scoped block-default CSS for the current set, via the builder's version-keyed cache.
+	 * Identical to {@see self::css()} for every block that declares no `editor_selector`; scoped under
+	 * `.editor-styles-wrapper` and re-targeted at the block's editor markup for the ones that do (see
+	 * {@see Css_Builder::editor_css()}).
+	 *
+	 * Returns an empty string under the same failure conditions as {@see self::css()}.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function editor_css(): string {
+		$slug = $this->active->get();
+
+		try {
+			$version = $this->store->get_version( $slug );
+		} catch ( Throwable $e ) {
+			return '';
+		}
+
+		return $this->css_builder->editor_css_for_version( $version, $slug );
 	}
 }

--- a/includes/resources/Design_Tokens/Projection/Contracts/Abstract_Css_Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Contracts/Abstract_Css_Projector.php
@@ -1,0 +1,32 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts;
+
+/**
+ * Base for the CSS-emitting projectors: supplies the default {@see self::editor_css()} so a projector
+ * whose editor output matches its front-end output — the common case — inherits it, and only a projector
+ * that needs a differently-scoped editor selector (currently {@see \KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css\Projector})
+ * overrides it.
+ *
+ * The context gates and the actual builders stay with each concrete projector: enqueue_front_end(),
+ * enqueue_editor(), and css() are left for the subclass because they differ per projector (different
+ * style handles, builders, and active-set plumbing).
+ *
+ * @since TBD
+ */
+abstract class Abstract_Css_Projector implements Css_Projector {
+
+	/**
+	 * The editor CSS, defaulting to the front-end {@see self::css()}: a context-independent projector emits
+	 * rules that carry no dependency on the editor's markup shape (a `:root` custom-property block, or a slot
+	 * var retarget), so the editor needs no separate build. A projector whose editor markup renders a binding
+	 * on a different element overrides this with an editor-scoped selector.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function editor_css(): string {
+		return $this->css();
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Contracts/Css_Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Contracts/Css_Projector.php
@@ -46,4 +46,15 @@ interface Css_Projector {
 	 * @return string
 	 */
 	public function css(): string;
+
+	/**
+	 * The projector's EDITOR css — identical to css() for a context-independent projector, and overridden
+	 * where the editor needs a differently-scoped selector (e.g. a block whose editor markup wraps the
+	 * bound element in a div, so the front-end selector lands on the wrong node).
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function editor_css(): string;
 }

--- a/includes/resources/Design_Tokens/Projection/Contracts/Css_Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Contracts/Css_Projector.php
@@ -6,12 +6,14 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts;
  * A projector that builds design-token CSS and appends it to KB's front-end and editor style handles.
  *
  * The shared shape of the CSS-emitting projectors (token vars, variants, block defaults):
- * each enqueues its CSS on the front end and in the editor, and exposes the same string through `css()` — the
- * unguarded builder the enqueue methods wrap behind their context gates. Scoped to the CSS projectors on
- * purpose: other projectors in this namespace seed block attributes or the Kadence palette rather than a
- * style handle, so they are not CSS projectors.
+ * each enqueues its CSS on the front end and in the editor, and exposes its unguarded builder through
+ * `css()` (front end) and `editor_css()` (editor) — the strings the enqueue methods wrap behind their
+ * context gates. The two are identical for a context-independent projector and differ only where the
+ * editor needs a differently-scoped selector (e.g. a block whose editor markup wraps the bound element).
+ * Scoped to the CSS projectors on purpose: other projectors in this namespace seed block attributes or
+ * the Kadence palette rather than a style handle, so they are not CSS projectors.
  *
- * {@see \KadenceWP\KadenceBlocks\Design_Tokens\Projection\Editor_Css} aggregates the editor `css()` of every
+ * {@see \KadenceWP\KadenceBlocks\Design_Tokens\Projection\Editor_Css} aggregates the `editor_css()` of every
  * CSS projector, so a new one joins by implementing this contract and adding itself to the collection from
  * its own provider.
  *

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
@@ -205,6 +205,19 @@ final class Projector implements Css_Projector {
 	}
 
 	/**
+	 * The editor build, identical to {@see self::css()}: this projector emits `:root { --kb-token--*: … }`
+	 * custom properties, which carry no block-scoped selector, so nothing about the editor's markup shape
+	 * (e.g. a wrapper div) requires a different build.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function editor_css(): string {
+		return $this->css();
+	}
+
+	/**
 	 * The breakpoint => media-query string map for the per-breakpoint responsive redeclaration, resolved at
 	 * emit time so the filterable KB breakpoints are final. Keyed to match the resolver's breakpoint keys;
 	 * defaults mirror Kadence_Blocks_CSS::get_media_queries(). Desktop is the base (:root), so only the

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
@@ -4,7 +4,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
-use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts\Css_Projector;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts\Abstract_Css_Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Responsive;
@@ -37,7 +37,7 @@ use Throwable;
  *
  * @since TBD
  */
-final class Projector implements Css_Projector {
+final class Projector extends Abstract_Css_Projector {
 
 	/**
 	 * @var Token_Registry
@@ -202,19 +202,6 @@ final class Projector implements Css_Projector {
 		}
 
 		return $this->css_builder->css_for_version( $resolved_by_slug, $versions, $active, $this->breakpoints() );
-	}
-
-	/**
-	 * The editor build, identical to {@see self::css()}: this projector emits `:root { --kb-token--*: … }`
-	 * custom properties, which carry no block-scoped selector, so nothing about the editor's markup shape
-	 * (e.g. a wrapper div) requires a different build.
-	 *
-	 * @since TBD
-	 *
-	 * @return string
-	 */
-	public function editor_css(): string {
-		return $this->css();
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Projection/Editor_Css.php
+++ b/includes/resources/Design_Tokens/Projection/Editor_Css.php
@@ -9,15 +9,23 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
  * endpoint can serve exactly the CSS the projectors enqueue at page load — for live re-injection into the
  * block-editor canvas when a variant (or, later, a token value) changes without a reload.
  *
- * Each source's `css()` is the unguarded builder; the enqueue-context gate (the block-editor page check)
- * stays in each `enqueue_editor()` and does not apply off a block-editor page request, so it is deliberately
- * not repeated here. This aggregator applies the one gate that still matters: a deactivated registry projects
- * nothing, so it returns ''. The sources are concatenated in the order the Projection provider supplies them,
- * which mirrors the load-time enqueue — the token vars first (the foundation the other layers reference),
- * then variants, native retarget, and block defaults. Each source already fails open to '' on its own, so one
- * broken layer never suppresses the others. Multi-set (multi-palette) support is preserved verbatim: the
- * token-var and variant builders each emit every set's namespaced vars plus the per-set switch selectors,
- * unchanged.
+ * Each source's `editor_css()` is the unguarded builder; the enqueue-context gate (the block-editor page
+ * check) stays in each `enqueue_editor()` and does not apply off a block-editor page request, so it is
+ * deliberately not repeated here. This aggregator applies the one gate that still matters: a deactivated
+ * registry projects nothing, so it returns ''. The sources are concatenated in the order the Projection
+ * provider supplies them, which mirrors the load-time enqueue — the token vars first (the foundation the
+ * other layers reference), then variants, native retarget, and block defaults. Each source already fails
+ * open to '' on its own, so one broken layer never suppresses the others. Multi-set (multi-palette) support
+ * is preserved verbatim: the token-var and variant builders each emit every set's namespaced vars plus the
+ * per-set switch selectors, unchanged.
+ *
+ * `editor_css()` equals `css()` for the context-independent projectors (token vars, variant) — their output
+ * carries no dependency on the editor's markup shape. It differs only for the block-default projector, whose
+ * editor build re-targets a block's rule at its editor-rendered element (e.g. `.editor-styles-wrapper
+ * .wp-block-kadence-advancedheading .kadence-advancedheading-text` instead of the front-end
+ * `.wp-block-kadence-advancedheading`) for blocks whose `useBlockProps()` wrapper div is not the element the
+ * bindings style. Calling `editor_css()` here rather than `css()` is what gives a live re-injection (a token
+ * change applied with no page reload) the same selector the editor's own page-load enqueue used.
  *
  * The projectors are gathered from the {@see Css_Projectors} collection, which each CSS projector's own
  * provider adds to — so a new editor-CSS projector joins from its own module, with no change to this class or
@@ -71,7 +79,7 @@ final class Editor_Css {
 		$css = '';
 
 		foreach ( $this->projectors->all() as $projector ) {
-			$css .= $projector->css();
+			$css .= $projector->editor_css();
 		}
 
 		return $css;

--- a/includes/resources/Design_Tokens/Projection/Variant/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Variant/Projector.php
@@ -4,7 +4,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Variant;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Set_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
-use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts\Css_Projector;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts\Abstract_Css_Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Location;
 use Throwable;
@@ -19,7 +19,7 @@ use Throwable;
  *
  * @since TBD
  */
-final class Projector implements Css_Projector {
+final class Projector extends Abstract_Css_Projector {
 
 	/**
 	 * @var Token_Registry
@@ -138,19 +138,6 @@ final class Projector implements Css_Projector {
 		} catch ( Throwable $e ) {
 			return '';
 		}
-	}
-
-	/**
-	 * The editor build, identical to {@see self::css()}: this projector's scoped rules retarget the
-	 * `--global-*` slot vars, and slot names carry no dependency on the editor's markup shape (e.g. a
-	 * wrapper div), so nothing needs a different build.
-	 *
-	 * @since TBD
-	 *
-	 * @return string
-	 */
-	public function editor_css(): string {
-		return $this->css();
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Projection/Variant/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Variant/Projector.php
@@ -141,6 +141,19 @@ final class Projector implements Css_Projector {
 	}
 
 	/**
+	 * The editor build, identical to {@see self::css()}: this projector's scoped rules retarget the
+	 * `--global-*` slot vars, and slot names carry no dependency on the editor's markup shape (e.g. a
+	 * wrapper div), so nothing needs a different build.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function editor_css(): string {
+		return $this->css();
+	}
+
+	/**
 	 * Every token set slug to emit: the stored sets plus the always-addressable default, which renders from
 	 * baseline even with no row. Mirrors the REST collection's default-inclusive listing, and always
 	 * includes the active set (the active-set pointer only ever resolves to default or a stored set).

--- a/includes/resources/Design_Tokens/Registry/Variant_Set.php
+++ b/includes/resources/Design_Tokens/Registry/Variant_Set.php
@@ -64,16 +64,33 @@ final class Variant_Set {
 	public ?string $label;
 
 	/**
+	 * The selector the {@see \KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css\Css_Builder}
+	 * targets IN PLACE OF the block's `.wp-block-*` root when it builds the editor-scoped variant of the
+	 * block-default CSS, or null when the block root is the right target in the editor too (the common
+	 * case). Needed only when the block's editor markup does not put `.wp-block-*` on the element the
+	 * bindings are meant to style — e.g. a wrapper `<div>` around the real rendered element — so the
+	 * front-end selector would land the rule on the wrong node in the editor canvas.
+	 *
 	 * @since TBD
 	 *
-	 * @param string                 $block    The block name.
-	 * @param array<string, Binding> $bindings The block's bindable surface, keyed by property.
-	 * @param string|null            $label    The picker control label, or null for a preset set.
+	 * @var string|null
 	 */
-	private function __construct( string $block, array $bindings, ?string $label ) {
-		$this->block    = $block;
-		$this->bindings = $bindings;
-		$this->label    = $label;
+	public ?string $editor_selector;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param string                 $block           The block name.
+	 * @param array<string, Binding> $bindings        The block's bindable surface, keyed by property.
+	 * @param string|null            $label           The picker control label, or null for a preset set.
+	 * @param string|null            $editor_selector The editor-only selector override, or null to reuse the
+	 *                                                 front-end selector in the editor too.
+	 */
+	private function __construct( string $block, array $bindings, ?string $label, ?string $editor_selector ) {
+		$this->block           = $block;
+		$this->bindings        = $bindings;
+		$this->label           = $label;
+		$this->editor_selector = $editor_selector;
 	}
 
 	/**
@@ -82,9 +99,10 @@ final class Variant_Set {
 	 * @since TBD
 	 *
 	 * @param array<string, mixed> $set The declaration: "block", optional "bindings" (property =>
-	 *                                  {@see Binding::from_array()}) and optional "label" (the picker control
-	 *                                  label; omit for a preset set with no picker). Variant names, default
-	 *                                  and values are document data, not declared here.
+	 *                                  {@see Binding::from_array()}), optional "label" (the picker control
+	 *                                  label; omit for a preset set with no picker), and optional
+	 *                                  "editor_selector" (see {@see self::$editor_selector}). Variant names,
+	 *                                  default and values are document data, not declared here.
 	 *
 	 * @throws InvalidArgumentException When "block" is missing or a binding is malformed.
 	 *
@@ -100,7 +118,8 @@ final class Variant_Set {
 		return new self(
 			$set['block'],
 			self::bindings( $set['block'], $set['bindings'] ?? [] ),
-			isset( $set['label'] ) && is_string( $set['label'] ) ? $set['label'] : null
+			isset( $set['label'] ) && is_string( $set['label'] ) ? $set['label'] : null,
+			isset( $set['editor_selector'] ) && is_string( $set['editor_selector'] ) ? $set['editor_selector'] : null
 		);
 	}
 

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -420,8 +420,17 @@ return [
 			// overrides a theme's per-tag element styles (h1/h2/p, specificity 0,0,1), which is what lets the
 			// design-system defaults "re-skin" an unset heading. A per-instance value renders at higher
 			// specificity (the `.kt-adv-heading<uid>` instance selector) and still wins.
-			'block'    => 'kadence/advancedheading',
-			'bindings' => [
+			//
+			// In the editor, useBlockProps() puts `.wp-block-kadence-advancedheading` on a wrapper <div>, not
+			// on the heading element the bindings above are meant to style — the real heading is a descendant
+			// carrying the stable `kadence-advancedheading-text` class. So the editor build of this CSS (see
+			// Css_Builder::editor_css()) targets that descendant instead, scoped under `.editor-styles-wrapper`
+			// so it still outranks the theme's element styles there too. Per-instance color/font-size render as
+			// INLINE styles on that same element (and font-weight inline on its child), so they keep winning
+			// regardless of this rule's specificity.
+			'block'           => 'kadence/advancedheading',
+			'editor_selector' => '.wp-block-kadence-advancedheading .kadence-advancedheading-text',
+			'bindings'        => [
 				'color'         => [
 					'token'    => 'semantic.color.text',
 					'css_prop' => 'color',

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -202,6 +202,63 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
+	 * In the editor, useBlockProps() puts `.wp-block-kadence-advancedheading` on a wrapper <div>, not on the
+	 * heading element the bindings style — the real heading carries the stable `kadence-advancedheading-text`
+	 * class instead. The declared `editor_selector` re-targets the editor build of the rule at that
+	 * descendant, scoped under `.editor-styles-wrapper` so it still outranks the theme's own per-tag element
+	 * styles there, while still carrying every one of the block's 12 bound declarations.
+	 *
+	 * @return void
+	 */
+	public function testTheEditorBuildRetargetsTheAdvancedHeadingRuleAtTheRealHeadingElement(): void {
+		$registry = $this->container->get( Token_Registry::class );
+
+		$css = $this->builder( $registry )->editor_css();
+
+		$this->assertStringContainsString(
+			'.editor-styles-wrapper .wp-block-kadence-advancedheading .kadence-advancedheading-text{color:var(' . Css_Var::from_id( 'semantic.color.text' ) . ',#1A202C);',
+			$css
+		);
+		$this->assertStringContainsString(
+			'background-color:var(' . Css_Var::from_id( 'semantic.color.heading-bg' ) . ',transparent);',
+			$css
+		);
+		$this->assertStringContainsString(
+			'font-family:var(' . Css_Var::from_id( 'semantic.font-family.control' ) . ',Inter, system-ui, sans-serif);',
+			$css
+		);
+		$this->assertStringContainsString( 'font-size:var(' . Css_Var::from_id( 'semantic.font-size.heading' ) . ',2rem);', $css );
+		$this->assertStringContainsString( 'line-height:var(' . Css_Var::from_id( 'semantic.line-height.heading' ) . ',1.125);', $css );
+		$this->assertStringContainsString( 'font-weight:var(' . Css_Var::from_id( 'semantic.font-weight.heading' ) . ',400);', $css );
+		$this->assertStringContainsString( 'letter-spacing:var(' . Css_Var::from_id( 'semantic.letter-spacing.control' ) . ',0);', $css );
+		$this->assertStringContainsString( 'text-transform:var(' . Css_Var::from_id( 'semantic.text-transform.control' ) . ',none);', $css );
+		$this->assertStringContainsString( 'padding:var(' . Css_Var::from_id( 'semantic.spacing.heading-padding' ) . ',0);', $css );
+		$this->assertStringContainsString( 'border-color:var(' . Css_Var::from_id( 'semantic.color.border' ) . ',#E2E8F0);', $css );
+		$this->assertStringContainsString( 'border-width:var(' . Css_Var::from_id( 'semantic.border-width.default' ) . ',1px);', $css );
+		$this->assertStringContainsString( 'border-radius:var(' . Css_Var::from_id( 'semantic.radius.heading' ) . ',0);}', $css );
+
+		// The front-end rule for the SAME block must stay on the block root, with no editor-only prefix.
+		$this->assertStringNotContainsString( '.editor-styles-wrapper', $this->builder( $registry )->css() );
+	}
+
+	/**
+	 * A block whose Variant_Set declares no `editor_selector` (e.g. Image) must emit an editor build
+	 * byte-for-byte identical to its front-end build — no `.editor-styles-wrapper` prefix and no
+	 * re-targeting — so blocks without the wrapper-div problem see zero regression from this mechanism. Uses
+	 * an isolated registry (rather than the shipped one) so the assertion is not diluted by the shipped
+	 * Advanced Heading declaration, which DOES declare an `editor_selector` and legitimately diverges.
+	 *
+	 * @return void
+	 */
+	public function testABlockWithNoEditorSelectorEmitsIdenticalFrontEndAndEditorCss(): void {
+		$builder = $this->builder( $this->image_registry() );
+
+		$this->assertSame( $builder->css(), $builder->editor_css() );
+		$this->assertStringContainsString( '.wp-block-kadence-image img{border-radius:var(', $builder->editor_css() );
+		$this->assertStringNotContainsString( '.editor-styles-wrapper', $builder->editor_css() );
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testItContributesNothingForABindingWithoutACssProp(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/ProjectorTest.php
@@ -144,6 +144,19 @@ final class ProjectorTest extends TestCase {
 		$this->assertStringContainsString( '--kb-token--', $css );
 	}
 
+	// ---- Editor CSS -----------------------------------------------------------------------------------
+
+	/**
+	 * The token-var projector is context-independent — it emits `:root { --kb-token--*: … }` custom
+	 * properties with no block-scoped selector — so its editor build is byte-for-byte identical to its
+	 * front-end build.
+	 *
+	 * @return void
+	 */
+	public function testEditorCssEqualsCss(): void {
+		$this->assertSame( $this->projector->css(), $this->projector->editor_css() );
+	}
+
 	// ---- Filter routing -------------------------------------------------------------------------------
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Variant/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Variant/ProjectorTest.php
@@ -67,6 +67,19 @@ final class ProjectorTest extends TestCase {
 		$this->assertStringContainsString( '--global-palette1:var(--kb-token--variant--kadence-singlebtn--primary--button-bg', $css );
 	}
 
+	/**
+	 * The variant projector is context-independent — its scoped rules retarget the `--global-*` slot vars,
+	 * which carry no dependency on the editor's markup shape — so its editor build is byte-for-byte
+	 * identical to its front-end build.
+	 *
+	 * @return void
+	 */
+	public function testEditorCssEqualsCss(): void {
+		$projector = $this->projector( $this->button_set() );
+
+		$this->assertSame( $projector->css(), $projector->editor_css() );
+	}
+
 	public function testItIsANoopWhenTheRegistryIsDeactivated(): void {
 		$registry = $this->button_set();
 		$registry->deactivate();

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Variant_SetTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Variant_SetTest.php
@@ -43,6 +43,31 @@ final class Variant_SetTest extends TestCase {
 		$this->assertNull( Variant_Set::from_array( $this->declaration() )->label );
 	}
 
+	/**
+	 * A block whose editor markup puts the `.wp-block-*` class on a wrapper rather than the element the
+	 * bindings style (e.g. Advanced Heading) declares an `editor_selector` so the editor build of the
+	 * block-default CSS can retarget the rule at the real element.
+	 *
+	 * @return void
+	 */
+	public function testItRetainsTheEditorSelectorWhenDeclared(): void {
+		$set = Variant_Set::from_array(
+			$this->declaration() + [ 'editor_selector' => '.wp-block-kadence-advancedheading .kadence-advancedheading-text' ]
+		);
+
+		$this->assertSame( '.wp-block-kadence-advancedheading .kadence-advancedheading-text', $set->editor_selector );
+	}
+
+	/**
+	 * A block that renders identically in the editor and on the front end (the common case) omits
+	 * `editor_selector`, and the parser must leave it null rather than defaulting to some other selector.
+	 *
+	 * @return void
+	 */
+	public function testTheEditorSelectorIsNullWhenOmitted(): void {
+		$this->assertNull( Variant_Set::from_array( $this->declaration() )->editor_selector );
+	}
+
 	public function testItParsesTokenReferenceAndInlineBindings(): void {
 		$set = Variant_Set::from_array( $this->declaration() );
 

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Projected_Css_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Projected_Css_ControllerTest.php
@@ -81,6 +81,44 @@ final class Projected_Css_ControllerTest extends TestCase {
 	}
 
 	/**
+	 * The aggregated CSS carries the EDITOR-scoped block-default rule for Advanced Heading — the shipped
+	 * declaration's `editor_selector` re-targets the rule at the block's real heading element, scoped under
+	 * `.editor-styles-wrapper` — not the bare front-end rule on the `useBlockProps()` wrapper div. Proves the
+	 * live re-injection path (this endpoint) matches the selector the editor's own page-load enqueue used,
+	 * rather than the front-end build.
+	 *
+	 * @return void
+	 */
+	public function testItServesTheEditorScopedBlockDefaultRuleForAdvancedHeadingNotTheFrontEndOne(): void {
+		$css = $this->css();
+
+		$this->assertStringContainsString(
+			'.editor-styles-wrapper .wp-block-kadence-advancedheading .kadence-advancedheading-text{',
+			$css,
+			'The editor-scoped, re-targeted Advanced Heading rule should be present.'
+		);
+		$this->assertStringNotContainsString(
+			'.wp-block-kadence-advancedheading{',
+			$css,
+			'The bare front-end Advanced Heading rule (on the wrapper div) should not be present.'
+		);
+	}
+
+	/**
+	 * The token-var layer's editor contribution is unchanged by the aggregation switch to `editor_css()`: the
+	 * Css_Var projector is context-independent, so its editor build equals its front-end build and the
+	 * `:root`/`--kb-token--` declarations still surface in the aggregated CSS.
+	 *
+	 * @return void
+	 */
+	public function testItStillContainsTheUnchangedTokenVarContributions(): void {
+		$css = $this->css();
+
+		$this->assertStringContainsString( ':root', $css, 'The token-var :root block should be present.' );
+		$this->assertStringContainsString( '--kb-token--', $css, 'The token-var declarations should be present.' );
+	}
+
+	/**
 	 * The read route is gated by the design-tokens capability: denied for a user without it, allowed for an
 	 * administrator.
 	 *


### PR DESCRIPTION
🎬 https://www.loom.com/share/299881253c7e40ac93aa538cbf10e9d3

## Summary

Gives the `Block_Default_Css` projector a separate **editor** output so a block's token defaults render correctly in the block editor, matching the front end. Front-end output is unchanged.

## The problem

The projector emitted **one** CSS string used for both the front-end and editor style handles. For `kadence/advancedheading` that breaks in the editor: `useBlockProps()` puts `wp-block-kadence-advancedheading` on a **wrapper `<div>`**, while the actual heading is a descendant `<h2 class="… kadence-advancedheading-text">`. So the rule `.wp-block-kadence-advancedheading{…}` landed on the wrapper div in the editor — non-inherited props (background, padding, border) styled the wrong element, and the theme's `.editor-styles-wrapper <tag>` rules overrode the inherited typography on the real heading. On the front end the same class is on the heading, so it was always correct there.

## The fix

- **`Css_Builder`** gains an editor build. For a block that declares an `editor_selector`, the editor rule is scoped under `.editor-styles-wrapper` and retargeted at that selector; blocks without one emit editor CSS **byte-for-byte identical** to their front-end CSS (no change for `image`/`single-icon`/`rowlayout`/`column`). The front-end `css()` path is untouched.
- **`Variant_Set`** carries an optional `editor_selector`.
- **`declarations.php`** declares `editor_selector` for `kadence/advancedheading` → `.wp-block-kadence-advancedheading .kadence-advancedheading-text`, so the editor rule is `.editor-styles-wrapper .wp-block-kadence-advancedheading .kadence-advancedheading-text{…}`.
- **`Projector::enqueue_editor()`** now emits the editor build; `enqueue_front_end()` is unchanged.
- **Cache keys are context-separated** (`front:` / `editor:` memo prefixes and distinct object-cache keys) so the two builds never collide.

Specificity holds: the editor rule (three classes) beats the theme's per-tag rule, and the block's own per-instance editor styles are applied **inline** (`style=…` on the heading/RichText), so a value set on the block always wins.

## Verified in the editor

In the live block editor: the token typography (font-weight 400, text-transform, font-size) now applies to the real `<h2>`; the old front-end-selector rule is no longer present in the editor; and a per-instance color set on the block still wins over the token.

## Live re-injection parity (also in this PR)

`Projection/Editor_Css.php` aggregates the projectors for the `/projected-css` REST endpoint, which the editor uses to **live re-inject** CSS when a token/variant changes without a reload (`src/extension/design-tokens/live-css.js`). To keep that path in parity too, this PR adds `editor_css()` to the `Css_Projector` interface — `Css_Var`/`Variant` return `css()` (their selectors are context-independent), `Block_Default_Css` returns its editor-scoped build — and `Editor_Css` now aggregates `editor_css()`. So **both** editor page-load and live re-injection use the correctly-scoped editor CSS. No follow-up.

## Test plan

- `Css_BuilderTest`: asserts the editor CSS for advancedheading uses the `.editor-styles-wrapper … .kadence-advancedheading-text` selector with all 13 declarations; asserts the front-end CSS is unchanged; asserts a block without an `editor_selector` emits editor CSS byte-for-byte equal to its front-end CSS.
- `Variant_SetTest`: parses `editor_selector` / null when omitted.
- `Resources/Design_Tokens/Projection/Block_Default_Css` 13/13, `Resources/Design_Tokens/Registry` 137/137; `phpstan` clean (baseline untouched); `cspell` clean.

---

Stacked on #1166 (`[1/2]`). Base branch of this PR is `SOFT-3403/phase-1-advancedheading-token-bindings`.