### PR TITLE
fix(design-tokens): ship only the default color palette in the baseline

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -684,38 +684,6 @@
 							]
 						}
 					]
-				},
-				"sunset": {
-					"label": "Sunset",
-					"groups": [
-						{
-							"id": "accent",
-							"label": "Accent",
-							"swatches": [
-								{ "token": "primitive.color.brand.primary", "label": "Main 1", "$value": "#DD6B20" },
-								{ "token": "primitive.color.brand.secondary", "label": "Main 2", "$value": "#C05621" },
-								{ "token": "primitive.color.brand.accent", "label": "Main 3", "$value": "#F6AD55" },
-								{ "token": "primitive.color.brand.button", "label": "Button", "$value": "#DD6B20" },
-								{ "token": "primitive.color.brand.button-hover", "label": "Button Hover", "$value": "#C05621" }
-							]
-						}
-					]
-				},
-				"forest": {
-					"label": "Forest",
-					"groups": [
-						{
-							"id": "accent",
-							"label": "Accent",
-							"swatches": [
-								{ "token": "primitive.color.brand.primary", "label": "Main 1", "$value": "#2F855A" },
-								{ "token": "primitive.color.brand.secondary", "label": "Main 2", "$value": "#276749" },
-								{ "token": "primitive.color.brand.accent", "label": "Main 3", "$value": "#68D391" },
-								{ "token": "primitive.color.brand.button", "label": "Button", "$value": "#2F855A" },
-								{ "token": "primitive.color.brand.button-hover", "label": "Button Hover", "$value": "#276749" }
-							]
-						}
-					]
 				}
 			},
 			"presets": {

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Palette_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Palette_CatalogTest.php
@@ -43,8 +43,8 @@ final class Palette_CatalogTest extends TestCase {
 	}
 
 	/**
-	 * With nothing stored, the catalog reports the active library slug, its `$current` palette id, and the
-	 * shipped baseline palettes each as a `{ id, label }` pair with a non-empty string label.
+	 * With nothing stored, the catalog reports the active library slug, its `$current` palette id, and the sole
+	 * shipped baseline palette (`default`) as a `{ id, label }` pair with a non-empty string label.
 	 *
 	 * @return void
 	 */
@@ -56,8 +56,6 @@ final class Palette_CatalogTest extends TestCase {
 
 		$ids = array_column( $catalog['palettes'], 'id' );
 		$this->assertContains( 'default', $ids );
-		$this->assertContains( 'sunset', $ids );
-		$this->assertContains( 'forest', $ids );
 
 		// Every entry is a { id, label } pair with a non-empty string label.
 		foreach ( $catalog['palettes'] as $palette ) {

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Palette/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Palette/ProjectorTest.php
@@ -3,14 +3,17 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Projection\Palette;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Palette\Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use Tests\Support\Classes\TestCase;
 
 /**
- * Covers the palette switch-layer projector: it emits a `[data-kb-palette="<id>"]` selector for each of the
- * active library's shipped palettes, and is a no-op when the registry is deactivated.
+ * Covers the palette switch-layer projector: it emits a `[data-kb-palette="<id>"]` selector for each palette
+ * the active library defines that differs from the baseline default, and is a no-op when the registry is
+ * deactivated. The baseline ships only the `default` palette (whose graph equals the baseline, so it emits no
+ * declarations on its own), so the per-palette cases seed a local non-default palette to switch to.
  */
 final class ProjectorTest extends TestCase {
 
@@ -25,6 +28,11 @@ final class ProjectorTest extends TestCase {
 	private Token_Registry $registry;
 
 	/**
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
 	 * @return void
 	 */
 	protected function setUp(): void {
@@ -32,6 +40,7 @@ final class ProjectorTest extends TestCase {
 
 		$this->projector = $this->container->get( Projector::class );
 		$this->registry  = $this->container->get( Token_Registry::class );
+		$this->store     = $this->container->get( Token_Store::class );
 	}
 
 	/**
@@ -44,17 +53,18 @@ final class ProjectorTest extends TestCase {
 	}
 
 	/**
-	 * The projector emits a switch selector for each shipped palette, re-pointing the brand color vars to the
-	 * palette's values (here the "sunset" starter palette).
+	 * The projector emits a switch selector for each palette that differs from the baseline default, re-pointing
+	 * the brand color vars to the palette's values (here a seeded "custom" palette).
 	 *
 	 * @return void
 	 */
-	public function testItEmitsASwitchSelectorForEachShippedPalette(): void {
+	public function testItEmitsASwitchSelectorForEachPalette(): void {
+		$this->store->save_document( (string) wp_json_encode( $this->custom_palette_overrides() ) );
+
 		$css = $this->projector->css();
 
 		$this->assertStringContainsString( '[data-kb-palette="default"]{', $css );
-		$this->assertStringContainsString( '[data-kb-palette="sunset"]{', $css );
-		$this->assertStringContainsString( '[data-kb-palette="forest"]{', $css );
+		$this->assertStringContainsString( '[data-kb-palette="custom"]{', $css );
 
 		$this->assertStringContainsString(
 			Css_Var::from_id( 'primitive.color.brand.primary' ) . ':#DD6B20;',
@@ -70,19 +80,21 @@ final class ProjectorTest extends TestCase {
 	 * @return void
 	 */
 	public function testTheSwitchSelectorCarriesTheResolvedColorGraph(): void {
+		$this->store->save_document( (string) wp_json_encode( $this->custom_palette_overrides() ) );
+
 		$css = $this->projector->css();
 
-		// Isolate just the sunset selector's declarations (up to its closing brace).
-		$start = strpos( $css, '[data-kb-palette="sunset"]{' );
+		// Isolate just the custom selector's declarations (up to its closing brace).
+		$start = strpos( $css, '[data-kb-palette="custom"]{' );
 		$this->assertNotFalse( $start );
 		$block = substr( $css, (int) $start, (int) strpos( $css, '}', (int) $start ) - (int) $start + 1 );
 
-		// Sunset's own button primitive delta is present.
+		// The custom palette's own button primitive delta is present.
 		$this->assertStringContainsString( Css_Var::from_id( 'primitive.color.brand.button' ) . ':#DD6B20;', $block );
 
-		// The semantic that aliases the re-tinted button primitive is resolved to sunset's color (not just the
-		// primitive) — this is what makes a block reading the semantic re-skin, and what the button's preset
-		// var chains to.
+		// The semantic that aliases the re-tinted button primitive is resolved to the custom palette's color (not
+		// just the primitive) — this is what makes a block reading the semantic re-skin, and what the button's
+		// preset var chains to.
 		$this->assertStringContainsString( Css_Var::from_id( 'semantic.color.button-primary-bg' ) . ':#DD6B20;', $block );
 	}
 
@@ -123,5 +135,61 @@ final class ProjectorTest extends TestCase {
 		$this->projector->enqueue_front_end();
 
 		$this->assertEmpty( wp_styles()->get_data( 'kadence-blocks-global-variables', 'after' ) );
+	}
+
+	/**
+	 * Seed a non-default "custom" palette (brand primary + button both re-tinted to #DD6B20) into the active
+	 * library, so the projector has a palette that differs from the baseline default to emit a switch selector
+	 * for. The baseline ships only the `default` palette, whose graph equals the baseline and so emits no
+	 * `[data-kb-palette]` declarations on its own.
+	 *
+	 * @return void
+	 */
+	private function custom_palette_overrides(): array {
+		return [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'colorPalettes' => [
+						'$current' => 'custom',
+						'custom'   => [
+							'label'  => 'Custom',
+							'groups' => [
+								[
+									'id'       => 'accent',
+									'label'    => 'Accent',
+									'swatches' => [
+										[
+											'token'  => 'primitive.color.brand.primary',
+											'label'  => 'Main 1',
+											'$value' => '#DD6B20',
+										],
+										[
+											'token'  => 'primitive.color.brand.secondary',
+											'label'  => 'Main 2',
+											'$value' => '#C05621',
+										],
+										[
+											'token'  => 'primitive.color.brand.accent',
+											'label'  => 'Main 3',
+											'$value' => '#F6AD55',
+										],
+										[
+											'token'  => 'primitive.color.brand.button',
+											'label'  => 'Button',
+											'$value' => '#DD6B20',
+										],
+										[
+											'token'  => 'primitive.color.brand.button-hover',
+											'label'  => 'Button Hover',
+											'$value' => '#C05621',
+										],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+		];
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_PalettesTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_PalettesTest.php
@@ -9,8 +9,8 @@ use Tests\Support\Classes\TestCase;
 
 /**
  * Covers the effective palettes reader: the shipped baseline's colorPalettes deep-merged with the stored
- * overrides, its `$current` / `$default` pointer resolution, and the resolve-time overlay diff — asserted
- * against the real baseline so these also guard its palette definitions.
+ * overrides, its `$current` / `$default` pointer resolution, and the resolve-time overlay diff. The baseline
+ * ships only the `default` palette, so the non-default cases define their own local palette to switch to.
  */
 final class Effective_PalettesTest extends TestCase {
 
@@ -35,7 +35,7 @@ final class Effective_PalettesTest extends TestCase {
 	}
 
 	/**
-	 * With nothing stored, the reader returns the baseline palettes and their pointers.
+	 * With nothing stored, the reader returns the sole shipped baseline palette (`default`) and its pointers.
 	 *
 	 * @return void
 	 */
@@ -43,8 +43,6 @@ final class Effective_PalettesTest extends TestCase {
 		$ids = $this->palettes->palette_ids();
 
 		$this->assertContains( 'default', $ids );
-		$this->assertContains( 'sunset', $ids );
-		$this->assertContains( 'forest', $ids );
 
 		$this->assertSame( 'default', $this->palettes->default_palette() );
 		$this->assertSame( 'default', $this->palettes->current() );
@@ -79,40 +77,34 @@ final class Effective_PalettesTest extends TestCase {
 	 * @return void
 	 */
 	public function testPointingCurrentAtANonDefaultPaletteBuildsTheOverlay(): void {
-		$overrides = [
-			'$extensions' => [
-				'com.kadence.designTokens' => [
-					'colorPalettes' => [ '$current' => 'sunset' ],
-				],
-			],
-		];
+		$overlay = $this->palettes->overlay_for_overrides( $this->custom_palette_overrides() );
 
-		$overlay = $this->palettes->overlay_for_overrides( $overrides );
-
-		// Sunset re-tints the brand accents (its swatches differ from the baseline default palette).
+		// The custom palette re-tints the brand accents (its swatches differ from the baseline default palette).
 		$this->assertSame( '#DD6B20', $overlay['primitive.color.brand.primary'] );
 		$this->assertSame( '#C05621', $overlay['primitive.color.brand.secondary'] );
 		$this->assertSame( '#F6AD55', $overlay['primitive.color.brand.accent'] );
 
-		// It does not touch the neutral ramp — sunset defines no swatch for it.
+		// It does not touch the neutral ramp — the custom palette defines no swatch for it.
 		$this->assertArrayNotHasKey( 'primitive.color.neutral.900', $overlay );
 	}
 
 	/**
-	 * The effective colors for a partial palette are the default palette overlaid with its own deltas: a
-	 * sunset swatch (brand) wins, while a token sunset omits (a neutral) falls back to the default value. This
+	 * The effective colors for a partial palette are the default palette overlaid with its own deltas: the
+	 * palette's own swatch (brand) wins, while a token it omits (a neutral) falls back to the default value. This
 	 * is the complete color set the per-block switch layer emits.
 	 *
 	 * @return void
 	 */
 	public function testEffectiveSwatchValuesOverlayThePaletteOverTheDefault(): void {
-		$effective = $this->palettes->effective_swatch_values( 'sunset' );
+		$this->store->save_document( (string) wp_json_encode( $this->custom_palette_overrides() ), 'default' );
 
-		// Sunset's own delta wins for the brand + button colors it defines.
+		$effective = $this->palettes->effective_swatch_values( 'custom' );
+
+		// The custom palette's own delta wins for the brand + button colors it defines.
 		$this->assertSame( '#DD6B20', $effective['primitive.color.brand.primary'] );
 		$this->assertSame( '#DD6B20', $effective['primitive.color.brand.button'] );
 
-		// A token sunset omits falls back to the default palette's value (a complete set).
+		// A token the custom palette omits falls back to the default palette's value (a complete set).
 		$this->assertSame( '#1A202C', $effective['primitive.color.neutral.900'] );
 		$this->assertSame( '#E2E8F0', $effective['primitive.color.neutral.200'] );
 	}
@@ -157,5 +149,60 @@ final class Effective_PalettesTest extends TestCase {
 		$this->assertContains( 'midnight', $this->palettes->palette_ids() );
 		$this->assertSame( 'midnight', $this->palettes->current() );
 		$this->assertSame( '#0b1020', $this->palettes->current_swatch_values()['primitive.color.brand.primary'] );
+	}
+
+	/**
+	 * A stored-overrides document that defines a non-default "custom" palette — brand + button deltas only, no
+	 * neutral ramp — pointing `$current` at it. The baseline ships only the `default` palette, so the non-default
+	 * cases own the palette they switch to instead of leaning on a baseline placeholder.
+	 *
+	 * @return array<string, mixed> The decoded overrides document.
+	 */
+	private function custom_palette_overrides(): array {
+		return [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'colorPalettes' => [
+						'$current' => 'custom',
+						'custom'   => [
+							'label'  => 'Custom',
+							'groups' => [
+								[
+									'id'       => 'accent',
+									'label'    => 'Accent',
+									'swatches' => [
+										[
+											'token'  => 'primitive.color.brand.primary',
+											'label'  => 'Main 1',
+											'$value' => '#DD6B20',
+										],
+										[
+											'token'  => 'primitive.color.brand.secondary',
+											'label'  => 'Main 2',
+											'$value' => '#C05621',
+										],
+										[
+											'token'  => 'primitive.color.brand.accent',
+											'label'  => 'Main 3',
+											'$value' => '#F6AD55',
+										],
+										[
+											'token'  => 'primitive.color.brand.button',
+											'label'  => 'Button',
+											'$value' => '#DD6B20',
+										],
+										[
+											'token'  => 'primitive.color.brand.button-hover',
+											'label'  => 'Button Hover',
+											'$value' => '#C05621',
+										],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+		];
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
@@ -728,16 +728,13 @@ final class Token_ResolverTest extends TestCase {
 		$this->assertSame( '#3182CE', $resolver->resolve()->value( 'semantic.color.link' ) );
 		$spacing = $resolver->resolve()->value( 'semantic.spacing.block' );
 
-		// Switch the library to the shipped "sunset" palette by writing $current; the write bumps the version.
-		$store->save_document(
-			(string) wp_json_encode(
-				[ '$extensions' => [ 'com.kadence.designTokens' => [ 'colorPalettes' => [ '$current' => 'sunset' ] ] ] ]
-			)
-		);
+		// Switch the library to a non-default "custom" palette by writing it and pointing $current at it; the
+		// write bumps the version.
+		$store->save_document( (string) wp_json_encode( $this->custom_palette_overrides() ) );
 
 		$resolved = $resolver->resolve();
 
-		// The brand primitive and the semantic link that aliases it both re-tint to sunset's color.
+		// The brand primitive and the semantic link that aliases it both re-tint to the custom palette's color.
 		$this->assertSame( '#DD6B20', $resolved->value( 'primitive.color.brand.primary' ) );
 		$this->assertSame( '#DD6B20', $resolved->value( 'semantic.color.link' ) );
 
@@ -757,11 +754,7 @@ final class Token_ResolverTest extends TestCase {
 		/** @var Token_Store $store */
 		$store = $this->container->get( Token_Store::class );
 
-		$store->save_document(
-			(string) wp_json_encode(
-				[ '$extensions' => [ 'com.kadence.designTokens' => [ 'colorPalettes' => [ '$current' => 'sunset' ] ] ] ]
-			)
-		);
+		$store->save_document( (string) wp_json_encode( $this->custom_palette_overrides() ) );
 		$this->assertSame( '#DD6B20', $resolver->resolve()->value( 'primitive.color.brand.primary' ) );
 
 		$store->save_document(
@@ -976,5 +969,60 @@ final class Token_ResolverTest extends TestCase {
 		$this->assertSame( '1.125rem', $resolved->value( 'semantic.font-size.control' ) );
 		$this->assertSame( [], $resolved->projected_responsive() );
 		$this->assertNull( $resolved->value_at( 'semantic.font-size.control', 'tablet' ) );
+	}
+
+	/**
+	 * A stored-overrides document that defines a non-default "custom" color palette (brand + button deltas, no
+	 * neutral ramp) and points `$current` at it. The baseline ships only the `default` palette, so the
+	 * palette-switch tests define the palette they switch to here rather than leaning on a baseline placeholder.
+	 *
+	 * @return array<string, mixed> The decoded overrides document.
+	 */
+	private function custom_palette_overrides(): array {
+		return [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'colorPalettes' => [
+						'$current' => 'custom',
+						'custom'   => [
+							'label'  => 'Custom',
+							'groups' => [
+								[
+									'id'       => 'accent',
+									'label'    => 'Accent',
+									'swatches' => [
+										[
+											'token'  => 'primitive.color.brand.primary',
+											'label'  => 'Main 1',
+											'$value' => '#DD6B20',
+										],
+										[
+											'token'  => 'primitive.color.brand.secondary',
+											'label'  => 'Main 2',
+											'$value' => '#C05621',
+										],
+										[
+											'token'  => 'primitive.color.brand.accent',
+											'label'  => 'Main 3',
+											'$value' => '#F6AD55',
+										],
+										[
+											'token'  => 'primitive.color.brand.button',
+											'label'  => 'Button',
+											'$value' => '#DD6B20',
+										],
+										[
+											'token'  => 'primitive.color.brand.button-hover',
+											'label'  => 'Button Hover',
+											'$value' => '#C05621',
+										],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+		];
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
@@ -50,11 +50,14 @@ final class Palettes_ControllerTest extends TestCase {
 	}
 
 	/**
-	 * The listing returns the library's $default / $current pointers and each shipped palette's id + label.
+	 * The listing returns the library's $default / $current pointers and each palette's id + label — the shipped
+	 * `default` plus a stored non-default palette.
 	 *
 	 * @return void
 	 */
-	public function testGetItemsListsTheShippedPalettes(): void {
+	public function testGetItemsListsThePalettes(): void {
+		$this->create_custom_palette();
+
 		$data = $this->controller->get_items( new WP_REST_Request( WP_REST_Server::READABLE ) )->get_data();
 
 		$this->assertSame( 'default', $data['$default'] );
@@ -62,22 +65,23 @@ final class Palettes_ControllerTest extends TestCase {
 
 		$ids = array_column( $data['palettes'], 'id' );
 		$this->assertContains( 'default', $ids );
-		$this->assertContains( 'sunset', $ids );
-		$this->assertContains( 'forest', $ids );
+		$this->assertContains( 'custom', $ids );
 	}
 
 	/**
-	 * Reading a shipped palette returns its label and groups; an unknown id is a 404.
+	 * Reading a defined palette returns its label and groups; an unknown id is a 404.
 	 *
 	 * @return void
 	 */
 	public function testGetItemReturnsAPaletteAndUnknownIsNotFound(): void {
+		$this->create_custom_palette();
+
 		$request = new WP_REST_Request( WP_REST_Server::READABLE );
-		$request->set_param( 'id', 'sunset' );
+		$request->set_param( 'id', 'custom' );
 
 		$response = $this->controller->get_item( $request );
 		$this->assertSame( WP_Http::OK, $response->get_status() );
-		$this->assertSame( 'Sunset', $response->get_data()['label'] );
+		$this->assertSame( 'Custom', $response->get_data()['label'] );
 
 		$missing = new WP_REST_Request( WP_REST_Server::READABLE );
 		$missing->set_param( 'id', 'nope' );
@@ -90,12 +94,14 @@ final class Palettes_ControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testSetCurrentPersistsAndRejectsUnknown(): void {
+		$this->create_custom_palette();
+
 		$request = new WP_REST_Request( 'PUT' );
-		$request->set_param( 'current', 'sunset' );
+		$request->set_param( 'current', 'custom' );
 
 		$response = $this->controller->set_current( $request );
 		$this->assertNotInstanceOf( WP_Error::class, $response );
-		$this->assertSame( 'sunset', $this->palettes->current() );
+		$this->assertSame( 'custom', $this->palettes->current() );
 
 		$bad = new WP_REST_Request( 'PUT' );
 		$bad->set_param( 'current', 'nope' );
@@ -124,8 +130,10 @@ final class Palettes_ControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testGetItemReturnsTheEffectiveViewWithInheritedValues(): void {
+		$this->create_custom_palette();
+
 		$request = new WP_REST_Request( WP_REST_Server::READABLE );
-		$request->set_param( 'id', 'sunset' );
+		$request->set_param( 'id', 'custom' );
 
 		$data     = $this->controller->get_item( $request )->get_data();
 		$swatches = [];
@@ -136,11 +144,11 @@ final class Palettes_ControllerTest extends TestCase {
 			}
 		}
 
-		// A sunset delta is overridden and carries sunset's value.
+		// A custom-palette delta is overridden and carries the custom palette's value.
 		$this->assertTrue( $swatches['primitive.color.brand.primary']['overridden'] );
 		$this->assertSame( '#DD6B20', $swatches['primitive.color.brand.primary']['$value'] );
 
-		// A token sunset omits is present but inherited from the default palette's value.
+		// A token the custom palette omits is present but inherited from the default palette's value.
 		$this->assertFalse( $swatches['primitive.color.neutral.900']['overridden'] );
 		$this->assertSame( '#1A202C', $swatches['primitive.color.neutral.900']['$value'] );
 	}
@@ -522,6 +530,18 @@ final class Palettes_ControllerTest extends TestCase {
 		$this->assertArrayHasKey( 'POST', $methods );
 		$this->assertArrayHasKey( 'PUT', $methods );
 		$this->assertArrayHasKey( 'DELETE', $methods );
+	}
+
+	/**
+	 * Create a non-default "custom" palette (a single brand-primary delta of #DD6B20, labelled "Custom") through
+	 * the controller's own write path, without pointing `$current` at it. The baseline no longer ships a
+	 * non-default palette, so the list / read / $current cases own the one they exercise — and creating it inactive
+	 * keeps the library `$current` on `default` until a test sets it explicitly.
+	 *
+	 * @return void
+	 */
+	private function create_custom_palette(): void {
+		$this->controller->update_item( $this->write_request( 'custom', 'Custom', '#DD6B20' ) );
 	}
 
 	/**


### PR DESCRIPTION
🎫 https://linear.app/nexcess/issue/SOFT-4026/remove-the-placeholder-sunset-forest-color-palettes-from-the-baseline

Removes the placeholder `sunset` and `forest` color palettes from the baseline document, leaving only the genuine `default` palette plus the `$default` / `$current` pointers. They existed only as fixtures for exercising palette switching and do not correspond to anything real in the plugin.

The palette resolver, projector, catalog, and REST tests that leaned on those baseline placeholders now define their own local `custom` palette, so the suite no longer depends on shipped fixtures.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
