### PR TITLE
[DTM] SOFT-4083 [2/23]: Preset helpers and fetch hook

### DIFF
--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -1,0 +1,185 @@
+/* eslint-env jest */
+import {
+	aliasToId,
+	idToAlias,
+	resolveTokenValue,
+	presetRows,
+	presetInitialValues,
+	presetSaveTokens,
+	nextPresetSlug,
+} from '../helpers/presets';
+
+describe('aliasToId', () => {
+	it('strips the braces off an alias', () => {
+		expect(aliasToId('{semantic.color.action-primary}')).toBe('semantic.color.action-primary');
+	});
+
+	it('passes a literal value through unchanged', () => {
+		expect(aliasToId('#3633e1')).toBe('#3633e1');
+	});
+
+	it('round-trips through idToAlias', () => {
+		expect(idToAlias(aliasToId('{semantic.color.action-primary}'))).toBe('{semantic.color.action-primary}');
+	});
+});
+
+describe('idToAlias', () => {
+	it('wraps a bare id in braces', () => {
+		expect(idToAlias('semantic.color.action-primary')).toBe('{semantic.color.action-primary}');
+	});
+
+	it('passes an already-wrapped value through unchanged', () => {
+		expect(idToAlias('{semantic.color.action-primary}')).toBe('{semantic.color.action-primary}');
+	});
+
+	it('passes an empty value through unchanged', () => {
+		expect(idToAlias('')).toBe('');
+	});
+});
+
+describe('resolveTokenValue', () => {
+	const values = { 'semantic.color.action-primary': '#3633e1' };
+
+	it('resolves an alias against the values map', () => {
+		expect(resolveTokenValue(values, '{semantic.color.action-primary}')).toBe('#3633e1');
+	});
+
+	it('returns a literal value verbatim', () => {
+		expect(resolveTokenValue(values, 'transparent')).toBe('transparent');
+	});
+
+	it('resolves a dangling alias to an empty string', () => {
+		expect(resolveTokenValue(values, '{semantic.color.does-not-exist}')).toBe('');
+	});
+});
+
+describe('presetRows', () => {
+	const values = {
+		'semantic.color.action-primary': '#3633e1',
+		'semantic.color.on-primary': '#ffffff',
+	};
+
+	it('maps the payload to row view models in payload order, resolving preview values', () => {
+		const payload = {
+			userCreated: [],
+			presets: {
+				primary: {
+					label: 'Primary',
+					tokens: {
+						'button-bg': '{semantic.color.action-primary}',
+						'button-text': '{semantic.color.on-primary}',
+						'button-radius': '0.5rem',
+					},
+				},
+				secondary: {
+					label: 'Secondary',
+					tokens: {
+						'button-bg': 'transparent',
+						'button-text': '{semantic.color.action-primary}',
+						'button-radius': '0.25rem',
+					},
+				},
+			},
+		};
+
+		const rows = presetRows(payload, values);
+
+		expect(rows.map((row) => row.id)).toEqual(['primary', 'secondary']);
+		expect(rows[0]).toEqual({
+			id: 'primary',
+			label: 'Primary',
+			userCreated: false,
+			preview: { background: '#3633e1', color: '#ffffff', borderRadius: '0.5rem' },
+		});
+		expect(rows[1].preview).toEqual({ background: 'transparent', color: '#3633e1', borderRadius: '0.25rem' });
+	});
+
+	it('falls back to the slug for a label-less preset', () => {
+		const payload = { userCreated: [], presets: { outline: { tokens: {} } } };
+
+		expect(presetRows(payload, values)[0].label).toBe('outline');
+	});
+
+	it('marks userCreated true only for the listed slugs', () => {
+		const payload = {
+			userCreated: ['outline'],
+			presets: { primary: { tokens: {} }, outline: { tokens: {} } },
+		};
+
+		const rows = presetRows(payload, values);
+
+		expect(rows.find((row) => row.id === 'primary').userCreated).toBe(false);
+		expect(rows.find((row) => row.id === 'outline').userCreated).toBe(true);
+	});
+
+	it('marks nothing user-created when the payload has no userCreated key (fail closed)', () => {
+		const payload = { presets: { primary: { tokens: {} }, outline: { tokens: {} } } };
+
+		const rows = presetRows(payload, values);
+
+		expect(rows.every((row) => row.userCreated === false)).toBe(true);
+	});
+});
+
+describe('presetInitialValues', () => {
+	it('seeds all five bound properties as bare ids', () => {
+		const payload = {
+			presets: {
+				primary: {
+					label: 'Primary',
+					tokens: {
+						'button-bg': '{semantic.color.action-primary}',
+						'button-text': '{semantic.color.on-primary}',
+						'button-bg-hover': '{semantic.color.action-primary-hover}',
+						'button-text-hover': '{semantic.color.on-primary}',
+						'button-radius': '0.5rem',
+					},
+				},
+			},
+		};
+
+		expect(presetInitialValues(payload, 'primary')).toEqual({
+			label: 'Primary',
+			tokens: {
+				'button-bg': 'semantic.color.action-primary',
+				'button-text': 'semantic.color.on-primary',
+				'button-bg-hover': 'semantic.color.action-primary-hover',
+				'button-text-hover': 'semantic.color.on-primary',
+				'button-radius': '0.5rem',
+			},
+		});
+	});
+
+	it('returns null for an unknown slug', () => {
+		expect(presetInitialValues({ presets: {} }, 'missing')).toBeNull();
+	});
+});
+
+describe('presetSaveTokens', () => {
+	it('wraps bare ids as aliases', () => {
+		expect(presetSaveTokens({ 'button-bg': 'semantic.color.action-primary' })).toEqual({
+			'button-bg': '{semantic.color.action-primary}',
+		});
+	});
+
+	it('passes an already-wrapped alias through unchanged', () => {
+		expect(presetSaveTokens({ 'button-bg': '{semantic.color.action-primary}' })).toEqual({
+			'button-bg': '{semantic.color.action-primary}',
+		});
+	});
+
+	it('passes a literal value through unchanged', () => {
+		expect(presetSaveTokens({ 'button-bg': 'transparent' })).toEqual({ 'button-bg': 'transparent' });
+	});
+});
+
+describe('nextPresetSlug', () => {
+	it('mints the bare base when free', () => {
+		expect(nextPresetSlug([], 'button')).toBe('button');
+	});
+
+	it('mints a numeric suffix against taken slugs', () => {
+		expect(nextPresetSlug(['button'], 'button')).toBe('button-2');
+		expect(nextPresetSlug(['button', 'button-2'], 'button')).toBe('button-3');
+	});
+});

--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -7,6 +7,7 @@ import {
 	presetInitialValues,
 	presetSaveTokens,
 	nextPresetSlug,
+	getButtonPresetProperties,
 } from '../helpers/presets';
 
 describe('aliasToId', () => {
@@ -122,7 +123,19 @@ describe('presetRows', () => {
 });
 
 describe('presetInitialValues', () => {
+	afterEach(() => {
+		delete window.kadenceDesignTokens;
+	});
+
 	it('seeds all five bound properties as bare ids', () => {
+		window.kadenceDesignTokens = {
+			presets: {
+				'kadence/singlebtn': {
+					properties: ['button-bg', 'button-text', 'button-bg-hover', 'button-text-hover', 'button-radius'],
+				},
+			},
+		};
+
 		const payload = {
 			presets: {
 				primary: {
@@ -170,6 +183,42 @@ describe('presetSaveTokens', () => {
 
 	it('passes a literal value through unchanged', () => {
 		expect(presetSaveTokens({ 'button-bg': 'transparent' })).toEqual({ 'button-bg': 'transparent' });
+	});
+});
+
+describe('getButtonPresetProperties', () => {
+	afterEach(() => {
+		delete window.kadenceDesignTokens;
+	});
+
+	it('derives the property list from the feed when present', () => {
+		window.kadenceDesignTokens = {
+			presets: {
+				'kadence/singlebtn': {
+					properties: ['button-bg', 'button-text', 'button-radius'],
+				},
+			},
+		};
+
+		expect(getButtonPresetProperties()).toEqual(['button-bg', 'button-text', 'button-radius']);
+	});
+
+	it('throws when the feed is absent', () => {
+		delete window.kadenceDesignTokens;
+
+		expect(() => getButtonPresetProperties()).toThrow(/properties is missing or empty/);
+	});
+
+	it('throws when the button block is missing from the feed', () => {
+		window.kadenceDesignTokens = { presets: { 'kadence/other-block': { properties: ['x'] } } };
+
+		expect(() => getButtonPresetProperties()).toThrow(/properties is missing or empty/);
+	});
+
+	it('throws when the feed has an empty properties array', () => {
+		window.kadenceDesignTokens = { presets: { 'kadence/singlebtn': { properties: [] } } };
+
+		expect(() => getButtonPresetProperties()).toThrow(/properties is missing or empty/);
 	});
 });
 

--- a/src/style-library/helpers/presets.js
+++ b/src/style-library/helpers/presets.js
@@ -1,0 +1,201 @@
+/**
+ * Pure preset payload/row/slug helpers for the Button preset screen (and, unchanged, any preset
+ * screen that reuses this contract): mapping a preset GET payload to row view models, the
+ * alias<->id codec the preset write surface needs (presets store `{dot.path}` aliases, not bare
+ * ids), resolving a stored token value (alias or literal) against the feed's resolved value map,
+ * seeding a settings-panel draft, and minting the next free preset slug. No React, no JSX, no
+ * REST — see `hooks/use-button-presets.js` for the state binding and `api/client.js` for the REST
+ * wrappers this module's output feeds.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { nextScaleSlug } from './scale';
+
+/**
+ * The frozen bound surface a button preset defines, in the order the panel and previews read it.
+ * The single JS spelling of the properties `declarations.php` binds for the button block — every
+ * seed, save, and preview walk goes through this list, so this app can never write a property the
+ * server's `guard_surface` would reject as unbound.
+ *
+ * @since TBD
+ */
+export const BUTTON_PRESET_PROPERTIES = [
+	'button-bg',
+	'button-text',
+	'button-bg-hover',
+	'button-text-hover',
+	'button-radius',
+];
+
+/**
+ * Convert a stored alias to its bare dot-path id. A value that is not brace-wrapped (a literal) is
+ * returned verbatim.
+ *
+ * @param {string} value The stored token value, e.g. `'{semantic.color.action-primary}'`.
+ *
+ * @since TBD
+ *
+ * @return {string} The bare id, or the literal value unchanged.
+ */
+export function aliasToId(value) {
+	if (typeof value !== 'string' || !value.startsWith('{') || !value.endsWith('}')) {
+		return value;
+	}
+
+	return value.slice(1, -1);
+}
+
+/**
+ * Whether a bare string is a token dot-path id rather than a literal value. Every registered
+ * token id lives under one of the document's two roots (`primitive.*` or `semantic.*` — see the
+ * baseline's top-level keys), which a raw literal (a color, a CSS dimension) never starts with,
+ * even one that happens to contain a dot (e.g. `'0.5rem'`).
+ *
+ * @param {string} value The candidate value.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the value is shaped like a token id.
+ */
+function looksLikeTokenId(value) {
+	return typeof value === 'string' && (value.startsWith('primitive.') || value.startsWith('semantic.'));
+}
+
+/**
+ * Convert a bare dot-path id to its alias form for writing. A value already brace-wrapped, empty,
+ * or not shaped like a token id (a literal color, dimension, etc.) is returned verbatim.
+ *
+ * @param {string} value A bare dot-path id, e.g. `'semantic.color.action-primary'`.
+ *
+ * @since TBD
+ *
+ * @return {string} The alias-wrapped value.
+ */
+export function idToAlias(value) {
+	if (!looksLikeTokenId(value)) {
+		return value;
+	}
+
+	return `{${value}}`;
+}
+
+/**
+ * Resolve a stored preset token value against the feed's resolved value map: an alias resolves to
+ * its target's resolved value, a literal is returned as-is, and an alias pointing at nothing
+ * resolves to an empty string.
+ *
+ * @param {Record<string, string>} values The feed's resolved value map (`feed.values`).
+ * @param {string}                 value  The stored token value (alias or literal).
+ *
+ * @since TBD
+ *
+ * @return {string} The resolved value, or `''` for a dangling alias.
+ */
+export function resolveTokenValue(values, value) {
+	if (typeof value !== 'string' || !value.startsWith('{') || !value.endsWith('}')) {
+		return value ?? '';
+	}
+
+	return values?.[aliasToId(value)] ?? '';
+}
+
+/**
+ * Map a block's preset GET payload to the row view models a preset screen renders, in payload
+ * order.
+ *
+ * `userCreated` is read fail-closed: a payload with no `userCreated` key (an older server) marks
+ * every row baseline, mirroring `helpers/token-capabilities.js`'s fail-closed default.
+ *
+ * @param {{presets?: Record<string, {label?: string, tokens?: Record<string, string>}>, userCreated?: string[]}} payload The preset GET payload.
+ * @param {Record<string, string>}                                                                                 values  The feed's resolved value map.
+ *
+ * @since TBD
+ *
+ * @return {Array<{id: string, label: string, userCreated: boolean, preview: {background: string, color: string, borderRadius: string}}>} The preset rows.
+ */
+export function presetRows(payload, values) {
+	const presets = payload?.presets ?? {};
+	const userCreated = Array.isArray(payload?.userCreated) ? payload.userCreated : [];
+
+	return Object.entries(presets).map(([slug, preset]) => {
+		const tokens = preset?.tokens ?? {};
+
+		return {
+			id: slug,
+			label: preset?.label ?? slug,
+			userCreated: userCreated.includes(slug),
+			preview: {
+				background: resolveTokenValue(values, tokens['button-bg']),
+				color: resolveTokenValue(values, tokens['button-text']),
+				borderRadius: resolveTokenValue(values, tokens['button-radius']),
+			},
+		};
+	});
+}
+
+/**
+ * Seed a settings-panel draft for one preset: its label and its bound properties as bare ids
+ * (ready for a token picker), or `null` for an unknown slug — the `scaleInitialValues` null
+ * contract a stale-open-item self-heal relies on.
+ *
+ * @param {{presets?: Record<string, {label?: string, tokens?: Record<string, string>}>}} payload The preset GET payload.
+ * @param {string}                                                                        slug    The preset slug to seed.
+ *
+ * @since TBD
+ *
+ * @return {?{label: string, tokens: Record<string, string>}} The seeded draft, or null.
+ */
+export function presetInitialValues(payload, slug) {
+	const preset = payload?.presets?.[slug];
+
+	if (!preset) {
+		return null;
+	}
+
+	const tokens = preset.tokens ?? {};
+
+	return {
+		label: preset.label ?? slug,
+		tokens: BUTTON_PRESET_PROPERTIES.reduce((acc, property) => {
+			acc[property] = aliasToId(tokens[property] ?? '');
+			return acc;
+		}, {}),
+	};
+}
+
+/**
+ * Build the write-side token map from a settings-panel draft: each present entry wrapped as an
+ * alias (or passed through when already an alias or a literal). Only the keys present in the
+ * draft are sent.
+ *
+ * @param {Record<string, string>} draftTokens The panel's draft token map (bare ids).
+ *
+ * @since TBD
+ *
+ * @return {Record<string, string>} The property => alias-or-literal map ready for the write.
+ */
+export function presetSaveTokens(draftTokens) {
+	return Object.entries(draftTokens ?? {}).reduce((acc, [property, value]) => {
+		acc[property] = idToAlias(value);
+		return acc;
+	}, {});
+}
+
+/**
+ * Mint the first free preset slug for a new button preset: the bare base first, then the base
+ * with a numeric suffix. Delegates to `nextScaleSlug` — a preset slug has no dots, so the
+ * terminal-segment extraction that helper performs is the identity, and the collision semantics
+ * (sanitize_key's lowercase fixed point) are the same for both.
+ *
+ * @param {string[]} existingSlugs The preset slugs already taken.
+ * @param {string}   base          The slug stem, e.g. `'button'`.
+ *
+ * @since TBD
+ *
+ * @return {string} The first free slug.
+ */
+export function nextPresetSlug(existingSlugs, base) {
+	return nextScaleSlug(existingSlugs, base);
+}

--- a/src/style-library/helpers/presets.js
+++ b/src/style-library/helpers/presets.js
@@ -12,22 +12,43 @@
  * Internal dependencies
  */
 import { nextScaleSlug } from './scale';
+import { getDesignTokensFeed } from './tokens';
 
 /**
- * The frozen bound surface a button preset defines, in the order the panel and previews read it.
- * The single JS spelling of the properties `declarations.php` binds for the button block — every
- * seed, save, and preview walk goes through this list, so this app can never write a property the
- * server's `guard_surface` would reject as unbound.
+ * The block whose preset bindings this module reads off the feed.
  *
  * @since TBD
  */
-export const BUTTON_PRESET_PROPERTIES = [
-	'button-bg',
-	'button-text',
-	'button-bg-hover',
-	'button-text-hover',
-	'button-radius',
-];
+const BUTTON_BLOCK = 'kadence/singlebtn';
+
+/**
+ * The button's bound property surface, in the order the panel and previews read it. Derived from
+ * the localized feed (`feed.presets['kadence/singlebtn'].properties`, itself
+ * `array_keys( $bindings->bindings )` off `declarations.php` — see
+ * `Design_Tokens\Admin\Feed\Presets::all()`), so this app can never drift from the properties the
+ * server's `guard_surface` accepts as bound. On the Style Library screen the feed is always
+ * present — it is inline-scripted onto the page before this bundle runs (see
+ * `Design_Tokens\Admin\Feed\Localizer`) — so a missing or empty surface here is a genuine bug, not
+ * a normal condition. Throwing surfaces that bug immediately instead of letting every preset seed
+ * and save silently no-op, which would be data loss with no error.
+ *
+ * @since TBD
+ *
+ * @throws {Error} When the feed has no non-empty `properties` array for the button block.
+ *
+ * @return {string[]} The button's bound property ids, in read order.
+ */
+export function getButtonPresetProperties() {
+	const properties = getDesignTokensFeed()?.presets?.[BUTTON_BLOCK]?.properties;
+
+	if (!Array.isArray(properties) || properties.length === 0) {
+		throw new Error(
+			`getButtonPresetProperties: feed.presets['${BUTTON_BLOCK}'].properties is missing or empty. Check the Design_Tokens\\Admin\\Feed\\Localizer output for this screen.`
+		);
+	}
+
+	return properties;
+}
 
 /**
  * Convert a stored alias to its bare dot-path id. A value that is not brace-wrapped (a literal) is
@@ -158,7 +179,7 @@ export function presetInitialValues(payload, slug) {
 
 	return {
 		label: preset.label ?? slug,
-		tokens: BUTTON_PRESET_PROPERTIES.reduce((acc, property) => {
+		tokens: getButtonPresetProperties().reduce((acc, property) => {
 			acc[property] = aliasToId(tokens[property] ?? '');
 			return acc;
 		}, {}),

--- a/src/style-library/hooks/use-button-presets.js
+++ b/src/style-library/hooks/use-button-presets.js
@@ -1,0 +1,90 @@
+/**
+ * Fetch-and-bind hook for a block's preset collection — the `use-libraries.js` shape (a state slot
+ * plus an effect that re-fetches), not `useScaleScreen`'s live-feed-in-hand shape, because presets
+ * have no counterpart in the localized feed: there is no group to map, so the payload has to be
+ * fetched on its own.
+ *
+ * Takes the block name as an argument (default the Button block) so a later preset screen built on
+ * the same contract can reuse this hook unchanged.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useMemo, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { fetchBlockPresets } from '../api/client';
+import { presetInitialValues, presetRows } from '../helpers/presets';
+
+/**
+ * The block this app's Button screen edits.
+ *
+ * @since TBD
+ */
+const BUTTON_BLOCK = 'kadence/singlebtn';
+
+/**
+ * Fetch a block's preset collection and bind it to row view models.
+ *
+ * Re-fetches whenever the library slug or version changes — the version bumps on every preset
+ * write's `refreshFeed`, which is the cross-slot invalidation signal a sibling settings panel's
+ * save relies on to make this hook's rows current again.
+ *
+ * @param {Object} library The design-tokens feed hook's return value (`useDesignTokensFeed()`).
+ * @param {string} block   The block name whose presets are fetched.
+ *
+ * @since TBD
+ *
+ * @return {{payload: ?object, isLoading: boolean, loadError: ?Error, rows: Array<Object>, initialValuesFor: Function}}
+ */
+export function useButtonPresets(library, block = BUTTON_BLOCK) {
+	const [payload, setPayload] = useState(null);
+	const [isLoading, setIsLoading] = useState(true);
+	const [loadError, setLoadError] = useState(null);
+
+	const namespace = library?.rest?.namespace;
+	const slug = library?.slug;
+	const version = library?.version;
+
+	useEffect(() => {
+		if (!namespace || !slug) {
+			return;
+		}
+
+		let cancelled = false;
+
+		setIsLoading(true);
+		setLoadError(null);
+
+		fetchBlockPresets(namespace, block, slug)
+			.then((result) => {
+				if (!cancelled) {
+					setPayload(result);
+				}
+			})
+			.catch((err) => {
+				if (!cancelled) {
+					setLoadError(err);
+				}
+			})
+			.finally(() => {
+				if (!cancelled) {
+					setIsLoading(false);
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [namespace, block, slug, version]);
+
+	const rows = useMemo(() => presetRows(payload, library?.values), [payload, library?.values]);
+
+	const initialValuesFor = (presetSlug) => presetInitialValues(payload, presetSlug);
+
+	return { payload, isLoading, loadError, rows, initialValuesFor };
+}


### PR DESCRIPTION
Pure preset payload/row/slug helpers, plus the `useButtonPresets` fetch-and-bind hook. Nothing renders them yet — this is the data layer the screen above consumes.

## Test instructions

1. Run `npx wp-scripts test-unit-js src/style-library/__tests__/presets.test.js`.
2. Read `presetInitialValues` and the slug helpers against the payload shape from the endpoint in the slice below — the contract between them is the thing worth reviewing here.
3. There is no UI to click at this slice.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4083/phase-1b-preset-helpers-hook
bun run build-wp
```

The Style Library is at **WP Admin → Kadence → Style Library**. The Button preset screen is under **Block Presets → Button**. Block-editor checks use a **Kadence Single Button** block on any post.
</details>

---

Slice 2 of 23 in the SOFT-4083 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading and displaying button presets from the style library.
  * Added preset data handling, including token values, editable drafts, saved settings, and automatic preset naming.
  * Added loading and error states for preset retrieval.

* **Tests**
  * Added comprehensive coverage for preset conversion, resolution, mapping, validation, serialization, and slug generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->