### PR TITLE
[DTM] SOFT-4150: Live preview and unsaved-changes guard

### DIFF
--- a/src/style-library/__tests__/scale.test.js
+++ b/src/style-library/__tests__/scale.test.js
@@ -3,6 +3,7 @@ import {
 	applyRowOrder,
 	customScaleTokenId,
 	nextScaleSlug,
+	overlayDraft,
 	scaleInitialValues,
 	scaleRows,
 	scaleValueField,
@@ -153,5 +154,54 @@ describe('scaleValueField', () => {
 			path: 'value',
 			responsive: false,
 		});
+	});
+});
+
+describe('overlayDraft', () => {
+	const rows = [
+		{ id: 'a', label: 'A', value: '1px', userCreated: false },
+		{ id: 'b', label: 'B', value: '2px', userCreated: true },
+	];
+
+	it('returns the same array reference for a null draft', () => {
+		expect(overlayDraft(rows, 'a', null)).toBe(rows);
+	});
+
+	it('returns the same array reference when the itemId matches no row', () => {
+		expect(overlayDraft(rows, 'ghost', { label: 'X', value: '9px' })).toBe(rows);
+	});
+
+	it('overlays label and value verbatim on the matching row only', () => {
+		const next = overlayDraft(rows, 'a', { label: 'A edited', value: '3px' });
+
+		expect(next[0]).toEqual({ id: 'a', label: 'A edited', value: '3px', userCreated: false });
+		expect(next[1]).toBe(rows[1]);
+	});
+
+	it('overlays an empty string rather than falling back to the saved value', () => {
+		const next = overlayDraft(rows, 'a', { label: '', value: '' });
+
+		expect(next[0].label).toBe('');
+		expect(next[0].value).toBe('');
+	});
+
+	it('preserves id and userCreated on the overlaid row', () => {
+		const next = overlayDraft(rows, 'b', { label: 'B edited', value: '5px' });
+
+		expect(next[1].id).toBe('b');
+		expect(next[1].userCreated).toBe(true);
+	});
+
+	it("keeps every non-matching row's object identity", () => {
+		const next = overlayDraft(rows, 'a', { label: 'A edited', value: '3px' });
+
+		expect(next[1]).toBe(rows[1]);
+	});
+
+	it("leaves a key absent from the draft at the row's own value", () => {
+		const next = overlayDraft(rows, 'a', { label: 'A edited' });
+
+		expect(next[0].label).toBe('A edited');
+		expect(next[0].value).toBe('1px');
 	});
 });

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -18,6 +18,7 @@ import { LibrarySelector } from '../components/organisms/LibrarySelector';
 import { ActivateLibraryButton } from '../components/organisms/ActivateLibraryButton';
 import { RenameLibraryModal } from '../components/organisms/RenameLibraryModal';
 import { DeleteLibraryModal } from '../components/organisms/DeleteLibraryModal';
+import { UnsavedChangesModal } from '../components/organisms/UnsavedChangesModal';
 import { PlaceholderScreen } from '../components/pages/PlaceholderScreen';
 import { ColorPaletteScreen } from '../components/pages/ColorPaletteScreen';
 import { BorderRadiusScreen } from '../components/pages/BorderRadiusScreen';
@@ -28,6 +29,7 @@ import { ShadowScreen } from '../components/pages/ShadowScreen';
 import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
 import { useLibraries } from '../hooks/use-libraries';
+import { DraftChannelContext, useDraftChannelState } from '../hooks/use-draft-channel';
 import { DEFAULT_SCREEN_ID } from '../constants/screens';
 import { buildBaseStylesNav, buildBlockPresetsNav, resolveScreen } from '../helpers/screens';
 import { libraryDisplayTitle } from '../helpers/libraries';
@@ -64,6 +66,11 @@ export function StyleLibraryApp() {
 	const feed = useDesignTokensFeed();
 	const { route, navigate, replace } = useStyleLibraryRoute();
 	const libraries = useLibraries(feed.feed, feed.refreshFeed);
+
+	// The draft channel (see `hooks/use-draft-channel.js`): built here because this is the one
+	// component that already renders both the screen and its settings-panel slot, so it is the only
+	// place a provider for the two of them can live.
+	const channel = useDraftChannelState();
 
 	const baseStylesNav = useMemo(() => buildBaseStylesNav(), []);
 	const blockPresetsNav = useMemo(() => buildBlockPresetsNav(feed.feed), [feed.feed]);
@@ -112,7 +119,9 @@ export function StyleLibraryApp() {
 	// `scope` is the PREVIOUS screen's own sub-selection (Color Palette's is a palette id) — it
 	// must be cleared on every screen switch alongside `item`, or it leaks onto a screen with no
 	// idea what to do with it (e.g. a palette id showing up in Typography's URL).
-	const onNavigate = (id) => navigate({ screen: id, scope: '', item: '' });
+	// Screen switching loses the open draft exactly like closing the panel (the settings-panel slot
+	// unmounts either way), so it is guarded identically.
+	const onNavigate = (id) => channel.guard(() => navigate({ screen: id, scope: '', item: '' }));
 
 	// Two different libraries are named in the header: the one being edited (the selector's value,
 	// and the target of rename/delete/activate) and the one the site renders with (named in the
@@ -142,75 +151,86 @@ export function StyleLibraryApp() {
 	);
 
 	return (
-		<AppShell
-			isBlocked={libraries.isSwappingLibrary}
-			header={
-				<AppHeader
-					librarySlot={
-						<LibrarySelector
-							libraries={libraries.libraries}
-							activeSlug={libraries.activeSlug}
-							editingSlug={libraries.editingSlug}
-							editingTitle={editingTitle}
-							isBusy={libraries.isBusy}
-							isSwapping={libraries.isSwappingLibrary}
-							openError={libraries.openError}
-							createError={libraries.createError}
-							onOpen={libraries.openLibrary}
-							onCreate={libraries.createLibrary}
-							onClearOpenError={libraries.clearOpenError}
-							onClearCreateError={libraries.clearCreateError}
-						/>
-					}
-					actionsSlot={
-						<>
-							<ActivateLibraryButton
-								editingSlug={libraries.editingSlug}
-								editingTitle={editingTitle}
-								activeTitle={activeTitle}
-								isEditingActive={libraries.isEditingActive}
-								isBusy={libraries.isBusy}
-								error={libraries.activateError}
-								onClearError={libraries.clearActivateError}
-								onActivate={libraries.activateLibrary}
-							/>
-							<RenameLibraryModal
-								slug={libraries.editingSlug}
-								currentTitle={editingTitle}
+		<DraftChannelContext.Provider value={channel}>
+			<AppShell
+				isBlocked={libraries.isSwappingLibrary}
+				header={
+					<AppHeader
+						librarySlot={
+							<LibrarySelector
 								libraries={libraries.libraries}
-								isBusy={libraries.isBusy}
-								error={libraries.renameError}
-								onClearError={libraries.clearRenameError}
-								onRename={libraries.renameLibrary}
-							/>
-							<DeleteLibraryModal
-								editingSlug={libraries.editingSlug}
-								editingTitle={editingTitle}
 								activeSlug={libraries.activeSlug}
-								libraries={libraries.libraries}
+								editingSlug={libraries.editingSlug}
+								editingTitle={editingTitle}
 								isBusy={libraries.isBusy}
-								error={libraries.deleteError}
-								onClearError={libraries.clearDeleteError}
-								onDelete={libraries.deleteLibrary}
+								isSwapping={libraries.isSwappingLibrary}
+								openError={libraries.openError}
+								createError={libraries.createError}
+								onOpen={libraries.openLibrary}
+								onCreate={libraries.createLibrary}
+								onClearOpenError={libraries.clearOpenError}
+								onClearCreateError={libraries.clearCreateError}
 							/>
-						</>
-					}
-				/>
-			}
-			sidebar={
-				<AppSidebar
-					baseStylesNav={baseStylesNav}
-					blockPresetsNav={blockPresetsNav}
-					activeId={activeScreenId}
-					onNavigate={onNavigate}
-				/>
-			}
-			content={<resolution.Component label={label} route={route} navigate={navigate} library={feed} />}
-			settingsPanel={
-				resolution.Component.SettingsPanel && route.item ? (
-					<resolution.Component.SettingsPanel route={route} navigate={navigate} library={feed} />
-				) : null
-			}
-		/>
+						}
+						actionsSlot={
+							<>
+								<ActivateLibraryButton
+									editingSlug={libraries.editingSlug}
+									editingTitle={editingTitle}
+									activeTitle={activeTitle}
+									isEditingActive={libraries.isEditingActive}
+									isBusy={libraries.isBusy}
+									error={libraries.activateError}
+									onClearError={libraries.clearActivateError}
+									onActivate={libraries.activateLibrary}
+								/>
+								<RenameLibraryModal
+									slug={libraries.editingSlug}
+									currentTitle={editingTitle}
+									libraries={libraries.libraries}
+									isBusy={libraries.isBusy}
+									error={libraries.renameError}
+									onClearError={libraries.clearRenameError}
+									onRename={libraries.renameLibrary}
+								/>
+								<DeleteLibraryModal
+									editingSlug={libraries.editingSlug}
+									editingTitle={editingTitle}
+									activeSlug={libraries.activeSlug}
+									libraries={libraries.libraries}
+									isBusy={libraries.isBusy}
+									error={libraries.deleteError}
+									onClearError={libraries.clearDeleteError}
+									onDelete={libraries.deleteLibrary}
+								/>
+							</>
+						}
+					/>
+				}
+				sidebar={
+					<AppSidebar
+						baseStylesNav={baseStylesNav}
+						blockPresetsNav={blockPresetsNav}
+						activeId={activeScreenId}
+						onNavigate={onNavigate}
+					/>
+				}
+				content={<resolution.Component label={label} route={route} navigate={navigate} library={feed} />}
+				settingsPanel={
+					resolution.Component.SettingsPanel && route.item ? (
+						<resolution.Component.SettingsPanel route={route} navigate={navigate} library={feed} />
+					) : null
+				}
+			/>
+			<UnsavedChangesModal
+				isOpen={channel.isGuardOpen}
+				label={channel.publication?.label}
+				isBusy={channel.isGuardBusy}
+				error={channel.guardError}
+				onSave={channel.confirmSave}
+				onDiscard={channel.confirmDiscard}
+				onCancel={channel.cancelGuard}
+			/>
+		</DraftChannelContext.Provider>
 	);
 }

--- a/src/style-library/components/organisms/UnsavedChangesModal.js
+++ b/src/style-library/components/organisms/UnsavedChangesModal.js
@@ -1,0 +1,86 @@
+/**
+ * The unsaved-changes guard's confirmation modal: presentational only. All state — whether it is
+ * open, whether a Save is in flight, and the last Save failure — lives in the draft channel
+ * (`hooks/use-draft-channel.js`); this component only renders it and reports button clicks back.
+ * Shaped after `DeleteLibraryModal`: an error `Notice` above the body, tertiary Cancel + destructive
+ * secondary + primary confirm in the actions row, a progressive pending label instead of a spinner,
+ * and every dismiss path gated off while busy.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button, Modal, Notice } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './UnsavedChangesModal.scss';
+
+/**
+ * Render the unsaved-changes confirmation modal.
+ *
+ * @param {Object}             props           The component props.
+ * @param {boolean}            props.isOpen    Whether a guarded action is parked and the modal
+ *                                              should render.
+ * @param {string}             props.label     The open token's saved display label (not the draft
+ *                                              label — a mid-edit or emptied name must not produce
+ *                                              "unsaved changes to ''").
+ * @param {boolean}            props.isBusy    Whether the modal's Save is in flight.
+ * @param {?{message: string}} props.error     The last modal-Save failure, if any.
+ * @param {Function}           props.onSave    Commits the draft, then completes the parked action.
+ * @param {Function}           props.onDiscard Reverts the draft, then completes the parked action.
+ * @param {Function}           props.onCancel  Drops the parked action; the dirty draft stays.
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The modal, or `null` while closed.
+ */
+export function UnsavedChangesModal({ isOpen, label, isBusy, error, onSave, onDiscard, onCancel }) {
+	if (!isOpen) {
+		return null;
+	}
+
+	const body = label
+		? sprintf(
+				// translators: %s: the token's saved display label.
+				__(
+					"You have unsaved changes to '%s'. Save them, or discard them to go back to the saved values.",
+					'kadence-blocks'
+				),
+				label
+			)
+		: __('You have unsaved changes. Save them, or discard them to go back to the saved values.', 'kadence-blocks');
+
+	return (
+		<Modal
+			title={__('Unsaved Changes', 'kadence-blocks')}
+			className="kadence-blocks-style-library__unsaved-changes-modal"
+			onRequestClose={onCancel}
+			// Locked while pending, the same as `DeleteLibraryModal`: a dismissal mid-Save must not
+			// let the user walk away from (or re-trigger) a request that is still in flight.
+			isDismissible={!isBusy}
+			shouldCloseOnEsc={!isBusy}
+			shouldCloseOnClickOutside={!isBusy}
+		>
+			{error && (
+				<Notice status="error" isDismissible={false}>
+					{error.message}
+				</Notice>
+			)}
+			<p>{body}</p>
+			<div className="kadence-blocks-style-library__unsaved-changes-modal-actions">
+				<Button variant="tertiary" onClick={onCancel} disabled={isBusy}>
+					{__('Cancel', 'kadence-blocks')}
+				</Button>
+				<Button variant="secondary" isDestructive onClick={onDiscard} disabled={isBusy}>
+					{__('Discard', 'kadence-blocks')}
+				</Button>
+				<Button variant="primary" onClick={onSave} disabled={isBusy}>
+					{isBusy ? __('Saving…', 'kadence-blocks') : __('Save', 'kadence-blocks')}
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/src/style-library/components/organisms/UnsavedChangesModal.scss
+++ b/src/style-library/components/organisms/UnsavedChangesModal.scss
@@ -1,0 +1,13 @@
+// Capped to the same step as the delete/activation modals, so the body copy wraps as a paragraph
+// rather than stretching to the viewport width. See DeleteLibraryModal.scss for why the selector is
+// compound.
+.components-modal__frame.kadence-blocks-style-library__unsaved-changes-modal {
+	max-width: var(--kb-sl-size-modal-medium);
+}
+
+.kadence-blocks-style-library__unsaved-changes-modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: var(--kb-sl-space-10);
+	margin-top: var(--kb-sl-space-20);
+}

--- a/src/style-library/components/pages/ScaleScreen.js
+++ b/src/style-library/components/pages/ScaleScreen.js
@@ -35,6 +35,8 @@ import { ScreenHeader } from '../organisms/ScreenHeader';
 import { RowList } from '../templates/RowList';
 import { EmptyState } from '../molecules/EmptyState';
 import { useScaleScreen } from '../../hooks/use-scale-screen';
+import { useDraftChannel } from '../../hooks/use-draft-channel';
+import { overlayDraft } from '../../helpers/scale';
 
 /**
  * Render a scale screen's body.
@@ -52,25 +54,48 @@ import { useScaleScreen } from '../../hooks/use-scale-screen';
  */
 export function ScaleScreen({ config, route, navigate, library }) {
 	const scale = useScaleScreen(config, library, route, navigate);
+	const channel = useDraftChannel();
 
+	// A null channel (no `DraftChannelContext.Provider` mounted) degrades to today's direct calls —
+	// keeps this screen usable in isolation, e.g. the dev gallery.
+	const mintToken = () => scale.addToken().then((id) => navigate({ item: id }));
 	const addAction = (
 		<Button
 			icon={plus}
 			variant="secondary"
 			disabled={scale.isBusy}
-			onClick={() => scale.addToken().then((id) => navigate({ item: id }))}
+			onClick={() => (channel ? channel.guard(mintToken) : mintToken())}
 		>
 			{config.addLabel}
 		</Button>
 	);
 
-	const items = scale.rows.map((row) => ({
+	// Strictly keyed to the open route item: a publication from a panel editing a different token
+	// (or one that already unmounted) can never leak onto this screen's rows.
+	const draft =
+		channel && channel.publication && channel.publication.itemId === route.item ? channel.publication.draft : null;
+	const rows = overlayDraft(scale.rows, route.item, draft);
+
+	const items = rows.map((row) => ({
 		id: row.id,
 		label: row.label,
 		value: config.formatValue ? config.formatValue(row) : row.value,
 		preview: config.renderPreview(row),
 		isDraggable: true,
 	}));
+
+	// Selecting the already-open token is a no-op (the draft survives — `useSettingsPanel` only
+	// re-seeds on itemId change) so it must bypass the guard entirely; prompting for a click that
+	// changes nothing would be pure friction.
+	const selectToken = (id) => {
+		if (id === route.item) {
+			return;
+		}
+
+		const run = () => scale.selectToken(id);
+
+		channel ? channel.guard(run) : run();
+	};
 
 	return (
 		<div
@@ -90,7 +115,7 @@ export function ScaleScreen({ config, route, navigate, library }) {
 			<RowList
 				items={items}
 				selectedId={scale.selectedId}
-				onSelect={scale.selectToken}
+				onSelect={selectToken}
 				onReorder={scale.reorderTokens}
 				empty={<EmptyState title={config.title} description={config.addLabel} action={addAction} />}
 			/>

--- a/src/style-library/components/pages/ScaleSettings.js
+++ b/src/style-library/components/pages/ScaleSettings.js
@@ -20,6 +20,7 @@ import { SettingsPanel } from '../templates/SettingsPanel';
 import { SettingsForm } from '../organisms/SettingsForm';
 import { useSettingsPanel } from '../../hooks/use-settings-panel';
 import { useScaleScreen } from '../../hooks/use-scale-screen';
+import { useDraftChannel } from '../../hooks/use-draft-channel';
 import { isDeletable } from '../../helpers/token-capabilities';
 import { scaleValueField } from '../../helpers/scale';
 
@@ -38,6 +39,7 @@ import { scaleValueField } from '../../helpers/scale';
  */
 export function ScaleSettings({ config, route, navigate, library }) {
 	const scale = useScaleScreen(config, library, route, navigate);
+	const channel = useDraftChannel();
 	const id = route.item;
 	const token = scale.tokenById(id);
 	const initialValues = scale.initialValuesFor(id);
@@ -51,6 +53,33 @@ export function ScaleSettings({ config, route, navigate, library }) {
 			navigate({ item: '' });
 		}
 	}, [id, token, navigate]);
+
+	// Publishes the live draft on every change (including each keystroke) and wipes it on cleanup —
+	// which fires both on unmount and on the next publish, so a stale-item self-heal or an item
+	// switch never leaves a dangling publication behind. Only this panel ever publishes; the screen
+	// is read-only on the channel, and the app structure guarantees a single mounted panel.
+	useEffect(() => {
+		if (!channel || !id || !token) {
+			return undefined;
+		}
+
+		channel.publish({ itemId: id, label: token.label, draft: panel.draft, isDirty: panel.isDirty });
+
+		return () => channel.clearPublication();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [channel, id, token, panel.draft, panel.isDirty]);
+
+	// Reassigned every render, never held in state (decision 10b in the plan): these close over the
+	// current `panel.draft`, so storing them in state would either loop the publish effect above
+	// (new identity every render) or hand the guard modal a stale draft. `save` is the raw promise,
+	// re-thrown rejection and all — the modal's own Save button is the one place that needs to see a
+	// failure, unlike the panel's own Save button below, which swallows it into `scale.saveError`.
+	if (channel) {
+		channel.actionsRef.current = {
+			save: () => scale.saveToken(id, panel.draft, initialValues),
+			discard: panel.resetDraft,
+		};
+	}
 
 	if (!id || !token) {
 		return null;
@@ -77,9 +106,14 @@ export function ScaleSettings({ config, route, navigate, library }) {
 			.catch(() => {});
 	};
 
+	// Delete is deliberately never guarded: destroying the token makes its draft moot, so prompting
+	// "save your changes?" about a token the user just chose to delete would be nonsense — this
+	// keeps calling `handleDelete` (and, through it, the raw `navigate({ item: '' })`) directly.
+	const handleClose = () => (channel ? channel.guard(panel.close) : panel.close());
+
 	return (
 		<SettingsPanel
-			onClose={panel.close}
+			onClose={handleClose}
 			onDelete={isDeletable(token) ? handleDelete : null}
 			onSave={handleSave}
 			isDirty={panel.isDirty}

--- a/src/style-library/components/pages/ScaleSettings.js
+++ b/src/style-library/components/pages/ScaleSettings.js
@@ -54,20 +54,30 @@ export function ScaleSettings({ config, route, navigate, library }) {
 		}
 	}, [id, token, navigate]);
 
+	// Pulled out of `channel` rather than depending on `channel` itself: `useDraftChannelState()`
+	// (called by `StyleLibraryApp` on every one of its renders) returns a fresh object literal each
+	// time, while `publish`/`clearPublication` are individually stable (`useCallback(..., [])`).
+	// Depending on `channel` would re-fire this effect's cleanup — which nulls the pending guard
+	// action — on every unrelated app re-render, including the very re-render `guard()` triggers to
+	// open the unsaved-changes modal, destroying the pending action before it can render. Depending
+	// on the stable callbacks instead means the effect only re-runs for a real id/token/draft change
+	// or an actual unmount.
+	const publish = channel?.publish;
+	const clearPublication = channel?.clearPublication;
+
 	// Publishes the live draft on every change (including each keystroke) and wipes it on cleanup —
 	// which fires both on unmount and on the next publish, so a stale-item self-heal or an item
 	// switch never leaves a dangling publication behind. Only this panel ever publishes; the screen
 	// is read-only on the channel, and the app structure guarantees a single mounted panel.
 	useEffect(() => {
-		if (!channel || !id || !token) {
+		if (!publish || !clearPublication || !id || !token) {
 			return undefined;
 		}
 
-		channel.publish({ itemId: id, label: token.label, draft: panel.draft, isDirty: panel.isDirty });
+		publish({ itemId: id, label: token.label, draft: panel.draft, isDirty: panel.isDirty });
 
-		return () => channel.clearPublication();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [channel, id, token, panel.draft, panel.isDirty]);
+		return () => clearPublication();
+	}, [publish, clearPublication, id, token, panel.draft, panel.isDirty]);
 
 	// Reassigned every render, never held in state (decision 10b in the plan): these close over the
 	// current `panel.draft`, so storing them in state would either loop the publish effect above

--- a/src/style-library/helpers/scale.js
+++ b/src/style-library/helpers/scale.js
@@ -171,3 +171,60 @@ export function scaleInitialValues(entry, values, parseValue) {
 export function scaleValueField(valueField) {
 	return { ...valueField, path: 'value', responsive: false };
 }
+
+/**
+ * Overlay a live settings-panel draft onto the row it edits, so the label, value column, and
+ * preview all show what Save would write instead of waiting for it. Draft keys are taken verbatim
+ * when present (an own-property check, not a truthiness check) — an emptied field previews as
+ * empty, because a live preview must be honest about what Save would write, not a prettified
+ * stand-in for it. `id` and `userCreated` are never overlaid; only `label` and `value` come from
+ * the draft.
+ *
+ * Returns the exact same array reference for a `null`/absent draft or an `itemId` matching no row
+ * (the `applyRowOrder` no-op discipline), so a memoized items mapping downstream can skip work when
+ * nothing is overlaid. Every non-matching row keeps its exact object identity either way.
+ *
+ * @param {Array<{id: string, label: string, value: string, userCreated: boolean}>} rows   The rows
+ *                                                                                          in feed
+ *                                                                                          order.
+ * @param {string}                                                                   itemId The
+ *                                                                                          open
+ *                                                                                          route
+ *                                                                                          item id.
+ * @param {?{label?: string, value?: string}}                                        draft  The
+ *                                                                                          open
+ *                                                                                          panel's
+ *                                                                                          live
+ *                                                                                          draft, or
+ *                                                                                          `null`.
+ *
+ * @since TBD
+ *
+ * @return {Array<Object>} The rows, with the matching row's `label`/`value` overlaid.
+ */
+export function overlayDraft(rows, itemId, draft) {
+	if (!draft || !itemId) {
+		return rows;
+	}
+
+	const index = rows.findIndex((row) => row.id === itemId);
+
+	if (index === -1) {
+		return rows;
+	}
+
+	const overlaid = { ...rows[index] };
+
+	if (Object.prototype.hasOwnProperty.call(draft, 'label')) {
+		overlaid.label = draft.label;
+	}
+
+	if (Object.prototype.hasOwnProperty.call(draft, 'value')) {
+		overlaid.value = draft.value;
+	}
+
+	const next = [...rows];
+	next[index] = overlaid;
+
+	return next;
+}

--- a/src/style-library/hooks/use-draft-channel.js
+++ b/src/style-library/hooks/use-draft-channel.js
@@ -1,6 +1,6 @@
 /**
- * The draft channel: the one sanctioned exception to the screen/settings-panel siblings-only rule
- * (see `.local/style-library-reference.md` section 10). A screen and its settings panel are
+ * The draft channel: the one sanctioned exception to the screen/settings-panel siblings-only rule.
+ * A screen and its settings panel are
  * mounted as siblings under `AppShell`, each running its own data-hook instance, sharing state
  * only through the feed and the route — the feed only changes on Save. That leaves the open
  * panel's in-flight draft with no path to the row it edits, so `StyleLibraryApp` (the one

--- a/src/style-library/hooks/use-draft-channel.js
+++ b/src/style-library/hooks/use-draft-channel.js
@@ -1,0 +1,156 @@
+/**
+ * The draft channel: the one sanctioned exception to the screen/settings-panel siblings-only rule
+ * (see `.local/style-library-reference.md` section 10). A screen and its settings panel are
+ * mounted as siblings under `AppShell`, each running its own data-hook instance, sharing state
+ * only through the feed and the route — the feed only changes on Save. That leaves the open
+ * panel's in-flight draft with no path to the row it edits, so `StyleLibraryApp` (the one
+ * component that already renders both slots) provides this channel: the panel publishes its draft,
+ * the screen reads it back strictly keyed to the open item, and the app drives an unsaved-changes
+ * guard over both.
+ *
+ * The channel is ephemeral and never a second source of truth: it is written only by the mounted
+ * settings panel, cleared by that panel's own effect cleanup (unmount or item change), and read by
+ * a screen only when the publication's `itemId` matches the open route item. Nothing from it is
+ * ever written back into the feed, the route, or storage.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { createContext, useCallback, useContext, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * The draft-channel context. Default value `null` — a consumer with no provider mounted (e.g. a
+ * component rendered in isolation, such as the dev gallery) treats a `null` channel as "no channel"
+ * and falls back to its pre-channel behavior.
+ *
+ * @since TBD
+ */
+export const DraftChannelContext = createContext(null);
+
+/**
+ * Build the draft-channel value. Called once, by `StyleLibraryApp`, which passes the result to
+ * `DraftChannelContext.Provider` and also reads it directly — a component cannot consume the very
+ * context it provides.
+ *
+ * @since TBD
+ *
+ * @return {{publication: ?Object, publish: Function, clearPublication: Function, actionsRef: Object, guard: Function, isGuardOpen: boolean, isGuardBusy: boolean, guardError: ?Object, confirmSave: Function, confirmDiscard: Function, cancelGuard: Function}}
+ *         The channel value.
+ */
+export function useDraftChannelState() {
+	const [publication, setPublication] = useState(null);
+	const [pendingAction, setPendingAction] = useState(null);
+	const [isGuardBusy, setIsGuardBusy] = useState(false);
+	const [guardError, setGuardError] = useState(null);
+
+	// Mirrors `publication` so `guard()` below can stay a stable callback (no `publication` in its
+	// deps) while still reading the *current* dirty bit at call time — the same ref-mirror pattern
+	// `use-scale-screen.js` uses for `feedVersionRef`, needed here for the same reason: a memoized
+	// caller built before the last keystroke must not see a stale clean/dirty bit.
+	const publicationRef = useRef(publication);
+	publicationRef.current = publication;
+
+	// The registered save/discard actions. A ref, reassigned every render by the publishing panel
+	// (never `useState`): the callbacks close over the panel's current draft, so storing them in
+	// state would either loop the publish effect (a new function identity every render) or hand the
+	// modal a stale draft frozen at whatever render first stored it.
+	const actionsRef = useRef(null);
+
+	const publish = useCallback((next) => setPublication(next), []);
+
+	const clearPublication = useCallback(() => {
+		setPublication(null);
+		// A panel that unmounts out-of-band (the stale-item self-heal, a cross-tab delete) must not
+		// leave an orphaned modal pointing at actions that no longer exist.
+		setPendingAction(null);
+		setGuardError(null);
+	}, []);
+
+	const guard = useCallback((fn) => {
+		const current = publicationRef.current;
+
+		if (!current || !current.isDirty) {
+			fn();
+
+			return;
+		}
+
+		// The updater form, so React never mistakes `fn` for a lazy state initializer.
+		setPendingAction(() => fn);
+	}, []);
+
+	const cancelGuard = useCallback(() => {
+		setPendingAction(null);
+		setGuardError(null);
+	}, []);
+
+	const confirmSave = useCallback(() => {
+		const actions = actionsRef.current;
+		const fn = pendingAction;
+
+		if (!actions || !fn) {
+			return;
+		}
+
+		setIsGuardBusy(true);
+		setGuardError(null);
+
+		return actions
+			.save()
+			.then(() => {
+				setIsGuardBusy(false);
+				setPendingAction(null);
+				fn();
+			})
+			.catch((error) => {
+				// Kept open, not cleared: the pending action stays parked so the user can retry Save
+				// or fall back to Discard without re-triggering whatever navigation asked for the
+				// guard in the first place.
+				setIsGuardBusy(false);
+				setGuardError({ message: error?.message || __('Saving failed.', 'kadence-blocks') });
+			});
+	}, [pendingAction]);
+
+	const confirmDiscard = useCallback(() => {
+		const actions = actionsRef.current;
+		const fn = pendingAction;
+
+		if (!actions || !fn) {
+			return;
+		}
+
+		actions.discard();
+		setPendingAction(null);
+		setGuardError(null);
+		fn();
+	}, [pendingAction]);
+
+	return {
+		publication,
+		publish,
+		clearPublication,
+		actionsRef,
+		guard,
+		isGuardOpen: Boolean(pendingAction),
+		isGuardBusy,
+		guardError,
+		confirmSave,
+		confirmDiscard,
+		cancelGuard,
+	};
+}
+
+/**
+ * The consumer hook: `ScaleScreen` reads `publication` and calls `guard()`; `ScaleSettings`
+ * additionally publishes and registers `actionsRef.current`. Returns `null` when no
+ * `DraftChannelContext.Provider` is mounted.
+ *
+ * @since TBD
+ *
+ * @return {?Object} The channel value, or `null` outside a provider.
+ */
+export function useDraftChannel() {
+	return useContext(DraftChannelContext);
+}


### PR DESCRIPTION
Editing a token gave no feedback until the edit was committed: the row preview kept showing the saved value while you were choosing a new one, and closing the sidebar or selecting another token silently discarded the draft. This makes the preview live, and puts a confirmation in front of the two ways a draft could previously be lost without warning.

## Live preview

Changing any setting — the value or the name — updates that token's row immediately, per keystroke. The value column, the label, and the rendered preview all follow the draft.

## Unsaved-changes guard

With a dirty draft, a modal appears before anything that would abandon it, naming the token and offering **Cancel**, **Discard** or **Save**. Discard reverts and continues; Save commits and then continues; a failed save keeps the modal open with the error and never navigates.

Guarded: switching rows, closing the sidebar, switching screens, and "+ Add" (which is a row switch — the whole mint-then-navigate continuation is parked, so cancelling mints nothing).

Not guarded: **delete**, deliberately — deleting a token makes its own draft moot, and prompting there would be nonsense. Browser-level page unload is out of scope.

## How the draft reaches the row

The screen and its settings panel are separate sibling components, each calling `useScaleScreen` as its own instance, sharing state only through the feed and the route. That separation is the established settings-panel contract and it is what fixed an earlier bug where a panel resolved the wrong token, so it is preserved rather than unwound. But the feed only changes on save, so the draft had no path to the row.

`hooks/use-draft-channel.js` adds that path: a context provided by `StyleLibraryApp` — the one component that already renders both the screen slot and the panel slot. The panel publishes `{ itemId, label, draft, isDirty }`; the screen reads it and overlays the matching row through a new pure `overlayDraft()` in `helpers/scale.js`, applied *before* `formatValue` and `renderPreview` so all three go live together.

The overlay is keyed three ways so a draft can never bleed onto the wrong row: the panel clears its publication on unmount, the reader requires `publication.itemId === route.item`, and the overlay itself requires `row.id === itemId`.

The channel also holds the guard: `guard(fn)` runs `fn` immediately when the draft is clean, and otherwise parks it as a pending continuation until the user resolves the modal.

## One bug worth calling out, found by driving the app

The first working build blocked guarded navigation but never showed the modal — the user was silently stuck with no way to proceed and no console error.

The publish effect had the whole `channel` object in its dependency array, and `useDraftChannelState()` returns a plain object literal, so it has a new identity on every render of `StyleLibraryApp`. `guard()` setting the pending action re-rendered the app, which gave the effect a new `channel` identity, which ran its cleanup, which called `clearPublication()` — nulling the pending action in the same commit the modal should have mounted.

The effect now depends on the individually stable `publish`/`clearPublication` callbacks (each `useCallback(..., [])`) instead of the object that wraps them, which makes the failure structurally impossible rather than currently absent. It also let the `exhaustive-deps` suppression go away.

Neither jest nor lint could have caught this — the app's JS tests cover pure functions and hooks only, and both layers were green while the feature was unusable.

## Verification

`overlayDraft` is the pure piece and has real jest coverage (7 cases). `eslint` and `cspell` clean; 205 jest tests green; the build succeeds. No PHP is involved.

Driven in the browser on Border Radius: live preview per keystroke on value and name; the modal appearing on row switch and on sidebar close; Discard reverting the preview and completing the navigation; Save committing and then completing it; clean navigation still frictionless. The modal renders correctly styled, which also confirms its `--kb-sl-*` custom properties resolve on the portalled node — WordPress mounts modals outside the app root, and this app declares those tokens on the page body class for exactly that reason.

Not exercised by hand: a failing save inside the modal, and the guard on the three sibling screens (they share these components, so it is mechanical, but only Border Radius was driven).

## Not included

The **Color Palette** screen, which has the same behavior and should adopt this. It is not on this branch — it lives on the separate stack for that screen — so it adopts the channel unchanged once both lines reach the trunk. Nothing here is scale-specific.

## Screenshots

**The row previewing an unsaved value**
<img width="1568" height="684" alt="live-preview" src="https://github.com/user-attachments/assets/127296b2-38d3-4832-a102-a5e73e834a75" />

**The unsaved-changes guard**
<img width="1568" height="684" alt="unsaved-changes-modal" src="https://github.com/user-attachments/assets/39122692-421c-4726-9a36-b0f1cbb83d6f" />
