### PR TITLE
[DTM] SOFT-4082: Shadow screen

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -348,6 +348,38 @@
 				"$type": "dimension",
 				"$value": "2.441rem"
 			}
+		},
+		"shadow": {
+			"xs": {
+				"$type": "shadow",
+				"$value": {
+					"color": "#1717171f",
+					"offsetX": "0px",
+					"offsetY": "1px",
+					"blur": "2px",
+					"spread": "0px"
+				}
+			},
+			"sm": {
+				"$type": "shadow",
+				"$value": {
+					"color": "#1717171f",
+					"offsetX": "0px",
+					"offsetY": "2px",
+					"blur": "4px",
+					"spread": "0px"
+				}
+			},
+			"md": {
+				"$type": "shadow",
+				"$value": {
+					"color": "#1717171f",
+					"offsetX": "0px",
+					"offsetY": "2px",
+					"blur": "8px",
+					"spread": "0px"
+				}
+			}
 		}
 	},
 	"semantic": {

--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -340,6 +340,38 @@
 				"$type": "dimension",
 				"$value": "2.441rem"
 			}
+		},
+		"shadow": {
+			"xs": {
+				"$type": "shadow",
+				"$value": {
+					"color": "#1717171f",
+					"offsetX": "0px",
+					"offsetY": "1px",
+					"blur": "2px",
+					"spread": "0px"
+				}
+			},
+			"sm": {
+				"$type": "shadow",
+				"$value": {
+					"color": "#1717171f",
+					"offsetX": "0px",
+					"offsetY": "2px",
+					"blur": "4px",
+					"spread": "0px"
+				}
+			},
+			"md": {
+				"$type": "shadow",
+				"$value": {
+					"color": "#1717171f",
+					"offsetX": "0px",
+					"offsetY": "2px",
+					"blur": "8px",
+					"spread": "0px"
+				}
+			}
 		}
 	},
 	"semantic": {

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -109,6 +109,28 @@ $icon_size_tokens = array_map(
 	$icon_size_slugs
 );
 
+// The shadow scale steps are primitives the Style Library's Shadow screen lists and edits
+// directly; the shadow semantics (semantic.shadow.card / .media) keep their own curated values and
+// declare no projections onto this scale, so re-pointing a semantic at one of these primitives is
+// deliberately not done here — semantic.shadow.card's color is aliased to a palette primitive, and
+// re-pointing would detach it. group_key mirrors the radius/border-width/icon-size scales'
+// mechanism above: it is the stable machine id "+ Add Shadow" mints custom tokens into, resolved
+// back to the group label at read time by Token_Registry::group_label_for().
+$shadow_slugs = [ 'xs', 'sm', 'md' ];
+
+$shadow_tokens = array_map(
+	static function ( string $slug ): array {
+		return [
+			'id'        => 'primitive.shadow.' . $slug,
+			'type'      => 'shadow',
+			'label'     => strtoupper( $slug ),
+			'group'     => __( 'Shadow', 'kadence-blocks' ),
+			'group_key' => 'shadow',
+		];
+	},
+	$shadow_slugs
+);
+
 // The fluid font-size scale steps are primitives (the slug IS a scale step), each holding the shipped
 // clamp() value from includes/init.php and claiming the Kadence Blocks font-size slug it backs
 // (class-kadence-blocks-css.php): the Css_Var builder redefines --global-kb-font-size-<slug> as the
@@ -374,7 +396,8 @@ return [
 		$font_size_primitive_tokens,
 		$radius_tokens,
 		$border_width_tokens,
-		$icon_size_tokens
+		$icon_size_tokens,
+		$shadow_tokens
 	),
 	/**
 	 * Preset bindings for the Button block: that it accepts presets, plus the per-property bindings (a

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -119,6 +119,28 @@ $icon_size_tokens = array_map(
 	$icon_size_slugs
 );
 
+// The shadow scale steps are primitives the Style Library's Shadow screen lists and edits
+// directly; the shadow semantics (semantic.shadow.card / .media) keep their own curated values and
+// declare no projections onto this scale, so re-pointing a semantic at one of these primitives is
+// deliberately not done here — semantic.shadow.card's color is aliased to a palette primitive, and
+// re-pointing would detach it. group_key mirrors the radius/border-width/icon-size scales'
+// mechanism above: it is the stable machine id "+ Add Shadow" mints custom tokens into, resolved
+// back to the group label at read time by Token_Registry::group_label_for().
+$shadow_slugs = [ 'xs', 'sm', 'md' ];
+
+$shadow_tokens = array_map(
+	static function ( string $slug ): array {
+		return [
+			'id'        => 'primitive.shadow.' . $slug,
+			'type'      => 'shadow',
+			'label'     => strtoupper( $slug ),
+			'group'     => __( 'Shadow', 'kadence-blocks' ),
+			'group_key' => 'shadow',
+		];
+	},
+	$shadow_slugs
+);
+
 // The fluid font-size scale steps are primitives (the slug IS a scale step), each holding the shipped
 // clamp() value from includes/init.php and claiming the Kadence Blocks font-size slug it backs
 // (class-kadence-blocks-css.php): the Css_Var builder redefines --global-kb-font-size-<slug> as the
@@ -385,7 +407,8 @@ return [
 		$font_size_primitive_tokens,
 		$radius_tokens,
 		$border_width_tokens,
-		$icon_size_tokens
+		$icon_size_tokens,
+		$shadow_tokens
 	),
 	/**
 	 * Preset bindings for the Button block: that it accepts presets, plus the per-property bindings (a

--- a/src/style-library/__tests__/scale-flows.test.js
+++ b/src/style-library/__tests__/scale-flows.test.js
@@ -221,6 +221,71 @@ describe('saveScaleTokenFlow', () => {
 		expect(onError).toHaveBeenCalledWith({ message: failure.message });
 		expect(onBusy.mock.calls).toEqual([[true], [false]]);
 	});
+
+	it('uses the supplied buildLeaf for the value write', async () => {
+		client.saveTokenLeaf.mockResolvedValue({});
+		const refreshFeed = jest.fn().mockResolvedValue({});
+		const buildLeaf = jest.fn().mockReturnValue({ $type: 'shadow', $value: { color: '#171717' } });
+		const draftValue = { color: '#171717', offsetX: 0, offsetY: 2, blur: 8, spread: 0, inset: false };
+
+		await saveScaleTokenFlow({
+			...baseArgs,
+			tokenType: 'shadow',
+			draft: { label: 'MD', value: draftValue },
+			initial: { label: 'MD', value: { ...draftValue, offsetY: 4 } },
+			refreshFeed,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+			buildLeaf,
+		});
+
+		expect(buildLeaf).toHaveBeenCalledWith('shadow', draftValue);
+		expect(client.saveTokenLeaf).toHaveBeenCalledWith(
+			'kb-design-tokens/v1',
+			baseArgs.tokenId,
+			{ $type: 'shadow', $value: { color: '#171717' } },
+			'default'
+		);
+	});
+
+	it('defaults to buildTokenLeaf when no buildLeaf is supplied', async () => {
+		client.saveTokenLeaf.mockResolvedValue({});
+		const refreshFeed = jest.fn().mockResolvedValue({});
+
+		await saveScaleTokenFlow({
+			...baseArgs,
+			draft: { label: 'SM', value: '0.25rem' },
+			initial: { label: 'SM', value: '0.125rem' },
+			refreshFeed,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(client.saveTokenLeaf).toHaveBeenCalledWith(
+			'kb-design-tokens/v1',
+			baseArgs.tokenId,
+			{ $type: 'dimension', $value: '0.25rem' },
+			'default'
+		);
+	});
+
+	it('detects an object value change deeply, issuing no request when unchanged', async () => {
+		const refreshFeed = jest.fn();
+		const draftValue = { color: '#171717', offsetX: 0, offsetY: 2, blur: 8, spread: 0, inset: false };
+
+		await saveScaleTokenFlow({
+			...baseArgs,
+			draft: { label: 'MD', value: { ...draftValue } },
+			initial: { label: 'MD', value: { ...draftValue } },
+			refreshFeed,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(client.setTokenLabel).not.toHaveBeenCalled();
+		expect(client.saveTokenLeaf).not.toHaveBeenCalled();
+		expect(refreshFeed).not.toHaveBeenCalled();
+	});
 });
 
 describe('deleteScaleTokenFlow', () => {

--- a/src/style-library/__tests__/scale.test.js
+++ b/src/style-library/__tests__/scale.test.js
@@ -114,6 +114,24 @@ describe('scaleInitialValues', () => {
 
 		expect(scaleInitialValues(entry, {})).toEqual({ label: 'SM', value: '' });
 	});
+
+	it('applies parseValue to the resolved value', () => {
+		const entry = { id: 'primitive.shadow.sm', label: 'SM' };
+		const values = { 'primitive.shadow.sm': '0px 2px 4px 0px #171717' };
+		const parseValue = (css) => ({ raw: css });
+
+		expect(scaleInitialValues(entry, values, parseValue)).toEqual({
+			label: 'SM',
+			value: { raw: '0px 2px 4px 0px #171717' },
+		});
+	});
+
+	it('without parseValue behaves exactly as before', () => {
+		const entry = { id: 'primitive.dimension.radius.sm', label: 'SM' };
+		const values = { 'primitive.dimension.radius.sm': '0.125rem' };
+
+		expect(scaleInitialValues(entry, values)).toEqual({ label: 'SM', value: '0.125rem' });
+	});
 });
 
 describe('scaleValueField', () => {

--- a/src/style-library/__tests__/shadow.test.js
+++ b/src/style-library/__tests__/shadow.test.js
@@ -1,0 +1,123 @@
+/* eslint-env jest */
+import { buildShadowLeaf, parseShadowValue, shadowCss, shadowLeafValue } from '../helpers/shadow';
+
+describe('parseShadowValue', () => {
+	it('parses the plain shorthand into numbers and a color', () => {
+		expect(parseShadowValue('0px 2px 8px 0px #1717171f')).toEqual({
+			color: '#1717171f',
+			offsetX: 0,
+			offsetY: 2,
+			blur: 8,
+			spread: 0,
+			inset: false,
+		});
+	});
+
+	it('reads the inset prefix as inset true', () => {
+		expect(parseShadowValue('inset 0px 2px 4px 0px #000000')).toEqual({
+			color: '#000000',
+			offsetX: 0,
+			offsetY: 2,
+			blur: 4,
+			spread: 0,
+			inset: true,
+		});
+	});
+
+	it('keeps a color with internal spaces intact', () => {
+		expect(parseShadowValue('0px 2px 8px 0px rgba(23, 23, 23, 0.12)')).toEqual({
+			color: 'rgba(23, 23, 23, 0.12)',
+			offsetX: 0,
+			offsetY: 2,
+			blur: 8,
+			spread: 0,
+			inset: false,
+		});
+	});
+
+	it('returns the default shape for an empty string, or one that fails to parse', () => {
+		const defaultShape = { color: '#000000', offsetX: 0, offsetY: 0, blur: 0, spread: 0, inset: false };
+
+		expect(parseShadowValue('')).toEqual(defaultShape);
+		expect(parseShadowValue('not a shadow')).toEqual(defaultShape);
+		expect(parseShadowValue(undefined)).toEqual(defaultShape);
+	});
+
+	it('reads the numeric part of a non-px dimension', () => {
+		// The decision 5 limitation, pinned so it is a choice, not an accident: a custom shadow
+		// written out-of-band with a non-px offset still displays (the numeric part), and the next
+		// Save normalizes it to px.
+		expect(parseShadowValue('0px 0.5rem 8px 0px #000000').offsetY).toBe(0.5);
+	});
+});
+
+describe('shadowLeafValue', () => {
+	it('serializes numbers as px strings and zero as 0px', () => {
+		expect(shadowLeafValue({ color: '#171717', offsetX: 0, offsetY: 2, blur: 8, spread: 0 })).toEqual({
+			color: '#171717',
+			offsetX: '0px',
+			offsetY: '2px',
+			blur: '8px',
+			spread: '0px',
+		});
+	});
+
+	it('omits inset when false and writes strict true otherwise', () => {
+		const base = { color: '#171717', offsetX: 0, offsetY: 2, blur: 8, spread: 0 };
+
+		const withoutInset = shadowLeafValue({ ...base, inset: false });
+		const withInset = shadowLeafValue({ ...base, inset: true });
+
+		expect(withoutInset).not.toHaveProperty('inset');
+		expect(withInset.inset).toBe(true);
+	});
+});
+
+describe('buildShadowLeaf', () => {
+	it('wraps the composite value with the $type', () => {
+		const draft = { color: '#171717', offsetX: 0, offsetY: 2, blur: 8, spread: 0, inset: false };
+
+		expect(buildShadowLeaf('shadow', draft)).toEqual({
+			$type: 'shadow',
+			$value: { color: '#171717', offsetX: '0px', offsetY: '2px', blur: '8px', spread: '0px' },
+		});
+	});
+});
+
+describe('shadowCss', () => {
+	it('passes a string through verbatim', () => {
+		expect(shadowCss('0px 2px 8px 0px #1717171f')).toBe('0px 2px 8px 0px #1717171f');
+	});
+
+	it('serializes an object in renderer order with the inset prefix', () => {
+		const draft = { color: '#171717', offsetX: 0, offsetY: 2, blur: 8, spread: 0, inset: true };
+
+		expect(shadowCss(draft)).toBe('inset 0px 2px 8px 0px #171717');
+	});
+
+	it('serializes an object with no inset prefix when inset is false', () => {
+		const draft = { color: '#171717', offsetX: 0, offsetY: 2, blur: 8, spread: 0, inset: false };
+
+		expect(shadowCss(draft)).toBe('0px 2px 8px 0px #171717');
+	});
+
+	it('returns an empty string for an empty or missing value', () => {
+		expect(shadowCss('')).toBe('');
+		expect(shadowCss(null)).toBe('');
+		expect(shadowCss(undefined)).toBe('');
+	});
+});
+
+describe('parse and serialize round-trip the renderer shorthand', () => {
+	it('round-trips a string through parseShadowValue and shadowCss for px values', () => {
+		const original = '0px 2px 8px 0px #1717171f';
+
+		expect(shadowCss(parseShadowValue(original))).toBe(original);
+	});
+
+	it('round-trips an inset string through parseShadowValue and shadowCss', () => {
+		const original = 'inset 1px 1px 2px 0px #000000';
+
+		expect(shadowCss(parseShadowValue(original))).toBe(original);
+	});
+});

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -25,6 +25,7 @@ import { BorderRadiusScreen } from '../components/pages/BorderRadiusScreen';
 import { BorderWidthScreen } from '../components/pages/BorderWidthScreen';
 import { SpacingScreen } from '../components/pages/SpacingScreen';
 import { IconSizesScreen } from '../components/pages/IconSizesScreen';
+import { ShadowScreen } from '../components/pages/ShadowScreen';
 import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
 import { useLibraries } from '../hooks/use-libraries';
@@ -46,6 +47,7 @@ const SCREEN_COMPONENTS = {
 	'border-width': BorderWidthScreen,
 	spacing: SpacingScreen,
 	'icon-sizes': IconSizesScreen,
+	shadow: ShadowScreen,
 };
 
 /**

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -24,6 +24,7 @@ import { BorderRadiusScreen } from '../components/pages/BorderRadiusScreen';
 import { BorderWidthScreen } from '../components/pages/BorderWidthScreen';
 import { SpacingScreen } from '../components/pages/SpacingScreen';
 import { IconSizesScreen } from '../components/pages/IconSizesScreen';
+import { ShadowScreen } from '../components/pages/ShadowScreen';
 import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
 import { useLibraries } from '../hooks/use-libraries';
@@ -43,6 +44,7 @@ const SCREEN_COMPONENTS = {
 	'border-width': BorderWidthScreen,
 	spacing: SpacingScreen,
 	'icon-sizes': IconSizesScreen,
+	shadow: ShadowScreen,
 };
 
 /**

--- a/src/style-library/components/pages/ShadowScreen.js
+++ b/src/style-library/components/pages/ShadowScreen.js
@@ -1,7 +1,7 @@
 /**
  * The Shadow screen: the scale config, the shadowed-square preview renderer, and the two thin
  * wrappers that plug into the shared `ScaleScreen`/`ScaleSettings` contract (see
- * `.local/style-library-reference.md`). The first consumer of the contract's composite value seam
+ * `ScaleScreen.js`'s module docblock). The first consumer of the contract's composite value seam
  * (`parseValue`/`buildLeaf`) — the panel edits a six-field object (`ShadowField`, unchanged from the
  * scaffold work) while the feed and the backend deal in one CSS string and dimension-string
  * sub-fields; `helpers/shadow.js` is where that boundary is crossed.
@@ -41,8 +41,8 @@ function renderShadowPreview(row) {
 }
 
 /**
- * The Shadow screen's config — see `ScaleScreen`'s module docblock and
- * `.local/style-library-reference.md` for the full per-screen config contract. `formatValue` is set
+ * The Shadow screen's config — see `ScaleScreen`'s module docblock for the full per-screen config
+ * contract. `formatValue` is set
  * to always return an empty string: the board's rows carry no value column at all, and `ListRow`
  * already renders no column for a falsy `value`.
  *

--- a/src/style-library/components/pages/ShadowScreen.js
+++ b/src/style-library/components/pages/ShadowScreen.js
@@ -1,0 +1,96 @@
+/**
+ * The Shadow screen: the scale config, the shadowed-square preview renderer, and the two thin
+ * wrappers that plug into the shared `ScaleScreen`/`ScaleSettings` contract (see
+ * `.local/style-library-reference.md`). The first consumer of the contract's composite value seam
+ * (`parseValue`/`buildLeaf`) — the panel edits a six-field object (`ShadowField`, unchanged from the
+ * scaffold work) while the feed and the backend deal in one CSS string and dimension-string
+ * sub-fields; `helpers/shadow.js` is where that boundary is crossed.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ScaleScreen } from './ScaleScreen';
+import { ScaleSettings } from './ScaleSettings';
+import { buildShadowLeaf, parseShadowValue, shadowCss } from '../../helpers/shadow';
+import './ShadowScreen.scss';
+
+/**
+ * The shadowed-square preview for one row: a 48px white square with clearance on every side (the
+ * shared `ListRow` slot is unlocked to `overflow: visible` for this screen — see `ShadowScreen.scss`
+ * — because a shadow is drawn *outside* its box, and the default framed slot clips it entirely).
+ * `row.value` is either the feed's resolved CSS string or an overlaid draft object (the composite
+ * case `overlayDraft` copies verbatim); `shadowCss()` accepts both. An empty or unresolved value
+ * renders the square with no shadow — the honest rendering of what Save would write.
+ *
+ * @param {{id: string, label: string, value: string|Object, userCreated: boolean}} row The row descriptor.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The preview element.
+ */
+function renderShadowPreview(row) {
+	return (
+		<span className="kadence-blocks-style-library__shadow-preview" style={{ boxShadow: shadowCss(row.value) }} />
+	);
+}
+
+/**
+ * The Shadow screen's config — see `ScaleScreen`'s module docblock and
+ * `.local/style-library-reference.md` for the full per-screen config contract. `formatValue` is set
+ * to always return an empty string: the board's rows carry no value column at all, and `ListRow`
+ * already renders no column for a falsy `value`.
+ *
+ * @since TBD
+ */
+export const SHADOW_CONFIG = {
+	id: 'shadow',
+	title: __('Shadow', 'kadence-blocks'),
+	addLabel: __('Add Shadow', 'kadence-blocks'),
+	group: __('Shadow', 'kadence-blocks'),
+	groupKey: 'shadow',
+	tokenType: 'shadow',
+	slugBase: 'shadow',
+	newTokenLabel: __('New Shadow', 'kadence-blocks'),
+	// The MD seed, already in backend shape (dimension strings, no `inset` key) — `addScaleTokenFlow`
+	// passes this straight into the create payload's `$value`.
+	newTokenValue: { color: '#1717171f', offsetX: '0px', offsetY: '2px', blur: '8px', spread: '0px' },
+	valueField: { type: 'shadow', label: __('Shadow', 'kadence-blocks') },
+	formatValue: () => '',
+	parseValue: parseShadowValue,
+	buildLeaf: buildShadowLeaf,
+	renderPreview: renderShadowPreview,
+};
+
+/**
+ * The Shadow screen body.
+ *
+ * @param {Object} props The props `ScaleScreen` accepts (`{ label, route, navigate, library }`).
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The screen.
+ */
+export function ShadowScreen(props) {
+	return <ScaleScreen config={SHADOW_CONFIG} {...props} />;
+}
+
+/**
+ * The Shadow screen's settings panel.
+ *
+ * @param {Object} props The props `ScaleSettings` accepts (`{ route, navigate, library }`).
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The panel.
+ */
+function ShadowSettings(props) {
+	return <ScaleSettings config={SHADOW_CONFIG} {...props} />;
+}
+
+ShadowScreen.SettingsPanel = ShadowSettings;

--- a/src/style-library/components/pages/ShadowScreen.scss
+++ b/src/style-library/components/pages/ShadowScreen.scss
@@ -1,0 +1,24 @@
+// A shadow is drawn *outside* the element casting it, but `.list-row-preview`'s shared default is
+// `overflow: hidden` on an exactly-sized frame — anything a shadowed child casts past that frame's
+// edge is clipped away entirely, which would make every row preview here render with no visible
+// shadow at all. Scoped through the `scale-screen--shadow` modifier: the 80px box itself stays as
+// the layout cell (width/height untouched), only its clipping and default fill are removed so the
+// square inside it has room to cast a shadow that actually reads.
+.kadence-blocks-style-library__scale-screen--shadow .kadence-blocks-style-library__list-row-preview {
+	overflow: visible;
+	border: 0;
+	background: transparent;
+}
+
+// The shadowed square itself: fixed 48px inside the 80px slot, centered by the slot's own flex
+// layout, giving 16px of clearance on every side for the cast shadow to read — matching the board's
+// light square sitting proud of the row.
+.kadence-blocks-style-library__shadow-preview {
+	box-sizing: border-box;
+	display: block;
+	width: 3rem;
+	height: 3rem;
+	border: var(--kb-sl-border-width-input) solid var(--kb-sl-color-gray-200);
+	border-radius: var(--kb-sl-radius-s);
+	background: var(--kb-sl-color-white);
+}

--- a/src/style-library/constants/screens.js
+++ b/src/style-library/constants/screens.js
@@ -34,7 +34,6 @@ export const BASE_STYLES_SCREENS = [
 	{ id: 'border-width', label: __('Border Width', 'kadence-blocks') },
 	{ id: 'spacing', label: __('Spacing', 'kadence-blocks') },
 	{ id: 'icon-sizes', label: __('Icon Sizes', 'kadence-blocks') },
-	// @todo SOFT-4082: replace the placeholder with the Shadow screen.
 	{ id: 'shadow', label: __('Shadow', 'kadence-blocks') },
 ];
 

--- a/src/style-library/constants/screens.js
+++ b/src/style-library/constants/screens.js
@@ -35,7 +35,6 @@ export const BASE_STYLES_SCREENS = [
 	{ id: 'border-width', label: __('Border Width', 'kadence-blocks') },
 	{ id: 'spacing', label: __('Spacing', 'kadence-blocks') },
 	{ id: 'icon-sizes', label: __('Icon Sizes', 'kadence-blocks') },
-	// @todo SOFT-4082: replace the placeholder with the Shadow screen.
 	{ id: 'shadow', label: __('Shadow', 'kadence-blocks') },
 ];
 

--- a/src/style-library/helpers/scale-flows.js
+++ b/src/style-library/helpers/scale-flows.js
@@ -116,6 +116,10 @@ export function addScaleTokenFlow({
  * @param {Function} args.refreshFeed Replaces the feed with a fresh REST read for a slug.
  * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
  * @param {Function} args.onError     Called with `{ message }` on failure.
+ * @param {Function} [args.buildLeaf] Optional. Builds the full token leaf from `(tokenType, value)`;
+ *                                    defaults to `buildTokenLeaf` (the string/responsive-envelope
+ *                                    shape). A screen whose value is a composite object (e.g.
+ *                                    Shadow's `buildShadowLeaf`) supplies its own.
  *
  * @since TBD
  *
@@ -133,6 +137,7 @@ export function saveScaleTokenFlow({
 	refreshFeed,
 	onBusy,
 	onError,
+	buildLeaf = buildTokenLeaf,
 }) {
 	const labelChanged = draft.label !== initial.label;
 	const valueChanged = !isEqual(draft.value, initial.value);
@@ -150,7 +155,7 @@ export function saveScaleTokenFlow({
 	}
 
 	if (valueChanged) {
-		chain = chain.then(() => saveTokenLeaf(namespace, tokenId, buildTokenLeaf(tokenType, draft.value), slug));
+		chain = chain.then(() => saveTokenLeaf(namespace, tokenId, buildLeaf(tokenType, draft.value), slug));
 	}
 
 	return chain

--- a/src/style-library/helpers/scale.js
+++ b/src/style-library/helpers/scale.js
@@ -123,27 +123,35 @@ export function customScaleTokenId(tokenType, slug) {
 }
 
 /**
- * Seed a settings-panel draft for one row: the effective label and the resolved scalar value.
- * Primitive scales never take a responsive value (only presets do — see `ScaleSettings`), so this
- * always reads the resolved scalar and never an authored responsive/clamp envelope, even when the
- * leaf carries one from before the rule was enforced.
+ * Seed a settings-panel draft for one row: the effective label and the resolved value, optionally
+ * run through a per-screen parser first. Primitive scales never take a responsive value (only
+ * presets do — see `ScaleSettings`), so this always reads the resolved scalar and never an
+ * authored responsive/clamp envelope, even when the leaf carries one from before the rule was
+ * enforced.
  *
- * @param {?{id: string, label: string}} entry  The row/schema entry (`{ id, label, ... }`), or null
- *                                               for an unknown id.
- * @param {Record<string, string>}       values The feed's resolved value map.
+ * @param {?{id: string, label: string}} entry      The row/schema entry (`{ id, label, ... }`), or
+ *                                                   null for an unknown id.
+ * @param {Record<string, string>}       values     The feed's resolved value map.
+ * @param {Function}                     parseValue Optional. Transforms the resolved string into
+ *                                                   the draft's `value` shape (e.g. the Shadow
+ *                                                   screen's `parseShadowValue`). Absent behaves as
+ *                                                   the identity function, byte-identical to before
+ *                                                   this argument existed.
  *
  * @since TBD
  *
- * @return {?{label: string, value: string}} The seeded draft, or null for an unknown id.
+ * @return {?{label: string, value: *}} The seeded draft, or null for an unknown id.
  */
-export function scaleInitialValues(entry, values) {
+export function scaleInitialValues(entry, values, parseValue) {
 	if (!entry) {
 		return null;
 	}
 
+	const resolved = values?.[entry.id] ?? '';
+
 	return {
 		label: entry.label,
-		value: values?.[entry.id] ?? '',
+		value: parseValue ? parseValue(resolved) : resolved,
 	};
 }
 

--- a/src/style-library/helpers/shadow.js
+++ b/src/style-library/helpers/shadow.js
@@ -1,0 +1,141 @@
+/**
+ * The Shadow screen's value-shape boundary: converting between the feed's resolved CSS shorthand
+ * string, the composite draft `ShadowField` edits (plain numbers), and the composite leaf the
+ * backend stores (dimension strings). No React, no JSX, no REST — see
+ * `components/pages/ShadowScreen.js` for where these plug into the scale-screen contract's
+ * `parseValue`/`buildLeaf` config seam.
+ */
+
+/**
+ * The shadow draft's default shape — the same default `ShadowField` itself falls back to, so a
+ * resolved value that is empty or fails to parse seeds the panel with a shape the field already
+ * knows how to render rather than a bespoke "nothing yet" sentinel.
+ *
+ * @since TBD
+ */
+const DEFAULT_SHADOW_DRAFT = { color: '#000000', offsetX: 0, offsetY: 0, blur: 0, spread: 0, inset: false };
+
+/**
+ * The renderer shorthand's grammar, matching what `Css_Renderer::shadow()` produces: an optional
+ * leading `inset `, four space-separated dimension tokens (offsetX, offsetY, blur, spread), then
+ * the color as the remainder of the string. Capturing the color as "everything after the fourth
+ * dimension" (rather than a fifth token) keeps a color with internal spaces —
+ * `rgba(23, 23, 23, 0.12)` — intact.
+ *
+ * @since TBD
+ */
+const SHADOW_SHORTHAND_PATTERN = /^(inset\s+)?(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.+)$/;
+
+/**
+ * Parse a resolved shadow CSS string into the composite draft shape `ShadowField` edits.
+ *
+ * @param {string} css The resolved `box-shadow` shorthand (e.g. `"0px 2px 8px 0px #1717171f"`, with
+ *                      an optional `inset ` prefix), or a string that is empty or fails to parse.
+ *
+ * @since TBD
+ *
+ * @return {{color: string, offsetX: number, offsetY: number, blur: number, spread: number, inset: boolean}}
+ *         The parsed draft, or the field's default shape when the input is empty or fails to parse —
+ *         the honest "nothing stored" seed.
+ */
+export function parseShadowValue(css) {
+	const match = typeof css === 'string' ? css.trim().match(SHADOW_SHORTHAND_PATTERN) : null;
+
+	if (!match) {
+		return { ...DEFAULT_SHADOW_DRAFT };
+	}
+
+	const [, insetPrefix, offsetX, offsetY, blur, spread, color] = match;
+
+	return {
+		color,
+		offsetX: parseFloat(offsetX) || 0,
+		offsetY: parseFloat(offsetY) || 0,
+		blur: parseFloat(blur) || 0,
+		spread: parseFloat(spread) || 0,
+		inset: Boolean(insetPrefix),
+	};
+}
+
+/**
+ * Build the composite `$value` a shadow token leaf stores from the panel's draft: every numeric
+ * sub-field serialized as a px dimension string (the numeric fields are px-only — the board shows
+ * no unit selector, and the composite's blur/spread are lengths where px is the universal
+ * authoring unit), `inset` omitted entirely when false (the optional-field map exists precisely so
+ * absent means unset — writing `false` would be valid but pointlessly grows every token) and
+ * written as strict `true` otherwise.
+ *
+ * @param {{color: string, offsetX: number, offsetY: number, blur: number, spread: number, inset?: boolean}} draftValue
+ *        The panel's current draft.
+ *
+ * @since TBD
+ *
+ * @return {{color: string, offsetX: string, offsetY: string, blur: string, spread: string, inset?: true}}
+ *         The composite leaf `$value`.
+ */
+export function shadowLeafValue(draftValue) {
+	const shadow = { ...DEFAULT_SHADOW_DRAFT, ...(draftValue || {}) };
+
+	const value = {
+		color: shadow.color,
+		offsetX: `${Number(shadow.offsetX) || 0}px`,
+		offsetY: `${Number(shadow.offsetY) || 0}px`,
+		blur: `${Number(shadow.blur) || 0}px`,
+		spread: `${Number(shadow.spread) || 0}px`,
+	};
+
+	if (shadow.inset === true) {
+		value.inset = true;
+	}
+
+	return value;
+}
+
+/**
+ * Build the full token leaf for a shadow save write — the `config.buildLeaf` implementation the
+ * scale-screen contract's optional seam calls instead of the generic `buildTokenLeaf()`, which only
+ * understands string and responsive-envelope values, not a composite object.
+ *
+ * @param {string} tokenType The DTCG `$type` (`'shadow'`).
+ * @param {Object} draftValue The panel's current draft.
+ *
+ * @since TBD
+ *
+ * @return {{$type: string, $value: Object}} The composite token leaf.
+ */
+export function buildShadowLeaf(tokenType, draftValue) {
+	return { $type: tokenType, $value: shadowLeafValue(draftValue) };
+}
+
+/**
+ * Render a `box-shadow` CSS value from either shape a row's `value` can hold on this screen: the
+ * feed's resolved string (passed through verbatim) or an overlaid live draft object (serialized in
+ * the same order `Css_Renderer` emits). This is what lets the live preview update on every
+ * keystroke with no draft-channel or overlay change — `overlayDraft` copies the draft's `value`
+ * verbatim, and this helper is the one place on the screen that has to accept both shapes.
+ *
+ * @param {string|{color: string, offsetX: number|string, offsetY: number|string, blur: number|string, spread: number|string, inset?: boolean}} value
+ *        A row's `value`, resolved string or draft object.
+ *
+ * @since TBD
+ *
+ * @return {string} The `box-shadow` CSS value, or an empty string for an empty/missing value.
+ */
+export function shadowCss(value) {
+	if (typeof value === 'string') {
+		return value;
+	}
+
+	if (!value) {
+		return '';
+	}
+
+	const shadow = { ...DEFAULT_SHADOW_DRAFT, ...value };
+	const offsetX = typeof shadow.offsetX === 'string' ? shadow.offsetX : `${Number(shadow.offsetX) || 0}px`;
+	const offsetY = typeof shadow.offsetY === 'string' ? shadow.offsetY : `${Number(shadow.offsetY) || 0}px`;
+	const blur = typeof shadow.blur === 'string' ? shadow.blur : `${Number(shadow.blur) || 0}px`;
+	const spread = typeof shadow.spread === 'string' ? shadow.spread : `${Number(shadow.spread) || 0}px`;
+	const shorthand = `${offsetX} ${offsetY} ${blur} ${spread} ${shadow.color}`;
+
+	return shadow.inset === true ? `inset ${shorthand}` : shorthand;
+}

--- a/src/style-library/hooks/use-scale-screen.js
+++ b/src/style-library/hooks/use-scale-screen.js
@@ -94,7 +94,10 @@ export function useScaleScreen(config, library, route, navigate) {
 
 	const tokenById = useCallback((id) => baseRows.find((row) => row.id === id) ?? null, [baseRows]);
 
-	const initialValuesFor = useCallback((id) => scaleInitialValues(tokenById(id), feed?.values), [tokenById, feed]);
+	const initialValuesFor = useCallback(
+		(id) => scaleInitialValues(tokenById(id), feed?.values, config.parseValue),
+		[tokenById, feed, config.parseValue]
+	);
 
 	const addToken = useCallback(() => {
 		setAddError(null);
@@ -129,6 +132,7 @@ export function useScaleScreen(config, library, route, navigate) {
 				refreshFeed: library.refreshFeed,
 				onBusy: setIsBusy,
 				onError: setSaveError,
+				buildLeaf: config.buildLeaf,
 			});
 		},
 		[library, feed, config, feedVersion]

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -588,6 +588,135 @@ final class Feed_ControllerTest extends TestCase {
 	}
 
 	/**
+	 * The declared shadow scale surfaces as its own feed group, in declaration order, with every
+	 * step's value resolved to the `Css_Renderer` shorthand and no projections — the Shadow
+	 * screen's data source end to end.
+	 *
+	 * @return void
+	 */
+	public function testGetItemReturnsTheShadowScaleGroup(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', Token_Store::default_slug() );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$this->assertArrayHasKey( 'Shadow', $data['schema']['groups'] );
+
+		$ids = array_column( $data['schema']['groups']['Shadow'], 'id' );
+		$this->assertSame(
+			[
+				'primitive.shadow.xs',
+				'primitive.shadow.sm',
+				'primitive.shadow.md',
+			],
+			$ids
+		);
+
+		foreach ( $data['schema']['groups']['Shadow'] as $entry ) {
+			$this->assertSame( [], $entry['projections'], 'The declared shadow scale carries no projections of its own.' );
+		}
+
+		$this->assertSame( '0px 1px 2px 0px #1717171f', $data['values']['primitive.shadow.xs'] );
+		$this->assertSame( '0px 2px 4px 0px #1717171f', $data['values']['primitive.shadow.sm'] );
+		$this->assertSame( '0px 2px 8px 0px #1717171f', $data['values']['primitive.shadow.md'] );
+	}
+
+	/**
+	 * `semantic.shadow.card` keeps resolving through its own curated, palette-linked value after
+	 * the shadow primitive scale is declared — declaring the scale for the Style Library screen
+	 * must not disturb the semantic's existing alias.
+	 *
+	 * @return void
+	 */
+	public function testSemanticShadowCardIsUnaffectedByTheDeclaredScale(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', Token_Store::default_slug() );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$this->assertNotSame(
+			$data['values']['primitive.shadow.md'],
+			$data['values']['semantic.shadow.card'],
+			'semantic.shadow.card must keep its own curated value, not follow the new scale.'
+		);
+	}
+
+	/**
+	 * A user-created token minted into the shadow group (the stable key this ticket declares as
+	 * `group_key` alongside the newly declared shadow scale) surfaces inside the declared "Shadow"
+	 * UI-schema group and is flagged `userCreated`, and a stored `inset` sub-field round-trips into
+	 * the resolved value with the `inset ` prefix `Css_Renderer::shadow()` emits.
+	 *
+	 * @return void
+	 */
+	public function testUserPrimitiveGroupedIntoShadowSurfacesInItsFeedGroupWithInsetResolved(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.shadow.custom.shadow-2';
+
+		$document = (string) wp_json_encode(
+			[
+				'primitive'   => [
+					'shadow' => [
+						'custom' => [
+							'shadow-2' => [
+								'$type'  => 'shadow',
+								'$value' => [
+									'color'   => '#171717',
+									'offsetX' => '0px',
+									'offsetY' => '4px',
+									'blur'    => '12px',
+									'spread'  => '0px',
+									'inset'   => true,
+								],
+							],
+						],
+					],
+				],
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'userPrimitives' => [
+							$id => [
+								'label' => 'Elevated',
+								'group' => 'shadow',
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$this->store->save_document( $document, $slug );
+
+		/** @var User_Primitive_Registrar $registrar */
+		$registrar = $this->container->get( User_Primitive_Registrar::class );
+		$registrar->sync();
+
+		/** @var Token_Registry $registry */
+		$registry = $this->container->get( Token_Registry::class );
+		$schema   = $registry->to_ui_schema();
+
+		$this->assertArrayHasKey( 'Shadow', $schema['groups'] );
+
+		$found = null;
+
+		foreach ( $schema['groups']['Shadow'] as $entry ) {
+			if ( $id === $entry['id'] ) {
+				$found = $entry;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $found, 'The grouped custom token must appear in the declared "Shadow" UI-schema group.' );
+		$this->assertTrue( $found['userCreated'] );
+
+		/** @var Token_Resolver $resolver */
+		$resolver = $this->container->get( Token_Resolver::class );
+		$resolved = $resolver->resolve( $slug );
+
+		$this->assertSame( 'inset 0px 4px 12px 0px #171717', $resolved->value( $id ) );
+	}
+
+	/**
 	 * A slug naming no known library is rejected with a 404, mirroring Documents_Controller and
 	 * Active_Token_Library_Controller rather than silently substituting a different library's
 	 * data for the one requested.

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -584,6 +584,135 @@ final class Feed_ControllerTest extends TestCase {
 	}
 
 	/**
+	 * The declared shadow scale surfaces as its own feed group, in declaration order, with every
+	 * step's value resolved to the `Css_Renderer` shorthand and no projections — the Shadow
+	 * screen's data source end to end.
+	 *
+	 * @return void
+	 */
+	public function testGetItemReturnsTheShadowScaleGroup(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', Token_Store::default_slug() );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$this->assertArrayHasKey( 'Shadow', $data['schema']['groups'] );
+
+		$ids = array_column( $data['schema']['groups']['Shadow'], 'id' );
+		$this->assertSame(
+			[
+				'primitive.shadow.xs',
+				'primitive.shadow.sm',
+				'primitive.shadow.md',
+			],
+			$ids
+		);
+
+		foreach ( $data['schema']['groups']['Shadow'] as $entry ) {
+			$this->assertSame( [], $entry['projections'], 'The declared shadow scale carries no projections of its own.' );
+		}
+
+		$this->assertSame( '0px 1px 2px 0px #1717171f', $data['values']['primitive.shadow.xs'] );
+		$this->assertSame( '0px 2px 4px 0px #1717171f', $data['values']['primitive.shadow.sm'] );
+		$this->assertSame( '0px 2px 8px 0px #1717171f', $data['values']['primitive.shadow.md'] );
+	}
+
+	/**
+	 * `semantic.shadow.card` keeps resolving through its own curated, palette-linked value after
+	 * the shadow primitive scale is declared — declaring the scale for the Style Library screen
+	 * must not disturb the semantic's existing alias.
+	 *
+	 * @return void
+	 */
+	public function testSemanticShadowCardIsUnaffectedByTheDeclaredScale(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'slug', Token_Store::default_slug() );
+
+		$data = $this->controller->get_item( $request )->get_data();
+
+		$this->assertNotSame(
+			$data['values']['primitive.shadow.md'],
+			$data['values']['semantic.shadow.card'],
+			'semantic.shadow.card must keep its own curated value, not follow the new scale.'
+		);
+	}
+
+	/**
+	 * A user-created token minted into the shadow group (the stable key this ticket declares as
+	 * `group_key` alongside the newly declared shadow scale) surfaces inside the declared "Shadow"
+	 * UI-schema group and is flagged `userCreated`, and a stored `inset` sub-field round-trips into
+	 * the resolved value with the `inset ` prefix `Css_Renderer::shadow()` emits.
+	 *
+	 * @return void
+	 */
+	public function testUserPrimitiveGroupedIntoShadowSurfacesInItsFeedGroupWithInsetResolved(): void {
+		$slug = Token_Store::default_slug();
+		$id   = 'primitive.shadow.custom.shadow-2';
+
+		$document = (string) wp_json_encode(
+			[
+				'primitive'   => [
+					'shadow' => [
+						'custom' => [
+							'shadow-2' => [
+								'$type'  => 'shadow',
+								'$value' => [
+									'color'   => '#171717',
+									'offsetX' => '0px',
+									'offsetY' => '4px',
+									'blur'    => '12px',
+									'spread'  => '0px',
+									'inset'   => true,
+								],
+							],
+						],
+					],
+				],
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'userPrimitives' => [
+							$id => [
+								'label' => 'Elevated',
+								'group' => 'shadow',
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$this->store->save_document( $document, $slug );
+
+		/** @var User_Primitive_Registrar $registrar */
+		$registrar = $this->container->get( User_Primitive_Registrar::class );
+		$registrar->sync();
+
+		/** @var Token_Registry $registry */
+		$registry = $this->container->get( Token_Registry::class );
+		$schema   = $registry->to_ui_schema();
+
+		$this->assertArrayHasKey( 'Shadow', $schema['groups'] );
+
+		$found = null;
+
+		foreach ( $schema['groups']['Shadow'] as $entry ) {
+			if ( $id === $entry['id'] ) {
+				$found = $entry;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $found, 'The grouped custom token must appear in the declared "Shadow" UI-schema group.' );
+		$this->assertTrue( $found['userCreated'] );
+
+		/** @var Token_Resolver $resolver */
+		$resolver = $this->container->get( Token_Resolver::class );
+		$resolved = $resolver->resolve( $slug );
+
+		$this->assertSame( 'inset 0px 4px 12px 0px #171717', $resolved->value( $id ) );
+	}
+
+	/**
 	 * A slug naming no known library is rejected with a 404, mirroring Documents_Controller and
 	 * Active_Token_Library_Controller rather than silently substituting a different library's
 	 * data for the one requested.


### PR DESCRIPTION
> **Replaces #1236.** That PR was auto-marked merged with an empty diff when SOFT-4082 was
> reordered to sit *below* SOFT-4150 — its head became an ancestor of its base, so GitHub
> considered it already merged. No code was merged anywhere as a result, and this PR carries
> the identical commits, now targeting `SOFT-4081/icon-sizes-screen`. **Still needs review.**

Builds the **Shadow** screen of the Style Library — the last of the BASE STYLES scale screens, and the first consumer of the `shadow` composite backend.

## The design was not missing

This ticket previously said no Shadow board could be found and told whoever picked it up to confirm with design first. That was wrong. The board is on the canvas at node [`481:22041`](https://www.figma.com/design/IEheoiM2vqbyTevD64ifXa/Kadence-Blocks-Sidebar?node-id=481-22041) — but it is *named* "Border Radius" in Figma, which is why a search by board name missed it. Worth renaming it there so nobody repeats the search.

## What it adds

- `components/pages/ShadowScreen.js` / `.scss` — the config, the preview renderer, and the screen/panel wrappers.
- `helpers/shadow.js` — pure parse/serialize/render helpers, jest-covered.
- `declarations.php` + `baseline.json` — `primitive.shadow.{xs,sm,md}` under a `Shadow` group with `group_key: 'shadow'`.

`ShadowField` is reused **unchanged**: the scaffold work had already built the Color row, the X/Y/Blur/Spread inputs and the Inset toggle, and it was already registered as a `shadow` field type, so a schema can declare it directly.

## It rides the shared contract after all

The Border Radius plan explicitly excluded Shadow from the `ScaleScreen` contract, on the grounds that it has six fields and no value column. On inspection both assumptions were softer than they looked — `SettingsForm` already renders a `shadow` field type, and `ListRow` already suppresses a falsy value column. So this reverses that exclusion rather than forking the screen.

The contract gains exactly two optional, identity-defaulted seams: `parseValue` (resolved value → draft) and `buildLeaf` (draft → token leaf). The four existing screens pass neither and are behaviorally unchanged. A bespoke screen would have duplicated the write flows, the serialized reorder, the stale-item self-heal and the draft-channel wiring to avoid two function keys.

## The number-versus-string boundary

`ShadowField` emits bare numbers for X/Y/Blur/Spread; the composite stores dimension strings (`"0px"`, `"2px"`). The conversion lives at the screen boundary in `helpers/shadow.js`, not inside `ShadowField` — changing the field would affect every other consumer of it. Values are px-only, matching the board, which shows no unit selector.

Confirmed against the running app: a save writes `{ offsetX: "0px", offsetY: "1px", blur: "2px", spread: "0px", inset: true }` — strings, not numbers — and `inset` is omitted entirely when false.

## Two decisions worth reviewing

**The seeded colors are literal hex, not palette aliases.** The panel seeds by parsing the *resolved* CSS value, so any alias in a shadow primitive would be silently rewritten to a literal the first time someone saves that row. Literal seeds make that a non-event. The same reasoning is why **`semantic.shadow.card` and `semantic.shadow.media` are left untouched** — `card` aliases `primitive.color.neutral.900`, and re-pointing it at the new scale would detach it from the palette.

The consequence, which design should know about: a shadow color set through this screen can only ever be a literal. Pointing a shadow at a palette token is not possible here.

**The preview slot needs `overflow: visible`.** A shadow is drawn outside its box, and the shared row slot clips with `overflow: hidden` — left alone, every shadow on the screen would be invisible and the previews would look like empty squares. The override is scoped to this screen through the per-screen root modifier.

## Verification

`phpstan` clean with no baseline changes; `phpcs`, `cspell` and `eslint` clean; the full `Resources/Design_Tokens` suite green (1264 tests); snapshot suites green with no diffs; 224 jest tests including 11 new cases for the shadow helpers.

Driven in the browser: the three rows render with visibly increasing shadows and no clipping; the panel matches the board field for field and seeds correctly from the stored value; **live preview works on the composite** (editing Blur moved that row to `0px 2px 28px 0px` while its siblings kept their stored values); the unsaved-changes guard and Discard behave as they do on the scalar screens; Inset renders live and round-trips through a save.

Not exercised by hand: drag-reorder on this screen, the "+ Add Shadow" mint flow, and the Color popover's portal styling.

## Not included

Stacked shadows — a DTCG `$value` that is an array of shadow objects stays unsupported in v1, and a shadow token remains a single object. If the design ever wants layered shadows that is a separate backend change.

## Screenshots

**The screen with MD selected**
<img width="1568" height="461" alt="screen-with-panel" src="https://github.com/user-attachments/assets/71057212-1041-4085-8d67-e5d7ba4ffa0f" />
