### PR TITLE
[DTM] SOFT-3904 [1/3]: Shared PHP-JS conformance fixture parity

### DIFF
--- a/src/extension/design-tokens/__tests__/alias-css-output.test.js
+++ b/src/extension/design-tokens/__tests__/alias-css-output.test.js
@@ -19,6 +19,7 @@ import { registerTokenAliasFilters } from '../register-filters';
 
 const helpersRoot = path.dirname(require.resolve('@kadence/helpers/package.json'));
 const KadenceBlocksCSS = require(path.join(helpersRoot, 'dist/cjs/css/index.js')).default;
+const KadenceColorOutput = require(path.join(helpersRoot, 'dist/cjs/kadence-color-output/index.js')).default;
 
 const ALIAS = '{semantic.radius.media}';
 const ALIAS_VAR = 'var(--kb-token--semantic--radius--media)';
@@ -122,5 +123,22 @@ describe('the seam is what resolves the alias', () => {
 		// With no listener, the agnostic helper cannot recognize the alias: render_size falls through
 		// its numeric/variable branches and does not emit the token var.
 		expect(new KadenceBlocksCSS().render_size(ALIAS, 'px')).not.toBe(ALIAS_VAR);
+	});
+});
+
+describe('KadenceColorOutput (colorValue filter seam)', () => {
+	it('resolves an alias to a bare var through the colorValue filter', () => {
+		expect(KadenceColorOutput('{semantic.color.shadow}')).toBe('var(--kb-token--semantic--color--shadow)');
+	});
+
+	it('passes a non-alias color through unchanged', () => {
+		expect(KadenceColorOutput('#3182CE')).toBe('#3182CE');
+	});
+
+	it('leaves an alias unresolved when the plugin filter is not registered', () => {
+		removeFilter('kadence.helpers.colorValue', 'kadence-blocks/token-alias');
+		removeFilter('kadence.helpers.dimensionValue', 'kadence-blocks/token-alias');
+
+		expect(KadenceColorOutput('{semantic.color.shadow}')).not.toBe('var(--kb-token--semantic--color--shadow)');
 	});
 });

--- a/src/extension/design-tokens/__tests__/fixtures/token-alias-conformance.json
+++ b/src/extension/design-tokens/__tests__/fixtures/token-alias-conformance.json
@@ -5,7 +5,8 @@
 		{ "alias": "{primitive.color.brand.primary}", "cssVar": "var(--kb-token--primitive--color--brand--primary)" },
 		{ "alias": "{semantic.color.button-primary-bg}", "cssVar": "var(--kb-token--semantic--color--button-primary-bg)" },
 		{ "alias": "{primitive.spacing.md}", "cssVar": "var(--kb-token--primitive--spacing--md)" },
-		{ "alias": "{a}", "cssVar": "var(--kb-token--a)" }
+		{ "alias": "{a}", "cssVar": "var(--kb-token--a)" },
+		{ "alias": "{semantic.icon-size.default}", "cssVar": "var(--kb-token--semantic--icon-size--default)" }
 	],
 	"nonAliases": [
 		"palette1",

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/AliasConformanceTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/AliasConformanceTest.php
@@ -1,0 +1,164 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Schema\Vocabulary;
+
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Proves the PHP alias->var() transform stays byte-identical to the JS one by asserting against the
+ * SAME fixture the jest suite reads (never a forked copy). A drift in `Alias::is_alias()`,
+ * `Alias::path_of()`, or `Css_Var::from_id()` on the PHP side, or in `resolveTokenAlias()` on the JS
+ * side, fails whichever suite still expects the old string.
+ *
+ * @since TBD
+ */
+final class AliasConformanceTest extends TestCase {
+
+	/**
+	 * Every alias entry in the shared conformance fixture is recognized by the strict predicate and
+	 * resolves, through `Alias::path_of()` + `Css_Var::from_id()`, to the exact `var()` string the JS
+	 * suite also asserts for that entry.
+	 *
+	 * @dataProvider aliasProvider
+	 *
+	 * @param string $alias   The alias string, e.g. "{semantic.radius.media}".
+	 * @param string $css_var The expected "var(--kb-token--<id>)" string.
+	 *
+	 * @return void
+	 */
+	public function testAliasesResolveToTheExpectedCssVar( string $alias, string $css_var ): void {
+		$this->assertTrue( Alias::is_alias( $alias ) );
+		$this->assertSame( $css_var, 'var(' . Css_Var::from_id( Alias::path_of( $alias ) ) . ')' );
+	}
+
+	/**
+	 * Every nonAlias entry in the shared conformance fixture is rejected by the strict predicate, so no
+	 * render path ever mints a `var()` from it.
+	 *
+	 * @dataProvider nonAliasProvider
+	 *
+	 * @param mixed $non_alias A value the fixture asserts is not a well-formed alias.
+	 *
+	 * @return void
+	 */
+	public function testNonAliasesAreRejected( $non_alias ): void {
+		$this->assertFalse( Alias::is_alias( $non_alias ) );
+	}
+
+	/**
+	 * A braced-but-malformed string (a fumbled alias attempt) is caught by the loose predicate but
+	 * still rejected by the strict one — the fail-open seam this ticket pins.
+	 *
+	 * @dataProvider braceButMalformedProvider
+	 *
+	 * @param string $value A braced-but-malformed value from the shared conformance fixture.
+	 *
+	 * @return void
+	 */
+	public function testBracedButMalformedValuesAreLooseButNotStrict( string $value ): void {
+		$this->assertTrue( Alias::looks_like_alias( $value ) );
+		$this->assertFalse( Alias::is_alias( $value ) );
+	}
+
+	/**
+	 * A plain, unbraced literal is rejected by both the strict and the loose predicate. The JS pattern
+	 * (`/^\{[\w.-]+\}$/`) has no loose counterpart at all, so a plain literal is simply never a
+	 * candidate in either language.
+	 *
+	 * @dataProvider plainLiteralProvider
+	 *
+	 * @param string $value A plain, unbraced literal from the shared conformance fixture.
+	 *
+	 * @return void
+	 */
+	public function testPlainLiteralsAreRejectedByBothPredicates( string $value ): void {
+		$this->assertFalse( Alias::is_alias( $value ) );
+		$this->assertFalse( Alias::looks_like_alias( $value ) );
+	}
+
+	/**
+	 * Guards against a truncated fixture: both sections must actually contain cases, or the parity
+	 * assertions above would pass vacuously.
+	 *
+	 * @return void
+	 */
+	public function testBothFixtureSectionsAreNonEmpty(): void {
+		$fixture = $this->load_fixture();
+
+		$this->assertNotEmpty( $fixture['aliases'] );
+		$this->assertNotEmpty( $fixture['nonAliases'] );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function aliasProvider(): Generator {
+		foreach ( $this->load_fixture()['aliases'] as $entry ) {
+			yield $entry['alias'] => [
+				'alias'   => $entry['alias'],
+				'css_var' => $entry['cssVar'],
+			];
+		}
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function nonAliasProvider(): Generator {
+		foreach ( $this->load_fixture()['nonAliases'] as $index => $non_alias ) {
+			yield sprintf( 'nonAliases[%d]: %s', $index, wp_json_encode( $non_alias ) ) => [
+				'non_alias' => $non_alias,
+			];
+		}
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function braceButMalformedProvider(): Generator {
+		foreach ( $this->load_fixture()['nonAliases'] as $value ) {
+			if ( ! is_string( $value ) || ( strpos( $value, '{' ) === false && strpos( $value, '}' ) === false ) ) {
+				continue;
+			}
+
+			yield $value => [ 'value' => $value ];
+		}
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function plainLiteralProvider(): Generator {
+		foreach ( $this->load_fixture()['nonAliases'] as $value ) {
+			if ( ! is_string( $value ) || $value === '' || strpos( $value, '{' ) !== false || strpos( $value, '}' ) !== false ) {
+				continue;
+			}
+
+			yield $value => [ 'value' => $value ];
+		}
+	}
+
+	/**
+	 * The shared alias/cssVar conformance fixture, decoded. The SAME file the jest suite reads, so
+	 * neither language can drift without both suites' data changing together.
+	 *
+	 * @return array{aliases: array<int, array{alias: string, cssVar: string}>, nonAliases: array<int, mixed>}
+	 */
+	private function load_fixture(): array {
+		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		return (array) json_decode( (string) file_get_contents( $this->fixture_path() ), true );
+	}
+
+	/**
+	 * Absolute path to the shared conformance fixture, derived from the plugin root so it resolves the
+	 * same way regardless of which working directory slic runs the suite from.
+	 *
+	 * @return string
+	 */
+	private function fixture_path(): string {
+		return KADENCE_BLOCKS_PATH . 'src/extension/design-tokens/__tests__/fixtures/token-alias-conformance.json';
+	}
+}


### PR DESCRIPTION
## Summary

The anti-drift keystone for design-token aliases. A block control can store a token reference as a whole-string alias (`{dot.alias}`), and that value is resolved twice: in PHP for the front end (`Alias::path_of` + `Css_Var::from_id`) and in JS for the editor preview (`resolveTokenAlias`). If the two ever disagree by one character, an authored token renders one way in the editor and another on the front end.

This phase makes one JSON fixture the executable contract for both languages. Tests only — no shipped code changes.

## What this adds

- **`tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/AliasConformanceTest.php`** — a new wpunit test that loads the *same* fixture the jest suite loads (`src/extension/design-tokens/__tests__/fixtures/token-alias-conformance.json`, no second copy) and asserts, per entry:
  - each alias: `Alias::is_alias()` is true, and `'var(' . Css_Var::from_id( Alias::path_of( $alias ) ) . ')'` is byte-identical to the fixture's expected `cssVar`;
  - each non-alias: `Alias::is_alias()` is false;
  - the loose-vs-strict boundary: braced-but-malformed values (`{bad path}`, `{unclosed`, `unopened}`, `{}`) are `looks_like_alias()` true but `is_alias()` false, while plain literals (`palette1`, `16px`) are false for both;
  - a guard that both fixture sections are non-empty, so a truncated fixture fails loudly instead of passing vacuously.
- **Fixture edge case** — added `{semantic.icon-size.default}` → `var(--kb-token--semantic--icon-size--default)` to exercise the hyphen+dot mixed-id sanitization edge. Both suites pick it up automatically.
- **JS gap-fill** — added the `KadenceColorOutput` / `colorValue` filter-seam pass-through cases to `alias-css-output.test.js` (the existing file covered `dimensionValue` but never the color seam). The loose-vs-strict boundary was already covered by the fixture-driven cases in `alias.test.js`.

## Acceptance property

Verified by hand: a one-character edit to any fixture `cssVar` fails **both** `bun run test` and the wpunit conformance test. One fixture, two suites, cannot drift.

## Test plan

- `slic run wpunit Resources/Design_Tokens/Schema/Vocabulary/AliasConformanceTest` — green (28 tests).
- `bun run test` — green.
- cspell clean on changed files; `phpstan-baseline.neon` untouched.

## Stacking

Part of the SOFT-3904 stack, based on `SOFT-3992/phase-3-token-set-to-library` (this work merges after the SOFT-3992 rename stack). Followed by `[2/3]` (BC snapshots) and `[3/3]` (emission + fail-open).
