### PR TITLE
[DTM] SOFT-4076 [4/5]: Palette and swatch mutations

### DIFF
--- a/includes/resources/Design_Tokens/Resolver/Effective_Palettes.php
+++ b/includes/resources/Design_Tokens/Resolver/Effective_Palettes.php
@@ -130,6 +130,31 @@ final class Effective_Palettes {
 	}
 
 	/**
+	 * The palette ids a library defines that are NOT in the baseline — i.e. the user-created ones.
+	 * An id that shadows a baseline palette is excluded, since deleting it reverts that palette to
+	 * baseline rather than removing it.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token library slug.
+	 *
+	 * @return string[]
+	 */
+	public function user_created( string $slug = 'default' ): array {
+		$baseline_ids = [];
+
+		foreach ( array_keys( $this->palettes_of( $this->baseline->document() ) ) as $key ) {
+			if ( is_string( $key ) && strpos( $key, '$' ) === 0 ) {
+				continue;
+			}
+
+			$baseline_ids[] = (string) $key;
+		}
+
+		return array_values( array_diff( $this->palette_ids( $slug ), $baseline_ids ) );
+	}
+
+	/**
 	 * The library's `$default` palette id (the shipped/fallback palette), falling back to "default".
 	 *
 	 * @since TBD

--- a/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
@@ -1146,7 +1146,8 @@ final class Palettes_Controller extends Controller {
 	}
 
 	/**
-	 * The palette listing for a library: the `$default` / `$current` pointers and each palette's id + label.
+	 * The palette listing for a library: the `$default` / `$current` pointers, each palette's id + label, and
+	 * which ids are user-created (the only ones a delete removes rather than reverts to baseline).
 	 *
 	 * @since TBD
 	 *
@@ -1171,6 +1172,7 @@ final class Palettes_Controller extends Controller {
 			Extensions::get_default_key() => $this->palettes->default_palette( $slug ),
 			Extensions::get_current_key() => $this->palettes->current( $slug ),
 			'palettes'                    => $palettes,
+			'userCreated'                 => $this->palettes->user_created( $slug ),
 		];
 	}
 

--- a/src/style-library/__tests__/palette-flows.test.js
+++ b/src/style-library/__tests__/palette-flows.test.js
@@ -7,10 +7,12 @@ import {
 	deletePaletteFlow,
 	openPaletteFlow,
 	removeSwatchFlow,
+	renamePaletteFlow,
 	reorderSwatchesFlow,
 	saveSwatchEditsFlow,
 	writeDefaultPaletteFlow,
 } from '../helpers/palette-flows';
+import { stripEffectiveFlags } from '../helpers/palettes';
 import * as client from '../api/client';
 
 // A factory, not bare automocking: the real module imports `@wordpress/api-fetch`, which is
@@ -504,6 +506,138 @@ describe('deletePaletteFlow', () => {
 		).rejects.toBe(failure);
 
 		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+	});
+});
+
+describe('renamePaletteFlow', () => {
+	it('rejects an empty label with an inline error and no request', async () => {
+		const onError = jest.fn();
+
+		await expect(
+			renamePaletteFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				id: 'sunset',
+				label: '   ',
+				listing: { defaultId: DEFAULT_ID, palettes: [{ id: 'sunset', label: 'Sunset' }] },
+				reload: jest.fn(),
+				onBusy: jest.fn(),
+				onError,
+			})
+		).rejects.toThrow();
+
+		expect(client.fetchPalette).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: expect.stringMatching(/enter a palette name/i) });
+	});
+
+	it('rejects a label that collides with a DIFFERENT palette, without requesting', async () => {
+		const onError = jest.fn();
+		const listing = {
+			defaultId: DEFAULT_ID,
+			palettes: [
+				{ id: 'sunset', label: 'Sunset' },
+				{ id: 'forest', label: 'Forest' },
+			],
+		};
+
+		await expect(
+			renamePaletteFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				id: 'sunset',
+				label: 'Forest',
+				listing,
+				reload: jest.fn(),
+				onBusy: jest.fn(),
+				onError,
+			})
+		).rejects.toThrow();
+
+		expect(client.fetchPalette).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: expect.stringMatching(/already exists/i) });
+	});
+
+	it('allows renaming a palette to its own current label', async () => {
+		client.fetchPalette.mockResolvedValue(selectedView());
+		client.savePalette.mockResolvedValue({});
+		const reload = jest.fn().mockResolvedValue(undefined);
+		const listing = { defaultId: DEFAULT_ID, palettes: [{ id: 'sunset', label: 'Sunset' }] };
+
+		await renamePaletteFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			id: 'sunset',
+			label: 'Sunset',
+			listing,
+			reload,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(client.savePalette).toHaveBeenCalledWith(
+			NAMESPACE,
+			'sunset',
+			expect.objectContaining({ label: 'Sunset' }),
+			SLUG
+		);
+	});
+
+	it('preserves the id, re-sends the palette’s own groups under the new label, and reloads the listing', async () => {
+		client.fetchPalette.mockResolvedValue(selectedView());
+		client.savePalette.mockResolvedValue({});
+		const reload = jest.fn().mockResolvedValue(undefined);
+		const onBusy = jest.fn();
+		const listing = { defaultId: DEFAULT_ID, palettes: [{ id: 'sunset', label: 'Sunset' }] };
+
+		await renamePaletteFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			id: 'sunset',
+			label: 'Sunset Dusk',
+			listing,
+			reload,
+			onBusy,
+			onError: jest.fn(),
+		});
+
+		// Reads and writes the SAME id throughout — never a slug derived from the new label (that
+		// derivation is `createPaletteFlow`'s job for a brand-new palette, not this flow's).
+		expect(client.fetchPalette).toHaveBeenCalledWith(NAMESPACE, 'sunset', SLUG);
+		const [namespaceArg, idArg, payload, slugArg] = client.savePalette.mock.calls[0];
+
+		expect(namespaceArg).toBe(NAMESPACE);
+		expect(idArg).toBe('sunset');
+		expect(slugArg).toBe(SLUG);
+		expect(payload.label).toBe('Sunset Dusk');
+		expect(payload.groups).toEqual(stripEffectiveFlags(selectedView().groups));
+		expect(reload).toHaveBeenCalled();
+		// No feed refresh: a palette's label never reaches a resolved token value (see the flow's
+		// own docblock), so there is nothing for a refresh to correct.
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+
+	it('surfaces the error, clears busy, and rejects when the rename request fails', async () => {
+		const failure = new Error('Could not rename the palette.');
+		client.fetchPalette.mockRejectedValue(failure);
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+		const listing = { defaultId: DEFAULT_ID, palettes: [{ id: 'sunset', label: 'Sunset' }] };
+
+		await expect(
+			renamePaletteFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				id: 'sunset',
+				label: 'Sunset Dusk',
+				listing,
+				reload: jest.fn(),
+				onBusy,
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy).toHaveBeenLastCalledWith(false);
 	});
 });
 

--- a/src/style-library/__tests__/palette-flows.test.js
+++ b/src/style-library/__tests__/palette-flows.test.js
@@ -549,7 +549,7 @@ describe('createPaletteFlow', () => {
 });
 
 describe('deletePaletteFlow', () => {
-	it('deletes, defers to reload for the server-resolved fallback, and never activates a successor', async () => {
+	it('deletes a palette that is not the live one without activating a successor', async () => {
 		client.deletePalette.mockResolvedValue({ $default: DEFAULT_ID, $current: DEFAULT_ID, palettes: [] });
 		const reload = jest.fn().mockResolvedValue(undefined);
 		const refreshFeed = jest.fn().mockResolvedValue(undefined);
@@ -559,6 +559,7 @@ describe('deletePaletteFlow', () => {
 			namespace: NAMESPACE,
 			slug: SLUG,
 			id: 'sunset',
+			currentId: DEFAULT_ID,
 			reload,
 			refreshFeed,
 			onBusy,
@@ -571,9 +572,58 @@ describe('deletePaletteFlow', () => {
 		expect(reload).toHaveBeenCalled();
 		expect(refreshFeed).toHaveBeenCalledWith(SLUG);
 		expect(onBusy.mock.calls).toEqual([[true], [false]]);
-		// No successor is ever activated first — unlike deleteLibraryFlow, deleting a palette that
-		// is merely being edited has no live-site effect to sequence around.
 		expect(client.setCurrentPalette).not.toHaveBeenCalled();
+	});
+
+	it('refuses to delete the live palette with no successor chosen, and issues no request', async () => {
+		const onError = jest.fn();
+
+		await expect(
+			deletePaletteFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				id: 'sunset',
+				currentId: 'sunset',
+				reload: jest.fn(),
+				refreshFeed: jest.fn(),
+				onBusy: jest.fn(),
+				onError,
+			})
+		).rejects.toThrow();
+
+		expect(client.setCurrentPalette).not.toHaveBeenCalled();
+		expect(client.deletePalette).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: expect.stringMatching(/choose which palette/i) });
+	});
+
+	it('activates the chosen successor before deleting the live palette', async () => {
+		const order = [];
+		client.setCurrentPalette.mockImplementation(() => {
+			order.push('activate');
+			return Promise.resolve({ current: 'forest' });
+		});
+		client.deletePalette.mockImplementation(() => {
+			order.push('delete');
+			return Promise.resolve({});
+		});
+		const onActivated = jest.fn();
+
+		await deletePaletteFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			id: 'sunset',
+			currentId: 'sunset',
+			successorId: 'forest',
+			reload: jest.fn().mockResolvedValue(undefined),
+			refreshFeed: jest.fn().mockResolvedValue(undefined),
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+			onActivated,
+		});
+
+		expect(order).toEqual(['activate', 'delete']);
+		expect(client.setCurrentPalette).toHaveBeenCalledWith(NAMESPACE, 'forest', SLUG);
+		expect(onActivated).toHaveBeenCalledWith('forest');
 	});
 
 	it('surfaces the default-palette 400 message', async () => {

--- a/src/style-library/__tests__/palette-flows.test.js
+++ b/src/style-library/__tests__/palette-flows.test.js
@@ -454,6 +454,7 @@ describe('createPaletteFlow', () => {
 			label: 'Forest',
 			listing: { defaultId: DEFAULT_ID, palettes: [] },
 			reload: jest.fn().mockResolvedValue(undefined),
+			refreshFeed: jest.fn().mockResolvedValue(undefined),
 			openPalette: jest.fn().mockResolvedValue(undefined),
 			onBusy,
 			onError: jest.fn(),
@@ -475,6 +476,7 @@ describe('createPaletteFlow', () => {
 			label: 'Forest',
 			listing,
 			reload,
+			refreshFeed: jest.fn().mockResolvedValue(undefined),
 			openPalette,
 			onBusy: jest.fn(),
 			onError: jest.fn(),
@@ -509,6 +511,7 @@ describe('createPaletteFlow', () => {
 			label: 'Forest',
 			listing,
 			reload,
+			refreshFeed: jest.fn().mockResolvedValue(undefined),
 			openPalette,
 			onBusy: jest.fn(),
 			onError: jest.fn(),
@@ -519,6 +522,28 @@ describe('createPaletteFlow', () => {
 		// exists), so this ordering means the listing already carries the new row by the time
 		// `editingId` moves onto it — otherwise the dropdown would render the raw id for one tick.
 		expect(order).toEqual(['reload', 'openPalette']);
+	});
+
+	it('refreshes the feed, so the version token a later write is checked against is not left stale', async () => {
+		client.fetchPalette.mockResolvedValue(defaultView());
+		client.savePalette.mockResolvedValue({});
+		const refreshFeed = jest.fn().mockResolvedValue(undefined);
+
+		await createPaletteFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			label: 'Forest',
+			listing: { defaultId: DEFAULT_ID, palettes: [] },
+			reload: jest.fn().mockResolvedValue(undefined),
+			openPalette: jest.fn().mockResolvedValue(undefined),
+			refreshFeed,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		// Without this the page keeps the version it read before the create, and the next write —
+		// adding a color, say — is rejected with a 409 conflict.
+		expect(refreshFeed).toHaveBeenCalledWith(SLUG);
 	});
 
 	it('surfaces the error, clears busy, and rejects when the create request fails', async () => {
@@ -659,6 +684,7 @@ describe('renamePaletteFlow', () => {
 				label: '   ',
 				listing: { defaultId: DEFAULT_ID, palettes: [{ id: 'sunset', label: 'Sunset' }] },
 				reload: jest.fn(),
+				refreshFeed: jest.fn().mockResolvedValue(undefined),
 				onBusy: jest.fn(),
 				onError,
 			})
@@ -708,6 +734,7 @@ describe('renamePaletteFlow', () => {
 			label: 'Sunset',
 			listing,
 			reload,
+			refreshFeed: jest.fn().mockResolvedValue(undefined),
 			onBusy: jest.fn(),
 			onError: jest.fn(),
 		});
@@ -718,6 +745,27 @@ describe('renamePaletteFlow', () => {
 			expect.objectContaining({ label: 'Sunset' }),
 			SLUG
 		);
+	});
+
+	it('refreshes the feed, so a rename does not leave the version token stale', async () => {
+		client.fetchPalette.mockResolvedValue(selectedView());
+		client.savePalette.mockResolvedValue({});
+		const refreshFeed = jest.fn().mockResolvedValue(undefined);
+
+		await renamePaletteFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			id: 'sunset',
+			label: 'Dusk',
+			listing: { defaultId: DEFAULT_ID, palettes: [{ id: 'sunset', label: 'Sunset' }] },
+			reload: jest.fn().mockResolvedValue(undefined),
+			refreshFeed,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		// A label changes no resolved value, but it does bump the stored document's version.
+		expect(refreshFeed).toHaveBeenCalledWith(SLUG);
 	});
 
 	it('preserves the id, re-sends the palette’s own groups under the new label, and reloads the listing', async () => {
@@ -734,6 +782,7 @@ describe('renamePaletteFlow', () => {
 			label: 'Sunset Dusk',
 			listing,
 			reload,
+			refreshFeed: jest.fn().mockResolvedValue(undefined),
 			onBusy,
 			onError: jest.fn(),
 		});

--- a/src/style-library/__tests__/palette-flows.test.js
+++ b/src/style-library/__tests__/palette-flows.test.js
@@ -443,6 +443,25 @@ describe('createPaletteFlow', () => {
 		expect(onError).toHaveBeenCalledWith({ message: expect.stringMatching(/already exists/i) });
 	});
 
+	it('settles the busy flag on success so the screen leaves its loading state', async () => {
+		client.fetchPalette.mockResolvedValue(defaultView());
+		client.savePalette.mockResolvedValue({});
+		const onBusy = jest.fn();
+
+		await createPaletteFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			label: 'Forest',
+			listing: { defaultId: DEFAULT_ID, palettes: [] },
+			reload: jest.fn().mockResolvedValue(undefined),
+			openPalette: jest.fn().mockResolvedValue(undefined),
+			onBusy,
+			onError: jest.fn(),
+		});
+
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+
 	it('seeds the new node from the default view, opens it, and never activates it', async () => {
 		client.fetchPalette.mockResolvedValue(defaultView());
 		client.savePalette.mockResolvedValue({});

--- a/src/style-library/__tests__/palette-flows.test.js
+++ b/src/style-library/__tests__/palette-flows.test.js
@@ -7,10 +7,12 @@ import {
 	deletePaletteFlow,
 	openPaletteFlow,
 	removeSwatchFlow,
+	renamePaletteFlow,
 	reorderSwatchesFlow,
 	saveSwatchEditsFlow,
 	writeDefaultPaletteFlow,
 } from '../helpers/palette-flows';
+import { stripEffectiveFlags } from '../helpers/palettes';
 import * as client from '../api/client';
 
 // A factory, not bare automocking: the real module imports `@wordpress/api-fetch`, which is
@@ -573,6 +575,138 @@ describe('deletePaletteFlow', () => {
 		).rejects.toBe(failure);
 
 		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+	});
+});
+
+describe('renamePaletteFlow', () => {
+	it('rejects an empty label with an inline error and no request', async () => {
+		const onError = jest.fn();
+
+		await expect(
+			renamePaletteFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				id: 'sunset',
+				label: '   ',
+				listing: { defaultId: DEFAULT_ID, palettes: [{ id: 'sunset', label: 'Sunset' }] },
+				reload: jest.fn(),
+				onBusy: jest.fn(),
+				onError,
+			})
+		).rejects.toThrow();
+
+		expect(client.fetchPalette).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: expect.stringMatching(/enter a palette name/i) });
+	});
+
+	it('rejects a label that collides with a DIFFERENT palette, without requesting', async () => {
+		const onError = jest.fn();
+		const listing = {
+			defaultId: DEFAULT_ID,
+			palettes: [
+				{ id: 'sunset', label: 'Sunset' },
+				{ id: 'forest', label: 'Forest' },
+			],
+		};
+
+		await expect(
+			renamePaletteFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				id: 'sunset',
+				label: 'Forest',
+				listing,
+				reload: jest.fn(),
+				onBusy: jest.fn(),
+				onError,
+			})
+		).rejects.toThrow();
+
+		expect(client.fetchPalette).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: expect.stringMatching(/already exists/i) });
+	});
+
+	it('allows renaming a palette to its own current label', async () => {
+		client.fetchPalette.mockResolvedValue(selectedView());
+		client.savePalette.mockResolvedValue({});
+		const reload = jest.fn().mockResolvedValue(undefined);
+		const listing = { defaultId: DEFAULT_ID, palettes: [{ id: 'sunset', label: 'Sunset' }] };
+
+		await renamePaletteFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			id: 'sunset',
+			label: 'Sunset',
+			listing,
+			reload,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(client.savePalette).toHaveBeenCalledWith(
+			NAMESPACE,
+			'sunset',
+			expect.objectContaining({ label: 'Sunset' }),
+			SLUG
+		);
+	});
+
+	it('preserves the id, re-sends the palette’s own groups under the new label, and reloads the listing', async () => {
+		client.fetchPalette.mockResolvedValue(selectedView());
+		client.savePalette.mockResolvedValue({});
+		const reload = jest.fn().mockResolvedValue(undefined);
+		const onBusy = jest.fn();
+		const listing = { defaultId: DEFAULT_ID, palettes: [{ id: 'sunset', label: 'Sunset' }] };
+
+		await renamePaletteFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			id: 'sunset',
+			label: 'Sunset Dusk',
+			listing,
+			reload,
+			onBusy,
+			onError: jest.fn(),
+		});
+
+		// Reads and writes the SAME id throughout — never a slug derived from the new label (that
+		// derivation is `createPaletteFlow`'s job for a brand-new palette, not this flow's).
+		expect(client.fetchPalette).toHaveBeenCalledWith(NAMESPACE, 'sunset', SLUG);
+		const [namespaceArg, idArg, payload, slugArg] = client.savePalette.mock.calls[0];
+
+		expect(namespaceArg).toBe(NAMESPACE);
+		expect(idArg).toBe('sunset');
+		expect(slugArg).toBe(SLUG);
+		expect(payload.label).toBe('Sunset Dusk');
+		expect(payload.groups).toEqual(stripEffectiveFlags(selectedView().groups));
+		expect(reload).toHaveBeenCalled();
+		// No feed refresh: a palette's label never reaches a resolved token value (see the flow's
+		// own docblock), so there is nothing for a refresh to correct.
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+
+	it('surfaces the error, clears busy, and rejects when the rename request fails', async () => {
+		const failure = new Error('Could not rename the palette.');
+		client.fetchPalette.mockRejectedValue(failure);
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+		const listing = { defaultId: DEFAULT_ID, palettes: [{ id: 'sunset', label: 'Sunset' }] };
+
+		await expect(
+			renamePaletteFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				id: 'sunset',
+				label: 'Sunset Dusk',
+				listing,
+				reload: jest.fn(),
+				onBusy,
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy).toHaveBeenLastCalledWith(false);
 	});
 });
 

--- a/src/style-library/__tests__/palettes.test.js
+++ b/src/style-library/__tests__/palettes.test.js
@@ -7,10 +7,12 @@ import {
 	isCustomColorToken,
 	isDefaultPalette,
 	isDuplicatePaletteLabel,
+	isUserCreatedPalette,
 	mapPaletteToSwatchGroups,
 	newSwatchValue,
 	nextCustomColorSlug,
 	paletteDisplayLabel,
+	paletteSuccessorOptions,
 	removeSwatchFromGroups,
 	renameSwatchInGroups,
 	reorderGroupSwatches,
@@ -390,3 +392,49 @@ function deepFreeze(value) {
 
 	return Object.freeze(value);
 }
+
+describe('paletteSuccessorOptions', () => {
+	const listing = {
+		defaultId: 'default',
+		palettes: [
+			{ id: 'default', label: 'Default' },
+			{ id: 'sunset', label: 'Sunset' },
+			{ id: 'forest', label: '' },
+		],
+	};
+
+	it('offers every palette but the one being deleted, in listing order', () => {
+		expect(paletteSuccessorOptions(listing, 'sunset')).toEqual([
+			{ id: 'default', label: 'Default' },
+			{ id: 'forest', label: '' },
+		]);
+	});
+
+	it('keeps the default palette as a candidate', () => {
+		expect(paletteSuccessorOptions(listing, 'forest').map((row) => row.id)).toContain('default');
+	});
+
+	it('returns nothing for a listing that has not loaded', () => {
+		expect(paletteSuccessorOptions(undefined, 'sunset')).toEqual([]);
+		expect(paletteSuccessorOptions({}, 'sunset')).toEqual([]);
+	});
+});
+
+describe('isUserCreatedPalette', () => {
+	const listing = { defaultId: 'default', userCreated: ['ocean'] };
+
+	it('reports a palette the listing names as user-created', () => {
+		expect(isUserCreatedPalette(listing, 'ocean')).toBe(true);
+	});
+
+	it('reports a baseline palette as not user-created', () => {
+		expect(isUserCreatedPalette(listing, 'sunset')).toBe(false);
+		expect(isUserCreatedPalette(listing, 'default')).toBe(false);
+	});
+
+	it('fails closed when the listing carries no signal', () => {
+		expect(isUserCreatedPalette({}, 'ocean')).toBe(false);
+		expect(isUserCreatedPalette(undefined, 'ocean')).toBe(false);
+		expect(isUserCreatedPalette(listing, '')).toBe(false);
+	});
+});

--- a/src/style-library/__tests__/palettes.test.js
+++ b/src/style-library/__tests__/palettes.test.js
@@ -177,6 +177,20 @@ describe('slugifyPaletteLabel / isDuplicatePaletteLabel', () => {
 		expect(isDuplicatePaletteLabel('Forest', listing)).toBe(false);
 		expect(isDuplicatePaletteLabel('   ', listing)).toBe(false);
 	});
+
+	it('excludes the given id from the collision check, so renaming to its own label is allowed', () => {
+		const listing = {
+			palettes: [
+				{ id: 'sunset', label: 'Sunset' },
+				{ id: 'forest', label: 'Forest' },
+			],
+		};
+
+		// Retyping "Sunset" while renaming the "sunset" palette itself is not a collision…
+		expect(isDuplicatePaletteLabel('Sunset', listing, 'sunset')).toBe(false);
+		// …but retyping a name that belongs to a DIFFERENT palette still is.
+		expect(isDuplicatePaletteLabel('Forest', listing, 'sunset')).toBe(true);
+	});
 });
 
 describe('stripEffectiveFlags', () => {

--- a/src/style-library/components/organisms/ActivatePaletteButton.js
+++ b/src/style-library/components/organisms/ActivatePaletteButton.js
@@ -1,0 +1,94 @@
+/**
+ * The header's "Set as active" affordance and its confirmation modal for palettes, mirroring
+ * `ActivateLibraryButton` exactly: it owns its own open state, and renders nothing while the
+ * palette being edited is already `$current` — there is no action to offer, and the dropdown's own
+ * Active badge already says which one is live, so a second label here would only repeat it.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ActivatePaletteModal } from './ActivatePaletteModal';
+import './ActivatePaletteButton.scss';
+
+/**
+ * Render the activate action and, when open, its confirmation modal.
+ *
+ * @param {Object}             props                 The component props.
+ * @param {string}             props.editingId       The palette the app is showing, and the activation target.
+ * @param {string}             props.editingLabel    That palette's display label.
+ * @param {string}             props.activeLabel     The display label of the palette the site uses now.
+ * @param {boolean}            props.isEditingActive Whether the palette being edited is already the active one.
+ * @param {boolean}            props.isBusy          Whether a palette operation is in flight.
+ * @param {?{message: string}} props.error           The current activation error, if any.
+ * @param {Function}           props.onClearError    Dismisses the current activation error.
+ * @param {Function}           props.onActivate      Called with an id to make that palette active.
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The action and, while open, its modal — or null when the palette being
+ *                         edited is already active.
+ */
+export function ActivatePaletteButton({
+	editingId,
+	editingLabel,
+	activeLabel,
+	isEditingActive,
+	isBusy,
+	error,
+	onClearError,
+	onActivate,
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	if (isEditingActive) {
+		return null;
+	}
+
+	// Closes the modal and clears its own error, whether that is a confirmed activation, a Cancel
+	// click, or the Modal's own dismiss paths (Escape, click-outside) — all of which are already
+	// gated off while `isBusy`, so this never fires mid-request.
+	const handleClose = () => {
+		setIsOpen(false);
+		onClearError();
+	};
+
+	// The modal closes only once the pointer has actually moved. `.catch` deliberately does nothing
+	// beyond swallowing the rejection — a failed activation already re-set `isBusy`/`error` in the
+	// hook, and staying open is exactly the behavior a caught rejection gives here for free.
+	const handleConfirm = () => {
+		onActivate(editingId)
+			.then(() => handleClose())
+			.catch(() => {});
+	};
+
+	return (
+		<>
+			<Button
+				variant="secondary"
+				disabled={isBusy}
+				onClick={() => setIsOpen(true)}
+				className="kadence-blocks-style-library__activate-palette-action"
+			>
+				{__('Set as active', 'kadence-blocks')}
+			</Button>
+			{isOpen && (
+				<ActivatePaletteModal
+					currentLabel={activeLabel}
+					nextLabel={editingLabel}
+					isBusy={isBusy}
+					error={error}
+					onClose={handleClose}
+					onConfirm={handleConfirm}
+				/>
+			)}
+		</>
+	);
+}

--- a/src/style-library/components/organisms/ActivatePaletteButton.scss
+++ b/src/style-library/components/organisms/ActivatePaletteButton.scss
@@ -1,0 +1,10 @@
+// Qualified with the app root so this outranks wp-admin's own default button sizing, the same
+// way the select toggle's rule does. Mirrors ActivateLibraryButton.scss.
+.kadence-blocks-style-library-root .kadence-blocks-style-library__activate-palette-action {
+	height: var(--kb-sl-space-50);
+	padding: 0 var(--kb-sl-space-15);
+	font-size: var(--kb-sl-font-size-m);
+	line-height: var(--kb-sl-line-height-s);
+	font-weight: var(--kb-sl-font-weight-medium);
+	white-space: nowrap;
+}

--- a/src/style-library/components/organisms/ActivatePaletteModal.js
+++ b/src/style-library/components/organisms/ActivatePaletteModal.js
@@ -1,0 +1,80 @@
+/**
+ * The confirmation shown before a palette becomes `$current` — the one the site renders with.
+ * Mirrors `ActivateLibraryModal`: choosing a palette from the header dropdown only opens it for
+ * editing, so this modal is the whole reason activation is safe. The copy names both palettes and
+ * describes what a visitor will actually see change, rather than talking about settings in the
+ * abstract.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button, Modal, Notice } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './ActivatePaletteModal.scss';
+
+/**
+ * Render the activation confirmation.
+ *
+ * @param {Object}             props              The component props.
+ * @param {string}             props.currentLabel The display label of the palette the site uses now.
+ * @param {string}             props.nextLabel    The display label of the palette about to go live.
+ * @param {boolean}            props.isBusy       Whether the activation request is in flight.
+ * @param {?{message: string}} props.error        The current activation error, if any.
+ * @param {Function}           props.onClose      Called to dismiss the modal.
+ * @param {Function}           props.onConfirm    Called to activate the palette.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The modal.
+ */
+export function ActivatePaletteModal({ currentLabel, nextLabel, isBusy, error, onClose, onConfirm }) {
+	return (
+		<Modal
+			title={sprintf(
+				// translators: %s: the palette's display label.
+				__('Set "%s" as the active palette?', 'kadence-blocks'),
+				nextLabel
+			)}
+			className="kadence-blocks-style-library__activate-palette-modal"
+			onRequestClose={onClose}
+			// Locked while pending: no close icon, Escape does nothing, clicking outside does
+			// nothing. A site-wide restyle in flight must not be walkable-away-from mid-request.
+			isDismissible={!isBusy}
+			shouldCloseOnEsc={!isBusy}
+			shouldCloseOnClickOutside={!isBusy}
+		>
+			{error && (
+				<Notice status="error" isDismissible={false}>
+					{error.message}
+				</Notice>
+			)}
+			<p>
+				{sprintf(
+					// translators: 1: the palette the site currently uses. 2: the palette being activated.
+					__(
+						'Your site currently uses "%1$s". Setting "%2$s" as active changes the colors across your whole site right away — on the front end and in the editor.',
+						'kadence-blocks'
+					),
+					currentLabel,
+					nextLabel
+				)}
+			</p>
+			<div className="kadence-blocks-style-library__activate-palette-modal-actions">
+				{/* Cancel carries the autofocus: the safe choice should be the one a stray Enter
+				 * press lands on, since the other one restyles the entire site. */}
+				<Button variant="tertiary" onClick={onClose} disabled={isBusy} autoFocus>
+					{__('Cancel', 'kadence-blocks')}
+				</Button>
+				<Button variant="primary" disabled={isBusy} onClick={onConfirm}>
+					{/* The progressive label is the only progress indication — no spinner alongside it. */}
+					{isBusy ? __('Setting active…', 'kadence-blocks') : __('Set as active', 'kadence-blocks')}
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/src/style-library/components/organisms/ActivatePaletteModal.scss
+++ b/src/style-library/components/organisms/ActivatePaletteModal.scss
@@ -1,0 +1,13 @@
+// Mirrors ActivateLibraryModal.scss — see that file for why the selector is compound (it lands on
+// `.components-modal__frame`, and the max-width is capped so the consequence copy wraps at a
+// readable measure instead of stretching to the viewport cap).
+.components-modal__frame.kadence-blocks-style-library__activate-palette-modal {
+	max-width: var(--kb-sl-size-modal-medium);
+}
+
+.kadence-blocks-style-library__activate-palette-modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: var(--kb-sl-space-10);
+	margin-top: var(--kb-sl-space-20);
+}

--- a/src/style-library/components/organisms/AddColorGroupModal.js
+++ b/src/style-library/components/organisms/AddColorGroupModal.js
@@ -1,0 +1,86 @@
+/**
+ * The "Add Color Group" modal: a name field and Cancel / Add actions. Same skeleton as
+ * `CreatePaletteModal` — they do not merge, because their validation, copy, and flow
+ * (`addGroupFlow`) differ: this one mints the group's first swatch in the same write, since the
+ * server drops a color group with zero swatches even on the default palette.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button, Modal, Notice, TextControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { slugifyPaletteLabel } from '../../helpers/palettes';
+import './AddColorGroupModal.scss';
+
+/**
+ * Render the add-color-group modal.
+ *
+ * @param {Object}             props         The component props.
+ * @param {Object}             props.palette The palette being edited's effective view, for the duplicate-group check.
+ * @param {boolean}            props.isBusy  Whether the add request is in flight.
+ * @param {?{message: string}} props.error   The current structure error, if any.
+ * @param {Function}           props.onClose Called to dismiss the modal.
+ * @param {Function}           props.onAdd   Called with the typed label to create the group.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The modal.
+ */
+export function AddColorGroupModal({ palette, isBusy, error, onClose, onAdd }) {
+	const [label, setLabel] = useState('');
+	const groupId = slugifyPaletteLabel(label);
+	const isDuplicate = groupId !== '' && (palette?.groups ?? []).some((group) => group.id === groupId);
+
+	return (
+		<Modal
+			title={__('Add Color Group', 'kadence-blocks')}
+			className="kadence-blocks-style-library__add-color-group-modal"
+			onRequestClose={onClose}
+			// Locked while pending: no close icon, Escape does nothing, clicking outside does
+			// nothing. An add request in flight cannot be walked away from mid-request.
+			isDismissible={!isBusy}
+			shouldCloseOnEsc={!isBusy}
+			shouldCloseOnClickOutside={!isBusy}
+		>
+			{error && (
+				<Notice status="error" isDismissible={false}>
+					{error.message}
+				</Notice>
+			)}
+			<TextControl
+				label={__('Group name', 'kadence-blocks')}
+				value={label}
+				onChange={setLabel}
+				disabled={isBusy}
+				help={
+					isDuplicate
+						? sprintf(
+								// translators: %s: the group name the user typed.
+								__('A color group named "%s" already exists.', 'kadence-blocks'),
+								label
+							)
+						: undefined
+				}
+			/>
+			<div className="kadence-blocks-style-library__add-color-group-modal-actions">
+				<Button variant="tertiary" onClick={onClose} disabled={isBusy}>
+					{__('Cancel', 'kadence-blocks')}
+				</Button>
+				<Button
+					variant="primary"
+					disabled={isBusy || groupId === '' || isDuplicate}
+					onClick={() => onAdd(label)}
+				>
+					{/* The progressive label is the only progress indication — no spinner alongside it. */}
+					{isBusy ? __('Adding…', 'kadence-blocks') : __('Add', 'kadence-blocks')}
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/src/style-library/components/organisms/AddColorGroupModal.js
+++ b/src/style-library/components/organisms/AddColorGroupModal.js
@@ -35,7 +35,7 @@ import './AddColorGroupModal.scss';
 export function AddColorGroupModal({ palette, isBusy, error, onClose, onAdd }) {
 	const [label, setLabel] = useState('');
 	const groupId = slugifyPaletteLabel(label);
-	const isDuplicate = groupId !== '' && (palette?.groups ?? []).some((group) => group.id === groupId);
+	const isDuplicate = !isBusy && groupId !== '' && (palette?.groups ?? []).some((group) => group.id === groupId);
 
 	return (
 		<Modal

--- a/src/style-library/components/organisms/AddColorGroupModal.scss
+++ b/src/style-library/components/organisms/AddColorGroupModal.scss
@@ -1,0 +1,6 @@
+.kadence-blocks-style-library__add-color-group-modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: var(--kb-sl-space-10);
+	margin-top: var(--kb-sl-space-20);
+}

--- a/src/style-library/components/organisms/CreatePaletteModal.js
+++ b/src/style-library/components/organisms/CreatePaletteModal.js
@@ -38,7 +38,7 @@ import './CreatePaletteModal.scss';
 export function CreatePaletteModal({ listing, isBusy, error, onClose, onCreate }) {
 	const [label, setLabel] = useState('');
 	const slug = slugifyPaletteLabel(label);
-	const isDuplicate = isDuplicatePaletteLabel(label, listing);
+	const isDuplicate = !isBusy && isDuplicatePaletteLabel(label, listing);
 
 	return (
 		<Modal

--- a/src/style-library/components/organisms/CreatePaletteModal.js
+++ b/src/style-library/components/organisms/CreatePaletteModal.js
@@ -1,0 +1,89 @@
+/**
+ * The "Create Color Palette" modal: a name field and Cancel / Create actions. Modeled on
+ * `CreateLibraryModal` — a title field, the same derived-slug duplicate check, and the same
+ * resolved/rejected-promise close contract — but for palettes, whose slug and duplicate rule
+ * (`slugifyPaletteLabel` / `isDuplicatePaletteLabel`) already exist from the data-layer flows.
+ *
+ * A successful create both creates and opens the new palette (`createPaletteFlow`); it never
+ * activates it, so the caller closes this modal on the create resolving, not on any activation.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button, Modal, Notice, TextControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { isDuplicatePaletteLabel, slugifyPaletteLabel } from '../../helpers/palettes';
+import './CreatePaletteModal.scss';
+
+/**
+ * Render the create-palette modal.
+ *
+ * @param {Object}              props          The component props.
+ * @param {Object}              props.listing  The palette listing (`{ palettes }`), for the duplicate-label check.
+ * @param {boolean}              props.isBusy   Whether the create request is in flight.
+ * @param {?{message: string}}  props.error    The current create error, if any.
+ * @param {Function}             props.onClose  Called to dismiss the modal.
+ * @param {Function}             props.onCreate Called with the typed label to create the palette.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The modal.
+ */
+export function CreatePaletteModal({ listing, isBusy, error, onClose, onCreate }) {
+	const [label, setLabel] = useState('');
+	const slug = slugifyPaletteLabel(label);
+	const isDuplicate = isDuplicatePaletteLabel(label, listing);
+
+	return (
+		<Modal
+			title={__('Create Color Palette', 'kadence-blocks')}
+			className="kadence-blocks-style-library__create-palette-modal"
+			onRequestClose={onClose}
+			// Locked while pending: no close icon, Escape does nothing, clicking outside does
+			// nothing. A create request in flight cannot be walked away from mid-request.
+			isDismissible={!isBusy}
+			shouldCloseOnEsc={!isBusy}
+			shouldCloseOnClickOutside={!isBusy}
+		>
+			{error && (
+				<Notice status="error" isDismissible={false}>
+					{error.message}
+				</Notice>
+			)}
+			<TextControl
+				label={__('Palette name', 'kadence-blocks')}
+				value={label}
+				onChange={setLabel}
+				disabled={isBusy}
+				help={
+					isDuplicate
+						? sprintf(
+								// translators: %s: the palette name the user typed.
+								__('A palette named "%s" already exists.', 'kadence-blocks'),
+								label
+							)
+						: undefined
+				}
+			/>
+			<div className="kadence-blocks-style-library__create-palette-modal-actions">
+				<Button variant="tertiary" onClick={onClose} disabled={isBusy}>
+					{__('Cancel', 'kadence-blocks')}
+				</Button>
+				<Button
+					variant="primary"
+					disabled={isBusy || slug === '' || isDuplicate}
+					onClick={() => onCreate(label)}
+				>
+					{/* The progressive label is the only progress indication — no spinner alongside it. */}
+					{isBusy ? __('Creating…', 'kadence-blocks') : __('Create', 'kadence-blocks')}
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/src/style-library/components/organisms/CreatePaletteModal.scss
+++ b/src/style-library/components/organisms/CreatePaletteModal.scss
@@ -1,0 +1,6 @@
+.kadence-blocks-style-library__create-palette-modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: var(--kb-sl-space-10);
+	margin-top: var(--kb-sl-space-20);
+}

--- a/src/style-library/components/organisms/DeletePaletteModal.js
+++ b/src/style-library/components/organisms/DeletePaletteModal.js
@@ -1,0 +1,81 @@
+/**
+ * The confirmation shown before the palette being edited is deleted. Simpler than
+ * `DeleteLibraryModal`: there is no successor picker. Opening a palette never writes `$current`
+ * (`openPaletteFlow`), so deleting a palette that is merely being edited has no live-site effect to
+ * sequence around, and when the deleted palette does happen to be `$current`, the server resolves
+ * its own fallback and returns it in the listing `deletePaletteFlow` re-reads — a confirm is all
+ * this deletion ever asks for.
+ *
+ * The trigger button lives in `ColorPaletteScreen`'s header, not here — unlike
+ * `DeleteLibraryModal`, which owns both; this modal only renders while its caller's `isOpen` state
+ * says so.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button, Modal, Notice } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './DeletePaletteModal.scss';
+
+/**
+ * Render the delete-palette confirmation.
+ *
+ * @param {Object}             props           The component props.
+ * @param {string}             props.label     The palette being edited's display label.
+ * @param {boolean}            props.isActive  Whether the palette being edited is also `$current`.
+ * @param {boolean}            props.isBusy    Whether the delete request is in flight.
+ * @param {?{message: string}} props.error     The current delete error, if any.
+ * @param {Function}           props.onClose   Called to dismiss the modal.
+ * @param {Function}           props.onConfirm Called to delete the palette.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The modal.
+ */
+export function DeletePaletteModal({ label, isActive, isBusy, error, onClose, onConfirm }) {
+	return (
+		<Modal
+			title={sprintf(
+				// translators: %s: the palette's display label.
+				__('Delete "%s"?', 'kadence-blocks'),
+				label
+			)}
+			className="kadence-blocks-style-library__delete-palette-modal"
+			onRequestClose={onClose}
+			// Locked while pending: no close icon, Escape does nothing, clicking outside does
+			// nothing. A delete request in flight cannot be walked away from mid-request.
+			isDismissible={!isBusy}
+			shouldCloseOnEsc={!isBusy}
+			shouldCloseOnClickOutside={!isBusy}
+		>
+			{error && (
+				<Notice status="error" isDismissible={false}>
+					{error.message}
+				</Notice>
+			)}
+			<p>{__('Its color overrides are removed permanently.', 'kadence-blocks')}</p>
+			{isActive && (
+				<p>
+					{__(
+						'This is also your active palette, so your site will fall back to another one automatically.',
+						'kadence-blocks'
+					)}
+				</p>
+			)}
+			<div className="kadence-blocks-style-library__delete-palette-modal-actions">
+				<Button variant="tertiary" onClick={onClose} disabled={isBusy} autoFocus>
+					{__('Cancel', 'kadence-blocks')}
+				</Button>
+				<Button variant="primary" isDestructive disabled={isBusy} onClick={onConfirm}>
+					{/* The progressive label is the only progress indication — no spinner alongside it. */}
+					{isBusy ? __('Deleting…', 'kadence-blocks') : __('Delete', 'kadence-blocks')}
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/src/style-library/components/organisms/DeletePaletteModal.js
+++ b/src/style-library/components/organisms/DeletePaletteModal.js
@@ -1,10 +1,8 @@
 /**
- * The confirmation shown before the palette being edited is deleted. Simpler than
- * `DeleteLibraryModal`: there is no successor picker. Opening a palette never writes `$current`
- * (`openPaletteFlow`), so deleting a palette that is merely being edited has no live-site effect to
- * sequence around, and when the deleted palette does happen to be `$current`, the server resolves
- * its own fallback and returns it in the listing `deletePaletteFlow` re-reads — a confirm is all
- * this deletion ever asks for.
+ * The confirmation shown before the palette being edited is deleted or reset. A baseline palette is
+ * never removed — dropping its overrides reverts it to the shipped colors and it stays in the
+ * listing — so it is offered as a Reset, and only a user-created palette is a real Delete. Mirrors
+ * `DeleteLibraryModal`, which draws the same line for the default library.
  *
  * The trigger button lives in `ColorPaletteScreen`'s header, not here — unlike
  * `DeleteLibraryModal`, which owns both; this modal only renders while its caller's `isOpen` state
@@ -14,37 +12,67 @@
 /**
  * WordPress dependencies
  */
-import { Button, Modal, Notice } from '@wordpress/components';
+import { Button, Modal, Notice, SelectControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { paletteDisplayLabel } from '../../helpers/palettes';
 import './DeletePaletteModal.scss';
 
 /**
  * Render the delete-palette confirmation.
  *
  * @param {Object}             props           The component props.
- * @param {string}             props.label     The palette being edited's display label.
- * @param {boolean}            props.isActive  Whether the palette being edited is also `$current`.
- * @param {boolean}            props.isBusy    Whether the delete request is in flight.
- * @param {?{message: string}} props.error     The current delete error, if any.
- * @param {Function}           props.onClose   Called to dismiss the modal.
- * @param {Function}           props.onConfirm Called to delete the palette.
+ * @param {string}             props.label         The palette being edited's display label.
+ * @param {boolean}            props.isUserCreated Whether this palette is removable rather than resettable.
+ * @param {Array}              props.successors    The palettes the active pointer can move to.
+ * @param {boolean}            props.isActive      Whether the palette being edited is also `$current`.
+ * @param {boolean}            props.isBusy        Whether the request is in flight.
+ * @param {?{message: string}} props.error         The current error, if any.
+ * @param {Function}           props.onClose       Called to dismiss the modal.
+ * @param {Function}           props.onConfirm     Called with the chosen successor id to run the action.
  *
  * @since TBD
  *
  * @return {JSX.Element} The modal.
  */
-export function DeletePaletteModal({ label, isActive, isBusy, error, onClose, onConfirm }) {
-	return (
-		<Modal
-			title={sprintf(
+export function DeletePaletteModal({
+	label,
+	isUserCreated,
+	successors = [],
+	isActive,
+	isBusy,
+	error,
+	onClose,
+	onConfirm,
+}) {
+	const [successorId, setSuccessorId] = useState('');
+
+	// A reset leaves the palette in place and still active, so there is nothing to succeed it.
+	const needsSuccessor = isActive && isUserCreated;
+	const isSuccessorForced = needsSuccessor && successors.length === 1;
+	const chosenSuccessor = isSuccessorForced ? successors[0].id : successorId;
+
+	const restingLabel = isUserCreated ? __('Delete', 'kadence-blocks') : __('Reset', 'kadence-blocks');
+	const pendingLabel = isUserCreated ? __('Deleting…', 'kadence-blocks') : __('Resetting…', 'kadence-blocks');
+	const title = isUserCreated
+		? sprintf(
 				// translators: %s: the palette's display label.
 				__('Delete "%s"?', 'kadence-blocks'),
 				label
-			)}
+			)
+		: sprintf(
+				// translators: %s: the palette's display label.
+				__('Reset "%s"?', 'kadence-blocks'),
+				label
+			);
+
+	return (
+		<Modal
+			title={title}
 			className="kadence-blocks-style-library__delete-palette-modal"
 			onRequestClose={onClose}
 			// Locked while pending: no close icon, Escape does nothing, clicking outside does
@@ -58,22 +86,55 @@ export function DeletePaletteModal({ label, isActive, isBusy, error, onClose, on
 					{error.message}
 				</Notice>
 			)}
-			<p>{__('Its color overrides are removed permanently.', 'kadence-blocks')}</p>
-			{isActive && (
+			<p>
+				{isUserCreated
+					? __('Its color overrides are removed permanently.', 'kadence-blocks')
+					: __('Its colors return to the shipped baseline. The palette itself stays.', 'kadence-blocks')}
+			</p>
+			{isSuccessorForced && (
 				<p>
-					{__(
-						'This is also your active palette, so your site will fall back to another one automatically.',
-						'kadence-blocks'
+					{sprintf(
+						// translators: %s: the palette the site will use instead.
+						__(
+							'This is also your active palette, so your site will use "%s" instead. Its colors go live across your site immediately — on the front end and in the editor.',
+							'kadence-blocks'
+						),
+						paletteDisplayLabel(successors[0])
 					)}
 				</p>
+			)}
+			{needsSuccessor && !isSuccessorForced && (
+				<>
+					<p>
+						{__(
+							'This is also your active palette, so your site needs another one. The palette you choose below goes live immediately — its colors change across your site on the front end and in the editor.',
+							'kadence-blocks'
+						)}
+					</p>
+					<SelectControl
+						label={__('Which palette should your site use instead?', 'kadence-blocks')}
+						value={successorId}
+						disabled={isBusy}
+						onChange={setSuccessorId}
+						options={[
+							{ value: '', label: __('Select a palette…', 'kadence-blocks') },
+							...successors.map((row) => ({ value: row.id, label: paletteDisplayLabel(row) })),
+						]}
+					/>
+				</>
 			)}
 			<div className="kadence-blocks-style-library__delete-palette-modal-actions">
 				<Button variant="tertiary" onClick={onClose} disabled={isBusy} autoFocus>
 					{__('Cancel', 'kadence-blocks')}
 				</Button>
-				<Button variant="primary" isDestructive disabled={isBusy} onClick={onConfirm}>
+				<Button
+					variant="primary"
+					isDestructive
+					disabled={isBusy || (needsSuccessor && !chosenSuccessor)}
+					onClick={() => onConfirm(chosenSuccessor)}
+				>
 					{/* The progressive label is the only progress indication — no spinner alongside it. */}
-					{isBusy ? __('Deleting…', 'kadence-blocks') : __('Delete', 'kadence-blocks')}
+					{isBusy ? pendingLabel : restingLabel}
 				</Button>
 			</div>
 		</Modal>

--- a/src/style-library/components/organisms/DeletePaletteModal.scss
+++ b/src/style-library/components/organisms/DeletePaletteModal.scss
@@ -1,3 +1,7 @@
+.components-modal__frame.kadence-blocks-style-library__delete-palette-modal {
+	max-width: var(--kb-sl-size-modal-medium);
+}
+
 .kadence-blocks-style-library__delete-palette-modal-actions {
 	display: flex;
 	justify-content: flex-end;

--- a/src/style-library/components/organisms/DeletePaletteModal.scss
+++ b/src/style-library/components/organisms/DeletePaletteModal.scss
@@ -1,0 +1,6 @@
+.kadence-blocks-style-library__delete-palette-modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: var(--kb-sl-space-10);
+	margin-top: var(--kb-sl-space-20);
+}

--- a/src/style-library/components/organisms/RenamePaletteModal.js
+++ b/src/style-library/components/organisms/RenamePaletteModal.js
@@ -1,0 +1,127 @@
+/**
+ * The header's "Rename" action and its modal for palettes, mirroring `RenameLibraryModal`: a
+ * single label field over the palette being edited, seeded with its current label.
+ *
+ * Unlike Delete, Rename is available on the default palette too — the server only refuses
+ * DELETING it, not relabeling it.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button, Modal, Notice, TextControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { isDuplicatePaletteLabel } from '../../helpers/palettes';
+import './RenamePaletteModal.scss';
+
+/**
+ * Render the rename action and, when open, its modal.
+ *
+ * @param {Object}             props              The component props.
+ * @param {string}             props.id           The palette to rename (the one being edited).
+ * @param {string}             props.currentLabel That palette's current display label.
+ * @param {Object}             props.listing      The palette listing (`{ palettes }`), for the duplicate-label check.
+ * @param {boolean}            props.isBusy       Whether a palette operation is in flight.
+ * @param {?{message: string}} props.error        The current rename error, if any.
+ * @param {Function}           props.onClearError Dismisses the current rename error.
+ * @param {Function}           props.onRename     Called with the id and the new label.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The action and, when open, its modal.
+ */
+export function RenamePaletteModal({ id, currentLabel, listing, isBusy, error, onClearError, onRename }) {
+	const [isOpen, setIsOpen] = useState(false);
+	// Seeded from the current label so the common edit — fixing a typo — starts from the text
+	// being fixed rather than an empty field.
+	const [label, setLabel] = useState(currentLabel);
+
+	const trimmed = label.trim();
+	const isDuplicate = isDuplicatePaletteLabel(trimmed, listing, id);
+	const isUnchanged = trimmed === currentLabel.trim();
+
+	const handleOpen = () => {
+		setLabel(currentLabel);
+		setIsOpen(true);
+	};
+
+	// Closes and clears its own error, whether that is a completed rename, a Cancel click, or the
+	// Modal's own dismiss paths — all already gated off while `isBusy`, so this never fires
+	// mid-request.
+	const handleClose = () => {
+		setIsOpen(false);
+		onClearError();
+	};
+
+	// `.catch` swallows the rejection only: a failure already landed in `error` via the hook, and
+	// not closing is exactly what leaves the inline Notice on screen for the user to act on.
+	const handleConfirm = () => {
+		onRename(id, trimmed)
+			.then(() => handleClose())
+			.catch(() => {});
+	};
+
+	return (
+		<>
+			<Button
+				variant="tertiary"
+				disabled={isBusy}
+				onClick={handleOpen}
+				className="kadence-blocks-style-library__rename-palette-action"
+			>
+				{__('Rename', 'kadence-blocks')}
+			</Button>
+			{isOpen && (
+				<Modal
+					title={__('Rename Palette', 'kadence-blocks')}
+					className="kadence-blocks-style-library__rename-palette-modal"
+					onRequestClose={handleClose}
+					// Locked while pending, like every other palette modal.
+					isDismissible={!isBusy}
+					shouldCloseOnEsc={!isBusy}
+					shouldCloseOnClickOutside={!isBusy}
+				>
+					{error && (
+						<Notice status="error" isDismissible={false}>
+							{error.message}
+						</Notice>
+					)}
+					<TextControl
+						label={__('Palette name', 'kadence-blocks')}
+						value={label}
+						onChange={setLabel}
+						disabled={isBusy}
+						help={
+							isDuplicate
+								? sprintf(
+										// translators: %s: the palette name the user typed.
+										__('A palette named "%s" already exists.', 'kadence-blocks'),
+										trimmed
+									)
+								: undefined
+						}
+					/>
+					<div className="kadence-blocks-style-library__rename-palette-modal-actions">
+						<Button variant="tertiary" onClick={handleClose} disabled={isBusy}>
+							{__('Cancel', 'kadence-blocks')}
+						</Button>
+						<Button
+							variant="primary"
+							// Unchanged is disabled alongside empty and duplicate: a rename to the same label
+							// would spend a request to change nothing.
+							disabled={isBusy || trimmed === '' || isDuplicate || isUnchanged}
+							onClick={handleConfirm}
+						>
+							{isBusy ? __('Saving…', 'kadence-blocks') : __('Save', 'kadence-blocks')}
+						</Button>
+					</div>
+				</Modal>
+			)}
+		</>
+	);
+}

--- a/src/style-library/components/organisms/RenamePaletteModal.scss
+++ b/src/style-library/components/organisms/RenamePaletteModal.scss
@@ -1,0 +1,17 @@
+// Qualified with the app root so this outranks wp-admin's own default button sizing, matching
+// the sibling header actions. Mirrors RenameLibraryModal.scss.
+.kadence-blocks-style-library-root .kadence-blocks-style-library__rename-palette-action {
+	height: var(--kb-sl-space-50);
+	padding: 0 var(--kb-sl-space-15);
+	font-size: var(--kb-sl-font-size-m);
+	line-height: var(--kb-sl-line-height-s);
+	font-weight: var(--kb-sl-font-weight-medium);
+	white-space: nowrap;
+}
+
+.kadence-blocks-style-library__rename-palette-modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: var(--kb-sl-space-10);
+	margin-top: var(--kb-sl-space-20);
+}

--- a/src/style-library/components/organisms/ScreenHeader.js
+++ b/src/style-library/components/organisms/ScreenHeader.js
@@ -1,12 +1,12 @@
 /**
  * The per-screen header row: title, optional inline controls beside it, the primary action on the
  * right. Pure layout — every optional region is a slot the caller fills, and this component knows
- * nothing about what fills them (a palette selector, a delete link — all the caller's).
+ * nothing about what fills them (a palette selector, a rename/delete link — all the caller's).
  *
  * `title` + `primaryAction` is the common shape — most Base Styles / Block Presets screens render
- * only those two. `inlineControl` and `destructiveAction` are exceptional (only Color Palette uses
- * them); both stay generic and optional rather than special-casing Color Palette into this
- * organism.
+ * only those two. `inlineControl`, `secondaryAction`, and `destructiveAction` are exceptional
+ * (only Color Palette uses them); all three stay generic and optional rather than special-casing
+ * Color Palette into this organism.
  */
 
 /**
@@ -20,20 +20,30 @@ import './ScreenHeader.scss';
  * @param {Object}       props                     The component props.
  * @param {string}       props.title               The screen title.
  * @param {?JSX.Element} [props.inlineControl]      Control rendered beside the title (e.g. a select).
- * @param {?JSX.Element} [props.destructiveAction]  The red text-link slot beside the inline control.
+ * @param {?JSX.Element} [props.secondaryAction]    A non-destructive text-link slot beside the destructive action (e.g. Rename).
+ * @param {?JSX.Element} [props.destructiveAction]  The red text-link slot beside the secondary action.
  * @param {?JSX.Element} [props.primaryAction]      The primary "+ Add …" button slot.
  *
  * @since TBD
  *
  * @return {JSX.Element} The header row.
  */
-export function ScreenHeader({ title, inlineControl = null, destructiveAction = null, primaryAction = null }) {
+export function ScreenHeader({
+	title,
+	inlineControl = null,
+	secondaryAction = null,
+	destructiveAction = null,
+	primaryAction = null,
+}) {
 	return (
 		<div className="kadence-blocks-style-library__screen-header">
 			<div className="kadence-blocks-style-library__screen-header-lead">
 				<h2 className="kadence-blocks-style-library__screen-header-title">{title}</h2>
 				{inlineControl && (
 					<span className="kadence-blocks-style-library__screen-header-inline-control">{inlineControl}</span>
+				)}
+				{secondaryAction && (
+					<span className="kadence-blocks-style-library__screen-header-secondary">{secondaryAction}</span>
 				)}
 				{destructiveAction && (
 					<span className="kadence-blocks-style-library__screen-header-destructive">{destructiveAction}</span>

--- a/src/style-library/components/organisms/ScreenHeader.scss
+++ b/src/style-library/components/organisms/ScreenHeader.scss
@@ -15,9 +15,31 @@
 	min-width: 0;
 }
 
+// Color Palette's lead can hold five items at once (title, palette dropdown, Set-as-active,
+// Rename, Delete) with `flex-wrap: nowrap`, so under horizontal pressure (a narrow viewport, or
+// the settings panel open, which takes ~200px off the content column) something has to give. Every
+// action slot below holds its intrinsic width instead — the title (further down) is the one
+// designated to shrink and truncate.
+.kadence-blocks-style-library__screen-header-inline-control,
+.kadence-blocks-style-library__screen-header-secondary,
+.kadence-blocks-style-library__screen-header-destructive {
+	flex-shrink: 0;
+	white-space: nowrap;
+}
+
+// The dropdown and the Set-as-active button both live in this one slot (`ColorPaletteScreen`
+// passes them as a fragment) — without its own flex row, the dropdown's block-level root would
+// force the button onto a second line inside the slot instead of sitting beside it.
+.kadence-blocks-style-library__screen-header-inline-control {
+	display: flex;
+	align-items: center;
+	gap: var(--kb-sl-space-15);
+}
+
 .kadence-blocks-style-library__screen-header-trail {
 	@include flex-row(var(--kb-sl-space-15));
 
+	flex-shrink: 0;
 	min-width: 0;
 }
 
@@ -29,6 +51,14 @@
 	font-size: var(--kb-sl-font-size-18);
 	font-weight: var(--kb-sl-font-weight-semibold);
 	line-height: var(--kb-sl-line-height-l);
+	// The one thing in the header allowed to give: `min-width: 0` lets it shrink below its own
+	// content's width inside the flex row above (a plain flex item otherwise refuses to shrink
+	// past that), and the three rules together turn the overflow that would otherwise happen into
+	// a truncated, single-line label instead of a squashed or overflowing header.
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 // `variant="secondary"` is the caller's contract for this slot — core's secondary button already
@@ -43,6 +73,9 @@
 	font-size: var(--kb-sl-font-size-m);
 	font-weight: var(--kb-sl-font-weight-medium);
 	line-height: var(--kb-sl-line-height-s);
+	// The trail already holds its intrinsic width (`flex-shrink: 0` above); this stops the label
+	// itself from breaking mid-word if that width still runs short of the text.
+	white-space: nowrap;
 
 	// The same shared icon-glyph token `AddTile`'s plus icon uses, so the two render identically —
 	// see --kb-sl-size-action-icon-glyph in _semantic.scss. No `fill` override needed here: this is

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -2,16 +2,17 @@
  * The Color Palette screen: the palette selector in the screen header and the swatch grid of the
  * current palette's effective view. Palette structure is read here and edited through the palette
  * flows (`helpers/palette-flows.js`) via `hooks/use-palettes.js`; this component never chooses a
- * write target itself, and — this phase — never writes at all: selecting a palette in the header
- * only opens it for viewing, and selecting a swatch only writes `?kb-item=` to the route.
+ * write target itself — selecting a palette in the header only opens it for viewing, and every
+ * mutation below is a thin binding onto a flow that already encodes its own write routing.
  */
 
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
-import { Spinner } from '@wordpress/components';
+import { useMemo, useState } from '@wordpress/element';
+import { Button, Notice, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { plus } from '@wordpress/icons';
 
 /**
  * External dependencies
@@ -25,8 +26,13 @@ import { ScreenHeader } from '../organisms/ScreenHeader';
 import { SwatchGrid } from '../organisms/SwatchGrid';
 import { SelectDropdown } from '../molecules/SelectDropdown';
 import { EmptyState } from '../molecules/EmptyState';
+import { ActivatePaletteButton } from '../organisms/ActivatePaletteButton';
+import { CreatePaletteModal } from '../organisms/CreatePaletteModal';
+import { RenamePaletteModal } from '../organisms/RenamePaletteModal';
+import { DeletePaletteModal } from '../organisms/DeletePaletteModal';
+import { AddColorGroupModal } from '../organisms/AddColorGroupModal';
 import { usePalettes } from '../../hooks/use-palettes';
-import { mapPaletteToSwatchGroups, paletteDisplayLabel } from '../../helpers/palettes';
+import { isDefaultPalette, mapPaletteToSwatchGroups, paletteDisplayLabel } from '../../helpers/palettes';
 import { ColorPaletteSettings } from './ColorPaletteSettings';
 import './ColorPaletteScreen.scss';
 
@@ -66,9 +72,25 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 	// own separate instance below.
 	const palettes = usePalettes(library.feed, library.refreshFeed, route, navigate);
 
+	// Plain UI state, not route state — a half-typed modal must not enter browser history.
+	const [isCreateOpen, setIsCreateOpen] = useState(false);
+	const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+	const [isAddGroupOpen, setIsAddGroupOpen] = useState(false);
+
+	const editingRow = palettes.listing.palettes.find((row) => row.id === palettes.editingId);
+	const activeRow = palettes.listing.palettes.find((row) => row.id === palettes.activeId);
+
 	const options = useMemo(
-		() => palettes.listing.palettes.map((row) => ({ value: row.id, label: paletteDisplayLabel(row) })),
-		[palettes.listing.palettes]
+		() =>
+			palettes.listing.palettes.map((row) => ({
+				value: row.id,
+				label: paletteDisplayLabel(row),
+				// The Active badge tracks `$current` independently of which row is being edited —
+				// opening a palette never moves it (see `openPaletteFlow`).
+				badges:
+					row.id === palettes.activeId ? [{ text: __('Active', 'kadence-blocks'), variant: 'state' }] : [],
+			})),
+		[palettes.listing.palettes, palettes.activeId]
 	);
 
 	const gridGroups = useMemo(
@@ -78,9 +100,9 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 				items: group.items.map((item) => ({
 					...item,
 					previewStyle: swatchPreviewStyle(item.value),
-					// Reordering persists once the default-palette write lands; until then no drag handle
-					// renders, so the grid reads as non-reorderable rather than lying.
-					isDraggable: false,
+					// The default-palette structure write this needed now exists (`reorderSwatchesFlow`),
+					// so the selected card's drag handle renders.
+					isDraggable: true,
 				})),
 			})),
 		[palettes.palette]
@@ -91,37 +113,177 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 			<ScreenHeader
 				title={label}
 				inlineControl={
-					<SelectDropdown
-						value={palettes.editingId}
-						options={options}
-						// Opens the palette for viewing only — never writes `$current`. A future reader who
-						// "fixes" this to also activate would silently re-tint the live site every time
-						// someone merely looks at a different palette; see `openPaletteFlow`'s own docblock.
-						onChange={(id) => palettes.openPalette(id).catch(() => {})}
+					<>
+						<SelectDropdown
+							value={palettes.editingId}
+							options={options}
+							// Opens the palette for viewing only — never writes `$current`. A future reader who
+							// "fixes" this to also activate would silently re-tint the live site every time
+							// someone merely looks at a different palette; see `openPaletteFlow`'s own docblock.
+							onChange={(id) => palettes.openPalette(id).catch(() => {})}
+							isBusy={palettes.isBusy}
+							error={palettes.openError}
+							onClearError={palettes.clearOpenError}
+							trailingAction={{
+								label: __('Create Color Palette', 'kadence-blocks'),
+								onClick: () => setIsCreateOpen(true),
+							}}
+						/>
+						<ActivatePaletteButton
+							editingId={palettes.editingId}
+							editingLabel={paletteDisplayLabel(editingRow)}
+							activeLabel={paletteDisplayLabel(activeRow)}
+							isEditingActive={palettes.isEditingActive}
+							isBusy={palettes.isBusy}
+							error={palettes.activateError}
+							onClearError={palettes.clearActivateError}
+							onActivate={palettes.activatePalette}
+						/>
+					</>
+				}
+				secondaryAction={
+					// Unlike Delete, available on the default palette too — the server only refuses
+					// DELETING it (`delete_item()`'s explicit default-id guard), not relabeling it
+					// (`update_item()` carries no such guard). Always targets the palette being edited,
+					// exactly like Delete, for the same open/activate-split reason.
+					<RenamePaletteModal
+						id={palettes.editingId}
+						currentLabel={paletteDisplayLabel(editingRow)}
+						listing={palettes.listing}
 						isBusy={palettes.isBusy}
-						error={palettes.openError}
-						onClearError={palettes.clearOpenError}
+						error={palettes.renameError}
+						onClearError={palettes.clearRenameError}
+						onRename={palettes.renamePalette}
 					/>
 				}
-				// The "Delete" destructive action and the "+ Add Color Group" primary action both depend
-				// on write flows this phase deliberately excludes — both header slots stay empty rather
-				// than render a button with nothing behind it.
+				destructiveAction={
+					// The server refuses to delete `$default` (400), so the affordance is absent, not
+					// disabled, for it — the same treatment `DeleteLibraryModal`'s precedent sets. Delete
+					// always targets the palette being edited, never `activeId`: under the open/activate
+					// split you can be editing a palette that isn't live, and deleting the live one instead
+					// would silently re-tint the site as a side effect of cleaning up an unrelated draft.
+					isDefaultPalette(palettes.listing, palettes.editingId) ? null : (
+						<Button
+							isDestructive
+							variant="link"
+							// Reuses DeleteLibraryModal's own styling — the same red text-link treatment, no
+							// new rule needed for a class this app already ships.
+							className="kadence-blocks-style-library__delete-library-action"
+							onClick={() => setIsDeleteOpen(true)}
+						>
+							{__('Delete', 'kadence-blocks')}
+						</Button>
+					)
+				}
+				primaryAction={
+					<Button variant="secondary" icon={plus} onClick={() => setIsAddGroupOpen(true)}>
+						{__('Add Color Group', 'kadence-blocks')}
+					</Button>
+				}
 			/>
 			{palettes.isLoading ? (
 				<Spinner />
 			) : palettes.palette ? (
-				<SwatchGrid
-					groups={gridGroups}
-					selectedId={route.item}
-					onSelect={(token) => navigate({ item: token })}
-					onAdd={() => {
-						// @todo Style Library Color Palette mutations: wire the add-color flow.
-					}}
-					addLabel={__('Add color', 'kadence-blocks')}
-				/>
+				<>
+					{/* Suppressed while the add-group modal is open — that flow shares this same
+					 * `structureError` slot (per the settled six-slot design) and shows it inline
+					 * instead, so surfacing it here too would render the same message twice. */}
+					{!isAddGroupOpen && palettes.structureError && (
+						<Notice status="error" onRemove={palettes.clearStructureError}>
+							{palettes.structureError.message}
+						</Notice>
+					)}
+					<SwatchGrid
+						groups={gridGroups}
+						selectedId={route.item}
+						onSelect={(token) => navigate({ item: token })}
+						onReorder={(groupId, orderedTokens) => palettes.reorderSwatches(groupId, orderedTokens)}
+						onAdd={(groupId) =>
+							palettes
+								.addColor(groupId)
+								.then((newToken) => navigate({ item: newToken }))
+								// Swallowed: a failure already lands in `structureError`, rendered above.
+								.catch(() => {})
+						}
+						addLabel={__('Add color', 'kadence-blocks')}
+					/>
+				</>
 			) : (
 				<EmptyState
 					title={palettes.openError?.message || __('This palette could not be loaded.', 'kadence-blocks')}
+				/>
+			)}
+			{isCreateOpen && (
+				<CreatePaletteModal
+					listing={palettes.listing}
+					isBusy={palettes.isBusy}
+					error={palettes.createError}
+					onClose={() => {
+						setIsCreateOpen(false);
+						palettes.clearCreateError();
+					}}
+					onCreate={(paletteLabel) =>
+						palettes
+							.createPalette(paletteLabel)
+							.then(() => {
+								setIsCreateOpen(false);
+								palettes.clearCreateError();
+							})
+							// Swallowed: an invalid/duplicate label or a request failure already lands in
+							// `createError`, rendered inline — the modal stays open on it.
+							.catch(() => {})
+					}
+				/>
+			)}
+			{isDeleteOpen && (
+				<DeletePaletteModal
+					label={paletteDisplayLabel(editingRow)}
+					isActive={palettes.isEditingActive}
+					isBusy={palettes.isBusy}
+					error={palettes.deleteError}
+					onClose={() => {
+						setIsDeleteOpen(false);
+						palettes.clearDeleteError();
+					}}
+					onConfirm={() =>
+						palettes
+							.deletePalette(palettes.editingId)
+							.then(() => {
+								setIsDeleteOpen(false);
+								palettes.clearDeleteError();
+							})
+							// Swallowed: a request failure already lands in `deleteError`, rendered inline —
+							// the modal stays open on it.
+							.catch(() => {})
+					}
+				/>
+			)}
+			{isAddGroupOpen && (
+				<AddColorGroupModal
+					palette={palettes.palette}
+					isBusy={palettes.isBusy}
+					error={palettes.structureError}
+					onClose={() => {
+						setIsAddGroupOpen(false);
+						palettes.clearStructureError();
+					}}
+					onAdd={(groupLabel) =>
+						palettes
+							.addGroup(groupLabel)
+							.then((newToken) => {
+								setIsAddGroupOpen(false);
+								palettes.clearStructureError();
+
+								// Selects the group's new swatch so the panel opens on it, mirroring the
+								// grid's own `AddTile` binding above (`addColor(...).then((newToken) =>
+								// navigate({ item: newToken }))`) — `addGroupFlow` resolves with the new
+								// swatch's token the same way `addColorFlow` does.
+								navigate({ item: newToken });
+							})
+							// Swallowed: an invalid/duplicate label or a request failure already lands in
+							// `structureError`, rendered inline — the modal stays open on it.
+							.catch(() => {})
+					}
 				/>
 			)}
 		</div>

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -2,16 +2,17 @@
  * The Color Palette screen: the palette selector in the screen header and the swatch grid of the
  * current palette's effective view. Palette structure is read here and edited through the palette
  * flows (`helpers/palette-flows.js`) via `hooks/use-palettes.js`; this component never chooses a
- * write target itself, and — this phase — never writes at all: selecting a palette in the header
- * only opens it for viewing, and selecting a swatch only writes `?kb-item=` to the route.
+ * write target itself — selecting a palette in the header only opens it for viewing, and every
+ * mutation below is a thin binding onto a flow that already encodes its own write routing.
  */
 
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
-import { Spinner } from '@wordpress/components';
+import { useMemo, useState } from '@wordpress/element';
+import { Button, Notice, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { plus } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -21,8 +22,13 @@ import { ScreenHeader } from '../organisms/ScreenHeader';
 import { SwatchGrid } from '../organisms/SwatchGrid';
 import { SelectDropdown } from '../molecules/SelectDropdown';
 import { EmptyState } from '../molecules/EmptyState';
+import { ActivatePaletteButton } from '../organisms/ActivatePaletteButton';
+import { CreatePaletteModal } from '../organisms/CreatePaletteModal';
+import { RenamePaletteModal } from '../organisms/RenamePaletteModal';
+import { DeletePaletteModal } from '../organisms/DeletePaletteModal';
+import { AddColorGroupModal } from '../organisms/AddColorGroupModal';
 import { usePalettes } from '../../hooks/use-palettes';
-import { mapPaletteToSwatchGroups, paletteDisplayLabel } from '../../helpers/palettes';
+import { isDefaultPalette, mapPaletteToSwatchGroups, paletteDisplayLabel } from '../../helpers/palettes';
 import { ColorPaletteSettings } from './ColorPaletteSettings';
 import './ColorPaletteScreen.scss';
 
@@ -62,9 +68,25 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 	// own separate instance below.
 	const palettes = usePalettes(library.feed, library.refreshFeed, route, navigate);
 
+	// Plain UI state, not route state — a half-typed modal must not enter browser history.
+	const [isCreateOpen, setIsCreateOpen] = useState(false);
+	const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+	const [isAddGroupOpen, setIsAddGroupOpen] = useState(false);
+
+	const editingRow = palettes.listing.palettes.find((row) => row.id === palettes.editingId);
+	const activeRow = palettes.listing.palettes.find((row) => row.id === palettes.activeId);
+
 	const options = useMemo(
-		() => palettes.listing.palettes.map((row) => ({ value: row.id, label: paletteDisplayLabel(row) })),
-		[palettes.listing.palettes]
+		() =>
+			palettes.listing.palettes.map((row) => ({
+				value: row.id,
+				label: paletteDisplayLabel(row),
+				// The Active badge tracks `$current` independently of which row is being edited —
+				// opening a palette never moves it (see `openPaletteFlow`).
+				badges:
+					row.id === palettes.activeId ? [{ text: __('Active', 'kadence-blocks'), variant: 'state' }] : [],
+			})),
+		[palettes.listing.palettes, palettes.activeId]
 	);
 
 	const gridGroups = useMemo(
@@ -74,9 +96,9 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 				items: group.items.map((item) => ({
 					...item,
 					previewStyle: swatchPreviewStyle(item.value),
-					// Reordering persists once the default-palette write lands; until then no drag handle
-					// renders, so the grid reads as non-reorderable rather than lying.
-					isDraggable: false,
+					// The default-palette structure write this needed now exists (`reorderSwatchesFlow`),
+					// so the selected card's drag handle renders.
+					isDraggable: true,
 				})),
 			})),
 		[palettes.palette]
@@ -87,37 +109,177 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 			<ScreenHeader
 				title={label}
 				inlineControl={
-					<SelectDropdown
-						value={palettes.editingId}
-						options={options}
-						// Opens the palette for viewing only — never writes `$current`. A future reader who
-						// "fixes" this to also activate would silently re-tint the live site every time
-						// someone merely looks at a different palette; see `openPaletteFlow`'s own docblock.
-						onChange={(id) => palettes.openPalette(id).catch(() => {})}
+					<>
+						<SelectDropdown
+							value={palettes.editingId}
+							options={options}
+							// Opens the palette for viewing only — never writes `$current`. A future reader who
+							// "fixes" this to also activate would silently re-tint the live site every time
+							// someone merely looks at a different palette; see `openPaletteFlow`'s own docblock.
+							onChange={(id) => palettes.openPalette(id).catch(() => {})}
+							isBusy={palettes.isBusy}
+							error={palettes.openError}
+							onClearError={palettes.clearOpenError}
+							trailingAction={{
+								label: __('Create Color Palette', 'kadence-blocks'),
+								onClick: () => setIsCreateOpen(true),
+							}}
+						/>
+						<ActivatePaletteButton
+							editingId={palettes.editingId}
+							editingLabel={paletteDisplayLabel(editingRow)}
+							activeLabel={paletteDisplayLabel(activeRow)}
+							isEditingActive={palettes.isEditingActive}
+							isBusy={palettes.isBusy}
+							error={palettes.activateError}
+							onClearError={palettes.clearActivateError}
+							onActivate={palettes.activatePalette}
+						/>
+					</>
+				}
+				secondaryAction={
+					// Unlike Delete, available on the default palette too — the server only refuses
+					// DELETING it (`delete_item()`'s explicit default-id guard), not relabeling it
+					// (`update_item()` carries no such guard). Always targets the palette being edited,
+					// exactly like Delete, for the same open/activate-split reason.
+					<RenamePaletteModal
+						id={palettes.editingId}
+						currentLabel={paletteDisplayLabel(editingRow)}
+						listing={palettes.listing}
 						isBusy={palettes.isBusy}
-						error={palettes.openError}
-						onClearError={palettes.clearOpenError}
+						error={palettes.renameError}
+						onClearError={palettes.clearRenameError}
+						onRename={palettes.renamePalette}
 					/>
 				}
-				// The "Delete" destructive action and the "+ Add Color Group" primary action both depend
-				// on write flows this phase deliberately excludes — both header slots stay empty rather
-				// than render a button with nothing behind it.
+				destructiveAction={
+					// The server refuses to delete `$default` (400), so the affordance is absent, not
+					// disabled, for it — the same treatment `DeleteLibraryModal`'s precedent sets. Delete
+					// always targets the palette being edited, never `activeId`: under the open/activate
+					// split you can be editing a palette that isn't live, and deleting the live one instead
+					// would silently re-tint the site as a side effect of cleaning up an unrelated draft.
+					isDefaultPalette(palettes.listing, palettes.editingId) ? null : (
+						<Button
+							isDestructive
+							variant="link"
+							// Reuses DeleteLibraryModal's own styling — the same red text-link treatment, no
+							// new rule needed for a class this app already ships.
+							className="kadence-blocks-style-library__delete-library-action"
+							onClick={() => setIsDeleteOpen(true)}
+						>
+							{__('Delete', 'kadence-blocks')}
+						</Button>
+					)
+				}
+				primaryAction={
+					<Button variant="secondary" icon={plus} onClick={() => setIsAddGroupOpen(true)}>
+						{__('Add Color Group', 'kadence-blocks')}
+					</Button>
+				}
 			/>
 			{palettes.isLoading ? (
 				<Spinner />
 			) : palettes.palette ? (
-				<SwatchGrid
-					groups={gridGroups}
-					selectedId={route.item}
-					onSelect={(token) => navigate({ item: token })}
-					onAdd={() => {
-						// @todo Style Library Color Palette mutations: wire the add-color flow.
-					}}
-					addLabel={__('Add color', 'kadence-blocks')}
-				/>
+				<>
+					{/* Suppressed while the add-group modal is open — that flow shares this same
+					 * `structureError` slot (per the settled six-slot design) and shows it inline
+					 * instead, so surfacing it here too would render the same message twice. */}
+					{!isAddGroupOpen && palettes.structureError && (
+						<Notice status="error" onRemove={palettes.clearStructureError}>
+							{palettes.structureError.message}
+						</Notice>
+					)}
+					<SwatchGrid
+						groups={gridGroups}
+						selectedId={route.item}
+						onSelect={(token) => navigate({ item: token })}
+						onReorder={(groupId, orderedTokens) => palettes.reorderSwatches(groupId, orderedTokens)}
+						onAdd={(groupId) =>
+							palettes
+								.addColor(groupId)
+								.then((newToken) => navigate({ item: newToken }))
+								// Swallowed: a failure already lands in `structureError`, rendered above.
+								.catch(() => {})
+						}
+						addLabel={__('Add color', 'kadence-blocks')}
+					/>
+				</>
 			) : (
 				<EmptyState
 					title={palettes.openError?.message || __('This palette could not be loaded.', 'kadence-blocks')}
+				/>
+			)}
+			{isCreateOpen && (
+				<CreatePaletteModal
+					listing={palettes.listing}
+					isBusy={palettes.isBusy}
+					error={palettes.createError}
+					onClose={() => {
+						setIsCreateOpen(false);
+						palettes.clearCreateError();
+					}}
+					onCreate={(paletteLabel) =>
+						palettes
+							.createPalette(paletteLabel)
+							.then(() => {
+								setIsCreateOpen(false);
+								palettes.clearCreateError();
+							})
+							// Swallowed: an invalid/duplicate label or a request failure already lands in
+							// `createError`, rendered inline — the modal stays open on it.
+							.catch(() => {})
+					}
+				/>
+			)}
+			{isDeleteOpen && (
+				<DeletePaletteModal
+					label={paletteDisplayLabel(editingRow)}
+					isActive={palettes.isEditingActive}
+					isBusy={palettes.isBusy}
+					error={palettes.deleteError}
+					onClose={() => {
+						setIsDeleteOpen(false);
+						palettes.clearDeleteError();
+					}}
+					onConfirm={() =>
+						palettes
+							.deletePalette(palettes.editingId)
+							.then(() => {
+								setIsDeleteOpen(false);
+								palettes.clearDeleteError();
+							})
+							// Swallowed: a request failure already lands in `deleteError`, rendered inline —
+							// the modal stays open on it.
+							.catch(() => {})
+					}
+				/>
+			)}
+			{isAddGroupOpen && (
+				<AddColorGroupModal
+					palette={palettes.palette}
+					isBusy={palettes.isBusy}
+					error={palettes.structureError}
+					onClose={() => {
+						setIsAddGroupOpen(false);
+						palettes.clearStructureError();
+					}}
+					onAdd={(groupLabel) =>
+						palettes
+							.addGroup(groupLabel)
+							.then((newToken) => {
+								setIsAddGroupOpen(false);
+								palettes.clearStructureError();
+
+								// Selects the group's new swatch so the panel opens on it, mirroring the
+								// grid's own `AddTile` binding above (`addColor(...).then((newToken) =>
+								// navigate({ item: newToken }))`) — `addGroupFlow` resolves with the new
+								// swatch's token the same way `addColorFlow` does.
+								navigate({ item: newToken });
+							})
+							// Swallowed: an invalid/duplicate label or a request failure already lands in
+							// `structureError`, rendered inline — the modal stays open on it.
+							.catch(() => {})
+					}
 				/>
 			)}
 		</div>

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -28,7 +28,12 @@ import { RenamePaletteModal } from '../organisms/RenamePaletteModal';
 import { DeletePaletteModal } from '../organisms/DeletePaletteModal';
 import { AddColorGroupModal } from '../organisms/AddColorGroupModal';
 import { usePalettes } from '../../hooks/use-palettes';
-import { isDefaultPalette, mapPaletteToSwatchGroups, paletteDisplayLabel } from '../../helpers/palettes';
+import {
+	isUserCreatedPalette,
+	mapPaletteToSwatchGroups,
+	paletteDisplayLabel,
+	paletteSuccessorOptions,
+} from '../../helpers/palettes';
 import { ColorPaletteSettings } from './ColorPaletteSettings';
 import './ColorPaletteScreen.scss';
 
@@ -74,6 +79,7 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 	const [isAddGroupOpen, setIsAddGroupOpen] = useState(false);
 
 	const editingRow = palettes.listing.palettes.find((row) => row.id === palettes.editingId);
+	const isEditingUserCreated = isUserCreatedPalette(palettes.listing, palettes.editingId);
 	const activeRow = palettes.listing.palettes.find((row) => row.id === palettes.activeId);
 
 	const options = useMemo(
@@ -153,23 +159,21 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 					/>
 				}
 				destructiveAction={
-					// The server refuses to delete `$default` (400), so the affordance is absent, not
-					// disabled, for it — the same treatment `DeleteLibraryModal`'s precedent sets. Delete
-					// always targets the palette being edited, never `activeId`: under the open/activate
-					// split you can be editing a palette that isn't live, and deleting the live one instead
+					// Always targets the palette being edited, never `activeId`: under the open/activate
+					// split you can be editing a palette that isn't live, and acting on the live one instead
 					// would silently re-tint the site as a side effect of cleaning up an unrelated draft.
-					isDefaultPalette(palettes.listing, palettes.editingId) ? null : (
-						<Button
-							isDestructive
-							variant="link"
-							// Reuses DeleteLibraryModal's own styling — the same red text-link treatment, no
-							// new rule needed for a class this app already ships.
-							className="kadence-blocks-style-library__delete-library-action"
-							onClick={() => setIsDeleteOpen(true)}
-						>
-							{__('Delete', 'kadence-blocks')}
-						</Button>
-					)
+					// The `$default` palette is offered too — as a Reset, since the server refuses to remove
+					// it but does drop its overrides.
+					<Button
+						isDestructive
+						variant="link"
+						// Reuses DeleteLibraryModal's own styling — the same red text-link treatment, no
+						// new rule needed for a class this app already ships.
+						className="kadence-blocks-style-library__delete-library-action"
+						onClick={() => setIsDeleteOpen(true)}
+					>
+						{isEditingUserCreated ? __('Delete', 'kadence-blocks') : __('Reset', 'kadence-blocks')}
+					</Button>
 				}
 				primaryAction={
 					<Button variant="secondary" icon={plus} onClick={() => setIsAddGroupOpen(true)}>
@@ -234,6 +238,8 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 			{isDeleteOpen && (
 				<DeletePaletteModal
 					label={paletteDisplayLabel(editingRow)}
+					isUserCreated={isEditingUserCreated}
+					successors={paletteSuccessorOptions(palettes.listing, palettes.editingId)}
 					isActive={palettes.isEditingActive}
 					isBusy={palettes.isBusy}
 					error={palettes.deleteError}
@@ -241,9 +247,9 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 						setIsDeleteOpen(false);
 						palettes.clearDeleteError();
 					}}
-					onConfirm={() =>
+					onConfirm={(successorId) =>
 						palettes
-							.deletePalette(palettes.editingId)
+							.deletePalette(palettes.editingId, successorId)
 							.then(() => {
 								setIsDeleteOpen(false);
 								palettes.clearDeleteError();

--- a/src/style-library/components/pages/ColorPaletteSettings.js
+++ b/src/style-library/components/pages/ColorPaletteSettings.js
@@ -1,8 +1,8 @@
 /**
  * The Color Palette screen's settings panel: edits one swatch — its display name (a structure edit
  * written to the default palette) and its color (a granular value write on the palette being
- * edited). Mounted by the app when a swatch token is the open route item; see
- * `ColorPaletteScreen.SettingsPanel`.
+ * edited) — and deletes it (also a structure edit, with a best-effort token cleanup after). Mounted
+ * by the app when a swatch token is the open route item; see `ColorPaletteScreen.SettingsPanel`.
  */
 
 /**
@@ -91,7 +91,16 @@ export function ColorPaletteSettings({ route, navigate, library }) {
 		<SettingsPanel
 			onClose={panel.close}
 			onSave={onSave}
-			onDelete={null /* swatch deletion ships with the default-palette write */}
+			// Renders for every swatch: what Delete removes is a palette row (user-editable document
+			// data), not the token — `removeSwatch` decides internally whether the underlying token
+			// is user-created and only then best-effort cleans it up (settled decision 8).
+			onDelete={() =>
+				palettes
+					.removeSwatch(token)
+					.then(() => navigate({ item: '' }))
+					// Swallowed: a row-removal write failure already lands in `saveError`, rendered above.
+					.catch(() => {})
+			}
 			isDirty={panel.isDirty}
 		>
 			{palettes.saveError && (

--- a/src/style-library/helpers/palette-flows.js
+++ b/src/style-library/helpers/palette-flows.js
@@ -366,40 +366,61 @@ export function createPaletteFlow({ namespace, slug, label, listing, reload, ope
 }
 
 /**
- * Delete a palette. The server refuses to delete the `$default` palette (400), so this is only
- * ever called for a non-default id.
+ * Delete a palette, first handing the active pointer to a successor when the palette being deleted
+ * is the live one. Mirrors `deleteLibraryFlow`.
  *
- * Unlike `deleteLibraryFlow`, this never activates a successor first. Two things make that
- * ordering unnecessary here, not merely skipped: first, opening no longer writes `$current`, so
- * deleting a palette that is merely being edited (not the live one) has no effect on what a
- * visitor sees, regardless of ordering — there is nothing to sequence. Second, when the deleted
- * palette *is* `$current`, the server resolves its own fallback and returns it in the same
- * response (`prepare_items()`), the same way it always has; there is no UI for naming a preferred
- * successor for a palette the way `DeleteLibraryModal` offers one for a library; a confirm is all
- * this deletion ever asks for. `reload` re-reads the listing from the server rather than the flow
- * assuming which palette ends up current or which one the app should now edit — mirroring
- * `deleteLibraryFlow`'s re-read of the active-library pointer for the analogous case, and letting
- * the hook fall the edited palette back to `$current` when the one just deleted was it.
+ * Activation runs before the delete: left alone the server resolves a dangling `$current` to
+ * `$default`, so the site would briefly wear a palette nobody chose.
  *
  * @param {Object}   args
  * @param {string}   args.namespace   The REST namespace.
  * @param {string}   args.slug        The token library slug.
  * @param {string}   args.id          The palette id to delete.
+ * @param {string}   args.currentId   The listing's `$current` palette id, which decides whether a
+ *                                    successor is required at all.
+ * @param {string}   [args.successorId] The palette to make current first. Required only when
+ *                                    deleting the current palette.
  * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook.
  * @param {Function} args.refreshFeed Replaces the feed for a slug.
  * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
  * @param {Function} args.onError     Called with `{ message }` on failure.
+ * @param {Function} [args.onActivated] Called with the id the server reports as current, once the
+ *                                    successor is activated.
  *
  * @since TBD
  *
- * @return {Promise<void>} Resolves once the delete, the reload, and the feed refresh complete;
- *                          rejects on failure (e.g. the default-palette 400) after
+ * @return {Promise<void>} Resolves once the activation, delete, reload, and feed refresh complete;
+ *                          rejects on a missing successor or a request failure, after
  *                          `onError`/`onBusy` have run.
  */
-export function deletePaletteFlow({ namespace, slug, id, reload, refreshFeed, onBusy, onError }) {
+export function deletePaletteFlow({
+	namespace,
+	slug,
+	id,
+	currentId,
+	successorId,
+	reload,
+	refreshFeed,
+	onBusy,
+	onError,
+	onActivated,
+}) {
+	const needsSuccessor = id === currentId;
+
+	if (needsSuccessor && !successorId) {
+		const message = __('Choose which palette your site should use instead.', 'kadence-blocks');
+		onError({ message });
+		return Promise.reject(new Error(message));
+	}
+
 	onBusy(true);
 
-	return deletePalette(namespace, id, slug)
+	const activation = needsSuccessor
+		? setCurrentPalette(namespace, successorId, slug).then((result) => onActivated(result?.current ?? successorId))
+		: Promise.resolve();
+
+	return activation
+		.then(() => deletePalette(namespace, id, slug))
 		.then(() => reload())
 		.then(() => refreshFeed(slug))
 		.then(() => onBusy(false))

--- a/src/style-library/helpers/palette-flows.js
+++ b/src/style-library/helpers/palette-flows.js
@@ -1,8 +1,8 @@
 /**
- * Pure orchestration for the Color Palette screen's write flows: open, activate, create, delete,
- * the settings-panel save (rename + recolor), swatch removal, add color, add color group, and
- * within-group reorder. Extracted out of `hooks/use-palettes` so each flow can be exercised
- * directly in tests without rendering a component — a flow takes the REST calls it needs
+ * Pure orchestration for the Color Palette screen's write flows: open, activate, create, rename,
+ * delete, the settings-panel save (swatch rename + recolor), swatch removal, add color, add color
+ * group, and within-group reorder. Extracted out of `hooks/use-palettes` so each flow can be
+ * exercised directly in tests without rendering a component — a flow takes the REST calls it needs
  * (imported here, so a test mocks `api/client`) plus a small set of injected callbacks for the
  * state a caller reacts to (busy, a scoped error slot, and a `reload`/`refreshFeed` pair the hook
  * provides). Every flow settles pessimistically and re-throws on failure so its caller (a modal,
@@ -401,6 +401,75 @@ export function deletePaletteFlow({ namespace, slug, id, reload, refreshFeed, on
 	return deletePalette(namespace, id, slug)
 		.then(() => reload())
 		.then(() => refreshFeed(slug))
+		.then(() => onBusy(false))
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+			throw err;
+		});
+}
+
+/**
+ * Rename a palette: re-send its own effective view under the SAME id with a new label. Available
+ * for any palette, including the default — the server only refuses DELETING the default palette,
+ * not relabeling it (`Palettes_Controller::update_item()` carries no default-id guard, unlike
+ * `delete_item()`).
+ *
+ * `id` is never re-derived from `label` here — that is the one deliberate divergence from
+ * `createPaletteFlow`, which mints an id from the typed label because it is minting a NEW palette.
+ * A rename's target already exists and is referenced elsewhere by that exact id (the `$current` /
+ * `$default` pointers, and `data-kb-palette="<id>"` attributes already rendered onto blocks);
+ * re-deriving it from the new label would silently orphan every one of those references. Do not
+ * "fix" this to match `createPaletteFlow`'s id derivation — it would corrupt every reference the
+ * unchanged id currently satisfies.
+ *
+ * Re-sending the palette's own effective view is safe and lossless: `prepare_for_storage()`
+ * re-reduces a non-default palette back to its deltas on write (dropping swatches that already
+ * equal the default value), so this round-trips exactly what was already stored, just under a new
+ * label. No `refreshFeed` here, unlike every write above — a palette's `label` lives under
+ * `$extensions.colorPalettes` in the stored document, and `Effective_Document::build()` (the layer
+ * `Token_Resolver` walks to produce resolved CSS) explicitly walks only `Layers::token_layers()`
+ * and returns "$extensions stripped"; `apply_palette_overlay()` likewise only ever touches a
+ * swatch's `$value`, never its `label`. A label change cannot reach a single resolved token value,
+ * so there is nothing for a feed refresh to correct.
+ *
+ * @param {Object}   args
+ * @param {string}   args.namespace The REST namespace.
+ * @param {string}   args.slug      The token library slug.
+ * @param {string}   args.id        The palette id to rename — unchanged by this flow.
+ * @param {string}   args.label     The typed label.
+ * @param {Object}   args.listing   The current listing (`{ palettes }`), for the duplicate-label check.
+ * @param {Function} args.reload    Re-reads the listing (and the edited view) from the hook, so the
+ *                                  dropdown's label updates immediately.
+ * @param {Function} args.onBusy    Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError   Called with `{ message }` on failure or invalid input.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once the rename and the listing reload complete; rejects on an
+ *                          empty or duplicate label, or a request failure, after `onError` has
+ *                          already run.
+ */
+export function renamePaletteFlow({ namespace, slug, id, label, listing, reload, onBusy, onError }) {
+	const trimmed = String(label ?? '').trim();
+
+	if (trimmed === '') {
+		const message = __('Enter a palette name.', 'kadence-blocks');
+		onError({ message });
+		return Promise.reject(new Error(message));
+	}
+
+	if (isDuplicatePaletteLabel(trimmed, listing, id)) {
+		const message = __('A palette with that name already exists.', 'kadence-blocks');
+		onError({ message });
+		return Promise.reject(new Error(message));
+	}
+
+	onBusy(true);
+
+	return fetchPalette(namespace, id, slug)
+		.then((view) => savePalette(namespace, id, { label: trimmed, groups: stripEffectiveFlags(view.groups) }, slug))
+		.then(() => reload())
 		.then(() => onBusy(false))
 		.catch((err) => {
 			onError({ message: errorMessage(err) });

--- a/src/style-library/helpers/palette-flows.js
+++ b/src/style-library/helpers/palette-flows.js
@@ -355,6 +355,7 @@ export function createPaletteFlow({ namespace, slug, label, listing, reload, ope
 			// still-missing-from-the-list id for one render.
 			.then(() => reload())
 			.then(() => openPalette(id))
+			.then(() => onBusy(false))
 			.catch((err) => {
 				onError({ message: errorMessage(err) });
 				onBusy(false);

--- a/src/style-library/helpers/palette-flows.js
+++ b/src/style-library/helpers/palette-flows.js
@@ -1,8 +1,8 @@
 /**
- * Pure orchestration for the Color Palette screen's write flows: open, activate, create, delete,
- * the settings-panel save (rename + recolor), swatch removal, add color, add color group, and
- * within-group reorder. Extracted out of `hooks/use-palettes` so each flow can be exercised
- * directly in tests without rendering a component — a flow takes the REST calls it needs
+ * Pure orchestration for the Color Palette screen's write flows: open, activate, create, rename,
+ * delete, the settings-panel save (swatch rename + recolor), swatch removal, add color, add color
+ * group, and within-group reorder. Extracted out of `hooks/use-palettes` so each flow can be
+ * exercised directly in tests without rendering a component — a flow takes the REST calls it needs
  * (imported here, so a test mocks `api/client`) plus a small set of injected callbacks for the
  * state a caller reacts to (busy, a scoped error slot, and a `reload`/`refreshFeed` pair the hook
  * provides). Every flow settles pessimistically and re-throws on failure so its caller (a modal,
@@ -384,6 +384,75 @@ export function deletePaletteFlow({ namespace, slug, id, reload, refreshFeed, on
 	return deletePalette(namespace, id, slug)
 		.then(() => reload())
 		.then(() => refreshFeed(slug))
+		.then(() => onBusy(false))
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+			throw err;
+		});
+}
+
+/**
+ * Rename a palette: re-send its own effective view under the SAME id with a new label. Available
+ * for any palette, including the default — the server only refuses DELETING the default palette,
+ * not relabeling it (`Palettes_Controller::update_item()` carries no default-id guard, unlike
+ * `delete_item()`).
+ *
+ * `id` is never re-derived from `label` here — that is the one deliberate divergence from
+ * `createPaletteFlow`, which mints an id from the typed label because it is minting a NEW palette.
+ * A rename's target already exists and is referenced elsewhere by that exact id (the `$current` /
+ * `$default` pointers, and `data-kb-palette="<id>"` attributes already rendered onto blocks);
+ * re-deriving it from the new label would silently orphan every one of those references. Do not
+ * "fix" this to match `createPaletteFlow`'s id derivation — it would corrupt every reference the
+ * unchanged id currently satisfies.
+ *
+ * Re-sending the palette's own effective view is safe and lossless: `prepare_for_storage()`
+ * re-reduces a non-default palette back to its deltas on write (dropping swatches that already
+ * equal the default value), so this round-trips exactly what was already stored, just under a new
+ * label. No `refreshFeed` here, unlike every write above — a palette's `label` lives under
+ * `$extensions.colorPalettes` in the stored document, and `Effective_Document::build()` (the layer
+ * `Token_Resolver` walks to produce resolved CSS) explicitly walks only `Layers::token_layers()`
+ * and returns "$extensions stripped"; `apply_palette_overlay()` likewise only ever touches a
+ * swatch's `$value`, never its `label`. A label change cannot reach a single resolved token value,
+ * so there is nothing for a feed refresh to correct.
+ *
+ * @param {Object}   args
+ * @param {string}   args.namespace The REST namespace.
+ * @param {string}   args.slug      The token library slug.
+ * @param {string}   args.id        The palette id to rename — unchanged by this flow.
+ * @param {string}   args.label     The typed label.
+ * @param {Object}   args.listing   The current listing (`{ palettes }`), for the duplicate-label check.
+ * @param {Function} args.reload    Re-reads the listing (and the edited view) from the hook, so the
+ *                                  dropdown's label updates immediately.
+ * @param {Function} args.onBusy    Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError   Called with `{ message }` on failure or invalid input.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once the rename and the listing reload complete; rejects on an
+ *                          empty or duplicate label, or a request failure, after `onError` has
+ *                          already run.
+ */
+export function renamePaletteFlow({ namespace, slug, id, label, listing, reload, onBusy, onError }) {
+	const trimmed = String(label ?? '').trim();
+
+	if (trimmed === '') {
+		const message = __('Enter a palette name.', 'kadence-blocks');
+		onError({ message });
+		return Promise.reject(new Error(message));
+	}
+
+	if (isDuplicatePaletteLabel(trimmed, listing, id)) {
+		const message = __('A palette with that name already exists.', 'kadence-blocks');
+		onError({ message });
+		return Promise.reject(new Error(message));
+	}
+
+	onBusy(true);
+
+	return fetchPalette(namespace, id, slug)
+		.then((view) => savePalette(namespace, id, { label: trimmed, groups: stripEffectiveFlags(view.groups) }, slug))
+		.then(() => reload())
 		.then(() => onBusy(false))
 		.catch((err) => {
 			onError({ message: errorMessage(err) });

--- a/src/style-library/helpers/palette-flows.js
+++ b/src/style-library/helpers/palette-flows.js
@@ -313,6 +313,11 @@ export function activatePaletteFlow({ namespace, slug, id, reload, refreshFeed, 
  *                                    ordering note below).
  * @param {Function} args.openPalette Opens a palette for editing (typically `openPaletteFlow`
  *                                    bound to the new id).
+ * @param {Function} args.refreshFeed Replaces the feed for a slug. Required even though a new
+ *                                    palette changes no resolved value: the feed carries the
+ *                                    version token every later write is checked against, so
+ *                                    skipping it leaves the page one version behind and the next
+ *                                    write is rejected with a 409 conflict.
  * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
  * @param {Function} args.onError     Called with `{ message }` on failure or invalid input.
  *
@@ -322,7 +327,17 @@ export function activatePaletteFlow({ namespace, slug, id, reload, refreshFeed, 
  *                          palette opened for editing; rejects on an empty or duplicate label, or a
  *                          request failure, after `onError` has already run.
  */
-export function createPaletteFlow({ namespace, slug, label, listing, reload, openPalette, onBusy, onError }) {
+export function createPaletteFlow({
+	namespace,
+	slug,
+	label,
+	listing,
+	reload,
+	openPalette,
+	refreshFeed,
+	onBusy,
+	onError,
+}) {
 	const id = slugifyPaletteLabel(label);
 
 	// Both validation failures reject rather than resolve: a caller that closes its modal on a
@@ -353,6 +368,7 @@ export function createPaletteFlow({ namespace, slug, label, listing, reload, ope
 			// resolve its label and render it as a real option instead of falling back to the raw
 			// id. Reloading after `openPalette` instead would leave the dropdown showing the new,
 			// still-missing-from-the-list id for one render.
+			.then(() => refreshFeed(slug))
 			.then(() => reload())
 			.then(() => openPalette(id))
 			.then(() => onBusy(false))
@@ -448,12 +464,11 @@ export function deletePaletteFlow({
  * Re-sending the palette's own effective view is safe and lossless: `prepare_for_storage()`
  * re-reduces a non-default palette back to its deltas on write (dropping swatches that already
  * equal the default value), so this round-trips exactly what was already stored, just under a new
- * label. No `refreshFeed` here, unlike every write above — a palette's `label` lives under
- * `$extensions.colorPalettes` in the stored document, and `Effective_Document::build()` (the layer
- * `Token_Resolver` walks to produce resolved CSS) explicitly walks only `Layers::token_layers()`
- * and returns "$extensions stripped"; `apply_palette_overlay()` likewise only ever touches a
- * swatch's `$value`, never its `label`. A label change cannot reach a single resolved token value,
- * so there is nothing for a feed refresh to correct.
+ * label. `refreshFeed` is still needed even though no resolved value can change — a palette's
+ * `label` lives under `$extensions.colorPalettes`, which `Effective_Document::build()` strips, so
+ * the CSS is identical either way. The feed also carries the version token every later write is
+ * checked against, and this write bumps it, so skipping the refresh leaves the page one version
+ * behind and the next write is rejected with a 409 conflict.
  *
  * @param {Object}   args
  * @param {string}   args.namespace The REST namespace.
@@ -461,10 +476,12 @@ export function deletePaletteFlow({
  * @param {string}   args.id        The palette id to rename — unchanged by this flow.
  * @param {string}   args.label     The typed label.
  * @param {Object}   args.listing   The current listing (`{ palettes }`), for the duplicate-label check.
- * @param {Function} args.reload    Re-reads the listing (and the edited view) from the hook, so the
- *                                  dropdown's label updates immediately.
- * @param {Function} args.onBusy    Called with a boolean as the request starts and settles.
- * @param {Function} args.onError   Called with `{ message }` on failure or invalid input.
+ * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook, so
+ *                                    the dropdown's label updates immediately.
+ * @param {Function} args.refreshFeed Replaces the feed for a slug, so its version token matches the
+ *                                    document this write just bumped.
+ * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure or invalid input.
  *
  * @since TBD
  *
@@ -472,7 +489,7 @@ export function deletePaletteFlow({
  *                          empty or duplicate label, or a request failure, after `onError` has
  *                          already run.
  */
-export function renamePaletteFlow({ namespace, slug, id, label, listing, reload, onBusy, onError }) {
+export function renamePaletteFlow({ namespace, slug, id, label, listing, reload, refreshFeed, onBusy, onError }) {
 	const trimmed = String(label ?? '').trim();
 
 	if (trimmed === '') {
@@ -491,6 +508,7 @@ export function renamePaletteFlow({ namespace, slug, id, label, listing, reload,
 
 	return fetchPalette(namespace, id, slug)
 		.then((view) => savePalette(namespace, id, { label: trimmed, groups: stripEffectiveFlags(view.groups) }, slug))
+		.then(() => refreshFeed(slug))
 		.then(() => reload())
 		.then(() => onBusy(false))
 		.catch((err) => {

--- a/src/style-library/helpers/palettes.js
+++ b/src/style-library/helpers/palettes.js
@@ -176,18 +176,23 @@ export function slugifyPaletteLabel(label) {
  * Whether a typed palette label collides with an existing palette id once run through
  * `slugifyPaletteLabel`.
  *
- * @param {string}         label   The typed palette label.
- * @param {Object}         listing The palette listing (`{ palettes }`).
+ * @param {string}  label       The typed palette label.
+ * @param {Object}  listing     The palette listing (`{ palettes }`).
+ * @param {string}  [excludeId] A palette id to exclude from the check — a rename compares the
+ *                               typed label against every OTHER palette, so retyping the palette's
+ *                               own current label (whose derived slug is its own unchanged id)
+ *                               is not reported as a collision with itself.
  *
  * @since TBD
  *
- * @return {boolean} True when the label's derived slug matches an existing palette id.
+ * @return {boolean} True when the label's derived slug matches an existing palette id other than
+ *         `excludeId`.
  */
-export function isDuplicatePaletteLabel(label, listing) {
+export function isDuplicatePaletteLabel(label, listing, excludeId) {
 	const slug = slugifyPaletteLabel(label);
 	const rows = Array.isArray(listing?.palettes) ? listing.palettes : [];
 
-	return slug !== '' && rows.some((row) => row.id === slug);
+	return slug !== '' && rows.some((row) => row.id === slug && row.id !== excludeId);
 }
 
 /**

--- a/src/style-library/helpers/palettes.js
+++ b/src/style-library/helpers/palettes.js
@@ -160,6 +160,42 @@ export function paletteDisplayLabel(row) {
 }
 
 /**
+ * Whether a palette was created by the user rather than shipped in the baseline. Only a
+ * user-created palette can be removed; deleting a baseline one drops its overrides and reverts it
+ * to baseline, leaving it in the listing. Fails closed — an id the listing does not vouch for
+ * counts as baseline, so the destructive label is never shown against a guess.
+ *
+ * @param {Object} listing The palette listing (`{ userCreated }`).
+ * @param {string} id      The palette id to check.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the palette is user-created.
+ */
+export function isUserCreatedPalette(listing, id) {
+	const ids = Array.isArray(listing?.userCreated) ? listing.userCreated : [];
+
+	return Boolean(id) && ids.includes(id);
+}
+
+/**
+ * The palettes a deleted palette can hand the active pointer to: every palette but itself, in
+ * listing order. Mirrors `successorOptions` for libraries.
+ *
+ * @param {Object} listing  The palette listing (`{ palettes }`).
+ * @param {string} targetId The palette being deleted.
+ *
+ * @since TBD
+ *
+ * @return {Array<{id: string, label: string}>} The candidate rows.
+ */
+export function paletteSuccessorOptions(listing, targetId) {
+	const rows = Array.isArray(listing?.palettes) ? listing.palettes : [];
+
+	return rows.filter((row) => row?.id && row.id !== targetId);
+}
+
+/**
  * Derive a palette id from a typed label — the same kebab grammar token/library ids use.
  *
  * @param {string} label The typed palette label.

--- a/src/style-library/hooks/use-palettes.js
+++ b/src/style-library/hooks/use-palettes.js
@@ -16,6 +16,7 @@ import {
 	createPaletteFlow,
 	deletePaletteFlow,
 	removeSwatchFlow,
+	renamePaletteFlow,
 	reorderSwatchesFlow,
 	saveSwatchEditsFlow,
 } from '../helpers/palette-flows';
@@ -60,10 +61,11 @@ import { flattenSchemaTokens } from '../helpers/tokens';
  * @since TBD
  *
  * @return {Object} `{ listing, activeId, editingId, isEditingActive, palette, isLoading, isBusy,
- *                  openError, activateError, createError, deleteError, saveError, structureError,
- *                  clearOpenError, clearActivateError, clearCreateError, clearDeleteError,
- *                  clearSaveError, clearStructureError,
- *                  openPalette, activatePalette, createPalette, deletePalette,
+ *                  openError, activateError, createError, renameError, deleteError, saveError,
+ *                  structureError,
+ *                  clearOpenError, clearActivateError, clearCreateError, clearRenameError,
+ *                  clearDeleteError, clearSaveError, clearStructureError,
+ *                  openPalette, activatePalette, createPalette, renamePalette, deletePalette,
  *                  saveSwatchEdits, removeSwatch, addColor, addGroup, reorderSwatches }`.
  */
 export function usePalettes(feed, refreshFeed, route, navigate) {
@@ -74,6 +76,7 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 	const [openError, setOpenError] = useState(null);
 	const [activateError, setActivateError] = useState(null);
 	const [createError, setCreateError] = useState(null);
+	const [renameError, setRenameError] = useState(null);
 	const [deleteError, setDeleteError] = useState(null);
 	const [saveError, setSaveError] = useState(null);
 	const [structureError, setStructureError] = useState(null);
@@ -157,6 +160,7 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 	const clearOpenError = useCallback(() => setOpenError(null), []);
 	const clearActivateError = useCallback(() => setActivateError(null), []);
 	const clearCreateError = useCallback(() => setCreateError(null), []);
+	const clearRenameError = useCallback(() => setRenameError(null), []);
 	const clearDeleteError = useCallback(() => setDeleteError(null), []);
 	const clearSaveError = useCallback(() => setSaveError(null), []);
 	const clearStructureError = useCallback(() => setStructureError(null), []);
@@ -231,6 +235,23 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 			});
 		},
 		[namespace, slug, listing, reload, openPalette]
+	);
+
+	const renamePalette = useCallback(
+		(id, label) => {
+			setRenameError(null);
+			return renamePaletteFlow({
+				namespace,
+				slug,
+				id,
+				label,
+				listing,
+				reload,
+				onBusy: setIsBusy,
+				onError: setRenameError,
+			});
+		},
+		[namespace, slug, listing, reload]
 	);
 
 	const removePalette = useCallback(
@@ -372,18 +393,21 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 		openError,
 		activateError,
 		createError,
+		renameError,
 		deleteError,
 		saveError,
 		structureError,
 		clearOpenError,
 		clearActivateError,
 		clearCreateError,
+		clearRenameError,
 		clearDeleteError,
 		clearSaveError,
 		clearStructureError,
 		openPalette,
 		activatePalette,
 		createPalette: addPalette,
+		renamePalette,
 		deletePalette: removePalette,
 		saveSwatchEdits,
 		removeSwatch,

--- a/src/style-library/hooks/use-palettes.js
+++ b/src/style-library/hooks/use-palettes.js
@@ -69,7 +69,7 @@ import { flattenSchemaTokens } from '../helpers/tokens';
  *                  saveSwatchEdits, removeSwatch, addColor, addGroup, reorderSwatches }`.
  */
 export function usePalettes(feed, refreshFeed, route, navigate) {
-	const [listing, setListing] = useState({ defaultId: '', currentId: '', palettes: [] });
+	const [listing, setListing] = useState({ defaultId: '', currentId: '', palettes: [], userCreated: [] });
 	const [palette, setPalette] = useState(null);
 	const [isLoading, setIsLoading] = useState(true);
 	const [isBusy, setIsBusy] = useState(false);
@@ -112,6 +112,7 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 				defaultId: response.$default,
 				currentId: response.$current,
 				palettes: response.palettes ?? [],
+				userCreated: response.userCreated ?? [],
 			};
 
 			setListing(nextListing);
@@ -255,19 +256,22 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 	);
 
 	const removePalette = useCallback(
-		(id) => {
+		(id, successorId) => {
 			setDeleteError(null);
 			return deletePaletteFlow({
 				namespace,
 				slug,
 				id,
+				currentId: listing.currentId,
+				successorId,
 				reload,
 				refreshFeed,
 				onBusy: setIsBusy,
 				onError: setDeleteError,
+				onActivated: (activatedId) => setListing((prev) => ({ ...prev, currentId: activatedId })),
 			});
 		},
-		[namespace, slug, reload, refreshFeed]
+		[namespace, slug, listing.currentId, reload, refreshFeed]
 	);
 
 	const saveSwatchEdits = useCallback(

--- a/src/style-library/hooks/use-palettes.js
+++ b/src/style-library/hooks/use-palettes.js
@@ -231,11 +231,12 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 				// comment), there is no separate error/busy path left to route through `createError`
 				// instead of `openError`.
 				openPalette,
+				refreshFeed,
 				onBusy: setIsBusy,
 				onError: setCreateError,
 			});
 		},
-		[namespace, slug, listing, reload, openPalette]
+		[namespace, slug, listing, reload, refreshFeed, openPalette]
 	);
 
 	const renamePalette = useCallback(
@@ -248,11 +249,12 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 				label,
 				listing,
 				reload,
+				refreshFeed,
 				onBusy: setIsBusy,
 				onError: setRenameError,
 			});
 		},
-		[namespace, slug, listing, reload]
+		[namespace, slug, listing, reload, refreshFeed]
 	);
 
 	const removePalette = useCallback(


### PR DESCRIPTION
Every write the Color Palette screen offers, bound to the already-tested flows.

## What's here

- **Add color** — mints a user color primitive, then appends it as a swatch.
- **Add Color Group** — the group is created *with* its first swatch, because the server drops an empty group even on the default palette.
- **Create Color Palette** — from the dropdown's trailing action. Creates and **opens**; never activates.
- **Rename palette** — the id stays fixed and only the label changes. The id is referenced by the `$current` pointer and by `data-kb-palette` attributes already rendered onto blocks, so re-deriving it from the new label would orphan them.
- **Set as active** — `ActivatePaletteButton` + `ActivatePaletteModal`, plus an Active badge in the dropdown. The only action that writes `$current`, which re-tints resolved colors across the whole site. The button renders nothing when the palette being edited is already active.
- **Delete palette** — targets the palette being **edited**, not the active one. Hidden for `$default`, which the server refuses to delete. Afterwards the listing is re-read so the fallback is whatever the server resolved.
- **Swatch delete** — removes the row from the default palette first, then best-effort cleanup of a user-created token, so a cleanup failure never reverses the removal.
- **Persisted reordering** — within a group.
- `ScreenHeader` gains a `secondaryAction` slot, and its lead row now holds the action slots at their intrinsic width while the title truncates, since Color Palette can fill it with five items at once.

## Note on reordering

Order is part of a palette's structure, so it is shared across every palette, exactly like the set of swatches, their labels, and their grouping. Only color values are per-palette. See `.local/palette-shared-structure-note.md`.

## Test plan

- `bun run test`.
- In wp-admin, verified: create does not activate; activate moves `$current` and the badge; a color added while editing one palette appears on all of them; a new group survives with its first swatch; deleting the active palette falls back to the server-resolved `$current`; Delete is absent (not disabled) on the default palette.
- Still worth a manual pass: drag-reorder persistence across a reload.


## Screenshots

**Header on a non-active palette** — all five lead items at once, which is also what the lead-row hardening is for
<img width="1528" height="804" alt="pr4-header-actions" src="https://github.com/user-attachments/assets/ae305883-dcca-45fb-830b-62c12ac1c5bf" />

**Activate confirmation**
<img width="1528" height="804" alt="pr4-activate-modal" src="https://github.com/user-attachments/assets/4575869b-85a8-4326-8c50-a938531fa38e" />