### PR TITLE
[DTM] SOFT-4099: Non-color user primitives

### DIFF
--- a/includes/resources/Design_Tokens/Document/Reserved_Namespace.php
+++ b/includes/resources/Design_Tokens/Document/Reserved_Namespace.php
@@ -91,16 +91,47 @@ final class Reserved_Namespace {
 	}
 
 	/**
-	 * Build the canonical id for a terminal slug: primitive.color.custom.<slug>.
+	 * Build the canonical id for a supported type and terminal slug: primitive.<type>.custom.<slug>.
+	 *
+	 * A pure string builder, like the slug handling before it: the type is not validated here.
+	 * Callers pass a type that already passed is_supported_type() (the create gate) or was read
+	 * from a stored tree leaf (the rename cascade, the orphan scan); an unsupported type yields
+	 * an id the user-primitive document invariant rejects downstream.
 	 *
 	 * @since TBD
 	 *
+	 * @param string $type The DTCG $type segment (spec spelling).
 	 * @param string $slug The terminal slug.
 	 *
 	 * @return string
 	 */
-	public static function canonical( string $slug ): string {
-		return self::LAYER . '.' . Token_Type::get_type_color() . '.' . self::SEGMENT . '.' . $slug;
+	public static function canonical( string $type, string $slug ): string {
+		return self::LAYER . '.' . $type . '.' . self::SEGMENT . '.' . $slug;
+	}
+
+	/**
+	 * Whether a $type supports user-created primitives: registered, and itself a valid
+	 * kebab-case id segment.
+	 *
+	 * The second predicate is load-bearing, not stylistic: the type spelling becomes the second
+	 * segment of a REGISTERED token id, and Token_Definition::from_user_primitive() rejects any
+	 * segment outside ^[a-z0-9]+([.-][a-z0-9]+)*$ (the id feeds Css_Var::from_id()). A camelCase
+	 * $type (fontWeight, lineHeight, ...) would store fine but could never register — the token
+	 * would silently never surface. Composites are not excluded: the shadow $type is a valid
+	 * segment, and the composite validate/render/reference machinery is fully wired.
+	 *
+	 * Deliberately narrower than is_reserved_id()/contains_reserved_path(), which guard the
+	 * whole namespace for every registered type: a generic write must not reach under
+	 * primitive.fontWeight.custom.* just because creation does not support that spelling yet.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $type The candidate DTCG $type.
+	 *
+	 * @return bool
+	 */
+	public static function is_supported_type( string $type ): bool {
+		return Token_Type::is_valid( $type ) && self::is_valid_slug( $type );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Document/User_Primitive_Document_Validator.php
+++ b/includes/resources/Design_Tokens/Document/User_Primitive_Document_Validator.php
@@ -12,7 +12,7 @@ use KadenceWP\KadenceBlocks\Utils\Cast;
  * Enforces the user-primitive document invariant: every envelope entry has a matching valid
  * tree leaf, and every custom tree leaf has a matching envelope entry.
  *
- * Only primitive.color.custom.* is accepted.
+ * Only primitive.<type>.custom.* leaves of supported types are accepted.
  *
  * @since TBD
  */
@@ -101,7 +101,7 @@ final class User_Primitive_Document_Validator {
 		if ( ! Reserved_Namespace::is_reserved_id( $id ) ) {
 			$errors[] = new User_Primitive_Validation_Error(
 				$id,
-				sprintf( 'User primitive id "%s" is not in the allowed namespace (primitive.color.custom.*).', $id )
+				sprintf( 'User primitive id "%s" is not in the allowed namespace (primitive.<type>.custom.*).', $id )
 			);
 
 			return $errors;
@@ -129,12 +129,18 @@ final class User_Primitive_Document_Validator {
 			return $errors;
 		}
 
-		$type = $leaf[ Token_Type::get_type_key() ] ?? null;
+		$type    = $leaf[ Token_Type::get_type_key() ] ?? null;
+		$segment = explode( '.', $id )[1];
 
-		if ( $type !== Token_Type::get_type_color() ) {
+		if ( ! is_string( $type ) || ! Reserved_Namespace::is_supported_type( $type ) ) {
 			$errors[] = new User_Primitive_Validation_Error(
 				$id,
-				sprintf( 'User primitive "%s" tree leaf has $type "%s"; only "color" is allowed at this time.', $id, Cast::to_string( $type ) )
+				sprintf( 'User primitive "%s" tree leaf has $type "%s"; that type does not support user-created primitives.', $id, Cast::to_string( $type ) )
+			);
+		} elseif ( $type !== $segment ) {
+			$errors[] = new User_Primitive_Validation_Error(
+				$id,
+				sprintf( 'User primitive "%s" tree leaf declares $type "%s", which does not match its id namespace.', $id, $type )
 			);
 		}
 
@@ -151,7 +157,15 @@ final class User_Primitive_Document_Validator {
 	}
 
 	/**
-	 * Walk primitive.color.custom.* in the document and return any id that has no envelope entry.
+	 * Walk primitive.<type>.custom.* for every registered type in the document and return any
+	 * id that has no envelope entry.
+	 *
+	 * This walk terminates one level below "custom": it iterates the direct children of the
+	 * custom group and treats every array child as a leaf slug. It must never descend into a
+	 * node or read $value — a shadow leaf's sub-field map lives inside that opaque node, so
+	 * descending would let color/offsetX/... be mistaken for orphan slugs. The walk stays safe
+	 * because it keys off tree position, not node shape; do not "improve" it into a recursive
+	 * walk.
 	 *
 	 * @since TBD
 	 *
@@ -166,29 +180,31 @@ final class User_Primitive_Document_Validator {
 			return [];
 		}
 
-		$color = $primitive['color'] ?? [];
-
-		if ( ! is_array( $color ) ) {
-			return [];
-		}
-
-		$custom = $color['custom'] ?? [];
-
-		if ( ! is_array( $custom ) ) {
-			return [];
-		}
-
 		$orphans = [];
 
-		foreach ( $custom as $slug => $node ) {
-			if ( ! is_string( $slug ) || strncmp( $slug, '$', 1 ) === 0 || ! is_array( $node ) ) {
+		foreach ( Token_Type::all() as $type ) {
+			$subtree = $primitive[ $type ] ?? [];
+
+			if ( ! is_array( $subtree ) ) {
 				continue;
 			}
 
-			$id = Reserved_Namespace::canonical( $slug );
+			$custom = $subtree['custom'] ?? [];
 
-			if ( ! $this->index->has( $document, $id ) ) {
-				$orphans[] = $id;
+			if ( ! is_array( $custom ) ) {
+				continue;
+			}
+
+			foreach ( $custom as $slug => $node ) {
+				if ( ! is_string( $slug ) || strncmp( $slug, '$', 1 ) === 0 || ! is_array( $node ) ) {
+					continue;
+				}
+
+				$id = Reserved_Namespace::canonical( $type, $slug );
+
+				if ( ! $this->index->has( $document, $id ) ) {
+					$orphans[] = $id;
+				}
 			}
 		}
 

--- a/includes/resources/Design_Tokens/Resolver/Css_Renderer.php
+++ b/includes/resources/Design_Tokens/Resolver/Css_Renderer.php
@@ -67,14 +67,15 @@ final class Css_Renderer {
 	}
 
 	/**
-	 * Render a shadow composite to "<offsetX> <offsetY> <blur> <spread> <color>".
+	 * Render a shadow composite to "<offsetX> <offsetY> <blur> <spread> <color>", prefixed with
+	 * "inset " when the optional "inset" sub-field is present and strictly true.
 	 *
 	 * v1 supports a single shadow object. DTCG also permits a $value that is an array of
 	 * shadow objects (stacked box-shadows); that shape is intentionally not handled here —
 	 * Token_Resolver passes a list through untouched, and supporting it is a follow-up that
 	 * would change this method (join each layer with ", ") and the resolver's list handling.
 	 *
-	 * @param mixed|array{color: string, offsetX: string, offsetY: string, blur: string, spread: string} $value
+	 * @param mixed|array{color: string, offsetX: string, offsetY: string, blur: string, spread: string, inset?: bool} $value
 	 *              The resolved shadow shape; typed loosely so a malformed (non-array) token still degrades to "".
 	 */
 	private function shadow( $value ): string {
@@ -85,7 +86,7 @@ final class Css_Renderer {
 			return '';
 		}
 
-		return trim( sprintf(
+		$shorthand = trim( sprintf(
 			'%s %s %s %s %s',
 			$value['offsetX'] ?? '0',
 			$value['offsetY'] ?? '0',
@@ -93,5 +94,10 @@ final class Css_Renderer {
 			$value['spread']  ?? '0',
 			$value['color']   ?? ''
 		) );
+
+		// "inset" is optional and, unlike the required fields, only ever a strict boolean (Composite_Value
+		// rejects anything else at write time) — so absent, false, or a malformed value all fall through
+		// to the plain shorthand, keeping every pre-existing shadow token byte-identical.
+		return ( $value['inset'] ?? null ) === true ? 'inset ' . $shorthand : $shorthand;
 	}
 }

--- a/includes/resources/Design_Tokens/Rest/V1/User_Primitives_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/User_Primitives_Controller.php
@@ -54,7 +54,7 @@ final class User_Primitives_Controller extends Controller {
 
 	/**
 	 * The id path segment for user-primitive sub-resources.
-	 * Matches the canonical path format: primitive.color.custom.<slug>
+	 * Matches the canonical path format: primitive.<type>.custom.<slug>
 	 *
 	 * @since TBD
 	 *
@@ -291,7 +291,7 @@ final class User_Primitives_Controller extends Controller {
 	}
 
 	/**
-	 * Create a new user-defined color primitive.
+	 * Create a new user-defined primitive.
 	 *
 	 * @since TBD
 	 *
@@ -323,22 +323,23 @@ final class User_Primitives_Controller extends Controller {
 			);
 		}
 
-		$type      = Cast::to_string( $request->get_param( '$type' ) );
-		$value     = $request->get_param( '$value' );
-		$label     = $this->sanitize_label( Cast::to_string( $request->get_param( 'label' ) ), $slug_input );
-		$canonical = Reserved_Namespace::canonical( $slug_input );
-		$stored    = $this->pipeline->load_document( $slug );
+		$type  = Cast::to_string( $request->get_param( '$type' ) );
+		$value = $request->get_param( '$value' );
+		$label = $this->sanitize_label( Cast::to_string( $request->get_param( 'label' ) ), $slug_input );
 
-		if ( $type !== Token_Type::get_type_color() ) {
+		if ( ! Reserved_Namespace::is_supported_type( $type ) ) {
 			return new WP_Error(
 				'rest_design_tokens_type_not_supported',
-				__( 'Only color primitives can be created in this version.', 'kadence-blocks' ),
+				__( 'That $type does not support user-created primitives in this version.', 'kadence-blocks' ),
 				[
 					'status' => WP_Http::UNPROCESSABLE_ENTITY,
 					'$type'  => $type,
 				]
 			);
 		}
+
+		$canonical = Reserved_Namespace::canonical( $type, $slug_input );
+		$stored    = $this->pipeline->load_document( $slug );
 
 		if ( $this->baseline->has( $canonical ) ) {
 			return new WP_Error(
@@ -561,7 +562,7 @@ final class User_Primitives_Controller extends Controller {
 			);
 		}
 
-		$new_id    = Reserved_Namespace::canonical( $new_slug );
+		$new_id    = Reserved_Namespace::canonical( $type, $new_slug );
 		$new_label = $this->sanitize_label( Cast::to_string( $request->get_param( 'label' ) ), $new_slug );
 
 		if ( $this->baseline->has( $new_id ) || $this->index->has( $stored, $new_id ) ) {
@@ -768,7 +769,7 @@ final class User_Primitives_Controller extends Controller {
 
 		return new WP_Error(
 			'rest_invalid_param',
-			__( 'The id must be a canonical color custom primitive path (primitive.color.custom.<slug>).', 'kadence-blocks' ),
+			__( 'The id must be a canonical custom primitive path (primitive.<type>.custom.<slug>).', 'kadence-blocks' ),
 			[
 				'status' => WP_Http::BAD_REQUEST,
 				'id'     => $id,

--- a/includes/resources/Design_Tokens/Schema/Validation/Values/Composite_Value.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Values/Composite_Value.php
@@ -83,9 +83,29 @@ abstract class Composite_Value implements Value_Validator {
 			$errors = array_merge( $errors, Kind::validate( $kind, $value[ $field ], $path . '.' . $field ) );
 		}
 
-		// Any sub-field not in the map (and not a "$"-prefixed extension) is unknown.
+		$optional = Token_Type::optional_fields( $this->type() );
+
+		// Optional sub-fields (e.g. shadow's "inset") are validated only when present, and never through
+		// Kind::validate() — every optional kind so far ("boolean") has no v1 $type, so Kind has no
+		// literal validator for it and would accept any well-formed alias in its place unchecked; a
+		// strict literal check is required instead.
+		foreach ( $optional as $field => $kind ) {
+			if ( ! array_key_exists( $field, $value ) ) {
+				continue;
+			}
+
+			if ( $kind === Token_Type::get_kind_boolean() && ! is_bool( $value[ $field ] ) ) {
+				$errors[] = new Validation_Error(
+					$path . '.' . $field,
+					Validation_Error::get_code_value_invalid(),
+					sprintf( 'A %s value has an "%s" sub-field that must be a literal boolean (true or false); aliases are not accepted.', $this->type(), $field )
+				);
+			}
+		}
+
+		// Any sub-field not in the required or optional map (and not a "$"-prefixed extension) is unknown.
 		foreach ( array_keys( $value ) as $field ) {
-			if ( isset( $fields[ $field ] ) || ( is_string( $field ) && strncmp( $field, '$', 1 ) === 0 ) ) {
+			if ( isset( $fields[ $field ] ) || isset( $optional[ $field ] ) || ( is_string( $field ) && strncmp( $field, '$', 1 ) === 0 ) ) {
 				continue;
 			}
 

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Token_Type.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Token_Type.php
@@ -112,6 +112,17 @@ final class Token_Type {
 	private const KEY = '$type';
 
 	/**
+	 * The "boolean" kind label used by OPTIONAL_FIELDS. Not a v1 $type (DTCG has no boolean $type),
+	 * so it never appears in TYPES — it only marks an optional composite sub-field as a strict
+	 * literal boolean in Composite_Value::validate().
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const KIND_BOOLEAN = 'boolean';
+
+	/**
 	 * Every v1 $type, in declaration order.
 	 *
 	 * @var string[]
@@ -146,6 +157,26 @@ final class Token_Type {
 			'offsetY' => self::DIMENSION,
 			'blur'    => self::DIMENSION,
 			'spread'  => self::DIMENSION,
+		],
+	];
+
+	/**
+	 * The composite types and their sub-field => kind map for fields that MAY be present but are never
+	 * required. Kept separate from COMPOSITE_FIELDS (which Composite_Value::validate() treats as the
+	 * required set) so adding an optional field never turns an existing baseline token invalid — the
+	 * shadow tokens in baseline.json predate "inset" and carry only the five required fields.
+	 *
+	 * "boolean" is a label, not a v1 $type: DTCG has no boolean $type and none is registered here, so an
+	 * optional field is not dispatched through Kind::validate() (which would accept an alias for any
+	 * kind) — the composite validator checks it as a strict literal instead.
+	 *
+	 * @var array<string, array<string, string>>
+	 *
+	 * @since TBD
+	 */
+	private const OPTIONAL_FIELDS = [
+		self::SHADOW => [
+			'inset' => self::KIND_BOOLEAN,
 		],
 	];
 
@@ -200,6 +231,21 @@ final class Token_Type {
 	}
 
 	/**
+	 * The optional sub-field => kind map for a composite $type, or an empty array for a non-composite
+	 * type or one with no optional fields. A field returned here is never required by
+	 * Composite_Value::validate() — it is only validated when present.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $type The composite $type.
+	 *
+	 * @return array<string, string> Field name => the sub-field's kind label.
+	 */
+	public static function optional_fields( string $type ): array {
+		return self::OPTIONAL_FIELDS[ $type ] ?? [];
+	}
+
+	/**
 	 * The DTCG leaf key that carries a token's $type.
 	 *
 	 * @since TBD
@@ -208,6 +254,17 @@ final class Token_Type {
 	 */
 	public static function get_type_key(): string {
 		return self::KEY;
+	}
+
+	/**
+	 * The "boolean" kind label used by an optional composite sub-field (e.g. shadow's "inset").
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_kind_boolean(): string {
+		return self::KIND_BOOLEAN;
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Document/Reserved_NamespaceTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/Reserved_NamespaceTest.php
@@ -4,6 +4,7 @@ namespace Tests\wpunit\Resources\Design_Tokens\Document;
 
 use Generator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Reserved_Namespace;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
 use Tests\Support\Classes\TestCase;
 
 /**
@@ -128,17 +129,115 @@ final class Reserved_NamespaceTest extends TestCase {
 	// -------------------------------------------------------------------------
 
 	/**
+	 * canonical() builds the full dot-path id from a type and a terminal slug.
+	 *
+	 * @dataProvider canonicalTypeProvider
+	 *
+	 * @param string $type     The DTCG $type segment.
+	 * @param string $expected The expected canonical id.
+	 *
 	 * @return void
 	 */
-	public function testCanonicalBuildsTheFullIdFromASlug(): void {
-		$this->assertSame( 'primitive.color.custom.brand-accent', Reserved_Namespace::canonical( 'brand-accent' ) );
+	public function testCanonicalBuildsTheFullIdFromASlug( string $type, string $expected ): void {
+		$this->assertSame( $expected, Reserved_Namespace::canonical( $type, 'brand-accent' ) );
 	}
 
 	/**
+	 * @return Generator
+	 */
+	public function canonicalTypeProvider(): Generator {
+		yield 'color' => [
+			'type'     => Token_Type::get_type_color(),
+			'expected' => 'primitive.color.custom.brand-accent',
+		];
+
+		yield 'dimension' => [
+			'type'     => Token_Type::get_type_dimension(),
+			'expected' => 'primitive.dimension.custom.brand-accent',
+		];
+
+		yield 'shadow' => [
+			'type'     => Token_Type::get_type_shadow(),
+			'expected' => 'primitive.shadow.custom.brand-accent',
+		];
+	}
+
+	/**
+	 * canonical() output for every supported type is recognized as reserved by is_reserved_id().
+	 *
+	 * @dataProvider supportedTypeProvider
+	 *
+	 * @param string $type The DTCG $type segment.
+	 *
 	 * @return void
 	 */
-	public function testCanonicalOutputIsRecognizedAsReserved(): void {
-		$this->assertTrue( Reserved_Namespace::is_reserved_id( Reserved_Namespace::canonical( 'brand-accent' ) ) );
+	public function testCanonicalOutputIsRecognizedAsReserved( string $type ): void {
+		$this->assertTrue( Reserved_Namespace::is_reserved_id( Reserved_Namespace::canonical( $type, 'brand-accent' ) ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function supportedTypeProvider(): Generator {
+		yield 'color' => [ 'type' => Token_Type::get_type_color() ];
+		yield 'dimension' => [ 'type' => Token_Type::get_type_dimension() ];
+		yield 'shadow' => [ 'type' => Token_Type::get_type_shadow() ];
+	}
+
+	// -------------------------------------------------------------------------
+	// is_supported_type()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * is_supported_type() derives its allowlist from registration plus the kebab-case id-segment
+	 * grammar, so a registered but camelCase-spelled scalar type is refused even though it is a
+	 * valid $type — the camelCase yields guard against someone later simplifying the predicate
+	 * to Token_Type::is_valid() alone and silently shipping tokens that can never register.
+	 *
+	 * @dataProvider supportedTypePredicateProvider
+	 *
+	 * @param string $type     The candidate $type.
+	 * @param bool   $expected Whether $type is expected to support user-created primitives.
+	 *
+	 * @return void
+	 */
+	public function testIsSupportedType( string $type, bool $expected ): void {
+		$this->assertSame( $expected, Reserved_Namespace::is_supported_type( $type ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function supportedTypePredicateProvider(): Generator {
+		yield 'color' => [
+			'type'     => Token_Type::get_type_color(),
+			'expected' => true,
+		];
+
+		yield 'dimension' => [
+			'type'     => Token_Type::get_type_dimension(),
+			'expected' => true,
+		];
+
+		yield 'shadow, a kebab-safe composite' => [
+			'type'     => Token_Type::get_type_shadow(),
+			'expected' => true,
+		];
+
+		yield 'fontWeight, a camelCase scalar' => [
+			'type'     => Token_Type::get_type_font_weight(),
+			'expected' => false,
+		];
+
+		yield 'fontFamily, a camelCase scalar' => [
+			'type'     => Token_Type::get_type_font_family(),
+			'expected' => false,
+		];
+
+		yield 'bogus, an unregistered type' => [
+			'type'     => 'bogus',
+			'expected' => false,
+		];
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/wpunit/Resources/Design_Tokens/Document/User_Primitive_Document_ValidatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/User_Primitive_Document_ValidatorTest.php
@@ -10,6 +10,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Baseline\Empty_Baseline_Docum
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
 use Tests\Support\Classes\TestCase;
 
 /**
@@ -92,6 +93,62 @@ final class User_Primitive_Document_ValidatorTest extends TestCase {
 		$this->assertSame( [], $errors );
 	}
 
+	/**
+	 * Gate 3 is open for a dimension user primitive: a literal $value under
+	 * primitive.dimension.custom.* validates cleanly.
+	 *
+	 * @return void
+	 */
+	public function testValidDocumentWithDimensionEntryReturnsNoErrors(): void {
+		$id  = 'primitive.dimension.custom.gap-md';
+		$doc = $this->doc_with_envelope_only( $id, 'Gap MD' );
+		$doc = $this->set_tree_leaf( $doc, $id, Token_Type::get_type_dimension(), '1.5rem' );
+
+		$errors = $this->validator->validate( $doc );
+
+		$this->assertSame( [], $errors );
+	}
+
+	/**
+	 * Gate 3 is open for the shadow composite, and the orphan walk does not descend into
+	 * the sub-field map to misreport it as an orphan leaf.
+	 *
+	 * @return void
+	 */
+	public function testValidDocumentWithShadowEntryReturnsNoErrors(): void {
+		$id  = 'primitive.shadow.custom.elevated';
+		$doc = $this->doc_with_envelope_only( $id, 'Elevated' );
+		$doc = $this->set_tree_leaf_value( $doc, $id, Token_Type::get_type_shadow(), $this->shadow_value() );
+
+		$errors = $this->validator->validate( $doc );
+
+		$this->assertSame( [], $errors );
+	}
+
+	/**
+	 * A document mixing color, dimension, and shadow user primitives returns no errors,
+	 * pinning that the generalized checks and the orphan walk cover every type together.
+	 *
+	 * @return void
+	 */
+	public function testMixedTypeDocumentReturnsNoErrors(): void {
+		$color_id     = 'primitive.color.custom.brand';
+		$dimension_id = 'primitive.dimension.custom.gap-md';
+		$shadow_id    = 'primitive.shadow.custom.elevated';
+
+		$doc = $this->doc_with_color_entry( $color_id, 'Brand', '#3182CE' );
+
+		$doc = $this->index->add( $doc, $dimension_id, 'Gap MD' );
+		$doc = $this->set_tree_leaf( $doc, $dimension_id, Token_Type::get_type_dimension(), '1.5rem' );
+
+		$doc = $this->index->add( $doc, $shadow_id, 'Elevated' );
+		$doc = $this->set_tree_leaf_value( $doc, $shadow_id, Token_Type::get_type_shadow(), $this->shadow_value() );
+
+		$errors = $this->validator->validate( $doc );
+
+		$this->assertSame( [], $errors );
+	}
+
 	// -------------------------------------------------------------------------
 	// envelope entry missing tree leaf
 	// -------------------------------------------------------------------------
@@ -128,6 +185,31 @@ final class User_Primitive_Document_ValidatorTest extends TestCase {
 		$this->assertStringContainsString( 'no provenance envelope entry', $errors[0]->get_message() );
 	}
 
+	/**
+	 * The orphan scan covers every type segment, not one: it finds a leaf with no envelope entry under
+	 * dimension and shadow just as it does under color, and a shadow's object $value sub-fields
+	 * are not themselves reported as orphans.
+	 *
+	 * @return void
+	 */
+	public function testOrphanScanCoversEveryTypeSegment(): void {
+		$color_id     = 'primitive.color.custom.orphan';
+		$dimension_id = 'primitive.dimension.custom.orphan';
+		$shadow_id    = 'primitive.shadow.custom.orphan';
+
+		$doc = $this->doc_with_tree_only( $color_id, '#FFFFFF' );
+		$doc = $this->set_tree_leaf( $doc, $dimension_id, Token_Type::get_type_dimension(), '1rem' );
+		$doc = $this->set_tree_leaf_value( $doc, $shadow_id, Token_Type::get_type_shadow(), $this->shadow_value() );
+
+		$errors = $this->validator->validate( $doc );
+
+		$ids = array_map( static fn( User_Primitive_Validation_Error $e ) => $e->get_id(), $errors );
+		$this->assertCount( 3, $errors );
+		$this->assertContains( $color_id, $ids );
+		$this->assertContains( $dimension_id, $ids );
+		$this->assertContains( $shadow_id, $ids );
+	}
+
 	// -------------------------------------------------------------------------
 	// id outside allowed namespace
 	// -------------------------------------------------------------------------
@@ -151,11 +233,14 @@ final class User_Primitive_Document_ValidatorTest extends TestCase {
 	// -------------------------------------------------------------------------
 
 	/**
+	 * A leaf declaring a camelCase $type (which can never register, per is_supported_type()) is refused
+	 * with the "does not support user-created primitives" error.
+	 *
 	 * @return void
 	 */
 	public function testTreeLeafWithWrongTypeReturnsTypeError(): void {
-		$id  = 'primitive.color.custom.size';
-		$doc = $this->doc_with_leaf_type( $id, 'Size', 'dimension', '16px' );
+		$id  = 'primitive.fontWeight.custom.size';
+		$doc = $this->doc_with_leaf_type( $id, 'Size', 'fontWeight', '600' );
 
 		$errors = $this->validator->validate( $doc );
 
@@ -165,12 +250,92 @@ final class User_Primitive_Document_ValidatorTest extends TestCase {
 		$messages = array_map( static fn( User_Primitive_Validation_Error $e ) => $e->get_message(), $errors );
 		$found    = false;
 		foreach ( $messages as $msg ) {
-			if ( strpos( $msg, 'only "color" is allowed' ) !== false ) {
+			if ( strpos( $msg, 'does not support user-created primitives' ) !== false ) {
 				$found = true;
 				break;
 			}
 		}
-		$this->assertTrue( $found, 'Expected a type error message mentioning "only "color" is allowed".' );
+		$this->assertTrue( $found, 'Expected a type error message mentioning "does not support user-created primitives".' );
+	}
+
+	// -------------------------------------------------------------------------
+	// $type / id segment mismatch
+	// -------------------------------------------------------------------------
+
+	/**
+	 * A supported $type that disagrees with its id's type segment is a self-inconsistent
+	 * document the invariant flags, regardless of which supported type is declared.
+	 *
+	 * @dataProvider segmentMismatchProvider
+	 *
+	 * @param string $id           The canonical id, whose second segment is the "true" type.
+	 * @param string $declared_type The $type the tree leaf declares, which disagrees with $id.
+	 *
+	 * @return void
+	 */
+	public function testTreeLeafTypeMismatchingIdSegmentReturnsMismatchError( string $id, string $declared_type ): void {
+		$doc = $this->doc_with_leaf_type( $id, 'Label', $declared_type, '16px' );
+
+		$errors = $this->validator->validate( $doc );
+
+		$ids = array_map( static fn( User_Primitive_Validation_Error $e ) => $e->get_id(), $errors );
+		$this->assertContains( $id, $ids );
+
+		$messages = array_map( static fn( User_Primitive_Validation_Error $e ) => $e->get_message(), $errors );
+		$found    = false;
+		foreach ( $messages as $msg ) {
+			if ( strpos( $msg, 'does not match its id namespace' ) !== false ) {
+				$found = true;
+				break;
+			}
+		}
+		$this->assertTrue( $found, 'Expected a $type / id namespace mismatch error.' );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function segmentMismatchProvider(): Generator {
+		yield 'dimension id with a color leaf type' => [
+			'id'            => 'primitive.dimension.custom.x',
+			'declared_type' => Token_Type::get_type_color(),
+		];
+
+		yield 'color id with a dimension leaf type' => [
+			'id'            => 'primitive.color.custom.x',
+			'declared_type' => Token_Type::get_type_dimension(),
+		];
+	}
+
+	// -------------------------------------------------------------------------
+	// shadow whole-$value alias
+	// -------------------------------------------------------------------------
+
+	/**
+	 * A shadow leaf whose whole $value is an alias string hits the same no-alias invariant
+	 * every other type does — the generalization does not carve out a composite exception.
+	 *
+	 * @return void
+	 */
+	public function testShadowTreeLeafWithAliasValueReturnsAliasError(): void {
+		$id  = 'primitive.shadow.custom.alias-shadow';
+		$doc = $this->doc_with_envelope_only( $id, 'Alias Shadow' );
+		$doc = $this->set_tree_leaf( $doc, $id, Token_Type::get_type_shadow(), '{primitive.shadow.elevation.md}' );
+
+		$errors = $this->validator->validate( $doc );
+
+		$ids = array_map( static fn( User_Primitive_Validation_Error $e ) => $e->get_id(), $errors );
+		$this->assertContains( $id, $ids );
+
+		$messages = array_map( static fn( User_Primitive_Validation_Error $e ) => $e->get_message(), $errors );
+		$found    = false;
+		foreach ( $messages as $msg ) {
+			if ( strpos( $msg, 'aliases are not allowed' ) !== false ) {
+				$found = true;
+				break;
+			}
+		}
+		$this->assertTrue( $found, 'Expected an alias error.' );
 	}
 
 	// -------------------------------------------------------------------------
@@ -477,6 +642,49 @@ final class User_Primitive_Document_ValidatorTest extends TestCase {
 		$node['$value'] = $value;
 
 		return $doc;
+	}
+
+	/**
+	 * Set a token leaf node in the primitive tree at a dot-path id, accepting any $value shape
+	 * (a composite's object $value, in particular).
+	 *
+	 * @param array<string, mixed> $doc
+	 * @param string               $id
+	 * @param string               $type
+	 * @param mixed                $value
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function set_tree_leaf_value( array $doc, string $id, string $type, $value ): array {
+		$segments = explode( '.', $id );
+		$node     = &$doc;
+
+		foreach ( $segments as $segment ) {
+			if ( ! isset( $node[ $segment ] ) || ! is_array( $node[ $segment ] ) ) {
+				$node[ $segment ] = [];
+			}
+			$node = &$node[ $segment ];
+		}
+
+		$node['$type']  = $type;
+		$node['$value'] = $value;
+
+		return $doc;
+	}
+
+	/**
+	 * A literal, fully-populated shadow composite $value fixture.
+	 *
+	 * @return array<string, string>
+	 */
+	private function shadow_value(): array {
+		return [
+			'color'   => '#1A202C',
+			'offsetX' => '0px',
+			'offsetY' => '2px',
+			'blur'    => '8px',
+			'spread'  => '0px',
+		];
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/ProjectorTest.php
@@ -239,6 +239,31 @@ final class ProjectorTest extends TestCase {
 		$this->assertSame( $colors, $this->projector->filter_global_colors( $colors ) );
 	}
 
+	// ---- User-created primitives ---------------------------------------------------------------------
+
+	/**
+	 * A stored shadow user primitive reaches Css_Renderer::shadow() through the resolver with
+	 * zero resolver/renderer changes: the projected CSS carries the token's custom property
+	 * with the rendered single-shadow shorthand. This is the first projection pin for a
+	 * user-created token of any type.
+	 *
+	 * @return void
+	 */
+	public function testItProjectsAStoredShadowUserPrimitiveAsTheSingleShadowShorthand(): void {
+		$id = 'primitive.shadow.custom.elevated';
+
+		$this->store->save_document( $this->shadow_user_primitive_document( $id, 'Elevated' ) );
+
+		$this->projector->enqueue_front_end();
+
+		$css = $this->inline_css();
+
+		$this->assertStringContainsString(
+			Css_Var::from_id( $id ) . ':0px 2px 8px 0px #1A202C',
+			$css
+		);
+	}
+
 	// ---- Active library ----------------------------------------------------------------------------------
 
 	/**
@@ -353,6 +378,45 @@ final class ProjectorTest extends TestCase {
 								'$type'  => 'color',
 								'$value' => self::BRAND_B_BUTTON,
 							],
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * A stored document containing one shadow user primitive: the tree leaf plus its provenance
+	 * envelope entry, the shape the create endpoint would have written.
+	 *
+	 * @param string $id    The canonical dot-path id.
+	 * @param string $label The label to store in the provenance map.
+	 *
+	 * @return string
+	 */
+	private function shadow_user_primitive_document( string $id, string $label ): string {
+		return (string) wp_json_encode(
+			[
+				'primitive'   => [
+					'shadow' => [
+						'custom' => [
+							'elevated' => [
+								'$type'  => 'shadow',
+								'$value' => [
+									'color'   => '#1A202C',
+									'offsetX' => '0px',
+									'offsetY' => '2px',
+									'blur'    => '8px',
+									'spread'  => '0px',
+								],
+							],
+						],
+					],
+				],
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'userPrimitives' => [
+							$id => [ 'label' => $label ],
 						],
 					],
 				],

--- a/tests/wpunit/Resources/Design_Tokens/Registry/User_Primitive_RegistrarTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/User_Primitive_RegistrarTest.php
@@ -38,11 +38,26 @@ final class User_Primitive_RegistrarTest extends TestCase {
 	 * @return string JSON-encoded document.
 	 */
 	private function encode_document( string $id, string $type, string $label ): string {
+		return $this->encode_document_with_value( $id, $type, $label, '#ff0000' );
+	}
+
+	/**
+	 * Encode a document with one user primitive, accepting any $value shape (a composite's
+	 * object $value, in particular).
+	 *
+	 * @param string $id    Dot-path id (e.g. "primitive.my-color").
+	 * @param string $type  DTCG $type (e.g. "color").
+	 * @param string $label Human-readable label.
+	 * @param mixed  $value DTCG $value.
+	 *
+	 * @return string JSON-encoded document.
+	 */
+	private function encode_document_with_value( string $id, string $type, string $label, $value ): string {
 		$segments = explode( '.', $id );
 
 		$leaf = [
 			'$type'  => $type,
-			'$value' => '#ff0000',
+			'$value' => $value,
 		];
 
 		$tree = $leaf;
@@ -95,6 +110,69 @@ final class User_Primitive_RegistrarTest extends TestCase {
 		$this->assertNotNull( $token );
 		$this->assertSame( 'color', $token->type );
 		$this->assertSame( 'My Color', $token->label );
+		$this->assertFalse( $logger->hasWarningRecords() );
+	}
+
+	/**
+	 * A stored document with a dimension user primitive registers it, proving the registrar
+	 * is already type-agnostic — no registrar changes are needed for a non-color scalar.
+	 *
+	 * @return void
+	 */
+	public function testDimensionEntryRegistersWithTypeFromTree(): void {
+		$store    = $this->container->get( Token_Store::class );
+		$registry = new Token_Registry();
+		$logger   = new TestLogger();
+
+		$store->save_document(
+			$this->encode_document_with_value( 'primitive.dimension.custom.gap-md', 'dimension', 'Gap MD', '1.5rem' )
+		);
+
+		$this->make_registrar( $registry, $logger )->sync();
+
+		$this->assertSame( [ 'primitive.dimension.custom.gap-md' ], $registry->user_created_ids() );
+
+		$token = $registry->get( 'primitive.dimension.custom.gap-md' );
+		$this->assertNotNull( $token );
+		$this->assertSame( 'dimension', $token->type );
+		$this->assertTrue( $token->is_user_created() );
+		$this->assertSame( 'Gap MD', $token->label );
+		$this->assertFalse( $logger->hasWarningRecords() );
+	}
+
+	/**
+	 * A stored document with a shadow user primitive registers it — the registrar and
+	 * Token_Definition's charset guard accept the "shadow" id segment with zero registrar
+	 * changes, even though the leaf's $value is an object rather than a scalar.
+	 *
+	 * @return void
+	 */
+	public function testShadowEntryRegisters(): void {
+		$store    = $this->container->get( Token_Store::class );
+		$registry = new Token_Registry();
+		$logger   = new TestLogger();
+
+		$shadow_value = [
+			'color'   => '#1A202C',
+			'offsetX' => '0px',
+			'offsetY' => '2px',
+			'blur'    => '8px',
+			'spread'  => '0px',
+		];
+
+		$store->save_document(
+			$this->encode_document_with_value( 'primitive.shadow.custom.elevated', 'shadow', 'Elevated', $shadow_value )
+		);
+
+		$this->make_registrar( $registry, $logger )->sync();
+
+		$this->assertSame( [ 'primitive.shadow.custom.elevated' ], $registry->user_created_ids() );
+
+		$token = $registry->get( 'primitive.shadow.custom.elevated' );
+		$this->assertNotNull( $token );
+		$this->assertSame( 'shadow', $token->type );
+		$this->assertTrue( $token->is_user_created() );
+		$this->assertSame( 'Elevated', $token->label );
 		$this->assertFalse( $logger->hasWarningRecords() );
 	}
 

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Css_RendererTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Css_RendererTest.php
@@ -66,6 +66,51 @@ final class Css_RendererTest extends TestCase {
 		$this->assertSame( '', $this->renderer->render( 'shadow', '#fff' ) );
 	}
 
+	/**
+	 * A shadow whose "inset" sub-field is strictly true renders with the leading "inset " keyword,
+	 * matching CSS's requirement that the keyword come first in the shorthand.
+	 *
+	 * @return void
+	 */
+	public function testShadowWithInsetTrueRendersLeadingKeyword(): void {
+		$shadow = [
+			'color'   => '#1A202C',
+			'offsetX' => '0px',
+			'offsetY' => '2px',
+			'blur'    => '8px',
+			'spread'  => '0px',
+			'inset'   => true,
+		];
+
+		$this->assertSame( 'inset 0px 2px 8px 0px #1A202C', $this->renderer->render( 'shadow', $shadow ) );
+	}
+
+	/**
+	 * A shadow whose "inset" sub-field is strictly false renders byte-identical to the same shadow with
+	 * no "inset" field at all — this pins that every pre-existing shadow token (which never carries the
+	 * field) keeps its exact output.
+	 *
+	 * @return void
+	 */
+	public function testShadowWithInsetFalseRendersIdenticallyToNoInset(): void {
+		$shadow = [
+			'color'   => '#1A202C',
+			'offsetX' => '0px',
+			'offsetY' => '2px',
+			'blur'    => '8px',
+			'spread'  => '0px',
+		];
+
+		$withFalseInset          = $shadow;
+		$withFalseInset['inset'] = false;
+
+		$this->assertSame(
+			$this->renderer->render( 'shadow', $shadow ),
+			$this->renderer->render( 'shadow', $withFalseInset )
+		);
+		$this->assertSame( '0px 2px 8px 0px #1A202C', $this->renderer->render( 'shadow', $withFalseInset ) );
+	}
+
 	public function testNonScalarScalarTypeReturnsEmptyString(): void {
 		$this->assertSame( '', $this->renderer->render( 'color', [ 'unexpected' => 'array' ] ) );
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/User_Primitives_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/User_Primitives_ControllerTest.php
@@ -579,10 +579,11 @@ final class User_Primitives_ControllerTest extends TestCase {
 	}
 
 	/**
-	 * A shadow `$value` with an unknown sub-field (here, `inset`) is rejected by
+	 * A shadow `$value` with a genuinely unknown sub-field (here, `glow`) is rejected by
 	 * Composite_Value's composite_field_unknown code. This also covers the DTCG stacked-array
 	 * shape implicitly: a list body fails the same declared-field checks (every numeric key
-	 * reads as unknown).
+	 * reads as unknown). `inset` is deliberately not used here since it is now a supported
+	 * optional field (see the inset-specific tests below).
 	 *
 	 * @return void
 	 */
@@ -598,15 +599,79 @@ final class User_Primitives_ControllerTest extends TestCase {
 			'offsetY' => '2px',
 			'blur'    => '8px',
 			'spread'  => '0px',
-			'inset'   => 'true',
+			'glow'    => 'true',
 		];
 
-		$request = $this->make_create_request( $slug, 'inset-shadow', 'shadow', $shadow_value, $version );
+		$request = $this->make_create_request( $slug, 'unknown-field-shadow', 'shadow', $shadow_value, $version );
 		$result  = $this->controller->create_item( $request );
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
 		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * A shadow `$value` whose `inset` sub-field is a non-boolean literal (a string, not the
+	 * literal PHP boolean) is rejected by Composite_Value's strict-boolean check, surfaced
+	 * through the same rest_design_tokens_invalid shape a missing/unknown sub-field gets.
+	 *
+	 * @return void
+	 */
+	public function testShadowValueWithNonBooleanInsetIsRejectedByThePipeline(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}' );
+		$version = $this->store->get_version( $slug );
+
+		$shadow_value = [
+			'color'   => '#1A202C',
+			'offsetX' => '0px',
+			'offsetY' => '2px',
+			'blur'    => '8px',
+			'spread'  => '0px',
+			'inset'   => 'true',
+		];
+
+		$request = $this->make_create_request( $slug, 'non-boolean-inset-shadow', 'shadow', $shadow_value, $version );
+		$result  = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * A shadow user primitive created with a literal boolean `inset` sub-field round-trips
+	 * through the create endpoint: 201, and the stored leaf's `$value` carries `inset` intact
+	 * alongside the five required fields — the case this ticket exists to enable.
+	 *
+	 * @return void
+	 */
+	public function testItCreatesANewShadowPrimitiveWithInset(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}' );
+		$version = $this->store->get_version( $slug );
+
+		$shadow_value = [
+			'color'   => '#1A202C',
+			'offsetX' => '0px',
+			'offsetY' => '2px',
+			'blur'    => '8px',
+			'spread'  => '0px',
+			'inset'   => true,
+		];
+
+		$request = $this->make_create_request( $slug, 'inset-shadow', 'shadow', $shadow_value, $version, 'Inset Shadow' );
+		$result  = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( WP_Http::CREATED, $result->get_status() );
+
+		$doc  = $result->get_data()['document'];
+		$leaf = $doc['primitive']['shadow']['custom']['inset-shadow'];
+		$this->assertSame( 'shadow', $leaf['$type'] );
+		$this->assertSame( $shadow_value, $leaf['$value'] );
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/User_Primitives_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/User_Primitives_ControllerTest.php
@@ -458,24 +458,254 @@ final class User_Primitives_ControllerTest extends TestCase {
 	}
 
 	// -------------------------------------------------------------------------
-	// create_item — type not supported (non-color)
+	// create_item — successful create (dimension, shadow)
 	// -------------------------------------------------------------------------
 
 	/**
+	 * A dimension primitive create mirrors the color case: 201, the leaf lands under
+	 * primitive.dimension.custom.<slug>, and the envelope entry is recorded.
+	 *
 	 * @return void
 	 */
-	public function testItRejects422ForNonColorType(): void {
+	public function testItCreatesANewDimensionPrimitive(): void {
 		$slug = Token_Store::default_slug();
 
 		$this->store->save_document( '{}' );
 		$version = $this->store->get_version( $slug );
 
-		$request = $this->make_create_request( $slug, 'my-dim', 'dimension', '16px', $version );
+		$request = $this->make_create_request( $slug, 'gap-md', 'dimension', '1.5rem', $version, 'Gap MD' );
+		$result  = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( WP_Http::CREATED, $result->get_status() );
+
+		$data = $result->get_data();
+		$this->assertSame( $slug, $data['slug'] );
+		$this->assertNotSame( $version, $data['version'] );
+
+		$doc  = $data['document'];
+		$leaf = $doc['primitive']['dimension']['custom']['gap-md'];
+		$this->assertSame( 'dimension', $leaf['$type'] );
+		$this->assertSame( '1.5rem', $leaf['$value'] );
+
+		$ext = $doc[ Extensions::get_extensions_key() ][ Extensions::get_namespace() ][ Extensions::get_section_user_primitives() ];
+		$this->assertArrayHasKey( 'primitive.dimension.custom.gap-md', $ext );
+	}
+
+	/**
+	 * A shadow primitive create proves the shape-agnostic `$value` arg and leaf build end to
+	 * end: the object `$value` (five literal sub-fields) is stored intact.
+	 *
+	 * @return void
+	 */
+	public function testItCreatesANewShadowPrimitive(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}' );
+		$version = $this->store->get_version( $slug );
+
+		$shadow_value = [
+			'color'   => '#1A202C',
+			'offsetX' => '0px',
+			'offsetY' => '2px',
+			'blur'    => '8px',
+			'spread'  => '0px',
+		];
+
+		$request = $this->make_create_request( $slug, 'elevated', 'shadow', $shadow_value, $version, 'Elevated' );
+		$result  = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( WP_Http::CREATED, $result->get_status() );
+
+		$doc  = $result->get_data()['document'];
+		$leaf = $doc['primitive']['shadow']['custom']['elevated'];
+		$this->assertSame( 'shadow', $leaf['$type'] );
+		$this->assertSame( $shadow_value, $leaf['$value'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// create_item — invalid value rejected by the pipeline's per-type validator
+	// -------------------------------------------------------------------------
+
+	/**
+	 * An invalid dimension `$value` is rejected by the pipeline's validator, the same error
+	 * surface a bad color value gets today — the create path adds no bypass around per-type
+	 * value validation.
+	 *
+	 * @return void
+	 */
+	public function testInvalidDimensionValueIsRejectedByThePipeline(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}' );
+		$version = $this->store->get_version( $slug );
+
+		$request = $this->make_create_request( $slug, 'bad-dim', 'dimension', 'banana', $version );
+		$result  = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * A shadow `$value` missing a declared sub-field (here, `spread`) is rejected by
+	 * Composite_Value's composite_field_missing code, surfaced through the same
+	 * rest_design_tokens_invalid shape.
+	 *
+	 * @return void
+	 */
+	public function testShadowValueWithMissingSubFieldIsRejectedByThePipeline(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}' );
+		$version = $this->store->get_version( $slug );
+
+		$shadow_value = [
+			'color'   => '#1A202C',
+			'offsetX' => '0px',
+			'offsetY' => '2px',
+			'blur'    => '8px',
+			// 'spread' intentionally omitted.
+		];
+
+		$request = $this->make_create_request( $slug, 'incomplete-shadow', 'shadow', $shadow_value, $version );
+		$result  = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * A shadow `$value` with an unknown sub-field (here, `inset`) is rejected by
+	 * Composite_Value's composite_field_unknown code. This also covers the DTCG stacked-array
+	 * shape implicitly: a list body fails the same declared-field checks (every numeric key
+	 * reads as unknown).
+	 *
+	 * @return void
+	 */
+	public function testShadowValueWithUnknownSubFieldIsRejectedByThePipeline(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}' );
+		$version = $this->store->get_version( $slug );
+
+		$shadow_value = [
+			'color'   => '#1A202C',
+			'offsetX' => '0px',
+			'offsetY' => '2px',
+			'blur'    => '8px',
+			'spread'  => '0px',
+			'inset'   => 'true',
+		];
+
+		$request = $this->make_create_request( $slug, 'inset-shadow', 'shadow', $shadow_value, $version );
+		$result  = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// create_item — shadow sub-field alias references
+	// -------------------------------------------------------------------------
+
+	/**
+	 * A shadow whose `color` sub-field aliases a baseline color token succeeds: sub-field
+	 * aliases validate through Kind, and the write guard permits references to non-user tokens.
+	 *
+	 * @return void
+	 */
+	public function testShadowSubFieldAliasToBaselineTokenSucceeds(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}' );
+		$version = $this->store->get_version( $slug );
+
+		$shadow_value = [
+			'color'   => '{primitive.color.neutral.900}',
+			'offsetX' => '0px',
+			'offsetY' => '2px',
+			'blur'    => '8px',
+			'spread'  => '0px',
+		];
+
+		$request = $this->make_create_request( $slug, 'baseline-aliased', 'shadow', $shadow_value, $version );
+		$result  = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( WP_Http::CREATED, $result->get_status() );
+	}
+
+	/**
+	 * A shadow whose `color` sub-field aliases a user-created color primitive is refused —
+	 * pinning that the dangling-alias state rewrite_node() cannot rewrite is unreachable
+	 * through the REST surface, so rename needs no composite awareness (settled decision E).
+	 *
+	 * @return void
+	 */
+	public function testShadowSubFieldAliasToUserPrimitiveIsRefused(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.color.custom.user-color';
+
+		$this->store->save_document( wp_json_encode( $this->doc_with_primitive( $id, 'User Color' ) ) );
+		$version = $this->store->get_version( $slug );
+
+		$shadow_value = [
+			'color'   => '{' . $id . '}',
+			'offsetX' => '0px',
+			'offsetY' => '2px',
+			'blur'    => '8px',
+			'spread'  => '0px',
+		];
+
+		$request = $this->make_create_request( $slug, 'user-aliased', 'shadow', $shadow_value, $version );
+		$result  = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_user_primitive_reference_unsupported', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// create_item — type not supported
+	// -------------------------------------------------------------------------
+
+	/**
+	 * A create for a $type outside the derived allowlist 422s with the existing
+	 * rest_design_tokens_type_not_supported contract, whether the type is a registered
+	 * camelCase scalar (which can never register, per is_supported_type()) or entirely unregistered.
+	 *
+	 * @dataProvider unsupportedTypeProvider
+	 *
+	 * @param string $type The unsupported DTCG $type.
+	 *
+	 * @return void
+	 */
+	public function testItRejects422ForUnsupportedType( string $type ): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}' );
+		$version = $this->store->get_version( $slug );
+
+		$request = $this->make_create_request( $slug, 'my-token', $type, '16px', $version );
 		$result  = $this->controller->create_item( $request );
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'rest_design_tokens_type_not_supported', $result->get_error_code() );
 		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function unsupportedTypeProvider(): Generator {
+		yield 'fontWeight, a camelCase scalar' => [ 'type' => 'fontWeight' ];
+		yield 'fontFamily, a camelCase scalar' => [ 'type' => 'fontFamily' ];
+		yield 'bogus, an unregistered type'    => [ 'type' => 'bogus' ];
 	}
 
 	// -------------------------------------------------------------------------
@@ -518,6 +748,49 @@ final class User_Primitives_ControllerTest extends TestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * The no-alias invariant follows the generalization to every type: a whole-`$value` alias
+	 * on a dimension create is rejected the same way a color one is.
+	 *
+	 * @return void
+	 */
+	public function testAliasValueOnDimensionIsRejectedByInvariant(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}' );
+		$version = $this->store->get_version( $slug );
+
+		$request = $this->make_create_request( $slug, 'alias-dim', 'dimension', '{primitive.dimension.spacing.md}', $version );
+		$result  = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// create_item — id collision is scoped per type
+	// -------------------------------------------------------------------------
+
+	/**
+	 * The user-primitive namespaces are disjoint by construction: creating
+	 * primitive.dimension.custom.x does not collide with an existing primitive.color.custom.x.
+	 *
+	 * @return void
+	 */
+	public function testIdCollisionDoesNotCrossTypeNamespaces(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.color.custom.x';
+
+		$this->store->save_document( wp_json_encode( $this->doc_with_primitive( $id, 'X' ) ) );
+		$version = $this->store->get_version( $slug );
+
+		$request = $this->make_create_request( $slug, 'x', 'dimension', '1rem', $version );
+		$result  = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( WP_Http::CREATED, $result->get_status() );
 	}
 
 	// -------------------------------------------------------------------------
@@ -600,6 +873,63 @@ final class User_Primitives_ControllerTest extends TestCase {
 		// The primitive tree is gone; the user primitives index is empty.
 		$doc = $data['document'];
 		$this->assertArrayNotHasKey( 'to-delete', $doc['primitive']['color']['custom'] ?? [] );
+		$primitives_index = $doc[ Extensions::get_extensions_key() ][ Extensions::get_namespace() ][ Extensions::get_section_user_primitives() ] ?? [];
+		$this->assertArrayNotHasKey( $id, $primitives_index );
+	}
+
+	/**
+	 * The delete path is id-driven and passes untouched for non-color types: a dimension
+	 * primitive's leaf and envelope entry are both gone after delete.
+	 *
+	 * @return void
+	 */
+	public function testItDeletesADimensionPrimitive(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.dimension.custom.to-delete';
+
+		$this->store->save_document( wp_json_encode( $this->doc_with_typed_primitive( $id, 'To Delete', 'dimension', '1rem' ) ) );
+		$version = $this->store->get_version( $slug );
+
+		$request = $this->make_delete_request( $slug, $id, $version );
+		$result  = $this->controller->delete_item( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( WP_Http::OK, $result->get_status() );
+
+		$doc = $result->get_data()['document'];
+		$this->assertArrayNotHasKey( 'to-delete', $doc['primitive']['dimension']['custom'] ?? [] );
+		$primitives_index = $doc[ Extensions::get_extensions_key() ][ Extensions::get_namespace() ][ Extensions::get_section_user_primitives() ] ?? [];
+		$this->assertArrayNotHasKey( $id, $primitives_index );
+	}
+
+	/**
+	 * A shadow primitive's object $value removes cleanly through the same id-driven delete
+	 * path — the composite shape needs no special handling on delete.
+	 *
+	 * @return void
+	 */
+	public function testItDeletesAShadowPrimitive(): void {
+		$slug         = Token_Store::default_slug();
+		$id           = 'primitive.shadow.custom.to-delete';
+		$shadow_value = [
+			'color'   => '#1A202C',
+			'offsetX' => '0px',
+			'offsetY' => '2px',
+			'blur'    => '8px',
+			'spread'  => '0px',
+		];
+
+		$this->store->save_document( wp_json_encode( $this->doc_with_typed_primitive( $id, 'To Delete', 'shadow', $shadow_value ) ) );
+		$version = $this->store->get_version( $slug );
+
+		$request = $this->make_delete_request( $slug, $id, $version );
+		$result  = $this->controller->delete_item( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( WP_Http::OK, $result->get_status() );
+
+		$doc = $result->get_data()['document'];
+		$this->assertArrayNotHasKey( 'to-delete', $doc['primitive']['shadow']['custom'] ?? [] );
 		$primitives_index = $doc[ Extensions::get_extensions_key() ][ Extensions::get_namespace() ][ Extensions::get_section_user_primitives() ] ?? [];
 		$this->assertArrayNotHasKey( $id, $primitives_index );
 	}
@@ -927,6 +1257,32 @@ final class User_Primitives_ControllerTest extends TestCase {
 
 		$this->assertIsArray( $leaf );
 		$this->assertSame( 'color', $leaf['$type'] );
+	}
+
+	/**
+	 * Renaming a non-color primitive keeps it in its own type's namespace — the latent-bug
+	 * fix to canonical()'s rename call site. Before the fix, this would have re-filed the
+	 * renamed primitive under primitive.color.custom.* regardless of its actual $type.
+	 *
+	 * @return void
+	 */
+	public function testRenameKeepsANonColorPrimitiveInItsOwnTypeNamespace(): void {
+		$slug   = Token_Store::default_slug();
+		$old_id = 'primitive.dimension.custom.gap-md';
+		$doc    = $this->doc_with_typed_primitive( $old_id, 'Gap MD', 'dimension', '1.5rem' );
+
+		$this->store->save_document( wp_json_encode( $doc ) );
+		$version = $this->store->get_version( $slug );
+
+		$request = $this->make_rename_request( $slug, $old_id, 'gap-lg', $version );
+		$result  = $this->controller->rename_item( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( WP_Http::OK, $result->get_status() );
+
+		$doc_after = $result->get_data()['document'];
+		$this->assertArrayHasKey( 'gap-lg', $doc_after['primitive']['dimension']['custom'] );
+		$this->assertArrayNotHasKey( 'gap-lg', $doc_after['primitive']['color']['custom'] ?? [] );
 	}
 
 	// -------------------------------------------------------------------------
@@ -1259,6 +1615,43 @@ final class User_Primitives_ControllerTest extends TestCase {
 						$slug => [
 							'$type'  => 'color',
 							'$value' => '#336699',
+						],
+					],
+				],
+			],
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					Extensions::get_section_user_primitives() => [
+						$id => [ 'label' => $label ],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Build a minimal overrides document with one user primitive of an arbitrary $type and
+	 * $value registered in the index — the general form of doc_with_primitive() for the
+	 * dimension/shadow rename and delete round-trip tests.
+	 *
+	 * @param string $id    The canonical dot-path id.
+	 * @param string $label The label to store in the provenance map.
+	 * @param string $type  The DTCG $type.
+	 * @param mixed  $value The DTCG $value.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function doc_with_typed_primitive( string $id, string $label, string $type, $value ): array {
+		$segments = explode( '.', $id );
+		$slug     = end( $segments );
+
+		return [
+			'primitive'                      => [
+				$type => [
+					'custom' => [
+						$slug => [
+							'$type'  => $type,
+							'$value' => $value,
 						],
 					],
 				],

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Values/Value_ValidatorsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Values/Value_ValidatorsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Schema\Validation\Values;
 
+use Generator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Validation_Error;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Border_Style_Value;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Values\Color_Value;
@@ -151,6 +152,115 @@ final class Value_ValidatorsTest extends TestCase {
 
 		$this->assertCount( 1, $errors );
 		$this->assertSame( Validation_Error::get_code_value_invalid(), $errors[0]->code );
+	}
+
+	/**
+	 * A shadow with no "inset" sub-field is valid — this pins the baseline shape
+	 * (semantic.shadow.card/media carry only the five required fields) so adding the optional field
+	 * never invalidates a pre-existing shadow token.
+	 *
+	 * @return void
+	 */
+	public function testShadowWithNoInsetIsValid(): void {
+		$value = [
+			'color'   => '#1A202C',
+			'offsetX' => '0px',
+			'offsetY' => '2px',
+			'blur'    => '8px',
+			'spread'  => '0px',
+		];
+
+		$this->assertSame( [], ( new Shadow_Value() )->validate( $value, 's.$value' ) );
+	}
+
+	/**
+	 * A literal boolean "inset", true or false, is a valid optional sub-field.
+	 *
+	 * @dataProvider validInsetProvider
+	 *
+	 * @param bool $inset The literal boolean to validate.
+	 *
+	 * @return void
+	 */
+	public function testShadowAcceptsLiteralBooleanInset( bool $inset ): void {
+		$value = [
+			'color'   => '#1A202C',
+			'offsetX' => '0px',
+			'offsetY' => '2px',
+			'blur'    => '8px',
+			'spread'  => '0px',
+			'inset'   => $inset,
+		];
+
+		$this->assertSame( [], ( new Shadow_Value() )->validate( $value, 's.$value' ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function validInsetProvider(): Generator {
+		yield 'true' => [ 'inset' => true ];
+		yield 'false' => [ 'inset' => false ];
+	}
+
+	/**
+	 * "inset" is a strict boolean: a truthy string, an integer, or an alias are each rejected with
+	 * value_invalid rather than being coerced or, for the alias case, resolved.
+	 *
+	 * @dataProvider malformedInsetProvider
+	 *
+	 * @param mixed $inset The malformed candidate for the "inset" sub-field.
+	 *
+	 * @return void
+	 */
+	public function testShadowRejectsNonLiteralBooleanInset( $inset ): void {
+		$value = [
+			'color'   => '#1A202C',
+			'offsetX' => '0px',
+			'offsetY' => '2px',
+			'blur'    => '8px',
+			'spread'  => '0px',
+			'inset'   => $inset,
+		];
+
+		$errors = ( new Shadow_Value() )->validate( $value, 's.$value' );
+
+		$this->assertCount( 1, $errors );
+		$this->assertSame( Validation_Error::get_code_value_invalid(), $errors[0]->code );
+		$this->assertSame( 's.$value.inset', $errors[0]->path );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function malformedInsetProvider(): Generator {
+		yield 'string true' => [ 'inset' => 'true' ];
+		yield 'integer one' => [ 'inset' => 1 ];
+		yield 'alias' => [ 'inset' => '{primitive.color.gray.900}' ];
+	}
+
+	/**
+	 * A valid "inset" is never reported as an unknown sub-field, while a genuine typo alongside it still
+	 * is — the unknown-field walk must consult both the required and the optional map.
+	 *
+	 * @return void
+	 */
+	public function testShadowAcceptsInsetButStillRejectsAGenuinelyUnknownField(): void {
+		$value = [
+			'color'   => '#1A202C',
+			'offsetX' => '0px',
+			'offsetY' => '2px',
+			'blur'    => '8px',
+			'spread'  => '0px',
+			'inset'   => true,
+			'bogus'   => 'x',
+		];
+
+		$errors = ( new Shadow_Value() )->validate( $value, 's.$value' );
+
+		$this->assertCount( 1, $errors );
+		$this->assertSame( Validation_Error::get_code_composite_field_unknown(), $errors[0]->code );
+		$this->assertSame( 's.$value.bogus', $errors[0]->path );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/Token_TypeTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/Token_TypeTest.php
@@ -109,4 +109,41 @@ final class Token_TypeTest extends TestCase {
 		$this->assertSame( [], Token_Type::composite_fields( Token_Type::get_type_color() ) );
 		$this->assertSame( [], Token_Type::composite_fields( Token_Type::get_type_font_weight() ) );
 	}
+
+	/**
+	 * The required shadow field map stays exactly the five pre-existing fields: this is the regression
+	 * guard for "inset must not become required", since a required sixth field would invalidate every
+	 * baseline shadow token that predates it.
+	 *
+	 * @return void
+	 */
+	public function testShadowRequiredFieldsStayExactlyTheOriginalFive(): void {
+		$this->assertSame(
+			[ 'color', 'offsetX', 'offsetY', 'blur', 'spread' ],
+			array_keys( Token_Type::composite_fields( Token_Type::get_type_shadow() ) )
+		);
+	}
+
+	/**
+	 * Shadow's optional-field map carries "inset" and nothing else, so an alias/boolean check has
+	 * exactly one field to apply to today.
+	 *
+	 * @return void
+	 */
+	public function testShadowOptionalFieldsContainInset(): void {
+		$this->assertSame(
+			[ 'inset' => 'boolean' ],
+			Token_Type::optional_fields( Token_Type::get_type_shadow() )
+		);
+	}
+
+	/**
+	 * A non-composite type has no optional sub-fields, mirroring composite_fields()'s empty return.
+	 *
+	 * @return void
+	 */
+	public function testNonCompositeTypesHaveNoOptionalFields(): void {
+		$this->assertSame( [], Token_Type::optional_fields( Token_Type::get_type_color() ) );
+		$this->assertSame( [], Token_Type::optional_fields( Token_Type::get_type_font_weight() ) );
+	}
 }


### PR DESCRIPTION
Opens user-created design-token primitives beyond `color`. Previously the create endpoint accepted only color primitives; a user can now also create `dimension` and `shadow` primitives, which is what the Border Radius, Border Width, Spacing, Icon Sizes and Shadow scale screens need behind their "+ Add" actions.

## What changed

Three gates stood between the color-only surface and a type-agnostic one. The registry end was already type-agnostic, and so were the composite validate/render/reference paths — none of that needed touching.

**`Reserved_Namespace`**
- `canonical()` takes a required leading `$type` instead of hardcoding color. It stays a pure string builder: callers pass a type that already passed the create gate, or one read from a stored tree leaf.
- New `is_supported_type()`: a type supports user-created primitives when it is registered **and** its spelling is itself a valid kebab-case id segment.

**`User_Primitives_Controller`**
- The create gate uses `is_supported_type()`, evaluated before the canonical id is built.
- Both `canonical()` call sites pass a type. The rename site is a latent-bug fix: it read the primitive's `$type` from the stored tree but rebuilt the id with the color-hardcoded builder, so renaming a non-color primitive would have re-filed it under `primitive.color.custom.*`.

**`User_Primitive_Document_Validator`**
- The color-only leaf check became `is_supported_type()`, plus a new invariant: a leaf's `$type` must equal its id's type segment, so `primitive.dimension.custom.x` declaring `$type: color` is rejected as the self-inconsistent document it is.
- The orphan walk covers every registered type instead of the hardcoded `primitive.color.custom.*`.

## The second predicate is load-bearing

A registered token id must match `^[a-z0-9]+([.-][a-z0-9]+)*$` (`Token_Definition::from_user_primitive()`, feeding `Css_Var::from_id()`), and the `$type` spelling becomes the id's second segment. Six of the nine registered types are camelCase — `fontFamily`, `fontWeight`, `lineHeight`, `fontStyle`, `textTransform`, `borderStyle` — so an id built from them would store fine, pass `is_reserved_id()`, and then silently never register. The kebab-safe check excludes them at the door rather than letting a create return 201 for a token that can never surface.

That leaves exactly `color`, `dimension` and `shadow` supported today. The set is derived, not hand-maintained, so a future kebab-spelled type is admitted with no code change. Unblocking the camelCase six needs its own decision (an id-segment mapping like `fontWeight` → `font-weight`, or relaxing the id charset) and is left to a follow-up.

## Two asymmetries that are intentional

**Guards stay broader than the create gate.** `is_reserved_id()`, `contains_reserved_path()` and the orphan walk still cover every registered type. They protect the whole reserved namespace — a generic document write must not reach under `primitive.fontWeight.custom.*` just because creation does not support that spelling — while `is_supported_type()` answers the narrower "can a create mint this today".

**The orphan walk is deliberately not recursive.** It terminates one level below `custom` and never reads `$value`. A shadow leaf's `$value` is a map of sub-fields (`color`, `offsetX`, `offsetY`, `blur`, `spread`); descending would read those as orphan slugs. There is a comment on the method saying so, because "improving" it into a recursive walk is the obvious wrong move.

## Shadow gains an optional `inset` sub-field

The block-editor shadow control offers a Custom shadow with an Inset toggle, which the shadow composite could not express — so a shadow user primitive could not either. `inset` is now supported, with three constraints driving the shape:

- **It is optional, and lives in its own map.** `Composite_Value` treats every field in `composite_fields()` as required, so putting `inset` there would have invalidated both baseline shadow tokens (`semantic.shadow.card`, `semantic.shadow.media`) — a site-wide validation failure. The required map is unchanged; a new optional map carries `inset`, and a test pins the required map at exactly the original five fields.
- **It is a strict boolean, and no new `$type` is registered.** The DTCG vocabulary has no boolean, and `Kind::validate()` accepts a well-formed alias for any kind before it ever reaches a literal validator — so routing `inset` through `Kind` would wave `inset: "{some.token}"` through unchecked. The optional-field pass validates it directly instead: `true`/`false` only, aliases refused, `"true"` and `1` rejected as `value_invalid`.
- **Rendering is unchanged unless inset is true.** `Css_Renderer::shadow()` prefixes `inset ` only on a strict `true`; absent, `false`, or malformed all render byte-identically to before, which the existing snapshot and renderer tests confirm.

The unknown-field branch consults both maps, so `inset` is accepted while a genuine typo is still rejected. The optional-field concept is data-driven like the required one, so a future optional sub-field extends the map rather than this walker.

## Composite (`shadow`) needed no new machinery

Verified rather than assumed: `Dtcg_Validator` already maps shadow to `Shadow_Value` and walks composite fields with their own error codes; `Schema/Validation/Kind` already makes the alias-or-literal decision per sub-field; `Css_Renderer` already renders the shorthand (the `inset` prefix above is the only addition); `Token_Reference_Policy` already scans composite values recursively and classes those hits as unsupported references, so delete and rename refuse them the same way they always did. The create endpoint's `$value` arg declares no `type`, so an object body already passed argument validation.

The DTCG stacked-shadow shape (a `$value` that is an array of shadow objects) stays unsupported in v1, as `Css_Renderer` documents. No new gate was needed — `Composite_Value` already rejects it as missing and unknown field errors.

## Tests

227 wpunit tests pass across the eight suites touched, including three swept for regressions. New coverage: the `is_supported_type()` predicate across supported, camelCase and unregistered types; dimension and shadow creates; invalid dimension values and missing/unknown shadow sub-fields; a shadow sub-field aliasing a baseline token (accepted) versus a user primitive (refused); the leaf-`$type`-matches-segment invariant; cross-type id collisions; the rename-keeps-its-namespace pin for the latent bug; dimension and shadow delete round-trips; the orphan scan across all three type segments; and an end-to-end projection assertion proving a stored shadow user primitive renders to `0px 2px 8px 0px #1A202C`.

Plus the `inset` coverage: the required-map regression guard; the optional map's contents; a shadow with no `inset`, with `inset: true`, and with `inset: false` all valid; `"true"`, `1` and an alias each rejected; an unknown sub-field still rejected alongside a valid `inset`; the renderer's leading keyword and its byte-identical output when inset is absent or false; and a shadow user primitive created with `inset` round-tripping through the REST endpoint.

`phpstan analyse` is clean with no baseline changes.

