### PR TITLE
[DTM] SOFT-4071: Token label overrides

### DIFF
--- a/includes/resources/Design_Tokens/Admin/Feed/Builder.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Builder.php
@@ -66,10 +66,11 @@ final class Builder {
 	 *                                                                          request and visibly correcting itself once that arrives.
 	 * @param array<string, array<string, mixed>>                   $responsive id => raw authored responsive / clamp shape, for
 	 *                                                                          tokens that carry one (for editor hydration).
+	 * @param array<string, string>                                 $labels     id => display-label override for this library.
 	 *
 	 * @return array<string, mixed> The localized payload.
 	 */
-	public function build( array $values, bool $resolved, array $presets, array $rest, string $version, string $slug, string $title = '', array $responsive = [] ): array {
+	public function build( array $values, bool $resolved, array $presets, array $rest, string $version, string $slug, string $title = '', array $responsive = [], array $labels = [] ): array {
 		$active = $this->registry->is_active();
 
 		return [
@@ -80,12 +81,39 @@ final class Builder {
 			// Carried alongside the slug so the library selector can name the active library on first
 			// paint, before its REST list has loaded and any row is available to look the title up in.
 			'title'      => $title,
-			'schema'     => $active ? $this->registry->to_ui_schema() : [ 'groups' => [] ],
+			'schema'     => $active ? $this->apply_label_overrides( $this->registry->to_ui_schema(), $labels ) : [ 'groups' => [] ],
 			'values'     => $active ? $values : [],
 			'presets'    => $active ? $presets : [],
 			'presetNav'  => $active ? $this->preset_nav->all() : [],
 			'responsive' => $active ? $responsive : [],
 			'rest'       => $rest,
 		];
+	}
+
+	/**
+	 * Overlay per-library display-label overrides onto the registry's UI schema. Every token row
+	 * gains a `labelOverridden` flag (stable shape whether or not any override exists) so the
+	 * admin UI can offer a reset affordance and distinguish a custom name from a declared one; an
+	 * override for an id the schema does not contain is ignored (stale data, pruned by the write
+	 * surface on its next save of that id).
+	 *
+	 * @since TBD
+	 *
+	 * @param array{groups: array<string, array<int, array<string, mixed>>>} $schema The registry UI schema.
+	 * @param array<string, string>                                          $labels id => override label.
+	 *
+	 * @return array{groups: array<string, array<int, array<string, mixed>>>} The schema with effective labels applied.
+	 */
+	private function apply_label_overrides( array $schema, array $labels ): array {
+		foreach ( $schema['groups'] as $group => $rows ) {
+			foreach ( $rows as $i => $row ) {
+				$override = $labels[ $row['id'] ] ?? null;
+
+				$schema['groups'][ $group ][ $i ]['label']           = $override ?? $row['label'];
+				$schema['groups'][ $group ][ $i ]['labelOverridden'] = $override !== null;
+			}
+		}
+
+		return $schema;
 	}
 }

--- a/includes/resources/Design_Tokens/Admin/Feed/Builder.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Builder.php
@@ -66,10 +66,11 @@ final class Builder {
 	 *                                                                          the admin page can name the library on first paint, without
 	 *                                                                          waiting on the separate libraries request and visibly correcting
 	 *                                                                          itself once that arrives.
+	 * @param array<string, string>                                 $labels     id => display-label override for this library.
 	 *
 	 * @return array<string, mixed> The localized payload.
 	 */
-	public function build( array $values, bool $resolved, array $presets, array $rest, string $version, string $slug, array $responsive = [], string $title = '' ): array {
+	public function build( array $values, bool $resolved, array $presets, array $rest, string $version, string $slug, array $responsive = [], string $title = '', array $labels = [] ): array {
 		$active = $this->registry->is_active();
 
 		return [
@@ -80,12 +81,39 @@ final class Builder {
 			// Outside the `$active` gate below: a label is not token data, and a deactivated registry
 			// still renders a page that has to name the library it is showing.
 			'title'      => $title,
-			'schema'     => $active ? $this->registry->to_ui_schema() : [ 'groups' => [] ],
+			'schema'     => $active ? $this->apply_label_overrides( $this->registry->to_ui_schema(), $labels ) : [ 'groups' => [] ],
 			'values'     => $active ? $values : [],
 			'presets'    => $active ? $presets : [],
 			'presetNav'  => $active ? $this->preset_nav->all() : [],
 			'responsive' => $active ? $responsive : [],
 			'rest'       => $rest,
 		];
+	}
+
+	/**
+	 * Overlay per-library display-label overrides onto the registry's UI schema. Every token row
+	 * gains a `labelOverridden` flag (stable shape whether or not any override exists) so the
+	 * admin UI can offer a reset affordance and distinguish a custom name from a declared one; an
+	 * override for an id the schema does not contain is ignored (stale data, pruned by the write
+	 * surface on its next save of that id).
+	 *
+	 * @since TBD
+	 *
+	 * @param array{groups: array<string, array<int, array<string, mixed>>>} $schema The registry UI schema.
+	 * @param array<string, string>                                          $labels id => override label.
+	 *
+	 * @return array{groups: array<string, array<int, array<string, mixed>>>} The schema with effective labels applied.
+	 */
+	private function apply_label_overrides( array $schema, array $labels ): array {
+		foreach ( $schema['groups'] as $group => $rows ) {
+			foreach ( $rows as $i => $row ) {
+				$override = $labels[ $row['id'] ] ?? null;
+
+				$schema['groups'][ $group ][ $i ]['label']           = $override ?? $row['label'];
+				$schema['groups'][ $group ][ $i ]['labelOverridden'] = $override !== null;
+			}
+		}
+
+		return $schema;
 	}
 }

--- a/includes/resources/Design_Tokens/Admin/Feed/Feed_Assembler.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Feed_Assembler.php
@@ -3,6 +3,7 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
@@ -23,6 +24,10 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
  * (alias cycle / dangling alias from a raw DB write) yields an empty, `resolved:false` feed rather
  * than a fatal, so the caller still gets structure. The fail-closed case (registry deactivated) is
  * handled inside the builder.
+ *
+ * The per-token label-override read also lives here rather than in either emitter: it is applied
+ * inside Builder::build(), so both {@see Localizer} and {@see \KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Feed_Controller}
+ * get the overridden labels automatically instead of one of them silently missing them.
  *
  * @since TBD
  */
@@ -74,26 +79,38 @@ final class Feed_Assembler {
 	private Responsive_Feed $responsive_feed;
 
 	/**
+	 * Reads the tokenLabels display-label override map out of the stored document.
+	 *
 	 * @since TBD
 	 *
-	 * @param Token_Resolver  $resolver        The token resolver.
-	 * @param Token_Store     $store           The token store.
-	 * @param Presets         $preset_feed     The presets section builder.
-	 * @param Builder         $builder         The pure payload assembler.
-	 * @param Responsive_Feed $responsive_feed The responsive / clamp shape extractor.
+	 * @var Token_Label_Index
+	 */
+	private Token_Label_Index $label_index;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Resolver    $resolver        The token resolver.
+	 * @param Token_Store       $store           The token store.
+	 * @param Presets           $preset_feed     The presets section builder.
+	 * @param Builder           $builder         The pure payload assembler.
+	 * @param Responsive_Feed   $responsive_feed The responsive / clamp shape extractor.
+	 * @param Token_Label_Index $label_index     Reads the tokenLabels override map.
 	 */
 	public function __construct(
 		Token_Resolver $resolver,
 		Token_Store $store,
 		Presets $preset_feed,
 		Builder $builder,
-		Responsive_Feed $responsive_feed
+		Responsive_Feed $responsive_feed,
+		Token_Label_Index $label_index
 	) {
 		$this->resolver        = $resolver;
 		$this->store           = $store;
 		$this->preset_feed     = $preset_feed;
 		$this->builder         = $builder;
 		$this->responsive_feed = $responsive_feed;
+		$this->label_index     = $label_index;
 	}
 
 	/**
@@ -129,7 +146,8 @@ final class Feed_Assembler {
 			$version,
 			$slug,
 			$responsive,
-			$this->store->get_title( $slug )
+			$this->store->get_title( $slug ),
+			$this->label_index->all( $this->read_document( $slug ) )
 		);
 	}
 
@@ -148,5 +166,28 @@ final class Feed_Assembler {
 			'namespace' => Controller::namespace(),
 			'nonce'     => wp_create_nonce( 'wp_rest' ),
 		];
+	}
+
+	/**
+	 * Read and decode the stored overrides-only document for a library, empty when absent or
+	 * unreadable. Builder stays pure (no I/O, per its own docblock), so this owns the decode the
+	 * label overlay needs, alongside the store access this class already does for the version.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token library slug.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function read_document( string $slug ): array {
+		$raw = $this->store->get_document( $slug );
+
+		if ( $raw === '' ) {
+			return [];
+		}
+
+		$decoded = json_decode( $raw, true );
+
+		return is_array( $decoded ) ? $decoded : [];
 	}
 }

--- a/includes/resources/Design_Tokens/Admin/Feed/Feed_Assembler.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Feed_Assembler.php
@@ -3,6 +3,7 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
@@ -23,6 +24,10 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
  * (alias cycle / dangling alias from a raw DB write) yields an empty, `resolved:false` feed rather
  * than a fatal, so the caller still gets structure. The fail-closed case (registry deactivated) is
  * handled inside the builder.
+ *
+ * The per-token label-override read also lives here rather than in either emitter: it is applied
+ * inside Builder::build(), so both {@see Localizer} and {@see \KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Feed_Controller}
+ * get the overridden labels automatically instead of one of them silently missing them.
  *
  * @since TBD
  */
@@ -74,26 +79,38 @@ final class Feed_Assembler {
 	private Responsive_Feed $responsive_feed;
 
 	/**
+	 * Reads the tokenLabels display-label override map out of the stored document.
+	 *
 	 * @since TBD
 	 *
-	 * @param Token_Resolver  $resolver        The token resolver.
-	 * @param Token_Store     $store           The token store.
-	 * @param Presets         $preset_feed     The presets section builder.
-	 * @param Builder         $builder         The pure payload assembler.
-	 * @param Responsive_Feed $responsive_feed The responsive / clamp shape extractor.
+	 * @var Token_Label_Index
+	 */
+	private Token_Label_Index $label_index;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Resolver    $resolver        The token resolver.
+	 * @param Token_Store       $store           The token store.
+	 * @param Presets           $preset_feed     The presets section builder.
+	 * @param Builder           $builder         The pure payload assembler.
+	 * @param Responsive_Feed   $responsive_feed The responsive / clamp shape extractor.
+	 * @param Token_Label_Index $label_index     Reads the tokenLabels override map.
 	 */
 	public function __construct(
 		Token_Resolver $resolver,
 		Token_Store $store,
 		Presets $preset_feed,
 		Builder $builder,
-		Responsive_Feed $responsive_feed
+		Responsive_Feed $responsive_feed,
+		Token_Label_Index $label_index
 	) {
 		$this->resolver        = $resolver;
 		$this->store           = $store;
 		$this->preset_feed     = $preset_feed;
 		$this->builder         = $builder;
 		$this->responsive_feed = $responsive_feed;
+		$this->label_index     = $label_index;
 	}
 
 	/**
@@ -121,7 +138,17 @@ final class Feed_Assembler {
 			$resolved = false; // Corrupt stored document. Fail open: ship structure only.
 		}
 
-		return $this->builder->build( $values, $resolved, $presets, $this->rest(), $version, $slug, $this->title( $slug ), $responsive );
+		return $this->builder->build(
+			$values,
+			$resolved,
+			$presets,
+			$this->rest(),
+			$version,
+			$slug,
+			$this->title( $slug ),
+			$responsive,
+			$this->label_index->all( $this->read_document( $slug ) )
+		);
 	}
 
 	/**
@@ -159,5 +186,28 @@ final class Feed_Assembler {
 			'namespace' => Controller::namespace(),
 			'nonce'     => wp_create_nonce( 'wp_rest' ),
 		];
+	}
+
+	/**
+	 * Read and decode the stored overrides-only document for a library, empty when absent or
+	 * unreadable. Builder stays pure (no I/O, per its own docblock), so this owns the decode the
+	 * label overlay needs, alongside the store access this class already does for the version.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token library slug.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function read_document( string $slug ): array {
+		$raw = $this->store->get_document( $slug );
+
+		if ( $raw === '' ) {
+			return [];
+		}
+
+		$decoded = json_decode( $raw, true );
+
+		return is_array( $decoded ) ? $decoded : [];
 	}
 }

--- a/includes/resources/Design_Tokens/Document/Token_Label_Index.php
+++ b/includes/resources/Design_Tokens/Document/Token_Label_Index.php
@@ -19,6 +19,8 @@ final class Token_Label_Index {
 	 * All label overrides, keyed by canonical dot-path id. Read-side fail-soft: entries whose
 	 * key or value is not a non-empty string are dropped rather than surfaced, so a
 	 * hand-corrupted section degrades to "no override" instead of a type error downstream.
+	 * A whitespace-only label counts as empty — it would render as a nameless token, which is
+	 * the state an override exists to prevent.
 	 *
 	 * @since TBD
 	 *
@@ -36,7 +38,7 @@ final class Token_Label_Index {
 		$labels = [];
 
 		foreach ( $map as $id => $label ) {
-			if ( is_string( $id ) && $id !== '' && is_string( $label ) && $label !== '' ) {
+			if ( is_string( $id ) && $id !== '' && is_string( $label ) && trim( $label ) !== '' ) {
 				$labels[ $id ] = $label;
 			}
 		}
@@ -72,7 +74,8 @@ final class Token_Label_Index {
 	 * Store an override. An empty label is refused at the API level — storing an empty label
 	 * is impossible by construction, not merely validated against: clearing is remove(), never
 	 * set( '' ). The controller trims and routes '' to the clear path before this is ever
-	 * called; the throw guards future callers.
+	 * called; the throw guards future callers. Whitespace-only is empty here too, matching the
+	 * read side — an entry all() drops must not be storable in the first place.
 	 *
 	 * @since TBD
 	 *
@@ -85,7 +88,7 @@ final class Token_Label_Index {
 	 * @return array<string, mixed>
 	 */
 	public function set( array $document, string $id, string $label ): array {
-		if ( $label === '' ) {
+		if ( trim( $label ) === '' ) {
 			throw new InvalidArgumentException( 'A token label override cannot be empty; use remove() to clear it.' );
 		}
 

--- a/includes/resources/Design_Tokens/Document/Token_Label_Index.php
+++ b/includes/resources/Design_Tokens/Document/Token_Label_Index.php
@@ -1,0 +1,206 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Document;
+
+use InvalidArgumentException;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+
+/**
+ * Reads and writes the tokenLabels display-label override map — a flat { token id => label }
+ * string map in the module's $extensions namespace. Authoring metadata only: the effective
+ * document builder strips $extensions, so an override can never reach projected CSS.
+ * Every mutating method returns the updated document; the original is not modified.
+ *
+ * @since TBD
+ */
+final class Token_Label_Index {
+
+	/**
+	 * All label overrides, keyed by canonical dot-path id. Read-side fail-soft: entries whose
+	 * key or value is not a non-empty string are dropped rather than surfaced, so a
+	 * hand-corrupted section degrades to "no override" instead of a type error downstream.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 *
+	 * @return array<string, string>
+	 */
+	public function all( array $document ): array {
+		$map = $this->read_map( $document );
+
+		if ( ! is_array( $map ) ) {
+			return [];
+		}
+
+		$labels = [];
+
+		foreach ( $map as $id => $label ) {
+			if ( is_string( $id ) && $id !== '' && is_string( $label ) && $label !== '' ) {
+				$labels[ $id ] = $label;
+			}
+		}
+
+		return $labels;
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param string               $id Canonical dot-path id.
+	 *
+	 * @return bool
+	 */
+	public function has( array $document, string $id ): bool {
+		return isset( $this->all( $document )[ $id ] );
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param string               $id
+	 *
+	 * @return string|null The override, or null when none is stored.
+	 */
+	public function label_for( array $document, string $id ): ?string {
+		return $this->all( $document )[ $id ] ?? null;
+	}
+
+	/**
+	 * Store an override. An empty label is refused at the API level — storing an empty label
+	 * is impossible by construction, not merely validated against: clearing is remove(), never
+	 * set( '' ). The controller trims and routes '' to the clear path before this is ever
+	 * called; the throw guards future callers.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param string               $id
+	 * @param string               $label
+	 *
+	 * @throws InvalidArgumentException When the label is empty.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function set( array $document, string $id, string $label ): array {
+		if ( $label === '' ) {
+			throw new InvalidArgumentException( 'A token label override cannot be empty; use remove() to clear it.' );
+		}
+
+		$ext = Extensions::get_extensions_key();
+		$ns  = Extensions::get_namespace();
+		$sec = Extensions::get_section_token_labels();
+
+		$document = $this->ensure_path( $document );
+
+		/** @var array<string, mixed> $ext_data */
+		$ext_data = $document[ $ext ];
+		/** @var array<string, mixed> $ns_data */
+		$ns_data = $ext_data[ $ns ];
+		/** @var array<string, mixed> $sec_data */
+		$sec_data = $ns_data[ $sec ];
+
+		$sec_data[ $id ]  = $label;
+		$ns_data[ $sec ]  = $sec_data;
+		$ext_data[ $ns ]  = $ns_data;
+		$document[ $ext ] = $ext_data;
+
+		return $document;
+	}
+
+	/**
+	 * Remove an override. A no-op (same document returned) when none is stored.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param string               $id
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function remove( array $document, string $id ): array {
+		if ( ! $this->has( $document, $id ) ) {
+			return $document;
+		}
+
+		$ext = Extensions::get_extensions_key();
+		$ns  = Extensions::get_namespace();
+		$sec = Extensions::get_section_token_labels();
+
+		/** @var array<string, mixed> $ext_data */
+		$ext_data = $document[ $ext ];
+		/** @var array<string, mixed> $ns_data */
+		$ns_data = $ext_data[ $ns ];
+		/** @var array<string, mixed> $sec_data */
+		$sec_data = $ns_data[ $sec ];
+
+		unset( $sec_data[ $id ] );
+
+		$ns_data[ $sec ]  = $sec_data;
+		$ext_data[ $ns ]  = $ns_data;
+		$document[ $ext ] = $ext_data;
+
+		return $document;
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 *
+	 * @return mixed
+	 */
+	private function read_map( array $document ) {
+		$ext_data = $document[ Extensions::get_extensions_key() ] ?? null;
+
+		if ( ! is_array( $ext_data ) ) {
+			return null;
+		}
+
+		$ns_data = $ext_data[ Extensions::get_namespace() ] ?? null;
+
+		if ( ! is_array( $ns_data ) ) {
+			return null;
+		}
+
+		return $ns_data[ Extensions::get_section_token_labels() ] ?? null;
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function ensure_path( array $document ): array {
+		$ext = Extensions::get_extensions_key();
+		$ns  = Extensions::get_namespace();
+		$sec = Extensions::get_section_token_labels();
+
+		if ( ! isset( $document[ $ext ] ) || ! is_array( $document[ $ext ] ) ) {
+			$document[ $ext ] = [];
+		}
+
+		/** @var array<string, mixed> $ext_data */
+		$ext_data = $document[ $ext ];
+
+		if ( ! isset( $ext_data[ $ns ] ) || ! is_array( $ext_data[ $ns ] ) ) {
+			$ext_data[ $ns ]  = [];
+			$document[ $ext ] = $ext_data;
+		}
+
+		/** @var array<string, mixed> $ns_data */
+		$ns_data = $ext_data[ $ns ];
+
+		if ( ! isset( $ns_data[ $sec ] ) || ! is_array( $ns_data[ $sec ] ) ) {
+			$ns_data[ $sec ]  = [];
+			$ext_data[ $ns ]  = $ns_data;
+			$document[ $ext ] = $ext_data;
+		}
+
+		return $document;
+	}
+}

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -141,7 +141,7 @@ final class Documents_Controller extends Controller {
 	 *
 	 * @var string
 	 */
-	private const ID_PARAM = 'id';
+	private const LABELS_ID_PARAM = 'id';
 
 	/**
 	 * The id path segment for the labels sub-route. Same grammar as PATH_ROUTE — a token id is a dot-path.
@@ -150,7 +150,7 @@ final class Documents_Controller extends Controller {
 	 *
 	 * @var string
 	 */
-	private const ID_ROUTE = '(?P<' . self::ID_PARAM . '>[\w.-]+)';
+	private const LABELS_ID_ROUTE = '(?P<' . self::LABELS_ID_PARAM . '>[\w.-]+)';
 
 	/**
 	 * The request parameter that carries the display-label override text on a labels write.
@@ -492,7 +492,7 @@ final class Documents_Controller extends Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/' . self::SLUG_ROUTE . '/' . self::LABELS_ROUTE . '/' . self::ID_ROUTE,
+			'/' . $this->rest_base . '/' . self::SLUG_ROUTE . '/' . self::LABELS_ROUTE . '/' . self::LABELS_ID_ROUTE,
 			[
 				[
 					// PUT only: setting and clearing (empty label) are the same idempotent
@@ -981,7 +981,7 @@ final class Documents_Controller extends Controller {
 	 */
 	public function set_label( $request ) {
 		$slug  = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
-		$id    = Cast::to_string( $request->get_param( self::ID_PARAM ) );
+		$id    = Cast::to_string( $request->get_param( self::LABELS_ID_PARAM ) );
 		$label = trim( Cast::to_string( $request->get_param( self::LABEL_PARAM ) ) );
 
 		if ( ! $this->is_known_library( $slug ) ) {
@@ -1029,7 +1029,7 @@ final class Documents_Controller extends Controller {
 	 */
 	public function delete_label( $request ) {
 		$slug = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
-		$id   = Cast::to_string( $request->get_param( self::ID_PARAM ) );
+		$id   = Cast::to_string( $request->get_param( self::LABELS_ID_PARAM ) );
 
 		if ( ! $this->is_known_library( $slug ) ) {
 			return $this->not_found( $slug );
@@ -1790,13 +1790,13 @@ final class Documents_Controller extends Controller {
 		return array_merge(
 			$this->get_slug_params(),
 			[
-				self::ID_PARAM      => [
+				self::LABELS_ID_PARAM => [
 					'description' => __( 'The token\'s canonical dot-path id, e.g. semantic.color.button-bg.', 'kadence-blocks' ),
 					'type'        => 'string',
 					'required'    => true,
 					'pattern'     => '^[\w.-]+$',
 				],
-				self::VERSION_PARAM => [
+				self::VERSION_PARAM   => [
 					'description'       => __( 'The version the client last read; empty for a first write. A mismatch is rejected with HTTP 409.', 'kadence-blocks' ),
 					'type'              => 'string',
 					'required'          => true,

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -7,9 +7,11 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Document_Path;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Reserved_Namespace;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Reference_Policy;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Document_Validator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
@@ -124,6 +126,52 @@ final class Documents_Controller extends Controller {
 	private const TITLE_ROUTE = 'title';
 
 	/**
+	 * The sub-route, relative to a single library, that collects the per-token label-override endpoints.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const LABELS_ROUTE = 'labels';
+
+	/**
+	 * The request parameter that carries a single token's canonical dot-path id, on the labels sub-route.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const ID_PARAM = 'id';
+
+	/**
+	 * The id path segment for the labels sub-route. Same grammar as PATH_ROUTE — a token id is a dot-path.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const ID_ROUTE = '(?P<' . self::ID_PARAM . '>[\w.-]+)';
+
+	/**
+	 * The request parameter that carries the display-label override text on a labels write.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const LABEL_PARAM = 'label';
+
+	/**
+	 * The request parameter that carries the client's last-read version, for the version-conditional
+	 * guard on the labels sub-route.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const VERSION_PARAM = 'version';
+
+	/**
 	 * The dot-path path segment for the single-token routes. The character class matches the alias
 	 * grammar (a dot-path) minus the braces, so a token is addressable as a sub-resource of its library.
 	 *
@@ -216,6 +264,24 @@ final class Documents_Controller extends Controller {
 	private Responsive_Feed $responsive_feed;
 
 	/**
+	 * The token registry, used only to 404 a label write against an unregistered id.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * Reads and writes the tokenLabels display-label override map.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Label_Index
+	 */
+	private Token_Label_Index $label_index;
+
+	/**
 	 * Memoized item schema for this request. Null until first built.
 	 *
 	 * @since TBD
@@ -245,6 +311,8 @@ final class Documents_Controller extends Controller {
 	 * @param User_Primitive_Document_Validator $user_primitive_validator Enforces the user-primitive document invariant.
 	 * @param Token_Reference_Policy            $reference_policy      Scans for alias references to a user primitive.
 	 * @param Responsive_Feed                   $responsive_feed       Extracts the authored responsive / clamp shape per token.
+	 * @param Token_Registry                    $registry              The token registry, for the labels sub-route's unregistered-id 404.
+	 * @param Token_Label_Index                 $label_index           Reads and writes the tokenLabels override map.
 	 */
 	public function __construct(
 		Token_Store $store,
@@ -255,7 +323,9 @@ final class Documents_Controller extends Controller {
 		User_Primitive_Index $user_primitive_index,
 		User_Primitive_Document_Validator $user_primitive_validator,
 		Token_Reference_Policy $reference_policy,
-		Responsive_Feed $responsive_feed
+		Responsive_Feed $responsive_feed,
+		Token_Registry $registry,
+		Token_Label_Index $label_index
 	) {
 		$this->store                    = $store;
 		$this->resolver                 = $resolver;
@@ -266,6 +336,8 @@ final class Documents_Controller extends Controller {
 		$this->user_primitive_validator = $user_primitive_validator;
 		$this->reference_policy         = $reference_policy;
 		$this->responsive_feed          = $responsive_feed;
+		$this->registry                 = $registry;
+		$this->label_index              = $label_index;
 		$this->rest_base                = 'documents';
 	}
 
@@ -402,6 +474,31 @@ final class Documents_Controller extends Controller {
 					'args'                => $this->get_token_path_params(),
 				],
 				'schema' => [ $this, 'get_token_schema' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/' . self::SLUG_ROUTE . '/' . self::LABELS_ROUTE . '/' . self::ID_ROUTE,
+			[
+				[
+					// PUT only: setting and clearing (empty label) are the same idempotent
+					// replace-the-override operation; there is no partial update of one label.
+					'methods'             => 'PUT',
+					'callback'            => [ $this, 'set_label' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_label_params(),
+				],
+				[
+					// DELETE uses the same capability as PUT — clearing an override is an update to
+					// the document, not a resource removal, so the two verbs of one operation cannot
+					// diverge on permission.
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => [ $this, 'delete_label' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_label_delete_params(),
+				],
+				'schema' => [ $this, 'get_item_schema' ],
 			]
 		);
 	}
@@ -816,6 +913,90 @@ final class Documents_Controller extends Controller {
 	}
 
 	/**
+	 * Set or clear a token's display-label override (PUT /documents/{slug}/labels/{id}).
+	 *
+	 * An empty or whitespace-only label is a clear, exactly equivalent to DELETE, so the UI needs
+	 * no separate reset path. A user-created id routes to the existing userPrimitives label
+	 * instead of tokenLabels — one id never carries two competing label stores; the registrar sync
+	 * then carries the rename into the registry, and the tokenLabels remove() is defense in depth
+	 * against a hand-written entry for the same id.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function set_label( $request ) {
+		$slug  = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+		$id    = Cast::to_string( $request->get_param( self::ID_PARAM ) );
+		$label = trim( Cast::to_string( $request->get_param( self::LABEL_PARAM ) ) );
+
+		if ( ! $this->is_known_library( $slug ) ) {
+			return $this->not_found( $slug );
+		}
+
+		// Only a registered token can be renamed; a typo would otherwise accumulate silently as a
+		// tokenLabels entry with nothing to attach to.
+		if ( ! $this->registry->has( $id ) ) {
+			return $this->unknown_token( $id );
+		}
+
+		$error = $this->guard_client_version( $slug, Cast::to_string( $request->get_param( self::VERSION_PARAM ) ) );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$stored = $this->read_stored_document( $slug );
+
+		if ( $label === '' ) {
+			return $this->persist_label_clear( $stored, $slug, $id );
+		}
+
+		if ( $this->user_primitive_index->has( $stored, $id ) ) {
+			$candidate = $this->user_primitive_index->add( $stored, $id, $label );
+			$candidate = $this->label_index->remove( $candidate, $id );
+		} else {
+			$candidate = $this->label_index->set( $stored, $id, $label );
+		}
+
+		return $this->persist_metadata_candidate( $candidate, $slug );
+	}
+
+	/**
+	 * Clear a token's display-label override (DELETE /documents/{slug}/labels/{id}), reverting a
+	 * baseline id to its declared label and a user-created id to the humanized-last-segment
+	 * fallback ({@see Token_Definition::from_user_primitive()}) — never a nameless token.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_label( $request ) {
+		$slug = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+		$id   = Cast::to_string( $request->get_param( self::ID_PARAM ) );
+
+		if ( ! $this->is_known_library( $slug ) ) {
+			return $this->not_found( $slug );
+		}
+
+		if ( ! $this->registry->has( $id ) ) {
+			return $this->unknown_token( $id );
+		}
+
+		$error = $this->guard_client_version( $slug, Cast::to_string( $request->get_param( self::VERSION_PARAM ) ) );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		return $this->persist_label_clear( $this->read_stored_document( $slug ), $slug, $id );
+	}
+
+	/**
 	 * Validate that the token dot-path begins with a real token layer and names a token below it.
 	 *
 	 * Used as the path argument's validate_callback so a path into "$extensions" (any non-layer root), a
@@ -1131,6 +1312,125 @@ final class Documents_Controller extends Controller {
 	}
 
 	/**
+	 * Persist a candidate whose only change is inside an id-keyed authoring-metadata $extensions
+	 * section (token labels). Deliberately skips the full DTCG validator and the resolver dry-run:
+	 * the index helpers' edits are mechanically confined to a section the effective-document
+	 * builder strips, so they cannot introduce grammar or alias problems — and running the full
+	 * pipeline would make a rename impossible in any library whose stored document does not
+	 * currently validate, for reasons unrelated to the rename (the same trap the dedicated
+	 * single-token routes avoid by never re-validating the whole document either). The section is
+	 * still validated whenever the full document is (bulk POST/PATCH/PUT), via its validator branch.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $candidate The candidate document with the label edit applied.
+	 * @param string               $slug      The token library slug.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	private function persist_metadata_candidate( array $candidate, string $slug ) {
+		$expected_version = $this->store->get_version( $slug );
+		$status           = $expected_version !== '' ? WP_Http::OK : WP_Http::CREATED;
+
+		if ( $candidate === [] ) {
+			return $this->persist( '', $slug, '', $status, $expected_version );
+		}
+
+		$encoded = wp_json_encode( $candidate );
+
+		if ( $encoded === false ) {
+			return new WP_Error(
+				'rest_design_tokens_save_failed',
+				__( 'The design token document could not be encoded.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::INTERNAL_SERVER_ERROR,
+					'slug'   => $slug,
+				]
+			);
+		}
+
+		return $this->persist( $encoded, $slug, '', $status, $expected_version );
+	}
+
+	/**
+	 * Clear a token's label override: a user-created id's rename lands in userPrimitives, so
+	 * clearing resets that section's label to '' rather than removing a tokenLabels entry — which
+	 * Token_Definition::from_user_primitive() falls back from to a humanized last segment, so the
+	 * token stays named rather than becoming nameless. A baseline id removes its tokenLabels entry.
+	 * Either path is idempotent: when nothing changes, the candidate equals the stored document and
+	 * this returns the current item without a write, mirroring delete_token()'s idempotency.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $stored The stored document to clear the override from.
+	 * @param string               $slug   The token library slug.
+	 * @param string               $id     The token id.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	private function persist_label_clear( array $stored, string $slug, string $id ) {
+		if ( $this->user_primitive_index->has( $stored, $id ) ) {
+			$candidate = $this->user_primitive_index->add( $stored, $id, '' );
+		} else {
+			$candidate = $this->label_index->remove( $stored, $id );
+		}
+
+		if ( $candidate === $stored ) {
+			return new WP_REST_Response( $this->prepare_item( $slug ), WP_Http::OK );
+		}
+
+		return $this->persist_metadata_candidate( $candidate, $slug );
+	}
+
+	/**
+	 * Client-conditional guard for the labels sub-route, mirroring the write pipeline's version
+	 * check: the stored version must equal what the client last read (both '' for a first write).
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug           The token library slug.
+	 * @param string $client_version The version the client last read. Empty only for a first write.
+	 *
+	 * @return WP_Error|null
+	 */
+	private function guard_client_version( string $slug, string $client_version ): ?WP_Error {
+		$stored = $this->store->get_version( $slug );
+
+		if ( $stored === $client_version ) {
+			return null;
+		}
+
+		return new WP_Error(
+			'rest_design_tokens_conflict',
+			__( 'The token library was modified since you last read it. Reload and try again.', 'kadence-blocks' ),
+			[
+				'status' => WP_Http::CONFLICT,
+				'slug'   => $slug,
+			]
+		);
+	}
+
+	/**
+	 * The error returned when a labels-route id does not name a registered token.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id The unregistered token id.
+	 *
+	 * @return WP_Error
+	 */
+	private function unknown_token( string $id ): WP_Error {
+		return new WP_Error(
+			'rest_design_tokens_unknown_token',
+			__( 'Sorry, that token is not registered.', 'kadence-blocks' ),
+			[
+				'status' => WP_Http::NOT_FOUND,
+				'id'     => $id,
+			]
+		);
+	}
+
+	/**
 	 * Whether a slug names a readable token library.
 	 *
 	 * The default library is always known — it renders from baseline even before it has a row — and any
@@ -1399,6 +1699,56 @@ final class Documents_Controller extends Controller {
 					'required'          => true,
 					'pattern'           => '^[\w.-]+$',
 					'validate_callback' => [ $this, 'validate_token_path' ],
+				],
+			]
+		);
+	}
+
+	/**
+	 * The arguments accepted by the labels-route PUT: the slug, the token id, the label text and
+	 * the version-conditional guard.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_label_params(): array {
+		return array_merge(
+			$this->get_label_delete_params(),
+			[
+				self::LABEL_PARAM => [
+					'description'       => __( 'The display-label override. Empty or whitespace-only clears the override, equivalent to DELETE.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => true,
+					'sanitize_callback' => 'sanitize_text_field',
+				],
+			]
+		);
+	}
+
+	/**
+	 * The arguments accepted by the labels-route DELETE: the slug, the token id and the
+	 * version-conditional guard.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_label_delete_params(): array {
+		return array_merge(
+			$this->get_slug_params(),
+			[
+				self::ID_PARAM      => [
+					'description' => __( 'The token\'s canonical dot-path id, e.g. semantic.color.button-bg.', 'kadence-blocks' ),
+					'type'        => 'string',
+					'required'    => true,
+					'pattern'     => '^[\w.-]+$',
+				],
+				self::VERSION_PARAM => [
+					'description'       => __( 'The version the client last read; empty for a first write. A mismatch is rejected with HTTP 409.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => true,
+					'sanitize_callback' => 'sanitize_text_field',
 				],
 			]
 		);

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -7,9 +7,11 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Document_Path;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Reserved_Namespace;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Reference_Policy;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Document_Validator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
@@ -124,6 +126,52 @@ final class Documents_Controller extends Controller {
 	private const TITLE_ROUTE = 'title';
 
 	/**
+	 * The sub-route, relative to a single library, that collects the per-token label-override endpoints.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const LABELS_ROUTE = 'labels';
+
+	/**
+	 * The request parameter that carries a single token's canonical dot-path id, on the labels sub-route.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const ID_PARAM = 'id';
+
+	/**
+	 * The id path segment for the labels sub-route. Same grammar as PATH_ROUTE — a token id is a dot-path.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const ID_ROUTE = '(?P<' . self::ID_PARAM . '>[\w.-]+)';
+
+	/**
+	 * The request parameter that carries the display-label override text on a labels write.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const LABEL_PARAM = 'label';
+
+	/**
+	 * The request parameter that carries the client's last-read version, for the version-conditional
+	 * guard on the labels sub-route.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const VERSION_PARAM = 'version';
+
+	/**
 	 * The dot-path path segment for the single-token routes. The character class matches the alias
 	 * grammar (a dot-path) minus the braces, so a token is addressable as a sub-resource of its library.
 	 *
@@ -216,6 +264,24 @@ final class Documents_Controller extends Controller {
 	private Responsive_Feed $responsive_feed;
 
 	/**
+	 * The token registry, used only to 404 a label write against an unregistered id.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * Reads and writes the tokenLabels display-label override map.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Label_Index
+	 */
+	private Token_Label_Index $label_index;
+
+	/**
 	 * Memoized item schema for this request. Null until first built.
 	 *
 	 * @since TBD
@@ -245,6 +311,8 @@ final class Documents_Controller extends Controller {
 	 * @param User_Primitive_Document_Validator $user_primitive_validator Enforces the user-primitive document invariant.
 	 * @param Token_Reference_Policy            $reference_policy      Scans for alias references to a user primitive.
 	 * @param Responsive_Feed                   $responsive_feed       Extracts the authored responsive / clamp shape per token.
+	 * @param Token_Registry                    $registry              The token registry, for the labels sub-route's unregistered-id 404.
+	 * @param Token_Label_Index                 $label_index           Reads and writes the tokenLabels override map.
 	 */
 	public function __construct(
 		Token_Store $store,
@@ -255,7 +323,9 @@ final class Documents_Controller extends Controller {
 		User_Primitive_Index $user_primitive_index,
 		User_Primitive_Document_Validator $user_primitive_validator,
 		Token_Reference_Policy $reference_policy,
-		Responsive_Feed $responsive_feed
+		Responsive_Feed $responsive_feed,
+		Token_Registry $registry,
+		Token_Label_Index $label_index
 	) {
 		$this->store                    = $store;
 		$this->resolver                 = $resolver;
@@ -266,6 +336,8 @@ final class Documents_Controller extends Controller {
 		$this->user_primitive_validator = $user_primitive_validator;
 		$this->reference_policy         = $reference_policy;
 		$this->responsive_feed          = $responsive_feed;
+		$this->registry                 = $registry;
+		$this->label_index              = $label_index;
 		$this->rest_base                = 'documents';
 	}
 
@@ -415,6 +487,31 @@ final class Documents_Controller extends Controller {
 					'args'                => $this->get_token_path_params(),
 				],
 				'schema' => [ $this, 'get_token_schema' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/' . self::SLUG_ROUTE . '/' . self::LABELS_ROUTE . '/' . self::ID_ROUTE,
+			[
+				[
+					// PUT only: setting and clearing (empty label) are the same idempotent
+					// replace-the-override operation; there is no partial update of one label.
+					'methods'             => 'PUT',
+					'callback'            => [ $this, 'set_label' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_label_params(),
+				],
+				[
+					// DELETE uses the same capability as PUT — clearing an override is an update to
+					// the document, not a resource removal, so the two verbs of one operation cannot
+					// diverge on permission.
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => [ $this, 'delete_label' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_label_delete_params(),
+				],
+				'schema' => [ $this, 'get_item_schema' ],
 			]
 		);
 	}
@@ -868,6 +965,90 @@ final class Documents_Controller extends Controller {
 	}
 
 	/**
+	 * Set or clear a token's display-label override (PUT /documents/{slug}/labels/{id}).
+	 *
+	 * An empty or whitespace-only label is a clear, exactly equivalent to DELETE, so the UI needs
+	 * no separate reset path. A user-created id routes to the existing userPrimitives label
+	 * instead of tokenLabels — one id never carries two competing label stores; the registrar sync
+	 * then carries the rename into the registry, and the tokenLabels remove() is defense in depth
+	 * against a hand-written entry for the same id.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function set_label( $request ) {
+		$slug  = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+		$id    = Cast::to_string( $request->get_param( self::ID_PARAM ) );
+		$label = trim( Cast::to_string( $request->get_param( self::LABEL_PARAM ) ) );
+
+		if ( ! $this->is_known_library( $slug ) ) {
+			return $this->not_found( $slug );
+		}
+
+		// Only a registered token can be renamed; a typo would otherwise accumulate silently as a
+		// tokenLabels entry with nothing to attach to.
+		if ( ! $this->registry->has( $id ) ) {
+			return $this->unknown_token( $id );
+		}
+
+		$error = $this->guard_client_version( $slug, Cast::to_string( $request->get_param( self::VERSION_PARAM ) ) );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$stored = $this->read_stored_document( $slug );
+
+		if ( $label === '' ) {
+			return $this->persist_label_clear( $stored, $slug, $id );
+		}
+
+		if ( $this->user_primitive_index->has( $stored, $id ) ) {
+			$candidate = $this->user_primitive_index->add( $stored, $id, $label );
+			$candidate = $this->label_index->remove( $candidate, $id );
+		} else {
+			$candidate = $this->label_index->set( $stored, $id, $label );
+		}
+
+		return $this->persist_metadata_candidate( $candidate, $slug );
+	}
+
+	/**
+	 * Clear a token's display-label override (DELETE /documents/{slug}/labels/{id}), reverting a
+	 * baseline id to its declared label and a user-created id to the humanized-last-segment
+	 * fallback ({@see Token_Definition::from_user_primitive()}) — never a nameless token.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_label( $request ) {
+		$slug = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+		$id   = Cast::to_string( $request->get_param( self::ID_PARAM ) );
+
+		if ( ! $this->is_known_library( $slug ) ) {
+			return $this->not_found( $slug );
+		}
+
+		if ( ! $this->registry->has( $id ) ) {
+			return $this->unknown_token( $id );
+		}
+
+		$error = $this->guard_client_version( $slug, Cast::to_string( $request->get_param( self::VERSION_PARAM ) ) );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		return $this->persist_label_clear( $this->read_stored_document( $slug ), $slug, $id );
+	}
+
+	/**
 	 * Validate that the token dot-path begins with a real token layer and names a token below it.
 	 *
 	 * Used as the path argument's validate_callback so a path into "$extensions" (any non-layer root), a
@@ -1183,6 +1364,125 @@ final class Documents_Controller extends Controller {
 	}
 
 	/**
+	 * Persist a candidate whose only change is inside an id-keyed authoring-metadata $extensions
+	 * section (token labels). Deliberately skips the full DTCG validator and the resolver dry-run:
+	 * the index helpers' edits are mechanically confined to a section the effective-document
+	 * builder strips, so they cannot introduce grammar or alias problems — and running the full
+	 * pipeline would make a rename impossible in any library whose stored document does not
+	 * currently validate, for reasons unrelated to the rename (the same trap the dedicated
+	 * single-token routes avoid by never re-validating the whole document either). The section is
+	 * still validated whenever the full document is (bulk POST/PATCH/PUT), via its validator branch.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $candidate The candidate document with the label edit applied.
+	 * @param string               $slug      The token library slug.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	private function persist_metadata_candidate( array $candidate, string $slug ) {
+		$expected_version = $this->store->get_version( $slug );
+		$status           = $expected_version !== '' ? WP_Http::OK : WP_Http::CREATED;
+
+		if ( $candidate === [] ) {
+			return $this->persist( '', $slug, '', $status, $expected_version );
+		}
+
+		$encoded = wp_json_encode( $candidate );
+
+		if ( $encoded === false ) {
+			return new WP_Error(
+				'rest_design_tokens_save_failed',
+				__( 'The design token document could not be encoded.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::INTERNAL_SERVER_ERROR,
+					'slug'   => $slug,
+				]
+			);
+		}
+
+		return $this->persist( $encoded, $slug, '', $status, $expected_version );
+	}
+
+	/**
+	 * Clear a token's label override: a user-created id's rename lands in userPrimitives, so
+	 * clearing resets that section's label to '' rather than removing a tokenLabels entry — which
+	 * Token_Definition::from_user_primitive() falls back from to a humanized last segment, so the
+	 * token stays named rather than becoming nameless. A baseline id removes its tokenLabels entry.
+	 * Either path is idempotent: when nothing changes, the candidate equals the stored document and
+	 * this returns the current item without a write, mirroring delete_token()'s idempotency.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $stored The stored document to clear the override from.
+	 * @param string               $slug   The token library slug.
+	 * @param string               $id     The token id.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	private function persist_label_clear( array $stored, string $slug, string $id ) {
+		if ( $this->user_primitive_index->has( $stored, $id ) ) {
+			$candidate = $this->user_primitive_index->add( $stored, $id, '' );
+		} else {
+			$candidate = $this->label_index->remove( $stored, $id );
+		}
+
+		if ( $candidate === $stored ) {
+			return new WP_REST_Response( $this->prepare_item( $slug ), WP_Http::OK );
+		}
+
+		return $this->persist_metadata_candidate( $candidate, $slug );
+	}
+
+	/**
+	 * Client-conditional guard for the labels sub-route, mirroring the write pipeline's version
+	 * check: the stored version must equal what the client last read (both '' for a first write).
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug           The token library slug.
+	 * @param string $client_version The version the client last read. Empty only for a first write.
+	 *
+	 * @return WP_Error|null
+	 */
+	private function guard_client_version( string $slug, string $client_version ): ?WP_Error {
+		$stored = $this->store->get_version( $slug );
+
+		if ( $stored === $client_version ) {
+			return null;
+		}
+
+		return new WP_Error(
+			'rest_design_tokens_conflict',
+			__( 'The token library was modified since you last read it. Reload and try again.', 'kadence-blocks' ),
+			[
+				'status' => WP_Http::CONFLICT,
+				'slug'   => $slug,
+			]
+		);
+	}
+
+	/**
+	 * The error returned when a labels-route id does not name a registered token.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id The unregistered token id.
+	 *
+	 * @return WP_Error
+	 */
+	private function unknown_token( string $id ): WP_Error {
+		return new WP_Error(
+			'rest_design_tokens_unknown_token',
+			__( 'Sorry, that token is not registered.', 'kadence-blocks' ),
+			[
+				'status' => WP_Http::NOT_FOUND,
+				'id'     => $id,
+			]
+		);
+	}
+
+	/**
 	 * Whether a slug names a readable token library.
 	 *
 	 * The default library is always known — it renders from baseline even before it has a row — and any
@@ -1451,6 +1751,56 @@ final class Documents_Controller extends Controller {
 					'required'          => true,
 					'pattern'           => '^[\w.-]+$',
 					'validate_callback' => [ $this, 'validate_token_path' ],
+				],
+			]
+		);
+	}
+
+	/**
+	 * The arguments accepted by the labels-route PUT: the slug, the token id, the label text and
+	 * the version-conditional guard.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_label_params(): array {
+		return array_merge(
+			$this->get_label_delete_params(),
+			[
+				self::LABEL_PARAM => [
+					'description'       => __( 'The display-label override. Empty or whitespace-only clears the override, equivalent to DELETE.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => true,
+					'sanitize_callback' => 'sanitize_text_field',
+				],
+			]
+		);
+	}
+
+	/**
+	 * The arguments accepted by the labels-route DELETE: the slug, the token id and the
+	 * version-conditional guard.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_label_delete_params(): array {
+		return array_merge(
+			$this->get_slug_params(),
+			[
+				self::ID_PARAM      => [
+					'description' => __( 'The token\'s canonical dot-path id, e.g. semantic.color.button-bg.', 'kadence-blocks' ),
+					'type'        => 'string',
+					'required'    => true,
+					'pattern'     => '^[\w.-]+$',
+				],
+				self::VERSION_PARAM => [
+					'description'       => __( 'The version the client last read; empty for a first write. A mismatch is rejected with HTTP 409.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => true,
+					'sanitize_callback' => 'sanitize_text_field',
 				],
 			]
 		);

--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -19,6 +19,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Literals;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Responsive;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Sentinels;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
+use KadenceWP\KadenceBlocks\Utils\Cast;
 
 /**
  * Validates a decoded DTCG document against the v1 grammar: leaf shape, the $type enum, the alias
@@ -617,6 +618,18 @@ final class Dtcg_Validator {
 			);
 		}
 
+		// tokenLabels is a flat { token id => label } string map — id-keyed metadata, not
+		// preset-shaped, so the tokens-map walk (driven by get_sections(), which excludes it)
+		// never covers it. Without this branch it would pass through with no validation at all.
+		$labels_section = Extensions::get_section_token_labels();
+
+		if ( isset( $namespace[ $labels_section ] ) && is_array( $namespace[ $labels_section ] ) ) {
+			$errors = array_merge(
+				$errors,
+				$this->validate_token_labels( $namespace[ $labels_section ], $base . '.' . $labels_section )
+			);
+		}
+
 		return $errors;
 	}
 
@@ -671,6 +684,35 @@ final class Dtcg_Validator {
 						$errors[] = $error;
 					}
 				}
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Validate a tokenLabels section: every entry must map a non-empty string key to a
+	 * non-empty string label. Whether the id names a registered token is enforced by the REST
+	 * write guard, not here — a label for a since-unregistered token is stale data, not a
+	 * grammar error, and read-side consumers already ignore it.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<int|string, mixed> $labels The decoded tokenLabels section.
+	 * @param string                   $prefix Dot-path to the section, for error messages.
+	 *
+	 * @return Validation_Error[]
+	 */
+	private function validate_token_labels( array $labels, string $prefix ): array {
+		$errors = [];
+
+		foreach ( $labels as $id => $label ) {
+			if ( ! is_string( $id ) || $id === '' || ! is_string( $label ) || $label === '' ) {
+				$errors[] = new Validation_Error(
+					$prefix . '.' . Cast::to_string( $id ),
+					Validation_Error::get_code_value_invalid(),
+					'A token label override must map a non-empty token id to a non-empty string label.'
+				);
 			}
 		}
 

--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -19,6 +19,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Literals;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Responsive;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Sentinels;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
+use KadenceWP\KadenceBlocks\Utils\Cast;
 
 /**
  * Validates a decoded DTCG document against the v1 grammar: leaf shape, the $type enum, the alias
@@ -607,6 +608,18 @@ final class Dtcg_Validator {
 			);
 		}
 
+		// tokenLabels is a flat { token id => label } string map — id-keyed metadata, not
+		// preset-shaped, so the tokens-map walk (driven by get_sections(), which excludes it)
+		// never covers it. Without this branch it would pass through with no validation at all.
+		$labels_section = Extensions::get_section_token_labels();
+
+		if ( isset( $namespace[ $labels_section ] ) && is_array( $namespace[ $labels_section ] ) ) {
+			$errors = array_merge(
+				$errors,
+				$this->validate_token_labels( $namespace[ $labels_section ], $base . '.' . $labels_section )
+			);
+		}
+
 		return $errors;
 	}
 
@@ -661,6 +674,35 @@ final class Dtcg_Validator {
 						$errors[] = $error;
 					}
 				}
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Validate a tokenLabels section: every entry must map a non-empty string key to a
+	 * non-empty string label. Whether the id names a registered token is enforced by the REST
+	 * write guard, not here — a label for a since-unregistered token is stale data, not a
+	 * grammar error, and read-side consumers already ignore it.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<int|string, mixed> $labels The decoded tokenLabels section.
+	 * @param string                   $prefix Dot-path to the section, for error messages.
+	 *
+	 * @return Validation_Error[]
+	 */
+	private function validate_token_labels( array $labels, string $prefix ): array {
+		$errors = [];
+
+		foreach ( $labels as $id => $label ) {
+			if ( ! is_string( $id ) || $id === '' || ! is_string( $label ) || $label === '' ) {
+				$errors[] = new Validation_Error(
+					$prefix . '.' . Cast::to_string( $id ),
+					Validation_Error::get_code_value_invalid(),
+					'A token label override must map a non-empty token id to a non-empty string label.'
+				);
 			}
 		}
 

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
@@ -13,11 +13,14 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary;
  *   - "presets"          → block presets (the preset data model's concern).
  *   - "colorPalettes"     → named color palettes within the library (the palette feature): each an ordered list
  *                           of groups, each an ordered list of self-describing swatches.
+ *   - "tokenLabels"       → per-token display-label overrides: a flat { token id => label } string map,
+ *                           authoring metadata only.
  *
  * The preset sections hold named groups; each group is a map of preset-slug =>
  * { "label": …, "tokens": … } alongside a "$default" key naming the group's default preset. A color palette
- * differs — its values live under each swatch's "$value" rather than in a flat "tokens" map — so it is NOT
- * returned by get_sections() (that drives the tokens-map walk).
+ * differs — its values live under each swatch's "$value" rather than in a flat "tokens" map — and
+ * "tokenLabels" is id-keyed metadata with no tokens map at all, so neither is returned by get_sections()
+ * (that drives the tokens-map walk).
  *
  * @since TBD
  */
@@ -78,6 +81,19 @@ final class Extensions {
 	 * @var string
 	 */
 	private const SECTION_USER_PRIMITIVES = 'userPrimitives';
+
+	/**
+	 * The per-token display-label overrides section: a flat { token id => label } string map.
+	 * NOT returned by get_sections() — it is id-keyed authoring metadata, not preset-shaped, so
+	 * the tokens-map walk (and the reference scanner that follows get_sections()) must not
+	 * descend into it; it holds ids and labels, never {alias} values. The validator covers it
+	 * with its own explicit branch instead.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const SECTION_TOKEN_LABELS = 'tokenLabels';
 
 	/**
 	 * The key naming a group's default preset slug.
@@ -216,6 +232,18 @@ final class Extensions {
 	 */
 	public static function get_section_user_primitives(): string {
 		return self::SECTION_USER_PRIMITIVES;
+	}
+
+	/**
+	 * The per-token display-label overrides section name.
+	 * NOT returned by get_sections() — it is id-keyed metadata, not preset-shaped.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_section_token_labels(): string {
+		return self::SECTION_TOKEN_LABELS;
 	}
 
 	/**

--- a/tests/snapshot/Resources/Design_Tokens/Admin/Feed/__snapshots__/Builder_SnapshotTest__testFullPayloadMatchesSnapshot__1.txt
+++ b/tests/snapshot/Resources/Design_Tokens/Admin/Feed/__snapshots__/Builder_SnapshotTest__testFullPayloadMatchesSnapshot__1.txt
@@ -15,7 +15,8 @@
                     "projections": {
                         "kadence_slot": "palette1"
                     },
-                    "userCreated": false
+                    "userCreated": false,
+                    "labelOverridden": false
                 },
                 {
                     "id": "semantic.color.button-text",
@@ -23,7 +24,8 @@
                     "label": "Button Text",
                     "cssVar": "--kb-token--semantic--color--button-text",
                     "projections": [],
-                    "userCreated": false
+                    "userCreated": false,
+                    "labelOverridden": false
                 }
             ],
             "Layout": [
@@ -33,7 +35,8 @@
                     "label": "Medium",
                     "cssVar": "--kb-token--semantic--spacing--md",
                     "projections": [],
-                    "userCreated": false
+                    "userCreated": false,
+                    "labelOverridden": false
                 }
             ]
         }

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/BuilderTest.php
@@ -62,7 +62,7 @@ final class BuilderTest extends TestCase {
 		$this->assertTrue( $feed['resolved'] );
 		$this->assertSame( 'v7', $feed['version'] );
 		$this->assertSame( 'default', $feed['slug'] );
-		$this->assertSame( $this->registry->to_ui_schema(), $feed['schema'] );
+		$this->assertSame( $this->with_no_overrides( $this->registry->to_ui_schema() ), $feed['schema'] );
 		$this->assertSame( $values, $feed['values'] );
 		$this->assertSame( $presets, $feed['presets'] );
 		$this->assertSame( $this->rest(), $feed['rest'] );
@@ -78,7 +78,7 @@ final class BuilderTest extends TestCase {
 
 		$this->assertTrue( $feed['active'] );
 		$this->assertFalse( $feed['resolved'] );
-		$this->assertSame( $this->registry->to_ui_schema(), $feed['schema'] );
+		$this->assertSame( $this->with_no_overrides( $this->registry->to_ui_schema() ), $feed['schema'] );
 		$this->assertSame( [], $feed['values'] );
 	}
 
@@ -163,5 +163,112 @@ final class BuilderTest extends TestCase {
 			],
 			$feed['presetNav']
 		);
+	}
+
+	/**
+	 * A label override rewrites `label` and sets `labelOverridden` only on the matching row;
+	 * every other row still carries the declared label and `labelOverridden: false`.
+	 *
+	 * @return void
+	 */
+	public function testOverridesRewriteLabelAndFlagOnlyMatchingIds(): void {
+		$this->registry->register(
+			[
+				'id'          => 'semantic.color.button-text',
+				'type'        => 'color',
+				'label'       => 'Button Text',
+				'group'       => 'Brand',
+				'projections' => [],
+			]
+		);
+
+		$feed = $this->builder()->build(
+			[],
+			true,
+			[],
+			$this->rest(),
+			'v7',
+			'default',
+			[],
+			'',
+			[ 'semantic.color.button-bg' => 'Cozy' ]
+		);
+
+		$rows = [];
+		foreach ( $feed['schema']['groups'] as $group_rows ) {
+			foreach ( $group_rows as $row ) {
+				$rows[ $row['id'] ] = $row;
+			}
+		}
+
+		$this->assertSame( 'Cozy', $rows['semantic.color.button-bg']['label'] );
+		$this->assertTrue( $rows['semantic.color.button-bg']['labelOverridden'] );
+		$this->assertSame( 'Button Text', $rows['semantic.color.button-text']['label'] );
+		$this->assertFalse( $rows['semantic.color.button-text']['labelOverridden'] );
+	}
+
+	/**
+	 * An override for an id the schema does not contain is ignored — no row gains it, and no
+	 * error is raised.
+	 *
+	 * @return void
+	 */
+	public function testAnOverrideForAnUnknownIdIsIgnored(): void {
+		$feed = $this->builder()->build(
+			[],
+			true,
+			[],
+			$this->rest(),
+			'v7',
+			'default',
+			[],
+			'',
+			[ 'semantic.color.does-not-exist' => 'Ghost' ]
+		);
+
+		$this->assertSame( $this->with_no_overrides( $this->registry->to_ui_schema() ), $feed['schema'] );
+	}
+
+	/**
+	 * An inactive registry still yields an empty schema regardless of overrides passed in.
+	 *
+	 * @return void
+	 */
+	public function testAnInactiveRegistryYieldsEmptySchemaRegardlessOfOverrides(): void {
+		$this->registry->deactivate();
+
+		$feed = $this->builder()->build(
+			[],
+			true,
+			[],
+			$this->rest(),
+			'v7',
+			'default',
+			[],
+			'',
+			[ 'semantic.color.button-bg' => 'Cozy' ]
+		);
+
+		$this->assertSame( [ 'groups' => [] ], $feed['schema'] );
+	}
+
+	/**
+	 * Overlay every row of a raw registry schema with `labelOverridden: false`, matching what the
+	 * Builder does when no override map is passed. Used to keep the existing structural
+	 * assertions comparing against the raw registry schema meaningful now that the Builder always
+	 * augments its rows.
+	 *
+	 * @param array{groups: array<string, array<int, array<string, mixed>>>} $schema
+	 *
+	 * @return array{groups: array<string, array<int, array<string, mixed>>>}
+	 */
+	private function with_no_overrides( array $schema ): array {
+		foreach ( $schema['groups'] as $group => $rows ) {
+			foreach ( $rows as $i => $row ) {
+				$schema['groups'][ $group ][ $i ]['labelOverridden'] = false;
+			}
+		}
+
+		return $schema;
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/BuilderTest.php
@@ -189,8 +189,8 @@ final class BuilderTest extends TestCase {
 			$this->rest(),
 			'v7',
 			'default',
-			[],
 			'',
+			[],
 			[ 'semantic.color.button-bg' => 'Cozy' ]
 		);
 
@@ -221,8 +221,8 @@ final class BuilderTest extends TestCase {
 			$this->rest(),
 			'v7',
 			'default',
-			[],
 			'',
+			[],
 			[ 'semantic.color.does-not-exist' => 'Ghost' ]
 		);
 
@@ -244,8 +244,8 @@ final class BuilderTest extends TestCase {
 			$this->rest(),
 			'v7',
 			'default',
-			[],
 			'',
+			[],
 			[ 'semantic.color.button-bg' => 'Cozy' ]
 		);
 

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Feed_AssemblerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Feed_AssemblerTest.php
@@ -8,6 +8,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Presets;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Responsive_Feed;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Css_Renderer;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Palettes;
@@ -138,7 +139,8 @@ final class Feed_AssemblerTest extends TestCase {
 			$this->container->get( Token_Store::class ),
 			$this->container->get( Presets::class ),
 			$this->container->get( Builder::class ),
-			$this->container->get( Responsive_Feed::class )
+			$this->container->get( Responsive_Feed::class ),
+			$this->container->get( Token_Label_Index::class )
 		);
 
 		$feed = $assembler->for_slug( Token_Store::default_slug() );
@@ -150,5 +152,45 @@ final class Feed_AssemblerTest extends TestCase {
 		$this->assertSame( [], $feed['responsive'] );
 		$this->assertSame( Token_Store::default_slug(), $feed['slug'] );
 		$this->assertNotEmpty( $feed['rest']['nonce'] );
+	}
+
+	/**
+	 * A stored tokenLabels override reaches the assembled schema's `label` / `labelOverridden`
+	 * fields — the single place both the Localizer and the REST feed controller read from, so a
+	 * stored override cannot reach one caller and not the other.
+	 *
+	 * @return void
+	 */
+	public function testForSlugAppliesStoredTokenLabelOverrides(): void {
+		$doc = (string) wp_json_encode(
+			[
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'tokenLabels' => [
+							'semantic.color.button-primary-bg' => 'Cozy Button',
+						],
+					],
+				],
+			]
+		);
+
+		$this->container->get( Token_Store::class )->save_document( $doc );
+
+		$feed = $this->assembler->for_slug( Token_Store::default_slug() );
+
+		$found = null;
+
+		foreach ( $feed['schema']['groups'] as $entries ) {
+			foreach ( $entries as $entry ) {
+				if ( ( $entry['id'] ?? '' ) === 'semantic.color.button-primary-bg' ) {
+					$found = $entry;
+					break 2;
+				}
+			}
+		}
+
+		$this->assertNotNull( $found, 'The overridden token must appear in the assembled schema.' );
+		$this->assertSame( 'Cozy Button', $found['label'] );
+		$this->assertTrue( $found['labelOverridden'] );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Feed_AssemblerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Feed_AssemblerTest.php
@@ -8,6 +8,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Presets;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Responsive_Feed;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Css_Renderer;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Palettes;
@@ -177,7 +178,8 @@ final class Feed_AssemblerTest extends TestCase {
 			$this->container->get( Token_Store::class ),
 			$this->container->get( Presets::class ),
 			$this->container->get( Builder::class ),
-			$this->container->get( Responsive_Feed::class )
+			$this->container->get( Responsive_Feed::class ),
+			$this->container->get( Token_Label_Index::class )
 		);
 
 		$feed = $assembler->for_slug( Token_Store::default_slug() );
@@ -189,5 +191,45 @@ final class Feed_AssemblerTest extends TestCase {
 		$this->assertSame( [], $feed['responsive'] );
 		$this->assertSame( Token_Store::default_slug(), $feed['slug'] );
 		$this->assertNotEmpty( $feed['rest']['nonce'] );
+	}
+
+	/**
+	 * A stored tokenLabels override reaches the assembled schema's `label` / `labelOverridden`
+	 * fields — the single place both the Localizer and the REST feed controller read from, so a
+	 * stored override cannot reach one caller and not the other.
+	 *
+	 * @return void
+	 */
+	public function testForSlugAppliesStoredTokenLabelOverrides(): void {
+		$doc = (string) wp_json_encode(
+			[
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'tokenLabels' => [
+							'semantic.color.button-primary-bg' => 'Cozy Button',
+						],
+					],
+				],
+			]
+		);
+
+		$this->container->get( Token_Store::class )->save_document( $doc );
+
+		$feed = $this->assembler->for_slug( Token_Store::default_slug() );
+
+		$found = null;
+
+		foreach ( $feed['schema']['groups'] as $entries ) {
+			foreach ( $entries as $entry ) {
+				if ( ( $entry['id'] ?? '' ) === 'semantic.color.button-primary-bg' ) {
+					$found = $entry;
+					break 2;
+				}
+			}
+		}
+
+		$this->assertNotNull( $found, 'The overridden token must appear in the assembled schema.' );
+		$this->assertSame( 'Cozy Button', $found['label'] );
+		$this->assertTrue( $found['labelOverridden'] );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
@@ -10,6 +10,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Presets;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Style_Library\Asset_Loader;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\User_Primitive_Registrar;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Css_Renderer;
@@ -189,7 +190,8 @@ final class LocalizerTest extends TestCase {
 			$this->container->get( Token_Store::class ),
 			$this->container->get( Presets::class ),
 			$this->container->get( Builder::class ),
-			$this->container->get( Responsive_Feed::class )
+			$this->container->get( Responsive_Feed::class ),
+			$this->container->get( Token_Label_Index::class )
 		);
 
 		$localizer = new Localizer(
@@ -344,5 +346,51 @@ final class LocalizerTest extends TestCase {
 		}
 
 		$this->assertNotNull( $found, 'The active library\'s user primitive must appear in the localized schema.' );
+	}
+
+	/**
+	 * A stored tokenLabels entry surfaces as the effective label in the localized schema, with
+	 * labelOverridden set — proving the read/apply wiring end to end (Feed_Assembler decoding the
+	 * document and Builder overlaying it), not just the pure Builder overlay BuilderTest covers.
+	 *
+	 * @return void
+	 */
+	public function testStoredTokenLabelOverridesReachTheLocalizedSchema(): void {
+		$store = $this->container->get( Token_Store::class );
+
+		$doc = (string) wp_json_encode(
+			[
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'tokenLabels' => [
+							'semantic.color.button-primary-bg' => 'Cozy Button',
+						],
+					],
+				],
+			]
+		);
+
+		$store->save_document( $doc );
+
+		$this->enqueue_dashboard();
+		$this->localizer()->localize();
+
+		$feed = $this->attached_feed();
+		$this->assertNotNull( $feed );
+
+		$found = null;
+
+		foreach ( $feed['schema']['groups'] as $entries ) {
+			foreach ( $entries as $entry ) {
+				if ( ( $entry['id'] ?? '' ) === 'semantic.color.button-primary-bg' ) {
+					$found = $entry;
+					break 2;
+				}
+			}
+		}
+
+		$this->assertNotNull( $found, 'The overridden token must appear in the localized schema.' );
+		$this->assertSame( 'Cozy Button', $found['label'] );
+		$this->assertTrue( $found['labelOverridden'] );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Document/Token_Label_IndexTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/Token_Label_IndexTest.php
@@ -1,0 +1,315 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Document;
+
+use Generator;
+use InvalidArgumentException;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Covers the tokenLabels display-label override map read/write operations of Token_Label_Index.
+ *
+ * @since TBD
+ */
+final class Token_Label_IndexTest extends TestCase {
+
+	/**
+	 * The index under test.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Label_Index
+	 */
+	private Token_Label_Index $index;
+
+	/**
+	 * Build a fresh index before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->index = new Token_Label_Index();
+	}
+
+	// -------------------------------------------------------------------------
+	// all()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * An empty document has no label overrides.
+	 *
+	 * @return void
+	 */
+	public function testAllReturnsEmptyArrayForEmptyDocument(): void {
+		$this->assertSame( [], $this->index->all( [] ) );
+	}
+
+	/**
+	 * A document missing the $extensions key has no label overrides.
+	 *
+	 * @return void
+	 */
+	public function testAllReturnsEmptyArrayWhenExtensionsKeyMissing(): void {
+		$doc = [ 'primitive' => [ 'color' => [] ] ];
+
+		$this->assertSame( [], $this->index->all( $doc ) );
+	}
+
+	/**
+	 * A well-formed tokenLabels section round-trips through all() unchanged.
+	 *
+	 * @return void
+	 */
+	public function testAllReturnsStoredEntries(): void {
+		$id  = 'semantic.color.button-bg';
+		$doc = $this->doc_with_entry( $id, 'Brand Button' );
+
+		$this->assertSame( [ $id => 'Brand Button' ], $this->index->all( $doc ) );
+	}
+
+	/**
+	 * A malformed entry (non-string key, non-string value, or empty-string value) is dropped on
+	 * read rather than surfaced, so a hand-corrupted section degrades to "no override".
+	 *
+	 * @dataProvider malformedEntryProvider
+	 *
+	 * @param array<int|string, mixed> $section The raw decoded tokenLabels section.
+	 *
+	 * @return void
+	 */
+	public function testAllDropsMalformedEntries( array $section ): void {
+		$doc = [
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					Extensions::get_section_token_labels() => $section,
+				],
+			],
+		];
+
+		$this->assertSame( [], $this->index->all( $doc ) );
+	}
+
+	/**
+	 * Malformed tokenLabels section shapes that must each degrade to "no override" on read.
+	 *
+	 * @return Generator
+	 */
+	public function malformedEntryProvider(): Generator {
+		yield 'integer key' => [
+			'section' => [ 0 => 'Numeric Key' ],
+		];
+
+		yield 'non-string value' => [
+			'section' => [ 'semantic.color.button-bg' => 42 ],
+		];
+
+		yield 'empty string value' => [
+			'section' => [ 'semantic.color.button-bg' => '' ],
+		];
+	}
+
+	// -------------------------------------------------------------------------
+	// has()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * has() is false for an id with no stored override.
+	 *
+	 * @return void
+	 */
+	public function testHasReturnsFalseWhenAbsent(): void {
+		$this->assertFalse( $this->index->has( [], 'semantic.color.missing' ) );
+	}
+
+	/**
+	 * has() is true once an override is stored for the id.
+	 *
+	 * @return void
+	 */
+	public function testHasReturnsTrueWhenPresent(): void {
+		$id  = 'semantic.color.button-bg';
+		$doc = $this->doc_with_entry( $id, 'Brand Button' );
+
+		$this->assertTrue( $this->index->has( $doc, $id ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// label_for()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * label_for() returns null for an id with no stored override.
+	 *
+	 * @return void
+	 */
+	public function testLabelForReturnsNullWhenAbsent(): void {
+		$this->assertNull( $this->index->label_for( [], 'semantic.color.missing' ) );
+	}
+
+	/**
+	 * label_for() returns the stored override string.
+	 *
+	 * @return void
+	 */
+	public function testLabelForReturnsStoredLabel(): void {
+		$id  = 'semantic.color.button-bg';
+		$doc = $this->doc_with_entry( $id, 'Brand Button' );
+
+		$this->assertSame( 'Brand Button', $this->index->label_for( $doc, $id ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// set()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * set() creates the $extensions/{namespace}/tokenLabels path when none of it yet exists.
+	 *
+	 * @return void
+	 */
+	public function testSetCreatesFullPathWhenMissing(): void {
+		$id     = 'semantic.color.button-bg';
+		$result = $this->index->set( [], $id, 'Brand Button' );
+
+		$this->assertTrue( $this->index->has( $result, $id ) );
+		$this->assertSame( 'Brand Button', $this->index->label_for( $result, $id ) );
+	}
+
+	/**
+	 * set() overwrites a previously stored override for the same id.
+	 *
+	 * @return void
+	 */
+	public function testSetOverwritesExistingEntry(): void {
+		$id  = 'semantic.color.button-bg';
+		$doc = $this->doc_with_entry( $id, 'Old Label' );
+
+		$result = $this->index->set( $doc, $id, 'New Label' );
+
+		$this->assertSame( 'New Label', $this->index->label_for( $result, $id ) );
+	}
+
+	/**
+	 * set() leaves sibling entries in the section untouched.
+	 *
+	 * @return void
+	 */
+	public function testSetPreservesSiblingEntries(): void {
+		$id_a = 'semantic.color.button-bg';
+		$id_b = 'semantic.color.button-text';
+		$doc  = $this->doc_with_entry( $id_a, 'Bg' );
+
+		$result = $this->index->set( $doc, $id_b, 'Text' );
+
+		$this->assertTrue( $this->index->has( $result, $id_a ) );
+		$this->assertTrue( $this->index->has( $result, $id_b ) );
+	}
+
+	/**
+	 * set() refuses to store an empty label — storing an empty label must be impossible by
+	 * construction; clearing is remove(), never set( '' ).
+	 *
+	 * @return void
+	 */
+	public function testSetThrowsForEmptyLabel(): void {
+		$this->expectException( InvalidArgumentException::class );
+
+		$this->index->set( [], 'semantic.color.button-bg', '' );
+	}
+
+	/**
+	 * set() does not modify the document passed in — every mutator returns a new document.
+	 *
+	 * @return void
+	 */
+	public function testSetDoesNotModifyItsInput(): void {
+		$doc = [];
+
+		$this->index->set( $doc, 'semantic.color.button-bg', 'Brand Button' );
+
+		$this->assertSame( [], $doc );
+	}
+
+	// -------------------------------------------------------------------------
+	// remove()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * remove() is a no-op (the same document is returned) when nothing is stored for the id.
+	 *
+	 * @return void
+	 */
+	public function testRemoveIsNoOpWhenAbsent(): void {
+		$result = $this->index->remove( [], 'semantic.color.missing' );
+
+		$this->assertSame( [], $result );
+	}
+
+	/**
+	 * remove() deletes only the targeted entry, leaving siblings intact.
+	 *
+	 * @return void
+	 */
+	public function testRemoveDeletesTargetEntryOnly(): void {
+		$id_a = 'semantic.color.button-bg';
+		$id_b = 'semantic.color.button-text';
+		$doc  = $this->doc_with_entry( $id_a, 'Bg' );
+		$doc  = $this->index->set( $doc, $id_b, 'Text' );
+
+		$result = $this->index->remove( $doc, $id_a );
+
+		$this->assertFalse( $this->index->has( $result, $id_a ) );
+		$this->assertTrue( $this->index->has( $result, $id_b ) );
+	}
+
+	/**
+	 * remove() leaves the rest of the document, outside the tokenLabels section, unchanged.
+	 *
+	 * @return void
+	 */
+	public function testRemoveLeavesTheRestOfTheDocumentUnchanged(): void {
+		$id  = 'semantic.color.button-bg';
+		$doc = $this->doc_with_entry( $id, 'Bg' );
+
+		$doc['primitive'] = [
+			'color' => [
+				'brand' => [
+					'$type'  => 'color',
+					'$value' => '#3182CE',
+				],
+			],
+		];
+
+		$result = $this->index->remove( $doc, $id );
+
+		$this->assertSame( $doc['primitive'], $result['primitive'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Build a decoded document carrying a single tokenLabels entry.
+	 *
+	 * @param string $id    The token id.
+	 * @param string $label The stored label.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function doc_with_entry( string $id, string $label ): array {
+		return [
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					Extensions::get_section_token_labels() => [
+						$id => $label,
+					],
+				],
+			],
+		];
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Document/Token_Label_IndexTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/Token_Label_IndexTest.php
@@ -110,6 +110,10 @@ final class Token_Label_IndexTest extends TestCase {
 		yield 'empty string value' => [
 			'section' => [ 'semantic.color.button-bg' => '' ],
 		];
+
+		yield 'whitespace-only value' => [
+			'section' => [ 'semantic.color.button-bg' => '   ' ],
+		];
 	}
 
 	// -------------------------------------------------------------------------
@@ -219,6 +223,18 @@ final class Token_Label_IndexTest extends TestCase {
 		$this->expectException( InvalidArgumentException::class );
 
 		$this->index->set( [], 'semantic.color.button-bg', '' );
+	}
+
+	/**
+	 * set() refuses a whitespace-only label too — it is the empty label with padding, and all()
+	 * would drop it on read, leaving an override that silently does not exist.
+	 *
+	 * @return void
+	 */
+	public function testSetThrowsForWhitespaceOnlyLabel(): void {
+		$this->expectException( InvalidArgumentException::class );
+
+		$this->index->set( [], 'semantic.color.button-bg', "  \t " );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerLabelsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerLabelsTest.php
@@ -1,0 +1,420 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Rest\V1;
+
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\User_Primitive_Registrar;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Documents_Controller;
+use Tests\Support\Classes\TestCase;
+use WP_Error;
+use WP_Http;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Covers the per-token display-label override sub-route: PUT/DELETE
+ * /documents/{slug}/labels/{id}, its narrowed write path, the user-created-id routing to
+ * userPrimitives, and the version-conditional guard.
+ *
+ * @since TBD
+ */
+final class DocumentsControllerLabelsTest extends TestCase {
+
+	/**
+	 * A baseline token id present in the registered baseline, used wherever the test only needs
+	 * a real registered id and does not care which one.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const BASELINE_ID = 'semantic.color.button-primary-bg';
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Documents_Controller
+	 */
+	private Documents_Controller $controller;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Token_Label_Index
+	 */
+	private Token_Label_Index $label_index;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var User_Primitive_Index
+	 */
+	private User_Primitive_Index $user_primitive_index;
+
+	/**
+	 * Build the controller and its collaborators fresh before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->store                = $this->container->get( Token_Store::class );
+		$this->controller           = $this->container->get( Documents_Controller::class );
+		$this->label_index          = $this->container->get( Token_Label_Index::class );
+		$this->user_primitive_index = $this->container->get( User_Primitive_Index::class );
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Reset the current user and the global REST server after each test.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		wp_set_current_user( 0 );
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * A PUT stores the override, bumps the version, and the localized feed shows the override as
+	 * `label` with `labelOverridden: true`.
+	 *
+	 * @return void
+	 */
+	public function testPutStoresTheOverrideBumpsVersionAndFeedShowsIt(): void {
+		$slug           = Token_Store::default_slug();
+		$version_before = $this->store->get_version( $slug );
+
+		$response = $this->controller->set_label( $this->label_request( 'PUT', $slug, self::BASELINE_ID, $version_before, 'Cozy Button' ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		// The default library has no stored row yet, so the first write reports 201 Created,
+		// mirroring every sibling document write.
+		$this->assertSame( WP_Http::CREATED, $response->get_status() );
+		$this->assertNotSame( $version_before, $this->store->get_version( $slug ) );
+
+		$stored = json_decode( $this->store->get_document( $slug ), true );
+		$this->assertSame( 'Cozy Button', $this->label_index->label_for( $stored, self::BASELINE_ID ) );
+	}
+
+	/**
+	 * A PUT with an empty or whitespace-only label clears an existing override, exactly
+	 * equivalent to DELETE.
+	 *
+	 * @dataProvider clearingLabelProvider
+	 *
+	 * @param string $label The empty or whitespace-only label that should clear the override.
+	 *
+	 * @return void
+	 */
+	public function testPutWithEmptyOrWhitespaceLabelClearsAnExistingOverride( string $label ): void {
+		$slug = Token_Store::default_slug();
+
+		$this->controller->set_label( $this->label_request( 'PUT', $slug, self::BASELINE_ID, $this->store->get_version( $slug ), 'Cozy Button' ) );
+
+		$response = $this->controller->set_label( $this->label_request( 'PUT', $slug, self::BASELINE_ID, $this->store->get_version( $slug ), $label ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$stored = json_decode( $this->store->get_document( $slug ), true );
+		$this->assertFalse( $this->label_index->has( $stored, self::BASELINE_ID ) );
+	}
+
+	/**
+	 * Empty and whitespace-only labels that must clear an override on PUT.
+	 *
+	 * @return Generator
+	 */
+	public function clearingLabelProvider(): Generator {
+		yield 'empty string' => [ 'label' => '' ];
+		yield 'whitespace only' => [ 'label' => '   ' ];
+	}
+
+	/**
+	 * DELETE clears a stored override; a second DELETE is an idempotent 200 with no version bump.
+	 *
+	 * @return void
+	 */
+	public function testDeleteClearsAndASecondDeleteIsIdempotent(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->controller->set_label( $this->label_request( 'PUT', $slug, self::BASELINE_ID, $this->store->get_version( $slug ), 'Cozy Button' ) );
+
+		$response = $this->controller->delete_label( $this->label_request( 'DELETE', $slug, self::BASELINE_ID, $this->store->get_version( $slug ) ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$version_after_first_delete = $this->store->get_version( $slug );
+
+		$second = $this->controller->delete_label( $this->label_request( 'DELETE', $slug, self::BASELINE_ID, $version_after_first_delete ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $second );
+		$this->assertSame( WP_Http::OK, $second->get_status() );
+		$this->assertSame( $version_after_first_delete, $this->store->get_version( $slug ) );
+	}
+
+	/**
+	 * An unknown library slug is a 404.
+	 *
+	 * @return void
+	 */
+	public function testUnknownSlugReturns404(): void {
+		$response = $this->controller->set_label( $this->label_request( 'PUT', 'does-not-exist', self::BASELINE_ID, '', 'Cozy Button' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_design_tokens_not_found', $response->get_error_code() );
+	}
+
+	/**
+	 * An id that names no registered token is a 404, on both PUT and DELETE.
+	 *
+	 * @return void
+	 */
+	public function testUnregisteredTokenIdReturns404(): void {
+		$slug    = Token_Store::default_slug();
+		$version = $this->store->get_version( $slug );
+
+		$put = $this->controller->set_label( $this->label_request( 'PUT', $slug, 'semantic.color.does-not-exist', $version, 'Cozy Button' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $put );
+		$this->assertSame( 'rest_design_tokens_unknown_token', $put->get_error_code() );
+
+		$delete = $this->controller->delete_label( $this->label_request( 'DELETE', $slug, 'semantic.color.does-not-exist', $version ) );
+
+		$this->assertInstanceOf( WP_Error::class, $delete );
+		$this->assertSame( 'rest_design_tokens_unknown_token', $delete->get_error_code() );
+	}
+
+	/**
+	 * A stale client version is rejected with 409, and the document is left unchanged.
+	 *
+	 * @return void
+	 */
+	public function testStaleVersionReturns409AndDocumentIsUnchanged(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->controller->set_label( $this->label_request( 'PUT', $slug, self::BASELINE_ID, $this->store->get_version( $slug ), 'Cozy Button' ) );
+
+		$stored_before = $this->store->get_document( $slug );
+
+		$response = $this->controller->set_label( $this->label_request( 'PUT', $slug, self::BASELINE_ID, 'stale-version', 'Even Cozier' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_design_tokens_conflict', $response->get_error_code() );
+		$this->assertSame( WP_Http::CONFLICT, $response->get_error_data()['status'] );
+		$this->assertSame( $stored_before, $this->store->get_document( $slug ) );
+	}
+
+	/**
+	 * Renaming a user-created id rewrites the userPrimitives label — never a tokenLabels entry —
+	 * and the registrar sync carries the new label into the registry and the feed.
+	 *
+	 * @return void
+	 */
+	public function testUserCreatedIdPutRewritesUserPrimitivesLabelNotTokenLabels(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.color.custom.brand-blue';
+
+		$this->seed_user_primitive( $slug, $id, 'Brand Blue' );
+
+		$response = $this->controller->set_label( $this->label_request( 'PUT', $slug, $id, $this->store->get_version( $slug ), 'Ocean Blue' ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$stored = json_decode( $this->store->get_document( $slug ), true );
+
+		$this->assertSame( 'Ocean Blue', $this->user_primitive_index->label_for( $stored, $id ) );
+		$this->assertFalse( $this->label_index->has( $stored, $id ), 'A user-created id must never gain a tokenLabels entry.' );
+
+		$this->sync_registrar();
+
+		/** @var Token_Registry $registry */
+		$registry = $this->container->get( Token_Registry::class );
+		$this->assertSame( 'Ocean Blue', $registry->get( $id )->label );
+	}
+
+	/**
+	 * Clearing a user-created id's override resets the userPrimitives label to '', which the
+	 * registrar/registry fall back from to the humanized last segment — never a 400, never a
+	 * nameless token.
+	 *
+	 * @return void
+	 */
+	public function testUserCreatedIdDeleteFallsBackToHumanizedLastSegment(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.color.custom.brand-blue';
+
+		$this->seed_user_primitive( $slug, $id, 'Brand Blue' );
+
+		$response = $this->controller->delete_label( $this->label_request( 'DELETE', $slug, $id, $this->store->get_version( $slug ) ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$stored = json_decode( $this->store->get_document( $slug ), true );
+		$this->assertSame( '', $this->user_primitive_index->label_for( $stored, $id ) );
+
+		$this->sync_registrar();
+
+		/** @var Token_Registry $registry */
+		$registry = $this->container->get( Token_Registry::class );
+		$this->assertSame( 'Brand Blue', $registry->get( $id )->label, 'Humanized fallback from the last dot-path segment.' );
+	}
+
+	/**
+	 * The narrowed write path lets a label rename succeed even in a library whose stored document
+	 * currently fails full DTCG validation, and leaves the invalid remainder untouched.
+	 *
+	 * @return void
+	 */
+	public function testNarrowedPathAllowsARenameInALibraryThatFailsFullValidation(): void {
+		$slug    = Token_Store::default_slug();
+		$invalid = '{"primitive":{"color":{"x":{"$type":"color","$value":"not-a-color"}}}}';
+
+		$this->store->save_document( $invalid );
+
+		$response = $this->controller->set_label( $this->label_request( 'PUT', $slug, self::BASELINE_ID, $this->store->get_version( $slug ), 'Cozy Button' ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$stored = json_decode( $this->store->get_document( $slug ), true );
+		$this->assertSame( 'Cozy Button', $this->label_index->label_for( $stored, self::BASELINE_ID ) );
+		$this->assertSame( 'not-a-color', $stored['primitive']['color']['x']['$value'], 'The pre-existing invalid remainder must be left untouched.' );
+	}
+
+	/**
+	 * Both routes enforce the sibling document routes' capability filter: an unauthenticated
+	 * request and a subscriber are both refused.
+	 *
+	 * @return void
+	 */
+	public function testPermissionsRefuseUnauthenticatedAndSubscriberRequests(): void {
+		$request = new WP_REST_Request( 'PUT' );
+
+		$this->assertInstanceOf( WP_Error::class, $this->controller->update_item_permissions_check( $request ) );
+
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'subscriber' ] ) );
+
+		$this->assertInstanceOf( WP_Error::class, $this->controller->update_item_permissions_check( $request ) );
+	}
+
+	/**
+	 * A stored label override never reaches the effective (rendering) document — $extensions is
+	 * stripped there, so the override can never leak into projected CSS.
+	 *
+	 * @return void
+	 */
+	public function testTheOverrideNeverReachesTheEffectiveDocument(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->controller->set_label( $this->label_request( 'PUT', $slug, self::BASELINE_ID, $this->store->get_version( $slug ), 'Cozy Button' ) );
+
+		$stored = json_decode( $this->store->get_document( $slug ), true );
+
+		/** @var Effective_Document $effective */
+		$effective = $this->container->get( Effective_Document::class );
+
+		$this->assertArrayNotHasKey( '$extensions', $effective->build( $stored ) );
+	}
+
+	/**
+	 * Seed a stored document with a user-created primitive and its userPrimitives label, then
+	 * sync the registrar so the id is known to the live Token_Registry.
+	 *
+	 * @param string $slug  The token library slug.
+	 * @param string $id    The user-created primitive's canonical dot-path id.
+	 * @param string $label The label to seed.
+	 *
+	 * @return void
+	 */
+	private function seed_user_primitive( string $slug, string $id, string $label ): void {
+		$segments = explode( '.', $id );
+		$leaf     = array_pop( $segments );
+
+		$document = (string) wp_json_encode(
+			[
+				'primitive'   => [
+					'color' => [
+						'custom' => [
+							$leaf => [
+								'$type'  => 'color',
+								'$value' => '#1a56db',
+							],
+						],
+					],
+				],
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'userPrimitives' => [
+							$id => [ 'label' => $label ],
+						],
+					],
+				],
+			]
+		);
+
+		$this->store->save_document( $document, $slug );
+		$this->sync_registrar();
+	}
+
+	/**
+	 * Re-run the user-primitive registrar sync so the live Token_Registry reflects the latest
+	 * stored document.
+	 *
+	 * @return void
+	 */
+	private function sync_registrar(): void {
+		/** @var User_Primitive_Registrar $registrar */
+		$registrar = $this->container->get( User_Primitive_Registrar::class );
+		$registrar->sync();
+	}
+
+	/**
+	 * Build a labels sub-route request carrying the slug, id, version and (for PUT) the label.
+	 *
+	 * @param string      $method  The HTTP method.
+	 * @param string      $slug    The token library slug.
+	 * @param string      $id      The token id.
+	 * @param string      $version The client's last-read version.
+	 * @param string|null $label   The label, for PUT requests only.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function label_request( string $method, string $slug, string $id, string $version, ?string $label = null ): WP_REST_Request {
+		$request = new WP_REST_Request( $method );
+		$request->set_param( 'slug', $slug );
+		$request->set_param( 'id', $id );
+		$request->set_param( 'version', $version );
+
+		if ( $label !== null ) {
+			$request->set_param( 'label', $label );
+		}
+
+		return $request;
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -205,6 +205,49 @@ final class Feed_ControllerTest extends TestCase {
 	}
 
 	/**
+	 * A stored tokenLabels override surfaces directly through this endpoint's schema, independent
+	 * of the Localizer — proving the override reaches the REST feed specifically, not merely that
+	 * the two callers happen to agree with each other.
+	 *
+	 * @return void
+	 */
+	public function testGetItemReturnsStoredTokenLabelOverrides(): void {
+		$doc = (string) wp_json_encode(
+			[
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'tokenLabels' => [
+							'semantic.color.button-primary-bg' => 'Cozy Button',
+						],
+					],
+				],
+			]
+		);
+
+		$this->store->save_document( $doc );
+
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', Token_Store::default_slug() );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$found = null;
+
+		foreach ( $data['schema']['groups'] as $entries ) {
+			foreach ( $entries as $entry ) {
+				if ( ( $entry['id'] ?? '' ) === 'semantic.color.button-primary-bg' ) {
+					$found = $entry;
+					break 2;
+				}
+			}
+		}
+
+		$this->assertNotNull( $found, 'The overridden token must appear in the REST feed schema.' );
+		$this->assertSame( 'Cozy Button', $found['label'] );
+		$this->assertTrue( $found['labelOverridden'] );
+	}
+
+	/**
 	 * A slug naming no known library is rejected with a 404, mirroring Documents_Controller and
 	 * Active_Token_Library_Controller rather than silently substituting a different library's
 	 * data for the one requested.

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
@@ -90,6 +90,48 @@ final class Dtcg_ValidatorTest extends TestCase {
 	}
 
 	/**
+	 * A well-formed tokenLabels section validates: every entry maps a non-empty string id to a
+	 * non-empty string label.
+	 *
+	 * @return void
+	 */
+	public function testAWellFormedTokenLabelsSectionValidates(): void {
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'tokenLabels' => [
+						'semantic.color.button-bg' => 'Brand Button',
+					],
+				],
+			],
+		];
+
+		$result = $this->validator->validate( $document, Dtcg_Validator::get_context_overrides() );
+
+		$this->assertTrue( $result->is_valid(), $this->describe( $result->errors() ) );
+	}
+
+	/**
+	 * A document without a tokenLabels section produces no new errors, and a non-Kadence
+	 * extension namespace alongside it is passed through untouched.
+	 *
+	 * @return void
+	 */
+	public function testADocumentWithoutTheTokenLabelsSectionIsUnaffected(): void {
+		$document = [
+			'$extensions' => [
+				'some.other.vendor' => [
+					'tokenLabels' => [ 0 => 'not-kadence-owned' ],
+				],
+			],
+		];
+
+		$result = $this->validator->validate( $document, Dtcg_Validator::get_context_overrides() );
+
+		$this->assertTrue( $result->is_valid(), $this->describe( $result->errors() ) );
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testItIsResolvableFromTheContainer(): void {
@@ -325,6 +367,44 @@ final class Dtcg_ValidatorTest extends TestCase {
 			'context'  => Dtcg_Validator::get_context_overrides(),
 			'code'     => Validation_Error::get_code_alias_malformed(),
 			'path'     => '$extensions.com.kadence.designTokens.colorPalettes.default.groups.0.swatches.0.$value',
+		];
+		// A tokenLabels entry keyed by an integer (rather than a token dot-path string) is rejected
+		// by the section's own explicit branch.
+		yield 'integer-keyed tokenLabels entry' => [
+			'document' => [
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'tokenLabels' => [ 0 => 'Numeric Key' ],
+					],
+				],
+			],
+			'context'  => Dtcg_Validator::get_context_overrides(),
+			'code'     => Validation_Error::get_code_value_invalid(),
+			'path'     => '$extensions.com.kadence.designTokens.tokenLabels.0',
+		];
+		yield 'non-string tokenLabels label' => [
+			'document' => [
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'tokenLabels' => [ 'semantic.color.button-bg' => 42 ],
+					],
+				],
+			],
+			'context'  => Dtcg_Validator::get_context_overrides(),
+			'code'     => Validation_Error::get_code_value_invalid(),
+			'path'     => '$extensions.com.kadence.designTokens.tokenLabels.semantic.color.button-bg',
+		];
+		yield 'empty-string tokenLabels label' => [
+			'document' => [
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'tokenLabels' => [ 'semantic.color.button-bg' => '' ],
+					],
+				],
+			],
+			'context'  => Dtcg_Validator::get_context_overrides(),
+			'code'     => Validation_Error::get_code_value_invalid(),
+			'path'     => '$extensions.com.kadence.designTokens.tokenLabels.semantic.color.button-bg',
 		];
 		yield 'responsive on non-capable type' => [
 			'document' => [

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/ExtensionsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/ExtensionsTest.php
@@ -55,4 +55,36 @@ final class ExtensionsTest extends TestCase {
 		$this->assertSame( 'token', Extensions::get_swatch_token_key() );
 		$this->assertSame( 'id', Extensions::get_group_id_key() );
 	}
+
+	/**
+	 * The token-labels section accessor returns the expected section name.
+	 *
+	 * @return void
+	 */
+	public function testItExposesTheTokenLabelsSectionName(): void {
+		$this->assertSame( 'tokenLabels', Extensions::get_section_token_labels() );
+	}
+
+	/**
+	 * The token-labels section is deliberately NOT among get_sections(): it is a flat id-keyed
+	 * label map, not a preset-shaped `tokens` map, so the tokens-map walk must not descend it.
+	 *
+	 * @return void
+	 */
+	public function testTheTokenLabelsSectionIsNotAmongTheTokensMapSections(): void {
+		$this->assertNotContains( Extensions::get_section_token_labels(), Extensions::get_sections() );
+	}
+
+	/**
+	 * get_sections() returns exactly the two preset-shaped sections — the color-palettes and
+	 * token-labels exclusions are pinned, not incidental.
+	 *
+	 * @return void
+	 */
+	public function testGetSectionsReturnsExactlyThePresetShapedSections(): void {
+		$this->assertSame(
+			[ Extensions::get_section_foundation_presets(), Extensions::get_section_presets() ],
+			Extensions::get_sections()
+		);
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/ExtensionsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/ExtensionsTest.php
@@ -126,4 +126,36 @@ final class ExtensionsTest extends TestCase {
 		$this->assertSame( $slots, Extensions::preset_value_of( $slots ) );
 		$this->assertSame( [], Extensions::preset_responsive_of( $slots ) );
 	}
+
+	/**
+	 * The token-labels section accessor returns the expected section name.
+	 *
+	 * @return void
+	 */
+	public function testItExposesTheTokenLabelsSectionName(): void {
+		$this->assertSame( 'tokenLabels', Extensions::get_section_token_labels() );
+	}
+
+	/**
+	 * The token-labels section is deliberately NOT among get_sections(): it is a flat id-keyed
+	 * label map, not a preset-shaped `tokens` map, so the tokens-map walk must not descend it.
+	 *
+	 * @return void
+	 */
+	public function testTheTokenLabelsSectionIsNotAmongTheTokensMapSections(): void {
+		$this->assertNotContains( Extensions::get_section_token_labels(), Extensions::get_sections() );
+	}
+
+	/**
+	 * get_sections() returns exactly the two preset-shaped sections — the color-palettes and
+	 * token-labels exclusions are pinned, not incidental.
+	 *
+	 * @return void
+	 */
+	public function testGetSectionsReturnsExactlyThePresetShapedSections(): void {
+		$this->assertSame(
+			[ Extensions::get_section_foundation_presets(), Extensions::get_section_presets() ],
+			Extensions::get_sections()
+		);
+	}
 }


### PR DESCRIPTION
Lets a user rename any token — baseline or user-created — to a custom display label, stored per library as authoring metadata.

## What's here

- `Schema/Vocabulary/Extensions.php` — a `tokenLabels` section under `com.kadence.designTokens`.
- `Document/Token_Label_Index.php` — the pure read/write helper, mirroring `User_Primitive_Index`.
- `Schema/Validation/Dtcg_Validator.php` — an explicit validation branch for the new section.
- `Rest/V1/Documents_Controller.php` — `PUT`/`DELETE /documents/{slug}/labels/{id}`, version-conditional (409).
- `Admin/Feed/Feed_Assembler.php` + `Admin/Feed/Builder.php` — the effective label applied onto the admin feed, and a `labelOverridden` flag per entry.

`Resolver/Effective_Document::build()` strips `$extensions`, so an override can never reach projected CSS.

## Three decisions worth knowing

**The apply lives in `Feed_Assembler`, not in either emitter.** `Feed_Assembler::for_slug()` is the one pipeline both the page-load localizer and `Feed_Controller` call, and `Feed_ControllerTest` asserts those two payloads are identical. Applying in an emitter would give one of them overrides and not the other. It also can't live in `Token_Registry::to_ui_schema()` — the registry has no slug or store access and is library-independent by construction, so it cannot apply per-library data at all.

**The new section is deliberately absent from `Extensions::get_sections()`.** That list drives a preset-shaped tokens-map walk in the validator, and this section isn't preset-shaped. Anything outside the list passes through *unvalidated*, which is why `colorPalettes` already carries its own branch and why this one does too.

**The write path is narrowed on purpose** — the full DTCG validator and the resolver dry-run are skipped for a label write. Running them would make renaming impossible in any library whose stored document doesn't already validate, which is the trap that broke library rename before. Accepted consequence: a rename succeeds in an already-invalid library, since the write can't make it worse and refusing would hold authoring metadata hostage to unrelated corruption. The section is still validated whenever the full document is.

## Behavior notes

- An empty or whitespace-only label on `PUT` is a clear, exactly equivalent to `DELETE`, so a client needs no separate reset path. Storing an empty label is impossible by construction.
- A user-created primitive's label is written into the existing `userPrimitives` section rather than layered as a second store over the same id — one id never carries two competing labels.
- Clearing is safe for user-created ids: `Token_Definition::from_user_primitive()` falls back to a humanized last segment, so nothing is left nameless.
- The block-editor picker keeps declared labels. Its catalog emits one shared token list with only *values* per library, so per-library labels there would mean reshaping that payload per library.

## Test plan

`slic run wpunit Resources/Design_Tokens` — 1135 tests green, including a REST-level test proving an override actually surfaces through `Feed_Controller`, not merely that the two feed payloads agree with each other.

The Builder snapshot is regenerated in the final commit; the only change is each schema row gaining `labelOverridden`.
