### PR TITLE
[DTM] SOFT-4073: Token sort order

### DIFF
--- a/includes/resources/Design_Tokens/Admin/Feed/Builder.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Builder.php
@@ -67,7 +67,7 @@ final class Builder {
 	 * @param array<string, array<string, mixed>>                   $responsive id => raw authored responsive / clamp shape, for
 	 *                                                                          tokens that carry one (for editor hydration).
 	 * @param array<string, string>                                 $labels     id => display-label override for this library.
-	 * @param array<string, list<string>>                           $order      group => ordered token ids for this library.
+	 * @param array<int, string>                                    $order      The flat ordered token id list for this library.
 	 *
 	 * @return array<string, mixed> The localized payload.
 	 */
@@ -121,39 +121,46 @@ final class Builder {
 	}
 
 	/**
-	 * Permute each schema group by its stored order. The stored order is partial and advisory:
-	 * ordered ids that exist in the group come first, in stored sequence; every remaining row
-	 * follows in declaration order — unmentioned ids append rather than sort last so a token
-	 * added after the order was saved (a later release, a newly created primitive) is never
-	 * silently pushed out of view. The result of every branch is the same row set the registry
-	 * emitted — a reorder can never hide a token — and a group with no stored order is returned
-	 * untouched (declaration order). Removing the stored order therefore restores declaration
+	 * Permute every schema group by the stored flat order. For each group independently: rows
+	 * whose id appears in the flat list come first, sorted by their position in that list; every
+	 * remaining row follows in declaration order — unmentioned ids append rather than sort last so
+	 * a token added after the order was saved (a later release, a newly created primitive) is
+	 * never silently pushed out of view. An id belonging to a different group simply never matches
+	 * one of this group's rows, so cross-group entries in the flat list are ignored naturally —
+	 * no explicit filtering by group is needed. The result of every branch is the same row set the
+	 * registry emitted — a reorder can never hide a token — and an empty stored order returns the
+	 * schema untouched (declaration order), so removing the stored order restores declaration
 	 * order with no other code path involved.
 	 *
 	 * @since TBD
 	 *
 	 * @param array{groups: array<string, array<int, array<string, mixed>>>} $schema The (label-overlaid) UI schema.
-	 * @param array<string, list<string>>                                    $order  group => ordered token ids.
+	 * @param array<int, string>                                             $order  The flat ordered token id list.
 	 *
 	 * @return array{groups: array<string, array<int, array<string, mixed>>>} The schema with groups permuted.
 	 */
 	private function apply_group_order( array $schema, array $order ): array {
-		foreach ( $order as $group => $ordered_ids ) {
-			if ( ! isset( $schema['groups'][ $group ] ) || $ordered_ids === [] ) {
-				continue;
-			}
+		if ( $order === [] ) {
+			return $schema;
+		}
 
-			$rows_by_id = array_column( $schema['groups'][ $group ], null, 'id' );
-			$sorted     = [];
+		$positions = array_flip( $order );
 
-			foreach ( $ordered_ids as $id ) {
-				if ( isset( $rows_by_id[ $id ] ) ) {
-					$sorted[ $id ] = $rows_by_id[ $id ]; // Stale ids fall through, ignored.
+		foreach ( $schema['groups'] as $group => $rows ) {
+			$ordered   = [];
+			$unordered = [];
+
+			foreach ( $rows as $row ) {
+				if ( isset( $positions[ $row['id'] ] ) ) {
+					$ordered[] = $row;
+				} else {
+					$unordered[] = $row; // Not in the stored order — declaration order, appended after.
 				}
 			}
 
-			// Everything the stored order did not mention, in declaration order.
-			$schema['groups'][ $group ] = array_values( $sorted + $rows_by_id );
+			usort( $ordered, fn( array $a, array $b ): int => $positions[ $a['id'] ] <=> $positions[ $b['id'] ] );
+
+			$schema['groups'][ $group ] = array_merge( $ordered, $unordered );
 		}
 
 		return $schema;

--- a/includes/resources/Design_Tokens/Admin/Feed/Builder.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Builder.php
@@ -67,10 +67,11 @@ final class Builder {
 	 *                                                                          waiting on the separate libraries request and visibly correcting
 	 *                                                                          itself once that arrives.
 	 * @param array<string, string>                                 $labels     id => display-label override for this library.
+	 * @param array<string, list<string>>                           $order      group => ordered token ids for this library.
 	 *
 	 * @return array<string, mixed> The localized payload.
 	 */
-	public function build( array $values, bool $resolved, array $presets, array $rest, string $version, string $slug, array $responsive = [], string $title = '', array $labels = [] ): array {
+	public function build( array $values, bool $resolved, array $presets, array $rest, string $version, string $slug, array $responsive = [], string $title = '', array $labels = [], array $order = [] ): array {
 		$active = $this->registry->is_active();
 
 		return [
@@ -81,7 +82,9 @@ final class Builder {
 			// Outside the `$active` gate below: a label is not token data, and a deactivated registry
 			// still renders a page that has to name the library it is showing.
 			'title'      => $title,
-			'schema'     => $active ? $this->apply_label_overrides( $this->registry->to_ui_schema(), $labels ) : [ 'groups' => [] ],
+			'schema'     => $active
+				? $this->apply_group_order( $this->apply_label_overrides( $this->registry->to_ui_schema(), $labels ), $order )
+				: [ 'groups' => [] ],
 			'values'     => $active ? $values : [],
 			'presets'    => $active ? $presets : [],
 			'presetNav'  => $active ? $this->preset_nav->all() : [],
@@ -112,6 +115,45 @@ final class Builder {
 				$schema['groups'][ $group ][ $i ]['label']           = $override ?? $row['label'];
 				$schema['groups'][ $group ][ $i ]['labelOverridden'] = $override !== null;
 			}
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Permute each schema group by its stored order. The stored order is partial and advisory:
+	 * ordered ids that exist in the group come first, in stored sequence; every remaining row
+	 * follows in declaration order — unmentioned ids append rather than sort last so a token
+	 * added after the order was saved (a later release, a newly created primitive) is never
+	 * silently pushed out of view. The result of every branch is the same row set the registry
+	 * emitted — a reorder can never hide a token — and a group with no stored order is returned
+	 * untouched (declaration order). Removing the stored order therefore restores declaration
+	 * order with no other code path involved.
+	 *
+	 * @since TBD
+	 *
+	 * @param array{groups: array<string, array<int, array<string, mixed>>>} $schema The (label-overlaid) UI schema.
+	 * @param array<string, list<string>>                                    $order  group => ordered token ids.
+	 *
+	 * @return array{groups: array<string, array<int, array<string, mixed>>>} The schema with groups permuted.
+	 */
+	private function apply_group_order( array $schema, array $order ): array {
+		foreach ( $order as $group => $ordered_ids ) {
+			if ( ! isset( $schema['groups'][ $group ] ) || $ordered_ids === [] ) {
+				continue;
+			}
+
+			$rows_by_id = array_column( $schema['groups'][ $group ], null, 'id' );
+			$sorted     = [];
+
+			foreach ( $ordered_ids as $id ) {
+				if ( isset( $rows_by_id[ $id ] ) ) {
+					$sorted[ $id ] = $rows_by_id[ $id ]; // Stale ids fall through, ignored.
+				}
+			}
+
+			// Everything the stored order did not mention, in declaration order.
+			$schema['groups'][ $group ] = array_values( $sorted + $rows_by_id );
 		}
 
 		return $schema;

--- a/includes/resources/Design_Tokens/Admin/Feed/Builder.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Builder.php
@@ -67,10 +67,11 @@ final class Builder {
 	 * @param array<string, array<string, mixed>>                   $responsive id => raw authored responsive / clamp shape, for
 	 *                                                                          tokens that carry one (for editor hydration).
 	 * @param array<string, string>                                 $labels     id => display-label override for this library.
+	 * @param array<string, list<string>>                           $order      group => ordered token ids for this library.
 	 *
 	 * @return array<string, mixed> The localized payload.
 	 */
-	public function build( array $values, bool $resolved, array $presets, array $rest, string $version, string $slug, string $title = '', array $responsive = [], array $labels = [] ): array {
+	public function build( array $values, bool $resolved, array $presets, array $rest, string $version, string $slug, string $title = '', array $responsive = [], array $labels = [], array $order = [] ): array {
 		$active = $this->registry->is_active();
 
 		return [
@@ -81,7 +82,9 @@ final class Builder {
 			// Carried alongside the slug so the library selector can name the active library on first
 			// paint, before its REST list has loaded and any row is available to look the title up in.
 			'title'      => $title,
-			'schema'     => $active ? $this->apply_label_overrides( $this->registry->to_ui_schema(), $labels ) : [ 'groups' => [] ],
+			'schema'     => $active
+				? $this->apply_group_order( $this->apply_label_overrides( $this->registry->to_ui_schema(), $labels ), $order )
+				: [ 'groups' => [] ],
 			'values'     => $active ? $values : [],
 			'presets'    => $active ? $presets : [],
 			'presetNav'  => $active ? $this->preset_nav->all() : [],
@@ -112,6 +115,45 @@ final class Builder {
 				$schema['groups'][ $group ][ $i ]['label']           = $override ?? $row['label'];
 				$schema['groups'][ $group ][ $i ]['labelOverridden'] = $override !== null;
 			}
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Permute each schema group by its stored order. The stored order is partial and advisory:
+	 * ordered ids that exist in the group come first, in stored sequence; every remaining row
+	 * follows in declaration order — unmentioned ids append rather than sort last so a token
+	 * added after the order was saved (a later release, a newly created primitive) is never
+	 * silently pushed out of view. The result of every branch is the same row set the registry
+	 * emitted — a reorder can never hide a token — and a group with no stored order is returned
+	 * untouched (declaration order). Removing the stored order therefore restores declaration
+	 * order with no other code path involved.
+	 *
+	 * @since TBD
+	 *
+	 * @param array{groups: array<string, array<int, array<string, mixed>>>} $schema The (label-overlaid) UI schema.
+	 * @param array<string, list<string>>                                    $order  group => ordered token ids.
+	 *
+	 * @return array{groups: array<string, array<int, array<string, mixed>>>} The schema with groups permuted.
+	 */
+	private function apply_group_order( array $schema, array $order ): array {
+		foreach ( $order as $group => $ordered_ids ) {
+			if ( ! isset( $schema['groups'][ $group ] ) || $ordered_ids === [] ) {
+				continue;
+			}
+
+			$rows_by_id = array_column( $schema['groups'][ $group ], null, 'id' );
+			$sorted     = [];
+
+			foreach ( $ordered_ids as $id ) {
+				if ( isset( $rows_by_id[ $id ] ) ) {
+					$sorted[ $id ] = $rows_by_id[ $id ]; // Stale ids fall through, ignored.
+				}
+			}
+
+			// Everything the stored order did not mention, in declaration order.
+			$schema['groups'][ $group ] = array_values( $sorted + $rows_by_id );
 		}
 
 		return $schema;

--- a/includes/resources/Design_Tokens/Admin/Feed/Builder.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Builder.php
@@ -67,7 +67,7 @@ final class Builder {
 	 *                                                                          waiting on the separate libraries request and visibly correcting
 	 *                                                                          itself once that arrives.
 	 * @param array<string, string>                                 $labels     id => display-label override for this library.
-	 * @param array<string, list<string>>                           $order      group => ordered token ids for this library.
+	 * @param array<int, string>                                    $order      The flat ordered token id list for this library.
 	 *
 	 * @return array<string, mixed> The localized payload.
 	 */
@@ -121,39 +121,46 @@ final class Builder {
 	}
 
 	/**
-	 * Permute each schema group by its stored order. The stored order is partial and advisory:
-	 * ordered ids that exist in the group come first, in stored sequence; every remaining row
-	 * follows in declaration order — unmentioned ids append rather than sort last so a token
-	 * added after the order was saved (a later release, a newly created primitive) is never
-	 * silently pushed out of view. The result of every branch is the same row set the registry
-	 * emitted — a reorder can never hide a token — and a group with no stored order is returned
-	 * untouched (declaration order). Removing the stored order therefore restores declaration
+	 * Permute every schema group by the stored flat order. For each group independently: rows
+	 * whose id appears in the flat list come first, sorted by their position in that list; every
+	 * remaining row follows in declaration order — unmentioned ids append rather than sort last so
+	 * a token added after the order was saved (a later release, a newly created primitive) is
+	 * never silently pushed out of view. An id belonging to a different group simply never matches
+	 * one of this group's rows, so cross-group entries in the flat list are ignored naturally —
+	 * no explicit filtering by group is needed. The result of every branch is the same row set the
+	 * registry emitted — a reorder can never hide a token — and an empty stored order returns the
+	 * schema untouched (declaration order), so removing the stored order restores declaration
 	 * order with no other code path involved.
 	 *
 	 * @since TBD
 	 *
 	 * @param array{groups: array<string, array<int, array<string, mixed>>>} $schema The (label-overlaid) UI schema.
-	 * @param array<string, list<string>>                                    $order  group => ordered token ids.
+	 * @param array<int, string>                                             $order  The flat ordered token id list.
 	 *
 	 * @return array{groups: array<string, array<int, array<string, mixed>>>} The schema with groups permuted.
 	 */
 	private function apply_group_order( array $schema, array $order ): array {
-		foreach ( $order as $group => $ordered_ids ) {
-			if ( ! isset( $schema['groups'][ $group ] ) || $ordered_ids === [] ) {
-				continue;
-			}
+		if ( $order === [] ) {
+			return $schema;
+		}
 
-			$rows_by_id = array_column( $schema['groups'][ $group ], null, 'id' );
-			$sorted     = [];
+		$positions = array_flip( $order );
 
-			foreach ( $ordered_ids as $id ) {
-				if ( isset( $rows_by_id[ $id ] ) ) {
-					$sorted[ $id ] = $rows_by_id[ $id ]; // Stale ids fall through, ignored.
+		foreach ( $schema['groups'] as $group => $rows ) {
+			$ordered   = [];
+			$unordered = [];
+
+			foreach ( $rows as $row ) {
+				if ( isset( $positions[ $row['id'] ] ) ) {
+					$ordered[] = $row;
+				} else {
+					$unordered[] = $row; // Not in the stored order — declaration order, appended after.
 				}
 			}
 
-			// Everything the stored order did not mention, in declaration order.
-			$schema['groups'][ $group ] = array_values( $sorted + $rows_by_id );
+			usort( $ordered, fn( array $a, array $b ): int => $positions[ $a['id'] ] <=> $positions[ $b['id'] ] );
+
+			$schema['groups'][ $group ] = array_merge( $ordered, $unordered );
 		}
 
 		return $schema;

--- a/includes/resources/Design_Tokens/Admin/Feed/Feed_Assembler.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Feed_Assembler.php
@@ -4,6 +4,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Order_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
@@ -25,9 +26,10 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
  * than a fatal, so the caller still gets structure. The fail-closed case (registry deactivated) is
  * handled inside the builder.
  *
- * The per-token label-override read also lives here rather than in either emitter: it is applied
- * inside Builder::build(), so both {@see Localizer} and {@see \KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Feed_Controller}
- * get the overridden labels automatically instead of one of them silently missing them.
+ * The per-token label-override and per-group sort-order reads also live here rather than in either
+ * emitter: they are applied inside Builder::build(), so both {@see Localizer} and
+ * {@see \KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Feed_Controller} get the overridden labels
+ * and stored order automatically instead of one of them silently missing them.
  *
  * @since TBD
  */
@@ -88,6 +90,15 @@ final class Feed_Assembler {
 	private Token_Label_Index $label_index;
 
 	/**
+	 * Reads the tokenOrder map out of the stored document.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Order_Index
+	 */
+	private Token_Order_Index $order_index;
+
+	/**
 	 * @since TBD
 	 *
 	 * @param Token_Resolver    $resolver        The token resolver.
@@ -96,6 +107,7 @@ final class Feed_Assembler {
 	 * @param Builder           $builder         The pure payload assembler.
 	 * @param Responsive_Feed   $responsive_feed The responsive / clamp shape extractor.
 	 * @param Token_Label_Index $label_index     Reads the tokenLabels override map.
+	 * @param Token_Order_Index $order_index     Reads the tokenOrder map.
 	 */
 	public function __construct(
 		Token_Resolver $resolver,
@@ -103,7 +115,8 @@ final class Feed_Assembler {
 		Presets $preset_feed,
 		Builder $builder,
 		Responsive_Feed $responsive_feed,
-		Token_Label_Index $label_index
+		Token_Label_Index $label_index,
+		Token_Order_Index $order_index
 	) {
 		$this->resolver        = $resolver;
 		$this->store           = $store;
@@ -111,6 +124,7 @@ final class Feed_Assembler {
 		$this->builder         = $builder;
 		$this->responsive_feed = $responsive_feed;
 		$this->label_index     = $label_index;
+		$this->order_index     = $order_index;
 	}
 
 	/**
@@ -138,6 +152,8 @@ final class Feed_Assembler {
 			$resolved = false; // Corrupt stored document. Fail open: ship structure only.
 		}
 
+		$document = $this->read_document( $slug );
+
 		return $this->builder->build(
 			$values,
 			$resolved,
@@ -147,7 +163,8 @@ final class Feed_Assembler {
 			$slug,
 			$this->title( $slug ),
 			$responsive,
-			$this->label_index->all( $this->read_document( $slug ) )
+			$this->label_index->all( $document ),
+			$this->order_index->all( $document )
 		);
 	}
 

--- a/includes/resources/Design_Tokens/Admin/Feed/Feed_Assembler.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Feed_Assembler.php
@@ -4,6 +4,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Order_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
@@ -25,9 +26,10 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
  * than a fatal, so the caller still gets structure. The fail-closed case (registry deactivated) is
  * handled inside the builder.
  *
- * The per-token label-override read also lives here rather than in either emitter: it is applied
- * inside Builder::build(), so both {@see Localizer} and {@see \KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Feed_Controller}
- * get the overridden labels automatically instead of one of them silently missing them.
+ * The per-token label-override and per-group sort-order reads also live here rather than in either
+ * emitter: they are applied inside Builder::build(), so both {@see Localizer} and
+ * {@see \KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Feed_Controller} get the overridden labels
+ * and stored order automatically instead of one of them silently missing them.
  *
  * @since TBD
  */
@@ -88,6 +90,15 @@ final class Feed_Assembler {
 	private Token_Label_Index $label_index;
 
 	/**
+	 * Reads the tokenOrder map out of the stored document.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Order_Index
+	 */
+	private Token_Order_Index $order_index;
+
+	/**
 	 * @since TBD
 	 *
 	 * @param Token_Resolver    $resolver        The token resolver.
@@ -96,6 +107,7 @@ final class Feed_Assembler {
 	 * @param Builder           $builder         The pure payload assembler.
 	 * @param Responsive_Feed   $responsive_feed The responsive / clamp shape extractor.
 	 * @param Token_Label_Index $label_index     Reads the tokenLabels override map.
+	 * @param Token_Order_Index $order_index     Reads the tokenOrder map.
 	 */
 	public function __construct(
 		Token_Resolver $resolver,
@@ -103,7 +115,8 @@ final class Feed_Assembler {
 		Presets $preset_feed,
 		Builder $builder,
 		Responsive_Feed $responsive_feed,
-		Token_Label_Index $label_index
+		Token_Label_Index $label_index,
+		Token_Order_Index $order_index
 	) {
 		$this->resolver        = $resolver;
 		$this->store           = $store;
@@ -111,6 +124,7 @@ final class Feed_Assembler {
 		$this->builder         = $builder;
 		$this->responsive_feed = $responsive_feed;
 		$this->label_index     = $label_index;
+		$this->order_index     = $order_index;
 	}
 
 	/**
@@ -138,6 +152,8 @@ final class Feed_Assembler {
 			$resolved = false; // Corrupt stored document. Fail open: ship structure only.
 		}
 
+		$document = $this->read_document( $slug );
+
 		return $this->builder->build(
 			$values,
 			$resolved,
@@ -147,7 +163,8 @@ final class Feed_Assembler {
 			$slug,
 			$responsive,
 			$this->store->get_title( $slug ),
-			$this->label_index->all( $this->read_document( $slug ) )
+			$this->label_index->all( $document ),
+			$this->order_index->all( $document )
 		);
 	}
 

--- a/includes/resources/Design_Tokens/Admin/Feed/Feed_Assembler.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Feed_Assembler.php
@@ -90,7 +90,7 @@ final class Feed_Assembler {
 	private Token_Label_Index $label_index;
 
 	/**
-	 * Reads the tokenOrder map out of the stored document.
+	 * Reads the tokenOrder flat ordered id list out of the stored document.
 	 *
 	 * @since TBD
 	 *
@@ -107,7 +107,7 @@ final class Feed_Assembler {
 	 * @param Builder           $builder         The pure payload assembler.
 	 * @param Responsive_Feed   $responsive_feed The responsive / clamp shape extractor.
 	 * @param Token_Label_Index $label_index     Reads the tokenLabels override map.
-	 * @param Token_Order_Index $order_index     Reads the tokenOrder map.
+	 * @param Token_Order_Index $order_index     Reads the tokenOrder flat ordered id list.
 	 */
 	public function __construct(
 		Token_Resolver $resolver,

--- a/includes/resources/Design_Tokens/Document/Token_Order_Index.php
+++ b/includes/resources/Design_Tokens/Document/Token_Order_Index.php
@@ -40,6 +40,9 @@ final class Token_Order_Index {
 				continue;
 			}
 
+			// The `$ids === []` check is required, not redundant: `range( 0, -1 )` returns
+			// `[ 0, -1 ]` in PHP, not `[]`, so without this short-circuit an empty order list
+			// would be misclassified as malformed rather than as a valid empty list.
 			$is_list = $ids === [] || array_keys( $ids ) === range( 0, count( $ids ) - 1 );
 
 			if ( ! $is_list ) {

--- a/includes/resources/Design_Tokens/Document/Token_Order_Index.php
+++ b/includes/resources/Design_Tokens/Document/Token_Order_Index.php
@@ -5,143 +5,99 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
 
 /**
- * Reads and writes the tokenOrder map — { group => ordered token id list } in the module's
+ * Reads and writes the tokenOrder list — a single flat ordered token id list — in the module's
  * $extensions namespace. Authoring metadata only; the effective document builder strips
  * $extensions, so order never affects rendering. Every mutating method returns the updated
  * document; the original is not modified.
+ *
+ * The list is keyed by token id, never by group, even though every write route is per-group (see
+ * {@see \KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Documents_Controller::GROUP_ROUTE}): a
+ * token id is a stable, locale-independent dot-path, while the group segment on that route is a
+ * translated UI-schema label that exists only to address and validate the request. Persisting
+ * under the group label would reproduce the exact locale-dependency this storage shape exists to
+ * remove — a stored order would silently stop matching its group the moment the site language
+ * changed. `set_group()` / `remove_group()` therefore take the caller-supplied set of ids
+ * belonging to the target group, so they can isolate that group's slice of the flat list without
+ * ever storing the group name itself.
  *
  * @since TBD
  */
 final class Token_Order_Index {
 
 	/**
-	 * All stored group orders. Read-side fail-soft: a group entry that is not a sequential list of
-	 * non-empty strings is dropped (degrades to declaration order), and non-string ids inside an
-	 * otherwise-valid list are filtered out, so a hand-corrupted section degrades to "no order"
-	 * instead of a type error downstream.
+	 * The full stored order. Read-side fail-soft: a section that is not a sequential list is
+	 * dropped wholesale (degrades to declaration order everywhere), and non-string or empty
+	 * entries inside an otherwise-valid list are filtered out, so a hand-corrupted section
+	 * degrades to "no order" instead of a type error downstream.
 	 *
 	 * @since TBD
 	 *
 	 * @param array<string, mixed> $document
-	 *
-	 * @return array<string, list<string>>
-	 */
-	public function all( array $document ): array {
-		$map = $this->read_map( $document );
-
-		if ( ! is_array( $map ) ) {
-			return [];
-		}
-
-		$orders = [];
-
-		foreach ( $map as $group => $ids ) {
-			if ( ! is_string( $group ) || $group === '' || ! is_array( $ids ) ) {
-				continue;
-			}
-
-			// The `$ids === []` check is required, not redundant: `range( 0, -1 )` returns
-			// `[ 0, -1 ]` in PHP, not `[]`, so without this short-circuit an empty order list
-			// would be misclassified as malformed rather than as a valid empty list.
-			$is_list = $ids === [] || array_keys( $ids ) === range( 0, count( $ids ) - 1 );
-
-			if ( ! $is_list ) {
-				continue;
-			}
-
-			$ids = array_values( array_filter( $ids, fn( $id ) => is_string( $id ) && $id !== '' ) );
-
-			$orders[ $group ] = $ids;
-		}
-
-		return $orders;
-	}
-
-	/**
-	 * The stored order for one group, [] when none is stored.
-	 *
-	 * @since TBD
-	 *
-	 * @param array<string, mixed> $document
-	 * @param string               $group
 	 *
 	 * @return list<string>
 	 */
-	public function for_group( array $document, string $group ): array {
-		return $this->all( $document )[ $group ] ?? [];
+	public function all( array $document ): array {
+		$ids = $this->read_list( $document );
+
+		if ( ! is_array( $ids ) ) {
+			return [];
+		}
+
+		// The `$ids === []` check is required, not redundant: `range( 0, -1 )` returns
+		// `[ 0, -1 ]` in PHP, not `[]`, so without this short-circuit an empty order list would be
+		// misclassified as malformed rather than as a valid empty list.
+		$is_list = $ids === [] || array_keys( $ids ) === range( 0, count( $ids ) - 1 );
+
+		if ( ! $is_list ) {
+			return [];
+		}
+
+		return array_values( array_filter( $ids, fn( $id ) => is_string( $id ) && $id !== '' ) );
 	}
 
 	/**
-	 * Store a group's order wholesale (the endpoint's PUT-replaces contract). Deduplicates keeping
-	 * first occurrence. An empty id list is legal and distinct from remove_group() only in that it
-	 * round-trips as an explicit entry — the controller normalizes that case to remove_group() so
-	 * "no preference" has one spelling.
+	 * Store one group's order wholesale (the endpoint's PUT-replaces contract): the target
+	 * group's own ids are removed from the flat list and the new sequence is re-appended, leaving
+	 * every other group's relative order untouched, since only relative position within a group is
+	 * ever read. Deduplicates the incoming ids, keeping first occurrence.
 	 *
 	 * @since TBD
 	 *
 	 * @param array<string, mixed> $document
-	 * @param string               $group
-	 * @param array<int, string>   $ids
+	 * @param array<int, string>   $group_ids The full set of token ids registered in the target group,
+	 *                                         used to isolate that group's entries within the flat list.
+	 * @param array<int, string>   $ids       The group's new ordered id list.
 	 *
 	 * @return array<string, mixed>
 	 */
-	public function set_group( array $document, string $group, array $ids ): array {
+	public function set_group( array $document, array $group_ids, array $ids ): array {
 		$ids = array_values( array_unique( $ids ) );
 
-		$ext = Extensions::get_extensions_key();
-		$ns  = Extensions::get_namespace();
-		$sec = Extensions::get_section_token_order();
+		$remaining = array_values( array_diff( $this->all( $document ), $group_ids ) );
 
-		$document = $this->ensure_path( $document );
-
-		/** @var array<string, mixed> $ext_data */
-		$ext_data = $document[ $ext ];
-		/** @var array<string, mixed> $ns_data */
-		$ns_data = $ext_data[ $ns ];
-		/** @var array<string, mixed> $sec_data */
-		$sec_data = $ns_data[ $sec ];
-
-		$sec_data[ $group ] = $ids;
-		$ns_data[ $sec ]    = $sec_data;
-		$ext_data[ $ns ]    = $ns_data;
-		$document[ $ext ]   = $ext_data;
-
-		return $document;
+		return $this->write_list( $document, array_merge( $remaining, $ids ) );
 	}
 
 	/**
-	 * Remove a group's stored order — declaration order applies again. No-op when absent.
+	 * Remove one group's ids from the stored order — declaration order applies again for that
+	 * group. No-op (the same document is returned) when the group has no ids currently stored.
 	 *
 	 * @since TBD
 	 *
 	 * @param array<string, mixed> $document
-	 * @param string               $group
+	 * @param array<int, string>   $group_ids The full set of token ids registered in the target group.
 	 *
 	 * @return array<string, mixed>
 	 */
-	public function remove_group( array $document, string $group ): array {
-		if ( ! isset( $this->all( $document )[ $group ] ) ) {
+	public function remove_group( array $document, array $group_ids ): array {
+		$current   = $this->all( $document );
+		$remaining = array_values( array_diff( $current, $group_ids ) );
+
+		if ( $remaining === $current ) {
 			return $document;
 		}
 
-		$ext = Extensions::get_extensions_key();
-		$ns  = Extensions::get_namespace();
-		$sec = Extensions::get_section_token_order();
-
-		/** @var array<string, mixed> $ext_data */
-		$ext_data = $document[ $ext ];
-		/** @var array<string, mixed> $ns_data */
-		$ns_data = $ext_data[ $ns ];
-		/** @var array<string, mixed> $sec_data */
-		$sec_data = $ns_data[ $sec ];
-
-		unset( $sec_data[ $group ] );
-
-		$ns_data[ $sec ]  = $sec_data;
-		$ext_data[ $ns ]  = $ns_data;
-		$document[ $ext ] = $ext_data;
-
-		return $document;
+		return $this->write_list( $document, $remaining );
 	}
 
 	/**
@@ -151,7 +107,7 @@ final class Token_Order_Index {
 	 *
 	 * @return mixed
 	 */
-	private function read_map( array $document ) {
+	private function read_list( array $document ) {
 		$ext_data = $document[ Extensions::get_extensions_key() ] ?? null;
 
 		if ( ! is_array( $ext_data ) ) {
@@ -165,6 +121,33 @@ final class Token_Order_Index {
 		}
 
 		return $ns_data[ Extensions::get_section_token_order() ] ?? null;
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param array<int, string>   $ids
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function write_list( array $document, array $ids ): array {
+		$document = $this->ensure_path( $document );
+
+		$ext = Extensions::get_extensions_key();
+		$ns  = Extensions::get_namespace();
+		$sec = Extensions::get_section_token_order();
+
+		/** @var array<string, mixed> $ext_data */
+		$ext_data = $document[ $ext ];
+		/** @var array<string, mixed> $ns_data */
+		$ns_data = $ext_data[ $ns ];
+
+		$ns_data[ $sec ]  = $ids;
+		$ext_data[ $ns ]  = $ns_data;
+		$document[ $ext ] = $ext_data;
+
+		return $document;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Document/Token_Order_Index.php
+++ b/includes/resources/Design_Tokens/Document/Token_Order_Index.php
@@ -1,0 +1,202 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Document;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+
+/**
+ * Reads and writes the tokenOrder map — { group => ordered token id list } in the module's
+ * $extensions namespace. Authoring metadata only; the effective document builder strips
+ * $extensions, so order never affects rendering. Every mutating method returns the updated
+ * document; the original is not modified.
+ *
+ * @since TBD
+ */
+final class Token_Order_Index {
+
+	/**
+	 * All stored group orders. Read-side fail-soft: a group entry that is not a sequential list of
+	 * non-empty strings is dropped (degrades to declaration order), and non-string ids inside an
+	 * otherwise-valid list are filtered out, so a hand-corrupted section degrades to "no order"
+	 * instead of a type error downstream.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 *
+	 * @return array<string, list<string>>
+	 */
+	public function all( array $document ): array {
+		$map = $this->read_map( $document );
+
+		if ( ! is_array( $map ) ) {
+			return [];
+		}
+
+		$orders = [];
+
+		foreach ( $map as $group => $ids ) {
+			if ( ! is_string( $group ) || $group === '' || ! is_array( $ids ) ) {
+				continue;
+			}
+
+			$is_list = $ids === [] || array_keys( $ids ) === range( 0, count( $ids ) - 1 );
+
+			if ( ! $is_list ) {
+				continue;
+			}
+
+			$ids = array_values( array_filter( $ids, fn( $id ) => is_string( $id ) && $id !== '' ) );
+
+			$orders[ $group ] = $ids;
+		}
+
+		return $orders;
+	}
+
+	/**
+	 * The stored order for one group, [] when none is stored.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param string               $group
+	 *
+	 * @return list<string>
+	 */
+	public function for_group( array $document, string $group ): array {
+		return $this->all( $document )[ $group ] ?? [];
+	}
+
+	/**
+	 * Store a group's order wholesale (the endpoint's PUT-replaces contract). Deduplicates keeping
+	 * first occurrence. An empty id list is legal and distinct from remove_group() only in that it
+	 * round-trips as an explicit entry — the controller normalizes that case to remove_group() so
+	 * "no preference" has one spelling.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param string               $group
+	 * @param array<int, string>   $ids
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function set_group( array $document, string $group, array $ids ): array {
+		$ids = array_values( array_unique( $ids ) );
+
+		$ext = Extensions::get_extensions_key();
+		$ns  = Extensions::get_namespace();
+		$sec = Extensions::get_section_token_order();
+
+		$document = $this->ensure_path( $document );
+
+		/** @var array<string, mixed> $ext_data */
+		$ext_data = $document[ $ext ];
+		/** @var array<string, mixed> $ns_data */
+		$ns_data = $ext_data[ $ns ];
+		/** @var array<string, mixed> $sec_data */
+		$sec_data = $ns_data[ $sec ];
+
+		$sec_data[ $group ] = $ids;
+		$ns_data[ $sec ]    = $sec_data;
+		$ext_data[ $ns ]    = $ns_data;
+		$document[ $ext ]   = $ext_data;
+
+		return $document;
+	}
+
+	/**
+	 * Remove a group's stored order — declaration order applies again. No-op when absent.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param string               $group
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function remove_group( array $document, string $group ): array {
+		if ( ! isset( $this->all( $document )[ $group ] ) ) {
+			return $document;
+		}
+
+		$ext = Extensions::get_extensions_key();
+		$ns  = Extensions::get_namespace();
+		$sec = Extensions::get_section_token_order();
+
+		/** @var array<string, mixed> $ext_data */
+		$ext_data = $document[ $ext ];
+		/** @var array<string, mixed> $ns_data */
+		$ns_data = $ext_data[ $ns ];
+		/** @var array<string, mixed> $sec_data */
+		$sec_data = $ns_data[ $sec ];
+
+		unset( $sec_data[ $group ] );
+
+		$ns_data[ $sec ]  = $sec_data;
+		$ext_data[ $ns ]  = $ns_data;
+		$document[ $ext ] = $ext_data;
+
+		return $document;
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 *
+	 * @return mixed
+	 */
+	private function read_map( array $document ) {
+		$ext_data = $document[ Extensions::get_extensions_key() ] ?? null;
+
+		if ( ! is_array( $ext_data ) ) {
+			return null;
+		}
+
+		$ns_data = $ext_data[ Extensions::get_namespace() ] ?? null;
+
+		if ( ! is_array( $ns_data ) ) {
+			return null;
+		}
+
+		return $ns_data[ Extensions::get_section_token_order() ] ?? null;
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function ensure_path( array $document ): array {
+		$ext = Extensions::get_extensions_key();
+		$ns  = Extensions::get_namespace();
+		$sec = Extensions::get_section_token_order();
+
+		if ( ! isset( $document[ $ext ] ) || ! is_array( $document[ $ext ] ) ) {
+			$document[ $ext ] = [];
+		}
+
+		/** @var array<string, mixed> $ext_data */
+		$ext_data = $document[ $ext ];
+
+		if ( ! isset( $ext_data[ $ns ] ) || ! is_array( $ext_data[ $ns ] ) ) {
+			$ext_data[ $ns ]  = [];
+			$document[ $ext ] = $ext_data;
+		}
+
+		/** @var array<string, mixed> $ns_data */
+		$ns_data = $ext_data[ $ns ];
+
+		if ( ! isset( $ns_data[ $sec ] ) || ! is_array( $ns_data[ $sec ] ) ) {
+			$ns_data[ $sec ]  = [];
+			$ext_data[ $ns ]  = $ns_data;
+			$document[ $ext ] = $ext_data;
+		}
+
+		return $document;
+	}
+}

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -193,11 +193,20 @@ final class Documents_Controller extends Controller {
 	/**
 	 * The group path segment for the order sub-route.
 	 *
+	 * Unlike the token dot-path routes, this segment carries a human-readable, `__()`-translated
+	 * UI-schema group label (e.g. "Font Size"), not a slug — so it cannot be restricted to
+	 * `\w`/`-`. WordPress decodes the request path before matching route regexes (see
+	 * `WP::parse_request()`), so by match time the segment is the literal, fully-decoded label:
+	 * spaces, punctuation, and non-ASCII characters all appear as themselves, not percent-escapes.
+	 * The only character that must stay excluded is the path separator, since the group is a
+	 * single URL path segment; anything else is accepted here and validated against the real
+	 * declared groups downstream in `unknown_group()`.
+	 *
 	 * @since TBD
 	 *
 	 * @var string
 	 */
-	private const GROUP_ROUTE = '(?P<' . self::GROUP_PARAM . '>[\w-]+)';
+	private const GROUP_ROUTE = '(?P<' . self::GROUP_PARAM . '>[^/]+)';
 
 	/**
 	 * The request parameter that carries the ordered list of token ids on an order write.
@@ -2027,7 +2036,9 @@ final class Documents_Controller extends Controller {
 					'description' => __( 'The UI-schema group name whose token order is being set.', 'kadence-blocks' ),
 					'type'        => 'string',
 					'required'    => true,
-					'pattern'     => '^[\w-]+$',
+					// Matches self::GROUP_ROUTE: a translated group label, not a slug — only the
+					// path separator is excluded. See the GROUP_ROUTE docblock for why.
+					'pattern'     => '^[^/]+$',
 				],
 				self::VERSION_PARAM => [
 					'description'       => __( 'The version the client last read; empty for a first write. A mismatch is rejected with HTTP 409.', 'kadence-blocks' ),

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -8,6 +8,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Document\Document_Path;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Reserved_Namespace;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Order_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Reference_Policy;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Document_Validator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Index;
@@ -172,6 +173,42 @@ final class Documents_Controller extends Controller {
 	private const VERSION_PARAM = 'version';
 
 	/**
+	 * The sub-route, relative to a single library, that collects the per-group sort-order endpoints.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const ORDER_ROUTE = 'order';
+
+	/**
+	 * The request parameter that carries the UI-schema group name, on the order sub-route.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const GROUP_PARAM = 'group';
+
+	/**
+	 * The group path segment for the order sub-route.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const GROUP_ROUTE = '(?P<' . self::GROUP_PARAM . '>[\w-]+)';
+
+	/**
+	 * The request parameter that carries the ordered list of token ids on an order write.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const ORDER_PARAM = 'order';
+
+	/**
 	 * The dot-path path segment for the single-token routes. The character class matches the alias
 	 * grammar (a dot-path) minus the braces, so a token is addressable as a sub-resource of its library.
 	 *
@@ -282,6 +319,15 @@ final class Documents_Controller extends Controller {
 	private Token_Label_Index $label_index;
 
 	/**
+	 * Reads and writes the tokenOrder per-group sort-order map.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Order_Index
+	 */
+	private Token_Order_Index $order_index;
+
+	/**
 	 * Memoized item schema for this request. Null until first built.
 	 *
 	 * @since TBD
@@ -313,6 +359,7 @@ final class Documents_Controller extends Controller {
 	 * @param Responsive_Feed                   $responsive_feed       Extracts the authored responsive / clamp shape per token.
 	 * @param Token_Registry                    $registry              The token registry, for the labels sub-route's unregistered-id 404.
 	 * @param Token_Label_Index                 $label_index           Reads and writes the tokenLabels override map.
+	 * @param Token_Order_Index                 $order_index           Reads and writes the tokenOrder per-group sort-order map.
 	 */
 	public function __construct(
 		Token_Store $store,
@@ -325,7 +372,8 @@ final class Documents_Controller extends Controller {
 		Token_Reference_Policy $reference_policy,
 		Responsive_Feed $responsive_feed,
 		Token_Registry $registry,
-		Token_Label_Index $label_index
+		Token_Label_Index $label_index,
+		Token_Order_Index $order_index
 	) {
 		$this->store                    = $store;
 		$this->resolver                 = $resolver;
@@ -338,6 +386,7 @@ final class Documents_Controller extends Controller {
 		$this->responsive_feed          = $responsive_feed;
 		$this->registry                 = $registry;
 		$this->label_index              = $label_index;
+		$this->order_index              = $order_index;
 		$this->rest_base                = 'documents';
 	}
 
@@ -497,6 +546,31 @@ final class Documents_Controller extends Controller {
 					'callback'            => [ $this, 'delete_label' ],
 					'permission_callback' => [ $this, 'update_item_permissions_check' ],
 					'args'                => $this->get_label_delete_params(),
+				],
+				'schema' => [ $this, 'get_item_schema' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/' . self::SLUG_ROUTE . '/' . self::ORDER_ROUTE . '/' . self::GROUP_ROUTE,
+			[
+				[
+					// PUT only, mirroring the labels sub-route: the endpoint replaces a group's whole
+					// order, so there is no partial-update verb to distinguish from PUT.
+					'methods'             => 'PUT',
+					'callback'            => [ $this, 'set_order' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_order_params(),
+				],
+				[
+					// DELETE uses the same capability as PUT — clearing a stored order is an update to
+					// the document, not a resource removal, so the two verbs of one operation cannot
+					// diverge on permission.
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => [ $this, 'delete_order' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_order_delete_params(),
 				],
 				'schema' => [ $this, 'get_item_schema' ],
 			]
@@ -997,6 +1071,93 @@ final class Documents_Controller extends Controller {
 	}
 
 	/**
+	 * Store a group's token sort order wholesale (PUT /documents/{slug}/order/{group}).
+	 *
+	 * The submitted ids are pruned to those registered in the target group, first occurrence wins
+	 * on duplicates. Silent by design — the stored order is advisory, and a client racing a token
+	 * deletion must not fail its whole reorder over one vanished id. Pruning to an empty list stores
+	 * no entry at all, so "no preference" has one spelling. An unknown group, by contrast, is a
+	 * 404 — that is a caller bug, and accepting it would accumulate unreachable sections nothing can
+	 * display or clear from the UI.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function set_order( $request ) {
+		$slug  = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+		$group = Cast::to_string( $request->get_param( self::GROUP_PARAM ) );
+
+		if ( ! $this->is_known_library( $slug ) ) {
+			return $this->not_found( $slug );
+		}
+
+		$registered = $this->registry->to_ui_schema()['groups'][ $group ] ?? null;
+
+		if ( $registered === null ) {
+			return $this->unknown_group( $group );
+		}
+
+		$error = $this->guard_client_version( $slug, Cast::to_string( $request->get_param( self::VERSION_PARAM ) ) );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$group_ids = array_column( $registered, 'id' );
+		$submitted = array_map( [ Cast::class, 'to_string' ], (array) $request->get_param( self::ORDER_PARAM ) );
+		$ids       = array_values( array_unique( array_intersect( $submitted, $group_ids ) ) );
+
+		$stored    = $this->read_stored_document( $slug );
+		$candidate = $ids === []
+			? $this->order_index->remove_group( $stored, $group )
+			: $this->order_index->set_group( $stored, $group, $ids );
+
+		return $this->persist_metadata_candidate( $candidate, $slug );
+	}
+
+	/**
+	 * Clear a group's stored token sort order (DELETE /documents/{slug}/order/{group}), reverting
+	 * that group to declaration order. Idempotent: when nothing is stored for the group, this
+	 * returns the current item without a write, mirroring delete_label()'s idempotency.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_order( $request ) {
+		$slug  = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+		$group = Cast::to_string( $request->get_param( self::GROUP_PARAM ) );
+
+		if ( ! $this->is_known_library( $slug ) ) {
+			return $this->not_found( $slug );
+		}
+
+		if ( ! isset( $this->registry->to_ui_schema()['groups'][ $group ] ) ) {
+			return $this->unknown_group( $group );
+		}
+
+		$error = $this->guard_client_version( $slug, Cast::to_string( $request->get_param( self::VERSION_PARAM ) ) );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$stored    = $this->read_stored_document( $slug );
+		$candidate = $this->order_index->remove_group( $stored, $group );
+
+		if ( $candidate === $stored ) {
+			return new WP_REST_Response( $this->prepare_item( $slug ), WP_Http::OK );
+		}
+
+		return $this->persist_metadata_candidate( $candidate, $slug );
+	}
+
+	/**
 	 * Validate that the token dot-path begins with a real token layer and names a token below it.
 	 *
 	 * Used as the path argument's validate_callback so a path into "$extensions" (any non-layer root), a
@@ -1313,17 +1474,18 @@ final class Documents_Controller extends Controller {
 
 	/**
 	 * Persist a candidate whose only change is inside an id-keyed authoring-metadata $extensions
-	 * section (token labels). Deliberately skips the full DTCG validator and the resolver dry-run:
-	 * the index helpers' edits are mechanically confined to a section the effective-document
-	 * builder strips, so they cannot introduce grammar or alias problems — and running the full
-	 * pipeline would make a rename impossible in any library whose stored document does not
-	 * currently validate, for reasons unrelated to the rename (the same trap the dedicated
-	 * single-token routes avoid by never re-validating the whole document either). The section is
-	 * still validated whenever the full document is (bulk POST/PATCH/PUT), via its validator branch.
+	 * section (token labels or token order). Deliberately skips the full DTCG validator and the
+	 * resolver dry-run: the index helpers' edits are mechanically confined to a section the
+	 * effective-document builder strips, so they cannot introduce grammar or alias problems — and
+	 * running the full pipeline would make a rename or reorder impossible in any library whose
+	 * stored document does not currently validate, for reasons unrelated to the edit (the same
+	 * trap the dedicated single-token routes avoid by never re-validating the whole document
+	 * either). The section is still validated whenever the full document is (bulk POST/PATCH/PUT),
+	 * via its validator branch.
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, mixed> $candidate The candidate document with the label edit applied.
+	 * @param array<string, mixed> $candidate The candidate document with the metadata edit applied.
 	 * @param string               $slug      The token library slug.
 	 *
 	 * @return WP_REST_Response|WP_Error
@@ -1426,6 +1588,26 @@ final class Documents_Controller extends Controller {
 			[
 				'status' => WP_Http::NOT_FOUND,
 				'id'     => $id,
+			]
+		);
+	}
+
+	/**
+	 * The error returned when an order-route group does not name a UI-schema group.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $group The unknown group name.
+	 *
+	 * @return WP_Error
+	 */
+	private function unknown_group( string $group ): WP_Error {
+		return new WP_Error(
+			'rest_design_tokens_unknown_group',
+			__( 'Sorry, that token group does not exist.', 'kadence-blocks' ),
+			[
+				'status' => WP_Http::NOT_FOUND,
+				'group'  => $group,
 			]
 		);
 	}
@@ -1743,6 +1925,57 @@ final class Documents_Controller extends Controller {
 					'type'        => 'string',
 					'required'    => true,
 					'pattern'     => '^[\w.-]+$',
+				],
+				self::VERSION_PARAM => [
+					'description'       => __( 'The version the client last read; empty for a first write. A mismatch is rejected with HTTP 409.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => true,
+					'sanitize_callback' => 'sanitize_text_field',
+				],
+			]
+		);
+	}
+
+	/**
+	 * The arguments accepted by the order-route PUT: the slug, the group, the ordered id list and
+	 * the version-conditional guard.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_order_params(): array {
+		return array_merge(
+			$this->get_order_delete_params(),
+			[
+				self::ORDER_PARAM => [
+					'description'          => __( 'The token ids in their new order for this group.', 'kadence-blocks' ),
+					'type'                 => 'array',
+					'required'             => true,
+					'items'                => [ 'type' => 'string' ],
+					'additionalProperties' => false,
+				],
+			]
+		);
+	}
+
+	/**
+	 * The arguments accepted by the order-route DELETE: the slug, the group and the
+	 * version-conditional guard.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_order_delete_params(): array {
+		return array_merge(
+			$this->get_slug_params(),
+			[
+				self::GROUP_PARAM   => [
+					'description' => __( 'The UI-schema group name whose token order is being set.', 'kadence-blocks' ),
+					'type'        => 'string',
+					'required'    => true,
+					'pattern'     => '^[\w-]+$',
 				],
 				self::VERSION_PARAM => [
 					'description'       => __( 'The version the client last read; empty for a first write. A mismatch is rejected with HTTP 409.', 'kadence-blocks' ),

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -328,7 +328,7 @@ final class Documents_Controller extends Controller {
 	private Token_Label_Index $label_index;
 
 	/**
-	 * Reads and writes the tokenOrder per-group sort-order map.
+	 * Reads and writes the tokenOrder flat ordered id list.
 	 *
 	 * @since TBD
 	 *
@@ -368,7 +368,7 @@ final class Documents_Controller extends Controller {
 	 * @param Responsive_Feed                   $responsive_feed       Extracts the authored responsive / clamp shape per token.
 	 * @param Token_Registry                    $registry              The token registry, for the labels sub-route's unregistered-id 404.
 	 * @param Token_Label_Index                 $label_index           Reads and writes the tokenLabels override map.
-	 * @param Token_Order_Index                 $order_index           Reads and writes the tokenOrder per-group sort-order map.
+	 * @param Token_Order_Index                 $order_index           Reads and writes the tokenOrder flat ordered id list.
 	 */
 	public function __construct(
 		Token_Store $store,
@@ -1115,14 +1115,14 @@ final class Documents_Controller extends Controller {
 			return $error;
 		}
 
-		$group_ids = array_column( $registered, 'id' );
+		$group_ids = array_map( [ Cast::class, 'to_string' ], array_column( $registered, 'id' ) );
 		$submitted = array_map( [ Cast::class, 'to_string' ], (array) $request->get_param( self::ORDER_PARAM ) );
 		$ids       = array_values( array_unique( array_intersect( $submitted, $group_ids ) ) );
 
 		$stored    = $this->read_stored_document( $slug );
 		$candidate = $ids === []
-			? $this->order_index->remove_group( $stored, $group )
-			: $this->order_index->set_group( $stored, $group, $ids );
+			? $this->order_index->remove_group( $stored, $group_ids )
+			: $this->order_index->set_group( $stored, $group_ids, $ids );
 
 		return $this->persist_metadata_candidate( $candidate, $slug );
 	}
@@ -1146,7 +1146,9 @@ final class Documents_Controller extends Controller {
 			return $this->not_found( $slug );
 		}
 
-		if ( ! isset( $this->registry->to_ui_schema()['groups'][ $group ] ) ) {
+		$registered = $this->registry->to_ui_schema()['groups'][ $group ] ?? null;
+
+		if ( $registered === null ) {
 			return $this->unknown_group( $group );
 		}
 
@@ -1156,8 +1158,9 @@ final class Documents_Controller extends Controller {
 			return $error;
 		}
 
+		$group_ids = array_map( [ Cast::class, 'to_string' ], array_column( $registered, 'id' ) );
 		$stored    = $this->read_stored_document( $slug );
-		$candidate = $this->order_index->remove_group( $stored, $group );
+		$candidate = $this->order_index->remove_group( $stored, $group_ids );
 
 		if ( $candidate === $stored ) {
 			return new WP_REST_Response( $this->prepare_item( $slug ), WP_Http::OK );

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -2034,11 +2034,10 @@ final class Documents_Controller extends Controller {
 			$this->get_order_delete_params(),
 			[
 				self::ORDER_PARAM => [
-					'description'          => __( 'The token ids in their new order for this group.', 'kadence-blocks' ),
-					'type'                 => 'array',
-					'required'             => true,
-					'items'                => [ 'type' => 'string' ],
-					'additionalProperties' => false,
+					'description' => __( 'The token ids in their new order for this group.', 'kadence-blocks' ),
+					'type'        => 'array',
+					'required'    => true,
+					'items'       => [ 'type' => 'string' ],
 				],
 			]
 		);

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -195,12 +195,13 @@ final class Documents_Controller extends Controller {
 	 *
 	 * Unlike the token dot-path routes, this segment carries a human-readable, `__()`-translated
 	 * UI-schema group label (e.g. "Font Size"), not a slug — so it cannot be restricted to
-	 * `\w`/`-`. WordPress decodes the request path before matching route regexes (see
-	 * `WP::parse_request()`), so by match time the segment is the literal, fully-decoded label:
-	 * spaces, punctuation, and non-ASCII characters all appear as themselves, not percent-escapes.
-	 * The only character that must stay excluded is the path separator, since the group is a
-	 * single URL path segment; anything else is accepted here and validated against the real
-	 * declared groups downstream in `unknown_group()`.
+	 * `\w`/`-`. Unlike the front-end `WP::parse_request()` path, the REST server matches route
+	 * regexes against the raw, still percent-encoded request path (`WP_REST_Server::dispatch()`
+	 * never calls `urldecode()`/`rawurldecode()` on it), so a multi-word label reaches this pattern
+	 * as e.g. `Font%20Size`, not `Font Size`. The pattern only needs to exclude the path separator,
+	 * since the group is a single URL path segment; the percent-encoding is undone afterward by the
+	 * `sanitize_callback` on the group arg (see `get_order_delete_params()`), and the decoded value
+	 * is what is validated against the real declared groups in `unknown_group()`.
 	 *
 	 * @since TBD
 	 *
@@ -1207,6 +1208,26 @@ final class Documents_Controller extends Controller {
 	}
 
 	/**
+	 * Decode the order sub-route's group path segment (sanitize_callback for the group arg).
+	 *
+	 * The REST server does not urldecode a route param before it reaches this callback (see the
+	 * `GROUP_ROUTE` docblock), so a multi-word label such as "Font Size" arrives as `Font%20Size`.
+	 * `rawurldecode()` (not `urldecode()`) is deliberate: this is a path segment, not a form-encoded
+	 * query value, so a literal `+` in a group label must stay a `+`, not become a space. Decoding
+	 * happens exactly once, here at the args layer, so every handler reading `self::GROUP_PARAM`
+	 * already sees the real label.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $value The raw, still percent-encoded group value from the URL.
+	 *
+	 * @return string The decoded group label.
+	 */
+	public function decode_group( $value ): string {
+		return rawurldecode( Cast::to_string( $value ) );
+	}
+
+	/**
 	 * The JSON Schema for a token-library document item.
 	 *
 	 * @since TBD
@@ -1984,12 +2005,15 @@ final class Documents_Controller extends Controller {
 			$this->get_slug_params(),
 			[
 				self::GROUP_PARAM   => [
-					'description' => __( 'The UI-schema group name whose token order is being set.', 'kadence-blocks' ),
-					'type'        => 'string',
-					'required'    => true,
+					'description'       => __( 'The UI-schema group name whose token order is being set.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => true,
 					// Matches self::GROUP_ROUTE: a translated group label, not a slug — only the
 					// path separator is excluded. See the GROUP_ROUTE docblock for why.
-					'pattern'     => '^[^/]+$',
+					'pattern'           => '^[^/]+$',
+					// The value on the wire is still percent-encoded (e.g. "Font%20Size"); decode it
+					// once here so set_order()/delete_order() both see the real label. See decode_group().
+					'sanitize_callback' => [ $this, 'decode_group' ],
 				],
 				self::VERSION_PARAM => [
 					'description'       => __( 'The version the client last read; empty for a first write. A mismatch is rejected with HTTP 409.', 'kadence-blocks' ),

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -193,11 +193,20 @@ final class Documents_Controller extends Controller {
 	/**
 	 * The group path segment for the order sub-route.
 	 *
+	 * Unlike the token dot-path routes, this segment carries a human-readable, `__()`-translated
+	 * UI-schema group label (e.g. "Font Size"), not a slug — so it cannot be restricted to
+	 * `\w`/`-`. WordPress decodes the request path before matching route regexes (see
+	 * `WP::parse_request()`), so by match time the segment is the literal, fully-decoded label:
+	 * spaces, punctuation, and non-ASCII characters all appear as themselves, not percent-escapes.
+	 * The only character that must stay excluded is the path separator, since the group is a
+	 * single URL path segment; anything else is accepted here and validated against the real
+	 * declared groups downstream in `unknown_group()`.
+	 *
 	 * @since TBD
 	 *
 	 * @var string
 	 */
-	private const GROUP_ROUTE = '(?P<' . self::GROUP_PARAM . '>[\w-]+)';
+	private const GROUP_ROUTE = '(?P<' . self::GROUP_PARAM . '>[^/]+)';
 
 	/**
 	 * The request parameter that carries the ordered list of token ids on an order write.
@@ -1975,7 +1984,9 @@ final class Documents_Controller extends Controller {
 					'description' => __( 'The UI-schema group name whose token order is being set.', 'kadence-blocks' ),
 					'type'        => 'string',
 					'required'    => true,
-					'pattern'     => '^[\w-]+$',
+					// Matches self::GROUP_ROUTE: a translated group label, not a slug — only the
+					// path separator is excluded. See the GROUP_ROUTE docblock for why.
+					'pattern'     => '^[^/]+$',
 				],
 				self::VERSION_PARAM => [
 					'description'       => __( 'The version the client last read; empty for a first write. A mismatch is rejected with HTTP 409.', 'kadence-blocks' ),

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -195,12 +195,13 @@ final class Documents_Controller extends Controller {
 	 *
 	 * Unlike the token dot-path routes, this segment carries a human-readable, `__()`-translated
 	 * UI-schema group label (e.g. "Font Size"), not a slug — so it cannot be restricted to
-	 * `\w`/`-`. WordPress decodes the request path before matching route regexes (see
-	 * `WP::parse_request()`), so by match time the segment is the literal, fully-decoded label:
-	 * spaces, punctuation, and non-ASCII characters all appear as themselves, not percent-escapes.
-	 * The only character that must stay excluded is the path separator, since the group is a
-	 * single URL path segment; anything else is accepted here and validated against the real
-	 * declared groups downstream in `unknown_group()`.
+	 * `\w`/`-`. Unlike the front-end `WP::parse_request()` path, the REST server matches route
+	 * regexes against the raw, still percent-encoded request path (`WP_REST_Server::dispatch()`
+	 * never calls `urldecode()`/`rawurldecode()` on it), so a multi-word label reaches this pattern
+	 * as e.g. `Font%20Size`, not `Font Size`. The pattern only needs to exclude the path separator,
+	 * since the group is a single URL path segment; the percent-encoding is undone afterward by the
+	 * `sanitize_callback` on the group arg (see `get_order_delete_params()`), and the decoded value
+	 * is what is validated against the real declared groups in `unknown_group()`.
 	 *
 	 * @since TBD
 	 *
@@ -1259,6 +1260,26 @@ final class Documents_Controller extends Controller {
 	}
 
 	/**
+	 * Decode the order sub-route's group path segment (sanitize_callback for the group arg).
+	 *
+	 * The REST server does not urldecode a route param before it reaches this callback (see the
+	 * `GROUP_ROUTE` docblock), so a multi-word label such as "Font Size" arrives as `Font%20Size`.
+	 * `rawurldecode()` (not `urldecode()`) is deliberate: this is a path segment, not a form-encoded
+	 * query value, so a literal `+` in a group label must stay a `+`, not become a space. Decoding
+	 * happens exactly once, here at the args layer, so every handler reading `self::GROUP_PARAM`
+	 * already sees the real label.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $value The raw, still percent-encoded group value from the URL.
+	 *
+	 * @return string The decoded group label.
+	 */
+	public function decode_group( $value ): string {
+		return rawurldecode( Cast::to_string( $value ) );
+	}
+
+	/**
 	 * The JSON Schema for a token-library document item.
 	 *
 	 * @since TBD
@@ -2036,12 +2057,15 @@ final class Documents_Controller extends Controller {
 			$this->get_slug_params(),
 			[
 				self::GROUP_PARAM   => [
-					'description' => __( 'The UI-schema group name whose token order is being set.', 'kadence-blocks' ),
-					'type'        => 'string',
-					'required'    => true,
+					'description'       => __( 'The UI-schema group name whose token order is being set.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => true,
 					// Matches self::GROUP_ROUTE: a translated group label, not a slug — only the
 					// path separator is excluded. See the GROUP_ROUTE docblock for why.
-					'pattern'     => '^[^/]+$',
+					'pattern'           => '^[^/]+$',
+					// The value on the wire is still percent-encoded (e.g. "Font%20Size"); decode it
+					// once here so set_order()/delete_order() both see the real label. See decode_group().
+					'sanitize_callback' => [ $this, 'decode_group' ],
 				],
 				self::VERSION_PARAM => [
 					'description'       => __( 'The version the client last read; empty for a first write. A mismatch is rejected with HTTP 409.', 'kadence-blocks' ),

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -8,6 +8,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Document\Document_Path;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Reserved_Namespace;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Order_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Reference_Policy;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Document_Validator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\User_Primitive_Index;
@@ -172,6 +173,42 @@ final class Documents_Controller extends Controller {
 	private const VERSION_PARAM = 'version';
 
 	/**
+	 * The sub-route, relative to a single library, that collects the per-group sort-order endpoints.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const ORDER_ROUTE = 'order';
+
+	/**
+	 * The request parameter that carries the UI-schema group name, on the order sub-route.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const GROUP_PARAM = 'group';
+
+	/**
+	 * The group path segment for the order sub-route.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const GROUP_ROUTE = '(?P<' . self::GROUP_PARAM . '>[\w-]+)';
+
+	/**
+	 * The request parameter that carries the ordered list of token ids on an order write.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const ORDER_PARAM = 'order';
+
+	/**
 	 * The dot-path path segment for the single-token routes. The character class matches the alias
 	 * grammar (a dot-path) minus the braces, so a token is addressable as a sub-resource of its library.
 	 *
@@ -282,6 +319,15 @@ final class Documents_Controller extends Controller {
 	private Token_Label_Index $label_index;
 
 	/**
+	 * Reads and writes the tokenOrder per-group sort-order map.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Order_Index
+	 */
+	private Token_Order_Index $order_index;
+
+	/**
 	 * Memoized item schema for this request. Null until first built.
 	 *
 	 * @since TBD
@@ -313,6 +359,7 @@ final class Documents_Controller extends Controller {
 	 * @param Responsive_Feed                   $responsive_feed       Extracts the authored responsive / clamp shape per token.
 	 * @param Token_Registry                    $registry              The token registry, for the labels sub-route's unregistered-id 404.
 	 * @param Token_Label_Index                 $label_index           Reads and writes the tokenLabels override map.
+	 * @param Token_Order_Index                 $order_index           Reads and writes the tokenOrder per-group sort-order map.
 	 */
 	public function __construct(
 		Token_Store $store,
@@ -325,7 +372,8 @@ final class Documents_Controller extends Controller {
 		Token_Reference_Policy $reference_policy,
 		Responsive_Feed $responsive_feed,
 		Token_Registry $registry,
-		Token_Label_Index $label_index
+		Token_Label_Index $label_index,
+		Token_Order_Index $order_index
 	) {
 		$this->store                    = $store;
 		$this->resolver                 = $resolver;
@@ -338,6 +386,7 @@ final class Documents_Controller extends Controller {
 		$this->responsive_feed          = $responsive_feed;
 		$this->registry                 = $registry;
 		$this->label_index              = $label_index;
+		$this->order_index              = $order_index;
 		$this->rest_base                = 'documents';
 	}
 
@@ -510,6 +559,31 @@ final class Documents_Controller extends Controller {
 					'callback'            => [ $this, 'delete_label' ],
 					'permission_callback' => [ $this, 'update_item_permissions_check' ],
 					'args'                => $this->get_label_delete_params(),
+				],
+				'schema' => [ $this, 'get_item_schema' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/' . self::SLUG_ROUTE . '/' . self::ORDER_ROUTE . '/' . self::GROUP_ROUTE,
+			[
+				[
+					// PUT only, mirroring the labels sub-route: the endpoint replaces a group's whole
+					// order, so there is no partial-update verb to distinguish from PUT.
+					'methods'             => 'PUT',
+					'callback'            => [ $this, 'set_order' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_order_params(),
+				],
+				[
+					// DELETE uses the same capability as PUT — clearing a stored order is an update to
+					// the document, not a resource removal, so the two verbs of one operation cannot
+					// diverge on permission.
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => [ $this, 'delete_order' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_order_delete_params(),
 				],
 				'schema' => [ $this, 'get_item_schema' ],
 			]
@@ -1049,6 +1123,93 @@ final class Documents_Controller extends Controller {
 	}
 
 	/**
+	 * Store a group's token sort order wholesale (PUT /documents/{slug}/order/{group}).
+	 *
+	 * The submitted ids are pruned to those registered in the target group, first occurrence wins
+	 * on duplicates. Silent by design — the stored order is advisory, and a client racing a token
+	 * deletion must not fail its whole reorder over one vanished id. Pruning to an empty list stores
+	 * no entry at all, so "no preference" has one spelling. An unknown group, by contrast, is a
+	 * 404 — that is a caller bug, and accepting it would accumulate unreachable sections nothing can
+	 * display or clear from the UI.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function set_order( $request ) {
+		$slug  = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+		$group = Cast::to_string( $request->get_param( self::GROUP_PARAM ) );
+
+		if ( ! $this->is_known_library( $slug ) ) {
+			return $this->not_found( $slug );
+		}
+
+		$registered = $this->registry->to_ui_schema()['groups'][ $group ] ?? null;
+
+		if ( $registered === null ) {
+			return $this->unknown_group( $group );
+		}
+
+		$error = $this->guard_client_version( $slug, Cast::to_string( $request->get_param( self::VERSION_PARAM ) ) );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$group_ids = array_column( $registered, 'id' );
+		$submitted = array_map( [ Cast::class, 'to_string' ], (array) $request->get_param( self::ORDER_PARAM ) );
+		$ids       = array_values( array_unique( array_intersect( $submitted, $group_ids ) ) );
+
+		$stored    = $this->read_stored_document( $slug );
+		$candidate = $ids === []
+			? $this->order_index->remove_group( $stored, $group )
+			: $this->order_index->set_group( $stored, $group, $ids );
+
+		return $this->persist_metadata_candidate( $candidate, $slug );
+	}
+
+	/**
+	 * Clear a group's stored token sort order (DELETE /documents/{slug}/order/{group}), reverting
+	 * that group to declaration order. Idempotent: when nothing is stored for the group, this
+	 * returns the current item without a write, mirroring delete_label()'s idempotency.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_order( $request ) {
+		$slug  = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+		$group = Cast::to_string( $request->get_param( self::GROUP_PARAM ) );
+
+		if ( ! $this->is_known_library( $slug ) ) {
+			return $this->not_found( $slug );
+		}
+
+		if ( ! isset( $this->registry->to_ui_schema()['groups'][ $group ] ) ) {
+			return $this->unknown_group( $group );
+		}
+
+		$error = $this->guard_client_version( $slug, Cast::to_string( $request->get_param( self::VERSION_PARAM ) ) );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$stored    = $this->read_stored_document( $slug );
+		$candidate = $this->order_index->remove_group( $stored, $group );
+
+		if ( $candidate === $stored ) {
+			return new WP_REST_Response( $this->prepare_item( $slug ), WP_Http::OK );
+		}
+
+		return $this->persist_metadata_candidate( $candidate, $slug );
+	}
+
+	/**
 	 * Validate that the token dot-path begins with a real token layer and names a token below it.
 	 *
 	 * Used as the path argument's validate_callback so a path into "$extensions" (any non-layer root), a
@@ -1365,17 +1526,18 @@ final class Documents_Controller extends Controller {
 
 	/**
 	 * Persist a candidate whose only change is inside an id-keyed authoring-metadata $extensions
-	 * section (token labels). Deliberately skips the full DTCG validator and the resolver dry-run:
-	 * the index helpers' edits are mechanically confined to a section the effective-document
-	 * builder strips, so they cannot introduce grammar or alias problems — and running the full
-	 * pipeline would make a rename impossible in any library whose stored document does not
-	 * currently validate, for reasons unrelated to the rename (the same trap the dedicated
-	 * single-token routes avoid by never re-validating the whole document either). The section is
-	 * still validated whenever the full document is (bulk POST/PATCH/PUT), via its validator branch.
+	 * section (token labels or token order). Deliberately skips the full DTCG validator and the
+	 * resolver dry-run: the index helpers' edits are mechanically confined to a section the
+	 * effective-document builder strips, so they cannot introduce grammar or alias problems — and
+	 * running the full pipeline would make a rename or reorder impossible in any library whose
+	 * stored document does not currently validate, for reasons unrelated to the edit (the same
+	 * trap the dedicated single-token routes avoid by never re-validating the whole document
+	 * either). The section is still validated whenever the full document is (bulk POST/PATCH/PUT),
+	 * via its validator branch.
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, mixed> $candidate The candidate document with the label edit applied.
+	 * @param array<string, mixed> $candidate The candidate document with the metadata edit applied.
 	 * @param string               $slug      The token library slug.
 	 *
 	 * @return WP_REST_Response|WP_Error
@@ -1478,6 +1640,26 @@ final class Documents_Controller extends Controller {
 			[
 				'status' => WP_Http::NOT_FOUND,
 				'id'     => $id,
+			]
+		);
+	}
+
+	/**
+	 * The error returned when an order-route group does not name a UI-schema group.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $group The unknown group name.
+	 *
+	 * @return WP_Error
+	 */
+	private function unknown_group( string $group ): WP_Error {
+		return new WP_Error(
+			'rest_design_tokens_unknown_group',
+			__( 'Sorry, that token group does not exist.', 'kadence-blocks' ),
+			[
+				'status' => WP_Http::NOT_FOUND,
+				'group'  => $group,
 			]
 		);
 	}
@@ -1797,6 +1979,57 @@ final class Documents_Controller extends Controller {
 					'pattern'     => '^[\w.-]+$',
 				],
 				self::VERSION_PARAM   => [
+					'description'       => __( 'The version the client last read; empty for a first write. A mismatch is rejected with HTTP 409.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => true,
+					'sanitize_callback' => 'sanitize_text_field',
+				],
+			]
+		);
+	}
+
+	/**
+	 * The arguments accepted by the order-route PUT: the slug, the group, the ordered id list and
+	 * the version-conditional guard.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_order_params(): array {
+		return array_merge(
+			$this->get_order_delete_params(),
+			[
+				self::ORDER_PARAM => [
+					'description'          => __( 'The token ids in their new order for this group.', 'kadence-blocks' ),
+					'type'                 => 'array',
+					'required'             => true,
+					'items'                => [ 'type' => 'string' ],
+					'additionalProperties' => false,
+				],
+			]
+		);
+	}
+
+	/**
+	 * The arguments accepted by the order-route DELETE: the slug, the group and the
+	 * version-conditional guard.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_order_delete_params(): array {
+		return array_merge(
+			$this->get_slug_params(),
+			[
+				self::GROUP_PARAM   => [
+					'description' => __( 'The UI-schema group name whose token order is being set.', 'kadence-blocks' ),
+					'type'        => 'string',
+					'required'    => true,
+					'pattern'     => '^[\w-]+$',
+				],
+				self::VERSION_PARAM => [
 					'description'       => __( 'The version the client last read; empty for a first write. A mismatch is rejected with HTTP 409.', 'kadence-blocks' ),
 					'type'              => 'string',
 					'required'          => true,

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -328,7 +328,7 @@ final class Documents_Controller extends Controller {
 	private Token_Label_Index $label_index;
 
 	/**
-	 * Reads and writes the tokenOrder per-group sort-order map.
+	 * Reads and writes the tokenOrder flat ordered id list.
 	 *
 	 * @since TBD
 	 *
@@ -368,7 +368,7 @@ final class Documents_Controller extends Controller {
 	 * @param Responsive_Feed                   $responsive_feed       Extracts the authored responsive / clamp shape per token.
 	 * @param Token_Registry                    $registry              The token registry, for the labels sub-route's unregistered-id 404.
 	 * @param Token_Label_Index                 $label_index           Reads and writes the tokenLabels override map.
-	 * @param Token_Order_Index                 $order_index           Reads and writes the tokenOrder per-group sort-order map.
+	 * @param Token_Order_Index                 $order_index           Reads and writes the tokenOrder flat ordered id list.
 	 */
 	public function __construct(
 		Token_Store $store,
@@ -1167,14 +1167,14 @@ final class Documents_Controller extends Controller {
 			return $error;
 		}
 
-		$group_ids = array_column( $registered, 'id' );
+		$group_ids = array_map( [ Cast::class, 'to_string' ], array_column( $registered, 'id' ) );
 		$submitted = array_map( [ Cast::class, 'to_string' ], (array) $request->get_param( self::ORDER_PARAM ) );
 		$ids       = array_values( array_unique( array_intersect( $submitted, $group_ids ) ) );
 
 		$stored    = $this->read_stored_document( $slug );
 		$candidate = $ids === []
-			? $this->order_index->remove_group( $stored, $group )
-			: $this->order_index->set_group( $stored, $group, $ids );
+			? $this->order_index->remove_group( $stored, $group_ids )
+			: $this->order_index->set_group( $stored, $group_ids, $ids );
 
 		return $this->persist_metadata_candidate( $candidate, $slug );
 	}
@@ -1198,7 +1198,9 @@ final class Documents_Controller extends Controller {
 			return $this->not_found( $slug );
 		}
 
-		if ( ! isset( $this->registry->to_ui_schema()['groups'][ $group ] ) ) {
+		$registered = $this->registry->to_ui_schema()['groups'][ $group ] ?? null;
+
+		if ( $registered === null ) {
 			return $this->unknown_group( $group );
 		}
 
@@ -1208,8 +1210,9 @@ final class Documents_Controller extends Controller {
 			return $error;
 		}
 
+		$group_ids = array_map( [ Cast::class, 'to_string' ], array_column( $registered, 'id' ) );
 		$stored    = $this->read_stored_document( $slug );
-		$candidate = $this->order_index->remove_group( $stored, $group );
+		$candidate = $this->order_index->remove_group( $stored, $group_ids );
 
 		if ( $candidate === $stored ) {
 			return new WP_REST_Response( $this->prepare_item( $slug ), WP_Http::OK );

--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -620,6 +620,18 @@ final class Dtcg_Validator {
 			);
 		}
 
+		// tokenOrder is a { group => ordered token id list } map — id-keyed metadata, not
+		// preset-shaped, so the tokens-map walk (driven by get_sections(), which excludes it) never
+		// covers it. Without this branch it would pass through with no validation at all.
+		$order_section = Extensions::get_section_token_order();
+
+		if ( isset( $namespace[ $order_section ] ) && is_array( $namespace[ $order_section ] ) ) {
+			$errors = array_merge(
+				$errors,
+				$this->validate_token_order( $namespace[ $order_section ], $base . '.' . $order_section )
+			);
+		}
+
 		return $errors;
 	}
 
@@ -702,6 +714,48 @@ final class Dtcg_Validator {
 					$prefix . '.' . Cast::to_string( $id ),
 					Validation_Error::get_code_value_invalid(),
 					'A token label override must map a non-empty token id to a non-empty string label.'
+				);
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Validate a tokenOrder section: every entry must map a non-empty string group name to a
+	 * sequential list of non-empty string token ids. Whether the ids resolve to registered tokens
+	 * in that group is the REST write guard's concern (which prunes on save) and the feed merge's
+	 * concern (which ignores on read) — a stale id is data drift, not a grammar error, so it does
+	 * not fail full-document validation.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<int|string, mixed> $order  The decoded tokenOrder section.
+	 * @param string                   $prefix Dot-path to the section, for error messages.
+	 *
+	 * @return Validation_Error[]
+	 */
+	private function validate_token_order( array $order, string $prefix ): array {
+		$errors = [];
+
+		foreach ( $order as $group => $ids ) {
+			$is_valid = is_string( $group ) && $group !== '' && is_array( $ids )
+				&& ( $ids === [] || array_keys( $ids ) === range( 0, count( $ids ) - 1 ) );
+
+			if ( $is_valid ) {
+				foreach ( $ids as $id ) {
+					if ( ! is_string( $id ) || $id === '' ) {
+						$is_valid = false;
+						break;
+					}
+				}
+			}
+
+			if ( ! $is_valid ) {
+				$errors[] = new Validation_Error(
+					$prefix . '.' . Cast::to_string( $group ),
+					Validation_Error::get_code_value_invalid(),
+					'A tokenOrder entry must map a non-empty group name to a sequential list of non-empty string token ids.'
 				);
 			}
 		}

--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -630,6 +630,18 @@ final class Dtcg_Validator {
 			);
 		}
 
+		// tokenOrder is a { group => ordered token id list } map — id-keyed metadata, not
+		// preset-shaped, so the tokens-map walk (driven by get_sections(), which excludes it) never
+		// covers it. Without this branch it would pass through with no validation at all.
+		$order_section = Extensions::get_section_token_order();
+
+		if ( isset( $namespace[ $order_section ] ) && is_array( $namespace[ $order_section ] ) ) {
+			$errors = array_merge(
+				$errors,
+				$this->validate_token_order( $namespace[ $order_section ], $base . '.' . $order_section )
+			);
+		}
+
 		return $errors;
 	}
 
@@ -712,6 +724,48 @@ final class Dtcg_Validator {
 					$prefix . '.' . Cast::to_string( $id ),
 					Validation_Error::get_code_value_invalid(),
 					'A token label override must map a non-empty token id to a non-empty string label.'
+				);
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Validate a tokenOrder section: every entry must map a non-empty string group name to a
+	 * sequential list of non-empty string token ids. Whether the ids resolve to registered tokens
+	 * in that group is the REST write guard's concern (which prunes on save) and the feed merge's
+	 * concern (which ignores on read) — a stale id is data drift, not a grammar error, so it does
+	 * not fail full-document validation.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<int|string, mixed> $order  The decoded tokenOrder section.
+	 * @param string                   $prefix Dot-path to the section, for error messages.
+	 *
+	 * @return Validation_Error[]
+	 */
+	private function validate_token_order( array $order, string $prefix ): array {
+		$errors = [];
+
+		foreach ( $order as $group => $ids ) {
+			$is_valid = is_string( $group ) && $group !== '' && is_array( $ids )
+				&& ( $ids === [] || array_keys( $ids ) === range( 0, count( $ids ) - 1 ) );
+
+			if ( $is_valid ) {
+				foreach ( $ids as $id ) {
+					if ( ! is_string( $id ) || $id === '' ) {
+						$is_valid = false;
+						break;
+					}
+				}
+			}
+
+			if ( ! $is_valid ) {
+				$errors[] = new Validation_Error(
+					$prefix . '.' . Cast::to_string( $group ),
+					Validation_Error::get_code_value_invalid(),
+					'A tokenOrder entry must map a non-empty group name to a sequential list of non-empty string token ids.'
 				);
 			}
 		}

--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -749,6 +749,9 @@ final class Dtcg_Validator {
 		$errors = [];
 
 		foreach ( $order as $group => $ids ) {
+			// The `$ids === []` check is required, not redundant: `range( 0, -1 )` returns
+			// `[ 0, -1 ]` in PHP, not `[]`, so without this short-circuit an empty order list
+			// would be misclassified as malformed rather than as a valid empty list.
 			$is_valid = is_string( $group ) && $group !== '' && is_array( $ids )
 				&& ( $ids === [] || array_keys( $ids ) === range( 0, count( $ids ) - 1 ) );
 

--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -630,9 +630,9 @@ final class Dtcg_Validator {
 			);
 		}
 
-		// tokenOrder is a { group => ordered token id list } map — id-keyed metadata, not
-		// preset-shaped, so the tokens-map walk (driven by get_sections(), which excludes it) never
-		// covers it. Without this branch it would pass through with no validation at all.
+		// tokenOrder is a single flat ordered token id list — not preset-shaped and not a
+		// { key => value } map, so the tokens-map walk (driven by get_sections(), which excludes
+		// it) never covers it. Without this branch it would pass through with no validation at all.
 		$order_section = Extensions::get_section_token_order();
 
 		if ( isset( $namespace[ $order_section ] ) && is_array( $namespace[ $order_section ] ) ) {
@@ -732,11 +732,12 @@ final class Dtcg_Validator {
 	}
 
 	/**
-	 * Validate a tokenOrder section: every entry must map a non-empty string group name to a
-	 * sequential list of non-empty string token ids. Whether the ids resolve to registered tokens
-	 * in that group is the REST write guard's concern (which prunes on save) and the feed merge's
-	 * concern (which ignores on read) — a stale id is data drift, not a grammar error, so it does
-	 * not fail full-document validation.
+	 * Validate a tokenOrder section: it must be a single sequential list of non-empty string
+	 * token ids — never keyed by group, so a stored order stays locale-independent regardless of
+	 * which translated UI-schema group label a request addresses it through. Whether an id
+	 * resolves to a registered token is the REST write guard's concern (which prunes on save) and
+	 * the feed merge's concern (which ignores on read) — a stale id is data drift, not a grammar
+	 * error, so it does not fail full-document validation.
 	 *
 	 * @since TBD
 	 *
@@ -746,29 +747,29 @@ final class Dtcg_Validator {
 	 * @return Validation_Error[]
 	 */
 	private function validate_token_order( array $order, string $prefix ): array {
+		// The `$order === []` check is required, not redundant: `range( 0, -1 )` returns
+		// `[ 0, -1 ]` in PHP, not `[]`, so without this short-circuit an empty order list would be
+		// misclassified as malformed rather than as a valid empty list.
+		$is_list = $order === [] || array_keys( $order ) === range( 0, count( $order ) - 1 );
+
+		if ( ! $is_list ) {
+			return [
+				new Validation_Error(
+					$prefix,
+					Validation_Error::get_code_value_invalid(),
+					'tokenOrder must be a sequential list of non-empty string token ids.'
+				),
+			];
+		}
+
 		$errors = [];
 
-		foreach ( $order as $group => $ids ) {
-			// The `$ids === []` check is required, not redundant: `range( 0, -1 )` returns
-			// `[ 0, -1 ]` in PHP, not `[]`, so without this short-circuit an empty order list
-			// would be misclassified as malformed rather than as a valid empty list.
-			$is_valid = is_string( $group ) && $group !== '' && is_array( $ids )
-				&& ( $ids === [] || array_keys( $ids ) === range( 0, count( $ids ) - 1 ) );
-
-			if ( $is_valid ) {
-				foreach ( $ids as $id ) {
-					if ( ! is_string( $id ) || $id === '' ) {
-						$is_valid = false;
-						break;
-					}
-				}
-			}
-
-			if ( ! $is_valid ) {
+		foreach ( $order as $index => $id ) {
+			if ( ! is_string( $id ) || $id === '' ) {
 				$errors[] = new Validation_Error(
-					$prefix . '.' . Cast::to_string( $group ),
+					$prefix . '.' . Cast::to_string( $index ),
 					Validation_Error::get_code_value_invalid(),
-					'A tokenOrder entry must map a non-empty group name to a sequential list of non-empty string token ids.'
+					'tokenOrder must be a sequential list of non-empty string token ids.'
 				);
 			}
 		}

--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -739,6 +739,9 @@ final class Dtcg_Validator {
 		$errors = [];
 
 		foreach ( $order as $group => $ids ) {
+			// The `$ids === []` check is required, not redundant: `range( 0, -1 )` returns
+			// `[ 0, -1 ]` in PHP, not `[]`, so without this short-circuit an empty order list
+			// would be misclassified as malformed rather than as a valid empty list.
 			$is_valid = is_string( $group ) && $group !== '' && is_array( $ids )
 				&& ( $ids === [] || array_keys( $ids ) === range( 0, count( $ids ) - 1 ) );
 

--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -620,9 +620,9 @@ final class Dtcg_Validator {
 			);
 		}
 
-		// tokenOrder is a { group => ordered token id list } map — id-keyed metadata, not
-		// preset-shaped, so the tokens-map walk (driven by get_sections(), which excludes it) never
-		// covers it. Without this branch it would pass through with no validation at all.
+		// tokenOrder is a single flat ordered token id list — not preset-shaped and not a
+		// { key => value } map, so the tokens-map walk (driven by get_sections(), which excludes
+		// it) never covers it. Without this branch it would pass through with no validation at all.
 		$order_section = Extensions::get_section_token_order();
 
 		if ( isset( $namespace[ $order_section ] ) && is_array( $namespace[ $order_section ] ) ) {
@@ -722,11 +722,12 @@ final class Dtcg_Validator {
 	}
 
 	/**
-	 * Validate a tokenOrder section: every entry must map a non-empty string group name to a
-	 * sequential list of non-empty string token ids. Whether the ids resolve to registered tokens
-	 * in that group is the REST write guard's concern (which prunes on save) and the feed merge's
-	 * concern (which ignores on read) — a stale id is data drift, not a grammar error, so it does
-	 * not fail full-document validation.
+	 * Validate a tokenOrder section: it must be a single sequential list of non-empty string
+	 * token ids — never keyed by group, so a stored order stays locale-independent regardless of
+	 * which translated UI-schema group label a request addresses it through. Whether an id
+	 * resolves to a registered token is the REST write guard's concern (which prunes on save) and
+	 * the feed merge's concern (which ignores on read) — a stale id is data drift, not a grammar
+	 * error, so it does not fail full-document validation.
 	 *
 	 * @since TBD
 	 *
@@ -736,29 +737,29 @@ final class Dtcg_Validator {
 	 * @return Validation_Error[]
 	 */
 	private function validate_token_order( array $order, string $prefix ): array {
+		// The `$order === []` check is required, not redundant: `range( 0, -1 )` returns
+		// `[ 0, -1 ]` in PHP, not `[]`, so without this short-circuit an empty order list would be
+		// misclassified as malformed rather than as a valid empty list.
+		$is_list = $order === [] || array_keys( $order ) === range( 0, count( $order ) - 1 );
+
+		if ( ! $is_list ) {
+			return [
+				new Validation_Error(
+					$prefix,
+					Validation_Error::get_code_value_invalid(),
+					'tokenOrder must be a sequential list of non-empty string token ids.'
+				),
+			];
+		}
+
 		$errors = [];
 
-		foreach ( $order as $group => $ids ) {
-			// The `$ids === []` check is required, not redundant: `range( 0, -1 )` returns
-			// `[ 0, -1 ]` in PHP, not `[]`, so without this short-circuit an empty order list
-			// would be misclassified as malformed rather than as a valid empty list.
-			$is_valid = is_string( $group ) && $group !== '' && is_array( $ids )
-				&& ( $ids === [] || array_keys( $ids ) === range( 0, count( $ids ) - 1 ) );
-
-			if ( $is_valid ) {
-				foreach ( $ids as $id ) {
-					if ( ! is_string( $id ) || $id === '' ) {
-						$is_valid = false;
-						break;
-					}
-				}
-			}
-
-			if ( ! $is_valid ) {
+		foreach ( $order as $index => $id ) {
+			if ( ! is_string( $id ) || $id === '' ) {
 				$errors[] = new Validation_Error(
-					$prefix . '.' . Cast::to_string( $group ),
+					$prefix . '.' . Cast::to_string( $index ),
 					Validation_Error::get_code_value_invalid(),
-					'A tokenOrder entry must map a non-empty group name to a sequential list of non-empty string token ids.'
+					'tokenOrder must be a sequential list of non-empty string token ids.'
 				);
 			}
 		}

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
@@ -15,8 +15,10 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary;
  *                           of groups, each an ordered list of self-describing swatches.
  *   - "tokenLabels"       → per-token display-label overrides: a flat { token id => label } string map,
  *                           authoring metadata only.
- *   - "tokenOrder"        → per-group token sort order: a { UI-schema group => ordered token id list }
- *                           map, authoring metadata only.
+ *   - "tokenOrder"        → token sort order: a single flat ordered token id list, authoring
+ *                           metadata only. Flat rather than group-keyed so the stored order stays
+ *                           locale-independent — a UI-schema group name is a translated display
+ *                           label, not a stable identifier (see Token_Order_Index).
  *
  * The preset sections hold named groups; each group is a map of preset-slug =>
  * { "label": …, "tokens": … } alongside a "$default" key naming the group's default preset. A color palette

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
@@ -15,6 +15,8 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary;
  *                           of groups, each an ordered list of self-describing swatches.
  *   - "tokenLabels"       → per-token display-label overrides: a flat { token id => label } string map,
  *                           authoring metadata only.
+ *   - "tokenOrder"        → per-group token sort order: a { UI-schema group => ordered token id list }
+ *                           map, authoring metadata only.
  *
  * The preset sections hold named groups; each group is a map of preset-slug =>
  * { "label": …, "tokens": … } alongside a "$default" key naming the group's default preset. A color palette
@@ -94,6 +96,21 @@ final class Extensions {
 	 * @var string
 	 */
 	private const SECTION_TOKEN_LABELS = 'tokenLabels';
+
+	/**
+	 * The per-group token sort-order section: a map of UI-schema group => ordered list of token
+	 * ids. NOT returned by get_sections() — it is id-keyed authoring metadata, not preset-shaped,
+	 * so the tokens-map walk (and the reference scanner that follows get_sections()) must not
+	 * descend into it; it holds ids only, never {alias} values. The stored order is partial and
+	 * advisory, never authoritative membership: readers append unmentioned ids in declaration
+	 * order and ignore stale ids, so an order can permute the registered set but never hide a
+	 * token. The validator covers it with its own explicit branch instead.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const SECTION_TOKEN_ORDER = 'tokenOrder';
 
 	/**
 	 * The key naming a group's default preset slug.
@@ -244,6 +261,18 @@ final class Extensions {
 	 */
 	public static function get_section_token_labels(): string {
 		return self::SECTION_TOKEN_LABELS;
+	}
+
+	/**
+	 * The per-group token sort-order section name.
+	 * NOT returned by get_sections() — it is id-keyed metadata, not preset-shaped.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_section_token_order(): string {
+		return self::SECTION_TOKEN_ORDER;
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/BuilderTest.php
@@ -286,8 +286,8 @@ final class BuilderTest extends TestCase {
 			$this->rest(),
 			'v7',
 			'default',
-			[],
 			'',
+			[],
 			[],
 			[ 'semantic.color.button-text', 'semantic.color.button-bg' ]
 		);
@@ -312,8 +312,8 @@ final class BuilderTest extends TestCase {
 			$this->rest(),
 			'v7',
 			'default',
-			[],
 			'',
+			[],
 			[],
 			[ 'semantic.color.does-not-exist', 'semantic.color.button-bg' ]
 		);
@@ -337,8 +337,8 @@ final class BuilderTest extends TestCase {
 			$this->rest(),
 			'v7',
 			'default',
-			[],
 			'',
+			[],
 			[],
 			[ 'spacing.sm' ]
 		);
@@ -357,7 +357,7 @@ final class BuilderTest extends TestCase {
 	 * @return void
 	 */
 	public function testAnEmptyOrderListIsTheIdentityTransform(): void {
-		$feed = $this->builder()->build( [], true, [], $this->rest(), 'v7', 'default', [], '', [], [] );
+		$feed = $this->builder()->build( [], true, [], $this->rest(), 'v7', 'default', '', [], [], [] );
 
 		$this->assertSame( $this->with_no_overrides( $this->registry->to_ui_schema() ), $feed['schema'] );
 	}
@@ -383,7 +383,7 @@ final class BuilderTest extends TestCase {
 			]
 		);
 
-		$feed = $this->builder()->build( [], true, [], $this->rest(), 'v7', 'default', [], '', [], $order );
+		$feed = $this->builder()->build( [], true, [], $this->rest(), 'v7', 'default', '', [], [], $order );
 
 		$this->assertEqualsCanonicalizing(
 			[ 'semantic.color.button-bg', 'semantic.color.button-text' ],
@@ -439,8 +439,8 @@ final class BuilderTest extends TestCase {
 			$this->rest(),
 			'v7',
 			'default',
-			[],
 			'',
+			[],
 			[ 'semantic.color.button-bg' => 'Cozy' ],
 			[ 'semantic.color.button-text', 'semantic.color.button-bg' ]
 		);

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/BuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Admin\Feed;
 
+use Generator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Preset_Nav;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
@@ -250,6 +251,206 @@ final class BuilderTest extends TestCase {
 		);
 
 		$this->assertSame( [ 'groups' => [] ], $feed['schema'] );
+	}
+
+	/**
+	 * A stored order permutes a group's rows: ordered ids come first in stored sequence, and every
+	 * remaining row from the registry follows in declaration order.
+	 *
+	 * @return void
+	 */
+	public function testOrderPermutesAGroupAndAppendsTheRestInDeclarationOrder(): void {
+		$this->registry->register(
+			[
+				'id'          => 'semantic.color.button-text',
+				'type'        => 'color',
+				'label'       => 'Button Text',
+				'group'       => 'Brand',
+				'projections' => [],
+			]
+		);
+		$this->registry->register(
+			[
+				'id'          => 'semantic.color.button-border',
+				'type'        => 'color',
+				'label'       => 'Button Border',
+				'group'       => 'Brand',
+				'projections' => [],
+			]
+		);
+
+		$feed = $this->builder()->build(
+			[],
+			true,
+			[],
+			$this->rest(),
+			'v7',
+			'default',
+			[],
+			'',
+			[],
+			[ 'Brand' => [ 'semantic.color.button-text', 'semantic.color.button-bg' ] ]
+		);
+
+		$this->assertSame(
+			[ 'semantic.color.button-text', 'semantic.color.button-bg', 'semantic.color.button-border' ],
+			array_column( $feed['schema']['groups']['Brand'], 'id' )
+		);
+	}
+
+	/**
+	 * A stale id in the stored order (naming no row in the group) is skipped, never surfaced as a
+	 * ghost row.
+	 *
+	 * @return void
+	 */
+	public function testOrderSkipsStaleIdsThatNameNoRowInTheGroup(): void {
+		$feed = $this->builder()->build(
+			[],
+			true,
+			[],
+			$this->rest(),
+			'v7',
+			'default',
+			[],
+			'',
+			[],
+			[ 'Brand' => [ 'semantic.color.does-not-exist', 'semantic.color.button-bg' ] ]
+		);
+
+		$this->assertSame(
+			[ 'semantic.color.button-bg' ],
+			array_column( $feed['schema']['groups']['Brand'], 'id' )
+		);
+	}
+
+	/**
+	 * A group with no stored order is returned untouched — declaration order.
+	 *
+	 * @return void
+	 */
+	public function testAGroupWithNoStoredOrderIsUntouched(): void {
+		$feed = $this->builder()->build(
+			[],
+			true,
+			[],
+			$this->rest(),
+			'v7',
+			'default',
+			[],
+			'',
+			[],
+			[ 'Spacing' => [ 'spacing.sm' ] ]
+		);
+
+		$this->assertSame(
+			array_column( $this->registry->to_ui_schema()['groups']['Brand'], 'id' ),
+			array_column( $feed['schema']['groups']['Brand'], 'id' )
+		);
+	}
+
+	/**
+	 * An empty order map is the identity transform — every group's row set and sequence is
+	 * unchanged, exactly the declaration order the registry emits. This is the property the
+	 * Builder payload snapshot pins: a snapshot regenerated for this ticket would hide a bug here.
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyOrderMapIsTheIdentityTransform(): void {
+		$feed = $this->builder()->build( [], true, [], $this->rest(), 'v7', 'default', [], '', [], [] );
+
+		$this->assertSame( $this->with_no_overrides( $this->registry->to_ui_schema() ), $feed['schema'] );
+	}
+
+	/**
+	 * Every fixture above preserves the full registered row set for the ordered group — a reorder
+	 * permutes but never hides a token, regardless of which malformed or partial order is applied.
+	 *
+	 * @dataProvider orderFixtureProvider
+	 *
+	 * @param array<string, list<string>> $order The stored order to apply.
+	 *
+	 * @return void
+	 */
+	public function testOrderNeverChangesTheRegisteredRowSet( array $order ): void {
+		$this->registry->register(
+			[
+				'id'          => 'semantic.color.button-text',
+				'type'        => 'color',
+				'label'       => 'Button Text',
+				'group'       => 'Brand',
+				'projections' => [],
+			]
+		);
+
+		$feed = $this->builder()->build( [], true, [], $this->rest(), 'v7', 'default', [], '', [], $order );
+
+		$this->assertEqualsCanonicalizing(
+			[ 'semantic.color.button-bg', 'semantic.color.button-text' ],
+			array_column( $feed['schema']['groups']['Brand'], 'id' )
+		);
+	}
+
+	/**
+	 * Order fixtures that must all preserve the full row set: a partial order, an order full of
+	 * stale ids, a duplicated id, and an empty group order.
+	 *
+	 * @return Generator
+	 */
+	public function orderFixtureProvider(): Generator {
+		yield 'partial order' => [
+			'order' => [ 'Brand' => [ 'semantic.color.button-text' ] ],
+		];
+
+		yield 'order full of stale ids' => [
+			'order' => [ 'Brand' => [ 'semantic.color.does-not-exist', 'semantic.color.also-missing' ] ],
+		];
+
+		yield 'duplicated id' => [
+			'order' => [ 'Brand' => [ 'semantic.color.button-bg', 'semantic.color.button-bg' ] ],
+		];
+
+		yield 'empty group order' => [
+			'order' => [ 'Brand' => [] ],
+		];
+	}
+
+	/**
+	 * A label override rides its row to the row's new position when both labels and order are
+	 * applied together.
+	 *
+	 * @return void
+	 */
+	public function testLabelsAndOrderTogetherKeepTheOverriddenLabelOnItsRow(): void {
+		$this->registry->register(
+			[
+				'id'          => 'semantic.color.button-text',
+				'type'        => 'color',
+				'label'       => 'Button Text',
+				'group'       => 'Brand',
+				'projections' => [],
+			]
+		);
+
+		$feed = $this->builder()->build(
+			[],
+			true,
+			[],
+			$this->rest(),
+			'v7',
+			'default',
+			[],
+			'',
+			[ 'semantic.color.button-bg' => 'Cozy' ],
+			[ 'Brand' => [ 'semantic.color.button-text', 'semantic.color.button-bg' ] ]
+		);
+
+		$rows = $feed['schema']['groups']['Brand'];
+
+		$this->assertSame( 'semantic.color.button-text', $rows[0]['id'] );
+		$this->assertSame( 'semantic.color.button-bg', $rows[1]['id'] );
+		$this->assertSame( 'Cozy', $rows[1]['label'] );
+		$this->assertTrue( $rows[1]['labelOverridden'] );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/BuilderTest.php
@@ -289,7 +289,7 @@ final class BuilderTest extends TestCase {
 			[],
 			'',
 			[],
-			[ 'Brand' => [ 'semantic.color.button-text', 'semantic.color.button-bg' ] ]
+			[ 'semantic.color.button-text', 'semantic.color.button-bg' ]
 		);
 
 		$this->assertSame(
@@ -315,7 +315,7 @@ final class BuilderTest extends TestCase {
 			[],
 			'',
 			[],
-			[ 'Brand' => [ 'semantic.color.does-not-exist', 'semantic.color.button-bg' ] ]
+			[ 'semantic.color.does-not-exist', 'semantic.color.button-bg' ]
 		);
 
 		$this->assertSame(
@@ -340,7 +340,7 @@ final class BuilderTest extends TestCase {
 			[],
 			'',
 			[],
-			[ 'Spacing' => [ 'spacing.sm' ] ]
+			[ 'spacing.sm' ]
 		);
 
 		$this->assertSame(
@@ -350,13 +350,13 @@ final class BuilderTest extends TestCase {
 	}
 
 	/**
-	 * An empty order map is the identity transform — every group's row set and sequence is
+	 * An empty order list is the identity transform — every group's row set and sequence is
 	 * unchanged, exactly the declaration order the registry emits. This is the property the
 	 * Builder payload snapshot pins: a snapshot regenerated for this ticket would hide a bug here.
 	 *
 	 * @return void
 	 */
-	public function testAnEmptyOrderMapIsTheIdentityTransform(): void {
+	public function testAnEmptyOrderListIsTheIdentityTransform(): void {
 		$feed = $this->builder()->build( [], true, [], $this->rest(), 'v7', 'default', [], '', [], [] );
 
 		$this->assertSame( $this->with_no_overrides( $this->registry->to_ui_schema() ), $feed['schema'] );
@@ -368,7 +368,7 @@ final class BuilderTest extends TestCase {
 	 *
 	 * @dataProvider orderFixtureProvider
 	 *
-	 * @param array<string, list<string>> $order The stored order to apply.
+	 * @param list<string> $order The stored flat order to apply.
 	 *
 	 * @return void
 	 */
@@ -393,25 +393,25 @@ final class BuilderTest extends TestCase {
 
 	/**
 	 * Order fixtures that must all preserve the full row set: a partial order, an order full of
-	 * stale ids, a duplicated id, and an empty group order.
+	 * stale ids, a duplicated id, and an empty order.
 	 *
 	 * @return Generator
 	 */
 	public function orderFixtureProvider(): Generator {
 		yield 'partial order' => [
-			'order' => [ 'Brand' => [ 'semantic.color.button-text' ] ],
+			'order' => [ 'semantic.color.button-text' ],
 		];
 
 		yield 'order full of stale ids' => [
-			'order' => [ 'Brand' => [ 'semantic.color.does-not-exist', 'semantic.color.also-missing' ] ],
+			'order' => [ 'semantic.color.does-not-exist', 'semantic.color.also-missing' ],
 		];
 
 		yield 'duplicated id' => [
-			'order' => [ 'Brand' => [ 'semantic.color.button-bg', 'semantic.color.button-bg' ] ],
+			'order' => [ 'semantic.color.button-bg', 'semantic.color.button-bg' ],
 		];
 
-		yield 'empty group order' => [
-			'order' => [ 'Brand' => [] ],
+		yield 'empty order' => [
+			'order' => [],
 		];
 	}
 
@@ -442,7 +442,7 @@ final class BuilderTest extends TestCase {
 			[],
 			'',
 			[ 'semantic.color.button-bg' => 'Cozy' ],
-			[ 'Brand' => [ 'semantic.color.button-text', 'semantic.color.button-bg' ] ]
+			[ 'semantic.color.button-text', 'semantic.color.button-bg' ]
 		);
 
 		$rows = $feed['schema']['groups']['Brand'];

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Feed_AssemblerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Feed_AssemblerTest.php
@@ -9,6 +9,8 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Responsive_Feed;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Order_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Css_Renderer;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Palettes;
@@ -179,7 +181,8 @@ final class Feed_AssemblerTest extends TestCase {
 			$this->container->get( Presets::class ),
 			$this->container->get( Builder::class ),
 			$this->container->get( Responsive_Feed::class ),
-			$this->container->get( Token_Label_Index::class )
+			$this->container->get( Token_Label_Index::class ),
+			$this->container->get( Token_Order_Index::class )
 		);
 
 		$feed = $assembler->for_slug( Token_Store::default_slug() );
@@ -231,5 +234,44 @@ final class Feed_AssemblerTest extends TestCase {
 		$this->assertNotNull( $found, 'The overridden token must appear in the assembled schema.' );
 		$this->assertSame( 'Cozy Button', $found['label'] );
 		$this->assertTrue( $found['labelOverridden'] );
+	}
+
+	/**
+	 * A stored tokenOrder entry surfaces in for_slug()'s assembled schema sequence — the wiring
+	 * that hands the decoded order map into Builder::build(), not the pure merge itself (covered
+	 * in BuilderTest).
+	 *
+	 * @return void
+	 */
+	public function testForSlugAppliesStoredTokenOrder(): void {
+		$schema = $this->container->get( Token_Registry::class )->to_ui_schema();
+		$groups = array_keys( $schema['groups'] );
+
+		$this->assertNotEmpty( $groups, 'The registry fixture must declare at least one group to reorder.' );
+
+		$group = $groups[0];
+		$ids   = array_column( $schema['groups'][ $group ], 'id' );
+
+		$this->assertGreaterThan( 1, count( $ids ), 'The group must carry at least two tokens to observe a permutation.' );
+
+		$reversed = array_reverse( $ids );
+
+		$doc = (string) wp_json_encode(
+			[
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'tokenOrder' => [
+							$group => $reversed,
+						],
+					],
+				],
+			]
+		);
+
+		$this->container->get( Token_Store::class )->save_document( $doc );
+
+		$feed = $this->assembler->for_slug( Token_Store::default_slug() );
+
+		$this->assertSame( $reversed, array_column( $feed['schema']['groups'][ $group ], 'id' ) );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Feed_AssemblerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Feed_AssemblerTest.php
@@ -9,6 +9,8 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Responsive_Feed;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Order_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Css_Renderer;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Palettes;
@@ -140,7 +142,8 @@ final class Feed_AssemblerTest extends TestCase {
 			$this->container->get( Presets::class ),
 			$this->container->get( Builder::class ),
 			$this->container->get( Responsive_Feed::class ),
-			$this->container->get( Token_Label_Index::class )
+			$this->container->get( Token_Label_Index::class ),
+			$this->container->get( Token_Order_Index::class )
 		);
 
 		$feed = $assembler->for_slug( Token_Store::default_slug() );
@@ -192,5 +195,44 @@ final class Feed_AssemblerTest extends TestCase {
 		$this->assertNotNull( $found, 'The overridden token must appear in the assembled schema.' );
 		$this->assertSame( 'Cozy Button', $found['label'] );
 		$this->assertTrue( $found['labelOverridden'] );
+	}
+
+	/**
+	 * A stored tokenOrder entry surfaces in for_slug()'s assembled schema sequence — the wiring
+	 * that hands the decoded order map into Builder::build(), not the pure merge itself (covered
+	 * in BuilderTest).
+	 *
+	 * @return void
+	 */
+	public function testForSlugAppliesStoredTokenOrder(): void {
+		$schema = $this->container->get( Token_Registry::class )->to_ui_schema();
+		$groups = array_keys( $schema['groups'] );
+
+		$this->assertNotEmpty( $groups, 'The registry fixture must declare at least one group to reorder.' );
+
+		$group = $groups[0];
+		$ids   = array_column( $schema['groups'][ $group ], 'id' );
+
+		$this->assertGreaterThan( 1, count( $ids ), 'The group must carry at least two tokens to observe a permutation.' );
+
+		$reversed = array_reverse( $ids );
+
+		$doc = (string) wp_json_encode(
+			[
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'tokenOrder' => [
+							$group => $reversed,
+						],
+					],
+				],
+			]
+		);
+
+		$this->container->get( Token_Store::class )->save_document( $doc );
+
+		$feed = $this->assembler->for_slug( Token_Store::default_slug() );
+
+		$this->assertSame( $reversed, array_column( $feed['schema']['groups'][ $group ], 'id' ) );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Feed_AssemblerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Feed_AssemblerTest.php
@@ -238,8 +238,8 @@ final class Feed_AssemblerTest extends TestCase {
 
 	/**
 	 * A stored tokenOrder entry surfaces in for_slug()'s assembled schema sequence — the wiring
-	 * that hands the decoded order map into Builder::build(), not the pure merge itself (covered
-	 * in BuilderTest).
+	 * that hands the decoded flat order list into Builder::build(), not the pure merge itself
+	 * (covered in BuilderTest).
 	 *
 	 * @return void
 	 */
@@ -260,9 +260,7 @@ final class Feed_AssemblerTest extends TestCase {
 			[
 				'$extensions' => [
 					'com.kadence.designTokens' => [
-						'tokenOrder' => [
-							$group => $reversed,
-						],
+						'tokenOrder' => $reversed,
 					],
 				],
 			]

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Feed_AssemblerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Feed_AssemblerTest.php
@@ -199,8 +199,8 @@ final class Feed_AssemblerTest extends TestCase {
 
 	/**
 	 * A stored tokenOrder entry surfaces in for_slug()'s assembled schema sequence — the wiring
-	 * that hands the decoded order map into Builder::build(), not the pure merge itself (covered
-	 * in BuilderTest).
+	 * that hands the decoded flat order list into Builder::build(), not the pure merge itself
+	 * (covered in BuilderTest).
 	 *
 	 * @return void
 	 */
@@ -221,9 +221,7 @@ final class Feed_AssemblerTest extends TestCase {
 			[
 				'$extensions' => [
 					'com.kadence.designTokens' => [
-						'tokenOrder' => [
-							$group => $reversed,
-						],
+						'tokenOrder' => $reversed,
 					],
 				],
 			]

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
@@ -11,6 +11,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Style_Library\Asset_Loader;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Order_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\User_Primitive_Registrar;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Css_Renderer;
@@ -191,7 +192,8 @@ final class LocalizerTest extends TestCase {
 			$this->container->get( Presets::class ),
 			$this->container->get( Builder::class ),
 			$this->container->get( Responsive_Feed::class ),
-			$this->container->get( Token_Label_Index::class )
+			$this->container->get( Token_Label_Index::class ),
+			$this->container->get( Token_Order_Index::class )
 		);
 
 		$localizer = new Localizer(

--- a/tests/wpunit/Resources/Design_Tokens/Document/Token_Order_IndexTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/Token_Order_IndexTest.php
@@ -1,0 +1,310 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Document;
+
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Order_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Covers the tokenOrder per-group sort-order map read/write operations of Token_Order_Index.
+ *
+ * @since TBD
+ */
+final class Token_Order_IndexTest extends TestCase {
+
+	/**
+	 * The index under test.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Order_Index
+	 */
+	private Token_Order_Index $index;
+
+	/**
+	 * Build a fresh index before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->index = new Token_Order_Index();
+	}
+
+	// -------------------------------------------------------------------------
+	// all()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * An empty document has no stored group orders.
+	 *
+	 * @return void
+	 */
+	public function testAllReturnsEmptyArrayForEmptyDocument(): void {
+		$this->assertSame( [], $this->index->all( [] ) );
+	}
+
+	/**
+	 * A document missing the $extensions key has no stored group orders.
+	 *
+	 * @return void
+	 */
+	public function testAllReturnsEmptyArrayWhenExtensionsKeyMissing(): void {
+		$doc = [ 'primitive' => [ 'color' => [] ] ];
+
+		$this->assertSame( [], $this->index->all( $doc ) );
+	}
+
+	/**
+	 * A well-formed tokenOrder section round-trips through all() unchanged.
+	 *
+	 * @return void
+	 */
+	public function testAllReturnsStoredEntries(): void {
+		$doc = $this->doc_with_entry( 'Brand', [ 'semantic.color.button-bg', 'semantic.color.button-text' ] );
+
+		$this->assertSame(
+			[ 'Brand' => [ 'semantic.color.button-bg', 'semantic.color.button-text' ] ],
+			$this->index->all( $doc )
+		);
+	}
+
+	/**
+	 * A malformed group entry — a non-list ("map-shaped") value, a non-string group key, or
+	 * non-string ids inside the list — is dropped (or filtered) on read rather than surfaced, so a
+	 * hand-corrupted section degrades to declaration order instead of a type error downstream.
+	 *
+	 * @dataProvider malformedSectionProvider
+	 *
+	 * @param array<int|string, mixed> $section  The raw decoded tokenOrder section.
+	 * @param array<string, list<string>> $expected The expected result of all() against that section.
+	 *
+	 * @return void
+	 */
+	public function testAllDropsOrFiltersMalformedEntries( array $section, array $expected ): void {
+		$doc = [
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					Extensions::get_section_token_order() => $section,
+				],
+			],
+		];
+
+		$this->assertSame( $expected, $this->index->all( $doc ) );
+	}
+
+	/**
+	 * Malformed tokenOrder section shapes and what all() must degrade each to.
+	 *
+	 * @return Generator
+	 */
+	public function malformedSectionProvider(): Generator {
+		yield 'integer-keyed group' => [
+			'section'  => [ 0 => [ 'semantic.color.button-bg' ] ],
+			'expected' => [],
+		];
+
+		yield 'map-shaped (non-sequential) group value' => [
+			'section'  => [ 'Brand' => [ 'a' => 'semantic.color.button-bg' ] ],
+			'expected' => [],
+		];
+
+		yield 'non-string id inside an otherwise valid list' => [
+			'section'  => [ 'Brand' => [ 'semantic.color.button-bg', 42, 'semantic.color.button-text' ] ],
+			'expected' => [ 'Brand' => [ 'semantic.color.button-bg', 'semantic.color.button-text' ] ],
+		];
+
+		yield 'non-array group value' => [
+			'section'  => [ 'Brand' => 'not-a-list' ],
+			'expected' => [],
+		];
+	}
+
+	// -------------------------------------------------------------------------
+	// for_group()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * for_group() returns [] for a group with no stored order.
+	 *
+	 * @return void
+	 */
+	public function testForGroupReturnsEmptyArrayWhenAbsent(): void {
+		$this->assertSame( [], $this->index->for_group( [], 'Brand' ) );
+	}
+
+	/**
+	 * for_group() returns [] for a document with no tokenOrder section.
+	 *
+	 * @return void
+	 */
+	public function testForGroupReturnsEmptyArrayForDocumentWithNoSection(): void {
+		$doc = [ 'primitive' => [ 'color' => [] ] ];
+
+		$this->assertSame( [], $this->index->for_group( $doc, 'Brand' ) );
+	}
+
+	/**
+	 * for_group() returns the stored order for the requested group.
+	 *
+	 * @return void
+	 */
+	public function testForGroupReturnsStoredOrder(): void {
+		$doc = $this->doc_with_entry( 'Brand', [ 'semantic.color.button-bg' ] );
+
+		$this->assertSame( [ 'semantic.color.button-bg' ], $this->index->for_group( $doc, 'Brand' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// set_group()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * set_group() creates the $extensions/{namespace}/tokenOrder path when none of it yet exists.
+	 *
+	 * @return void
+	 */
+	public function testSetGroupCreatesFullPathWhenMissing(): void {
+		$result = $this->index->set_group( [], 'Brand', [ 'semantic.color.button-bg' ] );
+
+		$this->assertSame( [ 'semantic.color.button-bg' ], $this->index->for_group( $result, 'Brand' ) );
+	}
+
+	/**
+	 * set_group() replaces a previously stored order for the same group wholesale.
+	 *
+	 * @return void
+	 */
+	public function testSetGroupReplacesExistingOrderWholesale(): void {
+		$doc = $this->doc_with_entry( 'Brand', [ 'semantic.color.button-bg', 'semantic.color.button-text' ] );
+
+		$result = $this->index->set_group( $doc, 'Brand', [ 'semantic.color.button-text' ] );
+
+		$this->assertSame( [ 'semantic.color.button-text' ], $this->index->for_group( $result, 'Brand' ) );
+	}
+
+	/**
+	 * set_group() deduplicates submitted ids, keeping the first occurrence.
+	 *
+	 * @return void
+	 */
+	public function testSetGroupDeduplicatesKeepingFirstOccurrence(): void {
+		$result = $this->index->set_group(
+			[],
+			'Brand',
+			[ 'semantic.color.button-bg', 'semantic.color.button-text', 'semantic.color.button-bg' ]
+		);
+
+		$this->assertSame(
+			[ 'semantic.color.button-bg', 'semantic.color.button-text' ],
+			$this->index->for_group( $result, 'Brand' )
+		);
+	}
+
+	/**
+	 * set_group() leaves a sibling group's stored order untouched.
+	 *
+	 * @return void
+	 */
+	public function testSetGroupPreservesSiblingGroups(): void {
+		$doc = $this->doc_with_entry( 'Brand', [ 'semantic.color.button-bg' ] );
+
+		$result = $this->index->set_group( $doc, 'Spacing', [ 'spacing.sm' ] );
+
+		$this->assertSame( [ 'semantic.color.button-bg' ], $this->index->for_group( $result, 'Brand' ) );
+		$this->assertSame( [ 'spacing.sm' ], $this->index->for_group( $result, 'Spacing' ) );
+	}
+
+	/**
+	 * set_group() does not modify the document passed in — every mutator returns a new document.
+	 *
+	 * @return void
+	 */
+	public function testSetGroupDoesNotModifyItsInput(): void {
+		$doc = [];
+
+		$this->index->set_group( $doc, 'Brand', [ 'semantic.color.button-bg' ] );
+
+		$this->assertSame( [], $doc );
+	}
+
+	// -------------------------------------------------------------------------
+	// remove_group()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * remove_group() is a no-op (the same document is returned) when nothing is stored for the
+	 * group.
+	 *
+	 * @return void
+	 */
+	public function testRemoveGroupIsNoOpWhenAbsent(): void {
+		$result = $this->index->remove_group( [], 'Brand' );
+
+		$this->assertSame( [], $result );
+	}
+
+	/**
+	 * remove_group() deletes only the targeted group, leaving sibling groups intact.
+	 *
+	 * @return void
+	 */
+	public function testRemoveGroupDeletesTargetGroupOnly(): void {
+		$doc = $this->doc_with_entry( 'Brand', [ 'semantic.color.button-bg' ] );
+		$doc = $this->index->set_group( $doc, 'Spacing', [ 'spacing.sm' ] );
+
+		$result = $this->index->remove_group( $doc, 'Brand' );
+
+		$this->assertSame( [], $this->index->for_group( $result, 'Brand' ) );
+		$this->assertSame( [ 'spacing.sm' ], $this->index->for_group( $result, 'Spacing' ) );
+	}
+
+	/**
+	 * remove_group() leaves the rest of the document, outside the tokenOrder section, unchanged.
+	 *
+	 * @return void
+	 */
+	public function testRemoveGroupLeavesTheRestOfTheDocumentUnchanged(): void {
+		$doc = $this->doc_with_entry( 'Brand', [ 'semantic.color.button-bg' ] );
+
+		$doc['primitive'] = [
+			'color' => [
+				'brand' => [
+					'$type'  => 'color',
+					'$value' => '#3182CE',
+				],
+			],
+		];
+
+		$result = $this->index->remove_group( $doc, 'Brand' );
+
+		$this->assertSame( $doc['primitive'], $result['primitive'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Build a decoded document carrying a single tokenOrder group entry.
+	 *
+	 * @param string       $group The group name.
+	 * @param array<string> $ids   The stored ordered id list.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function doc_with_entry( string $group, array $ids ): array {
+		return [
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					Extensions::get_section_token_order() => [
+						$group => $ids,
+					],
+				],
+			],
+		];
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Document/Token_Order_IndexTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/Token_Order_IndexTest.php
@@ -8,7 +8,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
 use Tests\Support\Classes\TestCase;
 
 /**
- * Covers the tokenOrder per-group sort-order map read/write operations of Token_Order_Index.
+ * Covers the tokenOrder flat ordered-id-list read/write operations of Token_Order_Index.
  *
  * @since TBD
  */
@@ -39,7 +39,7 @@ final class Token_Order_IndexTest extends TestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * An empty document has no stored group orders.
+	 * An empty document has no stored order.
 	 *
 	 * @return void
 	 */
@@ -48,7 +48,7 @@ final class Token_Order_IndexTest extends TestCase {
 	}
 
 	/**
-	 * A document missing the $extensions key has no stored group orders.
+	 * A document missing the $extensions key has no stored order.
 	 *
 	 * @return void
 	 */
@@ -64,23 +64,23 @@ final class Token_Order_IndexTest extends TestCase {
 	 * @return void
 	 */
 	public function testAllReturnsStoredEntries(): void {
-		$doc = $this->doc_with_entry( 'Brand', [ 'semantic.color.button-bg', 'semantic.color.button-text' ] );
+		$doc = $this->doc_with_order( [ 'semantic.color.button-bg', 'semantic.color.button-text' ] );
 
 		$this->assertSame(
-			[ 'Brand' => [ 'semantic.color.button-bg', 'semantic.color.button-text' ] ],
+			[ 'semantic.color.button-bg', 'semantic.color.button-text' ],
 			$this->index->all( $doc )
 		);
 	}
 
 	/**
-	 * A malformed group entry — a non-list ("map-shaped") value, a non-string group key, or
-	 * non-string ids inside the list — is dropped (or filtered) on read rather than surfaced, so a
-	 * hand-corrupted section degrades to declaration order instead of a type error downstream.
+	 * A malformed tokenOrder section — a non-list ("map-shaped") value, or non-string/empty ids
+	 * inside the list — is dropped (or filtered) on read rather than surfaced, so a hand-corrupted
+	 * section degrades to declaration order instead of a type error downstream.
 	 *
 	 * @dataProvider malformedSectionProvider
 	 *
 	 * @param array<int|string, mixed> $section  The raw decoded tokenOrder section.
-	 * @param array<string, list<string>> $expected The expected result of all() against that section.
+	 * @param list<string>             $expected The expected result of all() against that section.
 	 *
 	 * @return void
 	 */
@@ -102,60 +102,20 @@ final class Token_Order_IndexTest extends TestCase {
 	 * @return Generator
 	 */
 	public function malformedSectionProvider(): Generator {
-		yield 'integer-keyed group' => [
-			'section'  => [ 0 => [ 'semantic.color.button-bg' ] ],
-			'expected' => [],
-		];
-
-		yield 'map-shaped (non-sequential) group value' => [
-			'section'  => [ 'Brand' => [ 'a' => 'semantic.color.button-bg' ] ],
+		yield 'map-shaped (non-sequential) section value' => [
+			'section'  => [ 'a' => 'semantic.color.button-bg' ],
 			'expected' => [],
 		];
 
 		yield 'non-string id inside an otherwise valid list' => [
-			'section'  => [ 'Brand' => [ 'semantic.color.button-bg', 42, 'semantic.color.button-text' ] ],
-			'expected' => [ 'Brand' => [ 'semantic.color.button-bg', 'semantic.color.button-text' ] ],
+			'section'  => [ 'semantic.color.button-bg', 42, 'semantic.color.button-text' ],
+			'expected' => [ 'semantic.color.button-bg', 'semantic.color.button-text' ],
 		];
 
-		yield 'non-array group value' => [
-			'section'  => [ 'Brand' => 'not-a-list' ],
-			'expected' => [],
+		yield 'empty-string id inside an otherwise valid list' => [
+			'section'  => [ 'semantic.color.button-bg', '' ],
+			'expected' => [ 'semantic.color.button-bg' ],
 		];
-	}
-
-	// -------------------------------------------------------------------------
-	// for_group()
-	// -------------------------------------------------------------------------
-
-	/**
-	 * for_group() returns [] for a group with no stored order.
-	 *
-	 * @return void
-	 */
-	public function testForGroupReturnsEmptyArrayWhenAbsent(): void {
-		$this->assertSame( [], $this->index->for_group( [], 'Brand' ) );
-	}
-
-	/**
-	 * for_group() returns [] for a document with no tokenOrder section.
-	 *
-	 * @return void
-	 */
-	public function testForGroupReturnsEmptyArrayForDocumentWithNoSection(): void {
-		$doc = [ 'primitive' => [ 'color' => [] ] ];
-
-		$this->assertSame( [], $this->index->for_group( $doc, 'Brand' ) );
-	}
-
-	/**
-	 * for_group() returns the stored order for the requested group.
-	 *
-	 * @return void
-	 */
-	public function testForGroupReturnsStoredOrder(): void {
-		$doc = $this->doc_with_entry( 'Brand', [ 'semantic.color.button-bg' ] );
-
-		$this->assertSame( [ 'semantic.color.button-bg' ], $this->index->for_group( $doc, 'Brand' ) );
 	}
 
 	// -------------------------------------------------------------------------
@@ -168,22 +128,23 @@ final class Token_Order_IndexTest extends TestCase {
 	 * @return void
 	 */
 	public function testSetGroupCreatesFullPathWhenMissing(): void {
-		$result = $this->index->set_group( [], 'Brand', [ 'semantic.color.button-bg' ] );
+		$result = $this->index->set_group( [], [ 'semantic.color.button-bg' ], [ 'semantic.color.button-bg' ] );
 
-		$this->assertSame( [ 'semantic.color.button-bg' ], $this->index->for_group( $result, 'Brand' ) );
+		$this->assertSame( [ 'semantic.color.button-bg' ], $this->index->all( $result ) );
 	}
 
 	/**
-	 * set_group() replaces a previously stored order for the same group wholesale.
+	 * set_group() replaces a previously stored order for the same group's ids wholesale.
 	 *
 	 * @return void
 	 */
 	public function testSetGroupReplacesExistingOrderWholesale(): void {
-		$doc = $this->doc_with_entry( 'Brand', [ 'semantic.color.button-bg', 'semantic.color.button-text' ] );
+		$group_ids = [ 'semantic.color.button-bg', 'semantic.color.button-text' ];
+		$doc       = $this->doc_with_order( $group_ids );
 
-		$result = $this->index->set_group( $doc, 'Brand', [ 'semantic.color.button-text' ] );
+		$result = $this->index->set_group( $doc, $group_ids, [ 'semantic.color.button-text' ] );
 
-		$this->assertSame( [ 'semantic.color.button-text' ], $this->index->for_group( $result, 'Brand' ) );
+		$this->assertSame( [ 'semantic.color.button-text' ], $this->index->all( $result ) );
 	}
 
 	/**
@@ -194,28 +155,28 @@ final class Token_Order_IndexTest extends TestCase {
 	public function testSetGroupDeduplicatesKeepingFirstOccurrence(): void {
 		$result = $this->index->set_group(
 			[],
-			'Brand',
+			[ 'semantic.color.button-bg', 'semantic.color.button-text' ],
 			[ 'semantic.color.button-bg', 'semantic.color.button-text', 'semantic.color.button-bg' ]
 		);
 
 		$this->assertSame(
 			[ 'semantic.color.button-bg', 'semantic.color.button-text' ],
-			$this->index->for_group( $result, 'Brand' )
+			$this->index->all( $result )
 		);
 	}
 
 	/**
-	 * set_group() leaves a sibling group's stored order untouched.
+	 * set_group() leaves a sibling group's stored ids untouched, since only the target group's own
+	 * id set is removed from the flat list before the new sequence is appended.
 	 *
 	 * @return void
 	 */
 	public function testSetGroupPreservesSiblingGroups(): void {
-		$doc = $this->doc_with_entry( 'Brand', [ 'semantic.color.button-bg' ] );
+		$doc = $this->doc_with_order( [ 'semantic.color.button-bg' ] );
 
-		$result = $this->index->set_group( $doc, 'Spacing', [ 'spacing.sm' ] );
+		$result = $this->index->set_group( $doc, [ 'spacing.sm' ], [ 'spacing.sm' ] );
 
-		$this->assertSame( [ 'semantic.color.button-bg' ], $this->index->for_group( $result, 'Brand' ) );
-		$this->assertSame( [ 'spacing.sm' ], $this->index->for_group( $result, 'Spacing' ) );
+		$this->assertSame( [ 'semantic.color.button-bg', 'spacing.sm' ], $this->index->all( $result ) );
 	}
 
 	/**
@@ -226,7 +187,7 @@ final class Token_Order_IndexTest extends TestCase {
 	public function testSetGroupDoesNotModifyItsInput(): void {
 		$doc = [];
 
-		$this->index->set_group( $doc, 'Brand', [ 'semantic.color.button-bg' ] );
+		$this->index->set_group( $doc, [ 'semantic.color.button-bg' ], [ 'semantic.color.button-bg' ] );
 
 		$this->assertSame( [], $doc );
 	}
@@ -237,29 +198,28 @@ final class Token_Order_IndexTest extends TestCase {
 
 	/**
 	 * remove_group() is a no-op (the same document is returned) when nothing is stored for the
-	 * group.
+	 * group's ids.
 	 *
 	 * @return void
 	 */
 	public function testRemoveGroupIsNoOpWhenAbsent(): void {
-		$result = $this->index->remove_group( [], 'Brand' );
+		$result = $this->index->remove_group( [], [ 'semantic.color.button-bg' ] );
 
 		$this->assertSame( [], $result );
 	}
 
 	/**
-	 * remove_group() deletes only the targeted group, leaving sibling groups intact.
+	 * remove_group() deletes only the targeted group's ids, leaving sibling groups intact.
 	 *
 	 * @return void
 	 */
 	public function testRemoveGroupDeletesTargetGroupOnly(): void {
-		$doc = $this->doc_with_entry( 'Brand', [ 'semantic.color.button-bg' ] );
-		$doc = $this->index->set_group( $doc, 'Spacing', [ 'spacing.sm' ] );
+		$doc = $this->doc_with_order( [ 'semantic.color.button-bg' ] );
+		$doc = $this->index->set_group( $doc, [ 'spacing.sm' ], [ 'spacing.sm' ] );
 
-		$result = $this->index->remove_group( $doc, 'Brand' );
+		$result = $this->index->remove_group( $doc, [ 'semantic.color.button-bg' ] );
 
-		$this->assertSame( [], $this->index->for_group( $result, 'Brand' ) );
-		$this->assertSame( [ 'spacing.sm' ], $this->index->for_group( $result, 'Spacing' ) );
+		$this->assertSame( [ 'spacing.sm' ], $this->index->all( $result ) );
 	}
 
 	/**
@@ -268,7 +228,7 @@ final class Token_Order_IndexTest extends TestCase {
 	 * @return void
 	 */
 	public function testRemoveGroupLeavesTheRestOfTheDocumentUnchanged(): void {
-		$doc = $this->doc_with_entry( 'Brand', [ 'semantic.color.button-bg' ] );
+		$doc = $this->doc_with_order( [ 'semantic.color.button-bg' ] );
 
 		$doc['primitive'] = [
 			'color' => [
@@ -279,7 +239,7 @@ final class Token_Order_IndexTest extends TestCase {
 			],
 		];
 
-		$result = $this->index->remove_group( $doc, 'Brand' );
+		$result = $this->index->remove_group( $doc, [ 'semantic.color.button-bg' ] );
 
 		$this->assertSame( $doc['primitive'], $result['primitive'] );
 	}
@@ -289,20 +249,17 @@ final class Token_Order_IndexTest extends TestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Build a decoded document carrying a single tokenOrder group entry.
+	 * Build a decoded document carrying a flat tokenOrder list.
 	 *
-	 * @param string       $group The group name.
-	 * @param array<string> $ids   The stored ordered id list.
+	 * @param list<string> $ids The stored ordered id list.
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function doc_with_entry( string $group, array $ids ): array {
+	private function doc_with_order( array $ids ): array {
 		return [
 			Extensions::get_extensions_key() => [
 				Extensions::get_namespace() => [
-					Extensions::get_section_token_order() => [
-						$group => $ids,
-					],
+					Extensions::get_section_token_order() => $ids,
 				],
 			],
 		];

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerOrderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerOrderTest.php
@@ -220,7 +220,7 @@ final class DocumentsControllerOrderTest extends TestCase {
 		);
 
 		$stored = json_decode( $this->store->get_document( $slug ), true );
-		$this->assertSame( [ $this->group_ids[0] ], $this->order_index->for_group( $stored, $group ) );
+		$this->assertSame( [ $this->group_ids[0] ], $this->order_index->all( $stored ) );
 
 		// A follow-up PUT that prunes to nothing removes the stored entry entirely.
 		$this->controller->set_order(
@@ -228,7 +228,7 @@ final class DocumentsControllerOrderTest extends TestCase {
 		);
 
 		$stored = json_decode( $this->store->get_document( $slug ), true );
-		$this->assertArrayNotHasKey( $group, $this->order_index->all( $stored ) );
+		$this->assertSame( [], $this->order_index->all( $stored ) );
 	}
 
 	/**
@@ -378,7 +378,7 @@ final class DocumentsControllerOrderTest extends TestCase {
 		$this->assertSame( WP_Http::OK, $response->get_status() );
 
 		$stored = json_decode( $this->store->get_document( $slug ), true );
-		$this->assertSame( array_reverse( $this->group_ids ), $this->order_index->for_group( $stored, $group ) );
+		$this->assertSame( array_reverse( $this->group_ids ), $this->order_index->all( $stored ) );
 		$this->assertSame( 'not-a-color', $stored['primitive']['color']['x']['$value'], 'The pre-existing invalid remainder must be left untouched.' );
 	}
 
@@ -490,7 +490,7 @@ final class DocumentsControllerOrderTest extends TestCase {
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
 
 		$document = $response->get_data()['document'];
-		$order    = $this->order_index->for_group( $document, $group );
+		$order    = $this->order_index->all( $document );
 		$schema   = $this->registry->to_ui_schema()['groups'][ $group ];
 
 		$rows_by_id = array_column( $schema, null, 'id' );

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerOrderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerOrderTest.php
@@ -299,11 +299,15 @@ final class DocumentsControllerOrderTest extends TestCase {
 
 	/**
 	 * A real declared UI-schema group whose label contains a space (e.g. "Font Size") is
-	 * reachable through the actual WP REST dispatch layer. Every other test in this suite calls
-	 * the controller method directly, which never exercises `register_routes()`'s regex or the
-	 * `group` arg's `pattern` — this is the one test that dispatches a real request through
-	 * `$wp_rest_server`, so a route character class that excludes spaces (as it once did) would
-	 * fail this test with a 404 from WP's own routing layer instead of shipping unnoticed.
+	 * reachable through the actual WP REST dispatch layer, with the group segment built the way a
+	 * real client must build it: percent-encoded via `rawurlencode()`. Every other test in this
+	 * suite calls the controller method directly, which never exercises `register_routes()`'s
+	 * regex, the `group` arg's `pattern`/`sanitize_callback`, or WP's own URL routing — this is
+	 * the one test that dispatches a real request through `$wp_rest_server` on a path built the
+	 * way `WP_REST_Request::from_url()`/a browser `fetch()` would build it, so both a route
+	 * character class that excludes spaces and a handler that fails to decode the percent-escapes
+	 * (as it once did — a raw, unencoded path segment is not a request shape any real client can
+	 * send) would fail this test with a 404 instead of shipping unnoticed.
 	 *
 	 * @return void
 	 */
@@ -324,14 +328,14 @@ final class DocumentsControllerOrderTest extends TestCase {
 
 		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
 
-		$request = new WP_REST_Request( 'DELETE', '/kb-design-tokens/v1/documents/' . $slug . '/order/' . $group );
+		$request = new WP_REST_Request( 'DELETE', '/kb-design-tokens/v1/documents/' . $slug . '/order/' . rawurlencode( $group ) );
 		$request->set_param( 'version', $this->store->get_version( $slug ) );
 
 		global $wp_rest_server;
 		$response = $wp_rest_server->dispatch( $request );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
-		$this->assertSame( WP_Http::OK, $response->get_status(), 'The group route must match a label containing a space rather than 404 at the routing layer.' );
+		$this->assertSame( WP_Http::OK, $response->get_status(), 'The group route must match a percent-encoded multi-word label rather than 404 at the routing layer.' );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerOrderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerOrderTest.php
@@ -298,6 +298,43 @@ final class DocumentsControllerOrderTest extends TestCase {
 	}
 
 	/**
+	 * A real declared UI-schema group whose label contains a space (e.g. "Font Size") is
+	 * reachable through the actual WP REST dispatch layer. Every other test in this suite calls
+	 * the controller method directly, which never exercises `register_routes()`'s regex or the
+	 * `group` arg's `pattern` — this is the one test that dispatches a real request through
+	 * `$wp_rest_server`, so a route character class that excludes spaces (as it once did) would
+	 * fail this test with a 404 from WP's own routing layer instead of shipping unnoticed.
+	 *
+	 * @return void
+	 */
+	public function testGroupNameWithASpaceIsReachableThroughRealRestDispatch(): void {
+		$slug   = Token_Store::default_slug();
+		$schema = $this->registry->to_ui_schema();
+
+		$group = null;
+
+		foreach ( array_keys( $schema['groups'] ) as $candidate ) {
+			if ( str_contains( $candidate, ' ' ) ) {
+				$group = $candidate;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $group, 'At least one declared UI-schema group must contain a space (e.g. "Font Size").' );
+
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$request = new WP_REST_Request( 'DELETE', '/kb-design-tokens/v1/documents/' . $slug . '/order/' . $group );
+		$request->set_param( 'version', $this->store->get_version( $slug ) );
+
+		global $wp_rest_server;
+		$response = $wp_rest_server->dispatch( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status(), 'The group route must match a label containing a space rather than 404 at the routing layer.' );
+	}
+
+	/**
 	 * A stale client version is rejected with 409, and the document is left unchanged.
 	 *
 	 * @return void

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerOrderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerOrderTest.php
@@ -1,0 +1,509 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Rest\V1;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Order_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\User_Primitive_Registrar;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Documents_Controller;
+use Tests\Support\Classes\TestCase;
+use WP_Error;
+use WP_Http;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Covers the per-group token sort-order sub-route: PUT/DELETE /documents/{slug}/order/{group},
+ * its narrowed write path, the never-hides-a-token merge guarantee, and the version-conditional
+ * guard.
+ *
+ * @since TBD
+ */
+final class DocumentsControllerOrderTest extends TestCase {
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Documents_Controller
+	 */
+	private Documents_Controller $controller;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Token_Order_Index
+	 */
+	private Token_Order_Index $order_index;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * The full ordered id list registered under self::GROUP, discovered fresh per test so the
+	 * fixture stays correct regardless of which baseline tokens actually declare that group.
+	 *
+	 * @since TBD
+	 *
+	 * @var list<string>
+	 */
+	private array $group_ids;
+
+	/**
+	 * Build the controller and its collaborators fresh before each test, and discover a real
+	 * registered group carrying at least two tokens to reorder.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->store       = $this->container->get( Token_Store::class );
+		$this->controller  = $this->container->get( Documents_Controller::class );
+		$this->order_index = $this->container->get( Token_Order_Index::class );
+		$this->registry    = $this->container->get( Token_Registry::class );
+
+		$schema = $this->registry->to_ui_schema();
+		$groups = array_filter( $schema['groups'], fn( array $rows ): bool => count( $rows ) >= 2 );
+
+		$this->assertNotEmpty( $groups, 'At least one registered group must carry two or more tokens.' );
+
+		$this->group_ids = array_column( reset( $groups ), 'id' );
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Reset the current user and the global REST server after each test.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		wp_set_current_user( 0 );
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The group this fixture's tests target, discovered in setUp() (the constant is only a
+	 * documentation hint — the real group is whichever one has enough tokens).
+	 *
+	 * @return string
+	 */
+	private function group(): string {
+		$schema = $this->registry->to_ui_schema();
+
+		foreach ( $schema['groups'] as $group => $rows ) {
+			if ( array_column( $rows, 'id' ) === $this->group_ids ) {
+				return $group;
+			}
+		}
+
+		$this->fail( 'The fixture group could not be re-derived.' );
+	}
+
+	/**
+	 * A PUT stores the order, and the feed's group comes back in stored sequence with unmentioned
+	 * tokens appended in declaration order.
+	 *
+	 * @return void
+	 */
+	public function testPutStoresTheOrderAndFeedReflectsItWithUnmentionedTokensAppended(): void {
+		$slug    = Token_Store::default_slug();
+		$group   = $this->group();
+		$reverse = array_reverse( $this->group_ids );
+		$partial = [ $reverse[0] ];
+
+		$response = $this->controller->set_order( $this->order_request( 'PUT', $slug, $group, $this->store->get_version( $slug ), $partial ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::CREATED, $response->get_status() );
+
+		$expected = array_merge( $partial, array_diff( $this->group_ids, $partial ) );
+
+		$this->assertSame( $expected, $this->assembled_group_ids( $slug, $group ) );
+	}
+
+	/**
+	 * The merged group always contains exactly the registered row set, as an id set regardless of
+	 * sequence, when the stored order is partial — the never-hides-a-token pin.
+	 *
+	 * @return void
+	 */
+	public function testTheMergedGroupPreservesTheFullRowSetForAPartialOrder(): void {
+		$this->assertMergedGroupPreservesFullRowSet( [ $this->group_ids[0] ] );
+	}
+
+	/**
+	 * The merged group always contains exactly the registered row set when the stored order is
+	 * full of ids that name no registered token — the never-hides-a-token pin.
+	 *
+	 * @return void
+	 */
+	public function testTheMergedGroupPreservesTheFullRowSetForAnOrderFullOfStaleIds(): void {
+		$this->assertMergedGroupPreservesFullRowSet( [ 'semantic.color.does-not-exist', 'semantic.color.also-missing' ] );
+	}
+
+	/**
+	 * The merged group always contains exactly the registered row set when the submitted order
+	 * carries a duplicated id — the never-hides-a-token pin.
+	 *
+	 * @return void
+	 */
+	public function testTheMergedGroupPreservesTheFullRowSetForADuplicatedId(): void {
+		$this->assertMergedGroupPreservesFullRowSet( [ $this->group_ids[0], $this->group_ids[0] ] );
+	}
+
+	/**
+	 * The merged group always contains exactly the registered row set when pruning leaves an empty
+	 * result (the whole submitted order was stale) — the never-hides-a-token pin.
+	 *
+	 * @return void
+	 */
+	public function testTheMergedGroupPreservesTheFullRowSetAfterPruningToEmpty(): void {
+		$this->assertMergedGroupPreservesFullRowSet( [ 'semantic.color.does-not-exist' ] );
+	}
+
+	/**
+	 * PUT the given submitted order for the fixture group, then assert the assembled feed still
+	 * carries exactly the registered id set for that group, regardless of sequence.
+	 *
+	 * @param list<string> $submitted The ids submitted on the PUT.
+	 *
+	 * @return void
+	 */
+	private function assertMergedGroupPreservesFullRowSet( array $submitted ): void {
+		$slug  = Token_Store::default_slug();
+		$group = $this->group();
+
+		$this->controller->set_order( $this->order_request( 'PUT', $slug, $group, $this->store->get_version( $slug ), $submitted ) );
+
+		$this->assertEqualsCanonicalizing( $this->group_ids, $this->assembled_group_ids( $slug, $group ) );
+	}
+
+	/**
+	 * Ids not registered in the group are pruned from what is stored, and an order pruned to []
+	 * stores no entry at all.
+	 *
+	 * @return void
+	 */
+	public function testUnregisteredIdsArePrunedFromWhatIsStoredAndEmptyResultStoresNoEntry(): void {
+		$slug  = Token_Store::default_slug();
+		$group = $this->group();
+
+		$this->controller->set_order(
+			$this->order_request(
+				'PUT',
+				$slug,
+				$group,
+				$this->store->get_version( $slug ),
+				[ $this->group_ids[0], 'semantic.color.does-not-exist' ]
+			)
+		);
+
+		$stored = json_decode( $this->store->get_document( $slug ), true );
+		$this->assertSame( [ $this->group_ids[0] ], $this->order_index->for_group( $stored, $group ) );
+
+		// A follow-up PUT that prunes to nothing removes the stored entry entirely.
+		$this->controller->set_order(
+			$this->order_request( 'PUT', $slug, $group, $this->store->get_version( $slug ), [ 'semantic.color.does-not-exist' ] )
+		);
+
+		$stored = json_decode( $this->store->get_document( $slug ), true );
+		$this->assertArrayNotHasKey( $group, $this->order_index->all( $stored ) );
+	}
+
+	/**
+	 * DELETE removes the stored order and the feed returns to declaration order; a second DELETE
+	 * is an idempotent 200 with no version bump.
+	 *
+	 * @return void
+	 */
+	public function testDeleteRemovesTheOrderAndASecondDeleteIsIdempotent(): void {
+		$slug  = Token_Store::default_slug();
+		$group = $this->group();
+
+		$this->controller->set_order(
+			$this->order_request( 'PUT', $slug, $group, $this->store->get_version( $slug ), array_reverse( $this->group_ids ) )
+		);
+
+		$response = $this->controller->delete_order( $this->order_request( 'DELETE', $slug, $group, $this->store->get_version( $slug ) ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertSame( $this->group_ids, $this->assembled_group_ids( $slug, $group ) );
+
+		$version_after_first_delete = $this->store->get_version( $slug );
+
+		$second = $this->controller->delete_order( $this->order_request( 'DELETE', $slug, $group, $version_after_first_delete ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $second );
+		$this->assertSame( WP_Http::OK, $second->get_status() );
+		$this->assertSame( $version_after_first_delete, $this->store->get_version( $slug ) );
+	}
+
+	/**
+	 * An unknown library slug is a 404, on both PUT and DELETE.
+	 *
+	 * @return void
+	 */
+	public function testUnknownSlugReturns404(): void {
+		$put = $this->controller->set_order( $this->order_request( 'PUT', 'does-not-exist', $this->group(), '', [ 'x' ] ) );
+
+		$this->assertInstanceOf( WP_Error::class, $put );
+		$this->assertSame( 'rest_design_tokens_not_found', $put->get_error_code() );
+
+		$delete = $this->controller->delete_order( $this->order_request( 'DELETE', 'does-not-exist', $this->group(), '' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $delete );
+		$this->assertSame( 'rest_design_tokens_not_found', $delete->get_error_code() );
+	}
+
+	/**
+	 * A group that names no UI-schema group is a 404, on both PUT and DELETE.
+	 *
+	 * @return void
+	 */
+	public function testUnknownGroupReturns404(): void {
+		$slug    = Token_Store::default_slug();
+		$version = $this->store->get_version( $slug );
+
+		$put = $this->controller->set_order( $this->order_request( 'PUT', $slug, 'does-not-exist', $version, [ 'x' ] ) );
+
+		$this->assertInstanceOf( WP_Error::class, $put );
+		$this->assertSame( 'rest_design_tokens_unknown_group', $put->get_error_code() );
+
+		$delete = $this->controller->delete_order( $this->order_request( 'DELETE', $slug, 'does-not-exist', $version ) );
+
+		$this->assertInstanceOf( WP_Error::class, $delete );
+		$this->assertSame( 'rest_design_tokens_unknown_group', $delete->get_error_code() );
+	}
+
+	/**
+	 * A stale client version is rejected with 409, and the document is left unchanged.
+	 *
+	 * @return void
+	 */
+	public function testStaleVersionReturns409AndDocumentIsUnchanged(): void {
+		$slug  = Token_Store::default_slug();
+		$group = $this->group();
+
+		$this->controller->set_order(
+			$this->order_request( 'PUT', $slug, $group, $this->store->get_version( $slug ), array_reverse( $this->group_ids ) )
+		);
+
+		$stored_before = $this->store->get_document( $slug );
+
+		$response = $this->controller->set_order( $this->order_request( 'PUT', $slug, $group, 'stale-version', $this->group_ids ) );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_design_tokens_conflict', $response->get_error_code() );
+		$this->assertSame( WP_Http::CONFLICT, $response->get_error_data()['status'] );
+		$this->assertSame( $stored_before, $this->store->get_document( $slug ) );
+	}
+
+	/**
+	 * The narrowed write path lets a reorder succeed even in a library whose stored document
+	 * currently fails full DTCG validation, and leaves the invalid remainder untouched.
+	 *
+	 * @return void
+	 */
+	public function testNarrowedPathAllowsAReorderInALibraryThatFailsFullValidation(): void {
+		$slug    = Token_Store::default_slug();
+		$group   = $this->group();
+		$invalid = '{"primitive":{"color":{"x":{"$type":"color","$value":"not-a-color"}}}}';
+
+		$this->store->save_document( $invalid );
+
+		$response = $this->controller->set_order(
+			$this->order_request( 'PUT', $slug, $group, $this->store->get_version( $slug ), array_reverse( $this->group_ids ) )
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$stored = json_decode( $this->store->get_document( $slug ), true );
+		$this->assertSame( array_reverse( $this->group_ids ), $this->order_index->for_group( $stored, $group ) );
+		$this->assertSame( 'not-a-color', $stored['primitive']['color']['x']['$value'], 'The pre-existing invalid remainder must be left untouched.' );
+	}
+
+	/**
+	 * Order applies to a user-created token exactly like a baseline token: mint one, order it
+	 * first, and confirm the feed sequence reflects it.
+	 *
+	 * @return void
+	 */
+	public function testOrderAppliesToAUserCreatedTokenLikeABaselineToken(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.color.custom.brand-blue';
+
+		$document = (string) wp_json_encode(
+			[
+				'primitive'   => [
+					'color' => [
+						'custom' => [
+							'brand-blue' => [
+								'$type'  => 'color',
+								'$value' => '#1a56db',
+							],
+						],
+					],
+				],
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'userPrimitives' => [
+							$id => [ 'label' => 'Brand Blue' ],
+						],
+					],
+				],
+			]
+		);
+
+		$this->store->save_document( $document, $slug );
+
+		/** @var User_Primitive_Registrar $registrar */
+		$registrar = $this->container->get( User_Primitive_Registrar::class );
+		$registrar->sync();
+
+		$schema = $this->registry->to_ui_schema();
+		$group  = null;
+
+		foreach ( $schema['groups'] as $candidate => $rows ) {
+			if ( in_array( $id, array_column( $rows, 'id' ), true ) ) {
+				$group = $candidate;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $group, 'The newly created primitive must appear in some UI-schema group.' );
+
+		$response = $this->controller->set_order( $this->order_request( 'PUT', $slug, $group, $this->store->get_version( $slug ), [ $id ] ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+
+		$this->assertSame( $id, $this->assembled_group_ids( $slug, $group )[0] );
+	}
+
+	/**
+	 * Both routes enforce the sibling document routes' capability filter: an unauthenticated
+	 * request and a subscriber are both refused.
+	 *
+	 * @return void
+	 */
+	public function testPermissionsRefuseUnauthenticatedAndSubscriberRequests(): void {
+		$request = new WP_REST_Request( 'PUT' );
+
+		$this->assertInstanceOf( WP_Error::class, $this->controller->update_item_permissions_check( $request ) );
+
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'subscriber' ] ) );
+
+		$this->assertInstanceOf( WP_Error::class, $this->controller->update_item_permissions_check( $request ) );
+	}
+
+	/**
+	 * A stored order never reaches the effective (rendering) document — $extensions is stripped
+	 * there, so order can never leak into projected CSS.
+	 *
+	 * @return void
+	 */
+	public function testTheOrderNeverReachesTheEffectiveDocument(): void {
+		$slug  = Token_Store::default_slug();
+		$group = $this->group();
+
+		$this->controller->set_order(
+			$this->order_request( 'PUT', $slug, $group, $this->store->get_version( $slug ), array_reverse( $this->group_ids ) )
+		);
+
+		$stored = json_decode( $this->store->get_document( $slug ), true );
+
+		/** @var Effective_Document $effective */
+		$effective = $this->container->get( Effective_Document::class );
+
+		$this->assertArrayNotHasKey( '$extensions', $effective->build( $stored ) );
+	}
+
+	/**
+	 * Read back the assembled feed's ordered id list for one group.
+	 *
+	 * @param string $slug  The token library slug.
+	 * @param string $group The UI-schema group name.
+	 *
+	 * @return list<string>
+	 */
+	private function assembled_group_ids( string $slug, string $group ): array {
+		$response = $this->controller->get_item( $this->slug_request( $slug ) );
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+
+		$document = $response->get_data()['document'];
+		$order    = $this->order_index->for_group( $document, $group );
+		$schema   = $this->registry->to_ui_schema()['groups'][ $group ];
+
+		$rows_by_id = array_column( $schema, null, 'id' );
+		$sorted     = [];
+
+		foreach ( $order as $id ) {
+			if ( isset( $rows_by_id[ $id ] ) ) {
+				$sorted[ $id ] = $rows_by_id[ $id ];
+			}
+		}
+
+		return array_column( array_values( $sorted + $rows_by_id ), 'id' );
+	}
+
+	/**
+	 * Build a bare slug-only request, for get_item().
+	 *
+	 * @param string $slug The token library slug.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function slug_request( string $slug ): WP_REST_Request {
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'slug', $slug );
+
+		return $request;
+	}
+
+	/**
+	 * Build an order sub-route request carrying the slug, group, version and (for PUT) the
+	 * submitted id list.
+	 *
+	 * @param string        $method  The HTTP method.
+	 * @param string        $slug    The token library slug.
+	 * @param string        $group   The UI-schema group name.
+	 * @param string        $version The client's last-read version.
+	 * @param list<string>|null $order The submitted ordered id list, for PUT requests only.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function order_request( string $method, string $slug, string $group, string $version, ?array $order = null ): WP_REST_Request {
+		$request = new WP_REST_Request( $method );
+		$request->set_param( 'slug', $slug );
+		$request->set_param( 'group', $group );
+		$request->set_param( 'version', $version );
+
+		if ( $order !== null ) {
+			$request->set_param( 'order', $order );
+		}
+
+		return $request;
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
@@ -132,6 +132,70 @@ final class Dtcg_ValidatorTest extends TestCase {
 	}
 
 	/**
+	 * A well-formed tokenOrder section validates: every entry maps a non-empty string group name
+	 * to a sequential list of non-empty string token ids.
+	 *
+	 * @return void
+	 */
+	public function testAWellFormedTokenOrderSectionValidates(): void {
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'tokenOrder' => [
+						'Brand' => [ 'semantic.color.button-bg', 'semantic.color.button-text' ],
+					],
+				],
+			],
+		];
+
+		$result = $this->validator->validate( $document, Dtcg_Validator::get_context_overrides() );
+
+		$this->assertTrue( $result->is_valid(), $this->describe( $result->errors() ) );
+	}
+
+	/**
+	 * A stored id that names no registered token does not fail validation: whether it resolves is
+	 * data drift, enforced by the REST write guard and the feed merge, not full-document grammar.
+	 *
+	 * @return void
+	 */
+	public function testATokenOrderEntryNamingAnUnregisteredIdStillValidates(): void {
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'tokenOrder' => [
+						'Brand' => [ 'semantic.color.does-not-exist' ],
+					],
+				],
+			],
+		];
+
+		$result = $this->validator->validate( $document, Dtcg_Validator::get_context_overrides() );
+
+		$this->assertTrue( $result->is_valid(), $this->describe( $result->errors() ) );
+	}
+
+	/**
+	 * A document without a tokenOrder section produces no new errors, and a non-Kadence extension
+	 * namespace alongside it is passed through untouched.
+	 *
+	 * @return void
+	 */
+	public function testADocumentWithoutTheTokenOrderSectionIsUnaffected(): void {
+		$document = [
+			'$extensions' => [
+				'some.other.vendor' => [
+					'tokenOrder' => [ 0 => 'not-kadence-owned' ],
+				],
+			],
+		];
+
+		$result = $this->validator->validate( $document, Dtcg_Validator::get_context_overrides() );
+
+		$this->assertTrue( $result->is_valid(), $this->describe( $result->errors() ) );
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testItIsResolvableFromTheContainer(): void {
@@ -405,6 +469,56 @@ final class Dtcg_ValidatorTest extends TestCase {
 			'context'  => Dtcg_Validator::get_context_overrides(),
 			'code'     => Validation_Error::get_code_value_invalid(),
 			'path'     => '$extensions.com.kadence.designTokens.tokenLabels.semantic.color.button-bg',
+		];
+		// A tokenOrder group whose value is map-shaped (non-sequential keys) rather than an
+		// ordered list is rejected by the section's own explicit branch.
+		yield 'map-shaped (non-sequential) tokenOrder group value' => [
+			'document' => [
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'tokenOrder' => [ 'Brand' => [ 'a' => 'semantic.color.button-bg' ] ],
+					],
+				],
+			],
+			'context'  => Dtcg_Validator::get_context_overrides(),
+			'code'     => Validation_Error::get_code_value_invalid(),
+			'path'     => '$extensions.com.kadence.designTokens.tokenOrder.Brand',
+		];
+		yield 'non-string tokenOrder id' => [
+			'document' => [
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'tokenOrder' => [ 'Brand' => [ 'semantic.color.button-bg', 42 ] ],
+					],
+				],
+			],
+			'context'  => Dtcg_Validator::get_context_overrides(),
+			'code'     => Validation_Error::get_code_value_invalid(),
+			'path'     => '$extensions.com.kadence.designTokens.tokenOrder.Brand',
+		];
+		yield 'empty-string tokenOrder id' => [
+			'document' => [
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'tokenOrder' => [ 'Brand' => [ '' ] ],
+					],
+				],
+			],
+			'context'  => Dtcg_Validator::get_context_overrides(),
+			'code'     => Validation_Error::get_code_value_invalid(),
+			'path'     => '$extensions.com.kadence.designTokens.tokenOrder.Brand',
+		];
+		yield 'empty tokenOrder group name' => [
+			'document' => [
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'tokenOrder' => [ '' => [ 'semantic.color.button-bg' ] ],
+					],
+				],
+			],
+			'context'  => Dtcg_Validator::get_context_overrides(),
+			'code'     => Validation_Error::get_code_value_invalid(),
+			'path'     => '$extensions.com.kadence.designTokens.tokenOrder.',
 		];
 		yield 'responsive on non-capable type' => [
 			'document' => [

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
@@ -132,8 +132,7 @@ final class Dtcg_ValidatorTest extends TestCase {
 	}
 
 	/**
-	 * A well-formed tokenOrder section validates: every entry maps a non-empty string group name
-	 * to a sequential list of non-empty string token ids.
+	 * A well-formed tokenOrder section validates: a sequential list of non-empty string token ids.
 	 *
 	 * @return void
 	 */
@@ -141,9 +140,7 @@ final class Dtcg_ValidatorTest extends TestCase {
 		$document = [
 			'$extensions' => [
 				'com.kadence.designTokens' => [
-					'tokenOrder' => [
-						'Brand' => [ 'semantic.color.button-bg', 'semantic.color.button-text' ],
-					],
+					'tokenOrder' => [ 'semantic.color.button-bg', 'semantic.color.button-text' ],
 				],
 			],
 		];
@@ -163,9 +160,7 @@ final class Dtcg_ValidatorTest extends TestCase {
 		$document = [
 			'$extensions' => [
 				'com.kadence.designTokens' => [
-					'tokenOrder' => [
-						'Brand' => [ 'semantic.color.does-not-exist' ],
-					],
+					'tokenOrder' => [ 'semantic.color.does-not-exist' ],
 				],
 			],
 		];
@@ -470,55 +465,43 @@ final class Dtcg_ValidatorTest extends TestCase {
 			'code'     => Validation_Error::get_code_value_invalid(),
 			'path'     => '$extensions.com.kadence.designTokens.tokenLabels.semantic.color.button-bg',
 		];
-		// A tokenOrder group whose value is map-shaped (non-sequential keys) rather than an
-		// ordered list is rejected by the section's own explicit branch.
-		yield 'map-shaped (non-sequential) tokenOrder group value' => [
+		// tokenOrder must be a single flat sequential list (see Token_Order_Index for why it is
+		// never keyed by group); a map-shaped (non-sequential) value is rejected wholesale.
+		yield 'map-shaped (non-sequential) tokenOrder value' => [
 			'document' => [
 				'$extensions' => [
 					'com.kadence.designTokens' => [
-						'tokenOrder' => [ 'Brand' => [ 'a' => 'semantic.color.button-bg' ] ],
+						'tokenOrder' => [ 'a' => 'semantic.color.button-bg' ],
 					],
 				],
 			],
 			'context'  => Dtcg_Validator::get_context_overrides(),
 			'code'     => Validation_Error::get_code_value_invalid(),
-			'path'     => '$extensions.com.kadence.designTokens.tokenOrder.Brand',
+			'path'     => '$extensions.com.kadence.designTokens.tokenOrder',
 		];
 		yield 'non-string tokenOrder id' => [
 			'document' => [
 				'$extensions' => [
 					'com.kadence.designTokens' => [
-						'tokenOrder' => [ 'Brand' => [ 'semantic.color.button-bg', 42 ] ],
+						'tokenOrder' => [ 'semantic.color.button-bg', 42 ],
 					],
 				],
 			],
 			'context'  => Dtcg_Validator::get_context_overrides(),
 			'code'     => Validation_Error::get_code_value_invalid(),
-			'path'     => '$extensions.com.kadence.designTokens.tokenOrder.Brand',
+			'path'     => '$extensions.com.kadence.designTokens.tokenOrder.1',
 		];
 		yield 'empty-string tokenOrder id' => [
 			'document' => [
 				'$extensions' => [
 					'com.kadence.designTokens' => [
-						'tokenOrder' => [ 'Brand' => [ '' ] ],
+						'tokenOrder' => [ '' ],
 					],
 				],
 			],
 			'context'  => Dtcg_Validator::get_context_overrides(),
 			'code'     => Validation_Error::get_code_value_invalid(),
-			'path'     => '$extensions.com.kadence.designTokens.tokenOrder.Brand',
-		];
-		yield 'empty tokenOrder group name' => [
-			'document' => [
-				'$extensions' => [
-					'com.kadence.designTokens' => [
-						'tokenOrder' => [ '' => [ 'semantic.color.button-bg' ] ],
-					],
-				],
-			],
-			'context'  => Dtcg_Validator::get_context_overrides(),
-			'code'     => Validation_Error::get_code_value_invalid(),
-			'path'     => '$extensions.com.kadence.designTokens.tokenOrder.',
+			'path'     => '$extensions.com.kadence.designTokens.tokenOrder.0',
 		];
 		yield 'responsive on non-capable type' => [
 			'document' => [

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/ExtensionsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/ExtensionsTest.php
@@ -158,4 +158,23 @@ final class ExtensionsTest extends TestCase {
 			Extensions::get_sections()
 		);
 	}
+
+	/**
+	 * The token-order section accessor returns the expected section name.
+	 *
+	 * @return void
+	 */
+	public function testItExposesTheTokenOrderSectionName(): void {
+		$this->assertSame( 'tokenOrder', Extensions::get_section_token_order() );
+	}
+
+	/**
+	 * The token-order section is deliberately NOT among get_sections(): it is a group-keyed
+	 * id-list map, not a preset-shaped `tokens` map, so the tokens-map walk must not descend it.
+	 *
+	 * @return void
+	 */
+	public function testTheTokenOrderSectionIsNotAmongTheTokensMapSections(): void {
+		$this->assertNotContains( Extensions::get_section_token_order(), Extensions::get_sections() );
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/ExtensionsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/ExtensionsTest.php
@@ -87,4 +87,23 @@ final class ExtensionsTest extends TestCase {
 			Extensions::get_sections()
 		);
 	}
+
+	/**
+	 * The token-order section accessor returns the expected section name.
+	 *
+	 * @return void
+	 */
+	public function testItExposesTheTokenOrderSectionName(): void {
+		$this->assertSame( 'tokenOrder', Extensions::get_section_token_order() );
+	}
+
+	/**
+	 * The token-order section is deliberately NOT among get_sections(): it is a group-keyed
+	 * id-list map, not a preset-shaped `tokens` map, so the tokens-map walk must not descend it.
+	 *
+	 * @return void
+	 */
+	public function testTheTokenOrderSectionIsNotAmongTheTokensMapSections(): void {
+		$this->assertNotContains( Extensions::get_section_token_order(), Extensions::get_sections() );
+	}
 }


### PR DESCRIPTION
User-defined ordering of registered tokens, stored per library and applied where the Style Library lists them.

Builds directly on the label-override work in the PR below it — same extensions namespace, same index-helper shape, same validator pattern, same version-conditional route style, and the same apply seam.

## What's here

- `Schema/Vocabulary/Extensions.php` — a `tokenOrder` section under `com.kadence.designTokens`.
- `Document/Token_Order_Index.php` — the pure read/write helper.
- `Schema/Validation/Dtcg_Validator.php` — an explicit validation branch.
- `Rest/V1/Documents_Controller.php` — `PUT`/`DELETE /documents/{slug}/order/{group}`, reusing the existing version guard and metadata-persist path rather than duplicating them.
- `Admin/Feed/Feed_Assembler.php` + `Admin/Feed/Builder.php` — the order merged onto the admin feed.

## Storage shape

Group-keyed ordered id arrays, not a flat `{ id => int }` map. The UI schema already buckets tokens by group and a drag never crosses a group boundary, so ordered arrays make ties and out-of-range integers impossible by construction — a flat integer map would have to answer "what happens on a tie" and "what does 7 mean in a group of 4".

## The merge rules — the real risk in this change

Stored order is partial and advisory, never authoritative membership:

- Ids the map doesn't mention still appear, appended after the ordered ids in declaration order.
- Ids it mentions that no longer resolve are ignored on read and pruned on save.
- **Reordering can never hide a token.** The merged result is always the full registered set, only permuted.
- Removing the stored order restores declaration order.

Each has direct coverage. The never-hides-a-token rule is asserted across four fixtures — partial, stale, duplicate and empty — comparing id sets with `assertEqualsCanonicalizing`.

## The Builder snapshot is deliberately unchanged

An empty-order merge is the identity, so the snapshot fixture — which exercises `build()` with no stored order — comes out byte-identical. **A snapshot failure here is a bug in the merge, never a prompt to regenerate.** That property is what guarantees this feature can't disturb a library nobody has reordered.

## Scope

Feed layer only. `Editor/Pickable_Tokens_Catalog` is untouched, so the block-editor picker and the size/spacing dropdowns keep declaration order — a user-arranged scale reading 8px, 4px, 16px in a dropdown other people pick from would be a bad outcome, and that catalog emits one shared token list anyway, so per-library ordering there would multiply its payload by the number of libraries.

Palette order and preset order are out of scope — both are already ordered document data with their own endpoints.

## The order route: multi-word group labels

The route's `{group}` segment carries a `__()`-translated UI-schema label (`Font Size`, `Border Radius`, `Media Padding`), not a slug. Two things about that had to be fixed here.

The route regex was `[\w-]+`, which cannot match a space, so every multi-word group 404'd at WordPress's routing layer before reaching the handler. That is now `[^/]+` — only the path separator has to be excluded, since the group is a single path segment.

Widening the regex made the route *match*, but the value arriving at the handler was still percent-encoded: a browser must send `Border%20Radius`, and `WP_REST_Server` does not decode path segments before populating URL params, so the group lookup compared `"Border%20Radius"` against the real labels and missed. Every multi-word group returned `rest_design_tokens_unknown_group`; single-word groups worked, which is what made it look like the route was fine. The group param now goes through a `sanitize_callback` that applies `rawurldecode` once, shared by the PUT and DELETE routes. `rawurldecode` rather than `urldecode`, because a `+` in a path segment is a literal plus, not a space.

Both were caught only by driving the real UI — the original dispatch test built its route with a literal, unencoded space, which is a request no client can send, so it passed against broken code. It now encodes the segment with `rawurlencode`, and was confirmed to fail (404 against an expected 200) before the decode was applied.

## Test plan

`slic run wpunit Resources/Design_Tokens` — 1182 tests green. Snapshot suite green **without regeneration**.

The order route is additionally exercised through real `WP_REST_Server` dispatch with a percent-encoded multi-word group, which is the case every unit-level test missed.

