### PR TITLE
feat(design-tokens): route inline build_css box-shadow sites through alias-aware render_shadow

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -10,6 +10,7 @@
         "bun.lockb",
         "composer.lock",
         "composer.json",
+        "phpstan-baseline.neon",
         "build/**",
         "**/*.min.js",
         "**/*.asset.php",

--- a/includes/blocks/class-kadence-blocks-advanced-form-block.php
+++ b/includes/blocks/class-kadence-blocks-advanced-form-block.php
@@ -141,8 +141,21 @@ class Kadence_Blocks_Advanced_Form_Block extends Kadence_Blocks_Abstract_Block {
 		$css->render_border_styles( $border_style, 'fieldBorderStyle' );
 		$css->render_measure_output( $form_attributes, 'fieldBorderRadius', 'border-radius' );
 
-		if ( ! empty( $field_style['boxShadow'][0] ) && $field_style['boxShadow'][0] === true ) {
-			$css->add_property( 'box-shadow', ( isset( $field_style['boxShadow'][7] ) && true === $field_style['boxShadow'][7] ? 'inset ' : '' ) . ( isset( $field_style['boxShadow'][3] ) && is_numeric( $field_style['boxShadow'][3] ) ? $field_style['boxShadow'][3] : '2' ) . 'px ' . ( isset( $field_style['boxShadow'][4] ) && is_numeric( $field_style['boxShadow'][4] ) ? $field_style['boxShadow'][4] : '2' ) . 'px ' . ( isset( $field_style['boxShadow'][5] ) && is_numeric( $field_style['boxShadow'][5] ) ? $field_style['boxShadow'][5] : '3' ) . 'px ' . ( isset( $field_style['boxShadow'][6] ) && is_numeric( $field_style['boxShadow'][6] ) ? $field_style['boxShadow'][6] : '0' ) . 'px ' . $css->render_color( ( isset( $field_style['boxShadow'][1] ) && ! empty( $field_style['boxShadow'][1] ) ? $field_style['boxShadow'][1] : '#000000' ), ( isset( $field_style['boxShadow'][2] ) && is_numeric( $field_style['boxShadow'][2] ) ? $field_style['boxShadow'][2] : 0.4 ) ) );
+		if ( isset( $field_style['boxShadow'] ) && is_array( $field_style['boxShadow'] ) && ! empty( $field_style['boxShadow'][0] ) && $field_style['boxShadow'][0] === true ) {
+			$css->add_property(
+				'box-shadow',
+				$css->render_legacy_shadow(
+					$field_style['boxShadow'],
+					[
+						'hOffset' => '2',
+						'vOffset' => '2',
+						'blur'    => '3',
+						'spread'  => '0',
+						'color'   => '#000000',
+						'opacity' => 0.4,
+					]
+				)
+			);
 		}
 
 		$css->render_measure_output( $field_style, 'padding', 'padding', array( 'unit_key' => 'paddingUnit' ) );
@@ -208,8 +221,21 @@ class Kadence_Blocks_Advanced_Form_Block extends Kadence_Blocks_Abstract_Block {
 			$css->add_property( 'border-color',  $css->sanitize_color( $field_style['borderActive'] ) );
 		}
 
-		if ( ! empty( $field_style['boxShadowActive'][0] ) && $field_style['boxShadowActive'][0] === true ) {
-			$css->add_property( 'box-shadow', ( isset( $field_style['boxShadowActive'][7] ) && true === $field_style['boxShadowActive'][7] ? 'inset ' : '' ) . ( isset( $field_style['boxShadowActive'][3] ) && is_numeric( $field_style['boxShadowActive'][3] ) ? $field_style['boxShadowActive'][3] : '2' ) . 'px ' . ( isset( $field_style['boxShadowActive'][4] ) && is_numeric( $field_style['boxShadowActive'][4] ) ? $field_style['boxShadowActive'][4] : '2' ) . 'px ' . ( isset( $field_style['boxShadowActive'][5] ) && is_numeric( $field_style['boxShadowActive'][5] ) ? $field_style['boxShadowActive'][5] : '3' ) . 'px ' . ( isset( $field_style['boxShadowActive'][6] ) && is_numeric( $field_style['boxShadowActive'][6] ) ? $field_style['boxShadowActive'][6] : '0' ) . 'px ' . $css->render_color( ( isset( $field_style['boxShadowActive'][1] ) && ! empty( $field_style['boxShadowActive'][1] ) ? $field_style['boxShadowActive'][1] : '#000000' ), ( isset( $field_style['boxShadowActive'][2] ) && is_numeric( $field_style['boxShadowActive'][2] ) ? $field_style['boxShadowActive'][2] : 0.4 ) ) );
+		if ( isset( $field_style['boxShadowActive'] ) && is_array( $field_style['boxShadowActive'] ) && ! empty( $field_style['boxShadowActive'][0] ) && $field_style['boxShadowActive'][0] === true ) {
+			$css->add_property(
+				'box-shadow',
+				$css->render_legacy_shadow(
+					$field_style['boxShadowActive'],
+					[
+						'hOffset' => '2',
+						'vOffset' => '2',
+						'blur'    => '3',
+						'spread'  => '0',
+						'color'   => '#000000',
+						'opacity' => 0.4,
+					]
+				)
+			);
 		}
 
 

--- a/includes/blocks/class-kadence-blocks-advanced-form-block.php
+++ b/includes/blocks/class-kadence-blocks-advanced-form-block.php
@@ -5,6 +5,8 @@
  * @package Kadence Blocks
  */
 
+// cspell:ignore ajaxurl autoembed sizetype .
+
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -69,10 +71,10 @@ class Kadence_Blocks_Advanced_Form_Block extends Kadence_Blocks_Abstract_Block {
 	/**
 	 * Builds CSS for block.
 	 *
-	 * @param array $attributes the blocks attributes.
-	 * @param Kadence_Blocks_CSS $css the css class for blocks.
-	 * @param string $unique_id the blocks attr ID.
-	 * @param string $unique_style_id the blocks alternate ID for queries.
+	 * @param array              $attributes      the blocks attributes.
+	 * @param Kadence_Blocks_CSS $css             the css class for blocks.
+	 * @param string             $unique_id       the blocks attr ID.
+	 * @param string             $unique_style_id the blocks alternate ID for queries.
 	 */
 	public function build_css( $attributes, $css, $unique_id, $unique_style_id ) {
 

--- a/includes/blocks/class-kadence-blocks-advancedbtn-block.php
+++ b/includes/blocks/class-kadence-blocks-advancedbtn-block.php
@@ -5,6 +5,8 @@
  * @package Kadence Blocks
  */
 
+// cspell:ignore bgtype btnkey btnvalue simplelightbox videolight .
+
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -51,10 +53,10 @@ class Kadence_Blocks_Advancedbtn_Block extends Kadence_Blocks_Abstract_Block {
 	/**
 	 * Builds CSS for block.
 	 *
-	 * @param array $attributes the blocks attributes.
-	 * @param string $css the css class for blocks.
-	 * @param string $unique_id the blocks attr ID.
-	 * @param string $unique_style_id the blocks alternate ID for queries.
+	 * @param array              $attributes      the blocks attributes.
+	 * @param Kadence_Blocks_CSS $css             the css object for blocks.
+	 * @param string             $unique_id       the blocks attr ID.
+	 * @param string             $unique_style_id the blocks alternate ID for queries.
 	 */
 	public function build_css( $attributes, $css, $unique_id, $unique_style_id ) {
 		$css->set_style_id( 'kb-' . $this->block_name . $unique_style_id );

--- a/includes/blocks/class-kadence-blocks-advancedbtn-block.php
+++ b/includes/blocks/class-kadence-blocks-advancedbtn-block.php
@@ -326,7 +326,20 @@ class Kadence_Blocks_Advancedbtn_Block extends Kadence_Blocks_Abstract_Block {
 						$css->add_property( 'border-style', 'solid' );
 					}
 					if ( isset( $btnvalue['boxShadow'] ) && is_array( $btnvalue['boxShadow'] ) && isset( $btnvalue['boxShadow'][0] ) && true === $btnvalue['boxShadow'][0] ) {
-						$css->add_property( 'box-shadow', ( isset( $btnvalue['boxShadow'][7] ) && true === $btnvalue['boxShadow'][7] ? 'inset ' : '' ) . ( isset( $btnvalue['boxShadow'][3] ) && is_numeric( $btnvalue['boxShadow'][3] ) ? $btnvalue['boxShadow'][3] : '1' ) . 'px ' . ( isset( $btnvalue['boxShadow'][4] ) && is_numeric( $btnvalue['boxShadow'][4] ) ? $btnvalue['boxShadow'][4] : '1' ) . 'px ' . ( isset( $btnvalue['boxShadow'][5] ) && is_numeric( $btnvalue['boxShadow'][5] ) ? $btnvalue['boxShadow'][5] : '2' ) . 'px ' . ( isset( $btnvalue['boxShadow'][6] ) && is_numeric( $btnvalue['boxShadow'][6] ) ? $btnvalue['boxShadow'][6] : '0' ) . 'px ' . $css->render_color( ( isset( $btnvalue['boxShadow'][1] ) && ! empty( $btnvalue['boxShadow'][1] ) ? $btnvalue['boxShadow'][1] : '#000000' ), ( isset( $btnvalue['boxShadow'][2] ) && is_numeric( $btnvalue['boxShadow'][2] ) ? $btnvalue['boxShadow'][2] : 0.2 ) ) );
+						$css->add_property(
+							'box-shadow',
+							$css->render_legacy_shadow(
+								$btnvalue['boxShadow'],
+								[
+									'hOffset' => '1',
+									'vOffset' => '1',
+									'blur'    => '2',
+									'spread'  => '0',
+									'color'   => '#000000',
+									'opacity' => 0.2,
+								]
+							)
+						);
 					}
 
 					$css->render_measure_output( $btnvalue, 'margin', 'margin', [ 'unit_key' => 'marginUnit' ] );
@@ -341,7 +354,20 @@ class Kadence_Blocks_Advancedbtn_Block extends Kadence_Blocks_Abstract_Block {
 						$css->add_property( 'border-color', $css->render_color( $btnvalue['borderHover'], $alpha ) );
 					}
 					if ( isset( $btnvalue['boxShadowHover'] ) && is_array( $btnvalue['boxShadowHover'] ) && isset( $btnvalue['boxShadowHover'][0] ) && true === $btnvalue['boxShadowHover'][0] && isset( $btnvalue['boxShadowHover'][7] ) && true !== $btnvalue['boxShadowHover'][7] ) {
-						$css->add_property( 'box-shadow', ( isset( $btnvalue['boxShadowHover'][7] ) && true === $btnvalue['boxShadowHover'][7] ? 'inset ' : '' ) . ( isset( $btnvalue['boxShadowHover'][3] ) && is_numeric( $btnvalue['boxShadowHover'][3] ) ? $btnvalue['boxShadowHover'][3] : '2' ) . 'px ' . ( isset( $btnvalue['boxShadowHover'][4] ) && is_numeric( $btnvalue['boxShadowHover'][4] ) ? $btnvalue['boxShadowHover'][4] : '2' ) . 'px ' . ( isset( $btnvalue['boxShadowHover'][5] ) && is_numeric( $btnvalue['boxShadowHover'][5] ) ? $btnvalue['boxShadowHover'][5] : '3' ) . 'px ' . ( isset( $btnvalue['boxShadowHover'][6] ) && is_numeric( $btnvalue['boxShadowHover'][6] ) ? $btnvalue['boxShadowHover'][6] : '0' ) . 'px ' . $css->render_color( ( isset( $btnvalue['boxShadowHover'][1] ) && ! empty( $btnvalue['boxShadowHover'][1] ) ? $btnvalue['boxShadowHover'][1] : '#000000' ), ( isset( $btnvalue['boxShadowHover'][2] ) && is_numeric( $btnvalue['boxShadowHover'][2] ) ? $btnvalue['boxShadowHover'][2] : 0.4 ) ) );
+						$css->add_property(
+							'box-shadow',
+							$css->render_legacy_shadow(
+								$btnvalue['boxShadowHover'],
+								[
+									'hOffset' => '2',
+									'vOffset' => '2',
+									'blur'    => '3',
+									'spread'  => '0',
+									'color'   => '#000000',
+									'opacity' => 0.4,
+								]
+							)
+						);
 					}
 					if ( 'gradient' === $bgtype ) {
 						$css->set_selector( '.wp-block-kadence-advancedbtn.kt-btns' . $unique_id . ' .kt-btn-wrap-' . $btnkey . ' .kt-button::before' );
@@ -359,7 +385,20 @@ class Kadence_Blocks_Advancedbtn_Block extends Kadence_Blocks_Abstract_Block {
 							$css->add_property( 'background', $css->render_color( $btnvalue['backgroundHover'], $alpha ) );
 						}
 						if ( isset( $btnvalue['boxShadowHover'] ) && is_array( $btnvalue['boxShadowHover'] ) && isset( $btnvalue['boxShadowHover'][0] ) && true === $btnvalue['boxShadowHover'][0] && isset( $btnvalue['boxShadowHover'][7] ) && true === $btnvalue['boxShadowHover'][7] ) {
-							$css->add_property( 'box-shadow', ( isset( $btnvalue['boxShadowHover'][7] ) && true === $btnvalue['boxShadowHover'][7] ? 'inset ' : '' ) . ( isset( $btnvalue['boxShadowHover'][3] ) && is_numeric( $btnvalue['boxShadowHover'][3] ) ? $btnvalue['boxShadowHover'][3] : '2' ) . 'px ' . ( isset( $btnvalue['boxShadowHover'][4] ) && is_numeric( $btnvalue['boxShadowHover'][4] ) ? $btnvalue['boxShadowHover'][4] : '2' ) . 'px ' . ( isset( $btnvalue['boxShadowHover'][5] ) && is_numeric( $btnvalue['boxShadowHover'][5] ) ? $btnvalue['boxShadowHover'][5] : '3' ) . 'px ' . ( isset( $btnvalue['boxShadowHover'][6] ) && is_numeric( $btnvalue['boxShadowHover'][6] ) ? $btnvalue['boxShadowHover'][6] : '0' ) . 'px ' . $css->render_color( ( isset( $btnvalue['boxShadowHover'][1] ) && ! empty( $btnvalue['boxShadowHover'][1] ) ? $btnvalue['boxShadowHover'][1] : '#000000' ), ( isset( $btnvalue['boxShadowHover'][2] ) && is_numeric( $btnvalue['boxShadowHover'][2] ) ? $btnvalue['boxShadowHover'][2] : 0.4 ) ) );
+							$css->add_property(
+								'box-shadow',
+								$css->render_legacy_shadow(
+									$btnvalue['boxShadowHover'],
+									[
+										'hOffset' => '2',
+										'vOffset' => '2',
+										'blur'    => '3',
+										'spread'  => '0',
+										'color'   => '#000000',
+										'opacity' => 0.4,
+									]
+								)
+							);
 							$css->add_property( 'border-radius', ( isset( $btnvalue['borderRadius'] ) && is_numeric( $btnvalue['borderRadius'] ) ? $btnvalue['borderRadius'] : '3' ) . 'px' );
 						}
 					} else {
@@ -376,7 +415,20 @@ class Kadence_Blocks_Advancedbtn_Block extends Kadence_Blocks_Abstract_Block {
 							}
 						}
 						if ( isset( $btnvalue['boxShadowHover'] ) && is_array( $btnvalue['boxShadowHover'] ) && isset( $btnvalue['boxShadowHover'][0] ) && true === $btnvalue['boxShadowHover'][0] && isset( $btnvalue['boxShadowHover'][7] ) && true === $btnvalue['boxShadowHover'][7] ) {
-							$css->add_property( 'box-shadow', ( isset( $btnvalue['boxShadowHover'][7] ) && true === $btnvalue['boxShadowHover'][7] ? 'inset ' : '' ) . ( isset( $btnvalue['boxShadowHover'][3] ) && is_numeric( $btnvalue['boxShadowHover'][3] ) ? $btnvalue['boxShadowHover'][3] : '2' ) . 'px ' . ( isset( $btnvalue['boxShadowHover'][4] ) && is_numeric( $btnvalue['boxShadowHover'][4] ) ? $btnvalue['boxShadowHover'][4] : '2' ) . 'px ' . ( isset( $btnvalue['boxShadowHover'][5] ) && is_numeric( $btnvalue['boxShadowHover'][5] ) ? $btnvalue['boxShadowHover'][5] : '3' ) . 'px ' . ( isset( $btnvalue['boxShadowHover'][6] ) && is_numeric( $btnvalue['boxShadowHover'][6] ) ? $btnvalue['boxShadowHover'][6] : '0' ) . 'px ' . $css->render_color( ( isset( $btnvalue['boxShadowHover'][1] ) && ! empty( $btnvalue['boxShadowHover'][1] ) ? $btnvalue['boxShadowHover'][1] : '#000000' ), ( isset( $btnvalue['boxShadowHover'][2] ) && is_numeric( $btnvalue['boxShadowHover'][2] ) ? $btnvalue['boxShadowHover'][2] : 0.4 ) ) );
+							$css->add_property(
+								'box-shadow',
+								$css->render_legacy_shadow(
+									$btnvalue['boxShadowHover'],
+									[
+										'hOffset' => '2',
+										'vOffset' => '2',
+										'blur'    => '3',
+										'spread'  => '0',
+										'color'   => '#000000',
+										'opacity' => 0.4,
+									]
+								)
+							);
 						}
 					}
 					// Tablet CSS.

--- a/includes/blocks/class-kadence-blocks-advancedgallery-block.php
+++ b/includes/blocks/class-kadence-blocks-advancedgallery-block.php
@@ -5,6 +5,8 @@
  * @package Kadence Blocks
  */
 
+// cspell:ignore Csvg NODEFDTD NOIMPLIED alignnone arrowstyle dotstyle figcap fluidcarousel glight kses outlinedark outlinelight relcustom tcolumns thumbslider .
+
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -95,10 +97,10 @@ class Kadence_Blocks_Advancedgallery_Block extends Kadence_Blocks_Abstract_Block
 	/**
 	 * Builds CSS for block.
 	 *
-	 * @param array $attributes the blocks attributes.
-	 * @param Kadence_Blocks_CSS $css the css class for blocks.
-	 * @param string $unique_id the blocks attr ID.
-	 * @param string $unique_style_id the blocks alternate ID for queries.
+	 * @param array              $attributes      the blocks attributes.
+	 * @param Kadence_Blocks_CSS $css             the css class for blocks.
+	 * @param string             $unique_id       the blocks attr ID.
+	 * @param string             $unique_style_id the blocks alternate ID for queries.
 	 */
 	public function build_css( $attributes, $css, $unique_id, $unique_style_id ) {
 		$updated_version = ! empty( $attributes['kbVersion'] ) && $attributes['kbVersion'] > 1 ? true : false;
@@ -108,7 +110,7 @@ class Kadence_Blocks_Advancedgallery_Block extends Kadence_Blocks_Abstract_Block
 		$css->set_selector('.wp-block-kadence-advancedgallery.kb-gallery-wrap-id-' . $unique_id );
 
 		if ( isset( $attributes['margin'][0] ) ) {
-			// Fix for this margin unit being in a non-standard locaiton in array, should be updated.
+			// Fix for this margin unit being in a non-standard location in array, should be updated.
 			$margin_unit = ( ! empty( $attributes['marginUnit'] ) ? $attributes['marginUnit'] : 'px' );
 			$css->render_measure_output(
 				array_merge( $attributes['margin'][0], array( 'marginType' => $margin_unit ) ),
@@ -899,11 +901,11 @@ class Kadence_Blocks_Advancedgallery_Block extends Kadence_Blocks_Abstract_Block
 	 * This function can be used by Kadence Blocks Pro for dynamic content.
 	 * It creates a mosaic pattern layout for gallery images with specific grid classes.
 	 *
-	 * @param array $images Array of image objects with image data.
-	 * @param array $attributes Gallery block attributes.
-	 * @param array $gallery_classes Array of CSS classes for the gallery container.
-	 * @param string $image_filter Image filter setting.
-	 * @param bool $lightbox_cap Whether lightbox captions are enabled.
+	 * @param array  $images          Array of image objects with image data.
+	 * @param array  $attributes      Gallery block attributes.
+	 * @param array  $gallery_classes Array of CSS classes for the gallery container.
+	 * @param string $image_filter    Image filter setting.
+	 * @param bool   $lightbox_cap    Whether lightbox captions are enabled.
 	 * @return string HTML markup for the mosaic gallery.
 	 */
 	public function render_mosaic_gallery( $images, $attributes, $gallery_classes = array(), $image_filter = 'none', $lightbox_cap = false ) {
@@ -1008,7 +1010,10 @@ class Kadence_Blocks_Advancedgallery_Block extends Kadence_Blocks_Abstract_Block
 		return $output;
 	}
 	/**
-	 * Output Gallery image markeup.
+	 * Output Gallery image markup.
+	 *
+	 * @param array<string, mixed> $image      Image data.
+	 * @param array<string, mixed> $attributes Gallery block attributes.
 	 */
 	public function render_gallery_images( $image, $attributes ) {
 		$type          = ( ! empty( $attributes['type'] ) ? $attributes['type'] : 'masonry' );
@@ -1129,7 +1134,7 @@ class Kadence_Blocks_Advancedgallery_Block extends Kadence_Blocks_Abstract_Block
 		$figcap = '<' . $fig_tag . ' class="kadence-blocks-gallery-item__caption">' . ( ! empty( $caption ) && is_string( $caption ) ? wp_kses_post( $caption ) : '' ) . '</' . $fig_tag . '>';
 
 		//links in the main gallery caption can mess with lightbox function, strip them out.
-		//they're okay in the lighbox though
+		// they're okay in the lightbox though.
 		if( $link_to === 'media' && $lightbox === 'magnific' && ! empty( $figcap ) && is_string( $figcap ) ) {
 			$figcap = preg_replace('#<a.*?>(.*?)</a>#i', '\1', $figcap);
 		}
@@ -1196,7 +1201,10 @@ class Kadence_Blocks_Advancedgallery_Block extends Kadence_Blocks_Abstract_Block
 		return $output;
 	}
 	/**
-	 * Output Gallery image markeup.
+	 * Output Gallery image markup.
+	 *
+	 * @param array<string, mixed> $image      Image data.
+	 * @param array<string, mixed> $attributes Gallery block attributes.
 	 */
 	public function render_gallery_thumb_images( $image, $attributes ) {
 		$type          = ( ! empty( $attributes['type'] ) ? $attributes['type'] : 'masonry' );

--- a/includes/blocks/class-kadence-blocks-advancedgallery-block.php
+++ b/includes/blocks/class-kadence-blocks-advancedgallery-block.php
@@ -304,12 +304,38 @@ class Kadence_Blocks_Advancedgallery_Block extends Kadence_Blocks_Abstract_Block
 			if ( isset( $attributes['shadow'] ) && is_array( $attributes['shadow'] ) && is_array( $attributes['shadow'][ 0 ] ) ) {
 				$shadow = $attributes['shadow'][ 0 ];
 				$css->set_selector('.kb-gallery-id-' . $unique_id . ' .kadence-blocks-gallery-item .kb-gal-image-radius, .kb-gallery-id-' . $unique_id . ' .kadence-blocks-gallery-thumb-item .kb-gal-image-radius' );
-				$css->add_property('box-shadow', $shadow['hOffset'] . 'px ' . $shadow['vOffset'] . 'px ' . $shadow['blur'] . 'px ' . $shadow['spread'] . 'px ' . $css->render_color( $shadow['color'], $shadow['opacity'] ) );
+				$css->add_property(
+					'box-shadow',
+					$css->render_shadow(
+						$shadow,
+						[
+							'hOffset' => '4',
+							'vOffset' => '2',
+							'blur'    => '14',
+							'spread'  => '0',
+							'color'   => '#000000',
+							'opacity' => 0.2,
+						]
+					)
+				);
 			}
 			if ( isset( $attributes['shadowHover'] ) && is_array( $attributes['shadowHover'] ) && is_array( $attributes['shadowHover'][ 0 ] ) ) {
 				$shadow_hover = $attributes['shadowHover'][ 0 ];
 				$css->set_selector('.kb-gallery-id-' . $unique_id . ' .kadence-blocks-gallery-item:hover .kb-gal-image-radius, .kb-gallery-id-' . $unique_id . ' .kadence-blocks-gallery-thumb-item:hover .kb-gal-image-radius' );
-				$css->add_property('box-shadow', $shadow_hover['hOffset'] . 'px ' . $shadow_hover['vOffset'] . 'px ' . $shadow_hover['blur'] . 'px ' . $shadow_hover['spread'] . 'px ' . $css->render_color( $shadow_hover['color'], $shadow_hover['opacity'] ) );
+				$css->add_property(
+					'box-shadow',
+					$css->render_shadow(
+						$shadow_hover,
+						[
+							'hOffset' => '4',
+							'vOffset' => '2',
+							'blur'    => '14',
+							'spread'  => '0',
+							'color'   => '#000000',
+							'opacity' => 0.2,
+						]
+					)
+				);
 
 			} else {
 				$css->set_selector('.kb-gallery-id-' . $unique_id . ' .kadence-blocks-gallery-item:hover .kb-gal-image-radius' );

--- a/includes/blocks/class-kadence-blocks-column-block.php
+++ b/includes/blocks/class-kadence-blocks-column-block.php
@@ -229,7 +229,20 @@ class Kadence_Blocks_Column_Block extends Kadence_Blocks_Abstract_Block {
 		$css->set_media_state( 'desktop' );
 		if ( isset( $attributes['displayShadow'] ) && true == $attributes['displayShadow'] ) {
 			if ( isset( $attributes['shadow'] ) && is_array( $attributes['shadow'] ) && isset( $attributes['shadow'][0] ) && is_array( $attributes['shadow'][0] ) ) {
-				$css->add_property( 'box-shadow', ( isset( $attributes['shadow'][0]['inset'] ) && true === $attributes['shadow'][0]['inset'] ? 'inset ' : '' ) . ( isset( $attributes['shadow'][0]['hOffset'] ) && is_numeric( $attributes['shadow'][0]['hOffset'] ) ? $attributes['shadow'][0]['hOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadow'][0]['vOffset'] ) && is_numeric( $attributes['shadow'][0]['vOffset'] ) ? $attributes['shadow'][0]['vOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadow'][0]['blur'] ) && is_numeric( $attributes['shadow'][0]['blur'] ) ? $attributes['shadow'][0]['blur'] : '14' ) . 'px ' . ( isset( $attributes['shadow'][0]['spread'] ) && is_numeric( $attributes['shadow'][0]['spread'] ) ? $attributes['shadow'][0]['spread'] : '0' ) . 'px ' . $css->render_color( ( isset( $attributes['shadow'][0]['color'] ) && ! empty( $attributes['shadow'][0]['color'] ) ? $attributes['shadow'][0]['color'] : '#000000' ), ( isset( $attributes['shadow'][0]['opacity'] ) && is_numeric( $attributes['shadow'][0]['opacity'] ) ? $attributes['shadow'][0]['opacity'] : 0.2 ) ) );
+				$css->add_property(
+					'box-shadow',
+					$css->render_shadow(
+						$attributes['shadow'][0],
+						[
+							'hOffset' => '0',
+							'vOffset' => '0',
+							'blur'    => '14',
+							'spread'  => '0',
+							'color'   => '#000000',
+							'opacity' => 0.2,
+						]
+					)
+				);
 			} else {
 				$css->add_property( 'box-shadow', 'rgba(0, 0, 0, 0.2) 0px 0px 14px 0px' );
 			}
@@ -261,7 +274,20 @@ class Kadence_Blocks_Column_Block extends Kadence_Blocks_Abstract_Block {
 		if ( isset( $attributes['displayHoverShadow'] ) && true == $attributes['displayHoverShadow'] ) {
 			$css->set_selector( '.kadence-column' . $unique_id . ':hover > .kt-inside-inner-col' );
 			if ( isset( $attributes['shadowHover'] ) && is_array( $attributes['shadowHover'] ) && isset( $attributes['shadowHover'][0] ) && is_array( $attributes['shadowHover'][0] ) ) {
-				$css->add_property( 'box-shadow', ( isset( $attributes['shadowHover'][0]['inset'] ) && true === $attributes['shadowHover'][0]['inset'] ? 'inset ' : '' ) . ( isset( $attributes['shadowHover'][0]['hOffset'] ) && is_numeric( $attributes['shadowHover'][0]['hOffset'] ) ? $attributes['shadowHover'][0]['hOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadowHover'][0]['vOffset'] ) && is_numeric( $attributes['shadowHover'][0]['vOffset'] ) ? $attributes['shadowHover'][0]['vOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadowHover'][0]['blur'] ) && is_numeric( $attributes['shadowHover'][0]['blur'] ) ? $attributes['shadowHover'][0]['blur'] : '14' ) . 'px ' . ( isset( $attributes['shadowHover'][0]['spread'] ) && is_numeric( $attributes['shadowHover'][0]['spread'] ) ? $attributes['shadowHover'][0]['spread'] : '0' ) . 'px ' . $css->render_color( ( isset( $attributes['shadowHover'][0]['color'] ) && ! empty( $attributes['shadowHover'][0]['color'] ) ? $attributes['shadowHover'][0]['color'] : '#000000' ), ( isset( $attributes['shadowHover'][0]['opacity'] ) && is_numeric( $attributes['shadowHover'][0]['opacity'] ) ? $attributes['shadowHover'][0]['opacity'] : 0.2 ) ) );
+				$css->add_property(
+					'box-shadow',
+					$css->render_shadow(
+						$attributes['shadowHover'][0],
+						[
+							'hOffset' => '0',
+							'vOffset' => '0',
+							'blur'    => '14',
+							'spread'  => '0',
+							'color'   => '#000000',
+							'opacity' => 0.2,
+						]
+					)
+				);
 			} else {
 				$css->add_property( 'box-shadow', 'rgba(0, 0, 0, 0.2) 0px 0px 14px 0px' );
 			}

--- a/includes/blocks/class-kadence-blocks-column-block.php
+++ b/includes/blocks/class-kadence-blocks-column-block.php
@@ -5,6 +5,8 @@
  * @package Kadence Blocks
  */
 
+// cspell:ignore aligncenter .
+
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -43,10 +45,10 @@ class Kadence_Blocks_Column_Block extends Kadence_Blocks_Abstract_Block {
 	/**
 	 * Builds CSS for block.
 	 *
-	 * @param array $attributes the blocks attributes.
-	 * @param string $css the css class for blocks.
-	 * @param string $unique_id the blocks attr ID.
-	 * @param string $unique_style_id the blocks alternate ID for queries.
+	 * @param array              $attributes      the blocks attributes.
+	 * @param Kadence_Blocks_CSS $css             the css object for blocks.
+	 * @param string             $unique_id       the blocks attr ID.
+	 * @param string             $unique_style_id the blocks alternate ID for queries.
 	 */
 	public function build_css( $attributes, $css, $unique_id, $unique_style_id ) {
 		$css->set_style_id( 'kb-' . $this->block_name . $unique_style_id );
@@ -123,7 +125,7 @@ class Kadence_Blocks_Column_Block extends Kadence_Blocks_Abstract_Block {
 			$css->add_property( 'max-width', $attributes['maxWidth'][0] . $max_width_unit );
 			$css->add_property( 'margin-left', 'auto' );
 			$css->add_property( 'margin-right', 'auto' );
-			//Section inside Section compatablity.
+			// Section inside Section compatibility.
 			// $css->set_selector( '.wp-block-kadence-column>.kt-inside-inner-col>.kadence-column' . $unique_id );
 			// $css->add_property( 'flex', '1 ' . $attributes['maxWidth'][0] . ( isset( $attributes['maxWidthUnit'] ) ? $attributes['maxWidthUnit'] : 'px' ) );
 			$css->set_selector( '.wp-block-kadence-column.kb-section-dir-horizontal:not(.kb-section-md-dir-vertical)>.kt-inside-inner-col>.kadence-column' . $unique_id );
@@ -933,7 +935,7 @@ class Kadence_Blocks_Column_Block extends Kadence_Blocks_Abstract_Block {
 			}
 			$css->set_media_state( 'desktop' );
 		} else {
-			// New margin intentially targets outer container, improvement and don't have to worry about issues with row layout.
+			// New margin intentionally targets outer container, improvement and don't have to worry about issues with row layout.
 			$css->set_selector( '.kadence-column' . $unique_id . ', .kt-inside-inner-col > .kadence-column' . $unique_id . ':not(.specificity)' );
 			$css->render_measure_output(
 				$attributes,

--- a/includes/blocks/class-kadence-blocks-form-block.php
+++ b/includes/blocks/class-kadence-blocks-form-block.php
@@ -5,6 +5,8 @@
  * @package Kadence Blocks
  */
 
+// cspell:ignore ajaxurl bgtype lpignore missingkey .
+
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -52,10 +54,10 @@ class Kadence_Blocks_Form_Block extends Kadence_Blocks_Abstract_Block {
 	/**
 	 * Builds CSS for block.
 	 *
-	 * @param array $attributes the blocks attributes.
-	 * @param Kadence_Blocks_CSS $css the css class for blocks.
-	 * @param string $unique_id the blocks attr ID.
-	 * @param string $unique_style_id the blocks alternate ID for queries.
+	 * @param array              $attributes      the blocks attributes.
+	 * @param Kadence_Blocks_CSS $css             the css class for blocks.
+	 * @param string             $unique_id       the blocks attr ID.
+	 * @param string             $unique_style_id the blocks alternate ID for queries.
 	 */
 	public function build_css( $attributes, $css, $unique_id, $unique_style_id ) {
 

--- a/includes/blocks/class-kadence-blocks-form-block.php
+++ b/includes/blocks/class-kadence-blocks-form-block.php
@@ -203,7 +203,20 @@ class Kadence_Blocks_Form_Block extends Kadence_Blocks_Abstract_Block {
 					$css->add_property( 'border-color', $css->render_color( $style['border'], $alpha ) );
 				}
 				if ( isset( $style['boxShadow'] ) && is_array( $style['boxShadow'] ) && isset( $style['boxShadow'][0] ) && true === $style['boxShadow'][0] ) {
-					$css->add_property( 'box-shadow', ( isset( $style['boxShadow'][7] ) && true === $style['boxShadow'][7] ? 'inset ' : '' ) . ( isset( $style['boxShadow'][3] ) && is_numeric( $style['boxShadow'][3] ) ? $style['boxShadow'][3] : '1' ) . 'px ' . ( isset( $style['boxShadow'][4] ) && is_numeric( $style['boxShadow'][4] ) ? $style['boxShadow'][4] : '1' ) . 'px ' . ( isset( $style['boxShadow'][5] ) && is_numeric( $style['boxShadow'][5] ) ? $style['boxShadow'][5] : '2' ) . 'px ' . ( isset( $style['boxShadow'][6] ) && is_numeric( $style['boxShadow'][6] ) ? $style['boxShadow'][6] : '0' ) . 'px ' . $css->render_color( ( isset( $style['boxShadow'][1] ) && ! empty( $style['boxShadow'][1] ) ? $style['boxShadow'][1] : '#000000' ), ( isset( $style['boxShadow'][2] ) && is_numeric( $style['boxShadow'][2] ) ? $style['boxShadow'][2] : 0.2 ) ) );
+					$css->add_property(
+						'box-shadow',
+						$css->render_legacy_shadow(
+							$style['boxShadow'],
+							[
+								'hOffset' => '1',
+								'vOffset' => '1',
+								'blur'    => '2',
+								'spread'  => '0',
+								'color'   => '#000000',
+								'opacity' => 0.2,
+							]
+						)
+					);
 				}
 
 			}
@@ -217,7 +230,20 @@ class Kadence_Blocks_Form_Block extends Kadence_Blocks_Abstract_Block {
 					$css->add_property( 'border-color', $css->render_color( $style['borderActive'], $alpha ) );
 				}
 				if ( isset( $style['boxShadowActive'] ) && is_array( $style['boxShadowActive'] ) && isset( $style['boxShadowActive'][0] ) && true === $style['boxShadowActive'][0] ) {
-					$css->add_property( 'box-shadow', ( isset( $style['boxShadowActive'][7] ) && true === $style['boxShadowActive'][7] ? 'inset ' : '' ) . ( isset( $style['boxShadowActive'][3] ) && is_numeric( $style['boxShadowActive'][3] ) ? $style['boxShadowActive'][3] : '2' ) . 'px ' . ( isset( $style['boxShadowActive'][4] ) && is_numeric( $style['boxShadowActive'][4] ) ? $style['boxShadowActive'][4] : '2' ) . 'px ' . ( isset( $style['boxShadowActive'][5] ) && is_numeric( $style['boxShadowActive'][5] ) ? $style['boxShadowActive'][5] : '3' ) . 'px ' . ( isset( $style['boxShadowActive'][6] ) && is_numeric( $style['boxShadowActive'][6] ) ? $style['boxShadowActive'][6] : '0' ) . 'px ' . $css->render_color( ( isset( $style['boxShadowActive'][1] ) && ! empty( $style['boxShadowActive'][1] ) ? $style['boxShadowActive'][1] : '#000000' ), ( isset( $style['boxShadowActive'][2] ) && is_numeric( $style['boxShadowActive'][2] ) ? $style['boxShadowActive'][2] : 0.4 ) ) );
+					$css->add_property(
+						'box-shadow',
+						$css->render_legacy_shadow(
+							$style['boxShadowActive'],
+							[
+								'hOffset' => '2',
+								'vOffset' => '2',
+								'blur'    => '3',
+								'spread'  => '0',
+								'color'   => '#000000',
+								'opacity' => 0.4,
+							]
+						)
+					);
 				}
 				if ( isset( $style['backgroundActiveType'] ) && 'gradient' === $style['backgroundActiveType'] ) {
 					$bg1 = ( ! isset( $style['backgroundActive'] ) ? $css->render_color( '#444444', ( isset( $style['backgroundActiveOpacity'] ) && is_numeric( $style['backgroundActiveOpacity'] ) ? $style['backgroundActiveOpacity'] : 1 ) ) : $css->render_color( $style['backgroundActive'], ( isset( $style['backgroundActiveOpacity'] ) && is_numeric( $style['backgroundActiveOpacity'] ) ? $style['backgroundActiveOpacity'] : 1 ) ) );
@@ -440,7 +466,20 @@ class Kadence_Blocks_Form_Block extends Kadence_Blocks_Abstract_Block {
 				$css->add_property( 'border-color', $css->render_color( $submit['border'], $alpha ) );
 			}
 			if ( isset( $submit['boxShadow'] ) && is_array( $submit['boxShadow'] ) && isset( $submit['boxShadow'][0] ) && true === $submit['boxShadow'][0] ) {
-				$css->add_property( 'box-shadow', ( isset( $submit['boxShadow'][7] ) && true === $submit['boxShadow'][7] ? 'inset ' : '' ) . ( isset( $submit['boxShadow'][3] ) && is_numeric( $submit['boxShadow'][3] ) ? $submit['boxShadow'][3] : '1' ) . 'px ' . ( isset( $submit['boxShadow'][4] ) && is_numeric( $submit['boxShadow'][4] ) ? $submit['boxShadow'][4] : '1' ) . 'px ' . ( isset( $submit['boxShadow'][5] ) && is_numeric( $submit['boxShadow'][5] ) ? $submit['boxShadow'][5] : '2' ) . 'px ' . ( isset( $submit['boxShadow'][6] ) && is_numeric( $submit['boxShadow'][6] ) ? $submit['boxShadow'][6] : '0' ) . 'px ' . $css->render_color( ( isset( $submit['boxShadow'][1] ) && ! empty( $submit['boxShadow'][1] ) ? $submit['boxShadow'][1] : '#000000' ), ( isset( $submit['boxShadow'][2] ) && is_numeric( $submit['boxShadow'][2] ) ? $submit['boxShadow'][2] : 0.2 ) ) );
+				$css->add_property(
+					'box-shadow',
+					$css->render_legacy_shadow(
+						$submit['boxShadow'],
+						[
+							'hOffset' => '1',
+							'vOffset' => '1',
+							'blur'    => '2',
+							'spread'  => '0',
+							'color'   => '#000000',
+							'opacity' => 0.2,
+						]
+					)
+				);
 			}
 
 			$css->set_selector( '.kadence-form-' . $unique_id . ' .kb-form .kadence-blocks-form-field .kb-forms-submit:hover, .kadence-form-' . $unique_id . ' .kb-form .kadence-blocks-form-field .kb-forms-submit:focus ' );
@@ -452,7 +491,20 @@ class Kadence_Blocks_Form_Block extends Kadence_Blocks_Abstract_Block {
 				$css->add_property( 'border-color', $css->render_color( $submit['borderHover'], $alpha ) );
 			}
 			if ( isset( $submit['boxShadowHover'] ) && is_array( $submit['boxShadowHover'] ) && isset( $submit['boxShadowHover'][0] ) && true === $submit['boxShadowHover'][0] && isset( $submit['boxShadowHover'][7] ) && true !== $submit['boxShadowHover'][7] ) {
-				$css->add_property( 'box-shadow', ( isset( $submit['boxShadowHover'][7] ) && true === $submit['boxShadowHover'][7] ? 'inset ' : '' ) . ( isset( $submit['boxShadowHover'][3] ) && is_numeric( $submit['boxShadowHover'][3] ) ? $submit['boxShadowHover'][3] : '2' ) . 'px ' . ( isset( $submit['boxShadowHover'][4] ) && is_numeric( $submit['boxShadowHover'][4] ) ? $submit['boxShadowHover'][4] : '2' ) . 'px ' . ( isset( $submit['boxShadowHover'][5] ) && is_numeric( $submit['boxShadowHover'][5] ) ? $submit['boxShadowHover'][5] : '3' ) . 'px ' . ( isset( $submit['boxShadowHover'][6] ) && is_numeric( $submit['boxShadowHover'][6] ) ? $submit['boxShadowHover'][6] : '0' ) . 'px ' . $css->render_color( ( isset( $submit['boxShadowHover'][1] ) && ! empty( $submit['boxShadowHover'][1] ) ? $submit['boxShadowHover'][1] : '#000000' ), ( isset( $submit['boxShadowHover'][2] ) && is_numeric( $submit['boxShadowHover'][2] ) ? $submit['boxShadowHover'][2] : 0.4 ) ) );
+				$css->add_property(
+					'box-shadow',
+					$css->render_legacy_shadow(
+						$submit['boxShadowHover'],
+						[
+							'hOffset' => '2',
+							'vOffset' => '2',
+							'blur'    => '3',
+							'spread'  => '0',
+							'color'   => '#000000',
+							'opacity' => 0.4,
+						]
+					)
+				);
 			}
 			if ( 'gradient' !== $bgtype ) {
 				if ( isset( $submit['backgroundHover'] ) && ! empty( $submit['backgroundHover'] ) ) {
@@ -460,7 +512,20 @@ class Kadence_Blocks_Form_Block extends Kadence_Blocks_Abstract_Block {
 					$css->add_property( 'background', $css->render_color( $submit['backgroundHover'], $alpha ) );
 				}
 				if ( isset( $submit['boxShadowHover'] ) && is_array( $submit['boxShadowHover'] ) && isset( $submit['boxShadowHover'][0] ) && true === $submit['boxShadowHover'][0] && isset( $submit['boxShadowHover'][7] ) && true === $submit['boxShadowHover'][7] ) {
-					$css->add_property( 'box-shadow', ( isset( $submit['boxShadowHover'][7] ) && true === $submit['boxShadowHover'][7] ? 'inset ' : '' ) . ( isset( $submit['boxShadowHover'][3] ) && is_numeric( $submit['boxShadowHover'][3] ) ? $submit['boxShadowHover'][3] : '2' ) . 'px ' . ( isset( $submit['boxShadowHover'][4] ) && is_numeric( $submit['boxShadowHover'][4] ) ? $submit['boxShadowHover'][4] : '2' ) . 'px ' . ( isset( $submit['boxShadowHover'][5] ) && is_numeric( $submit['boxShadowHover'][5] ) ? $submit['boxShadowHover'][5] : '3' ) . 'px ' . ( isset( $submit['boxShadowHover'][6] ) && is_numeric( $submit['boxShadowHover'][6] ) ? $submit['boxShadowHover'][6] : '0' ) . 'px ' . $css->render_color( ( isset( $submit['boxShadowHover'][1] ) && ! empty( $submit['boxShadowHover'][1] ) ? $submit['boxShadowHover'][1] : '#000000' ), ( isset( $submit['boxShadowHover'][2] ) && is_numeric( $submit['boxShadowHover'][2] ) ? $submit['boxShadowHover'][2] : 0.4 ) ) );
+					$css->add_property(
+						'box-shadow',
+						$css->render_legacy_shadow(
+							$submit['boxShadowHover'],
+							[
+								'hOffset' => '2',
+								'vOffset' => '2',
+								'blur'    => '3',
+								'spread'  => '0',
+								'color'   => '#000000',
+								'opacity' => 0.4,
+							]
+						)
+					);
 				}
 			}
 
@@ -479,7 +544,20 @@ class Kadence_Blocks_Form_Block extends Kadence_Blocks_Abstract_Block {
 					$css->add_property( 'background', $css->render_color( $submit['backgroundHover'], $alpha ) );
 				}
 				if ( isset( $submit['boxShadowHover'] ) && is_array( $submit['boxShadowHover'] ) && isset( $submit['boxShadowHover'][0] ) && true === $submit['boxShadowHover'][0] && isset( $submit['boxShadowHover'][7] ) && true === $submit['boxShadowHover'][7] ) {
-					$css->add_property( 'box-shadow', ( isset( $submit['boxShadowHover'][7] ) && true === $submit['boxShadowHover'][7] ? 'inset ' : '' ) . ( isset( $submit['boxShadowHover'][3] ) && is_numeric( $submit['boxShadowHover'][3] ) ? $submit['boxShadowHover'][3] : '2' ) . 'px ' . ( isset( $submit['boxShadowHover'][4] ) && is_numeric( $submit['boxShadowHover'][4] ) ? $submit['boxShadowHover'][4] : '2' ) . 'px ' . ( isset( $submit['boxShadowHover'][5] ) && is_numeric( $submit['boxShadowHover'][5] ) ? $submit['boxShadowHover'][5] : '3' ) . 'px ' . ( isset( $submit['boxShadowHover'][6] ) && is_numeric( $submit['boxShadowHover'][6] ) ? $submit['boxShadowHover'][6] : '0' ) . 'px ' . $css->render_color( ( isset( $submit['boxShadowHover'][1] ) && ! empty( $submit['boxShadowHover'][1] ) ? $submit['boxShadowHover'][1] : '#000000' ), ( isset( $submit['boxShadowHover'][2] ) && is_numeric( $submit['boxShadowHover'][2] ) ? $submit['boxShadowHover'][2] : 0.4 ) ) );
+					$css->add_property(
+						'box-shadow',
+						$css->render_legacy_shadow(
+							$submit['boxShadowHover'],
+							[
+								'hOffset' => '2',
+								'vOffset' => '2',
+								'blur'    => '3',
+								'spread'  => '0',
+								'color'   => '#000000',
+								'opacity' => 0.4,
+							]
+						)
+					);
 					if ( isset( $submit['borderRadius'] ) && is_numeric( $submit['borderRadius'] ) ) {
 						$css->add_property( 'border-radius', $submit['borderRadius'] . 'px' );
 					}

--- a/includes/blocks/class-kadence-blocks-image-block.php
+++ b/includes/blocks/class-kadence-blocks-image-block.php
@@ -52,10 +52,10 @@ class Kadence_Blocks_Image_Block extends Kadence_Blocks_Abstract_Block {
 	/**
 	 * Builds CSS for block.
 	 *
-	 * @param array $attributes the blocks attributes.
-	 * @param Kadence_Blocks_CSS $css the css class for blocks.
-	 * @param string $unique_id the blocks attr ID.
-	 * @param string $unique_style_id the blocks alternate ID for queries.
+	 * @param array              $attributes      the blocks attributes.
+	 * @param Kadence_Blocks_CSS $css             the css class for blocks.
+	 * @param string             $unique_id       the blocks attr ID.
+	 * @param string             $unique_style_id the blocks alternate ID for queries.
 	 */
 	public function build_css( $attributes, $css, $unique_id, $unique_style_id ) {
 

--- a/includes/blocks/class-kadence-blocks-image-block.php
+++ b/includes/blocks/class-kadence-blocks-image-block.php
@@ -233,7 +233,20 @@ class Kadence_Blocks_Image_Block extends Kadence_Blocks_Abstract_Block {
 		// Box shadow
 		if ( isset( $attributes['displayBoxShadow'] ) && true == $attributes['displayBoxShadow'] ) {
 			if ( isset( $attributes['boxShadow'] ) && is_array( $attributes['boxShadow'] ) && isset( $attributes['boxShadow'][0] ) && is_array( $attributes['boxShadow'][0] ) ) {
-				$css->add_property( 'box-shadow', ( isset( $attributes['boxShadow'][0]['inset'] ) && true === $attributes['boxShadow'][0]['inset'] ? 'inset ' : '' ) . ( isset( $attributes['boxShadow'][0]['hOffset'] ) && is_numeric( $attributes['boxShadow'][0]['hOffset'] ) ? $attributes['boxShadow'][0]['hOffset'] : '0' ) . 'px ' . ( isset( $attributes['boxShadow'][0]['vOffset'] ) && is_numeric( $attributes['boxShadow'][0]['vOffset'] ) ? $attributes['boxShadow'][0]['vOffset'] : '0' ) . 'px ' . ( isset( $attributes['boxShadow'][0]['blur'] ) && is_numeric( $attributes['boxShadow'][0]['blur'] ) ? $attributes['boxShadow'][0]['blur'] : '14' ) . 'px ' . ( isset( $attributes['boxShadow'][0]['spread'] ) && is_numeric( $attributes['boxShadow'][0]['spread'] ) ? $attributes['boxShadow'][0]['spread'] : '0' ) . 'px ' . $css->render_color( ( isset( $attributes['boxShadow'][0]['color'] ) && ! empty( $attributes['boxShadow'][0]['color'] ) ? $attributes['boxShadow'][0]['color'] : '#000000' ), ( isset( $attributes['boxShadow'][0]['opacity'] ) && is_numeric( $attributes['boxShadow'][0]['opacity'] ) ? $attributes['boxShadow'][0]['opacity'] : 0.2 ) ) );
+				$css->add_property(
+					'box-shadow',
+					$css->render_shadow(
+						$attributes['boxShadow'][0],
+						[
+							'hOffset' => '0',
+							'vOffset' => '0',
+							'blur'    => '14',
+							'spread'  => '0',
+							'color'   => '#000000',
+							'opacity' => 0.2,
+						]
+					)
+				);
 			} else {
 				$css->add_property( 'box-shadow', 'rgba(0, 0, 0, 0.2) 0px 0px 14px 0px' );
 			}

--- a/includes/blocks/class-kadence-blocks-row-layout-block.php
+++ b/includes/blocks/class-kadence-blocks-row-layout-block.php
@@ -793,7 +793,20 @@ class Kadence_Blocks_Rowlayout_Block extends Kadence_Blocks_Abstract_Block {
 		// Box shadow
 		if ( isset( $attributes['displayBoxShadow'] ) && true == $attributes['displayBoxShadow'] ) {
 			if ( isset( $attributes['boxShadow'] ) && is_array( $attributes['boxShadow'] ) && isset( $attributes['boxShadow'][0] ) && is_array( $attributes['boxShadow'][0] ) ) {
-				$css->add_property( 'box-shadow', ( isset( $attributes['boxShadow'][0]['inset'] ) && true === $attributes['boxShadow'][0]['inset'] ? 'inset ' : '' ) . ( isset( $attributes['boxShadow'][0]['hOffset'] ) && is_numeric( $attributes['boxShadow'][0]['hOffset'] ) ? $attributes['boxShadow'][0]['hOffset'] : '0' ) . 'px ' . ( isset( $attributes['boxShadow'][0]['vOffset'] ) && is_numeric( $attributes['boxShadow'][0]['vOffset'] ) ? $attributes['boxShadow'][0]['vOffset'] : '0' ) . 'px ' . ( isset( $attributes['boxShadow'][0]['blur'] ) && is_numeric( $attributes['boxShadow'][0]['blur'] ) ? $attributes['boxShadow'][0]['blur'] : '14' ) . 'px ' . ( isset( $attributes['boxShadow'][0]['spread'] ) && is_numeric( $attributes['boxShadow'][0]['spread'] ) ? $attributes['boxShadow'][0]['spread'] : '0' ) . 'px ' . $css->render_color( ( isset( $attributes['boxShadow'][0]['color'] ) && ! empty( $attributes['boxShadow'][0]['color'] ) ? $attributes['boxShadow'][0]['color'] : '#000000' ), ( isset( $attributes['boxShadow'][0]['opacity'] ) && is_numeric( $attributes['boxShadow'][0]['opacity'] ) ? $attributes['boxShadow'][0]['opacity'] : 0.2 ) ) );
+				$css->add_property(
+					'box-shadow',
+					$css->render_shadow(
+						$attributes['boxShadow'][0],
+						[
+							'hOffset' => '0',
+							'vOffset' => '0',
+							'blur'    => '14',
+							'spread'  => '0',
+							'color'   => '#000000',
+							'opacity' => 0.2,
+						]
+					)
+				);
 			} else {
 				$css->add_property( 'box-shadow', 'rgba(0, 0, 0, 0.2) 0px 0px 14px 0px' );
 			}

--- a/includes/blocks/class-kadence-blocks-row-layout-block.php
+++ b/includes/blocks/class-kadence-blocks-row-layout-block.php
@@ -5,6 +5,8 @@
  * @package Kadence Blocks
  */
 
+// cspell:ignore alignnone arrowstyle blackonlight colorsecond colum crvi crvl crvli crvr crvri ctdi disablekb dotstyle generatepress littri littrii locsecond modestbranding mtns outlineblack outlinewhite overbg sltl sltli sltr sltri threelevels threelevelsi wavei wavesi .
+
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -86,7 +88,7 @@ class Kadence_Blocks_Rowlayout_Block extends Kadence_Blocks_Abstract_Block {
 	}
 
 	/**
-	 * Return a grid tempate coulmns string for custom column widths.
+	 * Return a grid template columns string for custom column widths.
 	 *
 	 * @param object $css the css object.
 	 * @param int    $columns the amount of columns.
@@ -323,10 +325,10 @@ class Kadence_Blocks_Rowlayout_Block extends Kadence_Blocks_Abstract_Block {
 	/**
 	 * Builds CSS for block.
 	 *
-	 * @param array  $attributes the blocks attributes.
-	 * @param string $css the css class for blocks.
-	 * @param string $unique_id the blocks attr ID.
-	 * @param string $unique_style_id the blocks alternate ID for queries.
+	 * @param array              $attributes      the blocks attributes.
+	 * @param Kadence_Blocks_CSS $css             the css object for blocks.
+	 * @param string             $unique_id       the blocks attr ID.
+	 * @param string             $unique_style_id the blocks alternate ID for queries.
 	 */
 	public function build_css( $attributes, $css, $unique_id, $unique_style_id ) {
 		$css->set_style_id( 'kb-' . $this->block_name . $unique_style_id );
@@ -572,7 +574,7 @@ class Kadence_Blocks_Rowlayout_Block extends Kadence_Blocks_Abstract_Block {
 
 		//Tablet layout
 		if ( empty( $attributes['tabletLayout'] ) && ! empty( $css->render_row_gap_property( $attributes, array( 'columnGutter', 'tabletGutter', 'mobileGutter' ), 'tablet', 'customGutter', 'gutterType' ) ) ) {
-			//no tablet layout, but we have a tablet guttter width, so render the inherited column layout from desktop, potentially with custom widths.
+			// no tablet layout, but we have a tablet gutter width, so render the inherited column layout from desktop, potentially with custom widths.
 			$css->set_media_state( 'tablet' );
 			$css->set_selector( $inner_selector );
 
@@ -1599,7 +1601,7 @@ class Kadence_Blocks_Rowlayout_Block extends Kadence_Blocks_Abstract_Block {
 			$src_base = 'youtube' == $background_video_type ? 'https://www.youtube.com/embed/' : 'https://player.vimeo.com/video/';
 			$video_id = 'youtube' == $background_video_type ? $video_attributes['youTube'] : $video_attributes['vimeo'];
 
-			// Vimeo and youtube share a bunch of params, that's convienent.
+			// Vimeo and youtube share a bunch of params, that's convenient.
 			$src_query_string = '?' . http_build_query(
 				array(
 					'autoplay' => 1,

--- a/includes/blocks/class-kadence-blocks-singlebtn-block.php
+++ b/includes/blocks/class-kadence-blocks-singlebtn-block.php
@@ -84,10 +84,10 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 	/**
 	 * Builds CSS for block.
 	 *
-	 * @param array  $attributes the blocks attributes.
-	 * @param string $css the css class for blocks.
-	 * @param string $unique_id the blocks attr ID.
-	 * @param string $unique_style_id the blocks alternate ID for queries.
+	 * @param array              $attributes      the blocks attributes.
+	 * @param Kadence_Blocks_CSS $css             the css object for blocks.
+	 * @param string             $unique_id       the blocks attr ID.
+	 * @param string             $unique_style_id the blocks alternate ID for queries.
 	 */
 	public function build_css( $attributes, $css, $unique_id, $unique_style_id ) {
 		$css->set_style_id( 'kb-' . $this->block_name . $unique_style_id );
@@ -239,7 +239,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 	/**
 	 * Build up the dynamic styles for a size.
 	 *
-	 * @param string               $css        The CSS builder instance.
+	 * @param Kadence_Blocks_CSS   $css        The CSS builder instance.
 	 * @param array<string, mixed> $attributes The block attributes.
 	 * @param string               $unique_id  The block's unique id.
 	 * @param string               $size       The responsive size.
@@ -247,7 +247,6 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 	 * @return void
 	 */
 	public function sized_dynamic_styles( $css, $attributes, $unique_id, $size = 'Desktop' ) {
-		/** @var Kadence_Blocks_CSS $css */
 		$sized_attributes         = $css->get_sized_attributes_auto( $attributes, $size, false );
 		$sized_attributes_inherit = $css->get_sized_attributes_auto( $attributes, $size );
 

--- a/includes/blocks/class-kadence-blocks-singlebtn-block.php
+++ b/includes/blocks/class-kadence-blocks-singlebtn-block.php
@@ -133,7 +133,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$css->render_measure_output( $attributes, 'margin', 'margin', [ 'unit_key' => 'marginUnit' ] );
 		if ( isset( $attributes['displayShadow'] ) && true === $attributes['displayShadow'] ) {
 			if ( isset( $attributes['shadow'] ) && is_array( $attributes['shadow'] ) && isset( $attributes['shadow'][0] ) && is_array( $attributes['shadow'][0] ) ) {
-				$css->add_property( 'box-shadow', ( isset( $attributes['shadow'][0]['inset'] ) && true === $attributes['shadow'][0]['inset'] ? 'inset ' : '' ) . ( isset( $attributes['shadow'][0]['hOffset'] ) && is_numeric( $attributes['shadow'][0]['hOffset'] ) ? $attributes['shadow'][0]['hOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadow'][0]['vOffset'] ) && is_numeric( $attributes['shadow'][0]['vOffset'] ) ? $attributes['shadow'][0]['vOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadow'][0]['blur'] ) && is_numeric( $attributes['shadow'][0]['blur'] ) ? $attributes['shadow'][0]['blur'] : '14' ) . 'px ' . ( isset( $attributes['shadow'][0]['spread'] ) && is_numeric( $attributes['shadow'][0]['spread'] ) ? $attributes['shadow'][0]['spread'] : '0' ) . 'px ' . $css->render_color( ( isset( $attributes['shadow'][0]['color'] ) && ! empty( $attributes['shadow'][0]['color'] ) ? $attributes['shadow'][0]['color'] : '#000000' ), ( isset( $attributes['shadow'][0]['opacity'] ) && is_numeric( $attributes['shadow'][0]['opacity'] ) ? $attributes['shadow'][0]['opacity'] : 0.2 ) ) );
+				$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadow'][0] ) );
 			} else {
 				$css->add_property( 'box-shadow', '1px 1px 2px 0px rgba(0, 0, 0, 0.2)' );
 			}
@@ -178,7 +178,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 				$css->set_selector( '.kb-btn' . $unique_id . '.kb-button:hover::before' );
 			}
 			if ( isset( $attributes['shadowHover'] ) && is_array( $attributes['shadowHover'] ) && isset( $attributes['shadowHover'][0] ) && is_array( $attributes['shadowHover'][0] ) ) {
-				$css->add_property( 'box-shadow', ( isset( $attributes['shadowHover'][0]['inset'] ) && true === $attributes['shadowHover'][0]['inset'] ? 'inset ' : '' ) . ( isset( $attributes['shadowHover'][0]['hOffset'] ) && is_numeric( $attributes['shadowHover'][0]['hOffset'] ) ? $attributes['shadowHover'][0]['hOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadowHover'][0]['vOffset'] ) && is_numeric( $attributes['shadowHover'][0]['vOffset'] ) ? $attributes['shadowHover'][0]['vOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadowHover'][0]['blur'] ) && is_numeric( $attributes['shadowHover'][0]['blur'] ) ? $attributes['shadowHover'][0]['blur'] : '14' ) . 'px ' . ( isset( $attributes['shadowHover'][0]['spread'] ) && is_numeric( $attributes['shadowHover'][0]['spread'] ) ? $attributes['shadowHover'][0]['spread'] : '0' ) . 'px ' . $css->render_color( ( isset( $attributes['shadowHover'][0]['color'] ) && ! empty( $attributes['shadowHover'][0]['color'] ) ? $attributes['shadowHover'][0]['color'] : '#000000' ), ( isset( $attributes['shadowHover'][0]['opacity'] ) && is_numeric( $attributes['shadowHover'][0]['opacity'] ) ? $attributes['shadowHover'][0]['opacity'] : 0.2 ) ) );
+				$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowHover'][0] ) );
 			} else {
 				$css->add_property( 'box-shadow', '2px 2px 3px 0px rgba(0, 0, 0, 0.4)' );
 			}
@@ -270,7 +270,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$css->render_border_styles( $attributes, 'borderTransparentStyle', true );
 		if ( isset( $attributes['displayShadowTransparent'] ) && true === $attributes['displayShadowTransparent'] ) {
 			if ( isset( $attributes['shadowTransparent'] ) && is_array( $attributes['shadowTransparent'] ) && isset( $attributes['shadowTransparent'][0] ) && is_array( $attributes['shadowTransparent'][0] ) ) {
-				$css->add_property( 'box-shadow', ( isset( $attributes['shadowTransparent'][0]['inset'] ) && true === $attributes['shadowTransparent'][0]['inset'] ? 'inset ' : '' ) . ( isset( $attributes['shadowTransparent'][0]['hOffset'] ) && is_numeric( $attributes['shadowTransparent'][0]['hOffset'] ) ? $attributes['shadowTransparent'][0]['hOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadowTransparent'][0]['vOffset'] ) && is_numeric( $attributes['shadowTransparent'][0]['vOffset'] ) ? $attributes['shadowTransparent'][0]['vOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadowTransparent'][0]['blur'] ) && is_numeric( $attributes['shadowTransparent'][0]['blur'] ) ? $attributes['shadowTransparent'][0]['blur'] : '14' ) . 'px ' . ( isset( $attributes['shadowTransparent'][0]['spread'] ) && is_numeric( $attributes['shadowTransparent'][0]['spread'] ) ? $attributes['shadowTransparent'][0]['spread'] : '0' ) . 'px ' . $css->render_color( ( isset( $attributes['shadowTransparent'][0]['color'] ) && ! empty( $attributes['shadowTransparent'][0]['color'] ) ? $attributes['shadowTransparent'][0]['color'] : '#000000' ), ( isset( $attributes['shadowTransparent'][0]['opacity'] ) && is_numeric( $attributes['shadowTransparent'][0]['opacity'] ) ? $attributes['shadowTransparent'][0]['opacity'] : 0.2 ) ) );
+				$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowTransparent'][0] ) );
 			} else {
 				$css->add_property( 'box-shadow', '1px 1px 2px 0px rgba(0, 0, 0, 0.2)' );
 			}
@@ -292,7 +292,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 				$css->set_selector( '.kb-btn' . $unique_id . '.kb-button:hover::before' );
 			}
 			if ( isset( $attributes['shadowTransparentHover'] ) && is_array( $attributes['shadowTransparentHover'] ) && isset( $attributes['shadowTransparentHover'][0] ) && is_array( $attributes['shadowTransparentHover'][0] ) ) {
-				$css->add_property( 'box-shadow', ( isset( $attributes['shadowTransparentHover'][0]['inset'] ) && true === $attributes['shadowTransparentHover'][0]['inset'] ? 'inset ' : '' ) . ( isset( $attributes['shadowTransparentHover'][0]['hOffset'] ) && is_numeric( $attributes['shadowTransparentHover'][0]['hOffset'] ) ? $attributes['shadowTransparentHover'][0]['hOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadowTransparentHover'][0]['vOffset'] ) && is_numeric( $attributes['shadowTransparentHover'][0]['vOffset'] ) ? $attributes['shadowTransparentHover'][0]['vOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadowTransparentHover'][0]['blur'] ) && is_numeric( $attributes['shadowTransparentHover'][0]['blur'] ) ? $attributes['shadowTransparentHover'][0]['blur'] : '14' ) . 'px ' . ( isset( $attributes['shadowTransparentHover'][0]['spread'] ) && is_numeric( $attributes['shadowTransparentHover'][0]['spread'] ) ? $attributes['shadowTransparentHover'][0]['spread'] : '0' ) . 'px ' . $css->render_color( ( isset( $attributes['shadowTransparentHover'][0]['color'] ) && ! empty( $attributes['shadowTransparentHover'][0]['color'] ) ? $attributes['shadowTransparentHover'][0]['color'] : '#000000' ), ( isset( $attributes['shadowTransparentHover'][0]['opacity'] ) && is_numeric( $attributes['shadowTransparentHover'][0]['opacity'] ) ? $attributes['shadowTransparentHover'][0]['opacity'] : 0.2 ) ) );
+				$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowTransparentHover'][0] ) );
 			} else {
 				$css->add_property( 'box-shadow', '2px 2px 3px 0px rgba(0, 0, 0, 0.4)' );
 			}
@@ -315,7 +315,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$css->render_border_styles( $attributes, 'borderStickyStyle', true );
 		if ( isset( $attributes['displayShadowSticky'] ) && true === $attributes['displayShadowSticky'] ) {
 			if ( isset( $attributes['shadowSticky'] ) && is_array( $attributes['shadowSticky'] ) && isset( $attributes['shadowSticky'][0] ) && is_array( $attributes['shadowSticky'][0] ) ) {
-				$css->add_property( 'box-shadow', ( isset( $attributes['shadowSticky'][0]['inset'] ) && true === $attributes['shadowSticky'][0]['inset'] ? 'inset ' : '' ) . ( isset( $attributes['shadowSticky'][0]['hOffset'] ) && is_numeric( $attributes['shadowSticky'][0]['hOffset'] ) ? $attributes['shadowSticky'][0]['hOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadowSticky'][0]['vOffset'] ) && is_numeric( $attributes['shadowSticky'][0]['vOffset'] ) ? $attributes['shadowSticky'][0]['vOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadowSticky'][0]['blur'] ) && is_numeric( $attributes['shadowSticky'][0]['blur'] ) ? $attributes['shadowSticky'][0]['blur'] : '14' ) . 'px ' . ( isset( $attributes['shadowSticky'][0]['spread'] ) && is_numeric( $attributes['shadowSticky'][0]['spread'] ) ? $attributes['shadowSticky'][0]['spread'] : '0' ) . 'px ' . $css->render_color( ( isset( $attributes['shadowSticky'][0]['color'] ) && ! empty( $attributes['shadowSticky'][0]['color'] ) ? $attributes['shadowSticky'][0]['color'] : '#000000' ), ( isset( $attributes['shadowSticky'][0]['opacity'] ) && is_numeric( $attributes['shadowSticky'][0]['opacity'] ) ? $attributes['shadowSticky'][0]['opacity'] : 0.2 ) ) );
+				$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowSticky'][0] ) );
 			} else {
 				$css->add_property( 'box-shadow', '1px 1px 2px 0px rgba(0, 0, 0, 0.2)' );
 			}
@@ -337,7 +337,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 				$css->set_selector( '.kb-btn' . $unique_id . '.kb-button:hover::before' );
 			}
 			if ( isset( $attributes['shadowStickyHover'] ) && is_array( $attributes['shadowStickyHover'] ) && isset( $attributes['shadowStickyHover'][0] ) && is_array( $attributes['shadowStickyHover'][0] ) ) {
-				$css->add_property( 'box-shadow', ( isset( $attributes['shadowStickyHover'][0]['inset'] ) && true === $attributes['shadowStickyHover'][0]['inset'] ? 'inset ' : '' ) . ( isset( $attributes['shadowStickyHover'][0]['hOffset'] ) && is_numeric( $attributes['shadowStickyHover'][0]['hOffset'] ) ? $attributes['shadowStickyHover'][0]['hOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadowStickyHover'][0]['vOffset'] ) && is_numeric( $attributes['shadowStickyHover'][0]['vOffset'] ) ? $attributes['shadowStickyHover'][0]['vOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadowStickyHover'][0]['blur'] ) && is_numeric( $attributes['shadowStickyHover'][0]['blur'] ) ? $attributes['shadowStickyHover'][0]['blur'] : '14' ) . 'px ' . ( isset( $attributes['shadowStickyHover'][0]['spread'] ) && is_numeric( $attributes['shadowStickyHover'][0]['spread'] ) ? $attributes['shadowStickyHover'][0]['spread'] : '0' ) . 'px ' . $css->render_color( ( isset( $attributes['shadowStickyHover'][0]['color'] ) && ! empty( $attributes['shadowStickyHover'][0]['color'] ) ? $attributes['shadowStickyHover'][0]['color'] : '#000000' ), ( isset( $attributes['shadowStickyHover'][0]['opacity'] ) && is_numeric( $attributes['shadowStickyHover'][0]['opacity'] ) ? $attributes['shadowStickyHover'][0]['opacity'] : 0.2 ) ) );
+				$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowStickyHover'][0] ) );
 			} else {
 				$css->add_property( 'box-shadow', '2px 2px 3px 0px rgba(0, 0, 0, 0.4)' );
 			}
@@ -498,6 +498,34 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		wp_register_script( 'kadence-blocks-glight-video-init', KADENCE_BLOCKS_URL . 'includes/assets/js/kb-glight-video-init.min.js', [ 'kadence-glightbox' ], KADENCE_BLOCKS_VERSION, true );
 		wp_register_script( 'kadence-blocks-popper', KADENCE_BLOCKS_URL . 'includes/assets/js/popper.min.js', [], KADENCE_BLOCKS_VERSION, true );
 		wp_register_script( 'kadence-blocks-tippy', KADENCE_BLOCKS_URL . 'includes/assets/js/kb-tippy.min.js', [ 'kadence-blocks-popper' ], KADENCE_BLOCKS_VERSION, true );
+	}
+
+	/**
+	 * Route a stored button box-shadow object through the alias-aware render_shadow().
+	 *
+	 * Applies this block's historic per-leg defaults so a literal shadow renders byte-identically
+	 * to the former inline builder, while a {dot.alias} on any numeric leg resolves to its token
+	 * var() instead of freezing to a literal.
+	 *
+	 * @since TBD
+	 *
+	 * @param Kadence_Blocks_CSS $css    The active CSS builder.
+	 * @param mixed              $shadow The stored shadow object ( e.g. $attributes['shadow'][0] ).
+	 *
+	 * @return string The rendered box-shadow declaration.
+	 */
+	private function render_button_shadow( $css, $shadow ): string {
+		return (string) $css->render_shadow(
+			is_array( $shadow ) ? $shadow : [],
+			[
+				'hOffset' => '0',
+				'vOffset' => '0',
+				'blur'    => '14',
+				'spread'  => '0',
+				'color'   => '#000000',
+				'opacity' => 0.2,
+			]
+		);
 	}
 }
 

--- a/includes/blocks/class-kadence-blocks-testimonials-block.php
+++ b/includes/blocks/class-kadence-blocks-testimonials-block.php
@@ -664,7 +664,20 @@ class Kadence_Blocks_Testimonials_Block extends Kadence_Blocks_Abstract_Block {
 			);
 			$shadow = isset( $attributes['shadow'][0] ) ? $attributes['shadow'][0] : $default_shadow;
 
-			$css->add_property( 'box-shadow', $shadow['hOffset'] .'px '. $shadow['vOffset'] .'px '. $shadow['blur'] . 'px '. $shadow['spread'] . 'px ' . $css->render_color( $shadow['color'], $shadow['opacity'] ) );
+			$css->add_property(
+				'box-shadow',
+				$css->render_shadow(
+					$shadow,
+					[
+						'hOffset' => '4',
+						'vOffset' => '2',
+						'blur'    => '14',
+						'spread'  => '0',
+						'color'   => '#000000',
+						'opacity' => 0.2,
+					]
+				)
+			);
 		}
 
 		if( !empty( $attributes['containerBorderWidth'][0] ) || !empty( $attributes['containerBorderWidth'][1] ) || !empty( $attributes['containerBorderWidth'][2] ) || !empty( $attributes['containerBorderWidth'][3] ) ) {

--- a/includes/blocks/class-kadence-blocks-testimonials-block.php
+++ b/includes/blocks/class-kadence-blocks-testimonials-block.php
@@ -5,6 +5,8 @@
  * @package Kadence Blocks
  */
 
+// cspell:ignore arrowstyle dotstyle halign inlineimage intrisic isize whiteondark .
+
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -52,10 +54,10 @@ class Kadence_Blocks_Testimonials_Block extends Kadence_Blocks_Abstract_Block {
 	/**
 	 * Builds CSS for block.
 	 *
-	 * @param array $attributes the blocks attributes.
-	 * @param Kadence_Blocks_CSS $css the css class for blocks.
-	 * @param string $unique_id the blocks attr ID.
-	 * @param string $unique_style_id the blocks alternate ID for queries.
+	 * @param array              $attributes      the blocks attributes.
+	 * @param Kadence_Blocks_CSS $css             the css class for blocks.
+	 * @param string             $unique_id       the blocks attr ID.
+	 * @param string             $unique_style_id the blocks alternate ID for queries.
 	 */
 	public function build_css( $attributes, $css, $unique_id, $unique_style_id ) {
 

--- a/includes/blocks/form/class-kadence-blocks-submit-block.php
+++ b/includes/blocks/form/class-kadence-blocks-submit-block.php
@@ -161,7 +161,20 @@ class Kadence_Blocks_Submit_Block extends Kadence_Blocks_Advanced_Form_Input_Blo
 		$css->render_measure_output( $attributes, 'margin', 'margin', [ 'unit_key' => 'marginUnit' ] );
 		if ( isset( $attributes['displayShadow'] ) && true === $attributes['displayShadow'] ) {
 			if ( isset( $attributes['shadow'] ) && is_array( $attributes['shadow'] ) && isset( $attributes['shadow'][0] ) && is_array( $attributes['shadow'][0] ) ) {
-				$css->add_property( 'box-shadow', ( isset( $attributes['shadow'][0]['inset'] ) && true === $attributes['shadow'][0]['inset'] ? 'inset ' : '' ) . ( isset( $attributes['shadow'][0]['hOffset'] ) && is_numeric( $attributes['shadow'][0]['hOffset'] ) ? $attributes['shadow'][0]['hOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadow'][0]['vOffset'] ) && is_numeric( $attributes['shadow'][0]['vOffset'] ) ? $attributes['shadow'][0]['vOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadow'][0]['blur'] ) && is_numeric( $attributes['shadow'][0]['blur'] ) ? $attributes['shadow'][0]['blur'] : '14' ) . 'px ' . ( isset( $attributes['shadow'][0]['spread'] ) && is_numeric( $attributes['shadow'][0]['spread'] ) ? $attributes['shadow'][0]['spread'] : '0' ) . 'px ' . $css->render_color( ( isset( $attributes['shadow'][0]['color'] ) && ! empty( $attributes['shadow'][0]['color'] ) ? $attributes['shadow'][0]['color'] : '#000000' ), ( isset( $attributes['shadow'][0]['opacity'] ) && is_numeric( $attributes['shadow'][0]['opacity'] ) ? $attributes['shadow'][0]['opacity'] : 0.2 ) ) );
+				$css->add_property(
+					'box-shadow',
+					$css->render_shadow(
+						$attributes['shadow'][0],
+						[
+							'hOffset' => '0',
+							'vOffset' => '0',
+							'blur'    => '14',
+							'spread'  => '0',
+							'color'   => '#000000',
+							'opacity' => 0.2,
+						]
+					)
+				);
 			} else {
 				$css->add_property( 'box-shadow', '1px 1px 2px 0px rgba(0, 0, 0, 0.2)' );
 			}
@@ -194,7 +207,20 @@ class Kadence_Blocks_Submit_Block extends Kadence_Blocks_Advanced_Form_Input_Blo
 				$css->set_selector( '.kb-btn' . $class_id . '.kb-button:hover::before' );
 			}
 			if ( isset( $attributes['shadowHover'] ) && is_array( $attributes['shadowHover'] ) && isset( $attributes['shadowHover'][0] ) && is_array( $attributes['shadowHover'][0] ) ) {
-				$css->add_property( 'box-shadow', ( isset( $attributes['shadowHover'][0]['inset'] ) && true === $attributes['shadowHover'][0]['inset'] ? 'inset ' : '' ) . ( isset( $attributes['shadowHover'][0]['hOffset'] ) && is_numeric( $attributes['shadowHover'][0]['hOffset'] ) ? $attributes['shadowHover'][0]['hOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadowHover'][0]['vOffset'] ) && is_numeric( $attributes['shadowHover'][0]['vOffset'] ) ? $attributes['shadowHover'][0]['vOffset'] : '0' ) . 'px ' . ( isset( $attributes['shadowHover'][0]['blur'] ) && is_numeric( $attributes['shadowHover'][0]['blur'] ) ? $attributes['shadowHover'][0]['blur'] : '14' ) . 'px ' . ( isset( $attributes['shadowHover'][0]['spread'] ) && is_numeric( $attributes['shadowHover'][0]['spread'] ) ? $attributes['shadowHover'][0]['spread'] : '0' ) . 'px ' . $css->render_color( ( isset( $attributes['shadowHover'][0]['color'] ) && ! empty( $attributes['shadowHover'][0]['color'] ) ? $attributes['shadowHover'][0]['color'] : '#000000' ), ( isset( $attributes['shadowHover'][0]['opacity'] ) && is_numeric( $attributes['shadowHover'][0]['opacity'] ) ? $attributes['shadowHover'][0]['opacity'] : 0.2 ) ) );
+				$css->add_property(
+					'box-shadow',
+					$css->render_shadow(
+						$attributes['shadowHover'][0],
+						[
+							'hOffset' => '0',
+							'vOffset' => '0',
+							'blur'    => '14',
+							'spread'  => '0',
+							'color'   => '#000000',
+							'opacity' => 0.2,
+						]
+					)
+				);
 			} else {
 				$css->add_property( 'box-shadow', '2px 2px 3px 0px rgba(0, 0, 0, 0.4)' );
 			}

--- a/includes/blocks/form/class-kadence-blocks-submit-block.php
+++ b/includes/blocks/form/class-kadence-blocks-submit-block.php
@@ -112,10 +112,10 @@ class Kadence_Blocks_Submit_Block extends Kadence_Blocks_Advanced_Form_Input_Blo
 	/**
 	 * Builds CSS for block.
 	 *
-	 * @param array  $attributes the blocks attributes.
-	 * @param string $css the css class for blocks.
-	 * @param string $unique_id the blocks attr ID.
-	 * @param string $unique_style_id the blocks alternate ID for queries.
+	 * @param array              $attributes      the blocks attributes.
+	 * @param Kadence_Blocks_CSS $css             the css object for blocks.
+	 * @param string             $unique_id       the blocks attr ID.
+	 * @param string             $unique_style_id the blocks alternate ID for queries.
 	 */
 	public function build_css( $attributes, $css, $unique_id, $unique_style_id ) {
 		$class_id = $this->class_id( $attributes );

--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -1558,10 +1558,17 @@ class Kadence_Blocks_CSS {
 	/**
 	 * Generates the shadow output.
 	 *
-	 * @param array  $shadow an array of shadow settings.
+	 * @param array                     $shadow   an array of shadow settings.
+	 * @param array<string, string|float> $defaults optional per-caller fallback literals used to fill
+	 *                                            any empty/missing leg before rendering. When omitted
+	 *                                            the method behaves exactly as before. Numeric and
+	 *                                            {alias} values always pass through untouched.
 	 * @return string
 	 */
-	public function render_shadow( $shadow ) {
+	public function render_shadow( $shadow, array $defaults = [] ) {
+		if ( ! empty( $defaults ) && is_array( $shadow ) ) {
+			$shadow = $this->normalize_shadow_defaults( $shadow, $defaults );
+		}
 		if ( empty( $shadow ) ) {
 			return false;
 		}
@@ -1607,6 +1614,67 @@ class Kadence_Blocks_CSS {
 		return $shadow_string;
 	}
 
+	/**
+	 * Fill any empty or missing shadow leg with the caller's legacy default so render_shadow()
+	 * can emit a complete declaration.
+	 *
+	 * Numeric and {alias} values pass through untouched so they still resolve to `<n>px` or
+	 * `var(--kb-token--...)`. Only a genuinely empty (`''`/missing) leg is replaced with the
+	 * supplied default, matching the historic per-site `is_numeric( $value ) ? $value : $default`
+	 * inline behavior.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed>        $shadow   The stored shadow parts (may be partial).
+	 * @param array<string, string|float> $defaults Per-caller fallback literals for empty legs.
+	 *
+	 * @return array<string, mixed> The complete keyed array.
+	 */
+	private function normalize_shadow_defaults( array $shadow, array $defaults ): array {
+		$pick = static function ( $value, $fallback ) {
+			return ( isset( $value ) && '' !== $value ) ? $value : $fallback;
+		};
+
+		return [
+			'hOffset' => $pick( $shadow['hOffset'] ?? null, $defaults['hOffset'] ),
+			'vOffset' => $pick( $shadow['vOffset'] ?? null, $defaults['vOffset'] ),
+			'blur'    => $pick( $shadow['blur'] ?? null, $defaults['blur'] ),
+			'spread'  => $pick( $shadow['spread'] ?? null, $defaults['spread'] ),
+			'color'   => $pick( $shadow['color'] ?? null, $defaults['color'] ),
+			'opacity' => ( isset( $shadow['opacity'] ) && is_numeric( $shadow['opacity'] ) ) ? $shadow['opacity'] : $defaults['opacity'],
+			'inset'   => ! empty( $shadow['inset'] ),
+		];
+	}
+
+	/**
+	 * Render a legacy positional box-shadow array through the alias-aware render_shadow().
+	 *
+	 * Several blocks store a box-shadow as a positional array where index 0 is the enabled flag,
+	 * 1 the color, 2 the opacity, 3-6 the offsets/blur/spread and 7 the inset flag. This maps that
+	 * shape onto the keyed array render_shadow() expects and applies the caller's per-state
+	 * defaults, so a {dot.alias} on any numeric leg resolves to its token var().
+	 *
+	 * @since TBD
+	 *
+	 * @param array<int, mixed>           $box_shadow The positional shadow array (indexes 1-7 are read).
+	 * @param array<string, string|float> $defaults   Per-caller fallback literals for empty legs.
+	 *
+	 * @return string The rendered box-shadow declaration.
+	 */
+	public function render_legacy_shadow( array $box_shadow, array $defaults ): string {
+		return (string) $this->render_shadow(
+			[
+				'color'   => $box_shadow[1] ?? '',
+				'opacity' => $box_shadow[2] ?? '',
+				'hOffset' => $box_shadow[3] ?? '',
+				'vOffset' => $box_shadow[4] ?? '',
+				'blur'    => $box_shadow[5] ?? '',
+				'spread'  => $box_shadow[6] ?? '',
+				'inset'   => ! empty( $box_shadow[7] ),
+			],
+			$defaults
+		);
+	}
 
 	/**
 	 * Generates the border radius color output.

--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -1615,38 +1615,6 @@ class Kadence_Blocks_CSS {
 	}
 
 	/**
-	 * Fill any empty or missing shadow leg with the caller's legacy default so render_shadow()
-	 * can emit a complete declaration.
-	 *
-	 * Numeric and {alias} values pass through untouched so they still resolve to `<n>px` or
-	 * `var(--kb-token--...)`. Only a genuinely empty (`''`/missing) leg is replaced with the
-	 * supplied default, matching the historic per-site `is_numeric( $value ) ? $value : $default`
-	 * inline behavior.
-	 *
-	 * @since TBD
-	 *
-	 * @param array<string, mixed>        $shadow   The stored shadow parts (may be partial).
-	 * @param array<string, string|float> $defaults Per-caller fallback literals for empty legs.
-	 *
-	 * @return array<string, mixed> The complete keyed array.
-	 */
-	private function normalize_shadow_defaults( array $shadow, array $defaults ): array {
-		$pick = static function ( $value, $fallback ) {
-			return ( isset( $value ) && '' !== $value ) ? $value : $fallback;
-		};
-
-		return [
-			'hOffset' => $pick( $shadow['hOffset'] ?? null, $defaults['hOffset'] ),
-			'vOffset' => $pick( $shadow['vOffset'] ?? null, $defaults['vOffset'] ),
-			'blur'    => $pick( $shadow['blur'] ?? null, $defaults['blur'] ),
-			'spread'  => $pick( $shadow['spread'] ?? null, $defaults['spread'] ),
-			'color'   => $pick( $shadow['color'] ?? null, $defaults['color'] ),
-			'opacity' => ( isset( $shadow['opacity'] ) && is_numeric( $shadow['opacity'] ) ) ? $shadow['opacity'] : $defaults['opacity'],
-			'inset'   => ! empty( $shadow['inset'] ),
-		];
-	}
-
-	/**
 	 * Render a legacy positional box-shadow array through the alias-aware render_shadow().
 	 *
 	 * Several blocks store a box-shadow as a positional array where index 0 is the enabled flag,
@@ -3132,6 +3100,38 @@ class Kadence_Blocks_CSS {
 		}
 
 		return $sized_array;
+	}
+
+	/**
+	 * Fill any empty or missing shadow leg with the caller's legacy default so render_shadow()
+	 * can emit a complete declaration.
+	 *
+	 * Numeric and {alias} values pass through untouched so they still resolve to `<n>px` or
+	 * `var(--kb-token--...)`. Only a genuinely empty (`''`/missing) leg is replaced with the
+	 * supplied default, matching the historic per-site `is_numeric( $value ) ? $value : $default`
+	 * inline behavior.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed>        $shadow   The stored shadow parts (may be partial).
+	 * @param array<string, string|float> $defaults Per-caller fallback literals for empty legs.
+	 *
+	 * @return array<string, mixed> The complete keyed array.
+	 */
+	private function normalize_shadow_defaults( array $shadow, array $defaults ): array {
+		$pick = static function ( $value, $fallback ) {
+			return ( isset( $value ) && '' !== $value ) ? $value : $fallback;
+		};
+
+		return [
+			'hOffset' => $pick( $shadow['hOffset'] ?? null, $defaults['hOffset'] ),
+			'vOffset' => $pick( $shadow['vOffset'] ?? null, $defaults['vOffset'] ),
+			'blur'    => $pick( $shadow['blur'] ?? null, $defaults['blur'] ),
+			'spread'  => $pick( $shadow['spread'] ?? null, $defaults['spread'] ),
+			'color'   => $pick( $shadow['color'] ?? null, $defaults['color'] ),
+			'opacity' => ( isset( $shadow['opacity'] ) && is_numeric( $shadow['opacity'] ) ) ? $shadow['opacity'] : $defaults['opacity'],
+			'inset'   => ! empty( $shadow['inset'] ),
+		];
 	}
 }
 Kadence_Blocks_CSS::get_instance();

--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -2603,8 +2603,8 @@ class Kadence_Blocks_CSS {
 	/**
 	 * Generates the opacity css output.
 	 *
-	 * @param array $attributes an array of attributes.
-	 * @param null|integer $name name of opacity attribute.
+	 * @param array       $attributes an array of attributes.
+	 * @param string|null $name name of opacity attribute.
 	 */
 	public function render_opacity_from_100( $attributes, $name = null ) {
 		if ( ! isset( $attributes[ $name ] ) || ! $this->is_number( $attributes[ $name ] ) ) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -911,11 +911,6 @@ parameters:
 			path: includes/blocks/class-kadence-blocks-abstract-block.php
 
 		-
-			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:get_attributes_with_defaults\\(\\) has parameter \\$cache with no type specified\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-abstract-block.php
-
-		-
 			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:get_attributes_with_defaults\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: includes/blocks/class-kadence-blocks-abstract-block.php
@@ -1017,11 +1012,6 @@ parameters:
 
 		-
 			message: "#^Method Kadence_Blocks_Abstract_Block\\:\\:should_render_inline_stylesheet\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-abstract-block.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$block_name$#"
 			count: 1
 			path: includes/blocks/class-kadence-blocks-abstract-block.php
 
@@ -1397,41 +1387,6 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 0 on mixed\\.$#"
-			count: 4
-			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
-
-		-
-			message: "#^Cannot access offset 1 on mixed\\.$#"
-			count: 2
-			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
-
-		-
-			message: "#^Cannot access offset 2 on mixed\\.$#"
-			count: 2
-			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
-
-		-
-			message: "#^Cannot access offset 3 on mixed\\.$#"
-			count: 2
-			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
-
-		-
-			message: "#^Cannot access offset 4 on mixed\\.$#"
-			count: 2
-			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
-
-		-
-			message: "#^Cannot access offset 5 on mixed\\.$#"
-			count: 2
-			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
-
-		-
-			message: "#^Cannot access offset 6 on mixed\\.$#"
-			count: 2
-			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
-
-		-
-			message: "#^Cannot access offset 7 on mixed\\.$#"
 			count: 2
 			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
 
@@ -1518,11 +1473,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$attributes of method Kadence_Blocks_CSS\\:\\:render_typography\\(\\) expects array, mixed given\\.$#"
 			count: 1
-			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
-
-		-
-			message: "#^Parameter \\#1 \\$color of method Kadence_Blocks_CSS\\:\\:render_color\\(\\) expects string, mixed given\\.$#"
-			count: 2
 			path: includes/blocks/class-kadence-blocks-advanced-form-block.php
 
 		-
@@ -1626,16 +1576,6 @@ parameters:
 			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
 
 		-
-			message: "#^Method Kadence_Blocks_Advancedheading_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
-
-		-
-			message: "#^Method Kadence_Blocks_Advancedheading_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
-
-		-
 			message: "#^Method Kadence_Blocks_Advancedheading_Block\\:\\:get_cascading_value\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
@@ -1726,61 +1666,6 @@ parameters:
 			path: includes/blocks/class-kadence-blocks-advanced-heading-block.php
 
 		-
-			message: "#^Cannot call method add_property\\(\\) on string\\.$#"
-			count: 94
-			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
-
-		-
-			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
-
-		-
-			message: "#^Cannot call method get_font_size\\(\\) on string\\.$#"
-			count: 6
-			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
-
-		-
-			message: "#^Cannot call method render_color\\(\\) on string\\.$#"
-			count: 21
-			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
-
-		-
-			message: "#^Cannot call method render_font_family\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
-
-		-
-			message: "#^Cannot call method render_font_weight\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
-
-		-
-			message: "#^Cannot call method render_gap\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
-
-		-
-			message: "#^Cannot call method render_measure_output\\(\\) on string\\.$#"
-			count: 3
-			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
-
-		-
-			message: "#^Cannot call method set_media_state\\(\\) on string\\.$#"
-			count: 19
-			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
-
-		-
-			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
-			count: 24
-			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
-
-		-
-			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
-
-		-
 			message: "#^Method Kadence_Blocks_Advancedbtn_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
@@ -1811,8 +1696,8 @@ parameters:
 			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
 
 		-
-			message: "#^Offset 7 on array in isset\\(\\) always exists and is not nullable\\.$#"
-			count: 3
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Advancedbtn_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
 			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
 
 		-
@@ -1821,22 +1706,7 @@ parameters:
 			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
 
 		-
-			message: "#^Result of && is always false\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
-
-		-
-			message: "#^Result of && is always true\\.$#"
-			count: 2
-			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
-
-		-
 			message: "#^Static property Kadence_Blocks_Advancedbtn_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Advancedbtn_Block\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between true and mixed will always evaluate to false\\.$#"
 			count: 1
 			path: includes/blocks/class-kadence-blocks-advancedbtn-block.php
 
@@ -1921,27 +1791,7 @@ parameters:
 			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
 
 		-
-			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:render_gallery_images\\(\\) has parameter \\$attributes with no type specified\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
-
-		-
-			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:render_gallery_images\\(\\) has parameter \\$image with no type specified\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
-
-		-
 			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:render_gallery_thumb_images\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
-
-		-
-			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:render_gallery_thumb_images\\(\\) has parameter \\$attributes with no type specified\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
-
-		-
-			message: "#^Method Kadence_Blocks_Advancedgallery_Block\\:\\:render_gallery_thumb_images\\(\\) has parameter \\$image with no type specified\\.$#"
 			count: 1
 			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
 
@@ -1991,7 +1841,27 @@ parameters:
 			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
 
 		-
+			message: "#^Parameter \\#1 \\$id of method Kadence_Blocks_Advancedgallery_Block\\:\\:get_image_srcset_output\\(\\) expects int\\|null, mixed given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
 			message: "#^Parameter \\#1 \\$node of method DOMDocument\\:\\:saveHTML\\(\\) expects DOMNode\\|null, mixed given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$post of function get_permalink expects int\\|WP_Post, mixed given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$post_id of function get_post_meta expects int, mixed given\\.$#"
+			count: 2
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Parameter \\#1 \\$post_id of function wp_get_attachment_caption expects int, mixed given\\.$#"
 			count: 1
 			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
 
@@ -2011,12 +1881,32 @@ parameters:
 			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
 
 		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, mixed given\\.$#"
+			count: 23
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
 			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, string\\|null given\\.$#"
 			count: 2
 			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
 
 		-
 			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Advancedgallery_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$url of method Kadence_Blocks_Advancedgallery_Block\\:\\:get_image_srcset_output\\(\\) expects string\\|null, mixed given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Parameter \\#3 \\$width of method Kadence_Blocks_Advancedgallery_Block\\:\\:get_image_srcset_output\\(\\) expects string\\|null, mixed given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
+
+		-
+			message: "#^Parameter \\#4 \\$height of method Kadence_Blocks_Advancedgallery_Block\\:\\:get_image_srcset_output\\(\\) expects string\\|null, mixed given\\.$#"
 			count: 1
 			path: includes/blocks/class-kadence-blocks-advancedgallery-block.php
 
@@ -2071,66 +1961,6 @@ parameters:
 			path: includes/blocks/class-kadence-blocks-column-block.php
 
 		-
-			message: "#^Cannot call method add_css_string\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-column-block.php
-
-		-
-			message: "#^Cannot call method add_property\\(\\) on string\\.$#"
-			count: 195
-			path: includes/blocks/class-kadence-blocks-column-block.php
-
-		-
-			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-column-block.php
-
-		-
-			message: "#^Cannot call method is_number\\(\\) on string\\.$#"
-			count: 81
-			path: includes/blocks/class-kadence-blocks-column-block.php
-
-		-
-			message: "#^Cannot call method render_border_styles\\(\\) on string\\.$#"
-			count: 2
-			path: includes/blocks/class-kadence-blocks-column-block.php
-
-		-
-			message: "#^Cannot call method render_color\\(\\) on string\\.$#"
-			count: 13
-			path: includes/blocks/class-kadence-blocks-column-block.php
-
-		-
-			message: "#^Cannot call method render_color_output\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-column-block.php
-
-		-
-			message: "#^Cannot call method render_measure_output\\(\\) on string\\.$#"
-			count: 6
-			path: includes/blocks/class-kadence-blocks-column-block.php
-
-		-
-			message: "#^Cannot call method render_row_gap\\(\\) on string\\.$#"
-			count: 3
-			path: includes/blocks/class-kadence-blocks-column-block.php
-
-		-
-			message: "#^Cannot call method set_media_state\\(\\) on string\\.$#"
-			count: 39
-			path: includes/blocks/class-kadence-blocks-column-block.php
-
-		-
-			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
-			count: 82
-			path: includes/blocks/class-kadence-blocks-column-block.php
-
-		-
-			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-column-block.php
-
-		-
 			message: "#^Method Kadence_Blocks_Column_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: includes/blocks/class-kadence-blocks-column-block.php
@@ -2176,7 +2006,7 @@ parameters:
 			path: includes/blocks/class-kadence-blocks-column-block.php
 
 		-
-			message: "#^Parameter \\#4 \\$css of method Kadence_Blocks_Column_Block\\:\\:set_vertical_align\\(\\) expects object, string given\\.$#"
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Column_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
 			count: 1
 			path: includes/blocks/class-kadence-blocks-column-block.php
 
@@ -2351,11 +2181,6 @@ parameters:
 			path: includes/blocks/class-kadence-blocks-form-block.php
 
 		-
-			message: "#^Offset 7 on array in isset\\(\\) always exists and is not nullable\\.$#"
-			count: 3
-			path: includes/blocks/class-kadence-blocks-form-block.php
-
-		-
 			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, mixed given\\.$#"
 			count: 4
 			path: includes/blocks/class-kadence-blocks-form-block.php
@@ -2371,27 +2196,12 @@ parameters:
 			path: includes/blocks/class-kadence-blocks-form-block.php
 
 		-
-			message: "#^Result of && is always false\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-form-block.php
-
-		-
-			message: "#^Result of && is always true\\.$#"
-			count: 2
-			path: includes/blocks/class-kadence-blocks-form-block.php
-
-		-
 			message: "#^Right side of && is always true\\.$#"
 			count: 12
 			path: includes/blocks/class-kadence-blocks-form-block.php
 
 		-
 			message: "#^Static property Kadence_Blocks_Form_Block\\:\\:\\$instance \\(null\\) does not accept Kadence_Blocks_Form_Block\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-form-block.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between true and mixed will always evaluate to false\\.$#"
 			count: 1
 			path: includes/blocks/class-kadence-blocks-form-block.php
 
@@ -3846,101 +3656,6 @@ parameters:
 			path: includes/blocks/class-kadence-blocks-row-layout-block.php
 
 		-
-			message: "#^Cannot call method add_css_string\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
-			message: "#^Cannot call method add_property\\(\\) on string\\.$#"
-			count: 174
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
-			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
-			message: "#^Cannot call method get_variable_value\\(\\) on string\\.$#"
-			count: 2
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
-			message: "#^Cannot call method is_number\\(\\) on string\\.$#"
-			count: 63
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
-			message: "#^Cannot call method is_variable_value\\(\\) on string\\.$#"
-			count: 2
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
-			message: "#^Cannot call method render_border_styles\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
-			message: "#^Cannot call method render_color\\(\\) on string\\.$#"
-			count: 13
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
-			message: "#^Cannot call method render_color_output\\(\\) on string\\.$#"
-			count: 10
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
-			message: "#^Cannot call method render_gradient\\(\\) on string\\.$#"
-			count: 6
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
-			message: "#^Cannot call method render_measure_output\\(\\) on string\\.$#"
-			count: 5
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
-			message: "#^Cannot call method render_opacity_from_100\\(\\) on string\\.$#"
-			count: 3
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
-			message: "#^Cannot call method render_row_gap\\(\\) on string\\.$#"
-			count: 2
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
-			message: "#^Cannot call method render_row_gap_property\\(\\) on string\\.$#"
-			count: 7
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
-			message: "#^Cannot call method set_media_state\\(\\) on string\\.$#"
-			count: 56
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
-			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
-			count: 80
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
-			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
-			message: "#^Cannot call method start_media_query\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
-			message: "#^Cannot call method stop_media_query\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
 			message: "#^Method Kadence_Blocks_Rowlayout_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: includes/blocks/class-kadence-blocks-row-layout-block.php
@@ -4071,18 +3786,8 @@ parameters:
 			path: includes/blocks/class-kadence-blocks-row-layout-block.php
 
 		-
-			message: "#^Offset 'borderRadiusOverflow' on array in isset\\(\\) always exists and is not nullable\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
 			message: "#^Parameter \\#1 \\$attributes of method Kadence_Blocks_Abstract_Block\\:\\:build_escaped_html_attributes\\(\\) expects array\\<string, bool\\|float\\|int\\|string\\>, array\\<string, mixed\\> given\\.$#"
 			count: 1
-			path: includes/blocks/class-kadence-blocks-row-layout-block.php
-
-		-
-			message: "#^Parameter \\#1 \\$css of method Kadence_Blocks_Rowlayout_Block\\:\\:get_template_columns\\(\\) expects object, string given\\.$#"
-			count: 6
 			path: includes/blocks/class-kadence-blocks-row-layout-block.php
 
 		-
@@ -4097,6 +3802,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$alpha of function kadence_blocks_hex2rgba expects float\\|int, float\\|int\\|string given\\.$#"
+			count: 1
+			path: includes/blocks/class-kadence-blocks-row-layout-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Rowlayout_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
 			count: 1
 			path: includes/blocks/class-kadence-blocks-row-layout-block.php
 
@@ -4381,77 +4091,12 @@ parameters:
 			path: includes/blocks/class-kadence-blocks-single-icon-list-block.php
 
 		-
-			message: "#^Cannot call method add_property\\(\\) on string\\.$#"
-			count: 31
-			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
-
-		-
-			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
-
-		-
-			message: "#^Cannot call method render_border_styles\\(\\) on string\\.$#"
-			count: 2
-			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
-
-		-
-			message: "#^Cannot call method render_color\\(\\) on string\\.$#"
-			count: 9
-			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
-
-		-
-			message: "#^Cannot call method render_measure_output\\(\\) on string\\.$#"
-			count: 5
-			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
-
-		-
-			message: "#^Cannot call method render_responsive_range\\(\\) on string\\.$#"
-			count: 3
-			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
-
-		-
-			message: "#^Cannot call method render_typography\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
-
-		-
-			message: "#^Cannot call method set_media_state\\(\\) on string\\.$#"
-			count: 6
-			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
-
-		-
-			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
-			count: 19
-			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
-
-		-
-			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
-
-		-
 			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
 
 		-
 			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:build_css\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
-
-		-
-			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:build_html\\(\\) has parameter \\$attributes with no type specified\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
-
-		-
-			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:build_html\\(\\) has parameter \\$content with no type specified\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
-
-		-
-			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:build_html\\(\\) has parameter \\$unique_id with no type specified\\.$#"
 			count: 1
 			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
 
@@ -4476,27 +4121,7 @@ parameters:
 			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
 
 		-
-			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$attributes with no type specified\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
-
-		-
-			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$css with no type specified\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
-
-		-
-			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:sized_dynamic_styles\\(\\) has parameter \\$unique_id with no type specified\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
-
-		-
-			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:sized_dynamic_styles\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
-
-		-
-			message: "#^Method Kadence_Blocks_Singlebtn_Block\\:\\:sized_dynamic_styles\\(\\) should return array but return statement is missing\\.$#"
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Singlebtn_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
 			count: 1
 			path: includes/blocks/class-kadence-blocks-singlebtn-block.php
 
@@ -6316,56 +5941,6 @@ parameters:
 			path: includes/blocks/form/class-kadence-blocks-select-block.php
 
 		-
-			message: "#^Cannot call method add_property\\(\\) on string\\.$#"
-			count: 26
-			path: includes/blocks/form/class-kadence-blocks-submit-block.php
-
-		-
-			message: "#^Cannot call method css_output\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/form/class-kadence-blocks-submit-block.php
-
-		-
-			message: "#^Cannot call method render_border_styles\\(\\) on string\\.$#"
-			count: 2
-			path: includes/blocks/form/class-kadence-blocks-submit-block.php
-
-		-
-			message: "#^Cannot call method render_color\\(\\) on string\\.$#"
-			count: 9
-			path: includes/blocks/form/class-kadence-blocks-submit-block.php
-
-		-
-			message: "#^Cannot call method render_measure_output\\(\\) on string\\.$#"
-			count: 5
-			path: includes/blocks/form/class-kadence-blocks-submit-block.php
-
-		-
-			message: "#^Cannot call method render_responsive_range\\(\\) on string\\.$#"
-			count: 2
-			path: includes/blocks/form/class-kadence-blocks-submit-block.php
-
-		-
-			message: "#^Cannot call method render_typography\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/form/class-kadence-blocks-submit-block.php
-
-		-
-			message: "#^Cannot call method set_media_state\\(\\) on string\\.$#"
-			count: 5
-			path: includes/blocks/form/class-kadence-blocks-submit-block.php
-
-		-
-			message: "#^Cannot call method set_selector\\(\\) on string\\.$#"
-			count: 16
-			path: includes/blocks/form/class-kadence-blocks-submit-block.php
-
-		-
-			message: "#^Cannot call method set_style_id\\(\\) on string\\.$#"
-			count: 1
-			path: includes/blocks/form/class-kadence-blocks-submit-block.php
-
-		-
 			message: "#^Method Kadence_Blocks_Submit_Block\\:\\:build_css\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: includes/blocks/form/class-kadence-blocks-submit-block.php
@@ -6382,6 +5957,11 @@ parameters:
 
 		-
 			message: "#^Method Kadence_Blocks_Submit_Block\\:\\:get_instance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: includes/blocks/form/class-kadence-blocks-submit-block.php
+
+		-
+			message: "#^Parameter \\#2 \\$css \\(Kadence_Blocks_CSS\\) of method Kadence_Blocks_Submit_Block\\:\\:build_css\\(\\) should be compatible with parameter \\$css \\(string\\) of method Kadence_Blocks_Abstract_Block\\:\\:build_css\\(\\)$#"
 			count: 1
 			path: includes/blocks/form/class-kadence-blocks-submit-block.php
 
@@ -9026,21 +8606,6 @@ parameters:
 			path: includes/class-kadence-blocks-editor-assets.php
 
 		-
-			message: "#^Offset 'domain' on array\\{key\\: string, email\\: string, product\\: string, api_key\\?\\: non\\-falsy\\-string, api_email\\?\\: non\\-falsy\\-string\\} in empty\\(\\) does not exist\\.$#"
-			count: 1
-			path: includes/class-kadence-blocks-editor-assets.php
-
-		-
-			message: "#^Offset 'env' does not exist on array\\{key\\: string, email\\: string, product\\: string, api_key\\?\\: non\\-falsy\\-string, api_email\\?\\: non\\-falsy\\-string, domain\\: string\\}\\.$#"
-			count: 1
-			path: includes/class-kadence-blocks-editor-assets.php
-
-		-
-			message: "#^Offset 'env' on array\\{key\\: string, email\\: string, product\\: string, api_key\\?\\: non\\-falsy\\-string, api_email\\?\\: non\\-falsy\\-string, domain\\: string\\} in empty\\(\\) does not exist\\.$#"
-			count: 1
-			path: includes/class-kadence-blocks-editor-assets.php
-
-		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
 			count: 1
 			path: includes/class-kadence-blocks-editor-assets.php
@@ -10228,11 +9793,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$response of method Kadence_Blocks_Prebuilt_Library_REST_Controller\\:\\:is_response_code_error\\(\\) expects array, array\\<string, array\\|string\\>\\|WP_Error given\\.$#"
 			count: 2
-			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
-
-		-
-			message: "#^Parameter \\#1 \\$route_namespace of function register_rest_route expects non\\-falsy\\-string, string given\\.$#"
-			count: 19
 			path: includes/class-kadence-blocks-prebuilt-library-rest-api.php
 
 		-
@@ -12276,11 +11836,6 @@ parameters:
 			path: includes/resources/Database/Database_Provider.php
 
 		-
-			message: "#^Offset 'is_premium' does not exist on array\\{name\\: string, page_url\\: string\\}\\.$#"
-			count: 1
-			path: includes/resources/Harbor/Actions/Get_Known_Plugins.php
-
-		-
 			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Harbor\\\\Actions\\\\Report_Legacy_Licenses\\:\\:__invoke\\(\\) has parameter \\$licenses with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: includes/resources/Harbor/Actions/Report_Legacy_Licenses.php
@@ -12831,11 +12386,6 @@ parameters:
 			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
 
 		-
-			message: "#^Cannot access offset mixed on mixed\\.$#"
-			count: 1
-			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
-
-		-
 			message: "#^Method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Rest\\\\Optimize_Rest_Controller\\:\\:get_create_params\\(\\) should return array\\<string, array\\{type\\: string, description\\: string, minimum\\: int\\<1, max\\>, required\\: true, sanitize_callback\\: callable\\(\\)\\: mixed, properties\\: array\\<string, mixed\\>\\}\\> but returns non\\-empty\\-array\\<string, array\\{type\\: 'object', properties\\: array\\}\\|array\\{type\\: string, description\\: string, minimum\\: int\\<1, max\\>, required\\: true, sanitize_callback\\: callable\\(\\)\\: mixed\\}\\>\\.$#"
 			count: 1
 			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
@@ -12848,11 +12398,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$attributes of static method KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Response\\\\WebsiteAnalysis\\:\\:from\\(\\) expects array\\{isStale\\?\\: bool, desktop\\: array, mobile\\: array, images\\: array\\}, mixed given\\.$#"
 			count: 1
-			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
-
-		-
-			message: "#^Parameter \\#1 \\$path of class KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Path\\\\Path constructor expects string, mixed given\\.$#"
-			count: 4
 			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
 
 		-
@@ -12898,11 +12443,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$value of function trailingslashit expects string, string\\|false given\\.$#"
 			count: 1
-			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
-
-		-
-			message: "#^Parameter \\#2 \\$post_id of class KadenceWP\\\\KadenceBlocks\\\\Optimizer\\\\Path\\\\Path constructor expects int\\|null, mixed given\\.$#"
-			count: 4
 			path: includes/resources/Optimizer/Rest/Optimize_Rest_Controller.php
 
 		-

--- a/tests/wpunit/KadenceBlocksCssTest.php
+++ b/tests/wpunit/KadenceBlocksCssTest.php
@@ -827,6 +827,98 @@ class KadenceBlocksCssTest extends WPTestCase {
 	}
 
 	/**
+	 * Passing per-caller $defaults fills any empty or missing leg so an inline builder routed
+	 * through render_shadow() stays byte-identical to its former output, while numeric and
+	 * {alias} legs still pass through untouched.
+	 *
+	 * @dataProvider renderShadowDefaultsProvider
+	 *
+	 * @param array  $shadow   The stored shadow parts (possibly partial).
+	 * @param array  $defaults The per-caller fallback literals.
+	 * @param string $expected The expected box-shadow declaration.
+	 *
+	 * @return void
+	 */
+	public function testRenderShadowAppliesDefaults( array $shadow, array $defaults, string $expected ): void {
+		$this->assertSame( $expected, $this->css->render_shadow( $shadow, $defaults ),
+			'Defaults must fill empty/missing legs without altering present numeric or alias legs' );
+	}
+
+	/**
+	 * Provides shadow objects, per-caller defaults, and the expected declaration for the
+	 * defaults-aware render_shadow() path used by the routed inline box-shadow builders.
+	 *
+	 * @return Generator
+	 */
+	public static function renderShadowDefaultsProvider(): Generator {
+		$button_defaults = [
+			'hOffset' => '0',
+			'vOffset' => '0',
+			'blur'    => '14',
+			'spread'  => '0',
+			'color'   => '#000000',
+			'opacity' => 0.2,
+		];
+		$hover_defaults = [
+			'hOffset' => '2',
+			'vOffset' => '2',
+			'blur'    => '3',
+			'spread'  => '0',
+			'color'   => '#000000',
+			'opacity' => 0.4,
+		];
+
+		yield 'complete literal shadow renders byte-identically' => [
+			'shadow'   => [ 'hOffset' => '1', 'vOffset' => '1', 'blur' => '2', 'spread' => '0', 'color' => '#000000', 'opacity' => 0.2, 'inset' => false ],
+			'defaults' => $button_defaults,
+			'expected' => '1px 1px 2px 0px rgba(0, 0, 0, 0.2)',
+		];
+		yield 'empty blur falls back to its default' => [
+			'shadow'   => [ 'hOffset' => '1', 'vOffset' => '1', 'blur' => '', 'spread' => '0', 'color' => '#000000', 'opacity' => 0.2, 'inset' => false ],
+			'defaults' => $button_defaults,
+			'expected' => '1px 1px 14px 0px rgba(0, 0, 0, 0.2)',
+		];
+		yield 'missing legs use the supplied defaults' => [
+			'shadow'   => [ 'color' => '#000000', 'opacity' => 0.2 ],
+			'defaults' => $button_defaults,
+			'expected' => '0px 0px 14px 0px rgba(0, 0, 0, 0.2)',
+		];
+		yield 'aliased offset passes through as a token var' => [
+			'shadow'   => [ 'hOffset' => '{semantic.shadow.x}', 'vOffset' => '1', 'blur' => '4', 'spread' => '2', 'color' => '#000000', 'opacity' => 0.5, 'inset' => false ],
+			'defaults' => $button_defaults,
+			'expected' => 'var(--kb-token--semantic--shadow--x) 1px 4px 2px rgba(0, 0, 0, 0.5)',
+		];
+		yield 'truthy inset prefixes the declaration' => [
+			'shadow'   => [ 'hOffset' => '1', 'vOffset' => '1', 'blur' => '2', 'spread' => '0', 'color' => '#000000', 'opacity' => 0.2, 'inset' => true ],
+			'defaults' => $button_defaults,
+			'expected' => 'inset 1px 1px 2px 0px rgba(0, 0, 0, 0.2)',
+		];
+		yield 'all-empty legs fall back to the hover defaults' => [
+			'shadow'   => [ 'color' => '', 'opacity' => '', 'hOffset' => '', 'vOffset' => '', 'blur' => '', 'spread' => '', 'inset' => false ],
+			'defaults' => $hover_defaults,
+			'expected' => '2px 2px 3px 0px rgba(0, 0, 0, 0.4)',
+		];
+	}
+
+	/**
+	 * With no $defaults the method is unchanged: a complete shadow still renders and a shadow
+	 * missing a required leg still returns false rather than emitting a partial declaration.
+	 *
+	 * @return void
+	 */
+	public function testRenderShadowWithoutDefaultsIsUnchanged(): void {
+		$this->assertSame(
+			'1px 1px 4px 2px rgba(0, 0, 0, 0.5)',
+			$this->css->render_shadow( [ 'color' => '#000000', 'opacity' => 0.5, 'spread' => 2, 'blur' => 4, 'hOffset' => 1, 'vOffset' => 1, 'inset' => false ] ),
+			'A complete shadow with no defaults renders exactly as before'
+		);
+		$this->assertFalse(
+			$this->css->render_shadow( [ 'color' => '#000000', 'opacity' => 0.5, 'spread' => 2, 'blur' => 4, 'hOffset' => 1, 'vOffset' => 1 ] ),
+			'A shadow missing a required leg still returns false when no defaults are supplied'
+		);
+	}
+
+	/**
 	 * render_border_styles emits a token var for an aliased width so the width branch
 	 * still fires, while numeric widths remain byte-identical.
 	 *


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-3901/route-inline-build-css-box-shadow-sites-through-alias-aware-render

Some blocks assembled `box-shadow` inline in their own `build_css()` with `is_numeric()`
chains, bypassing the alias-aware `Kadence_Blocks_CSS::render_shadow()` — so a `{dot.alias}`
token reference froze to a literal instead of resolving live.

This routes every inline box-shadow builder through the shared render path so literals stay
byte-identical while a `{dot.alias}` on any numeric leg resolves to `var(--kb-token--...)`:

- `render_shadow()` gains an optional `$defaults` arg (private `normalize_shadow_defaults()`
  fills empty/missing legs); a new `render_legacy_shadow()` maps the legacy positional
  `[0..7]` shadow shape onto it.
- All inline box-shadow builders across 10 blocks (object-keyed, legacy positional, and
  associative shapes) now go through these methods.
- Added `render_shadow($shadow, $defaults)` wpunit coverage: byte-identical literals,
  default fallbacks, alias pass-through, inset, and the positional remap.

**Baseline update.** `phpstan-baseline.neon` was regenerated with `composer phpstan-baseline`,
and is a **net reduction**: typing `build_css()`'s `$css` and routing the positional shadows
through `render_legacy_shadow()` cleared hundreds of stale "Cannot call method … on string"
and "offset on mixed" entries. The additions are the five `build_css() $css` LSP entries
(matching the 36 sibling blocks that already type `$css` as `Kadence_Blocks_CSS`) and
pre-existing type issues in the advancedgallery render helpers — surfaced only because
documenting their `array` params was required to pass phpcs.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
