### PR TITLE
[DTM] SOFT-4077: Map DTCG $type to a registered id segment

### DIFF
--- a/includes/resources/Design_Tokens/Document/Reserved_Namespace.php
+++ b/includes/resources/Design_Tokens/Document/Reserved_Namespace.php
@@ -57,7 +57,7 @@ final class Reserved_Namespace {
 	public static function is_reserved_id( string $id ): bool {
 		$types = array_map(
 			static fn( string $type ): string => preg_quote( $type, '/' ),
-			Token_Type::all()
+			Token_Type::get_id_segments()
 		);
 
 		return (bool) preg_match(
@@ -98,31 +98,34 @@ final class Reserved_Namespace {
 	 * from a stored tree leaf (the rename cascade, the orphan scan); an unsupported type yields
 	 * an id the user-primitive document invariant rejects downstream.
 	 *
+	 * The id's second segment is the type's REGISTERED id segment (Token_Type::get_id_segment()),
+	 * not necessarily the $type spelling itself: the id feeds Css_Var::from_id(), which requires
+	 * the kebab charset, while $type stays the DTCG spec spelling.
+	 *
 	 * @since TBD
 	 *
-	 * @param string $type The DTCG $type segment (spec spelling).
+	 * @param string $type The DTCG $type (spec spelling).
 	 * @param string $slug The terminal slug.
 	 *
 	 * @return string
 	 */
 	public static function canonical( string $type, string $slug ): string {
-		return self::LAYER . '.' . $type . '.' . self::SEGMENT . '.' . $slug;
+		return self::LAYER . '.' . Token_Type::get_id_segment( $type ) . '.' . self::SEGMENT . '.' . $slug;
 	}
 
 	/**
-	 * Whether a $type supports user-created primitives: registered, and itself a valid
-	 * kebab-case id segment.
+	 * Whether a $type supports user-created primitives: registered, full stop.
 	 *
-	 * The second predicate is load-bearing, not stylistic: the type spelling becomes the second
-	 * segment of a REGISTERED token id, and Token_Definition::from_user_primitive() rejects any
-	 * segment outside ^[a-z0-9]+([.-][a-z0-9]+)*$ (the id feeds Css_Var::from_id()). A camelCase
-	 * $type (fontWeight, lineHeight, ...) would store fine but could never register — the token
-	 * would silently never surface. Composites are not excluded: the shadow $type is a valid
-	 * segment, and the composite validate/render/reference machinery is fully wired.
+	 * Before the $type -> id-segment mapping existed, this also required the $type spelling
+	 * itself to be a valid kebab-case id segment, because the raw $type became the id's second
+	 * segment and Token_Definition::from_user_primitive() rejects any segment outside
+	 * ^[a-z0-9]+([.-][a-z0-9]+)*$ (the id feeds Css_Var::from_id()). Token_Type::get_id_segment()
+	 * now supplies a kebab-safe segment for every registered $type, so that second predicate is
+	 * vacuous and has been dropped; every registered $type supports user-created primitives.
 	 *
-	 * Deliberately narrower than is_reserved_id()/contains_reserved_path(), which guard the
-	 * whole namespace for every registered type: a generic write must not reach under
-	 * primitive.fontWeight.custom.* just because creation does not support that spelling yet.
+	 * Kept as a named method (not inlined to Token_Type::is_valid()) because it is the creation
+	 * gate three call sites and the REST 422 contract hang off, and a future version may
+	 * genuinely want to gate a type again.
 	 *
 	 * @since TBD
 	 *
@@ -131,7 +134,7 @@ final class Reserved_Namespace {
 	 * @return bool
 	 */
 	public static function is_supported_type( string $type ): bool {
-		return Token_Type::is_valid( $type ) && self::is_valid_slug( $type );
+		return Token_Type::is_valid( $type );
 	}
 
 	/**
@@ -151,7 +154,7 @@ final class Reserved_Namespace {
 
 		return count( $segments ) >= 3
 			&& $segments[0] === self::LAYER
-			&& in_array( $segments[1], Token_Type::all(), true )
+			&& in_array( $segments[1], Token_Type::get_id_segments(), true )
 			&& $segments[2] === self::SEGMENT;
 	}
 

--- a/includes/resources/Design_Tokens/Document/User_Primitive_Document_Validator.php
+++ b/includes/resources/Design_Tokens/Document/User_Primitive_Document_Validator.php
@@ -141,7 +141,7 @@ final class User_Primitive_Document_Validator {
 				$id,
 				sprintf( 'User primitive "%s" tree leaf has $type "%s"; that type does not support user-created primitives.', $id, Cast::to_string( $type ) )
 			);
-		} elseif ( $type !== $segment ) {
+		} elseif ( Token_Type::get_id_segment( $type ) !== $segment ) {
 			$errors[] = new User_Primitive_Validation_Error(
 				$id,
 				sprintf( 'User primitive "%s" tree leaf declares $type "%s", which does not match its id namespace.', $id, $type )
@@ -187,7 +187,7 @@ final class User_Primitive_Document_Validator {
 		$orphans = [];
 
 		foreach ( Token_Type::all() as $type ) {
-			$subtree = $primitive[ $type ] ?? [];
+			$subtree = $primitive[ Token_Type::get_id_segment( $type ) ] ?? [];
 
 			if ( ! is_array( $subtree ) ) {
 				continue;

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -166,9 +166,10 @@ $font_size_primitive_tokens = array_map(
 // The three preview fonts are primitives the Style Library's Typography screen lists as FONT
 // options; the font-family semantics (semantic.font-family.control / .heading) keep their own
 // values and already carry whatever projections deliver a family into a block, so these primitives
-// declare none of their own. No group_key: the user-primitive backend cannot mint a fontFamily
-// token today (its DTCG $type is camelCase, which can never be a valid kebab id segment), so
-// nothing can "+ Add Font" into this group until that backend gap is closed.
+// declare none of their own. group_key lets "+ Add Font" mint a user fontFamily primitive into
+// this same group: Token_Type maps the camelCase $type to the kebab id segment "font-family" (the
+// id feeds Css_Var::from_id(), which cannot take a camelCase segment), so the stored $type and the
+// registered id can differ while staying self-consistent.
 //
 // The id segment is kebab-case ("font-family", not "fontFamily") because Token_Definition::from_array()
 // validates every declared id against the kebab charset and throws on a camelCase segment — these
@@ -182,10 +183,11 @@ $font_family_slugs = [
 $font_family_tokens = array_map(
 	static function ( string $slug, string $label ): array {
 		return [
-			'id'    => 'primitive.font-family.' . $slug,
-			'type'  => 'fontFamily',
-			'label' => $label,
-			'group' => __( 'Font Family', 'kadence-blocks' ),
+			'id'        => 'primitive.font-family.' . $slug,
+			'type'      => 'fontFamily',
+			'label'     => $label,
+			'group'     => __( 'Font Family', 'kadence-blocks' ),
+			'group_key' => 'font-family',
 		];
 	},
 	array_keys( $font_family_slugs ),

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Token_Type.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Token_Type.php
@@ -142,6 +142,29 @@ final class Token_Type {
 	];
 
 	/**
+	 * The registered-id segment for each $type whose DTCG spelling is not itself a valid
+	 * kebab-case id segment. A $type absent from this map uses its own spelling verbatim.
+	 *
+	 * The id segment is not the same vocabulary as the $type spelling: an id feeds
+	 * Css_Var::from_id(), which only swaps "." for "--" and therefore requires the kebab
+	 * charset, while $type is the DTCG spec spelling and stays camelCase where the spec says so.
+	 * This map is the single place that reconciles the two so Reserved_Namespace and the
+	 * mirrored JS map never re-derive it independently.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string, string>
+	 */
+	private const ID_SEGMENTS = [
+		self::FONT_FAMILY    => 'font-family',
+		self::FONT_WEIGHT    => 'font-weight',
+		self::LINE_HEIGHT    => 'line-height',
+		self::FONT_STYLE     => 'font-style',
+		self::TEXT_TRANSFORM => 'text-transform',
+		self::BORDER_STYLE   => 'border-style',
+	];
+
+	/**
 	 * The composite types and their sub-field => $type maps. A field absent from the document is a
 	 * missing-field error; a field present but not listed here is an unknown-field error. Every field is
 	 * validated "alias OR literal-of-$type", so an alias is accepted in any sub-field.
@@ -189,6 +212,35 @@ final class Token_Type {
 	 */
 	public static function all(): array {
 		return self::TYPES;
+	}
+
+	/**
+	 * The registered-id segment for a $type: the mapped kebab spelling if one is registered in
+	 * ID_SEGMENTS, or the $type verbatim otherwise.
+	 *
+	 * A pure string mapper that performs no validation of its own — the same posture as Reserved_Namespace::canonical():
+	 * callers pass a $type that already passed is_valid(). An unregistered input returns
+	 * verbatim and produces an id downstream validation rejects.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $type The DTCG $type (spec spelling).
+	 *
+	 * @return string The registered-id segment for $type.
+	 */
+	public static function get_id_segment( string $type ): string {
+		return self::ID_SEGMENTS[ $type ] ?? $type;
+	}
+
+	/**
+	 * Every v1 $type's registered-id segment, in the same declaration order as all().
+	 *
+	 * @since TBD
+	 *
+	 * @return string[]
+	 */
+	public static function get_id_segments(): array {
+		return array_map( [ self::class, 'get_id_segment' ], self::TYPES );
 	}
 
 	/**

--- a/src/style-library/__tests__/scale.test.js
+++ b/src/style-library/__tests__/scale.test.js
@@ -93,6 +93,14 @@ describe('customScaleTokenId', () => {
 	it('builds primitive.<type>.custom.<slug>', () => {
 		expect(customScaleTokenId('dimension', 'radius-2')).toBe('primitive.dimension.custom.radius-2');
 	});
+
+	it('is unchanged for a type every sibling scale screen already passes (the no-op pin)', () => {
+		expect(customScaleTokenId('dimension', 'x')).toBe('primitive.dimension.custom.x');
+	});
+
+	it('maps a camelCase $type to its registered kebab id segment', () => {
+		expect(customScaleTokenId('fontFamily', 'abel')).toBe('primitive.font-family.custom.abel');
+	});
 });
 
 describe('scaleInitialValues', () => {

--- a/src/style-library/__tests__/tokens.test.js
+++ b/src/style-library/__tests__/tokens.test.js
@@ -1,5 +1,29 @@
 /* eslint-env jest */
-import { buildTokenLeaf, flattenSchemaTokens, isResponsiveType, refreshFeedFlow } from '../helpers/tokens';
+import {
+	buildTokenLeaf,
+	flattenSchemaTokens,
+	isResponsiveType,
+	refreshFeedFlow,
+	tokenTypeIdSegment,
+} from '../helpers/tokens';
+
+describe('tokenTypeIdSegment', () => {
+	it('maps every camelCase $type to its registered kebab id segment', () => {
+		expect(tokenTypeIdSegment('fontFamily')).toBe('font-family');
+		expect(tokenTypeIdSegment('fontWeight')).toBe('font-weight');
+		expect(tokenTypeIdSegment('lineHeight')).toBe('line-height');
+		expect(tokenTypeIdSegment('fontStyle')).toBe('font-style');
+		expect(tokenTypeIdSegment('textTransform')).toBe('text-transform');
+		expect(tokenTypeIdSegment('borderStyle')).toBe('border-style');
+	});
+
+	it('passes an already kebab-safe or unregistered type through verbatim', () => {
+		expect(tokenTypeIdSegment('color')).toBe('color');
+		expect(tokenTypeIdSegment('dimension')).toBe('dimension');
+		expect(tokenTypeIdSegment('shadow')).toBe('shadow');
+		expect(tokenTypeIdSegment('bogus')).toBe('bogus');
+	});
+});
 
 describe('flattenSchemaTokens', () => {
 	it('returns empty array when schema has no groups', () => {

--- a/src/style-library/helpers/scale.js
+++ b/src/style-library/helpers/scale.js
@@ -8,6 +8,11 @@
  */
 
 /**
+ * Internal dependencies
+ */
+import { tokenTypeIdSegment } from './tokens';
+
+/**
  * Map a feed's UI-schema group to the row descriptors a scale screen renders, in feed order.
  *
  * @param {{ groups?: Record<string, Array<Object>> }} schema The feed's UI schema.
@@ -109,9 +114,13 @@ export function nextScaleSlug(existingIds, slugBase) {
 
 /**
  * Build the canonical id for a minted custom primitive. Mirrors
- * `Document\Reserved_Namespace::canonical()`.
+ * `Document\Reserved_Namespace::canonical()`: the id's second segment is the type's REGISTERED id
+ * segment (`tokenTypeIdSegment()`), not necessarily the `$type` spelling itself — the id feeds
+ * `Css_Var::from_id()`, which requires the kebab charset, while `$type` stays the DTCG spec
+ * spelling. Identity for every type already kebab-case, so every sibling scale screen (which only
+ * ever passes `dimension`) is unaffected.
  *
- * @param {string} tokenType The DTCG `$type` (e.g. `'dimension'`).
+ * @param {string} tokenType The DTCG `$type` (e.g. `'dimension'`, `'fontFamily'`).
  * @param {string} slug      The terminal slug.
  *
  * @since TBD
@@ -119,7 +128,7 @@ export function nextScaleSlug(existingIds, slugBase) {
  * @return {string} The canonical dot-path id.
  */
 export function customScaleTokenId(tokenType, slug) {
-	return `primitive.${tokenType}.custom.${slug}`;
+	return `primitive.${tokenTypeIdSegment(tokenType)}.custom.${slug}`;
 }
 
 /**

--- a/src/style-library/helpers/tokens.js
+++ b/src/style-library/helpers/tokens.js
@@ -120,6 +120,40 @@ export const KADENCE_TOKEN_NAMESPACE = 'com.kadence.designTokens';
 export const RESPONSIVE_BREAKPOINTS = ['tablet', 'mobile'];
 
 /**
+ * The registered-id segment for each `$type` whose DTCG spelling is not itself a valid kebab-case
+ * id segment (mirrors PHP's `Schema\Vocabulary\Token_Type::ID_SEGMENTS`). A `$type` absent from
+ * this map uses its own spelling verbatim. The full six-entry map ships, not just `fontFamily`, so
+ * the two sides cannot drift entry by entry.
+ *
+ * @since TBD
+ *
+ * @type {Record<string, string>}
+ */
+export const TOKEN_TYPE_ID_SEGMENTS = {
+	fontFamily: 'font-family',
+	fontWeight: 'font-weight',
+	lineHeight: 'line-height',
+	fontStyle: 'font-style',
+	textTransform: 'text-transform',
+	borderStyle: 'border-style',
+};
+
+/**
+ * The registered-id segment for a `$type`: the mapped kebab spelling when one is registered in
+ * `TOKEN_TYPE_ID_SEGMENTS`, or the `$type` verbatim otherwise. Mirrors PHP's
+ * `Token_Type::get_id_segment()`.
+ *
+ * @param {string} type The DTCG `$type` (spec spelling).
+ *
+ * @since TBD
+ *
+ * @return {string} The registered-id segment for `type`.
+ */
+export function tokenTypeIdSegment(type) {
+	return TOKEN_TYPE_ID_SEGMENTS[type] ?? type;
+}
+
+/**
  * Build a DTCG leaf payload for a token value update.
  *
  * Accepts either a plain string (a flat token) or a structured value carrying a base plus a per-breakpoint

--- a/tests/wpunit/Resources/Design_Tokens/Document/Reserved_NamespaceTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/Reserved_NamespaceTest.php
@@ -66,6 +66,16 @@ final class Reserved_NamespaceTest extends TestCase {
 			'id'       => 'primitive.color.custom',
 			'expected' => false,
 		];
+
+		yield 'a font-family custom leaf, the mapped kebab segment' => [
+			'id'       => 'primitive.font-family.custom.abel',
+			'expected' => true,
+		];
+
+		yield 'the pre-mapping camelCase segment no longer matches' => [
+			'id'       => 'primitive.fontFamily.custom.abel',
+			'expected' => false,
+		];
 	}
 
 	// -------------------------------------------------------------------------
@@ -184,15 +194,50 @@ final class Reserved_NamespaceTest extends TestCase {
 		yield 'shadow' => [ 'type' => Token_Type::get_type_shadow() ];
 	}
 
+	/**
+	 * canonical() builds the id's second segment from the type's REGISTERED id segment
+	 * (Token_Type::get_id_segment()), not the raw $type spelling — a mapped type (fontFamily) and
+	 * an unmapped one (color) coexist through the same call, pinning that the mapping is applied
+	 * uniformly rather than special-cased.
+	 *
+	 * @dataProvider canonicalMappedSegmentProvider
+	 *
+	 * @param string $type     The DTCG $type.
+	 * @param string $slug     The terminal slug.
+	 * @param string $expected The expected canonical id.
+	 *
+	 * @return void
+	 */
+	public function testCanonicalUsesTheMappedIdSegment( string $type, string $slug, string $expected ): void {
+		$this->assertSame( $expected, Reserved_Namespace::canonical( $type, $slug ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function canonicalMappedSegmentProvider(): Generator {
+		yield 'fontFamily maps to the font-family id segment' => [
+			'type'     => Token_Type::get_type_font_family(),
+			'slug'     => 'abel',
+			'expected' => 'primitive.font-family.custom.abel',
+		];
+
+		yield 'color, already kebab-case, is unaffected by the mapping' => [
+			'type'     => Token_Type::get_type_color(),
+			'slug'     => 'x',
+			'expected' => 'primitive.color.custom.x',
+		];
+	}
+
 	// -------------------------------------------------------------------------
 	// is_supported_type()
 	// -------------------------------------------------------------------------
 
 	/**
-	 * is_supported_type() derives its allowlist from registration plus the kebab-case id-segment
-	 * grammar, so a registered but camelCase-spelled scalar type is refused even though it is a
-	 * valid $type — the camelCase yields guard against someone later simplifying the predicate
-	 * to Token_Type::is_valid() alone and silently shipping tokens that can never register.
+	 * is_supported_type() now means "registered", full stop: Token_Type::get_id_segment() supplies
+	 * a kebab-safe id segment for every registered $type (including the six whose DTCG spelling is
+	 * camelCase), so the old second predicate — the raw $type spelling itself had to be kebab-case —
+	 * is vacuous and has been dropped. Only an unregistered $type is refused now.
 	 *
 	 * @dataProvider supportedTypePredicateProvider
 	 *
@@ -224,14 +269,34 @@ final class Reserved_NamespaceTest extends TestCase {
 			'expected' => true,
 		];
 
-		yield 'fontWeight, a camelCase scalar' => [
-			'type'     => Token_Type::get_type_font_weight(),
-			'expected' => false,
+		yield 'fontFamily, mapped to the font-family id segment' => [
+			'type'     => Token_Type::get_type_font_family(),
+			'expected' => true,
 		];
 
-		yield 'fontFamily, a camelCase scalar' => [
-			'type'     => Token_Type::get_type_font_family(),
-			'expected' => false,
+		yield 'fontWeight, mapped to the font-weight id segment' => [
+			'type'     => Token_Type::get_type_font_weight(),
+			'expected' => true,
+		];
+
+		yield 'lineHeight, mapped to the line-height id segment' => [
+			'type'     => Token_Type::get_type_line_height(),
+			'expected' => true,
+		];
+
+		yield 'fontStyle, mapped to the font-style id segment' => [
+			'type'     => Token_Type::get_type_font_style(),
+			'expected' => true,
+		];
+
+		yield 'textTransform, mapped to the text-transform id segment' => [
+			'type'     => Token_Type::get_type_text_transform(),
+			'expected' => true,
+		];
+
+		yield 'borderStyle, mapped to the border-style id segment' => [
+			'type'     => Token_Type::get_type_border_style(),
+			'expected' => true,
 		];
 
 		yield 'bogus, an unregistered type' => [
@@ -301,6 +366,16 @@ final class Reserved_NamespaceTest extends TestCase {
 
 		yield 'too short to reach the custom segment' => [
 			'path'     => 'primitive.color',
+			'expected' => false,
+		];
+
+		yield 'a font-family custom leaf, the mapped kebab segment' => [
+			'path'     => 'primitive.font-family.custom.abel',
+			'expected' => true,
+		];
+
+		yield 'the pre-mapping camelCase segment no longer matches' => [
+			'path'     => 'primitive.fontFamily.custom.abel',
 			'expected' => false,
 		];
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Document/User_Primitive_Document_ValidatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/User_Primitive_Document_ValidatorTest.php
@@ -186,6 +186,25 @@ final class User_Primitive_Document_ValidatorTest extends TestCase {
 	}
 
 	/**
+	 * The orphan walk reads the primitive subtree by the type's MAPPED id segment
+	 * (Token_Type::get_id_segment()), not the raw $type — a font-family leaf with no envelope
+	 * entry is found and reported under the kebab id, matching where it actually lives in the
+	 * document tree.
+	 *
+	 * @return void
+	 */
+	public function testFontFamilyTreeLeafWithNoEnvelopeEntryReturnsOrphanErrorUnderTheKebabId(): void {
+		$id  = 'primitive.font-family.custom.orphan';
+		$doc = $this->set_tree_leaf( [], $id, Token_Type::get_type_font_family(), '["Abel"]' );
+
+		$errors = $this->validator->validate( $doc );
+
+		$this->assertCount( 1, $errors );
+		$this->assertSame( $id, $errors[0]->get_id() );
+		$this->assertStringContainsString( 'no provenance envelope entry', $errors[0]->get_message() );
+	}
+
+	/**
 	 * The orphan scan covers every type segment, not one: it finds a leaf with no envelope entry under
 	 * dimension and shadow just as it does under color, and a shadow's object $value sub-fields
 	 * are not themselves reported as orphans.
@@ -233,12 +252,14 @@ final class User_Primitive_Document_ValidatorTest extends TestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * A leaf declaring a camelCase $type (which can never register, per is_supported_type()) is refused
-	 * with the "does not support user-created primitives" error.
+	 * An id whose second segment is the raw camelCase $type spelling (rather than
+	 * Token_Type::get_id_segment()'s mapped kebab spelling) no longer matches is_reserved_id() at
+	 * all — the mapping means "fontWeight" is never a valid id segment, only "font-weight" is — so
+	 * this now fails the namespace gate itself, not the (dropped) unsupported-type predicate.
 	 *
 	 * @return void
 	 */
-	public function testTreeLeafWithWrongTypeReturnsTypeError(): void {
+	public function testTreeLeafWithCamelCaseIdSegmentReturnsNamespaceError(): void {
 		$id  = 'primitive.fontWeight.custom.size';
 		$doc = $this->doc_with_leaf_type( $id, 'Size', 'fontWeight', '600' );
 
@@ -250,12 +271,12 @@ final class User_Primitive_Document_ValidatorTest extends TestCase {
 		$messages = array_map( static fn( User_Primitive_Validation_Error $e ) => $e->get_message(), $errors );
 		$found    = false;
 		foreach ( $messages as $msg ) {
-			if ( strpos( $msg, 'does not support user-created primitives' ) !== false ) {
+			if ( strpos( $msg, 'allowed namespace' ) !== false ) {
 				$found = true;
 				break;
 			}
 		}
-		$this->assertTrue( $found, 'Expected a type error message mentioning "does not support user-created primitives".' );
+		$this->assertTrue( $found, 'Expected a namespace error message mentioning "allowed namespace".' );
 	}
 
 	// -------------------------------------------------------------------------
@@ -305,6 +326,31 @@ final class User_Primitive_Document_ValidatorTest extends TestCase {
 			'id'            => 'primitive.color.custom.x',
 			'declared_type' => Token_Type::get_type_dimension(),
 		];
+
+		yield 'the mapped font-family id segment with a fontWeight leaf type' => [
+			'id'            => 'primitive.font-family.custom.x',
+			'declared_type' => Token_Type::get_type_font_weight(),
+		];
+	}
+
+	/**
+	 * The invariant compares the MAPPED id segment against $type, not the raw $type spelling: a
+	 * fontFamily leaf under the font-family id segment is self-consistent and returns no mismatch
+	 * error, even though "fontFamily" !== "font-family" as raw strings.
+	 *
+	 * @return void
+	 */
+	public function testTreeLeafTypeMatchingMappedIdSegmentReturnsNoMismatchError(): void {
+		$id  = 'primitive.font-family.custom.x';
+		$doc = $this->doc_with_leaf_type( $id, 'Label', Token_Type::get_type_font_family(), '["Abel"]' );
+
+		$errors = $this->validator->validate( $doc );
+
+		$messages = array_map( static fn( User_Primitive_Validation_Error $e ) => $e->get_message(), $errors );
+
+		foreach ( $messages as $msg ) {
+			$this->assertStringNotContainsString( 'does not match its id namespace', $msg );
+		}
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/User_Primitives_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/User_Primitives_ControllerTest.php
@@ -492,6 +492,73 @@ final class User_Primitives_ControllerTest extends TestCase {
 		$this->assertArrayHasKey( 'primitive.dimension.custom.gap-md', $ext );
 	}
 
+	/**
+	 * A `fontFamily` create — unblocked by the $type -> id-segment mapping — mirrors the color and
+	 * dimension cases: 201, the leaf lands under the MAPPED kebab id segment
+	 * (primitive.font-family.custom.<slug>, never the camelCase primitive.fontFamily.custom.<slug>),
+	 * and the single-family `$value` (no invented generic fallback — the shipped font arrays carry
+	 * no category data) is stored verbatim.
+	 *
+	 * @return void
+	 */
+	public function testItCreatesANewFontFamilyPrimitive(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}' );
+		$version = $this->store->get_version( $slug );
+
+		$request = $this->make_create_request( $slug, 'abel', 'fontFamily', [ 'Abel' ], $version, 'Abel', 'font-family' );
+		$result  = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( WP_Http::CREATED, $result->get_status() );
+
+		$doc  = $result->get_data()['document'];
+		$leaf = $doc['primitive']['font-family']['custom']['abel'];
+		$this->assertSame( 'fontFamily', $leaf['$type'] );
+		$this->assertSame( [ 'Abel' ], $leaf['$value'] );
+
+		$ext = $doc[ Extensions::get_extensions_key() ][ Extensions::get_namespace() ][ Extensions::get_section_user_primitives() ];
+		$this->assertArrayHasKey( 'primitive.font-family.custom.abel', $ext );
+		$this->assertSame( 'font-family', $ext['primitive.font-family.custom.abel']['group'] );
+	}
+
+	/**
+	 * A malformed `fontFamily` $value (empty string, empty list, a list holding an empty string, or
+	 * a string-keyed map instead of a sequential list) is rejected by document validation exactly
+	 * like any other type's malformed value — the create path adds no bypass for this newly
+	 * unblocked type.
+	 *
+	 * @dataProvider malformedFontFamilyValueProvider
+	 *
+	 * @param mixed $value The malformed `$value` under test.
+	 *
+	 * @return void
+	 */
+	public function testMalformedFontFamilyValueIsRejectedByThePipeline( $value ): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}' );
+		$version = $this->store->get_version( $slug );
+
+		$request = $this->make_create_request( $slug, 'bad-font', 'fontFamily', $value, $version );
+		$result  = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function malformedFontFamilyValueProvider(): Generator {
+		yield 'an empty string' => [ 'value' => '' ];
+		yield 'an empty list' => [ 'value' => [] ];
+		yield 'a list holding an empty string' => [ 'value' => [ '' ] ];
+		yield 'a string-keyed map' => [ 'value' => [ 'name' => 'Abel' ] ];
+	}
+
 	// -------------------------------------------------------------------------
 	// create_item — the optional stable group key
 	// -------------------------------------------------------------------------
@@ -833,8 +900,10 @@ final class User_Primitives_ControllerTest extends TestCase {
 
 	/**
 	 * A create for a $type outside the derived allowlist 422s with the existing
-	 * rest_design_tokens_type_not_supported contract, whether the type is a registered
-	 * camelCase scalar (which can never register, per is_supported_type()) or entirely unregistered.
+	 * rest_design_tokens_type_not_supported contract. Since the $type -> id-segment mapping
+	 * (Token_Type::get_id_segment()), every REGISTERED $type — including the six whose DTCG
+	 * spelling is camelCase, such as fontFamily and fontWeight — supports user-created primitives;
+	 * only an unregistered $type still hits this 422.
 	 *
 	 * @dataProvider unsupportedTypeProvider
 	 *
@@ -860,9 +929,7 @@ final class User_Primitives_ControllerTest extends TestCase {
 	 * @return Generator
 	 */
 	public function unsupportedTypeProvider(): Generator {
-		yield 'fontWeight, a camelCase scalar' => [ 'type' => 'fontWeight' ];
-		yield 'fontFamily, a camelCase scalar' => [ 'type' => 'fontFamily' ];
-		yield 'bogus, an unregistered type'    => [ 'type' => 'bogus' ];
+		yield 'bogus, an unregistered type' => [ 'type' => 'bogus' ];
 	}
 
 	// -------------------------------------------------------------------------
@@ -1301,6 +1368,30 @@ final class User_Primitives_ControllerTest extends TestCase {
 		// Either outcome is correct: the guard did not crash, and no data was modified.
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertContains( $result->get_error_data()['status'], [ WP_Http::FORBIDDEN, WP_Http::NOT_FOUND ] );
+	}
+
+	/**
+	 * A baseline font-family id (primitive.font-family.sans) can never be deleted — but not
+	 * through the system-primitive 403 branch above: validate_canonical_id() requires the
+	 * reserved primitive.<type>.custom.<slug> shape, and no shipped baseline id is ever declared
+	 * under a ".custom." segment (that segment is reserved for user-created primitives only), so
+	 * a baseline id fails id-shape validation before the system-primitive guard is ever reached.
+	 * The never-delete-baseline rule is pinned on this group here at the shape-guard layer, which
+	 * every baseline id — font-family included — hits first.
+	 *
+	 * @return void
+	 */
+	public function testDeleteReturns400ForABaselineFontFamilyIdOutsideTheReservedShape(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}' );
+		$version = $this->store->get_version( $slug );
+
+		$result = $this->controller->delete_item( $this->make_delete_request( $slug, 'primitive.font-family.sans', $version ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_invalid_param', $result->get_error_code() );
+		$this->assertSame( WP_Http::BAD_REQUEST, $result->get_error_data()['status'] );
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/Token_TypeTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Vocabulary/Token_TypeTest.php
@@ -146,4 +146,102 @@ final class Token_TypeTest extends TestCase {
 		$this->assertSame( [], Token_Type::optional_fields( Token_Type::get_type_color() ) );
 		$this->assertSame( [], Token_Type::optional_fields( Token_Type::get_type_font_weight() ) );
 	}
+
+	/**
+	 * Every camelCase $type maps to its documented kebab id segment.
+	 *
+	 * @dataProvider mappedIdSegmentProvider
+	 *
+	 * @param string $type     The camelCase $type.
+	 * @param string $expected The expected kebab id segment.
+	 *
+	 * @return void
+	 */
+	public function testGetIdSegmentMapsCamelCaseTypes( string $type, string $expected ): void {
+		$this->assertSame( $expected, Token_Type::get_id_segment( $type ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function mappedIdSegmentProvider(): Generator {
+		yield 'fontFamily' => [
+			'type'     => Token_Type::get_type_font_family(),
+			'expected' => 'font-family',
+		];
+
+		yield 'fontWeight' => [
+			'type'     => Token_Type::get_type_font_weight(),
+			'expected' => 'font-weight',
+		];
+
+		yield 'lineHeight' => [
+			'type'     => Token_Type::get_type_line_height(),
+			'expected' => 'line-height',
+		];
+
+		yield 'fontStyle' => [
+			'type'     => Token_Type::get_type_font_style(),
+			'expected' => 'font-style',
+		];
+
+		yield 'textTransform' => [
+			'type'     => Token_Type::get_type_text_transform(),
+			'expected' => 'text-transform',
+		];
+
+		yield 'borderStyle' => [
+			'type'     => Token_Type::get_type_border_style(),
+			'expected' => 'border-style',
+		];
+	}
+
+	/**
+	 * A $type already kebab-safe (or unregistered) maps to itself: get_id_segment() is an identity
+	 * function outside its registered map.
+	 *
+	 * @dataProvider identityIdSegmentProvider
+	 *
+	 * @param string $type The $type under test.
+	 *
+	 * @return void
+	 */
+	public function testGetIdSegmentIsIdentityForKebabSafeTypes( string $type ): void {
+		$this->assertSame( $type, Token_Type::get_id_segment( $type ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function identityIdSegmentProvider(): Generator {
+		yield 'color' => [ 'type' => Token_Type::get_type_color() ];
+		yield 'dimension' => [ 'type' => Token_Type::get_type_dimension() ];
+		yield 'shadow' => [ 'type' => Token_Type::get_type_shadow() ];
+		yield 'an unregistered type' => [ 'type' => 'bogus' ];
+	}
+
+	/**
+	 * Every value get_id_segments() returns is itself a valid kebab-case id segment — the
+	 * regression pin that stops a future $type from reintroducing the camelCase-id bug the mapping
+	 * exists to fix.
+	 *
+	 * @return void
+	 */
+	public function testGetIdSegmentsAreAllValidKebabSegments(): void {
+		foreach ( Token_Type::get_id_segments() as $segment ) {
+			$this->assertMatchesRegularExpression( '/^[a-z0-9]+(-[a-z0-9]+)*$/', $segment );
+		}
+	}
+
+	/**
+	 * get_id_segments() maps every registered $type, in the same order as all().
+	 *
+	 * @return void
+	 */
+	public function testGetIdSegmentsMapsEveryTypeInDeclarationOrder(): void {
+		$this->assertSame(
+			[ 'color', 'dimension', 'font-family', 'font-weight', 'line-height', 'font-style', 'text-transform', 'border-style', 'shadow' ],
+			Token_Type::get_id_segments()
+		);
+	}
 }


### PR DESCRIPTION
Lets a user primitive exist for a DTCG `$type` whose spelling is not a valid id segment. Second of three stacked PRs for SOFT-4077 — **backend only, no UI**, deliberately separated so it can be reviewed on its own terms.

## The problem

A user primitive's id is `primitive.<$type>.custom.<slug>`, so the `$type` spelling *is* an id segment. Every registered id must match `^[a-z0-9]+([.-][a-z0-9]+)*$`, because it feeds `Css_Var::from_id()`. Six of the nine registered types are camelCase — `fontFamily`, `fontWeight`, `lineHeight`, `fontStyle`, `textTransform`, `borderStyle` — so none of them could ever be minted.

Typography needs `fontFamily`. Rather than special-casing it, this introduces the mapping the id charset always implied.

## The change

`Token_Type` gains a `$type` → id-segment map (`fontFamily` → `font-family`) with accessors, since it already owns the vocabulary. `Reserved_Namespace` builds and matches ids through it — `canonical()`, `is_reserved_id()` and `contains_reserved_path()`. No reverse lookup exists: every consumer was checked and none starts from a segment (the registrar and the rename path both read `$type` from the stored leaf; the orphan walk iterates forward).

`is_supported_type()` becomes exactly `Token_Type::is_valid()`. The kebab-safety predicate it used to carry is what the mapping now removes the need for.

The map is mirrored in JS for `customScaleTokenId()`, which made the same type-equals-segment assumption.

## Two things a reviewer should look at closely

**The leaf-`$type` invariant changes meaning.** It shipped days ago asserting that a leaf's `$type` equals its id's type segment. It now compares the **mapped** segment. `primitive.font-family.custom.x` declaring `$type: fontFamily` is correct; `primitive.fontFamily.custom.x` is now rejected earlier, by the namespace guard, because that id no longer matches the reserved shape at all.

**This widens what can be created.** All six camelCase types become creatable, not just `fontFamily`. That is deliberate: each already has a shipped `Value_Validator`, the create route's `$value` arg carries no type constraint, and `shadow`'s object `$value` already proved the path. A hand-maintained allowlist would be a second vocabulary to drift out of sync with `Token_Type`. If you would rather gate this, that is the decision to push back on — it is the one place this PR widens an API rather than fixing a bug.

## Test flips, all intended

- `Reserved_NamespaceTest`: `fontFamily`/`fontWeight` go `false` → `true` in the supported-type provider; four more camelCase types added as `true`; `bogus` stays `false`. New cases pin the mapped segment and that `primitive.fontFamily.custom.abel` is now *not* a reserved id while `primitive.font-family.custom.abel` is.
- `User_Primitive_Document_ValidatorTest`: the wrong-type test is renamed and now expects the namespace error rather than the unsupported-type error, because a camelCase id no longer reaches the type check. New cases cover a mapped-type match and a mapped-type mismatch, plus an orphan walk under `primitive.font-family.custom.*`.
- `User_Primitives_ControllerTest`: `fontWeight`/`fontFamily` leave the unsupported-type provider; only `bogus` remains.

## Verification

`phpstan` clean; `phpcs`, `cspell`, `eslint` clean; `Resources/Design_Tokens` green; snapshot suites green with zero diffs; jest green including the mirrored JS map.
