### PR TITLE
[DTM] SOFT-4076 [1/5]: Palette data layer

### DIFF
--- a/src/style-library/__tests__/palette-flows.test.js
+++ b/src/style-library/__tests__/palette-flows.test.js
@@ -1,0 +1,710 @@
+/* eslint-env jest */
+import {
+	activatePaletteFlow,
+	addColorFlow,
+	addGroupFlow,
+	createPaletteFlow,
+	deletePaletteFlow,
+	openPaletteFlow,
+	removeSwatchFlow,
+	reorderSwatchesFlow,
+	saveSwatchEditsFlow,
+	writeDefaultPaletteFlow,
+} from '../helpers/palette-flows';
+import * as client from '../api/client';
+
+// A factory, not bare automocking: the real module imports `@wordpress/api-fetch`, which is
+// externalized to the `wp.apiFetch` global in production and is not installed as an npm
+// dependency, so automocking (which loads the real module to introspect its shape) would fail to
+// resolve it.
+jest.mock('../api/client', () => ({
+	createUserPrimitive: jest.fn(),
+	deletePalette: jest.fn(),
+	deleteUserPrimitive: jest.fn(),
+	fetchPalette: jest.fn(),
+	savePalette: jest.fn(),
+	saveSwatch: jest.fn(),
+	setCurrentPalette: jest.fn(),
+}));
+
+const NAMESPACE = 'kb-design-tokens/v1';
+const SLUG = 'default';
+const DEFAULT_ID = 'default';
+
+const defaultView = () => ({
+	id: 'default',
+	label: 'Default',
+	groups: [
+		{
+			id: 'accent',
+			label: 'Accent',
+			swatches: [
+				{ token: 'primitive.color.brand.primary', label: 'Main 1', $value: '#111111', overridden: false },
+				{ token: 'primitive.color.brand.secondary', label: 'Main 2', $value: '#222222', overridden: false },
+			],
+		},
+	],
+});
+
+const selectedView = () => ({
+	id: 'sunset',
+	label: 'Sunset',
+	groups: [
+		{
+			id: 'accent',
+			label: 'Accent',
+			swatches: [
+				{ token: 'primitive.color.brand.primary', label: 'Main 1', $value: '#999999', overridden: true },
+				{ token: 'primitive.color.brand.secondary', label: 'Main 2', $value: '#222222', overridden: false },
+			],
+		},
+	],
+});
+
+beforeEach(() => {
+	jest.resetAllMocks();
+});
+
+describe('writeDefaultPaletteFlow', () => {
+	it('reads the DEFAULT view, saves the edited default payload, reloads, refreshes the feed, then clears busy', async () => {
+		client.fetchPalette.mockResolvedValue(defaultView());
+		client.savePalette.mockResolvedValue({ $default: DEFAULT_ID, $current: DEFAULT_ID, palettes: [] });
+		const reload = jest.fn().mockResolvedValue(undefined);
+		const refreshFeed = jest.fn().mockResolvedValue({ version: 'v2' });
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+		const edit = jest.fn((groups) => groups);
+
+		await writeDefaultPaletteFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			defaultId: DEFAULT_ID,
+			edit,
+			reload,
+			refreshFeed,
+			onBusy,
+			onError,
+		});
+
+		expect(client.fetchPalette).toHaveBeenCalledWith(NAMESPACE, DEFAULT_ID, SLUG);
+		// The trap-1 regression: the saved payload carries the default view's own values, never the
+		// selected palette's.
+		expect(client.savePalette).toHaveBeenCalledWith(
+			NAMESPACE,
+			DEFAULT_ID,
+			{ label: 'Default', groups: expect.arrayContaining([expect.objectContaining({ id: 'accent' })]) },
+			SLUG
+		);
+		const [, , payload] = client.savePalette.mock.calls[0];
+		expect(payload.groups[0].swatches[0].$value).toBe('#111111');
+		expect(reload).toHaveBeenCalled();
+		expect(refreshFeed).toHaveBeenCalledWith(SLUG);
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it('surfaces the error, clears busy, and re-throws on failure', async () => {
+		const failure = new Error('A palette must define at least one color group.');
+		client.fetchPalette.mockRejectedValue(failure);
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			writeDefaultPaletteFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				defaultId: DEFAULT_ID,
+				edit: (groups) => groups,
+				reload: jest.fn(),
+				refreshFeed: jest.fn(),
+				onBusy,
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+});
+
+describe('saveSwatchEditsFlow', () => {
+	const args = (overrides) => ({
+		namespace: NAMESPACE,
+		slug: SLUG,
+		defaultId: DEFAULT_ID,
+		editingId: 'sunset',
+		token: 'primitive.color.brand.primary',
+		reload: jest.fn().mockResolvedValue(undefined),
+		refreshFeed: jest.fn().mockResolvedValue(undefined),
+		onBusy: jest.fn(),
+		onError: jest.fn(),
+		...overrides,
+	});
+
+	it('resolves without any request when nothing changed', async () => {
+		const flowArgs = args({
+			draft: { label: 'Main 1', value: '#111111' },
+			initial: { label: 'Main 1', value: '#111111' },
+		});
+
+		await saveSwatchEditsFlow(flowArgs);
+
+		expect(client.fetchPalette).not.toHaveBeenCalled();
+		expect(client.saveSwatch).not.toHaveBeenCalled();
+		expect(flowArgs.onBusy).not.toHaveBeenCalled();
+		expect(flowArgs.reload).not.toHaveBeenCalled();
+	});
+
+	it('writes only the granular swatch (edited palette) for a color-only edit', async () => {
+		client.saveSwatch.mockResolvedValue({});
+		const flowArgs = args({
+			draft: { label: 'Main 1', value: '#abcdef' },
+			initial: { label: 'Main 1', value: '#111111' },
+		});
+
+		await saveSwatchEditsFlow(flowArgs);
+
+		expect(client.saveSwatch).toHaveBeenCalledWith(
+			NAMESPACE,
+			'sunset',
+			'primitive.color.brand.primary',
+			'#abcdef',
+			SLUG
+		);
+		expect(client.fetchPalette).not.toHaveBeenCalled();
+		expect(client.savePalette).not.toHaveBeenCalled();
+		expect(flowArgs.reload).toHaveBeenCalledTimes(1);
+		expect(flowArgs.refreshFeed).toHaveBeenCalledTimes(1);
+	});
+
+	it('writes only the default node for a label-only edit', async () => {
+		client.fetchPalette.mockResolvedValue(defaultView());
+		client.savePalette.mockResolvedValue({});
+		const flowArgs = args({
+			draft: { label: 'Renamed', value: '#111111' },
+			initial: { label: 'Main 1', value: '#111111' },
+		});
+
+		await saveSwatchEditsFlow(flowArgs);
+
+		expect(client.fetchPalette).toHaveBeenCalledWith(NAMESPACE, DEFAULT_ID, SLUG);
+		expect(client.savePalette).toHaveBeenCalledWith(
+			NAMESPACE,
+			DEFAULT_ID,
+			expect.objectContaining({ label: 'Default' }),
+			SLUG
+		);
+		expect(client.saveSwatch).not.toHaveBeenCalled();
+	});
+
+	it('runs rename before the color write when both changed, with one reload and one feed refresh', async () => {
+		client.fetchPalette.mockResolvedValue(defaultView());
+		client.savePalette.mockResolvedValue({});
+		client.saveSwatch.mockResolvedValue({});
+		const order = [];
+		client.savePalette.mockImplementation(async () => {
+			order.push('savePalette');
+			return {};
+		});
+		client.saveSwatch.mockImplementation(async () => {
+			order.push('saveSwatch');
+			return {};
+		});
+		const flowArgs = args({
+			draft: { label: 'Renamed', value: '#abcdef' },
+			initial: { label: 'Main 1', value: '#111111' },
+		});
+
+		await saveSwatchEditsFlow(flowArgs);
+
+		expect(order).toEqual(['savePalette', 'saveSwatch']);
+		expect(flowArgs.reload).toHaveBeenCalledTimes(1);
+		expect(flowArgs.refreshFeed).toHaveBeenCalledTimes(1);
+	});
+
+	it('surfaces the error, clears busy, and re-throws when a write fails', async () => {
+		const failure = new Error('Sorry, that swatch could not be saved.');
+		client.saveSwatch.mockRejectedValue(failure);
+		const flowArgs = args({
+			draft: { label: 'Main 1', value: '#abcdef' },
+			initial: { label: 'Main 1', value: '#111111' },
+		});
+
+		await expect(saveSwatchEditsFlow(flowArgs)).rejects.toBe(failure);
+
+		expect(flowArgs.onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(flowArgs.onBusy).toHaveBeenLastCalledWith(false);
+	});
+});
+
+describe('openPaletteFlow', () => {
+	it('fetches the effective view and calls onOpened — no write of any kind', async () => {
+		const view = selectedView();
+		client.fetchPalette.mockResolvedValue(view);
+		const onOpened = jest.fn();
+		const onBusy = jest.fn();
+
+		await openPaletteFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			id: 'sunset',
+			onOpened,
+			onBusy,
+			onError: jest.fn(),
+		});
+
+		expect(client.fetchPalette).toHaveBeenCalledWith(NAMESPACE, 'sunset', SLUG);
+		expect(onOpened).toHaveBeenCalledWith(view);
+		expect(client.setCurrentPalette).not.toHaveBeenCalled();
+		expect(client.savePalette).not.toHaveBeenCalled();
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+
+	it('reports through onError and re-throws on failure', async () => {
+		const failure = new Error('That palette does not exist.');
+		client.fetchPalette.mockRejectedValue(failure);
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			openPaletteFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				id: 'ghost',
+				onOpened: jest.fn(),
+				onBusy,
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+});
+
+describe('activatePaletteFlow', () => {
+	it('sets $current, reloads, refreshes the feed pessimistically', async () => {
+		client.setCurrentPalette.mockResolvedValue({ current: 'sunset' });
+		const reload = jest.fn().mockResolvedValue(undefined);
+		const refreshFeed = jest.fn().mockResolvedValue(undefined);
+		const onBusy = jest.fn();
+		const onActivated = jest.fn();
+
+		await activatePaletteFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			id: 'sunset',
+			reload,
+			refreshFeed,
+			onBusy,
+			onError: jest.fn(),
+			onActivated,
+		});
+
+		expect(client.setCurrentPalette).toHaveBeenCalledWith(NAMESPACE, 'sunset', SLUG);
+		expect(onActivated).toHaveBeenCalledWith('sunset');
+		expect(reload).toHaveBeenCalled();
+		expect(refreshFeed).toHaveBeenCalledWith(SLUG);
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+
+	it('reports through onError and re-throws on failure', async () => {
+		const failure = new Error('That palette does not exist.');
+		client.setCurrentPalette.mockRejectedValue(failure);
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			activatePaletteFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				id: 'ghost',
+				reload: jest.fn(),
+				refreshFeed: jest.fn(),
+				onBusy,
+				onError,
+				onActivated: jest.fn(),
+			})
+		).rejects.toBe(failure);
+
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+});
+
+describe('createPaletteFlow', () => {
+	it('rejects an empty label with an inline error and no request', async () => {
+		const onError = jest.fn();
+
+		await expect(
+			createPaletteFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				label: '   ',
+				listing: { defaultId: DEFAULT_ID, palettes: [] },
+				openPalette: jest.fn(),
+				onBusy: jest.fn(),
+				onError,
+			})
+		).rejects.toThrow();
+
+		expect(client.fetchPalette).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: expect.stringMatching(/enter a palette name/i) });
+	});
+
+	it('rejects a duplicate id with an inline error and no request', async () => {
+		const onError = jest.fn();
+		const listing = { defaultId: DEFAULT_ID, palettes: [{ id: 'sunset', label: 'Sunset' }] };
+
+		await expect(
+			createPaletteFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				label: 'Sunset',
+				listing,
+				openPalette: jest.fn(),
+				onBusy: jest.fn(),
+				onError,
+			})
+		).rejects.toThrow();
+
+		expect(client.fetchPalette).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: expect.stringMatching(/already exists/i) });
+	});
+
+	it('seeds the new node from the default view, opens it, and never activates it', async () => {
+		client.fetchPalette.mockResolvedValue(defaultView());
+		client.savePalette.mockResolvedValue({});
+		const openPalette = jest.fn().mockResolvedValue(undefined);
+		const listing = { defaultId: DEFAULT_ID, palettes: [] };
+
+		await createPaletteFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			label: 'Forest',
+			listing,
+			openPalette,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(client.fetchPalette).toHaveBeenCalledWith(NAMESPACE, DEFAULT_ID, SLUG);
+		expect(client.savePalette).toHaveBeenCalledWith(
+			NAMESPACE,
+			'forest',
+			expect.objectContaining({ label: 'Forest' }),
+			SLUG
+		);
+		expect(openPalette).toHaveBeenCalledWith('forest');
+		expect(client.setCurrentPalette).not.toHaveBeenCalled();
+	});
+
+	it('surfaces the error, clears busy, and rejects when the create request fails', async () => {
+		const failure = new Error('Could not create the palette.');
+		client.fetchPalette.mockRejectedValue(failure);
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+		const listing = { defaultId: DEFAULT_ID, palettes: [] };
+
+		await expect(
+			createPaletteFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				label: 'Forest',
+				listing,
+				openPalette: jest.fn(),
+				onBusy,
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy).toHaveBeenLastCalledWith(false);
+	});
+});
+
+describe('deletePaletteFlow', () => {
+	it('deletes, defers to reload for the server-resolved fallback, and never activates a successor', async () => {
+		client.deletePalette.mockResolvedValue({ $default: DEFAULT_ID, $current: DEFAULT_ID, palettes: [] });
+		const reload = jest.fn().mockResolvedValue(undefined);
+		const refreshFeed = jest.fn().mockResolvedValue(undefined);
+		const onBusy = jest.fn();
+
+		await deletePaletteFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			id: 'sunset',
+			reload,
+			refreshFeed,
+			onBusy,
+			onError: jest.fn(),
+		});
+
+		expect(client.deletePalette).toHaveBeenCalledWith(NAMESPACE, 'sunset', SLUG);
+		// The flow never assumes a fallback id itself — it defers to `reload`, which re-reads the
+		// listing from the server and so always reflects the server's own fallback decision.
+		expect(reload).toHaveBeenCalled();
+		expect(refreshFeed).toHaveBeenCalledWith(SLUG);
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+		// No successor is ever activated first — unlike deleteLibraryFlow, deleting a palette that
+		// is merely being edited has no live-site effect to sequence around.
+		expect(client.setCurrentPalette).not.toHaveBeenCalled();
+	});
+
+	it('surfaces the default-palette 400 message', async () => {
+		const failure = new Error('The default palette cannot be deleted.');
+		client.deletePalette.mockRejectedValue(failure);
+		const onError = jest.fn();
+
+		await expect(
+			deletePaletteFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				id: DEFAULT_ID,
+				reload: jest.fn(),
+				refreshFeed: jest.fn(),
+				onBusy: jest.fn(),
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+	});
+});
+
+describe('removeSwatchFlow', () => {
+	const baseArgs = (overrides) => ({
+		namespace: NAMESPACE,
+		slug: SLUG,
+		defaultId: DEFAULT_ID,
+		token: 'primitive.color.custom.custom-1',
+		reload: jest.fn().mockResolvedValue(undefined),
+		refreshFeed: jest.fn().mockResolvedValue({ version: 'v3' }),
+		onBusy: jest.fn(),
+		onError: jest.fn(),
+		...overrides,
+	});
+
+	beforeEach(() => {
+		client.fetchPalette.mockResolvedValue(defaultView());
+		client.savePalette.mockResolvedValue({});
+	});
+
+	it('deletes the user primitive only for a user-created token, after the palette write', async () => {
+		client.deleteUserPrimitive.mockResolvedValue({});
+		const flowArgs = baseArgs({ isUserCreated: true });
+
+		await removeSwatchFlow(flowArgs);
+
+		expect(client.savePalette).toHaveBeenCalled();
+		expect(client.deleteUserPrimitive).toHaveBeenCalledWith(SLUG, 'primitive.color.custom.custom-1', 'v3');
+	});
+
+	it('never calls deleteUserPrimitive for a baseline token', async () => {
+		const flowArgs = baseArgs({ token: 'primitive.color.brand.primary', isUserCreated: false });
+
+		await removeSwatchFlow(flowArgs);
+
+		expect(client.savePalette).toHaveBeenCalled();
+		expect(client.deleteUserPrimitive).not.toHaveBeenCalled();
+	});
+
+	it('never calls deleteUserPrimitive before the row-removal write has settled', async () => {
+		const order = [];
+		client.savePalette.mockImplementation(async () => {
+			order.push('savePalette');
+			return {};
+		});
+		client.deleteUserPrimitive.mockImplementation(async () => {
+			order.push('deleteUserPrimitive');
+			return {};
+		});
+		const flowArgs = baseArgs({
+			isUserCreated: true,
+			reload: jest.fn(async () => {
+				order.push('reload');
+			}),
+			refreshFeed: jest.fn(async () => {
+				order.push('refreshFeed');
+				return { version: 'v3' };
+			}),
+		});
+
+		await removeSwatchFlow(flowArgs);
+
+		expect(order).toEqual(['savePalette', 'reload', 'refreshFeed', 'deleteUserPrimitive', 'refreshFeed']);
+	});
+
+	it('resolves — does not reject — when deleteUserPrimitive fails after the row removal already succeeded, and still calls refreshFeed once more', async () => {
+		client.deleteUserPrimitive.mockRejectedValue(new Error('Referenced elsewhere.'));
+		const refreshFeed = jest.fn().mockResolvedValue({ version: 'v3' });
+		const flowArgs = baseArgs({ isUserCreated: true, refreshFeed });
+
+		await expect(removeSwatchFlow(flowArgs)).resolves.toBeUndefined();
+
+		expect(refreshFeed).toHaveBeenCalledTimes(2);
+		expect(flowArgs.onError).not.toHaveBeenCalled();
+	});
+
+	it('surfaces the error and rejects when the row-removal write itself fails', async () => {
+		const failure = new Error('A palette must define at least one color group.');
+		client.savePalette.mockRejectedValue(failure);
+		const flowArgs = baseArgs({ isUserCreated: true });
+
+		await expect(removeSwatchFlow(flowArgs)).rejects.toBe(failure);
+
+		expect(flowArgs.onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(client.deleteUserPrimitive).not.toHaveBeenCalled();
+	});
+});
+
+describe('addColorFlow', () => {
+	it('creates the primitive first, then appends the swatch to the default node, and resolves with the new token id', async () => {
+		client.createUserPrimitive.mockResolvedValue({ id: 'primitive.color.custom.custom-1', version: 'v2' });
+		client.fetchPalette.mockResolvedValue(defaultView());
+		client.savePalette.mockResolvedValue({});
+		const reload = jest.fn().mockResolvedValue(undefined);
+		const refreshFeed = jest.fn().mockResolvedValue(undefined);
+
+		const token = await addColorFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			defaultId: DEFAULT_ID,
+			groupId: 'accent',
+			tokens: [],
+			palette: selectedView(),
+			feedVersion: 'v1',
+			reload,
+			refreshFeed,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(client.createUserPrimitive).toHaveBeenCalledWith(
+			SLUG,
+			expect.objectContaining({ id: 'custom-1', $type: 'color', version: 'v1' })
+		);
+		const [, , payload] = client.savePalette.mock.calls[0];
+		expect(payload.groups.find((group) => group.id === 'accent').swatches).toContainEqual(
+			expect.objectContaining({ token: 'primitive.color.custom.custom-1' })
+		);
+		expect(token).toBe('primitive.color.custom.custom-1');
+	});
+
+	it('does not write the palette when the primitive create fails', async () => {
+		const failure = new Error('Only color primitives can be created in this version.');
+		client.createUserPrimitive.mockRejectedValue(failure);
+		const onError = jest.fn();
+
+		await expect(
+			addColorFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				defaultId: DEFAULT_ID,
+				groupId: 'accent',
+				tokens: [],
+				palette: selectedView(),
+				feedVersion: 'v1',
+				reload: jest.fn(),
+				refreshFeed: jest.fn(),
+				onBusy: jest.fn(),
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(client.savePalette).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+	});
+});
+
+describe('addGroupFlow', () => {
+	it('creates the group with its first swatch in a single default write', async () => {
+		client.createUserPrimitive.mockResolvedValue({ id: 'primitive.color.custom.custom-1', version: 'v2' });
+		client.fetchPalette.mockResolvedValue(defaultView());
+		client.savePalette.mockResolvedValue({});
+
+		const token = await addGroupFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			defaultId: DEFAULT_ID,
+			label: 'Background',
+			palette: selectedView(),
+			tokens: [],
+			feedVersion: 'v1',
+			reload: jest.fn().mockResolvedValue(undefined),
+			refreshFeed: jest.fn().mockResolvedValue(undefined),
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		const [, , payload] = client.savePalette.mock.calls[0];
+		const newGroup = payload.groups.find((group) => group.id === 'background');
+
+		expect(newGroup.swatches).toHaveLength(1);
+		expect(token).toBe('primitive.color.custom.custom-1');
+	});
+
+	it('rejects an empty or duplicate group label without requests', async () => {
+		const onError = jest.fn();
+
+		await expect(
+			addGroupFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				defaultId: DEFAULT_ID,
+				label: '   ',
+				palette: selectedView(),
+				tokens: [],
+				feedVersion: 'v1',
+				reload: jest.fn(),
+				refreshFeed: jest.fn(),
+				onBusy: jest.fn(),
+				onError,
+			})
+		).rejects.toThrow();
+
+		await expect(
+			addGroupFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				defaultId: DEFAULT_ID,
+				label: 'Accent',
+				palette: selectedView(),
+				tokens: [],
+				feedVersion: 'v1',
+				reload: jest.fn(),
+				refreshFeed: jest.fn(),
+				onBusy: jest.fn(),
+				onError,
+			})
+		).rejects.toThrow();
+
+		expect(client.createUserPrimitive).not.toHaveBeenCalled();
+	});
+});
+
+describe('reorderSwatchesFlow', () => {
+	it('writes the reordered DEFAULT node regardless of the selected palette', async () => {
+		client.fetchPalette.mockResolvedValue(defaultView());
+		client.savePalette.mockResolvedValue({});
+
+		await reorderSwatchesFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			defaultId: DEFAULT_ID,
+			groupId: 'accent',
+			orderedTokens: ['primitive.color.brand.secondary', 'primitive.color.brand.primary'],
+			reload: jest.fn().mockResolvedValue(undefined),
+			refreshFeed: jest.fn().mockResolvedValue(undefined),
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(client.fetchPalette).toHaveBeenCalledWith(NAMESPACE, DEFAULT_ID, SLUG);
+		const [, , payload] = client.savePalette.mock.calls[0];
+		expect(payload.groups[0].swatches.map((swatch) => swatch.token)).toEqual([
+			'primitive.color.brand.secondary',
+			'primitive.color.brand.primary',
+		]);
+	});
+});

--- a/src/style-library/__tests__/palette-flows.test.js
+++ b/src/style-library/__tests__/palette-flows.test.js
@@ -376,6 +376,7 @@ describe('createPaletteFlow', () => {
 		client.fetchPalette.mockResolvedValue(defaultView());
 		client.savePalette.mockResolvedValue({});
 		const openPalette = jest.fn().mockResolvedValue(undefined);
+		const reload = jest.fn().mockResolvedValue(undefined);
 		const listing = { defaultId: DEFAULT_ID, palettes: [] };
 
 		await createPaletteFlow({
@@ -383,6 +384,7 @@ describe('createPaletteFlow', () => {
 			slug: SLUG,
 			label: 'Forest',
 			listing,
+			reload,
 			openPalette,
 			onBusy: jest.fn(),
 			onError: jest.fn(),
@@ -399,11 +401,42 @@ describe('createPaletteFlow', () => {
 		expect(client.setCurrentPalette).not.toHaveBeenCalled();
 	});
 
+	it('reloads the listing before opening the new palette, so the fresh row exists first', async () => {
+		client.fetchPalette.mockResolvedValue(defaultView());
+		client.savePalette.mockResolvedValue({});
+		const order = [];
+		const reload = jest.fn(async () => {
+			order.push('reload');
+		});
+		const openPalette = jest.fn(async () => {
+			order.push('openPalette');
+		});
+		const listing = { defaultId: DEFAULT_ID, palettes: [] };
+
+		await createPaletteFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			label: 'Forest',
+			listing,
+			reload,
+			openPalette,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		// `reload()` must land BEFORE `openPalette()`: `hooks/use-palettes.js`'s `reload()` keeps
+		// `editingId` unchanged (it still points at the previously-edited palette, which still
+		// exists), so this ordering means the listing already carries the new row by the time
+		// `editingId` moves onto it — otherwise the dropdown would render the raw id for one tick.
+		expect(order).toEqual(['reload', 'openPalette']);
+	});
+
 	it('surfaces the error, clears busy, and rejects when the create request fails', async () => {
 		const failure = new Error('Could not create the palette.');
 		client.fetchPalette.mockRejectedValue(failure);
 		const onBusy = jest.fn();
 		const onError = jest.fn();
+		const reload = jest.fn().mockResolvedValue(undefined);
 		const listing = { defaultId: DEFAULT_ID, palettes: [] };
 
 		await expect(
@@ -412,6 +445,7 @@ describe('createPaletteFlow', () => {
 				slug: SLUG,
 				label: 'Forest',
 				listing,
+				reload,
 				openPalette: jest.fn(),
 				onBusy,
 				onError,
@@ -420,6 +454,7 @@ describe('createPaletteFlow', () => {
 
 		expect(onError).toHaveBeenCalledWith({ message: failure.message });
 		expect(onBusy).toHaveBeenLastCalledWith(false);
+		expect(reload).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/style-library/__tests__/palette-flows.test.js
+++ b/src/style-library/__tests__/palette-flows.test.js
@@ -125,6 +125,75 @@ describe('writeDefaultPaletteFlow', () => {
 		expect(onError).toHaveBeenCalledWith({ message: failure.message });
 		expect(onBusy.mock.calls).toEqual([[true], [false]]);
 	});
+
+	it('re-reads on failure, so an optimistically applied edit is put back to the server order', async () => {
+		const failure = new Error('Save failed.');
+		client.fetchPalette.mockResolvedValue(defaultView());
+		client.savePalette.mockRejectedValue(failure);
+		const reload = jest.fn().mockResolvedValue(undefined);
+
+		await expect(
+			writeDefaultPaletteFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				defaultId: DEFAULT_ID,
+				edit: (groups) => groups,
+				reload,
+				refreshFeed: jest.fn(),
+				onBusy: jest.fn(),
+				onError: jest.fn(),
+			})
+		).rejects.toBe(failure);
+
+		// The whole point: reload() is in the success path too, so a version of this flow that only
+		// reloaded there would leave the caller's optimistic edit on screen after a failed write.
+		expect(reload).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps reporting the write error when the rollback re-read also fails, and still clears busy', async () => {
+		const failure = new Error('Save failed.');
+		client.fetchPalette.mockResolvedValue(defaultView());
+		client.savePalette.mockRejectedValue(failure);
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			writeDefaultPaletteFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				defaultId: DEFAULT_ID,
+				edit: (groups) => groups,
+				reload: jest.fn().mockRejectedValue(new Error('Re-read failed.')),
+				refreshFeed: jest.fn(),
+				onBusy,
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+
+	it('does not refresh the feed when the write failed', async () => {
+		client.fetchPalette.mockResolvedValue(defaultView());
+		client.savePalette.mockRejectedValue(new Error('Save failed.'));
+		const refreshFeed = jest.fn();
+
+		await expect(
+			writeDefaultPaletteFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				defaultId: DEFAULT_ID,
+				edit: (groups) => groups,
+				reload: jest.fn().mockResolvedValue(undefined),
+				refreshFeed,
+				onBusy: jest.fn(),
+				onError: jest.fn(),
+			})
+		).rejects.toThrow();
+
+		expect(refreshFeed).not.toHaveBeenCalled();
+	});
 });
 
 describe('saveSwatchEditsFlow', () => {

--- a/src/style-library/__tests__/palettes.test.js
+++ b/src/style-library/__tests__/palettes.test.js
@@ -1,0 +1,346 @@
+/* eslint-env jest */
+import {
+	addGroupToGroups,
+	addSwatchToGroups,
+	customColorTokenId,
+	findSwatch,
+	isCustomColorToken,
+	isDefaultPalette,
+	isDuplicatePaletteLabel,
+	mapPaletteToSwatchGroups,
+	newSwatchValue,
+	nextCustomColorSlug,
+	paletteDisplayLabel,
+	removeSwatchFromGroups,
+	renameSwatchInGroups,
+	reorderGroupSwatches,
+	slugifyPaletteLabel,
+	stripEffectiveFlags,
+	swatchInitialValues,
+} from '../helpers/palettes';
+
+const effectivePalette = () => ({
+	id: 'default',
+	label: 'Default',
+	groups: [
+		{
+			id: 'accent',
+			label: 'Accent',
+			swatches: [
+				{ token: 'primitive.color.brand.primary', label: 'Main 1', $value: '#112233', overridden: false },
+				{ token: 'primitive.color.brand.secondary', label: 'Main 2', $value: '#445566', overridden: true },
+			],
+		},
+		{
+			id: 'contrast',
+			label: 'Contrast',
+			swatches: [
+				{ token: 'primitive.color.neutral.100', label: 'Neutral 100', $value: '#ffffff', overridden: false },
+			],
+		},
+	],
+});
+
+describe('mapPaletteToSwatchGroups', () => {
+	it('maps groups and swatches to grid ids/names/subLines', () => {
+		const groups = mapPaletteToSwatchGroups(effectivePalette());
+
+		expect(groups).toEqual([
+			{
+				id: 'accent',
+				label: 'Accent',
+				items: [
+					{
+						id: 'primitive.color.brand.primary',
+						name: 'Main 1',
+						subLine: '#112233',
+						value: '#112233',
+						overridden: false,
+					},
+					{
+						id: 'primitive.color.brand.secondary',
+						name: 'Main 2',
+						subLine: '#445566',
+						value: '#445566',
+						overridden: true,
+					},
+				],
+			},
+			{
+				id: 'contrast',
+				label: 'Contrast',
+				items: [
+					{
+						id: 'primitive.color.neutral.100',
+						name: 'Neutral 100',
+						subLine: '#ffffff',
+						value: '#ffffff',
+						overridden: false,
+					},
+				],
+			},
+		]);
+	});
+
+	it('uses the token as the item id and carries overridden through', () => {
+		const [accent] = mapPaletteToSwatchGroups(effectivePalette());
+
+		expect(accent.items[0].id).toBe('primitive.color.brand.primary');
+		expect(accent.items[1].overridden).toBe(true);
+	});
+
+	it('returns [] for a null/empty palette', () => {
+		expect(mapPaletteToSwatchGroups(null)).toEqual([]);
+		expect(mapPaletteToSwatchGroups({})).toEqual([]);
+	});
+});
+
+describe('findSwatch', () => {
+	it('finds a swatch by token and returns null for a missing one', () => {
+		expect(findSwatch(effectivePalette(), 'primitive.color.neutral.100')).toEqual({
+			token: 'primitive.color.neutral.100',
+			label: 'Neutral 100',
+			$value: '#ffffff',
+			overridden: false,
+		});
+		expect(findSwatch(effectivePalette(), 'primitive.color.missing')).toBeNull();
+	});
+});
+
+describe('swatchInitialValues', () => {
+	it('returns { label, value } and empty strings when the token is missing', () => {
+		expect(swatchInitialValues(effectivePalette(), 'primitive.color.brand.primary')).toEqual({
+			label: 'Main 1',
+			value: '#112233',
+		});
+		expect(swatchInitialValues(effectivePalette(), 'primitive.color.missing')).toEqual({ label: '', value: '' });
+	});
+});
+
+describe('isDefaultPalette', () => {
+	it('matches $default and fails closed on a missing pointer', () => {
+		expect(isDefaultPalette({ defaultId: 'default' }, 'default')).toBe(true);
+		expect(isDefaultPalette({ defaultId: 'default' }, 'sunset')).toBe(false);
+		expect(isDefaultPalette({ defaultId: '' }, 'sunset')).toBe(true);
+		expect(isDefaultPalette({}, 'sunset')).toBe(true);
+	});
+});
+
+describe('paletteDisplayLabel', () => {
+	it('falls back to the id for an empty label', () => {
+		expect(paletteDisplayLabel({ id: 'sunset', label: 'Sunset' })).toBe('Sunset');
+		expect(paletteDisplayLabel({ id: 'sunset', label: '' })).toBe('sunset');
+	});
+});
+
+describe('slugifyPaletteLabel / isDuplicatePaletteLabel', () => {
+	it('kebab-cases the label', () => {
+		expect(slugifyPaletteLabel('Sunset Glow')).toBe('sunset-glow');
+	});
+
+	it('detects a collision against the listing', () => {
+		const listing = { palettes: [{ id: 'sunset', label: 'Sunset' }] };
+
+		expect(isDuplicatePaletteLabel('Sunset', listing)).toBe(true);
+		expect(isDuplicatePaletteLabel('Forest', listing)).toBe(false);
+		expect(isDuplicatePaletteLabel('   ', listing)).toBe(false);
+	});
+});
+
+describe('stripEffectiveFlags', () => {
+	it('removes overridden and nothing else, immutably', () => {
+		const groups = effectivePalette().groups;
+		const stripped = stripEffectiveFlags(groups);
+
+		expect(stripped).toEqual([
+			{
+				id: 'accent',
+				label: 'Accent',
+				swatches: [
+					{ token: 'primitive.color.brand.primary', label: 'Main 1', $value: '#112233' },
+					{ token: 'primitive.color.brand.secondary', label: 'Main 2', $value: '#445566' },
+				],
+			},
+			{
+				id: 'contrast',
+				label: 'Contrast',
+				swatches: [{ token: 'primitive.color.neutral.100', label: 'Neutral 100', $value: '#ffffff' }],
+			},
+		]);
+		expect(groups[0].swatches[0].overridden).toBe(false);
+	});
+});
+
+describe('addSwatchToGroups', () => {
+	it('appends to the right group', () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+		const next = addSwatchToGroups(groups, 'contrast', {
+			token: 'primitive.color.custom.custom-1',
+			label: 'New Color',
+			$value: '#000000',
+		});
+
+		expect(next.find((group) => group.id === 'contrast').swatches).toHaveLength(2);
+		expect(groups.find((group) => group.id === 'contrast').swatches).toHaveLength(1);
+	});
+
+	it('no-ops (same reference) on an unknown group', () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+
+		expect(addSwatchToGroups(groups, 'ghost', { token: 'x', label: 'x', $value: '#000000' })).toBe(groups);
+	});
+});
+
+describe('removeSwatchFromGroups', () => {
+	it('removes the swatch and drops a group left empty', () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+		const next = removeSwatchFromGroups(groups, 'primitive.color.neutral.100');
+
+		expect(next).toHaveLength(1);
+		expect(next[0].id).toBe('accent');
+	});
+
+	it('no-ops on an unknown token', () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+
+		expect(removeSwatchFromGroups(groups, 'primitive.color.missing')).toBe(groups);
+	});
+});
+
+describe('renameSwatchInGroups', () => {
+	it('changes only the target swatch label', () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+		const next = renameSwatchInGroups(groups, 'primitive.color.brand.primary', 'Renamed');
+		const accent = next.find((group) => group.id === 'accent');
+
+		expect(accent.swatches[0].label).toBe('Renamed');
+		expect(accent.swatches[1].label).toBe('Main 2');
+	});
+});
+
+describe('reorderGroupSwatches', () => {
+	it('applies the ordered token list within one group only', () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+		const next = reorderGroupSwatches(groups, 'accent', [
+			'primitive.color.brand.secondary',
+			'primitive.color.brand.primary',
+		]);
+		const accent = next.find((group) => group.id === 'accent');
+
+		expect(accent.swatches.map((swatch) => swatch.token)).toEqual([
+			'primitive.color.brand.secondary',
+			'primitive.color.brand.primary',
+		]);
+		expect(next.find((group) => group.id === 'contrast')).toEqual(groups.find((group) => group.id === 'contrast'));
+	});
+
+	it('keeps tokens missing from the order at the end in their relative position', () => {
+		const groups = [
+			{
+				id: 'accent',
+				label: 'Accent',
+				swatches: [
+					{ token: 'a', label: 'A', $value: '#111' },
+					{ token: 'b', label: 'B', $value: '#222' },
+					{ token: 'c', label: 'C', $value: '#333' },
+				],
+			},
+		];
+		const next = reorderGroupSwatches(groups, 'accent', ['c']);
+
+		expect(next[0].swatches.map((swatch) => swatch.token)).toEqual(['c', 'a', 'b']);
+	});
+
+	it('no-ops on an unknown group id', () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+
+		expect(reorderGroupSwatches(groups, 'ghost', [])).toBe(groups);
+	});
+});
+
+describe('addGroupToGroups', () => {
+	it('appends the group', () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+		const newGroup = {
+			id: 'background',
+			label: 'Background',
+			swatches: [{ token: 'x', label: 'X', $value: '#000' }],
+		};
+		const next = addGroupToGroups(groups, newGroup);
+
+		expect(next).toHaveLength(3);
+		expect(next[2]).toEqual(newGroup);
+	});
+});
+
+describe('immutability', () => {
+	it('every node-edit helper leaves its input un-mutated', () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+		const frozen = JSON.parse(JSON.stringify(groups));
+
+		deepFreeze(groups);
+
+		addSwatchToGroups(groups, 'accent', { token: 'x', label: 'x', $value: '#000' });
+		removeSwatchFromGroups(groups, 'primitive.color.brand.primary');
+		renameSwatchInGroups(groups, 'primitive.color.brand.primary', 'Renamed');
+		reorderGroupSwatches(groups, 'accent', ['primitive.color.brand.secondary', 'primitive.color.brand.primary']);
+		addGroupToGroups(groups, { id: 'x', label: 'X', swatches: [] });
+
+		expect(groups).toEqual(frozen);
+	});
+});
+
+describe('nextCustomColorSlug', () => {
+	it('starts at custom-1 and skips existing suffixes', () => {
+		expect(nextCustomColorSlug([])).toBe('custom-1');
+		expect(nextCustomColorSlug(['primitive.color.custom.custom-1'])).toBe('custom-2');
+		expect(nextCustomColorSlug(['primitive.color.custom.custom-1', 'primitive.color.custom.custom-2'])).toBe(
+			'custom-3'
+		);
+		expect(nextCustomColorSlug(['primitive.color.custom.custom-2'])).toBe('custom-1');
+	});
+});
+
+describe('customColorTokenId', () => {
+	it('prefixes primitive.color.custom.', () => {
+		expect(customColorTokenId('custom-1')).toBe('primitive.color.custom.custom-1');
+	});
+});
+
+describe('newSwatchValue', () => {
+	it("copies the group's last swatch value and falls back to #000000", () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+
+		expect(newSwatchValue(groups, 'accent')).toBe('#445566');
+		expect(newSwatchValue(groups, 'ghost')).toBe('#000000');
+		expect(newSwatchValue([], 'accent')).toBe('#000000');
+	});
+});
+
+describe('isCustomColorToken', () => {
+	it('matches only the custom prefix', () => {
+		expect(isCustomColorToken('primitive.color.custom.custom-1')).toBe(true);
+		expect(isCustomColorToken('primitive.color.brand.primary')).toBe(false);
+		expect(isCustomColorToken('')).toBe(false);
+	});
+});
+
+/**
+ * Deep-freeze a fixture so an accidental mutation inside a helper throws instead of silently
+ * passing under strict mode, or passes visibly under sloppy mode via the equality check above.
+ *
+ * @param {Object} value The value to freeze, recursively.
+ *
+ * @since TBD
+ *
+ * @return {Object} The same value, frozen.
+ */
+function deepFreeze(value) {
+	Object.values(value).forEach((prop) => {
+		if (prop && typeof prop === 'object' && !Object.isFrozen(prop)) {
+			deepFreeze(prop);
+		}
+	});
+
+	return Object.freeze(value);
+}

--- a/src/style-library/api/client.js
+++ b/src/style-library/api/client.js
@@ -189,6 +189,22 @@ export function deleteSwatch(namespace, id, token, slug) {
 }
 
 /**
+ * Delete a palette. The library's default palette cannot be deleted — the server refuses with a
+ * 400 — and the response on success is the fresh palette listing.
+ *
+ * @param {string} namespace REST namespace.
+ * @param {string} id        The palette id.
+ * @param {string} slug      Token set slug.
+ *
+ * @since TBD
+ *
+ * @return {Promise<object>} The updated palette listing.
+ */
+export function deletePalette(namespace, id, slug) {
+	return apiFetch({ path: palettePath(namespace, id, slug), method: 'DELETE' });
+}
+
+/**
  * Fetch the alias-reference preview for a user primitive.
  *
  * @since TBD

--- a/src/style-library/helpers/palette-flows.js
+++ b/src/style-library/helpers/palette-flows.js
@@ -1,0 +1,687 @@
+/**
+ * Pure orchestration for the Color Palette screen's write flows: open, activate, create, delete,
+ * the settings-panel save (rename + recolor), swatch removal, add color, add color group, and
+ * within-group reorder. Extracted out of `hooks/use-palettes` so each flow can be exercised
+ * directly in tests without rendering a component — a flow takes the REST calls it needs
+ * (imported here, so a test mocks `api/client`) plus a small set of injected callbacks for the
+ * state a caller reacts to (busy, a scoped error slot, and a `reload`/`refreshFeed` pair the hook
+ * provides). Every flow settles pessimistically and re-throws on failure so its caller (a modal,
+ * or the settings panel) can tell success from failure; none reloads the page.
+ *
+ * `writeDefaultPaletteFlow` is the single place the default-vs-edited write routing (a palette's
+ * structure lives only on its `$default` node — see the module's own docblock below) is encoded.
+ * Every structural flow in this file funnels through it; only `saveSwatchEditsFlow`'s color half
+ * ever writes the palette being edited.
+ *
+ * The central distinction here mirrors `library-flows.js`: the palette a site *renders with*
+ * (`$current`) versus the palette the app is *editing*. Opening is free and reversible — it only
+ * reads an effective view, so a user can browse and edit any palette without touching what
+ * visitors see. Activating is the one flow that writes `$current`, and it is deliberate and
+ * guarded because that pointer is overlaid onto the color token leaves before alias flattening
+ * (`Token_Resolver::apply_palette_overlay()`), so it re-tints resolved color values across the
+ * whole app, not just this screen.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	createUserPrimitive,
+	deletePalette,
+	deleteUserPrimitive,
+	fetchPalette,
+	savePalette,
+	saveSwatch,
+	setCurrentPalette,
+} from '../api/client';
+import { errorMessage } from './library-flows';
+import {
+	addGroupToGroups,
+	addSwatchToGroups,
+	customColorTokenId,
+	isDuplicatePaletteLabel,
+	newSwatchValue,
+	nextCustomColorSlug,
+	removeSwatchFromGroups,
+	renameSwatchInGroups,
+	reorderGroupSwatches,
+	slugifyPaletteLabel,
+	stripEffectiveFlags,
+} from './palettes';
+
+/**
+ * Apply a structural edit to the DEFAULT palette node and persist it. Structure (which swatches
+ * exist, their labels, their grouping, their order) lives ONLY on the default palette — the
+ * effective view of every other palette is projected from it — so every structural flow below
+ * funnels through here, and none of them ever writes structure to the palette being edited.
+ *
+ * The payload is built from a FRESH read of the default palette's own view: the displayed
+ * (edited) palette's view carries that palette's own values, and using it here would overwrite
+ * the default palette's colors with another palette's deltas.
+ *
+ * @param {Object}   args
+ * @param {string}   args.namespace    The REST namespace (from the feed's REST descriptor).
+ * @param {string}   args.slug         The token library slug.
+ * @param {string}   args.defaultId    The listing's `$default` palette id.
+ * @param {Function} args.edit         Pure `(groups) => groups` transform (from `./palettes`).
+ * @param {Function} args.reload       Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.refreshFeed  Replaces the feed for a slug.
+ * @param {Function} args.onBusy       Called with a boolean as the chain starts and settles.
+ * @param {Function} args.onError      Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once the write, the re-reads, and the feed refresh complete;
+ *                          rejects on failure after `onError`/`onBusy` have run.
+ */
+export function writeDefaultPaletteFlow({ namespace, slug, defaultId, edit, reload, refreshFeed, onBusy, onError }) {
+	onBusy(true);
+
+	return fetchPalette(namespace, defaultId, slug)
+		.then((view) => {
+			const groups = edit(stripEffectiveFlags(view.groups));
+
+			return savePalette(namespace, defaultId, { label: view.label, groups }, slug);
+		})
+		.then(() => reload())
+		.then(() => refreshFeed(slug))
+		.then(() => onBusy(false))
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+			throw err;
+		});
+}
+
+/**
+ * Save the settings panel's edits for a swatch: a label change (a structure edit, written to the
+ * default palette node) and/or a value change (written to the palette being edited via the
+ * granular per-swatch endpoint) — the only flow in this module that ever targets the edited
+ * palette rather than the default node. A label change runs before a value change when both are
+ * dirty; either way there is exactly one `reload` and one `refreshFeed` for the whole save.
+ *
+ * The color write targets `editingId`, not `$current` — recoloring a swatch on a palette a user
+ * is building out must never require that palette to be live first.
+ *
+ * @param {Object}   args
+ * @param {string}   args.namespace   The REST namespace.
+ * @param {string}   args.slug        The token library slug.
+ * @param {string}   args.defaultId   The listing's `$default` palette id.
+ * @param {string}   args.editingId   The palette id currently open for editing.
+ * @param {string}   args.token       The swatch token dot-path being edited.
+ * @param {Object}   args.draft       The panel's draft values, `{ label, value }`.
+ * @param {Object}   args.initial     The values the panel opened with, `{ label, value }`.
+ * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.refreshFeed Replaces the feed for a slug.
+ * @param {Function} args.onBusy      Called with a boolean as the chain starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves immediately, with no request, when neither field changed;
+ *                          otherwise resolves once every dirty write, the reload, and the feed
+ *                          refresh complete, or rejects on failure after `onError`/`onBusy` run.
+ */
+export function saveSwatchEditsFlow({
+	namespace,
+	slug,
+	defaultId,
+	editingId,
+	token,
+	draft,
+	initial,
+	reload,
+	refreshFeed,
+	onBusy,
+	onError,
+}) {
+	const renamed = draft.label !== initial.label;
+	const recolored = draft.value !== initial.value;
+
+	if (!renamed && !recolored) {
+		return Promise.resolve();
+	}
+
+	onBusy(true);
+
+	let chain = Promise.resolve();
+
+	if (renamed) {
+		chain = chain
+			.then(() => fetchPalette(namespace, defaultId, slug))
+			.then((view) =>
+				savePalette(
+					namespace,
+					defaultId,
+					{
+						label: view.label,
+						groups: renameSwatchInGroups(stripEffectiveFlags(view.groups), token, draft.label),
+					},
+					slug
+				)
+			);
+	}
+
+	if (recolored) {
+		chain = chain.then(() => saveSwatch(namespace, editingId, token, draft.value, slug));
+	}
+
+	return chain
+		.then(() => reload())
+		.then(() => refreshFeed(slug))
+		.then(() => onBusy(false))
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+			throw err;
+		});
+}
+
+/**
+ * Show a palette in the app: fetch its effective view, and nothing else.
+ *
+ * This never writes `$current`. Choosing a palette from the header dropdown is a navigation act,
+ * not a publishing one — editing a palette other than the one the site renders with is the normal
+ * case (e.g. building out a dark variant while the site still runs a light one), and the API
+ * already supports that split with no new plumbing: `GET /palettes/{id}` returns any palette's
+ * effective view without touching `$current`. The site keeps rendering whatever palette is active
+ * until someone explicitly activates a different one through `activatePaletteFlow`. A future
+ * reader who "fixes" this to also write `$current` would silently re-tint the live site every time
+ * someone merely looks at a different palette — don't.
+ *
+ * Kept as its own flow, thin as it is, rather than a bare fetch inlined in the hook, only so
+ * `createPaletteFlow` can chain off it the way `createLibraryFlow` chains off `openLibraryFlow` —
+ * see that pair for the shape this mirrors.
+ *
+ * @param {Object}   args
+ * @param {string}   args.namespace The REST namespace.
+ * @param {string}   args.slug      The token library slug.
+ * @param {string}   args.id        The palette id to open for editing.
+ * @param {Function} args.onOpened  Called with the fetched effective view once the read completes.
+ * @param {Function} args.onBusy    Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError   Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once `onOpened` has run; rejects on failure, after
+ *                          `onError`/`onBusy` have already run.
+ */
+export function openPaletteFlow({ namespace, slug, id, onOpened, onBusy, onError }) {
+	onBusy(true);
+
+	return fetchPalette(namespace, id, slug)
+		.then((view) => onOpened(view))
+		.then(() => onBusy(false))
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+
+			// Re-thrown so a caller chaining off an open (createPaletteFlow, below) can tell a
+			// failed open from a successful one instead of treating this as done. A caller that
+			// only fires a plain open (no chained action) must catch this itself — the error is
+			// already surfaced through `onError` regardless.
+			throw err;
+		});
+}
+
+/**
+ * Point the library's `$current` palette pointer at `id` — the one palette-selection operation
+ * that changes the live site. Reloads and refreshes the feed for the same reason
+ * `writeDefaultPaletteFlow` does: `$current`'s swatch values are overlaid onto the color token
+ * leaves before alias flattening (`Token_Resolver::apply_palette_overlay()`), so activating
+ * re-tints resolved color values everywhere the feed's schema is consumed, not only on this
+ * screen — unlike `activateLibraryFlow`, which skips the refresh because a library's own content
+ * does not change when it becomes active.
+ *
+ * @param {Object}   args
+ * @param {string}   args.namespace   The REST namespace.
+ * @param {string}   args.slug        The token library slug.
+ * @param {string}   args.id          The palette id to make current.
+ * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.refreshFeed Replaces the feed for a slug.
+ * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure.
+ * @param {Function} args.onActivated Called with the id the server resolved as current.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once the pointer has moved, the listing has been re-read, and
+ *                          the feed refreshed; rejects on failure after `onError`/`onBusy` have run.
+ */
+export function activatePaletteFlow({ namespace, slug, id, reload, refreshFeed, onBusy, onError, onActivated }) {
+	onBusy(true);
+
+	return (
+		setCurrentPalette(namespace, id, slug)
+			// The resolved id comes from the response rather than the request, mirroring
+			// `activateLibraryFlow` — the server owns which palette ended up current.
+			.then((result) => onActivated(result?.current ?? id))
+			.then(() => reload())
+			.then(() => refreshFeed(slug))
+			.then(() => onBusy(false))
+			.catch((err) => {
+				onError({ message: errorMessage(err) });
+				onBusy(false);
+
+				// Re-thrown so the confirmation modal can tell success from failure and knows
+				// whether to close itself.
+				throw err;
+			})
+	);
+}
+
+/**
+ * Create a palette from a typed label, seeded from the default palette's own effective view (so
+ * it starts as a mirror of the default until something recolors it), then open it for editing.
+ *
+ * Creating a palette does not activate it, mirroring `createLibraryFlow`. A new palette starts as
+ * a copy of the default and is built up (recolored, renamed) over time; making it the site's live
+ * palette is a separate, explicit decision the user makes once it is ready — not a side effect of
+ * having typed a name.
+ *
+ * @param {Object}   args
+ * @param {string}   args.namespace   The REST namespace.
+ * @param {string}   args.slug        The token library slug.
+ * @param {string}   args.label       The typed palette label.
+ * @param {Object}   args.listing     The current listing (`{ defaultId, palettes }`), for the
+ *                                    duplicate-id check.
+ * @param {Function} args.openPalette Opens a palette for editing (typically `openPaletteFlow`
+ *                                    bound to the new id).
+ * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure or invalid input.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once the palette is created and opened for editing; rejects on
+ *                          an empty or duplicate label, or a request failure, after `onError` has
+ *                          already run.
+ */
+export function createPaletteFlow({ namespace, slug, label, listing, openPalette, onBusy, onError }) {
+	const id = slugifyPaletteLabel(label);
+
+	// Both validation failures reject rather than resolve: a caller that closes its modal on a
+	// resolved promise must instead leave it open on the inline error so the user can fix the
+	// label.
+	if (!id) {
+		const message = __('Enter a palette name.', 'kadence-blocks');
+		onError({ message });
+		return Promise.reject(new Error(message));
+	}
+
+	if (isDuplicatePaletteLabel(label, listing)) {
+		const message = __('A palette with that name already exists.', 'kadence-blocks');
+		onError({ message });
+		return Promise.reject(new Error(message));
+	}
+
+	onBusy(true);
+
+	return fetchPalette(namespace, listing.defaultId, slug)
+		.then((view) => savePalette(namespace, id, { label, groups: stripEffectiveFlags(view.groups) }, slug))
+		.then(() => openPalette(id))
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+
+			throw err;
+		});
+}
+
+/**
+ * Delete a palette. The server refuses to delete the `$default` palette (400), so this is only
+ * ever called for a non-default id.
+ *
+ * Unlike `deleteLibraryFlow`, this never activates a successor first. Two things make that
+ * ordering unnecessary here, not merely skipped: first, opening no longer writes `$current`, so
+ * deleting a palette that is merely being edited (not the live one) has no effect on what a
+ * visitor sees, regardless of ordering — there is nothing to sequence. Second, when the deleted
+ * palette *is* `$current`, the server resolves its own fallback and returns it in the same
+ * response (`prepare_items()`), the same way it always has; there is no UI for naming a preferred
+ * successor for a palette the way `DeleteLibraryModal` offers one for a library; a confirm is all
+ * this deletion ever asks for. `reload` re-reads the listing from the server rather than the flow
+ * assuming which palette ends up current or which one the app should now edit — mirroring
+ * `deleteLibraryFlow`'s re-read of the active-library pointer for the analogous case, and letting
+ * the hook fall the edited palette back to `$current` when the one just deleted was it.
+ *
+ * @param {Object}   args
+ * @param {string}   args.namespace   The REST namespace.
+ * @param {string}   args.slug        The token library slug.
+ * @param {string}   args.id          The palette id to delete.
+ * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.refreshFeed Replaces the feed for a slug.
+ * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once the delete, the reload, and the feed refresh complete;
+ *                          rejects on failure (e.g. the default-palette 400) after
+ *                          `onError`/`onBusy` have run.
+ */
+export function deletePaletteFlow({ namespace, slug, id, reload, refreshFeed, onBusy, onError }) {
+	onBusy(true);
+
+	return deletePalette(namespace, id, slug)
+		.then(() => reload())
+		.then(() => refreshFeed(slug))
+		.then(() => onBusy(false))
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+			throw err;
+		});
+}
+
+/**
+ * Rename a swatch — a structure edit, written to the default palette node.
+ *
+ * @param {Object}   args
+ * @param {string}   args.namespace   The REST namespace.
+ * @param {string}   args.slug        The token library slug.
+ * @param {string}   args.defaultId   The listing's `$default` palette id.
+ * @param {string}   args.token       The swatch token dot-path to rename.
+ * @param {string}   args.label       The new label.
+ * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.refreshFeed Replaces the feed for a slug.
+ * @param {Function} args.onBusy      Called with a boolean as the chain starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} See `writeDefaultPaletteFlow`.
+ */
+export function renameSwatchFlow({ namespace, slug, defaultId, token, label, reload, refreshFeed, onBusy, onError }) {
+	return writeDefaultPaletteFlow({
+		namespace,
+		slug,
+		defaultId,
+		edit: (groups) => renameSwatchInGroups(groups, token, label),
+		reload,
+		refreshFeed,
+		onBusy,
+		onError,
+	});
+}
+
+/**
+ * Reorder one group's swatches — a structure edit, written to the default palette node regardless
+ * of which palette is being edited (palette order is genuinely ordered document data, not
+ * the client-side-only reorder the rest of this app uses).
+ *
+ * @param {Object}         args
+ * @param {string}         args.namespace     The REST namespace.
+ * @param {string}         args.slug          The token library slug.
+ * @param {string}         args.defaultId     The listing's `$default` palette id.
+ * @param {string}         args.groupId       The group being reordered.
+ * @param {Array<string>}  args.orderedTokens The new swatch token order.
+ * @param {Function}       args.reload        Re-reads the listing (and the edited view) from the hook.
+ * @param {Function}       args.refreshFeed   Replaces the feed for a slug.
+ * @param {Function}       args.onBusy        Called with a boolean as the chain starts and settles.
+ * @param {Function}       args.onError       Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} See `writeDefaultPaletteFlow`.
+ */
+export function reorderSwatchesFlow({
+	namespace,
+	slug,
+	defaultId,
+	groupId,
+	orderedTokens,
+	reload,
+	refreshFeed,
+	onBusy,
+	onError,
+}) {
+	return writeDefaultPaletteFlow({
+		namespace,
+		slug,
+		defaultId,
+		edit: (groups) => reorderGroupSwatches(groups, groupId, orderedTokens),
+		reload,
+		refreshFeed,
+		onBusy,
+		onError,
+	});
+}
+
+/**
+ * Remove a swatch: strips its row from the default palette's structure first, then — only for a
+ * user-created token — best-effort deletes the underlying primitive as a second step.
+ *
+ * The order is load-bearing, not incidental. `Token_Reference_Policy` never scans palette
+ * swatches, so its reference gate was never what made this safe; safety instead comes from the
+ * row-removal write landing first, which removes the token from every palette's effective view
+ * (every palette's view is projected from the default node) before the primitive delete ever
+ * runs — no later read or write in this flow can re-guard the now-absent row. The cleanup step
+ * can still fail on a reference the policy DOES track elsewhere (e.g. a semantic-layer alias to
+ * the same primitive); because the row is already gone by the time that call runs, that failure
+ * must not read as the whole delete failing, so it is swallowed rather than re-thrown, and the
+ * feed is refreshed once more regardless of its outcome so a stale version never blocks the next
+ * mint.
+ *
+ * @param {Object}   args
+ * @param {string}   args.namespace     The REST namespace.
+ * @param {string}   args.slug          The token library slug.
+ * @param {string}   args.defaultId     The listing's `$default` palette id.
+ * @param {string}   args.token         The swatch token dot-path to remove.
+ * @param {boolean}  args.isUserCreated Whether `token` is a user-created custom color — gates
+ *                                      ONLY the cleanup step, never the row removal.
+ * @param {Function} args.reload        Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.refreshFeed   Replaces the feed for a slug; resolves with the fresh feed
+ *                                      payload, whose `version` the cleanup step's delete call needs.
+ * @param {Function} args.onBusy        Called with a boolean as the chain starts and settles.
+ * @param {Function} args.onError       Called with `{ message }` on failure of the row-removal write.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once the row-removal write (and, for a user-created token, the
+ *                          best-effort cleanup attempt) settle; rejects only when the row-removal
+ *                          write itself fails, after `onError`/`onBusy` have run.
+ */
+export function removeSwatchFlow({
+	namespace,
+	slug,
+	defaultId,
+	token,
+	isUserCreated,
+	reload,
+	refreshFeed,
+	onBusy,
+	onError,
+}) {
+	onBusy(true);
+
+	return fetchPalette(namespace, defaultId, slug)
+		.then((view) => {
+			const groups = removeSwatchFromGroups(stripEffectiveFlags(view.groups), token);
+
+			return savePalette(namespace, defaultId, { label: view.label, groups }, slug);
+		})
+		.then(() => reload())
+		.then(() => refreshFeed(slug))
+		.then((freshFeed) => {
+			if (!isUserCreated) {
+				onBusy(false);
+				return;
+			}
+
+			return deleteUserPrimitive(slug, token, freshFeed?.version)
+				.catch(() => {
+					// Best-effort: a cleanup failure never reverses the row removal.
+				})
+				.then(() => refreshFeed(slug))
+				.then(() => onBusy(false));
+		})
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+			throw err;
+		});
+}
+
+/**
+ * Mint a user color primitive and append it as a new swatch in `groupId` on the default palette —
+ * `guard_swatches()` rejects any swatch whose token does not already resolve to a registered
+ * color token, so the primitive must exist before the swatch referencing it can be saved.
+ *
+ * @param {Object}   args
+ * @param {string}   args.namespace   The REST namespace.
+ * @param {string}   args.slug        The token library slug.
+ * @param {string}   args.defaultId   The listing's `$default` palette id.
+ * @param {string}   args.groupId     The group to append the new swatch to.
+ * @param {Array<string>} args.tokens Every existing token id (feed tokens plus the palette's own
+ *                                    swatch tokens) the new slug must avoid colliding with.
+ * @param {Object}   args.palette     The palette being edited's effective view, for a
+ *                                    friendlier starting color (the group's last swatch's value).
+ * @param {string}   args.feedVersion The feed's current version, sent as the primitive create's
+ *                                    concurrency guard.
+ * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.refreshFeed Replaces the feed for a slug.
+ * @param {Function} args.onBusy      Called with a boolean as the chain starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<string>} Resolves with the new swatch's token id, so the caller can select it;
+ *                            rejects on failure after `onError`/`onBusy` have run.
+ */
+export function addColorFlow({
+	namespace,
+	slug,
+	defaultId,
+	groupId,
+	tokens,
+	palette,
+	feedVersion,
+	reload,
+	refreshFeed,
+	onBusy,
+	onError,
+}) {
+	const colorSlug = nextCustomColorSlug(tokens);
+	const value = newSwatchValue(palette?.groups, groupId);
+	const label = __('New Color', 'kadence-blocks');
+	const token = customColorTokenId(colorSlug);
+
+	onBusy(true);
+
+	return createUserPrimitive(slug, { id: colorSlug, $type: 'color', $value: value, label, version: feedVersion })
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+			throw err;
+		})
+		.then(() =>
+			writeDefaultPaletteFlow({
+				namespace,
+				slug,
+				defaultId,
+				edit: (groups) => addSwatchToGroups(groups, groupId, { token, label, $value: value }),
+				reload,
+				refreshFeed,
+				onBusy,
+				onError,
+			})
+		)
+		.then(() => token);
+}
+
+/**
+ * Create a new color group on the default palette, seeded with a first minted swatch — the server
+ * drops a group with zero swatches even on the default palette, so the group and its first color
+ * are written together in one request.
+ *
+ * @param {Object}   args
+ * @param {string}   args.namespace   The REST namespace.
+ * @param {string}   args.slug        The token library slug.
+ * @param {string}   args.defaultId   The listing's `$default` palette id.
+ * @param {string}   args.label       The typed group label.
+ * @param {Object}   args.palette     The palette being edited's effective view, for the
+ *                                    duplicate group-id check.
+ * @param {Array<string>} args.tokens Every existing token id the new swatch's slug must avoid
+ *                                    colliding with.
+ * @param {string}   args.feedVersion The feed's current version, sent as the primitive create's
+ *                                    concurrency guard.
+ * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.refreshFeed Replaces the feed for a slug.
+ * @param {Function} args.onBusy      Called with a boolean as the chain starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure or invalid input.
+ *
+ * @since TBD
+ *
+ * @return {Promise<string>} Resolves with the new group's first swatch's token id; rejects on an
+ *                            empty or duplicate group label, or a request failure, after
+ *                            `onError`/`onBusy` have run.
+ */
+export function addGroupFlow({
+	namespace,
+	slug,
+	defaultId,
+	label,
+	palette,
+	tokens,
+	feedVersion,
+	reload,
+	refreshFeed,
+	onBusy,
+	onError,
+}) {
+	const groupId = slugifyPaletteLabel(label);
+
+	if (!groupId) {
+		const message = __('Enter a color group name.', 'kadence-blocks');
+		onError({ message });
+		return Promise.reject(new Error(message));
+	}
+
+	if ((palette?.groups ?? []).some((group) => group.id === groupId)) {
+		const message = __('A color group with that name already exists.', 'kadence-blocks');
+		onError({ message });
+		return Promise.reject(new Error(message));
+	}
+
+	const colorSlug = nextCustomColorSlug(tokens);
+	const value = newSwatchValue(palette?.groups, groupId);
+	const swatchLabel = __('New Color', 'kadence-blocks');
+	const token = customColorTokenId(colorSlug);
+
+	onBusy(true);
+
+	return createUserPrimitive(slug, {
+		id: colorSlug,
+		$type: 'color',
+		$value: value,
+		label: swatchLabel,
+		version: feedVersion,
+	})
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+			throw err;
+		})
+		.then(() =>
+			writeDefaultPaletteFlow({
+				namespace,
+				slug,
+				defaultId,
+				edit: (groups) =>
+					addGroupToGroups(groups, {
+						id: groupId,
+						label,
+						swatches: [{ token, label: swatchLabel, $value: value }],
+					}),
+				reload,
+				refreshFeed,
+				onBusy,
+				onError,
+			})
+		)
+		.then(() => token);
+}

--- a/src/style-library/helpers/palette-flows.js
+++ b/src/style-library/helpers/palette-flows.js
@@ -77,7 +77,9 @@ import {
  * @since TBD
  *
  * @return {Promise<void>} Resolves once the write, the re-reads, and the feed refresh complete;
- *                          rejects on failure after `onError`/`onBusy` have run.
+ *                          rejects on failure after `onError`, a rollback re-read, and `onBusy` have
+ *                          run — so a caller that applied its edit optimistically is put back in sync
+ *                          with the server whether the write succeeded or not.
  */
 export function writeDefaultPaletteFlow({ namespace, slug, defaultId, edit, reload, refreshFeed, onBusy, onError }) {
 	onBusy(true);
@@ -93,8 +95,23 @@ export function writeDefaultPaletteFlow({ namespace, slug, defaultId, edit, relo
 		.then(() => onBusy(false))
 		.catch((err) => {
 			onError({ message: errorMessage(err) });
-			onBusy(false);
-			throw err;
+
+			// Re-read on the way out too, not only on success. A caller may have applied its edit
+			// optimistically — the swatch reorder does, and says so — and depends on this re-read to put
+			// the server's version back when the write fails. Reloading only in the success path leaves a
+			// failed edit sitting on screen next to its own error message.
+			//
+			// A re-read that itself fails is swallowed: the write error is the one worth reporting, and
+			// masking it with a second failure would hide what actually went wrong. `onBusy(false)` runs
+			// either way, so the UI never stays stuck behind a spinner.
+			return Promise.resolve()
+				.then(() => reload())
+				.catch(() => {})
+				.then(() => {
+					onBusy(false);
+
+					throw err;
+				});
 		});
 }
 

--- a/src/style-library/helpers/palette-flows.js
+++ b/src/style-library/helpers/palette-flows.js
@@ -290,6 +290,10 @@ export function activatePaletteFlow({ namespace, slug, id, reload, refreshFeed, 
  * @param {string}   args.label       The typed palette label.
  * @param {Object}   args.listing     The current listing (`{ defaultId, palettes }`), for the
  *                                    duplicate-id check.
+ * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook —
+ *                                    run BEFORE `openPalette` so the fresh listing already carries
+ *                                    the new row by the time `editingId` moves onto it (see the
+ *                                    ordering note below).
  * @param {Function} args.openPalette Opens a palette for editing (typically `openPaletteFlow`
  *                                    bound to the new id).
  * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
@@ -297,11 +301,11 @@ export function activatePaletteFlow({ namespace, slug, id, reload, refreshFeed, 
  *
  * @since TBD
  *
- * @return {Promise<void>} Resolves once the palette is created and opened for editing; rejects on
- *                          an empty or duplicate label, or a request failure, after `onError` has
- *                          already run.
+ * @return {Promise<void>} Resolves once the palette is created, the listing reloaded, and the new
+ *                          palette opened for editing; rejects on an empty or duplicate label, or a
+ *                          request failure, after `onError` has already run.
  */
-export function createPaletteFlow({ namespace, slug, label, listing, openPalette, onBusy, onError }) {
+export function createPaletteFlow({ namespace, slug, label, listing, reload, openPalette, onBusy, onError }) {
 	const id = slugifyPaletteLabel(label);
 
 	// Both validation failures reject rather than resolve: a caller that closes its modal on a
@@ -321,15 +325,26 @@ export function createPaletteFlow({ namespace, slug, label, listing, openPalette
 
 	onBusy(true);
 
-	return fetchPalette(namespace, listing.defaultId, slug)
-		.then((view) => savePalette(namespace, id, { label, groups: stripEffectiveFlags(view.groups) }, slug))
-		.then(() => openPalette(id))
-		.catch((err) => {
-			onError({ message: errorMessage(err) });
-			onBusy(false);
+	return (
+		fetchPalette(namespace, listing.defaultId, slug)
+			.then((view) => savePalette(namespace, id, { label, groups: stripEffectiveFlags(view.groups) }, slug))
+			// Reloaded BEFORE `openPalette`, not after: `hooks/use-palettes.js`'s `reload()` keeps
+			// `editingId` unchanged when the currently-edited palette still exists in the fresh
+			// listing (true here — nothing about creating a sibling palette removes it), so this
+			// step only refreshes `listing.palettes` with the new row. `openPalette` then moves
+			// `editingId` onto that row with the listing already populated, so the dropdown can
+			// resolve its label and render it as a real option instead of falling back to the raw
+			// id. Reloading after `openPalette` instead would leave the dropdown showing the new,
+			// still-missing-from-the-list id for one render.
+			.then(() => reload())
+			.then(() => openPalette(id))
+			.catch((err) => {
+				onError({ message: errorMessage(err) });
+				onBusy(false);
 
-			throw err;
-		});
+				throw err;
+			})
+	);
 }
 
 /**

--- a/src/style-library/helpers/palettes.js
+++ b/src/style-library/helpers/palettes.js
@@ -1,0 +1,370 @@
+/**
+ * Pure data helpers for the Color Palette screen: mapping a palette's effective view onto the
+ * `SwatchGrid` data shape, the immutable node-edit functions the structure-write flows compose
+ * over a fresh default-palette read, and the naming helpers the mint-a-primitive flows use. No
+ * REST and no JSX here — see `helpers/palette-flows.js` for the orchestration that calls the API
+ * and `components/pages/ColorPaletteScreen.js` for the JSX these mappings feed.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { slugifyLibraryTitle } from './libraries';
+
+/**
+ * The token prefix a user-created color primitive is minted under (mirrors
+ * `Reserved_Namespace::canonical()`).
+ *
+ * @since TBD
+ */
+const CUSTOM_COLOR_PREFIX = 'primitive.color.custom.';
+
+/**
+ * The starting value for a swatch with no neighboring color to copy.
+ *
+ * @since TBD
+ */
+const FALLBACK_SWATCH_VALUE = '#000000';
+
+/**
+ * Map a palette effective view to the data half of `SwatchGrid`'s `groups` prop. Pure data only —
+ * no JSX: the screen supplies each card's `preview` node and drag flags itself, because a React
+ * element in a helper would make this untestable under the pure-function policy.
+ *
+ * @param {Object} palette The palette effective view.
+ *
+ * @since TBD
+ *
+ * @return {Array<Object>} `[{ id, label, items: [{ id, name, subLine, value, overridden }] }]` —
+ *         `id` is the swatch token dot-path (stable, unique per palette, and what `?kb-item=`
+ *         carries), `subLine` the raw `$value`.
+ */
+export function mapPaletteToSwatchGroups(palette) {
+	if (!palette || !Array.isArray(palette.groups)) {
+		return [];
+	}
+
+	return palette.groups.map((group) => ({
+		id: group.id,
+		label: group.label,
+		items: (Array.isArray(group.swatches) ? group.swatches : []).map((swatch) => ({
+			id: swatch.token,
+			name: swatch.label,
+			subLine: swatch.$value,
+			value: swatch.$value,
+			overridden: Boolean(swatch.overridden),
+		})),
+	}));
+}
+
+/**
+ * The swatch entry for a token in an effective view, or null.
+ *
+ * @param {Object} palette The palette effective view.
+ * @param {string} token   The swatch token dot-path.
+ *
+ * @since TBD
+ *
+ * @return {Object|null} The swatch entry `{ token, label, $value, overridden }`, or null.
+ */
+export function findSwatch(palette, token) {
+	if (!palette || !Array.isArray(palette.groups)) {
+		return null;
+	}
+
+	for (const group of palette.groups) {
+		const swatch = (group.swatches ?? []).find((entry) => entry.token === token);
+
+		if (swatch) {
+			return swatch;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * The settings-panel initial values for a swatch.
+ *
+ * @param {Object} palette The palette effective view.
+ * @param {string} token   The swatch token dot-path.
+ *
+ * @since TBD
+ *
+ * @return {{label: string, value: string}} Empty strings when the swatch is missing, so the panel
+ *         can detect a stale item id.
+ */
+export function swatchInitialValues(palette, token) {
+	const swatch = findSwatch(palette, token);
+
+	return {
+		label: swatch?.label ?? '',
+		value: swatch?.$value ?? '',
+	};
+}
+
+/**
+ * Whether an id is the listing's `$default` palette. Fails closed: an empty or missing
+ * `$default` means every id counts as default, so destructive affordances stay hidden on
+ * malformed data rather than exposed against a guess.
+ *
+ * @param {Object} listing The palette listing (`{ defaultId, currentId, palettes }`).
+ * @param {string} id      The palette id to check.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when `id` is the default palette, or when the default pointer is unknown.
+ */
+export function isDefaultPalette(listing, id) {
+	const defaultId = listing?.defaultId;
+
+	return !defaultId || defaultId === id;
+}
+
+/**
+ * The display label for a palette listing row.
+ *
+ * @param {{id: string, label: string}} row The palette listing row.
+ *
+ * @since TBD
+ *
+ * @return {string} The row's label, or its id when the label is ''.
+ */
+export function paletteDisplayLabel(row) {
+	return row?.label || row?.id || '';
+}
+
+/**
+ * Derive a palette id from a typed label — the same kebab grammar token/library ids use.
+ *
+ * @param {string} label The typed palette label.
+ *
+ * @since TBD
+ *
+ * @return {string} The slug. '' when nothing survives.
+ */
+export function slugifyPaletteLabel(label) {
+	return slugifyLibraryTitle(label);
+}
+
+/**
+ * Whether a typed palette label collides with an existing palette id once run through
+ * `slugifyPaletteLabel`.
+ *
+ * @param {string}         label   The typed palette label.
+ * @param {Object}         listing The palette listing (`{ palettes }`).
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the label's derived slug matches an existing palette id.
+ */
+export function isDuplicatePaletteLabel(label, listing) {
+	const slug = slugifyPaletteLabel(label);
+	const rows = Array.isArray(listing?.palettes) ? listing.palettes : [];
+
+	return slug !== '' && rows.some((row) => row.id === slug);
+}
+
+/**
+ * Strip the view-only `overridden` flag from every swatch, producing write-payload groups. The
+ * effective view is read-only data annotated for display; a write payload sends only what the
+ * palette node itself stores.
+ *
+ * @param {Array<Object>} groups The effective view's `groups` array.
+ *
+ * @since TBD
+ *
+ * @return {Array<Object>} A new groups array; swatches carry only `token`, `label`, `$value`.
+ */
+export function stripEffectiveFlags(groups) {
+	return (groups ?? []).map((group) => ({
+		...group,
+		swatches: (group.swatches ?? []).map(({ token, label, $value }) => ({ token, label, $value })),
+	}));
+}
+
+/**
+ * Append a swatch to the group with `groupId`.
+ *
+ * @param {Array<Object>} groups  The write-payload groups array.
+ * @param {string}        groupId The target group's id.
+ * @param {Object}        swatch  The swatch to append, `{ token, label, $value }`.
+ *
+ * @since TBD
+ *
+ * @return {Array<Object>} A new groups array with the swatch appended; the same reference as
+ *         `groups` (a no-op) when `groupId` matches no group, so callers can detect the miss.
+ */
+export function addSwatchToGroups(groups, groupId, swatch) {
+	if (!(groups ?? []).some((group) => group.id === groupId)) {
+		return groups;
+	}
+
+	return groups.map((group) =>
+		group.id === groupId ? { ...group, swatches: [...(group.swatches ?? []), swatch] } : group
+	);
+}
+
+/**
+ * Remove the swatch with `token`, dropping a group left empty afterward — mirroring the server's
+ * `prepare_for_storage()`, so what the client sends is what the server would end up storing.
+ *
+ * @param {Array<Object>} groups The write-payload groups array.
+ * @param {string}        token  The swatch token dot-path to remove.
+ *
+ * @since TBD
+ *
+ * @return {Array<Object>} A new groups array with the swatch (and, if emptied, its group) removed;
+ *         the same reference as `groups` (a no-op) when no group carries `token`.
+ */
+export function removeSwatchFromGroups(groups, token) {
+	const rows = groups ?? [];
+
+	if (!rows.some((group) => (group.swatches ?? []).some((swatch) => swatch.token === token))) {
+		return groups;
+	}
+
+	return rows
+		.map((group) => ({ ...group, swatches: (group.swatches ?? []).filter((swatch) => swatch.token !== token) }))
+		.filter((group) => group.swatches.length > 0);
+}
+
+/**
+ * Set the `label` of the swatch with `token`.
+ *
+ * @param {Array<Object>} groups The write-payload groups array.
+ * @param {string}        token  The swatch token dot-path to rename.
+ * @param {string}        label  The new label.
+ *
+ * @since TBD
+ *
+ * @return {Array<Object>} A new groups array with the target swatch relabeled.
+ */
+export function renameSwatchInGroups(groups, token, label) {
+	return (groups ?? []).map((group) => ({
+		...group,
+		swatches: (group.swatches ?? []).map((swatch) => (swatch.token === token ? { ...swatch, label } : swatch)),
+	}));
+}
+
+/**
+ * Reorder one group's swatches to `orderedTokens`.
+ *
+ * @param {Array<Object>} groups        The write-payload groups array.
+ * @param {string}        groupId       The target group's id.
+ * @param {Array<string>} orderedTokens The swatch token order `SwatchGrid`'s `onReorder` emits.
+ *
+ * @since TBD
+ *
+ * @return {Array<Object>} A new groups array with the target group's swatches reordered; tokens
+ *         missing from `orderedTokens` keep their relative position at the end. The same
+ *         reference as `groups` (a no-op) when `groupId` matches no group.
+ */
+export function reorderGroupSwatches(groups, groupId, orderedTokens) {
+	if (!(groups ?? []).some((group) => group.id === groupId)) {
+		return groups;
+	}
+
+	return groups.map((group) => {
+		if (group.id !== groupId) {
+			return group;
+		}
+
+		const swatches = group.swatches ?? [];
+		const byToken = new Map(swatches.map((swatch) => [swatch.token, swatch]));
+		const ordered = orderedTokens.filter((token) => byToken.has(token)).map((token) => byToken.get(token));
+		const remaining = swatches.filter((swatch) => !orderedTokens.includes(swatch.token));
+
+		return { ...group, swatches: [...ordered, ...remaining] };
+	});
+}
+
+/**
+ * Append a new group. The caller must supply at least one swatch — the server drops an empty
+ * group even on the default palette, so "Add Color Group" must mint the group's first swatch in
+ * the same write.
+ *
+ * @param {Array<Object>} groups The write-payload groups array.
+ * @param {Object}        group  The group to append, `{ id, label, swatches }`.
+ *
+ * @since TBD
+ *
+ * @return {Array<Object>} A new groups array with `group` appended.
+ */
+export function addGroupToGroups(groups, group) {
+	return [...(groups ?? []), group];
+}
+
+/**
+ * The next free custom-color slug.
+ *
+ * @param {Array<string>} existingIds Every token id a new slug must avoid colliding with — the
+ *                                    flattened feed token ids plus the palette's own swatch
+ *                                    tokens, so a collision against either source is impossible.
+ *
+ * @since TBD
+ *
+ * @return {string} `custom-<n>`, starting at `custom-1` and skipping any suffix already in use.
+ */
+export function nextCustomColorSlug(existingIds) {
+	const taken = new Set(
+		(existingIds ?? [])
+			.filter((id) => id.startsWith(CUSTOM_COLOR_PREFIX))
+			.map((id) => id.slice(CUSTOM_COLOR_PREFIX.length))
+	);
+
+	let n = 1;
+
+	while (taken.has(`custom-${n}`)) {
+		n += 1;
+	}
+
+	return `custom-${n}`;
+}
+
+/**
+ * The canonical token id the server will mint for a slug.
+ *
+ * @param {string} slug The custom-color slug (e.g. `custom-1`).
+ *
+ * @since TBD
+ *
+ * @return {string} `primitive.color.custom.<slug>`.
+ */
+export function customColorTokenId(slug) {
+	return `${CUSTOM_COLOR_PREFIX}${slug}`;
+}
+
+/**
+ * The starting value for a new swatch in a group.
+ *
+ * @param {Array<Object>} groups  The palette's groups array (either shape — effective view or
+ *                                write payload; only `$value` is read).
+ * @param {string}        groupId The target group's id.
+ *
+ * @since TBD
+ *
+ * @return {string} The group's last swatch's `$value` when the group has one — a neighboring
+ *         color is a friendlier starting point than black — otherwise `#000000`.
+ */
+export function newSwatchValue(groups, groupId) {
+	const group = (groups ?? []).find((row) => row.id === groupId);
+	const swatches = group?.swatches ?? [];
+
+	return swatches.length > 0 ? swatches[swatches.length - 1].$value : FALLBACK_SWATCH_VALUE;
+}
+
+/**
+ * Whether a swatch token is a user-created custom color. Drives only the token-cleanup step of
+ * swatch deletion — the caller additionally checks the feed's `userCreated` flag where the feed
+ * entry exists, as defense-in-depth.
+ *
+ * @param {string} token The swatch token dot-path.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when `token` carries the custom-color prefix.
+ */
+export function isCustomColorToken(token) {
+	return typeof token === 'string' && token.startsWith(CUSTOM_COLOR_PREFIX);
+}

--- a/src/style-library/hooks/use-palettes.js
+++ b/src/style-library/hooks/use-palettes.js
@@ -1,0 +1,354 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { fetchPalette, fetchPalettes } from '../api/client';
+import { errorMessage } from '../helpers/library-flows';
+import { isCustomColorToken, reorderGroupSwatches } from '../helpers/palettes';
+import {
+	activatePaletteFlow,
+	addColorFlow,
+	addGroupFlow,
+	createPaletteFlow,
+	deletePaletteFlow,
+	openPaletteFlow,
+	removeSwatchFlow,
+	reorderSwatchesFlow,
+	saveSwatchEditsFlow,
+} from '../helpers/palette-flows';
+import { flattenSchemaTokens } from '../helpers/tokens';
+
+/**
+ * Palette state for the Color Palette screen and its settings panel: the listing, the palette
+ * being edited, and the write operations, all bound to the pure flows in `helpers/palette-flows`.
+ *
+ * Two ids, not one — mirroring `hooks/use-libraries.js`. `listing.currentId` (exposed as
+ * `activeId`) is the palette the *site* renders with — `$current`, overlaid onto resolved color
+ * values everywhere. `editingId` is the palette the *app* is showing. They start equal (there is
+ * no persisted "last edited palette", so the first load shows whatever is active) and diverge the
+ * moment `openPalette` is called for a different id. Keeping them apart is what makes browsing and
+ * editing a palette safe: nothing a visitor sees changes until someone explicitly activates one.
+ *
+ * Both the screen and its settings panel call this hook as sibling instances; they stay
+ * consistent because all shared state is server state — the hook re-reads the listing and the
+ * edited view whenever the feed identity changes (`[feed.slug, feed.version]`), and every flow
+ * ends with `refreshFeed`, which bumps that version for every instance at once.
+ *
+ * @param {Object}   feed        The design-tokens admin feed (slug, version, rest descriptor).
+ * @param {Function} refreshFeed Replaces the feed with a fresh REST read for a slug.
+ *
+ * @since TBD
+ *
+ * @return {Object} `{ listing, activeId, editingId, isEditingActive, palette, isLoading, isBusy,
+ *                  openError, activateError, createError, deleteError, saveError, structureError,
+ *                  clearOpenError, clearActivateError, clearCreateError, clearDeleteError,
+ *                  clearSaveError, clearStructureError,
+ *                  openPalette, activatePalette, createPalette, deletePalette,
+ *                  saveSwatchEdits, removeSwatch, addColor, addGroup, reorderSwatches }`.
+ */
+export function usePalettes(feed, refreshFeed) {
+	const [listing, setListing] = useState({ defaultId: '', currentId: '', palettes: [] });
+	const [editingId, setEditingId] = useState('');
+	const [palette, setPalette] = useState(null);
+	const [isLoading, setIsLoading] = useState(true);
+	const [isBusy, setIsBusy] = useState(false);
+	const [openError, setOpenError] = useState(null);
+	const [activateError, setActivateError] = useState(null);
+	const [createError, setCreateError] = useState(null);
+	const [deleteError, setDeleteError] = useState(null);
+	const [saveError, setSaveError] = useState(null);
+	const [structureError, setStructureError] = useState(null);
+
+	const namespace = feed?.rest?.namespace;
+	const slug = feed?.slug;
+	const feedTokens = useMemo(() => flattenSchemaTokens(feed?.schema), [feed]);
+
+	// Read inside `reload` without making it depend on `editingId` — see the comment there. A
+	// plain-assignment ref (no effect) is enough because it only ever needs the value as of the
+	// most recent render, and `reload` always runs after render, never during it.
+	const editingIdRef = useRef(editingId);
+	editingIdRef.current = editingId;
+
+	// Every mint flow (add color, add group) needs a slug that collides with neither a baseline
+	// nor an already-minted token, wherever that token currently lives — the feed's flattened list
+	// covers baseline and previously-refreshed custom colors, and the edited palette's own swatch
+	// tokens cover anything minted since the last refresh.
+	const existingTokenIds = useMemo(() => {
+		const swatchTokens = (palette?.groups ?? []).flatMap((group) =>
+			(group.swatches ?? []).map((swatch) => swatch.token)
+		);
+
+		return [...feedTokens.map((token) => token.id), ...swatchTokens];
+	}, [feedTokens, palette]);
+
+	// Re-reads the listing, then the edited view — falling back to the server-resolved `$current`
+	// when the palette last being edited is no longer in the list (deletePaletteFlow names no
+	// successor of its own; this is where that fallback actually happens, the same way
+	// `deleteLibraryFlow` defers to a fresh read of the active-library pointer). Every other write
+	// flow's `reload` call is a no-op for this fallback (the edited palette never disappears from
+	// underneath a structure or value write), so folding it in here — rather than only inside a
+	// delete-specific path — costs nothing beyond a cheap array scan.
+	const reload = useCallback(() => {
+		return fetchPalettes(namespace, slug).then((response) => {
+			const nextListing = {
+				defaultId: response.$default,
+				currentId: response.$current,
+				palettes: response.palettes ?? [],
+			};
+
+			setListing(nextListing);
+
+			const lastEditingId = editingIdRef.current;
+			const nextEditingId = nextListing.palettes.some((row) => row.id === lastEditingId)
+				? lastEditingId
+				: nextListing.currentId;
+
+			if (nextEditingId !== lastEditingId) {
+				setEditingId(nextEditingId);
+			}
+
+			return fetchPalette(namespace, nextEditingId, slug).then((view) => {
+				setPalette(view);
+				return nextListing;
+			});
+		});
+	}, [namespace, slug]);
+
+	useEffect(() => {
+		setIsLoading(true);
+		reload()
+			.catch((err) => setOpenError({ message: errorMessage(err) }))
+			.finally(() => setIsLoading(false));
+	}, [reload]);
+
+	const clearOpenError = useCallback(() => setOpenError(null), []);
+	const clearActivateError = useCallback(() => setActivateError(null), []);
+	const clearCreateError = useCallback(() => setCreateError(null), []);
+	const clearDeleteError = useCallback(() => setDeleteError(null), []);
+	const clearSaveError = useCallback(() => setSaveError(null), []);
+	const clearStructureError = useCallback(() => setStructureError(null), []);
+
+	// Shared by `openPalette` (below) and by `addPalette`'s post-create open — each call site
+	// passes its own `onError` so an open that fails as part of create reports through
+	// `createError`, never through `openError`, and its own `onBusy` so only the user-initiated
+	// open blocks the app. Creation runs behind its own modal, which reports progress itself.
+	const runOpen = useCallback(
+		({ id, onError, onBusy }) =>
+			openPaletteFlow({
+				namespace,
+				slug,
+				id,
+				onOpened: (view) => {
+					setEditingId(view.id);
+					setPalette(view);
+				},
+				onBusy,
+				onError,
+			}),
+		[namespace, slug]
+	);
+
+	const openPalette = useCallback(
+		(id) => {
+			setOpenError(null);
+			return runOpen({ id, onError: setOpenError, onBusy: setIsBusy });
+		},
+		[runOpen]
+	);
+
+	const activatePalette = useCallback(
+		(id) => {
+			setActivateError(null);
+			return activatePaletteFlow({
+				namespace,
+				slug,
+				id,
+				reload,
+				refreshFeed,
+				onBusy: setIsBusy,
+				onError: setActivateError,
+				onActivated: (activatedId) => setListing((prev) => ({ ...prev, currentId: activatedId })),
+			});
+		},
+		[namespace, slug, reload, refreshFeed]
+	);
+
+	const addPalette = useCallback(
+		(label) => {
+			setCreateError(null);
+			return createPaletteFlow({
+				namespace,
+				slug,
+				label,
+				listing,
+				openPalette: (id) => runOpen({ id, onError: setCreateError, onBusy: setIsBusy }),
+				onBusy: setIsBusy,
+				onError: setCreateError,
+			});
+		},
+		[namespace, slug, listing, runOpen]
+	);
+
+	const removePalette = useCallback(
+		(id) => {
+			setDeleteError(null);
+			return deletePaletteFlow({
+				namespace,
+				slug,
+				id,
+				reload,
+				refreshFeed,
+				onBusy: setIsBusy,
+				onError: setDeleteError,
+			});
+		},
+		[namespace, slug, reload, refreshFeed]
+	);
+
+	const saveSwatchEdits = useCallback(
+		(token, draft, initial) => {
+			setSaveError(null);
+			return saveSwatchEditsFlow({
+				namespace,
+				slug,
+				defaultId: listing.defaultId,
+				editingId,
+				token,
+				draft,
+				initial,
+				reload,
+				refreshFeed,
+				onBusy: setIsBusy,
+				onError: setSaveError,
+			});
+		},
+		[namespace, slug, listing, editingId, reload, refreshFeed]
+	);
+
+	const removeSwatch = useCallback(
+		(token) => {
+			setSaveError(null);
+
+			// Trust the feed's own `userCreated` flag when the token has a feed entry (defense in
+			// depth against a token id that merely looks custom-prefixed); fall back to the prefix
+			// check for a token minted since the last feed refresh, which has no feed entry yet.
+			const feedEntry = feedTokens.find((entry) => entry.id === token);
+			const isUserCreated = feedEntry ? Boolean(feedEntry.userCreated) : isCustomColorToken(token);
+
+			return removeSwatchFlow({
+				namespace,
+				slug,
+				defaultId: listing.defaultId,
+				token,
+				isUserCreated,
+				reload,
+				refreshFeed,
+				onBusy: setIsBusy,
+				onError: setSaveError,
+			});
+		},
+		[namespace, slug, listing, feedTokens, reload, refreshFeed]
+	);
+
+	const addColor = useCallback(
+		(groupId) => {
+			setStructureError(null);
+			return addColorFlow({
+				namespace,
+				slug,
+				defaultId: listing.defaultId,
+				groupId,
+				tokens: existingTokenIds,
+				palette,
+				feedVersion: feed?.version,
+				reload,
+				refreshFeed,
+				onBusy: setIsBusy,
+				onError: setStructureError,
+			});
+		},
+		[namespace, slug, listing, existingTokenIds, palette, feed?.version, reload, refreshFeed]
+	);
+
+	const addGroup = useCallback(
+		(label) => {
+			setStructureError(null);
+			return addGroupFlow({
+				namespace,
+				slug,
+				defaultId: listing.defaultId,
+				label,
+				palette,
+				tokens: existingTokenIds,
+				feedVersion: feed?.version,
+				reload,
+				refreshFeed,
+				onBusy: setIsBusy,
+				onError: setStructureError,
+			});
+		},
+		[namespace, slug, listing, palette, existingTokenIds, feed?.version, reload, refreshFeed]
+	);
+
+	const reorderSwatches = useCallback(
+		(groupId, orderedTokens) => {
+			setStructureError(null);
+
+			// Applied locally at drop time — a drop that snaps back behind a spinner is worse UX than
+			// a rare rollback. `reorderSwatchesFlow`'s `reload()` re-reads the effective view on both
+			// success (a no-op visually) and failure (restores server order), so this optimistic step
+			// never needs its own undo path.
+			setPalette((current) =>
+				current ? { ...current, groups: reorderGroupSwatches(current.groups, groupId, orderedTokens) } : current
+			);
+
+			return reorderSwatchesFlow({
+				namespace,
+				slug,
+				defaultId: listing.defaultId,
+				groupId,
+				orderedTokens,
+				reload,
+				refreshFeed,
+				onBusy: setIsBusy,
+				onError: setStructureError,
+			});
+		},
+		[namespace, slug, listing, reload, refreshFeed]
+	);
+
+	return {
+		listing,
+		activeId: listing.currentId,
+		editingId,
+		isEditingActive: editingId === listing.currentId,
+		palette,
+		isLoading,
+		isBusy,
+		openError,
+		activateError,
+		createError,
+		deleteError,
+		saveError,
+		structureError,
+		clearOpenError,
+		clearActivateError,
+		clearCreateError,
+		clearDeleteError,
+		clearSaveError,
+		clearStructureError,
+		openPalette,
+		activatePalette,
+		createPalette: addPalette,
+		deletePalette: removePalette,
+		saveSwatchEdits,
+		removeSwatch,
+		addColor,
+		addGroup,
+		reorderSwatches,
+	};
+}


### PR DESCRIPTION
The data layer for the Color Palette screen. Pure helpers and flows only — no UI.

## What's here

- `helpers/palettes.js` — the palette-view-to-`SwatchGrid` mapper, immutable node edits (add / remove / rename / reorder a swatch), and the custom-color naming helpers.
- `helpers/palette-flows.js` — open, activate, create, delete, the settings-panel save, swatch removal, add color, add color group, and reorder. Mirrors the `helpers/library-flows.js` + `hooks/use-libraries.js` split: pure orchestration here, thin state binding in the hook.
- `hooks/use-palettes.js` — the state binding.
- `api/client.js` — adds the one missing verb, `deletePalette()`.

No PHP. The palette REST surface already supports everything this screen needs.

## The rule the whole ticket rests on

A palette's **structure** — which swatches exist, their labels, their grouping, their order — lives only on the library's `$default` palette. `Palettes_Controller::effective_view()` builds every palette's groups from that node; a non-default palette stores only its value deltas.

So every structural edit writes the **default** palette, built from a fresh read of the default's own view, no matter which palette is being edited. Only a color value writes to the edited palette, through the granular per-swatch endpoint. `writeDefaultPaletteFlow` is the single place that encodes this, and its jest suite asserts the saved payload carries the default view's values rather than the edited palette's — the failure mode it guards against is silent data loss.

## Test plan

- `bun run test` — the flows and helpers are covered directly, including the routing guard above, the row-first ordering of swatch deletion, and that creating a palette never activates it.
- No UI to exercise yet; the screen lands in the next PR.


## Screenshots

None — this PR is the data layer and adds no UI. The screen itself lands in [2/5].
