### PR TITLE
[DTM] SOFT-4079: Border Width screen

### DIFF
--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -65,6 +65,26 @@ $radius_tokens = array_map(
 	$radius_slugs
 );
 
+// The border-width scale steps are primitives the Style Library's Border Width screen lists and
+// edits directly (semantic.border-width.default already carries the projection that delivers the
+// "sm" step into the image block, so the scale declares none of its own). group_key mirrors the
+// radius scale's mechanism above: it is the stable machine id "+ Add Border Width" mints custom
+// tokens into, resolved back to the group label at read time by Token_Registry::group_label_for().
+$border_width_slugs = [ 'sm', 'md', 'lg' ];
+
+$border_width_tokens = array_map(
+	static function ( string $slug ): array {
+		return [
+			'id'        => 'primitive.dimension.border-width.' . $slug,
+			'type'      => 'dimension',
+			'label'     => strtoupper( $slug ),
+			'group'     => __( 'Border Width', 'kadence-blocks' ),
+			'group_key' => 'border-width',
+		];
+	},
+	$border_width_slugs
+);
+
 // The fluid font-size scale steps are primitives (the slug IS a scale step), each holding the shipped
 // clamp() value from includes/init.php and claiming the Kadence Blocks font-size slug it backs
 // (class-kadence-blocks-css.php): the Css_Var builder redefines --global-kb-font-size-<slug> as the
@@ -328,7 +348,8 @@ return [
 		$spacing_tokens,
 		$gap_tokens,
 		$font_size_primitive_tokens,
-		$radius_tokens
+		$radius_tokens,
+		$border_width_tokens
 	),
 	/**
 	 * Preset bindings for the Button block: that it accepts presets, plus the per-property bindings (a

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -75,6 +75,26 @@ foreach ( $radius_labels as $slug => $label ) {
 	];
 }
 
+// The border-width scale steps are primitives the Style Library's Border Width screen lists and
+// edits directly (semantic.border-width.default already carries the projection that delivers the
+// "sm" step into the image block, so the scale declares none of its own). group_key mirrors the
+// radius scale's mechanism above: it is the stable machine id "+ Add Border Width" mints custom
+// tokens into, resolved back to the group label at read time by Token_Registry::group_label_for().
+$border_width_slugs = [ 'sm', 'md', 'lg' ];
+
+$border_width_tokens = array_map(
+	static function ( string $slug ): array {
+		return [
+			'id'        => 'primitive.dimension.border-width.' . $slug,
+			'type'      => 'dimension',
+			'label'     => strtoupper( $slug ),
+			'group'     => __( 'Border Width', 'kadence-blocks' ),
+			'group_key' => 'border-width',
+		];
+	},
+	$border_width_slugs
+);
+
 // The fluid font-size scale steps are primitives (the slug IS a scale step), each holding the shipped
 // clamp() value from includes/init.php and claiming the Kadence Blocks font-size slug it backs
 // (class-kadence-blocks-css.php): the Css_Var builder redefines --global-kb-font-size-<slug> as the
@@ -339,7 +359,8 @@ return [
 		$spacing_tokens,
 		$gap_tokens,
 		$font_size_primitive_tokens,
-		$radius_tokens
+		$radius_tokens,
+		$border_width_tokens
 	),
 	/**
 	 * Preset bindings for the Button block: that it accepts presets, plus the per-property bindings (a

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -21,6 +21,7 @@ import { DeleteLibraryModal } from '../components/organisms/DeleteLibraryModal';
 import { PlaceholderScreen } from '../components/pages/PlaceholderScreen';
 import { ColorPaletteScreen } from '../components/pages/ColorPaletteScreen';
 import { BorderRadiusScreen } from '../components/pages/BorderRadiusScreen';
+import { BorderWidthScreen } from '../components/pages/BorderWidthScreen';
 import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
 import { useLibraries } from '../hooks/use-libraries';
@@ -37,6 +38,7 @@ import { libraryDisplayTitle } from '../helpers/libraries';
 const SCREEN_COMPONENTS = {
 	'border-radius': BorderRadiusScreen,
 	'color-palette': ColorPaletteScreen,
+	'border-width': BorderWidthScreen,
 };
 
 /**

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -22,6 +22,7 @@ import { SettingsPanel } from '../components/templates/SettingsPanel';
 import { SettingsForm } from '../components/organisms/SettingsForm';
 import { PlaceholderScreen } from '../components/pages/PlaceholderScreen';
 import { BorderRadiusScreen } from '../components/pages/BorderRadiusScreen';
+import { BorderWidthScreen } from '../components/pages/BorderWidthScreen';
 import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
 import { useLibraries } from '../hooks/use-libraries';
@@ -40,6 +41,7 @@ import { libraryDisplayTitle } from '../helpers/libraries';
  */
 const SCREEN_COMPONENTS = {
 	'border-radius': BorderRadiusScreen,
+	'border-width': BorderWidthScreen,
 };
 
 /**

--- a/src/style-library/components/pages/BorderWidthScreen.js
+++ b/src/style-library/components/pages/BorderWidthScreen.js
@@ -1,0 +1,95 @@
+/**
+ * The Border Width screen: the scale config, the bordered-square preview renderer, and the two thin
+ * wrappers that plug into the shared `ScaleScreen`/`ScaleSettings` contract (see
+ * `.local/style-library-reference.md`). No link/unlink control — a `dimension` token stores one
+ * scalar; per-side border composition happens where tokens are consumed, not here.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ScaleScreen } from './ScaleScreen';
+import { ScaleSettings } from './ScaleSettings';
+import './BorderWidthScreen.scss';
+
+/**
+ * The bordered-square preview for one row: a fixed-size box (sized by the shared `ListRow` preview
+ * slot) whose border is drawn at the row's own resolved width — a `0` or hairline value renders a
+ * square with no visible border, which is the honest rendering of what the value writes.
+ *
+ * @param {{id: string, label: string, value: string, userCreated: boolean}} row The row descriptor.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The preview element.
+ */
+function renderBorderWidthPreview(row) {
+	return (
+		<span
+			className="kadence-blocks-style-library__border-width-preview"
+			style={{ borderStyle: 'solid', borderWidth: row.value }}
+		/>
+	);
+}
+
+/**
+ * The Border Width screen's config — see `ScaleScreen`'s module docblock and
+ * `.local/style-library-reference.md` for the full per-screen config contract.
+ *
+ * @since TBD
+ */
+export const BORDER_WIDTH_CONFIG = {
+	id: 'border-width',
+	title: __('Border', 'kadence-blocks'),
+	addLabel: __('Add Border Width', 'kadence-blocks'),
+	group: __('Border Width', 'kadence-blocks'),
+	groupKey: 'border-width',
+	tokenType: 'dimension',
+	slugBase: 'border-width',
+	newTokenLabel: __('New Border Width', 'kadence-blocks'),
+	newTokenValue: '2px',
+	valueField: {
+		type: 'unit',
+		label: __('Border', 'kadence-blocks'),
+		units: [
+			{ value: 'px', label: 'px' },
+			{ value: 'em', label: 'em' },
+			{ value: 'rem', label: 'rem' },
+		],
+		responsive: true,
+	},
+	renderPreview: renderBorderWidthPreview,
+};
+
+/**
+ * The Border Width screen body.
+ *
+ * @param {Object} props The props `ScaleScreen` accepts (`{ label, route, navigate, library }`).
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The screen.
+ */
+export function BorderWidthScreen(props) {
+	return <ScaleScreen config={BORDER_WIDTH_CONFIG} {...props} />;
+}
+
+/**
+ * The Border Width screen's settings panel.
+ *
+ * @param {Object} props The props `ScaleSettings` accepts (`{ route, navigate, library }`).
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The panel.
+ */
+function BorderWidthSettings(props) {
+	return <ScaleSettings config={BORDER_WIDTH_CONFIG} {...props} />;
+}
+
+BorderWidthScreen.SettingsPanel = BorderWidthSettings;

--- a/src/style-library/components/pages/BorderWidthScreen.js
+++ b/src/style-library/components/pages/BorderWidthScreen.js
@@ -1,7 +1,7 @@
 /**
  * The Border Width screen: the scale config, the bordered-square preview renderer, and the two thin
  * wrappers that plug into the shared `ScaleScreen`/`ScaleSettings` contract (see
- * `.local/style-library-reference.md`). No link/unlink control — a `dimension` token stores one
+ * `ScaleScreen.js`'s module docblock). No link/unlink control — a `dimension` token stores one
  * scalar; per-side border composition happens where tokens are consumed, not here.
  */
 
@@ -38,8 +38,8 @@ function renderBorderWidthPreview(row) {
 }
 
 /**
- * The Border Width screen's config — see `ScaleScreen`'s module docblock and
- * `.local/style-library-reference.md` for the full per-screen config contract.
+ * The Border Width screen's config — see `ScaleScreen`'s module docblock for the full per-screen
+ * config contract.
  *
  * @since TBD
  */

--- a/src/style-library/components/pages/BorderWidthScreen.js
+++ b/src/style-library/components/pages/BorderWidthScreen.js
@@ -61,7 +61,6 @@ export const BORDER_WIDTH_CONFIG = {
 			{ value: 'em', label: 'em' },
 			{ value: 'rem', label: 'rem' },
 		],
-		responsive: true,
 	},
 	renderPreview: renderBorderWidthPreview,
 };

--- a/src/style-library/components/pages/BorderWidthScreen.scss
+++ b/src/style-library/components/pages/BorderWidthScreen.scss
@@ -1,7 +1,17 @@
 // The bordered-square preview's own box. Sizing for the slot itself already comes from
 // `.list-row-preview` (ListRow.scss) — this element only has to fill that slot so its own
 // `border-width` (set inline, per row) has a visible box to frame.
+//
+// `box-sizing: border-box` is required here: a `<span>` defaults to `content-box`, so the inline
+// `border-width` was being added on top of the 100%/100% size instead of drawn inside it. The
+// flex parent (`.list-row-preview`, `display: flex`) then shrinks the box along its main
+// (horizontal) axis to fit, which visually compensated the inline and right edges back to the
+// right thickness — but the cross (vertical) axis isn't shrunk by flex layout, so the excess
+// height overflowed and was clipped by the parent's `overflow: hidden`, leaving the top and
+// bottom edges stuck thin regardless of the token's value. `border-box` keeps the border inside
+// the box on every axis, so all four sides thicken together.
 .kadence-blocks-style-library__border-width-preview {
+	box-sizing: border-box;
 	display: block;
 	width: 100%;
 	height: 100%;

--- a/src/style-library/components/pages/BorderWidthScreen.scss
+++ b/src/style-library/components/pages/BorderWidthScreen.scss
@@ -1,0 +1,10 @@
+// The bordered-square preview's own box. Sizing for the slot itself already comes from
+// `.list-row-preview` (ListRow.scss) — this element only has to fill that slot so its own
+// `border-width` (set inline, per row) has a visible box to frame.
+.kadence-blocks-style-library__border-width-preview {
+	display: block;
+	width: 100%;
+	height: 100%;
+	background: var(--kb-sl-color-gray-100);
+	border-color: var(--kb-sl-color-gray-700);
+}

--- a/src/style-library/constants/screens.js
+++ b/src/style-library/constants/screens.js
@@ -31,7 +31,6 @@ export const BASE_STYLES_SCREENS = [
 	// @todo SOFT-4077: replace the placeholder with the Typography screen.
 	{ id: 'typography', label: __('Typography', 'kadence-blocks') },
 	{ id: 'border-radius', label: __('Border Radius', 'kadence-blocks') },
-	// @todo SOFT-4079: replace the placeholder with the Border Width screen.
 	{ id: 'border-width', label: __('Border Width', 'kadence-blocks') },
 	// @todo SOFT-4080: replace the placeholder with the Spacing screen.
 	{ id: 'spacing', label: __('Spacing', 'kadence-blocks') },

--- a/src/style-library/constants/screens.js
+++ b/src/style-library/constants/screens.js
@@ -32,7 +32,6 @@ export const BASE_STYLES_SCREENS = [
 	// @todo SOFT-4077: replace the placeholder with the Typography screen.
 	{ id: 'typography', label: __('Typography', 'kadence-blocks') },
 	{ id: 'border-radius', label: __('Border Radius', 'kadence-blocks') },
-	// @todo SOFT-4079: replace the placeholder with the Border Width screen.
 	{ id: 'border-width', label: __('Border Width', 'kadence-blocks') },
 	// @todo SOFT-4080: replace the placeholder with the Spacing screen.
 	{ id: 'spacing', label: __('Spacing', 'kadence-blocks') },

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -5,6 +5,8 @@ namespace Tests\wpunit\Resources\Design_Tokens\Rest\V1;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Localizer;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\User_Primitive_Registrar;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Feed_Controller;
 use ReflectionClass;
@@ -278,6 +280,124 @@ final class Feed_ControllerTest extends TestCase {
 		$this->assertSame( '0.5rem', $data['values']['primitive.dimension.radius.md'] );
 		$this->assertSame( '1rem', $data['values']['primitive.dimension.radius.lg'] );
 		$this->assertSame( '9999px', $data['values']['primitive.dimension.radius.full'] );
+	}
+
+	/**
+	 * The declared border-width scale surfaces as its own feed group, in declaration order, with
+	 * every step's value resolved and no projections — the Border Width screen's data source end
+	 * to end.
+	 *
+	 * @return void
+	 */
+	public function testGetItemReturnsTheBorderWidthScaleGroup(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', Token_Store::default_slug() );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$this->assertArrayHasKey( 'Border Width', $data['schema']['groups'] );
+
+		$ids = array_column( $data['schema']['groups']['Border Width'], 'id' );
+		$this->assertSame(
+			[
+				'primitive.dimension.border-width.sm',
+				'primitive.dimension.border-width.md',
+				'primitive.dimension.border-width.lg',
+			],
+			$ids
+		);
+
+		foreach ( $data['schema']['groups']['Border Width'] as $entry ) {
+			$this->assertSame( [], $entry['projections'], 'The declared border-width scale carries no projections of its own.' );
+		}
+
+		$this->assertSame( '1px', $data['values']['primitive.dimension.border-width.sm'] );
+		$this->assertSame( '2px', $data['values']['primitive.dimension.border-width.md'] );
+		$this->assertSame( '4px', $data['values']['primitive.dimension.border-width.lg'] );
+	}
+
+	/**
+	 * `semantic.border-width.default` keeps resolving through the "sm" primitive after the scale is
+	 * declared — declaring the primitives for the Style Library screen must not disturb the alias
+	 * that already projects into the image block.
+	 *
+	 * @return void
+	 */
+	public function testSemanticBorderWidthDefaultStillResolvesThroughTheSmPrimitive(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', Token_Store::default_slug() );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$this->assertSame(
+			$data['values']['primitive.dimension.border-width.sm'],
+			$data['values']['semantic.border-width.default']
+		);
+	}
+
+	/**
+	 * A user-created token minted into the border-width group (the stable key, decision 3 of the
+	 * shared scale-screen contract) surfaces inside the declared "Border Width" UI-schema group and
+	 * is flagged `userCreated`, exercising the shared group-key backend against this screen's own
+	 * key. Asserted against `Token_Registry::to_ui_schema()` directly — the same surface
+	 * `DocumentsControllerOrderTest::testOrderIncludesAGroupedCustomToken` checks for the sibling
+	 * border-radius group — rather than through the REST controller, whose resolved dependency
+	 * chain can be constructed once and cached earlier in a suite run.
+	 *
+	 * @return void
+	 */
+	public function testUserPrimitiveGroupedIntoBorderWidthSurfacesInItsFeedGroupAsUserCreated(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.dimension.custom.border-width-2';
+
+		$document = (string) wp_json_encode(
+			[
+				'primitive'   => [
+					'dimension' => [
+						'custom' => [
+							'border-width-2' => [
+								'$type'  => 'dimension',
+								'$value' => '3px',
+							],
+						],
+					],
+				],
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'userPrimitives' => [
+							$id => [
+								'label' => 'New Border Width',
+								'group' => 'border-width',
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$this->store->save_document( $document, $slug );
+
+		/** @var User_Primitive_Registrar $registrar */
+		$registrar = $this->container->get( User_Primitive_Registrar::class );
+		$registrar->sync();
+
+		/** @var Token_Registry $registry */
+		$registry = $this->container->get( Token_Registry::class );
+		$schema   = $registry->to_ui_schema();
+
+		$this->assertArrayHasKey( 'Border Width', $schema['groups'] );
+
+		$found = null;
+
+		foreach ( $schema['groups']['Border Width'] as $entry ) {
+			if ( $id === $entry['id'] ) {
+				$found = $entry;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $found, 'The grouped custom token must appear in the declared "Border Width" UI-schema group.' );
+		$this->assertTrue( $found['userCreated'] );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -5,6 +5,8 @@ namespace Tests\wpunit\Resources\Design_Tokens\Rest\V1;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Localizer;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\User_Primitive_Registrar;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Feed_Controller;
 use ReflectionClass;
@@ -282,6 +284,124 @@ final class Feed_ControllerTest extends TestCase {
 		$this->assertSame( '0.5rem', $data['values']['primitive.dimension.radius.lg'] );
 		$this->assertSame( '1rem', $data['values']['primitive.dimension.radius.xl'] );
 		$this->assertSame( '9999px', $data['values']['primitive.dimension.radius.full'] );
+	}
+
+	/**
+	 * The declared border-width scale surfaces as its own feed group, in declaration order, with
+	 * every step's value resolved and no projections — the Border Width screen's data source end
+	 * to end.
+	 *
+	 * @return void
+	 */
+	public function testGetItemReturnsTheBorderWidthScaleGroup(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', Token_Store::default_slug() );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$this->assertArrayHasKey( 'Border Width', $data['schema']['groups'] );
+
+		$ids = array_column( $data['schema']['groups']['Border Width'], 'id' );
+		$this->assertSame(
+			[
+				'primitive.dimension.border-width.sm',
+				'primitive.dimension.border-width.md',
+				'primitive.dimension.border-width.lg',
+			],
+			$ids
+		);
+
+		foreach ( $data['schema']['groups']['Border Width'] as $entry ) {
+			$this->assertSame( [], $entry['projections'], 'The declared border-width scale carries no projections of its own.' );
+		}
+
+		$this->assertSame( '1px', $data['values']['primitive.dimension.border-width.sm'] );
+		$this->assertSame( '2px', $data['values']['primitive.dimension.border-width.md'] );
+		$this->assertSame( '4px', $data['values']['primitive.dimension.border-width.lg'] );
+	}
+
+	/**
+	 * `semantic.border-width.default` keeps resolving through the "sm" primitive after the scale is
+	 * declared — declaring the primitives for the Style Library screen must not disturb the alias
+	 * that already projects into the image block.
+	 *
+	 * @return void
+	 */
+	public function testSemanticBorderWidthDefaultStillResolvesThroughTheSmPrimitive(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', Token_Store::default_slug() );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$this->assertSame(
+			$data['values']['primitive.dimension.border-width.sm'],
+			$data['values']['semantic.border-width.default']
+		);
+	}
+
+	/**
+	 * A user-created token minted into the border-width group (the stable key, decision 3 of the
+	 * shared scale-screen contract) surfaces inside the declared "Border Width" UI-schema group and
+	 * is flagged `userCreated`, exercising the shared group-key backend against this screen's own
+	 * key. Asserted against `Token_Registry::to_ui_schema()` directly — the same surface
+	 * `DocumentsControllerOrderTest::testOrderIncludesAGroupedCustomToken` checks for the sibling
+	 * border-radius group — rather than through the REST controller, whose resolved dependency
+	 * chain can be constructed once and cached earlier in a suite run.
+	 *
+	 * @return void
+	 */
+	public function testUserPrimitiveGroupedIntoBorderWidthSurfacesInItsFeedGroupAsUserCreated(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.dimension.custom.border-width-2';
+
+		$document = (string) wp_json_encode(
+			[
+				'primitive'   => [
+					'dimension' => [
+						'custom' => [
+							'border-width-2' => [
+								'$type'  => 'dimension',
+								'$value' => '3px',
+							],
+						],
+					],
+				],
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'userPrimitives' => [
+							$id => [
+								'label' => 'New Border Width',
+								'group' => 'border-width',
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$this->store->save_document( $document, $slug );
+
+		/** @var User_Primitive_Registrar $registrar */
+		$registrar = $this->container->get( User_Primitive_Registrar::class );
+		$registrar->sync();
+
+		/** @var Token_Registry $registry */
+		$registry = $this->container->get( Token_Registry::class );
+		$schema   = $registry->to_ui_schema();
+
+		$this->assertArrayHasKey( 'Border Width', $schema['groups'] );
+
+		$found = null;
+
+		foreach ( $schema['groups']['Border Width'] as $entry ) {
+			if ( $id === $entry['id'] ) {
+				$found = $entry;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $found, 'The grouped custom token must appear in the declared "Border Width" UI-schema group.' );
+		$this->assertTrue( $found['userCreated'] );
 	}
 
 	/**


### PR DESCRIPTION
Builds the **Border Width** screen of the Style Library. Targets the Border Radius branch, which carries the shared `ScaleScreen` abstraction this consumes.

Thin by design — a per-screen config, a preview renderer, one screen registration, and one declaration group.

## What it adds

- `components/pages/BorderWidthScreen.js` / `.scss` — the config and a preview square rendered with the token's border width.
- `declarations.php` — declares `primitive.dimension.border-width.{sm,md,lg}` under a `Border Width` group with `group_key: 'border-width'`. The baseline already ships 1px/2px/4px, so `baseline.json` is untouched and no cache flush is needed.

The screen title is **"Border"** while the nav label stays "Border Width" — the two deliberately differ, as they do on Border Radius ("Corner Radius").

## Field choice

The value field is `unit`/`UnitField` with `px`/`em`/`rem`. No `%`, because `border-width` does not accept percentages. `StepperField` and `NumberUnitField` were both rejected for the same reason: they store bare numbers and cannot round-trip a `'2px'` dimension string, and `NumberUnitField` additionally pins one fixed unit rather than offering a choice.

## One test-infrastructure note

A test asserting through `Feed_Controller::get_item()` passed alone but failed in the full-suite run. `RegistrationHelperTest::tearDown()` rebinds the `Token_Registry` container singleton to undo its own pollution, but the controller's dependency chain keeps holding the original instance, so registrations added after that rebind are invisible to it. This is pre-existing behavior unrelated to this change. The test now asserts via `Token_Registry::to_ui_schema()` directly, the pattern the sort-order tests already use for the sibling case.

## Verification

`phpstan` clean with no baseline changes; `phpcs`, `cspell` and `eslint` clean; the full plugin suite green (2216 tests); 193 jest tests; build succeeds.

Checked in the browser: SM/MD/LG render at 1px/2px/4px with previews showing visibly thickening borders.

## Screenshots

**The screen**
<img width="1568" height="461" alt="screen" src="https://github.com/user-attachments/assets/3c2fee51-ffd3-4f4a-95e2-be4a70fd61a1" />