### PR TITLE
Fix TypeError in header sticky cleanup branch (parent used before assignment)

### DIFF
--- a/src/assets/js/kb-header-block.js
+++ b/src/assets/js/kb-header-block.js
@@ -485,7 +485,7 @@ class KBHeader {
 			this.stickyWrapper.style.height = null;
 			this.stickyWrapper.style.top = null;
 			this.stickyWrapper.style.position = 'initial';
-			parent.classList.remove('child-is-fixed');
+			this.stickyWrapper.parentNode.classList.remove('child-is-fixed');
 			document.body.classList.remove('header-is-fixed');
 			return;
 		}


### PR DESCRIPTION
Fixes #1258

### Problem

In `updateSticky()`, the early-return cleanup branch (taken whenever sticky is not enabled for the active screen size) references `parent` before the `var parent = this.stickyWrapper.parentNode;` assignment further down in the method:

- `src/assets/js/kb-header-block.js` line 488: `parent.classList.remove('child-is-fixed');` (use)
- line 550: `var parent = this.stickyWrapper.parentNode;` (assignment)

Because of `var` hoisting, `parent` is `undefined` at line 488. The bundler statically resolves this and ships `(void 0).classList.remove("child-is-fixed")` in `includes/assets/js/kb-header-block.min.js`, so the branch throws unconditionally:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'classList')
    at KBHeader.updateSticky
```

On any site where sticky is enabled for some breakpoints only (e.g. desktop-only), every scroll event on the other breakpoints throws, and `document.body.classList.remove('header-is-fixed')` on the following line never runs, so the body class can incorrectly persist across breakpoint changes.

### Fix

Use `this.stickyWrapper.parentNode` directly in the cleanup branch — the method's opening guard (`if (!this.stickyWrapper) return;`) guarantees it exists, and it is exactly the element the later `var parent` assignment refers to. The second `parent.classList.remove('child-is-fixed')` (line 726) runs after the assignment and stays unchanged.

Note: I have only changed the source file; the minified bundle under `includes/assets/js/` is not rebuilt in this PR.
