### PR TITLE
[DTM] SOFT-4078: Border Radius screen

### DIFF
--- a/includes/resources/Design_Tokens/Document/User_Primitive_Document_Validator.php
+++ b/includes/resources/Design_Tokens/Document/User_Primitive_Document_Validator.php
@@ -89,9 +89,9 @@ final class User_Primitive_Document_Validator {
 	/**
 	 * @since TBD
 	 *
-	 * @param array<string, mixed>        $document
-	 * @param string                      $id
-	 * @param array{label?: string}|mixed $entry
+	 * @param array<string, mixed>                        $document
+	 * @param string                                      $id
+	 * @param array{label?: string, group?: string}|mixed $entry
 	 *
 	 * @return User_Primitive_Validation_Error[]
 	 */
@@ -109,6 +109,10 @@ final class User_Primitive_Document_Validator {
 
 		if ( ! is_array( $entry ) || ! isset( $entry['label'] ) || ! is_string( $entry['label'] ) || $entry['label'] === '' ) {
 			$errors[] = new User_Primitive_Validation_Error( $id, sprintf( 'User primitive "%s" has a missing or empty label.', $id ) );
+		}
+
+		if ( is_array( $entry ) && isset( $entry['group'] ) && ( ! is_string( $entry['group'] ) || ! Reserved_Namespace::is_valid_slug( $entry['group'] ) ) ) {
+			$errors[] = new User_Primitive_Validation_Error( $id, sprintf( 'User primitive "%s" has an invalid group.', $id ) );
 		}
 
 		if ( $this->baseline->has( $id ) ) {

--- a/includes/resources/Design_Tokens/Document/User_Primitive_Index.php
+++ b/includes/resources/Design_Tokens/Document/User_Primitive_Index.php
@@ -20,7 +20,7 @@ final class User_Primitive_Index {
 	 *
 	 * @param array<string, mixed> $document
 	 *
-	 * @return array<string, array{label: string}>
+	 * @return array<string, array{label: string, group?: string}>
 	 */
 	public function all( array $document ): array {
 		$map = $this->read_map( $document );
@@ -55,15 +55,23 @@ final class User_Primitive_Index {
 	}
 
 	/**
+	 * Write (or overwrite) an entry's label. The group is preserved by default — `null` (the
+	 * default) keeps whatever group the existing entry already stores, so a caller with no group in
+	 * its own request (the label endpoints) never resets one a create or rename request set. A
+	 * string sets the group explicitly; `''` clears it, and an empty group is omitted from the
+	 * entry so a document with no grouped custom tokens stays byte-identical to before this param
+	 * existed.
+	 *
 	 * @since TBD
 	 *
 	 * @param array<string, mixed> $document
 	 * @param string               $id
 	 * @param string               $label
+	 * @param string|null          $group Null preserves the existing entry's group; a string sets it.
 	 *
 	 * @return array<string, mixed>
 	 */
-	public function add( array $document, string $id, string $label ): array {
+	public function add( array $document, string $id, string $label, ?string $group = null ): array {
 		$ext = Extensions::get_extensions_key();
 		$ns  = Extensions::get_namespace();
 		$sec = Extensions::get_section_user_primitives();
@@ -77,7 +85,18 @@ final class User_Primitive_Index {
 		/** @var array<string, mixed> $sec_data */
 		$sec_data = $ns_data[ $sec ];
 
-		$sec_data[ $id ]  = [ 'label' => $label ];
+		if ( $group === null ) {
+			$existing = $sec_data[ $id ] ?? null;
+			$group    = is_array( $existing ) && is_string( $existing['group'] ?? null ) ? $existing['group'] : '';
+		}
+
+		$entry = [ 'label' => $label ];
+
+		if ( $group !== '' ) {
+			$entry['group'] = $group;
+		}
+
+		$sec_data[ $id ]  = $entry;
 		$ns_data[ $sec ]  = $sec_data;
 		$ext_data[ $ns ]  = $ns_data;
 		$document[ $ext ] = $ext_data;
@@ -119,7 +138,9 @@ final class User_Primitive_Index {
 	}
 
 	/**
-	 * Swap the old id for the new id, updating the label.
+	 * Swap the old id for the new id, updating the label. The old entry's group carries to the new
+	 * id explicitly — the old entry is gone by the time add() would look for it, so relying on
+	 * add()'s own preserve-by-default lookup here would silently drop the group instead.
 	 *
 	 * @since TBD
 	 *
@@ -131,9 +152,12 @@ final class User_Primitive_Index {
 	 * @return array<string, mixed>
 	 */
 	public function rename( array $document, string $old_id, string $new_id, string $new_label ): array {
+		$old_entry = $this->all( $document )[ $old_id ] ?? null;
+		$group     = is_array( $old_entry ) && is_string( $old_entry['group'] ?? null ) ? $old_entry['group'] : '';
+
 		$document = $this->remove( $document, $old_id );
 
-		return $this->add( $document, $new_id, $new_label );
+		return $this->add( $document, $new_id, $new_label, $group );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Registry/Token_Definition.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Definition.php
@@ -51,6 +51,16 @@ final class Token_Definition {
 	public string $group;
 
 	/**
+	 * Stable machine key for the group, e.g. "border-radius". Empty for a group nothing can mint
+	 * a user primitive into. Never a translated string — see Token_Registry::group_label_for().
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public string $group_key;
+
+	/**
 	 * The canonical (or overridden) CSS custom-property name.
 	 *
 	 * @since TBD
@@ -85,6 +95,7 @@ final class Token_Definition {
 	 * @param string               $css_var      Canonical (or overridden) CSS custom-property name.
 	 * @param array<string, mixed> $projections  Projection targets keyed by projection id.
 	 * @param bool                 $user_created Whether the token was created by a user.
+	 * @param string               $group_key    Stable machine key for the group.
 	 */
 	private function __construct(
 		string $id,
@@ -93,7 +104,8 @@ final class Token_Definition {
 		string $group,
 		string $css_var,
 		array $projections,
-		bool $user_created = false
+		bool $user_created = false,
+		string $group_key = ''
 	) {
 		$this->id           = $id;
 		$this->type         = $type;
@@ -102,6 +114,7 @@ final class Token_Definition {
 		$this->css_var      = $css_var;
 		$this->projections  = $projections;
 		$this->user_created = $user_created;
+		$this->group_key    = $group_key;
 	}
 
 	/**
@@ -132,6 +145,13 @@ final class Token_Definition {
 		$group   = self::optional_string( $definition['group'] ?? null, 'group' );
 		$css_var = self::optional_string( $definition['css_var'] ?? null, 'css_var' );
 
+		$group_key = self::optional_string( $definition['group_key'] ?? null, 'group_key' );
+		if ( $group_key !== null && $group_key !== '' && ! preg_match( '/^[a-z0-9]+(-[a-z0-9]+)*$/', $group_key ) ) {
+			throw new InvalidArgumentException(
+				sprintf( 'Design token declaration "group_key" "%s" must be a lowercase kebab-case key.', $group_key )
+			);
+		}
+
 		// Type-checked here so a bad declaration raises the documented InvalidArgumentException rather than
 		// a raw TypeError from the constructor's typed param — this is a public helper.
 		$projections = $definition['projections'] ?? [];
@@ -146,7 +166,9 @@ final class Token_Definition {
 			$group ?? '',
 			// css_var override is rare; default is derived and impossible to drift from the id.
 			$css_var ?? Css_Var::from_id( $id ),
-			$projections
+			$projections,
+			false,
+			$group_key ?? ''
 		);
 	}
 
@@ -155,15 +177,17 @@ final class Token_Definition {
 	 *
 	 * @since TBD
 	 *
-	 * @param string $id    Canonical dot-path id.
-	 * @param string $type  DTCG $type.
-	 * @param string $label Display label; derived from the terminal slug when empty.
+	 * @param string $id        Canonical dot-path id.
+	 * @param string $type      DTCG $type.
+	 * @param string $label     Display label; derived from the terminal slug when empty.
+	 * @param string $group     Already-resolved, current-locale group label. Empty for ungrouped.
+	 * @param string $group_key Stable machine key the group label was resolved from. Empty for ungrouped.
 	 *
 	 * @throws \InvalidArgumentException When the id fails the charset check.
 	 *
 	 * @return self
 	 */
-	public static function from_user_primitive( string $id, string $type, string $label = '' ): self {
+	public static function from_user_primitive( string $id, string $type, string $label = '', string $group = '', string $group_key = '' ): self {
 		if ( ! preg_match( '/^[a-z0-9]+([.-][a-z0-9]+)*$/', $id ) ) {
 			throw new InvalidArgumentException(
 				sprintf( 'Design token id "%s" must be a dot-path of lowercase alphanumeric segments.', $id )
@@ -175,7 +199,7 @@ final class Token_Definition {
 			$label    = ucwords( str_replace( '-', ' ', (string) end( $segments ) ) );
 		}
 
-		return new self( $id, $type, $label, '', Css_Var::from_id( $id ), [], true );
+		return new self( $id, $type, $label, $group, Css_Var::from_id( $id ), [], true, $group_key );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Registry/Token_Registry.php
+++ b/includes/resources/Design_Tokens/Registry/Token_Registry.php
@@ -41,24 +41,30 @@ final class Token_Registry {
 	/**
 	 * Register a user-created primitive. Throws when the id is already held by a non-user-created token.
 	 *
+	 * $group must already be resolved to its current-locale label — this method never calls
+	 * group_label_for() itself; see User_Primitive_Registrar::register_entry(), the one caller with
+	 * a logger to report an unresolvable $group_key.
+	 *
 	 * @since TBD
 	 *
 	 * @param string $id
 	 * @param string $type
 	 * @param string $label
+	 * @param string $group     Already-resolved, current-locale group label. Empty for ungrouped.
+	 * @param string $group_key Stable machine key the group label was resolved from. Empty for ungrouped.
 	 *
 	 * @throws \RuntimeException When the id belongs to a system registration.
 	 *
 	 * @return void
 	 */
-	public function register_user_primitive( string $id, string $type, string $label = '' ): void {
+	public function register_user_primitive( string $id, string $type, string $label = '', string $group = '', string $group_key = '' ): void {
 		if ( isset( $this->tokens[ $id ] ) && ! $this->tokens[ $id ]->is_user_created() ) {
 			throw new \RuntimeException(
 				sprintf( 'Cannot register user primitive "%s": id is already registered as a system token.', $id )
 			);
 		}
 
-		$this->tokens[ $id ] = Token_Definition::from_user_primitive( $id, $type, $label );
+		$this->tokens[ $id ] = Token_Definition::from_user_primitive( $id, $type, $label, $group, $group_key );
 	}
 
 	/**
@@ -349,6 +355,34 @@ final class Token_Registry {
 		}
 
 		return [ 'groups' => $groups ];
+	}
+
+	/**
+	 * The current-locale group label a stable group_key resolves to, or null when no declared token
+	 * carries that key. A pure accessor: it scans the already-registered declarations for the key and
+	 * returns their translated group verbatim — it never calls __() itself, because the key is a
+	 * variable and a dynamic string passed to __() is invisible to WP's static string extraction and
+	 * would never be translated. The key only ever selects among labels that already exist as literal
+	 * __() calls in declarations.php.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $group_key The stable machine key, e.g. "border-radius".
+	 *
+	 * @return string|null
+	 */
+	public function group_label_for( string $group_key ): ?string {
+		if ( $group_key === '' ) {
+			return null;
+		}
+
+		foreach ( $this->tokens as $token ) {
+			if ( $token->group_key === $group_key ) {
+				return $token->group;
+			}
+		}
+
+		return null;
 	}
 
 	// ---- Fail-closed activation guard -------------------------------------------------------------

--- a/includes/resources/Design_Tokens/Registry/User_Primitive_Registrar.php
+++ b/includes/resources/Design_Tokens/Registry/User_Primitive_Registrar.php
@@ -114,10 +114,10 @@ final class User_Primitive_Registrar {
 	/**
 	 * @since TBD
 	 *
-	 * @param string                      $slug     The token library slug the entry was read from.
-	 * @param array<string, mixed>        $document
-	 * @param string                      $id
-	 * @param array{label?: string}|mixed $entry
+	 * @param string                                      $slug     The token library slug the entry was read from.
+	 * @param array<string, mixed>                        $document
+	 * @param string                                      $id
+	 * @param array{label?: string, group?: string}|mixed $entry
 	 *
 	 * @return void
 	 */
@@ -152,8 +152,24 @@ final class User_Primitive_Registrar {
 
 		$label = is_string( $entry['label'] ?? null ) ? $entry['label'] : '';
 
+		$group_key = is_string( $entry['group'] ?? null ) ? $entry['group'] : '';
+		$group     = '';
+
+		if ( $group_key !== '' ) {
+			$resolved = $this->registry->group_label_for( $group_key );
+
+			if ( $resolved === null ) {
+				// The declaration that owned this key is gone (a downgrade, a removed group) — fail soft to
+				// ungrouped rather than a fatal; the token still surfaces, just without a home screen.
+				$this->logger->warning( sprintf( 'User primitive "%s" in library "%s": group key "%s" no longer resolves — registering ungrouped.', $id, $slug, $group_key ) );
+				$group_key = '';
+			} else {
+				$group = $resolved;
+			}
+		}
+
 		try {
-			$this->registry->register_user_primitive( $id, $type, $label );
+			$this->registry->register_user_primitive( $id, $type, $label, $group, $group_key );
 		} catch ( \RuntimeException $e ) {
 			$this->logger->warning( sprintf( 'User primitive "%s" in library "%s": %s', $id, $slug, $e->getMessage() ) );
 		} catch ( \InvalidArgumentException $e ) { // @phpstan-ignore-line -- Token_Definition::from_user_primitive() throws this; Token_Registry::register_user_primitive() does not re-declare it.

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -50,20 +50,30 @@ $gap_tokens = array_map(
 // mints custom tokens into — Token_Registry::group_label_for() resolves it back to the group label
 // below at read time, so a custom radius token's group survives a site language change instead of
 // drifting into its own bucket (see User_Primitive_Registrar::register_entry()).
-$radius_slugs = [ 'none', 'sm', 'md', 'lg', 'full' ];
+// The step list mirrors the shipped baseline exactly: the screen renders whatever this group holds, and
+// a step declared without a baseline entry would trip Baseline_Guard. Labels are the scale's own, so the
+// Style Library and the editor's token picker name each step identically.
+$radius_labels = [
+	'none' => __( 'None', 'kadence-blocks' ),
+	'xs'   => __( 'Extra Small', 'kadence-blocks' ),
+	'sm'   => __( 'Small', 'kadence-blocks' ),
+	'md'   => __( 'Medium', 'kadence-blocks' ),
+	'lg'   => __( 'Large', 'kadence-blocks' ),
+	'xl'   => __( 'Extra Large', 'kadence-blocks' ),
+	'full' => __( 'Full', 'kadence-blocks' ),
+];
 
-$radius_tokens = array_map(
-	static function ( string $slug ): array {
-		return [
-			'id'        => 'primitive.dimension.radius.' . $slug,
-			'type'      => 'dimension',
-			'label'     => 'none' === $slug ? __( 'None', 'kadence-blocks' ) : strtoupper( $slug ),
-			'group'     => __( 'Border Radius', 'kadence-blocks' ),
-			'group_key' => 'border-radius',
-		];
-	},
-	$radius_slugs
-);
+$radius_tokens = [];
+
+foreach ( $radius_labels as $slug => $label ) {
+	$radius_tokens[] = [
+		'id'        => 'primitive.dimension.radius.' . $slug,
+		'type'      => 'dimension',
+		'label'     => $label,
+		'group'     => __( 'Border Radius', 'kadence-blocks' ),
+		'group_key' => 'border-radius',
+	];
+}
 
 // The fluid font-size scale steps are primitives (the slug IS a scale step), each holding the shipped
 // clamp() value from includes/init.php and claiming the Kadence Blocks font-size slug it backs
@@ -85,32 +95,6 @@ $font_size_primitive_tokens = array_map(
 	},
 	$font_size_slugs
 );
-
-// The radius scale steps are primitives (the slug IS a scale step). Registering them here surfaces the
-// radius SIZES in the token picker (a radius control offers these sizes rather than the component-specific
-// semantic radii, which alias this scale) and lets Css_Var emit each
-// --kb-token--primitive--dimension--radius--<slug> variable. Values live in the shipped baseline, so
-// registering changes nothing until a site owner overrides a step. They carry no projection: the semantic
-// radius tokens hold the block-level css_var bindings, and the primitives are pick targets only.
-$radius_labels = [
-	'none' => __( 'None', 'kadence-blocks' ),
-	'xs'   => __( 'Extra Small', 'kadence-blocks' ),
-	'sm'   => __( 'Small', 'kadence-blocks' ),
-	'md'   => __( 'Medium', 'kadence-blocks' ),
-	'lg'   => __( 'Large', 'kadence-blocks' ),
-	'xl'   => __( 'Extra Large', 'kadence-blocks' ),
-	'full' => __( 'Full', 'kadence-blocks' ),
-];
-
-$radius_tokens = [];
-foreach ( $radius_labels as $slug => $label ) {
-	$radius_tokens[] = [
-		'id'    => 'primitive.dimension.radius.' . $slug,
-		'type'  => 'dimension',
-		'label' => $label,
-		'group' => __( 'Radius', 'kadence-blocks' ),
-	];
-}
 
 /**
  * The brand + neutral primitives ARE the site's global color palette: each claims a Kadence palette slot

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -44,6 +44,27 @@ $gap_tokens = array_map(
 	$gap_slugs
 );
 
+// The border-radius scale steps are primitives the Style Library's Border Radius screen lists and
+// edits directly (semantic.radius.* already carries the projections that deliver these into blocks,
+// so the scale declares none of its own). group_key is the stable machine id "+ Add Border Radius"
+// mints custom tokens into — Token_Registry::group_label_for() resolves it back to the group label
+// below at read time, so a custom radius token's group survives a site language change instead of
+// drifting into its own bucket (see User_Primitive_Registrar::register_entry()).
+$radius_slugs = [ 'none', 'sm', 'md', 'lg', 'full' ];
+
+$radius_tokens = array_map(
+	static function ( string $slug ): array {
+		return [
+			'id'        => 'primitive.dimension.radius.' . $slug,
+			'type'      => 'dimension',
+			'label'     => 'none' === $slug ? __( 'None', 'kadence-blocks' ) : strtoupper( $slug ),
+			'group'     => __( 'Border Radius', 'kadence-blocks' ),
+			'group_key' => 'border-radius',
+		];
+	},
+	$radius_slugs
+);
+
 // The fluid font-size scale steps are primitives (the slug IS a scale step), each holding the shipped
 // clamp() value from includes/init.php and claiming the Kadence Blocks font-size slug it backs
 // (class-kadence-blocks-css.php): the Css_Var builder redefines --global-kb-font-size-<slug> as the
@@ -306,7 +327,8 @@ return [
 		$palette_tokens,
 		$spacing_tokens,
 		$gap_tokens,
-		$font_size_primitive_tokens
+		$font_size_primitive_tokens,
+		$radius_tokens
 	),
 	/**
 	 * Preset bindings for the Button block: that it accepts presets, plus the per-property bindings (a

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -44,6 +44,27 @@ $gap_tokens = array_map(
 	$gap_slugs
 );
 
+// The border-radius scale steps are primitives the Style Library's Border Radius screen lists and
+// edits directly (semantic.radius.* already carries the projections that deliver these into blocks,
+// so the scale declares none of its own). group_key is the stable machine id "+ Add Border Radius"
+// mints custom tokens into — Token_Registry::group_label_for() resolves it back to the group label
+// below at read time, so a custom radius token's group survives a site language change instead of
+// drifting into its own bucket (see User_Primitive_Registrar::register_entry()).
+$radius_slugs = [ 'none', 'sm', 'md', 'lg', 'full' ];
+
+$radius_tokens = array_map(
+	static function ( string $slug ): array {
+		return [
+			'id'        => 'primitive.dimension.radius.' . $slug,
+			'type'      => 'dimension',
+			'label'     => 'none' === $slug ? __( 'None', 'kadence-blocks' ) : strtoupper( $slug ),
+			'group'     => __( 'Border Radius', 'kadence-blocks' ),
+			'group_key' => 'border-radius',
+		];
+	},
+	$radius_slugs
+);
+
 // The fluid font-size scale steps are primitives (the slug IS a scale step), each holding the shipped
 // clamp() value from includes/init.php and claiming the Kadence Blocks font-size slug it backs
 // (class-kadence-blocks-css.php): the Css_Var builder redefines --global-kb-font-size-<slug> as the

--- a/includes/resources/Design_Tokens/Rest/V1/User_Primitives_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/User_Primitives_Controller.php
@@ -327,6 +327,30 @@ final class User_Primitives_Controller extends Controller {
 		$value = $request->get_param( '$value' );
 		$label = $this->sanitize_label( Cast::to_string( $request->get_param( 'label' ) ), $slug_input );
 
+		$group_key = Cast::to_string( $request->get_param( 'group' ) );
+
+		if ( $group_key !== '' && ! Reserved_Namespace::is_valid_slug( $group_key ) ) {
+			return new WP_Error(
+				'rest_kb_invalid_group',
+				__( 'The group must be a lowercase kebab-case key.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::BAD_REQUEST,
+					'group'  => $group_key,
+				]
+			);
+		}
+
+		if ( $group_key !== '' && $this->registry->group_label_for( $group_key ) === null ) {
+			return new WP_Error(
+				'rest_kb_unknown_group',
+				__( 'That group is not declared for user-created primitives.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::UNPROCESSABLE_ENTITY,
+					'group'  => $group_key,
+				]
+			);
+		}
+
 		if ( ! Reserved_Namespace::is_supported_type( $type ) ) {
 			return new WP_Error(
 				'rest_design_tokens_type_not_supported',
@@ -381,7 +405,7 @@ final class User_Primitives_Controller extends Controller {
 			'$value' => $value,
 		];
 		$candidate = $this->mutator->set( $stored, $canonical, $leaf );
-		$candidate = $this->index->add( $candidate, $canonical, $label );
+		$candidate = $this->index->add( $candidate, $canonical, $label, $group_key );
 
 		return $this->pipeline->validate_and_save( $candidate, $slug, '', $version, WP_Http::CREATED );
 	}
@@ -840,6 +864,12 @@ final class User_Primitives_Controller extends Controller {
 			],
 			'label'          => [
 				'description' => __( 'Optional human-readable label.', 'kadence-blocks' ),
+				'type'        => 'string',
+				'required'    => false,
+				'default'     => '',
+			],
+			'group'          => [
+				'description' => __( 'Optional stable machine key for the UI group this primitive should join.', 'kadence-blocks' ),
 				'type'        => 'string',
 				'required'    => false,
 				'default'     => '',

--- a/src/style-library/__tests__/paths.test.js
+++ b/src/style-library/__tests__/paths.test.js
@@ -12,6 +12,8 @@ import {
 	activeLibraryPath,
 	activateLibraryPath,
 	feedPath,
+	tokenLabelPath,
+	groupOrderPath,
 } from '../api/paths';
 
 describe('palette paths', () => {
@@ -111,5 +113,33 @@ describe('feedPath', () => {
 
 	it('escapes the slug', () => {
 		expect(feedPath('my set')).toBe('/kb-design-tokens/v1/feed/my%20set');
+	});
+});
+
+describe('tokenLabelPath', () => {
+	it('builds the label path for a token id', () => {
+		expect(tokenLabelPath('default', 'semantic.color.button-primary-bg')).toBe(
+			'/kb-design-tokens/v1/documents/default/labels/semantic.color.button-primary-bg'
+		);
+	});
+
+	it('escapes the slug and the id', () => {
+		expect(tokenLabelPath('my set', 'primitive.dimension.custom.radius 2')).toBe(
+			'/kb-design-tokens/v1/documents/my%20set/labels/primitive.dimension.custom.radius%202'
+		);
+	});
+});
+
+describe('groupOrderPath', () => {
+	it('builds the order path for a group', () => {
+		expect(groupOrderPath('default', 'Border Radius')).toBe(
+			'/kb-design-tokens/v1/documents/default/order/Border%20Radius'
+		);
+	});
+
+	it('escapes the slug', () => {
+		expect(groupOrderPath('my set', 'Border Radius')).toBe(
+			'/kb-design-tokens/v1/documents/my%20set/order/Border%20Radius'
+		);
 	});
 });

--- a/src/style-library/__tests__/scale-flows.test.js
+++ b/src/style-library/__tests__/scale-flows.test.js
@@ -1,0 +1,318 @@
+/* eslint-env jest */
+import {
+	addScaleTokenFlow,
+	deleteScaleTokenFlow,
+	reorderScaleTokensFlow,
+	saveScaleTokenFlow,
+} from '../helpers/scale-flows';
+import * as client from '../api/client';
+
+// A factory, not bare automocking — see library-flows.test.js's identical note: the real module
+// imports `@wordpress/api-fetch`, externalized in production and not an npm dependency here.
+jest.mock('../api/client', () => ({
+	createUserPrimitive: jest.fn(),
+	deleteUserPrimitive: jest.fn(),
+	saveTokenLeaf: jest.fn(),
+	setGroupOrder: jest.fn(),
+	setTokenLabel: jest.fn(),
+}));
+
+beforeEach(() => {
+	jest.resetAllMocks();
+});
+
+describe('addScaleTokenFlow', () => {
+	it('posts id, $type, $value, label, the stable group key, and version, refreshes the feed, and resolves the canonical id', async () => {
+		client.createUserPrimitive.mockResolvedValue({ version: 'v2' });
+		const refreshFeed = jest.fn().mockResolvedValue({});
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		const result = await addScaleTokenFlow({
+			groupKey: 'border-radius',
+			tokenType: 'dimension',
+			slugBase: 'radius',
+			label: 'New Radius',
+			value: '0.5rem',
+			existingIds: ['primitive.dimension.custom.radius'],
+			slug: 'default',
+			feedVersion: 'v1',
+			refreshFeed,
+			onBusy,
+			onError,
+		});
+
+		expect(client.createUserPrimitive).toHaveBeenCalledWith('default', {
+			id: 'radius-2',
+			$type: 'dimension',
+			$value: '0.5rem',
+			label: 'New Radius',
+			group: 'border-radius',
+			version: 'v1',
+		});
+		expect(refreshFeed).toHaveBeenCalledWith('default');
+		expect(result).toBe('primitive.dimension.custom.radius-2');
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it('surfaces the error, clears busy, and re-throws on failure', async () => {
+		const failure = new Error('Boom');
+		client.createUserPrimitive.mockRejectedValue(failure);
+		const refreshFeed = jest.fn();
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			addScaleTokenFlow({
+				groupKey: 'border-radius',
+				tokenType: 'dimension',
+				slugBase: 'radius',
+				label: 'New Radius',
+				value: '0.5rem',
+				existingIds: [],
+				slug: 'default',
+				feedVersion: 'v1',
+				refreshFeed,
+				onBusy,
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(refreshFeed).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+});
+
+describe('saveScaleTokenFlow', () => {
+	const baseArgs = {
+		slug: 'default',
+		namespace: 'kb-design-tokens/v1',
+		tokenId: 'primitive.dimension.radius.sm',
+		tokenType: 'dimension',
+		feedVersion: 'v1',
+	};
+
+	it('writes the label before the value when both changed', async () => {
+		client.setTokenLabel.mockResolvedValue({});
+		client.saveTokenLeaf.mockResolvedValue({});
+		const refreshFeed = jest.fn().mockResolvedValue({});
+		const callOrder = [];
+		client.setTokenLabel.mockImplementation(() => {
+			callOrder.push('label');
+			return Promise.resolve({});
+		});
+		client.saveTokenLeaf.mockImplementation(() => {
+			callOrder.push('value');
+			return Promise.resolve({});
+		});
+
+		await saveScaleTokenFlow({
+			...baseArgs,
+			draft: { label: 'Cozy SM', value: '0.25rem' },
+			initial: { label: 'SM', value: '0.125rem' },
+			refreshFeed,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(callOrder).toEqual(['label', 'value']);
+		expect(client.setTokenLabel).toHaveBeenCalledWith('default', baseArgs.tokenId, {
+			label: 'Cozy SM',
+			version: 'v1',
+		});
+		expect(client.saveTokenLeaf).toHaveBeenCalledWith(
+			'kb-design-tokens/v1',
+			baseArgs.tokenId,
+			{ $type: 'dimension', $value: '0.25rem' },
+			'default'
+		);
+		expect(refreshFeed).toHaveBeenCalledWith('default');
+	});
+
+	it('never calls setTokenLabel when the label is unchanged', async () => {
+		client.saveTokenLeaf.mockResolvedValue({});
+		const refreshFeed = jest.fn().mockResolvedValue({});
+
+		await saveScaleTokenFlow({
+			...baseArgs,
+			draft: { label: 'SM', value: '0.25rem' },
+			initial: { label: 'SM', value: '0.125rem' },
+			refreshFeed,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(client.setTokenLabel).not.toHaveBeenCalled();
+		expect(client.saveTokenLeaf).toHaveBeenCalled();
+	});
+
+	it('never calls saveTokenLeaf when the value is unchanged', async () => {
+		client.setTokenLabel.mockResolvedValue({});
+		const refreshFeed = jest.fn().mockResolvedValue({});
+
+		await saveScaleTokenFlow({
+			...baseArgs,
+			draft: { label: 'Cozy SM', value: '0.125rem' },
+			initial: { label: 'SM', value: '0.125rem' },
+			refreshFeed,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(client.saveTokenLeaf).not.toHaveBeenCalled();
+		expect(client.setTokenLabel).toHaveBeenCalled();
+	});
+
+	it('resolves without issuing a request when nothing changed', async () => {
+		const refreshFeed = jest.fn();
+
+		await saveScaleTokenFlow({
+			...baseArgs,
+			draft: { label: 'SM', value: '0.125rem' },
+			initial: { label: 'SM', value: '0.125rem' },
+			refreshFeed,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(client.setTokenLabel).not.toHaveBeenCalled();
+		expect(client.saveTokenLeaf).not.toHaveBeenCalled();
+		expect(refreshFeed).not.toHaveBeenCalled();
+	});
+
+	it('refreshes the feed once after a successful save', async () => {
+		client.setTokenLabel.mockResolvedValue({});
+		client.saveTokenLeaf.mockResolvedValue({});
+		const refreshFeed = jest.fn().mockResolvedValue({});
+
+		await saveScaleTokenFlow({
+			...baseArgs,
+			draft: { label: 'Cozy SM', value: '0.25rem' },
+			initial: { label: 'SM', value: '0.125rem' },
+			refreshFeed,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(refreshFeed).toHaveBeenCalledTimes(1);
+	});
+
+	it('surfaces the error, clears busy, and re-throws on failure', async () => {
+		const failure = new Error('Boom');
+		client.setTokenLabel.mockRejectedValue(failure);
+		const refreshFeed = jest.fn();
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			saveScaleTokenFlow({
+				...baseArgs,
+				draft: { label: 'Cozy SM', value: '0.125rem' },
+				initial: { label: 'SM', value: '0.125rem' },
+				refreshFeed,
+				onBusy,
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(refreshFeed).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+});
+
+describe('deleteScaleTokenFlow', () => {
+	it('deletes with the feed version and refreshes', async () => {
+		client.deleteUserPrimitive.mockResolvedValue({});
+		const refreshFeed = jest.fn().mockResolvedValue({});
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await deleteScaleTokenFlow({
+			slug: 'default',
+			tokenId: 'primitive.dimension.custom.radius-2',
+			feedVersion: 'v1',
+			refreshFeed,
+			onBusy,
+			onError,
+		});
+
+		expect(client.deleteUserPrimitive).toHaveBeenCalledWith('default', 'primitive.dimension.custom.radius-2', 'v1');
+		expect(refreshFeed).toHaveBeenCalledWith('default');
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+
+	it('surfaces the error, clears busy, and re-throws on failure', async () => {
+		const failure = new Error('Boom');
+		client.deleteUserPrimitive.mockRejectedValue(failure);
+		const refreshFeed = jest.fn();
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			deleteScaleTokenFlow({
+				slug: 'default',
+				tokenId: 'primitive.dimension.custom.radius-2',
+				feedVersion: 'v1',
+				refreshFeed,
+				onBusy,
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+});
+
+describe('reorderScaleTokensFlow', () => {
+	it('PUTs the full ordered id list with the version and refreshes', async () => {
+		client.setGroupOrder.mockResolvedValue({});
+		const refreshFeed = jest.fn().mockResolvedValue({});
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await reorderScaleTokensFlow({
+			slug: 'default',
+			group: 'Border Radius',
+			orderedIds: ['b', 'a'],
+			feedVersion: 'v1',
+			refreshFeed,
+			onBusy,
+			onError,
+		});
+
+		expect(client.setGroupOrder).toHaveBeenCalledWith('default', 'Border Radius', {
+			order: ['b', 'a'],
+			version: 'v1',
+		});
+		expect(refreshFeed).toHaveBeenCalledWith('default');
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+
+	it('surfaces the error, clears busy, and re-throws on failure', async () => {
+		const failure = new Error('Boom');
+		client.setGroupOrder.mockRejectedValue(failure);
+		const refreshFeed = jest.fn();
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			reorderScaleTokensFlow({
+				slug: 'default',
+				group: 'Border Radius',
+				orderedIds: ['b', 'a'],
+				feedVersion: 'v1',
+				refreshFeed,
+				onBusy,
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(refreshFeed).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+});

--- a/src/style-library/__tests__/scale.test.js
+++ b/src/style-library/__tests__/scale.test.js
@@ -1,0 +1,112 @@
+/* eslint-env jest */
+import { applyRowOrder, customScaleTokenId, nextScaleSlug, scaleInitialValues, scaleRows } from '../helpers/scale';
+
+describe('scaleRows', () => {
+	it('returns [] for a missing schema', () => {
+		expect(scaleRows(undefined, {}, 'Border Radius')).toEqual([]);
+		expect(scaleRows({}, {}, 'Border Radius')).toEqual([]);
+	});
+
+	it('returns [] for an unknown group', () => {
+		const schema = { groups: { 'Border Radius': [] } };
+
+		expect(scaleRows(schema, {}, 'Border Width')).toEqual([]);
+	});
+
+	it('maps id, effective label, resolved value, and userCreated in feed order', () => {
+		const schema = {
+			groups: {
+				'Border Radius': [
+					{ id: 'primitive.dimension.radius.none', label: 'None', userCreated: false },
+					{ id: 'primitive.dimension.custom.radius-2', label: 'Custom', userCreated: true },
+				],
+			},
+		};
+		const values = {
+			'primitive.dimension.radius.none': '0',
+			'primitive.dimension.custom.radius-2': '0.75rem',
+		};
+
+		expect(scaleRows(schema, values, 'Border Radius')).toEqual([
+			{ id: 'primitive.dimension.radius.none', label: 'None', value: '0', userCreated: false },
+			{ id: 'primitive.dimension.custom.radius-2', label: 'Custom', value: '0.75rem', userCreated: true },
+		]);
+	});
+
+	it('defaults a row missing from the values map to an empty string', () => {
+		const schema = { groups: { 'Border Radius': [{ id: 'primitive.dimension.radius.sm', label: 'SM' }] } };
+
+		expect(scaleRows(schema, {}, 'Border Radius')[0].value).toBe('');
+	});
+});
+
+describe('applyRowOrder', () => {
+	const rows = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+
+	it('sorts by the id list and appends unlisted rows in their incoming order', () => {
+		expect(applyRowOrder(rows, ['c', 'a'])).toEqual([{ id: 'c' }, { id: 'a' }, { id: 'b' }]);
+	});
+
+	it('ignores an id in the order that names no row', () => {
+		expect(applyRowOrder(rows, ['ghost', 'b', 'a'])).toEqual([{ id: 'b' }, { id: 'a' }, { id: 'c' }]);
+	});
+
+	it('returns the same reference for a no-op order', () => {
+		expect(applyRowOrder(rows, ['a', 'b', 'c'])).toBe(rows);
+	});
+
+	it('returns the same reference for an empty order list', () => {
+		expect(applyRowOrder(rows, [])).toBe(rows);
+	});
+});
+
+describe('nextScaleSlug', () => {
+	it('returns the bare base first when it is free', () => {
+		expect(nextScaleSlug([], 'radius')).toBe('radius');
+		expect(nextScaleSlug(['primitive.dimension.radius.sm'], 'radius')).toBe('radius');
+	});
+
+	it('returns the first free numeric suffix after the bare base is taken', () => {
+		const existingIds = ['primitive.dimension.custom.radius', 'primitive.dimension.custom.radius-2'];
+
+		expect(nextScaleSlug(existingIds, 'radius')).toBe('radius-3');
+	});
+
+	it('checks collisions by terminal segment, across any type or group', () => {
+		// 'radius' is taken by a token under a completely different type namespace — still a
+		// collision, because the id space is flat per DTCG $type, not per screen/group.
+		const existingIds = ['primitive.color.custom.radius'];
+
+		expect(nextScaleSlug(existingIds, 'radius')).toBe('radius-2');
+	});
+});
+
+describe('customScaleTokenId', () => {
+	it('builds primitive.<type>.custom.<slug>', () => {
+		expect(customScaleTokenId('dimension', 'radius-2')).toBe('primitive.dimension.custom.radius-2');
+	});
+});
+
+describe('scaleInitialValues', () => {
+	it('returns null for an unknown entry', () => {
+		expect(scaleInitialValues(null, {}, {})).toBeNull();
+	});
+
+	it('prefers the authored responsive shape over the scalar value', () => {
+		const entry = { id: 'primitive.dimension.radius.sm', label: 'SM' };
+		const values = { 'primitive.dimension.radius.sm': '0.125rem' };
+		const responsive = { 'primitive.dimension.radius.sm': { base: '0.125rem', responsive: { tablet: '0.25rem' } } };
+
+		expect(scaleInitialValues(entry, values, responsive)).toEqual({
+			label: 'SM',
+			value: { base: '0.125rem', responsive: { tablet: '0.25rem' } },
+		});
+	});
+
+	it('falls back to the resolved scalar value when nothing authored exists', () => {
+		const entry = { id: 'primitive.dimension.radius.sm', label: 'SM' };
+		const values = { 'primitive.dimension.radius.sm': '0.125rem' };
+
+		expect(scaleInitialValues(entry, values, {})).toEqual({ label: 'SM', value: '0.125rem' });
+	});
+});

--- a/src/style-library/__tests__/scale.test.js
+++ b/src/style-library/__tests__/scale.test.js
@@ -1,5 +1,12 @@
 /* eslint-env jest */
-import { applyRowOrder, customScaleTokenId, nextScaleSlug, scaleInitialValues, scaleRows } from '../helpers/scale';
+import {
+	applyRowOrder,
+	customScaleTokenId,
+	nextScaleSlug,
+	scaleInitialValues,
+	scaleRows,
+	scaleValueField,
+} from '../helpers/scale';
 
 describe('scaleRows', () => {
 	it('returns [] for a missing schema', () => {
@@ -89,24 +96,44 @@ describe('customScaleTokenId', () => {
 
 describe('scaleInitialValues', () => {
 	it('returns null for an unknown entry', () => {
-		expect(scaleInitialValues(null, {}, {})).toBeNull();
+		expect(scaleInitialValues(null, {})).toBeNull();
 	});
 
-	it('prefers the authored responsive shape over the scalar value', () => {
+	it('always seeds the resolved scalar value, never an authored responsive/clamp envelope', () => {
+		// Primitive scales never take a responsive value, so a leaf that still carries a
+		// responsive/clamp envelope from before the rule was enforced must be ignored here — the
+		// panel always shows the plain resolved scalar.
 		const entry = { id: 'primitive.dimension.radius.sm', label: 'SM' };
 		const values = { 'primitive.dimension.radius.sm': '0.125rem' };
-		const responsive = { 'primitive.dimension.radius.sm': { base: '0.125rem', responsive: { tablet: '0.25rem' } } };
 
-		expect(scaleInitialValues(entry, values, responsive)).toEqual({
-			label: 'SM',
-			value: { base: '0.125rem', responsive: { tablet: '0.25rem' } },
+		expect(scaleInitialValues(entry, values)).toEqual({ label: 'SM', value: '0.125rem' });
+	});
+
+	it('defaults the value to an empty string when the resolved map has no entry', () => {
+		const entry = { id: 'primitive.dimension.radius.sm', label: 'SM' };
+
+		expect(scaleInitialValues(entry, {})).toEqual({ label: 'SM', value: '' });
+	});
+});
+
+describe('scaleValueField', () => {
+	it('sets path to "value" and defaults responsive to false', () => {
+		expect(scaleValueField({ type: 'unit', label: 'Radius' })).toEqual({
+			type: 'unit',
+			label: 'Radius',
+			path: 'value',
+			responsive: false,
 		});
 	});
 
-	it('falls back to the resolved scalar value when nothing authored exists', () => {
-		const entry = { id: 'primitive.dimension.radius.sm', label: 'SM' };
-		const values = { 'primitive.dimension.radius.sm': '0.125rem' };
-
-		expect(scaleInitialValues(entry, values, {})).toEqual({ label: 'SM', value: '0.125rem' });
+	it('forces responsive to false even when the config wrongly declares it true', () => {
+		// Pins the structural guarantee: no per-screen config can opt a primitive-scale value field
+		// back into breakpoint controls, no matter what it declares.
+		expect(scaleValueField({ type: 'unit', label: 'Radius', responsive: true })).toEqual({
+			type: 'unit',
+			label: 'Radius',
+			path: 'value',
+			responsive: false,
+		});
 	});
 });

--- a/src/style-library/api/client.js
+++ b/src/style-library/api/client.js
@@ -14,6 +14,8 @@ import {
 	activateLibraryPath,
 	resolvedPath,
 	tokenPath,
+	tokenLabelPath,
+	groupOrderPath,
 	userPrimitiveReferencesPath,
 	userPrimitivesPath,
 	userPrimitivePath,
@@ -81,6 +83,43 @@ export function saveTokenLeaf(namespace, tokenId, leaf, slug) {
 		path: tokenPath(namespace, tokenId, slug),
 		method: 'PUT',
 		data: leaf,
+	});
+}
+
+/**
+ * Set or clear a token's display-label override.
+ *
+ * @since TBD
+ *
+ * @param {string}                             slug    Token library slug.
+ * @param {string}                             id      The token id (baseline dot-path, or a user
+ *                                                       primitive's canonical id).
+ * @param {{ label: string, version: string }} payload Request body.
+ * @return {Promise<object>} Updated document item.
+ */
+export function setTokenLabel(slug, id, payload) {
+	return apiFetch({
+		path: tokenLabelPath(slug, id),
+		method: 'PUT',
+		data: payload,
+	});
+}
+
+/**
+ * Persist a UI-schema group's full sort order.
+ *
+ * @since TBD
+ *
+ * @param {string}                                       slug    Token library slug.
+ * @param {string}                                        group   The UI-schema group label.
+ * @param {{ order: string[], version: string }}          payload Request body.
+ * @return {Promise<object>} Updated document item.
+ */
+export function setGroupOrder(slug, group, payload) {
+	return apiFetch({
+		path: groupOrderPath(slug, group),
+		method: 'PUT',
+		data: payload,
 	});
 }
 

--- a/src/style-library/api/paths.js
+++ b/src/style-library/api/paths.js
@@ -81,6 +81,33 @@ export function userPrimitiveRenamePath(slug, id) {
 }
 
 /**
+ * Build a REST path for a token's display-label override.
+ *
+ * @since TBD
+ *
+ * @param {string} slug Token library slug.
+ * @param {string} id   The token id (baseline dot-path, or a user primitive's canonical id).
+ * @return {string} REST path relative to wp-json root.
+ */
+export function tokenLabelPath(slug, id) {
+	return `/kb-design-tokens/v1/documents/${encodeURIComponent(slug)}/labels/${encodeURIComponent(id)}`;
+}
+
+/**
+ * Build a REST path for a UI-schema group's stored sort order. `group` is the translated feed
+ * group label (e.g. "Border Radius") — encoded because it contains a space.
+ *
+ * @since TBD
+ *
+ * @param {string} slug  Token library slug.
+ * @param {string} group The UI-schema group label.
+ * @return {string} REST path relative to wp-json root.
+ */
+export function groupOrderPath(slug, group) {
+	return `/kb-design-tokens/v1/documents/${encodeURIComponent(slug)}/order/${encodeURIComponent(group)}`;
+}
+
+/**
  * Build a REST path for the resolved token map.
  *
  * @since TBD

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -20,6 +20,7 @@ import { RenameLibraryModal } from '../components/organisms/RenameLibraryModal';
 import { DeleteLibraryModal } from '../components/organisms/DeleteLibraryModal';
 import { PlaceholderScreen } from '../components/pages/PlaceholderScreen';
 import { ColorPaletteScreen } from '../components/pages/ColorPaletteScreen';
+import { BorderRadiusScreen } from '../components/pages/BorderRadiusScreen';
 import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
 import { useLibraries } from '../hooks/use-libraries';
@@ -33,7 +34,10 @@ import { libraryDisplayTitle } from '../helpers/libraries';
  *
  * @since TBD
  */
-const SCREEN_COMPONENTS = { 'color-palette': ColorPaletteScreen };
+const SCREEN_COMPONENTS = {
+	'border-radius': BorderRadiusScreen,
+	'color-palette': ColorPaletteScreen,
+};
 
 /**
  * Render the Style Library application: feed gate, route hook, sidebar navigation, and the screen

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -21,6 +21,7 @@ import { DeleteLibraryModal } from '../components/organisms/DeleteLibraryModal';
 import { SettingsPanel } from '../components/templates/SettingsPanel';
 import { SettingsForm } from '../components/organisms/SettingsForm';
 import { PlaceholderScreen } from '../components/pages/PlaceholderScreen';
+import { BorderRadiusScreen } from '../components/pages/BorderRadiusScreen';
 import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
 import { useLibraries } from '../hooks/use-libraries';
@@ -31,10 +32,21 @@ import { buildBaseStylesNav, buildBlockPresetsNav, resolveScreen } from '../help
 import { libraryDisplayTitle } from '../helpers/libraries';
 
 /**
+ * The Base Styles screen ids that have a real screen component, rather than the
+ * `PlaceholderScreen` fallback every other entry still resolves to. One entry per landed
+ * per-screen ticket.
+ *
+ * @since TBD
+ */
+const SCREEN_COMPONENTS = {
+	'border-radius': BorderRadiusScreen,
+};
+
+/**
  * Render the Style Library application: feed gate, route hook, sidebar navigation, and the screen
- * resolved for the active route. The settings panel opens for the dev-only field-library demo
- * item; a real per-screen item is wired up by the per-screen tickets that ship a save/delete
- * implementation.
+ * resolved for the active route. A screen that declares a static `SettingsPanel` (see
+ * `SCREEN_COMPONENTS`) has it mounted whenever `route.item` is non-empty; every other screen still
+ * falls back to the dev-only field-library demo item's panel.
  *
  * @since TBD
  *
@@ -63,7 +75,7 @@ export function StyleLibraryApp() {
 		const baseStyles = {};
 
 		baseStylesNav.forEach((entry) => {
-			baseStyles[entry.id] = PlaceholderScreen;
+			baseStyles[entry.id] = SCREEN_COMPONENTS[entry.id] || PlaceholderScreen;
 		});
 
 		return { baseStyles, presetFallback: PlaceholderScreen };
@@ -187,10 +199,18 @@ export function StyleLibraryApp() {
 				/>
 			}
 			content={
-				<resolution.Component label={label} onOpenFieldLibraryDemo={() => navigate({ item: DEMO_ITEM_ID })} />
+				<resolution.Component
+					label={label}
+					route={route}
+					navigate={navigate}
+					library={feed}
+					onOpenFieldLibraryDemo={() => navigate({ item: DEMO_ITEM_ID })}
+				/>
 			}
 			settingsPanel={
-				isDemoItem ? (
+				resolution.Component.SettingsPanel && route.item ? (
+					<resolution.Component.SettingsPanel route={route} navigate={navigate} library={feed} />
+				) : isDemoItem ? (
 					<SettingsPanel
 						onClose={settingsPanelState.close}
 						onDelete={() => settingsPanelState.close()}

--- a/src/style-library/components/pages/BorderRadiusScreen.js
+++ b/src/style-library/components/pages/BorderRadiusScreen.js
@@ -58,7 +58,6 @@ export const BORDER_RADIUS_CONFIG = {
 			{ value: 'rem', label: 'rem' },
 			{ value: '%', label: '%' },
 		],
-		responsive: true,
 	},
 	renderPreview: renderRadiusPreview,
 };

--- a/src/style-library/components/pages/BorderRadiusScreen.js
+++ b/src/style-library/components/pages/BorderRadiusScreen.js
@@ -1,0 +1,92 @@
+/**
+ * The Border Radius screen: the scale config, the rounded-square preview renderer, and the two thin
+ * wrappers that plug into the shared `ScaleScreen`/`ScaleSettings` contract (see
+ * `.local/style-library-reference.md`). No link/unlink-corners control — a `dimension` token stores
+ * one scalar; per-corner composition happens where tokens are consumed (the preset `box-sides`
+ * field), not here.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ScaleScreen } from './ScaleScreen';
+import { ScaleSettings } from './ScaleSettings';
+import './BorderRadiusScreen.scss';
+
+/**
+ * The rounded-square preview for one row: a fixed-size box (sized by the shared `ListRow` preview
+ * slot) whose corner radius is the row's own resolved value — `9999px` renders the FULL circle and
+ * `0` renders square, both for free, with no per-step branching.
+ *
+ * @param {{id: string, label: string, value: string, userCreated: boolean}} row The row descriptor.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The preview element.
+ */
+function renderRadiusPreview(row) {
+	return <span className="kadence-blocks-style-library__border-radius-preview" style={{ borderRadius: row.value }} />;
+}
+
+/**
+ * The Border Radius screen's config — see `ScaleScreen`'s module docblock and
+ * `.local/style-library-reference.md` for the full per-screen config contract.
+ *
+ * @since TBD
+ */
+export const BORDER_RADIUS_CONFIG = {
+	id: 'border-radius',
+	title: __('Corner Radius', 'kadence-blocks'),
+	addLabel: __('Add Border Radius', 'kadence-blocks'),
+	group: __('Border Radius', 'kadence-blocks'),
+	groupKey: 'border-radius',
+	tokenType: 'dimension',
+	slugBase: 'radius',
+	newTokenLabel: __('New Radius', 'kadence-blocks'),
+	newTokenValue: '0.5rem',
+	valueField: {
+		type: 'unit',
+		label: __('Radius', 'kadence-blocks'),
+		units: [
+			{ value: 'px', label: 'px' },
+			{ value: 'em', label: 'em' },
+			{ value: 'rem', label: 'rem' },
+			{ value: '%', label: '%' },
+		],
+		responsive: true,
+	},
+	renderPreview: renderRadiusPreview,
+};
+
+/**
+ * The Border Radius screen body.
+ *
+ * @param {Object} props The props `ScaleScreen` accepts (`{ label, route, navigate, library }`).
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The screen.
+ */
+export function BorderRadiusScreen(props) {
+	return <ScaleScreen config={BORDER_RADIUS_CONFIG} {...props} />;
+}
+
+/**
+ * The Border Radius screen's settings panel.
+ *
+ * @param {Object} props The props `ScaleSettings` accepts (`{ route, navigate, library }`).
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The panel.
+ */
+function BorderRadiusSettings(props) {
+	return <ScaleSettings config={BORDER_RADIUS_CONFIG} {...props} />;
+}
+
+BorderRadiusScreen.SettingsPanel = BorderRadiusSettings;

--- a/src/style-library/components/pages/BorderRadiusScreen.js
+++ b/src/style-library/components/pages/BorderRadiusScreen.js
@@ -1,7 +1,7 @@
 /**
  * The Border Radius screen: the scale config, the rounded-square preview renderer, and the two thin
  * wrappers that plug into the shared `ScaleScreen`/`ScaleSettings` contract (see
- * `.local/style-library-reference.md`). No link/unlink-corners control — a `dimension` token stores
+ * `ScaleScreen.js`'s module docblock). No link/unlink-corners control — a `dimension` token stores
  * one scalar; per-corner composition happens where tokens are consumed (the preset `box-sides`
  * field), not here.
  */
@@ -34,8 +34,8 @@ function renderRadiusPreview(row) {
 }
 
 /**
- * The Border Radius screen's config — see `ScaleScreen`'s module docblock and
- * `.local/style-library-reference.md` for the full per-screen config contract.
+ * The Border Radius screen's config — see `ScaleScreen`'s module docblock for the full per-screen
+ * config contract.
  *
  * @since TBD
  */

--- a/src/style-library/components/pages/BorderRadiusScreen.scss
+++ b/src/style-library/components/pages/BorderRadiusScreen.scss
@@ -1,9 +1,21 @@
-// The rounded-square preview's own box. Sizing, background, and border for the slot itself already
-// come from `.list-row-preview` (ListRow.scss) — this element only has to fill that slot so its own
-// `border-radius` (set inline, per row) has a visible box to clip.
+// `.list-row-preview` (ListRow.scss) draws its own border, but that border is on the shared slot
+// itself, not this row's content — with `border-radius` set inline only on this child, the result
+// was a rounded fill sitting inside a still-square outline (FULL, 9999px, looked like a circle
+// trapped in a square). Scoped through the `scale-screen--border-radius` modifier, the slot's
+// border moves onto this element so there is exactly one bordered, rounded shape.
+.kadence-blocks-style-library__scale-screen--border-radius .kadence-blocks-style-library__list-row-preview {
+	border: 0;
+	background: transparent;
+}
+
+// The rounded-square preview's own box. Sizing comes from filling the slot (100%); border and
+// background live here, not on the slot, so the border follows this element's own `border-radius`
+// (set inline, per row).
 .kadence-blocks-style-library__border-radius-preview {
+	box-sizing: border-box;
 	display: block;
 	width: 100%;
 	height: 100%;
+	border: var(--kb-sl-border-width-input) solid var(--kb-sl-color-gray-700);
 	background: var(--kb-sl-color-gray-100);
 }

--- a/src/style-library/components/pages/BorderRadiusScreen.scss
+++ b/src/style-library/components/pages/BorderRadiusScreen.scss
@@ -1,0 +1,9 @@
+// The rounded-square preview's own box. Sizing, background, and border for the slot itself already
+// come from `.list-row-preview` (ListRow.scss) — this element only has to fill that slot so its own
+// `border-radius` (set inline, per row) has a visible box to clip.
+.kadence-blocks-style-library__border-radius-preview {
+	display: block;
+	width: 100%;
+	height: 100%;
+	background: var(--kb-sl-color-gray-100);
+}

--- a/src/style-library/components/pages/ScaleScreen.js
+++ b/src/style-library/components/pages/ScaleScreen.js
@@ -1,10 +1,25 @@
 /**
  * The generic scale-screen body shared by Border Radius, Border Width, Spacing, and Icon Sizes: a
  * header with the "+ Add X" primary action, the screen-scoped write-flow error notices, and a
- * sortable `RowList` over one feed group. Every consuming screen supplies a plain config object
- * (see `BorderRadiusScreen.js` for the shape and `.local/style-library-reference.md` for the full
- * contract) — this component and its sibling `ScaleSettings` carry no per-screen JSX or minting
- * parameters of their own.
+ * sortable `RowList` over one feed group. This component and its sibling `ScaleSettings` carry no
+ * per-screen JSX or minting parameters of their own: every consuming screen supplies a plain
+ * config object (`BorderRadiusScreen.js` is the smallest example) with these keys —
+ *
+ * - `id`             The screen id, matching its route segment.
+ * - `title`          The screen heading.
+ * - `addLabel`       The "+ Add X" button label.
+ * - `group`          The feed group whose tokens this screen lists, by its declared group name.
+ * - `groupKey`       That group's key, used when minting a token.
+ * - `tokenType`      The DTCG `$type` a minted token carries.
+ * - `slugBase`       The id segment a minted token's slug is derived from.
+ * - `newTokenLabel`  The label a minted token starts with.
+ * - `newTokenValue`  The value a minted token starts with.
+ * - `valueField`     The settings panel's value field descriptor (`type`, `label`, `units`).
+ * - `renderPreview`  Required. Renders one row's preview cell from the row descriptor.
+ * - `formatValue`    Optional. Maps a row to its value-column text; the raw value when absent.
+ * - `parseValue`     Optional. Maps a stored value to the panel's initial field value.
+ * - `buildLeaf`      Optional. Builds the DTCG leaf written on save, for a composite value.
+ * - `renderToolbar`  Optional. Renders a toolbar between the header and the list.
  */
 
 /**

--- a/src/style-library/components/pages/ScaleScreen.js
+++ b/src/style-library/components/pages/ScaleScreen.js
@@ -1,0 +1,84 @@
+/**
+ * The generic scale-screen body shared by Border Radius, Border Width, Spacing, and Icon Sizes: a
+ * header with the "+ Add X" primary action, the screen-scoped write-flow error notices, and a
+ * sortable `RowList` over one feed group. Every consuming screen supplies a plain config object
+ * (see `BorderRadiusScreen.js` for the shape and `.local/style-library-reference.md` for the full
+ * contract) — this component and its sibling `ScaleSettings` carry no per-screen JSX or minting
+ * parameters of their own.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button, Notice } from '@wordpress/components';
+import { plus } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { ScreenHeader } from '../organisms/ScreenHeader';
+import { RowList } from '../templates/RowList';
+import { EmptyState } from '../molecules/EmptyState';
+import { useScaleScreen } from '../../hooks/use-scale-screen';
+
+/**
+ * Render a scale screen's body.
+ *
+ * @param {Object}   props          The component props (`label` is accepted for parity with every
+ *                                   other screen but unused — `config.title` renders instead).
+ * @param {Object}   props.config   The per-screen scale config.
+ * @param {Object}   props.route    The current route (`{ screen, item }`).
+ * @param {Function} props.navigate The route navigator.
+ * @param {Object}   props.library  The design-tokens feed hook's return value.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The screen body.
+ */
+export function ScaleScreen({ config, route, navigate, library }) {
+	const scale = useScaleScreen(config, library, route, navigate);
+
+	const addAction = (
+		<Button
+			icon={plus}
+			variant="secondary"
+			disabled={scale.isBusy}
+			onClick={() => scale.addToken().then((id) => navigate({ item: id }))}
+		>
+			{config.addLabel}
+		</Button>
+	);
+
+	const items = scale.rows.map((row) => ({
+		id: row.id,
+		label: row.label,
+		value: config.formatValue ? config.formatValue(row) : row.value,
+		preview: config.renderPreview(row),
+		isDraggable: true,
+	}));
+
+	return (
+		<div
+			className={`kadence-blocks-style-library__scale-screen kadence-blocks-style-library__scale-screen--${config.id}`}
+		>
+			<ScreenHeader title={config.title} primaryAction={addAction} />
+			{scale.addError && (
+				<Notice status="error" isDismissible onRemove={scale.clearAddError}>
+					{scale.addError.message}
+				</Notice>
+			)}
+			{scale.orderError && (
+				<Notice status="error" isDismissible onRemove={scale.clearOrderError}>
+					{scale.orderError.message}
+				</Notice>
+			)}
+			<RowList
+				items={items}
+				selectedId={scale.selectedId}
+				onSelect={scale.selectToken}
+				onReorder={scale.reorderTokens}
+				empty={<EmptyState title={config.title} description={config.addLabel} action={addAction} />}
+			/>
+		</div>
+	);
+}

--- a/src/style-library/components/pages/ScaleSettings.js
+++ b/src/style-library/components/pages/ScaleSettings.js
@@ -2,8 +2,8 @@
  * The generic scale-screen settings panel shared by Border Radius, Border Width, Spacing, and Icon
  * Sizes: NAME + the per-screen value field, and a Delete/Save footer. Mirrors the Color Palette
  * screen's settings-panel shape — calls `useScaleScreen` as its own sibling instance (the screen
- * and its panel share state only through the feed and the route, per the settings-panel contract;
- * see `.local/style-library-reference.md` section 10).
+ * and its panel share state only through the feed and the route, with `use-draft-channel.js` as
+ * the one sanctioned exception).
  */
 
 /**

--- a/src/style-library/components/pages/ScaleSettings.js
+++ b/src/style-library/components/pages/ScaleSettings.js
@@ -1,0 +1,96 @@
+/**
+ * The generic scale-screen settings panel shared by Border Radius, Border Width, Spacing, and Icon
+ * Sizes: NAME + the per-screen value field, and a Delete/Save footer. Mirrors the Color Palette
+ * screen's settings-panel shape — calls `useScaleScreen` as its own sibling instance (the screen
+ * and its panel share state only through the feed and the route, per the settings-panel contract;
+ * see `.local/style-library-reference.md` section 10).
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { SettingsPanel } from '../templates/SettingsPanel';
+import { SettingsForm } from '../organisms/SettingsForm';
+import { useSettingsPanel } from '../../hooks/use-settings-panel';
+import { useScaleScreen } from '../../hooks/use-scale-screen';
+import { isDeletable } from '../../helpers/token-capabilities';
+
+/**
+ * Render a scale screen's settings panel.
+ *
+ * @param {Object}   props          The component props.
+ * @param {Object}   props.config   The per-screen scale config.
+ * @param {Object}   props.route    The current route (`{ screen, item }`).
+ * @param {Function} props.navigate The route navigator.
+ * @param {Object}   props.library  The design-tokens feed hook's return value.
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The panel, or null while a stale `kb-item` self-heals for a tick.
+ */
+export function ScaleSettings({ config, route, navigate, library }) {
+	const scale = useScaleScreen(config, library, route, navigate);
+	const id = route.item;
+	const token = scale.tokenById(id);
+	const initialValues = scale.initialValuesFor(id);
+	const panel = useSettingsPanel({ route, navigate, initialValues });
+
+	// A `kb-item` naming a token outside this screen's group (a stale deep link, or another
+	// screen's/palette's id) resolves to no row here — close the panel instead of rendering broken
+	// fields, the same self-healing idiom the app's own unknown-screen handling uses.
+	useEffect(() => {
+		if (id && !token) {
+			navigate({ item: '' });
+		}
+	}, [id, token, navigate]);
+
+	if (!id || !token) {
+		return null;
+	}
+
+	const schema = {
+		fields: [
+			{ type: 'text', path: 'label', label: __('Name', 'kadence-blocks') },
+			{ ...config.valueField, path: 'value' },
+		],
+	};
+
+	const handleSave = () => {
+		scale.saveToken(id, panel.draft, initialValues).catch(() => {});
+	};
+
+	const handleDelete = () => {
+		scale
+			.deleteToken(id)
+			.then(() => navigate({ item: '' }))
+			.catch(() => {});
+	};
+
+	return (
+		<SettingsPanel
+			onClose={panel.close}
+			onDelete={isDeletable(token) ? handleDelete : null}
+			onSave={handleSave}
+			isDirty={panel.isDirty}
+		>
+			{scale.saveError && (
+				<Notice status="error" isDismissible onRemove={scale.clearSaveError}>
+					{scale.saveError.message}
+				</Notice>
+			)}
+			{scale.deleteError && (
+				<Notice status="error" isDismissible onRemove={scale.clearDeleteError}>
+					{scale.deleteError.message}
+				</Notice>
+			)}
+			<SettingsForm schema={schema} values={panel.draft} onChange={panel.setFieldValue} />
+		</SettingsPanel>
+	);
+}

--- a/src/style-library/components/pages/ScaleSettings.js
+++ b/src/style-library/components/pages/ScaleSettings.js
@@ -21,6 +21,7 @@ import { SettingsForm } from '../organisms/SettingsForm';
 import { useSettingsPanel } from '../../hooks/use-settings-panel';
 import { useScaleScreen } from '../../hooks/use-scale-screen';
 import { isDeletable } from '../../helpers/token-capabilities';
+import { scaleValueField } from '../../helpers/scale';
 
 /**
  * Render a scale screen's settings panel.
@@ -55,10 +56,13 @@ export function ScaleSettings({ config, route, navigate, library }) {
 		return null;
 	}
 
+	// `scaleValueField()` forces the value field non-responsive regardless of what `config.valueField`
+	// declares — primitives never take a responsive value, only presets do (see that helper's
+	// docblock in `helpers/scale.js` for why the guarantee lives there and not as a per-config flag).
 	const schema = {
 		fields: [
 			{ type: 'text', path: 'label', label: __('Name', 'kadence-blocks') },
-			{ ...config.valueField, path: 'value' },
+			scaleValueField(config.valueField),
 		],
 	};
 

--- a/src/style-library/constants/screens.js
+++ b/src/style-library/constants/screens.js
@@ -30,7 +30,6 @@ export const BASE_STYLES_SCREENS = [
 	{ id: 'color-palette', label: __('Color Palette', 'kadence-blocks') },
 	// @todo SOFT-4077: replace the placeholder with the Typography screen.
 	{ id: 'typography', label: __('Typography', 'kadence-blocks') },
-	// @todo SOFT-4078: replace the placeholder with the Border Radius screen.
 	{ id: 'border-radius', label: __('Border Radius', 'kadence-blocks') },
 	// @todo SOFT-4079: replace the placeholder with the Border Width screen.
 	{ id: 'border-width', label: __('Border Width', 'kadence-blocks') },

--- a/src/style-library/constants/screens.js
+++ b/src/style-library/constants/screens.js
@@ -31,7 +31,6 @@ export const BASE_STYLES_SCREENS = [
 	{ id: 'color-palette', label: __('Color Palette', 'kadence-blocks') },
 	// @todo SOFT-4077: replace the placeholder with the Typography screen.
 	{ id: 'typography', label: __('Typography', 'kadence-blocks') },
-	// @todo SOFT-4078: replace the placeholder with the Border Radius screen.
 	{ id: 'border-radius', label: __('Border Radius', 'kadence-blocks') },
 	// @todo SOFT-4079: replace the placeholder with the Border Width screen.
 	{ id: 'border-width', label: __('Border Width', 'kadence-blocks') },

--- a/src/style-library/helpers/scale-flows.js
+++ b/src/style-library/helpers/scale-flows.js
@@ -1,0 +1,227 @@
+/**
+ * Pure orchestration for the four scale-screen write flows shared by Border Radius, Border Width,
+ * Spacing, and Icon Sizes: mint, save, delete, and reorder. Each flow takes the REST calls it needs
+ * (imported here, so a test mocks `api/client`) plus a small set of injected callbacks for the
+ * state a caller reacts to (busy, error, and a feed refresh) — the same `library-flows.js`
+ * discipline: every flow settles pessimistically and re-throws on failure so its caller
+ * (`hooks/use-scale-screen`) can tell success from failure, and none of them reloads the page.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { createUserPrimitive, deleteUserPrimitive, saveTokenLeaf, setGroupOrder, setTokenLabel } from '../api/client';
+import { isEqual } from './settings-schema';
+import { buildTokenLeaf } from './tokens';
+import { customScaleTokenId, nextScaleSlug } from './scale';
+
+/**
+ * Read the message off a REST error, falling back to a generic string when the error carries none
+ * (e.g. a network failure `apiFetch` surfaces as a plain thrown value). Duplicated from
+ * `library-flows.js`'s identical helper rather than imported — the two flow modules cover
+ * unrelated concerns (library management vs. token editing) and stay independent on purpose.
+ *
+ * @param {*} error The rejected value from an `apiFetch` call.
+ *
+ * @since TBD
+ *
+ * @return {string} A user-facing message.
+ */
+function errorMessage(error) {
+	return error?.message || __('Something went wrong. Please try again.', 'kadence-blocks');
+}
+
+/**
+ * Mint a new custom scale token: pick the first free slug, create it with the stable group key
+ * (decision 3 — the translated group label never enters a write payload), refresh the feed, and
+ * resolve the new token's canonical id so the caller can open its settings panel.
+ *
+ * @param {Object}   args
+ * @param {string}   args.groupKey     The stable machine group key (e.g. `'border-radius'`).
+ * @param {string}   args.tokenType    The DTCG `$type` for the minted primitive.
+ * @param {string}   args.slugBase     The slug stem for the minted token.
+ * @param {string}   args.label        The minted token's starting label.
+ * @param {string}   args.value        The minted token's starting `$value`.
+ * @param {string[]} args.existingIds  Every canonical id already registered, for slug collision.
+ * @param {string}   args.slug         Token library slug.
+ * @param {string}   args.feedVersion  The version token the client last read.
+ * @param {Function} args.refreshFeed  Replaces the feed with a fresh REST read for a slug.
+ * @param {Function} args.onBusy       Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError      Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<string>} Resolves with the new token's canonical id; rejects on failure, after
+ *                            `onError`/`onBusy` have already run.
+ */
+export function addScaleTokenFlow({
+	groupKey,
+	tokenType,
+	slugBase,
+	label,
+	value,
+	existingIds,
+	slug,
+	feedVersion,
+	refreshFeed,
+	onBusy,
+	onError,
+}) {
+	onBusy(true);
+
+	const terminalSlug = nextScaleSlug(existingIds, slugBase);
+	const id = customScaleTokenId(tokenType, terminalSlug);
+
+	return createUserPrimitive(slug, {
+		id: terminalSlug,
+		$type: tokenType,
+		$value: value,
+		label,
+		group: groupKey,
+		version: feedVersion,
+	})
+		.then(() => refreshFeed(slug))
+		.then(() => {
+			onBusy(false);
+			return id;
+		})
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+
+			throw err;
+		});
+}
+
+/**
+ * Save a scale token's edited label and/or value. Writes only what changed: the label write (which
+ * checks the version) always runs before the value write (which does not) when both changed — a
+ * leaf PUT bumps the document version, so running it second avoids invalidating the `feedVersion`
+ * the label PUT is about to send inside the same Save. A no-change call resolves without issuing a
+ * request.
+ *
+ * @param {Object}   args
+ * @param {string}   args.slug        Token library slug.
+ * @param {string}   args.namespace   REST namespace for the token-leaf write.
+ * @param {string}   args.tokenId     The token's canonical dot-path id.
+ * @param {string}   args.tokenType   The DTCG `$type`, for building the leaf payload.
+ * @param {Object}   args.draft       The panel's current draft (`{ label, value }`).
+ * @param {Object}   args.initial     The values the draft is compared against (`{ label, value }`).
+ * @param {string}   args.feedVersion The version token the client last read.
+ * @param {Function} args.refreshFeed Replaces the feed with a fresh REST read for a slug.
+ * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once every changed write (and the feed refresh) completes;
+ *                          rejects on failure, after `onError`/`onBusy` have already run.
+ */
+export function saveScaleTokenFlow({
+	slug,
+	namespace,
+	tokenId,
+	tokenType,
+	draft,
+	initial,
+	feedVersion,
+	refreshFeed,
+	onBusy,
+	onError,
+}) {
+	const labelChanged = draft.label !== initial.label;
+	const valueChanged = !isEqual(draft.value, initial.value);
+
+	if (!labelChanged && !valueChanged) {
+		return Promise.resolve();
+	}
+
+	onBusy(true);
+
+	let chain = Promise.resolve();
+
+	if (labelChanged) {
+		chain = chain.then(() => setTokenLabel(slug, tokenId, { label: draft.label, version: feedVersion }));
+	}
+
+	if (valueChanged) {
+		chain = chain.then(() => saveTokenLeaf(namespace, tokenId, buildTokenLeaf(tokenType, draft.value), slug));
+	}
+
+	return chain
+		.then(() => refreshFeed(slug))
+		.then(() => onBusy(false))
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+
+			throw err;
+		});
+}
+
+/**
+ * Delete a user-created scale token.
+ *
+ * @param {Object}   args
+ * @param {string}   args.slug        Token library slug.
+ * @param {string}   args.tokenId     The token's canonical dot-path id.
+ * @param {string}   args.feedVersion The version token the client last read.
+ * @param {Function} args.refreshFeed Replaces the feed with a fresh REST read for a slug.
+ * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once the delete and the feed refresh complete; rejects on
+ *                          failure, after `onError`/`onBusy` have already run.
+ */
+export function deleteScaleTokenFlow({ slug, tokenId, feedVersion, refreshFeed, onBusy, onError }) {
+	onBusy(true);
+
+	return deleteUserPrimitive(slug, tokenId, feedVersion)
+		.then(() => refreshFeed(slug))
+		.then(() => onBusy(false))
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+
+			throw err;
+		});
+}
+
+/**
+ * Persist a group's full reorder. The full ordered id list is always sent — the server prunes any
+ * foreign id itself, so this flow never has to know which ids belong to the group.
+ *
+ * @param {Object}   args
+ * @param {string}   args.slug        Token library slug.
+ * @param {string}   args.group       The UI-schema group label (the order route's address).
+ * @param {string[]} args.orderedIds  The full ordered id list for the group.
+ * @param {string}   args.feedVersion The version token the client last read.
+ * @param {Function} args.refreshFeed Replaces the feed with a fresh REST read for a slug.
+ * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once the order write and the feed refresh complete; rejects on
+ *                          failure, after `onError`/`onBusy` have already run.
+ */
+export function reorderScaleTokensFlow({ slug, group, orderedIds, feedVersion, refreshFeed, onBusy, onError }) {
+	onBusy(true);
+
+	return setGroupOrder(slug, group, { order: orderedIds, version: feedVersion })
+		.then(() => refreshFeed(slug))
+		.then(() => onBusy(false))
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+
+			throw err;
+		});
+}

--- a/src/style-library/helpers/scale.js
+++ b/src/style-library/helpers/scale.js
@@ -1,0 +1,151 @@
+/**
+ * Pure row/slug/value helpers behind the scale-screen contract shared by Border Radius, Border
+ * Width, Spacing, and Icon Sizes: mapping a feed's UI-schema group to row descriptors, applying a
+ * locally pending drag order, minting the next free custom slug, building a custom primitive's
+ * canonical id, and seeding a settings-panel draft from the feed. No React, no JSX, no REST — see
+ * `helpers/scale-flows.js` for the REST orchestration and `hooks/use-scale-screen.js` for the state
+ * binding.
+ */
+
+/**
+ * Map a feed's UI-schema group to the row descriptors a scale screen renders, in feed order.
+ *
+ * @param {{ groups?: Record<string, Array<Object>> }} schema The feed's UI schema.
+ * @param {Record<string, string>}                      values The feed's resolved value map.
+ * @param {string}                                       group  The UI-schema group label to list.
+ *
+ * @since TBD
+ *
+ * @return {Array<{id: string, label: string, value: string, userCreated: boolean}>} The rows, or
+ *         `[]` for a missing schema or an unknown group.
+ */
+export function scaleRows(schema, values, group) {
+	const entries = schema?.groups?.[group];
+
+	if (!Array.isArray(entries)) {
+		return [];
+	}
+
+	return entries.map((entry) => ({
+		id: entry.id,
+		label: entry.label,
+		value: values?.[entry.id] ?? '',
+		userCreated: entry.userCreated === true,
+	}));
+}
+
+/**
+ * Reorder rows by an id list: listed rows first in that order, unlisted rows appended in their
+ * incoming order. An id in `orderedIds` that names no row is ignored. Returns the exact same array
+ * reference when the order is already a no-op, so a caller can skip a re-render or a needless local
+ * override.
+ *
+ * @param {Array<{id: string}>} rows       The rows in their current order.
+ * @param {string[]}             orderedIds The desired id order.
+ *
+ * @since TBD
+ *
+ * @return {Array<Object>} The reordered rows.
+ */
+export function applyRowOrder(rows, orderedIds) {
+	if (!Array.isArray(orderedIds) || orderedIds.length === 0) {
+		return rows;
+	}
+
+	const remaining = new Map(rows.map((row) => [row.id, row]));
+	const ordered = [];
+
+	orderedIds.forEach((id) => {
+		if (remaining.has(id)) {
+			ordered.push(remaining.get(id));
+			remaining.delete(id);
+		}
+	});
+
+	const next = [...ordered, ...remaining.values()];
+	const isNoOp = next.length === rows.length && next.every((row, index) => row === rows[index]);
+
+	return isNoOp ? rows : next;
+}
+
+/**
+ * The first free terminal slug for a minted custom token: the bare base first, then the base with a
+ * numeric suffix (`radius`, `radius-2`, `radius-3`, ...).
+ *
+ * `existingIds` is the full list of canonical dot-path ids already registered — not just this
+ * screen's group — because the custom-primitive id space is flat per DTCG `$type`
+ * (`primitive.<type>.custom.<slug>`), so a collision can come from a token minted into any other
+ * group under the same type. Collision is checked by extracting each id's terminal (last)
+ * dot-segment rather than rebuilding the full candidate id, so this helper needs no `tokenType`
+ * argument and stays agnostic of which scale screen is calling it.
+ *
+ * @param {string[]} existingIds The full canonical ids already registered.
+ * @param {string}   slugBase    The slug stem (e.g. `'radius'`).
+ *
+ * @since TBD
+ *
+ * @return {string} The first free terminal slug.
+ */
+export function nextScaleSlug(existingIds, slugBase) {
+	const takenSlugs = new Set(
+		(existingIds || []).map((id) => {
+			const segments = String(id).split('.');
+			return segments[segments.length - 1];
+		})
+	);
+
+	if (!takenSlugs.has(slugBase)) {
+		return slugBase;
+	}
+
+	let suffix = 2;
+
+	while (takenSlugs.has(`${slugBase}-${suffix}`)) {
+		suffix += 1;
+	}
+
+	return `${slugBase}-${suffix}`;
+}
+
+/**
+ * Build the canonical id for a minted custom primitive. Mirrors
+ * `Document\Reserved_Namespace::canonical()`.
+ *
+ * @param {string} tokenType The DTCG `$type` (e.g. `'dimension'`).
+ * @param {string} slug      The terminal slug.
+ *
+ * @since TBD
+ *
+ * @return {string} The canonical dot-path id.
+ */
+export function customScaleTokenId(tokenType, slug) {
+	return `primitive.${tokenType}.custom.${slug}`;
+}
+
+/**
+ * Seed a settings-panel draft for one row: the effective label, and the value — preferring the
+ * authored responsive/clamp shape over the resolved scalar when the leaf carries one, so
+ * `buildTokenLeaf()` round-trips an existing tablet/mobile envelope instead of clobbering it with a
+ * flattened scalar on save.
+ *
+ * @param {?{id: string, label: string}}  entry      The row/schema entry (`{ id, label, ... }`), or
+ *                                                    null for an unknown id.
+ * @param {Record<string, string>}        values     The feed's resolved value map.
+ * @param {Record<string, Object>}        responsive The feed's authored responsive/clamp map.
+ *
+ * @since TBD
+ *
+ * @return {?{label: string, value: *}} The seeded draft, or null for an unknown id.
+ */
+export function scaleInitialValues(entry, values, responsive) {
+	if (!entry) {
+		return null;
+	}
+
+	const authored = responsive?.[entry.id];
+
+	return {
+		label: entry.label,
+		value: authored !== undefined ? authored : (values?.[entry.id] ?? ''),
+	};
+}

--- a/src/style-library/helpers/scale.js
+++ b/src/style-library/helpers/scale.js
@@ -123,29 +123,43 @@ export function customScaleTokenId(tokenType, slug) {
 }
 
 /**
- * Seed a settings-panel draft for one row: the effective label, and the value — preferring the
- * authored responsive/clamp shape over the resolved scalar when the leaf carries one, so
- * `buildTokenLeaf()` round-trips an existing tablet/mobile envelope instead of clobbering it with a
- * flattened scalar on save.
+ * Seed a settings-panel draft for one row: the effective label and the resolved scalar value.
+ * Primitive scales never take a responsive value (only presets do — see `ScaleSettings`), so this
+ * always reads the resolved scalar and never an authored responsive/clamp envelope, even when the
+ * leaf carries one from before the rule was enforced.
  *
- * @param {?{id: string, label: string}}  entry      The row/schema entry (`{ id, label, ... }`), or
- *                                                    null for an unknown id.
- * @param {Record<string, string>}        values     The feed's resolved value map.
- * @param {Record<string, Object>}        responsive The feed's authored responsive/clamp map.
+ * @param {?{id: string, label: string}} entry  The row/schema entry (`{ id, label, ... }`), or null
+ *                                               for an unknown id.
+ * @param {Record<string, string>}       values The feed's resolved value map.
  *
  * @since TBD
  *
- * @return {?{label: string, value: *}} The seeded draft, or null for an unknown id.
+ * @return {?{label: string, value: string}} The seeded draft, or null for an unknown id.
  */
-export function scaleInitialValues(entry, values, responsive) {
+export function scaleInitialValues(entry, values) {
 	if (!entry) {
 		return null;
 	}
 
-	const authored = responsive?.[entry.id];
-
 	return {
 		label: entry.label,
-		value: authored !== undefined ? authored : (values?.[entry.id] ?? ''),
+		value: values?.[entry.id] ?? '',
 	};
+}
+
+/**
+ * Build the settings-panel value field for a scale screen's config. Every screen built on this
+ * contract (Border Radius, Border Width, Spacing, Icon Sizes) edits a primitive scale, and
+ * primitives never take a responsive value — only presets do. `responsive` is forced to `false`
+ * here, last, after the config spread, so a config's own `responsive: true` (stale, copy-pasted, or
+ * simply wrong) can never survive into the field the panel actually renders.
+ *
+ * @param {Object} valueField The per-screen `config.valueField` schema fragment.
+ *
+ * @since TBD
+ *
+ * @return {Object} The value field, with `path: 'value'` and `responsive` forced to `false`.
+ */
+export function scaleValueField(valueField) {
+	return { ...valueField, path: 'value', responsive: false };
 }

--- a/src/style-library/hooks/use-scale-screen.js
+++ b/src/style-library/hooks/use-scale-screen.js
@@ -1,0 +1,218 @@
+/**
+ * The state binding over the pure scale flows (`helpers/scale.js` / `helpers/scale-flows.js`) for
+ * the shared scale-screen contract (Border Radius, Border Width, Spacing, Icon Sizes). No component
+ * imports `api/client` directly — every write goes through this hook.
+ *
+ * Unlike `usePalettes` there is no secondary fetch, no `reload`, and no `isLoading` — the feed IS
+ * the data source, already in hand at mount (the app gates render on `feed.isReady`), and every
+ * write ends in `refreshFeed`, which re-renders every sibling instance (the screen body and its
+ * settings panel are siblings under `AppShell`, each calling this hook independently) at once.
+ *
+ * Reordering is serialized through one in-flight promise chain so two rapid drops can never race
+ * the feed refresh in between and manufacture a 409 against themselves — see `reorderTokens` below
+ * for the mechanics.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { applyRowOrder, scaleInitialValues, scaleRows } from '../helpers/scale';
+import {
+	addScaleTokenFlow,
+	deleteScaleTokenFlow,
+	reorderScaleTokensFlow,
+	saveScaleTokenFlow,
+} from '../helpers/scale-flows';
+
+/**
+ * Bind a scale screen's config to live feed state and the four write flows.
+ *
+ * @param {Object}   config   The per-screen scale config (see `components/pages/BorderRadiusScreen.js`).
+ * @param {Object}   library  The design-tokens feed hook's return value (`useDesignTokensFeed()`).
+ * @param {Object}   route    The current route (`{ screen, item }`).
+ * @param {Function} navigate The route navigator.
+ *
+ * @since TBD
+ *
+ * @return {{rows: Array<Object>, selectedId: string, selectToken: Function, isBusy: boolean, addError: ?Object, saveError: ?Object, deleteError: ?Object, orderError: ?Object, clearAddError: Function, clearSaveError: Function, clearDeleteError: Function, clearOrderError: Function, addToken: Function, saveToken: Function, deleteToken: Function, reorderTokens: Function, tokenById: Function, initialValuesFor: Function}}
+ */
+export function useScaleScreen(config, library, route, navigate) {
+	const [isBusy, setIsBusy] = useState(false);
+	const [addError, setAddError] = useState(null);
+	const [saveError, setSaveError] = useState(null);
+	const [deleteError, setDeleteError] = useState(null);
+	const [orderError, setOrderError] = useState(null);
+	const [pendingOrder, setPendingOrder] = useState(null);
+
+	const feed = library.feed;
+	const feedVersion = feed?.version;
+
+	// Mirrors the feed so the queued reorder continuation below always dereferences the live
+	// version at execution time, never a value captured when the drop was enqueued — no re-render
+	// separates two rapid drops, so a captured version would still be the first drop's stale one and
+	// would manufacture the exact 409 the serialization exists to prevent.
+	const feedVersionRef = useRef(feedVersion);
+	feedVersionRef.current = feedVersion;
+
+	// One in-flight reorder promise: each call chains onto the previous reorder's settled promise,
+	// so a second drop's write waits for the first drop's flow (including its own refresh) before
+	// reading the refreshed version. The count (not a boolean) reflects every drop still queued or
+	// running, not just "one happens to be running right now" — the pendingOrder-clearing effect
+	// below reads it to decide whether the chain is idle.
+	const reorderChainRef = useRef(Promise.resolve());
+	const reorderPendingCountRef = useRef(0);
+
+	const baseRows = useMemo(() => scaleRows(feed?.schema, feed?.values, config.group), [feed, config.group]);
+
+	// The local reorder override clears itself once the feed catches up — but only while the
+	// reorder chain is idle, or the first drop's refresh would visually revert the second drop while
+	// its write is still queued (see reorderTokens). A failed link clears it itself, inline, as part
+	// of its own catch below.
+	useEffect(() => {
+		if (reorderPendingCountRef.current === 0) {
+			setPendingOrder(null);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [feedVersion]);
+
+	const rows = useMemo(
+		() => (pendingOrder ? applyRowOrder(baseRows, pendingOrder) : baseRows),
+		[baseRows, pendingOrder]
+	);
+
+	const selectToken = useCallback((id) => navigate({ item: id }), [navigate]);
+
+	const clearAddError = useCallback(() => setAddError(null), []);
+	const clearSaveError = useCallback(() => setSaveError(null), []);
+	const clearDeleteError = useCallback(() => setDeleteError(null), []);
+	const clearOrderError = useCallback(() => setOrderError(null), []);
+
+	const tokenById = useCallback((id) => baseRows.find((row) => row.id === id) ?? null, [baseRows]);
+
+	const initialValuesFor = useCallback(
+		(id) => scaleInitialValues(tokenById(id), feed?.values, feed?.responsive),
+		[tokenById, feed]
+	);
+
+	const addToken = useCallback(() => {
+		setAddError(null);
+
+		return addScaleTokenFlow({
+			groupKey: config.groupKey,
+			tokenType: config.tokenType,
+			slugBase: config.slugBase,
+			label: config.newTokenLabel,
+			value: config.newTokenValue,
+			existingIds: library.tokens.map((token) => token.id),
+			slug: library.slug,
+			feedVersion,
+			refreshFeed: library.refreshFeed,
+			onBusy: setIsBusy,
+			onError: setAddError,
+		});
+	}, [config, library, feedVersion]);
+
+	const saveToken = useCallback(
+		(id, draft, initial) => {
+			setSaveError(null);
+
+			return saveScaleTokenFlow({
+				slug: library.slug,
+				namespace: feed?.rest?.namespace,
+				tokenId: id,
+				tokenType: config.tokenType,
+				draft,
+				initial,
+				feedVersion,
+				refreshFeed: library.refreshFeed,
+				onBusy: setIsBusy,
+				onError: setSaveError,
+			});
+		},
+		[library, feed, config, feedVersion]
+	);
+
+	const deleteToken = useCallback(
+		(id) => {
+			setDeleteError(null);
+
+			return deleteScaleTokenFlow({
+				slug: library.slug,
+				tokenId: id,
+				feedVersion,
+				refreshFeed: library.refreshFeed,
+				onBusy: setIsBusy,
+				onError: setDeleteError,
+			});
+		},
+		[library, feedVersion]
+	);
+
+	const reorderTokens = useCallback(
+		(orderedIds) => {
+			// Applied immediately (optimistic), at drop time, before the write is even queued — a
+			// second rapid drop must show its own order right away, not wait for the first drop's
+			// network round trip.
+			setPendingOrder(orderedIds);
+			reorderPendingCountRef.current += 1;
+
+			const run = () => {
+				setOrderError(null);
+
+				return reorderScaleTokensFlow({
+					slug: library.slug,
+					group: config.group,
+					orderedIds,
+					// Dereferenced here, inside the queued continuation — see the module docblock and the
+					// `feedVersionRef` comment above for why this must never be a value captured earlier.
+					feedVersion: feedVersionRef.current,
+					refreshFeed: library.refreshFeed,
+					onBusy: setIsBusy,
+					onError: setOrderError,
+				})
+					.catch(() => {
+						// Caught here, not re-thrown: every link in the chain must settle (resolve) so
+						// `reorderChainRef` is never left permanently rejected — an uncaught rejection would
+						// silently skip every later drop's handler for the rest of the session. The error
+						// itself already reached `orderError` inside the flow above; snap the optimistic
+						// order back to whatever the feed last confirmed.
+						setPendingOrder(null);
+					})
+					.then(() => {
+						reorderPendingCountRef.current -= 1;
+					});
+			};
+
+			reorderChainRef.current = reorderChainRef.current.then(run);
+
+			return reorderChainRef.current;
+		},
+		[library, config]
+	);
+
+	return {
+		rows,
+		selectedId: route.item,
+		selectToken,
+		isBusy,
+		addError,
+		saveError,
+		deleteError,
+		orderError,
+		clearAddError,
+		clearSaveError,
+		clearDeleteError,
+		clearOrderError,
+		addToken,
+		saveToken,
+		deleteToken,
+		reorderTokens,
+		tokenById,
+		initialValuesFor,
+	};
+}

--- a/src/style-library/hooks/use-scale-screen.js
+++ b/src/style-library/hooks/use-scale-screen.js
@@ -94,10 +94,7 @@ export function useScaleScreen(config, library, route, navigate) {
 
 	const tokenById = useCallback((id) => baseRows.find((row) => row.id === id) ?? null, [baseRows]);
 
-	const initialValuesFor = useCallback(
-		(id) => scaleInitialValues(tokenById(id), feed?.values, feed?.responsive),
-		[tokenById, feed]
-	);
+	const initialValuesFor = useCallback((id) => scaleInitialValues(tokenById(id), feed?.values), [tokenById, feed]);
 
 	const addToken = useCallback(() => {
 		setAddError(null);

--- a/tests/wpunit/Resources/Design_Tokens/Document/User_Primitive_Document_ValidatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/User_Primitive_Document_ValidatorTest.php
@@ -393,6 +393,88 @@ final class User_Primitive_Document_ValidatorTest extends TestCase {
 	}
 
 	// -------------------------------------------------------------------------
+	// group
+	// -------------------------------------------------------------------------
+
+	/**
+	 * An envelope entry with no "group" key at all validates cleanly — group is optional and its
+	 * absence is the common case for every ungrouped custom token.
+	 *
+	 * @return void
+	 */
+	public function testEntryWithNoGroupKeyReturnsNoErrors(): void {
+		$id  = 'primitive.color.custom.brand';
+		$doc = $this->doc_with_color_entry( $id, 'Brand', '#3182CE' );
+
+		$this->assertSame( [], $this->validator->validate( $doc ) );
+	}
+
+	/**
+	 * An entry with a valid lowercase kebab-case group string validates cleanly.
+	 *
+	 * @return void
+	 */
+	public function testEntryWithAKebabCaseGroupReturnsNoErrors(): void {
+		$id  = 'primitive.color.custom.brand';
+		$doc = $this->doc_with_color_entry( $id, 'Brand', '#3182CE' );
+		$doc = $this->index->add( $doc, $id, 'Brand', 'border-radius' );
+
+		$this->assertSame( [], $this->validator->validate( $doc ) );
+	}
+
+	/**
+	 * A non-string "group" value is rejected — a hand-edited or corrupted document must not slip
+	 * past the invariant just because no real write path produces this shape.
+	 *
+	 * @return void
+	 */
+	public function testEntryWithANonStringGroupReturnsGroupError(): void {
+		$id  = 'primitive.color.custom.brand';
+		$doc = $this->doc_with_color_entry( $id, 'Brand', '#3182CE' );
+
+		$ext = Extensions::get_extensions_key();
+		$ns  = Extensions::get_namespace();
+		$sec = Extensions::get_section_user_primitives();
+		$doc[ $ext ][ $ns ][ $sec ][ $id ]['group'] = 123;
+
+		$errors   = $this->validator->validate( $doc );
+		$messages = array_map( static fn( User_Primitive_Validation_Error $e ) => $e->get_message(), $errors );
+
+		$found = false;
+		foreach ( $messages as $msg ) {
+			if ( strpos( $msg, 'invalid group' ) !== false ) {
+				$found = true;
+				break;
+			}
+		}
+		$this->assertTrue( $found, 'Expected a group error.' );
+	}
+
+	/**
+	 * A "group" string outside the kebab-case charset (e.g. underscores, uppercase) is rejected —
+	 * it must never reach the same charset a token id segment enforces.
+	 *
+	 * @return void
+	 */
+	public function testEntryWithANonKebabGroupReturnsGroupError(): void {
+		$id  = 'primitive.color.custom.brand';
+		$doc = $this->doc_with_color_entry( $id, 'Brand', '#3182CE' );
+		$doc = $this->index->add( $doc, $id, 'Brand', 'Border_Radius' );
+
+		$errors   = $this->validator->validate( $doc );
+		$messages = array_map( static fn( User_Primitive_Validation_Error $e ) => $e->get_message(), $errors );
+
+		$found = false;
+		foreach ( $messages as $msg ) {
+			if ( strpos( $msg, 'invalid group' ) !== false ) {
+				$found = true;
+				break;
+			}
+		}
+		$this->assertTrue( $found, 'Expected a group error.' );
+	}
+
+	// -------------------------------------------------------------------------
 	// baseline collision
 	// -------------------------------------------------------------------------
 

--- a/tests/wpunit/Resources/Design_Tokens/Document/User_Primitive_IndexTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/User_Primitive_IndexTest.php
@@ -155,6 +155,64 @@ final class User_Primitive_IndexTest extends TestCase {
 		$this->assertTrue( $this->index->has( $result, $id_b ) );
 	}
 
+	/**
+	 * The default `null` group preserves whatever group an existing entry already stores — the
+	 * shape the label endpoints rely on, since their request carries no group of its own.
+	 *
+	 * @return void
+	 */
+	public function testAddWithNullGroupPreservesTheExistingStoredGroup(): void {
+		$id  = 'primitive.dimension.custom.radius-md';
+		$doc = $this->doc_with_entry( $id, 'Radius MD', 'border-radius' );
+
+		$result = $this->index->add( $doc, $id, 'Renamed Radius' );
+
+		$this->assertSame( 'border-radius', $this->index->all( $result )[ $id ]['group'] );
+	}
+
+	/**
+	 * A string group argument sets the group explicitly, overriding whatever was stored before.
+	 *
+	 * @return void
+	 */
+	public function testAddWithAStringGroupSetsItExplicitly(): void {
+		$id  = 'primitive.dimension.custom.radius-md';
+		$doc = $this->doc_with_entry( $id, 'Radius MD', 'old-group' );
+
+		$result = $this->index->add( $doc, $id, 'Radius MD', 'border-radius' );
+
+		$this->assertSame( 'border-radius', $this->index->all( $result )[ $id ]['group'] );
+	}
+
+	/**
+	 * An empty-string group argument clears a stored group, and the entry omits the "group" key
+	 * entirely rather than storing an empty string — an ungrouped document stays byte-identical
+	 * to one that never had a group.
+	 *
+	 * @return void
+	 */
+	public function testAddWithAnEmptyStringGroupClearsItAndOmitsTheKey(): void {
+		$id  = 'primitive.dimension.custom.radius-md';
+		$doc = $this->doc_with_entry( $id, 'Radius MD', 'border-radius' );
+
+		$result = $this->index->add( $doc, $id, 'Radius MD', '' );
+
+		$this->assertArrayNotHasKey( 'group', $this->index->all( $result )[ $id ] );
+	}
+
+	/**
+	 * A brand-new entry written with the default null group has no prior entry to preserve, so it
+	 * simply omits the "group" key — the common case for every ungrouped create.
+	 *
+	 * @return void
+	 */
+	public function testAddWithNullGroupAndNoExistingEntryOmitsTheKey(): void {
+		$id     = 'primitive.color.custom.brand';
+		$result = $this->index->add( [], $id, 'Brand' );
+
+		$this->assertArrayNotHasKey( 'group', $this->index->all( $result )[ $id ] );
+	}
+
 	// -------------------------------------------------------------------------
 	// remove()
 	// -------------------------------------------------------------------------
@@ -217,6 +275,39 @@ final class User_Primitive_IndexTest extends TestCase {
 		$this->assertArrayNotHasKey( '$value', $all[ $new_id ] );
 	}
 
+	/**
+	 * The old entry's group carries to the new id — rename() reads it before remove() erases the
+	 * old entry, rather than relying on add()'s own preserve-by-default lookup (which would find
+	 * nothing, since the new id has no entry yet).
+	 *
+	 * @return void
+	 */
+	public function testRenameCarriesTheOldStoredGroupToTheNewId(): void {
+		$old_id = 'primitive.dimension.custom.radius-md';
+		$new_id = 'primitive.dimension.custom.radius-medium';
+		$doc    = $this->doc_with_entry( $old_id, 'Radius MD', 'border-radius' );
+
+		$result = $this->index->rename( $doc, $old_id, $new_id, 'Radius Medium' );
+
+		$this->assertSame( 'border-radius', $this->index->all( $result )[ $new_id ]['group'] );
+	}
+
+	/**
+	 * An ungrouped entry's rename stays ungrouped — the new entry omits the "group" key rather
+	 * than inheriting one from anywhere else.
+	 *
+	 * @return void
+	 */
+	public function testRenameOfAnUngroupedEntryLeavesTheNewEntryUngrouped(): void {
+		$old_id = 'primitive.color.custom.old-brand';
+		$new_id = 'primitive.color.custom.new-brand';
+		$doc    = $this->doc_with_entry( $old_id, 'Old Brand' );
+
+		$result = $this->index->rename( $doc, $old_id, $new_id, 'New Brand' );
+
+		$this->assertArrayNotHasKey( 'group', $this->index->all( $result )[ $new_id ] );
+	}
+
 	// -------------------------------------------------------------------------
 	// helpers
 	// -------------------------------------------------------------------------
@@ -224,15 +315,22 @@ final class User_Primitive_IndexTest extends TestCase {
 	/**
 	 * @param string $id
 	 * @param string $label
+	 * @param string $group Optional stable group key to seed alongside the label.
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function doc_with_entry( string $id, string $label ): array {
+	private function doc_with_entry( string $id, string $label, string $group = '' ): array {
+		$entry = [ 'label' => $label ];
+
+		if ( $group !== '' ) {
+			$entry['group'] = $group;
+		}
+
 		return [
 			Extensions::get_extensions_key() => [
 				Extensions::get_namespace() => [
 					Extensions::get_section_user_primitives() => [
-						$id => [ 'label' => $label ],
+						$id => $entry,
 					],
 				],
 			],

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
@@ -297,4 +297,45 @@ final class Token_RegistryTest extends TestCase {
 		$user_entry = $schema['groups'][''][0];
 		$this->assertTrue( $user_entry['userCreated'] );
 	}
+
+	/**
+	 * A declared group_key resolves to the current-locale label of the group it was declared
+	 * alongside, not any other group.
+	 *
+	 * @return void
+	 */
+	public function testGroupLabelForResolvesADeclaredKey(): void {
+		$this->registry->register(
+			[
+				'id'        => 'primitive.dimension.radius.sm',
+				'type'      => 'dimension',
+				'label'     => 'SM',
+				'group'     => 'Border Radius',
+				'group_key' => 'border-radius',
+			]
+		);
+
+		$this->assertSame( 'Border Radius', $this->registry->group_label_for( 'border-radius' ) );
+	}
+
+	/**
+	 * A key no declaration carries resolves to null rather than a fatal, so a caller can fail soft.
+	 *
+	 * @return void
+	 */
+	public function testGroupLabelForReturnsNullForAnUnknownKey(): void {
+		$this->assertNull( $this->registry->group_label_for( 'not-declared' ) );
+	}
+
+	/**
+	 * An empty key is never a valid lookup — it must not accidentally match an ungrouped token,
+	 * which also carries an empty group_key by default.
+	 *
+	 * @return void
+	 */
+	public function testGroupLabelForReturnsNullForAnEmptyKey(): void {
+		$this->register_button_bg();
+
+		$this->assertNull( $this->registry->group_label_for( '' ) );
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Registry/User_Primitive_RegistrarTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/User_Primitive_RegistrarTest.php
@@ -79,6 +79,103 @@ final class User_Primitive_RegistrarTest extends TestCase {
 	}
 
 	/**
+	 * Encode a document with one user primitive whose envelope entry carries a stable group key.
+	 *
+	 * @param string $id    Dot-path id.
+	 * @param string $type  DTCG $type.
+	 * @param string $label Human-readable label.
+	 * @param string $group Stable group key stored in the envelope.
+	 *
+	 * @return string JSON-encoded document.
+	 */
+	private function encode_document_with_group( string $id, string $type, string $label, string $group ): string {
+		$segments = explode( '.', $id );
+
+		$leaf = [
+			'$type'  => $type,
+			'$value' => '0.75rem',
+		];
+
+		$tree = $leaf;
+		for ( $i = count( $segments ) - 1; $i >= 0; $i-- ) {
+			$tree = [ $segments[ $i ] => $tree ];
+		}
+
+		$envelope = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'userPrimitives' => [
+						$id => [
+							'label' => $label,
+							'group' => $group,
+						],
+					],
+				],
+			],
+		];
+
+		return (string) wp_json_encode( array_merge( $tree, $envelope ) );
+	}
+
+	/**
+	 * A stored group key that resolves through a declared token carries the current-locale group
+	 * label into the registered definition, so the custom token surfaces in the same feed group
+	 * as its declared siblings.
+	 *
+	 * @return void
+	 */
+	public function testStoredGroupKeyResolvesToTheDeclaredGroupLabel(): void {
+		$store    = $this->container->get( Token_Store::class );
+		$registry = new Token_Registry();
+		$logger   = new TestLogger();
+
+		$registry->register(
+			[
+				'id'        => 'primitive.dimension.radius.sm',
+				'type'      => 'dimension',
+				'label'     => 'SM',
+				'group'     => 'Border Radius',
+				'group_key' => 'border-radius',
+			]
+		);
+
+		$store->save_document(
+			$this->encode_document_with_group( 'primitive.dimension.custom.radius-md', 'dimension', 'Radius MD', 'border-radius' )
+		);
+
+		$this->make_registrar( $registry, $logger )->sync();
+
+		$token = $registry->get( 'primitive.dimension.custom.radius-md' );
+		$this->assertNotNull( $token );
+		$this->assertSame( 'Border Radius', $token->group );
+		$this->assertFalse( $logger->hasWarningRecords() );
+	}
+
+	/**
+	 * A stored group key no declaration carries fails soft: the token still registers, ungrouped,
+	 * with a logged warning rather than a fatal — a plugin downgrade or a removed declaration
+	 * must not break the whole registrar sync.
+	 *
+	 * @return void
+	 */
+	public function testStoredGroupKeyThatNoLongerResolvesFailsSoftToUngrouped(): void {
+		$store    = $this->container->get( Token_Store::class );
+		$registry = new Token_Registry();
+		$logger   = new TestLogger();
+
+		$store->save_document(
+			$this->encode_document_with_group( 'primitive.dimension.custom.radius-md', 'dimension', 'Radius MD', 'no-such-group' )
+		);
+
+		$this->make_registrar( $registry, $logger )->sync();
+
+		$token = $registry->get( 'primitive.dimension.custom.radius-md' );
+		$this->assertNotNull( $token );
+		$this->assertSame( '', $token->group );
+		$this->assertTrue( $logger->hasWarningRecords() );
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testBootWithNoStoredDocumentsRegistersNothing(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerLabelsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerLabelsTest.php
@@ -286,6 +286,56 @@ final class DocumentsControllerLabelsTest extends TestCase {
 	}
 
 	/**
+	 * Renaming a grouped custom token's display label through the labels endpoint must not reset
+	 * the group it was created into — the label endpoint's request carries no group of its own, so
+	 * User_Primitive_Index::add() must preserve the entry's existing one rather than defaulting it
+	 * away. Proven end to end: the stored entry still carries the group, and after a registrar sync
+	 * the token still resolves into its declared feed group.
+	 *
+	 * @return void
+	 */
+	public function testRenamingAGroupedCustomTokenThroughLabelsEndpointPreservesItsGroup(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.dimension.custom.radius-md';
+
+		$this->seed_user_primitive( $slug, $id, 'Radius MD', 'border-radius' );
+
+		$response = $this->controller->set_label( $this->label_request( 'PUT', $slug, $id, $this->store->get_version( $slug ), 'Custom Radius' ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+
+		$stored = json_decode( $this->store->get_document( $slug ), true );
+		$this->assertSame( 'border-radius', $this->user_primitive_index->all( $stored )[ $id ]['group'] );
+
+		$this->sync_registrar();
+
+		/** @var Token_Registry $registry */
+		$registry = $this->container->get( Token_Registry::class );
+		$this->assertSame( 'Border Radius', $registry->get( $id )->group );
+	}
+
+	/**
+	 * Clearing a grouped custom token's label override (the DELETE-equivalent PUT-empty path)
+	 * also preserves the stored group — the clear path routes through the same add() call as a
+	 * rename.
+	 *
+	 * @return void
+	 */
+	public function testClearingAGroupedCustomTokensLabelPreservesItsGroup(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.dimension.custom.radius-md';
+
+		$this->seed_user_primitive( $slug, $id, 'Radius MD', 'border-radius' );
+
+		$response = $this->controller->delete_label( $this->label_request( 'DELETE', $slug, $id, $this->store->get_version( $slug ) ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+
+		$stored = json_decode( $this->store->get_document( $slug ), true );
+		$this->assertSame( 'border-radius', $this->user_primitive_index->all( $stored )[ $id ]['group'] );
+	}
+
+	/**
 	 * The narrowed write path lets a label rename succeed even in a library whose stored document
 	 * currently fails full DTCG validation, and leaves the invalid remainder untouched.
 	 *
@@ -349,21 +399,30 @@ final class DocumentsControllerLabelsTest extends TestCase {
 	 * @param string $slug  The token library slug.
 	 * @param string $id    The user-created primitive's canonical dot-path id.
 	 * @param string $label The label to seed.
+	 * @param string $group Optional stable group key to seed alongside the label.
 	 *
 	 * @return void
 	 */
-	private function seed_user_primitive( string $slug, string $id, string $label ): void {
+	private function seed_user_primitive( string $slug, string $id, string $label, string $group = '' ): void {
 		$segments = explode( '.', $id );
 		$leaf     = array_pop( $segments );
+		$type     = $segments[1];
+		$value    = $type === 'dimension' ? '0.75rem' : '#1a56db';
+
+		$entry = [ 'label' => $label ];
+
+		if ( $group !== '' ) {
+			$entry['group'] = $group;
+		}
 
 		$document = (string) wp_json_encode(
 			[
 				'primitive'   => [
-					'color' => [
+					$type => [
 						'custom' => [
 							$leaf => [
-								'$type'  => 'color',
-								'$value' => '#1a56db',
+								'$type'  => $type,
+								'$value' => $value,
 							],
 						],
 					],
@@ -371,7 +430,7 @@ final class DocumentsControllerLabelsTest extends TestCase {
 				'$extensions' => [
 					'com.kadence.designTokens' => [
 						'userPrimitives' => [
-							$id => [ 'label' => $label ],
+							$id => $entry,
 						],
 					],
 				],

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerOrderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerOrderTest.php
@@ -444,6 +444,62 @@ final class DocumentsControllerOrderTest extends TestCase {
 	}
 
 	/**
+	 * A user-created token minted into a declared group (the border-radius scale, decision 3)
+	 * is addressable through that group's order route exactly like its baseline siblings — the
+	 * grouping is not merely cosmetic, it participates in persisted sort order.
+	 *
+	 * @return void
+	 */
+	public function testOrderIncludesAGroupedCustomToken(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.dimension.custom.radius-md';
+
+		$document = (string) wp_json_encode(
+			[
+				'primitive'   => [
+					'dimension' => [
+						'custom' => [
+							'radius-md' => [
+								'$type'  => 'dimension',
+								'$value' => '0.75rem',
+							],
+						],
+					],
+				],
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'userPrimitives' => [
+							$id => [
+								'label' => 'Radius MD',
+								'group' => 'border-radius',
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$this->store->save_document( $document, $slug );
+
+		/** @var User_Primitive_Registrar $registrar */
+		$registrar = $this->container->get( User_Primitive_Registrar::class );
+		$registrar->sync();
+
+		$schema = $this->registry->to_ui_schema();
+		$this->assertArrayHasKey( 'Border Radius', $schema['groups'] );
+
+		$group_ids = array_column( $schema['groups']['Border Radius'], 'id' );
+		$this->assertContains( $id, $group_ids, 'The grouped custom token must appear in the declared feed group.' );
+
+		$response = $this->controller->set_order(
+			$this->order_request( 'PUT', $slug, 'Border Radius', $this->store->get_version( $slug ), [ $id ] )
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( $id, $this->assembled_group_ids( $slug, 'Border Radius' )[0] );
+	}
+
+	/**
 	 * Both routes enforce the sibling document routes' capability filter: an unauthenticated
 	 * request and a subscriber are both refused.
 	 *

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -265,18 +265,22 @@ final class Feed_ControllerTest extends TestCase {
 		$this->assertSame(
 			[
 				'primitive.dimension.radius.none',
+				'primitive.dimension.radius.xs',
 				'primitive.dimension.radius.sm',
 				'primitive.dimension.radius.md',
 				'primitive.dimension.radius.lg',
+				'primitive.dimension.radius.xl',
 				'primitive.dimension.radius.full',
 			],
 			$ids
 		);
 
 		$this->assertSame( '0', $data['values']['primitive.dimension.radius.none'] );
-		$this->assertSame( '0.125rem', $data['values']['primitive.dimension.radius.sm'] );
-		$this->assertSame( '0.5rem', $data['values']['primitive.dimension.radius.md'] );
-		$this->assertSame( '1rem', $data['values']['primitive.dimension.radius.lg'] );
+		$this->assertSame( '0.125rem', $data['values']['primitive.dimension.radius.xs'] );
+		$this->assertSame( '0.1875rem', $data['values']['primitive.dimension.radius.sm'] );
+		$this->assertSame( '0.375rem', $data['values']['primitive.dimension.radius.md'] );
+		$this->assertSame( '0.5rem', $data['values']['primitive.dimension.radius.lg'] );
+		$this->assertSame( '1rem', $data['values']['primitive.dimension.radius.xl'] );
 		$this->assertSame( '9999px', $data['values']['primitive.dimension.radius.full'] );
 	}
 

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -248,6 +248,39 @@ final class Feed_ControllerTest extends TestCase {
 	}
 
 	/**
+	 * The declared border-radius scale surfaces as its own feed group, in declaration order, with
+	 * every step's value resolved — the Border Radius screen's data source end to end.
+	 *
+	 * @return void
+	 */
+	public function testGetItemReturnsTheBorderRadiusScaleGroup(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', Token_Store::default_slug() );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$this->assertArrayHasKey( 'Border Radius', $data['schema']['groups'] );
+
+		$ids = array_column( $data['schema']['groups']['Border Radius'], 'id' );
+		$this->assertSame(
+			[
+				'primitive.dimension.radius.none',
+				'primitive.dimension.radius.sm',
+				'primitive.dimension.radius.md',
+				'primitive.dimension.radius.lg',
+				'primitive.dimension.radius.full',
+			],
+			$ids
+		);
+
+		$this->assertSame( '0', $data['values']['primitive.dimension.radius.none'] );
+		$this->assertSame( '0.125rem', $data['values']['primitive.dimension.radius.sm'] );
+		$this->assertSame( '0.5rem', $data['values']['primitive.dimension.radius.md'] );
+		$this->assertSame( '1rem', $data['values']['primitive.dimension.radius.lg'] );
+		$this->assertSame( '9999px', $data['values']['primitive.dimension.radius.full'] );
+	}
+
+	/**
 	 * A slug naming no known library is rejected with a 404, mirroring Documents_Controller and
 	 * Active_Token_Library_Controller rather than silently substituting a different library's
 	 * data for the one requested.

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/User_Primitives_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/User_Primitives_ControllerTest.php
@@ -492,6 +492,98 @@ final class User_Primitives_ControllerTest extends TestCase {
 		$this->assertArrayHasKey( 'primitive.dimension.custom.gap-md', $ext );
 	}
 
+	// -------------------------------------------------------------------------
+	// create_item — the optional stable group key
+	// -------------------------------------------------------------------------
+
+	/**
+	 * A create request carrying a group key that a real declaration owns (the shipped
+	 * border-radius scale) stores that key verbatim in the envelope, and the minted token
+	 * surfaces inside the matching feed group.
+	 *
+	 * @return void
+	 */
+	public function testCreateWithAKnownGroupStoresTheKeyAndJoinsTheGroup(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}' );
+		$version = $this->store->get_version( $slug );
+
+		$request = $this->make_create_request( $slug, 'radius-md', 'dimension', '0.75rem', $version, 'Radius MD', 'border-radius' );
+		$result  = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( WP_Http::CREATED, $result->get_status() );
+
+		$doc = $result->get_data()['document'];
+		$ext = $doc[ Extensions::get_extensions_key() ][ Extensions::get_namespace() ][ Extensions::get_section_user_primitives() ];
+
+		$this->assertSame( 'border-radius', $ext['primitive.dimension.custom.radius-md']['group'] );
+	}
+
+	/**
+	 * A create request with no group param behaves exactly as before: no "group" key is written
+	 * to the envelope entry at all.
+	 *
+	 * @return void
+	 */
+	public function testCreateWithoutAGroupStoresNoGroupKey(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}' );
+		$version = $this->store->get_version( $slug );
+
+		$request = $this->make_create_request( $slug, 'brand-teal', 'color', '#0d9488', $version, 'Brand Teal' );
+		$result  = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+
+		$doc = $result->get_data()['document'];
+		$ext = $doc[ Extensions::get_extensions_key() ][ Extensions::get_namespace() ][ Extensions::get_section_user_primitives() ];
+
+		$this->assertArrayNotHasKey( 'group', $ext['primitive.color.custom.brand-teal'] );
+	}
+
+	/**
+	 * A group key no declaration carries is rejected outright — minting into it would leave the
+	 * token invisible on its own screen.
+	 *
+	 * @return void
+	 */
+	public function testCreateWithAnUndeclaredGroupIsRejected(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}' );
+		$version = $this->store->get_version( $slug );
+
+		$request = $this->make_create_request( $slug, 'radius-md', 'dimension', '0.75rem', $version, 'Radius MD', 'not-a-declared-group' );
+		$result  = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_kb_unknown_group', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * A group key that is not lowercase kebab-case is rejected before any group lookup, mirroring
+	 * the id slug's own charset guard.
+	 *
+	 * @return void
+	 */
+	public function testCreateWithAMalformedGroupIsRejected(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}' );
+		$version = $this->store->get_version( $slug );
+
+		$request = $this->make_create_request( $slug, 'radius-md', 'dimension', '0.75rem', $version, 'Radius MD', 'Border_Radius' );
+		$result  = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_kb_invalid_group', $result->get_error_code() );
+		$this->assertSame( WP_Http::BAD_REQUEST, $result->get_error_data()['status'] );
+	}
+
 	/**
 	 * A shadow primitive create proves the shape-agnostic `$value` arg and leaf build end to
 	 * end: the object `$value` (five literal sub-fields) is stored intact.
@@ -1297,6 +1389,38 @@ final class User_Primitives_ControllerTest extends TestCase {
 		$this->assertArrayNotHasKey( 'old-name', $doc_after['primitive']['color']['custom'] );
 	}
 
+	/**
+	 * Renaming a grouped custom token's id (not just its label) carries the stored group to the
+	 * new id — User_Primitive_Index::rename() reads the old entry's group before removing it,
+	 * rather than losing it the way a naive add()-with-no-group call would.
+	 *
+	 * @return void
+	 */
+	public function testRenamingAGroupedTokensIdCarriesTheGroupToTheNewId(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}' );
+		$version = $this->store->get_version( $slug );
+
+		$create = $this->controller->create_item(
+			$this->make_create_request( $slug, 'radius-md', 'dimension', '0.75rem', $version, 'Radius MD', 'border-radius' )
+		);
+		$this->assertInstanceOf( WP_REST_Response::class, $create );
+
+		$new_version = $create->get_data()['version'];
+
+		$request = $this->make_rename_request( $slug, 'primitive.dimension.custom.radius-md', 'radius-medium', $new_version );
+		$result  = $this->controller->rename_item( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+
+		$doc = $result->get_data()['document'];
+		$ext = $doc[ Extensions::get_extensions_key() ][ Extensions::get_namespace() ][ Extensions::get_section_user_primitives() ];
+
+		$this->assertSame( 'border-radius', $ext['primitive.dimension.custom.radius-medium']['group'] );
+		$this->assertArrayNotHasKey( 'primitive.dimension.custom.radius-md', $ext );
+	}
+
 	// -------------------------------------------------------------------------
 	// rename_item — $type derived from stored tree, not client
 	// -------------------------------------------------------------------------
@@ -1778,10 +1902,11 @@ final class User_Primitives_ControllerTest extends TestCase {
 	 * @param mixed  $value   The DTCG `$value`.
 	 * @param string $version The version token.
 	 * @param string $label   Optional label.
+	 * @param string $group   Optional stable group key.
 	 *
 	 * @return WP_REST_Request
 	 */
-	private function make_create_request( string $slug, string $id, string $type, $value, string $version, string $label = '' ): WP_REST_Request {
+	private function make_create_request( string $slug, string $id, string $type, $value, string $version, string $label = '', string $group = '' ): WP_REST_Request {
 		$request = new WP_REST_Request( WP_REST_Server::CREATABLE );
 		$request->set_param( 'slug', $slug );
 		$request->set_param( 'id', $id );
@@ -1789,6 +1914,7 @@ final class User_Primitives_ControllerTest extends TestCase {
 		$request->set_param( '$value', $value );
 		$request->set_param( 'version', $version );
 		$request->set_param( 'label', $label );
+		$request->set_param( 'group', $group );
 
 		return $request;
 	}


### PR DESCRIPTION
Builds the **Border Radius** screen of the Style Library, and carries the shared abstraction the other three scale screens (Border Width, Spacing, Icon Sizes) consume.

Targets `SOFT-4073/token-sort-order`, the tip of the chain where the app, label overrides and sort order live. It also merges `SOFT-4099/non-color-user-primitives` (PR #1228) as its first commit, because "+ Add Border Radius" needs the `dimension` user-primitive create backend.

## The shared abstraction

Three of the four screens differ only in their config values and their row preview, so the screen body is generic:

- `components/pages/ScaleScreen.js` / `ScaleSettings.js` — `ScreenHeader` + `RowList` + settings panel, driven entirely by a per-screen config.
- `hooks/use-scale-screen.js` — the state binding: rows from the feed, select/save/delete/reorder/add.
- `helpers/scale.js`, `helpers/scale-flows.js` — the pure row/slug/value helpers and the four write flows, which is where the jest coverage lives.
- JS client wrappers for the label-override and sort-order routes, which shipped backend-only.

The per-screen config supplies the screen id, title, add-button label, group, group key, token type, slug stem, the new-token defaults, the settings value field, an optional `formatValue`, and `renderPreview`.

## Two backend deltas this screen could not avoid

**The radius scale was never declared.** `primitive.dimension.radius.*` existed in `baseline.json` but had no entry in `declarations.php`, so no feed group existed for the screen to list. Now declared under a `Border Radius` group. `baseline.json` is untouched.

**User-created primitives had no group.** `Token_Definition::from_user_primitive()` passed `''` unconditionally, so a minted token was invisible to its own screen and unreachable by the order endpoint. Create now accepts an optional group key.

## The group key is stable, never a translated label

`Token_Registry::to_ui_schema()` groups on `$token->group`, which for declared tokens is a `__()` display label. Persisting that label on a user primitive would evaluate it once in whatever locale was active and store it verbatim — after a language change the stored string would no longer match the freshly-translated one and the token would drop out of its own screen permanently. The sort-order work already re-keyed its storage off translated labels for exactly this reason.

So what is persisted is a stable kebab machine key. Declarations for mintable groups carry a `group_key` beside their existing literal `group` label; `Token_Registry::group_label_for()` is a pure accessor that selects the matching declared group's already-translated label; and `User_Primitive_Registrar` (which has the logger) resolves the stored key at sync time and passes the resolved label through, so `to_ui_schema()` needs no change. **No dynamic string is ever passed to `__()`** — every label stays a literal call in `declarations.php` and the key only selects among them.

Create rejects an unresolvable key; the registrar fail-softs an orphaned key to ungrouped with a logged warning. The order route's `{group}` segment stays label-addressed, because that is addressing and never storage.

## Group preservation lives inside the index

`User_Primitive_Index::add()` overwrites the whole envelope entry, and it has four call sites — create, `rename_item`, and the labels endpoint's `set_label` and `persist_label_clear`. Threading a group through create alone would have meant the first rename silently wiped it and the row vanished from its screen on the next feed refresh. Instead `add()` takes a nullable group (`null` preserves, a string sets, empty omits) and `rename()` carries the old entry's group forward, so the two label-write paths need no change and cannot regress it. A test renames a grouped custom token through the labels endpoint and asserts it is still grouped.

## Reorder is serialized

Two drags landing before the first refresh completes would otherwise both read the same feed version, and the second would lose the conflict and have its drop discarded. Each reorder chains onto the previous one's settled promise. Two details make that work and are commented as such: the version is dereferenced inside the queued continuation rather than captured at enqueue time (no re-render happens between two rapid drops), and every link catches internally so one failure cannot leave the chain permanently rejected.

## Verification

`phpstan` clean with no baseline changes; `phpcs`, `cspell` and `eslint` clean; every touched and adjacent wpunit suite green, including the Builder and CSS snapshot suites with no diffs; 193 jest tests.

Checked in the browser: the scale renders with previews tracking the radius, row selection drives the panel and the `kb-item` route arg, and "+ Add Border Radius" mints `primitive.dimension.custom.radius` into the right group, survives a reload, and deletes cleanly.

## Not included

Per-corner editing, the header preview toggle, new scale steps, any baseline value change, and delete/clear UI for label overrides or stored order.

## Screenshots

**The screen**
<img width="1568" height="684" alt="screen" src="https://github.com/user-attachments/assets/09daef10-1628-47fb-95f0-d2484c0aa8aa" />

**MD selected, settings panel open**
<img width="1568" height="684" alt="settings-panel" src="https://github.com/user-attachments/assets/6d65c53a-adc9-4be7-a01e-cd5d9a6639d0" />
