### PR TITLE
[DTM] SOFT-4075 [6/6]: Explicit library activation, rename, and safer delete

### DIFF
--- a/includes/resources/Design_Tokens/Admin/Feed/Builder.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Builder.php
@@ -62,10 +62,14 @@ final class Builder {
 	 * @param string                                                $slug       The token library slug the values/version/schema were resolved against.
 	 * @param array<string, array<string, mixed>>                   $responsive id => raw authored responsive / clamp shape, for
 	 *                                                                          tokens that carry one (for editor hydration).
+	 * @param string                                                $title      The library's stored label, '' when it has none. Carried here so
+	 *                                                                          the admin page can name the library on first paint, without
+	 *                                                                          waiting on the separate libraries request and visibly correcting
+	 *                                                                          itself once that arrives.
 	 *
 	 * @return array<string, mixed> The localized payload.
 	 */
-	public function build( array $values, bool $resolved, array $presets, array $rest, string $version, string $slug, array $responsive = [] ): array {
+	public function build( array $values, bool $resolved, array $presets, array $rest, string $version, string $slug, array $responsive = [], string $title = '' ): array {
 		$active = $this->registry->is_active();
 
 		return [
@@ -73,6 +77,9 @@ final class Builder {
 			'resolved'   => $active && $resolved,
 			'version'    => $version,
 			'slug'       => $slug,
+			// Outside the `$active` gate below: a label is not token data, and a deactivated registry
+			// still renders a page that has to name the library it is showing.
+			'title'      => $title,
 			'schema'     => $active ? $this->registry->to_ui_schema() : [ 'groups' => [] ],
 			'values'     => $active ? $values : [],
 			'presets'    => $active ? $presets : [],

--- a/includes/resources/Design_Tokens/Admin/Feed/Builder.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Builder.php
@@ -60,7 +60,10 @@ final class Builder {
 	 * @param array{root: string, namespace: string, nonce: string} $rest       REST root, namespace and nonce.
 	 * @param string                                                $version    Store version hash ('' from baseline).
 	 * @param string                                                $slug       The token library slug the values/version/schema were resolved against.
-	 * @param string                                                $title      The active library's display title, already defaulted for an untitled default library.
+	 * @param string                                                $title      The library's display title, already defaulted for an untitled
+	 *                                                                          default library. Carried here so the admin page can name the
+	 *                                                                          library on first paint, without waiting on the separate libraries
+	 *                                                                          request and visibly correcting itself once that arrives.
 	 * @param array<string, array<string, mixed>>                   $responsive id => raw authored responsive / clamp shape, for
 	 *                                                                          tokens that carry one (for editor hydration).
 	 *

--- a/includes/resources/Design_Tokens/Admin/Feed/Feed_Assembler.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Feed_Assembler.php
@@ -121,7 +121,16 @@ final class Feed_Assembler {
 			$resolved = false; // Corrupt stored document. Fail open: ship structure only.
 		}
 
-		return $this->builder->build( $values, $resolved, $presets, $this->rest(), $version, $slug, $responsive );
+		return $this->builder->build(
+			$values,
+			$resolved,
+			$presets,
+			$this->rest(),
+			$version,
+			$slug,
+			$responsive,
+			$this->store->get_title( $slug )
+		);
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Database/Token_Store.php
+++ b/includes/resources/Design_Tokens/Database/Token_Store.php
@@ -333,6 +333,8 @@ final class Token_Store extends Query {
 	 * @throws DatabaseQueryException If the update fails.
 	 */
 	public function save_title( string $slug, string $title ): bool {
+		$title = sanitize_text_field( $title );
+
 		if ( $title === '' ) {
 			return false;
 		}
@@ -576,6 +578,8 @@ final class Token_Store extends Query {
 		if ( $slug !== null ) {
 			$data = [ 'slug' => $slug ] + $data;
 		}
+
+		$title = sanitize_text_field( $title );
 
 		if ( $title !== '' ) {
 			$data['title'] = $title;

--- a/includes/resources/Design_Tokens/Database/Token_Store.php
+++ b/includes/resources/Design_Tokens/Database/Token_Store.php
@@ -290,6 +290,70 @@ final class Token_Store extends Query {
 	}
 
 	/**
+	 * Write a token library's human-readable label, touching nothing else.
+	 *
+	 * A title is metadata: it appears in the library picker and nowhere in any projection, so
+	 * renaming a library must not travel through the document write path. Doing so would re-validate
+	 * and re-resolve the entire stored document to change a label — turning a rename into a failure
+	 * for any library whose stored document does not currently validate, for reasons that have
+	 * nothing to do with the new name.
+	 *
+	 * Neither the version hash nor the change action moves here, for the same reason: no projector
+	 * output depends on a title, so bumping the version would invalidate the projected-CSS cache for
+	 * a change no visitor can see.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug  The token library slug.
+	 * @param string $title The new label. An empty string is rejected rather than treated as
+	 *                      "leave the stored title alone", which is what the document write path
+	 *                      does with an empty title — here, clearing is simply not an operation.
+	 *
+	 * @return bool True when the title was written.
+	 *
+	 * @throws DatabaseQueryException If the update fails.
+	 */
+	public function save_title( string $slug, string $title ): bool {
+		if ( $title === '' ) {
+			return false;
+		}
+
+		$existing = $this->qb()
+						->where( 'slug', $slug )
+						->get( ARRAY_A );
+
+		if ( ! is_array( $existing ) ) {
+			// The default library has no row until something is written to it, so naming it is that
+			// first write. The empty document stored alongside the title is not a change of content —
+			// it is exactly what the library already resolved to, since no row means "render from
+			// baseline". Every other slug is rejected by the caller before reaching this point.
+			try {
+				$this->qb()->insert( $this->build_document_data( '', $title, $slug ) );
+			} catch ( DatabaseQueryException $e ) {
+				// Duplicate-key on a concurrent first write → the row now exists and carries someone
+				// else's title; report the miss rather than a fatal.
+				return false;
+			}
+
+			return true;
+		}
+
+		$this->qb()
+			->where( 'slug', $slug )
+			->update(
+				[
+					'title'      => $title,
+					'updated_at' => current_time( 'mysql', true ),
+				]
+			);
+
+		// Deliberately not gated on the affected-row count: MySQL reports zero rows affected when an
+		// UPDATE sets a column to the value it already holds, which is a no-op, not a failure. A real
+		// write failure throws instead.
+		return true;
+	}
+
+	/**
 	 * Delete a named token library only when the stored version matches expected_version.
 	 *
 	 * The default library is never row-deleted; use save_document_conditional with an empty

--- a/includes/resources/Design_Tokens/Database/Token_Store.php
+++ b/includes/resources/Design_Tokens/Database/Token_Store.php
@@ -309,6 +309,70 @@ final class Token_Store extends Query {
 	}
 
 	/**
+	 * Write a token library's human-readable label, touching nothing else.
+	 *
+	 * A title is metadata: it appears in the library picker and nowhere in any projection, so
+	 * renaming a library must not travel through the document write path. Doing so would re-validate
+	 * and re-resolve the entire stored document to change a label — turning a rename into a failure
+	 * for any library whose stored document does not currently validate, for reasons that have
+	 * nothing to do with the new name.
+	 *
+	 * Neither the version hash nor the change action moves here, for the same reason: no projector
+	 * output depends on a title, so bumping the version would invalidate the projected-CSS cache for
+	 * a change no visitor can see.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug  The token library slug.
+	 * @param string $title The new label. An empty string is rejected rather than treated as
+	 *                      "leave the stored title alone", which is what the document write path
+	 *                      does with an empty title — here, clearing is simply not an operation.
+	 *
+	 * @return bool True when the title was written.
+	 *
+	 * @throws DatabaseQueryException If the update fails.
+	 */
+	public function save_title( string $slug, string $title ): bool {
+		if ( $title === '' ) {
+			return false;
+		}
+
+		$existing = $this->qb()
+						->where( 'slug', $slug )
+						->get( ARRAY_A );
+
+		if ( ! is_array( $existing ) ) {
+			// The default library has no row until something is written to it, so naming it is that
+			// first write. The empty document stored alongside the title is not a change of content —
+			// it is exactly what the library already resolved to, since no row means "render from
+			// baseline". Every other slug is rejected by the caller before reaching this point.
+			try {
+				$this->qb()->insert( $this->build_document_data( '', $title, $slug ) );
+			} catch ( DatabaseQueryException $e ) {
+				// Duplicate-key on a concurrent first write → the row now exists and carries someone
+				// else's title; report the miss rather than a fatal.
+				return false;
+			}
+
+			return true;
+		}
+
+		$this->qb()
+			->where( 'slug', $slug )
+			->update(
+				[
+					'title'      => $title,
+					'updated_at' => current_time( 'mysql', true ),
+				]
+			);
+
+		// Deliberately not gated on the affected-row count: MySQL reports zero rows affected when an
+		// UPDATE sets a column to the value it already holds, which is a no-op, not a failure. A real
+		// write failure throws instead.
+		return true;
+	}
+
+	/**
 	 * Delete a named token library only when the stored version matches expected_version.
 	 *
 	 * The default library is never row-deleted; use save_document_conditional with an empty

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -368,7 +368,11 @@ final class Documents_Controller extends Controller {
 					// Its own route rather than the title parameter the bulk write routes accept: a
 					// rename is a metadata edit, and routing it through a document write would
 					// re-validate and re-resolve the whole stored document to change a label.
-					'methods'             => 'PUT',
+					//
+					// EDITABLE rather than PUT alone: setting a title is idempotent, so all three write
+					// verbs can share the handler, and a WordPress client reaching for POST or PATCH is
+					// following the convention every core endpoint sets rather than making a mistake.
+					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => [ $this, 'update_title' ],
 					'permission_callback' => [ $this, 'update_item_permissions_check' ],
 					'args'                => $this->get_title_params(),

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -115,6 +115,15 @@ final class Documents_Controller extends Controller {
 	private const TOKENS_ROUTE = 'tokens';
 
 	/**
+	 * The sub-route, relative to a single library, that writes only its human-readable label.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const TITLE_ROUTE = 'title';
+
+	/**
 	 * The dot-path path segment for the single-token routes. The character class matches the alias
 	 * grammar (a dot-path) minus the braces, so a token is addressable as a sub-resource of its library.
 	 *
@@ -353,6 +362,23 @@ final class Documents_Controller extends Controller {
 
 		register_rest_route(
 			$this->namespace,
+			'/' . $this->rest_base . '/' . self::SLUG_ROUTE . '/' . self::TITLE_ROUTE,
+			[
+				[
+					// Its own route rather than the title parameter the bulk write routes accept: a
+					// rename is a metadata edit, and routing it through a document write would
+					// re-validate and re-resolve the whole stored document to change a label.
+					'methods'             => 'PUT',
+					'callback'            => [ $this, 'update_title' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_title_params(),
+				],
+				'schema' => [ $this, 'get_item_schema' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
 			'/' . $this->rest_base . '/' . self::SLUG_ROUTE . '/' . self::TOKENS_ROUTE . '/' . self::PATH_ROUTE,
 			[
 				[
@@ -571,6 +597,67 @@ final class Documents_Controller extends Controller {
 			$slug,
 			Cast::to_string( $request->get_param( self::TITLE_PARAM ) )
 		);
+	}
+
+	/**
+	 * Rename a token library (PUT /documents/{slug}/title).
+	 *
+	 * Writes the label alone. The stored document is neither read, validated, resolved nor rewritten,
+	 * so a rename cannot fail because of the document's contents — which is the whole reason this is
+	 * not the `title` parameter on the bulk write routes. Those merge-then-validate the entire
+	 * document, so using one to change a label makes renaming impossible for any library whose stored
+	 * document does not currently pass validation.
+	 *
+	 * The default library is renameable like any other: it has no row until something is written to
+	 * it, and naming it is a legitimate first write.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_title( $request ) {
+		$slug  = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+		$title = trim( Cast::to_string( $request->get_param( self::TITLE_PARAM ) ) );
+
+		if ( ! $this->is_known_library( $slug ) ) {
+			return new WP_Error(
+				'rest_design_tokens_not_found',
+				__( 'Sorry, that design token library does not exist.', 'kadence-blocks' ),
+				[
+					'status'         => WP_Http::NOT_FOUND,
+					self::SLUG_PARAM => $slug,
+				]
+			);
+		}
+
+		// Whitespace-only is empty once trimmed. Rejected rather than stored, and rejected rather than
+		// silently ignored — a library whose label is blank falls back to displaying its slug, which
+		// is never what someone typing a name intended.
+		if ( $title === '' ) {
+			return new WP_Error(
+				'rest_design_tokens_invalid_title',
+				__( 'A library title cannot be empty.', 'kadence-blocks' ),
+				[
+					'status'         => WP_Http::BAD_REQUEST,
+					self::SLUG_PARAM => $slug,
+				]
+			);
+		}
+
+		if ( ! $this->store->save_title( $slug, $title ) ) {
+			return new WP_Error(
+				'rest_design_tokens_save_failed',
+				__( 'The library title could not be saved.', 'kadence-blocks' ),
+				[
+					'status'         => WP_Http::INTERNAL_SERVER_ERROR,
+					self::SLUG_PARAM => $slug,
+				]
+			);
+		}
+
+		return new WP_REST_Response( $this->prepare_item( $slug ), WP_Http::OK );
 	}
 
 	/**
@@ -1204,6 +1291,31 @@ final class Documents_Controller extends Controller {
 				'sanitize_callback' => 'sanitize_key',
 			],
 		];
+	}
+
+	/**
+	 * The arguments accepted by the rename route: the slug and a required title.
+	 *
+	 * Required here, unlike the optional title the bulk write routes take alongside a document — a
+	 * request to this route carries nothing else, so an absent title would ask the server to do
+	 * nothing at all.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_title_params(): array {
+		return array_merge(
+			$this->get_slug_params(),
+			[
+				self::TITLE_PARAM => [
+					'description'       => __( 'The human-readable label for the token library.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => true,
+					'sanitize_callback' => 'sanitize_text_field',
+				],
+			]
+		);
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -365,6 +365,15 @@ final class Documents_Controller extends Controller {
 			'/' . $this->rest_base . '/' . self::SLUG_ROUTE . '/' . self::TITLE_ROUTE,
 			[
 				[
+					// The read half of the title resource. The document read carries the title too, so this
+					// is not the only way to obtain it — it is here so the sub-resource that accepts writes
+					// can also be read, rather than being write-only.
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_title' ],
+					'permission_callback' => [ $this, 'get_item_permissions_check' ],
+					'args'                => $this->get_slug_params(),
+				],
+				[
 					// Its own route rather than the title parameter the bulk write routes accept: a
 					// rename is a metadata edit, and routing it through a document write would
 					// re-validate and re-resolve the whole stored document to change a label.
@@ -600,6 +609,45 @@ final class Documents_Controller extends Controller {
 			$this->read_document_param( $request ),
 			$slug,
 			Cast::to_string( $request->get_param( self::TITLE_PARAM ) )
+		);
+	}
+
+	/**
+	 * Read a token library's title (GET /documents/{slug}/title).
+	 *
+	 * The document read already carries the title, so this adds no field a client could not otherwise
+	 * reach; it exists so the title sub-resource is readable as well as writable, and so a client that
+	 * only wants the label does not have to fetch and discard the whole stored document to get it.
+	 *
+	 * An unknown library is a 404, matching {@see self::update_title()} — the two halves of the resource
+	 * agree on which libraries exist.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_title( $request ) {
+		$slug = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+
+		if ( ! $this->is_known_library( $slug ) ) {
+			return new WP_Error(
+				'rest_design_tokens_not_found',
+				__( 'Sorry, that design token library does not exist.', 'kadence-blocks' ),
+				[
+					'status'         => WP_Http::NOT_FOUND,
+					self::SLUG_PARAM => $slug,
+				]
+			);
+		}
+
+		return new WP_REST_Response(
+			[
+				'slug'  => $slug,
+				'title' => $this->store->get_title( $slug ),
+			],
+			WP_Http::OK
 		);
 	}
 

--- a/includes/resources/Design_Tokens/Rest/V1/Feed_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Feed_Controller.php
@@ -174,6 +174,12 @@ final class Feed_Controller extends Controller {
 					'context'     => [ 'view' ],
 					'readonly'    => true,
 				],
+				'title'      => [
+					'description' => __( 'The library\'s stored label, empty when it has none.', 'kadence-blocks' ),
+					'type'        => 'string',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
 				'slug'       => [
 					'description' => __( 'The token library slug the feed was assembled for.', 'kadence-blocks' ),
 					'type'        => 'string',

--- a/src/style-library/__tests__/libraries.test.js
+++ b/src/style-library/__tests__/libraries.test.js
@@ -1,10 +1,12 @@
 /* eslint-env jest */
 import {
 	isDefaultLibrary,
+	isDuplicateLibraryName,
 	isDuplicateLibraryTitle,
 	libraryDisplayTitle,
 	slugifyLibraryTitle,
 	sortLibraries,
+	successorOptions,
 } from '../helpers/libraries';
 
 describe('isDefaultLibrary', () => {
@@ -119,5 +121,72 @@ describe('sortLibraries', () => {
 		sortLibraries(libraries);
 
 		expect(libraries).toEqual(original);
+	});
+});
+
+describe('isDuplicateLibraryName', () => {
+	const libraries = [
+		{ slug: 'brand-a', title: 'Winter 2026' },
+		{ slug: 'brand-b', title: 'Brand B' },
+	];
+
+	it('matches another library ignoring case and surrounding whitespace', () => {
+		expect(isDuplicateLibraryName('brand b', libraries, 'brand-a')).toBe(true);
+		expect(isDuplicateLibraryName('  Brand B  ', libraries, 'brand-a')).toBe(true);
+	});
+
+	it('lets a library keep its own name', () => {
+		// The user may edit the field and revert it — a library must not collide with itself.
+		expect(isDuplicateLibraryName('Winter 2026', libraries, 'brand-a')).toBe(false);
+	});
+
+	// The regression test for the slug/title divergence: a slug is minted from the title once, at
+	// creation, and never follows a rename. Checking a rename against slugs (as creation does)
+	// would refuse "Brand A" here even though nothing on screen is called that any more, leaving
+	// the user no way to understand the refusal.
+	it('ignores a slug collision when no library actually displays that name', () => {
+		expect(isDuplicateLibraryName('Brand A', libraries, 'brand-b')).toBe(false);
+	});
+
+	it('treats an empty name as no collision', () => {
+		expect(isDuplicateLibraryName('', libraries, 'brand-a')).toBe(false);
+		expect(isDuplicateLibraryName('   ', libraries, 'brand-a')).toBe(false);
+	});
+
+	it('compares against the displayed name of an untitled library', () => {
+		// An untitled non-default library displays its slug, so that is what a rename collides with.
+		expect(isDuplicateLibraryName('brand-c', [{ slug: 'brand-c', title: '' }], 'brand-a')).toBe(true);
+	});
+});
+
+// Guards the split from isDuplicateLibraryName above: creation still compares derived slugs,
+// because creation is where the slug is minted and a slug collision is a genuine conflict. The
+// two helpers answer different questions and must not be collapsed into one.
+describe('isDuplicateLibraryTitle still compares derived slugs', () => {
+	it('flags a title whose slug is taken even when no library displays that title', () => {
+		expect(isDuplicateLibraryTitle('Brand A', [{ slug: 'brand-a', title: 'Winter 2026' }])).toBe(true);
+	});
+});
+
+describe('successorOptions', () => {
+	it('excludes the delete target and keeps dropdown order', () => {
+		const libraries = [
+			{ slug: 'zeta', title: 'Zeta' },
+			{ slug: 'default', title: '' },
+			{ slug: 'alpha', title: 'Alpha' },
+		];
+
+		expect(successorOptions(libraries, 'alpha').map((library) => library.slug)).toEqual(['default', 'zeta']);
+	});
+
+	it('still offers the default library when the target is the only other one', () => {
+		// The default library can never be deleted (a DELETE against it resets it instead), so the
+		// successor list is never empty.
+		const libraries = [
+			{ slug: 'default', title: '' },
+			{ slug: 'brand-a', title: 'Brand A' },
+		];
+
+		expect(successorOptions(libraries, 'brand-a').map((library) => library.slug)).toEqual(['default']);
 	});
 });

--- a/src/style-library/__tests__/libraries.test.js
+++ b/src/style-library/__tests__/libraries.test.js
@@ -1,10 +1,12 @@
 /* eslint-env jest */
 import {
 	isDefaultLibrary,
+	isDuplicateLibraryName,
 	isDuplicateLibraryTitle,
 	libraryDisplayTitle,
 	slugifyLibraryTitle,
 	sortLibraries,
+	successorOptions,
 } from '../helpers/libraries';
 
 describe('isDefaultLibrary', () => {
@@ -111,5 +113,72 @@ describe('sortLibraries', () => {
 		sortLibraries(libraries);
 
 		expect(libraries).toEqual(original);
+	});
+});
+
+describe('isDuplicateLibraryName', () => {
+	const libraries = [
+		{ slug: 'brand-a', title: 'Winter 2026' },
+		{ slug: 'brand-b', title: 'Brand B' },
+	];
+
+	it('matches another library ignoring case and surrounding whitespace', () => {
+		expect(isDuplicateLibraryName('brand b', libraries, 'brand-a')).toBe(true);
+		expect(isDuplicateLibraryName('  Brand B  ', libraries, 'brand-a')).toBe(true);
+	});
+
+	it('lets a library keep its own name', () => {
+		// The user may edit the field and revert it — a library must not collide with itself.
+		expect(isDuplicateLibraryName('Winter 2026', libraries, 'brand-a')).toBe(false);
+	});
+
+	// The regression test for the slug/title divergence: a slug is minted from the title once, at
+	// creation, and never follows a rename. Checking a rename against slugs (as creation does)
+	// would refuse "Brand A" here even though nothing on screen is called that any more, leaving
+	// the user no way to understand the refusal.
+	it('ignores a slug collision when no library actually displays that name', () => {
+		expect(isDuplicateLibraryName('Brand A', libraries, 'brand-b')).toBe(false);
+	});
+
+	it('treats an empty name as no collision', () => {
+		expect(isDuplicateLibraryName('', libraries, 'brand-a')).toBe(false);
+		expect(isDuplicateLibraryName('   ', libraries, 'brand-a')).toBe(false);
+	});
+
+	it('compares against the displayed name of an untitled library', () => {
+		// An untitled non-default library displays its slug, so that is what a rename collides with.
+		expect(isDuplicateLibraryName('brand-c', [{ slug: 'brand-c', title: '' }], 'brand-a')).toBe(true);
+	});
+});
+
+// Guards the split from isDuplicateLibraryName above: creation still compares derived slugs,
+// because creation is where the slug is minted and a slug collision is a genuine conflict. The
+// two helpers answer different questions and must not be collapsed into one.
+describe('isDuplicateLibraryTitle still compares derived slugs', () => {
+	it('flags a title whose slug is taken even when no library displays that title', () => {
+		expect(isDuplicateLibraryTitle('Brand A', [{ slug: 'brand-a', title: 'Winter 2026' }])).toBe(true);
+	});
+});
+
+describe('successorOptions', () => {
+	it('excludes the delete target and keeps dropdown order', () => {
+		const libraries = [
+			{ slug: 'zeta', title: 'Zeta' },
+			{ slug: 'default', title: '' },
+			{ slug: 'alpha', title: 'Alpha' },
+		];
+
+		expect(successorOptions(libraries, 'alpha').map((library) => library.slug)).toEqual(['default', 'zeta']);
+	});
+
+	it('still offers the default library when the target is the only other one', () => {
+		// The default library can never be deleted (a DELETE against it resets it instead), so the
+		// successor list is never empty.
+		const libraries = [
+			{ slug: 'default', title: '' },
+			{ slug: 'brand-a', title: 'Brand A' },
+		];
+
+		expect(successorOptions(libraries, 'brand-a').map((library) => library.slug)).toEqual(['default']);
 	});
 });

--- a/src/style-library/__tests__/library-flows.test.js
+++ b/src/style-library/__tests__/library-flows.test.js
@@ -1,5 +1,12 @@
 /* eslint-env jest */
-import { createLibraryFlow, deleteLibraryFlow, errorMessage, switchLibraryFlow } from '../helpers/library-flows';
+import {
+	activateLibraryFlow,
+	createLibraryFlow,
+	deleteLibraryFlow,
+	errorMessage,
+	openLibraryFlow,
+	renameLibraryFlow,
+} from '../helpers/library-flows';
 import * as client from '../api/client';
 
 // A factory, not bare automocking: the real module imports `@wordpress/api-fetch`, which is
@@ -10,6 +17,7 @@ jest.mock('../api/client', () => ({
 	createLibrary: jest.fn(),
 	deleteLibrary: jest.fn(),
 	getActiveLibrary: jest.fn(),
+	renameLibrary: jest.fn(),
 	setActiveLibrary: jest.fn(),
 }));
 
@@ -28,17 +36,18 @@ describe('errorMessage', () => {
 	});
 });
 
-describe('switchLibraryFlow', () => {
-	it('activates the library, refreshes the feed, and never reloads the page', async () => {
-		client.setActiveLibrary.mockResolvedValue({ slug: 'brand-b' });
+describe('openLibraryFlow', () => {
+	// The regression test for the whole phase: choosing a library in the header dropdown must never
+	// change which library the site uses. If this ever fails, one click restyles the live site.
+	it('refreshes the feed without touching the active-library pointer', async () => {
 		const refreshFeed = jest.fn().mockResolvedValue({ slug: 'brand-b' });
 		const onBusy = jest.fn();
 		const onError = jest.fn();
 
-		await switchLibraryFlow({ slug: 'brand-b', refreshFeed, onBusy, onError });
+		await openLibraryFlow({ slug: 'brand-b', refreshFeed, onBusy, onError });
 
-		expect(client.setActiveLibrary).toHaveBeenCalledWith('brand-b');
 		expect(refreshFeed).toHaveBeenCalledWith('brand-b');
+		expect(client.setActiveLibrary).not.toHaveBeenCalled();
 		// Busy is toggled on, then off, on the success path — nothing else settles it.
 		expect(onBusy.mock.calls).toEqual([[true], [false]]);
 		expect(onError).not.toHaveBeenCalled();
@@ -46,14 +55,64 @@ describe('switchLibraryFlow', () => {
 
 	it('surfaces the error, clears busy, and rejects on failure', async () => {
 		const failure = new Error('Sorry, that design token library does not exist.');
-		client.setActiveLibrary.mockRejectedValue(failure);
-		const refreshFeed = jest.fn();
+		const refreshFeed = jest.fn().mockRejectedValue(failure);
 		const onBusy = jest.fn();
 		const onError = jest.fn();
 
-		await expect(switchLibraryFlow({ slug: 'ghost', refreshFeed, onBusy, onError })).rejects.toBe(failure);
+		await expect(openLibraryFlow({ slug: 'ghost', refreshFeed, onBusy, onError })).rejects.toBe(failure);
+
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+});
+
+describe('activateLibraryFlow', () => {
+	it('moves the pointer and reports the slug the server resolved, not the one requested', async () => {
+		// The response deliberately differs from the request: the server owns which library ended
+		// up active, and this asserts the flow reads it back rather than assuming.
+		client.setActiveLibrary.mockResolvedValue({ slug: 'brand-b-resolved' });
+		const onActivated = jest.fn();
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await activateLibraryFlow({ slug: 'brand-b', onBusy, onError, onActivated });
+
+		expect(client.setActiveLibrary).toHaveBeenCalledWith('brand-b');
+		expect(onActivated).toHaveBeenCalledWith('brand-b-resolved');
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	// Activating the library already on screen changes which library the front end reads, not any
+	// value inside it — a feed refresh here would cost a request and re-render every screen to
+	// produce identical output. Locked in so it is not "restored" as a missing step later.
+	it('does not refresh the feed', async () => {
+		client.setActiveLibrary.mockResolvedValue({ slug: 'brand-b' });
+		const refreshFeed = jest.fn();
+
+		await activateLibraryFlow({
+			slug: 'brand-b',
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+			onActivated: jest.fn(),
+			// Passed deliberately even though the signature ignores it — if someone wires a refresh
+			// back into this flow, this assertion is what catches it.
+			refreshFeed,
+		});
 
 		expect(refreshFeed).not.toHaveBeenCalled();
+	});
+
+	it('surfaces the error, clears busy, and rejects on failure', async () => {
+		const failure = new Error('Sorry, that design token library does not exist.');
+		client.setActiveLibrary.mockRejectedValue(failure);
+		const onActivated = jest.fn();
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(activateLibraryFlow({ slug: 'ghost', onBusy, onError, onActivated })).rejects.toBe(failure);
+
+		expect(onActivated).not.toHaveBeenCalled();
 		expect(onError).toHaveBeenCalledWith({ message: failure.message });
 		expect(onBusy.mock.calls).toEqual([[true], [false]]);
 	});
@@ -68,7 +127,7 @@ describe('createLibraryFlow', () => {
 			createLibraryFlow({
 				title: '   ',
 				libraries: [],
-				switchLibrary: jest.fn(),
+				openLibrary: jest.fn(),
 				loadLibraries: jest.fn(),
 				onBusy,
 				onError,
@@ -87,7 +146,7 @@ describe('createLibraryFlow', () => {
 			createLibraryFlow({
 				title: 'Brand A',
 				libraries: [{ slug: 'brand-a' }],
-				switchLibrary: jest.fn(),
+				openLibrary: jest.fn(),
 				loadLibraries: jest.fn(),
 				onBusy: jest.fn(),
 				onError,
@@ -98,9 +157,10 @@ describe('createLibraryFlow', () => {
 		expect(onError).toHaveBeenCalledWith({ message: expect.stringMatching(/already exists/i) });
 	});
 
-	it('creates, switches, and refreshes the libraries list, and never reloads the page', async () => {
+	// The second regression test for the phase: creating a library must not publish it to the site.
+	it('creates and opens the new library without activating it', async () => {
 		client.createLibrary.mockResolvedValue({ slug: 'brand-b' });
-		const switchLibrary = jest.fn().mockResolvedValue(undefined);
+		const openLibrary = jest.fn().mockResolvedValue(undefined);
 		const loadLibraries = jest.fn().mockResolvedValue(undefined);
 		const onBusy = jest.fn();
 		const onError = jest.fn();
@@ -108,14 +168,15 @@ describe('createLibraryFlow', () => {
 		await createLibraryFlow({
 			title: 'Brand B',
 			libraries: [],
-			switchLibrary,
+			openLibrary,
 			loadLibraries,
 			onBusy,
 			onError,
 		});
 
 		expect(client.createLibrary).toHaveBeenCalledWith('brand-b', 'Brand B');
-		expect(switchLibrary).toHaveBeenCalledWith('brand-b');
+		expect(openLibrary).toHaveBeenCalledWith('brand-b');
+		expect(client.setActiveLibrary).not.toHaveBeenCalled();
 		expect(loadLibraries).toHaveBeenCalled();
 		expect(onBusy).toHaveBeenCalledWith(true);
 		expect(onError).not.toHaveBeenCalled();
@@ -131,7 +192,7 @@ describe('createLibraryFlow', () => {
 			createLibraryFlow({
 				title: 'Brand B',
 				libraries: [],
-				switchLibrary: jest.fn(),
+				openLibrary: jest.fn(),
 				loadLibraries: jest.fn(),
 				onBusy,
 				onError,
@@ -142,10 +203,10 @@ describe('createLibraryFlow', () => {
 		expect(onBusy).toHaveBeenLastCalledWith(false);
 	});
 
-	it('routes a failure from the post-create switch step through its own onError, never calling loadLibraries', async () => {
+	it('routes a failure from the post-create open step through its own onError, never calling loadLibraries', async () => {
 		client.createLibrary.mockResolvedValue({ slug: 'brand-b' });
-		const switchFailure = new Error('Switch failed');
-		const switchLibrary = jest.fn().mockRejectedValue(switchFailure);
+		const openFailure = new Error('Open failed');
+		const openLibrary = jest.fn().mockRejectedValue(openFailure);
 		const loadLibraries = jest.fn();
 		const onBusy = jest.fn();
 		const onError = jest.fn();
@@ -154,25 +215,134 @@ describe('createLibraryFlow', () => {
 			createLibraryFlow({
 				title: 'Brand B',
 				libraries: [],
-				switchLibrary,
+				openLibrary,
 				loadLibraries,
 				onBusy,
 				onError,
 			})
-		).rejects.toBe(switchFailure);
+		).rejects.toBe(openFailure);
 
-		expect(switchLibrary).toHaveBeenCalledWith('brand-b');
+		expect(openLibrary).toHaveBeenCalledWith('brand-b');
 		expect(loadLibraries).not.toHaveBeenCalled();
-		// The caller (use-libraries) binds this onError to createError, never to switchError — a
-		// failure in the internal switch step must still report through create's own callback.
-		expect(onError).toHaveBeenCalledWith({ message: switchFailure.message });
+		// The caller (use-libraries) binds this onError to createError, never to openError — a
+		// failure in the internal open step must still report through create's own callback.
+		expect(onError).toHaveBeenCalledWith({ message: openFailure.message });
+	});
+});
+
+describe('renameLibraryFlow', () => {
+	it('renames the library and refreshes the list without touching the feed', async () => {
+		client.renameLibrary.mockResolvedValue({ slug: 'brand-a' });
+		const loadLibraries = jest.fn().mockResolvedValue(undefined);
+		const refreshFeed = jest.fn();
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await renameLibraryFlow({
+			slug: 'brand-a',
+			title: '  Winter 2026  ',
+			libraries: [{ slug: 'brand-a', title: 'Brand A' }],
+			loadLibraries,
+			onBusy,
+			onError,
+			refreshFeed,
+		});
+
+		// Trimmed before it reaches the API — the stored title should never carry stray whitespace.
+		expect(client.renameLibrary).toHaveBeenCalledWith('brand-a', 'Winter 2026');
+		expect(loadLibraries).toHaveBeenCalled();
+		// A library's name is not part of the feed payload, so there is nothing to re-read.
+		expect(refreshFeed).not.toHaveBeenCalled();
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it('rejects without calling the API when the new title is blank', async () => {
+		const onError = jest.fn();
+		const onBusy = jest.fn();
+
+		await expect(
+			renameLibraryFlow({
+				slug: 'brand-a',
+				title: '   ',
+				libraries: [{ slug: 'brand-a', title: 'Brand A' }],
+				loadLibraries: jest.fn(),
+				onBusy,
+				onError,
+			})
+		).rejects.toThrow();
+
+		// The server reads an empty title as "leave it alone", so a blank rename would look like it
+		// worked and change nothing — refusing here is what makes that honest.
+		expect(client.renameLibrary).not.toHaveBeenCalled();
+		expect(onBusy).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: expect.stringMatching(/enter a library title/i) });
+	});
+
+	it('rejects without calling the API when another library already has that name', async () => {
+		const onError = jest.fn();
+
+		await expect(
+			renameLibraryFlow({
+				slug: 'brand-a',
+				title: 'Brand B',
+				libraries: [
+					{ slug: 'brand-a', title: 'Brand A' },
+					{ slug: 'brand-b', title: 'Brand B' },
+				],
+				loadLibraries: jest.fn(),
+				onBusy: jest.fn(),
+				onError,
+			})
+		).rejects.toThrow();
+
+		expect(client.renameLibrary).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: expect.stringMatching(/already exists/i) });
+	});
+
+	it('allows a library to keep its own name', async () => {
+		client.renameLibrary.mockResolvedValue({ slug: 'brand-a' });
+		const loadLibraries = jest.fn().mockResolvedValue(undefined);
+
+		// The user may edit the field and revert it; the library must not collide with itself.
+		await renameLibraryFlow({
+			slug: 'brand-a',
+			title: 'Brand A',
+			libraries: [{ slug: 'brand-a', title: 'Brand A' }],
+			loadLibraries,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(client.renameLibrary).toHaveBeenCalledWith('brand-a', 'Brand A');
+	});
+
+	it('surfaces the error, clears busy, and rejects when the rename request fails', async () => {
+		const failure = new Error('Sorry, that design token library does not exist.');
+		client.renameLibrary.mockRejectedValue(failure);
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			renameLibraryFlow({
+				slug: 'brand-a',
+				title: 'Winter 2026',
+				libraries: [{ slug: 'brand-a', title: 'Brand A' }],
+				loadLibraries: jest.fn(),
+				onBusy,
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy).toHaveBeenLastCalledWith(false);
 	});
 });
 
 describe('deleteLibraryFlow', () => {
-	it('deletes a non-active library and only refreshes the libraries list', async () => {
+	it('deletes a non-active library and moves the app to the library the site uses', async () => {
 		client.deleteLibrary.mockResolvedValue({ deleted: true });
-		const refreshFeed = jest.fn();
+		const refreshFeed = jest.fn().mockResolvedValue({ slug: 'default' });
 		const loadLibraries = jest.fn().mockResolvedValue(undefined);
 		const onBusy = jest.fn();
 
@@ -183,36 +353,144 @@ describe('deleteLibraryFlow', () => {
 			loadLibraries,
 			onBusy,
 			onError: jest.fn(),
+			onActiveChanged: jest.fn(),
 		});
 
 		expect(client.deleteLibrary).toHaveBeenCalledWith('brand-b');
-		expect(refreshFeed).not.toHaveBeenCalled();
+		// The app was showing the deleted library, so the feed cannot stay on it.
+		expect(refreshFeed).toHaveBeenCalledWith('default');
+		expect(client.setActiveLibrary).not.toHaveBeenCalled();
 		expect(loadLibraries).toHaveBeenCalled();
 		expect(onBusy).toHaveBeenLastCalledWith(false);
 	});
 
-	it('deleting the active library re-reads the resolved pointer, refreshes the feed for it, and never reloads the page', async () => {
-		client.deleteLibrary.mockResolvedValue({ deleted: true });
-		client.getActiveLibrary.mockResolvedValue({ slug: 'default' });
-		const refreshFeed = jest.fn().mockResolvedValue({ slug: 'default' });
-		const loadLibraries = jest.fn().mockResolvedValue(undefined);
-		const onBusy = jest.fn();
+	it('activates the successor before deleting the active library', async () => {
+		// A shared call log, not two independent mocks: the ordering IS the correctness property
+		// here, and separate mocks can only prove both ran, never in which order.
+		const calls = [];
+		client.setActiveLibrary.mockImplementation((slug) => {
+			calls.push(`activate:${slug}`);
+			return Promise.resolve({ slug });
+		});
+		client.deleteLibrary.mockImplementation((slug) => {
+			calls.push(`delete:${slug}`);
+			return Promise.resolve({ deleted: true });
+		});
+		const onActiveChanged = jest.fn();
+		const refreshFeed = jest.fn().mockResolvedValue({ slug: 'brand-c' });
 
 		await deleteLibraryFlow({
 			slug: 'brand-b',
 			activeSlug: 'brand-b',
+			successorSlug: 'brand-c',
 			refreshFeed,
-			loadLibraries,
-			onBusy,
+			loadLibraries: jest.fn().mockResolvedValue(undefined),
+			onBusy: jest.fn(),
 			onError: jest.fn(),
+			onActiveChanged,
 		});
 
-		expect(client.deleteLibrary).toHaveBeenCalledWith('brand-b');
-		expect(client.getActiveLibrary).toHaveBeenCalled();
-		// The feed is refreshed for whatever the server resolves the pointer to, not the deleted slug.
+		// Deleting first would let the server fall the pointer back to the default in between,
+		// briefly serving a site-wide look nobody chose.
+		expect(calls).toEqual(['activate:brand-c', 'delete:brand-b']);
+		expect(onActiveChanged).toHaveBeenCalledWith('brand-c');
+		expect(refreshFeed).toHaveBeenCalledWith('brand-c');
+	});
+
+	// The requirement's regression test: nothing may be destroyed when no successor was named.
+	it('refuses to delete the active library when no successor was chosen', async () => {
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			deleteLibraryFlow({
+				slug: 'brand-b',
+				activeSlug: 'brand-b',
+				refreshFeed: jest.fn(),
+				loadLibraries: jest.fn(),
+				onBusy,
+				onError,
+				onActiveChanged: jest.fn(),
+			})
+		).rejects.toThrow();
+
+		expect(client.deleteLibrary).not.toHaveBeenCalled();
+		expect(client.setActiveLibrary).not.toHaveBeenCalled();
+		expect(onBusy).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: expect.stringMatching(/choose which library/i) });
+	});
+
+	it('leaves the target intact when activating the successor fails', async () => {
+		const failure = new Error('Sorry, that design token library does not exist.');
+		client.setActiveLibrary.mockRejectedValue(failure);
+		const onError = jest.fn();
+
+		await expect(
+			deleteLibraryFlow({
+				slug: 'brand-b',
+				activeSlug: 'brand-b',
+				successorSlug: 'ghost',
+				refreshFeed: jest.fn(),
+				loadLibraries: jest.fn(),
+				onBusy: jest.fn(),
+				onError,
+				onActiveChanged: jest.fn(),
+			})
+		).rejects.toBe(failure);
+
+		// Nothing was destroyed, and the pointer never moved — fully recoverable.
+		expect(client.deleteLibrary).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+	});
+
+	// Documents the one partial outcome this ordering accepts, so it is not later read as a bug:
+	// the site sits on a library the user explicitly chose and the target survives, which a retry
+	// finishes off. The alternative ordering trades this for default styles nobody picked.
+	it('reports the successor as active even when the delete itself fails', async () => {
+		const failure = new Error('The design token library could not be deleted.');
+		client.setActiveLibrary.mockResolvedValue({ slug: 'brand-c' });
+		client.deleteLibrary.mockRejectedValue(failure);
+		const onActiveChanged = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			deleteLibraryFlow({
+				slug: 'brand-b',
+				activeSlug: 'brand-b',
+				successorSlug: 'brand-c',
+				refreshFeed: jest.fn(),
+				loadLibraries: jest.fn(),
+				onBusy: jest.fn(),
+				onError,
+				onActiveChanged,
+			})
+		).rejects.toBe(failure);
+
+		expect(onActiveChanged).toHaveBeenCalledWith('brand-c');
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+	});
+
+	it('resets the active default library in place, with no successor and no activation', async () => {
+		client.deleteLibrary.mockResolvedValue({ deleted: false });
+		const refreshFeed = jest.fn().mockResolvedValue({ slug: 'default' });
+		const loadLibraries = jest.fn().mockResolvedValue(undefined);
+
+		await deleteLibraryFlow({
+			slug: 'default',
+			activeSlug: 'default',
+			refreshFeed,
+			loadLibraries,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+			onActiveChanged: jest.fn(),
+		});
+
+		// The default library is reset rather than removed, so it stays put and stays active —
+		// there is no successor question to answer.
+		expect(client.setActiveLibrary).not.toHaveBeenCalled();
+		expect(client.deleteLibrary).toHaveBeenCalledWith('default');
+		// Refreshed against itself, to pick up its now-baseline values.
 		expect(refreshFeed).toHaveBeenCalledWith('default');
-		expect(loadLibraries).toHaveBeenCalled();
-		expect(onBusy).toHaveBeenLastCalledWith(false);
 	});
 
 	it('surfaces the error, clears busy, and rejects when the delete request fails', async () => {
@@ -229,6 +507,7 @@ describe('deleteLibraryFlow', () => {
 				loadLibraries: jest.fn(),
 				onBusy,
 				onError,
+				onActiveChanged: jest.fn(),
 			})
 		).rejects.toBe(failure);
 

--- a/src/style-library/__tests__/paths.test.js
+++ b/src/style-library/__tests__/paths.test.js
@@ -8,6 +8,7 @@ import {
 	palettePath,
 	paletteCurrentPath,
 	documentsPath,
+	libraryTitlePath,
 	activeLibraryPath,
 	activateLibraryPath,
 	feedPath,
@@ -74,6 +75,16 @@ describe('userPrimitiveRenamePath', () => {
 describe('documentsPath', () => {
 	it('builds the documents collection path', () => {
 		expect(documentsPath()).toBe('/kb-design-tokens/v1/documents');
+	});
+});
+
+describe('libraryTitlePath', () => {
+	it('hangs the title endpoint off the library document path', () => {
+		expect(libraryTitlePath('kb-design-tokens/v1', 'brand-a')).toBe('/kb-design-tokens/v1/documents/brand-a/title');
+	});
+
+	it('falls back to the default library slug', () => {
+		expect(libraryTitlePath('kb-design-tokens/v1')).toBe('/kb-design-tokens/v1/documents/default/title');
 	});
 });
 

--- a/src/style-library/api/client.js
+++ b/src/style-library/api/client.js
@@ -9,6 +9,7 @@ import apiFetch from '@wordpress/api-fetch';
 import {
 	documentPath,
 	documentsPath,
+	libraryTitlePath,
 	activeLibraryPath,
 	activateLibraryPath,
 	resolvedPath,
@@ -315,29 +316,27 @@ export function createLibrary(slug, title) {
  * identity (the active-library pointer stores it, every document/palette/token route addresses by
  * it) and is never rewritten.
  *
- * The title is a column of its own, so an empty document body is all that is needed to leave
- * every stored token value untouched.
+ * Addresses the dedicated title endpoint rather than sending a title alongside an empty document
+ * to a document route. Those routes merge and then re-validate the whole stored document, so a
+ * rename through one fails for any library whose document does not currently validate — for
+ * reasons that have nothing to do with the new name. This route touches the label alone, so it
+ * cannot fail on the document's contents and does not bump the library's version.
  *
- * PATCH is not interchangeable with PUT here, and the method is hardcoded rather than exposed as
- * a parameter for that reason: PATCH deep-merges the given document into what is stored, so `{}`
- * is a no-op that preserves every override, while PUT against the same route *replaces* the
- * document and would wipe them all. Do not turn this into a shared helper that takes a method.
- *
- * Note the server treats an empty title as "leave the stored title untouched", so this cannot
- * clear a title back to empty — callers must reject an empty name before calling.
+ * The server rejects an empty title rather than reading it as "leave the stored one alone", so a
+ * blank rename reports a real error instead of silently doing nothing.
  *
  * @param {string} slug  Token library slug.
  * @param {string} title The new human-readable label.
  *
  * @since TBD
  *
- * @return {Promise<{slug: string, version: string, document: object}>} The updated document item.
+ * @return {Promise<{slug: string, title: string, version: string, document: object}>} The updated document item.
  */
 export function renameLibrary(slug, title) {
 	return apiFetch({
-		path: documentPath(NAMESPACE, slug),
-		method: 'PATCH',
-		data: { document: {}, title },
+		path: libraryTitlePath(NAMESPACE, slug),
+		method: 'PUT',
+		data: { title },
 	});
 }
 

--- a/src/style-library/api/client.js
+++ b/src/style-library/api/client.js
@@ -311,6 +311,37 @@ export function createLibrary(slug, title) {
 }
 
 /**
+ * Rename a token library. Only its human-readable title changes; the slug is the library's
+ * identity (the active-library pointer stores it, every document/palette/token route addresses by
+ * it) and is never rewritten.
+ *
+ * The title is a column of its own, so an empty document body is all that is needed to leave
+ * every stored token value untouched.
+ *
+ * PATCH is not interchangeable with PUT here, and the method is hardcoded rather than exposed as
+ * a parameter for that reason: PATCH deep-merges the given document into what is stored, so `{}`
+ * is a no-op that preserves every override, while PUT against the same route *replaces* the
+ * document and would wipe them all. Do not turn this into a shared helper that takes a method.
+ *
+ * Note the server treats an empty title as "leave the stored title untouched", so this cannot
+ * clear a title back to empty — callers must reject an empty name before calling.
+ *
+ * @param {string} slug  Token library slug.
+ * @param {string} title The new human-readable label.
+ *
+ * @since TBD
+ *
+ * @return {Promise<{slug: string, version: string, document: object}>} The updated document item.
+ */
+export function renameLibrary(slug, title) {
+	return apiFetch({
+		path: documentPath(NAMESPACE, slug),
+		method: 'PATCH',
+		data: { document: {}, title },
+	});
+}
+
+/**
  * Delete a token library. Deleting the default library resets it to baseline instead of removing
  * it — the same endpoint serves both, the server decides which behavior applies.
  *

--- a/src/style-library/api/paths.js
+++ b/src/style-library/api/paths.js
@@ -14,6 +14,22 @@ export function documentPath(namespace, slug = DEFAULT_LIBRARY_SLUG) {
 }
 
 /**
+ * Build a REST path for a token library's human-readable label.
+ *
+ * Its own endpoint, separate from the document routes: a rename writes the label alone and never
+ * validates, resolves or rewrites the stored document.
+ *
+ * @since TBD
+ *
+ * @param {string} namespace REST namespace (e.g. kb-design-tokens/v1).
+ * @param {string} slug      Token library slug.
+ * @return {string} REST path relative to wp-json root.
+ */
+export function libraryTitlePath(namespace, slug = DEFAULT_LIBRARY_SLUG) {
+	return `${documentPath(namespace, slug)}/title`;
+}
+
+/**
  * Build a REST path for the user-primitives collection of a document.
  *
  * @since TBD

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -15,6 +15,8 @@ import { AppShell } from '../components/templates/AppShell';
 import { AppHeader } from '../components/organisms/AppHeader';
 import { AppSidebar } from '../components/organisms/AppSidebar';
 import { LibrarySelector } from '../components/organisms/LibrarySelector';
+import { ActivateLibraryButton } from '../components/organisms/ActivateLibraryButton';
+import { RenameLibraryModal } from '../components/organisms/RenameLibraryModal';
 import { DeleteLibraryModal } from '../components/organisms/DeleteLibraryModal';
 import { SettingsPanel } from '../components/templates/SettingsPanel';
 import { SettingsForm } from '../components/organisms/SettingsForm';
@@ -26,6 +28,7 @@ import { useSettingsPanel } from '../hooks/use-settings-panel';
 import { DEFAULT_SCREEN_ID } from '../constants/screens';
 import { DEMO_ITEM_ID, DEMO_SETTINGS_SCHEMA, DEMO_SETTINGS_VALUES } from '../constants/demo-settings-schema';
 import { buildBaseStylesNav, buildBlockPresetsNav, resolveScreen } from '../helpers/screens';
+import { libraryDisplayTitle } from '../helpers/libraries';
 
 /**
  * Render the Style Library application: feed gate, route hook, sidebar navigation, and the screen
@@ -91,7 +94,23 @@ export function StyleLibraryApp() {
 	const navEntry = [...baseStylesNav, ...blockPresetsNav].find((entry) => entry.id === activeScreenId);
 	const label = navEntry ? navEntry.label : resolution.block || activeScreenId;
 	const onNavigate = (id) => navigate({ screen: id, item: '' });
-	const activeLibrary = libraries.libraries.find((library) => library.slug === libraries.activeSlug);
+
+	// Two different libraries are named in the header: the one being edited (the selector's value,
+	// and the target of rename/delete/activate) and the one the site renders with (named in the
+	// activation modal's copy). `libraryDisplayTitle` resolves either from the slug alone, so both
+	// stay correct on the first paint before the list has loaded.
+	const editingTitle = libraryDisplayTitle(
+		libraries.libraries.find((library) => library.slug === libraries.editingSlug) ?? {
+			slug: libraries.editingSlug,
+			title: '',
+		}
+	);
+	const activeTitle = libraryDisplayTitle(
+		libraries.libraries.find((library) => library.slug === libraries.activeSlug) ?? {
+			slug: libraries.activeSlug,
+			title: '',
+		}
+	);
 
 	return (
 		<AppShell
@@ -101,24 +120,48 @@ export function StyleLibraryApp() {
 						<LibrarySelector
 							libraries={libraries.libraries}
 							activeSlug={libraries.activeSlug}
+							editingSlug={libraries.editingSlug}
 							isBusy={libraries.isBusy}
-							switchError={libraries.switchError}
+							openError={libraries.openError}
 							createError={libraries.createError}
-							onSwitch={libraries.switchLibrary}
+							onOpen={libraries.openLibrary}
 							onCreate={libraries.createLibrary}
-							onClearSwitchError={libraries.clearSwitchError}
+							onClearOpenError={libraries.clearOpenError}
 							onClearCreateError={libraries.clearCreateError}
 						/>
 					}
 					actionsSlot={
-						<DeleteLibraryModal
-							activeSlug={libraries.activeSlug}
-							activeTitle={activeLibrary?.title}
-							isBusy={libraries.isBusy}
-							error={libraries.deleteError}
-							onClearError={libraries.clearDeleteError}
-							onDelete={libraries.deleteLibrary}
-						/>
+						<>
+							<ActivateLibraryButton
+								editingSlug={libraries.editingSlug}
+								editingTitle={editingTitle}
+								activeTitle={activeTitle}
+								isEditingActive={libraries.isEditingActive}
+								isBusy={libraries.isBusy}
+								error={libraries.activateError}
+								onClearError={libraries.clearActivateError}
+								onActivate={libraries.activateLibrary}
+							/>
+							<RenameLibraryModal
+								slug={libraries.editingSlug}
+								currentTitle={editingTitle}
+								libraries={libraries.libraries}
+								isBusy={libraries.isBusy}
+								error={libraries.renameError}
+								onClearError={libraries.clearRenameError}
+								onRename={libraries.renameLibrary}
+							/>
+							<DeleteLibraryModal
+								editingSlug={libraries.editingSlug}
+								editingTitle={editingTitle}
+								activeSlug={libraries.activeSlug}
+								libraries={libraries.libraries}
+								isBusy={libraries.isBusy}
+								error={libraries.deleteError}
+								onClearError={libraries.clearDeleteError}
+								onDelete={libraries.deleteLibrary}
+							/>
+						</>
 					}
 				/>
 			}

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -114,6 +114,7 @@ export function StyleLibraryApp() {
 
 	return (
 		<AppShell
+			isBlocked={libraries.isSwappingLibrary}
 			header={
 				<AppHeader
 					librarySlot={
@@ -122,6 +123,7 @@ export function StyleLibraryApp() {
 							activeSlug={libraries.activeSlug}
 							editingSlug={libraries.editingSlug}
 							isBusy={libraries.isBusy}
+							isSwapping={libraries.isSwappingLibrary}
 							openError={libraries.openError}
 							createError={libraries.createError}
 							onOpen={libraries.openLibrary}

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -116,6 +116,7 @@ export function StyleLibraryApp() {
 
 	return (
 		<AppShell
+			isBlocked={libraries.isSwappingLibrary}
 			header={
 				<AppHeader
 					librarySlot={
@@ -125,6 +126,7 @@ export function StyleLibraryApp() {
 							editingSlug={libraries.editingSlug}
 							editingTitle={editingTitle}
 							isBusy={libraries.isBusy}
+							isSwapping={libraries.isSwappingLibrary}
 							openError={libraries.openError}
 							createError={libraries.createError}
 							onOpen={libraries.openLibrary}

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -97,18 +97,28 @@ export function StyleLibraryApp() {
 
 	// Two different libraries are named in the header: the one being edited (the selector's value,
 	// and the target of rename/delete/activate) and the one the site renders with (named in the
-	// activation modal's copy). `libraryDisplayTitle` resolves either from the slug alone, so both
-	// stay correct on the first paint before the list has loaded.
+	// activation modal's copy).
+	//
+	// The fetched list is preferred over the feed for both, because a rename refreshes the list but
+	// deliberately not the feed — reading the feed first would leave the header showing the old
+	// name until something else reloaded it. The feed is the fallback, and it is what makes the
+	// first paint correct: it is printed inline with the page, so the header names the library
+	// immediately instead of showing a slug-derived guess and correcting itself a moment later when
+	// the list request lands.
 	const editingTitle = libraryDisplayTitle(
 		libraries.libraries.find((library) => library.slug === libraries.editingSlug) ?? {
 			slug: libraries.editingSlug,
-			title: '',
+			title: feed.title,
 		}
 	);
+
+	// No feed fallback here: the feed only ever describes the library being edited, so borrowing its
+	// title for a different library would be wrong rather than merely early. Before the list loads
+	// these are the same library anyway, and `libraryDisplayTitle` names it from the slug.
 	const activeTitle = libraryDisplayTitle(
 		libraries.libraries.find((library) => library.slug === libraries.activeSlug) ?? {
 			slug: libraries.activeSlug,
-			title: '',
+			title: libraries.isEditingActive ? feed.title : '',
 		}
 	);
 
@@ -122,6 +132,7 @@ export function StyleLibraryApp() {
 							libraries={libraries.libraries}
 							activeSlug={libraries.activeSlug}
 							editingSlug={libraries.editingSlug}
+							editingTitle={editingTitle}
 							isBusy={libraries.isBusy}
 							isSwapping={libraries.isSwappingLibrary}
 							openError={libraries.openError}

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -15,6 +15,8 @@ import { AppShell } from '../components/templates/AppShell';
 import { AppHeader } from '../components/organisms/AppHeader';
 import { AppSidebar } from '../components/organisms/AppSidebar';
 import { LibrarySelector } from '../components/organisms/LibrarySelector';
+import { ActivateLibraryButton } from '../components/organisms/ActivateLibraryButton';
+import { RenameLibraryModal } from '../components/organisms/RenameLibraryModal';
 import { DeleteLibraryModal } from '../components/organisms/DeleteLibraryModal';
 import { SettingsPanel } from '../components/templates/SettingsPanel';
 import { SettingsForm } from '../components/organisms/SettingsForm';
@@ -26,6 +28,7 @@ import { useSettingsPanel } from '../hooks/use-settings-panel';
 import { DEFAULT_SCREEN_ID } from '../constants/screens';
 import { DEMO_ITEM_ID, DEMO_SETTINGS_SCHEMA, DEMO_SETTINGS_VALUES } from '../constants/demo-settings-schema';
 import { buildBaseStylesNav, buildBlockPresetsNav, resolveScreen } from '../helpers/screens';
+import { libraryDisplayTitle } from '../helpers/libraries';
 
 /**
  * Render the Style Library application: feed gate, route hook, sidebar navigation, and the screen
@@ -91,7 +94,25 @@ export function StyleLibraryApp() {
 	const navEntry = [...baseStylesNav, ...blockPresetsNav].find((entry) => entry.id === activeScreenId);
 	const label = navEntry ? navEntry.label : resolution.block || activeScreenId;
 	const onNavigate = (id) => navigate({ screen: id, item: '' });
-	const activeLibrary = libraries.libraries.find((library) => library.slug === libraries.activeSlug);
+
+	// Two different libraries are named in the header: the one being edited (the selector's value,
+	// and the target of rename/delete/activate) and the one the site renders with (named in the
+	// activation modal's copy). `libraryDisplayTitle` resolves either from the slug alone, so both
+	// stay correct on the first paint before the list has loaded.
+	const editingTitle = libraryDisplayTitle(
+		libraries.libraries.find((library) => library.slug === libraries.editingSlug) ?? {
+			slug: libraries.editingSlug,
+			// The feed is assembled for the library being edited, so its title names that library
+			// on the first paint, before the list has loaded.
+			title: feed.feed?.title ?? '',
+		}
+	);
+	const activeTitle = libraryDisplayTitle(
+		libraries.libraries.find((library) => library.slug === libraries.activeSlug) ?? {
+			slug: libraries.activeSlug,
+			title: '',
+		}
+	);
 
 	return (
 		<AppShell
@@ -101,25 +122,49 @@ export function StyleLibraryApp() {
 						<LibrarySelector
 							libraries={libraries.libraries}
 							activeSlug={libraries.activeSlug}
-							activeTitle={activeLibrary?.title ?? feed.feed?.title}
+							editingSlug={libraries.editingSlug}
+							editingTitle={editingTitle}
 							isBusy={libraries.isBusy}
-							switchError={libraries.switchError}
+							openError={libraries.openError}
 							createError={libraries.createError}
-							onSwitch={libraries.switchLibrary}
+							onOpen={libraries.openLibrary}
 							onCreate={libraries.createLibrary}
-							onClearSwitchError={libraries.clearSwitchError}
+							onClearOpenError={libraries.clearOpenError}
 							onClearCreateError={libraries.clearCreateError}
 						/>
 					}
 					actionsSlot={
-						<DeleteLibraryModal
-							activeSlug={libraries.activeSlug}
-							activeTitle={activeLibrary?.title ?? feed.feed?.title}
-							isBusy={libraries.isBusy}
-							error={libraries.deleteError}
-							onClearError={libraries.clearDeleteError}
-							onDelete={libraries.deleteLibrary}
-						/>
+						<>
+							<ActivateLibraryButton
+								editingSlug={libraries.editingSlug}
+								editingTitle={editingTitle}
+								activeTitle={activeTitle}
+								isEditingActive={libraries.isEditingActive}
+								isBusy={libraries.isBusy}
+								error={libraries.activateError}
+								onClearError={libraries.clearActivateError}
+								onActivate={libraries.activateLibrary}
+							/>
+							<RenameLibraryModal
+								slug={libraries.editingSlug}
+								currentTitle={editingTitle}
+								libraries={libraries.libraries}
+								isBusy={libraries.isBusy}
+								error={libraries.renameError}
+								onClearError={libraries.clearRenameError}
+								onRename={libraries.renameLibrary}
+							/>
+							<DeleteLibraryModal
+								editingSlug={libraries.editingSlug}
+								editingTitle={editingTitle}
+								activeSlug={libraries.activeSlug}
+								libraries={libraries.libraries}
+								isBusy={libraries.isBusy}
+								error={libraries.deleteError}
+								onClearError={libraries.clearDeleteError}
+								onDelete={libraries.deleteLibrary}
+							/>
+						</>
 					}
 				/>
 			}

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -97,20 +97,28 @@ export function StyleLibraryApp() {
 
 	// Two different libraries are named in the header: the one being edited (the selector's value,
 	// and the target of rename/delete/activate) and the one the site renders with (named in the
-	// activation modal's copy). `libraryDisplayTitle` resolves either from the slug alone, so both
-	// stay correct on the first paint before the list has loaded.
+	// activation modal's copy).
+	//
+	// The fetched list is preferred over the feed for both, because a rename refreshes the list but
+	// deliberately not the feed — reading the feed first would leave the header showing the old
+	// name until something else reloaded it. The feed is the fallback, and it is what makes the
+	// first paint correct: it is printed inline with the page, so the header names the library
+	// immediately instead of showing a slug-derived guess and correcting itself a moment later when
+	// the list request lands.
 	const editingTitle = libraryDisplayTitle(
 		libraries.libraries.find((library) => library.slug === libraries.editingSlug) ?? {
 			slug: libraries.editingSlug,
-			// The feed is assembled for the library being edited, so its title names that library
-			// on the first paint, before the list has loaded.
-			title: feed.feed?.title ?? '',
+			title: feed.title,
 		}
 	);
+
+	// No feed fallback here: the feed only ever describes the library being edited, so borrowing its
+	// title for a different library would be wrong rather than merely early. Before the list loads
+	// these are the same library anyway, and `libraryDisplayTitle` names it from the slug.
 	const activeTitle = libraryDisplayTitle(
 		libraries.libraries.find((library) => library.slug === libraries.activeSlug) ?? {
 			slug: libraries.activeSlug,
-			title: '',
+			title: libraries.isEditingActive ? feed.title : '',
 		}
 	);
 

--- a/src/style-library/components/atoms/AddTile.scss
+++ b/src/style-library/components/atoms/AddTile.scss
@@ -1,6 +1,9 @@
 .kadence-blocks-style-library__add-tile {
-	// No width of its own — sizes to its own content plus the padding below, and stretches to match
-	// `SwatchCard`'s height via the row's own `align-items: stretch`.
+	// Floored at `SwatchCard`'s width so a wrapped grid lines up, rather than the tile sitting a few
+	// pixels wider than every card beside it. A floor, not a fixed width: a longer label grows the
+	// tile instead of overflowing it.
+	min-width: var(--kb-sl-size-swatch-card-width);
+	// Stretches to match `SwatchCard`'s height via the row's own `align-items: stretch`.
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: row;
@@ -24,13 +27,12 @@
 	}
 }
 
-// This inline padding stacks on top of the tile's own box padding above — two separate rules
-// because the design specifies them as two distinct values, not one asymmetric shorthand.
+// No gap and no inline padding: both are what pushed the tile's natural width past the card width
+// above, which left the `min-width` floor never engaging. The icon carries its own alignment box,
+// so the two sit close without needing a gap between them.
 .kadence-blocks-style-library__add-tile-content {
 	display: flex;
 	align-items: center;
-	gap: var(--kb-sl-space-05);
-	padding: 0 var(--kb-sl-space-05);
 }
 
 // The icon's hit/alignment box — shared with `ScreenHeader`'s primary action so the two plus icons

--- a/src/style-library/components/molecules/SelectDropdown.js
+++ b/src/style-library/components/molecules/SelectDropdown.js
@@ -28,7 +28,13 @@ import './SelectDropdown.scss';
  *
  * @param {Object}                               props                 The component props.
  * @param {string}                                props.value           The current option's value.
- * @param {Array<{value: string, label: string}>} props.options         The selectable options, in display order.
+ * @param {Array<{value: string, label: string, badges?: Array<{text: string, variant?: string}>}>} props.options
+ *                                                                       The selectable options, in display order. An option may carry short badges
+ *                                                                       rendered after its label in the menu (never in the toggle, which is a fixed
+ *                                                                       width the label already truncates against). `variant` is `'state'` for a
+ *                                                                       condition that changes over time and `'muted'` for an inherent property —
+ *                                                                       this component only maps them to class names, it does not know what any
+ *                                                                       badge means.
  * @param {Function}                              props.onChange        Called with a value when a different option is chosen.
  * @param {boolean}                               [props.isBusy]        Whether a change is in flight.
  * @param {?{message: string}}                    [props.error]         The current error, if any.
@@ -123,6 +129,17 @@ export function SelectDropdown({
 										}}
 									>
 										{option.label}
+										{option.badges?.map((badge) => (
+											<span
+												key={badge.text}
+												className={classnames(
+													'kadence-blocks-style-library__select-dropdown-badge',
+													`kadence-blocks-style-library__select-dropdown-badge--${badge.variant ?? 'muted'}`
+												)}
+											>
+												{badge.text}
+											</span>
+										))}
 									</MenuItem>
 								);
 							})}

--- a/src/style-library/components/molecules/SelectDropdown.js
+++ b/src/style-library/components/molecules/SelectDropdown.js
@@ -116,20 +116,41 @@ export function SelectDropdown({
 										role="menuitemradio"
 										aria-checked={isCurrent}
 										disabled={isBusy}
-										// Always rendered, empty on the rows without a check, so every row
-										// reserves the same trailing column. Without it the check's width
-										// only exists on one row, and everything to its left — badges
-										// especially — sits at a different right edge there than on its
-										// neighbors.
+										// Badges ride in the suffix rather than beside the label, so they and
+										// the check are siblings of the label's own box and the button's
+										// single `gap` spaces all three identically — no margins of their
+										// own to keep in step with it.
+										//
+										// The check slot is always rendered, empty on the rows without a
+										// check, so every row reserves the same trailing column. Without it
+										// the check's width exists on one row only, and everything to its
+										// left sits at a different right edge there than on its neighbors.
 										suffix={
-											<span className="kadence-blocks-style-library__select-dropdown-check-slot">
-												{isCurrent && (
-													<Icon
-														className="kadence-blocks-style-library__select-dropdown-check"
-														icon={check}
-													/>
+											<>
+												{option.badges?.length > 0 && (
+													<span className="kadence-blocks-style-library__select-dropdown-badges">
+														{option.badges.map((badge) => (
+															<span
+																key={badge.text}
+																className={classnames(
+																	'kadence-blocks-style-library__select-dropdown-badge',
+																	`kadence-blocks-style-library__select-dropdown-badge--${badge.variant ?? 'muted'}`
+																)}
+															>
+																{badge.text}
+															</span>
+														))}
+													</span>
 												)}
-											</span>
+												<span className="kadence-blocks-style-library__select-dropdown-check-slot">
+													{isCurrent && (
+														<Icon
+															className="kadence-blocks-style-library__select-dropdown-check"
+															icon={check}
+														/>
+													)}
+												</span>
+											</>
 										}
 										onClick={() => {
 											onClose();
@@ -140,26 +161,6 @@ export function SelectDropdown({
 										}}
 									>
 										{option.label}
-										{/* One wrapper around the run of badges rather than spacing each badge
-										 * off its neighbor: it gives the group a single box to right-align and
-										 * one `gap` to own, and it keeps the spacing off `:first-of-type`,
-										 * which would silently pick the wrong element the moment any other
-										 * span joins this row. */}
-										{option.badges?.length > 0 && (
-											<span className="kadence-blocks-style-library__select-dropdown-badges">
-												{option.badges.map((badge) => (
-													<span
-														key={badge.text}
-														className={classnames(
-															'kadence-blocks-style-library__select-dropdown-badge',
-															`kadence-blocks-style-library__select-dropdown-badge--${badge.variant ?? 'muted'}`
-														)}
-													>
-														{badge.text}
-													</span>
-												))}
-											</span>
-										)}
 									</MenuItem>
 								);
 							})}

--- a/src/style-library/components/molecules/SelectDropdown.js
+++ b/src/style-library/components/molecules/SelectDropdown.js
@@ -32,11 +32,14 @@ import './SelectDropdown.scss';
  *                                                                       The selectable options, in display order. An option may carry short badges
  *                                                                       rendered after its label in the menu (never in the toggle, which is a fixed
  *                                                                       width the label already truncates against). `variant` is `'state'` for a
- *                                                                       condition that changes over time and `'muted'` for an inherent property —
+ *                                                                       condition that changes over time and `'muted'` for an unchanging property —
  *                                                                       this component only maps them to class names, it does not know what any
  *                                                                       badge means.
  * @param {Function}                              props.onChange        Called with a value when a different option is chosen.
  * @param {boolean}                               [props.isBusy]        Whether a change is in flight.
+ * @param {boolean}                               [props.showSpinner]   Whether the inline busy spinner is drawn. Defaults to true; a caller that
+ *                                                                       already shows progress for the same wait elsewhere passes false to avoid a
+ *                                                                       second indicator. Independent of `isBusy`, which still disables the control.
  * @param {?{message: string}}                    [props.error]         The current error, if any.
  * @param {Function}                              [props.onClearError]  Dismisses the current error.
  * @param {?{label: string, onClick: Function}}   [props.trailingAction] A single action rendered below a divider, separate from the option list.
@@ -58,6 +61,7 @@ export function SelectDropdown({
 	options,
 	onChange,
 	isBusy,
+	showSpinner = true,
 	error,
 	onClearError,
 	trailingAction,
@@ -176,7 +180,7 @@ export function SelectDropdown({
 					</>
 				)}
 			/>
-			{isBusy && <Spinner className="kadence-blocks-style-library__select-dropdown-spinner" />}
+			{isBusy && showSpinner && <Spinner className="kadence-blocks-style-library__select-dropdown-spinner" />}
 			{error && (
 				<Notice
 					status="error"

--- a/src/style-library/components/molecules/SelectDropdown.js
+++ b/src/style-library/components/molecules/SelectDropdown.js
@@ -116,13 +116,20 @@ export function SelectDropdown({
 										role="menuitemradio"
 										aria-checked={isCurrent}
 										disabled={isBusy}
+										// Always rendered, empty on the rows without a check, so every row
+										// reserves the same trailing column. Without it the check's width
+										// only exists on one row, and everything to its left — badges
+										// especially — sits at a different right edge there than on its
+										// neighbors.
 										suffix={
-											isCurrent ? (
-												<Icon
-													className="kadence-blocks-style-library__select-dropdown-check"
-													icon={check}
-												/>
-											) : null
+											<span className="kadence-blocks-style-library__select-dropdown-check-slot">
+												{isCurrent && (
+													<Icon
+														className="kadence-blocks-style-library__select-dropdown-check"
+														icon={check}
+													/>
+												)}
+											</span>
 										}
 										onClick={() => {
 											onClose();
@@ -133,17 +140,26 @@ export function SelectDropdown({
 										}}
 									>
 										{option.label}
-										{option.badges?.map((badge) => (
-											<span
-												key={badge.text}
-												className={classnames(
-													'kadence-blocks-style-library__select-dropdown-badge',
-													`kadence-blocks-style-library__select-dropdown-badge--${badge.variant ?? 'muted'}`
-												)}
-											>
-												{badge.text}
+										{/* One wrapper around the run of badges rather than spacing each badge
+										 * off its neighbor: it gives the group a single box to right-align and
+										 * one `gap` to own, and it keeps the spacing off `:first-of-type`,
+										 * which would silently pick the wrong element the moment any other
+										 * span joins this row. */}
+										{option.badges?.length > 0 && (
+											<span className="kadence-blocks-style-library__select-dropdown-badges">
+												{option.badges.map((badge) => (
+													<span
+														key={badge.text}
+														className={classnames(
+															'kadence-blocks-style-library__select-dropdown-badge',
+															`kadence-blocks-style-library__select-dropdown-badge--${badge.variant ?? 'muted'}`
+														)}
+													>
+														{badge.text}
+													</span>
+												))}
 											</span>
-										))}
+										)}
 									</MenuItem>
 								);
 							})}

--- a/src/style-library/components/molecules/SelectDropdown.scss
+++ b/src/style-library/components/molecules/SelectDropdown.scss
@@ -262,6 +262,57 @@
 	text-decoration: none;
 }
 
+// Badges sit after an option's label, inside the same wrapping content row, so a long label
+// wraps and carries them along rather than pushing them out of the menu. `margin-left: auto` on
+// the first one pins the whole group to the row's trailing edge, which is where the token-value
+// picker puts its own "Default" tag.
+//
+// Two variants, because the two badges this menu shows are different kinds of fact and must not
+// read as one list of equal labels. `state` marks something that changes over time and is the
+// answer to "which one is live?", so it takes the theme color and the heavier weight; `muted` is
+// an inherent, unchanging property and stays reference-level quiet. A row can carry both — the
+// default library is also the active one on a fresh install, which is the common first-run case,
+// not an edge case.
+.kadence-blocks-style-library__select-dropdown-menu .kadence-blocks-style-library__select-dropdown-badge {
+	flex: 0 0 auto;
+	font-size: var(--kb-sl-font-size-s);
+	line-height: var(--kb-sl-line-height-s);
+	white-space: nowrap;
+
+	& + & {
+		margin-left: var(--kb-sl-space-10);
+	}
+
+	&:first-of-type {
+		margin-left: auto;
+		// Keeps the badge group off the label when a long label fills the row; the `auto` margin
+		// above only spaces them when there is slack left to distribute.
+		padding-left: var(--kb-sl-space-10);
+	}
+}
+
+.kadence-blocks-style-library__select-dropdown-badge--muted {
+	color: var(--kb-sl-color-text-muted);
+	font-weight: var(--kb-sl-font-weight-regular);
+}
+
+.kadence-blocks-style-library__select-dropdown-badge--state {
+	color: var(--kb-sl-color-theme);
+	font-weight: var(--kb-sl-font-weight-semibold);
+}
+
+// The hover/focus rule on the menu item swaps the whole row to the theme color, which would erase
+// the muted badge's deliberate quietness exactly when the user is looking at that row. Re-assert
+// it so the two variants stay distinguishable in every state.
+.kadence-blocks-style-library__select-dropdown-menu
+	.components-menu-item__button:hover
+	.kadence-blocks-style-library__select-dropdown-badge--muted,
+.kadence-blocks-style-library__select-dropdown-menu
+	.components-menu-item__button:focus-visible
+	.kadence-blocks-style-library__select-dropdown-badge--muted {
+	color: var(--kb-sl-color-text-muted);
+}
+
 .kadence-blocks-style-library__select-dropdown-error {
 	margin: 0;
 }

--- a/src/style-library/components/molecules/SelectDropdown.scss
+++ b/src/style-library/components/molecules/SelectDropdown.scss
@@ -155,6 +155,18 @@
 	padding: 0;
 }
 
+// The trailing column every row reserves, checked or not (see SelectDropdown.js). Sized to the
+// check it may hold so an empty slot occupies exactly what a filled one does; `flex: 0 0 auto`
+// keeps it from being squeezed by a long label.
+.kadence-blocks-style-library__select-dropdown-menu .kadence-blocks-style-library__select-dropdown-check-slot {
+	display: flex;
+	flex: 0 0 auto;
+	align-items: center;
+	justify-content: center;
+	width: var(--kb-sl-size-icon-check);
+	height: var(--kb-sl-size-icon-check);
+}
+
 // Ancestor-qualified so this outranks core's `.components-button svg { fill: currentcolor }`,
 // which otherwise wins on specificity (a class-plus-element selector beats a bare class one) and
 // leaves the check rendering in the inherited text color instead of the theme color.
@@ -233,6 +245,13 @@
 	.components-menu-item__item {
 		display: flex;
 		align-items: center;
+		// Fills the row rather than hugging its content, which is what gives the badge group's
+		// `margin-left: auto` some slack to push against. Core sizes this to its content and pins
+		// the suffix right with its own `margin-right: auto`; that lands the suffix in the same
+		// place, but leaves nothing inside the item for an auto margin to distribute.
+		flex: 1 1 auto;
+		// Lets a long label shrink instead of forcing the row wider than the menu.
+		min-width: 0;
 		// --kb-sl-space-30 (24px), not --kb-sl-line-height-m (also 24px): this is sizing the item's
 		// content row, the same role the identical-valued space token already plays for the
 		// check-icon gap just above — not spacing text lines, which is what the line-height ramp is
@@ -267,6 +286,23 @@
 // first one pins the group to the row's trailing edge, which is where the token-value picker puts
 // its own "Default" tag.
 //
+// The run of badges, right-aligned so it ends against the check icon's column rather than
+// trailing the label at whatever width that happens to be. `margin-left: auto` does the aligning;
+// the `padding-left` is the floor that keeps the group off a label long enough to consume all the
+// slack, at which point the auto margin has nothing left to distribute.
+//
+// The gap here and the padding both use the same step as the menu item's own item-to-suffix gap
+// (see `.components-menu-item__button` below), so badge-to-badge, label-to-badge and
+// badge-to-check are all spaced identically and the row reads as one evenly-spaced run.
+.kadence-blocks-style-library__select-dropdown-menu .kadence-blocks-style-library__select-dropdown-badges {
+	display: flex;
+	flex: 0 0 auto;
+	align-items: center;
+	gap: var(--kb-sl-space-30);
+	margin-left: auto;
+	padding-left: var(--kb-sl-space-30);
+}
+
 // Two variants, because the two badges this menu shows are different kinds of fact and must not
 // read as one list of equal labels. `state` says which library the site is actually serving — the
 // answer with consequences — so it takes the theme color and the heavier weight. `muted` marks an
@@ -278,17 +314,6 @@
 	font-size: var(--kb-sl-font-size-s);
 	line-height: var(--kb-sl-line-height-s);
 	white-space: nowrap;
-
-	& + & {
-		margin-left: var(--kb-sl-space-10);
-	}
-
-	&:first-of-type {
-		margin-left: auto;
-		// Keeps the badge group off the label when a long label fills the row; the `auto` margin
-		// above only spaces them when there is slack left to distribute.
-		padding-left: var(--kb-sl-space-10);
-	}
 }
 
 .kadence-blocks-style-library__select-dropdown-badge--muted {

--- a/src/style-library/components/molecules/SelectDropdown.scss
+++ b/src/style-library/components/molecules/SelectDropdown.scss
@@ -245,13 +245,13 @@
 	.components-menu-item__item {
 		display: flex;
 		align-items: center;
-		// Fills the row rather than hugging its content, which is what gives the badge group's
-		// `margin-left: auto` some slack to push against. Core sizes this to its content and pins
-		// the suffix right with its own `margin-right: auto`; that lands the suffix in the same
-		// place, but leaves nothing inside the item for an auto margin to distribute.
+		// Fills the row rather than hugging its content, so the badges and check that follow it are
+		// pushed to the trailing edge without either of them needing an auto margin.
 		flex: 1 1 auto;
-		// Lets a long label shrink instead of forcing the row wider than the menu.
-		min-width: 0;
+		// A floor for the label column, so a short label ("Default") still holds the row open and
+		// the badges after it land in the same place as on a row with a long one — otherwise each
+		// row's badges track its own label width and the column looks ragged.
+		min-width: var(--kb-sl-size-select-dropdown-label-min-width);
 		// --kb-sl-space-30 (24px), not --kb-sl-line-height-m (also 24px): this is sizing the item's
 		// content row, the same role the identical-valued space token already plays for the
 		// check-icon gap just above — not spacing text lines, which is what the line-height ramp is
@@ -286,21 +286,20 @@
 // first one pins the group to the row's trailing edge, which is where the token-value picker puts
 // its own "Default" tag.
 //
-// The run of badges, right-aligned so it ends against the check icon's column rather than
-// trailing the label at whatever width that happens to be. `margin-left: auto` does the aligning;
-// the `padding-left` is the floor that keeps the group off a label long enough to consume all the
-// slack, at which point the auto margin has nothing left to distribute.
+// The run of badges. A sibling of the label's box and the check slot, not a child of the label —
+// so the button's own `gap` (below) is the single thing spacing label, badges and check, and this
+// element carries no margin or padding of its own that would have to be kept in step with it.
 //
-// The gap here and the padding both use the same step as the menu item's own item-to-suffix gap
-// (see `.components-menu-item__button` below), so badge-to-badge, label-to-badge and
-// badge-to-check are all spaced identically and the row reads as one evenly-spaced run.
+// Right-alignment is not this element's job either: the label box grows to fill the row (see
+// `.components-menu-item__item`), which leaves the badges and the check sitting at the trailing
+// edge on their own.
 .kadence-blocks-style-library__select-dropdown-menu .kadence-blocks-style-library__select-dropdown-badges {
 	display: flex;
 	flex: 0 0 auto;
 	align-items: center;
+	// The same step the button uses between its own children, so badge-to-badge matches
+	// label-to-badge and badge-to-check and the row reads as one evenly-spaced run.
 	gap: var(--kb-sl-space-30);
-	margin-left: auto;
-	padding-left: var(--kb-sl-space-30);
 }
 
 // Two variants, because the two badges this menu shows are different kinds of fact and must not

--- a/src/style-library/components/molecules/SelectDropdown.scss
+++ b/src/style-library/components/molecules/SelectDropdown.scss
@@ -262,15 +262,15 @@
 	text-decoration: none;
 }
 
-// Badges sit after an option's label, inside the same wrapping content row, so a long label
-// wraps and carries them along rather than pushing them out of the menu. `margin-left: auto` on
-// the first one pins the whole group to the row's trailing edge, which is where the token-value
-// picker puts its own "Default" tag.
+// A badge sits after an option's label, inside the same wrapping content row, so a long label
+// wraps and carries it along rather than pushing it out of the menu. `margin-left: auto` on the
+// first one pins the group to the row's trailing edge, which is where the token-value picker puts
+// its own "Default" tag.
 //
 // Two variants, because the two badges this menu shows are different kinds of fact and must not
-// read as one list of equal labels. `state` marks something that changes over time and is the
-// answer to "which one is live?", so it takes the theme color and the heavier weight; `muted` is
-// an inherent, unchanging property and stays reference-level quiet. A row can carry both — the
+// read as one list of equal labels. `state` says which library the site is actually serving — the
+// answer with consequences — so it takes the theme color and the heavier weight. `muted` marks an
+// unchanging property of an option and stays reference-level quiet. A row can carry both: the
 // default library is also the active one on a fresh install, which is the common first-run case,
 // not an edge case.
 .kadence-blocks-style-library__select-dropdown-menu .kadence-blocks-style-library__select-dropdown-badge {
@@ -301,9 +301,9 @@
 	font-weight: var(--kb-sl-font-weight-semibold);
 }
 
-// The hover/focus rule on the menu item swaps the whole row to the theme color, which would erase
-// the muted badge's deliberate quietness exactly when the user is looking at that row. Re-assert
-// it so the two variants stay distinguishable in every state.
+// The menu item's hover/focus rule swaps the whole row to the theme color, which would erase the
+// muted badge's deliberate quietness exactly when the user is looking at that row — and would make
+// it indistinguishable from the themed one. Re-assert it so the two stay apart in every state.
 .kadence-blocks-style-library__select-dropdown-menu
 	.components-menu-item__button:hover
 	.kadence-blocks-style-library__select-dropdown-badge--muted,

--- a/src/style-library/components/organisms/ActivateLibraryButton.js
+++ b/src/style-library/components/organisms/ActivateLibraryButton.js
@@ -2,10 +2,9 @@
  * The header's "Set as active" affordance and its confirmation modal, owning its own open state
  * the way `DeleteLibraryModal` owns its trigger.
  *
- * Renders one of two things, never nothing: the button while the library being edited is not the
- * active one, and a static "Active" indicator while it is. Collapsing the slot instead would
- * reflow the header every time the user opens a different library, and would leave the most
- * important fact about the current screen — whether these edits are live — unstated.
+ * Renders nothing while the library being edited is already the active one — there is no action to
+ * offer, and the selector's own check icon already marks which library the site is live with, so a
+ * second "Active" label here would only repeat it.
  */
 
 /**
@@ -36,7 +35,8 @@ import './ActivateLibraryButton.scss';
  *
  * @since TBD
  *
- * @return {JSX.Element} The action or the indicator, plus the modal while open.
+ * @return {?JSX.Element} The action and, while open, its modal — or null when the library being
+ *                         edited is already active.
  */
 export function ActivateLibraryButton({
 	editingSlug,
@@ -51,11 +51,7 @@ export function ActivateLibraryButton({
 	const [isOpen, setIsOpen] = useState(false);
 
 	if (isEditingActive) {
-		return (
-			<span className="kadence-blocks-style-library__active-library-indicator">
-				{__('Active', 'kadence-blocks')}
-			</span>
-		);
+		return null;
 	}
 
 	// Closes the modal and clears its own error, whether that is a confirmed activation, a Cancel

--- a/src/style-library/components/organisms/ActivateLibraryButton.js
+++ b/src/style-library/components/organisms/ActivateLibraryButton.js
@@ -1,0 +1,100 @@
+/**
+ * The header's "Set as active" affordance and its confirmation modal, owning its own open state
+ * the way `DeleteLibraryModal` owns its trigger.
+ *
+ * Renders one of two things, never nothing: the button while the library being edited is not the
+ * active one, and a static "Active" indicator while it is. Collapsing the slot instead would
+ * reflow the header every time the user opens a different library, and would leave the most
+ * important fact about the current screen — whether these edits are live — unstated.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ActivateLibraryModal } from './ActivateLibraryModal';
+import './ActivateLibraryButton.scss';
+
+/**
+ * Render the activate action and, when open, its confirmation modal.
+ *
+ * @param {Object}             props                 The component props.
+ * @param {string}             props.editingSlug     The library the app is showing, and the activation target.
+ * @param {string}             props.editingTitle    That library's display title.
+ * @param {string}             props.activeTitle     The display title of the library the site uses now.
+ * @param {boolean}            props.isEditingActive Whether the library being edited is already the active one.
+ * @param {boolean}            props.isBusy          Whether a library operation is in flight.
+ * @param {?{message: string}} props.error           The current activation error, if any.
+ * @param {Function}           props.onClearError    Dismisses the current activation error.
+ * @param {Function}           props.onActivate      Called with a slug to make that library active.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The action or the indicator, plus the modal while open.
+ */
+export function ActivateLibraryButton({
+	editingSlug,
+	editingTitle,
+	activeTitle,
+	isEditingActive,
+	isBusy,
+	error,
+	onClearError,
+	onActivate,
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	if (isEditingActive) {
+		return (
+			<span className="kadence-blocks-style-library__active-library-indicator">
+				{__('Active', 'kadence-blocks')}
+			</span>
+		);
+	}
+
+	// Closes the modal and clears its own error, whether that is a confirmed activation, a Cancel
+	// click, or the Modal's own dismiss paths (Escape, click-outside) — all of which are already
+	// gated off while `isBusy`, so this never fires mid-request.
+	const handleClose = () => {
+		setIsOpen(false);
+		onClearError();
+	};
+
+	// The modal closes only once the pointer has actually moved. `.catch` deliberately does nothing
+	// beyond swallowing the rejection — a failed activation already re-set `isBusy`/`error` in the
+	// hook, and staying open is exactly the behavior a caught rejection gives here for free.
+	const handleConfirm = () => {
+		onActivate(editingSlug)
+			.then(() => handleClose())
+			.catch(() => {});
+	};
+
+	return (
+		<>
+			<Button
+				variant="secondary"
+				disabled={isBusy}
+				onClick={() => setIsOpen(true)}
+				className="kadence-blocks-style-library__activate-library-action"
+			>
+				{__('Set as active', 'kadence-blocks')}
+			</Button>
+			{isOpen && (
+				<ActivateLibraryModal
+					currentTitle={activeTitle}
+					nextTitle={editingTitle}
+					isBusy={isBusy}
+					error={error}
+					onClose={handleClose}
+					onConfirm={handleConfirm}
+				/>
+			)}
+		</>
+	);
+}

--- a/src/style-library/components/organisms/ActivateLibraryButton.scss
+++ b/src/style-library/components/organisms/ActivateLibraryButton.scss
@@ -1,0 +1,26 @@
+// Qualified with the app root so this outranks wp-admin's own default button sizing, the same
+// way the select toggle's rule does.
+.kadence-blocks-style-library-root .kadence-blocks-style-library__activate-library-action {
+	height: var(--kb-sl-space-50);
+	padding: 0 var(--kb-sl-space-15);
+	font-size: var(--kb-sl-font-size-m);
+	line-height: var(--kb-sl-line-height-s);
+	font-weight: var(--kb-sl-font-weight-medium);
+	white-space: nowrap;
+}
+
+// The resting state when the edited library is already live. Deliberately not a button and not
+// interactive — there is nothing to do here, and styling it like an action would invite a click
+// that could do nothing but disappoint. It matches the dropdown's own `state` badge, since the
+// two say the same thing about the same library.
+.kadence-blocks-style-library__active-library-indicator {
+	display: inline-flex;
+	align-items: center;
+	height: var(--kb-sl-space-50);
+	padding: 0 var(--kb-sl-space-15);
+	color: var(--kb-sl-color-theme);
+	font-size: var(--kb-sl-font-size-m);
+	line-height: var(--kb-sl-line-height-s);
+	font-weight: var(--kb-sl-font-weight-semibold);
+	white-space: nowrap;
+}

--- a/src/style-library/components/organisms/ActivateLibraryButton.scss
+++ b/src/style-library/components/organisms/ActivateLibraryButton.scss
@@ -8,19 +8,3 @@
 	font-weight: var(--kb-sl-font-weight-medium);
 	white-space: nowrap;
 }
-
-// The resting state when the edited library is already live. Deliberately not a button and not
-// interactive — there is nothing to do here, and styling it like an action would invite a click
-// that could do nothing but disappoint. It matches the dropdown's own `state` badge, since the
-// two say the same thing about the same library.
-.kadence-blocks-style-library__active-library-indicator {
-	display: inline-flex;
-	align-items: center;
-	height: var(--kb-sl-space-50);
-	padding: 0 var(--kb-sl-space-15);
-	color: var(--kb-sl-color-theme);
-	font-size: var(--kb-sl-font-size-m);
-	line-height: var(--kb-sl-line-height-s);
-	font-weight: var(--kb-sl-font-weight-semibold);
-	white-space: nowrap;
-}

--- a/src/style-library/components/organisms/ActivateLibraryModal.js
+++ b/src/style-library/components/organisms/ActivateLibraryModal.js
@@ -1,0 +1,91 @@
+/**
+ * The confirmation shown before a library becomes the one the site renders with.
+ *
+ * This modal is the whole reason activation is safe. Choosing a library from the header dropdown
+ * only opens it for editing; the site keeps rendering whatever is active until someone reads this
+ * and confirms. The copy therefore names both libraries and describes what a visitor will
+ * actually see change, rather than talking about settings in the abstract.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button, Modal, Notice } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './ActivateLibraryModal.scss';
+
+/**
+ * Render the activation confirmation.
+ *
+ * @param {Object}             props              The component props.
+ * @param {string}             props.currentTitle The display title of the library the site uses now.
+ * @param {string}             props.nextTitle    The display title of the library about to go live.
+ * @param {boolean}            props.isBusy       Whether the activation request is in flight.
+ * @param {?{message: string}} props.error        The current activation error, if any.
+ * @param {Function}           props.onClose      Called to dismiss the modal.
+ * @param {Function}           props.onConfirm    Called to activate the library.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The modal.
+ */
+export function ActivateLibraryModal({ currentTitle, nextTitle, isBusy, error, onClose, onConfirm }) {
+	return (
+		<Modal
+			title={sprintf(
+				// translators: %s: the library's display title.
+				__('Set "%s" as the active library?', 'kadence-blocks'),
+				nextTitle
+			)}
+			className="kadence-blocks-style-library__activate-library-modal"
+			onRequestClose={onClose}
+			// Locked while pending: no close icon, Escape does nothing, clicking outside does
+			// nothing. A site-wide restyle in flight must not be walkable-away-from mid-request.
+			isDismissible={!isBusy}
+			shouldCloseOnEsc={!isBusy}
+			shouldCloseOnClickOutside={!isBusy}
+		>
+			{error && (
+				<Notice status="error" isDismissible={false}>
+					{error.message}
+				</Notice>
+			)}
+			<p>
+				{sprintf(
+					// translators: 1: the library the site currently uses. 2: the library being activated.
+					__(
+						'Your site currently uses "%1$s". Setting "%2$s" as active changes the colors, typography, spacing, and other styles across your whole site right away — on the front end and in the editor.',
+						'kadence-blocks'
+					),
+					currentTitle,
+					nextTitle
+				)}
+			</p>
+			<p>
+				{sprintf(
+					// translators: %s: the library the site currently uses.
+					__(
+						'You can switch back at any time, but any custom values in "%s" stay in that library — they are not copied over.',
+						'kadence-blocks'
+					),
+					currentTitle
+				)}
+			</p>
+			<div className="kadence-blocks-style-library__activate-library-modal-actions">
+				{/* Cancel carries the autofocus: the safe choice should be the one a stray Enter
+				 * press lands on, since the other one restyles the entire site. */}
+				<Button variant="tertiary" onClick={onClose} disabled={isBusy} autoFocus>
+					{__('Cancel', 'kadence-blocks')}
+				</Button>
+				<Button variant="primary" disabled={isBusy} onClick={onConfirm}>
+					{/* The progressive label is the only progress indication — no spinner alongside it. */}
+					{isBusy ? __('Setting active…', 'kadence-blocks') : __('Set as active', 'kadence-blocks')}
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/src/style-library/components/organisms/ActivateLibraryModal.scss
+++ b/src/style-library/components/organisms/ActivateLibraryModal.scss
@@ -1,3 +1,15 @@
+// Core sizes a modal to its content, so the two paragraphs of consequence copy below stretch it
+// to the viewport cap and each line runs the full width of the screen — unreadable for text whose
+// whole job is to be read before confirming. Capped at the medium step rather than the small one:
+// this is prose, not a single field, and 24rem would trade the over-long lines for an over-tall
+// column.
+//
+// The class lands on `.components-modal__frame`; the compound selector is what outranks core's own
+// sizing rule on that element.
+.components-modal__frame.kadence-blocks-style-library__activate-library-modal {
+	max-width: var(--kb-sl-size-modal-medium);
+}
+
 .kadence-blocks-style-library__activate-library-modal-actions {
 	display: flex;
 	justify-content: flex-end;

--- a/src/style-library/components/organisms/ActivateLibraryModal.scss
+++ b/src/style-library/components/organisms/ActivateLibraryModal.scss
@@ -1,0 +1,6 @@
+.kadence-blocks-style-library__activate-library-modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: var(--kb-sl-space-10);
+	margin-top: var(--kb-sl-space-20);
+}

--- a/src/style-library/components/organisms/AppHeader.scss
+++ b/src/style-library/components/organisms/AppHeader.scss
@@ -21,6 +21,12 @@
 // consumes all the row's leftover space and pushes the actions slot to the far right edge; with
 // nothing set to grow, the actions slot instead sits immediately after the selector.
 .kadence-blocks-style-library__header-library,
+// A row, not a bare block: the slot holds several sibling controls (activate, rename, delete),
+// and without an explicit gap they would sit flush against each other — `Button` is inline-flex,
+// so the whitespace between JSX siblings is not rendered as a space.
 .kadence-blocks-style-library__header-actions {
+	display: flex;
 	flex: 0 0 auto;
+	align-items: center;
+	gap: var(--kb-sl-space-10);
 }

--- a/src/style-library/components/organisms/DeleteLibraryModal.js
+++ b/src/style-library/components/organisms/DeleteLibraryModal.js
@@ -1,46 +1,77 @@
 /**
  * The header's destructive library action: a red "Delete" text link and its confirmation modal.
- * Always targets the active library. Copy branches on whether the target is the default
+ * Always targets the library being edited. Copy branches on whether the target is the default
  * library — deleting it resets its token values to baseline instead of removing it, and the
  * confirmation must say so honestly rather than presenting a removal that will not happen.
+ *
+ * Deleting the library the site is currently rendering with additionally requires naming its
+ * successor. Without that, the server would drop the pointer back to the default library and the
+ * user would discover a site-wide restyle they never chose, as a side effect of a cleanup. The
+ * successor field starts empty and the confirm button stays disabled until it is answered.
  */
 
 /**
  * WordPress dependencies
  */
-import { Button, Modal, Notice } from '@wordpress/components';
+import { Button, Modal, Notice, SelectControl } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { isDefaultLibrary, libraryDisplayTitle } from '../../helpers/libraries';
+import { isDefaultLibrary, libraryDisplayTitle, successorOptions } from '../../helpers/libraries';
 import './DeleteLibraryModal.scss';
 
 /**
  * Render the delete/reset action and its confirmation modal.
  *
- * @param {Object}              props             The component props.
- * @param {string}              props.activeSlug  The active library slug, the delete target.
- * @param {string}              props.activeTitle The active library's display title.
- * @param {boolean}             props.isBusy      Whether a library operation is in flight.
- * @param {?{message: string}} props.error         The current delete error, if any.
- * @param {Function}            props.onClearError Dismisses the current delete error.
- * @param {Function}            props.onDelete     Called with the active slug to delete/reset it.
+ * @param {Object}             props              The component props.
+ * @param {string}             props.editingSlug  The library being edited, and the delete target.
+ * @param {string}             props.editingTitle That library's display title.
+ * @param {string}             props.activeSlug   The slug the site renders with.
+ * @param {Array<Object>}      props.libraries    The existing library rows, for the successor list.
+ * @param {boolean}            props.isBusy       Whether a library operation is in flight.
+ * @param {?{message: string}} props.error        The current delete error, if any.
+ * @param {Function}           props.onClearError Dismisses the current delete error.
+ * @param {Function}           props.onDelete     Called with the target slug and, when required, the successor slug.
  *
  * @since TBD
  *
  * @return {JSX.Element} The delete action and, when open, its modal.
  */
-export function DeleteLibraryModal({ activeSlug, activeTitle, isBusy, error, onClearError, onDelete }) {
+export function DeleteLibraryModal({
+	editingSlug,
+	editingTitle,
+	activeSlug,
+	libraries,
+	isBusy,
+	error,
+	onClearError,
+	onDelete,
+}) {
 	const [isOpen, setIsOpen] = useState(false);
-	const isDefault = isDefaultLibrary(activeSlug);
-	const label = libraryDisplayTitle({ slug: activeSlug, title: activeTitle ?? '' });
+	const [successorSlug, setSuccessorSlug] = useState('');
+
+	const isDefault = isDefaultLibrary(editingSlug);
+	const label = libraryDisplayTitle({ slug: editingSlug, title: editingTitle ?? '' });
+
+	// Only a real removal of the live library leaves the site without one. Resetting the default
+	// keeps it in place and still active, so there is nothing to succeed it.
+	const needsSuccessor = editingSlug === activeSlug && !isDefault;
+	const successors = needsSuccessor ? successorOptions(libraries, editingSlug) : [];
+
 	const restingLabel = isDefault ? __('Reset', 'kadence-blocks') : __('Delete', 'kadence-blocks');
 	// The progressive form of restingLabel — the only progress indication while the request is in
 	// flight; there is no spinner alongside it.
 	const pendingLabel = isDefault ? __('Resetting…', 'kadence-blocks') : __('Deleting…', 'kadence-blocks');
+
+	const handleOpen = () => {
+		// Reset per open, so a successor picked and then abandoned in an earlier attempt is never
+		// silently reused by the next one.
+		setSuccessorSlug('');
+		setIsOpen(true);
+	};
 
 	// Closes the modal and clears its own error, whether that is a confirmed delete, a Cancel
 	// click, or the Modal's own dismiss paths (Escape, click-outside) — all of which are already
@@ -51,14 +82,14 @@ export function DeleteLibraryModal({ activeSlug, activeTitle, isBusy, error, onC
 		onClearError();
 	};
 
-	// Deleting the active library (the only target this modal ever offers) resolves in place —
-	// the hook refreshes the feed for whatever library ends up active rather than reloading the
-	// page — so this modal has to close itself explicitly once that settles; nothing else will.
-	// `.catch` deliberately does nothing beyond swallowing the promise rejection — a failed delete
-	// already re-set `isBusy`/`error` in the hook, and staying open (not calling handleClose at
-	// all) is exactly the "do not close" behavior a caught rejection gives here for free.
+	// The flow resolves in place — the hook moves the feed to whatever library the app should land
+	// on rather than reloading the page — so this modal has to close itself once that settles;
+	// nothing else will. `.catch` deliberately does nothing beyond swallowing the promise
+	// rejection: a failed delete already re-set `isBusy`/`error` in the hook, and staying open
+	// (not calling handleClose at all) is exactly the "do not close" behavior a caught rejection
+	// gives here for free.
 	const handleConfirm = () => {
-		onDelete(activeSlug)
+		onDelete(editingSlug, needsSuccessor ? successorSlug : undefined)
 			.then(() => handleClose())
 			.catch(() => {});
 	};
@@ -69,7 +100,7 @@ export function DeleteLibraryModal({ activeSlug, activeTitle, isBusy, error, onC
 				variant="link"
 				isDestructive
 				disabled={isBusy}
-				onClick={() => setIsOpen(true)}
+				onClick={handleOpen}
 				className="kadence-blocks-style-library__delete-library-action"
 			>
 				{__('Delete', 'kadence-blocks')}
@@ -110,11 +141,43 @@ export function DeleteLibraryModal({ activeSlug, activeTitle, isBusy, error, onC
 									label
 								)}
 					</p>
+					{needsSuccessor && (
+						<>
+							<p>
+								{__(
+									'This is also your active library, so your site needs another one. The library you choose below goes live immediately — colors, typography, spacing, and other styles change across your site on the front end and in the editor.',
+									'kadence-blocks'
+								)}
+							</p>
+							<SelectControl
+								label={__('Which library should your site use instead?', 'kadence-blocks')}
+								value={successorSlug}
+								disabled={isBusy}
+								onChange={setSuccessorSlug}
+								// The empty option is deliberately kept selectable-looking rather than
+								// preselecting a library: defaulting to one would reproduce the very
+								// silent fallback this picker exists to remove, since the user would
+								// confirm without reading and land somewhere they never chose.
+								options={[
+									{ value: '', label: __('Select a library…', 'kadence-blocks') },
+									...successors.map((library) => ({
+										value: library.slug,
+										label: libraryDisplayTitle(library),
+									})),
+								]}
+							/>
+						</>
+					)}
 					<div className="kadence-blocks-style-library__delete-library-modal-actions">
 						<Button variant="tertiary" onClick={handleClose} disabled={isBusy}>
 							{__('Cancel', 'kadence-blocks')}
 						</Button>
-						<Button variant="primary" isDestructive disabled={isBusy} onClick={handleConfirm}>
+						<Button
+							variant="primary"
+							isDestructive
+							disabled={isBusy || (needsSuccessor && successorSlug === '')}
+							onClick={handleConfirm}
+						>
 							{isBusy ? pendingLabel : restingLabel}
 						</Button>
 					</div>

--- a/src/style-library/components/organisms/DeleteLibraryModal.js
+++ b/src/style-library/components/organisms/DeleteLibraryModal.js
@@ -1,46 +1,77 @@
 /**
  * The header's destructive library action: a red "Delete" text link and its confirmation modal.
- * Always targets the active library. Copy branches on whether the target is the default
+ * Always targets the library being edited. Copy branches on whether the target is the default
  * library — deleting it resets its token values to baseline instead of removing it, and the
  * confirmation must say so honestly rather than presenting a removal that will not happen.
+ *
+ * Deleting the library the site is currently rendering with additionally requires naming its
+ * successor. Without that, the server would drop the pointer back to the default library and the
+ * user would discover a site-wide restyle they never chose, as a side effect of a cleanup. The
+ * successor field starts empty and the confirm button stays disabled until it is answered.
  */
 
 /**
  * WordPress dependencies
  */
-import { Button, Modal, Notice } from '@wordpress/components';
+import { Button, Modal, Notice, SelectControl } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { isDefaultLibrary, libraryDisplayTitle } from '../../helpers/libraries';
+import { isDefaultLibrary, libraryDisplayTitle, successorOptions } from '../../helpers/libraries';
 import './DeleteLibraryModal.scss';
 
 /**
  * Render the delete/reset action and its confirmation modal.
  *
- * @param {Object}              props             The component props.
- * @param {string}              props.activeSlug  The active library slug, the delete target.
- * @param {string}              props.activeTitle The active library's display title.
- * @param {boolean}             props.isBusy      Whether a library operation is in flight.
- * @param {?{message: string}} props.error         The current delete error, if any.
- * @param {Function}            props.onClearError Dismisses the current delete error.
- * @param {Function}            props.onDelete     Called with the active slug to delete/reset it.
+ * @param {Object}             props              The component props.
+ * @param {string}             props.editingSlug  The library being edited, and the delete target.
+ * @param {string}             props.editingTitle That library's display title.
+ * @param {string}             props.activeSlug   The slug the site renders with.
+ * @param {Array<Object>}      props.libraries    The existing library rows, for the successor list.
+ * @param {boolean}            props.isBusy       Whether a library operation is in flight.
+ * @param {?{message: string}} props.error        The current delete error, if any.
+ * @param {Function}           props.onClearError Dismisses the current delete error.
+ * @param {Function}           props.onDelete     Called with the target slug and, when required, the successor slug.
  *
  * @since TBD
  *
  * @return {JSX.Element} The delete action and, when open, its modal.
  */
-export function DeleteLibraryModal({ activeSlug, activeTitle, isBusy, error, onClearError, onDelete }) {
+export function DeleteLibraryModal({
+	editingSlug,
+	editingTitle,
+	activeSlug,
+	libraries,
+	isBusy,
+	error,
+	onClearError,
+	onDelete,
+}) {
 	const [isOpen, setIsOpen] = useState(false);
-	const isDefault = isDefaultLibrary(activeSlug);
-	const label = libraryDisplayTitle({ slug: activeSlug, title: activeTitle ?? '' });
+	const [successorSlug, setSuccessorSlug] = useState('');
+
+	const isDefault = isDefaultLibrary(editingSlug);
+	const label = libraryDisplayTitle({ slug: editingSlug, title: editingTitle ?? '' });
+
+	// Only a real removal of the live library leaves the site without one. Resetting the default
+	// keeps it in place and still active, so there is nothing to succeed it.
+	const needsSuccessor = editingSlug === activeSlug && !isDefault;
+	const successors = needsSuccessor ? successorOptions(libraries, editingSlug) : [];
+
 	const restingLabel = isDefault ? __('Reset', 'kadence-blocks') : __('Delete', 'kadence-blocks');
 	// The progressive form of restingLabel — the only progress indication while the request is in
 	// flight; there is no spinner alongside it.
 	const pendingLabel = isDefault ? __('Resetting…', 'kadence-blocks') : __('Deleting…', 'kadence-blocks');
+
+	const handleOpen = () => {
+		// Reset per open, so a successor picked and then abandoned in an earlier attempt is never
+		// silently reused by the next one.
+		setSuccessorSlug('');
+		setIsOpen(true);
+	};
 
 	// Closes the modal and clears its own error, whether that is a confirmed delete, a Cancel
 	// click, or the Modal's own dismiss paths (Escape, click-outside) — all of which are already
@@ -51,14 +82,14 @@ export function DeleteLibraryModal({ activeSlug, activeTitle, isBusy, error, onC
 		onClearError();
 	};
 
-	// Deleting the active library (the only target this modal ever offers) resolves in place —
-	// the hook refreshes the feed for whatever library ends up active rather than reloading the
-	// page — so this modal has to close itself explicitly once that settles; nothing else will.
-	// `.catch` deliberately does nothing beyond swallowing the promise rejection — a failed delete
-	// already re-set `isBusy`/`error` in the hook, and staying open (not calling handleClose at
-	// all) is exactly the "do not close" behavior a caught rejection gives here for free.
+	// The flow resolves in place — the hook moves the feed to whatever library the app should land
+	// on rather than reloading the page — so this modal has to close itself once that settles;
+	// nothing else will. `.catch` deliberately does nothing beyond swallowing the promise
+	// rejection: a failed delete already re-set `isBusy`/`error` in the hook, and staying open
+	// (not calling handleClose at all) is exactly the "do not close" behavior a caught rejection
+	// gives here for free.
 	const handleConfirm = () => {
-		onDelete(activeSlug)
+		onDelete(editingSlug, needsSuccessor ? successorSlug : undefined)
 			.then(() => handleClose())
 			.catch(() => {});
 	};
@@ -69,7 +100,7 @@ export function DeleteLibraryModal({ activeSlug, activeTitle, isBusy, error, onC
 				variant="link"
 				isDestructive
 				disabled={isBusy}
-				onClick={() => setIsOpen(true)}
+				onClick={handleOpen}
 				className="kadence-blocks-style-library__delete-library-action"
 			>
 				{__('Delete', 'kadence-blocks')}
@@ -107,11 +138,43 @@ export function DeleteLibraryModal({ activeSlug, activeTitle, isBusy, error, onC
 									label
 								)}
 					</p>
+					{needsSuccessor && (
+						<>
+							<p>
+								{__(
+									'This is also your active library, so your site needs another one. The library you choose below goes live immediately — colors, typography, spacing, and other styles change across your site on the front end and in the editor.',
+									'kadence-blocks'
+								)}
+							</p>
+							<SelectControl
+								label={__('Which library should your site use instead?', 'kadence-blocks')}
+								value={successorSlug}
+								disabled={isBusy}
+								onChange={setSuccessorSlug}
+								// The empty option is deliberately kept selectable-looking rather than
+								// preselecting a library: defaulting to one would reproduce the very
+								// silent fallback this picker exists to remove, since the user would
+								// confirm without reading and land somewhere they never chose.
+								options={[
+									{ value: '', label: __('Select a library…', 'kadence-blocks') },
+									...successors.map((library) => ({
+										value: library.slug,
+										label: libraryDisplayTitle(library),
+									})),
+								]}
+							/>
+						</>
+					)}
 					<div className="kadence-blocks-style-library__delete-library-modal-actions">
 						<Button variant="tertiary" onClick={handleClose} disabled={isBusy}>
 							{__('Cancel', 'kadence-blocks')}
 						</Button>
-						<Button variant="primary" isDestructive disabled={isBusy} onClick={handleConfirm}>
+						<Button
+							variant="primary"
+							isDestructive
+							disabled={isBusy || (needsSuccessor && successorSlug === '')}
+							onClick={handleConfirm}
+						>
 							{isBusy ? pendingLabel : restingLabel}
 						</Button>
 					</div>

--- a/src/style-library/components/organisms/DeleteLibraryModal.js
+++ b/src/style-library/components/organisms/DeleteLibraryModal.js
@@ -7,7 +7,9 @@
  * Deleting the library the site is currently rendering with additionally requires naming its
  * successor. Without that, the server would drop the pointer back to the default library and the
  * user would discover a site-wide restyle they never chose, as a side effect of a cleanup. The
- * successor field starts empty and the confirm button stays disabled until it is answered.
+ * successor field starts empty and the confirm button stays disabled until it is answered — unless
+ * only one library could succeed it, in which case the copy names that library and there is no
+ * field, since a question with a single possible answer is friction rather than a safeguard.
  */
 
 /**
@@ -61,6 +63,18 @@ export function DeleteLibraryModal({
 	const needsSuccessor = editingSlug === activeSlug && !isDefault;
 	const successors = needsSuccessor ? successorOptions(libraries, editingSlug) : [];
 
+	// With a single candidate there is nothing to decide — the site can only land in one place, so
+	// asking would be a question with one answer. The consequence is still stated, naming that
+	// library outright; what is dropped is the choosing, not the telling.
+	//
+	// This is reachable on most sites, not a corner case: the default library can never be deleted,
+	// so any site with exactly two libraries hits it the moment it deletes the active one.
+	const isSuccessorForced = needsSuccessor && successors.length === 1;
+	// Read through rather than seeded into state on open: the libraries list arrives from its own
+	// request, so a modal opened before it lands would otherwise keep a stale '' with no picker
+	// rendered to correct it — a dead end with the confirm button disabled forever.
+	const chosenSuccessor = isSuccessorForced ? successors[0].slug : successorSlug;
+
 	const restingLabel = isDefault ? __('Reset', 'kadence-blocks') : __('Delete', 'kadence-blocks');
 	// The progressive form of restingLabel — the only progress indication while the request is in
 	// flight; there is no spinner alongside it.
@@ -89,7 +103,7 @@ export function DeleteLibraryModal({
 	// (not calling handleClose at all) is exactly the "do not close" behavior a caught rejection
 	// gives here for free.
 	const handleConfirm = () => {
-		onDelete(editingSlug, needsSuccessor ? successorSlug : undefined)
+		onDelete(editingSlug, needsSuccessor ? chosenSuccessor : undefined)
 			.then(() => handleClose())
 			.catch(() => {});
 	};
@@ -141,7 +155,19 @@ export function DeleteLibraryModal({
 									label
 								)}
 					</p>
-					{needsSuccessor && (
+					{isSuccessorForced && (
+						<p>
+							{sprintf(
+								// translators: %s: the library the site will use instead.
+								__(
+									'This is also your active library, so your site will use "%s" instead. Its colors, typography, spacing, and other styles go live across your site immediately — on the front end and in the editor.',
+									'kadence-blocks'
+								),
+								libraryDisplayTitle(successors[0])
+							)}
+						</p>
+					)}
+					{needsSuccessor && !isSuccessorForced && (
 						<>
 							<p>
 								{__(
@@ -157,7 +183,9 @@ export function DeleteLibraryModal({
 								// The empty option is deliberately kept selectable-looking rather than
 								// preselecting a library: defaulting to one would reproduce the very
 								// silent fallback this picker exists to remove, since the user would
-								// confirm without reading and land somewhere they never chose.
+								// confirm without reading and land somewhere they never chose. That
+								// reasoning does not apply when there is only one candidate, which is
+								// why that case skips the picker entirely rather than preselecting here.
 								options={[
 									{ value: '', label: __('Select a library…', 'kadence-blocks') },
 									...successors.map((library) => ({
@@ -175,7 +203,7 @@ export function DeleteLibraryModal({
 						<Button
 							variant="primary"
 							isDestructive
-							disabled={isBusy || (needsSuccessor && successorSlug === '')}
+							disabled={isBusy || (needsSuccessor && chosenSuccessor === '')}
 							onClick={handleConfirm}
 						>
 							{isBusy ? pendingLabel : restingLabel}

--- a/src/style-library/components/organisms/DeleteLibraryModal.js
+++ b/src/style-library/components/organisms/DeleteLibraryModal.js
@@ -7,7 +7,9 @@
  * Deleting the library the site is currently rendering with additionally requires naming its
  * successor. Without that, the server would drop the pointer back to the default library and the
  * user would discover a site-wide restyle they never chose, as a side effect of a cleanup. The
- * successor field starts empty and the confirm button stays disabled until it is answered.
+ * successor field starts empty and the confirm button stays disabled until it is answered — unless
+ * only one library could succeed it, in which case the copy names that library and there is no
+ * field, since a question with a single possible answer is friction rather than a safeguard.
  */
 
 /**
@@ -61,6 +63,18 @@ export function DeleteLibraryModal({
 	const needsSuccessor = editingSlug === activeSlug && !isDefault;
 	const successors = needsSuccessor ? successorOptions(libraries, editingSlug) : [];
 
+	// With a single candidate there is nothing to decide — the site can only land in one place, so
+	// asking would be a question with one answer. The consequence is still stated, naming that
+	// library outright; what is dropped is the choosing, not the telling.
+	//
+	// This is reachable on most sites, not a corner case: the default library can never be deleted,
+	// so any site with exactly two libraries hits it the moment it deletes the active one.
+	const isSuccessorForced = needsSuccessor && successors.length === 1;
+	// Read through rather than seeded into state on open: the libraries list arrives from its own
+	// request, so a modal opened before it lands would otherwise keep a stale '' with no picker
+	// rendered to correct it — a dead end with the confirm button disabled forever.
+	const chosenSuccessor = isSuccessorForced ? successors[0].slug : successorSlug;
+
 	const restingLabel = isDefault ? __('Reset', 'kadence-blocks') : __('Delete', 'kadence-blocks');
 	// The progressive form of restingLabel — the only progress indication while the request is in
 	// flight; there is no spinner alongside it.
@@ -89,7 +103,7 @@ export function DeleteLibraryModal({
 	// (not calling handleClose at all) is exactly the "do not close" behavior a caught rejection
 	// gives here for free.
 	const handleConfirm = () => {
-		onDelete(editingSlug, needsSuccessor ? successorSlug : undefined)
+		onDelete(editingSlug, needsSuccessor ? chosenSuccessor : undefined)
 			.then(() => handleClose())
 			.catch(() => {});
 	};
@@ -138,7 +152,19 @@ export function DeleteLibraryModal({
 									label
 								)}
 					</p>
-					{needsSuccessor && (
+					{isSuccessorForced && (
+						<p>
+							{sprintf(
+								// translators: %s: the library the site will use instead.
+								__(
+									'This is also your active library, so your site will use "%s" instead. Its colors, typography, spacing, and other styles go live across your site immediately — on the front end and in the editor.',
+									'kadence-blocks'
+								),
+								libraryDisplayTitle(successors[0])
+							)}
+						</p>
+					)}
+					{needsSuccessor && !isSuccessorForced && (
 						<>
 							<p>
 								{__(
@@ -154,7 +180,9 @@ export function DeleteLibraryModal({
 								// The empty option is deliberately kept selectable-looking rather than
 								// preselecting a library: defaulting to one would reproduce the very
 								// silent fallback this picker exists to remove, since the user would
-								// confirm without reading and land somewhere they never chose.
+								// confirm without reading and land somewhere they never chose. That
+								// reasoning does not apply when there is only one candidate, which is
+								// why that case skips the picker entirely rather than preselecting here.
 								options={[
 									{ value: '', label: __('Select a library…', 'kadence-blocks') },
 									...successors.map((library) => ({
@@ -172,7 +200,7 @@ export function DeleteLibraryModal({
 						<Button
 							variant="primary"
 							isDestructive
-							disabled={isBusy || (needsSuccessor && successorSlug === '')}
+							disabled={isBusy || (needsSuccessor && chosenSuccessor === '')}
 							onClick={handleConfirm}
 						>
 							{isBusy ? pendingLabel : restingLabel}

--- a/src/style-library/components/organisms/DeleteLibraryModal.scss
+++ b/src/style-library/components/organisms/DeleteLibraryModal.scss
@@ -23,6 +23,14 @@
 	}
 }
 
+// Capped for the same reason as the activation modal, and to the same step: on the path where the
+// deleted library is the active one this carries a paragraph of consequence copy, which core would
+// otherwise stretch to the viewport cap and render as full-width lines. See
+// ActivateLibraryModal.scss for why the selector is compound.
+.components-modal__frame.kadence-blocks-style-library__delete-library-modal {
+	max-width: var(--kb-sl-size-modal-medium);
+}
+
 .kadence-blocks-style-library__delete-library-modal-actions {
 	display: flex;
 	justify-content: flex-end;

--- a/src/style-library/components/organisms/LibrarySelector.js
+++ b/src/style-library/components/organisms/LibrarySelector.js
@@ -4,6 +4,10 @@
  * modal its trailing action opens. All of the selector's visual behavior (the toggle, the check
  * icon, the divider, the menu geometry) lives in `SelectDropdown` — this component only supplies
  * library data and the create flow.
+ *
+ * Choosing a library here *opens* it for editing. It does not change which library the site
+ * renders with; that is a separate, confirmed action (see `ActivateLibraryButton`). The badges
+ * below are what keep the two legible at the point of choosing.
  */
 
 /**
@@ -16,7 +20,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { SelectDropdown } from '../molecules/SelectDropdown';
-import { libraryDisplayTitle } from '../../helpers/libraries';
+import { isDefaultLibrary, libraryDisplayTitle } from '../../helpers/libraries';
 import { CreateLibraryModal } from './CreateLibraryModal';
 
 /**
@@ -24,13 +28,14 @@ import { CreateLibraryModal } from './CreateLibraryModal';
  *
  * @param {Object}        props                    The component props.
  * @param {Array<Object>} props.libraries          The ordered library rows (`{ slug, title }`).
- * @param {string}        props.activeSlug         The active library slug.
+ * @param {string}        props.activeSlug         The slug the site renders with.
+ * @param {string}        props.editingSlug        The slug the app is showing.
  * @param {boolean}       props.isBusy             Whether a library operation is in flight.
- * @param {?{message: string}} props.switchError   The current switch error, if any.
+ * @param {?{message: string}} props.openError     The current open error, if any.
  * @param {?{message: string}} props.createError   The current create error, if any.
- * @param {Function}      props.onSwitch           Called with a slug to switch the active library.
+ * @param {Function}      props.onOpen             Called with a slug to open that library for editing.
  * @param {Function}      props.onCreate           Called with a title to create a library.
- * @param {Function}      props.onClearSwitchError Dismisses the current switch error.
+ * @param {Function}      props.onClearOpenError   Dismisses the current open error.
  * @param {Function}      props.onClearCreateError Dismisses the current create error.
  *
  * @since TBD
@@ -40,46 +45,64 @@ import { CreateLibraryModal } from './CreateLibraryModal';
 export function LibrarySelector({
 	libraries,
 	activeSlug,
+	editingSlug,
 	isBusy,
-	switchError,
+	openError,
 	createError,
-	onSwitch,
+	onOpen,
 	onCreate,
-	onClearSwitchError,
+	onClearOpenError,
 	onClearCreateError,
 }) {
 	const [isCreateOpen, setIsCreateOpen] = useState(false);
 
-	const options = libraries.map((library) => ({
-		value: library.slug,
-		label: libraryDisplayTitle(library),
-	}));
+	const options = libraries.map((library) => {
+		const badges = [];
 
-	// A plain switch from the dropdown has no follow-up action waiting on its result — the
-	// `switchError` state above already surfaces a failure, so the rejection `onSwitch`'s promise
+		// Order is fixed — the inherent property before the mutable state — so a row carrying both
+		// does not reshuffle its badges as the active library moves.
+		if (isDefaultLibrary(library.slug)) {
+			// Answers "why can't I delete this one?" before the user tries: the default library is
+			// never removed, only reset to the shipped baseline.
+			badges.push({ text: __('Default', 'kadence-blocks'), variant: 'muted' });
+		}
+
+		if (library.slug === activeSlug) {
+			badges.push({ text: __('Active', 'kadence-blocks'), variant: 'state' });
+		}
+
+		return {
+			value: library.slug,
+			label: libraryDisplayTitle(library),
+			badges,
+		};
+	});
+
+	// A plain open from the dropdown has no follow-up action waiting on its result — the
+	// `openError` state above already surfaces a failure, so the rejection `onOpen`'s promise
 	// carries (there for a caller that chains off it, e.g. the create flow) is swallowed here
 	// rather than left unhandled.
-	const handleSwitch = (slug) => {
-		onSwitch(slug).catch(() => {});
+	const handleOpen = (slug) => {
+		onOpen(slug).catch(() => {});
 	};
 
 	return (
 		<>
 			<SelectDropdown
-				value={activeSlug}
+				value={editingSlug}
 				options={options}
-				// The slug alone is enough to name the active library correctly (see
-				// libraryDisplayTitle) — this is what the toggle shows on first paint, before
-				// `libraries` has loaded and any option can match `activeSlug`, so it never flashes
-				// the raw slug while the list is in flight.
-				valueLabel={libraryDisplayTitle({ slug: activeSlug, title: '' })}
+				// The slug alone is enough to name the library correctly (see libraryDisplayTitle) —
+				// this is what the toggle shows on first paint, before `libraries` has loaded and any
+				// option can match `editingSlug`, so it never flashes the raw slug while the list is
+				// in flight.
+				valueLabel={libraryDisplayTitle({ slug: editingSlug, title: '' })}
 				isBusy={isBusy}
 				// Suppressed while the create modal is open — it shows its own (separately scoped)
-				// createError inline instead, so surfacing switchError here too would display two
+				// createError inline instead, so surfacing openError here too would display two
 				// unrelated errors at once.
-				error={isCreateOpen ? null : switchError}
-				onClearError={onClearSwitchError}
-				onChange={handleSwitch}
+				error={isCreateOpen ? null : openError}
+				onClearError={onClearOpenError}
+				onChange={handleOpen}
 				trailingAction={{
 					label: __('Create Library', 'kadence-blocks'),
 					onClick: () => setIsCreateOpen(true),
@@ -97,9 +120,9 @@ export function LibrarySelector({
 					onCreate={(title) =>
 						onCreate(title)
 							.then(() => {
-								// A successful create is followed by a switch to the new library and a
-								// refreshed libraries list (see the hook) — this is the explicit close
-								// that used to be moot when the flow ended in a page reload.
+								// A successful create opens the new library and refreshes the libraries
+								// list (see the hook) — this is the explicit close that used to be moot
+								// when the flow ended in a page reload.
 								setIsCreateOpen(false);
 								onClearCreateError();
 							})

--- a/src/style-library/components/organisms/LibrarySelector.js
+++ b/src/style-library/components/organisms/LibrarySelector.js
@@ -4,6 +4,10 @@
  * modal its trailing action opens. All of the selector's visual behavior (the toggle, the check
  * icon, the divider, the menu geometry) lives in `SelectDropdown` — this component only supplies
  * library data and the create flow.
+ *
+ * Choosing a library here *opens* it for editing. It does not change which library the site
+ * renders with; that is a separate, confirmed action (see `ActivateLibraryButton`). The badges
+ * below are what keep the two legible at the point of choosing.
  */
 
 /**
@@ -16,7 +20,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { SelectDropdown } from '../molecules/SelectDropdown';
-import { libraryDisplayTitle } from '../../helpers/libraries';
+import { isDefaultLibrary, libraryDisplayTitle } from '../../helpers/libraries';
 import { CreateLibraryModal } from './CreateLibraryModal';
 
 /**
@@ -24,15 +28,16 @@ import { CreateLibraryModal } from './CreateLibraryModal';
  *
  * @param {Object}        props                    The component props.
  * @param {Array<Object>} props.libraries          The ordered library rows (`{ slug, title }`).
- * @param {string}        props.activeSlug         The active library slug.
- * @param {string}        [props.activeTitle]      The active library's display name, from the feed, so
+ * @param {string}        props.activeSlug         The slug the site renders with.
+ * @param {string}        props.editingSlug        The slug the app is showing.
+ * @param {string}        [props.editingTitle]     The edited library's display name, from the feed, so
  *                                                 the toggle can name it before `libraries` loads.
  * @param {boolean}       props.isBusy             Whether a library operation is in flight.
- * @param {?{message: string}} props.switchError   The current switch error, if any.
+ * @param {?{message: string}} props.openError     The current open error, if any.
  * @param {?{message: string}} props.createError   The current create error, if any.
- * @param {Function}      props.onSwitch           Called with a slug to switch the active library.
+ * @param {Function}      props.onOpen             Called with a slug to open that library for editing.
  * @param {Function}      props.onCreate           Called with a title to create a library.
- * @param {Function}      props.onClearSwitchError Dismisses the current switch error.
+ * @param {Function}      props.onClearOpenError   Dismisses the current open error.
  * @param {Function}      props.onClearCreateError Dismisses the current create error.
  *
  * @since TBD
@@ -42,46 +47,64 @@ import { CreateLibraryModal } from './CreateLibraryModal';
 export function LibrarySelector({
 	libraries,
 	activeSlug,
-	activeTitle,
+	editingSlug,
+	editingTitle,
 	isBusy,
-	switchError,
+	openError,
 	createError,
-	onSwitch,
+	onOpen,
 	onCreate,
-	onClearSwitchError,
+	onClearOpenError,
 	onClearCreateError,
 }) {
 	const [isCreateOpen, setIsCreateOpen] = useState(false);
 
-	const options = libraries.map((library) => ({
-		value: library.slug,
-		label: libraryDisplayTitle(library),
-	}));
+	const options = libraries.map((library) => {
+		const badges = [];
 
-	// A plain switch from the dropdown has no follow-up action waiting on its result — the
-	// `switchError` state above already surfaces a failure, so the rejection `onSwitch`'s promise
+		// Order is fixed — the inherent property before the mutable state — so a row carrying both
+		// does not reshuffle its badges as the active library moves.
+		if (isDefaultLibrary(library.slug)) {
+			// Answers "why can't I delete this one?" before the user tries: the default library is
+			// never removed, only reset to the shipped baseline.
+			badges.push({ text: __('Default', 'kadence-blocks'), variant: 'muted' });
+		}
+
+		if (library.slug === activeSlug) {
+			badges.push({ text: __('Active', 'kadence-blocks'), variant: 'state' });
+		}
+
+		return {
+			value: library.slug,
+			label: libraryDisplayTitle(library),
+			badges,
+		};
+	});
+
+	// A plain open from the dropdown has no follow-up action waiting on its result — the
+	// `openError` state above already surfaces a failure, so the rejection `onOpen`'s promise
 	// carries (there for a caller that chains off it, e.g. the create flow) is swallowed here
 	// rather than left unhandled.
-	const handleSwitch = (slug) => {
-		onSwitch(slug).catch(() => {});
+	const handleOpen = (slug) => {
+		onOpen(slug).catch(() => {});
 	};
 
 	return (
 		<>
 			<SelectDropdown
-				value={activeSlug}
+				value={editingSlug}
 				options={options}
 				// What the toggle shows on first paint, before `libraries` has loaded and any option can
-				// match `activeSlug`. The feed carries the active library's name for exactly this moment,
-				// so the toggle never flashes the raw slug while the list is in flight.
-				valueLabel={libraryDisplayTitle({ slug: activeSlug, title: activeTitle })}
+				// match `editingSlug`. The feed carries the edited library's name for exactly this
+				// moment, so the toggle never flashes the raw slug while the list is in flight.
+				valueLabel={libraryDisplayTitle({ slug: editingSlug, title: editingTitle })}
 				isBusy={isBusy}
 				// Suppressed while the create modal is open — it shows its own (separately scoped)
-				// createError inline instead, so surfacing switchError here too would display two
+				// createError inline instead, so surfacing openError here too would display two
 				// unrelated errors at once.
-				error={isCreateOpen ? null : switchError}
-				onClearError={onClearSwitchError}
-				onChange={handleSwitch}
+				error={isCreateOpen ? null : openError}
+				onClearError={onClearOpenError}
+				onChange={handleOpen}
 				trailingAction={{
 					label: __('Create Library', 'kadence-blocks'),
 					onClick: () => setIsCreateOpen(true),
@@ -99,9 +122,9 @@ export function LibrarySelector({
 					onCreate={(title) =>
 						onCreate(title)
 							.then(() => {
-								// A successful create is followed by a switch to the new library and a
-								// refreshed libraries list (see the hook) — this is the explicit close
-								// that used to be moot when the flow ended in a page reload.
+								// A successful create opens the new library and refreshes the libraries
+								// list (see the hook) — this is the explicit close that used to be moot
+								// when the flow ended in a page reload.
 								setIsCreateOpen(false);
 								onClearCreateError();
 							})

--- a/src/style-library/components/organisms/LibrarySelector.js
+++ b/src/style-library/components/organisms/LibrarySelector.js
@@ -33,6 +33,7 @@ import { CreateLibraryModal } from './CreateLibraryModal';
  * @param {Array<Object>} props.libraries          The ordered library rows (`{ slug, title }`).
  * @param {string}        props.activeSlug         The slug the site renders with.
  * @param {string}        props.editingSlug        The slug the app is showing.
+ * @param {string}        props.editingTitle       That library's display title, already resolved by the caller.
  * @param {boolean}       props.isBusy             Whether a library operation is in flight.
  * @param {boolean}       props.isSwapping         Whether the app is being repopulated for a different library.
  * @param {?{message: string}} props.openError     The current open error, if any.
@@ -50,6 +51,7 @@ export function LibrarySelector({
 	libraries,
 	activeSlug,
 	editingSlug,
+	editingTitle,
 	isBusy,
 	isSwapping,
 	openError,
@@ -96,11 +98,11 @@ export function LibrarySelector({
 			<SelectDropdown
 				value={editingSlug}
 				options={options}
-				// The slug alone is enough to name the library correctly (see libraryDisplayTitle) —
-				// this is what the toggle shows on first paint, before `libraries` has loaded and any
-				// option can match `editingSlug`, so it never flashes the raw slug while the list is
-				// in flight.
-				valueLabel={libraryDisplayTitle({ slug: editingSlug, title: '' })}
+				// What the toggle shows until `libraries` has loaded and an option can match
+				// `editingSlug`. The caller resolves it from the inline page feed, so the library is
+				// named correctly from the first paint rather than showing a slug-derived guess and
+				// silently correcting itself when the list request lands.
+				valueLabel={editingTitle}
 				isBusy={isBusy}
 				// The app draws its own scrim while a library is being opened, so the dropdown's
 				// inline spinner would be a second progress indicator for the same wait — and one

--- a/src/style-library/components/organisms/LibrarySelector.js
+++ b/src/style-library/components/organisms/LibrarySelector.js
@@ -33,8 +33,7 @@ import { CreateLibraryModal } from './CreateLibraryModal';
  * @param {Array<Object>} props.libraries          The ordered library rows (`{ slug, title }`).
  * @param {string}        props.activeSlug         The slug the site renders with.
  * @param {string}        props.editingSlug        The slug the app is showing.
- * @param {string}        [props.editingTitle]     The edited library's display name, from the feed, so
- *                                                 the toggle can name it before `libraries` loads.
+ * @param {string}        props.editingTitle       That library's display title, already resolved by the caller.
  * @param {boolean}       props.isBusy             Whether a library operation is in flight.
  * @param {boolean}       props.isSwapping         Whether the app is being repopulated for a different library.
  * @param {?{message: string}} props.openError     The current open error, if any.
@@ -99,10 +98,11 @@ export function LibrarySelector({
 			<SelectDropdown
 				value={editingSlug}
 				options={options}
-				// What the toggle shows on first paint, before `libraries` has loaded and any option can
-				// match `editingSlug`. The feed carries the edited library's name for exactly this
-				// moment, so the toggle never flashes the raw slug while the list is in flight.
-				valueLabel={libraryDisplayTitle({ slug: editingSlug, title: editingTitle })}
+				// What the toggle shows until `libraries` has loaded and an option can match
+				// `editingSlug`. The caller resolves it from the inline page feed, so the library is
+				// named correctly from the first paint rather than showing a slug-derived guess and
+				// silently correcting itself when the list request lands.
+				valueLabel={editingTitle}
 				isBusy={isBusy}
 				// The app draws its own scrim while a library is being opened, so the dropdown's
 				// inline spinner would be a second progress indicator for the same wait — and one

--- a/src/style-library/components/organisms/LibrarySelector.js
+++ b/src/style-library/components/organisms/LibrarySelector.js
@@ -6,8 +6,11 @@
  * library data and the create flow.
  *
  * Choosing a library here *opens* it for editing. It does not change which library the site
- * renders with; that is a separate, confirmed action (see `ActivateLibraryButton`). The badges
- * below are what keep the two legible at the point of choosing.
+ * renders with; that is a separate, confirmed action (see `ActivateLibraryButton`).
+ *
+ * The check icon keeps its ordinary meaning — the row you are on — because that is what a check in
+ * a menu reads as, and overloading it to mean "live" made the menu harder to read, not easier.
+ * Which library the site is serving is said in words instead, by the `Active` badge.
  */
 
 /**
@@ -33,6 +36,7 @@ import { CreateLibraryModal } from './CreateLibraryModal';
  * @param {string}        [props.editingTitle]     The edited library's display name, from the feed, so
  *                                                 the toggle can name it before `libraries` loads.
  * @param {boolean}       props.isBusy             Whether a library operation is in flight.
+ * @param {boolean}       props.isSwapping         Whether the app is being repopulated for a different library.
  * @param {?{message: string}} props.openError     The current open error, if any.
  * @param {?{message: string}} props.createError   The current create error, if any.
  * @param {Function}      props.onOpen             Called with a slug to open that library for editing.
@@ -50,6 +54,7 @@ export function LibrarySelector({
 	editingSlug,
 	editingTitle,
 	isBusy,
+	isSwapping,
 	openError,
 	createError,
 	onOpen,
@@ -62,8 +67,8 @@ export function LibrarySelector({
 	const options = libraries.map((library) => {
 		const badges = [];
 
-		// Order is fixed — the inherent property before the mutable state — so a row carrying both
-		// does not reshuffle its badges as the active library moves.
+		// Order is fixed — the unchanging property before the one that moves — so a row carrying
+		// both does not reshuffle its badges as the active library changes.
 		if (isDefaultLibrary(library.slug)) {
 			// Answers "why can't I delete this one?" before the user tries: the default library is
 			// never removed, only reset to the shipped baseline.
@@ -99,6 +104,10 @@ export function LibrarySelector({
 				// moment, so the toggle never flashes the raw slug while the list is in flight.
 				valueLabel={libraryDisplayTitle({ slug: editingSlug, title: editingTitle })}
 				isBusy={isBusy}
+				// The app draws its own scrim while a library is being opened, so the dropdown's
+				// inline spinner would be a second progress indicator for the same wait — and one
+				// sitting underneath the scrim at that. The control still disables via `isBusy`.
+				showSpinner={!isSwapping}
 				// Suppressed while the create modal is open — it shows its own (separately scoped)
 				// createError inline instead, so surfacing openError here too would display two
 				// unrelated errors at once.

--- a/src/style-library/components/organisms/LibrarySelector.js
+++ b/src/style-library/components/organisms/LibrarySelector.js
@@ -6,8 +6,11 @@
  * library data and the create flow.
  *
  * Choosing a library here *opens* it for editing. It does not change which library the site
- * renders with; that is a separate, confirmed action (see `ActivateLibraryButton`). The badges
- * below are what keep the two legible at the point of choosing.
+ * renders with; that is a separate, confirmed action (see `ActivateLibraryButton`).
+ *
+ * The check icon keeps its ordinary meaning — the row you are on — because that is what a check in
+ * a menu reads as, and overloading it to mean "live" made the menu harder to read, not easier.
+ * Which library the site is serving is said in words instead, by the `Active` badge.
  */
 
 /**
@@ -31,6 +34,7 @@ import { CreateLibraryModal } from './CreateLibraryModal';
  * @param {string}        props.activeSlug         The slug the site renders with.
  * @param {string}        props.editingSlug        The slug the app is showing.
  * @param {boolean}       props.isBusy             Whether a library operation is in flight.
+ * @param {boolean}       props.isSwapping         Whether the app is being repopulated for a different library.
  * @param {?{message: string}} props.openError     The current open error, if any.
  * @param {?{message: string}} props.createError   The current create error, if any.
  * @param {Function}      props.onOpen             Called with a slug to open that library for editing.
@@ -47,6 +51,7 @@ export function LibrarySelector({
 	activeSlug,
 	editingSlug,
 	isBusy,
+	isSwapping,
 	openError,
 	createError,
 	onOpen,
@@ -59,8 +64,8 @@ export function LibrarySelector({
 	const options = libraries.map((library) => {
 		const badges = [];
 
-		// Order is fixed — the inherent property before the mutable state — so a row carrying both
-		// does not reshuffle its badges as the active library moves.
+		// Order is fixed — the unchanging property before the one that moves — so a row carrying
+		// both does not reshuffle its badges as the active library changes.
 		if (isDefaultLibrary(library.slug)) {
 			// Answers "why can't I delete this one?" before the user tries: the default library is
 			// never removed, only reset to the shipped baseline.
@@ -97,6 +102,10 @@ export function LibrarySelector({
 				// in flight.
 				valueLabel={libraryDisplayTitle({ slug: editingSlug, title: '' })}
 				isBusy={isBusy}
+				// The app draws its own scrim while a library is being opened, so the dropdown's
+				// inline spinner would be a second progress indicator for the same wait — and one
+				// sitting underneath the scrim at that. The control still disables via `isBusy`.
+				showSpinner={!isSwapping}
 				// Suppressed while the create modal is open — it shows its own (separately scoped)
 				// createError inline instead, so surfacing openError here too would display two
 				// unrelated errors at once.

--- a/src/style-library/components/organisms/RenameLibraryModal.js
+++ b/src/style-library/components/organisms/RenameLibraryModal.js
@@ -1,0 +1,130 @@
+/**
+ * The header's "Rename" action and its modal: a single name field over the library being edited.
+ *
+ * Only the library's display name changes. Its slug — the identity the site's active-library
+ * pointer and every REST route address it by — is fixed at creation and never rewritten, so a
+ * rename is safe to do at any time and has no effect on stored token values.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button, Modal, Notice, TextControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { isDuplicateLibraryName } from '../../helpers/libraries';
+import './RenameLibraryModal.scss';
+
+/**
+ * Render the rename action and, when open, its modal.
+ *
+ * @param {Object}             props              The component props.
+ * @param {string}             props.slug         The library to rename (the one being edited).
+ * @param {string}             props.currentTitle That library's current display title.
+ * @param {Array<Object>}      props.libraries    The existing library rows, for the duplicate-name check.
+ * @param {boolean}            props.isBusy       Whether a library operation is in flight.
+ * @param {?{message: string}} props.error        The current rename error, if any.
+ * @param {Function}           props.onClearError Dismisses the current rename error.
+ * @param {Function}           props.onRename     Called with the slug and the new title.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The action and, when open, its modal.
+ */
+export function RenameLibraryModal({ slug, currentTitle, libraries, isBusy, error, onClearError, onRename }) {
+	const [isOpen, setIsOpen] = useState(false);
+	// Seeded from the current name so the common edit — fixing a typo — starts from the text being
+	// fixed rather than an empty field.
+	const [title, setTitle] = useState(currentTitle);
+
+	const trimmed = title.trim();
+	const isDuplicate = isDuplicateLibraryName(trimmed, libraries, slug);
+	const isUnchanged = trimmed === currentTitle.trim();
+
+	const handleOpen = () => {
+		setTitle(currentTitle);
+		setIsOpen(true);
+	};
+
+	// Closes and clears its own error, whether that is a completed rename, a Cancel click, or the
+	// Modal's own dismiss paths — all already gated off while `isBusy`, so this never fires
+	// mid-request.
+	const handleClose = () => {
+		setIsOpen(false);
+		onClearError();
+	};
+
+	// `.catch` swallows the rejection only: a failure already landed in `error` via the hook, and
+	// not closing is exactly what leaves the inline Notice on screen for the user to act on.
+	const handleConfirm = () => {
+		onRename(slug, trimmed)
+			.then(() => handleClose())
+			.catch(() => {});
+	};
+
+	return (
+		<>
+			<Button
+				variant="tertiary"
+				disabled={isBusy}
+				onClick={handleOpen}
+				className="kadence-blocks-style-library__rename-library-action"
+			>
+				{__('Rename', 'kadence-blocks')}
+			</Button>
+			{isOpen && (
+				<Modal
+					title={__('Rename Library', 'kadence-blocks')}
+					className="kadence-blocks-style-library__rename-library-modal"
+					onRequestClose={handleClose}
+					// Locked while pending, like every other library modal.
+					isDismissible={!isBusy}
+					shouldCloseOnEsc={!isBusy}
+					shouldCloseOnClickOutside={!isBusy}
+				>
+					{error && (
+						<Notice status="error" isDismissible={false}>
+							{error.message}
+						</Notice>
+					)}
+					<TextControl
+						label={__('Library title', 'kadence-blocks')}
+						value={title}
+						onChange={setTitle}
+						disabled={isBusy}
+						// Unlike creation, this compares against what libraries are actually *called*, not
+						// against derived slugs: a slug is minted once at creation and never follows a
+						// rename, so a slug-based check would refuse names nothing on screen is using.
+						help={
+							isDuplicate
+								? sprintf(
+										// translators: %s: the library name the user typed.
+										__('A library named "%s" already exists.', 'kadence-blocks'),
+										trimmed
+									)
+								: undefined
+						}
+					/>
+					<div className="kadence-blocks-style-library__rename-library-modal-actions">
+						<Button variant="tertiary" onClick={handleClose} disabled={isBusy}>
+							{__('Cancel', 'kadence-blocks')}
+						</Button>
+						<Button
+							variant="primary"
+							// Unchanged is disabled alongside empty and duplicate: a rename to the same name
+							// would spend a request and bump the library's version to change nothing.
+							disabled={isBusy || trimmed === '' || isDuplicate || isUnchanged}
+							onClick={handleConfirm}
+						>
+							{isBusy ? __('Saving…', 'kadence-blocks') : __('Save', 'kadence-blocks')}
+						</Button>
+					</div>
+				</Modal>
+			)}
+		</>
+	);
+}

--- a/src/style-library/components/organisms/RenameLibraryModal.scss
+++ b/src/style-library/components/organisms/RenameLibraryModal.scss
@@ -1,0 +1,17 @@
+// Qualified with the app root so this outranks wp-admin's own default button sizing, matching
+// the sibling header actions.
+.kadence-blocks-style-library-root .kadence-blocks-style-library__rename-library-action {
+	height: var(--kb-sl-space-50);
+	padding: 0 var(--kb-sl-space-15);
+	font-size: var(--kb-sl-font-size-m);
+	line-height: var(--kb-sl-line-height-s);
+	font-weight: var(--kb-sl-font-weight-medium);
+	white-space: nowrap;
+}
+
+.kadence-blocks-style-library__rename-library-modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: var(--kb-sl-space-10);
+	margin-top: var(--kb-sl-space-20);
+}

--- a/src/style-library/components/organisms/SettingsForm.js
+++ b/src/style-library/components/organisms/SettingsForm.js
@@ -11,7 +11,6 @@
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { Panel, PanelBody } from '@wordpress/components';
 
 /**
@@ -32,6 +31,24 @@ import './SettingsForm.scss';
  *
  * @return {JSX.Element} The form.
  */
+/**
+ * What an untitled panel renders instead of a `PanelBody`. Core gives `PanelBody` its own padding,
+ * so a titled panel is already inset; an untitled one renders bare and would sit flush against the
+ * settings panel's edges. The padding belongs here, on the case that lacks it, rather than on the
+ * shared scroll container — a container rule would land on both cases and double up wherever core's
+ * padding already applies.
+ *
+ * @param {Object}      props          The component props.
+ * @param {JSX.Element} props.children The panel's fields.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The wrapped fields.
+ */
+function UntitledPanelBody({ children }) {
+	return <div className="kadence-blocks-style-library__settings-form-untitled-panel">{children}</div>;
+}
+
 export function SettingsForm({ schema, values, onChange }) {
 	const normalized = normalizeSchema(schema);
 
@@ -56,7 +73,7 @@ export function SettingsForm({ schema, values, onChange }) {
 				);
 
 				if (!panel.title) {
-					return <Fragment key={panel.id}>{fields}</Fragment>;
+					return <UntitledPanelBody key={panel.id}>{fields}</UntitledPanelBody>;
 				}
 
 				return (

--- a/src/style-library/components/organisms/SettingsForm.scss
+++ b/src/style-library/components/organisms/SettingsForm.scss
@@ -4,6 +4,10 @@
 	@include flex-column(var(--kb-sl-space-15));
 }
 
+.kadence-blocks-style-library__settings-form-untitled-panel {
+	padding: var(--kb-sl-space-20) var(--kb-sl-space-15);
+}
+
 // Only the outer `Panel` border is suppressed (no frame shows one). `PanelBody`'s own
 // border-top/border-bottom and its `margin-top: -1px` adjacent-section collapse are left exactly as
 // core ships them — removing either doubles the divider between sections.

--- a/src/style-library/components/templates/AppShell.js
+++ b/src/style-library/components/templates/AppShell.js
@@ -4,6 +4,12 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
  * External dependencies
  */
 import classnames from 'classnames';
@@ -21,12 +27,15 @@ import './AppShell.scss';
  * @param {?JSX.Element} props.sidebar        The left navigation content, or null when empty.
  * @param {?JSX.Element} props.content        The active screen, or null when empty.
  * @param {?JSX.Element} props.settingsPanel  The settings panel, or null when closed.
+ * @param {boolean}      [props.isBlocked]    Whether to cover the frame with a busy scrim, for a
+ *                                            change that replaces the app's whole content rather
+ *                                            than one region of it.
  *
  * @since TBD
  *
  * @return {JSX.Element} The shell.
  */
-export function AppShell({ header, sidebar, content, settingsPanel }) {
+export function AppShell({ header, sidebar, content, settingsPanel, isBlocked }) {
 	return (
 		<div className="kadence-blocks-style-library__shell">
 			<header className="kadence-blocks-style-library__header">{header}</header>
@@ -41,6 +50,19 @@ export function AppShell({ header, sidebar, content, settingsPanel }) {
 				</main>
 				{settingsPanel && <aside className="kadence-blocks-style-library__settings">{settingsPanel}</aside>}
 			</div>
+			{isBlocked && (
+				/* Covers the header too, not just the content column: while the app is being
+				 * repopulated, the header's own controls describe the library that is on its way out,
+				 * so leaving them live would let a second change start against stale state. */
+				<div
+					className="kadence-blocks-style-library__blocker"
+					role="status"
+					aria-live="polite"
+					aria-label={__('Loading library…', 'kadence-blocks')}
+				>
+					<Spinner />
+				</div>
+			)}
 		</div>
 	);
 }

--- a/src/style-library/components/templates/AppShell.scss
+++ b/src/style-library/components/templates/AppShell.scss
@@ -18,6 +18,7 @@
 	flex: 1 1 auto;
 	min-width: 0;
 	overflow-y: auto;
+	padding: var(--kb-sl-space-20) var(--kb-sl-space-30);
 	background: var(--kb-sl-color-surface);
 
 	&--has-settings {

--- a/src/style-library/helpers/libraries.js
+++ b/src/style-library/helpers/libraries.js
@@ -92,6 +92,63 @@ export function libraryDisplayTitle(library) {
 }
 
 /**
+ * Whether a typed name collides with another library's *displayed* name, for the rename flow.
+ *
+ * Deliberately not `isDuplicateLibraryTitle`, which compares derived slugs. A slug is minted from
+ * the title once, at creation, and never changes afterwards — so the moment a library is renamed
+ * the two diverge permanently: one created as "Brand A" (slug `brand-a`) and renamed to
+ * "Winter 2026" keeps `brand-a` forever. Checking a rename against slugs would then reject
+ * "Brand A" as taken while nothing on screen is named that, leaving the user no way to understand
+ * the refusal. Creation still checks slugs — that is where the slug is minted and a slug
+ * collision is a real conflict — so the two questions stay two helpers.
+ *
+ * `excludeSlug` is the library being renamed, which must be allowed to keep its own name (the
+ * user may edit the field and revert it).
+ *
+ * @param {string}                                title       The typed library name.
+ * @param {Array<{slug: string, title: string}>} libraries    The existing library rows.
+ * @param {string}                                excludeSlug The slug of the library being renamed.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when another library already displays that name.
+ */
+export function isDuplicateLibraryName(title, libraries, excludeSlug) {
+	const candidate = String(title ?? '')
+		.trim()
+		.toLowerCase();
+
+	if (candidate === '') {
+		return false;
+	}
+
+	const rows = Array.isArray(libraries) ? libraries : [];
+
+	return rows.some(
+		(library) => library.slug !== excludeSlug && libraryDisplayTitle(library).trim().toLowerCase() === candidate
+	);
+}
+
+/**
+ * The libraries offered as a successor when the one being deleted is the active library — every
+ * library except the delete target, in dropdown order.
+ *
+ * Never empty in practice: the default library cannot be deleted (a DELETE against it resets its
+ * values to baseline instead of removing it), so it is always present and always a valid choice,
+ * even when the target is the only other library.
+ *
+ * @param {Array<{slug: string, title: string}>} libraries  The existing library rows.
+ * @param {string}                                targetSlug The library about to be deleted.
+ *
+ * @since TBD
+ *
+ * @return {Array<{slug: string, title: string}>} The candidate successors, ordered.
+ */
+export function successorOptions(libraries, targetSlug) {
+	return sortLibraries(libraries).filter((library) => library.slug !== targetSlug);
+}
+
+/**
  * Order the libraries for the dropdown: the default library first, the rest by title. A library
  * with no stored title (its `title` is the empty string, per the REST contract) sorts by its
  * slug instead.

--- a/src/style-library/helpers/libraries.js
+++ b/src/style-library/helpers/libraries.js
@@ -81,6 +81,63 @@ export function libraryDisplayTitle(library) {
 }
 
 /**
+ * Whether a typed name collides with another library's *displayed* name, for the rename flow.
+ *
+ * Deliberately not `isDuplicateLibraryTitle`, which compares derived slugs. A slug is minted from
+ * the title once, at creation, and never changes afterwards — so the moment a library is renamed
+ * the two diverge permanently: one created as "Brand A" (slug `brand-a`) and renamed to
+ * "Winter 2026" keeps `brand-a` forever. Checking a rename against slugs would then reject
+ * "Brand A" as taken while nothing on screen is named that, leaving the user no way to understand
+ * the refusal. Creation still checks slugs — that is where the slug is minted and a slug
+ * collision is a real conflict — so the two questions stay two helpers.
+ *
+ * `excludeSlug` is the library being renamed, which must be allowed to keep its own name (the
+ * user may edit the field and revert it).
+ *
+ * @param {string}                                title       The typed library name.
+ * @param {Array<{slug: string, title: string}>} libraries    The existing library rows.
+ * @param {string}                                excludeSlug The slug of the library being renamed.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when another library already displays that name.
+ */
+export function isDuplicateLibraryName(title, libraries, excludeSlug) {
+	const candidate = String(title ?? '')
+		.trim()
+		.toLowerCase();
+
+	if (candidate === '') {
+		return false;
+	}
+
+	const rows = Array.isArray(libraries) ? libraries : [];
+
+	return rows.some(
+		(library) => library.slug !== excludeSlug && libraryDisplayTitle(library).trim().toLowerCase() === candidate
+	);
+}
+
+/**
+ * The libraries offered as a successor when the one being deleted is the active library — every
+ * library except the delete target, in dropdown order.
+ *
+ * Never empty in practice: the default library cannot be deleted (a DELETE against it resets its
+ * values to baseline instead of removing it), so it is always present and always a valid choice,
+ * even when the target is the only other library.
+ *
+ * @param {Array<{slug: string, title: string}>} libraries  The existing library rows.
+ * @param {string}                                targetSlug The library about to be deleted.
+ *
+ * @since TBD
+ *
+ * @return {Array<{slug: string, title: string}>} The candidate successors, ordered.
+ */
+export function successorOptions(libraries, targetSlug) {
+	return sortLibraries(libraries).filter((library) => library.slug !== targetSlug);
+}
+
+/**
  * Order the libraries for the dropdown: the default library first, the rest by title. A library
  * with no stored title (its `title` is the empty string, per the REST contract) sorts by its
  * slug instead.

--- a/src/style-library/helpers/library-flows.js
+++ b/src/style-library/helpers/library-flows.js
@@ -1,12 +1,18 @@
 /**
- * Pure orchestration for the library-management flows the Style Library header runs: switch,
- * create-then-switch, and delete-or-reset. Extracted out of `hooks/use-libraries` so each flow can
- * be exercised directly in tests without rendering a component — a flow takes the REST calls it
- * needs (imported here, so a test mocks `api/client`) plus a small set of injected callbacks for
- * the state a caller reacts to (busy, error, and — for create/delete — a refresh of the libraries
- * list or the feed). None of the three flows reloads the page; each settles by resolving once its
- * side effects (the switch, the refreshed feed, the refreshed list) are done, or rejecting so its
- * caller (a modal) can tell success from failure.
+ * Pure orchestration for the library-management flows the Style Library header runs: open,
+ * activate, create-then-open, rename, and delete-or-reset. Extracted out of `hooks/use-libraries`
+ * so each flow can be exercised directly in tests without rendering a component — a flow takes the
+ * REST calls it needs (imported here, so a test mocks `api/client`) plus a small set of injected
+ * callbacks for the state a caller reacts to (busy, error, and a refresh of the libraries list,
+ * the feed, or the active-library pointer). None of the flows reloads the page; each settles by
+ * resolving once its side effects are done, or rejecting so its caller (a modal) can tell success
+ * from failure.
+ *
+ * The central distinction here is between the library a site *renders with* and the library the
+ * app is *editing*. Opening is free and reversible: it only re-reads the feed, so a user can
+ * browse and edit any library without touching what visitors see. Activating is the deliberate,
+ * guarded act that changes what the site uses, and it lives in exactly one flow so it stays easy
+ * to audit.
  */
 
 /**
@@ -17,8 +23,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { createLibrary, deleteLibrary, getActiveLibrary, setActiveLibrary } from '../api/client';
-import { slugifyLibraryTitle } from './libraries';
+import { createLibrary, deleteLibrary, renameLibrary, setActiveLibrary } from '../api/client';
+import { isDefaultLibrary, isDuplicateLibraryName, slugifyLibraryTitle } from './libraries';
 
 /**
  * Read the message off a REST error, falling back to a generic string when the error carries
@@ -35,55 +41,104 @@ export function errorMessage(error) {
 }
 
 /**
- * Point the active-library pointer at a slug, then refresh the feed for it.
+ * Show a library in the app: refresh the feed for it, and nothing else.
+ *
+ * This never writes the active-library pointer. Choosing a library from the header dropdown is a
+ * navigation act, not a publishing one — the site keeps rendering whatever library is active
+ * until someone explicitly activates a different one through `activateLibraryFlow`.
  *
  * @param {Object}   args
- * @param {string}   args.slug        The token library slug to make active.
+ * @param {string}   args.slug        The token library slug to open for editing.
  * @param {Function} args.refreshFeed Replaces the feed with a fresh REST read for a slug.
  * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
  * @param {Function} args.onError     Called with `{ message }` on failure.
  *
  * @since TBD
  *
- * @return {Promise<void>} Resolves once the switch and the feed refresh both complete; rejects on
- *                          failure, after `onError`/`onBusy` have already run.
+ * @return {Promise<void>} Resolves once the feed refresh completes; rejects on failure, after
+ *                          `onError`/`onBusy` have already run.
  */
-export function switchLibraryFlow({ slug, refreshFeed, onBusy, onError }) {
+export function openLibraryFlow({ slug, refreshFeed, onBusy, onError }) {
 	onBusy(true);
 
-	return setActiveLibrary(slug)
-		.then(() => refreshFeed(slug))
+	return refreshFeed(slug)
 		.then(() => onBusy(false))
 		.catch((err) => {
 			onError({ message: errorMessage(err) });
 			onBusy(false);
 
-			// Re-thrown so a caller chaining off a switch (the create flow, below) can tell a failed
-			// switch from a successful one instead of treating this as done. A caller that only fires
-			// a plain switch (no chained action) must catch this itself — the error is already
+			// Re-thrown so a caller chaining off an open (the create flow, below) can tell a failed
+			// open from a successful one instead of treating this as done. A caller that only fires
+			// a plain open (no chained action) must catch this itself — the error is already
 			// surfaced through `onError` regardless.
 			throw err;
 		});
 }
 
 /**
- * Create a library from a typed title, then switch to it and refresh the libraries list.
+ * Point the site's active-library pointer at a slug.
+ *
+ * The one place in the app that writes that pointer, so the blast radius of "the whole site
+ * restyles" stays auditable: if this function has one caller, the guarded modal is the only way
+ * a site can change its active library.
+ *
+ * Deliberately does not refresh the feed. Activating a library changes which library the front
+ * end reads, not any value inside it — the app is already showing this library's tokens, and
+ * re-reading them would cost a request and re-render every screen to produce identical output.
+ *
+ * @param {Object}   args
+ * @param {string}   args.slug        The token library slug to make active.
+ * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure.
+ * @param {Function} args.onActivated Called with the slug the server resolved as active.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once the pointer has moved; rejects on failure, after
+ *                          `onError`/`onBusy` have already run.
+ */
+export function activateLibraryFlow({ slug, onBusy, onError, onActivated }) {
+	onBusy(true);
+
+	return (
+		setActiveLibrary(slug)
+			// The resolved slug comes from the response rather than the request: the server owns
+			// which library ended up active, and reading it back is what keeps the app honest if it
+			// ever resolves something other than what was asked for.
+			.then((result) => onActivated(result?.slug ?? slug))
+			.then(() => onBusy(false))
+			.catch((err) => {
+				onError({ message: errorMessage(err) });
+				onBusy(false);
+
+				// Re-thrown so the confirmation modal can tell success from failure and knows whether
+				// to close itself.
+				throw err;
+			})
+	);
+}
+
+/**
+ * Create a library from a typed title, then open it for editing and refresh the libraries list.
+ *
+ * Creating a library does not activate it. A new library starts empty and is built up over time;
+ * publishing it to the site is a separate, explicit decision the user makes once it is ready.
  *
  * @param {Object}        args
  * @param {string}        args.title         The typed library title.
  * @param {Array<Object>} args.libraries     The existing library rows, for the duplicate-title check.
- * @param {Function}      args.switchLibrary Switches the active library (typically `switchLibraryFlow` bound to a slug).
+ * @param {Function}      args.openLibrary   Opens a library for editing (typically `openLibraryFlow` bound to a slug).
  * @param {Function}      args.loadLibraries Refreshes the libraries list.
  * @param {Function}      args.onBusy        Called with a boolean as the request starts and settles.
  * @param {Function}      args.onError       Called with `{ message }` on failure or invalid input.
  *
  * @since TBD
  *
- * @return {Promise<void>} Resolves once the library is created, switched to, and the list is
+ * @return {Promise<void>} Resolves once the library is created, opened, and the list is
  *                          refreshed; rejects on an invalid title, a duplicate title, or a
  *                          request failure, after `onError` has already run.
  */
-export function createLibraryFlow({ title, libraries, switchLibrary, loadLibraries, onBusy, onError }) {
+export function createLibraryFlow({ title, libraries, openLibrary, loadLibraries, onBusy, onError }) {
 	const slug = slugifyLibraryTitle(title);
 
 	// Both validation failures reject rather than resolve: a caller that closes on a resolved
@@ -104,7 +159,7 @@ export function createLibraryFlow({ title, libraries, switchLibrary, loadLibrari
 	onBusy(true);
 
 	return createLibrary(slug, title)
-		.then(() => switchLibrary(slug))
+		.then(() => openLibrary(slug))
 		.then(() => loadLibraries())
 		.catch((err) => {
 			onError({ message: errorMessage(err) });
@@ -117,50 +172,144 @@ export function createLibraryFlow({ title, libraries, switchLibrary, loadLibrari
 }
 
 /**
- * Delete (or, for the default library, reset) a library. When the deleted library was active,
- * re-reads the resolved active-library pointer and refreshes the feed for whatever library ends
- * up active, rather than assuming which slug that is.
+ * Rename a library, then refresh the libraries list so the dropdown label and ordering follow.
  *
- * @param {Object}   args
- * @param {string}   args.slug          The token library slug to delete or reset.
- * @param {string}   args.activeSlug    The currently active library slug.
- * @param {Function} args.refreshFeed   Replaces the feed with a fresh REST read for a slug.
- * @param {Function} args.loadLibraries Refreshes the libraries list.
- * @param {Function} args.onBusy        Called with a boolean as the request starts and settles.
- * @param {Function} args.onError       Called with `{ message }` on failure.
+ * Only the title changes; the slug is the library's permanent identity. The feed is deliberately
+ * not refreshed — a library's name is not part of the feed payload, and every screen renders
+ * token values rather than the library's name.
+ *
+ * @param {Object}        args
+ * @param {string}        args.slug          The library to rename.
+ * @param {string}        args.title         The new title.
+ * @param {Array<Object>} args.libraries     The existing library rows, for the duplicate-name check.
+ * @param {Function}      args.loadLibraries Refreshes the libraries list.
+ * @param {Function}      args.onBusy        Called with a boolean as the request starts and settles.
+ * @param {Function}      args.onError       Called with `{ message }` on failure or invalid input.
  *
  * @since TBD
  *
- * @return {Promise<void>} Resolves once the delete (and, when the target was active, the feed
- *                          refresh) completes; rejects on failure, after `onError` has already run.
+ * @return {Promise<void>} Resolves once the rename and the list refresh complete; rejects on an
+ *                          empty or duplicate name, or a request failure, after `onError` has run.
  */
-export function deleteLibraryFlow({ slug, activeSlug, refreshFeed, loadLibraries, onBusy, onError }) {
+export function renameLibraryFlow({ slug, title, libraries, loadLibraries, onBusy, onError }) {
+	const trimmed = String(title ?? '').trim();
+
+	// The server reads an empty title as "leave the stored one untouched", so a blank name would
+	// silently do nothing rather than clearing the name. Rejecting here makes that honest, and
+	// reuses the create flow's wording for the same condition.
+	if (trimmed === '') {
+		const message = __('Enter a library title.', 'kadence-blocks');
+		onError({ message });
+		return Promise.reject(new Error(message));
+	}
+
+	if (isDuplicateLibraryName(trimmed, libraries, slug)) {
+		const message = __('A library with that title already exists.', 'kadence-blocks');
+		onError({ message });
+		return Promise.reject(new Error(message));
+	}
+
 	onBusy(true);
 
-	return deleteLibrary(slug)
-		.then(() => {
-			if (slug !== activeSlug) {
-				onBusy(false);
-				return loadLibraries();
-			}
-
-			// Deleting the active library always leaves some library active (deleting the default
-			// resets it in place; deleting any other library falls the pointer back to the default) —
-			// re-read the resolved pointer rather than assuming which slug that is, then refresh the
-			// feed for it.
-			return getActiveLibrary()
-				.then(({ slug: nextActiveSlug }) => refreshFeed(nextActiveSlug))
-				.then(() => loadLibraries())
-				.then(() => onBusy(false));
-		})
+	return renameLibrary(slug, trimmed)
+		.then(() => loadLibraries())
+		.then(() => onBusy(false))
 		.catch((err) => {
 			onError({ message: errorMessage(err) });
 			onBusy(false);
 
-			// Re-thrown, unlike the create flow but for the same reason, because the caller (the
-			// delete/reset modal) needs to tell success from failure to know whether to close itself.
-			// Success and failure look the same (a resolved promise) without this; the modal would
-			// close on an error too, hiding the very Notice it left behind to explain what went wrong.
+			// Re-thrown so the rename modal stays open on its inline error instead of closing as if
+			// the rename had worked.
+			throw err;
+		});
+}
+
+/**
+ * Delete (or, for the default library, reset) a library.
+ *
+ * Deleting the library the site is currently using requires naming its successor: that library is
+ * activated *first*, then the target is deleted. The reverse order would let the server fall the
+ * pointer back to the default in between, briefly serving a site-wide look nobody chose. Doing it
+ * this way, the site moves straight from the old library to the chosen one and the delete that
+ * follows changes nothing a visitor can see.
+ *
+ * The default library is exempt: deleting it resets its values in place rather than removing it,
+ * so it remains and stays active, and there is no successor to name.
+ *
+ * @param {Object}   args
+ * @param {string}   args.slug            The token library slug to delete or reset.
+ * @param {string}   args.activeSlug      The slug the site currently renders with.
+ * @param {string}   [args.successorSlug] The library to activate first, required when deleting the
+ *                                        active non-default library.
+ * @param {Function} args.refreshFeed     Replaces the feed with a fresh REST read for a slug.
+ * @param {Function} args.loadLibraries   Refreshes the libraries list.
+ * @param {Function} args.onBusy          Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError         Called with `{ message }` on failure.
+ * @param {Function} args.onActiveChanged Called with the slug that ends up active, when it moves.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once the delete (and any activation and feed refresh it
+ *                          entails) completes; rejects on failure, after `onError` has run.
+ */
+export function deleteLibraryFlow({
+	slug,
+	activeSlug,
+	successorSlug,
+	refreshFeed,
+	loadLibraries,
+	onBusy,
+	onError,
+	onActiveChanged,
+}) {
+	const needsSuccessor = slug === activeSlug && !isDefaultLibrary(slug);
+
+	// The modal's disabled confirm button is the real gate, but this flow is the unit under test
+	// and a future caller could get it wrong — refusing here means no request is ever issued
+	// without somewhere for the site to land.
+	if (needsSuccessor && !successorSlug) {
+		const message = __('Choose which library your site should use instead.', 'kadence-blocks');
+		onError({ message });
+		return Promise.reject(new Error(message));
+	}
+
+	onBusy(true);
+
+	// Activate the successor before deleting, never after — see the docblock.
+	const activation = needsSuccessor
+		? setActiveLibrary(successorSlug).then((result) => onActiveChanged(result?.slug ?? successorSlug))
+		: Promise.resolve();
+
+	// Where the app lands afterwards. `slug` is always the library being edited (the modal offers
+	// no other target), so the feed it is showing is invalid the moment that row is gone and has
+	// to move somewhere that certainly exists.
+	let nextSlug = activeSlug; // Deleted a library the site was not using: fall back to the one it is.
+
+	if (needsSuccessor) {
+		nextSlug = successorSlug; // Deleted the live library: the successor just activated.
+	} else if (slug === activeSlug) {
+		nextSlug = slug; // Reset the default library: it stays put, now holding baseline values.
+	}
+
+	return activation
+		.then(() => deleteLibrary(slug))
+		.then(() => refreshFeed(nextSlug))
+		.then(() => loadLibraries())
+		.then(() => onBusy(false))
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+
+			// Re-thrown, like the create and rename flows and for the same reason: the modal needs to
+			// tell success from failure to know whether to close itself. Success and failure look the
+			// same (a resolved promise) without this; the modal would close on an error too, hiding
+			// the very Notice it left behind to explain what went wrong.
+			//
+			// Note a successor may already have been activated when the delete itself fails. That
+			// leaves the site on a library the user explicitly chose, with the target intact — a
+			// partial outcome, but every part of it was asked for, and retrying the delete finishes
+			// the job. Reordering to "delete first" to avoid it would trade this for a window where
+			// the site serves default styles nobody picked.
 			throw err;
 		});
 }

--- a/src/style-library/hooks/use-design-tokens-feed.js
+++ b/src/style-library/hooks/use-design-tokens-feed.js
@@ -24,7 +24,7 @@ import { DEFAULT_LIBRARY_SLUG } from '../constants';
  *
  * @since TBD
  *
- * @return {{ feed: object|null, tokens: object[], isReady: boolean, isActive: boolean, isResolved: boolean, values: Record<string, string>, responsive: Record<string, object>, rest: object|null, version: string, slug: string, refreshFeed: Function }}
+ * @return {{ feed: object|null, tokens: object[], isReady: boolean, isActive: boolean, isResolved: boolean, values: Record<string, string>, responsive: Record<string, object>, rest: object|null, version: string, slug: string, title: string, refreshFeed: Function }}
  */
 export function useDesignTokensFeed() {
 	const [feed, setFeed] = useState(() => getDesignTokensFeed());
@@ -59,6 +59,7 @@ export function useDesignTokensFeed() {
 		rest: feed?.rest ?? null,
 		version: feed?.version ?? '',
 		slug: feed?.slug ?? DEFAULT_LIBRARY_SLUG,
+		title: feed?.title ?? '',
 		refreshFeed,
 	};
 }

--- a/src/style-library/hooks/use-libraries.js
+++ b/src/style-library/hooks/use-libraries.js
@@ -8,52 +8,71 @@ import { useCallback, useEffect, useState } from '@wordpress/element';
  */
 import { fetchLibraries } from '../api/client';
 import { sortLibraries } from '../helpers/libraries';
-import { createLibraryFlow, deleteLibraryFlow, errorMessage, switchLibraryFlow } from '../helpers/library-flows';
+import {
+	activateLibraryFlow,
+	createLibraryFlow,
+	deleteLibraryFlow,
+	errorMessage,
+	openLibraryFlow,
+	renameLibraryFlow,
+} from '../helpers/library-flows';
 
 /**
- * The library management surface for the Style Library header: the list, the active slug, and
- * the switch/create/delete operations against the design-tokens REST API.
+ * The library management surface for the Style Library header: the list, the two slugs, and the
+ * open/activate/create/rename/delete operations against the design-tokens REST API.
  *
- * This hook is a thin binding of React state onto the pure flows in `helpers/library-flows` —
- * `switchLibraryFlow`, `createLibraryFlow`, `deleteLibraryFlow` — which do the actual request
- * orchestration and are what a test exercises directly. Activation and deletion wait for the
- * server before acting, because both are followed by an in-place feed refresh — an optimistic
- * flip that then errored would leave the UI lying about which library the feed describes.
- * Creation is also pessimistic: the modal stays busy until the create request resolves. None of
- * the three flows reloads the page; each settles by either refreshing the feed for the now-active
- * library or, on failure, clearing `isBusy` so the caller (the create/delete modal) can close or
- * stay open on its own.
+ * Two slugs, not one. `activeSlug` is the library the *site* renders with — every projector and
+ * the front end follow it. `editingSlug` is the library the *app* is showing. They start equal
+ * (the page-load feed is assembled for the active library) and diverge as soon as the user opens
+ * a different library to work on. Keeping them apart is what makes browsing and editing a library
+ * safe: nothing a visitor sees changes until someone explicitly activates one.
  *
- * Each of the three flows gets its own error slot (`switchError`, `createError`, `deleteError`)
- * rather than sharing one — a failed switch must never render inside the delete/reset modal, and
- * a failed delete must never resurface under the library dropdown. Each slot is cleared the
- * instant its own flow starts again, so a stale error from a previous attempt never lingers past
- * a fresh try at the same action.
+ * `editingSlug` stays derived from the feed, because the feed is the thing that actually moved —
+ * a second copy of it here could drift. `activeSlug` is real state, seeded from the initial feed
+ * slug and updated from the server's own response whenever the pointer moves.
  *
- * @param {Object}   feed        The design-tokens admin feed (provides the initial active slug).
+ * This hook is a thin binding of React state onto the pure flows in `helpers/library-flows`,
+ * which do the request orchestration and are what a test exercises directly. Every flow waits for
+ * the server rather than flipping optimistically — an optimistic change that then errored would
+ * leave the UI lying about which library it is showing, or worse, which one the site is using.
+ * None of the flows reloads the page.
+ *
+ * Each flow gets its own error slot rather than sharing one — a failed open must never render
+ * inside the delete modal, and a failed rename must never resurface under the library dropdown.
+ * Each slot is cleared the instant its own flow starts again, so a stale error from a previous
+ * attempt never lingers past a fresh try at the same action.
+ *
+ * @param {Object}   feed        The design-tokens admin feed (provides the library being edited).
  * @param {Function} refreshFeed Replaces the feed with a fresh REST read for a slug (from
- *                               `use-design-tokens-feed`), so switching or deleting the active
- *                               library re-renders every consumer without a page reload.
+ *                               `use-design-tokens-feed`), so opening a library re-renders every
+ *                               consumer without a page reload.
  *
  * @since TBD
  *
- * @return {Object} `{ libraries, activeSlug, isLoading, isBusy, switchError, createError,
- *                  deleteError, clearSwitchError, clearCreateError, clearDeleteError,
- *                  switchLibrary, createLibrary, deleteLibrary }`.
+ * @return {Object} The library list, the two slugs, the busy flag, the per-flow error slots and
+ *                  the functions that clear them, and the five operations.
  */
 export function useLibraries(feed, refreshFeed) {
 	const [libraries, setLibraries] = useState([]);
 	const [isLoading, setIsLoading] = useState(true);
 	const [isBusy, setIsBusy] = useState(false);
-	const [switchError, setSwitchError] = useState(null);
+	const [openError, setOpenError] = useState(null);
+	const [activateError, setActivateError] = useState(null);
 	const [createError, setCreateError] = useState(null);
+	const [renameError, setRenameError] = useState(null);
 	const [deleteError, setDeleteError] = useState(null);
-	const activeSlug = feed?.slug;
+	const editingSlug = feed?.slug;
+
+	// Seeded from the feed rather than fetched. The page-load feed is always assembled for the
+	// active library (see Admin\Feed\Localizer), so on first paint the two are the same and a
+	// separate request would only re-learn what the page already told us. Every later move of the
+	// pointer goes through a flow that reports the server's resolved slug back here.
+	const [activeSlug, setActiveSlug] = useState(editingSlug);
 
 	const loadLibraries = useCallback(() => {
 		return fetchLibraries()
 			.then((rows) => setLibraries(sortLibraries(rows)))
-			.catch((err) => setSwitchError({ message: errorMessage(err) }));
+			.catch((err) => setOpenError({ message: errorMessage(err) }));
 	}, []);
 
 	useEffect(() => {
@@ -61,25 +80,37 @@ export function useLibraries(feed, refreshFeed) {
 		loadLibraries().finally(() => setIsLoading(false));
 	}, [loadLibraries]);
 
-	const clearSwitchError = useCallback(() => setSwitchError(null), []);
+	const clearOpenError = useCallback(() => setOpenError(null), []);
+	const clearActivateError = useCallback(() => setActivateError(null), []);
 	const clearCreateError = useCallback(() => setCreateError(null), []);
+	const clearRenameError = useCallback(() => setRenameError(null), []);
 	const clearDeleteError = useCallback(() => setDeleteError(null), []);
 
-	// Shared by `switchLibrary` (below) and by `addLibrary`'s post-create switch — each call site
-	// passes its own `onError` so a switch that fails as part of create reports through
-	// `createError`, never through `switchError`.
-	const runSwitch = useCallback(
-		({ slug, onError }) => switchLibraryFlow({ slug, refreshFeed, onBusy: setIsBusy, onError }),
+	// Shared by `openLibrary` (below) and by `addLibrary`'s post-create open — each call site
+	// passes its own `onError` so an open that fails as part of create reports through
+	// `createError`, never through `openError`.
+	const runOpen = useCallback(
+		({ slug, onError }) => openLibraryFlow({ slug, refreshFeed, onBusy: setIsBusy, onError }),
 		[refreshFeed]
 	);
 
-	const switchLibrary = useCallback(
+	const openLibrary = useCallback(
 		(slug) => {
-			setSwitchError(null);
-			return runSwitch({ slug, onError: setSwitchError });
+			setOpenError(null);
+			return runOpen({ slug, onError: setOpenError });
 		},
-		[runSwitch]
+		[runOpen]
 	);
+
+	const activateLibrary = useCallback((slug) => {
+		setActivateError(null);
+		return activateLibraryFlow({
+			slug,
+			onBusy: setIsBusy,
+			onError: setActivateError,
+			onActivated: setActiveSlug,
+		});
+	}, []);
 
 	const addLibrary = useCallback(
 		(title) => {
@@ -87,25 +118,42 @@ export function useLibraries(feed, refreshFeed) {
 			return createLibraryFlow({
 				title,
 				libraries,
-				switchLibrary: (slug) => runSwitch({ slug, onError: setCreateError }),
+				openLibrary: (slug) => runOpen({ slug, onError: setCreateError }),
 				loadLibraries,
 				onBusy: setIsBusy,
 				onError: setCreateError,
 			});
 		},
-		[libraries, runSwitch, loadLibraries]
+		[libraries, runOpen, loadLibraries]
+	);
+
+	const renameCurrentLibrary = useCallback(
+		(slug, title) => {
+			setRenameError(null);
+			return renameLibraryFlow({
+				slug,
+				title,
+				libraries,
+				loadLibraries,
+				onBusy: setIsBusy,
+				onError: setRenameError,
+			});
+		},
+		[libraries, loadLibraries]
 	);
 
 	const removeLibrary = useCallback(
-		(slug) => {
+		(slug, successorSlug) => {
 			setDeleteError(null);
 			return deleteLibraryFlow({
 				slug,
 				activeSlug,
+				successorSlug,
 				refreshFeed,
 				loadLibraries,
 				onBusy: setIsBusy,
 				onError: setDeleteError,
+				onActiveChanged: setActiveSlug,
 			});
 		},
 		[activeSlug, loadLibraries, refreshFeed]
@@ -114,16 +162,24 @@ export function useLibraries(feed, refreshFeed) {
 	return {
 		libraries,
 		activeSlug,
+		editingSlug,
+		isEditingActive: activeSlug === editingSlug,
 		isLoading,
 		isBusy,
-		switchError,
+		openError,
+		activateError,
 		createError,
+		renameError,
 		deleteError,
-		clearSwitchError,
+		clearOpenError,
+		clearActivateError,
 		clearCreateError,
+		clearRenameError,
 		clearDeleteError,
-		switchLibrary,
+		openLibrary,
+		activateLibrary,
 		createLibrary: addLibrary,
+		renameLibrary: renameCurrentLibrary,
 		deleteLibrary: removeLibrary,
 	};
 }

--- a/src/style-library/hooks/use-libraries.js
+++ b/src/style-library/hooks/use-libraries.js
@@ -62,6 +62,8 @@ export function useLibraries(feed, refreshFeed) {
 	const [createError, setCreateError] = useState(null);
 	const [renameError, setRenameError] = useState(null);
 	const [deleteError, setDeleteError] = useState(null);
+	const [isSwappingLibrary, setIsSwappingLibrary] = useState(false);
+
 	// The feed always carries a slug, but the default library is the one every read falls back to, so
 	// naming it here keeps a malformed feed from addressing REST paths with `undefined`.
 	const editingSlug = feed?.slug || DEFAULT_LIBRARY_SLUG;
@@ -89,20 +91,30 @@ export function useLibraries(feed, refreshFeed) {
 	const clearRenameError = useCallback(() => setRenameError(null), []);
 	const clearDeleteError = useCallback(() => setDeleteError(null), []);
 
+	// Marks the operations that replace the feed, and therefore the content of every screen at
+	// once, so the app can block itself rather than show a spinner next to one control. Distinct
+	// from `isBusy`, which is also true for a rename or an activation — neither of those changes
+	// anything on screen, and blanking the app for them would be theatre.
+	const setSwapBusy = useCallback((busy) => {
+		setIsBusy(busy);
+		setIsSwappingLibrary(busy);
+	}, []);
+
 	// Shared by `openLibrary` (below) and by `addLibrary`'s post-create open — each call site
 	// passes its own `onError` so an open that fails as part of create reports through
-	// `createError`, never through `openError`.
+	// `createError`, never through `openError`, and its own `onBusy` so only the user-initiated
+	// open blocks the app. Creation runs behind its own modal, which reports progress itself.
 	const runOpen = useCallback(
-		({ slug, onError }) => openLibraryFlow({ slug, refreshFeed, onBusy: setIsBusy, onError }),
+		({ slug, onError, onBusy }) => openLibraryFlow({ slug, refreshFeed, onBusy, onError }),
 		[refreshFeed]
 	);
 
 	const openLibrary = useCallback(
 		(slug) => {
 			setOpenError(null);
-			return runOpen({ slug, onError: setOpenError });
+			return runOpen({ slug, onError: setOpenError, onBusy: setSwapBusy });
 		},
-		[runOpen]
+		[runOpen, setSwapBusy]
 	);
 
 	const activateLibrary = useCallback((slug) => {
@@ -121,7 +133,7 @@ export function useLibraries(feed, refreshFeed) {
 			return createLibraryFlow({
 				title,
 				libraries,
-				openLibrary: (slug) => runOpen({ slug, onError: setCreateError }),
+				openLibrary: (slug) => runOpen({ slug, onError: setCreateError, onBusy: setIsBusy }),
 				loadLibraries,
 				onBusy: setIsBusy,
 				onError: setCreateError,
@@ -154,12 +166,12 @@ export function useLibraries(feed, refreshFeed) {
 				successorSlug,
 				refreshFeed,
 				loadLibraries,
-				onBusy: setIsBusy,
+				onBusy: setSwapBusy,
 				onError: setDeleteError,
 				onActiveChanged: setActiveSlug,
 			});
 		},
-		[activeSlug, loadLibraries, refreshFeed]
+		[activeSlug, loadLibraries, refreshFeed, setSwapBusy]
 	);
 
 	return {
@@ -169,6 +181,7 @@ export function useLibraries(feed, refreshFeed) {
 		isEditingActive: activeSlug === editingSlug,
 		isLoading,
 		isBusy,
+		isSwappingLibrary,
 		openError,
 		activateError,
 		createError,

--- a/src/style-library/hooks/use-libraries.js
+++ b/src/style-library/hooks/use-libraries.js
@@ -61,6 +61,7 @@ export function useLibraries(feed, refreshFeed) {
 	const [createError, setCreateError] = useState(null);
 	const [renameError, setRenameError] = useState(null);
 	const [deleteError, setDeleteError] = useState(null);
+	const [isSwappingLibrary, setIsSwappingLibrary] = useState(false);
 	const editingSlug = feed?.slug;
 
 	// Seeded from the feed rather than fetched. The page-load feed is always assembled for the
@@ -86,20 +87,30 @@ export function useLibraries(feed, refreshFeed) {
 	const clearRenameError = useCallback(() => setRenameError(null), []);
 	const clearDeleteError = useCallback(() => setDeleteError(null), []);
 
+	// Marks the operations that replace the feed, and therefore the content of every screen at
+	// once, so the app can block itself rather than show a spinner next to one control. Distinct
+	// from `isBusy`, which is also true for a rename or an activation — neither of those changes
+	// anything on screen, and blanking the app for them would be theatre.
+	const setSwapBusy = useCallback((busy) => {
+		setIsBusy(busy);
+		setIsSwappingLibrary(busy);
+	}, []);
+
 	// Shared by `openLibrary` (below) and by `addLibrary`'s post-create open — each call site
 	// passes its own `onError` so an open that fails as part of create reports through
-	// `createError`, never through `openError`.
+	// `createError`, never through `openError`, and its own `onBusy` so only the user-initiated
+	// open blocks the app. Creation runs behind its own modal, which reports progress itself.
 	const runOpen = useCallback(
-		({ slug, onError }) => openLibraryFlow({ slug, refreshFeed, onBusy: setIsBusy, onError }),
+		({ slug, onError, onBusy }) => openLibraryFlow({ slug, refreshFeed, onBusy, onError }),
 		[refreshFeed]
 	);
 
 	const openLibrary = useCallback(
 		(slug) => {
 			setOpenError(null);
-			return runOpen({ slug, onError: setOpenError });
+			return runOpen({ slug, onError: setOpenError, onBusy: setSwapBusy });
 		},
-		[runOpen]
+		[runOpen, setSwapBusy]
 	);
 
 	const activateLibrary = useCallback((slug) => {
@@ -118,7 +129,7 @@ export function useLibraries(feed, refreshFeed) {
 			return createLibraryFlow({
 				title,
 				libraries,
-				openLibrary: (slug) => runOpen({ slug, onError: setCreateError }),
+				openLibrary: (slug) => runOpen({ slug, onError: setCreateError, onBusy: setIsBusy }),
 				loadLibraries,
 				onBusy: setIsBusy,
 				onError: setCreateError,
@@ -151,12 +162,12 @@ export function useLibraries(feed, refreshFeed) {
 				successorSlug,
 				refreshFeed,
 				loadLibraries,
-				onBusy: setIsBusy,
+				onBusy: setSwapBusy,
 				onError: setDeleteError,
 				onActiveChanged: setActiveSlug,
 			});
 		},
-		[activeSlug, loadLibraries, refreshFeed]
+		[activeSlug, loadLibraries, refreshFeed, setSwapBusy]
 	);
 
 	return {
@@ -166,6 +177,7 @@ export function useLibraries(feed, refreshFeed) {
 		isEditingActive: activeSlug === editingSlug,
 		isLoading,
 		isBusy,
+		isSwappingLibrary,
 		openError,
 		activateError,
 		createError,

--- a/src/style-library/hooks/use-libraries.js
+++ b/src/style-library/hooks/use-libraries.js
@@ -9,54 +9,73 @@ import { useCallback, useEffect, useState } from '@wordpress/element';
 import { fetchLibraries } from '../api/client';
 import { DEFAULT_LIBRARY_SLUG } from '../constants';
 import { sortLibraries } from '../helpers/libraries';
-import { createLibraryFlow, deleteLibraryFlow, errorMessage, switchLibraryFlow } from '../helpers/library-flows';
+import {
+	activateLibraryFlow,
+	createLibraryFlow,
+	deleteLibraryFlow,
+	errorMessage,
+	openLibraryFlow,
+	renameLibraryFlow,
+} from '../helpers/library-flows';
 
 /**
- * The library management surface for the Style Library header: the list, the active slug, and
- * the switch/create/delete operations against the design-tokens REST API.
+ * The library management surface for the Style Library header: the list, the two slugs, and the
+ * open/activate/create/rename/delete operations against the design-tokens REST API.
  *
- * This hook is a thin binding of React state onto the pure flows in `helpers/library-flows` —
- * `switchLibraryFlow`, `createLibraryFlow`, `deleteLibraryFlow` — which do the actual request
- * orchestration and are what a test exercises directly. Activation and deletion wait for the
- * server before acting, because both are followed by an in-place feed refresh — an optimistic
- * flip that then errored would leave the UI lying about which library the feed describes.
- * Creation is also pessimistic: the modal stays busy until the create request resolves. None of
- * the three flows reloads the page; each settles by either refreshing the feed for the now-active
- * library or, on failure, clearing `isBusy` so the caller (the create/delete modal) can close or
- * stay open on its own.
+ * Two slugs, not one. `activeSlug` is the library the *site* renders with — every projector and
+ * the front end follow it. `editingSlug` is the library the *app* is showing. They start equal
+ * (the page-load feed is assembled for the active library) and diverge as soon as the user opens
+ * a different library to work on. Keeping them apart is what makes browsing and editing a library
+ * safe: nothing a visitor sees changes until someone explicitly activates one.
  *
- * Each of the three flows gets its own error slot (`switchError`, `createError`, `deleteError`)
- * rather than sharing one — a failed switch must never render inside the delete/reset modal, and
- * a failed delete must never resurface under the library dropdown. Each slot is cleared the
- * instant its own flow starts again, so a stale error from a previous attempt never lingers past
- * a fresh try at the same action.
+ * `editingSlug` stays derived from the feed, because the feed is the thing that actually moved —
+ * a second copy of it here could drift. `activeSlug` is real state, seeded from the initial feed
+ * slug and updated from the server's own response whenever the pointer moves.
  *
- * @param {Object}   feed        The design-tokens admin feed (provides the initial active slug).
+ * This hook is a thin binding of React state onto the pure flows in `helpers/library-flows`,
+ * which do the request orchestration and are what a test exercises directly. Every flow waits for
+ * the server rather than flipping optimistically — an optimistic change that then errored would
+ * leave the UI lying about which library it is showing, or worse, which one the site is using.
+ * None of the flows reloads the page.
+ *
+ * Each flow gets its own error slot rather than sharing one — a failed open must never render
+ * inside the delete modal, and a failed rename must never resurface under the library dropdown.
+ * Each slot is cleared the instant its own flow starts again, so a stale error from a previous
+ * attempt never lingers past a fresh try at the same action.
+ *
+ * @param {Object}   feed        The design-tokens admin feed (provides the library being edited).
  * @param {Function} refreshFeed Replaces the feed with a fresh REST read for a slug (from
- *                               `use-design-tokens-feed`), so switching or deleting the active
- *                               library re-renders every consumer without a page reload.
+ *                               `use-design-tokens-feed`), so opening a library re-renders every
+ *                               consumer without a page reload.
  *
  * @since TBD
  *
- * @return {Object} `{ libraries, activeSlug, isLoading, isBusy, switchError, createError,
- *                  deleteError, clearSwitchError, clearCreateError, clearDeleteError,
- *                  switchLibrary, createLibrary, deleteLibrary }`.
+ * @return {Object} The library list, the two slugs, the busy flag, the per-flow error slots and
+ *                  the functions that clear them, and the five operations.
  */
 export function useLibraries(feed, refreshFeed) {
 	const [libraries, setLibraries] = useState([]);
 	const [isLoading, setIsLoading] = useState(true);
 	const [isBusy, setIsBusy] = useState(false);
-	const [switchError, setSwitchError] = useState(null);
+	const [openError, setOpenError] = useState(null);
+	const [activateError, setActivateError] = useState(null);
 	const [createError, setCreateError] = useState(null);
+	const [renameError, setRenameError] = useState(null);
 	const [deleteError, setDeleteError] = useState(null);
 	// The feed always carries a slug, but the default library is the one every read falls back to, so
 	// naming it here keeps a malformed feed from addressing REST paths with `undefined`.
-	const activeSlug = feed?.slug || DEFAULT_LIBRARY_SLUG;
+	const editingSlug = feed?.slug || DEFAULT_LIBRARY_SLUG;
+
+	// Seeded from the feed rather than fetched. The page-load feed is always assembled for the
+	// active library (see Admin\Feed\Localizer), so on first paint the two are the same and a
+	// separate request would only re-learn what the page already told us. Every later move of the
+	// pointer goes through a flow that reports the server's resolved slug back here.
+	const [activeSlug, setActiveSlug] = useState(editingSlug);
 
 	const loadLibraries = useCallback(() => {
 		return fetchLibraries()
 			.then((rows) => setLibraries(sortLibraries(rows)))
-			.catch((err) => setSwitchError({ message: errorMessage(err) }));
+			.catch((err) => setOpenError({ message: errorMessage(err) }));
 	}, []);
 
 	useEffect(() => {
@@ -64,25 +83,37 @@ export function useLibraries(feed, refreshFeed) {
 		loadLibraries().finally(() => setIsLoading(false));
 	}, [loadLibraries]);
 
-	const clearSwitchError = useCallback(() => setSwitchError(null), []);
+	const clearOpenError = useCallback(() => setOpenError(null), []);
+	const clearActivateError = useCallback(() => setActivateError(null), []);
 	const clearCreateError = useCallback(() => setCreateError(null), []);
+	const clearRenameError = useCallback(() => setRenameError(null), []);
 	const clearDeleteError = useCallback(() => setDeleteError(null), []);
 
-	// Shared by `switchLibrary` (below) and by `addLibrary`'s post-create switch — each call site
-	// passes its own `onError` so a switch that fails as part of create reports through
-	// `createError`, never through `switchError`.
-	const runSwitch = useCallback(
-		({ slug, onError }) => switchLibraryFlow({ slug, refreshFeed, onBusy: setIsBusy, onError }),
+	// Shared by `openLibrary` (below) and by `addLibrary`'s post-create open — each call site
+	// passes its own `onError` so an open that fails as part of create reports through
+	// `createError`, never through `openError`.
+	const runOpen = useCallback(
+		({ slug, onError }) => openLibraryFlow({ slug, refreshFeed, onBusy: setIsBusy, onError }),
 		[refreshFeed]
 	);
 
-	const switchLibrary = useCallback(
+	const openLibrary = useCallback(
 		(slug) => {
-			setSwitchError(null);
-			return runSwitch({ slug, onError: setSwitchError });
+			setOpenError(null);
+			return runOpen({ slug, onError: setOpenError });
 		},
-		[runSwitch]
+		[runOpen]
 	);
+
+	const activateLibrary = useCallback((slug) => {
+		setActivateError(null);
+		return activateLibraryFlow({
+			slug,
+			onBusy: setIsBusy,
+			onError: setActivateError,
+			onActivated: setActiveSlug,
+		});
+	}, []);
 
 	const addLibrary = useCallback(
 		(title) => {
@@ -90,25 +121,42 @@ export function useLibraries(feed, refreshFeed) {
 			return createLibraryFlow({
 				title,
 				libraries,
-				switchLibrary: (slug) => runSwitch({ slug, onError: setCreateError }),
+				openLibrary: (slug) => runOpen({ slug, onError: setCreateError }),
 				loadLibraries,
 				onBusy: setIsBusy,
 				onError: setCreateError,
 			});
 		},
-		[libraries, runSwitch, loadLibraries]
+		[libraries, runOpen, loadLibraries]
+	);
+
+	const renameCurrentLibrary = useCallback(
+		(slug, title) => {
+			setRenameError(null);
+			return renameLibraryFlow({
+				slug,
+				title,
+				libraries,
+				loadLibraries,
+				onBusy: setIsBusy,
+				onError: setRenameError,
+			});
+		},
+		[libraries, loadLibraries]
 	);
 
 	const removeLibrary = useCallback(
-		(slug) => {
+		(slug, successorSlug) => {
 			setDeleteError(null);
 			return deleteLibraryFlow({
 				slug,
 				activeSlug,
+				successorSlug,
 				refreshFeed,
 				loadLibraries,
 				onBusy: setIsBusy,
 				onError: setDeleteError,
+				onActiveChanged: setActiveSlug,
 			});
 		},
 		[activeSlug, loadLibraries, refreshFeed]
@@ -117,16 +165,24 @@ export function useLibraries(feed, refreshFeed) {
 	return {
 		libraries,
 		activeSlug,
+		editingSlug,
+		isEditingActive: activeSlug === editingSlug,
 		isLoading,
 		isBusy,
-		switchError,
+		openError,
+		activateError,
 		createError,
+		renameError,
 		deleteError,
-		clearSwitchError,
+		clearOpenError,
+		clearActivateError,
 		clearCreateError,
+		clearRenameError,
 		clearDeleteError,
-		switchLibrary,
+		openLibrary,
+		activateLibrary,
 		createLibrary: addLibrary,
+		renameLibrary: renameCurrentLibrary,
 		deleteLibrary: removeLibrary,
 	};
 }

--- a/src/style-library/styles/_primitives.scss
+++ b/src/style-library/styles/_primitives.scss
@@ -51,6 +51,11 @@ body.kadence-blocks-style-library-page {
 	// this value — see the @supports block below.
 	--kb-sl-color-gray-200-tint-60: rgba(224, 224, 224, 0.6);
 
+	// White at 70% alpha — the scrim laid over the app while its content is being replaced. Kept
+	// translucent rather than opaque so the frame stays visible underneath and the app reads as
+	// busy rather than as gone.
+	--kb-sl-color-white-tint-70: rgba(255, 255, 255, 0.7);
+
 	// Spacing — Gutenberg's grid-unit scale, re-declared because core only ships it as Sass.
 	--kb-sl-space-05: 0.25rem;
 	--kb-sl-space-10: 0.5rem;

--- a/src/style-library/styles/_primitives.scss
+++ b/src/style-library/styles/_primitives.scss
@@ -138,7 +138,7 @@ body.kadence-blocks-style-library-page {
 
 	// The preview slot's width inside a card. Height reuses --kb-sl-space-50 directly rather than a
 	// second, numerically-identical primitive.
-	--kb-sl-size-swatch-preview-width: 5rem;
+	--kb-sl-size-swatch-preview-width: 5.5rem;
 	// `SwatchCard`'s own width (read by `.swatch-card-main`) — derived as the preview's width plus
 	// its own inline padding on both sides, so a change to either can't silently drift this out of
 	// alignment.

--- a/src/style-library/styles/_primitives.scss
+++ b/src/style-library/styles/_primitives.scss
@@ -132,6 +132,9 @@ body.kadence-blocks-style-library-page {
 	// The menu's width cap before its items wrap. Numerically equal to --kb-sl-size-modal-small by
 	// coincidence — stays its own token rather than pointing at the modal one.
 	--kb-sl-size-select-dropdown-max-width: 24rem;
+	// The floor for a menu item's label column, so a short label still holds the row open and the
+	// badges after it line up across rows instead of tracking each label's own width.
+	--kb-sl-size-select-dropdown-label-min-width: 8rem;
 
 	// The preview slot's width inside a card. Height reuses --kb-sl-space-50 directly rather than a
 	// second, numerically-identical primitive.

--- a/src/style-library/styles/_semantic.scss
+++ b/src/style-library/styles/_semantic.scss
@@ -41,6 +41,7 @@ body.kadence-blocks-style-library-page {
 	// --kb-sl-color-nav-tab-bg-selected but a separate alias — the two roles should stay free to
 	// diverge even though they currently agree.
 	--kb-sl-color-surface-hover: var(--kb-sl-color-theme-tint-4);
+	--kb-sl-color-scrim: var(--kb-sl-color-white-tint-70);
 
 	// Color — `gray-50` does two distinct jobs (`AddTile`'s resting surface, `ListRow`'s hover
 	// background), so each gets its own role alias rather than pointing at the primitive directly.

--- a/src/style-library/styles/_shell.scss
+++ b/src/style-library/styles/_shell.scss
@@ -68,6 +68,29 @@ body.kadence-blocks-style-library-page {
 	flex-direction: column;
 	@include mixins.app-viewport-height;
 	overflow: hidden;
+	// The containing block for the busy scrim below, which covers the whole frame.
+	position: relative;
+}
+
+// Laid over the entire frame while the app's content is being replaced — opening a different
+// library swaps the values behind every screen at once, so a spinner tucked beside the selector
+// understates what is happening and leaves the stale content looking current and clickable.
+//
+// Translucent rather than opaque, so the frame stays visible and the app reads as busy rather than
+// as gone. The low z-index is deliberate: it lives inside the shell's own stacking context, so it
+// covers the app and nothing else — never wp-admin's chrome, and never a modal.
+.kadence-blocks-style-library__blocker {
+	position: absolute;
+	inset: 0;
+	z-index: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: var(--kb-sl-color-scrim);
+	// Blocks every pointer interaction underneath for the duration. Keyboard focus can still reach
+	// the covered controls, which is a known gap — the operations they start are all guarded by
+	// their own busy checks, so the worst case is a queued request, not a corrupt state.
+	cursor: progress;
 }
 
 .kadence-blocks-style-library__loading {

--- a/src/style-library/styles/_shell.scss
+++ b/src/style-library/styles/_shell.scss
@@ -20,6 +20,27 @@ body.kadence-blocks-style-library-page {
 	#wpfooter {
 		display: none;
 	}
+
+	// Core stacks popovers above modals — `.components-popover` is z-index 1000000 while
+	// `.components-modal__screen-overlay` is 100000 — so a Popover that is still open when a modal
+	// opens floats over the modal's dim layer instead of being covered by it. The header's library
+	// dropdown does exactly that: open it, click Rename or Delete, and the menu stays drawn on top
+	// of the dialog.
+	//
+	// Core's ordering is deliberate, not a bug: it is what lets a popover opened *from inside* a
+	// modal (a color picker, a dropdown in a modal form) render above it. So this override is
+	// scoped to this admin page rather than applied globally. Modals portal to `document.body`,
+	// which carries this page's body class, so the rule still reaches them even though they render
+	// far outside the app root.
+	//
+	// The consequence to know about: on this page, a popover opened from inside one of these
+	// modals would now be covered by the modal it belongs to. None of the library modals contains
+	// one today — the delete modal's successor picker is a native `<select>`, which the browser
+	// draws in its own layer and z-index cannot touch. A modal that needs a real popover inside it
+	// will have to raise that popover above this value.
+	.components-modal__screen-overlay {
+		z-index: 1000001;
+	}
 }
 
 .kadence-blocks-style-library-root {

--- a/tests/snapshot/Resources/Design_Tokens/Admin/Feed/__snapshots__/Builder_SnapshotTest__testFullPayloadMatchesSnapshot__1.txt
+++ b/tests/snapshot/Resources/Design_Tokens/Admin/Feed/__snapshots__/Builder_SnapshotTest__testFullPayloadMatchesSnapshot__1.txt
@@ -3,6 +3,7 @@
     "resolved": true,
     "version": "v7",
     "slug": "default",
+    "title": "",
     "schema": {
         "groups": {
             "Brand": [

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerTest.php
@@ -1370,7 +1370,9 @@ final class DocumentsControllerTest extends TestCase {
 	}
 
 	/**
-	 * The rename route is registered under the library, accepts PUT, and exposes a schema.
+	 * The rename route is registered under the library, accepts every write verb a WordPress client is
+	 * likely to reach for, and exposes a schema. Setting a title is idempotent, so POST and PATCH are as
+	 * correct as PUT here and all three share one handler.
 	 *
 	 * @return void
 	 */
@@ -1380,9 +1382,12 @@ final class DocumentsControllerTest extends TestCase {
 		$slug_route  = $this->controller_constant( 'SLUG_ROUTE' );
 		$title_route = $this->controller_constant( 'TITLE_ROUTE' );
 
-		$route = "/$namespace/$base/$slug_route/$title_route";
+		$route   = "/$namespace/$base/$slug_route/$title_route";
+		$methods = $this->route_methods( $route );
 
-		$this->assertContains( 'PUT', $this->route_methods( $route ) );
+		$this->assertContains( 'PUT', $methods );
+		$this->assertContains( 'POST', $methods );
+		$this->assertContains( 'PATCH', $methods );
 
 		$options = $this->rest_server->get_route_options( $route );
 		$this->assertArrayHasKey( 'schema', $options );

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerTest.php
@@ -7,6 +7,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Documents_Controller;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Sentinels;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
+use Generator;
 use ReflectionClass;
 use ReflectionProperty;
 use Tests\Support\Classes\TestCase;
@@ -1325,6 +1326,162 @@ final class DocumentsControllerTest extends TestCase {
 		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertSame( 'rest_design_tokens_user_primitive_reference_unsupported', $response->get_error_code() );
 		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * The rename route is registered under the library, accepts PUT, and exposes a schema.
+	 *
+	 * @return void
+	 */
+	public function testItRegistersTheTitleRoute(): void {
+		$namespace   = $this->controller_namespace();
+		$base        = $this->controller_rest_base();
+		$slug_route  = $this->controller_constant( 'SLUG_ROUTE' );
+		$title_route = $this->controller_constant( 'TITLE_ROUTE' );
+
+		$route = "/$namespace/$base/$slug_route/$title_route";
+
+		$this->assertContains( 'PUT', $this->route_methods( $route ) );
+
+		$options = $this->rest_server->get_route_options( $route );
+		$this->assertArrayHasKey( 'schema', $options );
+		$this->assertIsCallable( $options['schema'] );
+	}
+
+	/**
+	 * Renaming a library writes its label and leaves its stored document and version alone.
+	 *
+	 * @return void
+	 */
+	public function testUpdateTitleWritesTheLabelWithoutTouchingTheDocument(): void {
+		$document = '{"primitive":{"color":{"a":{"$type":"color","$value":"#aaaaaa"}}}}';
+		$this->store->save_document( $document, 'brand-a', 'Brand A' );
+		$version = $this->store->get_version( 'brand-a' );
+
+		$response = $this->controller->update_title( $this->title_request( 'brand-a', 'Winter 2026' ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertSame( 'Winter 2026', $this->store->get_title( 'brand-a' ) );
+		$this->assertSame( $document, $this->store->get_document( 'brand-a' ) );
+		// The version drives the projected-CSS cache key. A label is in no projection, so renaming
+		// must not invalidate anything downstream.
+		$this->assertSame( $version, $this->store->get_version( 'brand-a' ) );
+	}
+
+	/**
+	 * A library whose stored document would fail validation can still be renamed.
+	 *
+	 * This is the reason the route exists. Sending a title alongside an empty document to a bulk
+	 * write route merges and re-validates the whole stored document, so a library holding anything
+	 * the validator rejects becomes impossible to rename — for reasons that have nothing to do with
+	 * the new name. The document here is deliberately not even valid JSON, which is a stronger
+	 * statement than "invalid DTCG": the rename must not read it at all.
+	 *
+	 * @return void
+	 */
+	public function testUpdateTitleSucceedsWhenTheStoredDocumentIsNotValidJson(): void {
+		$corrupt = '{ this is not json';
+		$this->store->save_document( $corrupt, 'brand-a', 'Brand A' );
+
+		$response = $this->controller->update_title( $this->title_request( 'brand-a', 'Winter 2026' ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertSame( 'Winter 2026', $this->store->get_title( 'brand-a' ) );
+		$this->assertSame( $corrupt, $this->store->get_document( 'brand-a' ) );
+	}
+
+	/**
+	 * The default library can be renamed even though it has no row until something is written to it.
+	 *
+	 * @return void
+	 */
+	public function testUpdateTitleNamesTheDefaultLibraryOnItsFirstWrite(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->assertFalse( $this->store->exists( $slug ) );
+
+		$response = $this->controller->update_title( $this->title_request( $slug, 'Our Brand' ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( 'Our Brand', $this->store->get_title( $slug ) );
+		// Named, but still rendering from baseline — naming a library is not authoring one.
+		$this->assertSame( '', $this->store->get_document( $slug ) );
+	}
+
+	/**
+	 * A blank or whitespace-only title is refused rather than stored or silently ignored.
+	 *
+	 * @dataProvider blankTitleProvider
+	 *
+	 * @param string $title The rejected title.
+	 *
+	 * @return void
+	 */
+	public function testUpdateTitleRejectsABlankTitle( string $title ): void {
+		$this->store->save_document( '{}', 'brand-a', 'Brand A' );
+
+		$response = $this->controller->update_title( $this->title_request( 'brand-a', $title ) );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_design_tokens_invalid_title', $response->get_error_code() );
+		$this->assertSame( WP_Http::BAD_REQUEST, $response->get_error_data()['status'] );
+		$this->assertSame( 'Brand A', $this->store->get_title( 'brand-a' ) );
+	}
+
+	/**
+	 * Titles that are empty once trimmed.
+	 *
+	 * @return Generator
+	 */
+	public function blankTitleProvider(): Generator {
+		yield 'empty' => [ 'title' => '' ];
+		yield 'spaces' => [ 'title' => '   ' ];
+		yield 'tab and newline' => [ 'title' => "\t\n" ];
+	}
+
+	/**
+	 * Renaming a library that does not exist is a 404, not a silent create.
+	 *
+	 * @return void
+	 */
+	public function testUpdateTitleIsNotFoundForAnUnknownLibrary(): void {
+		$response = $this->controller->update_title( $this->title_request( 'ghost', 'Ghost' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_design_tokens_not_found', $response->get_error_code() );
+		$this->assertSame( WP_Http::NOT_FOUND, $response->get_error_data()['status'] );
+		$this->assertFalse( $this->store->exists( 'ghost' ) );
+	}
+
+	/**
+	 * A surrounding-whitespace title is stored trimmed.
+	 *
+	 * @return void
+	 */
+	public function testUpdateTitleTrimsSurroundingWhitespace(): void {
+		$this->store->save_document( '{}', 'brand-a', 'Brand A' );
+
+		$this->controller->update_title( $this->title_request( 'brand-a', '  Winter 2026  ' ) );
+
+		$this->assertSame( 'Winter 2026', $this->store->get_title( 'brand-a' ) );
+	}
+
+	/**
+	 * Build a rename request carrying the slug and the new title.
+	 *
+	 * @param string $slug  The token library slug.
+	 * @param string $title The new label.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function title_request( string $slug, string $title ): WP_REST_Request {
+		$request = new WP_REST_Request( 'PUT' );
+		$request->set_param( 'slug', $slug );
+		$request->set_param( 'title', $title );
+
+		return $request;
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerTest.php
@@ -7,6 +7,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Documents_Controller;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Sentinels;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
+use Generator;
 use ReflectionClass;
 use ReflectionProperty;
 use Tests\Support\Classes\TestCase;
@@ -1366,6 +1367,162 @@ final class DocumentsControllerTest extends TestCase {
 		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertSame( 'rest_design_tokens_user_primitive_reference_unsupported', $response->get_error_code() );
 		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * The rename route is registered under the library, accepts PUT, and exposes a schema.
+	 *
+	 * @return void
+	 */
+	public function testItRegistersTheTitleRoute(): void {
+		$namespace   = $this->controller_namespace();
+		$base        = $this->controller_rest_base();
+		$slug_route  = $this->controller_constant( 'SLUG_ROUTE' );
+		$title_route = $this->controller_constant( 'TITLE_ROUTE' );
+
+		$route = "/$namespace/$base/$slug_route/$title_route";
+
+		$this->assertContains( 'PUT', $this->route_methods( $route ) );
+
+		$options = $this->rest_server->get_route_options( $route );
+		$this->assertArrayHasKey( 'schema', $options );
+		$this->assertIsCallable( $options['schema'] );
+	}
+
+	/**
+	 * Renaming a library writes its label and leaves its stored document and version alone.
+	 *
+	 * @return void
+	 */
+	public function testUpdateTitleWritesTheLabelWithoutTouchingTheDocument(): void {
+		$document = '{"primitive":{"color":{"a":{"$type":"color","$value":"#aaaaaa"}}}}';
+		$this->store->save_document( $document, 'brand-a', 'Brand A' );
+		$version = $this->store->get_version( 'brand-a' );
+
+		$response = $this->controller->update_title( $this->title_request( 'brand-a', 'Winter 2026' ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertSame( 'Winter 2026', $this->store->get_title( 'brand-a' ) );
+		$this->assertSame( $document, $this->store->get_document( 'brand-a' ) );
+		// The version drives the projected-CSS cache key. A label is in no projection, so renaming
+		// must not invalidate anything downstream.
+		$this->assertSame( $version, $this->store->get_version( 'brand-a' ) );
+	}
+
+	/**
+	 * A library whose stored document would fail validation can still be renamed.
+	 *
+	 * This is the reason the route exists. Sending a title alongside an empty document to a bulk
+	 * write route merges and re-validates the whole stored document, so a library holding anything
+	 * the validator rejects becomes impossible to rename — for reasons that have nothing to do with
+	 * the new name. The document here is deliberately not even valid JSON, which is a stronger
+	 * statement than "invalid DTCG": the rename must not read it at all.
+	 *
+	 * @return void
+	 */
+	public function testUpdateTitleSucceedsWhenTheStoredDocumentIsNotValidJson(): void {
+		$corrupt = '{ this is not json';
+		$this->store->save_document( $corrupt, 'brand-a', 'Brand A' );
+
+		$response = $this->controller->update_title( $this->title_request( 'brand-a', 'Winter 2026' ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertSame( 'Winter 2026', $this->store->get_title( 'brand-a' ) );
+		$this->assertSame( $corrupt, $this->store->get_document( 'brand-a' ) );
+	}
+
+	/**
+	 * The default library can be renamed even though it has no row until something is written to it.
+	 *
+	 * @return void
+	 */
+	public function testUpdateTitleNamesTheDefaultLibraryOnItsFirstWrite(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->assertFalse( $this->store->exists( $slug ) );
+
+		$response = $this->controller->update_title( $this->title_request( $slug, 'Our Brand' ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( 'Our Brand', $this->store->get_title( $slug ) );
+		// Named, but still rendering from baseline — naming a library is not authoring one.
+		$this->assertSame( '', $this->store->get_document( $slug ) );
+	}
+
+	/**
+	 * A blank or whitespace-only title is refused rather than stored or silently ignored.
+	 *
+	 * @dataProvider blankTitleProvider
+	 *
+	 * @param string $title The rejected title.
+	 *
+	 * @return void
+	 */
+	public function testUpdateTitleRejectsABlankTitle( string $title ): void {
+		$this->store->save_document( '{}', 'brand-a', 'Brand A' );
+
+		$response = $this->controller->update_title( $this->title_request( 'brand-a', $title ) );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_design_tokens_invalid_title', $response->get_error_code() );
+		$this->assertSame( WP_Http::BAD_REQUEST, $response->get_error_data()['status'] );
+		$this->assertSame( 'Brand A', $this->store->get_title( 'brand-a' ) );
+	}
+
+	/**
+	 * Titles that are empty once trimmed.
+	 *
+	 * @return Generator
+	 */
+	public function blankTitleProvider(): Generator {
+		yield 'empty' => [ 'title' => '' ];
+		yield 'spaces' => [ 'title' => '   ' ];
+		yield 'tab and newline' => [ 'title' => "\t\n" ];
+	}
+
+	/**
+	 * Renaming a library that does not exist is a 404, not a silent create.
+	 *
+	 * @return void
+	 */
+	public function testUpdateTitleIsNotFoundForAnUnknownLibrary(): void {
+		$response = $this->controller->update_title( $this->title_request( 'ghost', 'Ghost' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_design_tokens_not_found', $response->get_error_code() );
+		$this->assertSame( WP_Http::NOT_FOUND, $response->get_error_data()['status'] );
+		$this->assertFalse( $this->store->exists( 'ghost' ) );
+	}
+
+	/**
+	 * A surrounding-whitespace title is stored trimmed.
+	 *
+	 * @return void
+	 */
+	public function testUpdateTitleTrimsSurroundingWhitespace(): void {
+		$this->store->save_document( '{}', 'brand-a', 'Brand A' );
+
+		$this->controller->update_title( $this->title_request( 'brand-a', '  Winter 2026  ' ) );
+
+		$this->assertSame( 'Winter 2026', $this->store->get_title( 'brand-a' ) );
+	}
+
+	/**
+	 * Build a rename request carrying the slug and the new title.
+	 *
+	 * @param string $slug  The token library slug.
+	 * @param string $title The new label.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function title_request( string $slug, string $title ): WP_REST_Request {
+		$request = new WP_REST_Request( 'PUT' );
+		$request->set_param( 'slug', $slug );
+		$request->set_param( 'title', $title );
+
+		return $request;
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerTest.php
@@ -1388,10 +1388,74 @@ final class DocumentsControllerTest extends TestCase {
 		$this->assertContains( 'PUT', $methods );
 		$this->assertContains( 'POST', $methods );
 		$this->assertContains( 'PATCH', $methods );
+		$this->assertContains( 'GET', $methods );
 
 		$options = $this->rest_server->get_route_options( $route );
 		$this->assertArrayHasKey( 'schema', $options );
 		$this->assertIsCallable( $options['schema'] );
+	}
+
+	/**
+	 * Reading the title resource returns the stored label for that library.
+	 *
+	 * @return void
+	 */
+	public function testGetTitleReturnsTheStoredTitle(): void {
+		$this->store->save_document( '{"set":"a"}', 'brand-a', 'Winter 2026' );
+
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', 'brand-a' );
+
+		$data = $this->controller->get_title( $request )->get_data();
+
+		$this->assertSame( 'brand-a', $data['slug'] );
+		$this->assertSame( 'Winter 2026', $data['title'] );
+	}
+
+	/**
+	 * A library with no stored label reads back an empty title rather than its slug, so a client can tell
+	 * "unnamed" from "named after its slug".
+	 *
+	 * @return void
+	 */
+	public function testGetTitleReturnsEmptyForAnUntitledLibrary(): void {
+		$this->store->save_document( '{"set":"a"}', 'brand-a' );
+
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', 'brand-a' );
+
+		$this->assertSame( '', $this->controller->get_title( $request )->get_data()['title'] );
+	}
+
+	/**
+	 * Reading the title of a library that does not exist is a 404, matching what renaming one returns, so
+	 * both halves of the resource agree on which libraries exist.
+	 *
+	 * @return void
+	 */
+	public function testGetTitleReturnsNotFoundForAnUnknownLibrary(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', 'ghost' );
+
+		$response = $this->controller->get_title( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( WP_Http::NOT_FOUND, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * The title read reflects a rename immediately, so the two halves of the resource cannot disagree.
+	 *
+	 * @return void
+	 */
+	public function testGetTitleReflectsARename(): void {
+		$this->store->save_document( '{"set":"a"}', 'brand-a', 'Winter 2026' );
+		$this->controller->update_title( $this->title_request( 'brand-a', 'Spring 2027' ) );
+
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', 'brand-a' );
+
+		$this->assertSame( 'Spring 2027', $this->controller->get_title( $request )->get_data()['title'] );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -171,6 +171,40 @@ final class Feed_ControllerTest extends TestCase {
 	}
 
 	/**
+	 * The feed carries the library's stored label, so a client can name the library it is showing
+	 * from the page-load payload alone instead of waiting on the separate libraries request.
+	 *
+	 * @return void
+	 */
+	public function testGetItemReturnsTheStoredTitle(): void {
+		$this->store->save_document( '{}', 'brand-b', 'Winter 2026' );
+
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', 'brand-b' );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$this->assertSame( 'Winter 2026', $data['title'] );
+	}
+
+	/**
+	 * A library with no stored label reports an empty title rather than its slug or any other
+	 * synthesized value, leaving the client to decide how to name an untitled library.
+	 *
+	 * @return void
+	 */
+	public function testGetItemReturnsAnEmptyTitleForAnUntitledLibrary(): void {
+		$this->store->save_document( '{}', 'brand-b' );
+
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', 'brand-b' );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$this->assertSame( '', $data['title'] );
+	}
+
+	/**
 	 * A slug naming no known library is rejected with a 404, mirroring Documents_Controller and
 	 * Active_Token_Library_Controller rather than silently substituting a different library's
 	 * data for the one requested.


### PR DESCRIPTION
## Summary

Separates **the library the site renders with** from **the library you are editing**, and puts changing the former behind an explicit confirmation.

Before this, those were the same variable. The only way to look at another library was to make it live, so picking an option in the header dropdown immediately restyled the whole front end — no confirmation, no warning, no undo. Creating a library did the same thing implicitly, because the create flow chained a switch onto its own success.

Now the dropdown only changes what you are editing. Nothing a visitor sees moves until someone reads the confirmation and agrees.

## What changed

**Two slugs instead of one.** `useLibraries` returns `activeSlug` (the site pointer) and `editingSlug` (what the app shows). They start equal and diverge as soon as you open another library. `setActiveLibrary` now has exactly two callers: the activation flow, and the successor step of delete.

**`switchLibraryFlow` split in two** — `openLibraryFlow` (refreshes the feed, never touches the pointer) and `activateLibraryFlow` (writes the pointer, and deliberately does *not* refresh the feed, since activating the library already on screen changes nothing inside it).

**Deleting the active library requires naming its successor.** The confirm button stays disabled until one is chosen, and the successor is activated *before* the delete — the reverse order would let the server fall the pointer back to the default in between, briefly serving a site-wide look nobody picked. When only one library could take over, the picker is skipped and the copy names that library instead: the site can land in exactly one place, so asking would be a question with a single answer. The choosing is dropped, never the telling.

**Rename**, via a dedicated `PUT /documents/{slug}/title` route. This is the one PHP change and it is worth a look: sending a title alongside an empty document to a bulk write route merges and then re-validates the entire stored document, so a rename fails for any library whose document does not currently validate — for reasons that have nothing to do with the new name. This is not hypothetical; it is how the default library behaved. The new route writes the label column alone, bumps no version, and fires no change action.

**Selector indicators.** A muted `Default` badge marks the library that can only be reset, never deleted — answering "why can't I delete this one?" before anyone tries. A theme-colored `Active` badge marks the one the site is serving.

**A whole-app scrim while a library loads**, replacing the small spinner beside the selector. Opening a library replaces the values behind every screen at once, so a spinner tucked next to one control understated it and left stale content looking current and clickable. Driven by its own flag, not `isBusy` — rename and activate change nothing on screen, and blanking the app for those would be theatre.

**The header names the library on first paint.** The feed payload now carries `title`, so the toggle no longer shows a slug-derived guess and then corrects itself when the libraries request lands.

## Notable decisions

- **Title only, never slug.** The slug is the library's identity — the active pointer stores it, the table has a `UNIQUE KEY` on it, every route addresses by it — and it is invisible once a title exists.
- **Rename needs its own duplicate check.** `slugifyLibraryTitle` derives the slug at creation time only, so slug and title diverge permanently after a rename. Reusing the slug-based check would reject renaming to a name nothing on screen displays. Creation keeps the slug check, because that is where the slug is minted.
- **The successor dropdown has no preselection**, but is skipped entirely when there is only one candidate. Preselecting is the worst of both: a field the user can skim past while the destination quietly defaults. Naming the library in the sentence puts it in the text they have to read to reach the button. Worth knowing this is the common path, not a corner — the default library can never be deleted, so any site with two libraries meets it the first time it deletes the active one.
- **Modal z-index is scoped to this admin page.** Core stacks popovers above modals on purpose, so that a popover opened *inside* a modal works; overriding that globally would break those.
- **Activation's partial-failure case is documented, not designed away.** If activation succeeds and the delete then fails, the site sits on a library the user explicitly chose and the target survives — a retry finishes the job. The alternative ordering trades that for default styles nobody picked.

## Screenshots

**Selector while editing the active library** — the muted `Default` badge marks the library that can only be reset, never deleted; the themed `Active` badge marks the one the site is serving.

<img width="1567" height="521" alt="phase-6-selector-badges-editing-active" src="https://github.com/user-attachments/assets/cc29b449-ad92-4cf7-864f-d11a5f2083d2" />

**Selector while editing a non-active library** — the check sits on the library being edited, the `Active` badge stays on the one the site serves, and `Set as active` appears in the header. This is the split the whole PR is about, in one frame.

<img width="1567" height="521" alt="phase-6-selector-editing-non-active-library" src="https://github.com/user-attachments/assets/5c7094a4-8633-426d-ac02-5772c43b9a2b" />

**Set as active** — names both libraries and states the site-wide consequence before the confirm. Cancel is focused on open.

<img width="1467" height="812" alt="phase-6-set-as-active-confirmation" src="https://github.com/user-attachments/assets/d5c4ae9a-d1c0-42e6-a732-02c6e16f1ebd" />

**Rename** — `Save` is disabled while the name is unchanged, so a rename that would spend a request to change nothing cannot be submitted.

<img width="1467" height="812" alt="phase-6-rename-library" src="https://github.com/user-attachments/assets/df98dc51-6318-4ba4-bdf0-ce9b02ab8bd5" />

**Deleting the active library** — the successor picker, unselected, with the confirm button disabled until it is answered. On a site where only one library could take over, this picker is replaced by copy naming that library outright.

<img width="1026" height="652" alt="phase-6-delete-active-library-successor" src="https://github.com/user-attachments/assets/0643f0e8-2c34-4315-ae06-18dac9aa032c" />

## Test plan

- `npx jest src/style-library` — 162 pass (25 new across the flows and helpers)
- `slic run wpunit Resources/Design_Tokens/Rest/V1/DocumentsControllerTest` — 62 pass (9 new)
- `slic run wpunit Resources/Design_Tokens/Rest/V1/Feed_ControllerTest` — 8 pass (2 new)
- `slic run snapshot` — 3 pass (Builder snapshot gained one key)
- `vendor/bin/phpstan analyse`, `composer phpcs`, `npx eslint`, `cspell`, `npm run build` — all clean

Regression tests worth knowing about, because each one fails if an implicit behavior comes back:

- opening a library never calls `setActiveLibrary`
- creating a library never calls `setActiveLibrary`
- deleting the active library without a successor issues no request at all
- the successor is activated *before* the delete (asserted through a shared call log, since the ordering is the correctness property)
- renaming works against a stored document that is not even valid JSON, and leaves it byte-identical

## Manual verification

Not yet done end to end. Worth confirming on a real site: renaming the default library now succeeds, and a rename leaves token values intact (the PATCH-vs-PUT hazard is invisible in the modal itself).


