### PR TITLE
[DTM] SOFT-4076 [2/5]: Color Palette screen shell

### DIFF
--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -21,6 +21,7 @@ import { DeleteLibraryModal } from '../components/organisms/DeleteLibraryModal';
 import { SettingsPanel } from '../components/templates/SettingsPanel';
 import { SettingsForm } from '../components/organisms/SettingsForm';
 import { PlaceholderScreen } from '../components/pages/PlaceholderScreen';
+import { ColorPaletteScreen } from '../components/pages/ColorPaletteScreen';
 import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
 import { useLibraries } from '../hooks/use-libraries';
@@ -29,6 +30,14 @@ import { DEFAULT_SCREEN_ID } from '../constants/screens';
 import { DEMO_ITEM_ID, DEMO_SETTINGS_SCHEMA, DEMO_SETTINGS_VALUES } from '../constants/demo-settings-schema';
 import { buildBaseStylesNav, buildBlockPresetsNav, resolveScreen } from '../helpers/screens';
 import { libraryDisplayTitle } from '../helpers/libraries';
+
+/**
+ * The Base Styles ids with a real screen component, extended by each subsequent per-screen
+ * ticket. Every id not listed here falls back to `PlaceholderScreen` in the registry below.
+ *
+ * @since TBD
+ */
+const SCREEN_COMPONENTS = { 'color-palette': ColorPaletteScreen };
 
 /**
  * Render the Style Library application: feed gate, route hook, sidebar navigation, and the screen
@@ -56,14 +65,15 @@ export function StyleLibraryApp() {
 	const baseStylesNav = useMemo(() => buildBaseStylesNav(), []);
 	const blockPresetsNav = useMemo(() => buildBlockPresetsNav(feed.feed), [feed.feed]);
 
-	// Every Base Styles id resolves to the placeholder until its per-screen work lands, and the
-	// preset fallback is the placeholder until the first real preset screen ships.
+	// Every Base Styles id without an entry in SCREEN_COMPONENTS resolves to the placeholder until
+	// its per-screen work lands, and the preset fallback is the placeholder until the first real
+	// preset screen ships.
 	// @todo SOFT-4083 / SOFT-4084: first real preset screens replace this fallback.
 	const registry = useMemo(() => {
 		const baseStyles = {};
 
 		baseStylesNav.forEach((entry) => {
-			baseStyles[entry.id] = PlaceholderScreen;
+			baseStyles[entry.id] = SCREEN_COMPONENTS[entry.id] ?? PlaceholderScreen;
 		});
 
 		return { baseStyles, presetFallback: PlaceholderScreen };
@@ -187,7 +197,13 @@ export function StyleLibraryApp() {
 				/>
 			}
 			content={
-				<resolution.Component label={label} onOpenFieldLibraryDemo={() => navigate({ item: DEMO_ITEM_ID })} />
+				<resolution.Component
+					label={label}
+					route={route}
+					navigate={navigate}
+					library={feed}
+					onOpenFieldLibraryDemo={() => navigate({ item: DEMO_ITEM_ID })}
+				/>
 			}
 			settingsPanel={
 				isDemoItem ? (

--- a/src/style-library/components/molecules/SwatchCard.js
+++ b/src/style-library/components/molecules/SwatchCard.js
@@ -27,6 +27,14 @@ import './SwatchCard.scss';
  *
  * @param {Object}       props                  The component props.
  * @param {string}       props.id               The stable card id (also the dnd-kit sortable id).
+ * @param {Object}       [props.previewStyle]   Inline style applied to the preview slot itself, for
+ *                                              a preview that is only a fill (a solid color, a
+ *                                              gradient). The slot already draws the border, the
+ *                                              corner radius, and clips overflow, so filling it
+ *                                              directly avoids nesting a child that would stack a
+ *                                              second border inside those rounded corners. Pass
+ *                                              `preview` instead when the preview needs real
+ *                                              content rather than a fill.
  * @param {JSX.Element}  props.preview          The preview slot (a color square, a gradient, …) —
  *                                              always caller-supplied; see the module docblock for why
  *                                              this is never derived from `subLine`.
@@ -54,6 +62,7 @@ import './SwatchCard.scss';
 export function SwatchCard({
 	id,
 	preview,
+	previewStyle,
 	name,
 	subLine,
 	isSelected = false,
@@ -78,7 +87,9 @@ export function SwatchCard({
 				className="kadence-blocks-style-library__swatch-card-main"
 				onClick={() => onSelect(id)}
 			>
-				<span className="kadence-blocks-style-library__swatch-card-preview">{preview}</span>
+				<span className="kadence-blocks-style-library__swatch-card-preview" style={previewStyle}>
+					{preview}
+				</span>
 				<span className="kadence-blocks-style-library__swatch-card-name">{name}</span>
 				{subLine && <span className="kadence-blocks-style-library__swatch-card-sub-line">{subLine}</span>}
 			</button>

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -1,0 +1,124 @@
+/**
+ * The Color Palette screen: the palette selector in the screen header and the swatch grid of the
+ * current palette's effective view. Palette structure is read here and edited through the palette
+ * flows (`helpers/palette-flows.js`) via `hooks/use-palettes.js`; this component never chooses a
+ * write target itself, and — this phase — never writes at all: selecting a palette in the header
+ * only opens it for viewing, and selecting a swatch only writes `?kb-item=` to the route.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * External dependencies
+ */
+import { colord } from 'colord';
+
+/**
+ * Internal dependencies
+ */
+import { ScreenHeader } from '../organisms/ScreenHeader';
+import { SwatchGrid } from '../organisms/SwatchGrid';
+import { SelectDropdown } from '../molecules/SelectDropdown';
+import { EmptyState } from '../molecules/EmptyState';
+import { usePalettes } from '../../hooks/use-palettes';
+import { mapPaletteToSwatchGroups, paletteDisplayLabel } from '../../helpers/palettes';
+import './ColorPaletteScreen.scss';
+
+/**
+ * The fill for a swatch's preview slot: the swatch's raw `$value`, or a neutral gray-100 fallback
+ * when the value isn't a color `colord` can parse. A palette swatch is the only place in the app
+ * where a `$value` might not be a plain color — an alias-valued swatch written through raw REST is
+ * the only way to reach the fallback — and it must not paint garbage.
+ *
+ * @param {string} value The swatch's raw `$value`.
+ *
+ * @since TBD
+ *
+ * @return {Object} The inline style for `SwatchCard`'s `previewStyle`.
+ */
+function swatchPreviewStyle(value) {
+	return { background: colord(value).isValid() ? value : 'var(--kb-sl-color-gray-100)' };
+}
+
+/**
+ * Render the Color Palette screen.
+ *
+ * @param {Object}   props          The component props.
+ * @param {string}   props.label    The active screen's nav label.
+ * @param {Object}   props.route    The route from `useStyleLibraryRoute`.
+ * @param {Function} props.navigate The route navigator.
+ * @param {Object}   props.library  The design-tokens feed surface (`feed`, `slug`, `version`, `rest`, `refreshFeed`).
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The screen.
+ */
+export function ColorPaletteScreen({ label, route, navigate, library }) {
+	const palettes = usePalettes(library.feed, library.refreshFeed);
+
+	const options = useMemo(
+		() => palettes.listing.palettes.map((row) => ({ value: row.id, label: paletteDisplayLabel(row) })),
+		[palettes.listing.palettes]
+	);
+
+	const gridGroups = useMemo(
+		() =>
+			mapPaletteToSwatchGroups(palettes.palette).map((group) => ({
+				...group,
+				items: group.items.map((item) => ({
+					...item,
+					previewStyle: swatchPreviewStyle(item.value),
+					// Reordering persists once the mutations phase lands its default-palette write; until
+					// then no drag handle renders, so the grid reads as non-reorderable rather than lying.
+					isDraggable: false,
+				})),
+			})),
+		[palettes.palette]
+	);
+
+	return (
+		<div className="kadence-blocks-style-library__color-palette-screen">
+			<ScreenHeader
+				title={label}
+				inlineControl={
+					<SelectDropdown
+						value={palettes.editingId}
+						options={options}
+						// Opens the palette for viewing only — never writes `$current`. A future reader who
+						// "fixes" this to also activate would silently re-tint the live site every time
+						// someone merely looks at a different palette; see `openPaletteFlow`'s own docblock.
+						onChange={(id) => palettes.openPalette(id).catch(() => {})}
+						isBusy={palettes.isBusy}
+						error={palettes.openError}
+						onClearError={palettes.clearOpenError}
+					/>
+				}
+				// The "Delete" destructive action and the "+ Add Color Group" primary action both depend
+				// on write flows this phase deliberately excludes — both header slots stay empty rather
+				// than render a button with nothing behind it.
+			/>
+			{palettes.isLoading ? (
+				<Spinner />
+			) : palettes.palette ? (
+				<SwatchGrid
+					groups={gridGroups}
+					selectedId={route.item}
+					onSelect={(token) => navigate({ item: token })}
+					onAdd={() => {
+						// @todo Style Library Color Palette mutations: wire the add-color flow.
+					}}
+					addLabel={__('Add color', 'kadence-blocks')}
+				/>
+			) : (
+				<EmptyState
+					title={palettes.openError?.message || __('This palette could not be loaded.', 'kadence-blocks')}
+				/>
+			)}
+		</div>
+	);
+}

--- a/src/style-library/components/pages/ColorPaletteScreen.scss
+++ b/src/style-library/components/pages/ColorPaletteScreen.scss
@@ -1,0 +1,12 @@
+@use '../../styles/mixins' as *;
+
+.kadence-blocks-style-library__color-palette-screen {
+	@include flex-column(var(--kb-sl-space-30));
+}
+
+// SwatchCard's sub-line renders the swatch's raw `$value` unmodified; this screen renders it in
+// upper case visually only, scoped under the screen root rather than touching SwatchCard.scss,
+// which stays agnostic about the shape of any caller's `subLine`.
+.kadence-blocks-style-library__color-palette-screen .kadence-blocks-style-library__swatch-card-sub-line {
+	text-transform: uppercase;
+}

--- a/src/style-library/components/pages/PlaceholderScreen.js
+++ b/src/style-library/components/pages/PlaceholderScreen.js
@@ -151,6 +151,11 @@ function isGalleryRequested() {
  *
  * @param {Object}   props                          The component props.
  * @param {string}   props.label                    The active screen's nav label.
+ * @param {Object}   [props.route]                  The route from `useStyleLibraryRoute` — part of
+ *                                                   the uniform screen-prop contract every screen
+ *                                                   receives; unused here.
+ * @param {Function} [props.navigate]                The route navigator; unused here.
+ * @param {Object}   [props.library]                 The design-tokens feed surface; unused here.
  * @param {Function} [props.onOpenFieldLibraryDemo]  Opens the field-library demo in the settings panel
  *                                                    (`?kb-item=demo`); dev builds only.
  *

--- a/src/style-library/constants/screens.js
+++ b/src/style-library/constants/screens.js
@@ -27,7 +27,6 @@ export const PRESET_SCREENS_FILTER = 'kadence_blocks.style_library.preset_screen
  * @since TBD
  */
 export const BASE_STYLES_SCREENS = [
-	// @todo SOFT-4076: replace the placeholder with the Color Palette screen.
 	{ id: 'color-palette', label: __('Color Palette', 'kadence-blocks') },
 	// @todo SOFT-4077: replace the placeholder with the Typography screen.
 	{ id: 'typography', label: __('Typography', 'kadence-blocks') },


### PR DESCRIPTION
Replaces `PlaceholderScreen` with the real Color Palette screen.

## What's here

- `components/pages/ColorPaletteScreen.js` (+ scss) — `ScreenHeader` with a working palette dropdown, and `SwatchGrid` rendering the mapped groups.
- `app/StyleLibraryApp.js` — the registry swap for `color-palette`, plus the uniform screen-prop contract (`route`, `navigate`, `library`) every screen now receives.
- `components/molecules/SwatchCard.js` — an optional `previewStyle` prop.
- `constants/screens.js` — drops the satisfied `@todo`.

## Why `SwatchCard` gained `previewStyle`

The preview slot already draws the gray-200 border, owns the corner radius, and clips with `overflow: hidden`. Nesting a child element to carry the fill stacked a second concentric border inside those rounded corners. `previewStyle` paints the fill directly onto the slot instead. `preview` is still there for a preview that needs real content rather than a fill.

## Deliberately not here

Selecting a palette from the dropdown **opens** it for editing and performs no write. The activate action, the Active badge, Delete, and Add Color Group arrive with the mutations. An affordance renders only once it works — the one exception is `SwatchGrid`'s `AddTile`, which the component always renders; it no-ops with a `@todo` until then.

## Test plan

- `bun run test`.
- In wp-admin: the four baseline groups render with names and hex sub-lines; selecting a swatch writes `?kb-item=`; switching palettes repaints the grid and fires no write.


## Screenshots

**The screen**
<img width="1528" height="804" alt="pr2-screen" src="https://github.com/user-attachments/assets/c8678222-5621-440c-9755-7de24f721805" />

**Palette selector open**
<img width="1528" height="804" alt="pr2-palette-dropdown" src="https://github.com/user-attachments/assets/090a62fc-9670-446f-9c1e-3f4d8b649475" />