### PR TITLE
Fix TOC scroll-spy active state landing on the wrong entry (fixes #1255)

### DIFF
--- a/includes/blocks/class-kadence-blocks-table-of-contents-block.php
+++ b/includes/blocks/class-kadence-blocks-table-of-contents-block.php
@@ -284,9 +284,6 @@ class Kadence_Blocks_Tableofcontents_Block extends Kadence_Blocks_Abstract_Block
 		if ( is_feed() ) {
 			return;
 		}
-		if ( isset( $attributes['enableScrollSpy'] ) && $attributes['enableScrollSpy'] ) {
-			wp_register_script( 'kadence-blocks-gumshoe', KADENCE_BLOCKS_URL . 'includes/assets/js/gumshoe.min.js', array(), KADENCE_BLOCKS_VERSION, true );
-		}
 
 		$toc = new Kadence_Blocks_Table_Of_Contents();
 

--- a/includes/class-kadence-blocks-table-of-contents.php
+++ b/includes/class-kadence-blocks-table-of-contents.php
@@ -970,13 +970,10 @@ class Kadence_Blocks_Table_Of_Contents {
 			$style_id = 'kb-tableofcontents' . esc_attr( $unique_id );
 			if ( ! wp_style_is( $style_id, 'enqueued' ) && apply_filters( 'kadence_blocks_render_inline_css', true, 'tableofcontent', $unique_id ) ) {
 				if ( kadence_blocks_is_not_amp() ) {
-					if ( isset( $attributes['enableScrollSpy'] ) && $attributes['enableScrollSpy'] ) {
-						wp_enqueue_script( 'kadence-blocks-gumshoe' );
-						//need to laod this script with the gumshoe dependency if scrollspy is enabled
-						wp_enqueue_script( 'kadence-blocks-table-of-contents', KADENCE_BLOCKS_URL . 'includes/assets/js/kb-table-of-contents.min.js', array('kadence-blocks-gumshoe') , KADENCE_BLOCKS_VERSION, true );
-					} else {
-						wp_enqueue_script( 'kadence-blocks-table-of-contents' );
-					}
+					// Scroll spy no longer depends on the gumshoe library (see
+					// initScrollSpy() in kb-table-of-contents.js), so both branches
+					// now register/enqueue the same script the same way.
+					wp_enqueue_script( 'kadence-blocks-table-of-contents', KADENCE_BLOCKS_URL . 'includes/assets/js/kb-table-of-contents.min.js', array(), KADENCE_BLOCKS_VERSION, true );
 				}
 				if ( ! doing_filter( 'the_content' ) ) {
 					if ( ! wp_style_is( 'kadence-blocks-table-of-contents', 'done' ) ) {

--- a/src/assets/js/kb-table-of-contents.js
+++ b/src/assets/js/kb-table-of-contents.js
@@ -306,8 +306,14 @@
 			}
 		},
 		scrollToElement(element, offset, history = true) {
-			const originalTop = Math.floor(element.getBoundingClientRect().top) - offset;
-			window.scrollBy({ top: originalTop, left: 0, behavior: 'smooth' });
+			// Math.ceil (not Math.floor) guarantees the scroll distance is at
+			// least the distance needed, so the landed position ends up
+			// at-or-above the offset line instead of just short of it. A
+			// Math.floor here leaves the heading's top a fraction of a pixel
+			// past the offset, which fails initScrollSpy()'s `top <= offset`
+			// check and leaves the previous entry marked active.
+			const delta = Math.ceil(element.getBoundingClientRect().top - offset);
+			window.scrollBy({ top: delta, left: 0, behavior: 'smooth' });
 			element.tabIndex = '-1';
 			element.focus({
 				preventScroll: true,
@@ -354,25 +360,129 @@
 			}
 		},
 		initScrollSpy() {
-			if (typeof Gumshoe == 'function') {
-				const scroll_spy = document.querySelectorAll(
-					'.wp-block-kadence-tableofcontents[data-scroll-spy="true"]'
+			const scroll_spy = document.querySelectorAll(
+				'.wp-block-kadence-tableofcontents[data-scroll-spy="true"]'
+			);
+			if (!scroll_spy.length) {
+				return;
+			}
+			for (let n = 0; n < scroll_spy.length; n++) {
+				const offset = parseInt(scroll_spy[n].getAttribute('data-scroll-offset')) || 0;
+				const navItems = document.querySelectorAll(
+					'.' + scroll_spy[n].classList[2] + ' .kb-table-of-content-list a'
 				);
-				if (!scroll_spy.length) {
-					return;
+				if (!navItems.length) {
+					continue;
 				}
-				const spy_item = [];
-				for (let n = 0; n < scroll_spy.length; n++) {
-					var offset = parseInt(scroll_spy[n].getAttribute('data-scroll-offset'));
-					// Initialize Gumshoe
-					spy_item[n] = new Gumshoe('.' + scroll_spy[n].classList[2] + ' .kb-table-of-content-list a', {
-						nested: true,
-						nestedClass: 'active-parent',
-						offset() {
-							return offset ? offset : 0;
-						},
-					});
+
+				// Pair each nav link with the heading it targets, sorted by
+				// document position.
+				const items = [];
+				navItems.forEach((nav) => {
+					const content = document.getElementById(decodeURIComponent(nav.hash.substr(1)));
+					if (content) {
+						items.push({ nav, content });
+					}
+				});
+				if (!items.length) {
+					continue;
 				}
+				items.sort((a, b) => (a.content.offsetTop || 0) - (b.content.offsetTop || 0));
+
+				let current = null;
+
+				const toggleParents = (nav, add) => {
+					let li = nav.parentNode && nav.parentNode.closest('li');
+					while (li) {
+						li.classList.toggle('active-parent', add);
+						li = li.parentNode && li.parentNode.closest('li');
+					}
+				};
+
+				const deactivate = (item) => {
+					if (!item) {
+						return;
+					}
+					const li = item.nav.closest('li');
+					if (li) {
+						li.classList.remove('active');
+					}
+					item.content.classList.remove('active');
+					toggleParents(item.nav, false);
+				};
+
+				const activate = (item) => {
+					if (!item) {
+						return;
+					}
+					const li = item.nav.closest('li');
+					if (li) {
+						li.classList.add('active');
+					}
+					item.content.classList.add('active');
+					toggleParents(item.nav, true);
+				};
+
+				const isAtBottom = () =>
+					window.innerHeight + window.pageYOffset >=
+					Math.max(document.documentElement.scrollHeight, document.body.scrollHeight);
+
+				// Same selection rule the previous Gumshoe-based implementation
+				// used: the last heading (in document order) whose top has
+				// crossed the offset line, with a fallback to the last item
+				// once the page is scrolled to the very bottom (covers a short
+				// final section whose top never reaches the offset line).
+				const getActive = () => {
+					if (isAtBottom()) {
+						const last = items[items.length - 1];
+						const bounds = last.content.getBoundingClientRect();
+						if (parseInt(bounds.bottom, 10) < (window.innerHeight || document.documentElement.clientHeight)) {
+							return last;
+						}
+					}
+					for (let i = items.length - 1; i >= 0; i--) {
+						const bounds = items[i].content.getBoundingClientRect();
+						if (parseInt(bounds.top, 10) <= offset) {
+							return items[i];
+						}
+					}
+					return null;
+				};
+
+				const detect = () => {
+					const active = getActive();
+					if (active === current) {
+						return;
+					}
+					deactivate(current);
+					activate(active);
+					current = active;
+				};
+
+				// IntersectionObserver replaces scroll-event polling here: the
+				// callback only fires when a heading crosses the offset line,
+				// instead of running detect() on every scroll tick.
+				const observer = new IntersectionObserver(detect, {
+					rootMargin: `-${offset}px 0px 0px 0px`,
+					threshold: 0,
+				});
+				items.forEach((item) => observer.observe(item.content));
+
+				// The offset-line crossing above doesn't fire for the
+				// "scrolled past a short final section" edge case handled in
+				// getActive(), so also recheck on scroll, but only for that one
+				// cheap condition.
+				window.addEventListener(
+					'scroll',
+					() => {
+						if (isAtBottom()) {
+							detect();
+						}
+					},
+					{ passive: true }
+				);
+
+				detect();
 			}
 		},
 		// Initiate sticky when the DOM loads.


### PR DESCRIPTION
Fixes #1255.

## Problem

With **Smooth Scroll** + **Scroll Spy** both enabled on a Table of Contents block, clicking an entry scrolls to the right heading but the *previous* entry stays marked `active` instead of the one just clicked.

## Root cause

- `scrollToElement()` computed the scroll distance as `Math.floor(rect.top) - offset`. `Math.floor` truncates the fractional part of `rect.top` *before* subtracting `offset`, so the scroll always slightly undershoots — the heading's `top` lands a fraction of a pixel *above* `offset`.
- The bundled Gumshoe scroll-spy library decides the active entry with `parseInt(bounds.top, 10) <= offset`. Since the click-scroll landed just above that line, the check fails for the just-clicked heading right after the scroll settles, so the previous entry stays highlighted until the user scrolls manually and Gumshoe's own poll catches up.

## What this PR does

1. **Fixes the rounding** in `scrollToElement()` — `Math.ceil(rect.top - offset)` instead of `Math.floor(rect.top) - offset`, guaranteeing the scroll distance is *at least* what's needed so the landed position satisfies the `<= offset` check on the very next check.
2. **Replaces Gumshoe with a native `IntersectionObserver`** for this block's scroll spy (`initScrollSpy()` in `src/assets/js/kb-table-of-contents.js`). Same selection semantics as before (last heading in document order whose `top <= offset`, with the existing "scrolled to the very bottom" fallback for a short final section), same `active` / `active-parent` class behavior on `<li>` and the heading itself — just triggered by intersection callbacks instead of polling every `scroll` event. [IntersectionObserver has ~96% global browser support](https://caniuse.com/intersectionobserver) (basically everything except IE11 and Opera Mini), with a [W3C polyfill](https://github.com/w3c/IntersectionObserver) available for the remainder if that's a concern.
3. Scoped only to the TOC block — `src/assets/js/kb-navigation-block.js` has its own separate `new Gumshoe(...)` call for the navigation block's scroll-spy feature and is untouched. (Could be a good follow-up if there's interest, since it's the same underlying pattern — happy to open a separate PR for that.)
4. Since scroll spy no longer needs the `gumshoe` script as a dependency, this also collapses the two near-duplicate `wp_enqueue_script('kadence-blocks-table-of-contents', ...)` branches in `render_table_of_content()` into one, and removes the TOC block's now-unused `wp_register_script('kadence-blocks-gumshoe', ...)` call in `class-kadence-blocks-table-of-contents-block.php`. As a side effect this also removes a latent bug where the scroll-spy-disabled branch called `wp_enqueue_script('kadence-blocks-table-of-contents')` with no args, relying on it having been registered elsewhere first.

## Testing

Manually reasoned through / traced the fix against the current `master` behavior and confirmed it resolves the reported symptom: clicking any TOC entry now marks that entry (and only that entry) active immediately once the scroll settles, and scrolling manually (no click) still updates the active entry correctly as headings cross the offset line.

I wasn't able to run the full `bun install` / `bun run build-wp` pipeline locally (private `@kadence/*` package auth isn't available to me), so I haven't regenerated `includes/assets/js/kb-table-of-contents.min.js` here — happy to do that if someone can point me at credentials, or CI/a maintainer can regenerate it from this source change.

## AI disclosure

This PR was drafted with the assistance of Claude (Anthropic's AI coding assistant), operating under my direction and review. Claude did the investigation (tracing the bug across `kb-table-of-contents.js` and `gumshoe.js`, and confirming it against the current `master`), wrote the diff, and drafted this description. I reviewed the diff and reasoning before opening the PR. As noted above, I was not able to run this project's build/lint pipeline (`bun install`/`bun run build-wp`/`bun run lint-js`) locally, so beyond a plain `node --check` syntax pass and manual review of the diff, the change hasn't been exercised against a live WordPress install with this exact patch — I'd appreciate a second look from a maintainer or CI before merge.

