### PR TITLE
[DTM] SOFT-4075 [2/6]: Navigation and screen registry

### DIFF
--- a/includes/resources/Design_Tokens/Admin/Feed/Builder.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Builder.php
@@ -9,11 +9,12 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
  * React app reads.
  *
  * Reads token STRUCTURE from the registry ({@see Token_Registry::to_ui_schema()}) and folds in the
- * resolved VALUES, PRESETS, REST descriptor and store version handed in by the Localizer — which owns
- * every WordPress call. When the registry is inactive (the fail-closed guard) it returns an empty,
- * `active:false` payload so the React section hides and KB's existing UI is untouched; when values could
- * not be resolved (a corrupt store) the caller passes `$resolved = false` and an empty values map, so
- * structure still renders and the editor stays usable. No WordPress calls, no globals, no I/O.
+ * resolved VALUES, PRESETS, nav-ready block-presets section (from {@see Preset_Nav}), REST descriptor
+ * and store version handed in by the Localizer — which owns every WordPress call. When the registry is
+ * inactive (the fail-closed guard) it returns an empty, `active:false` payload so the React section
+ * hides and KB's existing UI is untouched; when values could not be resolved (a corrupt store) the
+ * caller passes `$resolved = false` and an empty values map, so structure still renders and the editor
+ * stays usable. No WordPress calls, no globals, no I/O.
  *
  * @since TBD
  */
@@ -29,12 +30,23 @@ final class Builder {
 	private Token_Registry $registry;
 
 	/**
+	 * The nav-ready block-presets section builder.
+	 *
 	 * @since TBD
 	 *
-	 * @param Token_Registry $registry The token registry.
+	 * @var Preset_Nav
 	 */
-	public function __construct( Token_Registry $registry ) {
-		$this->registry = $registry;
+	private Preset_Nav $preset_nav;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry $registry   The token registry.
+	 * @param Preset_Nav     $preset_nav The nav-ready block-presets section builder.
+	 */
+	public function __construct( Token_Registry $registry, Preset_Nav $preset_nav ) {
+		$this->registry   = $registry;
+		$this->preset_nav = $preset_nav;
 	}
 
 	/**
@@ -64,6 +76,7 @@ final class Builder {
 			'schema'     => $active ? $this->registry->to_ui_schema() : [ 'groups' => [] ],
 			'values'     => $active ? $values : [],
 			'presets'    => $active ? $presets : [],
+			'presetNav'  => $active ? $this->preset_nav->all() : [],
 			'responsive' => $active ? $responsive : [],
 			'rest'       => $rest,
 		];

--- a/includes/resources/Design_Tokens/Admin/Feed/Preset_Nav.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Preset_Nav.php
@@ -1,0 +1,121 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Preset_Bindings;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use WP_Block_Type_Registry;
+
+/**
+ * The nav-ready block-presets section of the admin feed: one ordered entry per block whose
+ * preset bindings declare a picker control label ({@see Preset_Bindings::$label}), carrying a
+ * DISPLAY label for the Style Library sidebar. Default-look-only binding sets (no picker label)
+ * are excluded — they have no user-facing presets. Which sets are INCLUDED and how each entry is
+ * LABELED are deliberately separate questions: inclusion is governed solely by
+ * {@see Preset_Bindings::$label} (see {@see self::all()}); the label shown is resolved by
+ * {@see self::label_for()} and never falls back to that same picker-control string, which names
+ * the inspector control rather than the block.
+ *
+ * @since TBD
+ */
+final class Preset_Nav {
+
+	/**
+	 * The token registry, source of the registered preset bindings.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry $registry The token registry.
+	 */
+	public function __construct( Token_Registry $registry ) {
+		$this->registry = $registry;
+	}
+
+	/**
+	 * Build the ordered nav entries: labeled (picker-driven) binding sets only.
+	 *
+	 * Order: registration order (the registry preserves it), which puts first-party blocks
+	 * before any third-party registrations. Membership is governed solely by
+	 * {@see Preset_Bindings::$label} being non-null — the Style Library section below only
+	 * changes how an included entry is labeled, never whether it is included.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<int, array{block: string, label: string}> The entries.
+	 */
+	public function all(): array {
+		$entries = [];
+
+		foreach ( $this->registry->all_preset_bindings() as $block => $bindings ) {
+			if ( $bindings->label === null ) {
+				continue; // Default-look-only — no user-facing preset concept, so no nav entry.
+			}
+
+			$entries[] = [
+				'block' => $block,
+				'label' => $this->label_for( $block, $bindings ),
+			];
+		}
+
+		return $entries;
+	}
+
+	/**
+	 * Resolve the DISPLAY label for a nav entry, tried in order:
+	 *
+	 * 1. The declared Style Library section's label ({@see Preset_Bindings::style_library_label()}) —
+	 *    the documented opt-in for a block-specific nav label.
+	 * 2. The block's registered title, read from {@see WP_Block_Type_Registry} — the same name
+	 *    shown for the block everywhere else in the editor.
+	 * 3. A humanized form of the block name (e.g. "kadence/my-block" -> "My Block") when the block
+	 *    is not registered at all — degrades gracefully rather than showing a raw block name or the
+	 *    picker control's `$label`.
+	 *
+	 * @since TBD
+	 *
+	 * @param string          $block    The block name.
+	 * @param Preset_Bindings $bindings The block's preset bindings.
+	 *
+	 * @return string The resolved display label.
+	 */
+	private function label_for( string $block, Preset_Bindings $bindings ): string {
+		$declared = $bindings->style_library_label();
+
+		if ( $declared !== null ) {
+			return $declared;
+		}
+
+		$type = WP_Block_Type_Registry::get_instance()->get_registered( $block );
+
+		if ( $type !== null && is_string( $type->title ) && $type->title !== '' ) {
+			return $type->title;
+		}
+
+		return self::humanize( $block );
+	}
+
+	/**
+	 * Humanize a block name into a readable label: the part after the last "/", with hyphens and
+	 * underscores turned into spaces and each word capitalized (e.g. "kadence/my-block" ->
+	 * "My Block").
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block The block name.
+	 *
+	 * @return string The humanized label.
+	 */
+	private static function humanize( string $block ): string {
+		$slug = strrchr( $block, '/' );
+		$slug = $slug === false ? $block : substr( $slug, 1 );
+
+		return ucwords( str_replace( [ '-', '_' ], ' ', $slug ) );
+	}
+}

--- a/includes/resources/Design_Tokens/Admin/Provider.php
+++ b/includes/resources/Design_Tokens/Admin/Provider.php
@@ -4,6 +4,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Admin;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Localizer;
+use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Preset_Nav;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Presets;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Style_Library\Asset_Loader;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Style_Library\Menu;
@@ -11,9 +12,9 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Style_Library\Screen;
 use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
 
 /**
- * Registers the admin UI schema feed: binds the builder, preset feed and localizer as
- * singletons, then hooks the localizer onto admin_head so the dashboard bundle receives
- * window.kadenceDesignTokens.
+ * Registers the admin UI schema feed: binds the builder, preset feed, nav-ready block-presets
+ * section and localizer as singletons, then hooks the localizer onto admin_head so the dashboard
+ * bundle receives window.kadenceDesignTokens.
  *
  * @since TBD
  */
@@ -27,6 +28,7 @@ final class Provider extends Provider_Contract {
 	public function register(): void {
 		$this->container->singleton( Builder::class );
 		$this->container->singleton( Presets::class );
+		$this->container->singleton( Preset_Nav::class );
 		$this->container->singleton( Localizer::class );
 		$this->container->singleton( Screen::class );
 		$this->container->singleton( Asset_Loader::class );

--- a/includes/resources/Design_Tokens/Registry/Preset_Bindings.php
+++ b/includes/resources/Design_Tokens/Registry/Preset_Bindings.php
@@ -30,6 +30,11 @@ use InvalidArgumentException;
  * "the button's background" maps to the same output slot whichever preset is active — only the value
  * changes.
  *
+ * The optional `style_library` section is a second, unrelated piece of structural config: the Style
+ * Library admin page's per-block presentation metadata (today, the BLOCK PRESETS nav label). It is
+ * intentionally distinct from `label` — that names the picker CONTROL rendered inside the block
+ * inspector, not the block itself, so it is the wrong string to show as a nav entry.
+ *
  * @since TBD
  */
 final class Preset_Bindings {
@@ -78,19 +83,35 @@ final class Preset_Bindings {
 	public ?string $editor_selector;
 
 	/**
+	 * The Style Library admin page's per-block presentation metadata, or null when the declaration
+	 * omits the optional "style_library" section. Keyed for forward compatibility rather than a bare
+	 * scalar: today it carries only "label" (the block's BLOCK PRESETS nav label — never the picker
+	 * control's `$label`, which names the inspector control, not the block); a later per-block
+	 * settings-field schema is expected to add sibling keys here without a breaking change.
+	 *
 	 * @since TBD
 	 *
-	 * @param string                 $block           The block name.
-	 * @param array<string, Binding> $bindings        The block's bindable surface, keyed by property.
-	 * @param string|null            $label           The picker control label, or null for preset bindings with no picker.
-	 * @param string|null            $editor_selector The editor-only selector override, or null to reuse the
-	 *                                                 front-end selector in the editor too.
+	 * @var array{label?: string}|null
 	 */
-	private function __construct( string $block, array $bindings, ?string $label, ?string $editor_selector ) {
+	public ?array $style_library;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param string                     $block           The block name.
+	 * @param array<string, Binding>     $bindings        The block's bindable surface, keyed by property.
+	 * @param string|null                $label           The picker control label, or null for preset bindings with no picker.
+	 * @param string|null                $editor_selector The editor-only selector override, or null to reuse the
+	 *                                                     front-end selector in the editor too.
+	 * @param array{label?: string}|null $style_library The Style Library admin page's per-block presentation
+	 *                                                   metadata, or null when the declaration omits it.
+	 */
+	private function __construct( string $block, array $bindings, ?string $label, ?string $editor_selector, ?array $style_library ) {
 		$this->block           = $block;
 		$this->bindings        = $bindings;
 		$this->label           = $label;
 		$this->editor_selector = $editor_selector;
+		$this->style_library   = $style_library;
 	}
 
 	/**
@@ -100,8 +121,9 @@ final class Preset_Bindings {
 	 *
 	 * @param array<string, mixed> $declaration The declaration: "block", optional "bindings" (property =>
 	 *                                  {@see Binding::from_array()}), optional "label" (the picker control
-	 *                                  label; omit for preset bindings with no picker), and optional
-	 *                                  "editor_selector" (see {@see self::$editor_selector}). Preset names,
+	 *                                  label; omit for preset bindings with no picker), optional
+	 *                                  "editor_selector" (see {@see self::$editor_selector}), and optional
+	 *                                  "style_library" (see {@see self::$style_library}). Preset names,
 	 *                                  default and values are document data, not declared here.
 	 *
 	 * @throws InvalidArgumentException When "block" is missing or a binding is malformed.
@@ -119,7 +141,8 @@ final class Preset_Bindings {
 			$declaration['block'],
 			self::bindings( $declaration['block'], $declaration['bindings'] ?? [] ),
 			isset( $declaration['label'] ) && is_string( $declaration['label'] ) ? $declaration['label'] : null,
-			isset( $declaration['editor_selector'] ) && is_string( $declaration['editor_selector'] ) ? $declaration['editor_selector'] : null
+			isset( $declaration['editor_selector'] ) && is_string( $declaration['editor_selector'] ) ? $declaration['editor_selector'] : null,
+			self::style_library( $declaration['style_library'] ?? null )
 		);
 	}
 
@@ -212,6 +235,21 @@ final class Preset_Bindings {
 	}
 
 	/**
+	 * The Style Library BLOCK PRESETS nav label declared for this block, or null when the
+	 * declaration has no "style_library" section or leaves "label" empty. Distinct from
+	 * {@see self::$label}, which names the picker CONTROL rather than the block.
+	 *
+	 * @since TBD
+	 *
+	 * @return string|null
+	 */
+	public function style_library_label(): ?string {
+		$label = $this->style_library['label'] ?? null;
+
+		return is_string( $label ) && $label !== '' ? $label : null;
+	}
+
+	/**
 	 * Build the property => Binding map from a declaration's "bindings".
 	 *
 	 * @since TBD
@@ -244,6 +282,32 @@ final class Preset_Bindings {
 		}
 
 		return $bindings;
+	}
+
+	/**
+	 * Parse the optional "style_library" declaration section: the Style Library admin page's
+	 * per-block presentation metadata. Lenient like "label" and "editor_selector" — a missing or
+	 * malformed section yields null rather than throwing, since it is optional and its absence must
+	 * not block registration of the block's preset bindings.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $declared The declared "style_library" value.
+	 *
+	 * @return array{label?: string}|null
+	 */
+	private static function style_library( $declared ): ?array {
+		if ( ! is_array( $declared ) ) {
+			return null;
+		}
+
+		$section = [];
+
+		if ( isset( $declared['label'] ) && is_string( $declared['label'] ) && $declared['label'] !== '' ) {
+			$section['label'] = $declared['label'];
+		}
+
+		return $section;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -329,9 +329,14 @@ return [
 			 * symmetric and each is overridable on its own semantic. Picking a preset re-skins a button with
 			 * zero changes to its render path; a fresh button follows the $default.
 			 */
-			'block'    => 'kadence/singlebtn',
-			'label'    => __( 'Style', 'kadence-blocks' ), // a picker-driven set; this is the editor control's label.
-			'bindings' => [
+			'block'         => 'kadence/singlebtn',
+			'label'         => __( 'Style', 'kadence-blocks' ), // a picker-driven set; this is the editor control's label.
+			'style_library' => [
+				// The Style Library BLOCK PRESETS nav label — distinct from "label" above, which names the
+				// inspector's picker control, not the block.
+				'label' => __( 'Button', 'kadence-blocks' ),
+			],
+			'bindings'      => [
 				'button-bg'         => [
 					'kadence_slot' => 'palette-btn-bg',
 					'control_attr' => 'background',

--- a/src/style-library/__tests__/screens.test.js
+++ b/src/style-library/__tests__/screens.test.js
@@ -1,0 +1,84 @@
+/* eslint-env jest */
+import { addFilter, removeFilter } from '@wordpress/hooks';
+import {
+	blockFromScreenId,
+	buildBaseStylesNav,
+	buildBlockPresetsNav,
+	presetScreenId,
+	resolveScreen,
+} from '../helpers/screens';
+import { BASE_STYLES_SCREENS, PRESET_SCREENS_FILTER } from '../constants/screens';
+
+describe('presetScreenId and blockFromScreenId', () => {
+	it('round-trip a block name', () => {
+		const screenId = presetScreenId('kadence/singlebtn');
+
+		expect(screenId).toBe('blocks/kadence/singlebtn');
+		expect(blockFromScreenId(screenId)).toBe('kadence/singlebtn');
+	});
+
+	it('returns empty for a base styles id', () => {
+		expect(blockFromScreenId('color-palette')).toBe('');
+	});
+});
+
+describe('buildBaseStylesNav', () => {
+	it('returns the seven fixed entries in design order', () => {
+		expect(buildBaseStylesNav()).toEqual(BASE_STYLES_SCREENS.map(({ id, label }) => ({ id, label })));
+		expect(buildBaseStylesNav()).toHaveLength(7);
+	});
+});
+
+describe('buildBlockPresetsNav', () => {
+	it('maps the feed presetNav section to nav entries with preset screen ids', () => {
+		const feed = { presetNav: [{ block: 'kadence/singlebtn', label: 'Style' }] };
+
+		expect(buildBlockPresetsNav(feed)).toEqual([
+			{ id: 'blocks/kadence/singlebtn', label: 'Style', block: 'kadence/singlebtn' },
+		]);
+	});
+
+	it('returns an empty list when the feed lacks presetNav', () => {
+		expect(buildBlockPresetsNav({})).toEqual([]);
+		expect(buildBlockPresetsNav(null)).toEqual([]);
+	});
+});
+
+describe('resolveScreen', () => {
+	const ColorPaletteScreen = () => null;
+	const PresetFallback = () => null;
+	const registry = { baseStyles: { 'color-palette': ColorPaletteScreen }, presetFallback: PresetFallback };
+
+	it('returns the base styles component for a known id', () => {
+		expect(resolveScreen('color-palette', registry)).toEqual({ Component: ColorPaletteScreen, block: '' });
+	});
+
+	it('returns null for an unknown id', () => {
+		expect(resolveScreen('nonsense', registry)).toBeNull();
+	});
+
+	it('uses a filter-registered component for its block', () => {
+		const ButtonScreen = () => null;
+
+		addFilter(PRESET_SCREENS_FILTER, 'test/screens', (screens) => ({
+			...screens,
+			'kadence/singlebtn': ButtonScreen,
+		}));
+
+		try {
+			expect(resolveScreen('blocks/kadence/singlebtn', registry)).toEqual({
+				Component: ButtonScreen,
+				block: 'kadence/singlebtn',
+			});
+		} finally {
+			removeFilter(PRESET_SCREENS_FILTER, 'test/screens');
+		}
+	});
+
+	it('falls back to the generic component for an unregistered block', () => {
+		expect(resolveScreen('blocks/kadence/unregistered', registry)).toEqual({
+			Component: PresetFallback,
+			block: 'kadence/unregistered',
+		});
+	});
+});

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -78,7 +78,14 @@ export function StyleLibraryApp() {
 	return (
 		<AppShell
 			header={<AppHeader librarySlot={null} actionsSlot={null} />}
-			sidebar={<AppSidebar feed={feed.feed} activeId={activeScreenId} onNavigate={onNavigate} />}
+			sidebar={
+				<AppSidebar
+					baseStylesNav={baseStylesNav}
+					blockPresetsNav={blockPresetsNav}
+					activeId={activeScreenId}
+					onNavigate={onNavigate}
+				/>
+			}
 			content={<resolution.Component label={label} />}
 			settingsPanel={null}
 		/>

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -5,6 +5,7 @@
 /**
  * WordPress dependencies
  */
+import { useEffect, useMemo } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 
 /**
@@ -12,24 +13,51 @@ import { Spinner } from '@wordpress/components';
  */
 import { AppShell } from '../components/templates/AppShell';
 import { AppHeader } from '../components/organisms/AppHeader';
+import { AppSidebar } from '../components/organisms/AppSidebar';
+import { PlaceholderScreen } from '../components/pages/PlaceholderScreen';
 import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
+import { DEFAULT_SCREEN_ID } from '../constants/screens';
+import { buildBaseStylesNav, buildBlockPresetsNav, resolveScreen } from '../helpers/screens';
 
 /**
- * Render the Style Library application: the feed gate, the route hook, and the app shell with
- * its header bar. The sidebar, content, and settings panel are still empty slots — they are
- * filled once the navigation, screen registry, and settings panel exist.
+ * Render the Style Library application: feed gate, route hook, sidebar navigation, and the screen
+ * resolved for the active route. The settings panel is still an empty slot — it is filled once
+ * the settings panel and field library exist.
  *
  * @since TBD
  *
- * @return {JSX.Element} The app.
+ * @return {?JSX.Element} The app, or null while the route is being normalized to a known screen.
  */
 export function StyleLibraryApp() {
 	const feed = useDesignTokensFeed();
+	const { route, navigate, replace } = useStyleLibraryRoute();
 
-	// Keeps the URL route state alive even though nothing consumes it here yet — the sidebar and
-	// screen registry read it once they land.
-	useStyleLibraryRoute();
+	const baseStylesNav = useMemo(() => buildBaseStylesNav(), []);
+	const blockPresetsNav = useMemo(() => buildBlockPresetsNav(feed.feed), [feed.feed]);
+
+	// Every Base Styles id resolves to the placeholder until its per-screen work lands, and the
+	// preset fallback is the placeholder until the first real preset screen ships.
+	// @todo SOFT-4083 / SOFT-4084: first real preset screens replace this fallback.
+	const registry = useMemo(() => {
+		const baseStyles = {};
+
+		baseStylesNav.forEach((entry) => {
+			baseStyles[entry.id] = PlaceholderScreen;
+		});
+
+		return { baseStyles, presetFallback: PlaceholderScreen };
+	}, [baseStylesNav]);
+
+	const activeScreenId = route.screen || DEFAULT_SCREEN_ID;
+	const resolution = resolveScreen(activeScreenId, registry);
+
+	useEffect(() => {
+		if (!resolution) {
+			// replace, not navigate — an unknown screen id must not enter browser history.
+			replace({ screen: DEFAULT_SCREEN_ID, item: '' });
+		}
+	}, [resolution, replace]);
 
 	if (!feed.isReady) {
 		return (
@@ -39,11 +67,19 @@ export function StyleLibraryApp() {
 		);
 	}
 
+	if (!resolution) {
+		return null;
+	}
+
+	const navEntry = [...baseStylesNav, ...blockPresetsNav].find((entry) => entry.id === activeScreenId);
+	const label = navEntry ? navEntry.label : resolution.block || activeScreenId;
+	const onNavigate = (id) => navigate({ screen: id, item: '' });
+
 	return (
 		<AppShell
 			header={<AppHeader librarySlot={null} actionsSlot={null} />}
-			sidebar={null}
-			content={null}
+			sidebar={<AppSidebar feed={feed.feed} activeId={activeScreenId} onNavigate={onNavigate} />}
+			content={<resolution.Component label={label} />}
 			settingsPanel={null}
 		/>
 	);

--- a/src/style-library/components/atoms/NavItem.js
+++ b/src/style-library/components/atoms/NavItem.js
@@ -1,0 +1,43 @@
+/**
+ * A single Style Library sidebar navigation entry. A `<button>`, not an `<a>` — navigation is
+ * driven by the History API, not real links.
+ */
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import './NavItem.scss';
+
+/**
+ * Render a sidebar navigation item.
+ *
+ * @param {Object}   props         The component props.
+ * @param {string}   props.label   The item label.
+ * @param {boolean}  props.active  Whether this item is the active screen.
+ * @param {Function} props.onClick Called when the item is clicked.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The nav item.
+ */
+export function NavItem({ label, active, onClick }) {
+	return (
+		<li className="kadence-blocks-style-library__nav-item">
+			<button
+				type="button"
+				className={classnames('kadence-blocks-style-library__nav-item-button', {
+					'kadence-blocks-style-library__nav-item-button--active': active,
+				})}
+				aria-current={active ? 'page' : undefined}
+				onClick={onClick}
+			>
+				{label}
+			</button>
+		</li>
+	);
+}

--- a/src/style-library/components/atoms/NavItem.scss
+++ b/src/style-library/components/atoms/NavItem.scss
@@ -1,0 +1,28 @@
+.kadence-blocks-style-library__nav-item-button {
+	display: block;
+	width: 100%;
+	padding: var(--kb-sl-space-10) var(--kb-sl-space-15);
+	border: 0;
+	border-radius: var(--kb-sl-radius-s);
+	background: transparent;
+	color: var(--kb-sl-color-nav-tab-text);
+	font-size: var(--kb-sl-font-size-small);
+	font-weight: var(--kb-sl-font-weight-regular);
+	line-height: var(--kb-sl-line-height-nav-tab);
+	text-align: left;
+	cursor: pointer;
+
+	// Hover only recolors the text with the theme color; the 4%-tint background is reserved for
+	// the selected state below so the two stay visually distinct.
+	&:hover {
+		color: var(--kb-sl-color-nav-tab-text-hover);
+	}
+
+	// Declared after :hover so a selected tab that is also hovered keeps its background and
+	// weight — both selectors share the same specificity, so source order decides the winner.
+	&--active {
+		background: var(--kb-sl-color-nav-tab-bg-selected);
+		color: var(--kb-sl-color-nav-tab-text-selected);
+		font-weight: var(--kb-sl-font-weight-medium);
+	}
+}

--- a/src/style-library/components/atoms/NavSection.js
+++ b/src/style-library/components/atoms/NavSection.js
@@ -1,0 +1,46 @@
+/**
+ * A labeled group of Style Library sidebar navigation items: an uppercase muted label above the
+ * item list.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { NavItem } from './NavItem';
+import './NavSection.scss';
+
+/**
+ * Render a sidebar navigation section. Renders nothing when it has no items, so an empty
+ * BLOCK PRESETS section (no labeled preset bindings registered) does not print a stray heading.
+ *
+ * @param {Object}                          props            The component props.
+ * @param {string}                          props.label      The section label.
+ * @param {Array<{id: string, label: string}>} props.items      The section's nav entries.
+ * @param {string}                          props.activeId   The active screen id.
+ * @param {Function}                        props.onNavigate Called with a screen id when an item is clicked.
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The section, or null when it has no items.
+ */
+export function NavSection({ label, items, activeId, onNavigate }) {
+	if (!items.length) {
+		return null;
+	}
+
+	return (
+		<div className="kadence-blocks-style-library__nav-section">
+			<h2 className="kadence-blocks-style-library__nav-section-label">{label}</h2>
+			<ul className="kadence-blocks-style-library__nav-list">
+				{items.map((item) => (
+					<NavItem
+						key={item.id}
+						label={item.label}
+						active={item.id === activeId}
+						onClick={() => onNavigate(item.id)}
+					/>
+				))}
+			</ul>
+		</div>
+	);
+}

--- a/src/style-library/components/atoms/NavSection.scss
+++ b/src/style-library/components/atoms/NavSection.scss
@@ -1,0 +1,17 @@
+.kadence-blocks-style-library__nav-section {
+	display: flex;
+	flex-direction: column;
+	gap: var(--kb-sl-space-10);
+}
+
+.kadence-blocks-style-library__nav-section-label {
+	// wp-admin sets h2 margin globally; zero it so the section's flex gap is the only spacing.
+	margin: 0;
+	color: var(--kb-sl-color-nav-section-title);
+	font-size: var(--kb-sl-font-size-meta);
+	font-weight: var(--kb-sl-font-weight-medium);
+	// The design has no explicit line-height for this element.
+	line-height: normal;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+}

--- a/src/style-library/components/organisms/AppSidebar.js
+++ b/src/style-library/components/organisms/AppSidebar.js
@@ -11,33 +11,33 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { NavSection } from '../atoms/NavSection';
-import { buildBaseStylesNav, buildBlockPresetsNav } from '../../helpers/screens';
 import './AppSidebar.scss';
 
 /**
  * Render the Style Library sidebar navigation.
  *
- * @param {Object}   props            The component props.
- * @param {Object}   props.feed       The design-tokens admin feed.
- * @param {string}   props.activeId   The active screen id from the route.
- * @param {Function} props.onNavigate Called with a screen id when an item is clicked.
+ * @param {Object}                              props                 The component props.
+ * @param {Array<{id: string, label: string}>}   props.baseStylesNav   The BASE STYLES nav entries.
+ * @param {Array<{id: string, label: string}>}   props.blockPresetsNav The BLOCK PRESETS nav entries.
+ * @param {string}                              props.activeId        The active screen id from the route.
+ * @param {Function}                            props.onNavigate      Called with a screen id when an item is clicked.
  *
  * @since TBD
  *
  * @return {JSX.Element} The sidebar.
  */
-export function AppSidebar({ feed, activeId, onNavigate }) {
+export function AppSidebar({ baseStylesNav, blockPresetsNav, activeId, onNavigate }) {
 	return (
 		<div className="kadence-blocks-style-library__nav">
 			<NavSection
 				label={__('Base Styles', 'kadence-blocks')}
-				items={buildBaseStylesNav()}
+				items={baseStylesNav}
 				activeId={activeId}
 				onNavigate={onNavigate}
 			/>
 			<NavSection
 				label={__('Block Presets', 'kadence-blocks')}
-				items={buildBlockPresetsNav(feed)}
+				items={blockPresetsNav}
 				activeId={activeId}
 				onNavigate={onNavigate}
 			/>

--- a/src/style-library/components/organisms/AppSidebar.js
+++ b/src/style-library/components/organisms/AppSidebar.js
@@ -1,0 +1,46 @@
+/**
+ * The Style Library left navigation: BASE STYLES and BLOCK PRESETS sections.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { NavSection } from '../atoms/NavSection';
+import { buildBaseStylesNav, buildBlockPresetsNav } from '../../helpers/screens';
+import './AppSidebar.scss';
+
+/**
+ * Render the Style Library sidebar navigation.
+ *
+ * @param {Object}   props            The component props.
+ * @param {Object}   props.feed       The design-tokens admin feed.
+ * @param {string}   props.activeId   The active screen id from the route.
+ * @param {Function} props.onNavigate Called with a screen id when an item is clicked.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The sidebar.
+ */
+export function AppSidebar({ feed, activeId, onNavigate }) {
+	return (
+		<div className="kadence-blocks-style-library__nav">
+			<NavSection
+				label={__('Base Styles', 'kadence-blocks')}
+				items={buildBaseStylesNav()}
+				activeId={activeId}
+				onNavigate={onNavigate}
+			/>
+			<NavSection
+				label={__('Block Presets', 'kadence-blocks')}
+				items={buildBlockPresetsNav(feed)}
+				activeId={activeId}
+				onNavigate={onNavigate}
+			/>
+		</div>
+	);
+}

--- a/src/style-library/components/organisms/AppSidebar.scss
+++ b/src/style-library/components/organisms/AppSidebar.scss
@@ -1,0 +1,6 @@
+.kadence-blocks-style-library__nav {
+	display: flex;
+	flex-direction: column;
+	gap: var(--kb-sl-space-30);
+	padding: var(--kb-sl-space-20);
+}

--- a/src/style-library/components/pages/PlaceholderScreen.js
+++ b/src/style-library/components/pages/PlaceholderScreen.js
@@ -1,0 +1,37 @@
+/**
+ * The generic Style Library screen: a centered, muted "coming soon" panel rendered for every nav
+ * entry until its per-screen work lands.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './PlaceholderScreen.scss';
+
+/**
+ * Render the placeholder screen.
+ *
+ * @param {Object} props       The component props.
+ * @param {string} props.label The active screen's nav label.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The placeholder screen.
+ *
+ * @todo Replaced per screen by the Style Library per-screen work.
+ */
+export function PlaceholderScreen({ label }) {
+	return (
+		<div className="kadence-blocks-style-library__placeholder-screen">
+			<h2 className="kadence-blocks-style-library__placeholder-screen-title">{label}</h2>
+			<p className="kadence-blocks-style-library__placeholder-screen-copy">
+				{__('This screen is coming soon.', 'kadence-blocks')}
+			</p>
+		</div>
+	);
+}

--- a/src/style-library/components/pages/PlaceholderScreen.scss
+++ b/src/style-library/components/pages/PlaceholderScreen.scss
@@ -1,0 +1,24 @@
+@use '../../styles/mixins' as *;
+
+.kadence-blocks-style-library__placeholder-screen {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	min-height: 100%;
+	padding: var(--kb-sl-space-40);
+	text-align: center;
+}
+
+.kadence-blocks-style-library__placeholder-screen-title {
+	@include section-heading(var(--kb-sl-font-size-page-title));
+
+	color: var(--kb-sl-color-text-primary);
+}
+
+.kadence-blocks-style-library__placeholder-screen-copy {
+	@include body-text;
+
+	margin-left: auto;
+	margin-right: auto;
+}

--- a/src/style-library/constants/screens.js
+++ b/src/style-library/constants/screens.js
@@ -1,0 +1,65 @@
+/**
+ * The Style Library screen catalog: the fixed BASE STYLES entries, the sidebar section
+ * definitions, and the extension-point names. Screen ids are stable — they are used in the URL
+ * (`?kb-screen=<id>`) and by the per-screen modules that claim them.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * The filter third parties use to register a screen component for their preset-bound block:
+ * `addFilter( PRESET_SCREENS_FILTER, 'my-plugin/screens', ( screens ) => ( { ...screens,
+ * 'my-vendor/my-block': MyScreen } ) )`. Keyed by block name, valued by component. Resolution runs
+ * on every screen render (inside `resolveScreen`), so a listener added after the app has already
+ * rendered a screen still takes effect on the next render or navigation.
+ *
+ * @since TBD
+ */
+export const PRESET_SCREENS_FILTER = 'kadence_blocks.style_library.preset_screens';
+
+/**
+ * The BASE STYLES sidebar section id.
+ *
+ * @since TBD
+ */
+export const BASE_STYLES_SECTION = 'base-styles';
+
+/**
+ * The BLOCK PRESETS sidebar section id.
+ *
+ * @since TBD
+ */
+export const BLOCK_PRESETS_SECTION = 'block-presets';
+
+/**
+ * The fixed BASE STYLES nav entries, in design order. Every entry renders `PlaceholderScreen`
+ * until its per-screen ticket lands.
+ *
+ * @since TBD
+ */
+export const BASE_STYLES_SCREENS = [
+	// @todo SOFT-4076: replace the placeholder with the Color Palette screen.
+	{ id: 'color-palette', label: __('Color Palette', 'kadence-blocks') },
+	// @todo SOFT-4077: replace the placeholder with the Typography screen.
+	{ id: 'typography', label: __('Typography', 'kadence-blocks') },
+	// @todo SOFT-4078: replace the placeholder with the Border Radius screen.
+	{ id: 'border-radius', label: __('Border Radius', 'kadence-blocks') },
+	// @todo SOFT-4079: replace the placeholder with the Border Width screen.
+	{ id: 'border-width', label: __('Border Width', 'kadence-blocks') },
+	// @todo SOFT-4080: replace the placeholder with the Spacing screen.
+	{ id: 'spacing', label: __('Spacing', 'kadence-blocks') },
+	// @todo SOFT-4081: replace the placeholder with the Icon Sizes screen.
+	{ id: 'icon-sizes', label: __('Icon Sizes', 'kadence-blocks') },
+	// @todo SOFT-4082: replace the placeholder with the Shadow screen.
+	{ id: 'shadow', label: __('Shadow', 'kadence-blocks') },
+];
+
+/**
+ * The screen the app falls back to when the route names no screen or an unknown one.
+ *
+ * @since TBD
+ */
+export const DEFAULT_SCREEN_ID = BASE_STYLES_SCREENS[0].id;

--- a/src/style-library/constants/screens.js
+++ b/src/style-library/constants/screens.js
@@ -21,20 +21,6 @@ import { __ } from '@wordpress/i18n';
 export const PRESET_SCREENS_FILTER = 'kadence_blocks.style_library.preset_screens';
 
 /**
- * The BASE STYLES sidebar section id.
- *
- * @since TBD
- */
-export const BASE_STYLES_SECTION = 'base-styles';
-
-/**
- * The BLOCK PRESETS sidebar section id.
- *
- * @since TBD
- */
-export const BLOCK_PRESETS_SECTION = 'block-presets';
-
-/**
  * The fixed BASE STYLES nav entries, in design order. Every entry renders `PlaceholderScreen`
  * until its per-screen ticket lands.
  *

--- a/src/style-library/helpers/screens.js
+++ b/src/style-library/helpers/screens.js
@@ -1,0 +1,116 @@
+/**
+ * Screen-id resolution for the Style Library: the pure nav builders, the block-preset screen-id
+ * codec, and the filter-then-fallback resolution both sidebar sections share. Screens plug into
+ * this contract by claiming a `BASE_STYLES_SCREENS` id or, for a block-preset screen, by
+ * registering a component on the `PRESET_SCREENS_FILTER`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { BASE_STYLES_SCREENS, PRESET_SCREENS_FILTER } from '../constants/screens';
+
+/**
+ * The screen-id prefix that namespaces every block-preset screen away from the fixed Base Styles
+ * ids, so the two id spaces can never collide.
+ *
+ * @since TBD
+ */
+const PRESET_SCREEN_PREFIX = 'blocks/';
+
+/**
+ * The screen id for a preset-bound block, e.g. `kadence/singlebtn` -> `blocks/kadence/singlebtn`.
+ *
+ * @param {string} block The block name.
+ *
+ * @since TBD
+ *
+ * @return {string} The screen id.
+ */
+export function presetScreenId(block) {
+	return `${PRESET_SCREEN_PREFIX}${block}`;
+}
+
+/**
+ * The block name a preset screen id addresses, or '' for a non-preset id.
+ *
+ * @param {string} screenId The screen id.
+ *
+ * @since TBD
+ *
+ * @return {string} The block name, or ''.
+ */
+export function blockFromScreenId(screenId) {
+	return typeof screenId === 'string' && screenId.startsWith(PRESET_SCREEN_PREFIX)
+		? screenId.slice(PRESET_SCREEN_PREFIX.length)
+		: '';
+}
+
+/**
+ * Build the BASE STYLES nav entries (fixed order, from the constants).
+ *
+ * @since TBD
+ *
+ * @return {Array<{id: string, label: string}>} The nav entries.
+ */
+export function buildBaseStylesNav() {
+	return BASE_STYLES_SCREENS.map(({ id, label }) => ({ id, label }));
+}
+
+/**
+ * Build the BLOCK PRESETS nav entries from the admin feed's `presetNav` section, already ordered
+ * and labeled by PHP. Tolerates a missing/empty section (older feed) by returning [].
+ *
+ * @param {Object} feed The `window.kadenceDesignTokens` feed object.
+ *
+ * @since TBD
+ *
+ * @return {Array<{id: string, label: string, block: string}>} The nav entries.
+ */
+export function buildBlockPresetsNav(feed) {
+	const entries = feed?.presetNav;
+
+	if (!Array.isArray(entries)) {
+		return [];
+	}
+
+	return entries.map(({ block, label }) => ({ id: presetScreenId(block), label, block }));
+}
+
+/**
+ * Resolve a screen id to the component that renders it. Preset ids consult the third-party
+ * registry (the preset-screens filter) first and fall back to the generic screen; unknown ids
+ * resolve to null so the caller can normalize the route. This is the single `applyFilters` call
+ * site for `PRESET_SCREENS_FILTER`.
+ *
+ * @param {string} screenId The screen id from the route.
+ * @param {Object} registry `{ baseStyles: {id: Component}, presetFallback: Component }` — the
+ *                           app-owned component map.
+ *
+ * @since TBD
+ *
+ * @return {?{Component: Function, block: string}} The resolution, or null for an unknown id.
+ */
+export function resolveScreen(screenId, registry) {
+	const block = blockFromScreenId(screenId);
+
+	if (block) {
+		/**
+		 * Filters the third-party preset screen components, keyed by block name.
+		 *
+		 * @param {Object} screens blockName => screen component.
+		 */
+		const screens = applyFilters(PRESET_SCREENS_FILTER, {});
+
+		return { Component: screens[block] || registry.presetFallback, block };
+	}
+
+	const Component = registry.baseStyles[screenId];
+
+	return Component ? { Component, block: '' } : null;
+}

--- a/tests/snapshot/Resources/Design_Tokens/Admin/Feed/Builder_SnapshotTest.php
+++ b/tests/snapshot/Resources/Design_Tokens/Admin/Feed/Builder_SnapshotTest.php
@@ -4,6 +4,7 @@
 namespace Tests\snapshot\Resources\Design_Tokens\Admin\Feed;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Builder;
+use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Preset_Nav;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use Tests\Support\Classes\SnapshotTestCase;
 
@@ -73,7 +74,7 @@ final class Builder_SnapshotTest extends SnapshotTestCase {
 			'nonce'     => 'test-nonce',
 		];
 
-		$feed = ( new Builder( $this->registry ) )->build( $values, true, $presets, $rest, 'v7', 'default' );
+		$feed = ( new Builder( $this->registry, new Preset_Nav( $this->registry ) ) )->build( $values, true, $presets, $rest, 'v7', 'default' );
 
 		// Structural assertions that must always hold regardless of snapshot content.
 		$this->assertTrue( $feed['active'] );

--- a/tests/snapshot/Resources/Design_Tokens/Admin/Feed/__snapshots__/Builder_SnapshotTest__testFullPayloadMatchesSnapshot__1.txt
+++ b/tests/snapshot/Resources/Design_Tokens/Admin/Feed/__snapshots__/Builder_SnapshotTest__testFullPayloadMatchesSnapshot__1.txt
@@ -68,6 +68,7 @@
             }
         }
     },
+    "presetNav": [],
     "responsive": [],
     "rest": {
         "root": "https:\/\/example.test\/wp-json\/",

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/BuilderTest.php
@@ -3,6 +3,7 @@
 namespace Tests\wpunit\Resources\Design_Tokens\Admin\Feed;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Builder;
+use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Preset_Nav;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use Tests\Support\Classes\TestCase;
 
@@ -36,11 +37,26 @@ final class BuilderTest extends TestCase {
 		];
 	}
 
+	/**
+	 * A builder wired to the test registry and its Preset_Nav collaborator.
+	 *
+	 * @return Builder
+	 */
+	private function builder(): Builder {
+		return new Builder( $this->registry, new Preset_Nav( $this->registry ) );
+	}
+
+	/**
+	 * An active registry passes through the given values, presets, REST descriptor and version,
+	 * paired with the registry's own structure.
+	 *
+	 * @return void
+	 */
 	public function testActiveRegistryPassesStructureAndInputsThrough(): void {
 		$values  = [ 'semantic.color.button-bg' => '#3182CE' ];
 		$presets = [ 'kadence/advancedbtn' => [ 'default' => 'primary' ] ];
 
-		$feed = ( new Builder( $this->registry ) )->build( $values, true, $presets, $this->rest(), 'v7', 'default' );
+		$feed = $this->builder()->build( $values, true, $presets, $this->rest(), 'v7', 'default' );
 
 		$this->assertTrue( $feed['active'] );
 		$this->assertTrue( $feed['resolved'] );
@@ -52,8 +68,13 @@ final class BuilderTest extends TestCase {
 		$this->assertSame( $this->rest(), $feed['rest'] );
 	}
 
+	/**
+	 * A failed resolution keeps the registry's structure in the feed but reports empty values.
+	 *
+	 * @return void
+	 */
 	public function testResolvedFalseKeepsStructureButEmptyValues(): void {
-		$feed = ( new Builder( $this->registry ) )->build( [], false, [], $this->rest(), 'v7', 'default' );
+		$feed = $this->builder()->build( [], false, [], $this->rest(), 'v7', 'default' );
 
 		$this->assertTrue( $feed['active'] );
 		$this->assertFalse( $feed['resolved'] );
@@ -61,8 +82,13 @@ final class BuilderTest extends TestCase {
 		$this->assertSame( [], $feed['values'] );
 	}
 
+	/**
+	 * A successful resolution with no values yet still reports resolved:true and an empty values map.
+	 *
+	 * @return void
+	 */
 	public function testResolvedTrueWithEmptyValuesPassesThroughUnchanged(): void {
-		$feed = ( new Builder( $this->registry ) )->build( [], true, [], $this->rest(), 'v7', 'default' );
+		$feed = $this->builder()->build( [], true, [], $this->rest(), 'v7', 'default' );
 
 		$this->assertTrue( $feed['active'] );
 		$this->assertTrue( $feed['resolved'] );
@@ -70,10 +96,16 @@ final class BuilderTest extends TestCase {
 		$this->assertSame( [], $feed['values'] );
 	}
 
+	/**
+	 * A deactivated registry yields an empty, inactive payload with structure, values, presets and
+	 * presetNav all cleared, while the REST descriptor, version and slug still pass through.
+	 *
+	 * @return void
+	 */
 	public function testDeactivatedRegistryYieldsEmptyInactivePayload(): void {
 		$this->registry->deactivate();
 
-		$feed = ( new Builder( $this->registry ) )->build(
+		$feed = $this->builder()->build(
 			[ 'semantic.color.button-bg' => '#3182CE' ],
 			true,
 			[ 'kadence/advancedbtn' => [] ],
@@ -87,6 +119,7 @@ final class BuilderTest extends TestCase {
 		$this->assertSame( [ 'groups' => [] ], $feed['schema'] );
 		$this->assertSame( [], $feed['values'] );
 		$this->assertSame( [], $feed['presets'] );
+		$this->assertSame( [], $feed['presetNav'] );
 		// The REST descriptor, version and slug are still present so the React app can wire even when hidden.
 		$this->assertSame( $this->rest(), $feed['rest'] );
 		$this->assertSame( 'v7', $feed['version'] );
@@ -94,11 +127,41 @@ final class BuilderTest extends TestCase {
 	}
 
 	/**
+	 * The slug passes through the feed unchanged regardless of whether the registry is active.
+	 *
 	 * @return void
 	 */
 	public function testSlugPassesThroughRegardlessOfActiveState(): void {
-		$feed = ( new Builder( $this->registry ) )->build( [], true, [], $this->rest(), 'v7', 'brand-b' );
+		$feed = $this->builder()->build( [], true, [], $this->rest(), 'v7', 'brand-b' );
 
 		$this->assertSame( 'brand-b', $feed['slug'] );
+	}
+
+	/**
+	 * An active registry with a labeled preset-bindings set surfaces it in the feed's presetNav
+	 * section, keyed as a nav entry rather than folded into the presets structure.
+	 *
+	 * @return void
+	 */
+	public function testActiveRegistryIncludesThePresetNavSection(): void {
+		$this->registry->register_preset_bindings(
+			[
+				'block'         => 'kadence/singlebtn',
+				'label'         => 'Style',
+				'style_library' => [ 'label' => 'Button' ],
+			]
+		);
+
+		$feed = $this->builder()->build( [], true, [], $this->rest(), 'v7', 'default' );
+
+		$this->assertSame(
+			[
+				[
+					'block' => 'kadence/singlebtn',
+					'label' => 'Button',
+				],
+			],
+			$feed['presetNav']
+		);
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/PresetNavTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/PresetNavTest.php
@@ -1,0 +1,247 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Admin\Feed;
+
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Builder;
+use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Preset_Nav;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Exercises Preset_Nav against the real shipped registry, so these assertions also guard which
+ * declared preset bindings are picker-driven.
+ */
+final class PresetNavTest extends TestCase {
+
+	private Token_Registry $registry;
+
+	/**
+	 * Resolve the shipped registry from the container so the shipped declarations are exercised.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->registry = $this->container->get( Token_Registry::class );
+	}
+
+	/**
+	 * The shipped registry surfaces exactly one nav entry today — the singlebtn block — carrying
+	 * its declared Style Library section label ("Button"), never the picker control's own label
+	 * ("Style").
+	 *
+	 * @return void
+	 */
+	public function testAllUsesTheDeclaredStyleLibraryLabel(): void {
+		$entries = ( new Preset_Nav( $this->registry ) )->all();
+
+		$this->assertSame(
+			[
+				[
+					'block' => 'kadence/singlebtn',
+					'label' => 'Button',
+				],
+			],
+			$entries
+		);
+	}
+
+	/**
+	 * A default-look-only binding set — one with no declared label — is excluded from the nav,
+	 * across every shipped block that registers bindings with no picker.
+	 *
+	 * @dataProvider defaultLookOnlyBlockProvider
+	 *
+	 * @param string $block The default-look-only block name.
+	 *
+	 * @return void
+	 */
+	public function testAllExcludesBindingSetsWithNoLabel( string $block ): void {
+		$entries = ( new Preset_Nav( $this->registry ) )->all();
+		$blocks  = array_column( $entries, 'block' );
+
+		$this->assertNotContains( $block, $blocks );
+	}
+
+	/**
+	 * A third-party block that declares a picker label on its preset bindings earns a nav entry
+	 * with zero JS — the documented inclusion opt-in — and, when it also declares a Style Library
+	 * section, that section's label is what the nav shows.
+	 *
+	 * @return void
+	 */
+	public function testAllIncludesAThirdPartyBindingSetThatDeclaresALabel(): void {
+		$registry = new Token_Registry();
+		$registry->register_preset_bindings(
+			[
+				'block'         => 'my-vendor/my-block',
+				'label'         => 'Style',
+				'style_library' => [ 'label' => 'My Block Style' ],
+			]
+		);
+
+		$entries = ( new Preset_Nav( $registry ) )->all();
+
+		$this->assertSame(
+			[
+				[
+					'block' => 'my-vendor/my-block',
+					'label' => 'My Block Style',
+				],
+			],
+			$entries
+		);
+	}
+
+	/**
+	 * The declared Style Library section label wins over the block's registered title even when
+	 * the block is registered under a different title — the section is the explicit opt-in and
+	 * takes precedence over both fallbacks.
+	 *
+	 * @return void
+	 */
+	public function testAllPrefersTheDeclaredStyleLibraryLabelOverTheRegisteredBlockTitle(): void {
+		register_block_type( 'my-vendor/my-block', [ 'title' => 'Registered Title' ] );
+
+		try {
+			$registry = new Token_Registry();
+			$registry->register_preset_bindings(
+				[
+					'block'         => 'my-vendor/my-block',
+					'label'         => 'Style',
+					'style_library' => [ 'label' => 'Declared Label' ],
+				]
+			);
+
+			$entries = ( new Preset_Nav( $registry ) )->all();
+
+			$this->assertSame( 'Declared Label', $entries[0]['label'] );
+		} finally {
+			unregister_block_type( 'my-vendor/my-block' );
+		}
+	}
+
+	/**
+	 * With no Style Library section declared, a registered block's own title is the nav label —
+	 * the second rung of the fallback chain.
+	 *
+	 * @return void
+	 */
+	public function testAllFallsBackToTheRegisteredBlockTitleWhenNoStyleLibrarySection(): void {
+		register_block_type( 'my-vendor/my-block', [ 'title' => 'Registered Title' ] );
+
+		try {
+			$registry = new Token_Registry();
+			$registry->register_preset_bindings(
+				[
+					'block' => 'my-vendor/my-block',
+					'label' => 'Style',
+				]
+			);
+
+			$entries = ( new Preset_Nav( $registry ) )->all();
+
+			$this->assertSame( 'Registered Title', $entries[0]['label'] );
+		} finally {
+			unregister_block_type( 'my-vendor/my-block' );
+		}
+	}
+
+	/**
+	 * With no Style Library section and no matching block registration, the nav label humanizes
+	 * the block name — the final rung of the fallback chain, so an unregistered block never shows
+	 * a raw slug or the picker control's own label.
+	 *
+	 * @return void
+	 */
+	public function testAllHumanizesTheBlockNameWhenUnregisteredAndNoStyleLibrarySection(): void {
+		$registry = new Token_Registry();
+		$registry->register_preset_bindings(
+			[
+				'block' => 'my-vendor/my-unregistered-block',
+				'label' => 'Style',
+			]
+		);
+
+		$entries = ( new Preset_Nav( $registry ) )->all();
+
+		$this->assertSame( 'My Unregistered Block', $entries[0]['label'] );
+	}
+
+	/**
+	 * Labeled binding sets appear in the nav in the order they were registered.
+	 *
+	 * @return void
+	 */
+	public function testAllPreservesRegistrationOrder(): void {
+		$registry = new Token_Registry();
+		$registry->register_preset_bindings(
+			[
+				'block'         => 'my-vendor/second',
+				'label'         => 'Style',
+				'style_library' => [ 'label' => 'Second' ],
+			]
+		);
+		$registry->register_preset_bindings(
+			[
+				'block'         => 'my-vendor/first',
+				'label'         => 'Style',
+				'style_library' => [ 'label' => 'First' ],
+			]
+		);
+
+		$entries = ( new Preset_Nav( $registry ) )->all();
+
+		$this->assertSame(
+			[
+				[
+					'block' => 'my-vendor/second',
+					'label' => 'Second',
+				],
+				[
+					'block' => 'my-vendor/first',
+					'label' => 'First',
+				],
+			],
+			$entries
+		);
+	}
+
+	/**
+	 * The admin feed's presetNav key mirrors Preset_Nav::all() for the active registry.
+	 *
+	 * @return void
+	 */
+	public function testBuilderFeedContainsThePresetNavKey(): void {
+		$builder = $this->container->get( Builder::class );
+		$rest    = [
+			'root'      => 'https://example.test/wp-json/',
+			'namespace' => 'kb-design-tokens/v1',
+			'nonce'     => 'abc123',
+		];
+
+		$feed = $builder->build( [], true, [], $rest, 'v1', 'default' );
+
+		$this->assertSame( ( new Preset_Nav( $this->registry ) )->all(), $feed['presetNav'] );
+	}
+
+	/**
+	 * The shipped blocks whose preset bindings declare no label — default-look-only sets with no
+	 * user-facing preset concept.
+	 *
+	 * @return Generator
+	 */
+	public function defaultLookOnlyBlockProvider(): Generator {
+		yield 'image' => [ 'block' => 'kadence/image' ];
+
+		yield 'rowlayout' => [ 'block' => 'kadence/rowlayout' ];
+
+		yield 'column' => [ 'block' => 'kadence/column' ];
+
+		yield 'single icon' => [ 'block' => 'kadence/single-icon' ];
+
+		yield 'advanced heading' => [ 'block' => 'kadence/advancedheading' ];
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Preset_BindingsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Preset_BindingsTest.php
@@ -3,6 +3,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Registry;
 
+use Generator;
 use InvalidArgumentException;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Binding;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Preset_Bindings;
@@ -157,5 +158,78 @@ final class Preset_BindingsTest extends TestCase {
 		$ui = Preset_Bindings::from_array( [ 'block' => 'kadence/advancedbtn' ] )->to_ui_schema();
 
 		$this->assertSame( [ 'bindings' => [] ], $ui );
+	}
+
+	/**
+	 * A declaration's optional "style_library" section parses its "label" into the accessor, kept
+	 * distinct from the picker control's own "label".
+	 *
+	 * @return void
+	 */
+	public function testStyleLibraryLabelIsReadFromTheDeclaredSection(): void {
+		$bindings = Preset_Bindings::from_array(
+			$this->declaration() + [
+				'label'         => 'Style',
+				'style_library' => [ 'label' => 'Button' ],
+			]
+		);
+
+		$this->assertSame( 'Button', $bindings->style_library_label() );
+		$this->assertSame( 'Style', $bindings->label );
+	}
+
+	/**
+	 * A declaration that omits "style_library" entirely stays valid: the section is null and the
+	 * label accessor reports null rather than throwing or defaulting to the picker control's label.
+	 *
+	 * @return void
+	 */
+	public function testStyleLibraryLabelIsNullWhenTheSectionIsOmitted(): void {
+		$bindings = Preset_Bindings::from_array( $this->declaration() );
+
+		$this->assertNull( $bindings->style_library );
+		$this->assertNull( $bindings->style_library_label() );
+	}
+
+	/**
+	 * A malformed "style_library" section (not an array) degrades to null rather than throwing —
+	 * the section is optional and must not block registration of the block's preset bindings.
+	 *
+	 * @return void
+	 */
+	public function testStyleLibraryLabelIsNullWhenTheSectionIsMalformed(): void {
+		$bindings = Preset_Bindings::from_array( $this->declaration() + [ 'style_library' => 'Button' ] );
+
+		$this->assertNull( $bindings->style_library );
+		$this->assertNull( $bindings->style_library_label() );
+	}
+
+	/**
+	 * A "style_library" section present but with an empty or non-string "label" yields a null
+	 * accessor rather than an empty-string label.
+	 *
+	 * @dataProvider invalidStyleLibraryLabelProvider
+	 *
+	 * @param mixed $label The invalid declared "style_library.label" value.
+	 *
+	 * @return void
+	 */
+	public function testStyleLibraryLabelIsNullWhenTheDeclaredLabelIsInvalid( $label ): void {
+		$bindings = Preset_Bindings::from_array( $this->declaration() + [ 'style_library' => [ 'label' => $label ] ] );
+
+		$this->assertNull( $bindings->style_library_label() );
+	}
+
+	/**
+	 * Invalid "style_library.label" values: empty string and non-string types.
+	 *
+	 * @return Generator
+	 */
+	public function invalidStyleLibraryLabelProvider(): Generator {
+		yield 'empty string' => [ 'label' => '' ];
+
+		yield 'integer' => [ 'label' => 4 ];
+
+		yield 'null' => [ 'label' => null ];
 	}
 }


### PR DESCRIPTION
Adds the sidebar navigation, the screen registry both nav sections resolve through, and the admin-feed section that makes the block-presets list data-driven.

## What this adds

- **Sidebar navigation** — `BASE STYLES` with the seven fixed screens in design order, and `BLOCK PRESETS` built from the admin feed. `AppSidebar`, `NavSection` and `NavItem` styled to the design: 13px labels, active item in the admin theme colour over a 4% tint, container padding with `gap` rather than sibling margins.
- **Screen registry** — one `screenId → component` resolution for both sections, with a `kadence_blocks.style_library.preset_screens` JS filter so an integrator can supply a custom screen for their block, and a generic fallback for anything unregistered. The filter string lives in a single exported constant.
- **`presetNav` admin feed** — new `Admin\Feed\Preset_Nav` listing blocks whose preset bindings declare a picker label, so a third party that registers bindings in PHP appears in the sidebar with no JS. The label resolves from a Style-Library section on the declaration, then the registered block title, then a humanized block name.
- **Placeholder screens** — every nav entry renders one, each naming the ticket that fills it in.

## Notes for review

- Only **picker-driven** binding sets are listed. A set with no declared label is default-look-only and has no user-facing preset concept, so it is deliberately excluded — today that means one entry, Button.
- The design's Backgrounds entry cannot appear yet: nothing registers a binding set for it. It will appear automatically once one is declared.

## Screenshot

<img width="1528" height="804" alt="phase-2-navigation-and-screen-registry" src="https://github.com/user-attachments/assets/7e9abeee-6d37-448e-8199-6a7868333d9c" />

## Test plan

- Both sections render; clicking an item updates `?kb-screen=` and the active treatment follows.
- A block registered via `kadence_blocks_register_design_preset_bindings()` with a label appears in `BLOCK PRESETS`.
- `slic run wpunit Resources/Design_Tokens/Admin/Feed`, `bun run test`.
