### PR TITLE
[DTM] SOFT-4081: Icon Sizes screen

### DIFF
--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -98,6 +98,27 @@ $border_width_tokens = array_map(
 	$border_width_slugs
 );
 
+// The icon-size scale steps are primitives the Style Library's Icon Sizes screen lists and edits
+// directly (semantic.icon-size.default already carries the projection that delivers the "md" step
+// into the icon block and the button's icon size, so the scale declares none of its own). group_key
+// mirrors the radius/border-width scales' mechanism above: it is the stable machine id "+ Add Icon
+// Size" mints custom tokens into, resolved back to the group label at read time by
+// Token_Registry::group_label_for().
+$icon_size_slugs = [ 'sm', 'md', 'lg' ];
+
+$icon_size_tokens = array_map(
+	static function ( string $slug ): array {
+		return [
+			'id'        => 'primitive.dimension.icon-size.' . $slug,
+			'type'      => 'dimension',
+			'label'     => strtoupper( $slug ),
+			'group'     => __( 'Icon Sizes', 'kadence-blocks' ),
+			'group_key' => 'icon-sizes',
+		];
+	},
+	$icon_size_slugs
+);
+
 // The fluid font-size scale steps are primitives (the slug IS a scale step), each holding the shipped
 // clamp() value from includes/init.php and claiming the Kadence Blocks font-size slug it backs
 // (class-kadence-blocks-css.php): the Css_Var builder redefines --global-kb-font-size-<slug> as the
@@ -363,7 +384,8 @@ return [
 		$gap_tokens,
 		$font_size_primitive_tokens,
 		$radius_tokens,
-		$border_width_tokens
+		$border_width_tokens,
+		$icon_size_tokens
 	),
 	/**
 	 * Preset bindings for the Button block: that it accepts presets, plus the per-property bindings (a

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -88,6 +88,27 @@ $border_width_tokens = array_map(
 	$border_width_slugs
 );
 
+// The icon-size scale steps are primitives the Style Library's Icon Sizes screen lists and edits
+// directly (semantic.icon-size.default already carries the projection that delivers the "md" step
+// into the icon block and the button's icon size, so the scale declares none of its own). group_key
+// mirrors the radius/border-width scales' mechanism above: it is the stable machine id "+ Add Icon
+// Size" mints custom tokens into, resolved back to the group label at read time by
+// Token_Registry::group_label_for().
+$icon_size_slugs = [ 'sm', 'md', 'lg' ];
+
+$icon_size_tokens = array_map(
+	static function ( string $slug ): array {
+		return [
+			'id'        => 'primitive.dimension.icon-size.' . $slug,
+			'type'      => 'dimension',
+			'label'     => strtoupper( $slug ),
+			'group'     => __( 'Icon Sizes', 'kadence-blocks' ),
+			'group_key' => 'icon-sizes',
+		];
+	},
+	$icon_size_slugs
+);
+
 // The fluid font-size scale steps are primitives (the slug IS a scale step), each holding the shipped
 // clamp() value from includes/init.php and claiming the Kadence Blocks font-size slug it backs
 // (class-kadence-blocks-css.php): the Css_Var builder redefines --global-kb-font-size-<slug> as the
@@ -352,7 +373,8 @@ return [
 		$gap_tokens,
 		$font_size_primitive_tokens,
 		$radius_tokens,
-		$border_width_tokens
+		$border_width_tokens,
+		$icon_size_tokens
 	),
 	/**
 	 * Preset bindings for the Button block: that it accepts presets, plus the per-property bindings (a

--- a/src/style-library/__tests__/icon-sizes.test.js
+++ b/src/style-library/__tests__/icon-sizes.test.js
@@ -1,0 +1,18 @@
+/* eslint-env jest */
+import { iconSizeRowValue } from '../helpers/icon-sizes';
+
+describe('iconSizeRowValue', () => {
+	it('formats a stored value as "<value> x <value>"', () => {
+		expect(iconSizeRowValue('1rem')).toBe('1rem x 1rem');
+	});
+
+	it('passes the stored string through verbatim on both sides (no unit conversion)', () => {
+		expect(iconSizeRowValue('24px')).toBe('24px x 24px');
+	});
+
+	it('returns an empty string for an empty, null, or undefined value', () => {
+		expect(iconSizeRowValue('')).toBe('');
+		expect(iconSizeRowValue(null)).toBe('');
+		expect(iconSizeRowValue(undefined)).toBe('');
+	});
+});

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -24,6 +24,7 @@ import { PlaceholderScreen } from '../components/pages/PlaceholderScreen';
 import { BorderRadiusScreen } from '../components/pages/BorderRadiusScreen';
 import { BorderWidthScreen } from '../components/pages/BorderWidthScreen';
 import { SpacingScreen } from '../components/pages/SpacingScreen';
+import { IconSizesScreen } from '../components/pages/IconSizesScreen';
 import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
 import { useLibraries } from '../hooks/use-libraries';
@@ -44,6 +45,7 @@ const SCREEN_COMPONENTS = {
 	'border-radius': BorderRadiusScreen,
 	'border-width': BorderWidthScreen,
 	spacing: SpacingScreen,
+	'icon-sizes': IconSizesScreen,
 };
 
 /**

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -23,6 +23,7 @@ import { ColorPaletteScreen } from '../components/pages/ColorPaletteScreen';
 import { BorderRadiusScreen } from '../components/pages/BorderRadiusScreen';
 import { BorderWidthScreen } from '../components/pages/BorderWidthScreen';
 import { SpacingScreen } from '../components/pages/SpacingScreen';
+import { IconSizesScreen } from '../components/pages/IconSizesScreen';
 import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
 import { useLibraries } from '../hooks/use-libraries';
@@ -41,6 +42,7 @@ const SCREEN_COMPONENTS = {
 	'color-palette': ColorPaletteScreen,
 	'border-width': BorderWidthScreen,
 	spacing: SpacingScreen,
+	'icon-sizes': IconSizesScreen,
 };
 
 /**

--- a/src/style-library/components/pages/IconSizesScreen.js
+++ b/src/style-library/components/pages/IconSizesScreen.js
@@ -1,7 +1,7 @@
 /**
  * The Icon Sizes screen: the scale config, the star preview renderer, and the two thin wrappers
- * that plug into the shared `ScaleScreen`/`ScaleSettings` contract (see
- * `.local/style-library-reference.md`). Two things make this screen genuinely different from its
+ * that plug into the shared `ScaleScreen`/`ScaleSettings` contract (see `ScaleScreen.js`'s module
+ * docblock). Two things make this screen genuinely different from its
  * siblings: the value column shows two dimensions for a one-dimension token (presentation-only,
  * via `iconSizeRowValue`), and the SIZE field restricts units to the ones
  * `Icon_Size_Adapter`'s px converter can actually round-trip.
@@ -23,8 +23,8 @@ import './IconSizesScreen.scss';
 /**
  * The full-bleed star preview for one row: a hand-authored path drawn to touch its `0 0 24 24`
  * viewBox's edges, sized inline to the row's own resolved value. A `@wordpress/icons` glyph is
- * deliberately not used here — those glyphs fill only a fraction of their declared viewBox (see
- * `.local/style-library-reference.md` section 15), and this preview's entire job is showing the
+ * deliberately not used here — those glyphs fill only a fraction of their declared viewBox, and
+ * this preview's entire job is showing the
  * icon *at the token's size*, which a partially-filled glyph would misrepresent. An empty or zero
  * value collapses the star — the honest rendering of what the value writes.
  *
@@ -49,8 +49,8 @@ function renderIconSizePreview(row) {
 }
 
 /**
- * The Icon Sizes screen's config — see `ScaleScreen`'s module docblock and
- * `.local/style-library-reference.md` for the full per-screen config contract.
+ * The Icon Sizes screen's config — see `ScaleScreen`'s module docblock for the full per-screen
+ * config contract.
  *
  * @since TBD
  */

--- a/src/style-library/components/pages/IconSizesScreen.js
+++ b/src/style-library/components/pages/IconSizesScreen.js
@@ -76,7 +76,6 @@ export const ICON_SIZES_CONFIG = {
 			{ value: 'em', label: 'em' },
 			{ value: 'rem', label: 'rem' },
 		],
-		responsive: true,
 	},
 	formatValue: (row) => iconSizeRowValue(row.value),
 	renderPreview: renderIconSizePreview,

--- a/src/style-library/components/pages/IconSizesScreen.js
+++ b/src/style-library/components/pages/IconSizesScreen.js
@@ -1,0 +1,111 @@
+/**
+ * The Icon Sizes screen: the scale config, the star preview renderer, and the two thin wrappers
+ * that plug into the shared `ScaleScreen`/`ScaleSettings` contract (see
+ * `.local/style-library-reference.md`). Two things make this screen genuinely different from its
+ * siblings: the value column shows two dimensions for a one-dimension token (presentation-only,
+ * via `iconSizeRowValue`), and the SIZE field restricts units to the ones
+ * `Icon_Size_Adapter`'s px converter can actually round-trip.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ScaleScreen } from './ScaleScreen';
+import { ScaleSettings } from './ScaleSettings';
+import { iconSizeRowValue } from '../../helpers/icon-sizes';
+import './IconSizesScreen.scss';
+
+/**
+ * The full-bleed star preview for one row: a hand-authored path drawn to touch its `0 0 24 24`
+ * viewBox's edges, sized inline to the row's own resolved value. A `@wordpress/icons` glyph is
+ * deliberately not used here — those glyphs fill only a fraction of their declared viewBox (see
+ * `.local/style-library-reference.md` section 15), and this preview's entire job is showing the
+ * icon *at the token's size*, which a partially-filled glyph would misrepresent. An empty or zero
+ * value collapses the star — the honest rendering of what the value writes.
+ *
+ * @param {{id: string, label: string, value: string, userCreated: boolean}} row The row descriptor.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The preview element.
+ */
+function renderIconSizePreview(row) {
+	return (
+		<svg
+			className="kadence-blocks-style-library__icon-size-preview"
+			viewBox="0 0 24 24"
+			style={{ width: row.value, height: row.value }}
+			aria-hidden="true"
+			focusable="false"
+		>
+			<path d="M12 0L14.69 8.29L23.41 8.29L16.36 13.42L19.05 21.71L12 16.58L4.95 21.71L7.64 13.42L0.59 8.29L9.31 8.29Z" />
+		</svg>
+	);
+}
+
+/**
+ * The Icon Sizes screen's config — see `ScaleScreen`'s module docblock and
+ * `.local/style-library-reference.md` for the full per-screen config contract.
+ *
+ * @since TBD
+ */
+export const ICON_SIZES_CONFIG = {
+	id: 'icon-sizes',
+	title: __('Icon Sizes', 'kadence-blocks'),
+	addLabel: __('Add Icon Size', 'kadence-blocks'),
+	group: __('Icon Sizes', 'kadence-blocks'),
+	groupKey: 'icon-sizes',
+	tokenType: 'dimension',
+	slugBase: 'icon-size',
+	newTokenLabel: __('New Icon Size', 'kadence-blocks'),
+	newTokenValue: '1.5rem',
+	// Restricted to the exact unit set `Converts_Number_To_Px::to_px()` accepts (px|rem|em) — a
+	// value outside this domain would silently decouple `kadence/single-icon`'s default `size`
+	// attribute from the token while every CSS-variable consumer kept following it, an
+	// undiagnosable split-brain the UI must not offer.
+	valueField: {
+		type: 'unit',
+		label: __('Size', 'kadence-blocks'),
+		units: [
+			{ value: 'px', label: 'px' },
+			{ value: 'em', label: 'em' },
+			{ value: 'rem', label: 'rem' },
+		],
+		responsive: true,
+	},
+	formatValue: (row) => iconSizeRowValue(row.value),
+	renderPreview: renderIconSizePreview,
+};
+
+/**
+ * The Icon Sizes screen body.
+ *
+ * @param {Object} props The props `ScaleScreen` accepts (`{ label, route, navigate, library }`).
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The screen.
+ */
+export function IconSizesScreen(props) {
+	return <ScaleScreen config={ICON_SIZES_CONFIG} {...props} />;
+}
+
+/**
+ * The Icon Sizes screen's settings panel.
+ *
+ * @param {Object} props The props `ScaleSettings` accepts (`{ route, navigate, library }`).
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The panel.
+ */
+function IconSizesSettings(props) {
+	return <ScaleSettings config={ICON_SIZES_CONFIG} {...props} />;
+}
+
+IconSizesScreen.SettingsPanel = IconSizesSettings;

--- a/src/style-library/components/pages/IconSizesScreen.scss
+++ b/src/style-library/components/pages/IconSizesScreen.scss
@@ -1,0 +1,21 @@
+// The star preview's own fill. Body-scoped `--kb-sl-*` custom properties (see
+// `.local/style-library-reference.md` section 3) so the `DragOverlay` portal, which renders
+// outside `.kadence-blocks-style-library-root`, still resolves the fill mid-drag.
+.kadence-blocks-style-library__icon-size-preview {
+	display: block;
+	fill: currentColor;
+	color: var(--kb-sl-color-gray-700);
+	// The mock's largest declared row (LG, 2.25rem/36px) sits well under this; the clamp only
+	// guards a pathological custom value (e.g. `50rem`) from making the row list hard to scan.
+	max-width: 3rem;
+	max-height: 3rem;
+}
+
+// Scoped to this screen via `ScaleScreen`'s per-screen root modifier class (see
+// `.local/style-library-reference.md`) — Border Radius and Border Width keep the default framed
+// 80px slot from `ListRow.scss`; Icon Sizes needs a bare star with no gray box around it, since
+// every declared star fits inside the slot's own 80px there is no need to unlock its dimensions.
+.kadence-blocks-style-library__scale-screen--icon-sizes .kadence-blocks-style-library__list-row-preview {
+	border: 0;
+	background: transparent;
+}

--- a/src/style-library/components/pages/IconSizesScreen.scss
+++ b/src/style-library/components/pages/IconSizesScreen.scss
@@ -5,10 +5,10 @@
 	display: block;
 	fill: currentColor;
 	color: var(--kb-sl-color-gray-700);
-	// The mock's largest declared row (LG, 2.25rem/36px) sits well under this; the clamp only
-	// guards a pathological custom value (e.g. `50rem`) from making the row list hard to scan.
-	max-width: 3rem;
-	max-height: 3rem;
+	// Unclamped on purpose: the preview must show a token's true CSS size, not a normalized
+	// approximation, so a custom icon size above the mock's largest declared step (LG, 2.25rem)
+	// still renders truthfully and the row grows to fit it. Accepted consequence: a very large
+	// custom value produces a very tall row.
 }
 
 // Scoped to this screen via `ScaleScreen`'s per-screen root modifier class (see

--- a/src/style-library/components/pages/IconSizesScreen.scss
+++ b/src/style-library/components/pages/IconSizesScreen.scss
@@ -1,6 +1,6 @@
-// The star preview's own fill. Body-scoped `--kb-sl-*` custom properties (see
-// `.local/style-library-reference.md` section 3) so the `DragOverlay` portal, which renders
-// outside `.kadence-blocks-style-library-root`, still resolves the fill mid-drag.
+// The star preview's own fill. Body-scoped `--kb-sl-*` custom properties (declared on the admin
+// page's body class, not on the app root) so the `DragOverlay` portal, which renders outside
+// `.kadence-blocks-style-library-root`, still resolves the fill mid-drag.
 .kadence-blocks-style-library__icon-size-preview {
 	display: block;
 	fill: currentColor;
@@ -11,8 +11,8 @@
 	// custom value produces a very tall row.
 }
 
-// Scoped to this screen via `ScaleScreen`'s per-screen root modifier class (see
-// `.local/style-library-reference.md`) — Border Radius and Border Width keep the default framed
+// Scoped to this screen via `ScaleScreen`'s per-screen root modifier class
+// (`--<config.id>`) — Border Radius and Border Width keep the default framed
 // 80px slot from `ListRow.scss`; Icon Sizes needs a bare star with no gray box around it, since
 // every declared star fits inside the slot's own 80px there is no need to unlock its dimensions.
 .kadence-blocks-style-library__scale-screen--icon-sizes .kadence-blocks-style-library__list-row-preview {

--- a/src/style-library/components/pages/IconSizesScreen.scss
+++ b/src/style-library/components/pages/IconSizesScreen.scss
@@ -19,3 +19,13 @@
 	border: 0;
 	background: transparent;
 }
+
+// `formatValue` (see IconSizesScreen.js) shows two dimensions (`N x N`), not the one `ListRow`'s
+// shared 6rem value column was sized for — the baseline scale's longest row ("2.25rem x 2.25rem",
+// 17 characters) wrapped onto two lines there. `ch` (not a fixed rem/px number) because the
+// column's own font is monospace (`ListRow.scss`), so `ch` tracks the actual glyph width; scoped
+// through the `scale-screen--icon-sizes` modifier so Border Radius/Border Width/Spacing, whose
+// values are short, keep the shared column width unchanged.
+.kadence-blocks-style-library__scale-screen--icon-sizes .kadence-blocks-style-library__list-row-value {
+	width: 19ch;
+}

--- a/src/style-library/constants/screens.js
+++ b/src/style-library/constants/screens.js
@@ -34,7 +34,6 @@ export const BASE_STYLES_SCREENS = [
 	{ id: 'border-radius', label: __('Border Radius', 'kadence-blocks') },
 	{ id: 'border-width', label: __('Border Width', 'kadence-blocks') },
 	{ id: 'spacing', label: __('Spacing', 'kadence-blocks') },
-	// @todo SOFT-4081: replace the placeholder with the Icon Sizes screen.
 	{ id: 'icon-sizes', label: __('Icon Sizes', 'kadence-blocks') },
 	// @todo SOFT-4082: replace the placeholder with the Shadow screen.
 	{ id: 'shadow', label: __('Shadow', 'kadence-blocks') },

--- a/src/style-library/constants/screens.js
+++ b/src/style-library/constants/screens.js
@@ -33,7 +33,6 @@ export const BASE_STYLES_SCREENS = [
 	{ id: 'border-radius', label: __('Border Radius', 'kadence-blocks') },
 	{ id: 'border-width', label: __('Border Width', 'kadence-blocks') },
 	{ id: 'spacing', label: __('Spacing', 'kadence-blocks') },
-	// @todo SOFT-4081: replace the placeholder with the Icon Sizes screen.
 	{ id: 'icon-sizes', label: __('Icon Sizes', 'kadence-blocks') },
 	// @todo SOFT-4082: replace the placeholder with the Shadow screen.
 	{ id: 'shadow', label: __('Shadow', 'kadence-blocks') },

--- a/src/style-library/helpers/icon-sizes.js
+++ b/src/style-library/helpers/icon-sizes.js
@@ -1,0 +1,25 @@
+/**
+ * The Icon Sizes screen's own pure formatting helper. The token stores one square dimension, but
+ * the board's row list shows two — the `N x N` display is presentation-only, kept out of
+ * `helpers/scale.js` because that file is shared contract surface owned by the base branch, while
+ * this formatter is Icon Sizes vocabulary.
+ */
+
+/**
+ * Format a stored icon-size dimension as the two-dimension string the row list shows, e.g.
+ * `'1rem'` becomes `'1rem x 1rem'`. The value is a single square dimension, so both sides of the
+ * `x` are the same stored string, verbatim — no unit conversion.
+ *
+ * @param {string} value The stored dimension value.
+ *
+ * @since TBD
+ *
+ * @return {string} The formatted `N x N` string, or an empty string for an empty/nullish value.
+ */
+export function iconSizeRowValue(value) {
+	if (!value) {
+		return '';
+	}
+
+	return `${value} x ${value}`;
+}

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -467,6 +467,123 @@ final class Feed_ControllerTest extends TestCase {
 	}
 
 	/**
+	 * The declared icon-size scale surfaces as its own feed group, in declaration order, with every
+	 * step's value resolved and no projections — the Icon Sizes screen's data source end to end.
+	 *
+	 * @return void
+	 */
+	public function testGetItemReturnsTheIconSizesScaleGroup(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', Token_Store::default_slug() );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$this->assertArrayHasKey( 'Icon Sizes', $data['schema']['groups'] );
+
+		$ids = array_column( $data['schema']['groups']['Icon Sizes'], 'id' );
+		$this->assertSame(
+			[
+				'primitive.dimension.icon-size.sm',
+				'primitive.dimension.icon-size.md',
+				'primitive.dimension.icon-size.lg',
+			],
+			$ids
+		);
+
+		foreach ( $data['schema']['groups']['Icon Sizes'] as $entry ) {
+			$this->assertSame( [], $entry['projections'], 'The declared icon-size scale carries no projections of its own.' );
+		}
+
+		$this->assertSame( '1rem', $data['values']['primitive.dimension.icon-size.sm'] );
+		$this->assertSame( '1.5rem', $data['values']['primitive.dimension.icon-size.md'] );
+		$this->assertSame( '2.25rem', $data['values']['primitive.dimension.icon-size.lg'] );
+	}
+
+	/**
+	 * `semantic.icon-size.default` keeps resolving through the "md" primitive after the scale is
+	 * declared — declaring the primitives for the Style Library screen must not disturb the alias
+	 * that already projects into the icon block and the button's icon size.
+	 *
+	 * @return void
+	 */
+	public function testSemanticIconSizeDefaultStillResolvesThroughTheMdPrimitive(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', Token_Store::default_slug() );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$this->assertSame(
+			$data['values']['primitive.dimension.icon-size.md'],
+			$data['values']['semantic.icon-size.default']
+		);
+	}
+
+	/**
+	 * A user-created token minted into the icon-sizes group (the stable key this ticket declares as
+	 * `group_key` alongside the newly declared icon-size scale) surfaces inside the declared
+	 * "Icon Sizes" UI-schema group and is flagged `userCreated`, exercising the shared group-key
+	 * backend against this screen's own key. Asserted against `Token_Registry::to_ui_schema()`
+	 * directly — the same surface `DocumentsControllerOrderTest::testOrderIncludesAGroupedCustomToken`
+	 * checks for the sibling border-radius group — rather than through the REST controller, whose
+	 * resolved dependency chain can be constructed once and cached earlier in a suite run.
+	 *
+	 * @return void
+	 */
+	public function testUserPrimitiveGroupedIntoIconSizesSurfacesInItsFeedGroupAsUserCreated(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.dimension.custom.icon-size-2';
+
+		$document = (string) wp_json_encode(
+			[
+				'primitive'   => [
+					'dimension' => [
+						'custom' => [
+							'icon-size-2' => [
+								'$type'  => 'dimension',
+								'$value' => '3rem',
+							],
+						],
+					],
+				],
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'userPrimitives' => [
+							$id => [
+								'label' => 'New Icon Size',
+								'group' => 'icon-sizes',
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$this->store->save_document( $document, $slug );
+
+		/** @var User_Primitive_Registrar $registrar */
+		$registrar = $this->container->get( User_Primitive_Registrar::class );
+		$registrar->sync();
+
+		/** @var Token_Registry $registry */
+		$registry = $this->container->get( Token_Registry::class );
+		$schema   = $registry->to_ui_schema();
+
+		$this->assertArrayHasKey( 'Icon Sizes', $schema['groups'] );
+
+		$found = null;
+
+		foreach ( $schema['groups']['Icon Sizes'] as $entry ) {
+			if ( $id === $entry['id'] ) {
+				$found = $entry;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $found, 'The grouped custom token must appear in the declared "Icon Sizes" UI-schema group.' );
+		$this->assertTrue( $found['userCreated'] );
+	}
+
+	/**
 	 * A slug naming no known library is rejected with a 404, mirroring Documents_Controller and
 	 * Active_Token_Library_Controller rather than silently substituting a different library's
 	 * data for the one requested.

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -471,6 +471,123 @@ final class Feed_ControllerTest extends TestCase {
 	}
 
 	/**
+	 * The declared icon-size scale surfaces as its own feed group, in declaration order, with every
+	 * step's value resolved and no projections — the Icon Sizes screen's data source end to end.
+	 *
+	 * @return void
+	 */
+	public function testGetItemReturnsTheIconSizesScaleGroup(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', Token_Store::default_slug() );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$this->assertArrayHasKey( 'Icon Sizes', $data['schema']['groups'] );
+
+		$ids = array_column( $data['schema']['groups']['Icon Sizes'], 'id' );
+		$this->assertSame(
+			[
+				'primitive.dimension.icon-size.sm',
+				'primitive.dimension.icon-size.md',
+				'primitive.dimension.icon-size.lg',
+			],
+			$ids
+		);
+
+		foreach ( $data['schema']['groups']['Icon Sizes'] as $entry ) {
+			$this->assertSame( [], $entry['projections'], 'The declared icon-size scale carries no projections of its own.' );
+		}
+
+		$this->assertSame( '1rem', $data['values']['primitive.dimension.icon-size.sm'] );
+		$this->assertSame( '1.5rem', $data['values']['primitive.dimension.icon-size.md'] );
+		$this->assertSame( '2.25rem', $data['values']['primitive.dimension.icon-size.lg'] );
+	}
+
+	/**
+	 * `semantic.icon-size.default` keeps resolving through the "md" primitive after the scale is
+	 * declared — declaring the primitives for the Style Library screen must not disturb the alias
+	 * that already projects into the icon block and the button's icon size.
+	 *
+	 * @return void
+	 */
+	public function testSemanticIconSizeDefaultStillResolvesThroughTheMdPrimitive(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', Token_Store::default_slug() );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$this->assertSame(
+			$data['values']['primitive.dimension.icon-size.md'],
+			$data['values']['semantic.icon-size.default']
+		);
+	}
+
+	/**
+	 * A user-created token minted into the icon-sizes group (the stable key this ticket declares as
+	 * `group_key` alongside the newly declared icon-size scale) surfaces inside the declared
+	 * "Icon Sizes" UI-schema group and is flagged `userCreated`, exercising the shared group-key
+	 * backend against this screen's own key. Asserted against `Token_Registry::to_ui_schema()`
+	 * directly — the same surface `DocumentsControllerOrderTest::testOrderIncludesAGroupedCustomToken`
+	 * checks for the sibling border-radius group — rather than through the REST controller, whose
+	 * resolved dependency chain can be constructed once and cached earlier in a suite run.
+	 *
+	 * @return void
+	 */
+	public function testUserPrimitiveGroupedIntoIconSizesSurfacesInItsFeedGroupAsUserCreated(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.dimension.custom.icon-size-2';
+
+		$document = (string) wp_json_encode(
+			[
+				'primitive'   => [
+					'dimension' => [
+						'custom' => [
+							'icon-size-2' => [
+								'$type'  => 'dimension',
+								'$value' => '3rem',
+							],
+						],
+					],
+				],
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'userPrimitives' => [
+							$id => [
+								'label' => 'New Icon Size',
+								'group' => 'icon-sizes',
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$this->store->save_document( $document, $slug );
+
+		/** @var User_Primitive_Registrar $registrar */
+		$registrar = $this->container->get( User_Primitive_Registrar::class );
+		$registrar->sync();
+
+		/** @var Token_Registry $registry */
+		$registry = $this->container->get( Token_Registry::class );
+		$schema   = $registry->to_ui_schema();
+
+		$this->assertArrayHasKey( 'Icon Sizes', $schema['groups'] );
+
+		$found = null;
+
+		foreach ( $schema['groups']['Icon Sizes'] as $entry ) {
+			if ( $id === $entry['id'] ) {
+				$found = $entry;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $found, 'The grouped custom token must appear in the declared "Icon Sizes" UI-schema group.' );
+		$this->assertTrue( $found['userCreated'] );
+	}
+
+	/**
 	 * A slug naming no known library is rejected with a 404, mirroring Documents_Controller and
 	 * Active_Token_Library_Controller rather than silently substituting a different library's
 	 * data for the one requested.


### PR DESCRIPTION
Builds the **Icon Sizes** screen of the Style Library, the last of the four scale screens. Targets the Spacing branch.

## What it adds

- `components/pages/IconSizesScreen.js` / `.scss` — the config and a star preview scaled to the token's size.
- `helpers/icon-sizes.js` + jest suite — the pure `N x N` value formatter.
- `declarations.php` — declares `primitive.dimension.icon-size.{sm,md,lg}` under an `Icon Sizes` group with `group_key: 'icon-sizes'`. The baseline already ships 1rem/1.5rem/2.25rem, so `baseline.json` is untouched.

## Three things specific to this screen

**The `N x N` column is presentation only.** The baseline stores one square dimension; rendering it as `1.5rem x 1.5rem` is formatting, not a second stored value. It goes through the shared contract's optional `formatValue` config key, implemented as a pure exported helper — the one genuinely testable piece here, and the only sibling adding a jest suite.

**No slider, which is a known departure from the board.** The mock pairs the number and unit with a slider, but neither existing field can carry it. `RangeNumberField` feeds `Number( value )` a dimension string, so `'1.5rem'` becomes `NaN`, and it emits bare numbers with 0–100 default bounds. `NumberUnitField`'s `withRange` does render a `RangeControl` beside the input, but it also stores bare numbers and pins one fixed unit rather than offering a choice. Neither can round-trip a dimension string, so the SIZE field is `unit`/`UnitField` like its siblings. Reworking a hybrid field to traffic in unit strings is a field-library change, not this ticket.

**Units are restricted to `px` / `em` / `rem`.** `Icon_Size_Adapter` overlays `kadence/single-icon`'s size attribute through `Converts_Number_To_Px::to_px()`, whose pattern matches only those three and returns null otherwise. A `%` or viewport unit would silently decouple icon blocks from the token while CSS-variable consumers kept following it — a split that would be very hard to diagnose from the UI.

The preview uses a hand-authored full-bleed star SVG rather than a stock glyph, because `@wordpress/icons` glyphs under-fill their viewBox and would misrepresent the size the token actually describes.

## The adapter is unaffected

Worth stating explicitly, since that adapter feeds a real block's default: declaring these primitives changed no adapter behavior and no snapshot output. The adapter reads `semantic.icon-size.default`, whose alias to the `md` primitive already existed; declaring them only makes them visible and editable. `Icon_Size_AdapterTest` (including its real-filter-chain and real-render-path cases), `Icon_Size_ResolutionTest`, and the CSS snapshot and token-emission suites all pass unchanged.

## Verification

`phpstan` clean with no baseline changes; `phpcs`, `cspell` and `eslint` clean; the Design_Tokens suite green (1261 tests); snapshot suites with no diffs; 196 jest tests; build succeeds.

Checked in the browser: SM/MD/LG render as `1rem x 1rem`, `1.5rem x 1.5rem` and `2.25rem x 2.25rem` with correctly scaled stars.

## Screenshots

**The screen**
<img width="1568" height="461" alt="screen" src="https://github.com/user-attachments/assets/655f51e2-0cc4-4574-b8fe-8330ba19e64c" />