### PR TITLE
[DTM] SOFT-4076 [5/5]: Color group management

### DIFF
--- a/src/style-library/__tests__/palette-flows.test.js
+++ b/src/style-library/__tests__/palette-flows.test.js
@@ -6,7 +6,9 @@ import {
 	createPaletteFlow,
 	deletePaletteFlow,
 	openPaletteFlow,
+	removeGroupFlow,
 	removeSwatchFlow,
+	renameGroupFlow,
 	renamePaletteFlow,
 	reorderSwatchesFlow,
 	saveSwatchEditsFlow,
@@ -1062,5 +1064,162 @@ describe('reorderSwatchesFlow', () => {
 			'primitive.color.brand.secondary',
 			'primitive.color.brand.primary',
 		]);
+	});
+});
+
+describe('renameGroupFlow', () => {
+	it('fetches and saves the DEFAULT palette with the relabeled group, keeping its id', async () => {
+		client.fetchPalette.mockResolvedValue(defaultView());
+		client.savePalette.mockResolvedValue({});
+		const reload = jest.fn().mockResolvedValue(undefined);
+		const refreshFeed = jest.fn().mockResolvedValue(undefined);
+
+		await renameGroupFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			defaultId: DEFAULT_ID,
+			groupId: 'accent',
+			label: 'Renamed Accent',
+			reload,
+			refreshFeed,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(client.fetchPalette).toHaveBeenCalledWith(NAMESPACE, DEFAULT_ID, SLUG);
+		const [, id, payload] = client.savePalette.mock.calls[0];
+		expect(id).toBe(DEFAULT_ID);
+		// The id-stability assertion: the saved group still carries its original id under the new
+		// label — the regression test for the `template_slot_for()` misfiling hazard.
+		expect(payload.groups.find((group) => group.label === 'Renamed Accent').id).toBe('accent');
+		expect(reload).toHaveBeenCalled();
+		expect(refreshFeed).toHaveBeenCalledWith(SLUG);
+	});
+
+	it('surfaces the error, clears busy, and re-throws on failure', async () => {
+		const failure = new Error('Could not rename the group.');
+		client.fetchPalette.mockRejectedValue(failure);
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			renameGroupFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				defaultId: DEFAULT_ID,
+				groupId: 'accent',
+				label: 'Renamed Accent',
+				reload: jest.fn(),
+				refreshFeed: jest.fn(),
+				onBusy,
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+});
+
+describe('removeGroupFlow', () => {
+	const baseArgs = (overrides) => ({
+		namespace: NAMESPACE,
+		slug: SLUG,
+		defaultId: DEFAULT_ID,
+		groupId: 'accent',
+		userCreatedTokens: [],
+		reload: jest.fn().mockResolvedValue(undefined),
+		refreshFeed: jest.fn().mockResolvedValue({ version: 'v3' }),
+		onBusy: jest.fn(),
+		onError: jest.fn(),
+		...overrides,
+	});
+
+	beforeEach(() => {
+		client.fetchPalette.mockResolvedValue(defaultView());
+		client.savePalette.mockResolvedValue({});
+	});
+
+	it('writes the group removal to the default node from a fresh read before any cleanup delete', async () => {
+		client.deleteUserPrimitive.mockResolvedValue({});
+		const order = [];
+		client.savePalette.mockImplementation(async () => {
+			order.push('savePalette');
+			return {};
+		});
+		client.deleteUserPrimitive.mockImplementation(async () => {
+			order.push('deleteUserPrimitive');
+			return {};
+		});
+		const flowArgs = baseArgs({
+			userCreatedTokens: ['primitive.color.custom.custom-1'],
+			reload: jest.fn(async () => {
+				order.push('reload');
+			}),
+			refreshFeed: jest.fn(async () => {
+				order.push('refreshFeed');
+				return { version: 'v3' };
+			}),
+		});
+
+		await removeGroupFlow(flowArgs);
+
+		expect(order).toEqual(['savePalette', 'reload', 'refreshFeed', 'deleteUserPrimitive', 'refreshFeed']);
+		expect(client.fetchPalette).toHaveBeenCalledWith(NAMESPACE, DEFAULT_ID, SLUG);
+	});
+
+	it('calls deleteUserPrimitive once per user-created token, each with the preceding refresh’s version', async () => {
+		client.deleteUserPrimitive.mockResolvedValue({});
+		let call = 0;
+		const refreshFeed = jest.fn(async () => {
+			call += 1;
+			return { version: `v${call}` };
+		});
+		const flowArgs = baseArgs({
+			userCreatedTokens: ['primitive.color.custom.custom-1', 'primitive.color.custom.custom-2'],
+			refreshFeed,
+		});
+
+		await removeGroupFlow(flowArgs);
+
+		expect(client.deleteUserPrimitive).toHaveBeenCalledTimes(2);
+		expect(client.deleteUserPrimitive).toHaveBeenNthCalledWith(1, SLUG, 'primitive.color.custom.custom-1', 'v1');
+		expect(client.deleteUserPrimitive).toHaveBeenNthCalledWith(2, SLUG, 'primitive.color.custom.custom-2', 'v2');
+	});
+
+	it('never calls deleteUserPrimitive for an empty userCreatedTokens list', async () => {
+		const flowArgs = baseArgs({ userCreatedTokens: [] });
+
+		await removeGroupFlow(flowArgs);
+
+		expect(client.savePalette).toHaveBeenCalled();
+		expect(client.deleteUserPrimitive).not.toHaveBeenCalled();
+	});
+
+	it('swallows an individual cleanup rejection, still attempts the rest, and resolves', async () => {
+		client.deleteUserPrimitive.mockRejectedValueOnce(new Error('Referenced elsewhere.')).mockResolvedValueOnce({});
+		const refreshFeed = jest.fn().mockResolvedValue({ version: 'v3' });
+		const flowArgs = baseArgs({
+			userCreatedTokens: ['primitive.color.custom.custom-1', 'primitive.color.custom.custom-2'],
+			refreshFeed,
+		});
+
+		await expect(removeGroupFlow(flowArgs)).resolves.toBeUndefined();
+
+		expect(client.deleteUserPrimitive).toHaveBeenCalledTimes(2);
+		// Once for the write's own refresh, once per cleanup attempt regardless of outcome.
+		expect(refreshFeed).toHaveBeenCalledTimes(3);
+		expect(flowArgs.onError).not.toHaveBeenCalled();
+	});
+
+	it('rejects (after onError) only when the group-removal write itself fails, with no cleanup attempt', async () => {
+		const failure = new Error('A palette must define at least one color group.');
+		client.savePalette.mockRejectedValue(failure);
+		const flowArgs = baseArgs({ userCreatedTokens: ['primitive.color.custom.custom-1'] });
+
+		await expect(removeGroupFlow(flowArgs)).rejects.toBe(failure);
+
+		expect(flowArgs.onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(client.deleteUserPrimitive).not.toHaveBeenCalled();
 	});
 });

--- a/src/style-library/__tests__/palette-flows.test.js
+++ b/src/style-library/__tests__/palette-flows.test.js
@@ -6,7 +6,9 @@ import {
 	createPaletteFlow,
 	deletePaletteFlow,
 	openPaletteFlow,
+	removeGroupFlow,
 	removeSwatchFlow,
+	renameGroupFlow,
 	renamePaletteFlow,
 	reorderSwatchesFlow,
 	saveSwatchEditsFlow,
@@ -875,5 +877,162 @@ describe('reorderSwatchesFlow', () => {
 			'primitive.color.brand.secondary',
 			'primitive.color.brand.primary',
 		]);
+	});
+});
+
+describe('renameGroupFlow', () => {
+	it('fetches and saves the DEFAULT palette with the relabeled group, keeping its id', async () => {
+		client.fetchPalette.mockResolvedValue(defaultView());
+		client.savePalette.mockResolvedValue({});
+		const reload = jest.fn().mockResolvedValue(undefined);
+		const refreshFeed = jest.fn().mockResolvedValue(undefined);
+
+		await renameGroupFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			defaultId: DEFAULT_ID,
+			groupId: 'accent',
+			label: 'Renamed Accent',
+			reload,
+			refreshFeed,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(client.fetchPalette).toHaveBeenCalledWith(NAMESPACE, DEFAULT_ID, SLUG);
+		const [, id, payload] = client.savePalette.mock.calls[0];
+		expect(id).toBe(DEFAULT_ID);
+		// The id-stability assertion: the saved group still carries its original id under the new
+		// label — the regression test for the `template_slot_for()` misfiling hazard.
+		expect(payload.groups.find((group) => group.label === 'Renamed Accent').id).toBe('accent');
+		expect(reload).toHaveBeenCalled();
+		expect(refreshFeed).toHaveBeenCalledWith(SLUG);
+	});
+
+	it('surfaces the error, clears busy, and re-throws on failure', async () => {
+		const failure = new Error('Could not rename the group.');
+		client.fetchPalette.mockRejectedValue(failure);
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			renameGroupFlow({
+				namespace: NAMESPACE,
+				slug: SLUG,
+				defaultId: DEFAULT_ID,
+				groupId: 'accent',
+				label: 'Renamed Accent',
+				reload: jest.fn(),
+				refreshFeed: jest.fn(),
+				onBusy,
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+});
+
+describe('removeGroupFlow', () => {
+	const baseArgs = (overrides) => ({
+		namespace: NAMESPACE,
+		slug: SLUG,
+		defaultId: DEFAULT_ID,
+		groupId: 'accent',
+		userCreatedTokens: [],
+		reload: jest.fn().mockResolvedValue(undefined),
+		refreshFeed: jest.fn().mockResolvedValue({ version: 'v3' }),
+		onBusy: jest.fn(),
+		onError: jest.fn(),
+		...overrides,
+	});
+
+	beforeEach(() => {
+		client.fetchPalette.mockResolvedValue(defaultView());
+		client.savePalette.mockResolvedValue({});
+	});
+
+	it('writes the group removal to the default node from a fresh read before any cleanup delete', async () => {
+		client.deleteUserPrimitive.mockResolvedValue({});
+		const order = [];
+		client.savePalette.mockImplementation(async () => {
+			order.push('savePalette');
+			return {};
+		});
+		client.deleteUserPrimitive.mockImplementation(async () => {
+			order.push('deleteUserPrimitive');
+			return {};
+		});
+		const flowArgs = baseArgs({
+			userCreatedTokens: ['primitive.color.custom.custom-1'],
+			reload: jest.fn(async () => {
+				order.push('reload');
+			}),
+			refreshFeed: jest.fn(async () => {
+				order.push('refreshFeed');
+				return { version: 'v3' };
+			}),
+		});
+
+		await removeGroupFlow(flowArgs);
+
+		expect(order).toEqual(['savePalette', 'reload', 'refreshFeed', 'deleteUserPrimitive', 'refreshFeed']);
+		expect(client.fetchPalette).toHaveBeenCalledWith(NAMESPACE, DEFAULT_ID, SLUG);
+	});
+
+	it('calls deleteUserPrimitive once per user-created token, each with the preceding refresh’s version', async () => {
+		client.deleteUserPrimitive.mockResolvedValue({});
+		let call = 0;
+		const refreshFeed = jest.fn(async () => {
+			call += 1;
+			return { version: `v${call}` };
+		});
+		const flowArgs = baseArgs({
+			userCreatedTokens: ['primitive.color.custom.custom-1', 'primitive.color.custom.custom-2'],
+			refreshFeed,
+		});
+
+		await removeGroupFlow(flowArgs);
+
+		expect(client.deleteUserPrimitive).toHaveBeenCalledTimes(2);
+		expect(client.deleteUserPrimitive).toHaveBeenNthCalledWith(1, SLUG, 'primitive.color.custom.custom-1', 'v1');
+		expect(client.deleteUserPrimitive).toHaveBeenNthCalledWith(2, SLUG, 'primitive.color.custom.custom-2', 'v2');
+	});
+
+	it('never calls deleteUserPrimitive for an empty userCreatedTokens list', async () => {
+		const flowArgs = baseArgs({ userCreatedTokens: [] });
+
+		await removeGroupFlow(flowArgs);
+
+		expect(client.savePalette).toHaveBeenCalled();
+		expect(client.deleteUserPrimitive).not.toHaveBeenCalled();
+	});
+
+	it('swallows an individual cleanup rejection, still attempts the rest, and resolves', async () => {
+		client.deleteUserPrimitive.mockRejectedValueOnce(new Error('Referenced elsewhere.')).mockResolvedValueOnce({});
+		const refreshFeed = jest.fn().mockResolvedValue({ version: 'v3' });
+		const flowArgs = baseArgs({
+			userCreatedTokens: ['primitive.color.custom.custom-1', 'primitive.color.custom.custom-2'],
+			refreshFeed,
+		});
+
+		await expect(removeGroupFlow(flowArgs)).resolves.toBeUndefined();
+
+		expect(client.deleteUserPrimitive).toHaveBeenCalledTimes(2);
+		// Once for the write's own refresh, once per cleanup attempt regardless of outcome.
+		expect(refreshFeed).toHaveBeenCalledTimes(3);
+		expect(flowArgs.onError).not.toHaveBeenCalled();
+	});
+
+	it('rejects (after onError) only when the group-removal write itself fails, with no cleanup attempt', async () => {
+		const failure = new Error('A palette must define at least one color group.');
+		client.savePalette.mockRejectedValue(failure);
+		const flowArgs = baseArgs({ userCreatedTokens: ['primitive.color.custom.custom-1'] });
+
+		await expect(removeGroupFlow(flowArgs)).rejects.toBe(failure);
+
+		expect(flowArgs.onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(client.deleteUserPrimitive).not.toHaveBeenCalled();
 	});
 });

--- a/src/style-library/__tests__/palettes.test.js
+++ b/src/style-library/__tests__/palettes.test.js
@@ -11,7 +11,9 @@ import {
 	newSwatchValue,
 	nextCustomColorSlug,
 	paletteDisplayLabel,
+	removeGroupFromGroups,
 	removeSwatchFromGroups,
+	renameGroupInGroups,
 	renameSwatchInGroups,
 	reorderGroupSwatches,
 	resolveEditingPaletteId,
@@ -331,6 +333,8 @@ describe('immutability', () => {
 		renameSwatchInGroups(groups, 'primitive.color.brand.primary', 'Renamed');
 		reorderGroupSwatches(groups, 'accent', ['primitive.color.brand.secondary', 'primitive.color.brand.primary']);
 		addGroupToGroups(groups, { id: 'x', label: 'X', swatches: [] });
+		renameGroupInGroups(groups, 'accent', 'Renamed Accent');
+		removeGroupFromGroups(groups, 'accent');
 
 		expect(groups).toEqual(frozen);
 	});
@@ -360,6 +364,57 @@ describe('newSwatchValue', () => {
 		expect(newSwatchValue(groups, 'accent')).toBe('#445566');
 		expect(newSwatchValue(groups, 'ghost')).toBe('#000000');
 		expect(newSwatchValue([], 'accent')).toBe('#000000');
+	});
+});
+
+describe('renameGroupInGroups', () => {
+	it('relabels only the target group and preserves its id', () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+		const next = renameGroupInGroups(groups, 'accent', 'Renamed Accent');
+		const renamed = next.find((group) => group.label === 'Renamed Accent');
+
+		// The regression test for the `template_slot_for()` misfiling hazard: a rename must never
+		// touch the id a swatch-placement lookup depends on.
+		expect(renamed.id).toBe('accent');
+		expect(next.find((group) => group.id === 'contrast').label).toBe('Contrast');
+	});
+
+	it('leaves every group’s swatches untouched', () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+		const next = renameGroupInGroups(groups, 'accent', 'Renamed Accent');
+
+		expect(next.find((group) => group.id === 'accent').swatches).toEqual(
+			groups.find((group) => group.id === 'accent').swatches
+		);
+	});
+
+	it('changes no labels when the group id matches nothing', () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+		const next = renameGroupInGroups(groups, 'ghost', 'Renamed');
+
+		expect(next.map((group) => group.label)).toEqual(groups.map((group) => group.label));
+	});
+});
+
+describe('removeGroupFromGroups', () => {
+	it('removes the target group and only it, keeping sibling order', () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+		const next = removeGroupFromGroups(groups, 'accent');
+
+		expect(next).toHaveLength(1);
+		expect(next[0].id).toBe('contrast');
+	});
+
+	it('returns the same reference when the id matches nothing', () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+
+		expect(removeGroupFromGroups(groups, 'ghost')).toBe(groups);
+	});
+
+	it('does not block removing the only remaining group — the server owns that rejection', () => {
+		const groups = [stripEffectiveFlags(effectivePalette().groups)[0]];
+
+		expect(removeGroupFromGroups(groups, 'accent')).toEqual([]);
 	});
 });
 

--- a/src/style-library/__tests__/palettes.test.js
+++ b/src/style-library/__tests__/palettes.test.js
@@ -13,7 +13,9 @@ import {
 	nextCustomColorSlug,
 	paletteDisplayLabel,
 	paletteSuccessorOptions,
+	removeGroupFromGroups,
 	removeSwatchFromGroups,
+	renameGroupInGroups,
 	renameSwatchInGroups,
 	reorderGroupSwatches,
 	resolveEditingPaletteId,
@@ -333,6 +335,8 @@ describe('immutability', () => {
 		renameSwatchInGroups(groups, 'primitive.color.brand.primary', 'Renamed');
 		reorderGroupSwatches(groups, 'accent', ['primitive.color.brand.secondary', 'primitive.color.brand.primary']);
 		addGroupToGroups(groups, { id: 'x', label: 'X', swatches: [] });
+		renameGroupInGroups(groups, 'accent', 'Renamed Accent');
+		removeGroupFromGroups(groups, 'accent');
 
 		expect(groups).toEqual(frozen);
 	});
@@ -362,6 +366,57 @@ describe('newSwatchValue', () => {
 		expect(newSwatchValue(groups, 'accent')).toBe('#445566');
 		expect(newSwatchValue(groups, 'ghost')).toBe('#000000');
 		expect(newSwatchValue([], 'accent')).toBe('#000000');
+	});
+});
+
+describe('renameGroupInGroups', () => {
+	it('relabels only the target group and preserves its id', () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+		const next = renameGroupInGroups(groups, 'accent', 'Renamed Accent');
+		const renamed = next.find((group) => group.label === 'Renamed Accent');
+
+		// The regression test for the `template_slot_for()` misfiling hazard: a rename must never
+		// touch the id a swatch-placement lookup depends on.
+		expect(renamed.id).toBe('accent');
+		expect(next.find((group) => group.id === 'contrast').label).toBe('Contrast');
+	});
+
+	it('leaves every group’s swatches untouched', () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+		const next = renameGroupInGroups(groups, 'accent', 'Renamed Accent');
+
+		expect(next.find((group) => group.id === 'accent').swatches).toEqual(
+			groups.find((group) => group.id === 'accent').swatches
+		);
+	});
+
+	it('changes no labels when the group id matches nothing', () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+		const next = renameGroupInGroups(groups, 'ghost', 'Renamed');
+
+		expect(next.map((group) => group.label)).toEqual(groups.map((group) => group.label));
+	});
+});
+
+describe('removeGroupFromGroups', () => {
+	it('removes the target group and only it, keeping sibling order', () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+		const next = removeGroupFromGroups(groups, 'accent');
+
+		expect(next).toHaveLength(1);
+		expect(next[0].id).toBe('contrast');
+	});
+
+	it('returns the same reference when the id matches nothing', () => {
+		const groups = stripEffectiveFlags(effectivePalette().groups);
+
+		expect(removeGroupFromGroups(groups, 'ghost')).toBe(groups);
+	});
+
+	it('does not block removing the only remaining group — the server owns that rejection', () => {
+		const groups = [stripEffectiveFlags(effectivePalette().groups)[0]];
+
+		expect(removeGroupFromGroups(groups, 'accent')).toEqual([]);
 	});
 });
 

--- a/src/style-library/components/atoms/SectionHeading.js
+++ b/src/style-library/components/atoms/SectionHeading.js
@@ -10,15 +10,29 @@
 import './SectionHeading.scss';
 
 /**
- * Render a section heading.
+ * Render a section heading, optionally with a trailing actions slot (e.g. an overflow menu).
  *
- * @param {Object}          props          The component props.
- * @param {import('react').ReactNode} props.children The heading text.
+ * @param {Object}                     props          The component props.
+ * @param {import('react').ReactNode}  props.children The heading text.
+ * @param {import('react').ReactNode}  [props.actions] Optional trailing actions, rendered on the
+ *                                                     heading row; the heading is unchanged when
+ *                                                     unset.
  *
  * @since TBD
  *
  * @return {JSX.Element} The heading.
  */
-export function SectionHeading({ children }) {
-	return <h3 className="kadence-blocks-style-library__section-heading">{children}</h3>;
+export function SectionHeading({ children, actions = null }) {
+	const heading = <h3 className="kadence-blocks-style-library__section-heading">{children}</h3>;
+
+	if (!actions) {
+		return heading;
+	}
+
+	return (
+		<div className="kadence-blocks-style-library__section-heading-row">
+			{heading}
+			<div className="kadence-blocks-style-library__section-heading-actions">{actions}</div>
+		</div>
+	);
 }

--- a/src/style-library/components/atoms/SectionHeading.scss
+++ b/src/style-library/components/atoms/SectionHeading.scss
@@ -9,3 +9,27 @@
 	margin: 0;
 	letter-spacing: 0.04em;
 }
+
+.kadence-blocks-style-library__section-heading-row {
+	display: flex;
+	align-items: center;
+	gap: var(--kb-sl-space-05);
+
+	.kadence-blocks-style-library__section-heading-actions {
+		// Opacity, never `display: none`/`visibility: hidden` — a hidden-by-display button falls out
+		// of the tab order, and the overflow menu must stay reachable by keyboard at all times.
+		opacity: 0;
+		transition: opacity 0.15s ease;
+	}
+
+	// `:focus-within` keeps keyboard use first-class: tabbing onto the trigger button reveals it
+	// without a pointer ever touching the row. The `[aria-expanded='true']` arm keeps the trigger
+	// visible while its menu is open and the pointer has moved into the portalled popover, which
+	// renders outside this row, so `:hover` alone would drop the trigger the instant the pointer
+	// left it.
+	&:hover .kadence-blocks-style-library__section-heading-actions,
+	&:focus-within .kadence-blocks-style-library__section-heading-actions,
+	.kadence-blocks-style-library__section-heading-actions:has([aria-expanded='true']) {
+		opacity: 1;
+	}
+}

--- a/src/style-library/components/organisms/DeleteColorGroupModal.js
+++ b/src/style-library/components/organisms/DeleteColorGroupModal.js
@@ -1,0 +1,79 @@
+/**
+ * The confirmation shown before a color group is deleted, modeled on `DeletePaletteModal`: names
+ * the group and its swatch count, because this destroys N swatches at once rather than one. The
+ * group's colors are removed from every palette — structure lives only on the default node, so a
+ * group delete is not scoped to the palette currently being viewed.
+ *
+ * The trigger lives in the group's overflow menu (`ColorPaletteScreen`), not here; this modal only
+ * renders while its caller's target state says so.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button, Modal, Notice } from '@wordpress/components';
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './DeleteColorGroupModal.scss';
+
+/**
+ * Render the delete-color-group confirmation.
+ *
+ * @param {Object}             props           The component props.
+ * @param {Object}             props.group     The group being deleted, `{ id, label, items }`.
+ * @param {boolean}            props.isBusy    Whether the delete request is in flight.
+ * @param {?{message: string}} props.error     The current structure error, if any.
+ * @param {Function}           props.onClose   Called to dismiss the modal.
+ * @param {Function}           props.onConfirm Called to delete the group.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The modal.
+ */
+export function DeleteColorGroupModal({ group, isBusy, error, onClose, onConfirm }) {
+	const count = group.items.length;
+
+	return (
+		<Modal
+			title={__('Delete Color Group?', 'kadence-blocks')}
+			className="kadence-blocks-style-library__delete-color-group-modal"
+			onRequestClose={onClose}
+			// Locked while pending: no close icon, Escape does nothing, clicking outside does
+			// nothing. A delete request in flight cannot be walked away from mid-request.
+			isDismissible={!isBusy}
+			shouldCloseOnEsc={!isBusy}
+			shouldCloseOnClickOutside={!isBusy}
+		>
+			{error && (
+				<Notice status="error" isDismissible={false}>
+					{error.message}
+				</Notice>
+			)}
+			<p>
+				{sprintf(
+					// translators: 1: the group's display label, 2: its swatch count.
+					_n(
+						'Delete the group "%1$s" and its %2$d color? This removes it from every palette.',
+						'Delete the group "%1$s" and its %2$d colors? This removes them from every palette.',
+						count,
+						'kadence-blocks'
+					),
+					group.label,
+					count
+				)}
+			</p>
+			<div className="kadence-blocks-style-library__delete-color-group-modal-actions">
+				<Button variant="tertiary" onClick={onClose} disabled={isBusy} autoFocus>
+					{__('Cancel', 'kadence-blocks')}
+				</Button>
+				<Button variant="primary" isDestructive disabled={isBusy} onClick={onConfirm}>
+					{/* The progressive label is the only progress indication — no spinner alongside it. */}
+					{isBusy ? __('Deleting…', 'kadence-blocks') : __('Delete', 'kadence-blocks')}
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/src/style-library/components/organisms/DeleteColorGroupModal.scss
+++ b/src/style-library/components/organisms/DeleteColorGroupModal.scss
@@ -1,0 +1,6 @@
+.kadence-blocks-style-library__delete-color-group-modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: var(--kb-sl-space-10);
+	margin-top: var(--kb-sl-space-20);
+}

--- a/src/style-library/components/organisms/RenameColorGroupModal.js
+++ b/src/style-library/components/organisms/RenameColorGroupModal.js
@@ -1,0 +1,80 @@
+/**
+ * The rename modal for a color group, mirroring `RenamePaletteModal`: a single label field seeded
+ * with the group's current label. Not merged with that modal — the seed, validation, copy, and
+ * flow (`renameGroup`) all differ, while reusing the same `Modal`-based skeleton.
+ *
+ * No uniqueness check: group **ids** are the uniqueness domain and this rename never touches the
+ * id (see `renameGroupInGroups`'s own docblock for why), so a duplicate label is display-only
+ * ambiguity the user chose — the same stance swatch rename already takes.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button, Modal, Notice, TextControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './RenameColorGroupModal.scss';
+
+/**
+ * Render the rename-color-group confirmation.
+ *
+ * @param {Object}             props              The component props.
+ * @param {Object}             props.group        The group being renamed, `{ id, label }`.
+ * @param {boolean}            props.isBusy       Whether a palette operation is in flight.
+ * @param {?{message: string}} props.error        The current structure error, if any.
+ * @param {Function}           props.onClose      Called to dismiss the modal.
+ * @param {Function}           props.onRename     Called with the new label to rename the group.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The modal.
+ */
+export function RenameColorGroupModal({ group, isBusy, error, onClose, onRename }) {
+	const [label, setLabel] = useState(group.label);
+	const trimmed = label.trim();
+	const isUnchanged = trimmed === group.label.trim();
+
+	return (
+		<Modal
+			title={__('Rename Color Group', 'kadence-blocks')}
+			className="kadence-blocks-style-library__rename-color-group-modal"
+			onRequestClose={onClose}
+			// Locked while pending, like every other palette modal.
+			isDismissible={!isBusy}
+			shouldCloseOnEsc={!isBusy}
+			shouldCloseOnClickOutside={!isBusy}
+		>
+			{error && (
+				<Notice status="error" isDismissible={false}>
+					{error.message}
+				</Notice>
+			)}
+			<TextControl
+				label={__('Group name', 'kadence-blocks')}
+				value={label}
+				onChange={setLabel}
+				disabled={isBusy}
+			/>
+			<p>{__('This changes the group’s display name on every palette.', 'kadence-blocks')}</p>
+			<div className="kadence-blocks-style-library__rename-color-group-modal-actions">
+				<Button variant="tertiary" onClick={onClose} disabled={isBusy}>
+					{__('Cancel', 'kadence-blocks')}
+				</Button>
+				<Button
+					variant="primary"
+					// Unchanged is disabled alongside empty: a rename to the same label would spend a
+					// request to change nothing.
+					disabled={isBusy || trimmed === '' || isUnchanged}
+					onClick={() => onRename(trimmed)}
+				>
+					{isBusy ? __('Saving…', 'kadence-blocks') : __('Save', 'kadence-blocks')}
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/src/style-library/components/organisms/RenameColorGroupModal.scss
+++ b/src/style-library/components/organisms/RenameColorGroupModal.scss
@@ -1,0 +1,6 @@
+.kadence-blocks-style-library__rename-color-group-modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: var(--kb-sl-space-10);
+	margin-top: var(--kb-sl-space-20);
+}

--- a/src/style-library/components/organisms/SwatchGrid.js
+++ b/src/style-library/components/organisms/SwatchGrid.js
@@ -30,12 +30,24 @@ import './SwatchGrid.scss';
  * @param {Function}       props.onAdd      Called with the group id when its add tile is clicked.
  * @param {string}         props.addLabel   The add-tile label (e.g. 'Add color') — no literal `+`,
  *                                          the icon supplies it.
+ * @param {Function}       [props.groupActions] Called with a group and returning the node for its
+ *                                          heading's actions slot (e.g. an overflow menu); the
+ *                                          grid stays agnostic about what the actions are, the
+ *                                          same division of labor as `SwatchCard`'s `preview`.
  *
  * @since TBD
  *
  * @return {JSX.Element} The grid.
  */
-export function SwatchGrid({ groups, selectedId = '', onSelect, onReorder = () => {}, onAdd, addLabel }) {
+export function SwatchGrid({
+	groups,
+	selectedId = '',
+	onSelect,
+	onReorder = () => {},
+	onAdd,
+	addLabel,
+	groupActions = null,
+}) {
 	return (
 		<div className="kadence-blocks-style-library__swatch-grid">
 			{groups.map((group) => (
@@ -47,6 +59,7 @@ export function SwatchGrid({ groups, selectedId = '', onSelect, onReorder = () =
 					onReorder={onReorder}
 					onAdd={onAdd}
 					addLabel={addLabel}
+					groupActions={groupActions}
 				/>
 			))}
 		</div>
@@ -65,12 +78,14 @@ export function SwatchGrid({ groups, selectedId = '', onSelect, onReorder = () =
  * @param {Function}      props.onReorder  Called with `(groupId, orderedIds)` after a drop.
  * @param {Function}      props.onAdd      Called with the group id when its add tile is clicked.
  * @param {string}        props.addLabel   The add-tile label.
+ * @param {Function}      [props.groupActions] Called with `group`, returning the heading's
+ *                                         actions slot node.
  *
  * @since TBD
  *
  * @return {JSX.Element} The group.
  */
-function SwatchGridGroup({ group, selectedId, onSelect, onReorder, onAdd, addLabel }) {
+function SwatchGridGroup({ group, selectedId, onSelect, onReorder, onAdd, addLabel, groupActions }) {
 	const ids = group.items.map((item) => item.id);
 	const { contextProps, sortableContextProps, useSortableItem, activeId } = useReorderableList({
 		ids,
@@ -80,7 +95,7 @@ function SwatchGridGroup({ group, selectedId, onSelect, onReorder, onAdd, addLab
 
 	return (
 		<div className="kadence-blocks-style-library__swatch-group">
-			<SectionHeading>{group.label}</SectionHeading>
+			<SectionHeading actions={groupActions ? groupActions(group) : null}>{group.label}</SectionHeading>
 			<DndContext {...contextProps}>
 				<SortableContext {...sortableContextProps} strategy={rectSortingStrategy}>
 					<div className="kadence-blocks-style-library__swatch-group-row">

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -10,9 +10,9 @@
  * WordPress dependencies
  */
 import { useMemo, useState } from '@wordpress/element';
-import { Button, Notice, Spinner } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { plus } from '@wordpress/icons';
+import { Button, DropdownMenu, MenuGroup, MenuItem, Notice, Spinner } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { moreVertical, plus } from '@wordpress/icons';
 
 /**
  * External dependencies
@@ -31,6 +31,8 @@ import { CreatePaletteModal } from '../organisms/CreatePaletteModal';
 import { RenamePaletteModal } from '../organisms/RenamePaletteModal';
 import { DeletePaletteModal } from '../organisms/DeletePaletteModal';
 import { AddColorGroupModal } from '../organisms/AddColorGroupModal';
+import { RenameColorGroupModal } from '../organisms/RenameColorGroupModal';
+import { DeleteColorGroupModal } from '../organisms/DeleteColorGroupModal';
 import { usePalettes } from '../../hooks/use-palettes';
 import { isDefaultPalette, mapPaletteToSwatchGroups, paletteDisplayLabel } from '../../helpers/palettes';
 import { ColorPaletteSettings } from './ColorPaletteSettings';
@@ -76,6 +78,10 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 	const [isCreateOpen, setIsCreateOpen] = useState(false);
 	const [isDeleteOpen, setIsDeleteOpen] = useState(false);
 	const [isAddGroupOpen, setIsAddGroupOpen] = useState(false);
+	// Carries the whole mapped group entry (`{ id, label, items }`), not just an id, so the modals
+	// can seed the label and count the swatches without a second lookup.
+	const [renameGroupTarget, setRenameGroupTarget] = useState(null);
+	const [deleteGroupTarget, setDeleteGroupTarget] = useState(null);
 
 	const editingRow = palettes.listing.palettes.find((row) => row.id === palettes.editingId);
 	const activeRow = palettes.listing.palettes.find((row) => row.id === palettes.activeId);
@@ -185,10 +191,11 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 				<Spinner />
 			) : palettes.palette ? (
 				<>
-					{/* Suppressed while the add-group modal is open — that flow shares this same
-					 * `structureError` slot (per the settled six-slot design) and shows it inline
-					 * instead, so surfacing it here too would render the same message twice. */}
-					{!isAddGroupOpen && palettes.structureError && (
+					{/* Suppressed while the add-group, rename-group, or delete-group modal is open —
+					 * every one of those flows shares this same `structureError` slot (per the settled
+					 * six-slot design) and shows it inline instead, so surfacing it here too would
+					 * render the same message twice. */}
+					{!isAddGroupOpen && !renameGroupTarget && !deleteGroupTarget && palettes.structureError && (
 						<Notice status="error" onRemove={palettes.clearStructureError}>
 							{palettes.structureError.message}
 						</Notice>
@@ -206,6 +213,46 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 								.catch(() => {})
 						}
 						addLabel={__('Add color', 'kadence-blocks')}
+						groupActions={(group) => (
+							<DropdownMenu
+								icon={moreVertical}
+								label={sprintf(
+									// translators: %s: the color group name.
+									__('Options for %s', 'kadence-blocks'),
+									group.label
+								)}
+								popoverProps={{ placement: 'bottom-end' }}
+								toggleProps={{ size: 'small' }}
+							>
+								{({ onClose }) => (
+									<MenuGroup>
+										<MenuItem
+											onClick={() => {
+												setRenameGroupTarget(group);
+												onClose();
+											}}
+										>
+											{__('Rename', 'kadence-blocks')}
+										</MenuItem>
+										{/* Absence, not a disabled item, when only one group remains — the server
+										 * rejects an empty `groups` array (`guard_palette_shape()`), and this
+										 * screen's ethos throughout is to hide an affordance it cannot honor rather
+										 * than disable it. */}
+										{gridGroups.length > 1 && (
+											<MenuItem
+												isDestructive
+												onClick={() => {
+													setDeleteGroupTarget(group);
+													onClose();
+												}}
+											>
+												{__('Delete', 'kadence-blocks')}
+											</MenuItem>
+										)}
+									</MenuGroup>
+								)}
+							</DropdownMenu>
+						)}
 					/>
 				</>
 			) : (
@@ -284,6 +331,65 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 							// `structureError`, rendered inline — the modal stays open on it.
 							.catch(() => {})
 					}
+				/>
+			)}
+			{renameGroupTarget && (
+				<RenameColorGroupModal
+					group={renameGroupTarget}
+					isBusy={palettes.isBusy}
+					error={palettes.structureError}
+					onClose={() => {
+						setRenameGroupTarget(null);
+						palettes.clearStructureError();
+					}}
+					onRename={(label) =>
+						palettes
+							.renameGroup(renameGroupTarget.id, label)
+							.then(() => {
+								setRenameGroupTarget(null);
+								palettes.clearStructureError();
+							})
+							// Swallowed: a request failure already lands in `structureError`, rendered
+							// inline — the modal stays open on it.
+							.catch(() => {})
+					}
+				/>
+			)}
+			{deleteGroupTarget && (
+				<DeleteColorGroupModal
+					group={deleteGroupTarget}
+					isBusy={palettes.isBusy}
+					error={palettes.structureError}
+					onClose={() => {
+						setDeleteGroupTarget(null);
+						palettes.clearStructureError();
+					}}
+					onConfirm={() => {
+						// Captured before the delete resolves: the group is gone from `gridGroups` by
+						// then, so this is the only point the selected swatch can still be checked
+						// against the group being removed.
+						const selectedInGroup = deleteGroupTarget.items.some((item) => item.id === route.item);
+
+						return (
+							palettes
+								.removeGroup(deleteGroupTarget.id)
+								.then(() => {
+									setDeleteGroupTarget(null);
+									palettes.clearStructureError();
+
+									// The panel must close when its swatch no longer exists in any palette —
+									// otherwise it points at a token that was just deleted. A failed best-effort
+									// token cleanup never reaches here: the flow resolves once the row removal
+									// has settled, regardless of the cleanup outcome.
+									if (selectedInGroup) {
+										navigate({ item: '' });
+									}
+								})
+								// Swallowed: a request failure already lands in `structureError`, rendered
+								// inline — the modal stays open on it.
+								.catch(() => {})
+						);
+					}}
 				/>
 			)}
 		</div>

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -10,9 +10,9 @@
  * WordPress dependencies
  */
 import { useMemo, useState } from '@wordpress/element';
-import { Button, Notice, Spinner } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { plus } from '@wordpress/icons';
+import { Button, DropdownMenu, MenuGroup, MenuItem, Notice, Spinner } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { moreVertical, plus } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -27,6 +27,8 @@ import { CreatePaletteModal } from '../organisms/CreatePaletteModal';
 import { RenamePaletteModal } from '../organisms/RenamePaletteModal';
 import { DeletePaletteModal } from '../organisms/DeletePaletteModal';
 import { AddColorGroupModal } from '../organisms/AddColorGroupModal';
+import { RenameColorGroupModal } from '../organisms/RenameColorGroupModal';
+import { DeleteColorGroupModal } from '../organisms/DeleteColorGroupModal';
 import { usePalettes } from '../../hooks/use-palettes';
 import {
 	isUserCreatedPalette,
@@ -77,6 +79,10 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 	const [isCreateOpen, setIsCreateOpen] = useState(false);
 	const [isDeleteOpen, setIsDeleteOpen] = useState(false);
 	const [isAddGroupOpen, setIsAddGroupOpen] = useState(false);
+	// Carries the whole mapped group entry (`{ id, label, items }`), not just an id, so the modals
+	// can seed the label and count the swatches without a second lookup.
+	const [renameGroupTarget, setRenameGroupTarget] = useState(null);
+	const [deleteGroupTarget, setDeleteGroupTarget] = useState(null);
 
 	const editingRow = palettes.listing.palettes.find((row) => row.id === palettes.editingId);
 	const isEditingUserCreated = isUserCreatedPalette(palettes.listing, palettes.editingId);
@@ -185,10 +191,11 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 				<Spinner />
 			) : palettes.palette ? (
 				<>
-					{/* Suppressed while the add-group modal is open — that flow shares this same
-					 * `structureError` slot (per the settled six-slot design) and shows it inline
-					 * instead, so surfacing it here too would render the same message twice. */}
-					{!isAddGroupOpen && palettes.structureError && (
+					{/* Suppressed while the add-group, rename-group, or delete-group modal is open —
+					 * every one of those flows shares this same `structureError` slot (per the settled
+					 * six-slot design) and shows it inline instead, so surfacing it here too would
+					 * render the same message twice. */}
+					{!isAddGroupOpen && !renameGroupTarget && !deleteGroupTarget && palettes.structureError && (
 						<Notice status="error" onRemove={palettes.clearStructureError}>
 							{palettes.structureError.message}
 						</Notice>
@@ -206,6 +213,46 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 								.catch(() => {})
 						}
 						addLabel={__('Add color', 'kadence-blocks')}
+						groupActions={(group) => (
+							<DropdownMenu
+								icon={moreVertical}
+								label={sprintf(
+									// translators: %s: the color group name.
+									__('Options for %s', 'kadence-blocks'),
+									group.label
+								)}
+								popoverProps={{ placement: 'bottom-end' }}
+								toggleProps={{ size: 'small' }}
+							>
+								{({ onClose }) => (
+									<MenuGroup>
+										<MenuItem
+											onClick={() => {
+												setRenameGroupTarget(group);
+												onClose();
+											}}
+										>
+											{__('Rename', 'kadence-blocks')}
+										</MenuItem>
+										{/* Absence, not a disabled item, when only one group remains — the server
+										 * rejects an empty `groups` array (`guard_palette_shape()`), and this
+										 * screen's ethos throughout is to hide an affordance it cannot honor rather
+										 * than disable it. */}
+										{gridGroups.length > 1 && (
+											<MenuItem
+												isDestructive
+												onClick={() => {
+													setDeleteGroupTarget(group);
+													onClose();
+												}}
+											>
+												{__('Delete', 'kadence-blocks')}
+											</MenuItem>
+										)}
+									</MenuGroup>
+								)}
+							</DropdownMenu>
+						)}
 					/>
 				</>
 			) : (
@@ -286,6 +333,65 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 							// `structureError`, rendered inline — the modal stays open on it.
 							.catch(() => {})
 					}
+				/>
+			)}
+			{renameGroupTarget && (
+				<RenameColorGroupModal
+					group={renameGroupTarget}
+					isBusy={palettes.isBusy}
+					error={palettes.structureError}
+					onClose={() => {
+						setRenameGroupTarget(null);
+						palettes.clearStructureError();
+					}}
+					onRename={(label) =>
+						palettes
+							.renameGroup(renameGroupTarget.id, label)
+							.then(() => {
+								setRenameGroupTarget(null);
+								palettes.clearStructureError();
+							})
+							// Swallowed: a request failure already lands in `structureError`, rendered
+							// inline — the modal stays open on it.
+							.catch(() => {})
+					}
+				/>
+			)}
+			{deleteGroupTarget && (
+				<DeleteColorGroupModal
+					group={deleteGroupTarget}
+					isBusy={palettes.isBusy}
+					error={palettes.structureError}
+					onClose={() => {
+						setDeleteGroupTarget(null);
+						palettes.clearStructureError();
+					}}
+					onConfirm={() => {
+						// Captured before the delete resolves: the group is gone from `gridGroups` by
+						// then, so this is the only point the selected swatch can still be checked
+						// against the group being removed.
+						const selectedInGroup = deleteGroupTarget.items.some((item) => item.id === route.item);
+
+						return (
+							palettes
+								.removeGroup(deleteGroupTarget.id)
+								.then(() => {
+									setDeleteGroupTarget(null);
+									palettes.clearStructureError();
+
+									// The panel must close when its swatch no longer exists in any palette —
+									// otherwise it points at a token that was just deleted. A failed best-effort
+									// token cleanup never reaches here: the flow resolves once the row removal
+									// has settled, regardless of the cleanup outcome.
+									if (selectedInGroup) {
+										navigate({ item: '' });
+									}
+								})
+								// Swallowed: a request failure already lands in `structureError`, rendered
+								// inline — the modal stays open on it.
+								.catch(() => {})
+						);
+					}}
 				/>
 			)}
 		</div>

--- a/src/style-library/helpers/palette-flows.js
+++ b/src/style-library/helpers/palette-flows.js
@@ -47,7 +47,9 @@ import {
 	isDuplicatePaletteLabel,
 	newSwatchValue,
 	nextCustomColorSlug,
+	removeGroupFromGroups,
 	removeSwatchFromGroups,
+	renameGroupInGroups,
 	renameSwatchInGroups,
 	reorderGroupSwatches,
 	slugifyPaletteLabel,
@@ -825,4 +827,116 @@ export function addGroupFlow({
 			})
 		)
 		.then(() => token);
+}
+
+/**
+ * Rename a color group — a structure edit, written to the default palette node. Label only: the
+ * group's id is immutable, because `template_slot_for()` places minted swatches by group id and
+ * every non-default palette's stored deltas key their groups by the same ids — changing the id
+ * would silently misfile future colors and orphan existing deltas.
+ *
+ * @param {Object}   args
+ * @param {string}   args.namespace   The REST namespace.
+ * @param {string}   args.slug        The token library slug.
+ * @param {string}   args.defaultId   The listing's `$default` palette id.
+ * @param {string}   args.groupId     The group id to rename.
+ * @param {string}   args.label       The new label.
+ * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.refreshFeed Replaces the feed for a slug.
+ * @param {Function} args.onBusy      Called with a boolean as the chain starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} See `writeDefaultPaletteFlow`.
+ */
+export function renameGroupFlow({ namespace, slug, defaultId, groupId, label, reload, refreshFeed, onBusy, onError }) {
+	return writeDefaultPaletteFlow({
+		namespace,
+		slug,
+		defaultId,
+		edit: (groups) => renameGroupInGroups(groups, groupId, label),
+		reload,
+		refreshFeed,
+		onBusy,
+		onError,
+	});
+}
+
+/**
+ * Remove a color group and every swatch in it: strips the group from the default palette's
+ * structure first, then — for each user-created token the group carried — best-effort deletes
+ * the underlying primitive, one at a time.
+ *
+ * Same load-bearing order as `removeSwatchFlow`, for the same reason: `Token_Reference_Policy`
+ * never scans palette swatches, so nothing server-side blocks deleting a primitive a palette
+ * still references — safety comes entirely from the group-removal write landing first, which
+ * removes every one of its tokens from every palette's effective view before any primitive
+ * delete runs. Each cleanup delete swallows its own failure and refreshes the feed regardless,
+ * so a token that is legitimately blocked (aliased outside the palette layer) neither reverses
+ * the group removal nor wedges the deletes after it on a stale version.
+ *
+ * @param {Object}        args
+ * @param {string}        args.namespace         The REST namespace.
+ * @param {string}        args.slug              The token library slug.
+ * @param {string}        args.defaultId         The listing's `$default` palette id.
+ * @param {string}        args.groupId           The group id to remove.
+ * @param {Array<string>} args.userCreatedTokens The group's user-created swatch tokens — gates
+ *                                               ONLY the cleanup steps, never the group removal.
+ * @param {Function}      args.reload            Re-reads the listing (and the edited view).
+ * @param {Function}      args.refreshFeed       Replaces the feed for a slug; resolves with the
+ *                                               fresh feed payload, whose `version` each cleanup
+ *                                               delete needs.
+ * @param {Function}      args.onBusy            Called with a boolean as the chain starts and settles.
+ * @param {Function}      args.onError           Called with `{ message }` on failure of the
+ *                                               group-removal write.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once the group-removal write and every best-effort cleanup
+ *                          attempt settle; rejects only when the group-removal write itself
+ *                          fails (e.g. the last-group 400), after `onError`/`onBusy` have run.
+ */
+export function removeGroupFlow({
+	namespace,
+	slug,
+	defaultId,
+	groupId,
+	userCreatedTokens,
+	reload,
+	refreshFeed,
+	onBusy,
+	onError,
+}) {
+	onBusy(true);
+
+	return fetchPalette(namespace, defaultId, slug)
+		.then((view) => {
+			const groups = removeGroupFromGroups(stripEffectiveFlags(view.groups), groupId);
+
+			return savePalette(namespace, defaultId, { label: view.label, groups }, slug);
+		})
+		.then(() => reload())
+		.then(() => refreshFeed(slug))
+		.then((freshFeed) => {
+			let chain = Promise.resolve(freshFeed);
+
+			userCreatedTokens.forEach((token) => {
+				chain = chain
+					.then((feed) =>
+						deleteUserPrimitive(slug, token, feed?.version).catch(() => {
+							// Best-effort: a cleanup failure never reverses the group removal and
+							// never blocks the deletes after it.
+						})
+					)
+					.then(() => refreshFeed(slug));
+			});
+
+			return chain.then(() => onBusy(false));
+		})
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+			throw err;
+		});
 }

--- a/src/style-library/helpers/palette-flows.js
+++ b/src/style-library/helpers/palette-flows.js
@@ -47,7 +47,9 @@ import {
 	isDuplicatePaletteLabel,
 	newSwatchValue,
 	nextCustomColorSlug,
+	removeGroupFromGroups,
 	removeSwatchFromGroups,
+	renameGroupInGroups,
 	renameSwatchInGroups,
 	reorderGroupSwatches,
 	slugifyPaletteLabel,
@@ -768,4 +770,116 @@ export function addGroupFlow({
 			})
 		)
 		.then(() => token);
+}
+
+/**
+ * Rename a color group — a structure edit, written to the default palette node. Label only: the
+ * group's id is immutable, because `template_slot_for()` places minted swatches by group id and
+ * every non-default palette's stored deltas key their groups by the same ids — changing the id
+ * would silently misfile future colors and orphan existing deltas.
+ *
+ * @param {Object}   args
+ * @param {string}   args.namespace   The REST namespace.
+ * @param {string}   args.slug        The token library slug.
+ * @param {string}   args.defaultId   The listing's `$default` palette id.
+ * @param {string}   args.groupId     The group id to rename.
+ * @param {string}   args.label       The new label.
+ * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.refreshFeed Replaces the feed for a slug.
+ * @param {Function} args.onBusy      Called with a boolean as the chain starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} See `writeDefaultPaletteFlow`.
+ */
+export function renameGroupFlow({ namespace, slug, defaultId, groupId, label, reload, refreshFeed, onBusy, onError }) {
+	return writeDefaultPaletteFlow({
+		namespace,
+		slug,
+		defaultId,
+		edit: (groups) => renameGroupInGroups(groups, groupId, label),
+		reload,
+		refreshFeed,
+		onBusy,
+		onError,
+	});
+}
+
+/**
+ * Remove a color group and every swatch in it: strips the group from the default palette's
+ * structure first, then — for each user-created token the group carried — best-effort deletes
+ * the underlying primitive, one at a time.
+ *
+ * Same load-bearing order as `removeSwatchFlow`, for the same reason: `Token_Reference_Policy`
+ * never scans palette swatches, so nothing server-side blocks deleting a primitive a palette
+ * still references — safety comes entirely from the group-removal write landing first, which
+ * removes every one of its tokens from every palette's effective view before any primitive
+ * delete runs. Each cleanup delete swallows its own failure and refreshes the feed regardless,
+ * so a token that is legitimately blocked (aliased outside the palette layer) neither reverses
+ * the group removal nor wedges the deletes after it on a stale version.
+ *
+ * @param {Object}        args
+ * @param {string}        args.namespace         The REST namespace.
+ * @param {string}        args.slug              The token library slug.
+ * @param {string}        args.defaultId         The listing's `$default` palette id.
+ * @param {string}        args.groupId           The group id to remove.
+ * @param {Array<string>} args.userCreatedTokens The group's user-created swatch tokens — gates
+ *                                               ONLY the cleanup steps, never the group removal.
+ * @param {Function}      args.reload            Re-reads the listing (and the edited view).
+ * @param {Function}      args.refreshFeed       Replaces the feed for a slug; resolves with the
+ *                                               fresh feed payload, whose `version` each cleanup
+ *                                               delete needs.
+ * @param {Function}      args.onBusy            Called with a boolean as the chain starts and settles.
+ * @param {Function}      args.onError           Called with `{ message }` on failure of the
+ *                                               group-removal write.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once the group-removal write and every best-effort cleanup
+ *                          attempt settle; rejects only when the group-removal write itself
+ *                          fails (e.g. the last-group 400), after `onError`/`onBusy` have run.
+ */
+export function removeGroupFlow({
+	namespace,
+	slug,
+	defaultId,
+	groupId,
+	userCreatedTokens,
+	reload,
+	refreshFeed,
+	onBusy,
+	onError,
+}) {
+	onBusy(true);
+
+	return fetchPalette(namespace, defaultId, slug)
+		.then((view) => {
+			const groups = removeGroupFromGroups(stripEffectiveFlags(view.groups), groupId);
+
+			return savePalette(namespace, defaultId, { label: view.label, groups }, slug);
+		})
+		.then(() => reload())
+		.then(() => refreshFeed(slug))
+		.then((freshFeed) => {
+			let chain = Promise.resolve(freshFeed);
+
+			userCreatedTokens.forEach((token) => {
+				chain = chain
+					.then((feed) =>
+						deleteUserPrimitive(slug, token, feed?.version).catch(() => {
+							// Best-effort: a cleanup failure never reverses the group removal and
+							// never blocks the deletes after it.
+						})
+					)
+					.then(() => refreshFeed(slug));
+			});
+
+			return chain.then(() => onBusy(false));
+		})
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+			throw err;
+		});
 }

--- a/src/style-library/helpers/palettes.js
+++ b/src/style-library/helpers/palettes.js
@@ -434,3 +434,44 @@ export function newSwatchValue(groups, groupId) {
 export function isCustomColorToken(token) {
 	return typeof token === 'string' && token.startsWith(CUSTOM_COLOR_PREFIX);
 }
+
+/**
+ * Set the `label` of the group with `groupId`. The group's id is never touched — a group id is
+ * load-bearing server state (`Palettes_Controller::template_slot_for()` places swatches by group
+ * id), so a rename is a label-only edit by design, mirroring `renameSwatchInGroups`.
+ *
+ * @param {Array<Object>} groups  The write-payload groups array.
+ * @param {string}        groupId The target group's id.
+ * @param {string}        label   The new label.
+ *
+ * @since TBD
+ *
+ * @return {Array<Object>} A new groups array with the target group relabeled.
+ */
+export function renameGroupInGroups(groups, groupId, label) {
+	return (groups ?? []).map((group) => (group.id === groupId ? { ...group, label } : group));
+}
+
+/**
+ * Remove the group with `groupId` — and every swatch in it. Deliberately does NOT block removing
+ * the last remaining group: `guard_palette_shape()` rejects `groups: []` with "A palette must
+ * define at least one color group", and that server rule is the authority; the UI hides the
+ * affordance instead (the caller's concern, not this helper's).
+ *
+ * @param {Array<Object>} groups  The write-payload groups array.
+ * @param {string}        groupId The group id to remove.
+ *
+ * @since TBD
+ *
+ * @return {Array<Object>} A new groups array without the group; the same reference as `groups`
+ *         (a no-op) when `groupId` matches no group, so callers can detect the miss.
+ */
+export function removeGroupFromGroups(groups, groupId) {
+	const rows = groups ?? [];
+
+	if (!rows.some((group) => group.id === groupId)) {
+		return groups;
+	}
+
+	return rows.filter((group) => group.id !== groupId);
+}

--- a/src/style-library/helpers/palettes.js
+++ b/src/style-library/helpers/palettes.js
@@ -398,3 +398,44 @@ export function newSwatchValue(groups, groupId) {
 export function isCustomColorToken(token) {
 	return typeof token === 'string' && token.startsWith(CUSTOM_COLOR_PREFIX);
 }
+
+/**
+ * Set the `label` of the group with `groupId`. The group's id is never touched — a group id is
+ * load-bearing server state (`Palettes_Controller::template_slot_for()` places swatches by group
+ * id), so a rename is a label-only edit by design, mirroring `renameSwatchInGroups`.
+ *
+ * @param {Array<Object>} groups  The write-payload groups array.
+ * @param {string}        groupId The target group's id.
+ * @param {string}        label   The new label.
+ *
+ * @since TBD
+ *
+ * @return {Array<Object>} A new groups array with the target group relabeled.
+ */
+export function renameGroupInGroups(groups, groupId, label) {
+	return (groups ?? []).map((group) => (group.id === groupId ? { ...group, label } : group));
+}
+
+/**
+ * Remove the group with `groupId` — and every swatch in it. Deliberately does NOT block removing
+ * the last remaining group: `guard_palette_shape()` rejects `groups: []` with "A palette must
+ * define at least one color group", and that server rule is the authority; the UI hides the
+ * affordance instead (the caller's concern, not this helper's).
+ *
+ * @param {Array<Object>} groups  The write-payload groups array.
+ * @param {string}        groupId The group id to remove.
+ *
+ * @since TBD
+ *
+ * @return {Array<Object>} A new groups array without the group; the same reference as `groups`
+ *         (a no-op) when `groupId` matches no group, so callers can detect the miss.
+ */
+export function removeGroupFromGroups(groups, groupId) {
+	const rows = groups ?? [];
+
+	if (!rows.some((group) => group.id === groupId)) {
+		return groups;
+	}
+
+	return rows.filter((group) => group.id !== groupId);
+}

--- a/src/style-library/hooks/use-palettes.js
+++ b/src/style-library/hooks/use-palettes.js
@@ -187,16 +187,16 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 	// needs to reject; kept as a resolved Promise so existing `.then()` callers (e.g.
 	// `createPaletteFlow`, which opens the palette it just created) keep working unchanged.
 	//
-	// Deliberately does NOT touch `item`: `navigate({ scope: id })` merges onto the current route,
-	// so a swatch open in the panel stays open across a palette switch. That is intentional, not an
-	// oversight — swatch tokens are shared across palettes (structure lives on the default node —
-	// decision 1/4), so the open item stays valid, and clearing it on every switch would be a
-	// regression a user has to re-select through. This is Color Palette's own call, not something
-	// `helpers/route.js`/`useStyleLibraryRoute` should impose on every screen.
+	// Clears `item` as well as setting `scope`. A swatch token is valid on every palette (structure
+	// lives on the default node), so the panel *could* stay open across a switch — but its values
+	// would change underneath the user without them asking, which reads as the panel silently
+	// editing something else. Switching palettes is a context switch, so the selection resets with
+	// it. This is Color Palette's own call, not something `helpers/route.js` imposes on every
+	// screen.
 	const openPalette = useCallback(
 		(id) => {
 			setOpenError(null);
-			navigate({ scope: id });
+			navigate({ scope: id, item: '' });
 
 			return Promise.resolve();
 		},

--- a/src/style-library/hooks/use-palettes.js
+++ b/src/style-library/hooks/use-palettes.js
@@ -15,7 +15,9 @@ import {
 	addGroupFlow,
 	createPaletteFlow,
 	deletePaletteFlow,
+	removeGroupFlow,
 	removeSwatchFlow,
+	renameGroupFlow,
 	renamePaletteFlow,
 	reorderSwatchesFlow,
 	saveSwatchEditsFlow,
@@ -66,7 +68,8 @@ import { flattenSchemaTokens } from '../helpers/tokens';
  *                  clearOpenError, clearActivateError, clearCreateError, clearRenameError,
  *                  clearDeleteError, clearSaveError, clearStructureError,
  *                  openPalette, activatePalette, createPalette, renamePalette, deletePalette,
- *                  saveSwatchEdits, removeSwatch, addColor, addGroup, reorderSwatches }`.
+ *                  saveSwatchEdits, removeSwatch, addColor, addGroup, reorderSwatches,
+ *                  renameGroup, removeGroup }`.
  */
 export function usePalettes(feed, refreshFeed, route, navigate) {
 	const [listing, setListing] = useState({ defaultId: '', currentId: '', palettes: [] });
@@ -382,6 +385,54 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 		[namespace, slug, listing, reload, refreshFeed]
 	);
 
+	const renameGroup = useCallback(
+		(groupId, label) => {
+			setStructureError(null);
+			return renameGroupFlow({
+				namespace,
+				slug,
+				defaultId: listing.defaultId,
+				groupId,
+				label,
+				reload,
+				refreshFeed,
+				onBusy: setIsBusy,
+				onError: setStructureError,
+			});
+		},
+		[namespace, slug, listing, reload, refreshFeed]
+	);
+
+	const removeGroup = useCallback(
+		(groupId) => {
+			setStructureError(null);
+
+			// Same defense-in-depth as `removeSwatch`: trust the feed's own `userCreated` flag when
+			// the token has a feed entry, fall back to the prefix check for a token minted since the
+			// last feed refresh.
+			const group = (palette?.groups ?? []).find((row) => row.id === groupId);
+			const userCreatedTokens = (group?.swatches ?? [])
+				.map((swatch) => swatch.token)
+				.filter((token) => {
+					const feedEntry = feedTokens.find((entry) => entry.id === token);
+					return feedEntry ? Boolean(feedEntry.userCreated) : isCustomColorToken(token);
+				});
+
+			return removeGroupFlow({
+				namespace,
+				slug,
+				defaultId: listing.defaultId,
+				groupId,
+				userCreatedTokens,
+				reload,
+				refreshFeed,
+				onBusy: setIsBusy,
+				onError: setStructureError,
+			});
+		},
+		[namespace, slug, listing, palette, feedTokens, reload, refreshFeed]
+	);
+
 	return {
 		listing,
 		activeId: listing.currentId,
@@ -414,5 +465,7 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 		addColor,
 		addGroup,
 		reorderSwatches,
+		renameGroup,
+		removeGroup,
 	};
 }

--- a/src/style-library/hooks/use-palettes.js
+++ b/src/style-library/hooks/use-palettes.js
@@ -15,7 +15,9 @@ import {
 	addGroupFlow,
 	createPaletteFlow,
 	deletePaletteFlow,
+	removeGroupFlow,
 	removeSwatchFlow,
+	renameGroupFlow,
 	renamePaletteFlow,
 	reorderSwatchesFlow,
 	saveSwatchEditsFlow,
@@ -66,7 +68,8 @@ import { flattenSchemaTokens } from '../helpers/tokens';
  *                  clearOpenError, clearActivateError, clearCreateError, clearRenameError,
  *                  clearDeleteError, clearSaveError, clearStructureError,
  *                  openPalette, activatePalette, createPalette, renamePalette, deletePalette,
- *                  saveSwatchEdits, removeSwatch, addColor, addGroup, reorderSwatches }`.
+ *                  saveSwatchEdits, removeSwatch, addColor, addGroup, reorderSwatches,
+ *                  renameGroup, removeGroup }`.
  */
 export function usePalettes(feed, refreshFeed, route, navigate) {
 	const [listing, setListing] = useState({ defaultId: '', currentId: '', palettes: [], userCreated: [] });
@@ -388,6 +391,54 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 		[namespace, slug, listing, reload, refreshFeed]
 	);
 
+	const renameGroup = useCallback(
+		(groupId, label) => {
+			setStructureError(null);
+			return renameGroupFlow({
+				namespace,
+				slug,
+				defaultId: listing.defaultId,
+				groupId,
+				label,
+				reload,
+				refreshFeed,
+				onBusy: setIsBusy,
+				onError: setStructureError,
+			});
+		},
+		[namespace, slug, listing, reload, refreshFeed]
+	);
+
+	const removeGroup = useCallback(
+		(groupId) => {
+			setStructureError(null);
+
+			// Same defense-in-depth as `removeSwatch`: trust the feed's own `userCreated` flag when
+			// the token has a feed entry, fall back to the prefix check for a token minted since the
+			// last feed refresh.
+			const group = (palette?.groups ?? []).find((row) => row.id === groupId);
+			const userCreatedTokens = (group?.swatches ?? [])
+				.map((swatch) => swatch.token)
+				.filter((token) => {
+					const feedEntry = feedTokens.find((entry) => entry.id === token);
+					return feedEntry ? Boolean(feedEntry.userCreated) : isCustomColorToken(token);
+				});
+
+			return removeGroupFlow({
+				namespace,
+				slug,
+				defaultId: listing.defaultId,
+				groupId,
+				userCreatedTokens,
+				reload,
+				refreshFeed,
+				onBusy: setIsBusy,
+				onError: setStructureError,
+			});
+		},
+		[namespace, slug, listing, palette, feedTokens, reload, refreshFeed]
+	);
+
 	return {
 		listing,
 		activeId: listing.currentId,
@@ -420,5 +471,7 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 		addColor,
 		addGroup,
 		reorderSwatches,
+		renameGroup,
+		removeGroup,
 	};
 }

--- a/src/style-library/hooks/use-palettes.js
+++ b/src/style-library/hooks/use-palettes.js
@@ -186,16 +186,16 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 	// needs to reject; kept as a resolved Promise so existing `.then()` callers (e.g.
 	// `createPaletteFlow`, which opens the palette it just created) keep working unchanged.
 	//
-	// Deliberately does NOT touch `item`: `navigate({ scope: id })` merges onto the current route,
-	// so a swatch open in the panel stays open across a palette switch. That is intentional, not an
-	// oversight — swatch tokens are shared across palettes (structure lives on the default node —
-	// decision 1/4), so the open item stays valid, and clearing it on every switch would be a
-	// regression a user has to re-select through. This is Color Palette's own call, not something
-	// `helpers/route.js`/`useStyleLibraryRoute` should impose on every screen.
+	// Clears `item` as well as setting `scope`. A swatch token is valid on every palette (structure
+	// lives on the default node), so the panel *could* stay open across a switch — but its values
+	// would change underneath the user without them asking, which reads as the panel silently
+	// editing something else. Switching palettes is a context switch, so the selection resets with
+	// it. This is Color Palette's own call, not something `helpers/route.js` imposes on every
+	// screen.
 	const openPalette = useCallback(
 		(id) => {
 			setOpenError(null);
-			navigate({ scope: id });
+			navigate({ scope: id, item: '' });
 
 			return Promise.resolve();
 		},


### PR DESCRIPTION
Rename and delete a color group — the last gap in the screen.

## What's here

- A `⋯` overflow menu on each group heading, via an optional actions slot on `SectionHeading` and a `groupActions` render prop on `SwatchGrid`. Hidden at rest with `opacity`, never `display` — the trigger stays in the tab order and reveals on `:focus-within`, so the menu is fully keyboard-operable.
- **Rename group** — a modal seeded with the current label. **The group id stays fixed.** `Palettes_Controller::template_slot_for()` looks the group up by id to decide where a newly minted swatch lands, so a changing id would silently misfile new colors into a fallback group.
- **Delete group** — a confirmation naming the group and its swatch count. Hidden when only one group remains, since the server rejects a palette with no groups. User-created tokens in the group get the same row-first, best-effort cleanup a single swatch delete uses.

Both operations are structural, so both write the default palette node through the existing shared write path.

## Also here

Switching palettes now closes the settings panel and clears the selection. A swatch token is valid on every palette, so the panel could stay open — but its values would change underneath the user without them asking, which reads as the panel silently editing something else.

## Test plan

- `bun run test`.
- In wp-admin, verified: renaming a group keeps its id, so a color added afterwards still lands in that group rather than the fallback; deleting a group removes it from every palette and cleans up its minted tokens; the panel closes when its open swatch was in the deleted group; the Delete item is absent at one remaining group; the menu works by keyboard alone and its portalled content resolves the `--kb-sl-*` layer.


## Screenshots

**Group overflow menu**
<img width="1528" height="804" alt="pr5-group-menu" src="https://github.com/user-attachments/assets/4ef675a1-a106-47d9-a206-d57b9ae04df4" />

**Delete group confirmation**
<img width="1528" height="804" alt="pr5-delete-group-modal" src="https://github.com/user-attachments/assets/8fef3ca0-8414-420b-9e06-36f60c7acfcc" />