### PR TITLE
fix: Improve type handling and return values

### DIFF
--- a/includes/blocks/class-kadence-blocks-abstract-block.php
+++ b/includes/blocks/class-kadence-blocks-abstract-block.php
@@ -258,7 +258,7 @@ class Kadence_Blocks_Abstract_Block {
 	 *
 	 * @since 3.7.8.1 Normalize the unique id before use.
 	 *
-	 * @param array    $attributes the blocks attribtues.
+	 * @param array    $attributes The blocks attributes.
 	 * @param string   $content the blocks content.
 	 * @param WP_Block $block_instance The instance of the WP_Block class that represents the block being rendered.
 	 */
@@ -294,7 +294,7 @@ class Kadence_Blocks_Abstract_Block {
 					$this->do_inline_styles( $content, $unique_style_id, $css );
 				}
 			} elseif ( ! wp_is_block_theme() && ! $css_class->has_header_styles( 'kb-' . $this->block_name . $unique_style_id ) && ! is_feed() && apply_filters( 'kadence_blocks_render_inline_css', true, $this->block_name, $unique_id ) ) {
-				// Some plugins run render block without outputing the content, this makes it so css can be rebuilt.
+				// Some plugins run render block without outputting the content, this makes it so css can be rebuilt.
 				$css = $this->build_css( $attributes, $css_class, $unique_id, $unique_style_id );
 				if ( ! empty( $css ) ) {
 					$this->do_inline_styles( $content, $unique_style_id, $css );
@@ -386,8 +386,8 @@ class Kadence_Blocks_Abstract_Block {
 	 * If the tag provided isn't allowed, return the default value.
 	 *
 	 * @param array  $attributes Array of the blocks attributes.
-	 * @param string $tag_key Offest on $attributes where the tag is set.
-	 * @param string $default Default tag to use if $tag_key attribue is undefined or invalid.
+	 * @param string $tag_key Offset on $attributes where the tag is set.
+	 * @param string $default Default tag to use if $tag_key attribute is undefined or invalid.
 	 * @param array  $allowed_tags Array of allowed tags.
 	 * @param string $level_key If defined, we'll assume heading tags are allowed.
 	 *
@@ -540,7 +540,7 @@ class Kadence_Blocks_Abstract_Block {
 	}
 
 	/**
-	 * Retuurn if this block should register itself. (can override for things like blocks in two plugins)
+	 * Return if this block should register itself. (can override for things like blocks in two plugins)
 	 *
 	 * @return boolean
 	 */

--- a/includes/blocks/class-kadence-blocks-abstract-block.php
+++ b/includes/blocks/class-kadence-blocks-abstract-block.php
@@ -567,7 +567,7 @@ class Kadence_Blocks_Abstract_Block {
 	 * @return string
 	 */
 	protected function sanitize_unique_id( $unique_id ) {
-		return preg_replace( '/[^A-Za-z0-9_-]/', '', str_replace( '/', '-', (string) $unique_id ) );
+		return (string) preg_replace( '/[^A-Za-z0-9_-]/', '', str_replace( '/', '-', (string) $unique_id ) );
 	}
 
 	/**

--- a/includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+++ b/includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
@@ -156,23 +156,27 @@ class Kadence_Blocks_Advanced_Form_Input_Block extends Kadence_Blocks_Abstract_B
 	/**
 	 * Add the field name to the HTML response.
 	 *
-	 * @param array $attributes The block attributes.
+	 * @param array<string, mixed> $attributes The block attributes.
 	 *
 	 * @return string
 	 */
 	public function field_name( $attributes ) {
-		return strval( ! empty( $attributes['inputName'] ) ? $attributes['inputName'] : 'field' . $attributes['uniqueID'] );
+		$name = ! empty( $attributes['inputName'] ) ? $attributes['inputName'] : 'field' . $attributes['uniqueID'];
+
+		return is_scalar( $name ) ? strval( $name ) : '';
 	}
 	/**
 	 * Add the field name to the HTML response.
 	 *
-	 * @param array $attributes The block attributes.
+	 * @param array<string, mixed> $attributes The block attributes.
 	 *
 	 * @return string
 	 */
 	public function field_id( $attributes ) {
 		$form_id = ! empty( $attributes['formID'] ) ? $attributes['formID'] : '';
-		return strval( ! empty( $attributes['anchor'] ) ? $attributes['anchor'] : 'field' . $form_id . $attributes['uniqueID'] );
+		$id      = ! empty( $attributes['anchor'] ) ? $attributes['anchor'] : 'field' . $form_id . $attributes['uniqueID'];
+
+		return is_scalar( $id ) ? strval( $id ) : '';
 	}
 	/**
 	 * Add the field wrapper class ID.

--- a/includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+++ b/includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
@@ -3,6 +3,8 @@
  * Class to Build the Advanced Form Block.
  *
  * @package Kadence Blocks
+ *
+ * cSpell:ignore unslash
  */
 
 // Exit if accessed directly.
@@ -154,7 +156,7 @@ class Kadence_Blocks_Advanced_Form_Input_Block extends Kadence_Blocks_Abstract_B
 	/**
 	 * Add the field name to the HTML response.
 	 *
-	 * @param $attributes array
+	 * @param array $attributes The block attributes.
 	 *
 	 * @return string
 	 */
@@ -164,7 +166,7 @@ class Kadence_Blocks_Advanced_Form_Input_Block extends Kadence_Blocks_Abstract_B
 	/**
 	 * Add the field name to the HTML response.
 	 *
-	 * @param $attributes array
+	 * @param array $attributes The block attributes.
 	 *
 	 * @return string
 	 */

--- a/includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
+++ b/includes/blocks/form/class-kadence-blocks-advanced-form-input-block.php
@@ -156,21 +156,21 @@ class Kadence_Blocks_Advanced_Form_Input_Block extends Kadence_Blocks_Abstract_B
 	 *
 	 * @param $attributes array
 	 *
-	 * @return void
+	 * @return string
 	 */
 	public function field_name( $attributes ) {
-		return ! empty( $attributes['inputName'] ) ? $attributes['inputName'] : 'field' . $attributes['uniqueID'];
+		return strval( ! empty( $attributes['inputName'] ) ? $attributes['inputName'] : 'field' . $attributes['uniqueID'] );
 	}
 	/**
 	 * Add the field name to the HTML response.
 	 *
 	 * @param $attributes array
 	 *
-	 * @return void
+	 * @return string
 	 */
 	public function field_id( $attributes ) {
 		$form_id = ! empty( $attributes['formID'] ) ? $attributes['formID'] : '';
-		return ! empty( $attributes['anchor'] ) ? $attributes['anchor'] : 'field' . $form_id . $attributes['uniqueID'];
+		return strval( ! empty( $attributes['anchor'] ) ? $attributes['anchor'] : 'field' . $form_id . $attributes['uniqueID'] );
 	}
 	/**
 	 * Add the field wrapper class ID.

--- a/includes/class-kadence-blocks-prebuilt-library-rest-api.php
+++ b/includes/class-kadence-blocks-prebuilt-library-rest-api.php
@@ -1411,7 +1411,7 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 			} else {
 				$endpoint = '/wp-json/kadence-cloud/v1/single/';
 			}
-			$library_url = $this->resolve_library_url( $library_url, $endpoint );
+			$library_url = $this->resolve_library_url( is_string( $library_url ) ? $library_url : '', $endpoint );
 			if ( empty( $library_url ) ) {
 				return rest_ensure_response( new WP_Error( 'invalid_request', __( 'Invalid Request, Unknown Library', 'kadence-blocks' ), [ 'status' => 400 ] ) );
 			}
@@ -1493,7 +1493,7 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 	 * @since 3.7.8.1 Restrict requests to known library locations.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response Response object on success, or WP_Error object on failure.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_connection( WP_REST_Request $request ) {
 		$library     = $request->get_param( self::PROP_LIBRARY );
@@ -1554,7 +1554,7 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 	 * @since 3.7.8.1 Restrict requests to known library locations.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response Response object on success, or WP_Error object on failure.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_library_categories( WP_REST_Request $request ) {
 		$this->get_license_keys();
@@ -1566,7 +1566,7 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 
 		if ( ! empty( $library_url ) ) {
 			$endpoint    = ! empty( $meta ) && 'pages' === $meta ? '/wp-json/kadence-cloud/v1/page-categories/' : '/wp-json/kadence-cloud/v1/categories/';
-			$library_url = $this->resolve_library_url( $library_url, $endpoint );
+			$library_url = $this->resolve_library_url( is_string( $library_url ) ? $library_url : '', $endpoint );
 			if ( empty( $library_url ) ) {
 				return rest_ensure_response( new WP_Error( 'invalid_request', __( 'Invalid Request, Unknown Library', 'kadence-blocks' ), [ 'status' => 400 ] ) );
 			}
@@ -1665,7 +1665,7 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 	 * @since 3.7.8.1 Restrict requests to known library locations.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response Response object on success, or WP_Error object on failure.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_library( WP_REST_Request $request ) {
 		$this->get_license_keys();
@@ -1677,7 +1677,7 @@ class Kadence_Blocks_Prebuilt_Library_REST_Controller extends WP_REST_Controller
 
 		if ( ! empty( $library_url ) ) {
 			$endpoint    = ! empty( $meta ) && 'pages' === $meta ? '/wp-json/kadence-cloud/v1/pages/' : '/wp-json/kadence-cloud/v1/get/';
-			$library_url = $this->resolve_library_url( $library_url, $endpoint );
+			$library_url = $this->resolve_library_url( is_string( $library_url ) ? $library_url : '', $endpoint );
 			if ( empty( $library_url ) ) {
 				return rest_ensure_response( new WP_Error( 'invalid_request', __( 'Invalid Request, Unknown Library', 'kadence-blocks' ), [ 'status' => 400 ] ) );
 			}

--- a/includes/resources/Traits/API_Url_Trait.php
+++ b/includes/resources/Traits/API_Url_Trait.php
@@ -143,14 +143,17 @@ trait API_Url_Trait {
 	 * @return string[]
 	 */
 	protected function get_saved_library_urls(): array {
-		$settings = json_decode( (string) get_option( 'kadence_blocks_cloud' ), true );
+		$stored   = get_option( 'kadence_blocks_cloud' );
+		$settings = is_string( $stored ) ? json_decode( $stored, true ) : null;
 		$urls     = [];
 
-		if ( ! empty( $settings['connections'] ) && is_array( $settings['connections'] ) ) {
-			foreach ( $settings['connections'] as $connection ) {
-				if ( ! empty( $connection['url'] ) ) {
-					$urls[] = rtrim( (string) $connection['url'], '/' );
-				}
+		if ( ! is_array( $settings ) || empty( $settings['connections'] ) || ! is_array( $settings['connections'] ) ) {
+			return $urls;
+		}
+
+		foreach ( $settings['connections'] as $connection ) {
+			if ( is_array( $connection ) && ! empty( $connection['url'] ) && is_scalar( $connection['url'] ) ) {
+				$urls[] = rtrim( (string) $connection['url'], '/' );
 			}
 		}
 

--- a/includes/resources/Traits/API_Url_Trait.php
+++ b/includes/resources/Traits/API_Url_Trait.php
@@ -147,13 +147,11 @@ trait API_Url_Trait {
 		$settings = is_string( $stored ) ? json_decode( $stored, true ) : null;
 		$urls     = [];
 
-		if ( ! is_array( $settings ) || empty( $settings['connections'] ) || ! is_array( $settings['connections'] ) ) {
-			return $urls;
-		}
-
-		foreach ( $settings['connections'] as $connection ) {
-			if ( is_array( $connection ) && ! empty( $connection['url'] ) && is_scalar( $connection['url'] ) ) {
-				$urls[] = rtrim( (string) $connection['url'], '/' );
+		if ( is_array( $settings ) && ! empty( $settings['connections'] ) && is_array( $settings['connections'] ) ) {
+			foreach ( $settings['connections'] as $connection ) {
+				if ( ! empty( $connection['url'] ) ) {
+					$urls[] = rtrim( (string) $connection['url'], '/' );
+				}
 			}
 		}
 

--- a/includes/resources/Traits/API_Url_Trait.php
+++ b/includes/resources/Traits/API_Url_Trait.php
@@ -149,7 +149,7 @@ trait API_Url_Trait {
 
 		if ( is_array( $settings ) && ! empty( $settings['connections'] ) && is_array( $settings['connections'] ) ) {
 			foreach ( $settings['connections'] as $connection ) {
-				if ( ! empty( $connection['url'] ) ) {
+				if ( is_array( $connection ) && ! empty( $connection['url'] ) ) {
 					$urls[] = rtrim( (string) $connection['url'], '/' );
 				}
 			}

--- a/includes/resources/Traits/Rest/Image_Trait.php
+++ b/includes/resources/Traits/Rest/Image_Trait.php
@@ -6,6 +6,8 @@ namespace KadenceWP\KadenceBlocks\Traits\Rest;
  * Shared image related functionality for REST controllers.
  *
  * @mixin \WP_REST_Controller
+ *
+ * cSpell:ignore absint
  */
 trait Image_Trait {
 

--- a/includes/resources/Traits/Rest/Image_Trait.php
+++ b/includes/resources/Traits/Rest/Image_Trait.php
@@ -19,15 +19,21 @@ trait Image_Trait {
 	public function sanitize_image_sizes_array( $sizes ): array {
 		$new_sizes = [];
 
-		if ( ! empty( $sizes ) || ! is_array( $sizes ) ) {
-			foreach ( $sizes as $value ) {
-				$new_sizes[] = [
-					'id'     => sanitize_text_field( $value['id'] ),
-					'width'  => absint( $value['width'] ),
-					'height' => absint( $value['height'] ),
-					'crop'   => filter_var( $value['crop'], FILTER_VALIDATE_BOOLEAN ),
-				];
+		if ( ! is_array( $sizes ) ) {
+			return $new_sizes;
+		}
+
+		foreach ( $sizes as $value ) {
+			if ( ! is_array( $value ) ) {
+				continue;
 			}
+
+			$new_sizes[] = [
+				'id'     => sanitize_text_field( $value['id'] ),
+				'width'  => absint( $value['width'] ),
+				'height' => absint( $value['height'] ),
+				'crop'   => filter_var( $value['crop'], FILTER_VALIDATE_BOOLEAN ),
+			];
 		}
 
 		return $new_sizes;


### PR DESCRIPTION
🎫  

This PR fixes the PHPStan errors on `release/M26.lanturn` that were introduced on latest releases.

Detailed breakdown:
- Correct the parameter and return docblocks on `field_name()` and `field_id()` in the advanced form input block, and cast their return value to a string. The false `@return void` was surfacing as errors in the blocks that consume them.
- Cast the `sanitize_unique_id()` return value to a string in the abstract block, and fix a few typos in its docblocks.
- Narrow the `library_url` request value to a string before passing it into typed methods in the prebuilt library REST API. No behaviour change.
- Check the stored option shape before reading it in `API_Url_Trait::get_saved_library_urls()`.
- Correct the array check in `Image_Trait::sanitize_image_sizes_array()` so non-array input is skipped instead of looped over.
- Adjust docblocks to the correct response types.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.