### PR TITLE
[DTM] SOFT-4077: Font catalog with Add and Delete

### DIFF
--- a/includes/resources/Design_Tokens/Admin/Feed/Font_Catalog.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Font_Catalog.php
@@ -84,6 +84,18 @@ final class Font_Catalog {
 	 * @return string[]
 	 */
 	private function custom_names(): array {
+		/**
+		 * Filters the site-registered custom fonts, the same list the block editor localizes as
+		 * c_fonts. Each entry is keyed by the font's family name or by a whole font-stack
+		 * expression (`"My Font", sans-serif`, the shape kadence_blocks_convert_custom_fonts()
+		 * builds when a fallback is registered); an integer-keyed string entry is a plain name.
+		 *
+		 * @since TBD
+		 *
+		 * @param array<string|int, mixed> $fonts The registered custom fonts.
+		 *
+		 * @return array<string|int, mixed> The registered custom fonts.
+		 */
 		$fonts = apply_filters( self::CUSTOM_FONTS_FILTER, [] );
 
 		if ( ! is_array( $fonts ) ) {
@@ -93,13 +105,37 @@ final class Font_Catalog {
 		$names = [];
 
 		foreach ( $fonts as $key => $value ) {
-			if ( is_string( $key ) ) {
-				$names[] = $key;
-			} elseif ( is_string( $value ) ) {
-				$names[] = $value;
+			$name = is_string( $key ) ? $this->family_of( $key ) : ( is_string( $value ) ? $this->family_of( $value ) : '' );
+
+			if ( $name !== '' ) {
+				$names[] = $name;
 			}
 		}
 
 		return $names;
+	}
+
+	/**
+	 * The family name a catalog entry names, taken from a font-stack expression when it carries
+	 * one: the first family, with its surrounding quotes removed.
+	 *
+	 * A registered fallback puts the whole stack in the key (`"My Font", sans-serif`). Catalogued
+	 * verbatim, that string becomes the picked font's `$value`, which Css_Renderer quotes as one
+	 * family — `font-family: "\"My Font\", sans-serif"`, invalid — and never matches its own
+	 * Google entry when the two lists are deduplicated. The family alone is what both need. The
+	 * fallback is deliberately not carried into the token: a font primitive is minted as a
+	 * single-family stack, the same rule that keeps a generic fallback from being invented for a
+	 * Google family.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $entry The catalog entry, a family name or a font-stack expression.
+	 *
+	 * @return string The family name, or "" when the entry names none.
+	 */
+	private function family_of( string $entry ): string {
+		$first = explode( ',', $entry )[0];
+
+		return trim( $first, " \t\n\r\0\x0B\"'" );
 	}
 }

--- a/includes/resources/Design_Tokens/Admin/Feed/Font_Catalog.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Font_Catalog.php
@@ -1,0 +1,105 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed;
+
+/**
+ * Reads and normalizes the font catalog the Typography screen's searchable dropdown lists:
+ * every Google font family name plus every site-registered custom font name.
+ *
+ * The Google names come from includes/gfonts-names-array.php, the same generated, flat name
+ * list the block editor already localizes (class-kadence-blocks-editor-assets.php's g_font_names).
+ * The larger includes/gfonts-array.php (variants/subsets/weights/italics per family) is not read
+ * here: it carries no category field, so it cannot contribute anything a generic-fallback stack
+ * would need, and shipping its 338KB to this catalog would be pure waste.
+ *
+ * Custom names come from the kadence_blocks_custom_fonts filter, the same one the block editor
+ * localizes as c_fonts — its shape is an associative array keyed by font name (a string key may
+ * itself be a font-stack expression such as `"My Font", sans-serif`), so a string key is taken as
+ * a name; an integer-keyed string entry (a plain list of names) passes through as-is.
+ *
+ * @since TBD
+ */
+final class Font_Catalog {
+
+	/**
+	 * The generated Google font names file, relative to the plugin root.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const NAMES_FILE = 'includes/gfonts-names-array.php';
+
+	/**
+	 * The filter the block editor already reads for site-registered custom fonts.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const CUSTOM_FONTS_FILTER = 'kadence_blocks_custom_fonts';
+
+	/**
+	 * The catalog: every Google family name, and every custom family name not already among them.
+	 *
+	 * @since TBD
+	 *
+	 * @return array{google: string[], custom: string[]}
+	 */
+	public function all(): array {
+		$google = $this->google_names();
+		$custom = array_values( array_diff( $this->custom_names(), $google ) );
+
+		return [
+			'google' => $google,
+			'custom' => $custom,
+		];
+	}
+
+	/**
+	 * The Google font names, fail-soft to an empty list when the generated file is absent — the
+	 * same posture class-kadence-blocks-editor-assets.php already takes for the same file.
+	 *
+	 * @since TBD
+	 *
+	 * @return string[]
+	 */
+	private function google_names(): array {
+		$path = KADENCE_BLOCKS_PATH . self::NAMES_FILE;
+
+		if ( ! file_exists( $path ) ) {
+			return [];
+		}
+
+		$names = include $path;
+
+		return is_array( $names ) ? array_values( array_filter( $names, 'is_string' ) ) : [];
+	}
+
+	/**
+	 * The site's custom font names, normalized from the custom-fonts filter's associative shape.
+	 *
+	 * @since TBD
+	 *
+	 * @return string[]
+	 */
+	private function custom_names(): array {
+		$fonts = apply_filters( self::CUSTOM_FONTS_FILTER, [] );
+
+		if ( ! is_array( $fonts ) ) {
+			return [];
+		}
+
+		$names = [];
+
+		foreach ( $fonts as $key => $value ) {
+			if ( is_string( $key ) ) {
+				$names[] = $key;
+			} elseif ( is_string( $value ) ) {
+				$names[] = $value;
+			}
+		}
+
+		return $names;
+	}
+}

--- a/includes/resources/Design_Tokens/Admin/Feed/Localizer.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Localizer.php
@@ -23,6 +23,12 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
  * The feed is emitted with wp_add_inline_script + wp_json_encode rather than wp_localize_script, which
  * would stringify the booleans, version and nested maps.
  *
+ * Alongside the feed, this also emits the font catalog ({@see Font_Catalog}) as a SEPARATE inline
+ * global, window.kadenceDesignTokensFontCatalog. It rides the same handle but is built once here,
+ * never inside Feed_Assembler's payload: the feed re-fetches after every write (refreshFeed) and
+ * on every library switch, while the catalog (~29KB of Google font names) is static and
+ * library-independent — folding it into the feed would re-send it on every save.
+ *
  * @since TBD
  */
 final class Localizer {
@@ -60,6 +66,15 @@ final class Localizer {
 	private const OBJECT = 'kadenceDesignTokens';
 
 	/**
+	 * The JS global the font catalog is emitted under.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const CATALOG_OBJECT = 'kadenceDesignTokensFontCatalog';
+
+	/**
 	 * The active-library pointer — the same slug the registry's user primitives and every projector
 	 * (CSS vars, theme.json, block presets, selectable presets) resolve against, so the dashboard edits the library that
 	 * is actually live rather than always the default one.
@@ -80,14 +95,25 @@ final class Localizer {
 	private Feed_Assembler $assembler;
 
 	/**
+	 * The font catalog reader, for the page-load-only catalog global.
+	 *
+	 * @since TBD
+	 *
+	 * @var Font_Catalog
+	 */
+	private Font_Catalog $catalog;
+
+	/**
 	 * @since TBD
 	 *
 	 * @param Active_Token_Library_Store $active    The active-library pointer.
 	 * @param Feed_Assembler             $assembler The shared pipeline that builds a feed payload for a slug.
+	 * @param Font_Catalog               $catalog   The font catalog reader.
 	 */
-	public function __construct( Active_Token_Library_Store $active, Feed_Assembler $assembler ) {
+	public function __construct( Active_Token_Library_Store $active, Feed_Assembler $assembler, Font_Catalog $catalog ) {
 		$this->active    = $active;
 		$this->assembler = $assembler;
+		$this->catalog   = $catalog;
 	}
 
 	/**
@@ -122,6 +148,35 @@ final class Localizer {
 		wp_add_inline_script(
 			$handle,
 			'window.' . self::OBJECT . ' = ' . $json . ';',
+			'before'
+		);
+
+		$this->localize_catalog( $handle );
+	}
+
+	/**
+	 * Attach the font catalog to the same handle, as its own inline global — built once per
+	 * page load, never rebuilt when the feed refreshes after a write.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $handle The script handle the feed was just attached to.
+	 *
+	 * @return void
+	 */
+	private function localize_catalog( string $handle ): void {
+		$json = wp_json_encode(
+			$this->catalog->all(),
+			JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+		);
+
+		if ( $json === false ) {
+			return; // Catalog cannot be serialized — skip rather than inject malformed JS.
+		}
+
+		wp_add_inline_script(
+			$handle,
+			'window.' . self::CATALOG_OBJECT . ' = ' . $json . ';',
 			'before'
 		);
 	}

--- a/includes/resources/Design_Tokens/Admin/Provider.php
+++ b/includes/resources/Design_Tokens/Admin/Provider.php
@@ -4,6 +4,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Admin;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Feed_Assembler;
+use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Font_Catalog;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Localizer;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Preset_Nav;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Presets;
@@ -31,6 +32,7 @@ final class Provider extends Provider_Contract {
 		$this->container->singleton( Presets::class );
 		$this->container->singleton( Preset_Nav::class );
 		$this->container->singleton( Feed_Assembler::class );
+		$this->container->singleton( Font_Catalog::class );
 		$this->container->singleton( Localizer::class );
 		$this->container->singleton( Screen::class );
 		$this->container->singleton( Asset_Loader::class );

--- a/src/style-library/__tests__/catalog-filter.test.js
+++ b/src/style-library/__tests__/catalog-filter.test.js
@@ -1,0 +1,48 @@
+/* eslint-env jest */
+// cspell:ignore Abril Fatface .
+import { CATALOG_RENDER_CAP, filterCatalogOptions } from '../helpers/catalog-filter';
+
+describe('filterCatalogOptions', () => {
+	const options = [
+		{ value: 'Abel', label: 'Abel' },
+		{ value: 'Abril Fatface', label: 'Abril Fatface' },
+		{ value: 'Georgia', label: 'Georgia' },
+	];
+
+	it('matches case-insensitively by substring', () => {
+		expect(filterCatalogOptions(options, 'abr')).toEqual({
+			visible: [options[1]],
+			truncated: false,
+		});
+	});
+
+	it('returns every option, capped, for an empty query', () => {
+		expect(filterCatalogOptions(options, '')).toEqual({ visible: options, truncated: false });
+		expect(filterCatalogOptions(options, undefined)).toEqual({ visible: options, truncated: false });
+	});
+
+	it('returns no matches for a query nothing contains', () => {
+		expect(filterCatalogOptions(options, 'zzz')).toEqual({ visible: [], truncated: false });
+	});
+
+	it('caps the visible rows and reports truncation once matches exceed the cap', () => {
+		const many = Array.from({ length: 5 }, (_, i) => ({ value: `Font ${i}`, label: `Font ${i}` }));
+
+		expect(filterCatalogOptions(many, 'font', 3)).toEqual({
+			visible: many.slice(0, 3),
+			truncated: true,
+		});
+	});
+
+	it('defaults the cap to CATALOG_RENDER_CAP', () => {
+		const many = Array.from({ length: CATALOG_RENDER_CAP + 5 }, (_, i) => ({
+			value: `Font ${i}`,
+			label: `Font ${i}`,
+		}));
+
+		const { visible, truncated } = filterCatalogOptions(many, '');
+
+		expect(visible).toHaveLength(CATALOG_RENDER_CAP);
+		expect(truncated).toBe(true);
+	});
+});

--- a/src/style-library/__tests__/font-flows.test.js
+++ b/src/style-library/__tests__/font-flows.test.js
@@ -1,0 +1,88 @@
+/* eslint-env jest */
+// cspell:ignore Abril Fatface abril fatface .
+import { addFontFlow } from '../helpers/font-flows';
+import * as client from '../api/client';
+
+// A factory, not bare automocking — see scale-flows.test.js's identical note: the real module
+// imports `@wordpress/api-fetch`, externalized in production and not an npm dependency here.
+jest.mock('../api/client', () => ({
+	createUserPrimitive: jest.fn(),
+}));
+
+beforeEach(() => {
+	jest.resetAllMocks();
+});
+
+describe('addFontFlow', () => {
+	it('posts the derived slug, label, single-family stack, and font-family group, refreshes the feed, and resolves the kebab canonical id', async () => {
+		client.createUserPrimitive.mockResolvedValue({ version: 'v2' });
+		const refreshFeed = jest.fn().mockResolvedValue({});
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		const result = await addFontFlow({
+			name: 'Abril Fatface',
+			existingIds: [],
+			slug: 'default',
+			feedVersion: 'v1',
+			refreshFeed,
+			onBusy,
+			onError,
+		});
+
+		expect(client.createUserPrimitive).toHaveBeenCalledWith('default', {
+			id: 'abril-fatface',
+			$type: 'fontFamily',
+			$value: ['Abril Fatface'],
+			label: 'Abril Fatface',
+			group: 'font-family',
+			version: 'v1',
+		});
+		expect(refreshFeed).toHaveBeenCalledWith('default');
+		expect(result).toBe('primitive.font-family.custom.abril-fatface');
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it('suffixes the derived slug on collision with an existing id', async () => {
+		client.createUserPrimitive.mockResolvedValue({ version: 'v2' });
+		const refreshFeed = jest.fn().mockResolvedValue({});
+
+		const result = await addFontFlow({
+			name: 'Abel',
+			existingIds: ['primitive.font-family.custom.abel'],
+			slug: 'default',
+			feedVersion: 'v1',
+			refreshFeed,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(client.createUserPrimitive).toHaveBeenCalledWith('default', expect.objectContaining({ id: 'abel-2' }));
+		expect(result).toBe('primitive.font-family.custom.abel-2');
+	});
+
+	it('surfaces the error, clears busy, and re-throws on failure', async () => {
+		const failure = new Error('Boom');
+		client.createUserPrimitive.mockRejectedValue(failure);
+		const refreshFeed = jest.fn();
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			addFontFlow({
+				name: 'Abel',
+				existingIds: [],
+				slug: 'default',
+				feedVersion: 'v1',
+				refreshFeed,
+				onBusy,
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(refreshFeed).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+});

--- a/src/style-library/__tests__/typography.test.js
+++ b/src/style-library/__tests__/typography.test.js
@@ -1,5 +1,13 @@
 /* eslint-env jest */
-import { fontOptions, fontSizeDisplayValue } from '../helpers/typography';
+// cspell:ignore Abril Fatface abril fatface Écriture ecriture .
+import {
+	findFontByFamily,
+	fontActionFor,
+	fontFamilySlug,
+	fontOptions,
+	fontSizeDisplayValue,
+	getFontCatalog,
+} from '../helpers/typography';
 
 describe('fontOptions', () => {
 	it('returns [] for a missing schema or unknown group', () => {
@@ -25,9 +33,24 @@ describe('fontOptions', () => {
 		};
 
 		expect(fontOptions(schema, values, 'Font Family')).toEqual([
-			{ id: 'primitive.font-family.sans', label: 'Inter', stack: 'Inter, system-ui, sans-serif' },
-			{ id: 'primitive.font-family.serif', label: 'Georgia', stack: 'Georgia, Cambria, serif' },
-			{ id: 'primitive.font-family.mono', label: 'Menlo', stack: 'Menlo, Consolas, monospace' },
+			{
+				id: 'primitive.font-family.sans',
+				label: 'Inter',
+				stack: 'Inter, system-ui, sans-serif',
+				userCreated: false,
+			},
+			{
+				id: 'primitive.font-family.serif',
+				label: 'Georgia',
+				stack: 'Georgia, Cambria, serif',
+				userCreated: false,
+			},
+			{
+				id: 'primitive.font-family.mono',
+				label: 'Menlo',
+				stack: 'Menlo, Consolas, monospace',
+				userCreated: false,
+			},
 		]);
 	});
 
@@ -36,6 +59,26 @@ describe('fontOptions', () => {
 		const values = { 'primitive.font-family.sans': '"Inter", system-ui, sans-serif' };
 
 		expect(fontOptions(schema, values, 'Font Family')[0].label).toBe('Inter');
+	});
+
+	it('passes userCreated through from the feed entry', () => {
+		const schema = {
+			groups: {
+				'Font Family': [
+					{ id: 'primitive.font-family.sans' },
+					{ id: 'primitive.font-family.custom.abel', userCreated: true },
+				],
+			},
+		};
+		const values = {
+			'primitive.font-family.sans': 'Inter, system-ui, sans-serif',
+			'primitive.font-family.custom.abel': 'Abel',
+		};
+
+		const options = fontOptions(schema, values, 'Font Family');
+
+		expect(options[0].userCreated).toBe(false);
+		expect(options[1].userCreated).toBe(true);
 	});
 });
 
@@ -54,5 +97,93 @@ describe('fontSizeDisplayValue', () => {
 
 	it('returns an empty value verbatim', () => {
 		expect(fontSizeDisplayValue('')).toBe('');
+	});
+});
+
+describe('getFontCatalog', () => {
+	const originalCatalog = window.kadenceDesignTokensFontCatalog;
+
+	afterEach(() => {
+		window.kadenceDesignTokensFontCatalog = originalCatalog;
+	});
+
+	it('fails safe to two empty lists when the global is missing', () => {
+		delete window.kadenceDesignTokensFontCatalog;
+
+		expect(getFontCatalog()).toEqual({ google: [], custom: [] });
+	});
+
+	it('fails safe to two empty lists when the global is malformed', () => {
+		window.kadenceDesignTokensFontCatalog = { google: 'not-an-array' };
+
+		expect(getFontCatalog()).toEqual({ google: [], custom: [] });
+	});
+
+	it('reads the google and custom lists verbatim when present', () => {
+		window.kadenceDesignTokensFontCatalog = { google: ['Abel', 'Abril Fatface'], custom: ['My Font'] };
+
+		expect(getFontCatalog()).toEqual({ google: ['Abel', 'Abril Fatface'], custom: ['My Font'] });
+	});
+});
+
+describe('findFontByFamily', () => {
+	const fonts = [
+		{ id: 'primitive.font-family.sans', label: 'Inter' },
+		{ id: 'primitive.font-family.serif', label: 'Georgia' },
+	];
+
+	it('matches a design-system font case-insensitively', () => {
+		expect(findFontByFamily(fonts, 'inter')).toEqual(fonts[0]);
+		expect(findFontByFamily(fonts, 'INTER')).toEqual(fonts[0]);
+	});
+
+	it('unquotes both sides before comparing', () => {
+		expect(findFontByFamily(fonts, '"Inter"')).toEqual(fonts[0]);
+		expect(findFontByFamily([{ id: 'x', label: '"Inter"' }], 'Inter')).toEqual({ id: 'x', label: '"Inter"' });
+	});
+
+	it('returns null when no font matches', () => {
+		expect(findFontByFamily(fonts, 'Abel')).toBeNull();
+	});
+});
+
+describe('fontFamilySlug', () => {
+	it('lowercases and hyphenates spaces', () => {
+		expect(fontFamilySlug('Abril Fatface')).toBe('abril-fatface');
+	});
+
+	it('strips diacritics', () => {
+		expect(fontFamilySlug('Écriture')).toBe('ecriture');
+	});
+
+	it('collapses any run of non alphanumeric characters to a single hyphen and trims the edges', () => {
+		expect(fontFamilySlug('  Foo!!  Bar__Baz  ')).toBe('foo-bar-baz');
+	});
+
+	it('falls back to "font" for a name that yields nothing (fully non-Latin)', () => {
+		expect(fontFamilySlug('日本語')).toBe('font');
+	});
+
+	it('falls back to "font" for an empty or missing name', () => {
+		expect(fontFamilySlug('')).toBe('font');
+		expect(fontFamilySlug(undefined)).toBe('font');
+	});
+});
+
+describe('fontActionFor', () => {
+	const baselineFont = { id: 'primitive.font-family.sans', label: 'Inter', userCreated: false };
+	const customFont = { id: 'primitive.font-family.custom.abel', label: 'Abel', userCreated: true };
+	const fonts = [baselineFont, customFont];
+
+	it('returns an enabled add action when the pick matches no design-system font', () => {
+		expect(fontActionFor(fonts, 'Abril Fatface')).toEqual({ type: 'add', disabled: false, font: null });
+	});
+
+	it('returns an enabled delete action when the pick matches a user-created font', () => {
+		expect(fontActionFor(fonts, 'Abel')).toEqual({ type: 'delete', disabled: false, font: customFont });
+	});
+
+	it('returns a disabled add action when the pick matches a baseline font', () => {
+		expect(fontActionFor(fonts, 'Inter')).toEqual({ type: 'add', disabled: true, font: baselineFont });
 	});
 });

--- a/src/style-library/components/molecules/SearchableSelectDropdown.js
+++ b/src/style-library/components/molecules/SearchableSelectDropdown.js
@@ -8,7 +8,8 @@
  *
  * The menu opens with a search input that is focused automatically, above a filtered, capped option list; a footer
  * row appears once the match count exceeds the cap, inviting the user to keep typing to narrow
- * further rather than ever rendering the full catalog. `filterCatalogOptions` — the matching + cap
+ * further rather than ever rendering the full catalog, and a query that matches nothing says so
+ * instead of leaving the menu blank. `filterCatalogOptions` — the matching + cap
  * logic — lives in `helpers/catalog-filter.js`, a plain module with no React/JSX, so it is
  * unit-testable without mounting this component or importing its `.scss` (this app's tests are
  * pure-helpers-only for exactly that reason).
@@ -121,6 +122,11 @@ export function SearchableSelectDropdown({ value, options, onChange, isBusy, cla
 								);
 							})}
 						</MenuGroup>
+						{visible.length === 0 && (
+							<div className="kadence-blocks-style-library__searchable-select-dropdown-empty">
+								{__('No fonts found', 'kadence-blocks')}
+							</div>
+						)}
 						{truncated && (
 							<div className="kadence-blocks-style-library__searchable-select-dropdown-footer">
 								{__('Keep typing to narrow the list', 'kadence-blocks')}

--- a/src/style-library/components/molecules/SearchableSelectDropdown.js
+++ b/src/style-library/components/molecules/SearchableSelectDropdown.js
@@ -1,0 +1,134 @@
+/**
+ * A searchable variant of `SelectDropdown` for a large, flat catalog (the Typography screen's font
+ * catalog: 1,916 Google families plus any site custom fonts) where a plain closed-list toggle+menu
+ * would render every option and read as visibly slow. `SelectDropdown`'s toggle/chevron/flush-menu
+ * geometry is the visual model here, not something this component extends — its contract (a small
+ * closed list, radio semantics, three existing callers) would only get more complicated by bolting
+ * search and a render cap onto it for one consumer.
+ *
+ * The menu opens with a search input that is focused automatically, above a filtered, capped option list; a footer
+ * row appears once the match count exceeds the cap, inviting the user to keep typing to narrow
+ * further rather than ever rendering the full catalog. `filterCatalogOptions` — the matching + cap
+ * logic — lives in `helpers/catalog-filter.js`, a plain module with no React/JSX, so it is
+ * unit-testable without mounting this component or importing its `.scss` (this app's tests are
+ * pure-helpers-only for exactly that reason).
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Button, Dropdown, MenuGroup, MenuItem, TextControl } from '@wordpress/components';
+import { Icon, chevronDown } from '@wordpress/icons';
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { filterCatalogOptions } from '../../helpers/catalog-filter';
+import './SearchableSelectDropdown.scss';
+
+/**
+ * Render the searchable catalog dropdown.
+ *
+ * @param {Object}                                                              props
+ * @param {string}                                                              props.value        The current option's value (a catalog family name, never a token id).
+ * @param {Array<{value: string, label: string, badge?: string}>}               props.options       The full, unfiltered option list, in display order. An option may carry a short `badge` (the "Custom" tag).
+ * @param {Function}                                                            props.onChange      Called with a value when a different option is chosen.
+ * @param {boolean}                                                             [props.isBusy]      Whether a change is in flight.
+ * @param {string}                                                              [props.className]   Extra class names for the root wrapper.
+ * @param {string}                                                              [props.valueLabel]  The label for `value` to show while no option in `options` matches it yet — falls back to the raw `value` when omitted.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The dropdown.
+ */
+export function SearchableSelectDropdown({ value, options, onChange, isBusy, className, valueLabel }) {
+	const [query, setQuery] = useState('');
+	const { visible, truncated } = useMemo(() => filterCatalogOptions(options, query), [options, query]);
+
+	const activeOption = options.find((option) => option.value === value);
+	const activeLabel = activeOption?.label ?? valueLabel ?? value;
+
+	return (
+		<div className={classnames('kadence-blocks-style-library__searchable-select-dropdown', className)}>
+			<Dropdown
+				className="kadence-blocks-style-library__searchable-select-dropdown-dropdown"
+				contentClassName="kadence-blocks-style-library__searchable-select-dropdown-menu"
+				popoverProps={{ placement: 'bottom-start', offset: 0 }}
+				onClose={() => setQuery('')}
+				renderToggle={({ isOpen, onToggle }) => (
+					<Button
+						className="kadence-blocks-style-library__searchable-select-dropdown-toggle"
+						aria-expanded={isOpen}
+						disabled={isBusy}
+						onClick={onToggle}
+					>
+						<span className="kadence-blocks-style-library__searchable-select-dropdown-label">
+							{activeLabel}
+						</span>
+						<span className="kadence-blocks-style-library__searchable-select-dropdown-icon">
+							<Icon
+								className="kadence-blocks-style-library__searchable-select-dropdown-chevron"
+								icon={chevronDown}
+							/>
+						</span>
+					</Button>
+				)}
+				renderContent={({ onClose }) => (
+					<>
+						<TextControl
+							__nextHasNoMarginBottom
+							autoFocus
+							className="kadence-blocks-style-library__searchable-select-dropdown-search"
+							placeholder={__('Search fonts…', 'kadence-blocks')}
+							value={query}
+							onChange={setQuery}
+						/>
+						<MenuGroup className="kadence-blocks-style-library__searchable-select-dropdown-options">
+							{visible.map((option) => {
+								const isCurrent = option.value === value;
+
+								return (
+									<MenuItem
+										key={option.value}
+										role="menuitemradio"
+										aria-checked={isCurrent}
+										disabled={isBusy}
+										suffix={
+											option.badge && (
+												<span className="kadence-blocks-style-library__searchable-select-dropdown-badge">
+													{option.badge}
+												</span>
+											)
+										}
+										onClick={() => {
+											onClose();
+											setQuery('');
+
+											if (!isCurrent) {
+												onChange(option.value);
+											}
+										}}
+									>
+										{option.label}
+									</MenuItem>
+								);
+							})}
+						</MenuGroup>
+						{truncated && (
+							<div className="kadence-blocks-style-library__searchable-select-dropdown-footer">
+								{__('Keep typing to narrow the list', 'kadence-blocks')}
+							</div>
+						)}
+					</>
+				)}
+			/>
+		</div>
+	);
+}

--- a/src/style-library/components/molecules/SearchableSelectDropdown.scss
+++ b/src/style-library/components/molecules/SearchableSelectDropdown.scss
@@ -27,13 +27,13 @@
 	text-align: left;
 
 	&:hover,
-	&[aria-expanded='true'] {
+	&[aria-expanded="true"] {
 		color: var(--kb-sl-color-text-primary);
 	}
 
 	&:focus,
 	&:focus-visible,
-	&[aria-expanded='true'] {
+	&[aria-expanded="true"] {
 		border-color: var(--kb-sl-color-control-border-focus);
 	}
 
@@ -72,7 +72,8 @@
 // border/shadow. A taller max-height + its own scroll region is the one geometry difference from
 // SelectDropdown's menu: the catalog list (even capped at 100 rows) is far longer than any closed
 // list this app shows elsewhere.
-.kadence-blocks-style-library__searchable-select-dropdown-menu .components-popover__content.components-popover__content {
+.kadence-blocks-style-library__searchable-select-dropdown-menu
+	.components-popover__content.components-popover__content {
 	display: flex;
 	flex-direction: column;
 	background: var(--kb-sl-color-surface);
@@ -122,7 +123,8 @@
 	}
 }
 
-.kadence-blocks-style-library__searchable-select-dropdown-menu .kadence-blocks-style-library__searchable-select-dropdown-badge {
+.kadence-blocks-style-library__searchable-select-dropdown-menu
+	.kadence-blocks-style-library__searchable-select-dropdown-badge {
 	flex: 0 0 auto;
 	color: var(--kb-sl-color-text-muted);
 	font-size: var(--kb-sl-font-size-s);
@@ -135,6 +137,16 @@
 	flex: 0 0 auto;
 	padding: var(--kb-sl-space-10) var(--kb-sl-space-15);
 	border-top: var(--kb-sl-border-width-input) solid var(--kb-sl-color-border);
+	color: var(--kb-sl-color-text-muted);
+	font-size: var(--kb-sl-font-size-s);
+	text-align: center;
+}
+
+// The empty state replaces the option list, so unlike the footer it carries no top border — there
+// is nothing above it to divide it from but the search input's own bottom edge.
+.kadence-blocks-style-library__searchable-select-dropdown-empty {
+	flex: 0 0 auto;
+	padding: var(--kb-sl-space-15);
 	color: var(--kb-sl-color-text-muted);
 	font-size: var(--kb-sl-font-size-s);
 	text-align: center;

--- a/src/style-library/components/molecules/SearchableSelectDropdown.scss
+++ b/src/style-library/components/molecules/SearchableSelectDropdown.scss
@@ -142,8 +142,7 @@
 	text-align: center;
 }
 
-// The empty state replaces the option list, so unlike the footer it carries no top border — there
-// is nothing above it to divide it from but the search input's own bottom edge.
+// Replaces the option list, so unlike the footer it needs no top border.
 .kadence-blocks-style-library__searchable-select-dropdown-empty {
 	flex: 0 0 auto;
 	padding: var(--kb-sl-space-15);

--- a/src/style-library/components/molecules/SearchableSelectDropdown.scss
+++ b/src/style-library/components/molecules/SearchableSelectDropdown.scss
@@ -1,0 +1,141 @@
+.kadence-blocks-style-library__searchable-select-dropdown {
+	display: flex;
+	align-items: center;
+	gap: var(--kb-sl-space-10);
+}
+
+.kadence-blocks-style-library__searchable-select-dropdown-dropdown {
+	display: block;
+}
+
+// Same fixed toggle geometry as SelectDropdown's toggle — the visual model this component follows
+// without extending.
+.kadence-blocks-style-library-root .kadence-blocks-style-library__searchable-select-dropdown-toggle {
+	display: flex;
+	flex: 0 0 auto;
+	align-items: center;
+	gap: var(--kb-sl-space-10);
+	height: var(--kb-sl-space-50);
+	width: var(--kb-sl-size-select-dropdown-width);
+	padding: 0 var(--kb-sl-space-10) 0 var(--kb-sl-space-15);
+	border: var(--kb-sl-border-width-input) solid var(--kb-sl-color-control-border);
+	border-radius: var(--kb-sl-radius-s);
+	color: var(--kb-sl-color-text-primary);
+	font-size: var(--kb-sl-font-size-m);
+	font-weight: var(--kb-sl-font-weight-regular);
+	line-height: normal;
+	text-align: left;
+
+	&:hover,
+	&[aria-expanded='true'] {
+		color: var(--kb-sl-color-text-primary);
+	}
+
+	&:focus,
+	&:focus-visible,
+	&[aria-expanded='true'] {
+		border-color: var(--kb-sl-color-control-border-focus);
+	}
+
+	&:focus,
+	&:focus-visible {
+		color: var(--kb-sl-color-text-primary);
+		box-shadow: none;
+		outline: none;
+	}
+}
+
+.kadence-blocks-style-library__searchable-select-dropdown-label {
+	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.kadence-blocks-style-library__searchable-select-dropdown-icon {
+	display: flex;
+	flex: 0 0 auto;
+	align-items: center;
+	justify-content: center;
+	width: var(--kb-sl-size-icon-chevron);
+	height: var(--kb-sl-size-icon-chevron);
+}
+
+.kadence-blocks-style-library__searchable-select-dropdown-chevron {
+	display: block;
+	width: 100%;
+	height: 100%;
+}
+
+// The popover surface, matching SelectDropdown's own replacement of core's approximate
+// border/shadow. A taller max-height + its own scroll region is the one geometry difference from
+// SelectDropdown's menu: the catalog list (even capped at 100 rows) is far longer than any closed
+// list this app shows elsewhere.
+.kadence-blocks-style-library__searchable-select-dropdown-menu .components-popover__content.components-popover__content {
+	display: flex;
+	flex-direction: column;
+	background: var(--kb-sl-color-surface);
+	border: var(--kb-sl-border-width-input) solid var(--kb-sl-color-gray-300);
+	border-radius: var(--kb-sl-radius-m);
+	min-width: var(--kb-sl-size-select-dropdown-width);
+	max-width: var(--kb-sl-size-select-dropdown-max-width);
+	max-height: min(60vh, 420px);
+	padding: var(--kb-sl-space-05);
+	box-shadow: var(--kb-sl-shadow-menu);
+	overflow: hidden;
+}
+
+.kadence-blocks-style-library__searchable-select-dropdown-search {
+	flex: 0 0 auto;
+	margin: var(--kb-sl-space-05) var(--kb-sl-space-05) 0;
+
+	input {
+		border-radius: var(--kb-sl-radius-s);
+	}
+}
+
+.kadence-blocks-style-library__searchable-select-dropdown-options {
+	flex: 1 1 auto;
+	overflow-y: auto;
+	padding: 0;
+}
+
+.kadence-blocks-style-library__searchable-select-dropdown-menu .components-menu-item__button {
+	align-items: center;
+	padding: var(--kb-sl-space-10) var(--kb-sl-space-15);
+	border-radius: var(--kb-sl-radius-s);
+	gap: var(--kb-sl-space-30);
+	font-size: var(--kb-sl-font-size-m);
+	line-height: var(--kb-sl-line-height-s);
+	font-weight: var(--kb-sl-font-weight-regular);
+	color: var(--kb-sl-color-gray-900);
+
+	&:focus {
+		box-shadow: none;
+		outline: none;
+	}
+
+	&:hover,
+	&:focus-visible {
+		color: var(--kb-sl-color-theme);
+	}
+}
+
+.kadence-blocks-style-library__searchable-select-dropdown-menu .kadence-blocks-style-library__searchable-select-dropdown-badge {
+	flex: 0 0 auto;
+	color: var(--kb-sl-color-text-muted);
+	font-size: var(--kb-sl-font-size-s);
+	font-weight: var(--kb-sl-font-weight-regular);
+	line-height: var(--kb-sl-line-height-s);
+	white-space: nowrap;
+}
+
+.kadence-blocks-style-library__searchable-select-dropdown-footer {
+	flex: 0 0 auto;
+	padding: var(--kb-sl-space-10) var(--kb-sl-space-15);
+	border-top: var(--kb-sl-border-width-input) solid var(--kb-sl-color-border);
+	color: var(--kb-sl-color-text-muted);
+	font-size: var(--kb-sl-font-size-s);
+	text-align: center;
+}

--- a/src/style-library/components/pages/TypographyScreen.js
+++ b/src/style-library/components/pages/TypographyScreen.js
@@ -2,17 +2,21 @@
  * The Typography screen: the scale config, the FONT preview toolbar, the sample-text preview
  * renderer, and the two thin wrappers that plug into the shared `ScaleScreen`/`ScaleSettings`
  * contract (see `ScaleScreen.js`'s module docblock). Two things make this screen genuinely
- * different from its siblings: a toolbar between the header and the list (the FONT dropdown, font
- * tabs, and the "+ Add Size" action) built on `ScaleScreen`'s optional `renderToolbar` seam, and
- * screen-level preview state (the currently previewed font) that `renderPreview` closes over —
- * absorbed entirely at this screen's own boundary, with no change to the shared hook or flows.
+ * different from its siblings: a toolbar between the header and the list (the FONT catalog
+ * dropdown, the contextual Add/Delete Font button, font tabs, and the "+ Add Size" action) built
+ * on `ScaleScreen`'s optional `renderToolbar` seam, and screen-level preview state (the currently
+ * previewed font, plus the font catalog's Add/Delete flow) that `renderPreview` and the toolbar
+ * close over — absorbed entirely at this screen's own boundary, with no change to the shared hook
+ * or flows.
  */
 
 /**
  * WordPress dependencies
  */
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Button, Notice } from '@wordpress/components';
+import { plus } from '@wordpress/icons';
 
 /**
  * External dependencies
@@ -24,8 +28,17 @@ import classnames from 'classnames';
  */
 import { ScaleScreen } from './ScaleScreen';
 import { ScaleSettings } from './ScaleSettings';
-import { SelectDropdown } from '../molecules/SelectDropdown';
-import { fontOptions, fontSizeDisplayValue } from '../../helpers/typography';
+import { SearchableSelectDropdown } from '../molecules/SearchableSelectDropdown';
+import { deleteScaleTokenFlow } from '../../helpers/scale-flows';
+import { addFontFlow } from '../../helpers/font-flows';
+import { useGoogleFontLoader } from '../../hooks/use-google-font-loader';
+import {
+	findFontByFamily,
+	fontActionFor,
+	fontOptions,
+	fontSizeDisplayValue,
+	getFontCatalog,
+} from '../../helpers/typography';
 import './TypographyScreen.scss';
 
 /**
@@ -43,6 +56,14 @@ const SAMPLE_TEXT = __('Visualize your font', 'kadence-blocks');
  * @since TBD
  */
 const FONT_FAMILY_GROUP = __('Font Family', 'kadence-blocks');
+
+/**
+ * The muted badge a catalog custom font carries in the dropdown menu, matching the `SelectDropdown`
+ * badge treatment used elsewhere in the app.
+ *
+ * @since TBD
+ */
+const CUSTOM_BADGE = __('Custom', 'kadence-blocks');
 
 /**
  * Build a `renderPreview` closing over the currently selected font's resolved stack. `row.value` is
@@ -72,22 +93,64 @@ function samplePreviewRenderer(fontStack) {
 }
 
 /**
- * Build the `renderToolbar( { addAction, isBusy } )` implementation: font tabs (only when more than
- * one family exists), the FONT label and dropdown, and the passed-in add action positioned at the
- * row's right edge — the toolbar positions `addAction`, it never re-implements it, so the shared
- * guard/busy discipline cannot fork between this screen and its siblings.
+ * Build the catalog dropdown's option list: every Google family name, then every custom family
+ * name, each carrying its catalog family name as `value` (never a token id — see
+ * `SearchableSelectDropdown`'s module docblock) and custom names tagged with the muted `Custom`
+ * badge.
  *
- * @param {Array<{id: string, label: string, stack: string}>} fonts          The FONT options, in feed order.
- * @param {string}                                             selectedFontId The currently previewed font's id.
- * @param {Function}                                            onSelectFont   Called with a font id when the
- *                                                                             selection changes (tab or dropdown).
+ * @since TBD
+ *
+ * @return {Array<{value: string, label: string, badge?: string}>} The dropdown's option list.
+ */
+function buildCatalogOptions() {
+	const { google, custom } = getFontCatalog();
+
+	return [
+		...google.map((name) => ({ value: name, label: name })),
+		...custom.map((name) => ({ value: name, label: name, badge: CUSTOM_BADGE })),
+	];
+}
+
+/**
+ * Build the `renderToolbar( { addAction, isBusy } )` implementation: font tabs (only when more than
+ * one family exists), the FONT label, the searchable catalog dropdown with its contextual
+ * Add/Delete Font button, and the passed-in add-size action positioned at the row's right edge —
+ * the toolbar positions `addAction`, it never re-implements it, so the shared guard/busy discipline
+ * cannot fork between this screen and its siblings.
+ *
+ * @param {Object}                                              args
+ * @param {Array<{id: string, label: string, stack: string}>}   args.fonts           The FONT options, in feed order.
+ * @param {string}                                              args.selectedFontId  The currently previewed font's id.
+ * @param {Function}                                             args.onSelectFont    Called with a font id when the tabs or a matching catalog pick change the preview.
+ * @param {Array<{value: string, label: string, badge?: string}>} args.catalogOptions The catalog dropdown's option list.
+ * @param {string}                                               args.dropdownValue   The catalog dropdown's current value (a catalog family name).
+ * @param {Function}                                              args.onPickCatalog   Called with a catalog family name when a dropdown option is chosen.
+ * @param {{type: ('add'|'delete'), disabled: boolean, font: ?Object}} args.fontAction The contextual button's state ({@see fontActionFor}).
+ * @param {Function}                                              args.onFontAction    Invokes the Add Font or Delete Font flow for the current `fontAction`.
+ * @param {boolean}                                               args.fontBusy        Whether an Add/Delete Font request is in flight.
+ * @param {?{message: string}}                                    args.fontError       The current Add/Delete Font error, if any.
+ * @param {Function}                                              args.onClearFontError Dismisses `fontError`.
  *
  * @since TBD
  *
  * @return {Function} The `config.renderToolbar` implementation.
  */
-function typographyToolbarRenderer(fonts, selectedFontId, onSelectFont) {
+function typographyToolbarRenderer({
+	fonts,
+	selectedFontId,
+	onSelectFont,
+	catalogOptions,
+	dropdownValue,
+	onPickCatalog,
+	fontAction,
+	onFontAction,
+	fontBusy,
+	fontError,
+	onClearFontError,
+}) {
 	return function renderToolbar({ addAction, isBusy }) {
+		const controlsBusy = isBusy || fontBusy;
+
 		return (
 			<div className="kadence-blocks-style-library__typography-toolbar">
 				{fonts.length > 1 && (
@@ -98,7 +161,7 @@ function typographyToolbarRenderer(fonts, selectedFontId, onSelectFont) {
 								type="button"
 								role="tab"
 								aria-selected={font.id === selectedFontId}
-								disabled={isBusy}
+								disabled={controlsBusy}
 								className={classnames('kadence-blocks-style-library__typography-font-tab', {
 									'kadence-blocks-style-library__typography-font-tab--active':
 										font.id === selectedFontId,
@@ -110,19 +173,37 @@ function typographyToolbarRenderer(fonts, selectedFontId, onSelectFont) {
 						))}
 					</div>
 				)}
+				{fontError && (
+					<Notice status="error" isDismissible onRemove={onClearFontError}>
+						{fontError.message}
+					</Notice>
+				)}
 				<div className="kadence-blocks-style-library__typography-toolbar-row">
 					<div className="kadence-blocks-style-library__typography-font-selector">
 						<span className="kadence-blocks-style-library__typography-font-label">
 							{__('Font', 'kadence-blocks')}
 						</span>
-						<SelectDropdown
-							className="kadence-blocks-style-library__typography-font-dropdown"
-							value={selectedFontId}
-							options={fonts.map((font) => ({ value: font.id, label: font.label }))}
-							onChange={onSelectFont}
-							isBusy={isBusy}
-							showSpinner={false}
-						/>
+						<div className="kadence-blocks-style-library__typography-font-picker">
+							<SearchableSelectDropdown
+								className="kadence-blocks-style-library__typography-font-dropdown"
+								value={dropdownValue}
+								options={catalogOptions}
+								onChange={onPickCatalog}
+								isBusy={controlsBusy}
+							/>
+							<Button
+								className="kadence-blocks-style-library__typography-font-action"
+								variant={fontAction.type === 'delete' ? 'tertiary' : 'secondary'}
+								icon={fontAction.type === 'delete' ? undefined : plus}
+								isDestructive={fontAction.type === 'delete'}
+								disabled={controlsBusy || fontAction.disabled}
+								onClick={onFontAction}
+							>
+								{fontAction.type === 'delete'
+									? __('Delete', 'kadence-blocks')
+									: __('Add Font', 'kadence-blocks')}
+							</Button>
+						</div>
 					</div>
 					<span className="kadence-blocks-style-library__typography-toolbar-add">{addAction}</span>
 				</div>
@@ -165,11 +246,12 @@ export const TYPOGRAPHY_CONFIG = {
 
 /**
  * The Typography screen body: the base config extended per render with the font-dependent
- * `renderPreview`/`renderToolbar` keys, and the selected-font state they close over. The selection
- * is view-only, session-scoped React state (never persisted) — it self-heals to the group's first
- * font whenever the selected id leaves the feed, the same stale-item idiom the rest of the app uses,
- * so a font deleted or renamed out from under an open selection never leaves the toolbar pointing at
- * nothing.
+ * `renderPreview`/`renderToolbar` keys, and the selected-font state (plus the catalog dropdown's
+ * pending pick and the Add/Delete Font flow state) they close over. The font selection is
+ * view-only, session-scoped React state (never persisted) — it self-heals to the group's first
+ * font whenever the selected id leaves the feed, the same stale-item idiom the rest of the app
+ * uses, so a font deleted or renamed out from under an open selection never leaves the toolbar
+ * pointing at nothing.
  *
  * @param {Object} props The props `ScaleScreen` accepts (`{ label, route, navigate, library }`).
  *
@@ -185,25 +267,121 @@ export function TypographyScreen(props) {
 		[library.feed]
 	);
 
+	const catalogOptions = useMemo(buildCatalogOptions, []);
+
 	const [selectedFontId, setSelectedFontId] = useState(() => fonts[0]?.id ?? '');
+	// The catalog dropdown's pending pick: null while it mirrors the previewed font, or a catalog
+	// family name once a pick matches no design-system font (armed for "+ Add Font" but not yet
+	// previewed: previewing a font the library does not own would need a webfont load for a token
+	// that may never be created).
+	const [pendingFontName, setPendingFontName] = useState(null);
+	const [fontBusy, setFontBusy] = useState(false);
+	const [fontError, setFontError] = useState(null);
 
 	useEffect(() => {
 		if (fonts.length > 0 && !fonts.some((font) => font.id === selectedFontId)) {
 			setSelectedFontId(fonts[0].id);
+			setPendingFontName(null);
 		}
 	}, [fonts, selectedFontId]);
 
 	const selectedFont = fonts.find((font) => font.id === selectedFontId) ?? null;
 
+	useGoogleFontLoader(selectedFont?.label ?? '');
+
+	// Switching tabs (or a catalog pick that matches a design-system font) always clears a pending
+	// catalog pick, so the dropdown goes back to mirroring the preview.
+	const selectPreviewFont = useCallback((id) => {
+		setPendingFontName(null);
+		setSelectedFontId(id);
+	}, []);
+
+	const dropdownValue = pendingFontName ?? selectedFont?.label ?? '';
+
+	const pickCatalogFont = useCallback(
+		(name) => {
+			const matched = findFontByFamily(fonts, name);
+
+			if (matched) {
+				selectPreviewFont(matched.id);
+			} else {
+				setPendingFontName(name);
+			}
+		},
+		[fonts, selectPreviewFont]
+	);
+
+	const fontAction = fontActionFor(fonts, dropdownValue);
+
+	// Add/Delete Font is deliberately never guarded (unlike selecting a row or navigating away with
+	// a dirty draft): neither touches the size-panel draft, and the post-write `refreshFeed`
+	// re-overlays it exactly as every sibling write does.
+	const handleFontAction = useCallback(() => {
+		setFontError(null);
+
+		if (fontAction.type === 'delete') {
+			deleteScaleTokenFlow({
+				slug: library.slug,
+				tokenId: fontAction.font.id,
+				feedVersion: library.version,
+				refreshFeed: library.refreshFeed,
+				onBusy: setFontBusy,
+				onError: setFontError,
+			})
+				.then(() => setPendingFontName(null))
+				.catch(() => {});
+
+			return;
+		}
+
+		addFontFlow({
+			name: dropdownValue,
+			existingIds: library.tokens.map((token) => token.id),
+			slug: library.slug,
+			feedVersion: library.version,
+			refreshFeed: library.refreshFeed,
+			onBusy: setFontBusy,
+			onError: setFontError,
+		})
+			.then((id) => selectPreviewFont(id))
+			.catch(() => {});
+	}, [fontAction, dropdownValue, library, selectPreviewFont]);
+
 	// `useScaleScreen`'s addToken/saveToken/reorderTokens list the whole config in their deps, so an
-	// inline object would rebuild all three every render.
+	// inline object would rebuild all three every render. The catalog toolbar widens what the config
+	// closes over, so the handlers it carries are memoized too — one rebuilt per render would defeat
+	// this.
 	const config = useMemo(
 		() => ({
 			...TYPOGRAPHY_CONFIG,
 			renderPreview: samplePreviewRenderer(selectedFont?.stack ?? ''),
-			renderToolbar: typographyToolbarRenderer(fonts, selectedFontId, setSelectedFontId),
+			renderToolbar: typographyToolbarRenderer({
+				fonts,
+				selectedFontId,
+				onSelectFont: selectPreviewFont,
+				catalogOptions,
+				dropdownValue,
+				onPickCatalog: pickCatalogFont,
+				fontAction,
+				onFontAction: handleFontAction,
+				fontBusy,
+				fontError,
+				onClearFontError: () => setFontError(null),
+			}),
 		}),
-		[fonts, selectedFont, selectedFontId]
+		[
+			selectedFont?.stack,
+			fonts,
+			selectedFontId,
+			selectPreviewFont,
+			catalogOptions,
+			dropdownValue,
+			pickCatalogFont,
+			fontAction,
+			handleFontAction,
+			fontBusy,
+			fontError,
+		]
 	);
 
 	return <ScaleScreen config={config} {...props} />;

--- a/src/style-library/components/pages/TypographyScreen.scss
+++ b/src/style-library/components/pages/TypographyScreen.scss
@@ -96,3 +96,11 @@
 .kadence-blocks-style-library__typography-font-label {
 	@include small-uppercase-label;
 }
+
+// The catalog dropdown and its contextual Add/Delete Font button sit side by side, beneath the
+// FONT label — the board's slot for both.
+.kadence-blocks-style-library__typography-font-picker {
+	@include flex-row(var(--kb-sl-space-10));
+
+	align-items: center;
+}

--- a/src/style-library/helpers/catalog-filter.js
+++ b/src/style-library/helpers/catalog-filter.js
@@ -1,0 +1,42 @@
+/**
+ * The font catalog dropdown's matching + render-cap logic, pulled out of
+ * `SearchableSelectDropdown.js` as its own pure module (no React/JSX/REST) so it is directly
+ * jest-covered without importing the component's JSX/`.scss` chain — this app's tests are
+ * pure-helpers-only for exactly that reason.
+ */
+
+/**
+ * The maximum number of matching options rendered at once. 1,916 uncapped rows is visibly slow to
+ * open, and a virtualization dependency is not worth it for a type-to-narrow catalog.
+ *
+ * @since TBD
+ */
+export const CATALOG_RENDER_CAP = 100;
+
+/**
+ * Filter a flat option list to those whose label case-insensitively contains `query`, capped to
+ * `cap` rendered rows. An empty query matches everything (subject to the same cap), so opening the
+ * menu with no search yet still shows a capped, non-empty starting list rather than nothing.
+ *
+ * @param {Array<{value: string, label: string}>} options The full option list.
+ * @param {string}                                 query   The search input's current value.
+ * @param {number}                                 [cap]   The maximum rendered rows. Defaults to
+ *                                                          `CATALOG_RENDER_CAP`.
+ *
+ * @since TBD
+ *
+ * @return {{visible: Array<Object>, truncated: boolean}} The rows to render, and whether the full
+ *         match count exceeds `cap` (the caller shows the "keep typing" footer when true).
+ */
+export function filterCatalogOptions(options, query, cap = CATALOG_RENDER_CAP) {
+	const needle = String(query ?? '')
+		.trim()
+		.toLowerCase();
+
+	const matches = needle === '' ? options : options.filter((option) => option.label.toLowerCase().includes(needle));
+
+	return {
+		visible: matches.slice(0, cap),
+		truncated: matches.length > cap,
+	};
+}

--- a/src/style-library/helpers/font-flows.js
+++ b/src/style-library/helpers/font-flows.js
@@ -1,0 +1,100 @@
+/**
+ * Pure orchestration for the Typography screen's font-catalog write flow: adding a picked catalog
+ * family as a user primitive. Font deletion needs no font-specific flow — it reuses
+ * `deleteScaleTokenFlow` verbatim, since deletion is token-generic. Same `scale-flows.js`
+ * discipline: the REST call is imported here (so a test mocks `api/client`), the caller supplies
+ * busy/error callbacks and a feed refresh, and the flow settles pessimistically and re-throws on
+ * failure.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { createUserPrimitive } from '../api/client';
+import { customScaleTokenId, nextScaleSlug } from './scale';
+import { fontFamilySlug } from './typography';
+
+/**
+ * The DTCG `$type` every minted font uses.
+ *
+ * @since TBD
+ */
+const FONT_FAMILY_TYPE = 'fontFamily';
+
+/**
+ * The stable group key every minted font is filed under (mirrors `declarations.php`'s
+ * `group_key: 'font-family'`).
+ *
+ * @since TBD
+ */
+const FONT_FAMILY_GROUP_KEY = 'font-family';
+
+/**
+ * Read the message off a REST error, falling back to a generic string when the error carries none.
+ * Duplicated from `scale-flows.js`'s identical helper rather than imported — the flow modules stay
+ * independent on purpose.
+ *
+ * @param {*} error The rejected value from an `apiFetch` call.
+ *
+ * @since TBD
+ *
+ * @return {string} A user-facing message.
+ */
+function errorMessage(error) {
+	return error?.message || __('Something went wrong. Please try again.', 'kadence-blocks');
+}
+
+/**
+ * Mint a picked catalog family as a user `fontFamily` primitive: derive a kebab slug from the
+ * family name (suffixing on collision, the `nextScaleSlug` idiom applied to the derived stem),
+ * create it as a single-family stack with no invented generic fallback (the shipped font arrays
+ * carry no category data, so appending one would be a guess), refresh the feed, and resolve the
+ * new token's canonical id via the segment-aware `customScaleTokenId` so the caller can preview it
+ * immediately.
+ *
+ * @param {Object}   args
+ * @param {string}   args.name        The picked catalog family name, verbatim (becomes the label).
+ * @param {string[]} args.existingIds Every canonical id already registered, for slug collision.
+ * @param {string}   args.slug        Token library slug.
+ * @param {string}   args.feedVersion The version token the client last read.
+ * @param {Function} args.refreshFeed Replaces the feed with a fresh REST read for a slug.
+ * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<string>} Resolves with the new font's canonical id; rejects on failure, after
+ *                            `onError`/`onBusy` have already run.
+ */
+export function addFontFlow({ name, existingIds, slug, feedVersion, refreshFeed, onBusy, onError }) {
+	onBusy(true);
+
+	const stem = fontFamilySlug(name);
+	const terminalSlug = nextScaleSlug(existingIds, stem);
+	const id = customScaleTokenId(FONT_FAMILY_TYPE, terminalSlug);
+
+	return createUserPrimitive(slug, {
+		id: terminalSlug,
+		$type: FONT_FAMILY_TYPE,
+		$value: [name],
+		label: name,
+		group: FONT_FAMILY_GROUP_KEY,
+		version: feedVersion,
+	})
+		.then(() => refreshFeed(slug))
+		.then(() => {
+			onBusy(false);
+			return id;
+		})
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+
+			throw err;
+		});
+}

--- a/src/style-library/helpers/typography.js
+++ b/src/style-library/helpers/typography.js
@@ -1,9 +1,17 @@
 /**
  * The Typography screen's pure helpers: mapping the `Font Family` feed group into the FONT
- * selector's options, and reading a fluid font-size step's authored scalar out of its resolved
- * `clamp(...)` CSS. No React, no JSX, no REST — see `components/pages/TypographyScreen.js` for
- * where these plug into the scale-screen contract.
+ * selector's options, reading a fluid font-size step's authored scalar out of its resolved
+ * `clamp(...)` CSS, and the font-catalog capability (reading the page-load catalog global,
+ * matching a catalog pick against a design-system font, deriving a slug that can be minted, and deciding the
+ * contextual Add/Delete button's state). No React, no JSX, no REST — see
+ * `components/pages/TypographyScreen.js` for where these plug into the scale-screen contract and
+ * `helpers/font-flows.js` for the Add Font write flow.
  */
+
+/**
+ * Internal dependencies
+ */
+import { isDeletable } from './token-capabilities';
 
 /**
  * Strip a pair of wrapping quotes (single or double) from a font-family name, the same trimming a
@@ -32,8 +40,9 @@ function unquoteFamily(family) {
  *
  * @since TBD
  *
- * @return {Array<{id: string, label: string, stack: string}>} The font options, or `[]` for a
- *         missing schema or an unknown group.
+ * @return {Array<{id: string, label: string, stack: string, userCreated: boolean}>} The font
+ *         options, or `[]` for a missing schema or an unknown group. `userCreated` passes through
+ *         the feed entry verbatim so `fontActionFor` can gate on it without re-reading the schema.
  */
 export function fontOptions(schema, values, group) {
 	const entries = schema?.groups?.[group];
@@ -50,6 +59,7 @@ export function fontOptions(schema, values, group) {
 			id: entry.id,
 			label: unquoteFamily(firstFamily),
 			stack,
+			userCreated: entry.userCreated === true,
 		};
 	});
 }
@@ -92,4 +102,94 @@ export function fontSizeDisplayValue(value) {
 	const args = match[1].split(',').map((arg) => arg.trim());
 
 	return args.length === 3 ? args[2] : value;
+}
+
+/**
+ * Read the page-load font catalog global the Localizer emits (Google font names plus site custom
+ * fonts). Fail-safe on a missing/malformed global, mirroring `getDesignTokensFeed()`'s posture —
+ * a caller never has to null-check before using either list.
+ *
+ * @since TBD
+ *
+ * @return {{google: string[], custom: string[]}} The catalog, or two empty lists when unavailable.
+ */
+export function getFontCatalog() {
+	const catalog = window.kadenceDesignTokensFontCatalog;
+
+	return {
+		google: Array.isArray(catalog?.google) ? catalog.google : [],
+		custom: Array.isArray(catalog?.custom) ? catalog.custom : [],
+	};
+}
+
+/**
+ * Find the design-system font (a `fontOptions()` entry) whose first family matches a catalog
+ * family name, case-insensitively and ignoring wrapping quotes on either side.
+ *
+ * @param {Array<{id: string, label: string}>} fonts The design-system fonts (`fontOptions()`).
+ * @param {string}                              name  The catalog family name to match.
+ *
+ * @since TBD
+ *
+ * @return {?{id: string, label: string}} The matching font, or `null` when none matches.
+ */
+export function findFontByFamily(fonts, name) {
+	const needle = unquoteFamily(String(name ?? '').trim()).toLowerCase();
+
+	return fonts.find((font) => unquoteFamily(String(font.label ?? '').trim()).toLowerCase() === needle) ?? null;
+}
+
+/**
+ * Derive a slug stem — a kebab-case id a new token can be minted with — from a catalog family name: lowercase, diacritics
+ * stripped (NFD-normalize, then drop the combining marks), any run outside `[a-z0-9]` collapsed to
+ * a single hyphen, edge hyphens trimmed. A name that yields nothing (fully non-Latin) falls back to
+ * `'font'` rather than an empty slug. Collision suffixing is `nextScaleSlug`'s job, not this
+ * helper's — this only derives the stem.
+ *
+ * @param {string} name The catalog family name.
+ *
+ * @since TBD
+ *
+ * @return {string} The derived slug stem, never empty.
+ */
+export function fontFamilySlug(name) {
+	const stripped = String(name ?? '')
+		.toLowerCase()
+		.normalize('NFD')
+		.replace(/[\u0300-\u036f]/g, '');
+
+	const slug = stripped.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+
+	return slug || 'font';
+}
+
+/**
+ * Decide the FONT dropdown's contextual button state for a catalog pick: `'add'` (enabled) when
+ * the pick matches no design-system font, `'delete'` when it matches a user-created one, or
+ * `'add'` (disabled) when it matches a baseline font — a baseline font can never be re-added and
+ * must never be offered for deletion (the server independently refuses baseline deletion with 403
+ * `rest_design_tokens_locked`; this is defense-in-depth, not the authority).
+ *
+ * @param {Array<{id: string, label: string, userCreated: boolean}>} fonts The design-system fonts
+ *                                                                          (`fontOptions()`).
+ * @param {string}                                                    name  The catalog family name
+ *                                                                          currently shown in the
+ *                                                                          dropdown.
+ *
+ * @since TBD
+ *
+ * @return {{type: ('add'|'delete'), disabled: boolean, font: ?Object}} The button state.
+ */
+export function fontActionFor(fonts, name) {
+	const match = findFontByFamily(fonts, name);
+
+	if (!match) {
+		return { type: 'add', disabled: false, font: null };
+	}
+
+	if (isDeletable(match)) {
+		return { type: 'delete', disabled: false, font: match };
+	}
+
+	return { type: 'add', disabled: true, font: match };
 }

--- a/src/style-library/hooks/use-google-font-loader.js
+++ b/src/style-library/hooks/use-google-font-loader.js
@@ -1,0 +1,66 @@
+/**
+ * Loads the currently previewed Google font's stylesheet into the page, so the Typography
+ * screen's sample text renders in the real face instead of the `system-ui` fallback. Nothing loads
+ * font files on the Style Library page otherwise — verified: zero `fonts.googleapis` references
+ * under `src/` outside a vendored player — so even the shipped baseline "Inter" preview would
+ * silently fall back without this.
+ *
+ * System families (e.g. Georgia, Menlo) are not in the Google catalog and are skipped by
+ * construction (the catalog-membership check below). Custom fonts are also skipped: the
+ * names-only custom-fonts filter carries no file URLs, so loading them is the custom-font
+ * provider's job, not this hook's — a custom preview renders correctly only when the site already
+ * loads those files in wp-admin.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { getFontCatalog } from '../helpers/typography';
+
+/**
+ * Every family name a `<link>` has already been injected for, across the whole page's lifetime —
+ * module-scoped (not component state) so switching the preview font back and forth never injects a
+ * duplicate stylesheet, and a link is never removed once added (browser-cached, cheap to keep).
+ *
+ * @since TBD
+ *
+ * @type {Set<string>}
+ */
+const loadedFamilies = new Set();
+
+/**
+ * Inject a Google Fonts stylesheet `<link>` for `familyName`, once, when that family is in the
+ * Google catalog.
+ *
+ * @param {string} familyName The currently previewed font's first family (`fontOptions()`'s
+ *                             `label`), or an empty string when nothing is selected yet.
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+export function useGoogleFontLoader(familyName) {
+	useEffect(() => {
+		if (!familyName || loadedFamilies.has(familyName)) {
+			return;
+		}
+
+		const { google } = getFontCatalog();
+
+		if (!google.includes(familyName)) {
+			return;
+		}
+
+		loadedFamilies.add(familyName);
+
+		const link = document.createElement('link');
+		link.rel = 'stylesheet';
+		link.href = `https://fonts.googleapis.com/css2?family=${encodeURIComponent(familyName)}&display=swap`;
+		document.head.appendChild(link);
+	}, [familyName]);
+}

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Font_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Font_CatalogTest.php
@@ -75,6 +75,61 @@ final class Font_CatalogTest extends TestCase {
 	}
 
 	/**
+	 * A font registered with a fallback — whose filter key is the whole stack expression
+	 * `"My Font", sans-serif`, the shape kadence_blocks_convert_custom_fonts() builds — is
+	 * catalogued under the family name alone, so what is stored (and later rendered as
+	 * `font-family`) is never a quoted stack nested inside another set of quotes.
+	 *
+	 * @return void
+	 */
+	public function testCustomNamesDropTheFallbackStackFromAKeyThatCarriesOne(): void {
+		add_filter(
+			'kadence_blocks_custom_fonts',
+			static function ( array $fonts ): array {
+				$fonts['"My Font", sans-serif'] = [
+					'name'    => '"My Font", sans-serif',
+					'weights' => [],
+					'styles'  => [],
+				];
+
+				return $fonts;
+			}
+		);
+
+		$result = $this->catalog->all();
+
+		$this->assertContains( 'My Font', $result['custom'] );
+		$this->assertNotContains( '"My Font", sans-serif', $result['custom'] );
+	}
+
+	/**
+	 * A Google family registered as a custom font WITH a fallback still deduplicates against the
+	 * Google list: the stack is reduced to the family name before the two lists are compared, so
+	 * the family is not offered twice.
+	 *
+	 * @return void
+	 */
+	public function testAFallbackStackDeduplicatesAgainstTheGoogleList(): void {
+		add_filter(
+			'kadence_blocks_custom_fonts',
+			static function ( array $fonts ): array {
+				$fonts['"Abel", sans-serif'] = [
+					'name'    => '"Abel", sans-serif',
+					'weights' => [],
+					'styles'  => [],
+				];
+
+				return $fonts;
+			}
+		);
+
+		$result = $this->catalog->all();
+
+		$this->assertNotContains( 'Abel', $result['custom'] );
+		$this->assertContains( 'Abel', $result['google'] );
+	}
+
+	/**
 	 * A custom-fonts filter returning a plain, integer-keyed list of names passes each name
 	 * through as-is.
 	 *

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Font_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Font_CatalogTest.php
@@ -1,0 +1,133 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Admin\Feed;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Font_Catalog;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Covers the font catalog reader/normalizer the Typography screen's searchable dropdown reads.
+ */
+final class Font_CatalogTest extends TestCase {
+
+	/**
+	 * @var Font_Catalog
+	 */
+	private Font_Catalog $catalog;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->catalog = $this->container->get( Font_Catalog::class );
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		remove_all_filters( 'kadence_blocks_custom_fonts' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The shipped Google names file is read into a non-empty list, and "Abel" — a stable, early
+	 * entry in the generated file — is among it, pinning that the file is actually being read
+	 * rather than silently falling back to an empty list.
+	 *
+	 * @return void
+	 */
+	public function testAllReturnsTheGoogleNamesFromTheGeneratedFile(): void {
+		$result = $this->catalog->all();
+
+		$this->assertArrayHasKey( 'google', $result );
+		$this->assertNotEmpty( $result['google'] );
+		$this->assertContains( 'Abel', $result['google'] );
+	}
+
+	/**
+	 * A custom-fonts filter returning the shape kadence_blocks_convert_custom_fonts() (init.php)
+	 * produces — string-keyed by the font-stack expression, each value an array with its own
+	 * "name" — normalizes to that string key as the catalog name.
+	 *
+	 * @return void
+	 */
+	public function testCustomNamesAreReadFromTheStringKeyedFilterShape(): void {
+		add_filter(
+			'kadence_blocks_custom_fonts',
+			static function ( array $fonts ): array {
+				$fonts['My Custom Font'] = [
+					'name'    => 'My Custom Font',
+					'weights' => [],
+					'styles'  => [],
+				];
+
+				return $fonts;
+			}
+		);
+
+		$result = $this->catalog->all();
+
+		$this->assertContains( 'My Custom Font', $result['custom'] );
+	}
+
+	/**
+	 * A custom-fonts filter returning a plain, integer-keyed list of names passes each name
+	 * through as-is.
+	 *
+	 * @return void
+	 */
+	public function testCustomNamesAreReadFromAnIntegerKeyedListShape(): void {
+		add_filter(
+			'kadence_blocks_custom_fonts',
+			static function ( array $fonts ): array {
+				$fonts[] = 'Another Custom Font';
+
+				return $fonts;
+			}
+		);
+
+		$result = $this->catalog->all();
+
+		$this->assertContains( 'Another Custom Font', $result['custom'] );
+	}
+
+	/**
+	 * A custom name that duplicates a Google name is deduplicated out of the "custom" list — the
+	 * dropdown must never list the same family twice.
+	 *
+	 * @return void
+	 */
+	public function testCustomNamesAreDeduplicatedAgainstTheGoogleList(): void {
+		add_filter(
+			'kadence_blocks_custom_fonts',
+			static function ( array $fonts ): array {
+				$fonts['Abel'] = [ 'name' => 'Abel' ];
+
+				return $fonts;
+			}
+		);
+
+		$result = $this->catalog->all();
+
+		$this->assertContains( 'Abel', $result['google'] );
+		$this->assertNotContains( 'Abel', $result['custom'] );
+	}
+
+	/**
+	 * A custom-fonts filter that returns something other than an array fails soft to an empty
+	 * custom list rather than throwing or emitting a warning.
+	 *
+	 * @return void
+	 */
+	public function testMalformedFilterReturnFailsSoftToAnEmptyCustomList(): void {
+		add_filter( 'kadence_blocks_custom_fonts', static fn() => 'not-an-array' );
+
+		$result = $this->catalog->all();
+
+		$this->assertSame( [], $result['custom'] );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
@@ -4,6 +4,7 @@ namespace Tests\wpunit\Resources\Design_Tokens\Admin\Feed;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Feed_Assembler;
+use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Font_Catalog;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Localizer;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Responsive_Feed;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Presets;
@@ -60,6 +61,12 @@ final class LocalizerTest extends TestCase {
 	/**
 	 * The decoded feed attached to the dashboard handle, or null when none was attached.
 	 *
+	 * The Localizer attaches TWO separate inline scripts to the handle (the feed, and — as its own
+	 * global, never folded into the feed payload — the page-load-only font catalog), each its own
+	 * entry in the 'before' data array. This walks the entries rather than imploding the whole array and running one
+	 * regular expression over it, so the catalog entry (whose global name is a superset string,
+	 * "window.kadenceDesignTokensFontCatalog") can never be mistaken for the feed entry.
+	 *
 	 * @return array<string, mixed>|null
 	 */
 	private function attached_feed(): ?array {
@@ -69,16 +76,18 @@ final class LocalizerTest extends TestCase {
 			return null;
 		}
 
-		$inline = implode( "\n", array_filter( $data, 'is_string' ) );
+		foreach ( array_filter( $data, 'is_string' ) as $entry ) {
+			if ( strpos( $entry, 'window.kadenceDesignTokens =' ) === false ) {
+				continue;
+			}
 
-		if ( strpos( $inline, 'window.kadenceDesignTokens' ) === false ) {
-			return null;
+			$json    = (string) preg_replace( '/^.*?window\.kadenceDesignTokens\s*=\s*(.*);\s*$/s', '$1', $entry );
+			$decoded = json_decode( $json, true );
+
+			return is_array( $decoded ) ? $decoded : null;
 		}
 
-		$json    = (string) preg_replace( '/^.*?window\.kadenceDesignTokens\s*=\s*(.*);\s*$/s', '$1', $inline );
-		$decoded = json_decode( $json, true );
-
-		return is_array( $decoded ) ? $decoded : null;
+		return null;
 	}
 
 	private function localizer(): Localizer {
@@ -135,6 +144,40 @@ final class LocalizerTest extends TestCase {
 		$this->assertSame( 'kb-design-tokens/v1', $feed['rest']['namespace'] );
 		$this->assertNotEmpty( $feed['rest']['nonce'] );
 		$this->assertSame( esc_url_raw( rest_url() ), $feed['rest']['root'] );
+	}
+
+	/**
+	 * The font catalog is attached as its own inline global — window.kadenceDesignTokensFontCatalog
+	 * — separate from window.kadenceDesignTokens, so a client can read the (static,
+	 * library-independent) catalog once at page load without it riding every feed refresh.
+	 *
+	 * @return void
+	 */
+	public function testItAttachesTheFontCatalogAsASeparateGlobal(): void {
+		$this->enqueue_dashboard();
+
+		$this->localizer()->localize();
+
+		$data = wp_scripts()->get_data( self::HANDLE, 'before' );
+		$this->assertIsArray( $data );
+
+		$catalog_entry = null;
+
+		foreach ( array_filter( $data, 'is_string' ) as $entry ) {
+			if ( strpos( $entry, 'window.kadenceDesignTokensFontCatalog =' ) !== false ) {
+				$catalog_entry = $entry;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $catalog_entry, 'The font catalog global must be attached to the dashboard handle.' );
+
+		$json    = (string) preg_replace( '/^.*?window\.kadenceDesignTokensFontCatalog\s*=\s*(.*);\s*$/s', '$1', $catalog_entry );
+		$decoded = json_decode( $json, true );
+
+		$this->assertIsArray( $decoded );
+		$this->assertArrayHasKey( 'google', $decoded );
+		$this->assertArrayHasKey( 'custom', $decoded );
 	}
 
 	public function testItAttachesNothingWhenTheDashboardIsNotOnThePage(): void {
@@ -198,7 +241,8 @@ final class LocalizerTest extends TestCase {
 
 		$localizer = new Localizer(
 			$this->container->get( Active_Token_Library_Store::class ),
-			$assembler
+			$assembler,
+			$this->container->get( Font_Catalog::class )
 		);
 
 		$localizer->localize();

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -895,6 +895,75 @@ final class Feed_ControllerTest extends TestCase {
 	}
 
 	/**
+	 * A user-created `fontFamily` primitive minted into the `font-family` group (the $type ->
+	 * id-segment mapping's headline unlock) surfaces inside the declared "Font Family" UI-schema
+	 * group as `userCreated`, and its single-family stack resolves with the spaced name quoted —
+	 * `Css_Renderer::font_family()`'s existing quoting rule, exercised end to end through a minted
+	 * token rather than only a baseline one.
+	 *
+	 * @return void
+	 */
+	public function testUserPrimitiveGroupedIntoFontFamilySurfacesInItsFeedGroupWithQuotedValue(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.font-family.custom.abril-fatface';
+
+		$document = (string) wp_json_encode(
+			[
+				'primitive'   => [
+					'font-family' => [
+						'custom' => [
+							'abril-fatface' => [
+								'$type'  => 'fontFamily',
+								'$value' => [ 'Abril Fatface' ],
+							],
+						],
+					],
+				],
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'userPrimitives' => [
+							$id => [
+								'label' => 'Abril Fatface',
+								'group' => 'font-family',
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$this->store->save_document( $document, $slug );
+
+		/** @var User_Primitive_Registrar $registrar */
+		$registrar = $this->container->get( User_Primitive_Registrar::class );
+		$registrar->sync();
+
+		/** @var Token_Registry $registry */
+		$registry = $this->container->get( Token_Registry::class );
+		$schema   = $registry->to_ui_schema();
+
+		$this->assertArrayHasKey( 'Font Family', $schema['groups'] );
+
+		$found = null;
+
+		foreach ( $schema['groups']['Font Family'] as $entry ) {
+			if ( $id === $entry['id'] ) {
+				$found = $entry;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $found, 'The grouped custom font must appear in the declared "Font Family" UI-schema group.' );
+		$this->assertTrue( $found['userCreated'] );
+
+		/** @var Token_Resolver $resolver */
+		$resolver = $this->container->get( Token_Resolver::class );
+		$resolved = $resolver->resolve( $slug );
+
+		$this->assertSame( '"Abril Fatface"', $resolved->value( $id ) );
+	}
+
+	/**
 	 * A slug naming no known library is rejected with a 404, mirroring Documents_Controller and
 	 * Active_Token_Library_Controller rather than silently substituting a different library's
 	 * data for the one requested.
@@ -976,6 +1045,12 @@ final class Feed_ControllerTest extends TestCase {
 	/**
 	 * The decoded feed attached to the dashboard handle, or null when none was attached.
 	 *
+	 * The Localizer attaches TWO separate inline scripts to the handle (the feed, and — as its own
+	 * global, never folded into the feed payload — the page-load-only font catalog), each its own
+	 * entry in the 'before' data array. This walks the entries rather than imploding the whole array and running one
+	 * regular expression over it, so the catalog entry (whose global name is a superset string,
+	 * "window.kadenceDesignTokensFontCatalog") can never be mistaken for the feed entry.
+	 *
 	 * @return array<string, mixed>|null
 	 */
 	private function attached_feed(): ?array {
@@ -985,16 +1060,18 @@ final class Feed_ControllerTest extends TestCase {
 			return null;
 		}
 
-		$inline = implode( "\n", array_filter( $data, 'is_string' ) );
+		foreach ( array_filter( $data, 'is_string' ) as $entry ) {
+			if ( strpos( $entry, 'window.kadenceDesignTokens =' ) === false ) {
+				continue;
+			}
 
-		if ( strpos( $inline, 'window.kadenceDesignTokens' ) === false ) {
-			return null;
+			$json    = (string) preg_replace( '/^.*?window\.kadenceDesignTokens\s*=\s*(.*);\s*$/s', '$1', $entry );
+			$decoded = json_decode( $json, true );
+
+			return is_array( $decoded ) ? $decoded : null;
 		}
 
-		$json    = (string) preg_replace( '/^.*?window\.kadenceDesignTokens\s*=\s*(.*);\s*$/s', '$1', $inline );
-		$decoded = json_decode( $json, true );
-
-		return is_array( $decoded ) ? $decoded : null;
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
Adds the font **catalog** to the Typography screen: a searchable dropdown over every available family, with a contextual **Add Font** / **Delete** button. Third of three stacked PRs for SOFT-4077, and the one that makes the previous two useful.

## The model

Two controls, doing different jobs — worth stating because an earlier reading had them duplicating each other:

- **Tabs** list the families in the design system and choose which one the size previews render in.
- **The dropdown is a catalog** of everything available, not a mirror of the tabs. Its button is contextual: pick a family that is not in the design system → **+ Add Font**; pick a custom one that is → **Delete**; pick a baseline family → the button is disabled, because baseline tokens are never deletable anywhere in this app.

## What it adds

- `Admin/Feed/Font_Catalog` + a second page-load-only inline global. It is **not** part of `Feed_Assembler`'s payload, which re-fetches on every write — a ~29KB list must not ride every save.
- `SearchableSelectDropdown` — the app had no searchable select, and the catalog is **1,916 families**, so a plain select was unusable. Built new per the app's independence rule.
- `use-google-font-loader` — nothing loaded font files on this page before, so a preview of "Inter" silently rendered as `system-ui`. Families in the Google catalog now get a stylesheet injected once each; system and custom families are skipped.
- The Add/Delete flows over the user-primitive endpoints.

## A minted family is a single-family stack

`$value` is `[ "Abril Fatface" ]` — the family alone, with **no invented generic fallback**. `gfonts-array.php` carries no category field (verified across all 1,916 entries), so there is no reliable way to know whether a family is serif, sans or display. Guessing `sans-serif` for a display face would be worse than omitting it.

## Worth a reviewer's attention

**External requests from wp-admin.** The loader injects `<link>` tags to `fonts.googleapis.com` so previews render truthfully. That is a real privacy/egress decision — some sites forbid it. There is no local-hosting toggle here; the plan flags it as an open question rather than assuming.

## Verification

`phpstan` clean; `phpcs`, `cspell`, `eslint` clean; `Resources/Design_Tokens` green (1305 tests); snapshot suites green with zero diffs; 258 jest tests.

Driven end to end in the browser: the catalog loads 1,916 families; search narrows correctly; picking a family not in the system enables **+ Add Font**; adding mints `primitive.font-family.custom.abril-fatface` with `$type: fontFamily` and `$value: ["Abril Fatface"]` — which is the `$type`→segment mapping from the previous PR working in anger; the new tab appears and activates; the previews render in the real downloaded face (`document.fonts.check` confirms it, not just eyeballing); the button flips to **Delete**; deleting removes the token and the tab and restores the previous family.

## Not included

A local-hosting or opt-out path for Google Fonts. Font **weights** and styles — a family is added at its default weight only. Also unchanged: the `Body` step and the px-based scale the boards show, which are open design questions on the ticket.

## Screenshots

**The catalog dropdown, searching**
<img width="1568" height="528" alt="c-catalog-search" src="https://github.com/user-attachments/assets/e8722472-ed4a-4ad3-b856-7e4d87bff7be" />

**After Add Font — new tab active, button flipped to Delete, previews in the real face**
<img width="1568" height="751" alt="c-font-added" src="https://github.com/user-attachments/assets/23c48c7b-00d6-4b01-8515-dc7defd6f690" />