### PR TITLE
[DTM] SOFT-4083 [1/23]: Preset REST access

### DIFF
--- a/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
@@ -756,30 +756,37 @@ final class Presets_Controller extends Controller {
 			'title'      => 'design-token-presets',
 			'type'       => 'object',
 			'properties' => [
-				'block'   => [
+				'block'       => [
 					'description' => __( 'The block name the preset collection belongs to.', 'kadence-blocks' ),
 					'type'        => 'string',
 					'context'     => [ 'view' ],
 					'readonly'    => true,
 				],
-				'slug'    => [
+				'slug'        => [
 					'description' => __( 'The token library slug.', 'kadence-blocks' ),
 					'type'        => 'string',
 					'context'     => [ 'view' ],
 					'readonly'    => true,
 				],
-				'version' => [
+				'version'     => [
 					'description' => __( 'The cache-busting version hash for the library, empty when it renders from baseline.', 'kadence-blocks' ),
 					'type'        => 'string',
 					'context'     => [ 'view' ],
 					'readonly'    => true,
 				],
-				'default' => [
+				'default'     => [
 					'description' => __( 'The default preset slug.', 'kadence-blocks' ),
 					'type'        => 'string',
 					'context'     => [ 'view' ],
 				],
-				'presets' => [
+				'userCreated' => [
+					'description' => __( 'The preset slugs the library defines beyond the baseline. Deleting one removes it; deleting anything else at most reverts an override.', 'kadence-blocks' ),
+					'type'        => 'array',
+					'items'       => [ 'type' => 'string' ],
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+				'presets'     => [
 					'description'          => __( 'The named presets, keyed by slug.', 'kadence-blocks' ),
 					'type'                 => 'object',
 					'context'              => [ 'view' ],
@@ -1287,17 +1294,19 @@ final class Presets_Controller extends Controller {
 	 * @param string $block The block name.
 	 * @param string $slug  The token library slug being read.
 	 *
-	 * @return array<string, mixed>
+	 * @return array<string, mixed> The item payload, including the `userCreated` preset slugs (those
+	 *                              the library defines beyond the baseline).
 	 */
 	private function prepare_item( string $block, string $slug ): array {
 		$node = $this->set_node( $this->presets->section( $slug ), $block );
 
 		return [
-			'block'   => $block,
-			'slug'    => $slug,
-			'version' => $this->store->get_version( $slug ),
-			'default' => $this->default_of( $node ),
-			'presets' => $this->named_presets( $node ),
+			'block'       => $block,
+			'slug'        => $slug,
+			'version'     => $this->store->get_version( $slug ),
+			'default'     => $this->default_of( $node ),
+			'userCreated' => $this->presets->user_created( $block, $slug ),
+			'presets'     => $this->named_presets( $node ),
 		];
 	}
 

--- a/src/style-library/__tests__/paths.test.js
+++ b/src/style-library/__tests__/paths.test.js
@@ -14,6 +14,8 @@ import {
 	feedPath,
 	tokenLabelPath,
 	groupOrderPath,
+	blockPresetsPath,
+	blockPresetPath,
 } from '../api/paths';
 
 describe('palette paths', () => {
@@ -140,6 +142,34 @@ describe('groupOrderPath', () => {
 	it('escapes the slug', () => {
 		expect(groupOrderPath('my set', 'Border Radius')).toBe(
 			'/kb-design-tokens/v1/documents/my%20set/order/Border%20Radius'
+		);
+	});
+});
+
+describe('blockPresetsPath', () => {
+	it('builds the collection path with the library query', () => {
+		expect(blockPresetsPath('kb-design-tokens/v1', 'kadence/singlebtn', 'default')).toBe(
+			'/kb-design-tokens/v1/presets/kadence/singlebtn?library=default'
+		);
+	});
+
+	it('encodes the vendor and block-name segments separately', () => {
+		expect(blockPresetsPath('kb-design-tokens/v1', 'kadence/singlebtn', 'my set')).toBe(
+			'/kb-design-tokens/v1/presets/kadence/singlebtn?library=my%20set'
+		);
+	});
+});
+
+describe('blockPresetPath', () => {
+	it('builds a single preset path with the library query', () => {
+		expect(blockPresetPath('kb-design-tokens/v1', 'kadence/singlebtn', 'primary', 'default')).toBe(
+			'/kb-design-tokens/v1/presets/kadence/singlebtn/primary?library=default'
+		);
+	});
+
+	it('escapes the preset slug and the library', () => {
+		expect(blockPresetPath('kb-design-tokens/v1', 'kadence/singlebtn', 'my preset', 'my set')).toBe(
+			'/kb-design-tokens/v1/presets/kadence/singlebtn/my%20preset?library=my%20set'
 		);
 	});
 });

--- a/src/style-library/api/client.js
+++ b/src/style-library/api/client.js
@@ -25,6 +25,8 @@ import {
 	paletteSwatchPath,
 	paletteCurrentPath,
 	feedPath,
+	blockPresetsPath,
+	blockPresetPath,
 } from './paths';
 import { DEFAULT_LIBRARY_SLUG } from '../constants';
 
@@ -407,6 +409,62 @@ export function renameLibrary(slug, title) {
  */
 export function deleteLibrary(slug) {
 	return apiFetch({ path: documentPath(NAMESPACE, slug), method: 'DELETE' });
+}
+
+/**
+ * Fetch a block's effective (baseline-merged) preset collection.
+ *
+ * @since TBD
+ *
+ * @param {string} namespace REST namespace.
+ * @param {string} block     The block name, e.g. `kadence/singlebtn`.
+ * @param {string} slug      Token library slug.
+ * @return {Promise<{block: string, slug: string, version: string, default: string, userCreated: string[], presets: Record<string, {label?: string, tokens: Record<string, string>}>}>} The block's preset collection.
+ */
+export function fetchBlockPresets(namespace, block, slug) {
+	return apiFetch({ path: blockPresetsPath(namespace, block, slug) });
+}
+
+/**
+ * Create a preset, or merge onto an existing one. The write is a deep merge into the stored preset:
+ * sibling presets and `$default` are left intact, and omitting `tokens` preserves the stored token
+ * map (a rename). There is deliberately no PUT wrapper — the PUT route replaces the block's whole
+ * preset collection and silently drops any preset the body omits, which would be a data-loss trap
+ * for a single-preset save.
+ *
+ * @since TBD
+ *
+ * @param {string}                                          namespace REST namespace.
+ * @param {string}                                          block     The block name, e.g. `kadence/singlebtn`.
+ * @param {{preset: string, label?: string, tokens?: Record<string, string>}} payload The preset slug, optional label, and optional token map.
+ * @param {string}                                          slug      Token library slug.
+ * @return {Promise<object>} The updated preset collection.
+ */
+export function saveBlockPreset(namespace, block, payload, slug) {
+	return apiFetch({
+		path: blockPresetsPath(namespace, block, slug),
+		method: 'POST',
+		data: payload,
+	});
+}
+
+/**
+ * Delete a preset. A preset that also exists in the baseline reverts to its baseline definition
+ * rather than disappearing.
+ *
+ * @since TBD
+ *
+ * @param {string} namespace REST namespace.
+ * @param {string} block     The block name, e.g. `kadence/singlebtn`.
+ * @param {string} preset    The preset slug.
+ * @param {string} slug      Token library slug.
+ * @return {Promise<object>} The updated preset collection.
+ */
+export function deleteBlockPreset(namespace, block, preset, slug) {
+	return apiFetch({
+		path: blockPresetPath(namespace, block, preset, slug),
+		method: 'DELETE',
+	});
 }
 
 /**

--- a/src/style-library/api/paths.js
+++ b/src/style-library/api/paths.js
@@ -240,3 +240,48 @@ export function paletteSwatchPath(namespace, id, token, slug = DEFAULT_LIBRARY_S
 export function paletteCurrentPath(namespace, slug = DEFAULT_LIBRARY_SLUG) {
 	return `/${namespace}/palettes/current?library=${encodeURIComponent(slug)}`;
 }
+
+/**
+ * Build the shared `/presets/{vendor}/{name}` segment of a block's preset routes. The block name's
+ * two segments are encoded separately — the "/" between vendor and block is a real path separator
+ * on the route (`Presets_Controller::BLOCK_ROUTE`).
+ *
+ * @since TBD
+ *
+ * @param {string} namespace REST namespace (e.g. kb-design-tokens/v1).
+ * @param {string} block     The block name, e.g. `kadence/singlebtn`.
+ * @return {string} REST path relative to wp-json root, with no trailing slash or query string.
+ */
+function blockPresetsBasePath(namespace, block) {
+	const [vendor, name] = block.split('/');
+	return `/${namespace}/presets/${encodeURIComponent(vendor)}/${encodeURIComponent(name)}`;
+}
+
+/**
+ * Build a REST path for a block's preset collection (read, create-or-merge).
+ *
+ * @since TBD
+ *
+ * @param {string} namespace REST namespace (e.g. kb-design-tokens/v1).
+ * @param {string} block     The block name, e.g. `kadence/singlebtn`.
+ * @param {string} slug      Token library slug.
+ * @return {string} REST path relative to wp-json root.
+ */
+export function blockPresetsPath(namespace, block, slug = DEFAULT_LIBRARY_SLUG) {
+	return `${blockPresetsBasePath(namespace, block)}?library=${encodeURIComponent(slug)}`;
+}
+
+/**
+ * Build a REST path for a single preset resource within a block's preset collection.
+ *
+ * @since TBD
+ *
+ * @param {string} namespace REST namespace (e.g. kb-design-tokens/v1).
+ * @param {string} block     The block name, e.g. `kadence/singlebtn`.
+ * @param {string} preset    The preset slug.
+ * @param {string} slug      Token library slug.
+ * @return {string} REST path relative to wp-json root.
+ */
+export function blockPresetPath(namespace, block, preset, slug = DEFAULT_LIBRARY_SLUG) {
+	return `${blockPresetsBasePath(namespace, block)}/${encodeURIComponent(preset)}?library=${encodeURIComponent(slug)}`;
+}

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
@@ -101,6 +101,19 @@ final class PresetsControllerTest extends TestCase {
 	}
 
 	/**
+	 * The item schema documents the `userCreated` property added to the GET item response.
+	 *
+	 * @return void
+	 */
+	public function testItemSchemaDescribesUserCreated(): void {
+		$schema = $this->controller->get_item_schema();
+
+		$this->assertArrayHasKey( 'userCreated', $schema['properties'] );
+		$this->assertSame( 'array', $schema['properties']['userCreated']['type'] );
+		$this->assertSame( 'string', $schema['properties']['userCreated']['items']['type'] );
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testItListsTheRegisteredPresetBlocks(): void {
@@ -147,6 +160,18 @@ final class PresetsControllerTest extends TestCase {
 	}
 
 	/**
+	 * A fresh library has no stored overrides, so every effective preset comes from the baseline and none is
+	 * reported as user-created.
+	 *
+	 * @return void
+	 */
+	public function testGetItemOnAFreshLibraryReportsNoUserCreatedPresets(): void {
+		$data = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) )->get_data();
+
+		$this->assertSame( [], $data['userCreated'] );
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testGetItemReturns404ForABlockThatAcceptsNoPresets(): void {
@@ -188,6 +213,57 @@ final class PresetsControllerTest extends TestCase {
 		$this->assertArrayHasKey( 'primary', $data['presets'] );
 		$this->assertArrayHasKey( 'secondary', $data['presets'] );
 		$this->assertSame( 'primary', $data['default'] );
+	}
+
+	/**
+	 * Creating a preset slug the baseline does not define adds it to the response's `userCreated` list, and a
+	 * subsequent read agrees.
+	 *
+	 * @return void
+	 */
+	public function testCreatingANewPresetSlugAddsItToUserCreated(): void {
+		$response = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'preset' => 'outline',
+					'label'  => 'Outline',
+					'tokens' => $this->button_tokens(),
+				]
+			)
+		);
+
+		$this->assertContains( 'outline', $response->get_data()['userCreated'] );
+
+		$data = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) )->get_data();
+		$this->assertContains( 'outline', $data['userCreated'] );
+	}
+
+	/**
+	 * A label-only merge onto a baseline slug (a "shadow") edits the baseline preset in place: it must not be
+	 * reported as user-created, and the preset's existing tokens must still resolve after the label-only write
+	 * — the merge must not have dropped them.
+	 *
+	 * @return void
+	 */
+	public function testALabelOnlyMergeOntoABaselineShadowLeavesUserCreatedEmpty(): void {
+		$response = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'preset' => 'primary',
+					'label'  => 'Renamed Primary',
+				]
+			)
+		);
+
+		$data = $response->get_data();
+
+		$this->assertNotContains( 'primary', $data['userCreated'] );
+		$this->assertSame( 'Renamed Primary', $data['presets']['primary']['label'] );
+		$this->assertNotEmpty( $data['presets']['primary']['tokens'] );
 	}
 
 	/**


### PR DESCRIPTION
Adds the preset REST paths and client wrappers, and exposes `userCreated` on the preset GET item response.

## Test instructions

1. Run `npx wp-scripts test-unit-js src/style-library/__tests__/paths.test.js` — the path builders are pure, so this is the fastest check.
2. Hit the item endpoint in a browser while logged in:
   `/wp-json/kb-design-tokens/v1/presets/kadence/singlebtn/primary?library=default`
3. Confirm the response includes a `userCreated` boolean. It should be `false` for a preset that ships with the library.
4. Nothing in the UI consumes this yet — that is expected at this slice.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4083/phase-1a-preset-rest-access
bun run build-wp
```

The Style Library is at **WP Admin → Kadence → Style Library**. The Button preset screen is under **Block Presets → Button**. Block-editor checks use a **Kadence Single Button** block on any post.
</details>

---

Slice 1 of 23 in the SOFT-4083 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.