### PR TITLE
[DTM] SOFT-3906: per-corner preset values + the save-as-preset 422

### DIFF
--- a/includes/resources/Design_Tokens/Editor/Preset_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Preset_Catalog.php
@@ -202,13 +202,18 @@ final class Preset_Catalog {
 	 * cannot compare against a `var()` chain. A preset whose resolution fails (undefined in this library) is
 	 * skipped, so one bad preset never empties the map.
 	 *
+	 * A dimension property whose preset stores per-corner values carries the corners as a list rather than
+	 * a joined string, so the editor's compare and the control's inherited-default display read each corner
+	 * on its own — a joined shorthand is not parseable as a single length.
+	 *
 	 * @since TBD
 	 *
 	 * @param string   $block The block name.
 	 * @param string   $slug  The token library slug.
 	 * @param string[] $names The preset slugs to resolve, in catalog order.
 	 *
-	 * @return array<string, array<string, string>> preset slug => ( property => literal value ).
+	 * @return array<string, array<string, string|string[]>> preset slug => ( property => literal value or
+	 *                                                       per-corner slot list ).
 	 */
 	private function values_for( string $block, string $slug, array $names ): array {
 		$values = [];

--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
@@ -213,14 +213,18 @@ final class Css_Builder {
 
 				$prop = $binding->css_prop();
 
-				if ( $prop === null || $value === '' ) {
+				// A per-corner slot list is a CSS shorthand here — this is a css-emitting surface, so the
+				// corners join into one declaration value (the resolver keeps them apart for the editor).
+				$literal = is_array( $value ) ? implode( ' ', $value ) : $value;
+
+				if ( $prop === null || $literal === '' ) {
 					continue;
 				}
 
 				$var      = $this->registry->css_var_for( (string) $binding->token );
 				$suffix   = $this->selector_suffix( $binding->css_selector() );
 
-				$by_suffix[ $suffix ][] = $prop . ':var(' . $var . ',' . $this->sanitize_value( $value ) . ')';
+				$by_suffix[ $suffix ][] = $prop . ':var(' . $var . ',' . $this->sanitize_value( $literal ) . ')';
 			}
 
 			foreach ( $by_suffix as $suffix => $declarations ) {

--- a/includes/resources/Design_Tokens/Registry/Preset_Bindings.php
+++ b/includes/resources/Design_Tokens/Registry/Preset_Bindings.php
@@ -35,6 +35,34 @@ use InvalidArgumentException;
 final class Preset_Bindings {
 
 	/**
+	 * The coarse input kind for a length-valued property — the only kind a per-corner slot list is
+	 * meaningful for.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const KIND_DIMENSION = 'dimension';
+
+	/**
+	 * The coarse input kind for a color-valued property.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const KIND_COLOR = 'color';
+
+	/**
+	 * The fallback kind for a property that classifies as neither a dimension nor a color.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const KIND_TEXT = 'text';
+
+	/**
 	 * The block name, e.g. "kadence/advancedbtn".
 	 *
 	 * @since TBD
@@ -183,6 +211,18 @@ final class Preset_Bindings {
 	}
 
 	/**
+	 * The coarse input kind for a length-valued property, the one kind a per-corner slot list is valid
+	 * for. Read by the REST write guard, which cannot compare against the constant directly.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_kind_dimension(): string {
+		return self::KIND_DIMENSION;
+	}
+
+	/**
 	 * A coarse input kind for a bound property — "color", "dimension" or "text" — so the editor's preset
 	 * form can render the right control per property. Read from the referenced token's group segment when the
 	 * binding is a token reference (e.g. `semantic.radius.media` => "dimension"), otherwise inferred from the
@@ -208,7 +248,7 @@ final class Preset_Bindings {
 
 		$by_name = self::classify( $property );
 
-		return $by_name !== '' ? $by_name : 'text';
+		return $by_name !== '' ? $by_name : self::KIND_TEXT;
 	}
 
 	/**
@@ -262,13 +302,13 @@ final class Preset_Bindings {
 
 		foreach ( [ 'radius', 'width', 'gap', 'spacing', 'space', 'size', 'height', 'dimension' ] as $needle ) {
 			if ( strpos( $term, $needle ) !== false ) {
-				return 'dimension';
+				return self::KIND_DIMENSION;
 			}
 		}
 
 		foreach ( [ 'color', 'bg', 'background', 'text', 'border', 'fill', 'stroke' ] as $needle ) {
 			if ( strpos( $term, $needle ) !== false ) {
-				return 'color';
+				return self::KIND_COLOR;
 			}
 		}
 

--- a/includes/resources/Design_Tokens/Resolver/Preset_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Preset_Resolver.php
@@ -136,7 +136,8 @@ final class Preset_Resolver {
 	 *
 	 * @throws Unknown_Preset_Exception When the block or preset is not defined.
 	 *
-	 * @return array<string, string> property => flattened literal CSS value.
+	 * @return array<string, string|string[]> property => flattened literal CSS value, or the per-corner
+	 *                                        slot list when the preset stores one.
 	 */
 	public function resolve_literal( string $block, string $preset, string $slug = 'default' ): array {
 		$tokens   = $this->preset_tokens( $block, $preset, $slug );
@@ -172,7 +173,8 @@ final class Preset_Resolver {
 	 *
 	 * @throws Unknown_Preset_Exception When the block is not defined or declares no default.
 	 *
-	 * @return array<string, string> property => flattened literal CSS value.
+	 * @return array<string, string|string[]> property => flattened literal CSS value, or the per-corner
+	 *                                        slot list when the preset stores one.
 	 */
 	public function resolve_default( string $block, string $slug = 'default' ): array {
 		return $this->resolve_literal( $block, $this->default_preset( $block, $slug ), $slug );
@@ -310,14 +312,19 @@ final class Preset_Resolver {
 	 * Flatten one binding value: an alias is looked up in the resolved id map; a scalar literal passes
 	 * through. Anything else (or an unresolvable alias) yields null so the property is dropped.
 	 *
+	 * A per-corner slot list flattens slot by slot and STAYS a list — it is deliberately not joined here.
+	 * flatten() feeds the editor and admin surfaces through resolve_literal(), and those read a dimension
+	 * corner by corner; a pre-joined "8px 4px 8px 4px" is not parseable as a single length and would read
+	 * back as one opaque literal. Joining is the css-emitting caller's job, in project().
+	 *
 	 * @since TBD
 	 *
-	 * @param mixed           $value    The raw binding value (alias string or literal).
+	 * @param mixed           $value    The raw binding value (alias string, literal, or slot list).
 	 * @param Resolved_Tokens $resolved The resolved token maps.
 	 *
-	 * @return string|null
+	 * @return string|string[]|null
 	 */
-	private function flatten( $value, Resolved_Tokens $resolved ): ?string {
+	private function flatten( $value, Resolved_Tokens $resolved ) {
 		if ( is_string( $value ) ) {
 			return Alias::is_alias( $value ) ? $resolved->value( Alias::path_of( $value ) ) : $value;
 		}
@@ -326,7 +333,42 @@ final class Preset_Resolver {
 			return (string) $value;
 		}
 
+		if ( is_array( $value ) ) {
+			return $this->flatten_slots( $value, $resolved );
+		}
+
 		return null;
+	}
+
+	/**
+	 * Flatten a per-corner slot list, or null when any slot fails to flatten.
+	 *
+	 * A single unresolvable slot drops the WHOLE property rather than emitting a partial shorthand: a
+	 * border-radius missing one corner is not a usable value, so failing the property is the same
+	 * fail-closed choice a scalar binding makes when its alias resolves to nothing.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<int|string, mixed> $slots    The raw slot list.
+	 * @param Resolved_Tokens          $resolved The resolved token maps.
+	 *
+	 * @return string[]|null
+	 */
+	private function flatten_slots( array $slots, Resolved_Tokens $resolved ): ?array {
+		$flat = [];
+
+		foreach ( $slots as $slot ) {
+			// Nested lists are rejected at validation; guard anyway so a hand-edited document fails closed.
+			$value = is_array( $slot ) ? null : $this->flatten( $slot, $resolved );
+
+			if ( ! is_string( $value ) ) {
+				return null;
+			}
+
+			$flat[] = $value;
+		}
+
+		return $flat === [] ? null : $flat;
 	}
 
 	/**
@@ -335,15 +377,29 @@ final class Preset_Resolver {
 	 * of flatten(), called only after flatten() has confirmed the value resolves, so the target var is
 	 * guaranteed to be emitted.
 	 *
+	 * A per-corner slot list projects each slot the same way and joins them with a space, yielding a CSS
+	 * shorthand (e.g. `var(--kb-token--…) 8px var(--kb-token--…) 8px`) that each aliased corner still
+	 * chains through, so a token edit reaches that corner live.
+	 *
 	 * @since TBD
 	 *
-	 * @param mixed $value The raw binding value (alias string or literal).
+	 * @param mixed $value The raw binding value (alias string, literal, or slot list).
 	 *
 	 * @return string
 	 */
 	private function project( $value ): string {
 		if ( is_string( $value ) && Alias::is_alias( $value ) ) {
 			return 'var(' . Css_Var::from_id( Alias::path_of( $value ) ) . ')';
+		}
+
+		if ( is_array( $value ) ) {
+			$projected = [];
+
+			foreach ( $value as $slot ) {
+				$projected[] = $this->project( $slot );
+			}
+
+			return implode( ' ', $projected );
 		}
 
 		return Cast::to_string( $value );

--- a/includes/resources/Design_Tokens/Resolver/Preset_Value_Normalizer.php
+++ b/includes/resources/Design_Tokens/Resolver/Preset_Value_Normalizer.php
@@ -68,15 +68,29 @@ final class Preset_Value_Normalizer {
 	 * The semantic alias for a captured value, or the value unchanged when it is already an alias, is not a
 	 * string, or matches no semantic.
 	 *
+	 * A per-corner slot list is matched slot by slot, so a corner captured as a literal re-joins the theming
+	 * cascade exactly as a scalar capture does. Without this a per-corner preset would be second-class:
+	 * frozen as literals while every scalar preset gets aliased.
+	 *
 	 * @since TBD
 	 *
 	 * @param string                  $property The property the value is set on, used to break ties.
-	 * @param mixed                   $value    The captured value (alias string or literal).
+	 * @param mixed                   $value    The captured value (alias string, literal, or slot list).
 	 * @param array<string, string[]> $index    The normalized-value => semantic-ids map.
 	 *
 	 * @return mixed The alias string when matched, otherwise the original value.
 	 */
 	private function alias_for( string $property, $value, array $index ) {
+		if ( is_array( $value ) ) {
+			$slots = [];
+
+			foreach ( $value as $key => $slot ) {
+				$slots[ $key ] = $this->alias_for( $property, $slot, $index );
+			}
+
+			return $slots;
+		}
+
 		if ( ! is_string( $value ) || Alias::is_alias( $value ) ) {
 			return $value;
 		}

--- a/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
@@ -5,6 +5,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Preset_Bindings;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Presets;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
@@ -475,6 +476,12 @@ final class Presets_Controller extends Controller {
 			return $error;
 		}
 
+		$error = $this->guard_slot_arrays( $block_node, $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
 		$slug       = $this->slug( $request );
 		$block_node = $this->normalize_block_node( $block_node, $slug );
 		$candidate  = $this->mutator->merge( $this->stored_document( $slug ), $this->partial( $block, $block_node ) );
@@ -530,6 +537,12 @@ final class Presets_Controller extends Controller {
 		}
 
 		$error = $this->guard_reserved_slugs( $block_node, $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$error = $this->guard_slot_arrays( $block_node, $block );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
@@ -996,6 +1009,60 @@ final class Presets_Controller extends Controller {
 						'status' => WP_Http::UNPROCESSABLE_ENTITY,
 						'block'  => $block,
 						'preset' => (string) $slug,
+					]
+				);
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Reject a per-corner slot list written to a property that is not a dimension.
+	 *
+	 * A slot list expresses the four sides of a measure control, so it is meaningful only where the bound
+	 * property is a dimension — a four-slot color says nothing. The DTCG validator cannot make this call:
+	 * it validates a preset token map by shape alone and never resolves the bound property's kind (the key
+	 * it walks is a property name like "button-radius", not a token id). The registry does know, so the
+	 * check lives here, alongside the other registry-aware guards.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $block_node The block's preset node being written.
+	 * @param string               $block      The block name, for error context.
+	 *
+	 * @return WP_Error|null A WP_Error when a slot list sits on a non-dimension property, null otherwise.
+	 */
+	private function guard_slot_arrays( array $block_node, string $block ): ?WP_Error {
+		$bindings = $this->registry->for_block( $block );
+
+		// An unregistered block is guard_block()'s error to report; nothing to check here.
+		if ( $bindings === null ) {
+			return null;
+		}
+
+		$tokens_key = Extensions::get_tokens_key();
+
+		foreach ( $block_node as $preset_slug => $preset ) {
+			if ( is_string( $preset_slug ) && strpos( $preset_slug, '$' ) === 0 ) {
+				continue;
+			}
+
+			$tokens = is_array( $preset ) && isset( $preset[ $tokens_key ] ) && is_array( $preset[ $tokens_key ] ) ? $preset[ $tokens_key ] : [];
+
+			foreach ( $tokens as $property => $value ) {
+				if ( ! is_array( $value ) || $bindings->kind( (string) $property ) === Preset_Bindings::get_kind_dimension() ) {
+					continue;
+				}
+
+				return new WP_Error(
+					'rest_design_tokens_invalid',
+					__( 'A per-corner value is only valid for a dimension property.', 'kadence-blocks' ),
+					[
+						'status'   => WP_Http::UNPROCESSABLE_ENTITY,
+						'block'    => $block,
+						'preset'   => (string) $preset_slug,
+						'property' => (string) $property,
 					]
 				);
 			}

--- a/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
@@ -1217,21 +1217,27 @@ final class Presets_Controller extends Controller {
 			$tokens = is_array( $preset ) && isset( $preset[ $tokens_key ] ) && is_array( $preset[ $tokens_key ] ) ? $preset[ $tokens_key ] : [];
 
 			foreach ( $tokens as $property => $value ) {
-				if ( ! Alias::is_alias( $value ) || $resolved->value( Alias::path_of( $value ) ) !== null ) {
-					continue;
-				}
+				// A per-corner slot list carries one alias per corner, so every slot is checked; otherwise a
+				// dangling corner would pass the write and silently drop the whole property at projection.
+				$candidates = is_array( $value ) ? $value : [ $value ];
 
-				return new WP_Error(
-					'rest_design_tokens_unresolvable',
-					__( 'A preset alias does not resolve to a token.', 'kadence-blocks' ),
-					[
-						'status'   => WP_Http::UNPROCESSABLE_ENTITY,
-						'block'    => $block,
-						'preset'   => (string) $preset_slug,
-						'property' => (string) $property,
-						'alias'    => $value,
-					]
-				);
+				foreach ( $candidates as $candidate ) {
+					if ( ! Alias::is_alias( $candidate ) || $resolved->value( Alias::path_of( $candidate ) ) !== null ) {
+						continue;
+					}
+
+					return new WP_Error(
+						'rest_design_tokens_unresolvable',
+						__( 'A preset alias does not resolve to a token.', 'kadence-blocks' ),
+						[
+							'status'   => WP_Http::UNPROCESSABLE_ENTITY,
+							'block'    => $block,
+							'preset'   => (string) $preset_slug,
+							'property' => (string) $property,
+							'alias'    => $candidate,
+						]
+					);
+				}
 			}
 		}
 

--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -757,8 +757,9 @@ final class Dtcg_Validator {
 	}
 
 	/**
-	 * Validate a per-corner slot list: exactly 1 slot (all corners) or 4 (top-left, top-right,
-	 * bottom-right, bottom-left), each an alias or a non-empty literal scalar. A slot is validated by the
+	 * Validate a per-corner slot list: exactly 4 slots (top-left, top-right, bottom-right, bottom-left),
+	 * each an alias or a non-empty literal scalar. "Every corner" is already expressed by a bare scalar, so
+	 * a shorter list would be a second spelling of the same thing. A slot is validated by the
 	 * same alias-or-literal rule as a scalar value, so "alias anywhere" stays one rule applied once; a
 	 * nested list is rejected because that rule accepts no array.
 	 *
@@ -772,15 +773,11 @@ final class Dtcg_Validator {
 	private function validate_extension_slots( array $slots, string $path ): ?Validation_Error {
 		$count = count( $slots );
 
-		if ( $count !== 1 && $count !== self::SLOT_LIST_SIDES ) {
+		if ( $count !== self::SLOT_LIST_SIDES ) {
 			return new Validation_Error(
 				$path,
 				Validation_Error::get_code_value_invalid(),
-				sprintf(
-					'A preset token slot list must hold exactly 1 or %d values, %d given.',
-					self::SLOT_LIST_SIDES,
-					$count
-				)
+				sprintf( 'A preset token slot list must hold exactly %d values, %d given.', self::SLOT_LIST_SIDES, $count )
 			);
 		}
 

--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -69,6 +69,16 @@ final class Dtcg_Validator {
 	private const CONTEXT_OVERRIDES = 'overrides';
 
 	/**
+	 * The side count of a per-corner preset token slot list, matching the 4-side measure attribute a
+	 * block stores (top-left, top-right, bottom-right, bottom-left).
+	 *
+	 * @since TBD
+	 *
+	 * @var int
+	 */
+	private const SLOT_LIST_SIDES = 4;
+
+	/**
 	 * Value validators keyed by $type.
 	 *
 	 * @since TBD
@@ -706,8 +716,10 @@ final class Dtcg_Validator {
 	}
 
 	/**
-	 * A foundation-preset / block-preset token value must be an alias or a non-empty literal scalar. The target token's
-	 * $type is not resolved here, so the literal is checked only for shape, not per-type grammar.
+	 * A foundation-preset / block-preset token value must be an alias, a non-empty literal scalar, or a
+	 * per-corner slot list. The target token's $type is not resolved here, so the literal is checked only
+	 * for shape, not per-type grammar; whether a slot list is meaningful for the bound property's kind is
+	 * a registry-aware question answered by the REST write guard, not by the schema.
 	 *
 	 * @since TBD
 	 *
@@ -733,11 +745,81 @@ final class Dtcg_Validator {
 			return null;
 		}
 
+		if ( is_array( $value ) && $this->is_list( $value ) ) {
+			return $this->validate_extension_slots( $value, $path );
+		}
+
 		return new Validation_Error(
 			$path,
 			Validation_Error::get_code_value_invalid(),
-			'A foundation-preset/block-preset token value must be an alias or a non-empty literal.'
+			'A foundation-preset/block-preset token value must be an alias, a non-empty literal, or a slot list.'
 		);
+	}
+
+	/**
+	 * Validate a per-corner slot list: exactly 1 slot (all corners) or 4 (top-left, top-right,
+	 * bottom-right, bottom-left), each an alias or a non-empty literal scalar. A slot is validated by the
+	 * same alias-or-literal rule as a scalar value, so "alias anywhere" stays one rule applied once; a
+	 * nested list is rejected because that rule accepts no array.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<int, mixed> $slots The slot list.
+	 * @param string            $path  Dot-path to the list.
+	 *
+	 * @return Validation_Error|null Null when valid.
+	 */
+	private function validate_extension_slots( array $slots, string $path ): ?Validation_Error {
+		$count = count( $slots );
+
+		if ( $count !== 1 && $count !== self::SLOT_LIST_SIDES ) {
+			return new Validation_Error(
+				$path,
+				Validation_Error::get_code_value_invalid(),
+				sprintf(
+					'A preset token slot list must hold exactly 1 or %d values, %d given.',
+					self::SLOT_LIST_SIDES,
+					$count
+				)
+			);
+		}
+
+		foreach ( $slots as $index => $slot ) {
+			if ( is_array( $slot ) ) {
+				return new Validation_Error(
+					$path . '.' . $index,
+					Validation_Error::get_code_value_invalid(),
+					'A preset token slot must be an alias or a non-empty literal, not a nested list.'
+				);
+			}
+
+			$error = $this->validate_extension_value( $slot, $path . '.' . $index );
+
+			if ( $error !== null ) {
+				return $error;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Whether an array is a list — sequential integer keys from zero. Hand-rolled because the plugin
+	 * supports PHP 7.4, where array_is_list() does not exist.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<int|string, mixed> $value The array to test.
+	 *
+	 * @return bool True when the array is a list.
+	 */
+	private function is_list( array $value ): bool {
+		// range( 0, -1 ) yields [ 0, -1 ], so the empty array is answered before the key compare.
+		if ( $value === [] ) {
+			return true;
+		}
+
+		return array_keys( $value ) === range( 0, count( $value ) - 1 );
 	}
 
 	/**

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -85,7 +85,11 @@ import { addFilter, applyFilters, doAction } from '@wordpress/hooks';
 import BackendStyles from './components/backend-styles';
 import { PresetButton } from '../../extension/preset-picker/PresetButton';
 import { usePresetBinding, resetAttr } from '../../extension/token-indicators';
-import { deriveMeasureMode, measureAttrsForDevice } from '../../extension/token-indicators/normalize';
+import {
+	deriveMeasureMode,
+	inheritedMeasureSlots,
+	measureAttrsForDevice,
+} from '../../extension/token-indicators/normalize';
 import { TokenLabel } from '../../extension/token-indicators/components/TokenLabel';
 import { TokenControlRow } from '../../extension/token-indicators/components/TokenControlRow';
 
@@ -277,6 +281,15 @@ export default function KadenceButtonEdit(props) {
 	// reset that clears the mapped attribute back to the preset value (served by the existing scoped CSS).
 	const tokenBinding = usePresetBinding('kadence/singlebtn', attributes);
 	const resetToken = (attr) => resetAttr(attr, setAttributes, tokenBinding[attr]?.kind);
+
+	// What an unset Border Radius corner falls back to on the active device: another breakpoint's corner
+	// before the preset's, matching the cascade the button actually renders through. The corners stay
+	// stored-empty — this only tells the field's popover which size is in effect and where it came from.
+	const inheritedBorderRadius = inheritedMeasureSlots(
+		previewDevice,
+		{ desktop: borderRadius, tablet: tabletBorderRadius },
+		tokenBinding.borderRadius?.presetValue
+	);
 
 	useEffect(() => {
 		setAttributes({ inQueryBlock: getInQueryBlock(context, inQueryBlock) });
@@ -1215,8 +1228,8 @@ export default function KadenceButtonEdit(props) {
 																context={{
 																	blockName: 'kadence/singlebtn',
 																	attribute: 'borderRadius',
-																	defaultValue:
-																		tokenBinding.borderRadius?.presetValue,
+																	defaultValue: inheritedBorderRadius.values,
+																	inheritedDefault: inheritedBorderRadius.inherited,
 																	unit: borderRadiusUnit,
 																	units: ['px', 'em', 'rem', '%'],
 																	onUnit: (value) =>
@@ -1233,6 +1246,13 @@ export default function KadenceButtonEdit(props) {
 																			? 0.1
 																			: 1,
 																}}
+																// The mode describes what THIS device stores, not what it
+																// inherits. A breakpoint that stores nothing has nothing
+																// that differs, so it reads as linked — deriving from the
+																// inherited corners instead would split an all-empty Tablet
+																// into four identical blank fields, showing a difference the
+																// user cannot see. Where the value comes from is surfaced by
+																// the field's popover, not by the link toggle.
 																control={
 																	borderRadiusModeOverride[previewDevice] ??
 																	deriveMeasureMode(
@@ -1242,14 +1262,31 @@ export default function KadenceButtonEdit(props) {
 																}
 																onChangeControl={(mode) => {
 																	if ('linked' === mode) {
+																		const corner =
+																			borderRadiusForDevice.value?.[0] ?? '';
+
+																		if ('' === corner) {
+																			// Nothing stored on this device, so there is
+																			// nothing to collapse — the corners are empty
+																			// because they inherit, and writing the
+																			// inherited value here would silently pin
+																			// Tablet/Mobile to Desktop's current radius.
+																			// Remember the choice instead, so the control
+																			// links without the corners leaving inherit.
+																			setBorderRadiusModeOverride((current) => ({
+																				...current,
+																				[previewDevice]: 'linked',
+																			}));
+
+																			return;
+																		}
+
 																		// Collapse to the top-left corner so the button
 																		// reflects the link immediately, and drop the
 																		// override so the derived mode (now all-equal)
 																		// reads as linked. Only the ACTIVE device's
 																		// attribute is written, so the other breakpoints
 																		// keep their own corners.
-																		const corner =
-																			borderRadiusForDevice.value?.[0] ?? '';
 																		setAttributes({
 																			[borderRadiusForDevice.attr]: [
 																				corner,

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -85,7 +85,7 @@ import { addFilter, applyFilters, doAction } from '@wordpress/hooks';
 import BackendStyles from './components/backend-styles';
 import { PresetButton } from '../../extension/preset-picker/PresetButton';
 import { usePresetBinding, resetAttr } from '../../extension/token-indicators';
-import { deriveMeasureMode } from '../../extension/token-indicators/normalize';
+import { deriveMeasureMode, measureAttrsForDevice } from '../../extension/token-indicators/normalize';
 import { TokenLabel } from '../../extension/token-indicators/components/TokenLabel';
 import { TokenControlRow } from '../../extension/token-indicators/components/TokenControlRow';
 
@@ -262,6 +262,14 @@ export default function KadenceButtonEdit(props) {
 		},
 		[clientId]
 	);
+	// The Border Radius control keeps ONE linked/individual mode but writes a different attribute per
+	// breakpoint, so the mode must be read from — and "link" must collapse — whichever device is active.
+	const borderRadiusForDevice = measureAttrsForDevice(
+		attributes,
+		'borderRadius',
+		{ tablet: 'tabletBorderRadius', mobile: 'mobileBorderRadius' },
+		previewDevice
+	);
 	const marginMouseOver = mouseOverVisualizer();
 	const paddingMouseOver = mouseOverVisualizer();
 
@@ -286,11 +294,13 @@ export default function KadenceButtonEdit(props) {
 	// linked), so no new attribute is needed and old buttons open in the right mode. This ephemeral
 	// override only records an explicit "unlink" of already-equal corners for the current session — it
 	// resets on remount, matching how the control's mode has always been session-local.
-	const [borderRadiusModeOverride, setBorderRadiusModeOverride] = useState(null);
+	// Keyed by device: the responsive control keeps ONE mode but writes three attributes, so a choice
+	// made on Tablet must not flip Desktop's corners (and vice versa).
+	const [borderRadiusModeOverride, setBorderRadiusModeOverride] = useState({});
 	// The override records a choice made about the PREVIOUS preset's corners, so selecting another preset
 	// drops it — otherwise an explicit "link" would stick and hide a new preset's per-corner radius.
 	useEffect(() => {
-		setBorderRadiusModeOverride(null);
+		setBorderRadiusModeOverride({});
 	}, [attributes.kbPreset]);
 	useEffect(() => {
 		if (!isSelected) {
@@ -1224,34 +1234,43 @@ export default function KadenceButtonEdit(props) {
 																			: 1,
 																}}
 																control={
-																	borderRadiusModeOverride ??
+																	borderRadiusModeOverride[previewDevice] ??
 																	deriveMeasureMode(
-																		borderRadius,
+																		borderRadiusForDevice.value,
 																		tokenBinding.borderRadius?.presetValue
 																	)
 																}
 																onChangeControl={(mode) => {
 																	if ('linked' === mode) {
-																		// Collapse to the top-left corner so the
-																		// button reflects the link immediately, and
-																		// drop the override so the derived mode
-																		// (now all-equal) reads as linked.
-																		const corner = borderRadius?.[0] ?? '';
+																		// Collapse to the top-left corner so the button
+																		// reflects the link immediately, and drop the
+																		// override so the derived mode (now all-equal)
+																		// reads as linked. Only the ACTIVE device's
+																		// attribute is written, so the other breakpoints
+																		// keep their own corners.
+																		const corner =
+																			borderRadiusForDevice.value?.[0] ?? '';
 																		setAttributes({
-																			borderRadius: [
+																			[borderRadiusForDevice.attr]: [
 																				corner,
 																				corner,
 																				corner,
 																				corner,
 																			],
 																		});
-																		setBorderRadiusModeOverride(null);
+																		setBorderRadiusModeOverride((current) => ({
+																			...current,
+																			[previewDevice]: undefined,
+																		}));
 																	} else {
 																		// Unlinking equal corners leaves the values
 																		// untouched, so remember the choice for this
-																		// session; a differing corner would derive
-																		// individual on its own.
-																		setBorderRadiusModeOverride('individual');
+																		// session AND this device; a differing corner
+																		// would derive individual on its own.
+																		setBorderRadiusModeOverride((current) => ({
+																			...current,
+																			[previewDevice]: 'individual',
+																		}));
 																	}
 																}}
 																reset={false}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -85,6 +85,7 @@ import { addFilter, applyFilters, doAction } from '@wordpress/hooks';
 import BackendStyles from './components/backend-styles';
 import { PresetButton } from '../../extension/preset-picker/PresetButton';
 import { usePresetBinding, resetAttr } from '../../extension/token-indicators';
+import { deriveMeasureMode } from '../../extension/token-indicators/normalize';
 import { TokenLabel } from '../../extension/token-indicators/components/TokenLabel';
 import { TokenControlRow } from '../../extension/token-indicators/components/TokenControlRow';
 
@@ -286,6 +287,11 @@ export default function KadenceButtonEdit(props) {
 	// override only records an explicit "unlink" of already-equal corners for the current session — it
 	// resets on remount, matching how the control's mode has always been session-local.
 	const [borderRadiusModeOverride, setBorderRadiusModeOverride] = useState(null);
+	// The override records a choice made about the PREVIOUS preset's corners, so selecting another preset
+	// drops it — otherwise an explicit "link" would stick and hide a new preset's per-corner radius.
+	useEffect(() => {
+		setBorderRadiusModeOverride(null);
+	}, [attributes.kbPreset]);
 	useEffect(() => {
 		if (!isSelected) {
 			setIsEditingURL(false);
@@ -1219,12 +1225,10 @@ export default function KadenceButtonEdit(props) {
 																}}
 																control={
 																	borderRadiusModeOverride ??
-																	(!borderRadius ||
-																	borderRadius.every(
-																		(corner) => corner === borderRadius[0]
+																	deriveMeasureMode(
+																		borderRadius,
+																		tokenBinding.borderRadius?.presetValue
 																	)
-																		? 'linked'
-																		: 'individual')
 																}
 																onChangeControl={(mode) => {
 																	if ('linked' === mode) {

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -1286,13 +1286,8 @@ export default function KadenceButtonEdit(props) {
 																			return;
 																		}
 
-																		// Collapse to the top-left corner so the button
-																		// reflects the link immediately. A blank top-left
-																		// clears the other corners with it — linking means
-																		// every corner matches the first one, empty
-																		// included. Only the ACTIVE device's attribute is
-																		// written, so the other breakpoints keep their own
-																		// corners.
+																		// Every corner matches the top-left, blank
+																		// included, and only on the ACTIVE device.
 																		setAttributes({
 																			[borderRadiusForDevice.attr]: [
 																				corner,
@@ -1301,10 +1296,8 @@ export default function KadenceButtonEdit(props) {
 																				corner,
 																			],
 																		});
-																		// All-equal corners derive linked on their own, so
-																		// the override can go — except when they collapsed
-																		// to blank and the preset carries a different value
-																		// per corner, which derives individual.
+																		// Equal corners derive linked on their own —
+																		// except blank ones under a per-corner preset.
 																		setBorderRadiusModeOverride((current) => ({
 																			...current,
 																			[previewDevice]:

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -1262,10 +1262,15 @@ export default function KadenceButtonEdit(props) {
 																}
 																onChangeControl={(mode) => {
 																	if ('linked' === mode) {
-																		const corner =
-																			borderRadiusForDevice.value?.[0] ?? '';
+																		const corners =
+																			borderRadiusForDevice.value ?? [];
+																		const corner = corners[0] ?? '';
+																		const isEmpty = corners.every(
+																			(value) =>
+																				'' === value || undefined === value
+																		);
 
-																		if ('' === corner) {
+																		if (isEmpty) {
 																			// Nothing stored on this device, so there is
 																			// nothing to collapse — the corners are empty
 																			// because they inherit, and writing the
@@ -1282,11 +1287,12 @@ export default function KadenceButtonEdit(props) {
 																		}
 
 																		// Collapse to the top-left corner so the button
-																		// reflects the link immediately, and drop the
-																		// override so the derived mode (now all-equal)
-																		// reads as linked. Only the ACTIVE device's
-																		// attribute is written, so the other breakpoints
-																		// keep their own corners.
+																		// reflects the link immediately. A blank top-left
+																		// clears the other corners with it — linking means
+																		// every corner matches the first one, empty
+																		// included. Only the ACTIVE device's attribute is
+																		// written, so the other breakpoints keep their own
+																		// corners.
 																		setAttributes({
 																			[borderRadiusForDevice.attr]: [
 																				corner,
@@ -1295,9 +1301,14 @@ export default function KadenceButtonEdit(props) {
 																				corner,
 																			],
 																		});
+																		// All-equal corners derive linked on their own, so
+																		// the override can go — except when they collapsed
+																		// to blank and the preset carries a different value
+																		// per corner, which derives individual.
 																		setBorderRadiusModeOverride((current) => ({
 																			...current,
-																			[previewDevice]: undefined,
+																			[previewDevice]:
+																				'' === corner ? 'linked' : undefined,
 																		}));
 																	} else {
 																		// Unlinking equal corners leaves the values

--- a/src/extension/design-tokens/__tests__/register-component-filters.test.js
+++ b/src/extension/design-tokens/__tests__/register-component-filters.test.js
@@ -131,6 +131,68 @@ describe('editor seam', () => {
 	});
 
 	/**
+	 * The per-corner inherited-from-another-breakpoint flag is narrowed to the slot being rendered, so a
+	 * corner that inherits reads as inherited while a sibling falling back to the preset does not.
+	 *
+	 * @return {void}
+	 */
+	it('narrows the per-corner inherited flag to the rendered slot', () => {
+		const inheritedDefault = [true, false, true, false];
+		const slot = (index) =>
+			applyFilters(EDITOR_HOOK, 'DEFAULT', {
+				control: 'measureRange',
+				index,
+				value: ['', '', '', ''],
+				onChange: jest.fn(),
+				context: { ...CONTEXT, defaultValue: ['1px', '2px', '3px', '4px'], inheritedDefault },
+			});
+
+		expect(slot(0).props.inherited).toBe(true);
+		expect(slot(1).props.inherited).toBe(false);
+	});
+
+	/**
+	 * The linked "all sides" slot arrives with a null index and stands for the first corner, so it reports
+	 * that corner's default and inherited flag rather than nothing.
+	 *
+	 * @return {void}
+	 */
+	it('reads the first corner for the linked slot, which has a null index', () => {
+		const result = applyFilters(EDITOR_HOOK, 'DEFAULT', {
+			control: 'measureRange',
+			index: null,
+			value: ['', '', '', ''],
+			onChange: jest.fn(),
+			context: {
+				...CONTEXT,
+				defaultValue: ['1px', '2px', '3px', '4px'],
+				inheritedDefault: [true, false, false, false],
+			},
+		});
+
+		expect(result.props.defaultValue).toBe('1px');
+		expect(result.props.inherited).toBe(true);
+	});
+
+	/**
+	 * With no inherited-default context the slot reports not-inherited, so a control that never passes the
+	 * flag keeps the preset-default wording.
+	 *
+	 * @return {void}
+	 */
+	it('reports not inherited when the context carries no inherited flag', () => {
+		const result = applyFilters(EDITOR_HOOK, 'DEFAULT', {
+			control: 'measureRange',
+			index: 0,
+			value: ['', '', '', ''],
+			onChange: jest.fn(),
+			context: { ...CONTEXT, defaultValue: '0.5rem' },
+		});
+
+		expect(result.props.inherited).toBe(false);
+	});
+
+	/**
 	 * Picking a token on an individual side writes the alias to only that side; clearing and a custom
 	 * value write to the same side, leaving the siblings untouched.
 	 *

--- a/src/extension/design-tokens/__tests__/register-component-filters.test.js
+++ b/src/extension/design-tokens/__tests__/register-component-filters.test.js
@@ -131,23 +131,6 @@ describe('editor seam', () => {
 	});
 
 	/**
-	 * A single-slot default means "every corner", so each slot reads that one value.
-	 *
-	 * @return {void}
-	 */
-	it('applies a single-slot default value to every corner', () => {
-		const result = applyFilters(EDITOR_HOOK, 'DEFAULT', {
-			control: 'measureRange',
-			index: 3,
-			value: ['', '', '', ''],
-			onChange: jest.fn(),
-			context: { ...CONTEXT, defaultValue: ['0.5rem'] },
-		});
-
-		expect(result.props.defaultValue).toBe('0.5rem');
-	});
-
-	/**
 	 * Picking a token on an individual side writes the alias to only that side; clearing and a custom
 	 * value write to the same side, leaving the siblings untouched.
 	 *

--- a/src/extension/design-tokens/__tests__/register-component-filters.test.js
+++ b/src/extension/design-tokens/__tests__/register-component-filters.test.js
@@ -95,6 +95,59 @@ describe('editor seam', () => {
 	});
 
 	/**
+	 * A scalar inherited default reaches every slot unchanged, so a preset holding one value still shows
+	 * that value as the default on each corner.
+	 *
+	 * @return {void}
+	 */
+	it('passes a scalar default value through to every slot', () => {
+		const result = applyFilters(EDITOR_HOOK, 'DEFAULT', {
+			control: 'measureRange',
+			index: 2,
+			value: ['', '', '', ''],
+			onChange: jest.fn(),
+			context: { ...CONTEXT, defaultValue: '0.5rem' },
+		});
+
+		expect(result.props.defaultValue).toBe('0.5rem');
+	});
+
+	/**
+	 * A per-corner inherited default is narrowed to the slot being rendered, so each corner shows its own
+	 * default rather than the whole list.
+	 *
+	 * @return {void}
+	 */
+	it('narrows a per-corner default value to the rendered slot', () => {
+		const result = applyFilters(EDITOR_HOOK, 'DEFAULT', {
+			control: 'measureRange',
+			index: 2,
+			value: ['', '', '', ''],
+			onChange: jest.fn(),
+			context: { ...CONTEXT, defaultValue: ['1px', '2px', '3px', '4px'] },
+		});
+
+		expect(result.props.defaultValue).toBe('3px');
+	});
+
+	/**
+	 * A single-slot default means "every corner", so each slot reads that one value.
+	 *
+	 * @return {void}
+	 */
+	it('applies a single-slot default value to every corner', () => {
+		const result = applyFilters(EDITOR_HOOK, 'DEFAULT', {
+			control: 'measureRange',
+			index: 3,
+			value: ['', '', '', ''],
+			onChange: jest.fn(),
+			context: { ...CONTEXT, defaultValue: ['0.5rem'] },
+		});
+
+		expect(result.props.defaultValue).toBe('0.5rem');
+	});
+
+	/**
 	 * Picking a token on an individual side writes the alias to only that side; clearing and a custom
 	 * value write to the same side, leaving the siblings untouched.
 	 *

--- a/src/extension/design-tokens/component-token-ui.js
+++ b/src/extension/design-tokens/component-token-ui.js
@@ -18,7 +18,7 @@
 /**
  * Internal block libraries
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	Button,
 	Dropdown,
@@ -65,21 +65,63 @@ export function findTokenEntry(tokens, value) {
 }
 
 /**
- * The label/value summary a token field shows on its trigger for the current slot value: the token's
- * label + resolved value when aliased (dot-path fallback when no matching entry is found), a `Custom`
- * label + literal (with unit) for a set literal, or — when the slot is unset — the inherited default's
- * size label and resolved value (so the trigger reads the effective size, not a bare "Default").
+ * An inherited default as a COMPARABLE, displayable value.
  *
- * @param {*}      value        The current slot value (alias string, literal number/string, or empty).
- * @param {Array}  tokens       The pickable-token list, used to resolve an alias/default to its label.
- * @param {string} unit         The control's current unit, appended to a literal for display.
- * @param {string} defaultValue The inherited default's resolved value, shown when the slot is unset.
+ * A default that comes from the preset is already resolved (`"0.5rem"`). One inherited from another
+ * breakpoint is the raw stored attribute instead — a token alias (`"{primitive.dimension.radius.sm}"`)
+ * or a bare number whose unit lives in a separate attribute. Passed through untouched, the alias leaks
+ * into the tooltip as a dot-path and neither shape ever equals a token's resolved `value`, so the popover
+ * could never mark the size that is actually in effect.
+ *
+ * The unit is only appended for an inherited number: a preset value already carries its own unit, and a
+ * unitless token value (`None` is `"0"`) must keep comparing equal to itself.
+ *
+ * @param {*}       defaultValue The inherited default (resolved preset value, alias, or bare number).
+ * @param {Array}   tokens       The pickable-token list, used to resolve an alias to its value.
+ * @param {string}  unit         The control's current unit, completing an inherited bare number.
+ * @param {boolean} [inherited]  Whether the default came from another breakpoint.
  *
  * @since TBD
  *
- * @return {{label: string, value: string}} The trigger label and its secondary value text.
+ * @return {string} The resolved value, or '' when there is none.
  */
-function fieldSummary(value, tokens, unit, defaultValue) {
+function resolveDefaultValue(defaultValue, tokens, unit, inherited) {
+	if (defaultValue === '' || defaultValue === undefined || defaultValue === null) {
+		return '';
+	}
+
+	if (isTokenAlias(defaultValue)) {
+		const entry = findTokenEntry(tokens, defaultValue);
+
+		return entry ? entry.value : '';
+	}
+
+	if (inherited && /^-?\d*\.?\d+$/.test(String(defaultValue))) {
+		return `${defaultValue}${unit || ''}`;
+	}
+
+	return String(defaultValue);
+}
+
+/**
+ * The label/value summary a token field shows on its trigger for the current slot value: the token's
+ * label + resolved value when aliased (dot-path fallback when no matching entry is found), a `Custom`
+ * label + literal (with unit) for a set literal, or NOTHING when the slot is unset.
+ *
+ * An unset slot renders blank on purpose, matching the plain number inputs the Border control uses: the
+ * field shows what this slot holds, and it holds nothing. Naming the inherited size here would read as a
+ * value set on this breakpoint, which is exactly the confusion an empty-means-inherit attribute has to
+ * avoid. Where that value comes from stays visible one layer in, on the popover's tagged row.
+ *
+ * @param {*}      value  The current slot value (alias string, literal number/string, or empty).
+ * @param {Array}  tokens The pickable-token list, used to resolve an alias to its label.
+ * @param {string} unit   The control's current unit, appended to a literal for display.
+ *
+ * @since TBD
+ *
+ * @return {{label: string, value: string}} The trigger label and its secondary value text, both '' when unset.
+ */
+function fieldSummary(value, tokens, unit) {
 	if (isTokenAlias(value)) {
 		const entry = findTokenEntry(tokens, value);
 		return {
@@ -92,13 +134,7 @@ function fieldSummary(value, tokens, unit, defaultValue) {
 		return { label: __('Custom', 'kadence-blocks'), value: `${value}${unit || ''}` };
 	}
 
-	// Unset: surface the inherited default's size (the token whose resolved value it matches) and value.
-	if (defaultValue) {
-		const match = (tokens || []).find((entry) => entry.value === defaultValue);
-		return { label: match ? match.label : __('Default', 'kadence-blocks'), value: defaultValue };
-	}
-
-	return { label: __('Default', 'kadence-blocks'), value: '' };
+	return { label: '', value: '' };
 }
 
 /**
@@ -111,6 +147,8 @@ function fieldSummary(value, tokens, unit, defaultValue) {
  * @param {Array}    props.tokens       The pickable-token list.
  * @param {string}   [props.defaultValue] The inherited default's resolved value; its size is tagged
  *                                      `Default` and marked active while the slot is unset.
+ * @param {boolean}  [props.inherited]  Whether that default comes from another breakpoint, which tags the
+ *                                      row `Inherited` instead.
  * @param {Function} props.onPick       Called with an entry's `alias` when a token is chosen.
  * @param {Function} props.onClear      Called when `Reset` is chosen; clears the slot's override.
  * @param {Function} props.onClose      Closes the popover after a choice.
@@ -119,7 +157,7 @@ function fieldSummary(value, tokens, unit, defaultValue) {
  *
  * @return {Object} The rendered token list.
  */
-function StyleLibraryTab({ value, tokens, defaultValue, onPick, onClear, onClose }) {
+function StyleLibraryTab({ value, tokens, defaultValue, inherited, onPick, onClear, onClose }) {
 	// Reset clears the slot's override back to the inherited default; it is inert when nothing is set.
 	const hasOverride = isTokenAlias(value) || (value !== '' && value !== undefined && value !== null);
 	// While unset, the size matching the inherited default reads as the active row.
@@ -152,7 +190,9 @@ function StyleLibraryTab({ value, tokens, defaultValue, onPick, onClear, onClose
 					>
 						<span className="kadence-token-field__item-label">{entry.label}</span>
 						{isDefault && (
-							<span className="kadence-token-field__item-tag">{__('Default', 'kadence-blocks')}</span>
+							<span className="kadence-token-field__item-tag">
+								{inherited ? __('Inherited', 'kadence-blocks') : __('Default', 'kadence-blocks')}
+							</span>
 						)}
 						<span className="kadence-token-field__item-value">{entry.value}</span>
 					</Button>
@@ -177,6 +217,8 @@ function StyleLibraryTab({ value, tokens, defaultValue, onPick, onClear, onClose
  * @param {Function} [props.onUnit]   Writes the control's unit.
  * @param {string}   [props.defaultValue] The inherited default's resolved value, shown on the trigger and
  *                                    tagged in the list when the slot is unset.
+ * @param {boolean}  [props.inherited] Whether that default comes from another breakpoint rather than the
+ *                                    preset, which reads as `Inherited` instead of the size name.
  * @param {*}        [props.icon]     The control's per-slot corner icon (from the default editor), shown
  *                                    beside the trigger to match the native corner input.
  * @param {number}   [props.min]      The custom slider/number minimum.
@@ -197,6 +239,7 @@ export function TokenFieldControl({
 	units,
 	onUnit,
 	defaultValue,
+	inherited,
 	icon,
 	min,
 	max,
@@ -206,7 +249,27 @@ export function TokenFieldControl({
 	onClear,
 	onCustom,
 }) {
-	const summary = fieldSummary(value, tokens, unit, defaultValue);
+	const summary = fieldSummary(value, tokens, unit);
+	// The inherited default has to be resolved before it is compared or shown — a raw alias or a unitless
+	// number would neither match a token row nor read as a value.
+	const resolvedDefault = resolveDefaultValue(defaultValue, tokens, unit, inherited);
+	// An unset field renders blank, so the button would have no accessible name and no way to tell a
+	// screen-reader user what it currently resolves to. The tooltip/aria-label carries the inherited value
+	// instead — available on hover and to assistive tech, without printing it in the field.
+	const inheritedName = inherited
+		? sprintf(
+				/* translators: %s: the inherited value, e.g. "8px". */ __('Inherited (%s)', 'kadence-blocks'),
+				resolvedDefault
+			)
+		: sprintf(
+				/* translators: %s: the default value, e.g. "3px". */ __('Default (%s)', 'kadence-blocks'),
+				resolvedDefault
+			);
+	const triggerName = summary.label
+		? `${summary.label}${summary.value ? ` (${summary.value})` : ''}`
+		: resolvedDefault
+			? inheritedName
+			: __('Default', 'kadence-blocks');
 	const aliased = isTokenAlias(value);
 	const entry = aliased ? findTokenEntry(tokens, value) : null;
 	const seed = entry ? parseCssLength(entry.value) : null;
@@ -281,10 +344,10 @@ export function TokenFieldControl({
 						className="kadence-token-field__trigger"
 						onClick={onToggle}
 						aria-expanded={isOpen}
-						label={summary.value ? `${summary.label} (${summary.value})` : summary.label}
+						label={triggerName}
 						showTooltip
 					>
-						<span className="kadence-token-field__label">{summary.label}</span>
+						{summary.label && <span className="kadence-token-field__label">{summary.label}</span>}
 						{summary.value && <span className="kadence-token-field__value">{summary.value}</span>}
 					</Button>
 				)}
@@ -318,7 +381,8 @@ export function TokenFieldControl({
 								<StyleLibraryTab
 									value={value}
 									tokens={tokens}
-									defaultValue={defaultValue}
+									defaultValue={resolvedDefault}
+									inherited={inherited}
 									onPick={onPick}
 									onClear={onClear}
 									onClose={onClose}

--- a/src/extension/design-tokens/register-component-filters.js
+++ b/src/extension/design-tokens/register-component-filters.js
@@ -112,8 +112,8 @@ function writerFor(ctx) {
  * The inherited default for one slot of a field control.
  *
  * A preset may resolve a dimension to a PER-CORNER list rather than one value, so the slot takes its
- * matching entry — a one-entry list means "every corner". Handed the list whole, the field would render
- * the whole shorthand as a single default (e.g. "1px,2px,3px,4px") on every corner.
+ * matching entry. Handed the list whole, the field would render the whole shorthand as a single default
+ * (e.g. "1px,2px,3px,4px") on every corner.
  *
  * @param {*}      defaultValue The context's inherited default (a value or a per-corner list).
  * @param {number} index        The slot index being rendered.
@@ -127,7 +127,7 @@ function defaultValueForSlot(defaultValue, index) {
 		return defaultValue;
 	}
 
-	return defaultValue.length === 1 ? defaultValue[0] : defaultValue[index];
+	return defaultValue[index];
 }
 
 function editorFilter(defaultEditor, ctx) {

--- a/src/extension/design-tokens/register-component-filters.js
+++ b/src/extension/design-tokens/register-component-filters.js
@@ -97,6 +97,32 @@ function writerFor(ctx) {
 }
 
 /**
+ * The inherited default for one slot of a field control.
+ *
+ * A preset may resolve a dimension to a PER-CORNER list rather than one value, so the slot takes its
+ * matching entry. Handed the list whole, the field would render the whole shorthand as a single default
+ * (e.g. "1px,2px,3px,4px") on every corner.
+ *
+ * The linked "all sides" slot arrives with a null index and stands for the first corner, exactly as the
+ * adapter's `leaf` reads it — without that fallback a linked field would look up `list[null]` and report
+ * no default at all.
+ *
+ * @param {*}      defaultValue The context's inherited default (a value or a per-corner list).
+ * @param {?number} index       The slot index being rendered; null for the linked slot.
+ *
+ * @since TBD
+ *
+ * @return {*} The default for this slot.
+ */
+function defaultValueForSlot(defaultValue, index) {
+	if (!Array.isArray(defaultValue)) {
+		return defaultValue;
+	}
+
+	return defaultValue[index ?? 0];
+}
+
+/**
  * Editor seam: replace a field control's numeric slot with a `TokenFieldControl` — the trigger + token
  * popover — whenever the control is token-mapped (a `context` resolves pickable tokens). Falls back to
  * the control's own editor for a control with no field adapter, no tokens, or no write handler.
@@ -108,28 +134,6 @@ function writerFor(ctx) {
  *
  * @return {*} The token field when the control is token-mapped, otherwise `defaultEditor`.
  */
-/**
- * The inherited default for one slot of a field control.
- *
- * A preset may resolve a dimension to a PER-CORNER list rather than one value, so the slot takes its
- * matching entry. Handed the list whole, the field would render the whole shorthand as a single default
- * (e.g. "1px,2px,3px,4px") on every corner.
- *
- * @param {*}      defaultValue The context's inherited default (a value or a per-corner list).
- * @param {number} index        The slot index being rendered.
- *
- * @since TBD
- *
- * @return {*} The default for this slot.
- */
-function defaultValueForSlot(defaultValue, index) {
-	if (!Array.isArray(defaultValue)) {
-		return defaultValue;
-	}
-
-	return defaultValue[index];
-}
-
 function editorFilter(defaultEditor, ctx) {
 	const adapter = ADAPTERS[ctx.control];
 	if (!adapter || !adapter.leaf) {
@@ -151,6 +155,7 @@ function editorFilter(defaultEditor, ctx) {
 			units={ctx.context?.units}
 			onUnit={ctx.context?.onUnit}
 			defaultValue={defaultValueForSlot(ctx.context?.defaultValue, ctx.index)}
+			inherited={!!defaultValueForSlot(ctx.context?.inheritedDefault, ctx.index)}
 			icon={defaultEditor?.props?.icon}
 			min={ctx.context?.min}
 			max={ctx.context?.max}

--- a/src/extension/design-tokens/register-component-filters.js
+++ b/src/extension/design-tokens/register-component-filters.js
@@ -108,6 +108,28 @@ function writerFor(ctx) {
  *
  * @return {*} The token field when the control is token-mapped, otherwise `defaultEditor`.
  */
+/**
+ * The inherited default for one slot of a field control.
+ *
+ * A preset may resolve a dimension to a PER-CORNER list rather than one value, so the slot takes its
+ * matching entry — a one-entry list means "every corner". Handed the list whole, the field would render
+ * the whole shorthand as a single default (e.g. "1px,2px,3px,4px") on every corner.
+ *
+ * @param {*}      defaultValue The context's inherited default (a value or a per-corner list).
+ * @param {number} index        The slot index being rendered.
+ *
+ * @since TBD
+ *
+ * @return {*} The default for this slot.
+ */
+function defaultValueForSlot(defaultValue, index) {
+	if (!Array.isArray(defaultValue)) {
+		return defaultValue;
+	}
+
+	return defaultValue.length === 1 ? defaultValue[0] : defaultValue[index];
+}
+
 function editorFilter(defaultEditor, ctx) {
 	const adapter = ADAPTERS[ctx.control];
 	if (!adapter || !adapter.leaf) {
@@ -128,7 +150,7 @@ function editorFilter(defaultEditor, ctx) {
 			unit={ctx.context?.unit || ''}
 			units={ctx.context?.units}
 			onUnit={ctx.context?.onUnit}
-			defaultValue={ctx.context?.defaultValue}
+			defaultValue={defaultValueForSlot(ctx.context?.defaultValue, ctx.index)}
 			icon={defaultEditor?.props?.icon}
 			min={ctx.context?.min}
 			max={ctx.context?.max}

--- a/src/extension/preset-picker/__tests__/capture.test.js
+++ b/src/extension/preset-picker/__tests__/capture.test.js
@@ -60,7 +60,7 @@ describe('capturedTokens', () => {
 	it('composes an edited dimension from its value and unit', () => {
 		const attributes = {
 			kbPreset: 'primary',
-			borderRadius: ['8', '', '', ''],
+			borderRadius: '8',
 			borderRadiusUnit: 'px',
 		};
 
@@ -76,6 +76,85 @@ describe('capturedTokens', () => {
 		};
 
 		expect(capturedTokens(BLOCK, SET, attributes)['button-radius']).toBe(alias);
+	});
+
+	it('captures four identical literals as a single value', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			borderRadius: ['8', '8', '8', '8'],
+			borderRadiusUnit: 'px',
+		};
+
+		expect(capturedTokens(BLOCK, SET, attributes)['button-radius']).toBe('8px');
+	});
+
+	it('captures mixed literal corners as a slot list', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			borderRadius: ['8', '8', '4', '4'],
+			borderRadiusUnit: 'px',
+		};
+
+		expect(capturedTokens(BLOCK, SET, attributes)['button-radius']).toEqual(['8px', '8px', '4px', '4px']);
+	});
+
+	it('captures mixed alias and literal corners as a slot list, with no unit on the aliases', () => {
+		const alias = '{primitive.dimension.radius.md}';
+		const attributes = {
+			kbPreset: 'primary',
+			borderRadius: [alias, '8', alias, '8'],
+			borderRadiusUnit: 'px',
+		};
+
+		expect(capturedTokens(BLOCK, SET, attributes)['button-radius']).toEqual([alias, '8px', alias, '8px']);
+	});
+
+	it('captures mixed alias corners as a slot list', () => {
+		const md = '{primitive.dimension.radius.md}';
+		const sm = '{primitive.dimension.radius.sm}';
+		const attributes = {
+			kbPreset: 'primary',
+			borderRadius: [md, sm, md, sm],
+			borderRadiusUnit: 'px',
+		};
+
+		expect(capturedTokens(BLOCK, SET, attributes)['button-radius']).toEqual([md, sm, md, sm]);
+	});
+
+	it('fills an empty corner from the preset value', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			borderRadius: ['8', '', '', ''],
+			borderRadiusUnit: 'px',
+		};
+
+		// The preset's button-radius is '4px', so the three untouched corners inherit it.
+		expect(capturedTokens(BLOCK, SET, attributes)['button-radius']).toEqual(['8px', '4px', '4px', '4px']);
+	});
+
+	it('fills an empty corner from the matching slot of a per-corner preset value', () => {
+		window.kadenceDesignTokensPresets.libraries[SET][BLOCK].values.primary['button-radius'] = [
+			'1px',
+			'2px',
+			'3px',
+			'4px',
+		];
+
+		const attributes = {
+			kbPreset: 'primary',
+			borderRadius: ['8', '', '', ''],
+			borderRadiusUnit: 'px',
+		};
+
+		expect(capturedTokens(BLOCK, SET, attributes)['button-radius']).toEqual(['8px', '2px', '3px', '4px']);
+	});
+
+	it('survives a round trip through the preset values without flattening', () => {
+		const slots = ['8px', '8px', '4px', '4px'];
+		window.kadenceDesignTokensPresets.libraries[SET][BLOCK].values.primary['button-radius'] = slots;
+
+		// Nothing edited: the not-edited fallback must hand the slot list back unchanged.
+		expect(capturedTokens(BLOCK, SET, { kbPreset: 'primary' })['button-radius']).toEqual(slots);
 	});
 
 	it('uses the default preset when no preset is selected', () => {

--- a/src/extension/preset-picker/__tests__/capture.test.js
+++ b/src/extension/preset-picker/__tests__/capture.test.js
@@ -67,6 +67,17 @@ describe('capturedTokens', () => {
 		expect(capturedTokens(BLOCK, SET, attributes)['button-radius']).toBe('8px');
 	});
 
+	it('captures a uniform token alias as a whole-string alias with no unit appended', () => {
+		const alias = '{primitive.dimension.radius.sm}';
+		const attributes = {
+			kbPreset: 'primary',
+			borderRadius: [alias, alias, alias, alias],
+			borderRadiusUnit: 'px',
+		};
+
+		expect(capturedTokens(BLOCK, SET, attributes)['button-radius']).toBe(alias);
+	});
+
 	it('uses the default preset when no preset is selected', () => {
 		const tokens = capturedTokens(BLOCK, SET, {});
 

--- a/src/extension/preset-picker/capture.js
+++ b/src/extension/preset-picker/capture.js
@@ -14,6 +14,7 @@ import {
 	normalizeText,
 	isEmptyValue,
 	dimensionSlots,
+	presetSlotAt,
 } from '../token-indicators/normalize';
 import { isTokenAlias } from '../design-tokens/alias';
 
@@ -34,27 +35,6 @@ import { isTokenAlias } from '../design-tokens/alias';
  */
 function slotToLiteral(slot, unit) {
 	return isTokenAlias(slot) ? slot : `${slot}${unit}`;
-}
-
-/**
- * The preset's own value for one corner, used to fill a corner the user never set.
- *
- * The preset value may itself be a slot list, in which case the corner takes the MATCHING slot — taking
- * the whole list would nest an array inside a slot, which the server rejects.
- *
- * @param {*}      presetValue The selected preset's value for this property.
- * @param {number} index       The corner index.
- *
- * @since TBD
- *
- * @return {string} The preset's value for that corner, or '' when it has none.
- */
-function presetSlotAt(presetValue, index) {
-	if (Array.isArray(presetValue)) {
-		return String(presetValue.length === 1 ? presetValue[0] : (presetValue[index] ?? ''));
-	}
-
-	return presetValue === undefined || presetValue === null ? '' : String(presetValue);
 }
 
 /**

--- a/src/extension/preset-picker/capture.js
+++ b/src/extension/preset-picker/capture.js
@@ -9,6 +9,7 @@
 import { get } from 'lodash';
 import { activeLibrary, blockProperties, blockPresetValues, blockDefaultPreset } from './index';
 import { normalizeColor, normalizeDimension, normalizeText, isEmptyValue } from '../token-indicators/normalize';
+import { isTokenAlias } from '../design-tokens/alias';
 
 /**
  * Reduce a block attribute value to the literal a preset token stores, per kind: a color resolves to its
@@ -28,7 +29,18 @@ function attrToLiteral(kind, value, unit) {
 		// its first populated side — matching how the indicator's bound/overridden compare reads a dimension.
 		const dimension = normalizeDimension(value, unit);
 
-		return dimension.value === '' ? '' : `${dimension.value}${dimension.unit}`;
+		if (dimension.value === '') {
+			return '';
+		}
+
+		// A token alias is a whole-string `{dot.path}` reference — the preset stores it verbatim. Appending
+		// the unit would produce `{dot.path}px`, which the server rejects as `alias_malformed` because
+		// `Alias::looks_like_alias()` fires on a brace anywhere in the value.
+		if (isTokenAlias(dimension.value)) {
+			return dimension.value;
+		}
+
+		return `${dimension.value}${dimension.unit}`;
 	}
 
 	if (kind === 'color') {

--- a/src/extension/preset-picker/capture.js
+++ b/src/extension/preset-picker/capture.js
@@ -8,39 +8,89 @@
  */
 import { get } from 'lodash';
 import { activeLibrary, blockProperties, blockPresetValues, blockDefaultPreset } from './index';
-import { normalizeColor, normalizeDimension, normalizeText, isEmptyValue } from '../token-indicators/normalize';
+import {
+	normalizeColor,
+	normalizeDimension,
+	normalizeText,
+	isEmptyValue,
+	dimensionSlots,
+} from '../token-indicators/normalize';
 import { isTokenAlias } from '../design-tokens/alias';
+
+/**
+ * Compose one dimension slot into the literal a preset stores: a token alias is stored verbatim, any
+ * other value gets the control's unit appended.
+ *
+ * A token alias is a whole-string `{dot.path}` reference. Appending the unit would produce
+ * `{dot.path}px`, which the server rejects as `alias_malformed` — `Alias::looks_like_alias()` fires on
+ * a brace anywhere in the value, so a suffixed alias is not "an alias with a unit", it is malformed.
+ *
+ * @param {string} slot The stored slot value.
+ * @param {string} unit The companion unit.
+ *
+ * @since TBD
+ *
+ * @return {string} The slot literal.
+ */
+function slotToLiteral(slot, unit) {
+	return isTokenAlias(slot) ? slot : `${slot}${unit}`;
+}
+
+/**
+ * The preset's own value for one corner, used to fill a corner the user never set.
+ *
+ * The preset value may itself be a slot list, in which case the corner takes the MATCHING slot — taking
+ * the whole list would nest an array inside a slot, which the server rejects.
+ *
+ * @param {*}      presetValue The selected preset's value for this property.
+ * @param {number} index       The corner index.
+ *
+ * @since TBD
+ *
+ * @return {string} The preset's value for that corner, or '' when it has none.
+ */
+function presetSlotAt(presetValue, index) {
+	if (Array.isArray(presetValue)) {
+		return String(presetValue.length === 1 ? presetValue[0] : (presetValue[index] ?? ''));
+	}
+
+	return presetValue === undefined || presetValue === null ? '' : String(presetValue);
+}
 
 /**
  * Reduce a block attribute value to the literal a preset token stores, per kind: a color resolves to its
  * literal, a dimension composes its value and unit (`8` + `px` -> `8px`), text passes through trimmed.
  *
- * @param {string} kind  The property kind ('color' | 'dimension' | 'text').
- * @param {*}      value The stored attribute value.
- * @param {string} unit  The companion unit (dimension only; '' otherwise).
+ * A dimension keeps its corners: four identical corners collapse to one value (so a uniform preset is
+ * stored exactly as before), and corners that differ are stored as a slot list so a per-corner radius
+ * survives the round trip instead of narrowing to its first side.
+ *
+ * @param {string} kind        The property kind ('color' | 'dimension' | 'text').
+ * @param {*}      value       The stored attribute value.
+ * @param {string} unit        The companion unit (dimension only; '' otherwise).
+ * @param {*}      presetValue The selected preset's value, used to fill an unset corner.
  *
  * @since TBD
  *
- * @return {string} The token literal.
+ * @return {string|string[]} The token literal, or the per-corner slot list.
  */
-function attrToLiteral(kind, value, unit) {
+function attrToLiteral(kind, value, unit, presetValue) {
 	if (kind === 'dimension') {
-		// A preset token is a single scalar, so a per-corner override (e.g. `['8','8','8','4']`) narrows to
-		// its first populated side — matching how the indicator's bound/overridden compare reads a dimension.
-		const dimension = normalizeDimension(value, unit);
-
-		if (dimension.value === '') {
+		if (normalizeDimension(value, unit).value === '') {
 			return '';
 		}
 
-		// A token alias is a whole-string `{dot.path}` reference — the preset stores it verbatim. Appending
-		// the unit would produce `{dot.path}px`, which the server rejects as `alias_malformed` because
-		// `Alias::looks_like_alias()` fires on a brace anywhere in the value.
-		if (isTokenAlias(dimension.value)) {
-			return dimension.value;
+		const slots = dimensionSlots(value).map((slot, index) =>
+			slot === '' ? presetSlotAt(presetValue, index) : slotToLiteral(slot, unit)
+		);
+
+		// A corner the user left unset whose preset has no value either cannot be expressed in a shorthand,
+		// so the whole property is omitted and inherited through the cascade instead.
+		if (slots.some((slot) => slot === '')) {
+			return '';
 		}
 
-		return `${dimension.value}${dimension.unit}`;
+		return slots.every((slot) => slot === slots[0]) ? slots[0] : slots;
 	}
 
 	if (kind === 'color') {
@@ -76,8 +126,9 @@ export function capturedTokens(blockName, library, attributes) {
 		// "Edited" here is simply "the control carries a value" — we snapshot the current visual state, so a
 		// value that happens to equal the preset is captured all the same (no differs-from-preset compare).
 		const edited = attr && !isEmptyValue(property.kind, raw);
+		const presetValue = get(presetValues, property.key, '');
 
-		tokens[property.key] = edited ? attrToLiteral(property.kind, raw, unit) : get(presetValues, property.key, '');
+		tokens[property.key] = edited ? attrToLiteral(property.kind, raw, unit, presetValue) : presetValue;
 
 		return tokens;
 	}, {});

--- a/src/extension/token-indicators/__tests__/normalize.test.js
+++ b/src/extension/token-indicators/__tests__/normalize.test.js
@@ -1,5 +1,12 @@
 /* eslint-env jest */
-import { deriveMeasureMode, isEmptyValue, matchesPreset, normalizeColor, normalizeDimension } from '../normalize';
+import {
+	deriveMeasureMode,
+	measureAttrsForDevice,
+	isEmptyValue,
+	matchesPreset,
+	normalizeColor,
+	normalizeDimension,
+} from '../normalize';
 
 describe('normalizeColor', () => {
 	beforeEach(() => {
@@ -106,6 +113,50 @@ describe('deriveMeasureMode', () => {
 	it('reads an unset value with no preset as linked', () => {
 		expect(deriveMeasureMode(undefined, undefined)).toBe('linked');
 		expect(deriveMeasureMode(['', '', '', ''], '')).toBe('linked');
+	});
+});
+
+describe('measureAttrsForDevice', () => {
+	const ATTRS = {
+		borderRadius: ['8', '8', '8', '8'],
+		tabletBorderRadius: ['8', '4', '8', '4'],
+		mobileBorderRadius: ['', '', '', ''],
+	};
+	const RESPONSIVE = { tablet: 'tabletBorderRadius', mobile: 'mobileBorderRadius' };
+
+	it('reads the desktop attribute for Desktop', () => {
+		expect(measureAttrsForDevice(ATTRS, 'borderRadius', RESPONSIVE, 'Desktop').value).toEqual(['8', '8', '8', '8']);
+		expect(measureAttrsForDevice(ATTRS, 'borderRadius', RESPONSIVE, 'Desktop').attr).toBe('borderRadius');
+	});
+
+	it('reads the tablet attribute for Tablet', () => {
+		const read = measureAttrsForDevice(ATTRS, 'borderRadius', RESPONSIVE, 'Tablet');
+
+		expect(read.value).toEqual(['8', '4', '8', '4']);
+		expect(read.attr).toBe('tabletBorderRadius');
+	});
+
+	it('reads the mobile attribute for Mobile', () => {
+		const read = measureAttrsForDevice(ATTRS, 'borderRadius', RESPONSIVE, 'Mobile');
+
+		expect(read.value).toEqual(['', '', '', '']);
+		expect(read.attr).toBe('mobileBorderRadius');
+	});
+
+	it('falls back to the desktop attribute when the device has no mapping', () => {
+		const read = measureAttrsForDevice(ATTRS, 'borderRadius', {}, 'Tablet');
+
+		expect(read.attr).toBe('borderRadius');
+	});
+
+	it('derives the mode per device, so breakpoints can differ', () => {
+		// Desktop corners are equal (linked) while tablet corners differ (individual).
+		expect(deriveMeasureMode(measureAttrsForDevice(ATTRS, 'borderRadius', RESPONSIVE, 'Desktop').value, '')).toBe(
+			'linked'
+		);
+		expect(deriveMeasureMode(measureAttrsForDevice(ATTRS, 'borderRadius', RESPONSIVE, 'Tablet').value, '')).toBe(
+			'individual'
+		);
 	});
 });
 

--- a/src/extension/token-indicators/__tests__/normalize.test.js
+++ b/src/extension/token-indicators/__tests__/normalize.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { isEmptyValue, matchesPreset, normalizeColor, normalizeDimension } from '../normalize';
+import { deriveMeasureMode, isEmptyValue, matchesPreset, normalizeColor, normalizeDimension } from '../normalize';
 
 describe('normalizeColor', () => {
 	beforeEach(() => {
@@ -71,6 +71,41 @@ describe('matchesPreset dimension', () => {
 
 	it('does not match a different value with the same unit', () => {
 		expect(matchesPreset('dimension', ['8', '8', '8', '8'], 'px', '1.5rem')).toBe(false);
+	});
+});
+
+describe('deriveMeasureMode', () => {
+	it('reads all-empty corners on a scalar preset as linked', () => {
+		expect(deriveMeasureMode(['', '', '', ''], '0.5rem')).toBe('linked');
+	});
+
+	it('reads all-empty corners on a per-corner preset as individual', () => {
+		expect(deriveMeasureMode(['', '', '', ''], ['0', '0.125rem', '9999px', '1rem'])).toBe('individual');
+	});
+
+	it('reads all-empty corners on a uniform per-corner preset as linked', () => {
+		expect(deriveMeasureMode(['', '', '', ''], ['8px', '8px', '8px', '8px'])).toBe('linked');
+	});
+
+	it('reads equal stored corners as linked whatever the preset holds', () => {
+		expect(deriveMeasureMode(['8', '8', '8', '8'], ['0', '0.125rem', '9999px', '1rem'])).toBe('linked');
+	});
+
+	it('reads a differing stored corner as individual', () => {
+		expect(deriveMeasureMode(['8', '8', '8', '4'], '0.5rem')).toBe('individual');
+	});
+
+	it('reads one overridden corner against an inherited scalar as individual', () => {
+		expect(deriveMeasureMode(['{primitive.dimension.radius.lg}', '', '', ''], '0.5rem')).toBe('individual');
+	});
+
+	it('reads a single-slot preset as applying to every corner', () => {
+		expect(deriveMeasureMode(['', '', '', ''], ['8px'])).toBe('linked');
+	});
+
+	it('reads an unset value with no preset as linked', () => {
+		expect(deriveMeasureMode(undefined, undefined)).toBe('linked');
+		expect(deriveMeasureMode(['', '', '', ''], '')).toBe('linked');
 	});
 });
 

--- a/src/extension/token-indicators/__tests__/normalize.test.js
+++ b/src/extension/token-indicators/__tests__/normalize.test.js
@@ -106,10 +106,6 @@ describe('deriveMeasureMode', () => {
 		expect(deriveMeasureMode(['{primitive.dimension.radius.lg}', '', '', ''], '0.5rem')).toBe('individual');
 	});
 
-	it('reads a single-slot preset as applying to every corner', () => {
-		expect(deriveMeasureMode(['', '', '', ''], ['8px'])).toBe('linked');
-	});
-
 	it('reads an unset value with no preset as linked', () => {
 		expect(deriveMeasureMode(undefined, undefined)).toBe('linked');
 		expect(deriveMeasureMode(['', '', '', ''], '')).toBe('linked');
@@ -171,10 +167,6 @@ describe('matchesPreset dimension against a per-corner preset value', () => {
 
 	it('does not match when the corners are positionally rotated', () => {
 		expect(matchesPreset('dimension', ['4', '8', '4', '8'], 'px', ['8px', '4px', '8px', '4px'])).toBe(false);
-	});
-
-	it('matches a uniform stored value against a single-slot preset value', () => {
-		expect(matchesPreset('dimension', ['8', '8', '8', '8'], 'px', ['8px'])).toBe(true);
 	});
 
 	it('does not match when the unit differs from the preset slots', () => {

--- a/src/extension/token-indicators/__tests__/normalize.test.js
+++ b/src/extension/token-indicators/__tests__/normalize.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 import {
 	deriveMeasureMode,
+	inheritedMeasureSlots,
 	measureAttrsForDevice,
 	isEmptyValue,
 	matchesPreset,
@@ -153,6 +154,52 @@ describe('measureAttrsForDevice', () => {
 		expect(deriveMeasureMode(measureAttrsForDevice(ATTRS, 'borderRadius', RESPONSIVE, 'Tablet').value, '')).toBe(
 			'individual'
 		);
+	});
+});
+
+describe('inheritedMeasureSlots', () => {
+	const DESKTOP = ['8', '4', '8', '4'];
+	const TABLET = ['2', '', '2', ''];
+
+	it('inherits the preset on Desktop, which has no wider breakpoint', () => {
+		const read = inheritedMeasureSlots('Desktop', { desktop: DESKTOP, tablet: TABLET }, '0.5rem');
+
+		expect(read.values).toEqual(['0.5rem', '0.5rem', '0.5rem', '0.5rem']);
+		expect(read.inherited).toEqual([false, false, false, false]);
+	});
+
+	it('spreads a per-corner preset across the Desktop corners', () => {
+		const read = inheritedMeasureSlots('Desktop', {}, ['0', '0.125rem', '9999px', '1rem']);
+
+		expect(read.values).toEqual(['0', '0.125rem', '9999px', '1rem']);
+	});
+
+	it('inherits the desktop corners on Tablet rather than the preset', () => {
+		const read = inheritedMeasureSlots('Tablet', { desktop: DESKTOP }, '0.5rem');
+
+		expect(read.values).toEqual(['8', '4', '8', '4']);
+		expect(read.inherited).toEqual([true, true, true, true]);
+	});
+
+	it('falls through an empty desktop corner to the preset, corner by corner', () => {
+		const read = inheritedMeasureSlots('Tablet', { desktop: ['8', '', '8', ''] }, '0.5rem');
+
+		expect(read.values).toEqual(['8', '0.5rem', '8', '0.5rem']);
+		expect(read.inherited).toEqual([true, false, true, false]);
+	});
+
+	it('prefers tablet over desktop on Mobile, per corner', () => {
+		const read = inheritedMeasureSlots('Mobile', { desktop: DESKTOP, tablet: TABLET }, '0.5rem');
+
+		expect(read.values).toEqual(['2', '4', '2', '4']);
+		expect(read.inherited).toEqual([true, true, true, true]);
+	});
+
+	it('ignores the device its own value, so a corner never inherits from itself', () => {
+		// Desktop stores four corners; asking for Desktop still resolves to the preset.
+		const read = inheritedMeasureSlots('Desktop', { desktop: DESKTOP }, '3px');
+
+		expect(read.values).toEqual(['3px', '3px', '3px', '3px']);
 	});
 });
 

--- a/src/extension/token-indicators/__tests__/normalize.test.js
+++ b/src/extension/token-indicators/__tests__/normalize.test.js
@@ -74,6 +74,32 @@ describe('matchesPreset dimension', () => {
 	});
 });
 
+describe('matchesPreset dimension against a per-corner preset value', () => {
+	it('matches when every corner equals its preset slot', () => {
+		expect(matchesPreset('dimension', ['8', '4', '8', '4'], 'px', ['8px', '4px', '8px', '4px'])).toBe(true);
+	});
+
+	it('does not match when one corner differs from its preset slot', () => {
+		expect(matchesPreset('dimension', ['8', '4', '8', '2'], 'px', ['8px', '4px', '8px', '4px'])).toBe(false);
+	});
+
+	it('does not match when the corners are positionally rotated', () => {
+		expect(matchesPreset('dimension', ['4', '8', '4', '8'], 'px', ['8px', '4px', '8px', '4px'])).toBe(false);
+	});
+
+	it('matches a uniform stored value against a single-slot preset value', () => {
+		expect(matchesPreset('dimension', ['8', '8', '8', '8'], 'px', ['8px'])).toBe(true);
+	});
+
+	it('does not match when the unit differs from the preset slots', () => {
+		expect(matchesPreset('dimension', ['8', '4', '8', '4'], 'rem', ['8px', '4px', '8px', '4px'])).toBe(false);
+	});
+
+	it('does not match a scalar stored value against a mixed per-corner preset value', () => {
+		expect(matchesPreset('dimension', '8', 'px', ['8px', '4px', '8px', '4px'])).toBe(false);
+	});
+});
+
 describe('matchesPreset text', () => {
 	it('matches trimmed equal strings', () => {
 		expect(matchesPreset('text', ' bold ', '', 'bold')).toBe(true);

--- a/src/extension/token-indicators/normalize.js
+++ b/src/extension/token-indicators/normalize.js
@@ -77,6 +77,24 @@ function dimensionSides(value) {
 }
 
 /**
+ * The stored sides of a dimension value with their POSITION preserved: a 4-side array maps one-to-one
+ * and an untouched side stays `''`, while a scalar is a single slot. This is the positional counterpart
+ * to `dimensionSides`, which drops empties and so cannot say WHICH corner a value belongs to — needed
+ * wherever a per-corner value is composed or compared slot by slot.
+ *
+ * @param {*} value The stored dimension value (number, string, or 4-side array).
+ *
+ * @since TBD
+ *
+ * @return {string[]} The slots as trimmed strings, empty slots preserved as ''.
+ */
+export function dimensionSlots(value) {
+	const raw = Array.isArray(value) ? value : [value];
+
+	return raw.map((side) => (side === undefined || side === null ? '' : String(side).trim()));
+}
+
+/**
  * Normalize a dimension attribute to `{ value, unit }`. A measurement control writes a 4-side array
  * (`[top, right, bottom, left]`); the representative value is the first populated side. An empty value
  * yields an empty marker so "no override" is detectable. This is the scalar view used for empty
@@ -159,6 +177,39 @@ function parseDimensionLiteral(literal) {
 }
 
 /**
+ * Whether a stored dimension matches a PER-CORNER preset value, compared slot by slot.
+ *
+ * Either side may carry a single entry, which means "every corner": a one-slot list is expanded to four
+ * before the compare, so a uniform stored value still matches a single-slot preset. Comparing by position
+ * means a rotated set of the same corners (e.g. `4,8,4,8` against `8,4,8,4`) correctly reads as overridden.
+ *
+ * @param {string[]} sides       The stored sides, empties already dropped.
+ * @param {string}   storedUnit  The stored companion unit.
+ * @param {Array}    presetSlots The preset's per-corner literals.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when every corner equals its preset slot.
+ */
+function matchesPresetSlots(sides, storedUnit, presetSlots) {
+	const expand = (list) => (list.length === 1 ? [list[0], list[0], list[0], list[0]] : list);
+
+	const stored = expand(sides);
+	const presets = expand(presetSlots.map(parseDimensionLiteral));
+
+	if (stored.length !== presets.length) {
+		return false;
+	}
+
+	return stored.every((side, index) => {
+		const preset = presets[index];
+		const unitMatches = preset.unit === '' || storedUnit === preset.unit;
+
+		return unitMatches && side === preset.value;
+	});
+}
+
+/**
  * Whether a stored value equals the selected preset's resolved value, normalized per kind.
  *
  * @param {string} kind        The property kind.
@@ -174,12 +225,19 @@ export function matchesPreset(kind, value, unit, presetValue) {
 	if (kind === 'dimension') {
 		const sides = dimensionSides(value);
 		const storedUnit = String(unit || '').trim();
-		const preset = parseDimensionLiteral(presetValue);
 
 		if (!sides.length) {
 			return false;
 		}
 
+		// A per-corner preset value is compared corner by corner. `parseDimensionLiteral` reads one length,
+		// so a slot list handed to it whole would never match and the control would read as overridden even
+		// when it exactly matches its preset.
+		if (Array.isArray(presetValue)) {
+			return matchesPresetSlots(sides, storedUnit, presetValue);
+		}
+
+		const preset = parseDimensionLiteral(presetValue);
 		const unitMatches = preset.unit === '' || storedUnit === preset.unit;
 
 		// Side-aware: a stored dimension matches only when EVERY populated side equals the preset value.

--- a/src/extension/token-indicators/normalize.js
+++ b/src/extension/token-indicators/normalize.js
@@ -95,6 +95,52 @@ export function dimensionSlots(value) {
 }
 
 /**
+ * The value one corner inherits from the selected preset.
+ *
+ * A preset value may be a single literal (every corner) or a PER-CORNER list, in which case the corner
+ * takes its matching slot; a one-entry list also means "every corner".
+ *
+ * @param {*}      presetValue The selected preset's value for the property.
+ * @param {number} index       The corner index.
+ *
+ * @since TBD
+ *
+ * @return {string} The inherited value for that corner, or '' when the preset has none.
+ */
+export function presetSlotAt(presetValue, index) {
+	if (Array.isArray(presetValue)) {
+		return String(presetValue.length === 1 ? presetValue[0] : (presetValue[index] ?? ''));
+	}
+
+	return presetValue === undefined || presetValue === null ? '' : String(presetValue);
+}
+
+/**
+ * The linked/individual mode a measure control should open in, derived from the corners the user would
+ * actually see: each stored corner where one is set, otherwise the value that corner inherits from the
+ * selected preset.
+ *
+ * Deriving from the stored attribute alone is not enough. A block on a preset stores NOTHING — every
+ * corner is empty, which trivially reads as "all equal" — so a preset carrying four different corners
+ * would open the control in linked mode and hide the difference it is displaying.
+ *
+ * @param {*} value       The stored dimension value (4-side array or scalar).
+ * @param {*} presetValue The selected preset's value for the property.
+ *
+ * @since TBD
+ *
+ * @return {string} 'linked' when every effective corner matches, otherwise 'individual'.
+ */
+export function deriveMeasureMode(value, presetValue) {
+	const stored = dimensionSlots(value);
+	const corners = [0, 1, 2, 3].map((index) =>
+		stored[index] !== undefined && stored[index] !== '' ? stored[index] : presetSlotAt(presetValue, index)
+	);
+
+	return corners.every((corner) => corner === corners[0]) ? 'linked' : 'individual';
+}
+
+/**
  * Normalize a dimension attribute to `{ value, unit }`. A measurement control writes a 4-side array
  * (`[top, right, bottom, left]`); the representative value is the first populated side. An empty value
  * yields an empty marker so "no override" is detectable. This is the scalar view used for empty

--- a/src/extension/token-indicators/normalize.js
+++ b/src/extension/token-indicators/normalize.js
@@ -139,6 +139,55 @@ export function measureAttrsForDevice(attributes, baseAttr, responsive = {}, dev
 }
 
 /**
+ * What each corner of a measure control inherits at the given device WHEN THE DEVICE STORES NOTHING —
+ * the device's own value is deliberately left out, because this is the value the corner falls back to.
+ *
+ * A responsive measure control renders through a desktop -> tablet -> mobile cascade that runs PER CORNER:
+ * an empty tablet corner takes the desktop corner, an empty mobile corner takes the tablet corner and
+ * then the desktop one. Only once the whole device chain is empty does the corner reach the selected
+ * preset. Resolving straight to the preset skips those steps, so a Tablet sitting on four different
+ * desktop corners would report the preset's single value — naming a size the button is not rendering at
+ * that breakpoint.
+ *
+ * Nothing here is written back, and this does NOT feed the linked/individual mode: the corners stay empty
+ * so they keep inheriting, and the resolved values only tell the field's popover which size is currently
+ * in effect and where it came from.
+ *
+ * @param {string} device        The active preview device ('Desktop' | 'Tablet' | 'Mobile').
+ * @param {Object} [values]      The stored dimension per device: { desktop, tablet }.
+ * @param {*}      [presetValue] The selected preset's value for the property, the last fallback.
+ *
+ * @since TBD
+ *
+ * @return {{ values: string[], inherited: boolean[] }} The four inherited corners, and per corner whether
+ *                                                      it came from another device rather than the preset.
+ */
+export function inheritedMeasureSlots(device, values = {}, presetValue) {
+	const desktop = dimensionSlots(values.desktop);
+	const tablet = dimensionSlots(values.tablet);
+
+	// Mobile falls through tablet before desktop; tablet only through desktop; desktop inherits the preset.
+	const chain = 'Mobile' === device ? [tablet, desktop] : 'Tablet' === device ? [desktop] : [];
+
+	const slots = [0, 1, 2, 3].map((index) => {
+		const from = chain.find((source) => {
+			const corner = source[index];
+
+			return corner !== undefined && corner !== null && corner !== '';
+		});
+
+		return from
+			? { value: String(from[index]), inherited: true }
+			: { value: presetSlotAt(presetValue, index), inherited: false };
+	});
+
+	return {
+		values: slots.map((slot) => slot.value),
+		inherited: slots.map((slot) => slot.inherited),
+	};
+}
+
+/**
  * The linked/individual mode a measure control should open in, derived from the corners the user would
  * actually see: each stored corner where one is set, otherwise the value that corner inherits from the
  * selected preset.

--- a/src/extension/token-indicators/normalize.js
+++ b/src/extension/token-indicators/normalize.js
@@ -97,8 +97,8 @@ export function dimensionSlots(value) {
 /**
  * The value one corner inherits from the selected preset.
  *
- * A preset value may be a single literal (every corner) or a PER-CORNER list, in which case the corner
- * takes its matching slot; a one-entry list also means "every corner".
+ * A preset value is either a single literal, which every corner inherits, or a PER-CORNER list, in which
+ * case the corner takes its matching slot.
  *
  * @param {*}      presetValue The selected preset's value for the property.
  * @param {number} index       The corner index.
@@ -109,7 +109,7 @@ export function dimensionSlots(value) {
  */
 export function presetSlotAt(presetValue, index) {
 	if (Array.isArray(presetValue)) {
-		return String(presetValue.length === 1 ? presetValue[0] : (presetValue[index] ?? ''));
+		return String(presetValue[index] ?? '');
 	}
 
 	return presetValue === undefined || presetValue === null ? '' : String(presetValue);
@@ -248,9 +248,9 @@ function parseDimensionLiteral(literal) {
 /**
  * Whether a stored dimension matches a PER-CORNER preset value, compared slot by slot.
  *
- * Either side may carry a single entry, which means "every corner": a one-slot list is expanded to four
- * before the compare, so a uniform stored value still matches a single-slot preset. Comparing by position
- * means a rotated set of the same corners (e.g. `4,8,4,8` against `8,4,8,4`) correctly reads as overridden.
+ * Comparing by position means a rotated set of the same corners (e.g. `4,8,4,8` against `8,4,8,4`) reads
+ * as overridden, and a stored value with a different number of populated sides than the preset has slots
+ * cannot match at all.
  *
  * @param {string[]} sides       The stored sides, empties already dropped.
  * @param {string}   storedUnit  The stored companion unit.
@@ -261,10 +261,8 @@ function parseDimensionLiteral(literal) {
  * @return {boolean} True when every corner equals its preset slot.
  */
 function matchesPresetSlots(sides, storedUnit, presetSlots) {
-	const expand = (list) => (list.length === 1 ? [list[0], list[0], list[0], list[0]] : list);
-
-	const stored = expand(sides);
-	const presets = expand(presetSlots.map(parseDimensionLiteral));
+	const stored = sides;
+	const presets = presetSlots.map(parseDimensionLiteral);
 
 	if (stored.length !== presets.length) {
 		return false;

--- a/src/extension/token-indicators/normalize.js
+++ b/src/extension/token-indicators/normalize.js
@@ -116,6 +116,29 @@ export function presetSlotAt(presetValue, index) {
 }
 
 /**
+ * The attribute a responsive measure control is editing at the given device, and its current value.
+ *
+ * A responsive measure control keeps ONE linked/individual mode but writes three separate attributes
+ * (`borderRadius` / `tabletBorderRadius` / `mobileBorderRadius`). Deriving the mode — or collapsing
+ * corners on "link" — against the desktop attribute while the editor is on Tablet reads and writes the
+ * wrong breakpoint, so both must resolve the device's own attribute first.
+ *
+ * @param {Object} attributes  The block's attributes.
+ * @param {string} baseAttr    The desktop attribute name.
+ * @param {Object} [responsive] Device key ('tablet' | 'mobile') => attribute name.
+ * @param {string} [device]    The active preview device ('Desktop' | 'Tablet' | 'Mobile').
+ *
+ * @since TBD
+ *
+ * @return {{ attr: string, value: * }} The device's attribute name and its stored value.
+ */
+export function measureAttrsForDevice(attributes, baseAttr, responsive = {}, device = 'Desktop') {
+	const attr = get(responsive, String(device).toLowerCase(), '') || baseAttr;
+
+	return { attr, value: get(attributes, attr, '') };
+}
+
+/**
  * The linked/individual mode a measure control should open in, derived from the corners the user would
  * actually see: each stored corner where one is set, otherwise the value that corner inherits from the
  * selected preset.

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
@@ -305,12 +305,90 @@ final class Preset_ResolverTest extends TestCase {
 	}
 
 	/**
+	 * A per-corner slot list flattens to literals slot by slot and stays an array, so the editor and admin
+	 * surfaces can read each corner rather than a pre-joined string they cannot parse.
+	 *
+	 * @return void
+	 */
+	public function testResolveLiteralKeepsASlotListUnjoined(): void {
+		$this->seedPreset(
+			Token_Store::default_slug(),
+			'corners',
+			'Corners',
+			[ 'button-radius' => [ '{semantic.radius.control}', '8px', '{semantic.radius.control}', '8px' ] ]
+		);
+
+		$values = $this->resolver->resolve_literal( self::BUTTON, 'corners' );
+
+		$this->assertSame( [ '0.5rem', '8px', '0.5rem', '8px' ], $values['button-radius'] );
+	}
+
+	/**
+	 * A per-corner slot list projects to a space-separated CSS shorthand, each aliased corner keeping its
+	 * var() indirection so the corner still follows a token edit live.
+	 *
+	 * @return void
+	 */
+	public function testResolveJoinsASlotListIntoAVarShorthand(): void {
+		$this->seedPreset(
+			Token_Store::default_slug(),
+			'corners',
+			'Corners',
+			[ 'button-radius' => [ '{semantic.radius.control}', '8px', '{semantic.radius.control}', '8px' ] ]
+		);
+
+		$projected = $this->resolver->resolve( self::BUTTON, 'corners' );
+
+		$this->assertSame(
+			'var(--kb-token--semantic--radius--control) 8px var(--kb-token--semantic--radius--control) 8px',
+			$projected['button-radius']
+		);
+	}
+
+	/**
+	 * A slot list holding an unresolvable alias drops the whole property, matching how a scalar binding
+	 * whose alias resolves to nothing is dropped rather than emitted half-formed.
+	 *
+	 * @return void
+	 */
+	public function testASlotListWithAnUnresolvableAliasDropsTheProperty(): void {
+		$this->seedPreset(
+			Token_Store::default_slug(),
+			'corners',
+			'Corners',
+			[ 'button-radius' => [ '{semantic.radius.control}', '{primitive.dimension.radius.nope}', '8px', '8px' ] ]
+		);
+
+		$this->assertArrayNotHasKey( 'button-radius', $this->resolver->resolve_literal( self::BUTTON, 'corners' ) );
+	}
+
+	/**
+	 * A single-slot list means "every corner", so it resolves exactly as the equivalent scalar does.
+	 *
+	 * @return void
+	 */
+	public function testASingleSlotListResolvesLikeAScalar(): void {
+		$this->seedPreset(
+			Token_Store::default_slug(),
+			'corners',
+			'Corners',
+			[ 'button-radius' => [ '{semantic.radius.control}' ] ]
+		);
+
+		$this->assertSame( [ '0.5rem' ], $this->resolver->resolve_literal( self::BUTTON, 'corners' )['button-radius'] );
+		$this->assertSame(
+			'var(--kb-token--semantic--radius--control)',
+			$this->resolver->resolve( self::BUTTON, 'corners' )['button-radius']
+		);
+	}
+
+	/**
 	 * Persist a single button preset into a token library's overrides document.
 	 *
-	 * @param string                $slug    The token library slug to write into.
-	 * @param string                $preset The preset slug.
-	 * @param string                $label   The preset label.
-	 * @param array<string, string> $tokens  The property => value map for the preset.
+	 * @param string               $slug   The token library slug to write into.
+	 * @param string               $preset The preset slug.
+	 * @param string               $label  The preset label.
+	 * @param array<string, mixed> $tokens The property => value map for the preset.
 	 *
 	 * @return void
 	 */

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
@@ -363,26 +363,6 @@ final class Preset_ResolverTest extends TestCase {
 	}
 
 	/**
-	 * A single-slot list means "every corner", so it resolves exactly as the equivalent scalar does.
-	 *
-	 * @return void
-	 */
-	public function testASingleSlotListResolvesLikeAScalar(): void {
-		$this->seedPreset(
-			Token_Store::default_slug(),
-			'corners',
-			'Corners',
-			[ 'button-radius' => [ '{semantic.radius.control}' ] ]
-		);
-
-		$this->assertSame( [ '0.5rem' ], $this->resolver->resolve_literal( self::BUTTON, 'corners' )['button-radius'] );
-		$this->assertSame(
-			'var(--kb-token--semantic--radius--control)',
-			$this->resolver->resolve( self::BUTTON, 'corners' )['button-radius']
-		);
-	}
-
-	/**
 	 * Persist a single button preset into a token library's overrides document.
 	 *
 	 * @param string               $slug   The token library slug to write into.

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
@@ -71,7 +71,6 @@ final class Preset_ResolverTest extends TestCase {
 	}
 
 	/**
-	/**
 	 * resolve() and resolve_literal() cover exactly the same properties — only the value form differs.
 	 *
 	 * @return void
@@ -320,7 +319,7 @@ final class Preset_ResolverTest extends TestCase {
 
 		$values = $this->resolver->resolve_literal( self::BUTTON, 'corners' );
 
-		$this->assertSame( [ '0.5rem', '8px', '0.5rem', '8px' ], $values['button-radius'] );
+		$this->assertSame( [ '0.1875rem', '8px', '0.1875rem', '8px' ], $values['button-radius'] );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_Value_NormalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_Value_NormalizerTest.php
@@ -96,8 +96,8 @@ final class Preset_Value_NormalizerTest extends TestCase {
 	 * @return void
 	 */
 	public function testItAliasesEachSlotOfAPerCornerValue(): void {
-		// 0.5rem is the resolved value of the control radius semantic; 8px matches nothing.
-		$result = $this->normalizer->normalize( [ 'button-radius' => [ '0.5rem', '8px', '0.5rem', '8px' ] ], self::SET );
+		// 0.1875rem is the resolved value of the control radius semantic; 8px matches nothing.
+		$result = $this->normalizer->normalize( [ 'button-radius' => [ '0.1875rem', '8px', '0.1875rem', '8px' ] ], self::SET );
 
 		$this->assertIsArray( $result['button-radius'] );
 		$this->assertTrue( Alias::is_alias( $result['button-radius'][0] ), 'A matched slot should become an alias.' );
@@ -105,7 +105,7 @@ final class Preset_Value_NormalizerTest extends TestCase {
 		$this->assertTrue( Alias::is_alias( $result['button-radius'][2] ) );
 		$this->assertSame( '8px', $result['button-radius'][3] );
 		$this->assertSame(
-			'0.5rem',
+			'0.1875rem',
 			$this->resolver->resolve( self::SET )->value( Alias::path_of( $result['button-radius'][0] ) ),
 			'The chosen alias should resolve back to the captured value.'
 		);

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_Value_NormalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_Value_NormalizerTest.php
@@ -90,6 +90,43 @@ final class Preset_Value_NormalizerTest extends TestCase {
 	}
 
 	/**
+	 * Each slot of a per-corner value is matched on its own, so a captured corner that equals a semantic's
+	 * value re-joins the theming cascade exactly as a scalar capture does.
+	 *
+	 * @return void
+	 */
+	public function testItAliasesEachSlotOfAPerCornerValue(): void {
+		// 0.5rem is the resolved value of the control radius semantic; 8px matches nothing.
+		$result = $this->normalizer->normalize( [ 'button-radius' => [ '0.5rem', '8px', '0.5rem', '8px' ] ], self::SET );
+
+		$this->assertIsArray( $result['button-radius'] );
+		$this->assertTrue( Alias::is_alias( $result['button-radius'][0] ), 'A matched slot should become an alias.' );
+		$this->assertSame( '8px', $result['button-radius'][1], 'An unmatched slot should stay a literal.' );
+		$this->assertTrue( Alias::is_alias( $result['button-radius'][2] ) );
+		$this->assertSame( '8px', $result['button-radius'][3] );
+		$this->assertSame(
+			'0.5rem',
+			$this->resolver->resolve( self::SET )->value( Alias::path_of( $result['button-radius'][0] ) ),
+			'The chosen alias should resolve back to the captured value.'
+		);
+	}
+
+	/**
+	 * A slot that already holds an alias is passed through untouched, so a token the user picked per corner
+	 * is never re-pointed at a different semantic.
+	 *
+	 * @return void
+	 */
+	public function testItLeavesAnExistingAliasSlotUnchanged(): void {
+		$result = $this->normalizer->normalize(
+			[ 'button-radius' => [ '{semantic.radius.control}', '8px', '8px', '8px' ] ],
+			self::SET
+		);
+
+		$this->assertSame( '{semantic.radius.control}', $result['button-radius'][0] );
+	}
+
+	/**
 	 * When several semantics share a value, the one whose id best matches the property's role wins: #ffffff is
 	 * shared by the plain and hover button-text semantics, and the hover property picks the hover semantic.
 	 *

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
@@ -448,6 +448,60 @@ final class PresetsControllerTest extends TestCase {
 	}
 
 	/**
+	 * A dimension property accepts a per-corner slot list, so a button whose corners carry different
+	 * radii can be saved as a preset without flattening to one value.
+	 *
+	 * @return void
+	 */
+	public function testASlotListOnADimensionPropertyIsAccepted(): void {
+		$slots = [ '{primitive.dimension.radius.md}', '8px', '{primitive.dimension.radius.md}', '8px' ];
+
+		$response = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'preset' => 'corners',
+					'tokens' => $this->button_tokens( [ 'button-radius' => $slots ] ),
+				]
+			)
+		);
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+
+		$stored = json_decode( $this->store->get_document( Token_Store::default_slug() ), true );
+		$tokens = $stored['$extensions']['com.kadence.designTokens']['presets'][ self::BUTTON ]['corners']['tokens'];
+
+		$this->assertSame( $slots, $tokens['button-radius'] );
+	}
+
+	/**
+	 * A slot list is meaningful only for a dimension property, so the registry-aware write guard rejects
+	 * one written to a color property. The schema validator checks shape only and cannot see the kind.
+	 *
+	 * @return void
+	 */
+	public function testASlotListOnANonDimensionPropertyIsRejected(): void {
+		$result = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'preset' => 'broken',
+					'tokens' => $this->button_tokens( [ 'button-bg' => [ '#ff0000', '#00ff00', '#0000ff', '#ffffff' ] ] ),
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+		$this->assertSame( 'button-bg', $result->get_error_data()['property'] );
+		// The write was rejected before commit.
+		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
+	}
+
+	/**
 	 * A preset that sets a property the block does not bind is rejected: an unbound property could never
 	 * project, so it must not be storable.
 	 *
@@ -715,9 +769,9 @@ final class PresetsControllerTest extends TestCase {
 	 * The button's full bound surface as literal values, so a written preset satisfies the full-surface
 	 * guard. Individual properties can be overridden for a specific assertion.
 	 *
-	 * @param array<string, string> $overrides Property values to override on the base surface.
+	 * @param array<string, mixed> $overrides Property values to override on the base surface.
 	 *
-	 * @return array<string, string>
+	 * @return array<string, mixed>
 	 */
 	private function button_tokens( array $overrides = [] ): array {
 		return array_merge(

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
@@ -502,6 +502,34 @@ final class PresetsControllerTest extends TestCase {
 	}
 
 	/**
+	 * An alias inside a per-corner slot list is checked for resolvability like a scalar alias is, so a
+	 * dangling reference is refused on write rather than silently dropping the property at projection.
+	 *
+	 * @return void
+	 */
+	public function testADanglingAliasInsideASlotListIsRejected(): void {
+		$slots = [ '{semantic.radius.control}', '{primitive.dimension.radius.nope}', '8px', '8px' ];
+
+		$result = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'preset' => 'corners',
+					'tokens' => $this->button_tokens( [ 'button-radius' => $slots ] ),
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_unresolvable', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+		$this->assertSame( 'button-radius', $result->get_error_data()['property'] );
+		// The write was rejected before commit.
+		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
+	}
+
+	/**
 	 * A preset that sets a property the block does not bind is rejected: an unbound property could never
 	 * project, so it must not be storable.
 	 *

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
@@ -490,6 +490,123 @@ final class Dtcg_ValidatorTest extends TestCase {
 	}
 
 	/**
+	 * A preset token value may be a per-corner slot list of exactly 1 or 4 entries, each an alias or a
+	 * literal, so a block storing a 4-side measure attribute can persist its corners into a preset.
+	 *
+	 * @dataProvider validSlotListProvider
+	 *
+	 * @param mixed $value The preset token value under test.
+	 *
+	 * @return void
+	 */
+	public function testAValidSlotListValidates( $value ): void {
+		$result = $this->validator->validate(
+			$this->preset_document( $value ),
+			Dtcg_Validator::get_context_overrides()
+		);
+
+		$this->assertTrue( $result->is_valid(), $this->describe( $result->errors() ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function validSlotListProvider(): Generator {
+		yield 'single alias slot' => [ 'value' => [ '{primitive.dimension.radius.sm}' ] ];
+
+		yield 'single literal slot' => [ 'value' => [ '8px' ] ];
+
+		yield 'four aliases' => [
+			'value' => [
+				'{primitive.dimension.radius.md}',
+				'{primitive.dimension.radius.sm}',
+				'{primitive.dimension.radius.md}',
+				'{primitive.dimension.radius.sm}',
+			],
+		];
+
+		yield 'four literals' => [ 'value' => [ '8px', '8px', '4px', '4px' ] ];
+
+		yield 'mixed alias and literal' => [
+			'value' => [ '{primitive.dimension.radius.md}', '8px', '{primitive.dimension.radius.sm}', '4px' ],
+		];
+
+		yield 'numeric literal slots' => [ 'value' => [ 0, 8, 0, 8 ] ];
+	}
+
+	/**
+	 * A preset token slot list is rejected when its length is not 1 or 4, when a slot nests another list,
+	 * when a slot is empty, or when a slot carries braces without being a whole-string alias.
+	 *
+	 * @dataProvider invalidSlotListProvider
+	 *
+	 * @param mixed  $value The preset token value under test.
+	 * @param string $code  The expected validation-error code.
+	 * @param string $path  The expected dot-path the error is reported at.
+	 *
+	 * @return void
+	 */
+	public function testAnInvalidSlotListIsRejected( $value, string $code, string $path ): void {
+		$errors = $this->validator->validate(
+			$this->preset_document( $value ),
+			Dtcg_Validator::get_context_overrides()
+		)->errors();
+
+		$this->assertCount( 1, $errors, $this->describe( $errors ) );
+		$this->assertSame( $code, $errors[0]->code );
+		$this->assertSame( $path, $errors[0]->path );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function invalidSlotListProvider(): Generator {
+		$base = '$extensions.com.kadence.designTokens.presets.kadence/x.default.tokens.button-radius';
+
+		yield 'two slots' => [
+			'value' => [ '8px', '4px' ],
+			'code'  => Validation_Error::get_code_value_invalid(),
+			'path'  => $base,
+		];
+
+		yield 'three slots' => [
+			'value' => [ '8px', '4px', '8px' ],
+			'code'  => Validation_Error::get_code_value_invalid(),
+			'path'  => $base,
+		];
+
+		yield 'five slots' => [
+			'value' => [ '8px', '4px', '8px', '4px', '2px' ],
+			'code'  => Validation_Error::get_code_value_invalid(),
+			'path'  => $base,
+		];
+
+		yield 'empty list' => [
+			'value' => [],
+			'code'  => Validation_Error::get_code_value_invalid(),
+			'path'  => $base,
+		];
+
+		yield 'nested list in a slot' => [
+			'value' => [ '8px', [ '4px' ], '8px', '4px' ],
+			'code'  => Validation_Error::get_code_value_invalid(),
+			'path'  => $base . '.1',
+		];
+
+		yield 'empty slot' => [
+			'value' => [ '8px', '', '8px', '4px' ],
+			'code'  => Validation_Error::get_code_value_invalid(),
+			'path'  => $base . '.1',
+		];
+
+		yield 'brace-bearing slot that is not a whole-string alias' => [
+			'value' => [ '8px', '{primitive.dimension.radius.sm}px', '8px', '4px' ],
+			'code'  => Validation_Error::get_code_alias_malformed(),
+			'path'  => $base . '.1',
+		];
+	}
+
+	/**
 	 * A dimension leaf carrying a well-formed per-breakpoint responsive map (literal and alias slots)
 	 * validates.
 	 *
@@ -691,7 +808,35 @@ final class Dtcg_ValidatorTest extends TestCase {
 	}
 
 	/**
-	 * @param Validation_Error[] $errors
+	 * A minimal overrides document carrying one block preset whose `button-radius` token holds the given
+	 * value, so a preset token value can be exercised in isolation.
+	 *
+	 * @param mixed $value The preset token value to place under `button-radius`.
+	 *
+	 * @return array<string, mixed> The document.
+	 */
+	private function preset_document( $value ): array {
+		return [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'presets' => [
+						'kadence/x' => [
+							'$default' => 'default',
+							'default'  => [
+								'label'  => 'Default',
+								'tokens' => [ 'button-radius' => $value ],
+							],
+						],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Render a list of validation errors as a readable multi-line string for assertion messages.
+	 *
+	 * @param Validation_Error[] $errors The errors to describe.
 	 *
 	 * @return string
 	 */

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
@@ -512,10 +512,6 @@ final class Dtcg_ValidatorTest extends TestCase {
 	 * @return Generator
 	 */
 	public function validSlotListProvider(): Generator {
-		yield 'single alias slot' => [ 'value' => [ '{primitive.dimension.radius.sm}' ] ];
-
-		yield 'single literal slot' => [ 'value' => [ '8px' ] ];
-
 		yield 'four aliases' => [
 			'value' => [
 				'{primitive.dimension.radius.md}',
@@ -562,6 +558,12 @@ final class Dtcg_ValidatorTest extends TestCase {
 	 */
 	public function invalidSlotListProvider(): Generator {
 		$base = '$extensions.com.kadence.designTokens.presets.kadence/x.default.tokens.button-radius';
+
+		yield 'one slot' => [
+			'value' => [ '8px' ],
+			'code'  => Validation_Error::get_code_value_invalid(),
+			'path'  => $base,
+		];
 
 		yield 'two slots' => [
 			'value' => [ '8px', '4px' ],


### PR DESCRIPTION
## Summary

Addresses the review on #1173: saving a preset returned a 422 when a corner held a design token, and the capture flattened four corners to one.

- A picked token alias is now stored verbatim. The capture used to append the control's unit, producing `{primitive.dimension.radius.sm}px`, which the server rejects as `alias_malformed` — `Alias::looks_like_alias()` fires on a brace anywhere in the value.
- A preset property can hold a **per-corner slot list**: exactly four values, each an alias or a literal, so a button with different corners saves as a preset instead of narrowing to its first side. Four identical corners still collapse to a single scalar, so every existing preset is byte-identical and there is no migration.
- The Border Radius control's linked/individual mode now follows the corners the user actually sees, and is tracked per breakpoint.

## Shape

A preset property stays a bare value unless the corners differ:

```json
"button-radius": "{semantic.radius.control}"
"button-radius": ["{radius.none}", "{radius.sm}", "{radius.full}", "{radius.lg}"]
```

Exactly four slots — "every corner" is already expressed by a scalar, so a shorter list would be a second spelling of the same thing.

## What changed

- `Dtcg_Validator` — accepts a four-slot list, each slot validated by the same alias-or-literal rule as a scalar, so "alias anywhere" stays one rule applied once.
- `Presets_Controller` — new `guard_slot_arrays()` rejects a slot list on a non-dimension property. The schema validator cannot make that call: the key it walks is a property name like `button-radius`, not a token id, so it never resolves a `$type`. The registry does know, so the check sits with the other registry-aware guards. `guard_aliases_resolve()` now walks every corner.
- `Preset_Resolver` — `flatten()` returns the slots **unjoined** so the editor reads each corner; `project()` joins them into a `var()` shorthand for CSS. Joining in `flatten()` would hand the editor one opaque string its per-corner display and compare cannot parse.
- `Preset_Value_Normalizer` — matches each corner on its own, so a captured per-corner literal re-joins the theming cascade like a scalar does.
- `matchesPreset` — compares corner by corner against a per-corner preset value. Without this a block matching its preset exactly would read as "overridden".
- The component seam narrows a per-corner inherited default to the slot being rendered.

## Two fixes to the linked/individual mode

Both were only reachable once per-corner presets existed.

1. The mode was derived from the block's own attribute, which is **empty** when a preset supplies the values — so it trivially read as "all equal" and opened linked, hiding a preset's four different corners. It now derives from the effective corners: the stored corner where set, otherwise what that corner inherits.
2. The responsive control keeps one mode but writes three attributes, so linking while on Tablet rewrote Desktop's corners. Mode and the session override are now per device.

## Also here

`semantic.radius.control` now resolves to the button's long-standing 3px rather than 8px, and the radius scale gains the steps that made that expressible (`xs` 2px, `sm` 3px, `md` 6px, `lg` 8px, `xl` 16px). Reviewed and approved separately — without it, every uncustomized button would have silently changed size.

## Test plan

- [x] PHPStan clean at level max, no baseline entries added
- [x] Full wpunit suite, snapshot suite byte-identical (the BC guard that matters — every existing preset is a scalar)
- [x] jest, phpcs, cspell clean
- [x] Verified in the editor: saved presets covering every capture case — four different corner tokens, mixed alias + literal, uniform alias collapsing to a scalar, and mixed literals — then confirmed each projects the expected CSS
