### PR TITLE
SOFT-4072: Skip and log unresolved token aliases at block render

### DIFF
--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -857,7 +857,7 @@ class Kadence_Blocks_CSS {
 		$line_height_reference = $this->get_backed_token_reference( $font['lineHeight'][0] ?? null );
 		if ( null !== $line_height_reference ) {
 			$this->add_property( 'line-height', $line_height_reference );
-		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight'][0] ) && ! empty( $font['lineHeight'][0] ) ) {
+		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight'][0] ) && ! empty( $font['lineHeight'][0] ) && ! Alias::is_alias( $font['lineHeight'][0] ) ) {
 			$this->add_property( 'line-height', $font['lineHeight'][0] . $line_type );
 		}
 		if ( isset( $font['letterSpacing'] ) && is_array( $font['letterSpacing'] ) ) {
@@ -914,7 +914,7 @@ class Kadence_Blocks_CSS {
 		$line_height_tablet_reference = $this->get_backed_token_reference( $font['lineHeight'][1] ?? null );
 		if ( null !== $line_height_tablet_reference ) {
 			$this->add_property( 'line-height', $line_height_tablet_reference );
-		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight'][1] ) && ! empty( $font['lineHeight'][1] ) ) {
+		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight'][1] ) && ! empty( $font['lineHeight'][1] ) && ! Alias::is_alias( $font['lineHeight'][1] ) ) {
 			$this->add_property( 'line-height', $font['lineHeight'][1] . $line_type );
 		}
 		$letter_spacing_tablet_key_reference = $this->get_backed_token_reference( $font['letterSpacing']['tablet'] ?? null );
@@ -943,7 +943,7 @@ class Kadence_Blocks_CSS {
 		$line_height_mobile_reference = $this->get_backed_token_reference( $font['lineHeight'][2] ?? null );
 		if ( null !== $line_height_mobile_reference ) {
 			$this->add_property( 'line-height', $line_height_mobile_reference );
-		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight'][2] ) && ! empty( $font['lineHeight'][2] ) ) {
+		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight'][2] ) && ! empty( $font['lineHeight'][2] ) && ! Alias::is_alias( $font['lineHeight'][2] ) ) {
 			$this->add_property( 'line-height', $font['lineHeight'][2] . $line_type );
 		}
 		$letter_spacing_mobile_key_reference = $this->get_backed_token_reference( $font['letterSpacing']['mobile'] ?? null );

--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -13,8 +13,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Resolved_Tokens;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
+use KadenceWP\KadenceBlocks\Psr\Log\LoggerInterface;
 
 /**
  * Class to create a minified css output.
@@ -843,34 +847,34 @@ class Kadence_Blocks_CSS {
 		if ( isset( $font['size'] ) && isset( $font['size'][0] ) && ! empty( $font['size'][0] ) ) {
 			$this->add_property( 'font-size', $this->get_font_size( $font['size'][0], $size_type ) );
 		}
-		$line_height_desktop_reference = $this->get_token_reference( $font['lineHeight']['desktop'] ?? null );
+		$line_height_desktop_reference = $this->get_backed_token_reference( $font['lineHeight']['desktop'] ?? null );
 		if ( null !== $line_height_desktop_reference ) {
 			$this->add_property( 'line-height', $line_height_desktop_reference );
-		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight']['desktop'] ) && ! empty( $font['lineHeight']['desktop'] ) ) {
+		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight']['desktop'] ) && ! empty( $font['lineHeight']['desktop'] ) && ! Alias::is_alias( $font['lineHeight']['desktop'] ) ) {
 			$this->add_property( 'line-height', $font['lineHeight']['desktop'] . $line_type );
 		}
 		// Numeric array.
-		$line_height_reference = $this->get_token_reference( $font['lineHeight'][0] ?? null );
+		$line_height_reference = $this->get_backed_token_reference( $font['lineHeight'][0] ?? null );
 		if ( null !== $line_height_reference ) {
 			$this->add_property( 'line-height', $line_height_reference );
 		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight'][0] ) && ! empty( $font['lineHeight'][0] ) ) {
 			$this->add_property( 'line-height', $font['lineHeight'][0] . $line_type );
 		}
 		if ( isset( $font['letterSpacing'] ) && is_array( $font['letterSpacing'] ) ) {
-			$letter_spacing_desktop_reference = $this->get_token_reference( $font['letterSpacing']['desktop'] ?? null );
+			$letter_spacing_desktop_reference = $this->get_backed_token_reference( $font['letterSpacing']['desktop'] ?? null );
 			if ( null !== $letter_spacing_desktop_reference ) {
 				$this->add_property( 'letter-spacing', $letter_spacing_desktop_reference );
 			} elseif ( isset( $font['letterSpacing']['desktop'] ) && is_numeric( $font['letterSpacing']['desktop'] ) ) {
 				$this->add_property( 'letter-spacing', $font['letterSpacing']['desktop'] . $letter_type );
 			}
-			$letter_spacing_reference = $this->get_token_reference( $font['letterSpacing'][0] ?? null );
+			$letter_spacing_reference = $this->get_backed_token_reference( $font['letterSpacing'][0] ?? null );
 			if ( null !== $letter_spacing_reference ) {
 				$this->add_property( 'letter-spacing', $letter_spacing_reference );
 			} elseif ( isset( $font['letterSpacing'][0] ) && is_numeric( $font['letterSpacing'][0] ) ) {
 				$this->add_property( 'letter-spacing', $font['letterSpacing'][0] . $letter_type );
 			}
 		} else {
-			$letter_spacing_scalar_reference = $this->get_token_reference( $font['letterSpacing'] ?? null );
+			$letter_spacing_scalar_reference = $this->get_backed_token_reference( $font['letterSpacing'] ?? null );
 			if ( null !== $letter_spacing_scalar_reference ) {
 				$this->add_property( 'letter-spacing', $letter_spacing_scalar_reference );
 			} elseif ( isset( $font['letterSpacing'] ) && is_numeric( $font['letterSpacing'] ) ) {
@@ -901,25 +905,25 @@ class Kadence_Blocks_CSS {
 		if ( isset( $font['size'] ) && isset( $font['size'][1] ) && ! empty( $font['size'][1] ) ) {
 			$this->add_property( 'font-size', $this->get_font_size( $font['size'][1], $size_type ) );
 		}
-		$line_height_tablet_key_reference = $this->get_token_reference( $font['lineHeight']['tablet'] ?? null );
+		$line_height_tablet_key_reference = $this->get_backed_token_reference( $font['lineHeight']['tablet'] ?? null );
 		if ( null !== $line_height_tablet_key_reference ) {
 			$this->add_property( 'line-height', $line_height_tablet_key_reference );
-		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight']['tablet'] ) && ! empty( $font['lineHeight']['tablet'] ) ) {
+		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight']['tablet'] ) && ! empty( $font['lineHeight']['tablet'] ) && ! Alias::is_alias( $font['lineHeight']['tablet'] ) ) {
 			$this->add_property( 'line-height', $font['lineHeight']['tablet'] . $line_type );
 		}
-		$line_height_tablet_reference = $this->get_token_reference( $font['lineHeight'][1] ?? null );
+		$line_height_tablet_reference = $this->get_backed_token_reference( $font['lineHeight'][1] ?? null );
 		if ( null !== $line_height_tablet_reference ) {
 			$this->add_property( 'line-height', $line_height_tablet_reference );
 		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight'][1] ) && ! empty( $font['lineHeight'][1] ) ) {
 			$this->add_property( 'line-height', $font['lineHeight'][1] . $line_type );
 		}
-		$letter_spacing_tablet_key_reference = $this->get_token_reference( $font['letterSpacing']['tablet'] ?? null );
+		$letter_spacing_tablet_key_reference = $this->get_backed_token_reference( $font['letterSpacing']['tablet'] ?? null );
 		if ( null !== $letter_spacing_tablet_key_reference ) {
 			$this->add_property( 'letter-spacing', $letter_spacing_tablet_key_reference );
 		} elseif ( isset( $font['letterSpacing'] ) && isset( $font['letterSpacing']['tablet'] ) && is_numeric( $font['letterSpacing']['tablet'] ) ) {
 			$this->add_property( 'letter-spacing', $font['letterSpacing']['tablet'] . $letter_type );
 		}
-		$letter_spacing_tablet_reference = $this->get_token_reference( $font['letterSpacing'][1] ?? null );
+		$letter_spacing_tablet_reference = $this->get_backed_token_reference( $font['letterSpacing'][1] ?? null );
 		if ( null !== $letter_spacing_tablet_reference ) {
 			$this->add_property( 'letter-spacing', $letter_spacing_tablet_reference );
 		} elseif ( isset( $font['letterSpacing'] ) && isset( $font['letterSpacing'][1] ) && is_numeric( $font['letterSpacing'][1] ) ) {
@@ -930,25 +934,25 @@ class Kadence_Blocks_CSS {
 		if ( isset( $font['size'] ) && isset( $font['size'][2] ) && ! empty( $font['size'][2] ) ) {
 			$this->add_property( 'font-size', $this->get_font_size( $font['size'][2], $size_type ) );
 		}
-		$line_height_mobile_key_reference = $this->get_token_reference( $font['lineHeight']['mobile'] ?? null );
+		$line_height_mobile_key_reference = $this->get_backed_token_reference( $font['lineHeight']['mobile'] ?? null );
 		if ( null !== $line_height_mobile_key_reference ) {
 			$this->add_property( 'line-height', $line_height_mobile_key_reference );
-		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight']['mobile'] ) && ! empty( $font['lineHeight']['mobile'] ) ) {
+		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight']['mobile'] ) && ! empty( $font['lineHeight']['mobile'] ) && ! Alias::is_alias( $font['lineHeight']['mobile'] ) ) {
 			$this->add_property( 'line-height', $font['lineHeight']['mobile'] . $line_type );
 		}
-		$line_height_mobile_reference = $this->get_token_reference( $font['lineHeight'][2] ?? null );
+		$line_height_mobile_reference = $this->get_backed_token_reference( $font['lineHeight'][2] ?? null );
 		if ( null !== $line_height_mobile_reference ) {
 			$this->add_property( 'line-height', $line_height_mobile_reference );
 		} elseif ( isset( $font['lineHeight'] ) && isset( $font['lineHeight'][2] ) && ! empty( $font['lineHeight'][2] ) ) {
 			$this->add_property( 'line-height', $font['lineHeight'][2] . $line_type );
 		}
-		$letter_spacing_mobile_key_reference = $this->get_token_reference( $font['letterSpacing']['mobile'] ?? null );
+		$letter_spacing_mobile_key_reference = $this->get_backed_token_reference( $font['letterSpacing']['mobile'] ?? null );
 		if ( null !== $letter_spacing_mobile_key_reference ) {
 			$this->add_property( 'letter-spacing', $letter_spacing_mobile_key_reference );
 		} elseif ( isset( $font['letterSpacing'] ) && isset( $font['letterSpacing']['mobile'] ) && is_numeric( $font['letterSpacing']['mobile'] ) ) {
 			$this->add_property( 'letter-spacing', $font['letterSpacing']['mobile'] . $letter_type );
 		}
-		$letter_spacing_mobile_reference = $this->get_token_reference( $font['letterSpacing'][2] ?? null );
+		$letter_spacing_mobile_reference = $this->get_backed_token_reference( $font['letterSpacing'][2] ?? null );
 		if ( null !== $letter_spacing_mobile_reference ) {
 			$this->add_property( 'letter-spacing', $letter_spacing_mobile_reference );
 		} elseif ( isset( $font['letterSpacing'] ) && isset( $font['letterSpacing'][2] ) && is_numeric( $font['letterSpacing'][2] ) ) {
@@ -1027,9 +1031,12 @@ class Kadence_Blocks_CSS {
 	/**
 	 * Resolve a design-token alias reference to its CSS custom-property var().
 	 *
-	 * A value matching the strict {dot.alias} form resolves to a bare
-	 * var(--kb-token--<id>) with no fallback literal; anything else returns null so
-	 * the caller falls through to its existing numeric/palette handling.
+	 * A value matching the strict {dot.alias} form resolves to a bare var(--kb-token--<id>) with no
+	 * fallback literal; anything else returns null so the caller falls through to its existing
+	 * numeric/palette handling. This is the pure syntactic recognizer — the byte-for-byte PHP peer of the
+	 * JS `resolveTokenAlias()` (see src/extension/design-tokens/alias.js and the shared conformance
+	 * fixture); it does NOT consider whether the token resolves. Render callers that must drop an
+	 * unresolved (e.g. since-deleted) token use {@see self::get_backed_token_reference()} instead.
 	 *
 	 * @since TBD
 	 *
@@ -1044,6 +1051,81 @@ class Kadence_Blocks_CSS {
 
 		return 'var(' . Css_Var::from_id( Alias::path_of( $value ) ) . ')';
 	}
+
+	/**
+	 * Like {@see self::get_token_reference()}, but only for a token that is backed by the active library —
+	 * i.e. one the Css_Var projector actually emits a `--kb-token--<id>` custom property for. A binding may
+	 * reference a stale alias (a token deleted after it was saved into a post); minting a var() for it
+	 * would leave a dead custom property with no definition, so render callers use this to emit nothing and
+	 * let the property fall back to whatever global CSS exists. A syntactically-valid but unbacked alias,
+	 * and any non-alias, both return null.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $value The raw attribute value.
+	 *
+	 * @return string|null The var() reference for a backed alias, or null otherwise.
+	 */
+	private function get_backed_token_reference( $value ): ?string {
+		$reference = $this->get_token_reference( $value );
+
+		// Only a string alias yields a non-null reference, so $value is a resolvable id path here.
+		if ( null === $reference || ! is_string( $value ) ) {
+			return null;
+		}
+
+		if ( ! $this->token_alias_is_backed( Alias::path_of( $value ) ) ) {
+			return null;
+		}
+
+		return $reference;
+	}
+
+	/**
+	 * Whether a design-token id is backed by the active library — i.e. the Css_Var projector emits a
+	 * `--kb-token--<id>` custom property for it. A binding may reference a stale alias (a token removed
+	 * after it was stored); minting a var() for it would leave a dead custom property with no definition,
+	 * so callers use this to skip the declaration and fall back to the global CSS instead.
+	 *
+	 * The active library's canonical id map is resolved once and memoized per request (keyed by slug), so
+	 * the per-value render path stays a hash lookup. Fails open: if the container/resolver is unavailable
+	 * or resolution throws, the alias is treated as backed (today's behavior) so a render never fatals and
+	 * transient resolver issues do not drop all token CSS.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id The design-token id (the alias path).
+	 *
+	 * @return bool True when the id resolves in the active library, or on any error (fail-open).
+	 */
+	private function token_alias_is_backed( string $id ): bool {
+		/** @var array<string, Resolved_Tokens> $backed_by_slug */
+		static $backed_by_slug = array();
+
+		try {
+			/** @var Active_Token_Library_Store $active */
+			$active = kadence_blocks()->get( Active_Token_Library_Store::class );
+			$slug   = $active->get();
+
+			if ( ! isset( $backed_by_slug[ $slug ] ) ) {
+				/** @var Token_Resolver $resolver */
+				$resolver                = kadence_blocks()->get( Token_Resolver::class );
+				$backed_by_slug[ $slug ] = $resolver->resolve( $slug );
+			}
+
+			$backed = $backed_by_slug[ $slug ]->value( $id ) !== null;
+
+			if ( ! $backed && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				/** @var LoggerInterface $logger */
+				$logger = kadence_blocks()->get( LoggerInterface::class );
+				$logger->error( sprintf( 'CSS render: skipped unresolved token alias "%s"; falling back to global CSS.', $id ) );
+			}
+
+			return $backed;
+		} catch ( \Throwable $e ) {
+			return true;
+		}
+	}
 	/**
 	 * Outputs a string if set.
 	 *
@@ -1052,7 +1134,7 @@ class Kadence_Blocks_CSS {
 	 * @return string
 	 */
 	public function render_number( $number = null, $unit = null ) {
-		$token_reference = $this->get_token_reference( $number );
+		$token_reference = $this->get_backed_token_reference( $number );
 		if ( null !== $token_reference ) {
 			return $token_reference;
 		}
@@ -1067,15 +1149,19 @@ class Kadence_Blocks_CSS {
 	 * Generates the color output.
 	 *
 	 * @param string $color any color attribute.
-	 * @return string
+	 * @return string|false
 	 */
 	public function render_color( $color, $opacity = null ) {
 		if ( empty( $color ) ) {
 			return false;
 		}
-		$token_reference = $this->get_token_reference( $color );
+		$token_reference = $this->get_backed_token_reference( $color );
 		if ( null !== $token_reference ) {
 			return $token_reference;
+		}
+		if ( is_string( $color ) && Alias::is_alias( $color ) ) {
+			// A strict alias that did not resolve: emit nothing so the property falls back to the global CSS.
+			return false;
 		}
 		if ( ! is_array( $color ) && strpos( $color, 'palette' ) === 0 ) {
 			switch ( $color ) {
@@ -1117,15 +1203,19 @@ class Kadence_Blocks_CSS {
 	 * Generates the color output.
 	 *
 	 * @param string $color any color attribute.
-	 * @return string
+	 * @return string|false
 	 */
 	public function sanitize_color( $color, $opacity = null ) {
 		if ( empty( $color ) ) {
 			return false;
 		}
-		$token_reference = $this->get_token_reference( $color );
+		$token_reference = $this->get_backed_token_reference( $color );
 		if ( null !== $token_reference ) {
 			return $token_reference;
+		}
+		if ( is_string( $color ) && Alias::is_alias( $color ) ) {
+			// A strict alias that did not resolve: emit nothing so the property falls back to the global CSS.
+			return false;
 		}
 		if ( ! is_array( $color ) && strpos( $color, 'palette' ) === 0 ) {
 			switch ( $color ) {
@@ -1230,7 +1320,7 @@ class Kadence_Blocks_CSS {
 		if ( ! isset( $attributes[ $name ] ) ) {
 			return false;
 		}
-		$token_reference = $this->get_token_reference( $attributes[ $name ] );
+		$token_reference = $this->get_backed_token_reference( $attributes[ $name ] );
 		if ( null !== $token_reference ) {
 			$this->add_property( $property, $token_reference );
 		} else {
@@ -1311,36 +1401,36 @@ class Kadence_Blocks_CSS {
 		$args = wp_parse_args( $args, $defaults );
 		$unit = ! empty( $attributes[ $args['unit_key'] ] ) ? $attributes[ $args['unit_key'] ] : $unit;
 		if ( isset( $attributes[ $name ] ) && is_array( $attributes[ $name ] ) ) {
-			$first_reference = $this->get_token_reference( $attributes[ $name ][0] ?? null );
+			$first_reference = $this->get_backed_token_reference( $attributes[ $name ][0] ?? null );
 			if ( null !== $first_reference ) {
 				$this->add_property( $args['first_prop'], $first_reference );
 			} else if ( $render_zero && is_numeric( $attributes[ $name ][0] ) ) {
 				$this->add_property( $args['first_prop'], $attributes[ $name ][0] . $unit );
-			} else if ( ! $render_zero && ! empty( $attributes[ $name ][0] ) ) {
+			} else if ( ! $render_zero && ! empty( $attributes[ $name ][0] ) && ! Alias::is_alias( $attributes[ $name ][0] ) ) {
 				$this->add_property( $args['first_prop'], $attributes[ $name ][0] . $unit );
 			}
-			$second_reference = $this->get_token_reference( $attributes[ $name ][1] ?? null );
+			$second_reference = $this->get_backed_token_reference( $attributes[ $name ][1] ?? null );
 			if ( null !== $second_reference ) {
 				$this->add_property( $args['second_prop'], $second_reference );
 			} else if ( $render_zero && is_numeric( $attributes[ $name ][1] ) ) {
 				$this->add_property( $args['second_prop'], $attributes[ $name ][1] . $unit );
-			} else if ( ! $render_zero && ! empty( $attributes[ $name ][1] ) ) {
+			} else if ( ! $render_zero && ! empty( $attributes[ $name ][1] ) && ! Alias::is_alias( $attributes[ $name ][1] ) ) {
 				$this->add_property( $args['second_prop'], $attributes[ $name ][1] . $unit );
 			}
-			$third_reference = $this->get_token_reference( $attributes[ $name ][2] ?? null );
+			$third_reference = $this->get_backed_token_reference( $attributes[ $name ][2] ?? null );
 			if ( null !== $third_reference ) {
 				$this->add_property( $args['third_prop'], $third_reference );
 			} else if ( $render_zero && is_numeric( $attributes[ $name ][2] ) ) {
 				$this->add_property( $args['third_prop'], $attributes[ $name ][2] . $unit );
-			} else if ( ! $render_zero && ! empty( $attributes[ $name ][2] ) ) {
+			} else if ( ! $render_zero && ! empty( $attributes[ $name ][2] ) && ! Alias::is_alias( $attributes[ $name ][2] ) ) {
 				$this->add_property( $args['third_prop'], $attributes[ $name ][2] . $unit );
 			}
-			$fourth_reference = $this->get_token_reference( $attributes[ $name ][3] ?? null );
+			$fourth_reference = $this->get_backed_token_reference( $attributes[ $name ][3] ?? null );
 			if ( null !== $fourth_reference ) {
 				$this->add_property( $args['fourth_prop'], $fourth_reference );
 			} else if ( $render_zero && is_numeric( $attributes[ $name ][3] ) ) {
 				$this->add_property( $args['fourth_prop'], $attributes[ $name ][3] . $unit );
-			} else if ( ! $render_zero && ! empty( $attributes[ $name ][3] ) ) {
+			} else if ( ! $render_zero && ! empty( $attributes[ $name ][3] ) && ! Alias::is_alias( $attributes[ $name ][3] ) ) {
 				$this->add_property( $args['fourth_prop'], $attributes[ $name ][3] . $unit );
 			}
 		}
@@ -1563,7 +1653,7 @@ class Kadence_Blocks_CSS {
 	 *                                            any empty/missing leg before rendering. When omitted
 	 *                                            the method behaves exactly as before. Numeric and
 	 *                                            {alias} values always pass through untouched.
-	 * @return string
+	 * @return string|false
 	 */
 	public function render_shadow( $shadow, array $defaults = [] ) {
 		if ( ! empty( $defaults ) && is_array( $shadow ) ) {
@@ -1596,15 +1686,28 @@ class Kadence_Blocks_CSS {
 		if ( ! isset( $shadow['inset'] ) ) {
 			return false;
 		}
-		$h_offset_reference = $this->get_token_reference( $shadow['hOffset'] );
+		$h_offset_reference = $this->get_backed_token_reference( $shadow['hOffset'] );
 		$h_offset           = null !== $h_offset_reference ? $h_offset_reference : ( ( ! empty( $shadow['hOffset'] ) ? $shadow['hOffset'] : '0' ) . 'px' );
-		$v_offset_reference = $this->get_token_reference( $shadow['vOffset'] );
+		$v_offset_reference = $this->get_backed_token_reference( $shadow['vOffset'] );
 		$v_offset           = null !== $v_offset_reference ? $v_offset_reference : ( ( ! empty( $shadow['vOffset'] ) ? $shadow['vOffset'] : '0' ) . 'px' );
-		$blur_reference     = $this->get_token_reference( $shadow['blur'] );
+		$blur_reference     = $this->get_backed_token_reference( $shadow['blur'] );
 		$blur               = null !== $blur_reference ? $blur_reference : ( ( ! empty( $shadow['blur'] ) ? $shadow['blur'] : '0' ) . 'px' );
-		$spread_reference   = $this->get_token_reference( $shadow['spread'] );
+		$spread_reference   = $this->get_backed_token_reference( $shadow['spread'] );
 		$spread             = null !== $spread_reference ? $spread_reference : ( ( ! empty( $shadow['spread'] ) ? $shadow['spread'] : '0' ) . 'px' );
 		$color              = ! empty( $shadow['color'] ) ? $this->render_color( $shadow['color'], $shadow['opacity'] ) : $this->render_color( '#000000', $shadow['opacity'] );
+
+		// A strict alias part that did not resolve (offset/blur/spread reference null, or an unresolved
+		// alias color returned false) invalidates the whole shorthand; emit nothing so the box-shadow
+		// falls back to the global CSS.
+		if (
+			( Alias::is_alias( $shadow['hOffset'] ) && null === $h_offset_reference ) ||
+			( Alias::is_alias( $shadow['vOffset'] ) && null === $v_offset_reference ) ||
+			( Alias::is_alias( $shadow['blur'] ) && null === $blur_reference ) ||
+			( Alias::is_alias( $shadow['spread'] ) && null === $spread_reference ) ||
+			false === $color
+		) {
+			return false;
+		}
 		if ( $shadow['inset'] ) {
 			$shadow_string = 'inset ' . $h_offset . ' ' . $v_offset . ' ' . $blur . ' ' . $spread . ' ' . $color;
 		} else {
@@ -1659,25 +1762,25 @@ class Kadence_Blocks_CSS {
 			return false;
 		}
 		if ( isset( $attributes[ $name ] ) && is_array( $attributes[ $name ] ) ) {
-			$top_left_reference = $this->get_token_reference( $attributes[ $name ][0] ?? null );
+			$top_left_reference = $this->get_backed_token_reference( $attributes[ $name ][0] ?? null );
 			if ( null !== $top_left_reference ) {
 				$this->add_property( 'border-top-left-radius', $top_left_reference );
 			} else if ( isset( $attributes[ $name ][0] ) && is_numeric( $attributes[ $name ][0] ) ) {
 				$this->add_property( 'border-top-left-radius', $attributes[ $name ][0] . $unit );
 			}
-			$top_right_reference = $this->get_token_reference( $attributes[ $name ][1] ?? null );
+			$top_right_reference = $this->get_backed_token_reference( $attributes[ $name ][1] ?? null );
 			if ( null !== $top_right_reference ) {
 				$this->add_property( 'border-top-right-radius', $top_right_reference );
 			} else if ( isset( $attributes[ $name ][1] ) && is_numeric( $attributes[ $name ][1] ) ) {
 				$this->add_property( 'border-top-right-radius', $attributes[ $name ][1] . $unit );
 			}
-			$bottom_right_reference = $this->get_token_reference( $attributes[ $name ][2] ?? null );
+			$bottom_right_reference = $this->get_backed_token_reference( $attributes[ $name ][2] ?? null );
 			if ( null !== $bottom_right_reference ) {
 				$this->add_property( 'border-bottom-right-radius', $bottom_right_reference );
 			} else if ( isset( $attributes[ $name ][2] ) && is_numeric( $attributes[ $name ][2] ) ) {
 				$this->add_property( 'border-bottom-right-radius', $attributes[ $name ][2] . $unit );
 			}
-			$bottom_left_reference = $this->get_token_reference( $attributes[ $name ][3] ?? null );
+			$bottom_left_reference = $this->get_backed_token_reference( $attributes[ $name ][3] ?? null );
 			if ( null !== $bottom_left_reference ) {
 				$this->add_property( 'border-bottom-left-radius', $bottom_left_reference );
 			} else if ( isset( $attributes[ $name ][3] ) && is_numeric( $attributes[ $name ][3] ) ) {
@@ -1857,13 +1960,13 @@ class Kadence_Blocks_CSS {
 		}
 		$unit = ! empty( $attributes[ $unit ] ) ? $attributes[ $unit ] : 'px';
 		if ( isset( $attributes[ $name ] ) && is_array( $attributes[ $name ] ) ) {
-			$desktop_reference = $this->get_token_reference( $attributes[ $name ][0] ?? null );
+			$desktop_reference = $this->get_backed_token_reference( $attributes[ $name ][0] ?? null );
 			if ( null !== $desktop_reference ) {
 				$this->add_property( $property, $desktop_reference );
 			} else if ( isset( $attributes[ $name ][0] ) && is_numeric( $attributes[ $name ][0] ) ) {
 				$this->add_property( $property, $attributes[ $name ][0] . $unit );
 			}
-			$tablet_reference = $this->get_token_reference( $attributes[ $name ][1] ?? null );
+			$tablet_reference = $this->get_backed_token_reference( $attributes[ $name ][1] ?? null );
 			if ( null !== $tablet_reference ) {
 				$this->set_media_state( 'tablet' );
 				$this->add_property( $property, $tablet_reference );
@@ -1871,7 +1974,7 @@ class Kadence_Blocks_CSS {
 				$this->set_media_state( 'tablet' );
 				$this->add_property( $property, $attributes[ $name ][1] . $unit );
 			}
-			$mobile_reference = $this->get_token_reference( $attributes[ $name ][2] ?? null );
+			$mobile_reference = $this->get_backed_token_reference( $attributes[ $name ][2] ?? null );
 			if ( null !== $mobile_reference ) {
 				$this->set_media_state( 'mobile' );
 				$this->add_property( $property, $mobile_reference );
@@ -1905,31 +2008,39 @@ class Kadence_Blocks_CSS {
 		$unit = ! empty( $attributes[ $unit ] ) ? $attributes[ $unit ] : 'px';
 
 		$this->set_media_state( 'desktop' );
-		$desktop_reference = $this->get_token_reference( $attributes[ $name[0] ] ?? null );
+		$desktop_reference = $this->get_backed_token_reference( $attributes[ $name[0] ] ?? null );
 		if ( null !== $desktop_reference ) {
 			$this->add_property( $property, $desktop_reference );
-		} else if ( isset( $attributes[ $name[0] ] ) && '' !== $attributes[ $name[0] ] ) {
-			$this->add_property( $property, $attributes[ $name[0] ] . $unit );
-		} else if ( $defaults[0] ) {
-			$this->add_property( $property, $defaults[0] . $unit );
+		} else if ( ! Alias::is_alias( $attributes[ $name[0] ] ?? null ) ) {
+			// A resolved alias emits above; an unresolved strict alias emits nothing so the property falls
+			// back to the global CSS. Only a non-alias reaches the literal/defaults handling.
+			if ( isset( $attributes[ $name[0] ] ) && '' !== $attributes[ $name[0] ] ) {
+				$this->add_property( $property, $attributes[ $name[0] ] . $unit );
+			} else if ( $defaults[0] ) {
+				$this->add_property( $property, $defaults[0] . $unit );
+			}
 		}
 		$this->set_media_state( 'tablet' );
-		$tablet_reference = $this->get_token_reference( $attributes[ $name[1] ] ?? null );
+		$tablet_reference = $this->get_backed_token_reference( $attributes[ $name[1] ] ?? null );
 		if ( null !== $tablet_reference ) {
 			$this->add_property( $property, $tablet_reference );
-		} else if ( isset( $attributes[ $name[1] ] ) && '' !== $attributes[ $name[1] ] ) {
-			$this->add_property( $property, $attributes[ $name[1] ] . $unit );
-		} else if ( $defaults[1] ) {
-			$this->add_property( $property, $defaults[1] . $unit );
+		} else if ( ! Alias::is_alias( $attributes[ $name[1] ] ?? null ) ) {
+			if ( isset( $attributes[ $name[1] ] ) && '' !== $attributes[ $name[1] ] ) {
+				$this->add_property( $property, $attributes[ $name[1] ] . $unit );
+			} else if ( $defaults[1] ) {
+				$this->add_property( $property, $defaults[1] . $unit );
+			}
 		}
 		$this->set_media_state( 'mobile' );
-		$mobile_reference = $this->get_token_reference( $attributes[ $name[2] ] ?? null );
+		$mobile_reference = $this->get_backed_token_reference( $attributes[ $name[2] ] ?? null );
 		if ( null !== $mobile_reference ) {
 			$this->add_property( $property, $mobile_reference );
-		} else if ( isset( $attributes[ $name[2] ] ) && '' !== $attributes[ $name[2] ] ) {
-			$this->add_property( $property, $attributes[ $name[2] ] . $unit );
-		} else if ( $defaults[2] ) {
-			$this->add_property( $property, $defaults[2] . $unit );
+		} else if ( ! Alias::is_alias( $attributes[ $name[2] ] ?? null ) ) {
+			if ( isset( $attributes[ $name[2] ] ) && '' !== $attributes[ $name[2] ] ) {
+				$this->add_property( $property, $attributes[ $name[2] ] . $unit );
+			} else if ( $defaults[2] ) {
+				$this->add_property( $property, $defaults[2] . $unit );
+			}
 		}
 		$this->set_media_state( 'desktop' );
 	}
@@ -2074,7 +2185,7 @@ class Kadence_Blocks_CSS {
 	 * @param array  $border an array of border settings.
 	 * @param string $side   the border side to render (top, right, bottom, left). Default 'top'.
 	 *
-	 * @return string
+	 * @return string|false
 	 */
 	public function render_border( $border, $side = 'top' ) {
 		if ( empty( $border ) || empty( $border[0] ) ) {
@@ -2100,10 +2211,17 @@ class Kadence_Blocks_CSS {
 		$color         = ( isset( $border_side[0] ) && ! empty( $border_side[0] ) ? $border_side[0] : 'transparent' );
 
 		// A token-reference width resolves to a self-contained var() (unit included), so the literal unit is dropped.
-		$width_reference = $this->get_token_reference( $width );
+		$width_reference = $this->get_backed_token_reference( $width );
 		$width_output    = null !== $width_reference ? $width_reference : $width . $unit;
+		$color_output    = $this->render_color( $color );
 
-		$border_string = $width_output . ' ' . $style . ' ' . $this->render_color( $color );
+		// A strict alias width or color that did not resolve invalidates the whole shorthand; emit nothing
+		// so the border falls back to the global CSS.
+		if ( ( Alias::is_alias( $width ) && null === $width_reference ) || false === $color_output ) {
+			return false;
+		}
+
+		$border_string = $width_output . ' ' . $style . ' ' . $color_output;
 
 		return $border_string;
 	}
@@ -2277,7 +2395,7 @@ class Kadence_Blocks_CSS {
 			$return_value = $this->sanitize_color($return_value);
 		}
 		if( $given_value == 'width') {
-			$width_reference = $this->get_token_reference( $return_value );
+			$width_reference = $this->get_backed_token_reference( $return_value );
 			if ( null !== $width_reference ) {
 				$return_value = $width_reference;
 			} else {
@@ -2412,8 +2530,8 @@ class Kadence_Blocks_CSS {
 			$this->add_property( $prop, $value . $unit );
 		} else if ( 'position' === $property && ! empty( $value ) ) {
 			$this->add_property( $prop, $value );
-		} else if ( ! empty( $value ) && null !== $this->get_token_reference( $value ) ) {
-			$this->add_property( $prop, $this->get_token_reference( $value ) );
+		} else if ( ! empty( $value ) && null !== $this->get_backed_token_reference( $value ) ) {
+			$this->add_property( $prop, $this->get_backed_token_reference( $value ) );
 		} else if ( ! empty( $value ) && $this->is_variable_value( $value ) ) {
 			$this->add_property( $prop, $this->get_variable_value( $value ) );
 		}
@@ -2508,7 +2626,7 @@ class Kadence_Blocks_CSS {
 	 * Generates the measure output.
 	 *
 	 * @param array $measure an array of font settings.
-	 * @return string
+	 * @return string|false
 	 */
 	public function render_measure( $measure, $unit = 'px' ) {
 		if ( empty( $measure ) ) {
@@ -2521,11 +2639,20 @@ class Kadence_Blocks_CSS {
 			return false;
 		}
 		$references = array(
-			$this->get_token_reference( $measure[0] ),
-			$this->get_token_reference( $measure[1] ?? null ),
-			$this->get_token_reference( $measure[2] ?? null ),
-			$this->get_token_reference( $measure[3] ?? null ),
+			$this->get_backed_token_reference( $measure[0] ),
+			$this->get_backed_token_reference( $measure[1] ?? null ),
+			$this->get_backed_token_reference( $measure[2] ?? null ),
+			$this->get_backed_token_reference( $measure[3] ?? null ),
 		);
+
+		// A strict alias side that did not resolve invalidates the whole value; emit nothing so the
+		// property falls back to the global CSS.
+		foreach ( array( $measure[0], $measure[1] ?? null, $measure[2] ?? null, $measure[3] ?? null ) as $index => $side ) {
+			if ( Alias::is_alias( $side ) && null === $references[ $index ] ) {
+				return false;
+			}
+		}
+
 		$has_alias  = null !== $references[0] || null !== $references[1] || null !== $references[2] || null !== $references[3];
 		if ( ! $has_alias && ! is_numeric( $measure[0] ) && ! is_numeric( $measure[1] ) && ! is_numeric( $measure[2] ) && ! is_numeric( $measure[3] ) ) {
 			return false;

--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -1089,7 +1089,7 @@ class Kadence_Blocks_CSS {
 	 *
 	 * The active library's canonical id map is resolved once and memoized per request (keyed by slug), so
 	 * the per-value render path stays a hash lookup. Fails open: if the container/resolver is unavailable
-	 * or resolution throws, the alias is treated as backed (today's behavior) so a render never fatals and
+	 * or resolution throws, the alias is treated as backed (today's behavior) so a render never crashes and
 	 * transient resolver issues do not drop all token CSS.
 	 *
 	 * @since TBD

--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -15,7 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
-use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Resolved_Tokens;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
 use KadenceWP\KadenceBlocks\Psr\Log\LoggerInterface;
@@ -1087,10 +1086,11 @@ class Kadence_Blocks_CSS {
 	 * after it was stored); minting a var() for it would leave a dead custom property with no definition,
 	 * so callers use this to skip the declaration and fall back to the global CSS instead.
 	 *
-	 * The active library's canonical id map is resolved once and memoized per request (keyed by slug), so
-	 * the per-value render path stays a hash lookup. Fails open: if the container/resolver is unavailable
-	 * or resolution throws, the alias is treated as backed (today's behavior) so a render never crashes and
-	 * transient resolver issues do not drop all token CSS.
+	 * The active library is resolved through Token_Resolver, which memoizes per store version, so repeated
+	 * lookups stay cheap and always reflect the current version. The unresolved-alias log is de-duplicated
+	 * per (library, id) so one stale alias does not flood the error log across a page's many blocks. Fails
+	 * open: if the container/resolver is unavailable or resolution throws, the alias is treated as backed
+	 * (today's behavior) so a render never crashes and transient resolver issues do not drop all token CSS.
 	 *
 	 * @since TBD
 	 *
@@ -1099,23 +1099,20 @@ class Kadence_Blocks_CSS {
 	 * @return bool True when the id resolves in the active library, or on any error (fail-open).
 	 */
 	private function token_alias_is_backed( string $id ): bool {
-		/** @var array<string, Resolved_Tokens> $backed_by_slug */
-		static $backed_by_slug = array();
+		/** @var array<string, bool> $logged */
+		static $logged = array();
 
 		try {
 			/** @var Active_Token_Library_Store $active */
 			$active = kadence_blocks()->get( Active_Token_Library_Store::class );
 			$slug   = $active->get();
 
-			if ( ! isset( $backed_by_slug[ $slug ] ) ) {
-				/** @var Token_Resolver $resolver */
-				$resolver                = kadence_blocks()->get( Token_Resolver::class );
-				$backed_by_slug[ $slug ] = $resolver->resolve( $slug );
-			}
+			/** @var Token_Resolver $resolver */
+			$resolver = kadence_blocks()->get( Token_Resolver::class );
+			$backed   = $resolver->resolve( $slug )->value( $id ) !== null;
 
-			$backed = $backed_by_slug[ $slug ]->value( $id ) !== null;
-
-			if ( ! $backed && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			if ( ! $backed && ! isset( $logged[ $slug . '|' . $id ] ) && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				$logged[ $slug . '|' . $id ] = true;
 				/** @var LoggerInterface $logger */
 				$logger = kadence_blocks()->get( LoggerInterface::class );
 				$logger->error( sprintf( 'CSS render: skipped unresolved token alias "%s"; falling back to global CSS.', $id ) );
@@ -2526,12 +2523,13 @@ class Kadence_Blocks_CSS {
 	 * @return void
 	 */
 	private function render_measure_side( $prop, $value, $unit, $property ) {
+		$token_reference = $this->get_backed_token_reference( $value );
 		if ( $this->is_number( $value ) ) {
 			$this->add_property( $prop, $value . $unit );
 		} else if ( 'position' === $property && ! empty( $value ) ) {
 			$this->add_property( $prop, $value );
-		} else if ( ! empty( $value ) && null !== $this->get_backed_token_reference( $value ) ) {
-			$this->add_property( $prop, $this->get_backed_token_reference( $value ) );
+		} else if ( ! empty( $value ) && null !== $token_reference ) {
+			$this->add_property( $prop, $token_reference );
 		} else if ( ! empty( $value ) && $this->is_variable_value( $value ) ) {
 			$this->add_property( $prop, $this->get_variable_value( $value ) );
 		}

--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
@@ -5,6 +5,8 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Value;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Preset_Resolver;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use KadenceWP\KadenceBlocks\Psr\Log\LoggerInterface;
 use RuntimeException;
 
 /**
@@ -79,6 +81,28 @@ final class Css_Builder {
 	private Preset_Resolver $presets;
 
 	/**
+	 * Resolves a library to its canonical id map — the authoritative set of tokens the Css_Var projector
+	 * emits a `--kb-token--<id>` variable for. A binding whose token id is absent from it points at a
+	 * variable no projector defines, so this is what "backed" is tested against (not the registry's declared
+	 * subset, which omits baseline-only semantic tokens such as `semantic.color.text`).
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Resolver
+	 */
+	private Token_Resolver $resolver;
+
+	/**
+	 * Logger for the unresolved-token diagnostics; the bound instance writes to the PHP error log under
+	 * WP_DEBUG and is a NullLogger otherwise (see {@see \KadenceWP\KadenceBlocks\Log\Log_Provider}).
+	 *
+	 * @since TBD
+	 *
+	 * @var LoggerInterface
+	 */
+	private LoggerInterface $logger;
+
+	/**
 	 * Per-request memo keyed on context (front end / editor) + store version + slug, so repeated builds
 	 * within a request are free and a write (which bumps the version) invalidates it without an explicit
 	 * purge. The context is part of the key because the editor build can differ from the front-end one.
@@ -92,12 +116,16 @@ final class Css_Builder {
 	/**
 	 * @since TBD
 	 *
-	 * @param Token_Registry   $registry The token registry.
-	 * @param Preset_Resolver $presets The preset resolver.
+	 * @param Token_Registry  $registry The token registry.
+	 * @param Preset_Resolver $presets  The preset resolver.
+	 * @param Token_Resolver  $resolver Resolves a library to its canonical id map, for the backed-token check.
+	 * @param LoggerInterface $logger   Logger for the unresolved-token diagnostics.
 	 */
-	public function __construct( Token_Registry $registry, Preset_Resolver $presets ) {
+	public function __construct( Token_Registry $registry, Preset_Resolver $presets, Token_Resolver $resolver, LoggerInterface $logger ) {
 		$this->registry = $registry;
-		$this->presets = $presets;
+		$this->presets  = $presets;
+		$this->resolver = $resolver;
+		$this->logger   = $logger;
 	}
 
 	/**
@@ -193,6 +221,11 @@ final class Css_Builder {
 				continue;
 			}
 
+			// The canonical id map of the library — the exact set the Css_Var projector emits a
+			// `--kb-token--<id>` variable for. resolve_default() above already warmed this memoized
+			// resolution, so it is a free lookup here (and cannot throw when resolve_default() did not).
+			$resolved = $this->resolver->resolve( $slug );
+
 			$selector = $editor && $bindings->editor_selector !== null
 				? '.editor-styles-wrapper ' . $bindings->editor_selector
 				: '.wp-block-' . str_replace( '/', '-', $block );
@@ -221,7 +254,27 @@ final class Css_Builder {
 					continue;
 				}
 
-				$var      = $this->registry->css_var_for( (string) $binding->token );
+				$token = (string) $binding->token;
+
+				// A binding may reference a token id the resolved library does not back (e.g. a stale alias
+				// left after a token was removed). css_var_for() would compute a `--kb-token--…` custom
+				// property nothing defines, and the declaration's literal fallback would keep rendering the
+				// default — a silent, invisible dead indirection. Skip the declaration entirely so the block
+				// falls back to its own native default CSS, and log the mismatch (under WP_DEBUG, via the
+				// injected logger).
+				if ( $resolved->value( $token ) === null ) {
+					$this->logger->error(
+						sprintf(
+							'Block-default CSS: block "%s" binds unresolved token id "%s"; skipping declaration.',
+							$block,
+							$token
+						)
+					);
+
+					continue;
+				}
+
+				$var      = $this->registry->css_var_for( $token );
 				$suffix   = $this->selector_suffix( $binding->css_selector() );
 
 				$by_suffix[ $suffix ][] = $prop . ':var(' . $var . ',' . $this->sanitize_value( $literal ) . ')';

--- a/src/extension/design-tokens/__tests__/register-filters.test.js
+++ b/src/extension/design-tokens/__tests__/register-filters.test.js
@@ -70,6 +70,31 @@ describe('registerTokenAliasFilters', () => {
 	});
 
 	/**
+	 * A localized pool whose active library resolved to no tokens is an answer, not a gap: every alias
+	 * reads as unbacked, matching the PHP renderer (which fails open only when resolution itself fails).
+	 */
+	it('treats every alias as unbacked when the active library resolved to an empty map', () => {
+		window.kadenceDesignTokensPresets = { active: 'default' };
+		window.kadenceDesignTokensPickable = { tokens: [], values: { default: {} } };
+
+		expect(applyFilters(HOOK, BACKED_ALIAS)).toBe(BACKED_ALIAS);
+	});
+
+	/**
+	 * A library the pool omits entirely (its stored document could not be resolved, so the catalog skipped
+	 * it) leaves backing undeterminable, so the listener fails open and resolves the alias.
+	 */
+	it('fails open when the active library is absent from the localized pool', () => {
+		window.kadenceDesignTokensPresets = { active: 'brand' };
+		window.kadenceDesignTokensPickable = {
+			tokens: [],
+			values: { default: { 'semantic.color.border': '#E2E8F0' } },
+		};
+
+		expect(applyFilters(HOOK, BACKED_ALIAS)).toBe(BACKED_VAR);
+	});
+
+	/**
 	 * The dimension hook is wired the same way as the color hook: a backed alias resolves to its var and a
 	 * stale alias is left untouched, proving the listener validates backing on both registered hooks (not
 	 * just passing raw values through).

--- a/src/extension/design-tokens/__tests__/register-filters.test.js
+++ b/src/extension/design-tokens/__tests__/register-filters.test.js
@@ -70,6 +70,26 @@ describe('registerTokenAliasFilters', () => {
 	});
 
 	/**
+	 * The dimension hook is wired the same way as the color hook: a backed alias resolves to its var and a
+	 * stale alias is left untouched, proving the listener validates backing on both registered hooks (not
+	 * just passing raw values through).
+	 */
+	it('resolves a backed alias and leaves a stale one on the dimension hook', () => {
+		window.kadenceDesignTokensPresets = { active: 'default' };
+		window.kadenceDesignTokensPickable = {
+			tokens: [],
+			values: { default: { 'semantic.radius.media': '8px' } },
+		};
+
+		const DIMENSION_HOOK = 'kadence.helpers.dimensionValue';
+
+		expect(applyFilters(DIMENSION_HOOK, '{semantic.radius.media}')).toBe(
+			'var(--kb-token--semantic--radius--media)'
+		);
+		expect(applyFilters(DIMENSION_HOOK, STALE_ALIAS)).toBe(STALE_ALIAS);
+	});
+
+	/**
 	 * A non-alias value passes through untouched on both registered hooks.
 	 */
 	it('passes a non-alias value through unchanged', () => {

--- a/src/extension/design-tokens/__tests__/register-filters.test.js
+++ b/src/extension/design-tokens/__tests__/register-filters.test.js
@@ -1,0 +1,79 @@
+/* eslint-env jest */
+/**
+ * The design-token alias filter listener.
+ *
+ * `@kadence/helpers` runs every emitted color/dimension value through the `kadence.helpers.colorValue`
+ * and `kadence.helpers.dimensionValue` filters. Kadence Blocks registers a listener that turns a strict
+ * `{dot.alias}` into its `var(--kb-token--<id>)` reference — but only when the token is still backed by
+ * the active library. A stale alias (a token deleted after it was saved into a post) is left as its raw
+ * value so the editor emits no dead var() and the property falls back to the global CSS, matching the
+ * front-end renderer. When no resolved-token data is localized (e.g. a bare test harness) the listener
+ * fails open and resolves any alias, preserving the pure recognizer's behavior.
+ */
+import { applyFilters, removeFilter } from '@wordpress/hooks';
+import { registerTokenAliasFilters } from '../register-filters';
+
+const HOOK = 'kadence.helpers.colorValue';
+const NAMESPACE = 'kadence-blocks/token-alias';
+
+const BACKED_ALIAS = '{semantic.color.border}';
+const BACKED_VAR = 'var(--kb-token--semantic--color--border)';
+const STALE_ALIAS = '{primitive.color.brand.deleted}';
+
+describe('registerTokenAliasFilters', () => {
+	beforeEach(() => {
+		registerTokenAliasFilters();
+	});
+
+	afterEach(() => {
+		removeFilter(HOOK, NAMESPACE);
+		removeFilter('kadence.helpers.dimensionValue', NAMESPACE);
+		delete window.kadenceDesignTokensPickable;
+		delete window.kadenceDesignTokensPresets;
+	});
+
+	/**
+	 * With a localized resolved map, a strict alias whose id is backed resolves to its bare token var.
+	 */
+	it('resolves a backed alias to its token var', () => {
+		window.kadenceDesignTokensPresets = { active: 'default' };
+		window.kadenceDesignTokensPickable = {
+			tokens: [],
+			values: { default: { 'semantic.color.border': '#E2E8F0' } },
+		};
+
+		expect(applyFilters(HOOK, BACKED_ALIAS)).toBe(BACKED_VAR);
+	});
+
+	/**
+	 * A strict alias whose id is absent from the resolved map (a since-deleted token) is left as its raw
+	 * value, so no dead var() is emitted and the property falls back to the global CSS.
+	 */
+	it('leaves a stale (unbacked) alias untouched so no dead var is emitted', () => {
+		window.kadenceDesignTokensPresets = { active: 'default' };
+		window.kadenceDesignTokensPickable = {
+			tokens: [],
+			values: { default: { 'semantic.color.border': '#E2E8F0' } },
+		};
+
+		expect(applyFilters(HOOK, STALE_ALIAS)).toBe(STALE_ALIAS);
+		expect(applyFilters(HOOK, STALE_ALIAS)).not.toContain('var(');
+	});
+
+	/**
+	 * With no resolved-token data localized, the listener fails open and resolves any strict alias, so the
+	 * pure recognizer's behavior is preserved where backing cannot be determined.
+	 */
+	it('fails open and resolves an alias when no resolved map is localized', () => {
+		expect(applyFilters(HOOK, BACKED_ALIAS)).toBe(BACKED_VAR);
+		expect(applyFilters(HOOK, STALE_ALIAS)).toBe('var(--kb-token--primitive--color--brand--deleted)');
+	});
+
+	/**
+	 * A non-alias value passes through untouched on both registered hooks.
+	 */
+	it('passes a non-alias value through unchanged', () => {
+		expect(applyFilters(HOOK, '#3182CE')).toBe('#3182CE');
+		expect(applyFilters('kadence.helpers.dimensionValue', '16px')).toBe('16px');
+	});
+});

--- a/src/extension/design-tokens/backed-tokens.js
+++ b/src/extension/design-tokens/backed-tokens.js
@@ -22,17 +22,26 @@ function activeLibrary() {
 }
 
 /**
- * The active library's resolved id => literal map (empty when the registry is inactive or the data is
- * not localized).
+ * The active library's resolved id => literal map, or null when there is no map to read: the pickable
+ * pool is not localized at all (the registry is fail-closed, or nothing localized it — e.g. a test
+ * harness), or the active library is missing from it (its stored document could not be resolved, so the
+ * catalog skipped it). Null means "backing cannot be determined"; an empty object is an answer — the
+ * library resolved and backs nothing.
  *
  * @since TBD
  *
- * @return {Object} id => literal value.
+ * @return {Object|null} id => literal value, or null when no map is available.
  */
 function resolvedValues() {
-	const values = get(window, 'kadenceDesignTokensPickable.values', {}) || {};
+	const values = get(window, 'kadenceDesignTokensPickable.values', null);
 
-	return get(values, [activeLibrary()], {}) || {};
+	if (!values || typeof values !== 'object') {
+		return null;
+	}
+
+	const library = get(values, [activeLibrary()], null);
+
+	return library && typeof library === 'object' ? library : null;
 }
 
 /**
@@ -40,19 +49,21 @@ function resolvedValues() {
  * id map. Used to skip a stale alias (a token deleted after it was saved into a post) so the editor never
  * emits a dead `var(--kb-token--<id>)`.
  *
- * Fails open when the resolved map is empty (registry inactive, or the data not localized — e.g. a test
- * harness): returns true so nothing is dropped, mirroring the PHP renderer's fail-open behavior.
+ * Fails open (returns true) only when there is no map to consult — the pool is not localized, or the
+ * active library is absent from it — which mirrors the PHP renderer, whose fail-open covers exactly the
+ * cases where the container or resolver cannot answer. A localized library that resolves to an empty map
+ * is an answer, not a gap, so every alias reads as unbacked there, in both languages alike.
  *
  * @param {string} id The design-token id (the alias path, e.g. "semantic.color.border").
  *
  * @since TBD
  *
- * @return {boolean} True when the id is backed, or when the resolved map is empty (fail-open).
+ * @return {boolean} True when the id is backed, or when no resolved map is available (fail-open).
  */
 export function isBackedToken(id) {
 	const values = resolvedValues();
 
-	if (Object.keys(values).length === 0) {
+	if (values === null) {
 		return true;
 	}
 

--- a/src/extension/design-tokens/backed-tokens.js
+++ b/src/extension/design-tokens/backed-tokens.js
@@ -1,0 +1,60 @@
+/**
+ * Whether a design-token alias is backed by the active library, for the editor's alias filter.
+ *
+ * The editor localizer prints the resolved id => literal map per library to
+ * `window.kadenceDesignTokensPickable.values` (the same set the Css_Var projector emits a
+ * `--kb-token--<id>` custom property for), and the active library slug to
+ * `window.kadenceDesignTokensPresets.active`. These pure window reads deliberately avoid importing the
+ * token-picker / preset-picker modules, whose `@kadence/components` dependency is unresolvable under the
+ * jest harness — the alias filter is a low-level output seam and must stay light.
+ */
+import { get } from 'lodash';
+
+/**
+ * The active token library slug, defaulting to "default".
+ *
+ * @since TBD
+ *
+ * @return {string} The active library slug.
+ */
+function activeLibrary() {
+	return get(window, 'kadenceDesignTokensPresets.active', 'default') || 'default';
+}
+
+/**
+ * The active library's resolved id => literal map (empty when the registry is inactive or the data is
+ * not localized).
+ *
+ * @since TBD
+ *
+ * @return {Object} id => literal value.
+ */
+function resolvedValues() {
+	const values = get(window, 'kadenceDesignTokensPickable.values', {}) || {};
+
+	return get(values, [activeLibrary()], {}) || {};
+}
+
+/**
+ * Whether a design-token id is backed by the active library — i.e. it appears in that library's resolved
+ * id map. Used to skip a stale alias (a token deleted after it was saved into a post) so the editor never
+ * emits a dead `var(--kb-token--<id>)`.
+ *
+ * Fails open when the resolved map is empty (registry inactive, or the data not localized — e.g. a test
+ * harness): returns true so nothing is dropped, mirroring the PHP renderer's fail-open behavior.
+ *
+ * @param {string} id The design-token id (the alias path, e.g. "semantic.color.border").
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the id is backed, or when the resolved map is empty (fail-open).
+ */
+export function isBackedToken(id) {
+	const values = resolvedValues();
+
+	if (Object.keys(values).length === 0) {
+		return true;
+	}
+
+	return Object.prototype.hasOwnProperty.call(values, id);
+}

--- a/src/extension/design-tokens/register-filters.js
+++ b/src/extension/design-tokens/register-filters.js
@@ -9,18 +9,34 @@
  */
 import { addFilter, removeFilter } from '@wordpress/hooks';
 import { isTokenAlias, resolveTokenAlias } from './alias';
+import { isBackedToken } from './backed-tokens';
 
 const NAMESPACE = 'kadence-blocks/token-alias';
 const HOOKS = ['kadence.helpers.colorValue', 'kadence.helpers.dimensionValue'];
 
 /**
- * Resolve a helper value: a design-token alias becomes its CSS var, anything else is unchanged.
+ * Resolve a helper value: a design-token alias backed by the active library becomes its CSS var, and
+ * anything else is unchanged. A syntactically-valid but unbacked alias — a token deleted after it was
+ * saved into a post — is left as the raw value, so the editor emits no dead `var(--kb-token--<id>)` and
+ * the property falls back to whatever global CSS exists (matching the front-end renderer).
  *
  * @param {*} value The raw value the helper received.
+ *
+ * @since TBD
+ *
  * @return {*} The resolved value.
  */
 function resolveAlias(value) {
-	return isTokenAlias(value) ? resolveTokenAlias(value) : value;
+	if (!isTokenAlias(value)) {
+		return value;
+	}
+
+	// Strip the { } braces to the dotted token id (the same slice resolveTokenAlias() does).
+	if (!isBackedToken(value.slice(1, -1))) {
+		return value;
+	}
+
+	return resolveTokenAlias(value);
 }
 
 /**

--- a/tests/wpunit/KadenceBlocksCssTest.php
+++ b/tests/wpunit/KadenceBlocksCssTest.php
@@ -626,13 +626,13 @@ class KadenceBlocksCssTest extends WPTestCase {
 	 */
 	public function testRenderColorResolvesTokenAlias(): void {
 		$this->assertSame(
-			'var(--kb-token--dark--primitive--color--brand--primary)',
-			$this->css->render_color( '{dark.primitive.color.brand.primary}' ),
+			'var(--kb-token--semantic--color--border)',
+			$this->css->render_color( '{semantic.color.border}' ),
 			'A color alias resolves to the bare token var'
 		);
 		$this->assertSame(
-			'var(--kb-token--dark--primitive--color--brand--primary)',
-			$this->css->sanitize_color( '{dark.primitive.color.brand.primary}' ),
+			'var(--kb-token--semantic--color--border)',
+			$this->css->sanitize_color( '{semantic.color.border}' ),
 			'sanitize_color resolves a color alias the same way'
 		);
 		$this->assertSame(
@@ -678,13 +678,13 @@ class KadenceBlocksCssTest extends WPTestCase {
 	 */
 	public function testRenderMeasureRangeResolvesTokenAlias(): void {
 		$this->css->render_measure_range(
-			[ 'borderWidth' => [ '{semantic.border.width}', 2, 2, 2 ] ],
+			[ 'borderWidth' => [ '{semantic.border-width.default}', 2, 2, 2 ] ],
 			'borderWidth',
 			'border-width'
 		);
 		$output = $this->css->css_output();
 
-		$this->assertStringContainsString( 'border-top-width:var(--kb-token--semantic--border--width)', $output,
+		$this->assertStringContainsString( 'border-top-width:var(--kb-token--semantic--border-width--default)', $output,
 			'An aliased side emits the token var with no unit' );
 		$this->assertStringContainsString( 'border-right-width:2px', $output,
 			'A numeric side is still rendered with its unit' );
@@ -697,8 +697,8 @@ class KadenceBlocksCssTest extends WPTestCase {
 	 * @return void
 	 */
 	public function testRenderRangeResolvesTokenAlias(): void {
-		$this->css->render_range( [ 'width' => '{semantic.size.width}' ], 'width', 'width' );
-		$this->assertStringContainsString( 'width:var(--kb-token--semantic--size--width)', $this->css->css_output(),
+		$this->css->render_range( [ 'width' => '{semantic.radius.media}' ], 'width', 'width' );
+		$this->assertStringContainsString( 'width:var(--kb-token--semantic--radius--media)', $this->css->css_output(),
 			'An aliased range value emits the token var with no unit' );
 
 		$numeric = new Kadence_Blocks_CSS();
@@ -715,17 +715,17 @@ class KadenceBlocksCssTest extends WPTestCase {
 	 */
 	public function testRenderResponsiveRangeResolvesTokenAlias(): void {
 		$this->css->render_responsive_range(
-			[ 'spacing' => [ '{semantic.space.md}', 20, '{semantic.space.sm}' ], 'spacingType' => 'px' ],
+			[ 'spacing' => [ '{semantic.spacing.media-padding}', 20, '{semantic.radius.control}' ], 'spacingType' => 'px' ],
 			'spacing',
 			'margin'
 		);
 		$output = $this->css->css_output();
 
-		$this->assertStringContainsString( 'margin:var(--kb-token--semantic--space--md)', $output,
+		$this->assertStringContainsString( 'margin:var(--kb-token--semantic--spacing--media-padding)', $output,
 			'An aliased desktop value emits the token var with no unit' );
 		$this->assertStringContainsString( 'margin:20px', $output,
 			'A numeric tablet value is still rendered with its unit' );
-		$this->assertStringContainsString( 'margin:var(--kb-token--semantic--space--sm)', $output,
+		$this->assertStringContainsString( 'margin:var(--kb-token--semantic--radius--control)', $output,
 			'An aliased mobile value emits the token var with no unit' );
 	}
 
@@ -737,13 +737,13 @@ class KadenceBlocksCssTest extends WPTestCase {
 	 */
 	public function testRenderResponsiveSizeResolvesTokenAlias(): void {
 		$this->css->render_responsive_size(
-			[ 'width' => '{semantic.size.width}', 'tabletWidth' => '20', 'mobileWidth' => '' ],
+			[ 'width' => '{semantic.radius.media}', 'tabletWidth' => '20', 'mobileWidth' => '' ],
 			[ 'width', 'tabletWidth', 'mobileWidth' ],
 			'width'
 		);
 		$output = $this->css->css_output();
 
-		$this->assertStringContainsString( 'width:var(--kb-token--semantic--size--width)', $output,
+		$this->assertStringContainsString( 'width:var(--kb-token--semantic--radius--media)', $output,
 			'An aliased desktop value emits the token var with no unit' );
 		$this->assertStringContainsString( 'width:20px', $output,
 			'A literal tablet value is still rendered with its unit' );
@@ -757,8 +757,8 @@ class KadenceBlocksCssTest extends WPTestCase {
 	 */
 	public function testRenderMeasureResolvesTokenAlias(): void {
 		$this->assertSame(
-			'var(--kb-token--semantic--space--md) 20px 0px 40px',
-			$this->css->render_measure( [ '{semantic.space.md}', 20, '', 40 ] ),
+			'var(--kb-token--semantic--spacing--media-padding) 20px 0px 40px',
+			$this->css->render_measure( [ '{semantic.spacing.media-padding}', 20, '', 40 ] ),
 			'An aliased side is a bare var and non-numeric siblings fall back to 0 with the unit'
 		);
 		$this->assertSame(
@@ -776,8 +776,8 @@ class KadenceBlocksCssTest extends WPTestCase {
 	 */
 	public function testRenderNumberResolvesTokenAlias(): void {
 		$this->assertSame(
-			'var(--kb-token--semantic--size--icon)',
-			$this->css->render_number( '{semantic.size.icon}', 'px' ),
+			'var(--kb-token--semantic--icon-size--default)',
+			$this->css->render_number( '{semantic.icon-size.default}', 'px' ),
 			'An alias returns the bare token var with no unit'
 		);
 		$this->assertSame(
@@ -799,13 +799,13 @@ class KadenceBlocksCssTest extends WPTestCase {
 	 */
 	public function testRenderShadowResolvesTokenAlias(): void {
 		$this->assertSame(
-			'var(--kb-token--semantic--shadow--x) 1px 4px 2px rgba(0, 0, 0, 0.5)',
+			'var(--kb-token--semantic--radius--media) 1px 4px 2px rgba(0, 0, 0, 0.5)',
 			$this->css->render_shadow( [
 				'color'   => '#000000',
 				'opacity' => 0.5,
 				'spread'  => 2,
 				'blur'    => 4,
-				'hOffset' => '{semantic.shadow.x}',
+				'hOffset' => '{semantic.radius.media}',
 				'vOffset' => 1,
 				'inset'   => false,
 			] ),
@@ -884,9 +884,9 @@ class KadenceBlocksCssTest extends WPTestCase {
 			'expected' => '0px 0px 14px 0px rgba(0, 0, 0, 0.2)',
 		];
 		yield 'aliased offset passes through as a token var' => [
-			'shadow'   => [ 'hOffset' => '{semantic.shadow.x}', 'vOffset' => '1', 'blur' => '4', 'spread' => '2', 'color' => '#000000', 'opacity' => 0.5, 'inset' => false ],
+			'shadow'   => [ 'hOffset' => '{semantic.radius.media}', 'vOffset' => '1', 'blur' => '4', 'spread' => '2', 'color' => '#000000', 'opacity' => 0.5, 'inset' => false ],
 			'defaults' => $button_defaults,
-			'expected' => 'var(--kb-token--semantic--shadow--x) 1px 4px 2px rgba(0, 0, 0, 0.5)',
+			'expected' => 'var(--kb-token--semantic--radius--media) 1px 4px 2px rgba(0, 0, 0, 0.5)',
 		];
 		yield 'truthy inset prefixes the declaration' => [
 			'shadow'   => [ 'hOffset' => '1', 'vOffset' => '1', 'blur' => '2', 'spread' => '0', 'color' => '#000000', 'opacity' => 0.2, 'inset' => true ],
@@ -928,7 +928,7 @@ class KadenceBlocksCssTest extends WPTestCase {
 		$this->css->render_border_styles( [
 			'borderStyle' => [
 				[
-					'top'    => [ '#000000', 'solid', '{semantic.border.width}' ],
+					'top'    => [ '#000000', 'solid', '{semantic.border-width.default}' ],
 					'right'  => [ '#000000', 'solid', 1 ],
 					'bottom' => [ '#000000', 'solid', 1 ],
 					'left'   => [ '#000000', 'solid', 1 ],
@@ -938,7 +938,7 @@ class KadenceBlocksCssTest extends WPTestCase {
 		] );
 		$output = $this->css->css_output();
 
-		$this->assertStringContainsString( 'border-top:var(--kb-token--semantic--border--width) solid #000000', $output,
+		$this->assertStringContainsString( 'border-top:var(--kb-token--semantic--border-width--default) solid #000000', $output,
 			'An aliased width resolves to the token var and the width branch still fires' );
 		$this->assertStringContainsString( 'border-right:1px solid #000000', $output,
 			'A numeric width is still rendered with its unit' );
@@ -953,15 +953,15 @@ class KadenceBlocksCssTest extends WPTestCase {
 	public function testRenderTypographyResolvesTokenAlias(): void {
 		$this->css->render_typography( [
 			'typography' => [
-				'lineHeight'    => [ '{semantic.line-height.tight}', '', '' ],
-				'letterSpacing' => [ '{semantic.letter-spacing.wide}', '', '' ],
+				'lineHeight'    => [ '{semantic.line-height.heading}', '', '' ],
+				'letterSpacing' => [ '{semantic.letter-spacing.heading}', '', '' ],
 			],
 		] );
 		$output = $this->css->css_output();
 
-		$this->assertStringContainsString( 'line-height:var(--kb-token--semantic--line-height--tight)', $output,
+		$this->assertStringContainsString( 'line-height:var(--kb-token--semantic--line-height--heading)', $output,
 			'An aliased line-height resolves to the token var with no unit' );
-		$this->assertStringContainsString( 'letter-spacing:var(--kb-token--semantic--letter-spacing--wide)', $output,
+		$this->assertStringContainsString( 'letter-spacing:var(--kb-token--semantic--letter-spacing--heading)', $output,
 			'An aliased letter-spacing resolves to the token var with no unit' );
 
 		$numeric = new Kadence_Blocks_CSS();

--- a/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
+++ b/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
@@ -377,6 +377,24 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	}
 
 	/**
+	 * A well-formed but unbacked alias in a numeric lineHeight slot emits no line-height declaration (and
+	 * never the raw alias text), so the property falls back to the global CSS. Covers the numeric-array
+	 * shape the typography paths use, not just the keyed one.
+	 *
+	 * @return void
+	 */
+	public function testRenderTypographyDropsUnresolvedNumericLineHeight(): void {
+		$this->css->render_typography( [
+			'typography' => [
+				'lineType'   => 'px',
+				'lineHeight' => [ '{semantic.does.not.exist}', '', '' ],
+			],
+		] );
+
+		$this->assertStringNotContainsString( 'line-height:', $this->css->css_output() );
+	}
+
+	/**
 	 * The fail-open matrix for render_border (width): a malformed, non-empty brace width is not
 	 * a strict alias, so it passes through literally with its unit suffix and never mints a var().
 	 *

--- a/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
+++ b/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
@@ -179,7 +179,7 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 			'typography' => [
 				'lineType'      => 'px',
 				'lineHeight'    => [ '{semantic.radius.media}', '', '' ],
-				'letterSpacing' => [ '{primitive.spacing.md}', '', '' ],
+				'letterSpacing' => [ '{semantic.radius.control}', '', '' ],
 			],
 		] );
 		$output = $this->css->css_output();
@@ -190,7 +190,7 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 			'render_typography must emit the bare var() for an aliased desktop line-height'
 		);
 		$this->assertStringContainsString(
-			'letter-spacing:var(--kb-token--primitive--spacing--md)',
+			'letter-spacing:var(--kb-token--semantic--radius--control)',
 			$output,
 			'render_typography must emit the bare var() for an aliased desktop letter-spacing'
 		);
@@ -257,15 +257,122 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	public function testRenderBorderResolvesAliasedWidthAndColorTogether(): void {
 		$border = [
 			[
-				'top'  => [ '{semantic.color.brand}', 'solid', '{semantic.border.width.thin}' ],
+				'top'  => [ '{semantic.color.border}', 'solid', '{semantic.border-width.default}' ],
 				'unit' => 'px',
 			],
 		];
 
 		$this->assertSame(
-			'var(--kb-token--semantic--border--width--thin) solid var(--kb-token--semantic--color--brand)',
+			'var(--kb-token--semantic--border-width--default) solid var(--kb-token--semantic--color--border)',
 			$this->css->render_border( $border, 'top' ),
 			'render_border must resolve both the aliased width and the aliased color'
+		);
+	}
+
+	/**
+	 * A syntactically-valid alias whose token is not backed by the active library resolves to no var()
+	 * in render_color; the method emits its empty sentinel so the property falls back to the global CSS
+	 * rather than minting a dead var().
+	 *
+	 * @return void
+	 */
+	public function testRenderColorEmitsNothingForUnresolvedAlias(): void {
+		$this->assertSame(
+			false,
+			$this->css->render_color( '{semantic.does.not.exist}' ),
+			'render_color must emit nothing for a well-formed but unresolved alias'
+		);
+	}
+
+	/**
+	 * sanitize_color emits nothing for a well-formed but unresolved alias, so the property falls back to
+	 * the global CSS rather than minting a dead var().
+	 *
+	 * @return void
+	 */
+	public function testSanitizeColorEmitsNothingForUnresolvedAlias(): void {
+		$this->assertSame(
+			false,
+			$this->css->sanitize_color( '{semantic.does.not.exist}' ),
+			'sanitize_color must emit nothing for a well-formed but unresolved alias'
+		);
+	}
+
+	/**
+	 * render_border drops the whole shorthand when the width is a well-formed but unresolved alias, so
+	 * the border falls back to the global CSS instead of a broken shorthand.
+	 *
+	 * @return void
+	 */
+	public function testRenderBorderDropsShorthandForUnresolvedAliasWidth(): void {
+		$border = [
+			[
+				'top'  => [ '#000000', 'solid', '{semantic.does.not.exist}' ],
+				'unit' => 'px',
+			],
+		];
+
+		$this->assertSame(
+			false,
+			$this->css->render_border( $border, 'top' ),
+			'render_border must drop the whole shorthand for an unresolved alias width'
+		);
+	}
+
+	/**
+	 * render_border drops the whole shorthand when the color is a well-formed but unresolved alias, even
+	 * with a valid numeric width.
+	 *
+	 * @return void
+	 */
+	public function testRenderBorderDropsShorthandForUnresolvedAliasColor(): void {
+		$border = [
+			[
+				'top'  => [ '{semantic.does.not.exist}', 'solid', '2' ],
+				'unit' => 'px',
+			],
+		];
+
+		$this->assertSame(
+			false,
+			$this->css->render_border( $border, 'top' ),
+			'render_border must drop the whole shorthand for an unresolved alias color'
+		);
+	}
+
+	/**
+	 * render_shadow drops the whole box-shadow shorthand when any part is a well-formed but unresolved
+	 * alias, so it falls back to the global CSS instead of a broken shorthand.
+	 *
+	 * @return void
+	 */
+	public function testRenderShadowDropsShorthandForUnresolvedAliasPart(): void {
+		$this->assertSame(
+			false,
+			$this->css->render_shadow( [
+				'color'   => '#000000',
+				'opacity' => 1,
+				'spread'  => 2,
+				'blur'    => 4,
+				'hOffset' => '{semantic.does.not.exist}',
+				'vOffset' => 1,
+				'inset'   => false,
+			] ),
+			'render_shadow must drop the whole shorthand for an unresolved alias part'
+		);
+	}
+
+	/**
+	 * render_measure drops the whole value when any side is a well-formed but unresolved alias, so the
+	 * property falls back to the global CSS instead of a partially-zeroed value.
+	 *
+	 * @return void
+	 */
+	public function testRenderMeasureDropsValueForUnresolvedAliasSide(): void {
+		$this->assertSame(
+			false,
+			$this->css->render_measure( [ '{semantic.does.not.exist}', 20, 30, 40 ] ),
+			'render_measure must drop the whole value for an unresolved alias side'
 		);
 	}
 

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -7,6 +7,11 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css\Css_Build
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Preset_Resolver;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use KadenceWP\KadenceBlocks\Monolog\Handler\TestHandler;
+use KadenceWP\KadenceBlocks\Monolog\Logger;
+use KadenceWP\KadenceBlocks\Psr\Log\LoggerInterface;
+use KadenceWP\KadenceBlocks\Psr\Log\NullLogger;
 use Tests\Support\Classes\TestCase;
 
 /**
@@ -23,12 +28,18 @@ final class Css_BuilderTest extends TestCase {
 	private Preset_Resolver $resolver;
 
 	/**
+	 * @var Token_Resolver
+	 */
+	private Token_Resolver $token_resolver;
+
+	/**
 	 * @return void
 	 */
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->resolver = $this->container->get( Preset_Resolver::class );
+		$this->resolver       = $this->container->get( Preset_Resolver::class );
+		$this->token_resolver = $this->container->get( Token_Resolver::class );
 	}
 
 	/**
@@ -296,14 +307,40 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
+	 * A binding whose `token` id is not backed by the resolved library emits no declaration for that control
+	 * at all — not even a `var()` with a literal fallback — so the block falls back to its own native
+	 * default CSS, and the mismatch is logged via the injected logger.
+	 *
+	 * @return void
+	 */
+	public function testItSkipsAndLogsABindingReferencingAnUnresolvedToken(): void {
+		$handler = new TestHandler();
+		$logger  = new Logger( 'test' );
+		$logger->pushHandler( $handler );
+
+		$css = $this->builder( $this->unresolved_token_registry(), $logger )->css();
+
+		// No declaration is emitted for the control: no rule for the block, no dead var() with a fallback.
+		$this->assertSame( '', $css );
+		$this->assertStringNotContainsString( 'border-radius:var(', $css );
+
+		// The mismatch is logged, naming the offending block and the unresolved token id.
+		$this->assertTrue( $handler->hasErrorThatContains( 'unresolved token id' ) );
+		$this->assertTrue( $handler->hasErrorThatContains( 'semantic.radius.gone' ) );
+		$this->assertTrue( $handler->hasErrorThatContains( 'kadence/image' ) );
+	}
+
+	/**
 	 * Build the builder with a given registry and the real (baseline-backed) preset resolver.
 	 *
-	 * @param Token_Registry $registry The registry whose preset bindings the builder reads.
+	 * @param Token_Registry       $registry The registry whose preset bindings the builder reads.
+	 * @param LoggerInterface|null $logger   The logger to inject; defaults to a NullLogger so tests that do
+	 *                                       not assert on logging are unaffected.
 	 *
 	 * @return Css_Builder
 	 */
-	private function builder( Token_Registry $registry ): Css_Builder {
-		return new Css_Builder( $registry, $this->resolver );
+	private function builder( Token_Registry $registry, ?LoggerInterface $logger = null ): Css_Builder {
+		return new Css_Builder( $registry, $this->resolver, $this->token_resolver, $logger ?? new NullLogger() );
 	}
 
 	/**
@@ -327,6 +364,33 @@ final class Css_BuilderTest extends TestCase {
 				'bindings' => [
 					'borderRadius' => [
 						'token'        => 'semantic.radius.media',
+						'css_prop'     => 'border-radius',
+						'css_selector' => 'img',
+					],
+				],
+			]
+		);
+
+		return $registry;
+	}
+
+	/**
+	 * A registry that binds the Image `borderRadius` css_prop to a token id the resolved library does not
+	 * back (`semantic.radius.gone` has no baseline entry), so the builder resolves a default literal for the
+	 * control (from the shipped document's `$default` preset) but finds the binding's token unresolved —
+	 * exercising the skip-and-log path. Mirrors {@see self::image_registry()} but points the binding at an
+	 * unbacked token id.
+	 *
+	 * @return Token_Registry
+	 */
+	private function unresolved_token_registry(): Token_Registry {
+		$registry = new Token_Registry();
+		$registry->register_preset_bindings(
+			[
+				'block'    => 'kadence/image',
+				'bindings' => [
+					'borderRadius' => [
+						'token'        => 'semantic.radius.gone',
 						'css_prop'     => 'border-radius',
 						'css_selector' => 'img',
 					],


### PR DESCRIPTION
🎫 https://linear.app/nexcess/issue/SOFT-4072/skip-log-unresolved-token-aliases-at-block-render
:video_camera: https://www.loom.com/share/6587bf85399b475aa11656f3b57a0cb4

<img width="1296" height="44" alt="image" src="https://github.com/user-attachments/assets/11107658-bf9c-4a52-9059-7e001459de19" />


The block-default CSS builder fed a binding's `token` id into `css_var_for()` without checking it was backed. An unregistered id produced a dead `--kb-token--…` custom property, but the declaration's `var()` literal fallback (the block's resolved default) kept the property rendering — a silent, invisible failure.

The builder now checks the binding's token against the resolved library's canonical id map (the exact set the Css_Var projector emits a `--kb-token--<id>` variable for) before building the var. An unbacked id is skipped entirely — no declaration, so the block renders its own native default — and logged via an injected PSR-3 logger under `WP_DEBUG`, matching the `Baseline_Guard` pattern.

The resolved library, not `Token_Registry::has()`, is the authoritative backed set: the registry holds only the declared-token subset and omits baseline-only semantic tokens (e.g. `semantic.color.text`), so a `has()` gate would wrongly suppress those working rules.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid design-token aliases from generating broken CSS variable references.
  * Unresolved colors, measurements, borders, shadows, typography, spacing, and responsive values now fall back safely.
  * CSS generation skips unavailable token bindings and records diagnostic details when debugging is enabled.
  * Improved handling of missing token data and stale aliases without affecting regular values.
  * Border and shadow shorthand styles are omitted when required token values cannot be resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->