### PR TITLE
[DTM] SOFT-4083 [3/23]: Button preset screen shell

### DIFF
--- a/src/style-library/__tests__/button-screen.test.js
+++ b/src/style-library/__tests__/button-screen.test.js
@@ -1,0 +1,127 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { ButtonScreen } from '../components/pages/ButtonScreen';
+import { useButtonPresets } from '../hooks/use-button-presets';
+
+// A factory: `use-button-presets.js` pulls in `../api/client`, which imports `@wordpress/api-fetch`
+// (externalized to the `wp.apiFetch` global in production, not an installed npm dependency), so
+// automocking would fail to resolve it. The screen only reads the hook's return value, so a bare
+// jest.fn() stand-in is enough.
+jest.mock('../hooks/use-button-presets', () => ({
+	useButtonPresets: jest.fn(),
+}));
+
+// `jest.config.js` maps the `@wordpress/components` specifier to the copy nested under
+// `@kadence/components/node_modules`, which resolves its own nested `react`/`react-dom` — a
+// different module instance than the top-level `react-dom/client` this test renders with. Mounting
+// a real `Button`/`Notice`/`Spinner` from that nested copy under the top-level renderer trips
+// React's "Invalid hook call" guard. Simple stand-ins sidestep the cross-copy mismatch; this test
+// only needs to tell the loading/empty/populated states apart, not exercise the real controls.
+jest.mock('@wordpress/components', () => ({
+	Button: ({ children, ...props }) => <button {...props}>{children}</button>,
+	Notice: ({ children, ...props }) => <div {...props}>{children}</div>,
+	Spinner: (props) => <div className="components-spinner" {...props} />,
+}));
+
+const LIBRARY = { rest: { namespace: 'kb-design-tokens/v1' }, slug: 'default', version: 1, values: {} };
+
+let container;
+let root;
+
+/**
+ * Render `ButtonScreen` with the given `useButtonPresets` stub and return the mounted container.
+ *
+ * @param {Object} presets The `useButtonPresets` return value to stub.
+ *
+ * @since TBD
+ *
+ * @return {HTMLElement} The container the screen was rendered into.
+ */
+function renderButtonScreen(presets) {
+	useButtonPresets.mockReturnValue(presets);
+
+	act(() => {
+		root.render(
+			createElement(ButtonScreen, {
+				label: 'Button',
+				route: { screen: 'blocks/kadence/singlebtn', item: '' },
+				navigate: () => {},
+				library: LIBRARY,
+			})
+		);
+	});
+
+	return container;
+}
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+	useButtonPresets.mockReset();
+});
+
+afterEach(() => {
+	act(() => {
+		root.unmount();
+	});
+	container.remove();
+});
+
+describe('ButtonScreen loading state', () => {
+	/**
+	 * While `useButtonPresets` is still fetching, the screen must show a busy indicator instead of
+	 * the empty state — `useButtonPresets` starts with `isLoading: true` and no rows, and rendering
+	 * the empty state at that point would flash "Add Button" before the presets arrive.
+	 *
+	 * @return {void}
+	 */
+	it('renders a spinner instead of the empty state while loading', () => {
+		renderButtonScreen({ payload: null, isLoading: true, loadError: null, rows: [], initialValuesFor: () => ({}) });
+
+		expect(container.querySelector('.components-spinner')).not.toBeNull();
+		expect(container.querySelector('.kadence-blocks-style-library__empty-state')).toBeNull();
+	});
+
+	/**
+	 * Once loading finishes with no rows, the empty state renders in place of the spinner.
+	 *
+	 * @return {void}
+	 */
+	it('renders the empty state once loading finishes with no rows', () => {
+		renderButtonScreen({ payload: {}, isLoading: false, loadError: null, rows: [], initialValuesFor: () => ({}) });
+
+		expect(container.querySelector('.components-spinner')).toBeNull();
+		expect(container.querySelector('.kadence-blocks-style-library__empty-state')).not.toBeNull();
+	});
+
+	/**
+	 * Once loading finishes with rows present, neither the spinner nor the empty state renders.
+	 *
+	 * @return {void}
+	 */
+	it('renders the rows once loading finishes with presets present', () => {
+		const rows = [
+			{
+				id: 'primary',
+				label: 'Primary',
+				preview: { background: '#111111', color: '#ffffff', borderRadius: '4px' },
+			},
+		];
+
+		renderButtonScreen({ payload: {}, isLoading: false, loadError: null, rows, initialValuesFor: () => ({}) });
+
+		expect(container.querySelector('.components-spinner')).toBeNull();
+		expect(container.querySelector('.kadence-blocks-style-library__empty-state')).toBeNull();
+		expect(container.querySelector('.kadence-blocks-style-library__row-list')).not.toBeNull();
+	});
+});

--- a/src/style-library/__tests__/button-screen.test.js
+++ b/src/style-library/__tests__/button-screen.test.js
@@ -10,6 +10,7 @@ import { createRoot } from 'react-dom/client';
  */
 import { ButtonScreen } from '../components/pages/ButtonScreen';
 import { useButtonPresets } from '../hooks/use-button-presets';
+import { useDraftChannel } from '../hooks/use-draft-channel';
 
 // A factory: `use-button-presets.js` pulls in `../api/client`, which imports `@wordpress/api-fetch`
 // (externalized to the `wp.apiFetch` global in production, not an installed npm dependency), so
@@ -25,9 +26,16 @@ jest.mock('../hooks/use-button-presets', () => ({
 // a real `Button`/`Notice`/`Spinner` from that nested copy under the top-level renderer trips
 // React's "Invalid hook call" guard. Simple stand-ins sidestep the cross-copy mismatch; this test
 // only needs to tell the loading/empty/populated states apart, not exercise the real controls.
+// The screen reads its draft overlay and its selection guard off this hook. Stubbed per test so
+// the overlay branch (which needs a publication for the open item) and the guard branch are
+// reachable without standing up the real provider.
+jest.mock('../hooks/use-draft-channel', () => ({
+	useDraftChannel: jest.fn(),
+}));
+
 jest.mock('@wordpress/components', () => ({
 	Button: ({ children, ...props }) => <button {...props}>{children}</button>,
-	Notice: ({ children, ...props }) => <div {...props}>{children}</div>,
+	Notice: ({ children, isDismissible, ...props }) => <div {...props}>{children}</div>,
 	Spinner: (props) => <div className="components-spinner" {...props} />,
 }));
 
@@ -39,21 +47,24 @@ let root;
 /**
  * Render `ButtonScreen` with the given `useButtonPresets` stub and return the mounted container.
  *
- * @param {Object} presets The `useButtonPresets` return value to stub.
+ * @param {Object}   presets    The `useButtonPresets` return value to stub.
+ * @param {Object}   [options]  Overrides for the props the selection and overlay paths read.
+ * @param {string}   [options.item]     The route's open `kb-item`.
+ * @param {Function} [options.navigate] The navigate spy.
  *
  * @since TBD
  *
  * @return {HTMLElement} The container the screen was rendered into.
  */
-function renderButtonScreen(presets) {
+function renderButtonScreen(presets, { item = '', navigate = () => {} } = {}) {
 	useButtonPresets.mockReturnValue(presets);
 
 	act(() => {
 		root.render(
 			createElement(ButtonScreen, {
 				label: 'Button',
-				route: { screen: 'blocks/kadence/singlebtn', item: '' },
-				navigate: () => {},
+				route: { screen: 'blocks/kadence/singlebtn', item },
+				navigate,
 				library: LIBRARY,
 			})
 		);
@@ -68,6 +79,8 @@ beforeEach(() => {
 	document.body.appendChild(container);
 	root = createRoot(container);
 	useButtonPresets.mockReset();
+	useDraftChannel.mockReset();
+	useDraftChannel.mockReturnValue(null);
 });
 
 afterEach(() => {
@@ -123,5 +136,146 @@ describe('ButtonScreen loading state', () => {
 		expect(container.querySelector('.components-spinner')).toBeNull();
 		expect(container.querySelector('.kadence-blocks-style-library__empty-state')).toBeNull();
 		expect(container.querySelector('.kadence-blocks-style-library__row-list')).not.toBeNull();
+	});
+});
+
+describe('ButtonScreen load failure', () => {
+	/**
+	 * A failed preset fetch renders its message as a notice. The list still renders, so a retry
+	 * that succeeds needs no remount.
+	 *
+	 * @return {void}
+	 */
+	it('renders the load error message and still renders the list', () => {
+		renderButtonScreen({
+			payload: null,
+			isLoading: false,
+			loadError: new Error('Request failed'),
+			rows: [],
+			initialValuesFor: () => ({}),
+		});
+
+		expect(container.textContent).toContain('Request failed');
+		expect(container.querySelector('.components-spinner')).toBeNull();
+	});
+});
+
+describe('ButtonScreen draft overlay', () => {
+	const ROWS = [
+		{
+			id: 'primary',
+			label: 'Primary',
+			preview: { background: '#111111', color: '#ffffff', borderRadius: '4px' },
+		},
+		{
+			id: 'secondary',
+			label: 'Secondary',
+			preview: { background: '#222222', color: '#ffffff', borderRadius: '4px' },
+		},
+	];
+
+	/**
+	 * A publication for the open item overlays that row's label, so the list shows what Save would
+	 * write rather than the last fetched value.
+	 *
+	 * @return {void}
+	 */
+	it('overlays the open row label from the draft publication', () => {
+		useDraftChannel.mockReturnValue({
+			publication: { itemId: 'primary', draft: { label: 'Primary edited' } },
+			guard: (fn) => fn(),
+		});
+
+		renderButtonScreen(
+			{ payload: {}, isLoading: false, loadError: null, rows: ROWS, initialValuesFor: () => ({}) },
+			{ item: 'primary' }
+		);
+
+		expect(container.textContent).toContain('Primary edited');
+		expect(container.textContent).toContain('Secondary');
+	});
+
+	/**
+	 * A publication belonging to a different item must not leak onto this screen's rows, so the
+	 * fetched labels stay as they are.
+	 *
+	 * @return {void}
+	 */
+	it('ignores a publication whose itemId is not the open item', () => {
+		useDraftChannel.mockReturnValue({
+			publication: { itemId: 'secondary', draft: { label: 'Leaked' } },
+			guard: (fn) => fn(),
+		});
+
+		renderButtonScreen(
+			{ payload: {}, isLoading: false, loadError: null, rows: ROWS, initialValuesFor: () => ({}) },
+			{ item: 'primary' }
+		);
+
+		expect(container.textContent).not.toContain('Leaked');
+		expect(container.textContent).toContain('Primary');
+	});
+});
+
+describe('ButtonScreen selection', () => {
+	const ROWS = [
+		{
+			id: 'primary',
+			label: 'Primary',
+			preview: { background: '#111111', color: '#ffffff', borderRadius: '4px' },
+		},
+		{
+			id: 'secondary',
+			label: 'Secondary',
+			preview: { background: '#222222', color: '#ffffff', borderRadius: '4px' },
+		},
+	];
+
+	/**
+	 * Selecting a different preset routes through the draft guard before navigating, so an unsaved
+	 * draft is never dropped silently.
+	 *
+	 * @return {void}
+	 */
+	it('routes a selection of another preset through the guard', () => {
+		const guard = jest.fn((fn) => fn());
+		const navigate = jest.fn();
+		useDraftChannel.mockReturnValue({ publication: null, guard });
+
+		renderButtonScreen(
+			{ payload: {}, isLoading: false, loadError: null, rows: ROWS, initialValuesFor: () => ({}) },
+			{ item: 'primary', navigate }
+		);
+
+		act(() => {
+			container.querySelectorAll('.kadence-blocks-style-library__list-row-main')[1].click();
+		});
+
+		expect(guard).toHaveBeenCalled();
+		expect(navigate).toHaveBeenCalledWith({ item: 'secondary' });
+	});
+
+	/**
+	 * Selecting the preset that is already open is a no-op that bypasses the guard entirely, so an
+	 * in-progress draft survives a stray click on its own row.
+	 *
+	 * @return {void}
+	 */
+	it('does nothing when the already-open preset is selected', () => {
+		const guard = jest.fn((fn) => fn());
+		const navigate = jest.fn();
+		useDraftChannel.mockReturnValue({ publication: null, guard });
+
+		renderButtonScreen(
+			{ payload: {}, isLoading: false, loadError: null, rows: ROWS, initialValuesFor: () => ({}) },
+			{ item: 'primary', navigate }
+		);
+
+		act(() => {
+			container.querySelectorAll('.kadence-blocks-style-library__list-row-main')[0].click();
+		});
+
+		expect(guard).not.toHaveBeenCalled();
+		expect(navigate).not.toHaveBeenCalled();
 	});
 });

--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -8,6 +8,7 @@ import {
 	presetSaveTokens,
 	nextPresetSlug,
 	getButtonPresetProperties,
+	overlayPresetRows,
 } from '../helpers/presets';
 
 describe('aliasToId', () => {
@@ -230,5 +231,68 @@ describe('nextPresetSlug', () => {
 	it('mints a numeric suffix against taken slugs', () => {
 		expect(nextPresetSlug(['button'], 'button')).toBe('button-2');
 		expect(nextPresetSlug(['button', 'button-2'], 'button')).toBe('button-3');
+	});
+});
+
+describe('overlayPresetRows', () => {
+	const values = {
+		'semantic.color.action-primary': '#3633e1',
+		'semantic.color.on-primary': '#ffffff',
+	};
+
+	const rows = [
+		{
+			id: 'primary',
+			label: 'Primary',
+			userCreated: false,
+			preview: { background: '#3633e1', color: '#ffffff', borderRadius: '0.5rem' },
+		},
+		{
+			id: 'secondary',
+			label: 'Secondary',
+			userCreated: false,
+			preview: { background: 'transparent', color: '#3633e1', borderRadius: '0.25rem' },
+		},
+	];
+
+	it('overlays label and re-resolved preview values for the matching row only', () => {
+		const draft = {
+			label: 'Primary CTA',
+			tokens: {
+				'button-bg': 'semantic.color.on-primary',
+				'button-text': 'semantic.color.action-primary',
+				'button-bg-hover': 'semantic.color.action-primary',
+				'button-text-hover': 'semantic.color.on-primary',
+				'button-radius': '1rem',
+			},
+		};
+
+		const next = overlayPresetRows(rows, 'primary', draft, values);
+
+		expect(next[0]).toEqual({
+			id: 'primary',
+			label: 'Primary CTA',
+			userCreated: false,
+			preview: { background: '#ffffff', color: '#3633e1', borderRadius: '1rem' },
+		});
+		expect(next[1]).toBe(rows[1]);
+	});
+
+	it('returns the same array reference for a null draft', () => {
+		expect(overlayPresetRows(rows, 'primary', null, values)).toBe(rows);
+	});
+
+	it('returns the same array reference for an item id matching no row', () => {
+		const draft = { label: 'Ghost', tokens: {} };
+
+		expect(overlayPresetRows(rows, 'missing', draft, values)).toBe(rows);
+	});
+
+	it('leaves non-matching rows object identity untouched', () => {
+		const draft = { label: 'Primary CTA', tokens: {} };
+
+		const next = overlayPresetRows(rows, 'primary', draft, values);
+
+		expect(next[1]).toBe(rows[1]);
 	});
 });

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -27,6 +27,7 @@ import { BorderWidthScreen } from '../components/pages/BorderWidthScreen';
 import { SpacingScreen } from '../components/pages/SpacingScreen';
 import { IconSizesScreen } from '../components/pages/IconSizesScreen';
 import { ShadowScreen } from '../components/pages/ShadowScreen';
+import '../components/pages/ButtonScreen';
 import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
 import { useLibraries } from '../hooks/use-libraries';
@@ -78,9 +79,8 @@ export function StyleLibraryApp() {
 	const blockPresetsNav = useMemo(() => buildBlockPresetsNav(feed.feed), [feed.feed]);
 
 	// Every Base Styles id without an entry in SCREEN_COMPONENTS resolves to the placeholder until
-	// its per-screen work lands, and the preset fallback is the placeholder until the first real
-	// preset screen ships.
-	// @todo SOFT-4083 / SOFT-4084: first real preset screens replace this fallback.
+	// its per-screen work lands, and the preset fallback stays the placeholder for any preset-bound
+	// block with no registered screen component on the preset-screens filter.
 	const registry = useMemo(() => {
 		const baseStyles = {};
 

--- a/src/style-library/components/pages/ButtonScreen.js
+++ b/src/style-library/components/pages/ButtonScreen.js
@@ -1,0 +1,140 @@
+/**
+ * The Button preset screen: self-registers for `kadence/singlebtn` on the preset-screens filter,
+ * exactly as a third party would (`constants/screens.js`'s `PRESET_SCREENS_FILTER` docblock). A
+ * header with a (for now inert) "+ Add Button" action over a `RowList` of preset rows, each showing
+ * a live-rendered Button chip resolved from the preset's bound color and radius tokens.
+ *
+ * This is a bespoke screen, not a `ScaleScreen` config: a preset row carries a five-property map
+ * with two states (Normal/Hover), not one scalar token value, so it composes the shared components
+ * directly. No settings panel yet — the static lands once the panel exists.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button, Notice } from '@wordpress/components';
+import { plus } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { ScreenHeader } from '../organisms/ScreenHeader';
+import { RowList } from '../templates/RowList';
+import { EmptyState } from '../molecules/EmptyState';
+import { useButtonPresets } from '../../hooks/use-button-presets';
+import { useDraftChannel } from '../../hooks/use-draft-channel';
+import { BUTTON_BLOCK, overlayPresetRows } from '../../helpers/presets';
+import { PRESET_SCREENS_FILTER } from '../../constants/screens';
+import './ButtonScreen.scss';
+
+/**
+ * The Button preset row's live preview chip: a non-interactive span reading "Button", styled from
+ * the row's resolved background/text/radius. Hover values are never previewed here — a static chip
+ * cannot honestly show `:hover`, the panel's Hover tab is the editing surface for that — and an
+ * unresolved value renders the property absent rather than an invented fallback.
+ *
+ * @param {{id: string, label: string, preview: {background: string, color: string, borderRadius: string}}} row The row descriptor.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The preview element.
+ */
+function renderButtonPreview(row) {
+	return (
+		<span
+			className="kadence-blocks-style-library__button-preset-preview"
+			style={{
+				background: row.preview.background || undefined,
+				color: row.preview.color || undefined,
+				borderRadius: row.preview.borderRadius || undefined,
+			}}
+		>
+			{__('Button', 'kadence-blocks')}
+		</span>
+	);
+}
+
+/**
+ * Render the Button screen body.
+ *
+ * @param {Object}   props          The component props.
+ * @param {string}   props.label    The PHP-fed nav label ("Button").
+ * @param {Object}   props.route    The current route (`{ screen, item }`).
+ * @param {Function} props.navigate The route navigator.
+ * @param {Object}   props.library  The design-tokens feed hook's return value.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The screen body.
+ */
+export function ButtonScreen({ label, route, navigate, library }) {
+	const presets = useButtonPresets(library);
+	const channel = useDraftChannel();
+
+	// Disabled with no handler until the mutations flow lands (decision 11): visible intent, not a
+	// hidden affordance.
+	const addAction = (
+		<Button icon={plus} variant="secondary" disabled>
+			{__('Add Button', 'kadence-blocks')}
+		</Button>
+	);
+
+	// Strictly keyed to the open route item — the `ScaleScreen.js` discipline — so a publication
+	// from a panel editing a different preset (or one that already unmounted) can never leak onto
+	// this screen's rows.
+	const draft =
+		channel && channel.publication && channel.publication.itemId === route.item ? channel.publication.draft : null;
+	const rows = overlayPresetRows(presets.rows, route.item, draft, library?.values);
+
+	const items = rows.map((row) => ({
+		id: row.id,
+		label: row.label,
+		preview: renderButtonPreview(row),
+		isDraggable: false,
+	}));
+
+	// Selecting the already-open preset is a no-op bypassing the guard entirely (the draft
+	// survives — `useSettingsPanel` only re-seeds on itemId change), the `ScaleScreen.js` pattern.
+	const selectPreset = (id) => {
+		if (id === route.item) {
+			return;
+		}
+
+		const run = () => navigate({ item: id });
+
+		channel ? channel.guard(run) : run();
+	};
+
+	return (
+		<div className="kadence-blocks-style-library__button-screen">
+			<ScreenHeader title={label} primaryAction={addAction} />
+			{presets.loadError && (
+				<Notice status="error" isDismissible={false}>
+					{presets.loadError.message}
+				</Notice>
+			)}
+			<RowList
+				items={items}
+				selectedId={route.item}
+				onSelect={selectPreset}
+				onReorder={() => {}}
+				empty={<EmptyState title={label} description={__('Add Button', 'kadence-blocks')} action={addAction} />}
+			/>
+		</div>
+	);
+}
+
+/**
+ * Register the Button screen for `kadence/singlebtn` on the public preset-screens filter, exactly
+ * as a third party would — the app never imports this component directly, so this module-scope
+ * call is the only registration path. `resolveScreen` (`helpers/screens.js`) applies the filter on
+ * every render, so a module-scope `addFilter` is race-free regardless of import order.
+ *
+ * @since TBD
+ */
+addFilter(PRESET_SCREENS_FILTER, 'kadence-blocks/style-library-button-screen', (screens) => ({
+	...screens,
+	[BUTTON_BLOCK]: ButtonScreen,
+}));

--- a/src/style-library/components/pages/ButtonScreen.js
+++ b/src/style-library/components/pages/ButtonScreen.js
@@ -12,7 +12,7 @@
 /**
  * WordPress dependencies
  */
-import { Button, Notice } from '@wordpress/components';
+import { Button, Notice, Spinner } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
@@ -115,13 +115,19 @@ export function ButtonScreen({ label, route, navigate, library }) {
 					{presets.loadError.message}
 				</Notice>
 			)}
-			<RowList
-				items={items}
-				selectedId={route.item}
-				onSelect={selectPreset}
-				onReorder={() => {}}
-				empty={<EmptyState title={label} description={__('Add Button', 'kadence-blocks')} action={addAction} />}
-			/>
+			{presets.isLoading ? (
+				<Spinner />
+			) : (
+				<RowList
+					items={items}
+					selectedId={route.item}
+					onSelect={selectPreset}
+					onReorder={() => {}}
+					empty={
+						<EmptyState title={label} description={__('Add Button', 'kadence-blocks')} action={addAction} />
+					}
+				/>
+			)}
 		</div>
 	);
 }

--- a/src/style-library/components/pages/ButtonScreen.scss
+++ b/src/style-library/components/pages/ButtonScreen.scss
@@ -33,7 +33,5 @@
 	font-weight: var(--kb-sl-font-weight-medium);
 	line-height: var(--kb-sl-line-height-s);
 	white-space: nowrap;
-	// Only the three properties `ButtonScreen.js` sets inline from the preset (background, color,
-	// border-radius) ease between values, so a preset swap doesn't snap in abruptly.
 	transition: background-color 300ms ease, color 300ms ease, border-radius 300ms ease;
 }

--- a/src/style-library/components/pages/ButtonScreen.scss
+++ b/src/style-library/components/pages/ButtonScreen.scss
@@ -33,4 +33,7 @@
 	font-weight: var(--kb-sl-font-weight-medium);
 	line-height: var(--kb-sl-line-height-s);
 	white-space: nowrap;
+	// Only the three properties `ButtonScreen.js` sets inline from the preset (background, color,
+	// border-radius) ease between values, so a preset swap doesn't snap in abruptly.
+	transition: background-color 300ms ease, color 300ms ease, border-radius 300ms ease;
 }

--- a/src/style-library/components/pages/ButtonScreen.scss
+++ b/src/style-library/components/pages/ButtonScreen.scss
@@ -1,0 +1,36 @@
+// The chip is content-sized (a button-shaped label, not a swatch), so this screen's rows relax
+// `ListRow`'s default framed 80px preview slot — the Spacing/Icon Sizes/Shadow slot-override
+// precedent — rather than squeezing the chip into a square frame it was never designed for.
+.kadence-blocks-style-library__button-screen .kadence-blocks-style-library__list-row-preview {
+	width: auto;
+	height: auto;
+	border: 0;
+	background: transparent;
+	overflow: visible;
+}
+
+// Preset names are full words ("Primary Outline"), not the short numeric labels the shared 4rem
+// column was sized for, so this screen widens its own label column instead of wrapping every name
+// onto two or three lines.
+.kadence-blocks-style-library__button-screen .kadence-blocks-style-library__list-row-label {
+	width: 15rem;
+}
+
+// The live Button chip. `border` stays transparent so a background-less preset (an unresolved or
+// dangling token) does not draw a stray line, while `outline` gives every chip a hairline edge from
+// a neutral token so a preset whose background matches the page (the board's Secondary preset)
+// still reads as a discrete shape. Pixel fidelity against the Figma is the polish phase's job — this
+// only guarantees the chip is never invisible.
+.kadence-blocks-style-library__button-preset-preview {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: var(--kb-sl-space-10) var(--kb-sl-space-20);
+	border: 1px solid transparent;
+	outline: 1px solid var(--kb-sl-color-gray-200);
+	outline-offset: -1px;
+	font-size: var(--kb-sl-font-size-small);
+	font-weight: var(--kb-sl-font-weight-medium);
+	line-height: var(--kb-sl-line-height-s);
+	white-space: nowrap;
+}

--- a/src/style-library/helpers/presets.js
+++ b/src/style-library/helpers/presets.js
@@ -15,11 +15,13 @@ import { nextScaleSlug } from './scale';
 import { getDesignTokensFeed } from './tokens';
 
 /**
- * The block whose preset bindings this module reads off the feed.
+ * The block name the Button preset screen edits — the single JS spelling, so the preset-screens
+ * filter registration, the fetch-and-bind hook, and any future preset screen reusing this contract
+ * never risk a typo'd duplicate.
  *
  * @since TBD
  */
-const BUTTON_BLOCK = 'kadence/singlebtn';
+export const BUTTON_BLOCK = 'kadence/singlebtn';
 
 /**
  * The button's bound property surface, in the order the panel and previews read it. Derived from
@@ -219,4 +221,53 @@ export function presetSaveTokens(draftTokens) {
  */
 export function nextPresetSlug(existingSlugs, base) {
 	return nextScaleSlug(existingSlugs, base);
+}
+
+/**
+ * Overlay a live settings-panel draft onto the row it edits: the label and a preview re-resolved
+ * from the draft's token map (bare ids), so the row chip always shows what Save would write instead
+ * of waiting for it — the preset analog of `overlayDraft` (`helpers/scale.js`), same
+ * reference-identity contract. Returns the exact same array reference for a `null`/absent draft or
+ * an `itemId` matching no row; every non-matching row keeps its exact object identity either way.
+ *
+ * @param {Array<{id: string, label: string, preview: {background: string, color: string, borderRadius: string}}>} rows   The rows in payload order.
+ * @param {string}                                                                                                   itemId The open route item id.
+ * @param {?{label?: string, tokens?: Record<string, string>}}                                                      draft  The open panel's live draft, or null.
+ * @param {Record<string, string>}                                                                                   values The feed's resolved value map.
+ *
+ * @since TBD
+ *
+ * @return {Array<Object>} The rows, with the matching row's label/preview overlaid.
+ */
+export function overlayPresetRows(rows, itemId, draft, values) {
+	if (!draft || !itemId) {
+		return rows;
+	}
+
+	const index = rows.findIndex((row) => row.id === itemId);
+
+	if (index === -1) {
+		return rows;
+	}
+
+	const overlaid = { ...rows[index] };
+
+	if (Object.prototype.hasOwnProperty.call(draft, 'label')) {
+		overlaid.label = draft.label;
+	}
+
+	if (draft.tokens) {
+		const resolveDraftToken = (property) => resolveTokenValue(values, idToAlias(draft.tokens[property] ?? ''));
+
+		overlaid.preview = {
+			background: resolveDraftToken('button-bg'),
+			color: resolveDraftToken('button-text'),
+			borderRadius: resolveDraftToken('button-radius'),
+		};
+	}
+
+	const next = [...rows];
+	next[index] = overlaid;
+
+	return next;
 }

--- a/src/style-library/hooks/use-button-presets.js
+++ b/src/style-library/hooks/use-button-presets.js
@@ -17,14 +17,7 @@ import { useEffect, useMemo, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { fetchBlockPresets } from '../api/client';
-import { presetInitialValues, presetRows } from '../helpers/presets';
-
-/**
- * The block this app's Button screen edits.
- *
- * @since TBD
- */
-const BUTTON_BLOCK = 'kadence/singlebtn';
+import { BUTTON_BLOCK, presetInitialValues, presetRows } from '../helpers/presets';
 
 /**
  * Fetch a block's preset collection and bind it to row view models.


### PR DESCRIPTION
Registers the Button screen in the Style Library and adds its shell, plus `overlayPresetRows`.

## Test instructions

1. Go to **Style Library → Block Presets → Button**.
2. Confirm the Primary and Secondary rows render with a live preview of each preset.
3. **Add Button should be disabled** and there should be no drag handles — both land in later slices. Selecting a row updates `kb-item` in the URL but has no visible effect yet: the settings panel arrives in slice 5.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4083/phase-2-button-screen-shell
bun run build-wp
```

The Style Library is at **WP Admin → Kadence → Style Library**. The Button preset screen is under **Block Presets → Button**. Block-editor checks use a **Kadence Single Button** block on any post.
</details>

## Screenshot

Button preset screen shell, Add Button disabled and no drag handles<img width="1512" height="788" alt="phase-2-button-screen-shell" src="https://github.com/user-attachments/assets/f24816a8-5fed-4113-8e71-62af8b81c5fc" />

---

Slice 3 of 23 in the SOFT-4083 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Button preset screen with live previews, preset selection, loading feedback, and an “Add Button” action.
  * Button previews now show labels and styling including colors, typography, spacing, and corner radius.
  * Draft button changes are reflected immediately in matching preset previews.

* **Bug Fixes**
  * Unregistered preset-based blocks now consistently fall back to the placeholder screen.
  * Preset previews preserve unchanged entries when no matching draft is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
