### PR TITLE
fix(design-tokens): resolve a token-reference border width in the legacy render_border()

### DIFF
--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -2069,8 +2069,11 @@ class Kadence_Blocks_CSS {
 	/**
 	 * Generates a border string for a single side at a single screen size.
 	 *
+	 * @since 3.3.2
+	 *
 	 * @param array  $border an array of border settings.
-	 * @param string $side   the border side to render (top, right, bottom, left).
+	 * @param string $side   the border side to render (top, right, bottom, left). Default 'top'.
+	 *
 	 * @return string
 	 */
 	public function render_border( $border, $side = 'top' ) {

--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -2069,7 +2069,8 @@ class Kadence_Blocks_CSS {
 	/**
 	 * Generates a border string for a single side at a single screen size.
 	 *
-	 * @param array $border an array of border settings.
+	 * @param array  $border an array of border settings.
+	 * @param string $side   the border side to render (top, right, bottom, left).
 	 * @return string
 	 */
 	public function render_border( $border, $side = 'top' ) {
@@ -2094,7 +2095,12 @@ class Kadence_Blocks_CSS {
 		$width         = ( isset( $border_side[2] ) && ! empty( $border_side[2] ) ? $border_side[2] : '0' );
 		$unit          = ( isset( $border[0]['unit'] ) && ! empty( $border[0]['unit'] ) ? $border[0]['unit'] : 'px' );
 		$color         = ( isset( $border_side[0] ) && ! empty( $border_side[0] ) ? $border_side[0] : 'transparent' );
-		$border_string = $width . $unit . ' ' . $style . ' ' . $this->render_color( $color );
+
+		// A token-reference width resolves to a self-contained var() (unit included), so the literal unit is dropped.
+		$width_reference = $this->get_token_reference( $width );
+		$width_output    = null !== $width_reference ? $width_reference : $width . $unit;
+
+		$border_string = $width_output . ' ' . $style . ' ' . $this->render_color( $color );
 
 		return $border_string;
 	}

--- a/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
+++ b/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
@@ -228,6 +228,80 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	}
 
 	/**
+	 * render_border emits the bare var() reference for a strict alias width, dropping the
+	 * literal unit, with the literal style and color untouched in the shorthand.
+	 *
+	 * @return void
+	 */
+	public function testRenderBorderEmitsBareVarForAliasedWidth(): void {
+		$border = [
+			[
+				'top'  => [ '#000000', 'solid', '{semantic.radius.media}' ],
+				'unit' => 'px',
+			],
+		];
+
+		$this->assertSame(
+			'var(--kb-token--semantic--radius--media) solid #000000',
+			$this->css->render_border( $border, 'top' ),
+			'render_border must emit the bare var() for a strict alias width, dropping the unit'
+		);
+	}
+
+	/**
+	 * render_border resolves a strict alias in both the width and color positions together,
+	 * emitting each as its own bare var() in the shorthand.
+	 *
+	 * @return void
+	 */
+	public function testRenderBorderResolvesAliasedWidthAndColorTogether(): void {
+		$border = [
+			[
+				'top'  => [ '{semantic.color.brand}', 'solid', '{semantic.border.width.thin}' ],
+				'unit' => 'px',
+			],
+		];
+
+		$this->assertSame(
+			'var(--kb-token--semantic--border--width--thin) solid var(--kb-token--semantic--color--brand)',
+			$this->css->render_border( $border, 'top' ),
+			'render_border must resolve both the aliased width and the aliased color'
+		);
+	}
+
+	/**
+	 * The fail-open matrix for render_border (width): a malformed, non-empty brace width is not
+	 * a strict alias, so it passes through literally with its unit suffix and never mints a var().
+	 *
+	 * @dataProvider malformedAliasProvider
+	 *
+	 * @param string $malformed The malformed brace string under test.
+	 *
+	 * @return void
+	 */
+	public function testRenderBorderFailsOpenForMalformedAliasWidth( string $malformed ): void {
+		$border = [
+			[
+				'top'  => [ '#000000', 'solid', $malformed ],
+				'unit' => 'px',
+			],
+		];
+
+		$actual = $this->css->render_border( $border, 'top' );
+
+		$this->assertSame(
+			$malformed . 'px solid #000000',
+			$actual,
+			'render_border must pass a malformed brace width through literally with its unit suffix'
+		);
+		$this->assertStringNotContainsString(
+			'--kb-token--',
+			(string) $actual,
+			'render_border must not mint a var() from a malformed brace width'
+		);
+	}
+
+	/**
 	 * The fail-open matrix: a malformed brace string must never mint a var() and never reach
 	 * numeric handling as if it were an alias, for every representative method's own value site.
 	 *


### PR DESCRIPTION
🎫 https://linear.app/nexcess/issue/SOFT-4181/legacy-render-border-freezes-a-token-reference-for-border-width-header

The legacy single-side `render_border()` (used by the header and navigation blocks) resolved a token-reference color through `render_color()` but emitted the width literally, so a `{dot.alias}` width was frozen into a broken value like `{semantic.border.width.thin}px`. The width now routes through `get_token_reference()` first, mirroring `get_border_value()`: it emits a self-contained `var(--kb-token--...)` and drops the literal unit, falling open to the numeric literal otherwise. Border style stays hard-coded.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved border styling when width values use design-token aliases, ensuring they render correctly without unintended units.
  - Preserved existing unit behavior for numeric border widths.
  - Improved handling of borders that combine aliased widths and colors.
  - Malformed token aliases now safely fall back to their original values instead of generating invalid styling.

- **Documentation**
  - Clarified border rendering behavior and supported side parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->