### PR TITLE
[DTM] SOFT-4077: Typography screen

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -293,7 +293,7 @@
 				}
 			}
 		},
-		"fontFamily": {
+		"font-family": {
 			"sans": {
 				"$type": "fontFamily",
 				"$value": [
@@ -526,7 +526,7 @@
 		"font-family": {
 			"control": {
 				"$type": "fontFamily",
-				"$value": "{primitive.fontFamily.sans}"
+				"$value": "{primitive.font-family.sans}"
 			},
 			"heading": {
 				"$type": "fontFamily",

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -169,6 +169,10 @@ $font_size_primitive_tokens = array_map(
 // declare none of their own. No group_key: the user-primitive backend cannot mint a fontFamily
 // token today (its DTCG $type is camelCase, which can never be a valid kebab id segment), so
 // nothing can "+ Add Font" into this group until that backend gap is closed.
+//
+// The id segment is kebab-case ("font-family", not "fontFamily") because Token_Definition::from_array()
+// validates every declared id against the kebab charset and throws on a camelCase segment — these
+// tokens (and the baseline.json tree backing them) could never have registered under the old spelling.
 $font_family_slugs = [
 	'sans'  => __( 'Sans', 'kadence-blocks' ),
 	'serif' => __( 'Serif', 'kadence-blocks' ),

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -156,10 +156,36 @@ $font_size_primitive_tokens = array_map(
 			'type'        => 'dimension',
 			'label'       => strtoupper( $slug ),
 			'group'       => __( 'Font Size', 'kadence-blocks' ),
+			'group_key'   => 'font-size',
 			'projections' => [ 'kb_font_size_slot' => $slug ],
 		];
 	},
 	$font_size_slugs
+);
+
+// The three preview fonts are primitives the Style Library's Typography screen lists as FONT
+// options; the font-family semantics (semantic.font-family.control / .heading) keep their own
+// values and already carry whatever projections deliver a family into a block, so these primitives
+// declare none of their own. No group_key: the user-primitive backend cannot mint a fontFamily
+// token today (its DTCG $type is camelCase, which can never be a valid kebab id segment), so
+// nothing can "+ Add Font" into this group until that backend gap is closed.
+$font_family_slugs = [
+	'sans'  => __( 'Sans', 'kadence-blocks' ),
+	'serif' => __( 'Serif', 'kadence-blocks' ),
+	'mono'  => __( 'Mono', 'kadence-blocks' ),
+];
+
+$font_family_tokens = array_map(
+	static function ( string $slug, string $label ): array {
+		return [
+			'id'    => 'primitive.font-family.' . $slug,
+			'type'  => 'fontFamily',
+			'label' => $label,
+			'group' => __( 'Font Family', 'kadence-blocks' ),
+		];
+	},
+	array_keys( $font_family_slugs ),
+	array_values( $font_family_slugs )
 );
 
 /**
@@ -405,6 +431,7 @@ return [
 		$spacing_tokens,
 		$gap_tokens,
 		$font_size_primitive_tokens,
+		$font_family_tokens,
 		$radius_tokens,
 		$border_width_tokens,
 		$icon_size_tokens,

--- a/src/style-library/__tests__/typography.test.js
+++ b/src/style-library/__tests__/typography.test.js
@@ -1,0 +1,58 @@
+/* eslint-env jest */
+import { fontOptions, fontSizeDisplayValue } from '../helpers/typography';
+
+describe('fontOptions', () => {
+	it('returns [] for a missing schema or unknown group', () => {
+		expect(fontOptions(undefined, {}, 'Font Family')).toEqual([]);
+		expect(fontOptions({ groups: {} }, {}, 'Font Family')).toEqual([]);
+		expect(fontOptions({ groups: { Other: [] } }, {}, 'Font Family')).toEqual([]);
+	});
+
+	it('maps id, first-family label, and the full stack in feed order', () => {
+		const schema = {
+			groups: {
+				'Font Family': [
+					{ id: 'primitive.font-family.sans' },
+					{ id: 'primitive.font-family.serif' },
+					{ id: 'primitive.font-family.mono' },
+				],
+			},
+		};
+		const values = {
+			'primitive.font-family.sans': 'Inter, system-ui, sans-serif',
+			'primitive.font-family.serif': 'Georgia, Cambria, serif',
+			'primitive.font-family.mono': 'Menlo, Consolas, monospace',
+		};
+
+		expect(fontOptions(schema, values, 'Font Family')).toEqual([
+			{ id: 'primitive.font-family.sans', label: 'Inter', stack: 'Inter, system-ui, sans-serif' },
+			{ id: 'primitive.font-family.serif', label: 'Georgia', stack: 'Georgia, Cambria, serif' },
+			{ id: 'primitive.font-family.mono', label: 'Menlo', stack: 'Menlo, Consolas, monospace' },
+		]);
+	});
+
+	it('strips wrapping quotes from a quoted first family', () => {
+		const schema = { groups: { 'Font Family': [{ id: 'primitive.font-family.sans' }] } };
+		const values = { 'primitive.font-family.sans': '"Inter", system-ui, sans-serif' };
+
+		expect(fontOptions(schema, values, 'Font Family')[0].label).toBe('Inter');
+	});
+});
+
+describe('fontSizeDisplayValue', () => {
+	it('extracts the clamp max from a clamp string', () => {
+		expect(fontSizeDisplayValue('clamp(0.8rem, 0.73rem + 0.217vw, 0.9rem)')).toBe('0.9rem');
+	});
+
+	it('returns a plain dimension verbatim', () => {
+		expect(fontSizeDisplayValue('1.5rem')).toBe('1.5rem');
+	});
+
+	it('returns a malformed clamp string verbatim', () => {
+		expect(fontSizeDisplayValue('clamp(1rem, 2rem)')).toBe('clamp(1rem, 2rem)');
+	});
+
+	it('returns an empty value verbatim', () => {
+		expect(fontSizeDisplayValue('')).toBe('');
+	});
+});

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -20,6 +20,7 @@ import { RenameLibraryModal } from '../components/organisms/RenameLibraryModal';
 import { DeleteLibraryModal } from '../components/organisms/DeleteLibraryModal';
 import { UnsavedChangesModal } from '../components/organisms/UnsavedChangesModal';
 import { PlaceholderScreen } from '../components/pages/PlaceholderScreen';
+import { TypographyScreen } from '../components/pages/TypographyScreen';
 import { ColorPaletteScreen } from '../components/pages/ColorPaletteScreen';
 import { BorderRadiusScreen } from '../components/pages/BorderRadiusScreen';
 import { BorderWidthScreen } from '../components/pages/BorderWidthScreen';
@@ -41,6 +42,7 @@ import { libraryDisplayTitle } from '../helpers/libraries';
  * @since TBD
  */
 const SCREEN_COMPONENTS = {
+	typography: TypographyScreen,
 	'border-radius': BorderRadiusScreen,
 	'color-palette': ColorPaletteScreen,
 	'border-width': BorderWidthScreen,

--- a/src/style-library/components/pages/ScaleScreen.js
+++ b/src/style-library/components/pages/ScaleScreen.js
@@ -101,7 +101,8 @@ export function ScaleScreen({ config, route, navigate, library }) {
 		<div
 			className={`kadence-blocks-style-library__scale-screen kadence-blocks-style-library__scale-screen--${config.id}`}
 		>
-			<ScreenHeader title={config.title} primaryAction={addAction} />
+			<ScreenHeader title={config.title} primaryAction={config.renderToolbar ? null : addAction} />
+			{config.renderToolbar && config.renderToolbar({ addAction, isBusy: scale.isBusy })}
 			{scale.addError && (
 				<Notice status="error" isDismissible onRemove={scale.clearAddError}>
 					{scale.addError.message}

--- a/src/style-library/components/pages/TypographyScreen.js
+++ b/src/style-library/components/pages/TypographyScreen.js
@@ -1,7 +1,7 @@
 /**
  * The Typography screen: the scale config, the FONT preview toolbar, the sample-text preview
  * renderer, and the two thin wrappers that plug into the shared `ScaleScreen`/`ScaleSettings`
- * contract (see `.local/style-library-reference.md`). Two things make this screen genuinely
+ * contract (see `ScaleScreen.js`'s module docblock). Two things make this screen genuinely
  * different from its siblings: a toolbar between the header and the list (the FONT dropdown, font
  * tabs, and the "+ Add Size" action) built on `ScaleScreen`'s optional `renderToolbar` seam, and
  * screen-level preview state (the currently previewed font) that `renderPreview` closes over —
@@ -132,8 +132,8 @@ function typographyToolbarRenderer(fonts, selectedFontId, onSelectFont) {
 }
 
 /**
- * The Typography screen's config — see `ScaleScreen`'s module docblock and
- * `.local/style-library-reference.md` for the full per-screen config contract. `formatValue`/
+ * The Typography screen's config — see `ScaleScreen`'s module docblock for the full per-screen
+ * config contract. `formatValue`/
  * `parseValue` both go through `fontSizeDisplayValue()`: the size chip and the SIZE field must both
  * seed from the authored scalar (a clamp's `max`), never the resolved `clamp(...)` string a
  * fluid step actually carries.
@@ -195,9 +195,12 @@ export function TypographyScreen(props) {
 
 	const selectedFont = fonts.find((font) => font.id === selectedFontId) ?? null;
 
-	// `useScaleScreen`'s memo deps read scalar config fields, not the config object's identity (see
-	// `.local/style-library-reference.md`), so rebuilding this object every render is safe as long as
-	// the field values it carries stay stable across renders that shouldn't change anything.
+	// Memoized because `useScaleScreen` splits how it reads this config: `baseRows` and
+	// `initialValuesFor` depend on scalar fields (`config.group`, `config.parseValue`), but
+	// `addToken`, `saveToken` and `reorderTokens` list the whole config object in their deps. A new
+	// object each render would therefore rebuild those three callbacks every render. Nothing reads
+	// them from an effect, so a config rebuilt inline would be wasted work rather than a bug — this
+	// keeps the identity stable so it stays neither.
 	const config = useMemo(
 		() => ({
 			...TYPOGRAPHY_CONFIG,

--- a/src/style-library/components/pages/TypographyScreen.js
+++ b/src/style-library/components/pages/TypographyScreen.js
@@ -195,12 +195,8 @@ export function TypographyScreen(props) {
 
 	const selectedFont = fonts.find((font) => font.id === selectedFontId) ?? null;
 
-	// Memoized because `useScaleScreen` splits how it reads this config: `baseRows` and
-	// `initialValuesFor` depend on scalar fields (`config.group`, `config.parseValue`), but
-	// `addToken`, `saveToken` and `reorderTokens` list the whole config object in their deps. A new
-	// object each render would therefore rebuild those three callbacks every render. Nothing reads
-	// them from an effect, so a config rebuilt inline would be wasted work rather than a bug — this
-	// keeps the identity stable so it stays neither.
+	// `useScaleScreen`'s addToken/saveToken/reorderTokens list the whole config in their deps, so an
+	// inline object would rebuild all three every render.
 	const config = useMemo(
 		() => ({
 			...TYPOGRAPHY_CONFIG,

--- a/src/style-library/components/pages/TypographyScreen.js
+++ b/src/style-library/components/pages/TypographyScreen.js
@@ -1,0 +1,227 @@
+/**
+ * The Typography screen: the scale config, the FONT preview toolbar, the sample-text preview
+ * renderer, and the two thin wrappers that plug into the shared `ScaleScreen`/`ScaleSettings`
+ * contract (see `.local/style-library-reference.md`). Two things make this screen genuinely
+ * different from its siblings: a toolbar between the header and the list (the FONT dropdown, font
+ * tabs, and the "+ Add Size" action) built on `ScaleScreen`'s optional `renderToolbar` seam, and
+ * screen-level preview state (the currently previewed font) that `renderPreview` closes over —
+ * absorbed entirely at this screen's own boundary, with no change to the shared hook or flows.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { ScaleScreen } from './ScaleScreen';
+import { ScaleSettings } from './ScaleSettings';
+import { SelectDropdown } from '../molecules/SelectDropdown';
+import { fontOptions, fontSizeDisplayValue } from '../../helpers/typography';
+import './TypographyScreen.scss';
+
+/**
+ * The fixed sample text every card renders, matching both boards. An editable sample is new UI
+ * state with no board spec, so it is not built.
+ *
+ * @since TBD
+ */
+const SAMPLE_TEXT = __('Visualize your font', 'kadence-blocks');
+
+/**
+ * The translated `Font Family` feed group label — display and request addressing only, mirroring
+ * `config.group`'s role for the `Font Size` group this screen edits.
+ *
+ * @since TBD
+ */
+const FONT_FAMILY_GROUP = __('Font Family', 'kadence-blocks');
+
+/**
+ * Build a `renderPreview` closing over the currently selected font's resolved stack. `row.value` is
+ * the feed's resolved value or an overlaid draft scalar (`overlayDraft` copies it verbatim) — an
+ * explicit SIZE edit converts a clamped step to a fixed value (the resolved `clamp(...)` string
+ * caps the rendered size at its own max, so preserving the old clamp under a new scalar would make
+ * the edit invisible), and this renderer styles with `row.value` exactly as stored, so both the
+ * fluid and the fixed case render honestly.
+ *
+ * @param {string} fontStack The selected font's resolved `font-family` CSS value.
+ *
+ * @since TBD
+ *
+ * @return {Function} The `config.renderPreview` implementation.
+ */
+function samplePreviewRenderer(fontStack) {
+	return function renderSamplePreview(row) {
+		return (
+			<span
+				className="kadence-blocks-style-library__typography-sample"
+				style={{ fontFamily: fontStack, fontSize: row.value }}
+			>
+				{SAMPLE_TEXT}
+			</span>
+		);
+	};
+}
+
+/**
+ * Build the `renderToolbar( { addAction, isBusy } )` implementation: font tabs (only when more than
+ * one family exists), the FONT label and dropdown, and the passed-in add action positioned at the
+ * row's right edge — the toolbar positions `addAction`, it never re-implements it, so the shared
+ * guard/busy discipline cannot fork between this screen and its siblings.
+ *
+ * @param {Array<{id: string, label: string, stack: string}>} fonts          The FONT options, in feed order.
+ * @param {string}                                             selectedFontId The currently previewed font's id.
+ * @param {Function}                                            onSelectFont   Called with a font id when the
+ *                                                                             selection changes (tab or dropdown).
+ *
+ * @since TBD
+ *
+ * @return {Function} The `config.renderToolbar` implementation.
+ */
+function typographyToolbarRenderer(fonts, selectedFontId, onSelectFont) {
+	return function renderToolbar({ addAction, isBusy }) {
+		return (
+			<div className="kadence-blocks-style-library__typography-toolbar">
+				{fonts.length > 1 && (
+					<div className="kadence-blocks-style-library__typography-font-tabs" role="tablist">
+						{fonts.map((font) => (
+							<button
+								key={font.id}
+								type="button"
+								role="tab"
+								aria-selected={font.id === selectedFontId}
+								disabled={isBusy}
+								className={classnames('kadence-blocks-style-library__typography-font-tab', {
+									'kadence-blocks-style-library__typography-font-tab--active':
+										font.id === selectedFontId,
+								})}
+								onClick={() => onSelectFont(font.id)}
+							>
+								{font.label}
+							</button>
+						))}
+					</div>
+				)}
+				<div className="kadence-blocks-style-library__typography-toolbar-row">
+					<div className="kadence-blocks-style-library__typography-font-selector">
+						<span className="kadence-blocks-style-library__typography-font-label">
+							{__('Font', 'kadence-blocks')}
+						</span>
+						<SelectDropdown
+							className="kadence-blocks-style-library__typography-font-dropdown"
+							value={selectedFontId}
+							options={fonts.map((font) => ({ value: font.id, label: font.label }))}
+							onChange={onSelectFont}
+							isBusy={isBusy}
+							showSpinner={false}
+						/>
+					</div>
+					<span className="kadence-blocks-style-library__typography-toolbar-add">{addAction}</span>
+				</div>
+			</div>
+		);
+	};
+}
+
+/**
+ * The Typography screen's config — see `ScaleScreen`'s module docblock and
+ * `.local/style-library-reference.md` for the full per-screen config contract. `formatValue`/
+ * `parseValue` both go through `fontSizeDisplayValue()`: the size chip and the SIZE field must both
+ * seed from the authored scalar (a clamp's `max`), never the resolved `clamp(...)` string a
+ * fluid step actually carries.
+ *
+ * @since TBD
+ */
+export const TYPOGRAPHY_CONFIG = {
+	id: 'typography',
+	title: __('Typography', 'kadence-blocks'),
+	addLabel: __('Add Size', 'kadence-blocks'),
+	group: __('Font Size', 'kadence-blocks'),
+	groupKey: 'font-size',
+	tokenType: 'dimension',
+	slugBase: 'font-size',
+	newTokenLabel: __('New Font Size', 'kadence-blocks'),
+	newTokenValue: '1rem',
+	valueField: {
+		type: 'unit',
+		label: __('Size', 'kadence-blocks'),
+		units: [
+			{ value: 'px', label: 'px' },
+			{ value: 'em', label: 'em' },
+			{ value: 'rem', label: 'rem' },
+		],
+	},
+	formatValue: (row) => fontSizeDisplayValue(row.value),
+	parseValue: fontSizeDisplayValue,
+};
+
+/**
+ * The Typography screen body: the base config extended per render with the font-dependent
+ * `renderPreview`/`renderToolbar` keys, and the selected-font state they close over. The selection
+ * is view-only, session-scoped React state (never persisted) — it self-heals to the group's first
+ * font whenever the selected id leaves the feed, the same stale-item idiom the rest of the app uses,
+ * so a font deleted or renamed out from under an open selection never leaves the toolbar pointing at
+ * nothing.
+ *
+ * @param {Object} props The props `ScaleScreen` accepts (`{ label, route, navigate, library }`).
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The screen.
+ */
+export function TypographyScreen(props) {
+	const { library } = props;
+
+	const fonts = useMemo(
+		() => fontOptions(library.feed?.schema, library.feed?.values, FONT_FAMILY_GROUP),
+		[library.feed]
+	);
+
+	const [selectedFontId, setSelectedFontId] = useState(() => fonts[0]?.id ?? '');
+
+	useEffect(() => {
+		if (fonts.length > 0 && !fonts.some((font) => font.id === selectedFontId)) {
+			setSelectedFontId(fonts[0].id);
+		}
+	}, [fonts, selectedFontId]);
+
+	const selectedFont = fonts.find((font) => font.id === selectedFontId) ?? null;
+
+	// `useScaleScreen`'s memo deps read scalar config fields, not the config object's identity (see
+	// `.local/style-library-reference.md`), so rebuilding this object every render is safe as long as
+	// the field values it carries stay stable across renders that shouldn't change anything.
+	const config = useMemo(
+		() => ({
+			...TYPOGRAPHY_CONFIG,
+			renderPreview: samplePreviewRenderer(selectedFont?.stack ?? ''),
+			renderToolbar: typographyToolbarRenderer(fonts, selectedFontId, setSelectedFontId),
+		}),
+		[fonts, selectedFont, selectedFontId]
+	);
+
+	return <ScaleScreen config={config} {...props} />;
+}
+
+/**
+ * The Typography screen's settings panel. Uses the base config directly — NAME + SIZE need none of
+ * the font-dependent keys the screen body extends per render.
+ *
+ * @param {Object} props The props `ScaleSettings` accepts (`{ route, navigate, library }`).
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The panel.
+ */
+function TypographySettings(props) {
+	return <ScaleSettings config={TYPOGRAPHY_CONFIG} {...props} />;
+}
+
+TypographyScreen.SettingsPanel = TypographySettings;

--- a/src/style-library/components/pages/TypographyScreen.scss
+++ b/src/style-library/components/pages/TypographyScreen.scss
@@ -3,9 +3,9 @@
 // The card row wraps onto two lines: the label/size chips stay on the first line, the sample text
 // preview drops to its own full-width line below. `.list-row-main`'s shared layout is a single
 // non-wrapping flex line, so this screen unlocks wrapping and restyles the label/value spans as
-// small pills — `MetaChip`'s visual treatment, not the component itself (see
-// `.local/style-library-reference.md`: mounting `MetaChip` here would need a new label/value-node
-// seam in the shared row mapping for purely presentational gain).
+// small pills — `MetaChip`'s visual treatment, not the component itself: mounting `MetaChip` here
+// would need a new label/value-node seam in `ListRow`'s shared row mapping for purely
+// presentational gain.
 .kadence-blocks-style-library__scale-screen--typography .kadence-blocks-style-library__list-row-main {
 	flex-wrap: wrap;
 	gap: var(--kb-sl-space-10) var(--kb-sl-space-15);

--- a/src/style-library/components/pages/TypographyScreen.scss
+++ b/src/style-library/components/pages/TypographyScreen.scss
@@ -1,0 +1,98 @@
+@use '../../styles/mixins' as *;
+
+// The card row wraps onto two lines: the label/size chips stay on the first line, the sample text
+// preview drops to its own full-width line below. `.list-row-main`'s shared layout is a single
+// non-wrapping flex line, so this screen unlocks wrapping and restyles the label/value spans as
+// small pills — `MetaChip`'s visual treatment, not the component itself (see
+// `.local/style-library-reference.md`: mounting `MetaChip` here would need a new label/value-node
+// seam in the shared row mapping for purely presentational gain).
+.kadence-blocks-style-library__scale-screen--typography .kadence-blocks-style-library__list-row-main {
+	flex-wrap: wrap;
+	gap: var(--kb-sl-space-10) var(--kb-sl-space-15);
+}
+
+.kadence-blocks-style-library__scale-screen--typography .kadence-blocks-style-library__list-row-label,
+.kadence-blocks-style-library__scale-screen--typography .kadence-blocks-style-library__list-row-value {
+	flex: 0 0 auto;
+	width: auto;
+	display: inline-flex;
+	align-items: center;
+	padding: 0 var(--kb-sl-space-10);
+	border-radius: var(--kb-sl-radius-full);
+	background: var(--kb-sl-color-gray-100);
+	color: var(--kb-sl-color-text-primary);
+	font-family: inherit;
+	font-size: var(--kb-sl-font-size-s);
+	font-weight: var(--kb-sl-font-weight-semibold);
+	line-height: 1.125rem;
+	white-space: nowrap;
+}
+
+// The sample text needs the card's full width on its own line — the shared preview slot's fixed
+// square, `overflow: hidden`, and gray fill exist for a content-agnostic swatch, not a sentence of
+// text at an arbitrary font size.
+.kadence-blocks-style-library__scale-screen--typography .kadence-blocks-style-library__list-row-preview {
+	flex: 1 1 100%;
+	width: auto;
+	height: auto;
+	justify-content: flex-start;
+	overflow: visible;
+	border: 0;
+	background: transparent;
+}
+
+.kadence-blocks-style-library__typography-sample {
+	display: block;
+	overflow-wrap: anywhere;
+	color: var(--kb-sl-color-text-primary);
+	line-height: var(--kb-sl-line-height-ratio-snug);
+}
+
+// The board's selected-card treatment: the shared tinted background already applies through
+// `--list-row--selected`; this adds the blue accent border the board shows on top of it.
+.kadence-blocks-style-library__scale-screen--typography .kadence-blocks-style-library__list-row--selected {
+	border-left: var(--kb-sl-border-width-input) solid var(--kb-sl-color-theme);
+}
+
+// The FONT preview toolbar, rendered by `ScaleScreen`'s optional `renderToolbar` seam between the
+// header and the row list.
+.kadence-blocks-style-library__typography-toolbar {
+	@include flex-column(var(--kb-sl-space-15));
+
+	margin: var(--kb-sl-space-20) 0;
+}
+
+.kadence-blocks-style-library__typography-font-tabs {
+	@include flex-row(var(--kb-sl-space-10));
+}
+
+.kadence-blocks-style-library__typography-font-tab {
+	padding: var(--kb-sl-space-10) var(--kb-sl-space-15);
+	border: 0;
+	border-radius: var(--kb-sl-radius-s);
+	background: transparent;
+	color: var(--kb-sl-color-text-secondary);
+	font-size: var(--kb-sl-font-size-s);
+	cursor: pointer;
+
+	&--active {
+		background: var(--kb-sl-color-gray-100);
+		color: var(--kb-sl-color-text-primary);
+		font-weight: var(--kb-sl-font-weight-semibold);
+	}
+}
+
+.kadence-blocks-style-library__typography-toolbar-row {
+	display: flex;
+	align-items: flex-end;
+	justify-content: space-between;
+	gap: var(--kb-sl-space-15);
+}
+
+.kadence-blocks-style-library__typography-font-selector {
+	@include flex-column(var(--kb-sl-space-10));
+}
+
+.kadence-blocks-style-library__typography-font-label {
+	@include small-uppercase-label;
+}

--- a/src/style-library/constants/screens.js
+++ b/src/style-library/constants/screens.js
@@ -28,7 +28,6 @@ export const PRESET_SCREENS_FILTER = 'kadence_blocks.style_library.preset_screen
  */
 export const BASE_STYLES_SCREENS = [
 	{ id: 'color-palette', label: __('Color Palette', 'kadence-blocks') },
-	// @todo SOFT-4077: replace the placeholder with the Typography screen.
 	{ id: 'typography', label: __('Typography', 'kadence-blocks') },
 	{ id: 'border-radius', label: __('Border Radius', 'kadence-blocks') },
 	{ id: 'border-width', label: __('Border Width', 'kadence-blocks') },

--- a/src/style-library/helpers/typography.js
+++ b/src/style-library/helpers/typography.js
@@ -1,0 +1,95 @@
+/**
+ * The Typography screen's pure helpers: mapping the `Font Family` feed group into the FONT
+ * selector's options, and reading a fluid font-size step's authored scalar out of its resolved
+ * `clamp(...)` CSS. No React, no JSX, no REST — see `components/pages/TypographyScreen.js` for
+ * where these plug into the scale-screen contract.
+ */
+
+/**
+ * Strip a pair of wrapping quotes (single or double) from a font-family name, the same trimming a
+ * browser applies when it renders a quoted family in a `font-family` list.
+ *
+ * @param {string} family A single family name, already trimmed of surrounding whitespace.
+ *
+ * @since TBD
+ *
+ * @return {string} The family name with a matching pair of wrapping quotes removed, or the input
+ *         verbatim when it carries none.
+ */
+function unquoteFamily(family) {
+	const match = family.match(/^(["'])(.*)\1$/);
+
+	return match ? match[2] : family;
+}
+
+/**
+ * Map the feed's `Font Family` UI-schema group to the FONT selector's options, in feed order.
+ *
+ * @param {{ groups?: Record<string, Array<Object>> }} schema The feed's UI schema.
+ * @param {Record<string, string>}                      values The feed's resolved value map.
+ * @param {string}                                       group  The UI-schema group label to list
+ *                                                                (the translated `Font Family` group).
+ *
+ * @since TBD
+ *
+ * @return {Array<{id: string, label: string, stack: string}>} The font options, or `[]` for a
+ *         missing schema or an unknown group.
+ */
+export function fontOptions(schema, values, group) {
+	const entries = schema?.groups?.[group];
+
+	if (!Array.isArray(entries)) {
+		return [];
+	}
+
+	return entries.map((entry) => {
+		const stack = values?.[entry.id] ?? '';
+		const firstFamily = stack.split(',')[0]?.trim() ?? '';
+
+		return {
+			id: entry.id,
+			label: unquoteFamily(firstFamily),
+			stack,
+		};
+	});
+}
+
+/**
+ * The shipped clamp bodies (`baseline.json`'s `Font Size` primitives) contain no nested
+ * parentheses, so splitting `clamp(...)`'s inner argument list on top-level commas is safe without
+ * a full CSS parser.
+ *
+ * @since TBD
+ */
+const CLAMP_PATTERN = /^clamp\((.*)\)$/;
+
+/**
+ * Read the authored scalar out of a fluid font-size step's resolved value. Every shipped `Font
+ * Size` baseline entry authors its scalar `$value` as the clamp's own `max` argument, so the max IS
+ * the value a size chip or a SIZE field should show — the resolved `clamp(...)` string is correct
+ * CSS for the sample text but wrong for either of those.
+ *
+ * @param {string} value The feed's resolved value for a font-size token, a plain dimension or a
+ *                        `clamp(min, preferred, max)` string.
+ *
+ * @since TBD
+ *
+ * @return {string} The clamp's `max` argument for a `clamp(...)` string, or the value verbatim for
+ *         a plain dimension, an empty string, or a `clamp(...)` string this parses no further than
+ *         three top-level arguments (the honest fallback).
+ */
+export function fontSizeDisplayValue(value) {
+	if (typeof value !== 'string') {
+		return value;
+	}
+
+	const match = value.trim().match(CLAMP_PATTERN);
+
+	if (!match) {
+		return value;
+	}
+
+	const args = match[1].split(',').map((arg) => arg.trim());
+
+	return args.length === 3 ? args[2] : value;
+}

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Baseline/Json_Baseline_DocumentTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Baseline/Json_Baseline_DocumentTest.php
@@ -49,7 +49,7 @@ final class Json_Baseline_DocumentTest extends TestCase {
 		// Numeric-keyed leaf (json_decode turns "0" into an int key).
 		$this->assertTrue( $baseline->has( 'primitive.color.neutral.0' ) );
 		// fontFamily leaf whose $value is an array.
-		$this->assertTrue( $baseline->has( 'primitive.fontFamily.sans' ) );
+		$this->assertTrue( $baseline->has( 'primitive.font-family.sans' ) );
 		// A composite leaf (object $value) is still a single token, not a group.
 		$this->assertTrue( $baseline->has( 'semantic.shadow.card' ) );
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
@@ -442,7 +442,7 @@ final class Token_ResolverTest extends TestCase {
 		$resolver = $this->resolver_for(
 			[
 				'primitive' => [
-					'fontFamily' => [
+					'font-family' => [
 						'sans' => [
 							'$type'  => 'fontFamily',
 							'$value' => [ 'Inter', 'system-ui', 'sans-serif' ],
@@ -454,7 +454,7 @@ final class Token_ResolverTest extends TestCase {
 
 		$this->assertSame(
 			'Inter, system-ui, sans-serif',
-			$resolver->resolve_overrides( [] )->value( 'primitive.fontFamily.sans' )
+			$resolver->resolve_overrides( [] )->value( 'primitive.font-family.sans' )
 		);
 	}
 

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -717,6 +717,184 @@ final class Feed_ControllerTest extends TestCase {
 	}
 
 	/**
+	 * The renamed, newly declared font-family primitives surface as their own feed group, in
+	 * declaration order, each resolved to the comma-joined stack the Typography screen's FONT
+	 * selector lists — the id rename from `primitive.fontFamily.*` to `primitive.font-family.*`
+	 * reaching all the way through registration and resolution.
+	 *
+	 * @return void
+	 */
+	public function testGetItemReturnsTheFontFamilyGroup(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', Token_Store::default_slug() );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$this->assertArrayHasKey( 'Font Family', $data['schema']['groups'] );
+
+		$ids = array_column( $data['schema']['groups']['Font Family'], 'id' );
+		$this->assertSame(
+			[
+				'primitive.font-family.sans',
+				'primitive.font-family.serif',
+				'primitive.font-family.mono',
+			],
+			$ids
+		);
+
+		$this->assertSame( 'Inter, system-ui, sans-serif', $data['values']['primitive.font-family.sans'] );
+		$this->assertSame( 'Georgia, Cambria, serif', $data['values']['primitive.font-family.serif'] );
+		$this->assertSame( 'Menlo, Consolas, monospace', $data['values']['primitive.font-family.mono'] );
+	}
+
+	/**
+	 * `semantic.font-family.control`'s alias followed the primitive rename in the same edit, so it
+	 * still resolves to the renamed primitive's value instead of dangling.
+	 *
+	 * @return void
+	 */
+	public function testSemanticFontFamilyControlResolvesThroughTheRenamedPrimitive(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', Token_Store::default_slug() );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$this->assertSame(
+			$data['values']['primitive.font-family.sans'],
+			$data['values']['semantic.font-family.control']
+		);
+	}
+
+	/**
+	 * The declared `Font Size` scale still lists its six steps in declaration order, and the group's
+	 * newly declared `group_key` resolves back to the group's translated label — the mechanism
+	 * "+ Add Size" mints custom tokens through.
+	 *
+	 * @return void
+	 */
+	public function testGetItemReturnsTheFontSizeScaleGroupWithItsGroupKey(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', Token_Store::default_slug() );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$ids = array_column( $data['schema']['groups']['Font Size'], 'id' );
+		$this->assertSame(
+			[
+				'primitive.dimension.font-size.sm',
+				'primitive.dimension.font-size.md',
+				'primitive.dimension.font-size.lg',
+				'primitive.dimension.font-size.xl',
+				'primitive.dimension.font-size.xxl',
+				'primitive.dimension.font-size.xxxl',
+			],
+			$ids
+		);
+
+		/** @var Token_Registry $registry */
+		$registry = $this->container->get( Token_Registry::class );
+		$this->assertSame( 'Font Size', $registry->group_label_for( 'font-size' ) );
+	}
+
+	/**
+	 * A user-created dimension primitive minted into the font-size group (the stable key this
+	 * ticket declares as `group_key` alongside the `Font Size` scale) surfaces inside the declared
+	 * "Font Size" UI-schema group and is flagged `userCreated` — "+ Add Size"'s data path end to
+	 * end.
+	 *
+	 * @return void
+	 */
+	public function testUserPrimitiveGroupedIntoFontSizeSurfacesInItsFeedGroup(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.dimension.custom.font-size';
+
+		$document = (string) wp_json_encode(
+			[
+				'primitive'   => [
+					'dimension' => [
+						'custom' => [
+							'font-size' => [
+								'$type'  => 'dimension',
+								'$value' => '1rem',
+							],
+						],
+					],
+				],
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'userPrimitives' => [
+							$id => [
+								'label' => 'New Font Size',
+								'group' => 'font-size',
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$this->store->save_document( $document, $slug );
+
+		/** @var User_Primitive_Registrar $registrar */
+		$registrar = $this->container->get( User_Primitive_Registrar::class );
+		$registrar->sync();
+
+		/** @var Token_Registry $registry */
+		$registry = $this->container->get( Token_Registry::class );
+		$schema   = $registry->to_ui_schema();
+
+		$this->assertArrayHasKey( 'Font Size', $schema['groups'] );
+
+		$found = null;
+
+		foreach ( $schema['groups']['Font Size'] as $entry ) {
+			if ( $id === $entry['id'] ) {
+				$found = $entry;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $found, 'The grouped custom token must appear in the declared "Font Size" UI-schema group.' );
+		$this->assertTrue( $found['userCreated'] );
+	}
+
+	/**
+	 * Writing a plain scalar leaf over a clamp-carrying `Font Size` step resolves to that scalar,
+	 * with no residual `clamp(...)` — the Typography screen's SIZE field can only ever write a
+	 * fixed value, and the step converting from fluid to fixed on an explicit edit is a documented
+	 * choice, not an accident.
+	 *
+	 * @return void
+	 */
+	public function testExplicitScalarWriteConvertsAClampedFontSizeStepToFixed(): void {
+		$slug = Token_Store::default_slug();
+
+		$document = (string) wp_json_encode(
+			[
+				'primitive' => [
+					'dimension' => [
+						'font-size' => [
+							'sm' => [
+								'$type'  => 'dimension',
+								'$value' => '1.5rem',
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$this->store->save_document( $document, $slug );
+
+		/** @var Token_Resolver $resolver */
+		$resolver = $this->container->get( Token_Resolver::class );
+		$resolved = $resolver->resolve( $slug );
+
+		$this->assertSame( '1.5rem', $resolved->value( 'primitive.dimension.font-size.sm' ) );
+		$this->assertStringNotContainsString( 'clamp(', $resolved->value( 'primitive.dimension.font-size.sm' ) );
+	}
+
+	/**
 	 * A slug naming no known library is rejected with a 404, mirroring Documents_Controller and
 	 * Active_Token_Library_Controller rather than silently substituting a different library's
 	 * data for the one requested.

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Values/Value_ValidatorsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Values/Value_ValidatorsTest.php
@@ -66,7 +66,7 @@ final class Value_ValidatorsTest extends TestCase {
 		$validator = new Font_Family_Value();
 
 		$this->assertSame( [], $validator->validate( [ 'Inter', 'system-ui', 'sans-serif' ], 'p.$value' ) );
-		$this->assertSame( [], $validator->validate( '{primitive.fontFamily.sans}', 'p.$value' ) );
+		$this->assertSame( [], $validator->validate( '{primitive.font-family.sans}', 'p.$value' ) );
 	}
 
 	/**


### PR DESCRIPTION
Builds the **Typography** screen of the Style Library — the size scale, rendered as cards with live sample text in the selected family.

This is the first of three stacked PRs for SOFT-4077. It is a complete, working screen on its own; the font **catalog** and **Add/Delete Font** arrive in the two that follow, because they need a backend change that deserves its own review.

## A rename that had to happen first

`primitive.fontFamily.{sans,serif,mono}` existed in `baseline.json` but **could never have been registered**. `Token_Definition::from_array()` — the declaration path — enforces the same `^[a-z0-9]+([.-][a-z0-9]+)*$` id charset as the user-primitive path and throws on a camelCase segment, because the id feeds `Css_Var::from_id()`. So those tokens could never reach the UI schema, and the font selector would have had nothing to list.

This was a pre-existing violation of the repo's own kebab-case rule, invisible only because nothing had declared them yet. Renamed to `primitive.font-family.*`, atomically with the `semantic.font-family.control` alias that points at it and the wpunit fixtures that reference it. The semantic layer was already correctly kebab-case, so the inconsistency was confined to the primitive layer.

Note the DTCG `$type` stays `fontFamily` — that vocabulary is separate from token *names*, exactly as the conventions doc says.

## What the screen does

- Font **tabs** list the families available in the design system and select which one the previews render in. This is a preview selector.
- Cards show a label chip, a size chip, and the sample text at that size — the sizes are the already-declared `primitive.dimension.font-size.*` group.
- Reorder, rename, live preview and the unsaved-changes guard all come from the shared scaffold.

## It rides the shared contract

One new optional seam: `renderToolbar`, which renders the font row between the header and the list and takes over the add action, because the board puts "+ Add Size" there rather than in the header. Identity-defaulted, so the other five screens are untouched — verified in the browser that Border Radius still renders its add button inside the header.

## Font sizes are fluid

Every `primitive.dimension.font-size.*` entry carries a `clamp` extension, so the resolved value is a full `clamp(...)` string and the steps project to `--global-kb-font-size-<slug>` site-wide. The card chips show the clamp **max** via a pure helper. An explicit edit converts that step to a fixed value — preserving a stale clamp would swallow the edit.

## Verification

`phpstan` clean; `phpcs`, `cspell` and `eslint` clean; `Resources/Design_Tokens` green (1269 tests); **all three snapshot suites green with zero diffs** — those fixtures carry no font tokens, so any diff here would have been a real regression rather than an expected change; 231 jest tests.

Checked in the browser: the screen renders, the tabs switch, and every sample re-renders in the selected family.

## Not included

The font **catalog** dropdown, **Add Font** and **Delete Font** — they need the `$type`→id-segment mapping, which is the next PR in this stack.

`primitive.fontSize.*` is left alone: a second, undeclared, camelCase font-size scale referenced only from preset maps inside `$extensions`. It is unregistered and inert. Recorded here as known tech debt rather than widened into this change.

## Screenshots

**The screen with the font tabs and size cards**
<img width="1568" height="751" alt="a-typography-screen" src="https://github.com/user-attachments/assets/418cf201-6ce7-4a0d-8364-d8f7b3db50f9" />
