### PR TITLE
[DTM] SOFT-3964: precise per-control token narrowing (sub-kind + role-pin)

### DIFF
--- a/includes/resources/Design_Tokens/Editor/Pickable_Tokens_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Pickable_Tokens_Catalog.php
@@ -13,10 +13,12 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Layers;
 /**
  * Builds the pickable-token pool the block editor's token picker reads.
  *
- * Two sections: `tokens` is the set-independent STRUCTURE — one { id, alias, label, type, layer }
+ * Two sections: `tokens` is the set-independent STRUCTURE — one { id, alias, label, type, layer, role }
  * entry per registered token, in registry order, where `alias` is the {id} string a pick will later
- * write to a block attribute and `layer` (semantic | primitive) is derived from the id's first
- * dot-segment so the picker can rank semantic tokens before primitives. `values` is the per-set
+ * write to a block attribute, `layer` (semantic | primitive) is derived from the id's first
+ * dot-segment so the picker can rank semantic tokens before primitives, and `role` is the sub-kind
+ * (radius | spacing | … ) derived from the id so the picker can narrow one `$type` to the control's
+ * sub-kind. `values` is the per-set
  * resolved literal map (set slug => ( id => literal )) used ONLY for the picker's preview
  * swatch/number — a pick writes the alias, never the literal. A set whose stored document cannot be
  * resolved (alias cycle / dangling alias from a raw DB write) is skipped, so one corrupt set never
@@ -25,6 +27,17 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Layers;
  * @since TBD
  */
 final class Pickable_Tokens_Catalog {
+
+	/**
+	 * The id segment wrapping the dimension primitives (`primitive.dimension.<role>.<step>`). Semantic
+	 * dimension tokens carry no such wrapper (`semantic.<role>.<name>`), so it is normalized away in
+	 * role derivation to make both layers report the same role for the same sub-kind.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const DIMENSION_GROUP = 'dimension';
 
 	/**
 	 * The token registry, source of the registered token structure.
@@ -71,7 +84,7 @@ final class Pickable_Tokens_Catalog {
 	 *
 	 * @since TBD
 	 *
-	 * @return array{tokens: array<int, array<string, string>>, values: array<string, array<string, string>>}
+	 * @return array{tokens: array<int, array{id: string, alias: string, label: string, type: string, layer: string, role: string}>, values: array<string, array<string, string>>}
 	 */
 	public function all(): array {
 		return [
@@ -81,12 +94,12 @@ final class Pickable_Tokens_Catalog {
 	}
 
 	/**
-	 * The pickable token structure: one { id, alias, label, type, layer } entry per registered token,
-	 * in registry insertion order. Set-independent — values live in values().
+	 * The pickable token structure: one { id, alias, label, type, layer, role } entry per registered
+	 * token, in registry insertion order. Set-independent — values live in values().
 	 *
 	 * @since TBD
 	 *
-	 * @return array<int, array{id: string, alias: string, label: string, type: string, layer: string}>
+	 * @return array<int, array{id: string, alias: string, label: string, type: string, layer: string, role: string}>
 	 */
 	private function tokens(): array {
 		$tokens = [];
@@ -98,10 +111,36 @@ final class Pickable_Tokens_Catalog {
 				'label' => $token->label,
 				'type'  => $token->type,
 				'layer' => $this->layer_of( $token->id ),
+				'role'  => $this->role_of( $token->id ),
 			];
 		}
 
 		return $tokens;
+	}
+
+	/**
+	 * The sub-kind role a token id carries — the discriminator that splits one DTCG `$type` into the
+	 * distinct things a control picks from: `dimension` fans out to `radius`, `spacing`, `gap`,
+	 * `border-width`, `icon-size`, `font-size`, and so on. Derived from the id, not stored: the role is
+	 * the segment right after the layer (`semantic.<role>.…`, `primitive.<role>.…`), except the
+	 * dimension primitives nest it one level deeper under the `dimension` wrapper
+	 * (`primitive.dimension.<role>.<step>`), which is normalized away so a semantic and a primitive
+	 * token of the same sub-kind report the same role. An id with no role segment yields "".
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id The token id (a dot-path).
+	 *
+	 * @return string The role sub-kind, or "" when the id carries none.
+	 */
+	private function role_of( string $id ): string {
+		$segments = explode( '.', $id );
+
+		if ( ( $segments[0] ?? '' ) === Layers::get_primitive() && ( $segments[1] ?? '' ) === self::DIMENSION_GROUP ) {
+			return $segments[2] ?? '';
+		}
+
+		return $segments[1] ?? '';
 	}
 
 	/**

--- a/src/extension/token-picker/__tests__/index.test.js
+++ b/src/extension/token-picker/__tests__/index.test.js
@@ -18,6 +18,7 @@ const POOL = {
 			label: 'Blue 500',
 			type: 'color',
 			layer: 'primitive',
+			role: 'color',
 		},
 		{
 			id: 'semantic.color.button-primary-bg',
@@ -25,6 +26,7 @@ const POOL = {
 			label: 'Button Primary Background',
 			type: 'color',
 			layer: 'semantic',
+			role: 'color',
 		},
 		{
 			id: 'primitive.dimension.radius.sm',
@@ -32,6 +34,7 @@ const POOL = {
 			label: 'Radius SM',
 			type: 'dimension',
 			layer: 'primitive',
+			role: 'radius',
 		},
 		{
 			id: 'semantic.radius.button',
@@ -39,6 +42,23 @@ const POOL = {
 			label: 'Button Radius',
 			type: 'dimension',
 			layer: 'semantic',
+			role: 'radius',
+		},
+		{
+			id: 'primitive.dimension.spacing.md',
+			alias: '{primitive.dimension.spacing.md}',
+			label: 'Spacing MD',
+			type: 'dimension',
+			layer: 'primitive',
+			role: 'spacing',
+		},
+		{
+			id: 'semantic.spacing.block',
+			alias: '{semantic.spacing.block}',
+			label: 'Block Spacing',
+			type: 'dimension',
+			layer: 'semantic',
+			role: 'spacing',
 		},
 		{
 			id: 'primitive.font-weight.bold',
@@ -46,6 +66,7 @@ const POOL = {
 			label: 'Bold',
 			type: 'fontWeight',
 			layer: 'primitive',
+			role: 'font-weight',
 		},
 	],
 	values: {
@@ -54,6 +75,8 @@ const POOL = {
 			'semantic.color.button-primary-bg': '#2b6cb0',
 			'primitive.dimension.radius.sm': '4px',
 			'semantic.radius.button': '0.5rem',
+			'primitive.dimension.spacing.md': '16px',
+			'semantic.spacing.block': '1.5rem',
 			'primitive.font-weight.bold': '700',
 		},
 		brand: { 'semantic.color.button-primary-bg': '#000000' },
@@ -74,6 +97,21 @@ const VARIANTS = {
 		},
 	},
 };
+
+/**
+ * A variant catalog whose `kadence/singlebtn` borderRadius control binds a role token, so the picker
+ * narrows to that token's sub-kind and pins it. Mirrors VARIANTS but with a non-null `token`.
+ */
+const boundVariants = (token) => ({
+	active: 'default',
+	sets: {
+		default: {
+			'kadence/singlebtn': {
+				properties: [{ key: 'button-radius', kind: 'dimension', token, control_attr: 'borderRadius' }],
+			},
+		},
+	},
+});
 
 describe('pickableTokenPool', () => {
 	beforeEach(() => {
@@ -118,6 +156,7 @@ describe('pickableTokensFor', () => {
 				label: 'Button Primary Background',
 				value: '#2b6cb0',
 				type: 'color',
+				role: 'color',
 			},
 			{
 				id: 'primitive.color.blue-500',
@@ -125,15 +164,21 @@ describe('pickableTokensFor', () => {
 				label: 'Blue 500',
 				value: '#3182ce',
 				type: 'color',
+				role: 'color',
 			},
 		]);
 	});
 
-	it('returns only dimension tokens, semantic first, with resolved values', () => {
+	it('returns every dimension token, semantic first, with resolved values', () => {
 		const result = pickableTokensFor('dimension');
 
-		expect(result.map((token) => token.id)).toEqual(['semantic.radius.button', 'primitive.dimension.radius.sm']);
-		expect(result.map((token) => token.value)).toEqual(['0.5rem', '4px']);
+		expect(result.map((token) => token.id)).toEqual([
+			'semantic.radius.button',
+			'semantic.spacing.block',
+			'primitive.dimension.radius.sm',
+			'primitive.dimension.spacing.md',
+		]);
+		expect(result.map((token) => token.value)).toEqual(['0.5rem', '1.5rem', '4px', '16px']);
 	});
 
 	it('returns only the fontWeight token for the text kind', () => {
@@ -157,6 +202,7 @@ describe('pickableTokensFor', () => {
 				label: 'Button Primary Background',
 				value: '#000000',
 				type: 'color',
+				role: 'color',
 			},
 			{
 				id: 'primitive.color.blue-500',
@@ -164,6 +210,7 @@ describe('pickableTokensFor', () => {
 				label: 'Blue 500',
 				value: '',
 				type: 'color',
+				role: 'color',
 			},
 		]);
 	});
@@ -194,7 +241,7 @@ describe('pickableTokensForControl', () => {
 		delete window.kadenceDesignTokensVariants;
 	});
 
-	it('resolves the mapped control kind and delegates to pickableTokensFor', () => {
+	it('delegates to the coarse kind list when the control binds no role token', () => {
 		expect(pickableTokensForControl('kadence/singlebtn', 'borderRadius')).toEqual(pickableTokensFor('dimension'));
 	});
 
@@ -204,5 +251,24 @@ describe('pickableTokensForControl', () => {
 
 	it('returns an empty array for an unknown block', () => {
 		expect(pickableTokensForControl('kadence/does-not-exist', 'borderRadius')).toEqual([]);
+	});
+
+	it('narrows to the bound token sub-kind, dropping other dimension roles', () => {
+		window.kadenceDesignTokensVariants = boundVariants('semantic.radius.button');
+
+		const result = pickableTokensForControl('kadence/singlebtn', 'borderRadius');
+
+		// Only radius tokens survive — spacing dimensions are dropped even though they share the kind.
+		expect(result.map((token) => token.id)).toEqual(['semantic.radius.button', 'primitive.dimension.radius.sm']);
+		expect(result.every((token) => token.role === 'radius')).toBe(true);
+	});
+
+	it('pins the bound token first, keeping semantic-first order for the rest', () => {
+		window.kadenceDesignTokensVariants = boundVariants('primitive.dimension.radius.sm');
+
+		const result = pickableTokensForControl('kadence/singlebtn', 'borderRadius');
+
+		// The bound primitive is pinned ahead of the semantic radius token it would otherwise trail.
+		expect(result.map((token) => token.id)).toEqual(['primitive.dimension.radius.sm', 'semantic.radius.button']);
 	});
 });

--- a/src/extension/token-picker/index.js
+++ b/src/extension/token-picker/index.js
@@ -4,8 +4,10 @@
  * The pool is printed by the server-side editor localizer to `window.kadenceDesignTokensPickable`:
  * `{ tokens: [{ id, alias, label, type, layer }], values: { <setSlug>: { <id>: literal } } }`.
  * This module turns it into the per-control PICKABLE list — hard type filter by the control's kind
- * (a radius control never lists color or font tokens), semantic-layer tokens ranked before
- * primitives, and each entry carrying the resolved literal `value` for the preview swatch/number.
+ * (a radius control never lists color or font tokens), narrowed to the control's bound sub-kind when
+ * it binds a role token (radius, not the whole `dimension` bucket) with that token pinned first,
+ * semantic-layer tokens ranked before primitives, and each entry carrying the resolved literal
+ * `value` for the preview swatch/number.
  * A pick writes the `alias` (the `{id}` string) — never the `value`; consumers of this module build
  * the picker UI and the attribute write, neither of which lives here.
  *
@@ -70,7 +72,7 @@ function valuesFor(set) {
  *
  * @since TBD
  *
- * @return {Array} The pickable list ([{ id, alias, label, value, type }]).
+ * @return {Array} The pickable list ([{ id, alias, label, value, type, role }]).
  */
 export function pickableTokensFor(kind, set) {
 	const types = KIND_TYPES[kind] || [];
@@ -91,13 +93,35 @@ export function pickableTokensFor(kind, set) {
 		label: token.label,
 		value: get(values, [token.id], ''),
 		type: token.type,
+		role: token.role || '',
 	}));
+}
+
+/**
+ * The role sub-kind of a token id, read from the pool the catalog already tagged (never parsed here) —
+ * the discriminator that narrows one $type to the control's sub-kind (a radius control's `dimension`
+ * to only radius tokens). Empty when the id is absent from the pool or carries no role.
+ *
+ * @param {string} id The token id (e.g. 'semantic.radius.media').
+ *
+ * @since TBD
+ *
+ * @return {string} The role, or '' when unknown.
+ */
+function roleForId(id) {
+	const tokens = get(pickableTokenPool(), 'tokens', []) || [];
+	const match = tokens.find((token) => token.id === id);
+
+	return match ? match.role || '' : '';
 }
 
 /**
  * The pickable tokens for one block control, keyed by the attribute the control writes: resolves
  * the control's kind from the variant catalog's { key, kind, token, control_attr } surface, then
- * filters and ranks the pool for that kind. Empty when the block maps no such control in the set —
+ * filters and ranks the pool for that kind. When the control binds a role token, the list is further
+ * narrowed to that token's sub-kind (a radius control's `dimension` to only radius tokens, never
+ * spacing) and the bound token is pinned to the top; without a bound token it stays the coarse
+ * kind list (type filter + semantic-first). Empty when the block maps no such control in the set —
  * an unmapped control offers no tokens, which is the "selectable only where it makes sense"
  * guarantee at the per-control call site.
  *
@@ -107,7 +131,7 @@ export function pickableTokensFor(kind, set) {
  *
  * @since TBD
  *
- * @return {Array} The pickable list ([{ id, alias, label, value, type }]), empty when unmapped.
+ * @return {Array} The pickable list ([{ id, alias, label, value, type, role }]), empty when unmapped.
  */
 export function pickableTokensForControl(blockName, controlAttr, set) {
 	const property = blockProperties(blockName, set).find((entry) => entry.control_attr === controlAttr);
@@ -116,5 +140,21 @@ export function pickableTokensForControl(blockName, controlAttr, set) {
 		return [];
 	}
 
-	return pickableTokensFor(property.kind, set);
+	const tokens = pickableTokensFor(property.kind, set);
+	const role = property.token ? roleForId(property.token) : '';
+
+	// No bound role token -> the coarse kind list (type filter + semantic-first), unchanged.
+	if (!role) {
+		return tokens;
+	}
+
+	// Narrow to the control's sub-kind, then pin the exact bound token first (semantic-first order
+	// carries through for the rest). An unresolved bound token drops out of the narrowed set, so the
+	// pin is a no-op rather than surfacing a token the filter already excluded.
+	const narrowed = tokens.filter((token) => token.role === role);
+
+	return [
+		...narrowed.filter((token) => token.id === property.token),
+		...narrowed.filter((token) => token.id !== property.token),
+	];
 }

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Pickable_Tokens_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Pickable_Tokens_CatalogTest.php
@@ -47,10 +47,68 @@ final class Pickable_Tokens_CatalogTest extends TestCase {
 		$this->assertNotEmpty( $tokens );
 
 		foreach ( $tokens as $token ) {
-			$this->assertSame( [ 'id', 'alias', 'label', 'type', 'layer' ], array_keys( $token ) );
+			$this->assertSame( [ 'id', 'alias', 'label', 'type', 'layer', 'role' ], array_keys( $token ) );
 			$this->assertSame( '{' . $token['id'] . '}', $token['alias'] );
 			$this->assertNotSame( '', $token['label'] );
 		}
+	}
+
+	/**
+	 * A semantic token reports the sub-kind segment right after the layer as its role (`semantic.<role>.…`),
+	 * so a control can narrow one `$type` to the tokens of its sub-kind. Pool-driven so it asserts against
+	 * whatever ids the loaded baseline registers rather than hardcoded ids.
+	 *
+	 * @return void
+	 */
+	public function testSemanticRoleIsTheSegmentAfterTheLayer(): void {
+		$semantic = array_filter(
+			$this->catalog->all()['tokens'],
+			static fn( array $token ): bool => strpos( $token['id'], 'semantic.' ) === 0
+		);
+
+		$this->assertNotEmpty( $semantic );
+
+		foreach ( $semantic as $token ) {
+			$this->assertSame( explode( '.', $token['id'] )[1], $token['role'] );
+		}
+	}
+
+	/**
+	 * A primitive dimension token reports the segment AFTER the `primitive.dimension.` wrapper as its
+	 * role, so the wrapper never leaks in as the role and a primitive lines up with the semantic token of
+	 * the same sub-kind.
+	 *
+	 * @return void
+	 */
+	public function testPrimitiveDimensionRoleStripsTheWrapper(): void {
+		$primitive_dimensions = array_filter(
+			$this->catalog->all()['tokens'],
+			static fn( array $token ): bool => strpos( $token['id'], 'primitive.dimension.' ) === 0
+		);
+
+		$this->assertNotEmpty( $primitive_dimensions );
+
+		foreach ( $primitive_dimensions as $token ) {
+			$this->assertSame( explode( '.', $token['id'] )[2], $token['role'] );
+			$this->assertNotSame( 'dimension', $token['role'] );
+		}
+	}
+
+	/**
+	 * A semantic dimension token and the primitive dimension tokens of the same sub-kind share a role,
+	 * so narrowing by role spans both layers rather than splitting on the `primitive.dimension.` wrapper.
+	 * Uses `spacing`, which every baseline registers in both layers.
+	 *
+	 * @return void
+	 */
+	public function testSemanticAndPrimitiveShareARoleForTheSameSubKind(): void {
+		$tokens = $this->catalog->all()['tokens'];
+
+		$semantic  = $this->first_with_prefix( $tokens, 'semantic.spacing.' );
+		$primitive = $this->first_with_prefix( $tokens, 'primitive.dimension.spacing.' );
+
+		$this->assertSame( 'spacing', $semantic['role'] );
+		$this->assertSame( $semantic['role'], $primitive['role'] );
 	}
 
 	/**
@@ -174,6 +232,26 @@ final class Pickable_Tokens_CatalogTest extends TestCase {
 		}
 
 		$this->fail( sprintf( 'No token of type "%s" in the pool.', $type ) );
+	}
+
+	/**
+	 * The first token entry whose id starts with a prefix, failing the test when the baseline registers
+	 * none (a broken fixture) so a renamed baseline prefix surfaces as a clear failure rather than a
+	 * silent skip.
+	 *
+	 * @param array<int, array<string, string>> $tokens The pool's token entries.
+	 * @param string                            $prefix The id prefix to find.
+	 *
+	 * @return array<string, string> The first matching token entry.
+	 */
+	private function first_with_prefix( array $tokens, string $prefix ): array {
+		foreach ( $tokens as $token ) {
+			if ( strpos( $token['id'], $prefix ) === 0 ) {
+				return $token;
+			}
+		}
+
+		$this->fail( sprintf( 'No token with id prefix "%s" in the pool.', $prefix ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Follow-up to the pickable-token surface (#1164, approved). That surface enforced the coarse half of "selectable only where it makes sense": a hard type filter by control kind plus a semantic-before-primitive rank. This delivers the precise half the original ticket scoped — narrowing one DTCG `$type` down to the control's sub-kind, and pinning the control's own bound token.

Stacked on #1164 — review/merge that first.

## Changes

**PHP — the catalog emits a `role` per token**

- `Pickable_Tokens_Catalog` now carries a `role` sub-kind on every pool entry (`{ id, alias, label, type, layer, role }`), derived from the id where the registry structure is authoritative. The role is the segment right after the layer (`semantic.<role>.…`, `primitive.<role>.…`), with the dimension primitives' `primitive.dimension.` wrapper normalized away so a semantic and primitive token of the same sub-kind report the same role. The JS never parses ids.

**JS — narrow to the bound sub-kind and pin the bound token**

- `pickableTokensForControl()`: when a control binds a role token, the list is narrowed to that token's `role` (a radius control lists only radius tokens, never spacing) and the bound token is pinned to the top; semantic-before-primitive carries through for the rest. A control with no bound token keeps the coarse kind list unchanged, so the fail-soft behavior is preserved.
- Each returned entry now carries its `role`.

## Test plan

- `slic run wpunit Resources/Design_Tokens/Editor/Pickable_Tokens_CatalogTest` green (role derivation across semantic / primitive-dimension / cross-layer parity). Assertions are pool-driven so they hold against whatever ids the loaded baseline registers.
- `bun run test src/extension/token-picker` green (14 tests: sub-kind narrowing drops other roles, bound-token pinning reorders, coarse fallback when no token is bound).
- `bun run lint-js` and `vendor/bin/phpstan analyse` clean.

Tracked as SOFT-3964.