### PR TITLE
[DTM] SOFT-4080: Spacing screen

### DIFF
--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -14,7 +14,9 @@
 // owner can retune each step. Usage-specific intent (semantic.spacing.section/.block/.inline) aliases the
 // scale and is where intent-based delivery points — mirroring how semantic.radius.media aliases the radius
 // scale. Defaults match KB's own values, so registering them changes nothing until overridden. ss-auto is
-// omitted: it resolves to "auto", not a length.
+// omitted: it resolves to "auto", not a length. group_key mirrors the radius/border-width scales' mechanism:
+// it is the stable machine id the Style Library's Spacing screen's "+ Add Spacing" mints custom tokens into,
+// resolved back to the group label at read time by Token_Registry::group_label_for().
 $spacing_slugs = [ 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ];
 $gap_slugs     = [ 'none', 'xs', 'sm', 'md', 'lg' ];
 
@@ -25,6 +27,7 @@ $spacing_tokens = array_map(
 			'type'        => 'dimension',
 			'label'       => strtoupper( $slug ),
 			'group'       => __( 'Spacing', 'kadence-blocks' ),
+			'group_key'   => 'spacing',
 			'projections' => [ 'kb_spacing_slot' => $slug ],
 		];
 	},

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -22,6 +22,7 @@ import { PlaceholderScreen } from '../components/pages/PlaceholderScreen';
 import { ColorPaletteScreen } from '../components/pages/ColorPaletteScreen';
 import { BorderRadiusScreen } from '../components/pages/BorderRadiusScreen';
 import { BorderWidthScreen } from '../components/pages/BorderWidthScreen';
+import { SpacingScreen } from '../components/pages/SpacingScreen';
 import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
 import { useLibraries } from '../hooks/use-libraries';
@@ -39,6 +40,7 @@ const SCREEN_COMPONENTS = {
 	'border-radius': BorderRadiusScreen,
 	'color-palette': ColorPaletteScreen,
 	'border-width': BorderWidthScreen,
+	spacing: SpacingScreen,
 };
 
 /**

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -23,6 +23,7 @@ import { SettingsForm } from '../components/organisms/SettingsForm';
 import { PlaceholderScreen } from '../components/pages/PlaceholderScreen';
 import { BorderRadiusScreen } from '../components/pages/BorderRadiusScreen';
 import { BorderWidthScreen } from '../components/pages/BorderWidthScreen';
+import { SpacingScreen } from '../components/pages/SpacingScreen';
 import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
 import { useLibraries } from '../hooks/use-libraries';
@@ -42,6 +43,7 @@ import { libraryDisplayTitle } from '../helpers/libraries';
 const SCREEN_COMPONENTS = {
 	'border-radius': BorderRadiusScreen,
 	'border-width': BorderWidthScreen,
+	spacing: SpacingScreen,
 };
 
 /**

--- a/src/style-library/components/pages/SpacingScreen.js
+++ b/src/style-library/components/pages/SpacingScreen.js
@@ -1,7 +1,7 @@
 /**
  * The Spacing screen: the scale config, the value-sized square preview renderer, and the two thin
  * wrappers that plug into the shared `ScaleScreen`/`ScaleSettings` contract (see
- * `.local/style-library-reference.md`). The `Spacing` group is already declared in
+ * `ScaleScreen.js`'s module docblock). The `Spacing` group is already declared in
  * `declarations.php` (its steps each carry a `kb_spacing_slot` projection, so a value edited here
  * changes every block that already stores that slug) — this screen only lists and edits it.
  */
@@ -40,8 +40,8 @@ function renderSpacingPreview(row) {
 }
 
 /**
- * The Spacing screen's config — see `ScaleScreen`'s module docblock and
- * `.local/style-library-reference.md` for the full per-screen config contract.
+ * The Spacing screen's config — see `ScaleScreen`'s module docblock for the full per-screen
+ * config contract.
  *
  * @since TBD
  */

--- a/src/style-library/components/pages/SpacingScreen.js
+++ b/src/style-library/components/pages/SpacingScreen.js
@@ -20,8 +20,9 @@ import './SpacingScreen.scss';
 
 /**
  * The value-sized square preview for one row: a `div` sized inline to the row's own resolved
- * value, clamped by the stylesheet at `6rem` so the largest steps pin rather than blowing up the
- * row — an empty or zero value degrades to a collapsed square, the honest rendering.
+ * value, with no maximum — the stylesheet leaves it unclamped so every step renders at its true
+ * CSS size and the row grows to fit it. An empty or zero value degrades to a collapsed square,
+ * the honest rendering.
  *
  * @param {{id: string, label: string, value: string, userCreated: boolean}} row The row descriptor.
  *

--- a/src/style-library/components/pages/SpacingScreen.js
+++ b/src/style-library/components/pages/SpacingScreen.js
@@ -64,7 +64,6 @@ export const SPACING_CONFIG = {
 			{ value: 'vh', label: 'vh' },
 			{ value: 'vw', label: 'vw' },
 		],
-		responsive: true,
 	},
 	renderPreview: renderSpacingPreview,
 };

--- a/src/style-library/components/pages/SpacingScreen.js
+++ b/src/style-library/components/pages/SpacingScreen.js
@@ -1,0 +1,98 @@
+/**
+ * The Spacing screen: the scale config, the value-sized square preview renderer, and the two thin
+ * wrappers that plug into the shared `ScaleScreen`/`ScaleSettings` contract (see
+ * `.local/style-library-reference.md`). The `Spacing` group is already declared in
+ * `declarations.php` (its steps each carry a `kb_spacing_slot` projection, so a value edited here
+ * changes every block that already stores that slug) — this screen only lists and edits it.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ScaleScreen } from './ScaleScreen';
+import { ScaleSettings } from './ScaleSettings';
+import './SpacingScreen.scss';
+
+/**
+ * The value-sized square preview for one row: a `div` sized inline to the row's own resolved
+ * value, clamped by the stylesheet at `6rem` so the largest steps pin rather than blowing up the
+ * row — an empty or zero value degrades to a collapsed square, the honest rendering.
+ *
+ * @param {{id: string, label: string, value: string, userCreated: boolean}} row The row descriptor.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The preview element.
+ */
+function renderSpacingPreview(row) {
+	return (
+		<div
+			className="kadence-blocks-style-library__spacing-preview"
+			style={{ width: row.value, height: row.value }}
+		/>
+	);
+}
+
+/**
+ * The Spacing screen's config — see `ScaleScreen`'s module docblock and
+ * `.local/style-library-reference.md` for the full per-screen config contract.
+ *
+ * @since TBD
+ */
+export const SPACING_CONFIG = {
+	id: 'spacing',
+	title: __('Spacing', 'kadence-blocks'),
+	addLabel: __('Add Spacing', 'kadence-blocks'),
+	group: __('Spacing', 'kadence-blocks'),
+	groupKey: 'spacing',
+	tokenType: 'dimension',
+	slugBase: 'spacing',
+	newTokenLabel: __('New Spacing', 'kadence-blocks'),
+	newTokenValue: '2rem',
+	valueField: {
+		type: 'unit',
+		label: __('Spacing', 'kadence-blocks'),
+		units: [
+			{ value: 'px', label: 'px' },
+			{ value: 'em', label: 'em' },
+			{ value: 'rem', label: 'rem' },
+			{ value: 'vh', label: 'vh' },
+			{ value: 'vw', label: 'vw' },
+		],
+		responsive: true,
+	},
+	renderPreview: renderSpacingPreview,
+};
+
+/**
+ * The Spacing screen body.
+ *
+ * @param {Object} props The props `ScaleScreen` accepts (`{ label, route, navigate, library }`).
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The screen.
+ */
+export function SpacingScreen(props) {
+	return <ScaleScreen config={SPACING_CONFIG} {...props} />;
+}
+
+/**
+ * The Spacing screen's settings panel.
+ *
+ * @param {Object} props The props `ScaleSettings` accepts (`{ route, navigate, library }`).
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The panel.
+ */
+function SpacingSettings(props) {
+	return <ScaleSettings config={SPACING_CONFIG} {...props} />;
+}
+
+SpacingScreen.SettingsPanel = SpacingSettings;

--- a/src/style-library/components/pages/SpacingScreen.scss
+++ b/src/style-library/components/pages/SpacingScreen.scss
@@ -1,0 +1,25 @@
+// The value-sized square preview's own box. Unlike the other scale screens, this preview does not
+// fill the shared `.list-row-preview` slot — it is sized to the token's own value (set inline, per
+// row) so the mock's "true CSS size" behavior reads correctly, hence the slot override just below.
+.kadence-blocks-style-library__spacing-preview {
+	display: block;
+	background: var(--kb-sl-color-gray-100);
+	border: var(--kb-sl-border-width-input) solid var(--kb-sl-color-gray-700);
+	// The largest declared steps (3XL/4XL/5XL, 104px-160px) would otherwise blow the row past the
+	// mock's own tallest row (96px); the preview is an at-a-glance visual, not a measurement
+	// instrument, so it pins here and the value column disambiguates the top three rows.
+	max-width: 6rem;
+	max-height: 6rem;
+}
+
+// Scoped to this screen via `ScaleScreen`'s per-screen root modifier class (see
+// `.local/style-library-reference.md`) — Border Radius and Border Width keep the default framed
+// 80px slot from `ListRow.scss`; only Spacing needs a bare, value-sized square with the row
+// growing to contain it.
+.kadence-blocks-style-library__scale-screen--spacing .kadence-blocks-style-library__list-row-preview {
+	width: auto;
+	height: auto;
+	border: 0;
+	background: transparent;
+	overflow: visible;
+}

--- a/src/style-library/components/pages/SpacingScreen.scss
+++ b/src/style-library/components/pages/SpacingScreen.scss
@@ -2,6 +2,10 @@
 // fill the shared `.list-row-preview` slot — it is sized to the token's own value (set inline, per
 // row) so the mock's "true CSS size" behavior reads correctly, hence the slot override just below.
 .kadence-blocks-style-library__spacing-preview {
+	// `border-box`, not the `<div>` default `content-box` — otherwise the border below adds on top
+	// of the inline width/height instead of drawing inside it, so the rendered box is 2px larger
+	// than the token's value on every step. Same fix as `.border-width-preview`.
+	box-sizing: border-box;
 	display: block;
 	background: var(--kb-sl-color-gray-100);
 	border: var(--kb-sl-border-width-input) solid var(--kb-sl-color-gray-700);

--- a/src/style-library/components/pages/SpacingScreen.scss
+++ b/src/style-library/components/pages/SpacingScreen.scss
@@ -14,8 +14,8 @@
 	// grows to fit it. Accepted consequence: a very large custom value produces a very tall row.
 }
 
-// Scoped to this screen via `ScaleScreen`'s per-screen root modifier class (see
-// `.local/style-library-reference.md`) — Border Radius and Border Width keep the default framed
+// Scoped to this screen via `ScaleScreen`'s per-screen root modifier class
+// (`--<config.id>`) — Border Radius and Border Width keep the default framed
 // 80px slot from `ListRow.scss`; only Spacing needs a bare, value-sized square with the row
 // growing to contain it.
 .kadence-blocks-style-library__scale-screen--spacing .kadence-blocks-style-library__list-row-preview {

--- a/src/style-library/components/pages/SpacingScreen.scss
+++ b/src/style-library/components/pages/SpacingScreen.scss
@@ -5,11 +5,9 @@
 	display: block;
 	background: var(--kb-sl-color-gray-100);
 	border: var(--kb-sl-border-width-input) solid var(--kb-sl-color-gray-700);
-	// The largest declared steps (3XL/4XL/5XL, 104px-160px) would otherwise blow the row past the
-	// mock's own tallest row (96px); the preview is an at-a-glance visual, not a measurement
-	// instrument, so it pins here and the value column disambiguates the top three rows.
-	max-width: 6rem;
-	max-height: 6rem;
+	// Unclamped on purpose: the preview must show a token's true CSS size, not a normalized
+	// approximation, so every step (including 3XL/4XL/5XL) renders at its real value and the row
+	// grows to fit it. Accepted consequence: a very large custom value produces a very tall row.
 }
 
 // Scoped to this screen via `ScaleScreen`'s per-screen root modifier class (see

--- a/src/style-library/constants/screens.js
+++ b/src/style-library/constants/screens.js
@@ -33,7 +33,6 @@ export const BASE_STYLES_SCREENS = [
 	{ id: 'typography', label: __('Typography', 'kadence-blocks') },
 	{ id: 'border-radius', label: __('Border Radius', 'kadence-blocks') },
 	{ id: 'border-width', label: __('Border Width', 'kadence-blocks') },
-	// @todo SOFT-4080: replace the placeholder with the Spacing screen.
 	{ id: 'spacing', label: __('Spacing', 'kadence-blocks') },
 	// @todo SOFT-4081: replace the placeholder with the Icon Sizes screen.
 	{ id: 'icon-sizes', label: __('Icon Sizes', 'kadence-blocks') },

--- a/src/style-library/constants/screens.js
+++ b/src/style-library/constants/screens.js
@@ -32,7 +32,6 @@ export const BASE_STYLES_SCREENS = [
 	{ id: 'typography', label: __('Typography', 'kadence-blocks') },
 	{ id: 'border-radius', label: __('Border Radius', 'kadence-blocks') },
 	{ id: 'border-width', label: __('Border Width', 'kadence-blocks') },
-	// @todo SOFT-4080: replace the placeholder with the Spacing screen.
 	{ id: 'spacing', label: __('Spacing', 'kadence-blocks') },
 	// @todo SOFT-4081: replace the placeholder with the Icon Sizes screen.
 	{ id: 'icon-sizes', label: __('Icon Sizes', 'kadence-blocks') },

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -401,6 +401,72 @@ final class Feed_ControllerTest extends TestCase {
 	}
 
 	/**
+	 * A user-created token minted into the spacing group (the stable key this ticket adds as
+	 * `group_key` on the already-declared spacing scale) surfaces inside the declared "Spacing"
+	 * UI-schema group and is flagged `userCreated`, exercising the shared group-key backend
+	 * against a pre-existing declaration rather than a newly declared one. Asserted against
+	 * `Token_Registry::to_ui_schema()` directly — the same surface
+	 * `DocumentsControllerOrderTest::testOrderIncludesAGroupedCustomToken` checks for the sibling
+	 * border-radius group — rather than through the REST controller, whose resolved dependency
+	 * chain can be constructed once and cached earlier in a suite run.
+	 *
+	 * @return void
+	 */
+	public function testUserPrimitiveGroupedIntoSpacingSurfacesInItsFeedGroupAsUserCreated(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.dimension.custom.spacing-2';
+
+		$document = (string) wp_json_encode(
+			[
+				'primitive'   => [
+					'dimension' => [
+						'custom' => [
+							'spacing-2' => [
+								'$type'  => 'dimension',
+								'$value' => '2.5rem',
+							],
+						],
+					],
+				],
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'userPrimitives' => [
+							$id => [
+								'label' => 'New Spacing',
+								'group' => 'spacing',
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$this->store->save_document( $document, $slug );
+
+		/** @var User_Primitive_Registrar $registrar */
+		$registrar = $this->container->get( User_Primitive_Registrar::class );
+		$registrar->sync();
+
+		/** @var Token_Registry $registry */
+		$registry = $this->container->get( Token_Registry::class );
+		$schema   = $registry->to_ui_schema();
+
+		$this->assertArrayHasKey( 'Spacing', $schema['groups'] );
+
+		$found = null;
+
+		foreach ( $schema['groups']['Spacing'] as $entry ) {
+			if ( $id === $entry['id'] ) {
+				$found = $entry;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $found, 'The grouped custom token must appear in the declared "Spacing" UI-schema group.' );
+		$this->assertTrue( $found['userCreated'] );
+	}
+
+	/**
 	 * A slug naming no known library is rejected with a 404, mirroring Documents_Controller and
 	 * Active_Token_Library_Controller rather than silently substituting a different library's
 	 * data for the one requested.

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -405,6 +405,72 @@ final class Feed_ControllerTest extends TestCase {
 	}
 
 	/**
+	 * A user-created token minted into the spacing group (the stable key this ticket adds as
+	 * `group_key` on the already-declared spacing scale) surfaces inside the declared "Spacing"
+	 * UI-schema group and is flagged `userCreated`, exercising the shared group-key backend
+	 * against a pre-existing declaration rather than a newly declared one. Asserted against
+	 * `Token_Registry::to_ui_schema()` directly — the same surface
+	 * `DocumentsControllerOrderTest::testOrderIncludesAGroupedCustomToken` checks for the sibling
+	 * border-radius group — rather than through the REST controller, whose resolved dependency
+	 * chain can be constructed once and cached earlier in a suite run.
+	 *
+	 * @return void
+	 */
+	public function testUserPrimitiveGroupedIntoSpacingSurfacesInItsFeedGroupAsUserCreated(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.dimension.custom.spacing-2';
+
+		$document = (string) wp_json_encode(
+			[
+				'primitive'   => [
+					'dimension' => [
+						'custom' => [
+							'spacing-2' => [
+								'$type'  => 'dimension',
+								'$value' => '2.5rem',
+							],
+						],
+					],
+				],
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'userPrimitives' => [
+							$id => [
+								'label' => 'New Spacing',
+								'group' => 'spacing',
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$this->store->save_document( $document, $slug );
+
+		/** @var User_Primitive_Registrar $registrar */
+		$registrar = $this->container->get( User_Primitive_Registrar::class );
+		$registrar->sync();
+
+		/** @var Token_Registry $registry */
+		$registry = $this->container->get( Token_Registry::class );
+		$schema   = $registry->to_ui_schema();
+
+		$this->assertArrayHasKey( 'Spacing', $schema['groups'] );
+
+		$found = null;
+
+		foreach ( $schema['groups']['Spacing'] as $entry ) {
+			if ( $id === $entry['id'] ) {
+				$found = $entry;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $found, 'The grouped custom token must appear in the declared "Spacing" UI-schema group.' );
+		$this->assertTrue( $found['userCreated'] );
+	}
+
+	/**
 	 * A slug naming no known library is rejected with a 404, mirroring Documents_Controller and
 	 * Active_Token_Library_Controller rather than silently substituting a different library's
 	 * data for the one requested.


### PR DESCRIPTION
Builds the **Spacing** screen of the Style Library. Targets the Border Width branch; the four scale screens were implemented as one linear chain.

The thinnest of the four — the spacing scale is the only one already declared, so this is a config, a preview renderer, a screen registration, and a single line of PHP.

## What it adds

- `components/pages/SpacingScreen.js` / `.scss` — the config and a filled preview square sized to the token's value.
- `declarations.php` — adds `group_key: 'spacing'` to the **existing** spacing declaration block. No new declarations, no `baseline.json` edit, and no change to any declared value or slug.

That last point is deliberate: each declared spacing step drives a `--global-kb-spacing-<slug>` custom property that existing block content already consumes, so this screen edits values real content depends on. Nothing about the shipped scale changes here — only its editability.

## The preview

Rendered at true CSS size, with the row growing to contain it, so the scale reads as a scale. It is clamped at 96px, which is where the mock's largest render sits: 3XL, 4XL and 5XL pin at the same size rather than stretching the list, and a pathological custom value cannot blow up the page.

`ListRow` frames its preview slot at a fixed 5rem and documents that slot as per-screen overridable. The shared `ScaleScreen` root carries a `scale-screen--<config.id>` modifier class for exactly this, and the override is scoped on it rather than leaking into the shared row chrome.

## Verification

`phpstan` clean with no baseline changes; `phpcs`, `cspell` and `eslint` clean; the Design_Tokens suite green (1258 tests); the CSS BC snapshot suite green with no diffs, which is the assurance that the declaration change did not disturb existing output; 193 jest tests; build succeeds.

Checked in the browser: previews render at true size with rows growing, and the clamp holds — 3XL, 4XL and 5XL pin identically while XXL at 5rem is visibly smaller.

## Screenshots

**The screen**
<img width="1469" height="812" alt="screen" src="https://github.com/user-attachments/assets/aa565239-4a80-436c-ad3a-91860a5030f1" />