### PR TITLE
[DTM] SOFT-3904 [base] Integration base for alias conformance and render-site BC guards

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -34,12 +34,33 @@ jobs:
       - uses: ramsey/composer-install@v3
 
       - name: Run PHPCS on changed lines
+        env:
+          GH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # On a pull_request the base is the PR's target branch; fall back to
           # master for a manual workflow_dispatch run.
           BASE_REF="${GITHUB_BASE_REF:-master}"
 
           git remote set-branches origin "$BASE_REF"
-          git fetch origin --depth=1
+          if ! git fetch origin --depth=1; then
+            # A re-run can replay a stale event payload: if the PR's base
+            # branch was renamed after this run was first queued,
+            # GITHUB_BASE_REF still names the old, now-deleted branch. Ask
+            # the API for the PR's current base and retry once before
+            # giving up.
+            if [ -z "$PR_NUMBER" ]; then
+              exit 1
+            fi
+
+            BASE_REF="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json baseRefName --jq .baseRefName)"
+
+            if [ -z "$BASE_REF" ]; then
+              exit 1
+            fi
+
+            git remote set-branches origin "$BASE_REF"
+            git fetch origin --depth=1
+          fi
 
           composer phpcs-ci "origin/$BASE_REF"

--- a/src/extension/design-tokens/__tests__/alias-css-output.test.js
+++ b/src/extension/design-tokens/__tests__/alias-css-output.test.js
@@ -19,6 +19,7 @@ import { registerTokenAliasFilters } from '../register-filters';
 
 const helpersRoot = path.dirname(require.resolve('@kadence/helpers/package.json'));
 const KadenceBlocksCSS = require(path.join(helpersRoot, 'dist/cjs/css/index.js')).default;
+const KadenceColorOutput = require(path.join(helpersRoot, 'dist/cjs/kadence-color-output/index.js')).default;
 
 const ALIAS = '{semantic.radius.media}';
 const ALIAS_VAR = 'var(--kb-token--semantic--radius--media)';
@@ -122,5 +123,22 @@ describe('the seam is what resolves the alias', () => {
 		// With no listener, the agnostic helper cannot recognize the alias: render_size falls through
 		// its numeric/variable branches and does not emit the token var.
 		expect(new KadenceBlocksCSS().render_size(ALIAS, 'px')).not.toBe(ALIAS_VAR);
+	});
+});
+
+describe('KadenceColorOutput (colorValue filter seam)', () => {
+	it('resolves an alias to a bare var through the colorValue filter', () => {
+		expect(KadenceColorOutput('{semantic.color.shadow}')).toBe('var(--kb-token--semantic--color--shadow)');
+	});
+
+	it('passes a non-alias color through unchanged', () => {
+		expect(KadenceColorOutput('#3182CE')).toBe('#3182CE');
+	});
+
+	it('leaves an alias unresolved when the plugin filter is not registered', () => {
+		removeFilter('kadence.helpers.colorValue', 'kadence-blocks/token-alias');
+		removeFilter('kadence.helpers.dimensionValue', 'kadence-blocks/token-alias');
+
+		expect(KadenceColorOutput('{semantic.color.shadow}')).not.toBe('var(--kb-token--semantic--color--shadow)');
 	});
 });

--- a/src/extension/design-tokens/__tests__/fixtures/token-alias-conformance.json
+++ b/src/extension/design-tokens/__tests__/fixtures/token-alias-conformance.json
@@ -5,7 +5,8 @@
 		{ "alias": "{primitive.color.brand.primary}", "cssVar": "var(--kb-token--primitive--color--brand--primary)" },
 		{ "alias": "{semantic.color.button-primary-bg}", "cssVar": "var(--kb-token--semantic--color--button-primary-bg)" },
 		{ "alias": "{primitive.spacing.md}", "cssVar": "var(--kb-token--primitive--spacing--md)" },
-		{ "alias": "{a}", "cssVar": "var(--kb-token--a)" }
+		{ "alias": "{a}", "cssVar": "var(--kb-token--a)" },
+		{ "alias": "{semantic.icon-size.default}", "cssVar": "var(--kb-token--semantic--icon-size--default)" }
 	],
 	"nonAliases": [
 		"palette1",

--- a/tests/wpunit/KadenceBlocksCssBcSnapshotTest.php
+++ b/tests/wpunit/KadenceBlocksCssBcSnapshotTest.php
@@ -243,4 +243,117 @@ final class KadenceBlocksCssBcSnapshotTest extends TestCase {
 			'expected' => false,
 		];
 	}
+
+	/**
+	 * render_measure_range (border-width) emits a byte-identical `border-*-width`
+	 * declaration for a numeric side (including a zero side), and adds nothing for an
+	 * empty or brace-containing non-alias side.
+	 *
+	 * @return void
+	 */
+	public function testRenderMeasureRangeBorderWidthBcCase(): void {
+		$this->css->render_measure_range(
+			[ 'borderWidth' => [ 2, 0, '', '1px solid {semantic.color.brand}' ] ],
+			'borderWidth',
+			'border-width'
+		);
+		$output = $this->css->css_output();
+
+		$this->assertStringContainsString( 'border-top-width:2px', $output,
+			'A numeric side is rendered with its unit' );
+		$this->assertStringContainsString( 'border-right-width:0px', $output,
+			'A zero side still renders since is_numeric(0) is true' );
+		$this->assertStringNotContainsString( 'border-bottom-width', $output,
+			'An empty side is not numeric and adds nothing' );
+		$this->assertStringNotContainsString( 'border-left-width', $output,
+			'A brace-containing non-alias side is not numeric and adds nothing' );
+	}
+
+	/**
+	 * render_measure returns byte-identical output for a fully numeric 4-side array
+	 * (including a zero side), and falls back to "0" + unit for a non-numeric,
+	 * non-alias side (empty string or a brace-containing literal).
+	 *
+	 * @dataProvider renderMeasureProvider
+	 *
+	 * @param array  $measure  The 4-side measure array.
+	 * @param string $expected The expected byte-identical output string.
+	 *
+	 * @return void
+	 */
+	public function testRenderMeasureBcCases( array $measure, string $expected ): void {
+		$this->assertSame( $expected, $this->css->render_measure( $measure ),
+			'render_measure must be byte-identical to its pre-recognizer output for numeric/literal input' );
+	}
+
+	/**
+	 * Provides numeric and boundary 4-side arrays for render_measure.
+	 *
+	 * @return Generator
+	 */
+	public static function renderMeasureProvider(): Generator {
+		yield 'fully numeric measure' => [
+			'measure'  => [ 10, 20, 30, 40 ],
+			'expected' => '10px 20px 30px 40px',
+		];
+		yield 'zero side renders its actual value, not the string fallback' => [
+			'measure'  => [ 0, 20, 30, 40 ],
+			'expected' => '0px 20px 30px 40px',
+		];
+		yield 'empty string side falls back to zero' => [
+			'measure'  => [ 10, '', 30, 40 ],
+			'expected' => '10px 0px 30px 40px',
+		];
+		yield 'brace-containing non-alias side falls back to zero' => [
+			'measure'  => [ 10, '1px solid {semantic.color.brand}', 30, 40 ],
+			'expected' => '10px 0px 30px 40px',
+		];
+	}
+
+	/**
+	 * render_border_radius emits a byte-identical `border-*-radius` declaration for a
+	 * numeric corner (including a zero corner), and adds nothing for an empty or
+	 * brace-containing non-alias corner.
+	 *
+	 * @return void
+	 */
+	public function testRenderBorderRadiusBcCase(): void {
+		$this->css->render_border_radius( [ 'borderRadius' => [ 1, 0, '', '1px solid {semantic.color.brand}' ] ] );
+		$output = $this->css->css_output();
+
+		$this->assertStringContainsString( 'border-top-left-radius:1px', $output,
+			'A numeric corner is rendered with its unit' );
+		$this->assertStringContainsString( 'border-top-right-radius:0px', $output,
+			'A zero corner still renders since is_numeric(0) is true' );
+		$this->assertStringNotContainsString( 'border-bottom-right-radius', $output,
+			'An empty corner is not numeric and adds nothing' );
+		$this->assertStringNotContainsString( 'border-bottom-left-radius', $output,
+			'A brace-containing non-alias corner is not numeric and adds nothing' );
+	}
+
+	/**
+	 * render_responsive_range emits a byte-identical declaration per breakpoint for
+	 * numeric values (including a zero breakpoint), and adds nothing for a
+	 * brace-containing non-alias breakpoint.
+	 *
+	 * @return void
+	 */
+	public function testRenderResponsiveRangeBcCase(): void {
+		$this->css->render_responsive_range(
+			[
+				'spacing'     => [ 10, 0, '1px solid {semantic.color.brand}' ],
+				'spacingType' => 'px',
+			],
+			'spacing',
+			'margin'
+		);
+		$output = $this->css->css_output();
+
+		$this->assertStringContainsString( 'margin:10px', $output,
+			'The desktop breakpoint is rendered with its unit' );
+		$this->assertStringContainsString( 'margin:0px', $output,
+			'The zero tablet breakpoint still renders since is_numeric(0) is true' );
+		$this->assertStringNotContainsString( '{semantic.color.brand}', $output,
+			'A brace-containing non-alias mobile breakpoint is not numeric and adds nothing' );
+	}
 }

--- a/tests/wpunit/KadenceBlocksCssBcSnapshotTest.php
+++ b/tests/wpunit/KadenceBlocksCssBcSnapshotTest.php
@@ -1,0 +1,177 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit;
+
+use Generator;
+use Kadence_Blocks_CSS;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Backward-compatibility guard for the alias recognizer's render sites.
+ *
+ * For every relaxed `render_*` method in {@see Kadence_Blocks_CSS}, numeric/literal
+ * (non-alias) input must produce output byte-for-byte identical to what the method
+ * produced before the alias-recognizer branch was added. The recognizer only ever
+ * fires on a strict `{dot.alias}` value; for everything else — plain numbers, `0`,
+ * empty values, and strings that merely contain a brace without being a strict alias
+ * — its added branch must be provably inert.
+ */
+final class KadenceBlocksCssBcSnapshotTest extends TestCase {
+
+	protected $css;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->css = new Kadence_Blocks_CSS();
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+	}
+
+	/**
+	 * render_number returns byte-identical output for numeric/literal input, and
+	 * short-circuits to false for non-numeric, non-alias input.
+	 *
+	 * @dataProvider renderNumberProvider
+	 *
+	 * @param mixed         $number   The raw number value.
+	 * @param string|null   $unit     The unit to append.
+	 * @param string|false  $expected The expected byte-identical output.
+	 *
+	 * @return void
+	 */
+	public function testRenderNumberBcCases( $number, ?string $unit, $expected ): void {
+		$this->assertSame( $expected, $this->css->render_number( $number, $unit ),
+			'render_number must be byte-identical to its pre-recognizer output for numeric/literal input' );
+	}
+
+	/**
+	 * Provides numeric/literal and boundary inputs for render_number.
+	 *
+	 * @return Generator
+	 */
+	public static function renderNumberProvider(): Generator {
+		yield 'positive integer with px unit' => [
+			'number'   => 16,
+			'unit'     => 'px',
+			'expected' => '16px',
+		];
+		yield 'float with em unit' => [
+			'number'   => 1.5,
+			'unit'     => 'em',
+			'expected' => '1.5em',
+		];
+		yield 'zero renders literally with unit' => [
+			'number'   => 0,
+			'unit'     => 'px',
+			'expected' => '0px',
+		];
+		yield 'negative number keeps its sign' => [
+			'number'   => -10,
+			'unit'     => 'px',
+			'expected' => '-10px',
+		];
+		yield 'no unit given returns the bare number' => [
+			'number'   => 16,
+			'unit'     => null,
+			'expected' => '16',
+		];
+		yield 'brace-containing non-alias is not numeric and fails' => [
+			'number'   => '1px solid {semantic.color.brand}',
+			'unit'     => 'px',
+			'expected' => false,
+		];
+		yield 'malformed alias fails open and returns false' => [
+			'number'   => '{bad path}',
+			'unit'     => 'px',
+			'expected' => false,
+		];
+		yield 'empty string returns false' => [
+			'number'   => '',
+			'unit'     => 'px',
+			'expected' => false,
+		];
+		yield 'null number returns false' => [
+			'number'   => null,
+			'unit'     => 'px',
+			'expected' => false,
+		];
+	}
+
+	/**
+	 * render_range returns byte-identical output for numeric and boundary input: it
+	 * adds a `property:value` declaration and returns null on success, or returns
+	 * false and adds nothing when the value is not numeric.
+	 *
+	 * @dataProvider renderRangeProvider
+	 *
+	 * @param array         $attributes      The attributes array keyed by "width".
+	 * @param string        $unit            The unit to append.
+	 * @param mixed         $expectedReturn  The expected return value.
+	 * @param string|null   $expectedFragment The expected declaration fragment, or null if none.
+	 *
+	 * @return void
+	 */
+	public function testRenderRangeBcCases( array $attributes, string $unit, $expectedReturn, ?string $expectedFragment ): void {
+		$actual = $this->css->render_range( $attributes, 'width', 'width', $unit );
+
+		$this->assertSame( $expectedReturn, $actual,
+			'render_range must return byte-identical values for numeric/literal input' );
+
+		$output = $this->css->css_output();
+
+		if ( null !== $expectedFragment ) {
+			$this->assertStringContainsString( $expectedFragment, $output,
+				'render_range must emit the byte-identical declaration for numeric input' );
+		} else {
+			$this->assertStringNotContainsString( 'width:', $output,
+				'render_range must add nothing when the value is not numeric' );
+		}
+	}
+
+	/**
+	 * Provides numeric and boundary inputs for render_range.
+	 *
+	 * @return Generator
+	 */
+	public static function renderRangeProvider(): Generator {
+		yield 'number with px unit' => [
+			'attributes'       => [ 'width' => 16 ],
+			'unit'             => 'px',
+			'expectedReturn'   => null,
+			'expectedFragment' => 'width:16px',
+		];
+		yield 'float with em unit' => [
+			'attributes'       => [ 'width' => 1.5 ],
+			'unit'             => 'em',
+			'expectedReturn'   => null,
+			'expectedFragment' => 'width:1.5em',
+		];
+		yield 'zero renders with unit' => [
+			'attributes'       => [ 'width' => 0 ],
+			'unit'             => 'px',
+			'expectedReturn'   => null,
+			'expectedFragment' => 'width:0px',
+		];
+		yield 'negative number keeps its sign' => [
+			'attributes'       => [ 'width' => -10 ],
+			'unit'             => 'px',
+			'expectedReturn'   => null,
+			'expectedFragment' => 'width:-10px',
+		];
+		yield 'brace-containing non-alias is not numeric and short-circuits' => [
+			'attributes'       => [ 'width' => '1px solid {semantic.color.brand}' ],
+			'unit'             => 'px',
+			'expectedReturn'   => false,
+			'expectedFragment' => null,
+		];
+		yield 'empty string short-circuits' => [
+			'attributes'       => [ 'width' => '' ],
+			'unit'             => 'px',
+			'expectedReturn'   => false,
+			'expectedFragment' => null,
+		];
+	}
+}

--- a/tests/wpunit/KadenceBlocksCssBcSnapshotTest.php
+++ b/tests/wpunit/KadenceBlocksCssBcSnapshotTest.php
@@ -174,4 +174,73 @@ final class KadenceBlocksCssBcSnapshotTest extends TestCase {
 			'expectedFragment' => null,
 		];
 	}
+
+	/**
+	 * render_color returns byte-identical output for literal colors, palette slugs,
+	 * and brace-containing non-alias strings, which must pass through untouched.
+	 *
+	 * @dataProvider renderColorProvider
+	 *
+	 * @param mixed        $color    The raw color value.
+	 * @param string|false $expected The expected byte-identical output.
+	 *
+	 * @return void
+	 */
+	public function testRenderColorBcCases( $color, $expected ): void {
+		$this->assertSame( $expected, $this->css->render_color( $color ),
+			'render_color must be byte-identical to its pre-recognizer output for literal input' );
+	}
+
+	/**
+	 * sanitize_color returns byte-identical output for literal colors, palette slugs,
+	 * and brace-containing non-alias strings, which must pass through untouched.
+	 *
+	 * @dataProvider renderColorProvider
+	 *
+	 * @param mixed        $color    The raw color value.
+	 * @param string|false $expected The expected byte-identical output.
+	 *
+	 * @return void
+	 */
+	public function testSanitizeColorBcCases( $color, $expected ): void {
+		$this->assertSame( $expected, $this->css->sanitize_color( $color ),
+			'sanitize_color must be byte-identical to its pre-recognizer output for literal input' );
+	}
+
+	/**
+	 * Provides literal, palette, and boundary color inputs shared by render_color and
+	 * sanitize_color.
+	 *
+	 * @return Generator
+	 */
+	public static function renderColorProvider(): Generator {
+		yield 'hex color is unchanged' => [
+			'color'    => '#3182CE',
+			'expected' => '#3182CE',
+		];
+		yield 'rgba string is unchanged' => [
+			'color'    => 'rgba(0, 0, 0, 0.5)',
+			'expected' => 'rgba(0, 0, 0, 0.5)',
+		];
+		yield 'palette slug resolves to the global palette var' => [
+			'color'    => 'palette1',
+			'expected' => 'var(--global-palette1, #3182CE)',
+		];
+		yield 'zero is falsy so empty() short-circuits to false' => [
+			'color'    => 0,
+			'expected' => false,
+		];
+		yield 'brace-containing non-alias string passes through unchanged' => [
+			'color'    => '1px solid {semantic.color.brand}',
+			'expected' => '1px solid {semantic.color.brand}',
+		];
+		yield 'empty string returns false' => [
+			'color'    => '',
+			'expected' => false,
+		];
+		yield 'null returns false' => [
+			'color'    => null,
+			'expected' => false,
+		];
+	}
 }

--- a/tests/wpunit/KadenceBlocksCssBcSnapshotTest.php
+++ b/tests/wpunit/KadenceBlocksCssBcSnapshotTest.php
@@ -485,4 +485,64 @@ final class KadenceBlocksCssBcSnapshotTest extends TestCase {
 		$this->assertStringNotContainsString( 'letter-spacing:1px solid', $brace_output,
 			'A brace-containing non-alias letter-spacing is rejected by the is_numeric() gate' );
 	}
+
+	/**
+	 * get_border_value (width) returns byte-identical output for a numeric width
+	 * (including a zero width), and returns an empty string for an empty or
+	 * brace-containing non-alias width.
+	 *
+	 * @dataProvider getBorderValueWidthProvider
+	 *
+	 * @param mixed  $width    The raw width value for the "top" side.
+	 * @param string $expected The expected byte-identical resolved width.
+	 *
+	 * @return void
+	 */
+	public function testGetBorderValueWidthBcCases( $width, string $expected ): void {
+		$attributes = [
+			'borderStyle' => [
+				[
+					'top'    => [ '#000000', 'solid', $width ],
+					'right'  => [ '#000000', 'solid', $width ],
+					'bottom' => [ '#000000', 'solid', $width ],
+					'left'   => [ '#000000', 'solid', $width ],
+					'unit'   => 'px',
+				],
+			],
+		];
+		$args = [
+			'desktop_key' => 'borderStyle',
+			'tablet_key'  => 'tabletBorderStyle',
+			'mobile_key'  => 'mobileBorderStyle',
+			'unit_key'    => 'unit',
+		];
+
+		$this->assertSame( $expected,
+			$this->css->get_border_value( $attributes, $args, 'top', 'desktop', 'width', false ),
+			'get_border_value must be byte-identical to its pre-recognizer output for numeric/literal width' );
+	}
+
+	/**
+	 * Provides numeric and boundary widths for get_border_value.
+	 *
+	 * @return Generator
+	 */
+	public static function getBorderValueWidthProvider(): Generator {
+		yield 'numeric width renders with its unit' => [
+			'width'    => 2,
+			'expected' => '2px',
+		];
+		yield 'zero width renders since is_number(0) is true' => [
+			'width'    => 0,
+			'expected' => '0px',
+		];
+		yield 'empty width falls back to the blank default' => [
+			'width'    => '',
+			'expected' => '',
+		];
+		yield 'brace-containing non-alias width is not numeric and returns blank' => [
+			'width'    => '1px solid {semantic.color.brand}',
+			'expected' => '',
+		];
+	}
 }

--- a/tests/wpunit/KadenceBlocksCssBcSnapshotTest.php
+++ b/tests/wpunit/KadenceBlocksCssBcSnapshotTest.php
@@ -429,4 +429,60 @@ final class KadenceBlocksCssBcSnapshotTest extends TestCase {
 			'expected' => '1px solid {semantic.color.brand}px 1px 4px 2px rgba(0, 0, 0, 0.5)',
 		];
 	}
+
+	/**
+	 * render_typography resolves line-height and letter-spacing byte-identically for
+	 * numeric input, and shows the two boundary asymmetries the recognizer must not
+	 * disturb: a falsy zero line-height is skipped by its `!empty()` gate while a zero
+	 * letter-spacing still renders under `is_numeric()`, and a brace-containing
+	 * non-alias line-height passes through unconditionally while the equivalent
+	 * letter-spacing is rejected by its `is_numeric()` gate.
+	 *
+	 * @return void
+	 */
+	public function testRenderTypographyLineHeightAndLetterSpacingBcCase(): void {
+		$this->css->render_typography( [
+			'typography' => [
+				'lineType'      => 'px',
+				'lineHeight'    => [ 1.5, '', '' ],
+				'letterSpacing' => [ 2, '', '' ],
+			],
+		] );
+		$numeric_output = $this->css->css_output();
+
+		$this->assertStringContainsString( 'line-height:1.5px', $numeric_output,
+			'A numeric line-height is rendered with its unit' );
+		$this->assertStringContainsString( 'letter-spacing:2px', $numeric_output,
+			'A numeric letter-spacing is rendered with its unit' );
+
+		$zero_css = new Kadence_Blocks_CSS();
+		$zero_css->render_typography( [
+			'typography' => [
+				'lineType'      => 'px',
+				'lineHeight'    => [ 0, '', '' ],
+				'letterSpacing' => [ 0, '', '' ],
+			],
+		] );
+		$zero_output = $zero_css->css_output();
+
+		$this->assertStringNotContainsString( 'line-height:', $zero_output,
+			'A falsy zero line-height is skipped by the !empty() gate' );
+		$this->assertStringContainsString( 'letter-spacing:0px', $zero_output,
+			'A zero letter-spacing still renders since its gate is is_numeric()' );
+
+		$brace_css = new Kadence_Blocks_CSS();
+		$brace_css->render_typography( [
+			'typography' => [
+				'lineType'      => 'px',
+				'lineHeight'    => [ '1px solid {semantic.color.brand}', '', '' ],
+				'letterSpacing' => [ '1px solid {semantic.color.brand}', '', '' ],
+			],
+		] );
+		$brace_output = $brace_css->css_output();
+
+		$this->assertStringContainsString( 'line-height:1px solid {semantic.color.brand}px', $brace_output,
+			'A brace-containing non-alias line-height passes through unconditionally with its unit suffix' );
+		$this->assertStringNotContainsString( 'letter-spacing:1px solid', $brace_output,
+			'A brace-containing non-alias letter-spacing is rejected by the is_numeric() gate' );
+	}
 }

--- a/tests/wpunit/KadenceBlocksCssBcSnapshotTest.php
+++ b/tests/wpunit/KadenceBlocksCssBcSnapshotTest.php
@@ -356,4 +356,77 @@ final class KadenceBlocksCssBcSnapshotTest extends TestCase {
 		$this->assertStringNotContainsString( '{semantic.color.brand}', $output,
 			'A brace-containing non-alias mobile breakpoint is not numeric and adds nothing' );
 	}
+
+	/**
+	 * render_shadow returns byte-identical output for a fully numeric box-shadow
+	 * (including a zero offset), respects the inset flag, and a brace-containing
+	 * non-alias offset passes through as a literal with its unit suffix.
+	 *
+	 * @dataProvider renderShadowProvider
+	 *
+	 * @param array  $shadow   The shadow attributes array.
+	 * @param string $expected The expected byte-identical box-shadow string.
+	 *
+	 * @return void
+	 */
+	public function testRenderShadowBcCases( array $shadow, string $expected ): void {
+		$this->assertSame( $expected, $this->css->render_shadow( $shadow ),
+			'render_shadow must be byte-identical to its pre-recognizer output for numeric/literal input' );
+	}
+
+	/**
+	 * Provides numeric, boundary, and inset box-shadow inputs for render_shadow.
+	 *
+	 * @return Generator
+	 */
+	public static function renderShadowProvider(): Generator {
+		yield 'fully numeric non-inset shadow' => [
+			'shadow'   => [
+				'color'   => '#000000',
+				'opacity' => 0.5,
+				'spread'  => 2,
+				'blur'    => 4,
+				'hOffset' => 1,
+				'vOffset' => 1,
+				'inset'   => false,
+			],
+			'expected' => '1px 1px 4px 2px rgba(0, 0, 0, 0.5)',
+		];
+		yield 'zero offsets fall back to the same "0" literal' => [
+			'shadow'   => [
+				'color'   => '#000000',
+				'opacity' => 0.5,
+				'spread'  => 2,
+				'blur'    => 4,
+				'hOffset' => 0,
+				'vOffset' => 0,
+				'inset'   => false,
+			],
+			'expected' => '0px 0px 4px 2px rgba(0, 0, 0, 0.5)',
+		];
+		yield 'inset shadow keeps the "inset " prefix' => [
+			'shadow'   => [
+				'color'   => '#000000',
+				'opacity' => 0.5,
+				'spread'  => 2,
+				'blur'    => 4,
+				'hOffset' => 1,
+				'vOffset' => 1,
+				'inset'   => true,
+			],
+			'expected' => 'inset 1px 1px 4px 2px rgba(0, 0, 0, 0.5)',
+		];
+		yield 'brace-containing non-alias hOffset passes through with its unit suffix' => [
+			'shadow'   => [
+				'color'   => '#000000',
+				'opacity' => 0.5,
+				'spread'  => 2,
+				'blur'    => 4,
+				'hOffset' => '1px solid {semantic.color.brand}',
+				'vOffset' => 1,
+				'inset'   => false,
+			],
+			'expected' => '1px solid {semantic.color.brand}px 1px 4px 2px rgba(0, 0, 0, 0.5)',
+		];
+	}
 }

--- a/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
+++ b/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
@@ -1,0 +1,203 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit;
+
+use Generator;
+use Kadence_Blocks_CSS;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Render-site contract for the alias recognizer's positive and negative halves.
+ *
+ * For every relaxed `render_*` method in {@see Kadence_Blocks_CSS}, a strict `{dot.alias}`
+ * value must come out as a bare `var(--kb-token--<id>)` in the built CSS (emission), a
+ * malformed brace string must never mint a `var()` or reach numeric handling as if it were
+ * an alias (fail-open), a 4-side/4-corner value with exactly one alias side must mix the
+ * `var()` with the sibling numeric sides correctly (per-side mixing), and an alias placed in
+ * any single box-shadow part must land in the right position of the shadow shorthand
+ * (inline box-shadow).
+ */
+final class KadenceBlocksCssTokenEmissionTest extends TestCase {
+
+	protected $css;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->css = new Kadence_Blocks_CSS();
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+	}
+
+	/**
+	 * render_number returns the bare var() reference for a strict alias, ignoring the unit.
+	 *
+	 * @return void
+	 */
+	public function testRenderNumberEmitsBareVarForAlias(): void {
+		$this->assertSame( 'var(--kb-token--semantic--radius--media)',
+			$this->css->render_number( '{semantic.radius.media}', 'px' ),
+			'render_number must emit the bare var() for a strict alias' );
+	}
+
+	/**
+	 * render_color returns the bare var() reference for a strict alias.
+	 *
+	 * @return void
+	 */
+	public function testRenderColorEmitsBareVarForAlias(): void {
+		$this->assertSame( 'var(--kb-token--semantic--radius--media)',
+			$this->css->render_color( '{semantic.radius.media}' ),
+			'render_color must emit the bare var() for a strict alias' );
+	}
+
+	/**
+	 * sanitize_color returns the bare var() reference for a strict alias.
+	 *
+	 * @return void
+	 */
+	public function testSanitizeColorEmitsBareVarForAlias(): void {
+		$this->assertSame( 'var(--kb-token--semantic--radius--media)',
+			$this->css->sanitize_color( '{semantic.radius.media}' ),
+			'sanitize_color must emit the bare var() for a strict alias' );
+	}
+
+	/**
+	 * render_range emits the bare var() reference as the declaration value for a strict alias.
+	 *
+	 * @return void
+	 */
+	public function testRenderRangeEmitsBareVarForAlias(): void {
+		$this->css->render_range( [ 'width' => '{semantic.radius.media}' ], 'width', 'width', 'px' );
+
+		$this->assertStringContainsString( 'width:var(--kb-token--semantic--radius--media)', $this->css->css_output(),
+			'render_range must emit the bare var() as the declaration value for a strict alias' );
+	}
+
+	/**
+	 * render_measure_range emits the bare var() reference on the first side for a strict alias.
+	 *
+	 * @return void
+	 */
+	public function testRenderMeasureRangeEmitsBareVarForAlias(): void {
+		$this->css->render_measure_range(
+			[ 'borderWidth' => [ '{semantic.radius.media}', 10, 20, 30 ] ],
+			'borderWidth',
+			'border-width'
+		);
+
+		$this->assertStringContainsString( 'border-top-width:var(--kb-token--semantic--radius--media)', $this->css->css_output(),
+			'render_measure_range must emit the bare var() on the aliased side' );
+	}
+
+	/**
+	 * render_measure returns the bare var() reference in place for the aliased side.
+	 *
+	 * @return void
+	 */
+	public function testRenderMeasureEmitsBareVarForAlias(): void {
+		$this->assertSame( 'var(--kb-token--semantic--radius--media) 20px 30px 40px',
+			$this->css->render_measure( [ '{semantic.radius.media}', 20, 30, 40 ] ),
+			'render_measure must emit the bare var() on the aliased side' );
+	}
+
+	/**
+	 * render_border_radius emits the bare var() reference on the first corner for a strict alias.
+	 *
+	 * @return void
+	 */
+	public function testRenderBorderRadiusEmitsBareVarForAlias(): void {
+		$this->css->render_border_radius( [ 'borderRadius' => [ '{semantic.radius.media}', 10, 20, 30 ] ] );
+
+		$this->assertStringContainsString( 'border-top-left-radius:var(--kb-token--semantic--radius--media)', $this->css->css_output(),
+			'render_border_radius must emit the bare var() on the aliased corner' );
+	}
+
+	/**
+	 * render_responsive_range emits the bare var() reference for the desktop breakpoint.
+	 *
+	 * @return void
+	 */
+	public function testRenderResponsiveRangeEmitsBareVarForAlias(): void {
+		$this->css->render_responsive_range(
+			[ 'spacing' => [ '{semantic.radius.media}', 20, 30 ] ],
+			'spacing',
+			'margin'
+		);
+
+		$this->assertStringContainsString( 'margin:var(--kb-token--semantic--radius--media)', $this->css->css_output(),
+			'render_responsive_range must emit the bare var() for the aliased desktop breakpoint' );
+	}
+
+	/**
+	 * render_shadow emits the bare var() reference in the hOffset position for a strict alias.
+	 *
+	 * @return void
+	 */
+	public function testRenderShadowEmitsBareVarForAlias(): void {
+		$this->assertSame( 'var(--kb-token--semantic--radius--media) 1px 4px 2px #000000',
+			$this->css->render_shadow( [
+				'color'   => '#000000',
+				'opacity' => 1,
+				'spread'  => 2,
+				'blur'    => 4,
+				'hOffset' => '{semantic.radius.media}',
+				'vOffset' => 1,
+				'inset'   => false,
+			] ),
+			'render_shadow must emit the bare var() in the hOffset position for a strict alias' );
+	}
+
+	/**
+	 * render_typography emits the bare var() reference for an aliased desktop line-height and
+	 * letter-spacing.
+	 *
+	 * @return void
+	 */
+	public function testRenderTypographyEmitsBareVarForAliasedLineHeightAndLetterSpacing(): void {
+		$this->css->render_typography( [
+			'typography' => [
+				'lineType'      => 'px',
+				'lineHeight'    => [ '{semantic.radius.media}', '', '' ],
+				'letterSpacing' => [ '{primitive.spacing.md}', '', '' ],
+			],
+		] );
+		$output = $this->css->css_output();
+
+		$this->assertStringContainsString( 'line-height:var(--kb-token--semantic--radius--media)', $output,
+			'render_typography must emit the bare var() for an aliased desktop line-height' );
+		$this->assertStringContainsString( 'letter-spacing:var(--kb-token--primitive--spacing--md)', $output,
+			'render_typography must emit the bare var() for an aliased desktop letter-spacing' );
+	}
+
+	/**
+	 * get_border_value (width) returns the bare var() reference for a strict alias width.
+	 *
+	 * @return void
+	 */
+	public function testGetBorderValueEmitsBareVarForAliasedWidth(): void {
+		$attributes = [
+			'borderStyle' => [
+				[
+					'top'    => [ '#000000', 'solid', '{semantic.radius.media}' ],
+					'right'  => [ '#000000', 'solid', '{semantic.radius.media}' ],
+					'bottom' => [ '#000000', 'solid', '{semantic.radius.media}' ],
+					'left'   => [ '#000000', 'solid', '{semantic.radius.media}' ],
+					'unit'   => 'px',
+				],
+			],
+		];
+		$args = [
+			'desktop_key' => 'borderStyle',
+			'tablet_key'  => 'tabletBorderStyle',
+			'mobile_key'  => 'mobileBorderStyle',
+			'unit_key'    => 'unit',
+		];
+
+		$this->assertSame( 'var(--kb-token--semantic--radius--media)',
+			$this->css->get_border_value( $attributes, $args, 'top', 'desktop', 'width', false ),
+			'get_border_value must emit the bare var() for a strict alias width' );
+	}
+}

--- a/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
+++ b/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
@@ -27,19 +27,17 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 		$this->css = new Kadence_Blocks_CSS();
 	}
 
-	protected function tearDown(): void {
-		parent::tearDown();
-	}
-
 	/**
 	 * render_number returns the bare var() reference for a strict alias, ignoring the unit.
 	 *
 	 * @return void
 	 */
 	public function testRenderNumberEmitsBareVarForAlias(): void {
-		$this->assertSame( 'var(--kb-token--semantic--radius--media)',
+		$this->assertSame(
+			'var(--kb-token--semantic--radius--media)',
 			$this->css->render_number( '{semantic.radius.media}', 'px' ),
-			'render_number must emit the bare var() for a strict alias' );
+			'render_number must emit the bare var() for a strict alias'
+		);
 	}
 
 	/**
@@ -48,9 +46,11 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	 * @return void
 	 */
 	public function testRenderColorEmitsBareVarForAlias(): void {
-		$this->assertSame( 'var(--kb-token--semantic--radius--media)',
+		$this->assertSame(
+			'var(--kb-token--semantic--radius--media)',
 			$this->css->render_color( '{semantic.radius.media}' ),
-			'render_color must emit the bare var() for a strict alias' );
+			'render_color must emit the bare var() for a strict alias'
+		);
 	}
 
 	/**
@@ -59,9 +59,11 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	 * @return void
 	 */
 	public function testSanitizeColorEmitsBareVarForAlias(): void {
-		$this->assertSame( 'var(--kb-token--semantic--radius--media)',
+		$this->assertSame(
+			'var(--kb-token--semantic--radius--media)',
 			$this->css->sanitize_color( '{semantic.radius.media}' ),
-			'sanitize_color must emit the bare var() for a strict alias' );
+			'sanitize_color must emit the bare var() for a strict alias'
+		);
 	}
 
 	/**
@@ -72,8 +74,11 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	public function testRenderRangeEmitsBareVarForAlias(): void {
 		$this->css->render_range( [ 'width' => '{semantic.radius.media}' ], 'width', 'width', 'px' );
 
-		$this->assertStringContainsString( 'width:var(--kb-token--semantic--radius--media)', $this->css->css_output(),
-			'render_range must emit the bare var() as the declaration value for a strict alias' );
+		$this->assertStringContainsString(
+			'width:var(--kb-token--semantic--radius--media)',
+			$this->css->css_output(),
+			'render_range must emit the bare var() as the declaration value for a strict alias'
+		);
 	}
 
 	/**
@@ -88,8 +93,11 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 			'border-width'
 		);
 
-		$this->assertStringContainsString( 'border-top-width:var(--kb-token--semantic--radius--media)', $this->css->css_output(),
-			'render_measure_range must emit the bare var() on the aliased side' );
+		$this->assertStringContainsString(
+			'border-top-width:var(--kb-token--semantic--radius--media)',
+			$this->css->css_output(),
+			'render_measure_range must emit the bare var() on the aliased side'
+		);
 	}
 
 	/**
@@ -98,9 +106,11 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	 * @return void
 	 */
 	public function testRenderMeasureEmitsBareVarForAlias(): void {
-		$this->assertSame( 'var(--kb-token--semantic--radius--media) 20px 30px 40px',
+		$this->assertSame(
+			'var(--kb-token--semantic--radius--media) 20px 30px 40px',
 			$this->css->render_measure( [ '{semantic.radius.media}', 20, 30, 40 ] ),
-			'render_measure must emit the bare var() on the aliased side' );
+			'render_measure must emit the bare var() on the aliased side'
+		);
 	}
 
 	/**
@@ -111,8 +121,11 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	public function testRenderBorderRadiusEmitsBareVarForAlias(): void {
 		$this->css->render_border_radius( [ 'borderRadius' => [ '{semantic.radius.media}', 10, 20, 30 ] ] );
 
-		$this->assertStringContainsString( 'border-top-left-radius:var(--kb-token--semantic--radius--media)', $this->css->css_output(),
-			'render_border_radius must emit the bare var() on the aliased corner' );
+		$this->assertStringContainsString(
+			'border-top-left-radius:var(--kb-token--semantic--radius--media)',
+			$this->css->css_output(),
+			'render_border_radius must emit the bare var() on the aliased corner'
+		);
 	}
 
 	/**
@@ -127,8 +140,11 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 			'margin'
 		);
 
-		$this->assertStringContainsString( 'margin:var(--kb-token--semantic--radius--media)', $this->css->css_output(),
-			'render_responsive_range must emit the bare var() for the aliased desktop breakpoint' );
+		$this->assertStringContainsString(
+			'margin:var(--kb-token--semantic--radius--media)',
+			$this->css->css_output(),
+			'render_responsive_range must emit the bare var() for the aliased desktop breakpoint'
+		);
 	}
 
 	/**
@@ -137,7 +153,8 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	 * @return void
 	 */
 	public function testRenderShadowEmitsBareVarForAlias(): void {
-		$this->assertSame( 'var(--kb-token--semantic--radius--media) 1px 4px 2px #000000',
+		$this->assertSame(
+			'var(--kb-token--semantic--radius--media) 1px 4px 2px #000000',
 			$this->css->render_shadow( [
 				'color'   => '#000000',
 				'opacity' => 1,
@@ -147,7 +164,8 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 				'vOffset' => 1,
 				'inset'   => false,
 			] ),
-			'render_shadow must emit the bare var() in the hOffset position for a strict alias' );
+			'render_shadow must emit the bare var() in the hOffset position for a strict alias'
+		);
 	}
 
 	/**
@@ -166,10 +184,16 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 		] );
 		$output = $this->css->css_output();
 
-		$this->assertStringContainsString( 'line-height:var(--kb-token--semantic--radius--media)', $output,
-			'render_typography must emit the bare var() for an aliased desktop line-height' );
-		$this->assertStringContainsString( 'letter-spacing:var(--kb-token--primitive--spacing--md)', $output,
-			'render_typography must emit the bare var() for an aliased desktop letter-spacing' );
+		$this->assertStringContainsString(
+			'line-height:var(--kb-token--semantic--radius--media)',
+			$output,
+			'render_typography must emit the bare var() for an aliased desktop line-height'
+		);
+		$this->assertStringContainsString(
+			'letter-spacing:var(--kb-token--primitive--spacing--md)',
+			$output,
+			'render_typography must emit the bare var() for an aliased desktop letter-spacing'
+		);
 	}
 
 	/**
@@ -196,9 +220,11 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 			'unit_key'    => 'unit',
 		];
 
-		$this->assertSame( 'var(--kb-token--semantic--radius--media)',
+		$this->assertSame(
+			'var(--kb-token--semantic--radius--media)',
 			$this->css->get_border_value( $attributes, $args, 'top', 'desktop', 'width', false ),
-			'get_border_value must emit the bare var() for a strict alias width' );
+			'get_border_value must emit the bare var() for a strict alias width'
+		);
 	}
 
 	/**
@@ -219,8 +245,11 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	public function testRenderNumberFailsOpenForMalformedAlias( string $malformed ): void {
 		$actual = $this->css->render_number( $malformed, 'px' );
 
-		$this->assertSame( false, $actual,
-			'render_number must return its own normal false result for an unusable value' );
+		$this->assertSame(
+			false,
+			$actual,
+			'render_number must return its own normal false result for an unusable value'
+		);
 	}
 
 	/**
@@ -238,10 +267,16 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 		$actual = $this->css->render_range( [ 'width' => $malformed ], 'width', 'width', 'px' );
 		$output = $this->css->css_output();
 
-		$this->assertSame( false, $actual,
-			'render_range must return its own normal false result for an unusable value' );
-		$this->assertSame( $baseline, $output,
-			'render_range must add no declaration for an unusable value' );
+		$this->assertSame(
+			false,
+			$actual,
+			'render_range must return its own normal false result for an unusable value'
+		);
+		$this->assertSame(
+			$baseline,
+			$output,
+			'render_range must add no declaration for an unusable value'
+		);
 	}
 
 	/**
@@ -257,10 +292,16 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	public function testRenderColorFailsOpenForMalformedAlias( string $malformed ): void {
 		$actual = $this->css->render_color( $malformed );
 
-		$this->assertSame( $malformed, $actual,
-			'render_color must pass a malformed brace string through unchanged, its normal literal result' );
-		$this->assertStringNotContainsString( 'var(', (string) $actual,
-			'render_color must not mint a var() from a malformed brace string' );
+		$this->assertSame(
+			$malformed,
+			$actual,
+			'render_color must pass a malformed brace string through unchanged, its normal literal result'
+		);
+		$this->assertStringNotContainsString(
+			'var(',
+			(string) $actual,
+			'render_color must not mint a var() from a malformed brace string'
+		);
 	}
 
 	/**
@@ -276,10 +317,16 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	public function testSanitizeColorFailsOpenForMalformedAlias( string $malformed ): void {
 		$actual = $this->css->sanitize_color( $malformed );
 
-		$this->assertSame( $malformed, $actual,
-			'sanitize_color must pass a malformed brace string through unchanged, its normal literal result' );
-		$this->assertStringNotContainsString( 'var(', (string) $actual,
-			'sanitize_color must not mint a var() from a malformed brace string' );
+		$this->assertSame(
+			$malformed,
+			$actual,
+			'sanitize_color must pass a malformed brace string through unchanged, its normal literal result'
+		);
+		$this->assertStringNotContainsString(
+			'var(',
+			(string) $actual,
+			'sanitize_color must not mint a var() from a malformed brace string'
+		);
 	}
 
 	/**
@@ -313,8 +360,11 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 
 		$actual = $this->css->get_border_value( $attributes, $args, 'top', 'desktop', 'width', false );
 
-		$this->assertSame( '', $actual,
-			'get_border_value must return its own normal blank-string result for an unusable width' );
+		$this->assertSame(
+			'',
+			$actual,
+			'get_border_value must return its own normal blank-string result for an unusable width'
+		);
 	}
 
 	/**
@@ -331,8 +381,11 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	public function testRenderMeasureFailsOpenForMalformedAlias( string $malformed ): void {
 		$actual = $this->css->render_measure( [ $malformed, $malformed, $malformed, $malformed ] );
 
-		$this->assertSame( false, $actual,
-			'render_measure must return its own normal false result when no side is numeric or a strict alias' );
+		$this->assertSame(
+			false,
+			$actual,
+			'render_measure must return its own normal false result when no side is numeric or a strict alias'
+		);
 	}
 
 	/**
@@ -354,8 +407,11 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 		);
 		$output = $this->css->css_output();
 
-		$this->assertSame( $baseline, $output,
-			'render_measure_range must add no declaration for any side when nothing is numeric or a strict alias' );
+		$this->assertSame(
+			$baseline,
+			$output,
+			'render_measure_range must add no declaration for any side when nothing is numeric or a strict alias'
+		);
 	}
 
 	/**
@@ -373,8 +429,11 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 		$this->css->render_border_radius( [ 'borderRadius' => [ $malformed, $malformed, $malformed, $malformed ] ] );
 		$output = $this->css->css_output();
 
-		$this->assertSame( $baseline, $output,
-			'render_border_radius must add no declaration for any corner when nothing is numeric or a strict alias' );
+		$this->assertSame(
+			$baseline,
+			$output,
+			'render_border_radius must add no declaration for any corner when nothing is numeric or a strict alias'
+		);
 	}
 
 	/**
@@ -399,8 +458,11 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 		);
 		$output = $this->css->css_output();
 
-		$this->assertSame( $baseline, $output,
-			'render_responsive_range must add no declaration for any breakpoint when nothing is numeric or a strict alias' );
+		$this->assertSame(
+			$baseline,
+			$output,
+			'render_responsive_range must add no declaration for any breakpoint when nothing is numeric or a strict alias'
+		);
 	}
 
 	/**
@@ -425,10 +487,16 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 			'inset'   => false,
 		] );
 
-		$this->assertSame( $malformed . 'px 1px 4px 2px #000000', $actual,
-			'render_shadow must pass a malformed brace hOffset through literally with its unit suffix' );
-		$this->assertStringNotContainsString( '--kb-token--', $actual,
-			'render_shadow must not mint a var() from a malformed brace string' );
+		$this->assertSame(
+			$malformed . 'px 1px 4px 2px #000000',
+			$actual,
+			'render_shadow must pass a malformed brace hOffset through literally with its unit suffix'
+		);
+		$this->assertStringNotContainsString(
+			'--kb-token--',
+			$actual,
+			'render_shadow must not mint a var() from a malformed brace string'
+		);
 	}
 
 	/**
@@ -454,12 +522,21 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 		$output = $this->css->css_output();
 		$added = substr( $output, 0, strlen( $output ) - strlen( $baseline ) );
 
-		$this->assertStringContainsString( 'line-height:' . $malformed . 'px', $added,
-			'render_typography must pass a malformed brace line-height through literally under its !empty() gate' );
-		$this->assertStringNotContainsString( 'letter-spacing:', $added,
-			'render_typography must reject a malformed brace letter-spacing outright under its is_numeric() gate' );
-		$this->assertStringNotContainsString( '--kb-token--', $added,
-			'render_typography must not mint a var() from a malformed brace string' );
+		$this->assertStringContainsString(
+			'line-height:' . $malformed . 'px',
+			$added,
+			'render_typography must pass a malformed brace line-height through literally under its !empty() gate'
+		);
+		$this->assertStringNotContainsString(
+			'letter-spacing:',
+			$added,
+			'render_typography must reject a malformed brace letter-spacing outright under its is_numeric() gate'
+		);
+		$this->assertStringNotContainsString(
+			'--kb-token--',
+			$added,
+			'render_typography must not mint a var() from a malformed brace string'
+		);
 	}
 
 	/**
@@ -489,8 +566,11 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	 * @return void
 	 */
 	public function testRenderMeasureMixesAliasedAndNumericSides( array $measure, string $expected ): void {
-		$this->assertSame( $expected, $this->css->render_measure( $measure ),
-			'render_measure must mix the aliased side with the sibling numeric sides correctly' );
+		$this->assertSame(
+			$expected,
+			$this->css->render_measure( $measure ),
+			'render_measure must mix the aliased side with the sibling numeric sides correctly'
+		);
 	}
 
 	/**
@@ -534,10 +614,16 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 		$this->css->render_measure_range( [ 'borderWidth' => $measure ], 'borderWidth', 'border-width' );
 		$output = $this->css->css_output();
 
-		$this->assertStringContainsString( $expectedProperty . ':' . $expectedValue, $output,
-			'render_measure_range must emit the var() on the aliased side' );
-		$this->assertStringContainsString( 'border-top-width:', $output,
-			'render_measure_range must still render the other numeric sides' );
+		$this->assertStringContainsString(
+			$expectedProperty . ':' . $expectedValue,
+			$output,
+			'render_measure_range must emit the var() on the aliased side'
+		);
+		$this->assertStringContainsString(
+			'border-top-width:',
+			$output,
+			'render_measure_range must still render the other numeric sides'
+		);
 	}
 
 	/**
@@ -575,8 +661,11 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 		$output = $this->css->css_output();
 
 		foreach ( $expected as $fragment ) {
-			$this->assertStringContainsString( $fragment, $output,
-				'render_measure_range must emit every expected fragment for the mixed sides' );
+			$this->assertStringContainsString(
+				$fragment,
+				$output,
+				'render_measure_range must emit every expected fragment for the mixed sides'
+			);
 		}
 	}
 
@@ -623,8 +712,11 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 		$output = $this->css->css_output();
 
 		foreach ( $expected as $fragment ) {
-			$this->assertStringContainsString( $fragment, $output,
-				'render_border_radius must emit every expected fragment for the mixed corners' );
+			$this->assertStringContainsString(
+				$fragment,
+				$output,
+				'render_border_radius must emit every expected fragment for the mixed corners'
+			);
 		}
 	}
 
@@ -685,8 +777,11 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	 * @return void
 	 */
 	public function testRenderShadowMixesAliasedAndNumericParts( array $shadow, string $expected ): void {
-		$this->assertSame( $expected, $this->css->render_shadow( $shadow ),
-			'render_shadow must emit the var() in the correct shorthand position for the aliased part' );
+		$this->assertSame(
+			$expected,
+			$this->css->render_shadow( $shadow ),
+			'render_shadow must emit the var() in the correct shorthand position for the aliased part'
+		);
 	}
 
 	/**

--- a/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
+++ b/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
@@ -669,4 +669,78 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 			],
 		];
 	}
+
+	/**
+	 * Inline box-shadow: render_shadow with an alias in each individual part (hOffset,
+	 * vOffset, blur, spread) carries the var() in the correct shorthand position with the
+	 * remaining parts numeric.
+	 *
+	 * @dataProvider shadowAliasedPartProvider
+	 *
+	 * @param array  $shadow   The shadow attributes array with one aliased part.
+	 * @param string $expected The expected byte-identical box-shadow shorthand.
+	 *
+	 * @return void
+	 */
+	public function testRenderShadowMixesAliasedAndNumericParts( array $shadow, string $expected ): void {
+		$this->assertSame( $expected, $this->css->render_shadow( $shadow ),
+			'render_shadow must emit the var() in the correct shorthand position for the aliased part' );
+	}
+
+	/**
+	 * Provides a box-shadow attributes array with the alias rotated through each of hOffset,
+	 * vOffset, blur, and spread, one part per case, with the other numeric parts held fixed.
+	 *
+	 * @return Generator
+	 */
+	public static function shadowAliasedPartProvider(): Generator {
+		yield 'alias in hOffset' => [
+			'shadow'   => [
+				'color'   => '#000000',
+				'opacity' => 1,
+				'spread'  => 2,
+				'blur'    => 4,
+				'hOffset' => '{semantic.radius.media}',
+				'vOffset' => 1,
+				'inset'   => false,
+			],
+			'expected' => 'var(--kb-token--semantic--radius--media) 1px 4px 2px #000000',
+		];
+		yield 'alias in vOffset' => [
+			'shadow'   => [
+				'color'   => '#000000',
+				'opacity' => 1,
+				'spread'  => 2,
+				'blur'    => 4,
+				'hOffset' => 1,
+				'vOffset' => '{semantic.radius.media}',
+				'inset'   => false,
+			],
+			'expected' => '1px var(--kb-token--semantic--radius--media) 4px 2px #000000',
+		];
+		yield 'alias in blur' => [
+			'shadow'   => [
+				'color'   => '#000000',
+				'opacity' => 1,
+				'spread'  => 2,
+				'blur'    => '{semantic.radius.media}',
+				'hOffset' => 1,
+				'vOffset' => 1,
+				'inset'   => false,
+			],
+			'expected' => '1px 1px var(--kb-token--semantic--radius--media) 2px #000000',
+		];
+		yield 'alias in spread' => [
+			'shadow'   => [
+				'color'   => '#000000',
+				'opacity' => 1,
+				'spread'  => '{semantic.radius.media}',
+				'blur'    => 4,
+				'hOffset' => 1,
+				'vOffset' => 1,
+				'inset'   => false,
+			],
+			'expected' => '1px 1px 4px var(--kb-token--semantic--radius--media) #000000',
+		];
+	}
 }

--- a/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
+++ b/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
@@ -349,6 +349,7 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	 * @return void
 	 */
 	public function testRenderMeasureRangeFailsOpenForMalformedAlias( string $malformed ): void {
+		$baseline = $this->css->css_output();
 		$this->css->render_measure_range(
 			[ 'borderWidth' => [ $malformed, $malformed, $malformed, $malformed ] ],
 			'borderWidth',
@@ -356,7 +357,7 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 		);
 		$output = $this->css->css_output();
 
-		$this->assertSame( '', $output,
+		$this->assertSame( $baseline, $output,
 			'render_measure_range must add no declaration for any side when nothing is numeric or a strict alias' );
 	}
 
@@ -371,10 +372,11 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	 * @return void
 	 */
 	public function testRenderBorderRadiusFailsOpenForMalformedAlias( string $malformed ): void {
+		$baseline = $this->css->css_output();
 		$this->css->render_border_radius( [ 'borderRadius' => [ $malformed, $malformed, $malformed, $malformed ] ] );
 		$output = $this->css->css_output();
 
-		$this->assertSame( '', $output,
+		$this->assertSame( $baseline, $output,
 			'render_border_radius must add no declaration for any corner when nothing is numeric or a strict alias' );
 	}
 
@@ -389,6 +391,7 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	 * @return void
 	 */
 	public function testRenderResponsiveRangeFailsOpenForMalformedAlias( string $malformed ): void {
+		$baseline = $this->css->css_output();
 		$this->css->render_responsive_range(
 			[
 				'spacing'     => [ $malformed, $malformed, $malformed ],
@@ -399,7 +402,7 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 		);
 		$output = $this->css->css_output();
 
-		$this->assertSame( '', $output,
+		$this->assertSame( $baseline, $output,
 			'render_responsive_range must add no declaration for any breakpoint when nothing is numeric or a strict alias' );
 	}
 

--- a/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
+++ b/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
@@ -443,6 +443,7 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	 * @return void
 	 */
 	public function testRenderTypographyFailsOpenForMalformedAlias( string $malformed ): void {
+		$baseline = $this->css->css_output();
 		$this->css->render_typography( [
 			'typography' => [
 				'lineType'      => 'px',
@@ -451,12 +452,13 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 			],
 		] );
 		$output = $this->css->css_output();
+		$added = substr( $output, 0, strlen( $output ) - strlen( $baseline ) );
 
-		$this->assertStringContainsString( 'line-height:' . $malformed . 'px', $output,
+		$this->assertStringContainsString( 'line-height:' . $malformed . 'px', $added,
 			'render_typography must pass a malformed brace line-height through literally under its !empty() gate' );
-		$this->assertStringNotContainsString( 'letter-spacing:', $output,
+		$this->assertStringNotContainsString( 'letter-spacing:', $added,
 			'render_typography must reject a malformed brace letter-spacing outright under its is_numeric() gate' );
-		$this->assertStringNotContainsString( '--kb-token--', $output,
+		$this->assertStringNotContainsString( '--kb-token--', $added,
 			'render_typography must not mint a var() from a malformed brace string' );
 	}
 

--- a/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
+++ b/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
@@ -473,4 +473,200 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 		yield 'unopened brace' => [ 'malformed' => 'unopened}' ];
 		yield 'empty braces' => [ 'malformed' => '{}' ];
 	}
+
+	/**
+	 * Per-side dimension mixing for render_measure: a 4-side value with exactly one side an
+	 * alias and the other three numeric produces the correct mixed CSS, with the alias
+	 * rotated through all four positions so a per-side loop ordering bug cannot hide.
+	 *
+	 * @dataProvider measureMixedSidesProvider
+	 *
+	 * @param array  $measure  The 4-side measure array with one aliased side.
+	 * @param string $expected The expected byte-identical mixed measure string.
+	 *
+	 * @return void
+	 */
+	public function testRenderMeasureMixesAliasedAndNumericSides( array $measure, string $expected ): void {
+		$this->assertSame( $expected, $this->css->render_measure( $measure ),
+			'render_measure must mix the aliased side with the sibling numeric sides correctly' );
+	}
+
+	/**
+	 * Provides a 4-side measure array with the alias rotated through each position.
+	 *
+	 * @return Generator
+	 */
+	public static function measureMixedSidesProvider(): Generator {
+		yield 'alias in first side' => [
+			'measure'  => [ '{semantic.radius.media}', 20, 30, 40 ],
+			'expected' => 'var(--kb-token--semantic--radius--media) 20px 30px 40px',
+		];
+		yield 'alias in second side' => [
+			'measure'  => [ 10, '{semantic.radius.media}', 30, 40 ],
+			'expected' => '10px var(--kb-token--semantic--radius--media) 30px 40px',
+		];
+		yield 'alias in third side' => [
+			'measure'  => [ 10, 20, '{semantic.radius.media}', 40 ],
+			'expected' => '10px 20px var(--kb-token--semantic--radius--media) 40px',
+		];
+		yield 'alias in fourth (last) side' => [
+			'measure'  => [ 10, 20, 30, '{semantic.radius.media}' ],
+			'expected' => '10px 20px 30px var(--kb-token--semantic--radius--media)',
+		];
+	}
+
+	/**
+	 * Per-side dimension mixing for render_measure_range: a 4-side value with exactly one
+	 * side an alias and the other three numeric emits the correct mixed declarations, with
+	 * the alias rotated through all four positions.
+	 *
+	 * @dataProvider measureRangeMixedSidesProvider
+	 *
+	 * @param array  $measure          The 4-side border-width array with one aliased side.
+	 * @param string $expectedProperty The css property expected to carry the var().
+	 * @param string $expectedValue    The expected var() value on that property.
+	 *
+	 * @return void
+	 */
+	public function testRenderMeasureRangeMixesAliasedAndNumericSides( array $measure, string $expectedProperty, string $expectedValue ): void {
+		$this->css->render_measure_range( [ 'borderWidth' => $measure ], 'borderWidth', 'border-width' );
+		$output = $this->css->css_output();
+
+		$this->assertStringContainsString( $expectedProperty . ':' . $expectedValue, $output,
+			'render_measure_range must emit the var() on the aliased side' );
+		$this->assertStringContainsString( 'border-top-width:', $output,
+			'render_measure_range must still render the other numeric sides' );
+	}
+
+	/**
+	 * Provides a 4-side border-width array with the alias rotated through each position.
+	 *
+	 * @return Generator
+	 */
+	public static function measureRangeMixedSidesProvider(): Generator {
+		yield 'alias in first (top) side' => [
+			'measure'          => [ '{semantic.radius.media}', 20, 30, 40 ],
+			'expectedProperty' => 'border-top-width',
+			'expectedValue'    => 'var(--kb-token--semantic--radius--media)',
+		];
+		yield 'alias in last (left) side' => [
+			'measure'          => [ 10, 20, 30, '{semantic.radius.media}' ],
+			'expectedProperty' => 'border-left-width',
+			'expectedValue'    => 'var(--kb-token--semantic--radius--media)',
+		];
+	}
+
+	/**
+	 * Confirms render_measure_range still renders the sibling numeric sides byte-identically
+	 * when one side is aliased, for both the first- and last-position rotations.
+	 *
+	 * @dataProvider measureRangeMixedSidesFullOutputProvider
+	 *
+	 * @param array  $measure  The 4-side border-width array with one aliased side.
+	 * @param string $expected The expected declarations, order-independent, all of which must
+	 *                         be present in the built CSS.
+	 *
+	 * @return void
+	 */
+	public function testRenderMeasureRangeMixedSidesRenderSiblingNumerics( array $measure, array $expected ): void {
+		$this->css->render_measure_range( [ 'borderWidth' => $measure ], 'borderWidth', 'border-width' );
+		$output = $this->css->css_output();
+
+		foreach ( $expected as $fragment ) {
+			$this->assertStringContainsString( $fragment, $output,
+				'render_measure_range must emit every expected fragment for the mixed sides' );
+		}
+	}
+
+	/**
+	 * Provides the full expected fragment set for the first- and last-position alias rotations.
+	 *
+	 * @return Generator
+	 */
+	public static function measureRangeMixedSidesFullOutputProvider(): Generator {
+		yield 'alias in first (top) side' => [
+			'measure'  => [ '{semantic.radius.media}', 20, 30, 40 ],
+			'expected' => [
+				'border-top-width:var(--kb-token--semantic--radius--media)',
+				'border-right-width:20px',
+				'border-bottom-width:30px',
+				'border-left-width:40px',
+			],
+		];
+		yield 'alias in last (left) side' => [
+			'measure'  => [ 10, 20, 30, '{semantic.radius.media}' ],
+			'expected' => [
+				'border-top-width:10px',
+				'border-right-width:20px',
+				'border-bottom-width:30px',
+				'border-left-width:var(--kb-token--semantic--radius--media)',
+			],
+		];
+	}
+
+	/**
+	 * Per-corner dimension mixing for render_border_radius: a 4-corner value with exactly one
+	 * corner an alias and the other three numeric emits the correct mixed declarations, with
+	 * the alias rotated through all four positions.
+	 *
+	 * @dataProvider borderRadiusMixedCornersProvider
+	 *
+	 * @param array $corners  The 4-corner border-radius array with one aliased corner.
+	 * @param array $expected The full set of expected declarations that must all be present.
+	 *
+	 * @return void
+	 */
+	public function testRenderBorderRadiusMixesAliasedAndNumericCorners( array $corners, array $expected ): void {
+		$this->css->render_border_radius( [ 'borderRadius' => $corners ] );
+		$output = $this->css->css_output();
+
+		foreach ( $expected as $fragment ) {
+			$this->assertStringContainsString( $fragment, $output,
+				'render_border_radius must emit every expected fragment for the mixed corners' );
+		}
+	}
+
+	/**
+	 * Provides a 4-corner border-radius array with the alias rotated through each position.
+	 *
+	 * @return Generator
+	 */
+	public static function borderRadiusMixedCornersProvider(): Generator {
+		yield 'alias in first (top-left) corner' => [
+			'corners'  => [ '{semantic.radius.media}', 20, 30, 40 ],
+			'expected' => [
+				'border-top-left-radius:var(--kb-token--semantic--radius--media)',
+				'border-top-right-radius:20px',
+				'border-bottom-right-radius:30px',
+				'border-bottom-left-radius:40px',
+			],
+		];
+		yield 'alias in second (top-right) corner' => [
+			'corners'  => [ 10, '{semantic.radius.media}', 30, 40 ],
+			'expected' => [
+				'border-top-left-radius:10px',
+				'border-top-right-radius:var(--kb-token--semantic--radius--media)',
+				'border-bottom-right-radius:30px',
+				'border-bottom-left-radius:40px',
+			],
+		];
+		yield 'alias in third (bottom-right) corner' => [
+			'corners'  => [ 10, 20, '{semantic.radius.media}', 40 ],
+			'expected' => [
+				'border-top-left-radius:10px',
+				'border-top-right-radius:20px',
+				'border-bottom-right-radius:var(--kb-token--semantic--radius--media)',
+				'border-bottom-left-radius:40px',
+			],
+		];
+		yield 'alias in fourth (last, bottom-left) corner' => [
+			'corners'  => [ 10, 20, 30, '{semantic.radius.media}' ],
+			'expected' => [
+				'border-top-left-radius:10px',
+				'border-top-right-radius:20px',
+				'border-bottom-right-radius:30px',
+				'border-bottom-left-radius:var(--kb-token--semantic--radius--media)',
+			],
+		];
+	}
 }

--- a/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
+++ b/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
@@ -200,4 +200,277 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 			$this->css->get_border_value( $attributes, $args, 'top', 'desktop', 'width', false ),
 			'get_border_value must emit the bare var() for a strict alias width' );
 	}
+
+	/**
+	 * The fail-open matrix: a malformed brace string must never mint a var() and never reach
+	 * numeric handling as if it were an alias, for every representative method's own value site.
+	 *
+	 * A looks-like-but-not-strict string must fall through the strict `Alias::is_alias()` gate
+	 * and land in the method's ordinary invalid-value handling. The call completing and this
+	 * method's assertions running is itself proof there is no fatal or TypeError along the way
+	 * (a regression here would be `is_numeric()`-adjacent code choking on a brace string).
+	 *
+	 * @dataProvider malformedAliasProvider
+	 *
+	 * @param string $malformed The malformed brace string under test.
+	 *
+	 * @return void
+	 */
+	public function testRenderNumberFailsOpenForMalformedAlias( string $malformed ): void {
+		$actual = $this->css->render_number( $malformed, 'px' );
+
+		$this->assertSame( false, $actual,
+			'render_number must return its own normal false result for an unusable value' );
+	}
+
+	/**
+	 * The fail-open matrix for render_range: a malformed brace string short-circuits to false
+	 * and adds no declaration.
+	 *
+	 * @dataProvider malformedAliasProvider
+	 *
+	 * @param string $malformed The malformed brace string under test.
+	 *
+	 * @return void
+	 */
+	public function testRenderRangeFailsOpenForMalformedAlias( string $malformed ): void {
+		$actual = $this->css->render_range( [ 'width' => $malformed ], 'width', 'width', 'px' );
+		$output = $this->css->css_output();
+
+		$this->assertSame( false, $actual,
+			'render_range must return its own normal false result for an unusable value' );
+		$this->assertStringNotContainsString( 'var(', $output,
+			'render_range must not mint a var() from a malformed brace string' );
+		$this->assertStringNotContainsString( '--kb-token--', $output,
+			'render_range must not mint a var() from a malformed brace string' );
+		$this->assertStringNotContainsString( 'width:', $output,
+			'render_range must add no declaration for an unusable value' );
+	}
+
+	/**
+	 * The fail-open matrix for render_color: a malformed brace string is not empty(), so it
+	 * passes through unchanged as the method's normal literal-passthrough result.
+	 *
+	 * @dataProvider malformedAliasProvider
+	 *
+	 * @param string $malformed The malformed brace string under test.
+	 *
+	 * @return void
+	 */
+	public function testRenderColorFailsOpenForMalformedAlias( string $malformed ): void {
+		$actual = $this->css->render_color( $malformed );
+
+		$this->assertSame( $malformed, $actual,
+			'render_color must pass a malformed brace string through unchanged, its normal literal result' );
+		$this->assertStringNotContainsString( 'var(', (string) $actual,
+			'render_color must not mint a var() from a malformed brace string' );
+	}
+
+	/**
+	 * The fail-open matrix for sanitize_color: a malformed brace string is not empty(), so it
+	 * passes through unchanged as the method's normal literal-passthrough result.
+	 *
+	 * @dataProvider malformedAliasProvider
+	 *
+	 * @param string $malformed The malformed brace string under test.
+	 *
+	 * @return void
+	 */
+	public function testSanitizeColorFailsOpenForMalformedAlias( string $malformed ): void {
+		$actual = $this->css->sanitize_color( $malformed );
+
+		$this->assertSame( $malformed, $actual,
+			'sanitize_color must pass a malformed brace string through unchanged, its normal literal result' );
+		$this->assertStringNotContainsString( 'var(', (string) $actual,
+			'sanitize_color must not mint a var() from a malformed brace string' );
+	}
+
+	/**
+	 * The fail-open matrix for get_border_value (width): a malformed brace string is not
+	 * numeric, so the method falls back to its normal blank-string result.
+	 *
+	 * @dataProvider malformedAliasProvider
+	 *
+	 * @param string $malformed The malformed brace string under test.
+	 *
+	 * @return void
+	 */
+	public function testGetBorderValueFailsOpenForMalformedAlias( string $malformed ): void {
+		$attributes = [
+			'borderStyle' => [
+				[
+					'top'    => [ '#000000', 'solid', $malformed ],
+					'right'  => [ '#000000', 'solid', $malformed ],
+					'bottom' => [ '#000000', 'solid', $malformed ],
+					'left'   => [ '#000000', 'solid', $malformed ],
+					'unit'   => 'px',
+				],
+			],
+		];
+		$args = [
+			'desktop_key' => 'borderStyle',
+			'tablet_key'  => 'tabletBorderStyle',
+			'mobile_key'  => 'mobileBorderStyle',
+			'unit_key'    => 'unit',
+		];
+
+		$actual = $this->css->get_border_value( $attributes, $args, 'top', 'desktop', 'width', false );
+
+		$this->assertSame( '', $actual,
+			'get_border_value must return its own normal blank-string result for an unusable width' );
+	}
+
+	/**
+	 * The fail-open matrix for render_measure: a malformed brace string on every side is
+	 * neither numeric nor a strict alias on any side, so the method returns its own normal
+	 * false result.
+	 *
+	 * @dataProvider malformedAliasProvider
+	 *
+	 * @param string $malformed The malformed brace string under test.
+	 *
+	 * @return void
+	 */
+	public function testRenderMeasureFailsOpenForMalformedAlias( string $malformed ): void {
+		$actual = $this->css->render_measure( [ $malformed, $malformed, $malformed, $malformed ] );
+
+		$this->assertSame( false, $actual,
+			'render_measure must return its own normal false result when no side is numeric or a strict alias' );
+	}
+
+	/**
+	 * The fail-open matrix for render_measure_range: a malformed brace string on every side
+	 * adds no declaration, since it is neither numeric nor a strict alias.
+	 *
+	 * @dataProvider malformedAliasProvider
+	 *
+	 * @param string $malformed The malformed brace string under test.
+	 *
+	 * @return void
+	 */
+	public function testRenderMeasureRangeFailsOpenForMalformedAlias( string $malformed ): void {
+		$this->css->render_measure_range(
+			[ 'borderWidth' => [ $malformed, $malformed, $malformed, $malformed ] ],
+			'borderWidth',
+			'border-width'
+		);
+		$output = $this->css->css_output();
+
+		$this->assertSame( '', $output,
+			'render_measure_range must add no declaration for any side when nothing is numeric or a strict alias' );
+	}
+
+	/**
+	 * The fail-open matrix for render_border_radius: a malformed brace string on every corner
+	 * adds no declaration, since it is neither numeric nor a strict alias.
+	 *
+	 * @dataProvider malformedAliasProvider
+	 *
+	 * @param string $malformed The malformed brace string under test.
+	 *
+	 * @return void
+	 */
+	public function testRenderBorderRadiusFailsOpenForMalformedAlias( string $malformed ): void {
+		$this->css->render_border_radius( [ 'borderRadius' => [ $malformed, $malformed, $malformed, $malformed ] ] );
+		$output = $this->css->css_output();
+
+		$this->assertSame( '', $output,
+			'render_border_radius must add no declaration for any corner when nothing is numeric or a strict alias' );
+	}
+
+	/**
+	 * The fail-open matrix for render_responsive_range: a malformed brace string on every
+	 * breakpoint adds no declaration, since it is neither numeric nor a strict alias.
+	 *
+	 * @dataProvider malformedAliasProvider
+	 *
+	 * @param string $malformed The malformed brace string under test.
+	 *
+	 * @return void
+	 */
+	public function testRenderResponsiveRangeFailsOpenForMalformedAlias( string $malformed ): void {
+		$this->css->render_responsive_range(
+			[
+				'spacing'     => [ $malformed, $malformed, $malformed ],
+				'spacingType' => 'px',
+			],
+			'spacing',
+			'margin'
+		);
+		$output = $this->css->css_output();
+
+		$this->assertSame( '', $output,
+			'render_responsive_range must add no declaration for any breakpoint when nothing is numeric or a strict alias' );
+	}
+
+	/**
+	 * The fail-open matrix for render_shadow: a malformed, non-empty brace string in hOffset is
+	 * not a strict alias, so the `!empty()` gate passes it through literally with its unit
+	 * suffix, the method's normal literal-passthrough result.
+	 *
+	 * @dataProvider malformedAliasProvider
+	 *
+	 * @param string $malformed The malformed brace string under test.
+	 *
+	 * @return void
+	 */
+	public function testRenderShadowFailsOpenForMalformedAlias( string $malformed ): void {
+		$actual = $this->css->render_shadow( [
+			'color'   => '#000000',
+			'opacity' => 1,
+			'spread'  => 2,
+			'blur'    => 4,
+			'hOffset' => $malformed,
+			'vOffset' => 1,
+			'inset'   => false,
+		] );
+
+		$this->assertSame( $malformed . 'px 1px 4px 2px #000000', $actual,
+			'render_shadow must pass a malformed brace hOffset through literally with its unit suffix' );
+		$this->assertStringNotContainsString( '--kb-token--', $actual,
+			'render_shadow must not mint a var() from a malformed brace string' );
+	}
+
+	/**
+	 * The fail-open matrix for render_typography: a malformed, non-empty brace string in
+	 * line-height passes through literally under its `!empty()` gate, while the same string in
+	 * letter-spacing is rejected outright by its `is_numeric()` gate and adds no declaration.
+	 *
+	 * @dataProvider malformedAliasProvider
+	 *
+	 * @param string $malformed The malformed brace string under test.
+	 *
+	 * @return void
+	 */
+	public function testRenderTypographyFailsOpenForMalformedAlias( string $malformed ): void {
+		$this->css->render_typography( [
+			'typography' => [
+				'lineType'      => 'px',
+				'lineHeight'    => [ $malformed, '', '' ],
+				'letterSpacing' => [ $malformed, '', '' ],
+			],
+		] );
+		$output = $this->css->css_output();
+
+		$this->assertStringContainsString( 'line-height:' . $malformed . 'px', $output,
+			'render_typography must pass a malformed brace line-height through literally under its !empty() gate' );
+		$this->assertStringNotContainsString( 'letter-spacing:', $output,
+			'render_typography must reject a malformed brace letter-spacing outright under its is_numeric() gate' );
+		$this->assertStringNotContainsString( '--kb-token--', $output,
+			'render_typography must not mint a var() from a malformed brace string' );
+	}
+
+	/**
+	 * Provides the malformed brace strings crossed against the representative methods: a
+	 * space inside the braces (loose-looks-like but strict-rejected), an unclosed brace, an
+	 * unopened brace, and empty braces.
+	 *
+	 * @return Generator
+	 */
+	public static function malformedAliasProvider(): Generator {
+		yield 'space inside braces' => [ 'malformed' => '{bad path}' ];
+		yield 'unclosed brace' => [ 'malformed' => '{unclosed' ];
+		yield 'unopened brace' => [ 'malformed' => 'unopened}' ];
+		yield 'empty braces' => [ 'malformed' => '{}' ];
+	}
 }

--- a/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
+++ b/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
@@ -234,16 +234,13 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	 * @return void
 	 */
 	public function testRenderRangeFailsOpenForMalformedAlias( string $malformed ): void {
+		$baseline = $this->css->css_output();
 		$actual = $this->css->render_range( [ 'width' => $malformed ], 'width', 'width', 'px' );
 		$output = $this->css->css_output();
 
 		$this->assertSame( false, $actual,
 			'render_range must return its own normal false result for an unusable value' );
-		$this->assertStringNotContainsString( 'var(', $output,
-			'render_range must not mint a var() from a malformed brace string' );
-		$this->assertStringNotContainsString( '--kb-token--', $output,
-			'render_range must not mint a var() from a malformed brace string' );
-		$this->assertStringNotContainsString( 'width:', $output,
+		$this->assertSame( $baseline, $output,
 			'render_range must add no declaration for an unusable value' );
 	}
 

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/AliasConformanceTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/AliasConformanceTest.php
@@ -1,0 +1,164 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Schema\Vocabulary;
+
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Proves the PHP alias->var() transform stays byte-identical to the JS one by asserting against the
+ * SAME fixture the jest suite reads (never a forked copy). A drift in `Alias::is_alias()`,
+ * `Alias::path_of()`, or `Css_Var::from_id()` on the PHP side, or in `resolveTokenAlias()` on the JS
+ * side, fails whichever suite still expects the old string.
+ *
+ * @since TBD
+ */
+final class AliasConformanceTest extends TestCase {
+
+	/**
+	 * Every alias entry in the shared conformance fixture is recognized by the strict predicate and
+	 * resolves, through `Alias::path_of()` + `Css_Var::from_id()`, to the exact `var()` string the JS
+	 * suite also asserts for that entry.
+	 *
+	 * @dataProvider aliasProvider
+	 *
+	 * @param string $alias   The alias string, e.g. "{semantic.radius.media}".
+	 * @param string $css_var The expected "var(--kb-token--<id>)" string.
+	 *
+	 * @return void
+	 */
+	public function testAliasesResolveToTheExpectedCssVar( string $alias, string $css_var ): void {
+		$this->assertTrue( Alias::is_alias( $alias ) );
+		$this->assertSame( $css_var, 'var(' . Css_Var::from_id( Alias::path_of( $alias ) ) . ')' );
+	}
+
+	/**
+	 * Every nonAlias entry in the shared conformance fixture is rejected by the strict predicate, so no
+	 * render path ever mints a `var()` from it.
+	 *
+	 * @dataProvider nonAliasProvider
+	 *
+	 * @param mixed $non_alias A value the fixture asserts is not a well-formed alias.
+	 *
+	 * @return void
+	 */
+	public function testNonAliasesAreRejected( $non_alias ): void {
+		$this->assertFalse( Alias::is_alias( $non_alias ) );
+	}
+
+	/**
+	 * A braced-but-malformed string (a fumbled alias attempt) is caught by the loose predicate but
+	 * still rejected by the strict one — the fail-open seam this ticket pins.
+	 *
+	 * @dataProvider braceButMalformedProvider
+	 *
+	 * @param string $value A braced-but-malformed value from the shared conformance fixture.
+	 *
+	 * @return void
+	 */
+	public function testBracedButMalformedValuesAreLooseButNotStrict( string $value ): void {
+		$this->assertTrue( Alias::looks_like_alias( $value ) );
+		$this->assertFalse( Alias::is_alias( $value ) );
+	}
+
+	/**
+	 * A plain, unbraced literal is rejected by both the strict and the loose predicate. The JS pattern
+	 * (`/^\{[\w.-]+\}$/`) has no loose counterpart at all, so a plain literal is simply never a
+	 * candidate in either language.
+	 *
+	 * @dataProvider plainLiteralProvider
+	 *
+	 * @param string $value A plain, unbraced literal from the shared conformance fixture.
+	 *
+	 * @return void
+	 */
+	public function testPlainLiteralsAreRejectedByBothPredicates( string $value ): void {
+		$this->assertFalse( Alias::is_alias( $value ) );
+		$this->assertFalse( Alias::looks_like_alias( $value ) );
+	}
+
+	/**
+	 * Guards against a truncated fixture: both sections must actually contain cases, or the parity
+	 * assertions above would pass vacuously.
+	 *
+	 * @return void
+	 */
+	public function testBothFixtureSectionsAreNonEmpty(): void {
+		$fixture = $this->load_fixture();
+
+		$this->assertNotEmpty( $fixture['aliases'] );
+		$this->assertNotEmpty( $fixture['nonAliases'] );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function aliasProvider(): Generator {
+		foreach ( $this->load_fixture()['aliases'] as $entry ) {
+			yield $entry['alias'] => [
+				'alias'   => $entry['alias'],
+				'css_var' => $entry['cssVar'],
+			];
+		}
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function nonAliasProvider(): Generator {
+		foreach ( $this->load_fixture()['nonAliases'] as $index => $non_alias ) {
+			yield sprintf( 'nonAliases[%d]: %s', $index, wp_json_encode( $non_alias ) ) => [
+				'non_alias' => $non_alias,
+			];
+		}
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function braceButMalformedProvider(): Generator {
+		foreach ( $this->load_fixture()['nonAliases'] as $value ) {
+			if ( ! is_string( $value ) || ( strpos( $value, '{' ) === false && strpos( $value, '}' ) === false ) ) {
+				continue;
+			}
+
+			yield $value => [ 'value' => $value ];
+		}
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function plainLiteralProvider(): Generator {
+		foreach ( $this->load_fixture()['nonAliases'] as $value ) {
+			if ( ! is_string( $value ) || $value === '' || strpos( $value, '{' ) !== false || strpos( $value, '}' ) !== false ) {
+				continue;
+			}
+
+			yield $value => [ 'value' => $value ];
+		}
+	}
+
+	/**
+	 * The shared alias/cssVar conformance fixture, decoded. The SAME file the jest suite reads, so
+	 * neither language can drift without both suites' data changing together.
+	 *
+	 * @return array{aliases: array<int, array{alias: string, cssVar: string}>, nonAliases: array<int, mixed>}
+	 */
+	private function load_fixture(): array {
+		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		return (array) json_decode( (string) file_get_contents( $this->fixture_path() ), true );
+	}
+
+	/**
+	 * Absolute path to the shared conformance fixture, derived from the plugin root so it resolves the
+	 * same way regardless of which working directory slic runs the suite from.
+	 *
+	 * @return string
+	 */
+	private function fixture_path(): string {
+		return KADENCE_BLOCKS_PATH . 'src/extension/design-tokens/__tests__/fixtures/token-alias-conformance.json';
+	}
+}


### PR DESCRIPTION
## Summary
- The design-token alias recognizer now has a full test contract, so an authored `{dot.alias}` reference resolves the same way in the editor and on the front end.
- One shared JSON fixture is the executable contract for both the PHP (wpunit) and JS (jest) suites — a one-character drift in an expected CSS variable fails both languages, not just one.
- Byte-identical backward-compatibility snapshots pin every relaxed `render_*` method: for any non-alias (numeric or literal) input, the output is byte-for-byte the same as its pre-recognizer behavior.
- The positive and negative halves of the render-site contract are covered at the real render sites: a strict alias emits the exact bare `var(--kb-token--<id>)`, and a malformed brace string never mints a `var()` or reaches numeric handling as if it were an alias (fail-open).
- The phpcs CI workflow falls back to the PR's current base ref when `GITHUB_BASE_REF` is stale, so the check stops failing on stacked PRs.
- Tests and CI only — no shipped plugin code changes.

## PRs included
- #1188 — shared PHP↔JS conformance fixture parity (`AliasConformanceTest`)
- #1189 — byte-identical BC snapshots for the `render_*` methods
- #1190 — strict-alias emission + malformed-brace fail-open matrix

## Test plan
- [x] PHPStan clean
- [x] Full wpunit/JS suites pass (`AliasConformanceTest` 28, `KadenceBlocksCssBcSnapshotTest` 45, `KadenceBlocksCssTokenEmissionTest` 71; `bun run test` green)
