### PR TITLE
[DTM] SOFT-4085: responsive preset values (per-breakpoint overrides)

### DIFF
--- a/includes/resources/Design_Tokens/Editor/Preset_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Preset_Catalog.php
@@ -162,6 +162,7 @@ final class Preset_Catalog {
 				'presets'    => $presets,
 				'properties' => $this->properties_for( $bindings ),
 				'values'     => $this->values_for( $block, $slug, $names ),
+				'responsive' => $this->responsive_for( $block, $slug, $names ),
 				'label'      => $bindings->label,
 			];
 		}
@@ -178,17 +179,18 @@ final class Preset_Catalog {
 	 *
 	 * @param Preset_Bindings $bindings The block's preset bindings.
 	 *
-	 * @return array<int, array{key: string, kind: string, token: string|null, control_attr: string|null}>
+	 * @return array<int, array{key: string, kind: string, token: string|null, control_attr: string|null, responsive_attrs: array<string, string>}>
 	 */
 	private function properties_for( Preset_Bindings $bindings ): array {
 		$properties = [];
 
 		foreach ( $bindings->bindings as $property => $binding ) {
 			$properties[] = [
-				'key'          => (string) $property,
-				'kind'         => $bindings->kind( (string) $property ),
-				'token'        => $binding->token,
-				'control_attr' => $binding->control_attr(),
+				'key'              => (string) $property,
+				'kind'             => $bindings->kind( (string) $property ),
+				'token'            => $binding->token,
+				'control_attr'     => $binding->control_attr(),
+				'responsive_attrs' => $binding->responsive_attrs(),
 			];
 		}
 
@@ -227,6 +229,38 @@ final class Preset_Catalog {
 		}
 
 		return $values;
+	}
+
+	/**
+	 * The per-breakpoint resolved values for a block's library: `preset slug => ( breakpoint => ( property
+	 * => literal ) )`, flattened for the same reason `values_for()` flattens — a control cannot compare
+	 * against a `var()` chain.
+	 *
+	 * A preset that declares no breakpoint overrides carries an empty map rather than being absent, so the
+	 * editor can read `responsive[preset]` unconditionally. A preset whose resolution fails is skipped,
+	 * matching `values_for()`.
+	 *
+	 * @since TBD
+	 *
+	 * @param string   $block The block name.
+	 * @param string   $slug  The token library slug.
+	 * @param string[] $names The preset slugs to resolve, in catalog order.
+	 *
+	 * @return array<string, array<string, array<string, string|string[]>>> preset slug => ( breakpoint =>
+	 *                                                                     ( property => literal value ) ).
+	 */
+	private function responsive_for( string $block, string $slug, array $names ): array {
+		$responsive = [];
+
+		foreach ( $names as $name ) {
+			try {
+				$responsive[ $name ] = $this->presets->resolve_responsive_literal( $block, $name, $slug );
+			} catch ( Unknown_Preset_Exception $e ) {
+				continue; // Preset undefined in this library — skip, fail soft.
+			}
+		}
+
+		return $responsive;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
@@ -520,19 +520,6 @@ final class Css_Builder {
 	}
 
 	/**
-	 * The canonical preset var name for a (block, preset, property):
-	 * "--kb-token--preset--<block>--<preset>--<property>", e.g.
-	 * --kb-token--preset--kadence-singlebtn--secondary--button-bg.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $block    The block name.
-	 * @param string $preset   The preset slug.
-	 * @param string $property The block property.
-	 *
-	 * @return string
-	 */
-	/**
 	 * Redeclare each preset var that varies by breakpoint inside that breakpoint's `@media` block.
 	 *
 	 * Only the canonical var is redeclared — the scoped `--global-*` / `--kb-*` bridges are untouched,
@@ -611,6 +598,19 @@ final class Css_Builder {
 		return md5( (string) wp_json_encode( $breakpoints ) );
 	}
 
+	/**
+	 * The canonical preset var name for a (block, preset, property):
+	 * "--kb-token--preset--<block>--<preset>--<property>", e.g.
+	 * --kb-token--preset--kadence-singlebtn--secondary--button-bg.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block    The block name.
+	 * @param string $preset   The preset slug.
+	 * @param string $property The block property.
+	 *
+	 * @return string
+	 */
 	private function preset_var( string $block, string $preset, string $property ): string {
 		return Css_Var::get_prefix()
 			. self::PRESET_SEGMENT

--- a/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
@@ -148,12 +148,15 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param string $active_slug The active library's slug.
+	 * @param string                $active_slug The active library's slug.
+	 * @param array<string, string> $breakpoints Breakpoint => media-query string (e.g.
+	 *                                           "tablet" => "(max-width: 1024px)"), for the per-breakpoint
+	 *                                           redeclarations. Empty emits none.
 	 *
 	 * @return string The CSS, or an empty string when no block contributes a slot-targeted value.
 	 */
-	public function css( string $active_slug ): string {
-		return $this->build( $active_slug );
+	public function css( string $active_slug, array $breakpoints = [] ): string {
+		return $this->build( $active_slug, $breakpoints );
 	}
 
 	/**
@@ -166,13 +169,15 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param string $active_slug The active library's slug.
-	 * @param string $version     The store version the active library was built from.
+	 * @param string                $active_slug The active library's slug.
+	 * @param string                $version     The store version the active library was built from.
+	 * @param array<string, string> $breakpoints Breakpoint => media-query string, for the per-breakpoint
+	 *                                           redeclarations.
 	 *
 	 * @return string
 	 */
-	public function css_for_version( string $active_slug, string $version ): string {
-		$cache_key = 'preset_css_root_' . KADENCE_BLOCKS_VERSION . '_' . $active_slug . '_' . $version;
+	public function css_for_version( string $active_slug, string $version, array $breakpoints = [] ): string {
+		$cache_key = 'preset_css_root_' . KADENCE_BLOCKS_VERSION . '_' . $active_slug . '_' . $version . '_' . $this->breakpoint_signature( $breakpoints );
 
 		if ( isset( $this->memo[ $cache_key ] ) ) {
 			return $this->memo[ $cache_key ];
@@ -184,7 +189,7 @@ final class Css_Builder {
 			return $this->memo[ $cache_key ] = $cached;
 		}
 
-		$css = $this->build( $active_slug );
+		$css = $this->build( $active_slug, $breakpoints );
 
 		wp_cache_set( $cache_key, $css, self::CACHE_GROUP, DAY_IN_SECONDS );
 
@@ -215,16 +220,18 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param string $active_slug The active library slug.
+	 * @param string                $active_slug The active library slug.
+	 * @param array<string, string> $breakpoints Breakpoint => media-query string.
 	 *
 	 * @return string
 	 */
-	private function build( string $active_slug ): string {
+	private function build( string $active_slug, array $breakpoints = [] ): string {
 		$collected = $this->collect( $active_slug );
 
 		return $this->canonical_block( $collected )
 			. $this->scoped_presets( $collected )
-			. $this->scoped_default( $collected );
+			. $this->scoped_default( $collected )
+			. $this->responsive_blocks( $active_slug, $collected, $breakpoints );
 	}
 
 	/**
@@ -525,6 +532,85 @@ final class Css_Builder {
 	 *
 	 * @return string
 	 */
+	/**
+	 * Redeclare each preset var that varies by breakpoint inside that breakpoint's `@media` block.
+	 *
+	 * Only the canonical var is redeclared — the scoped `--global-*` / `--kb-*` bridges are untouched,
+	 * because they already point at the preset var, so overriding it inside the media query is enough for
+	 * every consumer (including each corner of a per-corner shorthand) to follow. Mirrors the token
+	 * projection's {@see \KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Css_Builder} responsive
+	 * layer: same media wrapper, same :root scope, same "redeclare the same custom property" approach.
+	 *
+	 * @since TBD
+	 *
+	 * @param string                $active_slug The active library's slug.
+	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string}>>}> $collected The collected preset structure, for the block/preset list.
+	 * @param array<string, string> $breakpoints Breakpoint => media-query string.
+	 *
+	 * @return string
+	 */
+	private function responsive_blocks( string $active_slug, array $collected, array $breakpoints ): string {
+		if ( $collected === [] || $breakpoints === [] ) {
+			return '';
+		}
+
+		$by_breakpoint = [];
+
+		foreach ( $collected as $block => $data ) {
+			foreach ( array_keys( $data['presets'] ) as $preset ) {
+				try {
+					$responsive = $this->presets->resolve_responsive( $block, (string) $preset, $active_slug );
+				} catch ( RuntimeException $e ) {
+					continue; // A preset that stopped resolving contributes no overrides, like the flat layer.
+				}
+
+				foreach ( $responsive as $breakpoint => $properties ) {
+					foreach ( $properties as $property => $value ) {
+						// Only a property the flat layer emitted has a var to override; skip anything else so a
+						// media block can never introduce a var the base projection never defined.
+						if ( ! isset( $data['presets'][ $preset ][ $property ] ) ) {
+							continue;
+						}
+
+						$by_breakpoint[ $breakpoint ][] = $this->preset_var( $block, (string) $preset, (string) $property )
+							. ':' . $this->sanitize_value( $value ) . ';';
+					}
+				}
+			}
+		}
+
+		$css = '';
+
+		foreach ( $breakpoints as $breakpoint => $query ) {
+			if ( $query === '' || empty( $by_breakpoint[ $breakpoint ] ) ) {
+				continue;
+			}
+
+			$css .= '@media all and ' . $query . '{' . Scope::root() . '{' . implode( '', $by_breakpoint[ $breakpoint ] ) . '}}';
+		}
+
+		return $css;
+	}
+
+	/**
+	 * A stable signature for a breakpoint map, so the cache key changes when the filtered media queries do.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, string> $breakpoints Breakpoint => media-query string.
+	 *
+	 * @return string
+	 */
+	private function breakpoint_signature( array $breakpoints ): string {
+		if ( $breakpoints === [] ) {
+			return 'none';
+		}
+
+		ksort( $breakpoints );
+
+		return md5( (string) wp_json_encode( $breakpoints ) );
+	}
+
 	private function preset_var( string $block, string $preset, string $property ): string {
 		return Css_Var::get_prefix()
 			. self::PRESET_SEGMENT

--- a/includes/resources/Design_Tokens/Projection/Preset/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Preset/Projector.php
@@ -6,6 +6,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts\Abstract_Css_Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Responsive;
 use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Location;
 use Throwable;
 
@@ -129,9 +130,27 @@ final class Projector extends Abstract_Css_Projector {
 			$active  = $this->active->get();
 			$version = $this->store->get_version( $active );
 
-			return $this->css_builder->css_for_version( $active, $version );
+			return $this->css_builder->css_for_version( $active, $version, $this->breakpoints() );
 		} catch ( Throwable $e ) {
 			return '';
 		}
+	}
+
+	/**
+	 * The breakpoint => media-query map for the per-breakpoint preset redeclarations, resolved at emit time
+	 * so the filterable KB breakpoints are final. Keyed to match the resolver's breakpoint keys, and reading
+	 * the same filters the token projection does, so a site that moves its breakpoints moves both together.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, string>
+	 */
+	private function breakpoints(): array {
+		return [
+			/** This filter is documented in includes/class-kadence-blocks-css.php */
+			Responsive::get_tablet_key() => (string) apply_filters( 'kadence_tablet_media_query', '(max-width: 1024px)' ),
+			/** This filter is documented in includes/class-kadence-blocks-css.php */
+			Responsive::get_mobile_key() => (string) apply_filters( 'kadence_mobile_media_query', '(max-width: 767px)' ),
+		];
 	}
 }

--- a/includes/resources/Design_Tokens/Registry/Binding.php
+++ b/includes/resources/Design_Tokens/Registry/Binding.php
@@ -3,6 +3,7 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry;
 
 use InvalidArgumentException;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Responsive;
 
 /**
  * One preset binding: how a single block property (e.g. "button-bg") reaches output when a preset is
@@ -111,6 +112,16 @@ final class Binding {
 	private const CONTROL_ATTR = 'control_attr';
 
 	/**
+	 * Declaration key naming the per-breakpoint block attributes an editor control writes, keyed by
+	 * breakpoint. Editor-only metadata, like CONTROL_ATTR.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const RESPONSIVE_ATTRS = 'responsive_attrs';
+
+	/**
 	 * The inline string targets and their validation: each, when present, must be a non-empty string.
 	 *
 	 * @since TBD
@@ -158,18 +169,30 @@ final class Binding {
 	public ?string $control_attr;
 
 	/**
+	 * The per-breakpoint block attributes this binding's editor control writes, keyed by breakpoint
+	 * ("tablet" => "tabletBorderRadius"). Empty when the binding declares none.
+	 *
 	 * @since TBD
 	 *
-	 * @param string               $property     The block property this binding drives.
-	 * @param string|null          $token        Referenced token id, or null when inline.
-	 * @param array<string, mixed> $projections  Inline projection targets, empty when a token reference.
-	 * @param string|null          $control_attr The editor control attribute, or null when none declared.
+	 * @var array<string, string>
 	 */
-	private function __construct( string $property, ?string $token, array $projections, ?string $control_attr ) {
-		$this->property     = $property;
-		$this->token        = $token;
-		$this->projections  = $projections;
-		$this->control_attr = $control_attr;
+	public array $responsive_attrs;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param string                $property     The block property this binding drives.
+	 * @param string|null           $token        Referenced token id, or null when inline.
+	 * @param array<string, mixed>  $projections  Inline projection targets, empty when a token reference.
+	 * @param string|null           $control_attr     The editor control attribute, or null when none declared.
+	 * @param array<string, string> $responsive_attrs Breakpoint => attribute, empty when none declared.
+	 */
+	private function __construct( string $property, ?string $token, array $projections, ?string $control_attr, array $responsive_attrs = [] ) {
+		$this->property         = $property;
+		$this->token            = $token;
+		$this->projections      = $projections;
+		$this->control_attr     = $control_attr;
+		$this->responsive_attrs = $responsive_attrs;
 	}
 
 	/**
@@ -208,7 +231,7 @@ final class Binding {
 			);
 		}
 
-		return new self( $property, $token, $inline, self::control_attr_of( $property, $spec ) );
+		return new self( $property, $token, $inline, self::control_attr_of( $property, $spec ), self::responsive_attrs_of( $property, $spec ) );
 	}
 
 	/**
@@ -260,6 +283,22 @@ final class Binding {
 	 */
 	public function control_attr(): ?string {
 		return $this->control_attr;
+	}
+
+	/**
+	 * The per-breakpoint block attributes this binding's editor control writes, keyed by breakpoint, or an
+	 * empty map when it declares none.
+	 *
+	 * A block names these by a prefix convention ("borderRadius" => "tabletBorderRadius"), which is a
+	 * naming rule rather than something safely derivable across blocks, so it is declared. Editor-only,
+	 * like control_attr(): never a projection target.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, string> Breakpoint => attribute name.
+	 */
+	public function responsive_attrs(): array {
+		return $this->responsive_attrs;
 	}
 
 	/**
@@ -337,6 +376,61 @@ final class Binding {
 		}
 
 		return $inline;
+	}
+
+	/**
+	 * Parse a binding's `responsive_attrs` declaration into a breakpoint => attribute map.
+	 *
+	 * Breakpoint keys are checked against {@see Responsive::get_breakpoint_keys()} at registration, so a
+	 * typo fails loudly here rather than silently never capturing that device.
+	 *
+	 * @since TBD
+	 *
+	 * @param string               $property The property the binding is for, for error messages.
+	 * @param array<string, mixed> $spec     The binding declaration.
+	 *
+	 * @throws InvalidArgumentException When the map, a key, or a value is malformed.
+	 *
+	 * @return array<string, string> Breakpoint => attribute, empty when the declaration omits it.
+	 */
+	private static function responsive_attrs_of( string $property, array $spec ): array {
+		if ( ! array_key_exists( self::RESPONSIVE_ATTRS, $spec ) ) {
+			return [];
+		}
+
+		$declared = $spec[ self::RESPONSIVE_ATTRS ];
+
+		if ( ! is_array( $declared ) ) {
+			throw new InvalidArgumentException(
+				sprintf( 'Binding "%s" target "%s" must be a breakpoint => attribute map.', $property, self::RESPONSIVE_ATTRS )
+			);
+		}
+
+		$allowed = Responsive::get_breakpoint_keys();
+		$out     = [];
+
+		foreach ( $declared as $breakpoint => $attribute ) {
+			if ( ! in_array( (string) $breakpoint, $allowed, true ) ) {
+				throw new InvalidArgumentException(
+					sprintf(
+						'Binding "%s" declares unknown responsive breakpoint "%s"; expected one of: %s.',
+						$property,
+						(string) $breakpoint,
+						implode( ', ', $allowed )
+					)
+				);
+			}
+
+			if ( ! is_string( $attribute ) || $attribute === '' ) {
+				throw new InvalidArgumentException(
+					sprintf( 'Binding "%s" responsive attribute for "%s" must be a non-empty string.', $property, (string) $breakpoint )
+				);
+			}
+
+			$out[ (string) $breakpoint ] = $attribute;
+		}
+
+		return $out;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -377,8 +377,15 @@ return [
 					'control_attr' => 'colorHover',
 				],
 				'button-radius'     => [
-					'css_var'      => 'kb-btn-radius', // drives --kb-btn-radius so a preset can vary the radius.
-					'control_attr' => 'borderRadius',
+					'css_var'          => 'kb-btn-radius', // drives --kb-btn-radius so a preset can vary the radius.
+					'control_attr'     => 'borderRadius',
+					// The block names its per-device radius attributes by a prefix convention, which is a naming
+					// rule rather than something safely derivable, so the editor is told them rather than
+					// guessing. Lets a captured preset carry a different radius per breakpoint.
+					'responsive_attrs' => [
+						'tablet' => 'tabletBorderRadius',
+						'mobile' => 'mobileBorderRadius',
+					],
 				],
 			],
 		],

--- a/includes/resources/Design_Tokens/Resolver/Preset_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Preset_Resolver.php
@@ -99,11 +99,13 @@ final class Preset_Resolver {
 		$values = [];
 
 		foreach ( $tokens as $property => $value ) {
-			if ( $this->flatten( $value, $resolved ) === null ) {
+			$base = Extensions::preset_value_of( $value );
+
+			if ( $this->flatten( $base, $resolved ) === null ) {
 				continue;
 			}
 
-			$values[ $property ] = $this->project( $value );
+			$values[ $property ] = $this->project( $base );
 		}
 
 		return $values;
@@ -146,7 +148,7 @@ final class Preset_Resolver {
 		$values = [];
 
 		foreach ( $tokens as $property => $value ) {
-			$flat = $this->flatten( $value, $resolved );
+			$flat = $this->flatten( Extensions::preset_value_of( $value ), $resolved );
 
 			if ( $flat !== null ) {
 				$values[ $property ] = $flat;
@@ -154,6 +156,81 @@ final class Preset_Resolver {
 		}
 
 		return $values;
+	}
+
+	/**
+	 * Resolve a preset's PER-BREAKPOINT overrides for the css-var projection, in the same var()-preserving
+	 * form as resolve().
+	 *
+	 * A property that varies by breakpoint carries the same envelope a responsive token leaf uses, so an
+	 * override is just another preset value — alias, literal or per-corner slot list — and flattens and
+	 * projects through the identical path. Only breakpoints that actually override something appear.
+	 *
+	 * An override whose alias resolves to nothing is dropped for THAT breakpoint only: the base and the
+	 * other breakpoints are unaffected, so a stale reference degrades to "no override here" rather than
+	 * taking the whole property down.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block  The block name.
+	 * @param string $preset The preset slug.
+	 * @param string $slug   The token library whose effective presets and resolved values are read.
+	 *
+	 * @throws Unknown_Preset_Exception When the block or preset is not defined.
+	 *
+	 * @return array<string, array<string, string>> breakpoint => ( property => var()-preserving value ).
+	 */
+	public function resolve_responsive( string $block, string $preset, string $slug = 'default' ): array {
+		$resolved = $this->resolver->resolve( $slug );
+		$out      = [];
+
+		foreach ( $this->preset_tokens( $block, $preset, $slug ) as $property => $value ) {
+			foreach ( Extensions::preset_responsive_of( $value ) as $breakpoint => $override ) {
+				// Gate on the literal first, exactly as resolve() does, so an override that resolves to
+				// nothing never emits a var() pointing at a token the base projection did not define.
+				if ( $this->flatten( $override, $resolved ) === null ) {
+					continue;
+				}
+
+				$out[ (string) $breakpoint ][ (string) $property ] = $this->project( $override );
+			}
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Resolve a preset's PER-BREAKPOINT overrides to flattened LITERALS, for the editor surfaces that
+	 * cannot consume a var() chain. The literal counterpart of resolve_responsive(), covering exactly the
+	 * same overrides.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block  The block name.
+	 * @param string $preset The preset slug.
+	 * @param string $slug   The token library whose effective presets and resolved values are read.
+	 *
+	 * @throws Unknown_Preset_Exception When the block or preset is not defined.
+	 *
+	 * @return array<string, array<string, string|string[]>> breakpoint => ( property => literal value ).
+	 */
+	public function resolve_responsive_literal( string $block, string $preset, string $slug = 'default' ): array {
+		$resolved = $this->resolver->resolve( $slug );
+		$out      = [];
+
+		foreach ( $this->preset_tokens( $block, $preset, $slug ) as $property => $value ) {
+			foreach ( Extensions::preset_responsive_of( $value ) as $breakpoint => $override ) {
+				$flat = $this->flatten( $override, $resolved );
+
+				if ( $flat === null ) {
+					continue;
+				}
+
+				$out[ (string) $breakpoint ][ (string) $property ] = $flat;
+			}
+		}
+
+		return $out;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Resolver/Preset_Value_Normalizer.php
+++ b/includes/resources/Design_Tokens/Resolver/Preset_Value_Normalizer.php
@@ -3,7 +3,10 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Resolver;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Layers;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Responsive;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Sentinels;
 
 /**
  * Rewrites a preset's captured literal values into semantic aliases, so a value captured off a block
@@ -81,6 +84,21 @@ final class Preset_Value_Normalizer {
 	 * @return mixed The alias string when matched, otherwise the original value.
 	 */
 	private function alias_for( string $property, $value, array $index ) {
+		// A property that varies by breakpoint keeps its envelope; its base and each override are matched
+		// on their own, so a captured per-breakpoint literal re-joins the cascade like any other value.
+		if ( is_array( $value ) && array_key_exists( Sentinels::get_value_key(), $value ) ) {
+			$entry = $value;
+
+			$entry[ Sentinels::get_value_key() ] = $this->alias_for( $property, Extensions::preset_value_of( $value ), $index );
+
+			foreach ( Extensions::preset_responsive_of( $value ) as $breakpoint => $override ) {
+				$entry[ Extensions::get_extensions_key() ][ Extensions::get_namespace() ][ Responsive::get_responsive_key() ][ $breakpoint ] =
+					$this->alias_for( $property, $override, $index );
+			}
+
+			return $entry;
+		}
+
 		if ( is_array( $value ) ) {
 			$slots = [];
 

--- a/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
@@ -1018,6 +1018,27 @@ final class Presets_Controller extends Controller {
 	}
 
 	/**
+	 * Every value a preset token entry carries: its base, plus one entry per breakpoint override.
+	 *
+	 * A property that varies by breakpoint stores an envelope rather than a bare value, so a guard that
+	 * inspected the raw entry would both miss the overrides and mistake the envelope itself for a slot
+	 * list. Unwrapping here keeps each guard's own rule unchanged — it just runs over every value the
+	 * entry actually contributes.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $entry The preset token entry.
+	 *
+	 * @return array<int, mixed> The base value followed by each breakpoint override.
+	 */
+	private function preset_entry_values( $entry ): array {
+		return array_merge(
+			[ Extensions::preset_value_of( $entry ) ],
+			array_values( Extensions::preset_responsive_of( $entry ) )
+		);
+	}
+
+	/**
 	 * Reject a per-corner slot list written to a property that is not a dimension.
 	 *
 	 * A slot list expresses the four sides of a measure control, so it is meaningful only where the bound
@@ -1050,21 +1071,30 @@ final class Presets_Controller extends Controller {
 
 			$tokens = is_array( $preset ) && isset( $preset[ $tokens_key ] ) && is_array( $preset[ $tokens_key ] ) ? $preset[ $tokens_key ] : [];
 
-			foreach ( $tokens as $property => $value ) {
-				if ( ! is_array( $value ) || $bindings->kind( (string) $property ) === Preset_Bindings::get_kind_dimension() ) {
+			foreach ( $tokens as $property => $entry ) {
+				if ( $bindings->kind( (string) $property ) === Preset_Bindings::get_kind_dimension() ) {
 					continue;
 				}
 
-				return new WP_Error(
-					'rest_design_tokens_invalid',
-					__( 'A per-corner value is only valid for a dimension property.', 'kadence-blocks' ),
-					[
-						'status'   => WP_Http::UNPROCESSABLE_ENTITY,
-						'block'    => $block,
-						'preset'   => (string) $preset_slug,
-						'property' => (string) $property,
-					]
-				);
+				// Check the base and every breakpoint override. Each is unwrapped first, so what remains is
+				// a scalar, an alias or a slot list — an array here is therefore a slot list, never the
+				// responsive envelope (which is legal on any kind).
+				foreach ( $this->preset_entry_values( $entry ) as $value ) {
+					if ( ! is_array( $value ) ) {
+						continue;
+					}
+
+					return new WP_Error(
+						'rest_design_tokens_invalid',
+						__( 'A per-corner value is only valid for a dimension property.', 'kadence-blocks' ),
+						[
+							'status'   => WP_Http::UNPROCESSABLE_ENTITY,
+							'block'    => $block,
+							'preset'   => (string) $preset_slug,
+							'property' => (string) $property,
+						]
+					);
+				}
 			}
 		}
 
@@ -1216,10 +1246,15 @@ final class Presets_Controller extends Controller {
 
 			$tokens = is_array( $preset ) && isset( $preset[ $tokens_key ] ) && is_array( $preset[ $tokens_key ] ) ? $preset[ $tokens_key ] : [];
 
-			foreach ( $tokens as $property => $value ) {
-				// A per-corner slot list carries one alias per corner, so every slot is checked; otherwise a
-				// dangling corner would pass the write and silently drop the whole property at projection.
-				$candidates = is_array( $value ) ? $value : [ $value ];
+			foreach ( $tokens as $property => $entry ) {
+				// Flatten the entry to every value it carries — its base, each breakpoint override, and each
+				// corner of any slot list among them — so a dangling alias anywhere is caught on write rather
+				// than silently dropping its property (or breakpoint) at projection.
+				$candidates = [];
+
+				foreach ( $this->preset_entry_values( $entry ) as $value ) {
+					$candidates = array_merge( $candidates, is_array( $value ) ? array_values( $value ) : [ $value ] );
+				}
 
 				foreach ( $candidates as $candidate ) {
 					if ( ! Alias::is_alias( $candidate ) || $resolved->value( Alias::path_of( $candidate ) ) !== null ) {

--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -749,11 +749,74 @@ final class Dtcg_Validator {
 			return $this->validate_extension_slots( $value, $path );
 		}
 
+		if ( is_array( $value ) && array_key_exists( Sentinels::get_value_key(), $value ) ) {
+			return $this->validate_extension_envelope( $value, $path );
+		}
+
 		return new Validation_Error(
 			$path,
 			Validation_Error::get_code_value_invalid(),
-			'A foundation-preset/block-preset token value must be an alias, a non-empty literal, or a slot list.'
+			'A foundation-preset/block-preset token value must be an alias, a non-empty literal, a slot list, or a responsive entry.'
 		);
+	}
+
+	/**
+	 * Validate a preset token entry that varies by breakpoint: its `$value` is the base, and each override
+	 * under the vendor extension's `responsive` map is itself a preset token value.
+	 *
+	 * Mirrors {@see self::validate_responsive_shape()} — same envelope, same breakpoint-key check — but
+	 * validates each override by SHAPE rather than against a `$type`. A preset property has no `$type`
+	 * (the walk sees a property name like "button-radius", not a token id), which is also why the kind
+	 * gate lives in the REST write guard rather than here.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $entry The decoded entry.
+	 * @param string               $path  Dot-path to the entry.
+	 *
+	 * @return Validation_Error|null Null when valid.
+	 */
+	private function validate_extension_envelope( array $entry, string $path ): ?Validation_Error {
+		$error = $this->validate_extension_value( Extensions::preset_value_of( $entry ), $path );
+
+		if ( $error !== null ) {
+			return $error;
+		}
+
+		$responsive = Extensions::preset_responsive_of( $entry );
+
+		// An entry object with no overrides says nothing a bare value does not; refuse the dead shape.
+		if ( $responsive === [] ) {
+			return new Validation_Error(
+				$path,
+				Validation_Error::get_code_value_invalid(),
+				'A responsive preset token entry must declare at least one breakpoint override; use a bare value otherwise.'
+			);
+		}
+
+		$allowed = Responsive::get_breakpoint_keys();
+
+		foreach ( $responsive as $breakpoint => $override ) {
+			if ( ! in_array( $breakpoint, $allowed, true ) ) {
+				return new Validation_Error(
+					$path . '.' . $breakpoint,
+					Validation_Error::get_code_composite_field_unknown(),
+					sprintf(
+						'Unknown responsive breakpoint "%s"; expected one of: %s.',
+						(string) $breakpoint,
+						implode( ', ', $allowed )
+					)
+				);
+			}
+
+			$error = $this->validate_extension_value( $override, $path . '.' . $breakpoint );
+
+			if ( $error !== null ) {
+				return $error;
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
@@ -346,4 +346,47 @@ final class Extensions {
 	public static function get_group_id_key(): string {
 		return self::GROUP_ID_KEY;
 	}
+
+	/**
+	 * The base value of a preset token entry.
+	 *
+	 * A preset property is normally a bare value — an alias, a literal, or a per-corner slot list. A
+	 * property that varies by breakpoint instead carries the same envelope a responsive token leaf uses
+	 * ({@see Responsive}): its base under `$value`, its overrides under the vendor extension. This reader
+	 * collapses both shapes to the base, so no consumer hand-rolls the unwrap. A slot list has no `$value`
+	 * key, so it is never mistaken for an envelope.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $entry The preset token entry.
+	 *
+	 * @return mixed The base value.
+	 */
+	public static function preset_value_of( $entry ) {
+		if ( is_array( $entry ) && array_key_exists( Sentinels::get_value_key(), $entry ) ) {
+			return $entry[ Sentinels::get_value_key() ];
+		}
+
+		return $entry;
+	}
+
+	/**
+	 * The per-breakpoint overrides a preset token entry declares, or an empty array when it declares none.
+	 * Delegates to {@see Responsive} so the lookup path is byte-identical to a token leaf's.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $entry The preset token entry.
+	 *
+	 * @return array<string, mixed> Breakpoint => override value.
+	 */
+	public static function preset_responsive_of( $entry ): array {
+		if ( ! is_array( $entry ) || ! Responsive::has_responsive( $entry ) ) {
+			return [];
+		}
+
+		$responsive = Responsive::responsive_of( $entry );
+
+		return is_array( $responsive ) ? $responsive : [];
+	}
 }

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -89,6 +89,7 @@ import {
 	deriveMeasureMode,
 	inheritedMeasureSlots,
 	measureAttrsForDevice,
+	presetValueForDevice,
 } from '../../extension/token-indicators/normalize';
 import { TokenLabel } from '../../extension/token-indicators/components/TokenLabel';
 import { TokenControlRow } from '../../extension/token-indicators/components/TokenControlRow';
@@ -282,13 +283,22 @@ export default function KadenceButtonEdit(props) {
 	const tokenBinding = usePresetBinding('kadence/singlebtn', attributes);
 	const resetToken = (attr) => resetAttr(attr, setAttributes, tokenBinding[attr]?.kind);
 
+	// The preset's own value at the active device: a preset can set a different radius per breakpoint,
+	// and the button renders that, so naming the desktop value on Tablet would name a size the block is
+	// not showing there.
+	const borderRadiusPresetValue = presetValueForDevice(
+		tokenBinding.borderRadius?.presetValue,
+		tokenBinding.borderRadius?.responsive,
+		previewDevice
+	);
+
 	// What an unset Border Radius corner falls back to on the active device: another breakpoint's corner
 	// before the preset's, matching the cascade the button actually renders through. The corners stay
 	// stored-empty — this only tells the field's popover which size is in effect and where it came from.
 	const inheritedBorderRadius = inheritedMeasureSlots(
 		previewDevice,
 		{ desktop: borderRadius, tablet: tabletBorderRadius },
-		tokenBinding.borderRadius?.presetValue
+		borderRadiusPresetValue
 	);
 
 	useEffect(() => {
@@ -1257,7 +1267,7 @@ export default function KadenceButtonEdit(props) {
 																	borderRadiusModeOverride[previewDevice] ??
 																	deriveMeasureMode(
 																		borderRadiusForDevice.value,
-																		tokenBinding.borderRadius?.presetValue
+																		borderRadiusPresetValue
 																	)
 																}
 																onChangeControl={(mode) => {

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -283,9 +283,6 @@ export default function KadenceButtonEdit(props) {
 	const tokenBinding = usePresetBinding('kadence/singlebtn', attributes);
 	const resetToken = (attr) => resetAttr(attr, setAttributes, tokenBinding[attr]?.kind);
 
-	// The preset's own value at the active device: a preset can set a different radius per breakpoint,
-	// and the button renders that, so naming the desktop value on Tablet would name a size the block is
-	// not showing there.
 	const borderRadiusPresetValue = presetValueForDevice(
 		tokenBinding.borderRadius?.presetValue,
 		tokenBinding.borderRadius?.responsive,

--- a/src/extension/design-tokens/component-token-ui.js
+++ b/src/extension/design-tokens/component-token-ui.js
@@ -279,12 +279,7 @@ export function TokenFieldControl({
 	// The inherited default has to be resolved before it is compared or shown — a raw alias or a unitless
 	// number would neither match a token row nor read as a value.
 	const resolvedDefault = resolveDefaultValue(defaultValue, tokens, unit, inherited);
-	// What an unset field shows: the inherited default, muted. The block stores nothing either way —
-	// this only stops the field reading as "no radius" when the preset (or another breakpoint) is
-	// giving it one.
 	const fallback = defaultSummary(resolvedDefault, tokens);
-	// The tooltip/aria-label names where the shown value comes from — "Default (8px)" or "Inherited
-	// (8px)" — which the muted field text alone cannot say.
 	const inheritedName = inherited
 		? sprintf(
 				/* translators: %s: the inherited value, e.g. "8px". */ __('Inherited (%s)', 'kadence-blocks'),

--- a/src/extension/design-tokens/component-token-ui.js
+++ b/src/extension/design-tokens/component-token-ui.js
@@ -104,14 +104,40 @@ function resolveDefaultValue(defaultValue, tokens, unit, inherited) {
 }
 
 /**
+ * The label/value summary for the INHERITED default a field falls back to, so an unset field can show
+ * the size that is actually in effect instead of reading as empty.
+ *
+ * The default arrives resolved (`"9999px"`), which names a size but not the token it came from, so the
+ * pickable list is searched for the entry that resolves to the same value and its label is used when one
+ * matches. The result is rendered muted — the field is still unset, and picking it up as a set value is
+ * the confusion an empty-means-inherit attribute has to avoid.
+ *
+ * @param {string} resolvedDefault The inherited default, already resolved to a literal.
+ * @param {Array}  tokens          The pickable-token list, used to name the value.
+ *
+ * @since TBD
+ *
+ * @return {{label: string, value: string}} The label and value text, both '' when there is no default.
+ */
+function defaultSummary(resolvedDefault, tokens) {
+	if (!resolvedDefault) {
+		return { label: '', value: '' };
+	}
+
+	const entry = (tokens || []).find((candidate) => candidate.value === resolvedDefault) || null;
+
+	return { label: entry ? entry.label : '', value: resolvedDefault };
+}
+
+/**
  * The label/value summary a token field shows on its trigger for the current slot value: the token's
  * label + resolved value when aliased (dot-path fallback when no matching entry is found), a `Custom`
  * label + literal (with unit) for a set literal, or NOTHING when the slot is unset.
  *
- * An unset slot renders blank on purpose, matching the plain number inputs the Border control uses: the
- * field shows what this slot holds, and it holds nothing. Naming the inherited size here would read as a
- * value set on this breakpoint, which is exactly the confusion an empty-means-inherit attribute has to
- * avoid. Where that value comes from stays visible one layer in, on the popover's tagged row.
+ * An unset slot summarizes to nothing — what the field then shows is the inherited default, rendered
+ * muted by `defaultSummary` so it reads as a placeholder rather than a value stored on this breakpoint.
+ * Keeping the two apart is the point: this function answers "what does this slot hold", and an unset
+ * slot holds nothing.
  *
  * @param {*}      value  The current slot value (alias string, literal number/string, or empty).
  * @param {Array}  tokens The pickable-token list, used to resolve an alias to its label.
@@ -253,9 +279,12 @@ export function TokenFieldControl({
 	// The inherited default has to be resolved before it is compared or shown — a raw alias or a unitless
 	// number would neither match a token row nor read as a value.
 	const resolvedDefault = resolveDefaultValue(defaultValue, tokens, unit, inherited);
-	// An unset field renders blank, so the button would have no accessible name and no way to tell a
-	// screen-reader user what it currently resolves to. The tooltip/aria-label carries the inherited value
-	// instead — available on hover and to assistive tech, without printing it in the field.
+	// What an unset field shows: the inherited default, muted. The block stores nothing either way —
+	// this only stops the field reading as "no radius" when the preset (or another breakpoint) is
+	// giving it one.
+	const fallback = defaultSummary(resolvedDefault, tokens);
+	// The tooltip/aria-label names where the shown value comes from — "Default (8px)" or "Inherited
+	// (8px)" — which the muted field text alone cannot say.
 	const inheritedName = inherited
 		? sprintf(
 				/* translators: %s: the inherited value, e.g. "8px". */ __('Inherited (%s)', 'kadence-blocks'),
@@ -349,6 +378,16 @@ export function TokenFieldControl({
 					>
 						{summary.label && <span className="kadence-token-field__label">{summary.label}</span>}
 						{summary.value && <span className="kadence-token-field__value">{summary.value}</span>}
+						{!summary.label && !summary.value && fallback.value && (
+							<>
+								{fallback.label && (
+									<span className="kadence-token-field__label kadence-token-field__label--default">
+										{fallback.label}
+									</span>
+								)}
+								<span className="kadence-token-field__value">{fallback.value}</span>
+							</>
+						)}
 					</Button>
 				)}
 				renderContent={({ onClose }) => (

--- a/src/extension/design-tokens/component-token-ui.scss
+++ b/src/extension/design-tokens/component-token-ui.scss
@@ -278,8 +278,6 @@
 	white-space: nowrap;
 }
 
-// The inherited default's token name, shown when the field itself is unset. Muted like the value beside
-// it so the pair reads as a placeholder — the block stores nothing at this breakpoint.
 .kadence-token-field__label--default {
 	color: #949494;
 }

--- a/src/extension/design-tokens/component-token-ui.scss
+++ b/src/extension/design-tokens/component-token-ui.scss
@@ -59,7 +59,7 @@
 		border-color: #1e1e1e;
 	}
 
-	&[aria-expanded='true'] {
+	&[aria-expanded="true"] {
 		border-color: #3858e9;
 		box-shadow: 0 0 0 1px #3858e9;
 	}
@@ -276,4 +276,10 @@
 	color: #949494;
 	font-size: 13px;
 	white-space: nowrap;
+}
+
+// The inherited default's token name, shown when the field itself is unset. Muted like the value beside
+// it so the pair reads as a placeholder — the block stores nothing at this breakpoint.
+.kadence-token-field__label--default {
+	color: #949494;
 }

--- a/src/extension/design-tokens/token-literals.js
+++ b/src/extension/design-tokens/token-literals.js
@@ -1,0 +1,47 @@
+/**
+ * Resolved literal lookup for design-token aliases.
+ *
+ * The editor localizer prints every registered token's resolved literal per library to
+ * `window.kadenceDesignTokensPickable.values` (`{ <library>: { <id>: literal } }`). The picker uses it for
+ * its preview swatch; this module exposes the same lookup to anything that has to turn an alias back into
+ * the literal a resolved-values map stores, without going through the server.
+ */
+import { get } from 'lodash';
+import { isTokenAlias } from './alias';
+
+/**
+ * The resolved literal map for a token library, or an empty map when the pool is absent.
+ *
+ * @param {string} library The token library slug.
+ *
+ * @since TBD
+ *
+ * @return {Object} id => literal value.
+ */
+function libraryLiterals(library) {
+	const values = get(window, ['kadenceDesignTokensPickable', 'values'], {}) || {};
+
+	return get(values, [library], {}) || {};
+}
+
+/**
+ * The literal a value resolves to: an alias resolves through the library's token map, anything else is
+ * already a literal and passes through. An alias the library does not define also passes through, so a
+ * caller never silently swaps a meaningful value for an empty string.
+ *
+ * @param {*}      value   The value, an alias or a literal.
+ * @param {string} library The token library slug.
+ *
+ * @since TBD
+ *
+ * @return {*} The resolved literal.
+ */
+export function tokenLiteral(value, library) {
+	if (!isTokenAlias(value)) {
+		return value;
+	}
+
+	const literal = get(libraryLiterals(library), [value.slice(1, -1)], '');
+
+	return literal === '' ? value : literal;
+}

--- a/src/extension/preset-picker/SavePresetModal.js
+++ b/src/extension/preset-picker/SavePresetModal.js
@@ -9,7 +9,8 @@
 import { Modal, TextControl, Button, Notice } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { appendPreset } from './index';
+import { appendPreset, setPresetValues } from './index';
+import { capturedCatalogValues } from './capture';
 import { createPreset } from '../presets/api/client';
 import { refreshProjectedCss } from '../design-tokens/live-css';
 import { deriveSlug, dedupeSlug } from '../presets/slug';
@@ -51,7 +52,12 @@ export function SavePresetModal({ blockName, library, tokens, existingSlugs = []
 
 		createPreset(blockName, { preset: slug, label: label.trim(), tokens }, library)
 			.then(() => {
+				const { values, responsive } = capturedCatalogValues(tokens, library);
+
 				appendPreset(blockName, library, { slug, label: label.trim(), userCreated: true });
+				// Selecting the new preset clears the block's overrides, so its values have to be in the
+				// catalog before that happens or every control lands on a preset that defines nothing.
+				setPresetValues(blockName, library, slug, values, responsive);
 				refreshProjectedCss();
 				onSaved(slug);
 				onClose();

--- a/src/extension/preset-picker/SavePresetModal.js
+++ b/src/extension/preset-picker/SavePresetModal.js
@@ -55,8 +55,7 @@ export function SavePresetModal({ blockName, library, tokens, existingSlugs = []
 				const { values, responsive } = capturedCatalogValues(tokens, library);
 
 				appendPreset(blockName, library, { slug, label: label.trim(), userCreated: true });
-				// Selecting the new preset clears the block's overrides, so its values have to be in the
-				// catalog before that happens or every control lands on a preset that defines nothing.
+				// Must precede onSaved: selecting the preset clears the block's overrides.
 				setPresetValues(blockName, library, slug, values, responsive);
 				refreshProjectedCss();
 				onSaved(slug);

--- a/src/extension/preset-picker/__tests__/capture.test.js
+++ b/src/extension/preset-picker/__tests__/capture.test.js
@@ -4,7 +4,7 @@
 // its `PresetPicker` component. `capturedTokens` never renders it, so stub the module out.
 jest.mock('@kadence/components', () => ({}));
 
-import { capturedTokens } from '../capture';
+import { capturedTokens, capturedCatalogValues } from '../capture';
 
 const BLOCK = 'kadence/singlebtn';
 const SET = 'default';
@@ -225,6 +225,51 @@ describe('capturedTokens', () => {
 		).toEqual({ mobile: '2px' });
 	});
 
+	it('fills an unset corner at a breakpoint from the captured base, not from the preset', () => {
+		const full = '{primitive.dimension.radius.full}';
+		const xl = '{primitive.dimension.radius.xl}';
+		const attributes = {
+			kbPreset: 'primary',
+			borderRadius: [xl, xl, xl, xl],
+			borderRadiusUnit: 'px',
+			tabletBorderRadius: [full, '', '', ''],
+		};
+
+		// The three untouched Tablet corners keep rendering Desktop's radius, so they capture it — filling
+		// them from the preset's '4px' would pin Tablet against what the button actually shows.
+		expect(
+			capturedTokens(BLOCK, SET, attributes)['button-radius'].$extensions['com.kadence.designTokens'].responsive
+		).toEqual({ tablet: [full, xl, xl, xl] });
+	});
+
+	it('fills an unset Mobile corner from the captured Tablet value', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			borderRadius: ['8', '8', '8', '8'],
+			borderRadiusUnit: 'px',
+			tabletBorderRadius: ['4', '4', '4', '4'],
+			mobileBorderRadius: ['2', '', '', ''],
+		};
+
+		expect(
+			capturedTokens(BLOCK, SET, attributes)['button-radius'].$extensions['com.kadence.designTokens'].responsive
+		).toEqual({ tablet: '4px', mobile: ['2px', '4px', '4px', '4px'] });
+	});
+
+	it('fills an unset Mobile corner from the base when Tablet stores nothing', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			borderRadius: ['8', '8', '8', '8'],
+			borderRadiusUnit: 'px',
+			tabletBorderRadius: ['', '', '', ''],
+			mobileBorderRadius: ['2', '', '', ''],
+		};
+
+		expect(
+			capturedTokens(BLOCK, SET, attributes)['button-radius'].$extensions['com.kadence.designTokens'].responsive
+		).toEqual({ mobile: ['2px', '8px', '8px', '8px'] });
+	});
+
 	it('stays a bare value when no breakpoint is set', () => {
 		const attributes = {
 			kbPreset: 'primary',
@@ -246,5 +291,74 @@ describe('capturedTokens', () => {
 		const tokens = capturedTokens(BLOCK, SET, attributes);
 
 		expect(tokens).toEqual({ 'button-bg': '#00ff00', 'button-radius': '4px' });
+	});
+});
+
+describe('capturedCatalogValues', () => {
+	beforeEach(() => {
+		seedCatalog();
+
+		window.kadenceDesignTokensPickable = {
+			tokens: [],
+			values: {
+				default: {
+					'primitive.dimension.radius.xl': '1rem',
+					'primitive.dimension.radius.full': '9999px',
+				},
+			},
+		};
+	});
+
+	afterEach(() => {
+		delete window.kadenceDesignTokensPresets;
+		delete window.kadenceDesignTokensPickable;
+	});
+
+	it('resolves an alias to the library literal', () => {
+		const captured = capturedCatalogValues({ 'button-radius': '{primitive.dimension.radius.xl}' }, SET);
+
+		expect(captured).toEqual({ values: { 'button-radius': '1rem' }, responsive: {} });
+	});
+
+	it('passes a literal through untouched', () => {
+		const captured = capturedCatalogValues({ 'button-bg': '#ff0000' }, SET);
+
+		expect(captured.values).toEqual({ 'button-bg': '#ff0000' });
+	});
+
+	it('keeps an alias the library does not define, rather than emptying it', () => {
+		const captured = capturedCatalogValues({ 'button-radius': '{primitive.dimension.radius.none}' }, SET);
+
+		expect(captured.values['button-radius']).toBe('{primitive.dimension.radius.none}');
+	});
+
+	it('resolves a per-corner list slot by slot', () => {
+		const captured = capturedCatalogValues(
+			{ 'button-radius': ['{primitive.dimension.radius.full}', '8px', '8px', '8px'] },
+			SET
+		);
+
+		expect(captured.values['button-radius']).toEqual(['9999px', '8px', '8px', '8px']);
+	});
+
+	it('splits a responsive envelope into the base value and the per-breakpoint map', () => {
+		const captured = capturedCatalogValues(
+			{
+				'button-radius': {
+					$value: '{primitive.dimension.radius.xl}',
+					$extensions: {
+						'com.kadence.designTokens': {
+							responsive: { tablet: ['{primitive.dimension.radius.full}', '1rem', '1rem', '1rem'] },
+						},
+					},
+				},
+			},
+			SET
+		);
+
+		expect(captured).toEqual({
+			values: { 'button-radius': '1rem' },
+			responsive: { tablet: { 'button-radius': ['9999px', '1rem', '1rem', '1rem'] } },
+		});
 	});
 });

--- a/src/extension/preset-picker/__tests__/capture.test.js
+++ b/src/extension/preset-picker/__tests__/capture.test.js
@@ -25,7 +25,16 @@ function seedCatalog() {
 					presets: [{ slug: 'primary', label: 'Primary' }],
 					properties: [
 						{ key: 'button-bg', kind: 'color', token: null, control_attr: 'background' },
-						{ key: 'button-radius', kind: 'dimension', token: null, control_attr: 'borderRadius' },
+						{
+							key: 'button-radius',
+							kind: 'dimension',
+							token: null,
+							control_attr: 'borderRadius',
+							responsive_attrs: {
+								tablet: 'tabletBorderRadius',
+								mobile: 'mobileBorderRadius',
+							},
+						},
 					],
 					values: {
 						primary: { 'button-bg': '#111111', 'button-radius': '4px' },
@@ -155,6 +164,75 @@ describe('capturedTokens', () => {
 
 		// Nothing edited: the not-edited fallback must hand the slot list back unchanged.
 		expect(capturedTokens(BLOCK, SET, { kbPreset: 'primary' })['button-radius']).toEqual(slots);
+	});
+
+	it('captures a per-breakpoint override as a responsive envelope', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			borderRadius: ['8', '8', '8', '8'],
+			borderRadiusUnit: 'px',
+			mobileBorderRadius: ['2', '2', '2', '2'],
+		};
+
+		expect(capturedTokens(BLOCK, SET, attributes)['button-radius']).toEqual({
+			$value: '8px',
+			$extensions: { 'com.kadence.designTokens': { responsive: { mobile: '2px' } } },
+		});
+	});
+
+	it('captures per-corner values at a breakpoint', () => {
+		const alias = '{primitive.dimension.radius.md}';
+		const attributes = {
+			kbPreset: 'primary',
+			borderRadius: ['8', '8', '8', '8'],
+			borderRadiusUnit: 'px',
+			tabletBorderRadius: [alias, '4', alias, '4'],
+		};
+
+		expect(capturedTokens(BLOCK, SET, attributes)['button-radius']).toEqual({
+			$value: '8px',
+			$extensions: {
+				'com.kadence.designTokens': { responsive: { tablet: [alias, '4px', alias, '4px'] } },
+			},
+		});
+	});
+
+	it('captures both breakpoints when both are set', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			borderRadius: ['8', '8', '8', '8'],
+			borderRadiusUnit: 'px',
+			tabletBorderRadius: ['4', '4', '4', '4'],
+			mobileBorderRadius: ['2', '2', '2', '2'],
+		};
+
+		expect(
+			capturedTokens(BLOCK, SET, attributes)['button-radius'].$extensions['com.kadence.designTokens'].responsive
+		).toEqual({ tablet: '4px', mobile: '2px' });
+	});
+
+	it('omits a breakpoint whose attribute is unset, so it inherits', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			borderRadius: ['8', '8', '8', '8'],
+			borderRadiusUnit: 'px',
+			tabletBorderRadius: ['', '', '', ''],
+			mobileBorderRadius: ['2', '2', '2', '2'],
+		};
+
+		expect(
+			capturedTokens(BLOCK, SET, attributes)['button-radius'].$extensions['com.kadence.designTokens'].responsive
+		).toEqual({ mobile: '2px' });
+	});
+
+	it('stays a bare value when no breakpoint is set', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			borderRadius: ['8', '8', '8', '8'],
+			borderRadiusUnit: 'px',
+		};
+
+		expect(capturedTokens(BLOCK, SET, attributes)['button-radius']).toBe('8px');
 	});
 
 	it('uses the default preset when no preset is selected', () => {

--- a/src/extension/preset-picker/capture.js
+++ b/src/extension/preset-picker/capture.js
@@ -17,6 +17,23 @@ import {
 	presetSlotAt,
 } from '../token-indicators/normalize';
 import { isTokenAlias } from '../design-tokens/alias';
+import { tokenLiteral } from '../design-tokens/token-literals';
+
+/**
+ * The vendor extension a responsive token leaf carries its per-breakpoint overrides under. Mirrors the
+ * PHP `Extensions` vendor key.
+ *
+ * @since TBD
+ */
+const VENDOR_EXTENSION = 'com.kadence.designTokens';
+
+/**
+ * The breakpoints a responsive property can override, narrowest last — the order the device cascade runs
+ * in, so each breakpoint's unset corners fall back to the one above it.
+ *
+ * @since TBD
+ */
+const CASCADE = ['tablet', 'mobile'];
 
 /**
  * Compose one dimension slot into the literal a preset stores: a token alias is stored verbatim, any
@@ -90,28 +107,40 @@ function attrToLiteral(kind, value, unit, presetValue) {
  * inheriting; a property with no breakpoint values stays a bare value, leaving every existing preset
  * byte-identical.
  *
+ * A corner the breakpoint leaves unset inherits the way the editor renders it — through the device
+ * cascade, not from the preset: Tablet falls back to the captured base, Mobile to the captured Tablet
+ * value and then to the base. Filling from the preset instead would freeze the preset's default into the
+ * corners the user never touched, pinning them against the Desktop value they are rendering at.
+ *
  * @param {*}      base        The captured base (desktop) value.
  * @param {Object} property    The bound property, carrying `responsive_attrs`.
  * @param {Object} attributes  The block's current attributes.
  * @param {string} unit        The property's unit. A responsive measure control carries ONE unit across
  *                             all three devices, so every breakpoint composes against the same one.
- * @param {*}      presetValue The selected preset's value, used to fill an unset corner.
  *
  * @since TBD
  *
  * @return {*} The base value, or the responsive envelope wrapping it.
  */
-function withResponsive(base, property, attributes, unit, presetValue) {
+function withResponsive(base, property, attributes, unit) {
 	const responsive = {};
 
-	Object.entries(property.responsive_attrs || {}).forEach(([breakpoint, attr]) => {
-		const raw = get(attributes, attr, '');
+	// Cascade order, so a Mobile corner can inherit the Tablet value captured a step earlier.
+	CASCADE.forEach((breakpoint, index) => {
+		const attr = get(property.responsive_attrs, breakpoint, '');
+		const raw = attr ? get(attributes, attr, '') : '';
 
-		if (isEmptyValue(property.kind, raw)) {
+		if (!attr || isEmptyValue(property.kind, raw)) {
 			return;
 		}
 
-		const value = attrToLiteral(property.kind, raw, unit, presetValue);
+		// The nearest breakpoint above this one that captured a value, else the base.
+		const above = CASCADE.slice(0, index)
+			.reverse()
+			.map((breakpointAbove) => responsive[breakpointAbove])
+			.find((captured) => captured !== undefined);
+
+		const value = attrToLiteral(property.kind, raw, unit, above === undefined ? base : above);
 
 		if (value !== '') {
 			responsive[breakpoint] = value;
@@ -122,7 +151,60 @@ function withResponsive(base, property, attributes, unit, presetValue) {
 		return base;
 	}
 
-	return { $value: base, $extensions: { 'com.kadence.designTokens': { responsive } } };
+	return { $value: base, $extensions: { [VENDOR_EXTENSION]: { responsive } } };
+}
+
+/**
+ * Resolve a captured value to the literal the catalog's value map stores: an alias resolves through the
+ * library's token literals, a per-corner list resolves slot by slot.
+ *
+ * @param {*}      value   The captured value.
+ * @param {string} library The token library slug.
+ *
+ * @since TBD
+ *
+ * @return {*} The resolved literal, or the per-corner literal list.
+ */
+function capturedLiteral(value, library) {
+	return Array.isArray(value) ? value.map((slot) => tokenLiteral(slot, library)) : tokenLiteral(value, library);
+}
+
+/**
+ * The catalog view of a captured token map: the resolved `{ property: literal }` values plus the
+ * `{ breakpoint: { property: literal } }` overrides, matching what the server localizes for an existing
+ * preset (`values` / `responsive`).
+ *
+ * A newly saved preset is not in the localized catalog until the next page load, so the picker has to seed
+ * it from what was captured. Aliases are resolved here because the catalog stores literals — a control
+ * compares its own value against them, and a `{dot.path}` would never match.
+ *
+ * @param {Object} tokens  The captured token map ({ propertyKey: literal-or-envelope }).
+ * @param {string} library The token library the values were captured against.
+ *
+ * @since TBD
+ *
+ * @return {{ values: Object, responsive: Object }} The catalog value maps for the preset.
+ */
+export function capturedCatalogValues(tokens, library) {
+	const resolvedLibrary = library || activeLibrary();
+	const values = {};
+	const responsive = {};
+
+	Object.entries(tokens || {}).forEach(([key, captured]) => {
+		const overrides = get(captured, ['$extensions', VENDOR_EXTENSION, 'responsive'], null);
+		const base = overrides ? captured.$value : captured;
+
+		values[key] = capturedLiteral(base, resolvedLibrary);
+
+		Object.entries(overrides || {}).forEach(([breakpoint, value]) => {
+			responsive[breakpoint] = {
+				...(responsive[breakpoint] || {}),
+				[key]: capturedLiteral(value, resolvedLibrary),
+			};
+		});
+	});
+
+	return { values, responsive };
 }
 
 /**
@@ -154,7 +236,7 @@ export function capturedTokens(blockName, library, attributes) {
 		const presetValue = get(presetValues, property.key, '');
 		const base = edited ? attrToLiteral(property.kind, raw, unit, presetValue) : presetValue;
 
-		tokens[property.key] = withResponsive(base, property, attributes, unit, presetValue);
+		tokens[property.key] = withResponsive(base, property, attributes, unit);
 
 		return tokens;
 	}, {});

--- a/src/extension/preset-picker/capture.js
+++ b/src/extension/preset-picker/capture.js
@@ -134,7 +134,6 @@ function withResponsive(base, property, attributes, unit) {
 			return;
 		}
 
-		// The nearest breakpoint above this one that captured a value, else the base.
 		const above = CASCADE.slice(0, index)
 			.reverse()
 			.map((breakpointAbove) => responsive[breakpointAbove])

--- a/src/extension/preset-picker/capture.js
+++ b/src/extension/preset-picker/capture.js
@@ -81,6 +81,51 @@ function attrToLiteral(kind, value, unit, presetValue) {
 }
 
 /**
+ * Wrap a captured base value in the responsive envelope when the block carries per-breakpoint values for
+ * the property, otherwise return the base unchanged.
+ *
+ * The envelope is the same one a responsive token leaf uses — base under `$value`, overrides under the
+ * vendor extension — so each override is validated, resolved and projected by exactly the rules the base
+ * goes through. A breakpoint whose attribute is unset is omitted rather than frozen, so it keeps
+ * inheriting; a property with no breakpoint values stays a bare value, leaving every existing preset
+ * byte-identical.
+ *
+ * @param {*}      base        The captured base (desktop) value.
+ * @param {Object} property    The bound property, carrying `responsive_attrs`.
+ * @param {Object} attributes  The block's current attributes.
+ * @param {string} unit        The property's unit. A responsive measure control carries ONE unit across
+ *                             all three devices, so every breakpoint composes against the same one.
+ * @param {*}      presetValue The selected preset's value, used to fill an unset corner.
+ *
+ * @since TBD
+ *
+ * @return {*} The base value, or the responsive envelope wrapping it.
+ */
+function withResponsive(base, property, attributes, unit, presetValue) {
+	const responsive = {};
+
+	Object.entries(property.responsive_attrs || {}).forEach(([breakpoint, attr]) => {
+		const raw = get(attributes, attr, '');
+
+		if (isEmptyValue(property.kind, raw)) {
+			return;
+		}
+
+		const value = attrToLiteral(property.kind, raw, unit, presetValue);
+
+		if (value !== '') {
+			responsive[breakpoint] = value;
+		}
+	});
+
+	if (!Object.keys(responsive).length) {
+		return base;
+	}
+
+	return { $value: base, $extensions: { 'com.kadence.designTokens': { responsive } } };
+}
+
+/**
  * The block's current values across its preset surface, as a `{ propertyKey: literal }` token map: each
  * mapped control's edited value when it has one, else the selected preset's value. Feeds the "save as a
  * new preset" write so the new preset matches what the editor currently shows.
@@ -107,8 +152,9 @@ export function capturedTokens(blockName, library, attributes) {
 		// value that happens to equal the preset is captured all the same (no differs-from-preset compare).
 		const edited = attr && !isEmptyValue(property.kind, raw);
 		const presetValue = get(presetValues, property.key, '');
+		const base = edited ? attrToLiteral(property.kind, raw, unit, presetValue) : presetValue;
 
-		tokens[property.key] = edited ? attrToLiteral(property.kind, raw, unit, presetValue) : presetValue;
+		tokens[property.key] = withResponsive(base, property, attributes, unit, presetValue);
 
 		return tokens;
 	}, {});

--- a/src/extension/preset-picker/index.js
+++ b/src/extension/preset-picker/index.js
@@ -105,6 +105,24 @@ export function blockPresetValues(name, library) {
 }
 
 /**
+ * The per-preset, per-breakpoint resolved values for a block's library:
+ * `{ <presetSlug>: { <breakpoint>: { <property>: literalValue } } }`. Empty object when the block
+ * offers none, and a preset that declares no breakpoint overrides carries an empty map rather than
+ * being absent. The literals are flattened exactly like `blockPresetValues`, so a control can
+ * compare and display them the same way at any device.
+ *
+ * @param {string} name     The block name.
+ * @param {string} [library] The token library slug; defaults to the active library.
+ *
+ * @since TBD
+ *
+ * @return {Object} The per-preset, per-breakpoint value map.
+ */
+export function blockPresetResponsive(name, library) {
+	return get(blockEntry(name, library), 'responsive', {}) || {};
+}
+
+/**
  * The block library's default preset slug in a token library.
  *
  * @param {string} name     The block name.

--- a/src/extension/preset-picker/index.js
+++ b/src/extension/preset-picker/index.js
@@ -200,7 +200,7 @@ export function setPresetValues(name, library, slug, values, responsive) {
 
 /**
  * Remove a preset from the in-memory catalog for a block's library, so the picker drops it without a page
- * reload.
+ * reload. Its values go with it, so a later preset reusing the slug never inherits them.
  *
  * @param {string} name    The block name.
  * @param {string} library The token library slug.
@@ -216,7 +216,6 @@ export function removePreset(name, library, slug) {
 
 	entry.presets = entry.presets.filter((existing) => existing.slug !== slug);
 
-	// Drop the values with the preset, so a later preset reusing the slug never inherits them.
 	delete (entry.values || {})[slug];
 	delete (entry.responsive || {})[slug];
 }

--- a/src/extension/preset-picker/index.js
+++ b/src/extension/preset-picker/index.js
@@ -150,6 +150,37 @@ export function appendPreset(name, library, preset) {
 }
 
 /**
+ * Seed a preset's resolved values in the in-memory catalog for a block's library.
+ *
+ * A preset saved from the editor is absent from the localized catalog until the next page load, and the
+ * catalog's `values` map is what tells a control it is bound to the preset and which value it inherits.
+ * Without this seed the freshly selected preset looks like a preset that defines nothing: every control
+ * unbinds, so the block reads as un-edited and its values cannot be edited into a further preset.
+ *
+ * A no-op when the block has no entry for the token library.
+ *
+ * @param {string} name       The block name.
+ * @param {string} library    The token library slug.
+ * @param {string} slug       The preset slug.
+ * @param {Object} values     The preset's resolved values ({ property: literal }).
+ * @param {Object} responsive The preset's per-breakpoint values ({ breakpoint: { property: literal } }).
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+export function setPresetValues(name, library, slug, values, responsive) {
+	const entry = blockEntry(name, library);
+
+	if (!entry) {
+		return;
+	}
+
+	entry.values = { ...(entry.values || {}), [slug]: values || {} };
+	entry.responsive = { ...(entry.responsive || {}), [slug]: responsive || {} };
+}
+
+/**
  * Remove a preset from the in-memory catalog for a block's library, so the picker drops it without a page
  * reload.
  *
@@ -166,6 +197,10 @@ export function removePreset(name, library, slug) {
 	}
 
 	entry.presets = entry.presets.filter((existing) => existing.slug !== slug);
+
+	// Drop the values with the preset, so a later preset reusing the slug never inherits them.
+	delete (entry.values || {})[slug];
+	delete (entry.responsive || {})[slug];
 }
 
 /**

--- a/src/extension/token-indicators/__tests__/normalize.test.js
+++ b/src/extension/token-indicators/__tests__/normalize.test.js
@@ -7,6 +7,7 @@ import {
 	matchesPreset,
 	normalizeColor,
 	normalizeDimension,
+	presetValueForDevice,
 } from '../normalize';
 
 describe('normalizeColor', () => {
@@ -260,5 +261,34 @@ describe('normalizeDimension', () => {
 
 	it('pairs the first populated side with its unit', () => {
 		expect(normalizeDimension(['8', '8', '8', '8'], 'px')).toEqual({ value: '8', unit: 'px' });
+	});
+});
+
+describe('presetValueForDevice', () => {
+	it('takes the preset base value on Desktop, even when breakpoints are declared', () => {
+		expect(presetValueForDevice('0.5rem', { tablet: '9999px', mobile: '1rem' }, 'Desktop')).toBe('0.5rem');
+	});
+
+	it('takes the tablet override on Tablet', () => {
+		expect(presetValueForDevice('0.5rem', { tablet: '9999px' }, 'Tablet')).toBe('9999px');
+	});
+
+	it('falls back to the base on Tablet when the preset declares no tablet override', () => {
+		expect(presetValueForDevice('0.5rem', { mobile: '1rem' }, 'Tablet')).toBe('0.5rem');
+	});
+
+	it('falls back through tablet to the base on Mobile', () => {
+		expect(presetValueForDevice('0.5rem', { tablet: '9999px' }, 'Mobile')).toBe('9999px');
+		expect(presetValueForDevice('0.5rem', {}, 'Mobile')).toBe('0.5rem');
+	});
+
+	it('keeps a per-corner override list intact', () => {
+		const corners = ['9999px', '1rem', '1rem', '1rem'];
+
+		expect(presetValueForDevice('0.5rem', { tablet: corners }, 'Tablet')).toEqual(corners);
+	});
+
+	it('degrades to the base value with no responsive map at all', () => {
+		expect(presetValueForDevice('0.5rem', undefined, 'Mobile')).toBe('0.5rem');
 	});
 });

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -13,7 +13,13 @@
  */
 
 import { get } from 'lodash';
-import { activeLibrary, blockDefaultPreset, blockProperties, blockPresetValues } from '../preset-picker';
+import {
+	activeLibrary,
+	blockDefaultPreset,
+	blockProperties,
+	blockPresetValues,
+	blockPresetResponsive,
+} from '../preset-picker';
 import { isEmptyValue, matchesPreset } from './normalize';
 import './token-indicators.scss';
 
@@ -65,13 +71,14 @@ export function mappedAttrsFor(blockName, library) {
  *
  * @since TBD
  *
- * @return {Object} attrName => { property, token, kind, presetValue, bound, overridden }.
+ * @return {Object} attrName => { property, token, kind, presetValue, responsive, bound, overridden }.
  */
 export function usePresetBinding(blockName, attributes, library) {
 	const resolvedLibrary = library || activeLibrary();
 	const selected = get(attributes, 'kbPreset', '');
 	const properties = blockProperties(blockName, resolvedLibrary);
 	const values = blockPresetValues(blockName, resolvedLibrary);
+	const responsive = blockPresetResponsive(blockName, resolvedLibrary);
 
 	// The preset whose surface drives the indicators: the explicit selection, or the set's authoritative
 	// default preset when none is chosen (kbPreset is '' on every freshly inserted block, so this
@@ -79,6 +86,9 @@ export function usePresetBinding(blockName, attributes, library) {
 	// neither resolves, no control is bound.
 	const activePreset = selected || blockDefaultPreset(blockName, resolvedLibrary);
 	const presetValues = get(values, activePreset, {});
+	// The same surface at the other breakpoints, so a responsive control can report what the preset
+	// sets at the device the user is looking at instead of always naming the desktop value.
+	const presetBreakpoints = get(responsive, activePreset, {});
 
 	const state = {};
 
@@ -105,6 +115,10 @@ export function usePresetBinding(blockName, attributes, library) {
 			token: property.token,
 			kind,
 			presetValue,
+			responsive: {
+				tablet: get(presetBreakpoints, ['tablet', property.key]),
+				mobile: get(presetBreakpoints, ['mobile', property.key]),
+			},
 			bound: true,
 			overridden,
 		};

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -86,8 +86,6 @@ export function usePresetBinding(blockName, attributes, library) {
 	// neither resolves, no control is bound.
 	const activePreset = selected || blockDefaultPreset(blockName, resolvedLibrary);
 	const presetValues = get(values, activePreset, {});
-	// The same surface at the other breakpoints, so a responsive control can report what the preset
-	// sets at the device the user is looking at instead of always naming the desktop value.
 	const presetBreakpoints = get(responsive, activePreset, {});
 
 	const state = {};

--- a/src/extension/token-indicators/normalize.js
+++ b/src/extension/token-indicators/normalize.js
@@ -116,6 +116,33 @@ export function presetSlotAt(presetValue, index) {
 }
 
 /**
+ * The selected preset's value for a property AT THE ACTIVE DEVICE: its breakpoint override where the
+ * preset declares one, otherwise the value it inherits through the cascade.
+ *
+ * A preset can carry per-breakpoint values, and the button renders them — so a control sitting on
+ * Tablet that falls back to the preset's desktop value names a size the block is not rendering at
+ * that breakpoint. The fallback order mirrors the projected CSS: Mobile takes the mobile override,
+ * then the tablet one, then the base; Tablet takes the tablet override, then the base.
+ *
+ * @param {*}      presetValue  The preset's base value for the property.
+ * @param {Object} [responsive] The preset's breakpoint values ({ tablet, mobile }), each undefined
+ *                              when the preset declares no override there.
+ * @param {string} [device]     The active preview device ('Desktop' | 'Tablet' | 'Mobile').
+ *
+ * @since TBD
+ *
+ * @return {*} The preset's value in effect at that device.
+ */
+export function presetValueForDevice(presetValue, responsive = {}, device = 'Desktop') {
+	const chain =
+		'Mobile' === device ? [responsive.mobile, responsive.tablet] : 'Tablet' === device ? [responsive.tablet] : [];
+
+	const override = chain.find((value) => value !== undefined && value !== null && value !== '');
+
+	return override === undefined ? presetValue : override;
+}
+
+/**
  * The attribute a responsive measure control is editing at the given device, and its current value.
  *
  * A responsive measure control keeps ONE linked/individual mode but writes three separate attributes

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
@@ -159,4 +159,67 @@ final class Preset_CatalogTest extends TestCase {
 		$this->assertArrayHasKey( 'button-bg', $button['values']['primary'] );
 		$this->assertNotSame( '', $button['values']['primary']['button-bg'] );
 	}
+
+	/**
+	 * A preset whose property varies by breakpoint surfaces those overrides as flattened literals under a
+	 * `responsive` map, so a control can show the inherited default for the device the editor is on.
+	 *
+	 * @return void
+	 */
+	public function testItSurfacesPerBreakpointPresetValues(): void {
+		$this->seedResponsivePreset();
+
+		$button = $this->catalog->all()['libraries'][ Token_Store::default_slug() ][ self::BUTTON ];
+
+		$this->assertSame( '8px', $button['values']['hero']['button-radius'] );
+		$this->assertSame(
+			[ 'mobile' => [ 'button-radius' => '0.5rem' ] ],
+			$button['responsive']['hero']
+		);
+	}
+
+	/**
+	 * A preset with no per-breakpoint overrides carries an empty responsive map, so every existing preset
+	 * is unchanged in the feed.
+	 *
+	 * @return void
+	 */
+	public function testAPresetWithoutBreakpointsCarriesAnEmptyResponsiveMap(): void {
+		$button = $this->catalog->all()['libraries'][ Token_Store::default_slug() ][ self::BUTTON ];
+
+		$this->assertSame( [], $button['responsive']['primary'] );
+	}
+
+	/**
+	 * Persist a "hero" button preset whose radius takes an aliased override on mobile.
+	 *
+	 * @return void
+	 */
+	private function seedResponsivePreset(): void {
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'presets' => [
+						self::BUTTON => [
+							'hero' => [
+								'label'  => 'Hero',
+								'tokens' => [
+									'button-radius' => [
+										'$value'      => '8px',
+										'$extensions' => [
+											'com.kadence.designTokens' => [
+												'responsive' => [ 'mobile' => '{semantic.radius.control}' ],
+											],
+										],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$this->store->save_document( (string) wp_json_encode( $document ), Token_Store::default_slug() );
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
@@ -173,7 +173,7 @@ final class Preset_CatalogTest extends TestCase {
 
 		$this->assertSame( '8px', $button['values']['hero']['button-radius'] );
 		$this->assertSame(
-			[ 'mobile' => [ 'button-radius' => '0.5rem' ] ],
+			[ 'mobile' => [ 'button-radius' => '0.1875rem' ] ],
 			$button['responsive']['hero']
 		);
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
@@ -196,6 +196,100 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
+	 * A preset property that varies by breakpoint redeclares its preset var inside that breakpoint's
+	 * @media block. The block-level slot bridge is untouched — it already points at the preset var, so
+	 * overriding the var is enough for the breakpoint to take effect.
+	 *
+	 * @return void
+	 */
+	public function testItRedeclaresAPresetVarInsideItsBreakpointMediaBlock(): void {
+		$this->seedResponsivePreset();
+
+		$css = $this->builder( $this->registry )->css( 'default', $this->breakpoints() );
+
+		$this->assertStringContainsString(
+			'@media all and (max-width: 767px){:root,:root:where(.kb-tokens){--kb-token--preset--kadence-singlebtn--hero--button-radius:2px;}}',
+			$css
+		);
+		// The base value still lives in the flat, non-media declaration.
+		$this->assertStringContainsString( '--kb-token--preset--kadence-singlebtn--hero--button-radius:8px;', $css );
+	}
+
+	/**
+	 * An aliased override keeps its var() indirection inside the media block, so a token edit still reaches
+	 * that breakpoint live.
+	 *
+	 * @return void
+	 */
+	public function testAnAliasedOverrideKeepsItsVarIndirectionInTheMediaBlock(): void {
+		$this->seedResponsivePreset( [ 'tablet' => '{semantic.radius.control}' ] );
+
+		$css = $this->builder( $this->registry )->css( 'default', $this->breakpoints() );
+
+		$this->assertStringContainsString(
+			'@media all and (max-width: 1024px){:root,:root:where(.kb-tokens){--kb-token--preset--kadence-singlebtn--hero--button-radius:var(--kb-token--semantic--radius--control);}}',
+			$css
+		);
+	}
+
+	/**
+	 * A library whose presets declare no breakpoint overrides emits no media blocks at all, so every
+	 * existing preset projects byte-identically.
+	 *
+	 * @return void
+	 */
+	public function testItEmitsNoMediaBlocksWithoutResponsivePresets(): void {
+		$this->assertStringNotContainsString( '@media', $this->builder( $this->registry )->css( 'default', $this->breakpoints() ) );
+	}
+
+	/**
+	 * The breakpoint => media-query map a projector passes at emit time.
+	 *
+	 * @return array<string, string>
+	 */
+	private function breakpoints(): array {
+		return [
+			'tablet' => '(max-width: 1024px)',
+			'mobile' => '(max-width: 767px)',
+		];
+	}
+
+	/**
+	 * Persist a "hero" button preset whose radius varies by breakpoint into the active library.
+	 *
+	 * @param array<string, mixed> $responsive Breakpoint => override value.
+	 *
+	 * @return void
+	 */
+	private function seedResponsivePreset( array $responsive = [ 'mobile' => '2px' ] ): void {
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'presets' => [
+						'kadence/singlebtn' => [
+							'hero' => [
+								'label'  => 'Hero',
+								'tokens' => [
+									'button-radius' => [
+										'$value'      => '8px',
+										'$extensions' => [
+											'com.kadence.designTokens' => [
+												'responsive' => $responsive,
+											],
+										],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$this->store->save_document( (string) wp_json_encode( $document ), Token_Store::default_slug() );
+	}
+
+	/**
 	 * Persist a user-created "midnight" button preset into the "dark" token library only, so it is absent from
 	 * the active "default" library.
 	 *

--- a/tests/wpunit/Resources/Design_Tokens/Registry/BindingTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/BindingTest.php
@@ -206,6 +206,67 @@ final class BindingTest extends TestCase {
 	}
 
 	/**
+	 * A binding parses responsive_attrs into a breakpoint => attribute map. The block names its per-device
+	 * attributes by a prefix convention ("tabletBorderRadius"), which is not safely derivable, so it is
+	 * declared rather than string-built.
+	 *
+	 * @return void
+	 */
+	public function testItParsesTheResponsiveAttrsField(): void {
+		$binding = Binding::from_array(
+			'button-radius',
+			[
+				'css_var'          => 'kb-btn-radius',
+				'control_attr'     => 'borderRadius',
+				'responsive_attrs' => [
+					'tablet' => 'tabletBorderRadius',
+					'mobile' => 'mobileBorderRadius',
+				],
+			]
+		);
+
+		$this->assertSame(
+			[
+				'tablet' => 'tabletBorderRadius',
+				'mobile' => 'mobileBorderRadius',
+			],
+			$binding->responsive_attrs()
+		);
+		// Editor-only metadata, like control_attr: it must not leak into the projection targets.
+		$this->assertArrayNotHasKey( 'responsive_attrs', $binding->projections );
+	}
+
+	/**
+	 * A binding with no responsive_attrs declaration exposes an empty map, so a caller can iterate it
+	 * unconditionally.
+	 *
+	 * @return void
+	 */
+	public function testABindingWithoutResponsiveAttrsExposesAnEmptyMap(): void {
+		$binding = Binding::from_array( 'button-bg', [ 'kadence_slot' => 'palette-btn-bg' ] );
+
+		$this->assertSame( [], $binding->responsive_attrs() );
+	}
+
+	/**
+	 * An unknown breakpoint key in responsive_attrs is refused at registration, so a typo fails loudly
+	 * rather than silently never capturing that device.
+	 *
+	 * @return void
+	 */
+	public function testAnUnknownResponsiveBreakpointIsRefused(): void {
+		$this->expectException( InvalidArgumentException::class );
+
+		Binding::from_array(
+			'button-radius',
+			[
+				'css_var'          => 'kb-btn-radius',
+				'responsive_attrs' => [ 'watch' => 'watchBorderRadius' ],
+			]
+		);
+	}
+
+	/**
 	 * A binding with no control_attr declaration exposes null.
 	 *
 	 * @return void

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
@@ -362,6 +362,134 @@ final class Preset_ResolverTest extends TestCase {
 	}
 
 	/**
+	 * A responsive preset entry resolves its base value exactly as a bare entry does, so adding
+	 * breakpoints never changes what desktop renders.
+	 *
+	 * @return void
+	 */
+	public function testAResponsiveEntryResolvesItsBaseForDesktop(): void {
+		$this->seedPreset(
+			Token_Store::default_slug(),
+			'hero',
+			'Hero',
+			[ 'button-radius' => $this->responsiveEntry( '8px', [ 'mobile' => '2px' ] ) ]
+		);
+
+		$this->assertSame( '8px', $this->resolver->resolve_literal( self::BUTTON, 'hero' )['button-radius'] );
+		$this->assertSame( '8px', $this->resolver->resolve( self::BUTTON, 'hero' )['button-radius'] );
+	}
+
+	/**
+	 * Per-breakpoint overrides project to the same var()-preserving form as the base, keyed by breakpoint,
+	 * so an aliased override still chains through the token cascade.
+	 *
+	 * @return void
+	 */
+	public function testResolveResponsiveProjectsEachBreakpoint(): void {
+		$this->seedPreset(
+			Token_Store::default_slug(),
+			'hero',
+			'Hero',
+			[
+				'button-radius' => $this->responsiveEntry(
+					'8px',
+					[
+						'tablet' => [ '4px', '2px', '4px', '2px' ],
+						'mobile' => '{semantic.radius.control}',
+					]
+				),
+			]
+		);
+
+		$this->assertSame(
+			[
+				'tablet' => [ 'button-radius' => '4px 2px 4px 2px' ],
+				'mobile' => [ 'button-radius' => 'var(--kb-token--semantic--radius--control)' ],
+			],
+			$this->resolver->resolve_responsive( self::BUTTON, 'hero' )
+		);
+	}
+
+	/**
+	 * Per-breakpoint overrides also flatten to literals, for the editor surfaces that cannot consume a
+	 * var() chain.
+	 *
+	 * @return void
+	 */
+	public function testResolveResponsiveLiteralFlattensEachBreakpoint(): void {
+		$this->seedPreset(
+			Token_Store::default_slug(),
+			'hero',
+			'Hero',
+			[ 'button-radius' => $this->responsiveEntry( '8px', [ 'mobile' => '{semantic.radius.control}' ] ) ]
+		);
+
+		$this->assertSame(
+			[ 'mobile' => [ 'button-radius' => '0.5rem' ] ],
+			$this->resolver->resolve_responsive_literal( self::BUTTON, 'hero' )
+		);
+	}
+
+	/**
+	 * An override whose alias resolves to nothing is dropped for that breakpoint only, leaving the base and
+	 * the other breakpoints intact — the same fail-closed choice a scalar binding makes.
+	 *
+	 * @return void
+	 */
+	public function testAnUnresolvableOverrideDropsOnlyThatBreakpoint(): void {
+		$this->seedPreset(
+			Token_Store::default_slug(),
+			'hero',
+			'Hero',
+			[
+				'button-radius' => $this->responsiveEntry(
+					'8px',
+					[
+						'tablet' => '{primitive.dimension.radius.nope}',
+						'mobile' => '2px',
+					]
+				),
+			]
+		);
+
+		$responsive = $this->resolver->resolve_responsive( self::BUTTON, 'hero' );
+
+		$this->assertArrayNotHasKey( 'tablet', $responsive );
+		$this->assertSame( [ 'button-radius' => '2px' ], $responsive['mobile'] );
+		$this->assertSame( '8px', $this->resolver->resolve_literal( self::BUTTON, 'hero' )['button-radius'] );
+	}
+
+	/**
+	 * A preset with no responsive entries resolves to an empty breakpoint map, so every existing preset
+	 * contributes no media queries.
+	 *
+	 * @return void
+	 */
+	public function testAPresetWithNoResponsiveEntriesResolvesEmpty(): void {
+		$this->assertSame( [], $this->resolver->resolve_responsive( self::BUTTON, 'primary' ) );
+	}
+
+	/**
+	 * A preset token entry carrying per-breakpoint overrides, in the same envelope a responsive token leaf
+	 * uses.
+	 *
+	 * @param mixed                $base       The entry's base value.
+	 * @param array<string, mixed> $responsive Breakpoint => override value.
+	 *
+	 * @return array<string, mixed> The entry.
+	 */
+	private function responsiveEntry( $base, array $responsive ): array {
+		return [
+			'$value'      => $base,
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'responsive' => $responsive,
+				],
+			],
+		];
+	}
+
+	/**
 	 * Persist a single button preset into a token library's overrides document.
 	 *
 	 * @param string               $slug   The token library slug to write into.

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
@@ -425,7 +425,7 @@ final class Preset_ResolverTest extends TestCase {
 		);
 
 		$this->assertSame(
-			[ 'mobile' => [ 'button-radius' => '0.5rem' ] ],
+			[ 'mobile' => [ 'button-radius' => '0.1875rem' ] ],
 			$this->resolver->resolve_responsive_literal( self::BUTTON, 'hero' )
 		);
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_Value_NormalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_Value_NormalizerTest.php
@@ -127,6 +127,39 @@ final class Preset_Value_NormalizerTest extends TestCase {
 	}
 
 	/**
+	 * A per-breakpoint override is matched on its own, so a captured tablet/mobile literal re-joins the
+	 * theming cascade exactly as the base value does — and the envelope survives intact.
+	 *
+	 * @return void
+	 */
+	public function testItAliasesEachBreakpointOfAResponsiveEntry(): void {
+		$entry = [
+			'$value'      => '8px',
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					// 0.5rem is the control radius semantic's resolved value; 3px matches nothing.
+					'responsive' => [
+						'tablet' => '0.5rem',
+						'mobile' => '3px',
+					],
+				],
+			],
+		];
+
+		$result     = $this->normalizer->normalize( [ 'button-radius' => $entry ], self::SET )['button-radius'];
+		$responsive = $result['$extensions']['com.kadence.designTokens']['responsive'];
+
+		$this->assertSame( '8px', $result['$value'], 'An unmatched base literal should stay a literal.' );
+		$this->assertTrue( Alias::is_alias( $responsive['tablet'] ), 'A matched override should become an alias.' );
+		$this->assertSame(
+			'0.5rem',
+			$this->resolver->resolve( self::SET )->value( Alias::path_of( $responsive['tablet'] ) ),
+			'The chosen alias should resolve back to the captured value.'
+		);
+		$this->assertSame( '3px', $responsive['mobile'], 'An unmatched override should stay a literal.' );
+	}
+
+	/**
 	 * When several semantics share a value, the one whose id best matches the property's role wins: #ffffff is
 	 * shared by the plain and hover button-text semantics, and the hover property picks the hover semantic.
 	 *

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_Value_NormalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_Value_NormalizerTest.php
@@ -137,10 +137,10 @@ final class Preset_Value_NormalizerTest extends TestCase {
 			'$value'      => '8px',
 			'$extensions' => [
 				'com.kadence.designTokens' => [
-					// 0.5rem is the control radius semantic's resolved value; 3px matches nothing.
+					// 0.1875rem is the control radius semantic's resolved value; 9px matches nothing.
 					'responsive' => [
-						'tablet' => '0.5rem',
-						'mobile' => '3px',
+						'tablet' => '0.1875rem',
+						'mobile' => '9px',
 					],
 				],
 			],
@@ -152,11 +152,11 @@ final class Preset_Value_NormalizerTest extends TestCase {
 		$this->assertSame( '8px', $result['$value'], 'An unmatched base literal should stay a literal.' );
 		$this->assertTrue( Alias::is_alias( $responsive['tablet'] ), 'A matched override should become an alias.' );
 		$this->assertSame(
-			'0.5rem',
+			'0.1875rem',
 			$this->resolver->resolve( self::SET )->value( Alias::path_of( $responsive['tablet'] ) ),
 			'The chosen alias should resolve back to the captured value.'
 		);
-		$this->assertSame( '3px', $responsive['mobile'], 'An unmatched override should stay a literal.' );
+		$this->assertSame( '9px', $responsive['mobile'], 'An unmatched override should stay a literal.' );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
@@ -530,6 +530,98 @@ final class PresetsControllerTest extends TestCase {
 	}
 
 	/**
+	 * A dangling alias inside a per-breakpoint override is caught on write, exactly as one in the base
+	 * value is — otherwise it would pass the guards and silently drop at projection.
+	 *
+	 * @return void
+	 */
+	public function testADanglingAliasInAResponsiveOverrideIsRejected(): void {
+		$result = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'preset' => 'hero',
+					'tokens' => $this->button_tokens(
+						[
+							'button-radius' => $this->responsive_entry(
+								'8px',
+								[ 'mobile' => '{primitive.dimension.radius.nope}' ]
+							),
+						]
+					),
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_unresolvable', $result->get_error_code() );
+		$this->assertSame( 'button-radius', $result->get_error_data()['property'] );
+		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
+	}
+
+	/**
+	 * A per-corner slot list inside a breakpoint override is gated on the property's kind exactly as the
+	 * base value is, so a four-slot color cannot slip in through a breakpoint.
+	 *
+	 * @return void
+	 */
+	public function testASlotListInAResponsiveOverrideOnANonDimensionPropertyIsRejected(): void {
+		$result = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'preset' => 'hero',
+					'tokens' => $this->button_tokens(
+						[
+							'button-bg' => $this->responsive_entry(
+								'#3633e1',
+								[ 'mobile' => [ '#ff0000', '#00ff00', '#0000ff', '#ffffff' ] ]
+							),
+						]
+					),
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( 'button-bg', $result->get_error_data()['property'] );
+	}
+
+	/**
+	 * A well-formed responsive entry is stored intact, base and overrides together.
+	 *
+	 * @return void
+	 */
+	public function testAResponsivePresetEntryIsStored(): void {
+		$entry = $this->responsive_entry( [ '8px', '4px', '8px', '4px' ], [ 'mobile' => '2px' ] );
+
+		$response = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'preset' => 'hero',
+					'tokens' => $this->button_tokens( [ 'button-radius' => $entry ] ),
+				]
+			)
+		);
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+
+		$stored = json_decode( $this->store->get_document( Token_Store::default_slug() ), true );
+		$tokens = $stored['$extensions']['com.kadence.designTokens']['presets'][ self::BUTTON ]['hero']['tokens'];
+
+		$this->assertSame( [ '8px', '4px', '8px', '4px' ], $tokens['button-radius']['$value'] );
+		$this->assertSame(
+			'2px',
+			$tokens['button-radius']['$extensions']['com.kadence.designTokens']['responsive']['mobile']
+		);
+	}
+
+	/**
 	 * A preset that sets a property the block does not bind is rejected: an unbound property could never
 	 * project, so it must not be storable.
 	 *
@@ -791,6 +883,26 @@ final class PresetsControllerTest extends TestCase {
 		}
 
 		return $request;
+	}
+
+	/**
+	 * A preset token entry carrying per-breakpoint overrides, in the same envelope a responsive token leaf
+	 * uses.
+	 *
+	 * @param mixed                $base       The entry's base value.
+	 * @param array<string, mixed> $responsive Breakpoint => override value.
+	 *
+	 * @return array<string, mixed> The entry.
+	 */
+	private function responsive_entry( $base, array $responsive ): array {
+		return [
+			'$value'      => $base,
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'responsive' => $responsive,
+				],
+			],
+		];
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
@@ -609,6 +609,131 @@ final class Dtcg_ValidatorTest extends TestCase {
 	}
 
 	/**
+	 * A preset token entry may carry per-breakpoint overrides in the same envelope a responsive token leaf
+	 * uses, and each override follows the same alias / literal / slot-list rules as the base value.
+	 *
+	 * @dataProvider validResponsivePresetProvider
+	 *
+	 * @param mixed $entry The preset token entry under test.
+	 *
+	 * @return void
+	 */
+	public function testAResponsivePresetEntryValidates( $entry ): void {
+		$result = $this->validator->validate(
+			$this->preset_document( $entry ),
+			Dtcg_Validator::get_context_overrides()
+		);
+
+		$this->assertTrue( $result->is_valid(), $this->describe( $result->errors() ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function validResponsivePresetProvider(): Generator {
+		yield 'scalar base, literal overrides' => [
+			'entry' => $this->responsive_entry(
+				'8px',
+				[
+					'tablet' => '4px',
+					'mobile' => '2px',
+				] 
+			),
+		];
+
+		yield 'slot-list base, scalar overrides' => [
+			'entry' => $this->responsive_entry(
+				[ '8px', '4px', '8px', '4px' ],
+				[ 'mobile' => '{primitive.dimension.radius.sm}' ]
+			),
+		];
+
+		yield 'slot-list base, slot-list overrides' => [
+			'entry' => $this->responsive_entry(
+				[ '8px', '4px', '8px', '4px' ],
+				[ 'tablet' => [ '4px', '2px', '4px', '2px' ] ]
+			),
+		];
+
+		yield 'alias base, alias override' => [
+			'entry' => $this->responsive_entry(
+				'{semantic.radius.control}',
+				[ 'mobile' => '{primitive.dimension.radius.none}' ]
+			),
+		];
+
+		yield 'single breakpoint only' => [
+			'entry' => $this->responsive_entry( '8px', [ 'mobile' => '2px' ] ),
+		];
+	}
+
+	/**
+	 * A malformed responsive preset entry is rejected: an unknown breakpoint, an empty override map, a
+	 * missing base value, and a bad value at a breakpoint each fail at their own path.
+	 *
+	 * @dataProvider invalidResponsivePresetProvider
+	 *
+	 * @param mixed  $entry The preset token entry under test.
+	 * @param string $code  The expected validation-error code.
+	 * @param string $path  The expected dot-path the error is reported at.
+	 *
+	 * @return void
+	 */
+	public function testAnInvalidResponsivePresetEntryIsRejected( $entry, string $code, string $path ): void {
+		$errors = $this->validator->validate(
+			$this->preset_document( $entry ),
+			Dtcg_Validator::get_context_overrides()
+		)->errors();
+
+		$this->assertCount( 1, $errors, $this->describe( $errors ) );
+		$this->assertSame( $code, $errors[0]->code );
+		$this->assertSame( $path, $errors[0]->path );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function invalidResponsivePresetProvider(): Generator {
+		$base = '$extensions.com.kadence.designTokens.presets.kadence/x.default.tokens.button-radius';
+
+		yield 'unknown breakpoint' => [
+			'entry' => $this->responsive_entry( '8px', [ 'watch' => '2px' ] ),
+			'code'  => Validation_Error::get_code_composite_field_unknown(),
+			'path'  => $base . '.watch',
+		];
+
+		yield 'empty responsive map' => [
+			'entry' => $this->responsive_entry( '8px', [] ),
+			'code'  => Validation_Error::get_code_value_invalid(),
+			'path'  => $base,
+		];
+
+		yield 'empty override value' => [
+			'entry' => $this->responsive_entry( '8px', [ 'tablet' => '' ] ),
+			'code'  => Validation_Error::get_code_value_invalid(),
+			'path'  => $base . '.tablet',
+		];
+
+		yield 'brace-bearing override that is not a whole-string alias' => [
+			'entry' => $this->responsive_entry( '8px', [ 'mobile' => '{semantic.radius.control}px' ] ),
+			'code'  => Validation_Error::get_code_alias_malformed(),
+			'path'  => $base . '.mobile',
+		];
+
+		yield 'bad slot count in an override' => [
+			'entry' => $this->responsive_entry( '8px', [ 'tablet' => [ '4px', '2px' ] ] ),
+			'code'  => Validation_Error::get_code_value_invalid(),
+			'path'  => $base . '.tablet',
+		];
+
+		yield 'bad base value under a valid responsive map' => [
+			'entry' => $this->responsive_entry( '', [ 'tablet' => '4px' ] ),
+			'code'  => Validation_Error::get_code_value_invalid(),
+			'path'  => $base,
+		];
+	}
+
+	/**
 	 * A dimension leaf carrying a well-formed per-breakpoint responsive map (literal and alias slots)
 	 * validates.
 	 *
@@ -807,6 +932,26 @@ final class Dtcg_ValidatorTest extends TestCase {
 	private function get_baseline(): string {
 		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
 		return (string) file_get_contents( KADENCE_BLOCKS_PATH . 'includes/resources/Design_Tokens/Registry/Baseline/baseline.json' );
+	}
+
+	/**
+	 * A preset token entry carrying per-breakpoint overrides, in the same envelope a responsive token leaf
+	 * uses.
+	 *
+	 * @param mixed                $base       The entry's base value.
+	 * @param array<string, mixed> $responsive Breakpoint => override value.
+	 *
+	 * @return array<string, mixed> The entry.
+	 */
+	private function responsive_entry( $base, array $responsive ): array {
+		return [
+			'$value'      => $base,
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'responsive' => $responsive,
+				],
+			],
+		];
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/ExtensionsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/ExtensionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Schema\Vocabulary;
 
+use Generator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
 use Tests\Support\Classes\TestCase;
 
@@ -54,5 +55,75 @@ final class ExtensionsTest extends TestCase {
 		$this->assertSame( 'swatches', Extensions::get_swatches_key() );
 		$this->assertSame( 'token', Extensions::get_swatch_token_key() );
 		$this->assertSame( 'id', Extensions::get_group_id_key() );
+	}
+
+	/**
+	 * A bare preset token entry is its own base value and declares no per-breakpoint overrides, so every
+	 * existing preset reads through the new accessors unchanged.
+	 *
+	 * @dataProvider bareEntryProvider
+	 *
+	 * @param mixed $entry The bare preset token entry.
+	 *
+	 * @return void
+	 */
+	public function testABarePresetEntryIsItsOwnValue( $entry ): void {
+		$this->assertSame( $entry, Extensions::preset_value_of( $entry ) );
+		$this->assertSame( [], Extensions::preset_responsive_of( $entry ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function bareEntryProvider(): Generator {
+		yield 'literal' => [ 'entry' => '#3633e1' ];
+
+		yield 'alias' => [ 'entry' => '{semantic.radius.control}' ];
+
+		yield 'slot list' => [ 'entry' => [ '8px', '4px', '8px', '4px' ] ];
+
+		yield 'numeric' => [ 'entry' => 8 ];
+	}
+
+	/**
+	 * A preset token entry carrying the responsive envelope exposes its base value and its per-breakpoint
+	 * overrides separately, so a consumer never has to hand-roll the unwrap.
+	 *
+	 * @return void
+	 */
+	public function testAResponsivePresetEntryExposesItsBaseAndOverrides(): void {
+		$entry = [
+			'$value'      => [ '8px', '4px', '8px', '4px' ],
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'responsive' => [
+						'tablet' => '4px',
+						'mobile' => '{primitive.dimension.radius.sm}',
+					],
+				],
+			],
+		];
+
+		$this->assertSame( [ '8px', '4px', '8px', '4px' ], Extensions::preset_value_of( $entry ) );
+		$this->assertSame(
+			[
+				'tablet' => '4px',
+				'mobile' => '{primitive.dimension.radius.sm}',
+			],
+			Extensions::preset_responsive_of( $entry )
+		);
+	}
+
+	/**
+	 * A slot list is never mistaken for an envelope: it has no `$value` key, so it reads as its own base
+	 * value with no overrides even though it is an array.
+	 *
+	 * @return void
+	 */
+	public function testASlotListIsNotTreatedAsAnEnvelope(): void {
+		$slots = [ '{primitive.dimension.radius.lg}', '8px', '8px', '8px' ];
+
+		$this->assertSame( $slots, Extensions::preset_value_of( $slots ) );
+		$this->assertSame( [], Extensions::preset_responsive_of( $slots ) );
 	}
 }


### PR DESCRIPTION
## Summary

A block already stores a different border radius per breakpoint, and each of those can hold four per-corner values. A preset could not. This adds that, following the pattern responsive tokens already use.

Two concrete gaps closed:

1. A preset could not carry its own per-breakpoint values — the preset resolver and preset CSS builder had no breakpoint concept at all.
2. **"Save as a new preset" silently dropped tablet and mobile.** The capture read only the desktop attribute, so a user who set per-breakpoint corners lost them with no warning — the same class of bug as the corner flattening in #1202.

## What already worked, and needed no code

A preset pointing at a **token** was already responsive, per corner: the token layer emits `@media` redeclarations of `--kb-token--*` at `:root`, and each `var()` in a per-corner shorthand resolves independently at use time. Verified in the browser with a probe — redeclaring one token inside a media query changes only that corner.

So this PR is only about a preset carrying values the tokens do not.

## Shape

Mirrors the responsive token leaf exactly — `semantic.font-size.control` in the shipped baseline — so the override map sits next to the value it overrides:

```json
"button-radius": {
  "$value": ["{radius.lg}", "{radius.none}", "{radius.lg}", "{radius.none}"],
  "$extensions": {
    "com.kadence.designTokens": {
      "responsive": {
        "tablet": ["{radius.md}", "{radius.none}", "{radius.md}", "{radius.none}"],
        "mobile": ["4px", "0px", "4px", "0px"]
      }
    }
  }
}
```

Mirroring the leaf rather than inventing a preset-level node buys two things: `Responsive::has_responsive()` and `responsive_of()` work verbatim, and `validate_extension_tokens()` needs no change — the envelope hangs off the property, which that walk already visits. A preset-level `responsive` sibling would have needed one, since that loop returns as soon as it finds a `tokens` key and never descends to siblings.

A property with no breakpoints stays a bare value, so every existing preset is untouched and there is no migration.

## What changed

- `Extensions::preset_value_of()` / `preset_responsive_of()` — one reader, so the unwrap never spreads as `isset($x['$value'])` across the resolver, guards, catalog and capture.
- `Dtcg_Validator` — envelope branch. Each override is just another preset value, so it goes through `validate_extension_value()` unchanged; only the breakpoint-key check is new.
- `Preset_Resolver` — unwraps the base; adds `resolve_responsive()` and `resolve_responsive_literal()`. An override whose alias does not resolve drops that breakpoint only, leaving the base intact.
- `Projection/Preset/Css_Builder` — redeclares the preset var inside each breakpoint's `@media`, mirroring the token builder. Only the canonical var is redeclared: the scoped `--global-*` / `--kb-*` bridges already point at it, so every corner follows.
- Both REST write guards walk base plus every override. This also fixed `guard_slot_arrays()` wrongly rejecting *any* envelope on a non-dimension property, since it tested `is_array()` on the raw entry.
- `Preset_Value_Normalizer` aliases per breakpoint; `Preset_Catalog` exposes a per-breakpoint map for the editor.
- New `responsive_attrs` binding key on `button-radius`. The block names its per-device attributes by a prefix convention (`borderRadius` -> `tabletBorderRadius`), which is a naming rule rather than something safely derivable, so it is declared instead of string-built in JS.

## Test plan

- [x] PHPStan clean at level max, no baseline entries added
- [x] Full wpunit suite, snapshot suite byte-identical
- [x] jest, phpcs, cspell clean
- [x] Verified in the editor: saved a preset from a button with a different per-corner radius on desktop, tablet and mobile; confirmed it stores the envelope and projects the base plus both `@media` blocks
