### PR TITLE
[DTM] SOFT-4083 [4/23]: Token color select field

### DIFF
--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -9,6 +9,8 @@ import {
 	nextPresetSlug,
 	getButtonPresetProperties,
 	overlayPresetRows,
+	resolveSwatchColor,
+	buttonSettingsSchema,
 } from '../helpers/presets';
 
 describe('aliasToId', () => {
@@ -294,5 +296,45 @@ describe('overlayPresetRows', () => {
 		const next = overlayPresetRows(rows, 'primary', draft, values);
 
 		expect(next[1]).toBe(rows[1]);
+	});
+});
+
+describe('resolveSwatchColor', () => {
+	const options = [{ id: 'semantic.color.action-primary', value: '#3633e1' }];
+	const values = { 'semantic.color.action-primary': '#000000', 'primitive.color.gray-100': '#eeeeee' };
+
+	it("prefers the matching option's own resolved value", () => {
+		expect(resolveSwatchColor(options, values, 'semantic.color.action-primary')).toBe('#3633e1');
+	});
+
+	it('falls back to the values map for an id outside the options pool', () => {
+		expect(resolveSwatchColor(options, values, 'primitive.color.gray-100')).toBe('#eeeeee');
+	});
+
+	it('returns an empty string when unresolvable by either source', () => {
+		expect(resolveSwatchColor(options, values, 'semantic.color.does-not-exist')).toBe('');
+	});
+});
+
+describe('buttonSettingsSchema', () => {
+	it('lists NAME, the Text/Background color fields, and the role-narrowed Radius field on the Normal tab', () => {
+		const schema = buttonSettingsSchema('normal');
+		const paths = schema.panels.flatMap((panel) => panel.fields.map((field) => field.path));
+
+		expect(paths).toEqual(['label', 'tokens.button-text', 'tokens.button-bg', 'tokens.button-radius']);
+
+		const radiusField = schema.panels
+			.flatMap((panel) => panel.fields)
+			.find((field) => field.path === 'tokens.button-radius');
+
+		expect(radiusField).toMatchObject({ type: 'token-select', tokenType: 'dimension', role: 'radius' });
+	});
+
+	it('lists NAME and the hover color fields, with no radius field, on the Hover tab', () => {
+		const schema = buttonSettingsSchema('hover');
+		const paths = schema.panels.flatMap((panel) => panel.fields.map((field) => field.path));
+
+		expect(paths).toEqual(['label', 'tokens.button-text-hover', 'tokens.button-bg-hover']);
+		expect(paths).not.toContain('tokens.button-radius');
 	});
 });

--- a/src/style-library/__tests__/tokens.test.js
+++ b/src/style-library/__tests__/tokens.test.js
@@ -3,9 +3,11 @@ import {
 	buildTokenLeaf,
 	flattenSchemaTokens,
 	isResponsiveType,
+	pickableTokensForType,
 	refreshFeedFlow,
 	tokenTypeIdSegment,
 } from '../helpers/tokens';
+import { PICKABLE_TOKENS_GLOBAL } from '../constants';
 
 describe('tokenTypeIdSegment', () => {
 	it('maps every camelCase $type to its registered kebab id segment', () => {
@@ -157,6 +159,52 @@ describe('buildTokenLeaf', () => {
 		});
 
 		expect(leaf.$extensions).toBeUndefined();
+	});
+});
+
+describe('pickableTokensForType', () => {
+	const originalPool = window[PICKABLE_TOKENS_GLOBAL];
+	const originalFeed = window.kadenceDesignTokens;
+
+	beforeEach(() => {
+		window.kadenceDesignTokens = { slug: 'brand' };
+		window[PICKABLE_TOKENS_GLOBAL] = {
+			tokens: [
+				{ id: 'semantic.color.action-primary', label: 'Action Primary', type: 'color' },
+				{ id: 'primitive.dimension.radius.sm', label: 'Radius Small', type: 'dimension', role: 'radius' },
+				{ id: 'primitive.dimension.spacing.sm', label: 'Spacing Small', type: 'dimension', role: 'spacing' },
+			],
+			values: { brand: { 'semantic.color.action-primary': '#3633e1', 'primitive.dimension.radius.sm': '4px' } },
+		};
+	});
+
+	afterEach(() => {
+		window[PICKABLE_TOKENS_GLOBAL] = originalPool;
+		window.kadenceDesignTokens = originalFeed;
+	});
+
+	it('filters to a $type and behaves exactly as before when no role is given', () => {
+		const tokens = pickableTokensForType('dimension');
+
+		expect(tokens.map((token) => token.id)).toEqual([
+			'primitive.dimension.radius.sm',
+			'primitive.dimension.spacing.sm',
+		]);
+	});
+
+	it('narrows to matching entries when a role is given', () => {
+		const tokens = pickableTokensForType('dimension', 'radius');
+
+		expect(tokens).toHaveLength(1);
+		expect(tokens[0]).toMatchObject({ id: 'primitive.dimension.radius.sm', value: '4px', role: 'radius' });
+	});
+
+	it('resolves the active-library value for a color type', () => {
+		const tokens = pickableTokensForType('color');
+
+		expect(tokens).toEqual([
+			{ id: 'semantic.color.action-primary', label: 'Action Primary', value: '#3633e1', role: null },
+		]);
 	});
 });
 

--- a/src/style-library/components/molecules/fields/TokenColorSelectField.js
+++ b/src/style-library/components/molecules/fields/TokenColorSelectField.js
@@ -1,0 +1,111 @@
+/**
+ * A round-swatch token color picker (e.g. Button's Text / Background rows): a bordered row whose
+ * toggle is the field's own name beside a swatch of the currently selected token's resolved color,
+ * opening a menu of every pickable color token — each option showing its own swatch, label, and
+ * resolved value. Closes the gap between `ColorListField` (writes a raw CSS string, no token
+ * reference) and `TokenSelectField` (writes a token id but renders no swatch): this field writes a
+ * token id AND shows its color.
+ *
+ * Built on the same `Dropdown`/`MenuGroup`/`MenuItem` primitives `SelectDropdown` and
+ * `ColorListField` use, rather than `SelectDropdown` itself — that component's toggle always shows
+ * the *active option's* label, but this field's toggle must keep showing its own name (e.g. "Text"),
+ * never the selected color's name.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import { Icon, check } from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getDesignTokensFeed, pickableTokensForType } from '../../../helpers/tokens';
+import { resolveSwatchColor } from '../../../helpers/presets';
+import './TokenColorSelectField.scss';
+
+/**
+ * Render a token-color-select field.
+ *
+ * @param {Object}   props          The component props.
+ * @param {Object}   field          The field definition.
+ * @param {string}   field.label    The field's own name, shown on the toggle (e.g. "Text").
+ * @param {boolean}  [field.readOnly] Whether the control is non-interactive.
+ * @param {string}   props.value    The selected token id.
+ * @param {Function} props.onChange Called with the new token id on pick; never called when read-only.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The field.
+ */
+export function TokenColorSelectField({ field, value, onChange }) {
+	const options = pickableTokensForType('color');
+	const feed = getDesignTokensFeed();
+	const swatchColor = resolveSwatchColor(options, feed?.values, value);
+
+	return (
+		<div className="kadence-blocks-style-library__field kadence-blocks-style-library__field--token-color-select">
+			<Dropdown
+				className="kadence-blocks-style-library__field-token-color-select-dropdown"
+				popoverProps={{ placement: 'left-start' }}
+				renderToggle={({ isOpen, onToggle }) => (
+					<button
+						type="button"
+						className="kadence-blocks-style-library__field-token-color-select-toggle"
+						aria-expanded={isOpen}
+						// translators: %s: the field's own name (e.g. "Background").
+						aria-label={sprintf(__('%s color', 'kadence-blocks'), field.label)}
+						disabled={field.readOnly}
+						onClick={onToggle}
+					>
+						<span
+							className="kadence-blocks-style-library__field-token-color-select-swatch"
+							style={{ background: swatchColor || 'transparent' }}
+						/>
+						<span className="kadence-blocks-style-library__field-token-color-select-label">
+							{field.label}
+						</span>
+					</button>
+				)}
+				renderContent={({ onClose }) => (
+					<MenuGroup>
+						{options.map((option) => {
+							const isCurrent = option.id === value;
+
+							return (
+								<MenuItem
+									key={option.id}
+									role="menuitemradio"
+									aria-checked={isCurrent}
+									suffix={isCurrent ? <Icon icon={check} /> : null}
+									onClick={() => {
+										onClose();
+
+										if (!field.readOnly && !isCurrent) {
+											onChange(option.id);
+										}
+									}}
+								>
+									<span
+										className="kadence-blocks-style-library__field-token-color-select-option-swatch"
+										style={{ background: option.value || 'transparent' }}
+									/>
+									<span className="kadence-blocks-style-library__field-token-color-select-option-label">
+										{option.label}
+									</span>
+									{option.value && (
+										<span className="kadence-blocks-style-library__field-token-color-select-option-value">
+											{option.value}
+										</span>
+									)}
+								</MenuItem>
+							);
+						})}
+					</MenuGroup>
+				)}
+			/>
+		</div>
+	);
+}

--- a/src/style-library/components/molecules/fields/TokenColorSelectField.scss
+++ b/src/style-library/components/molecules/fields/TokenColorSelectField.scss
@@ -1,0 +1,40 @@
+.kadence-blocks-style-library__field-token-color-select-toggle {
+	display: flex;
+	align-items: center;
+	gap: var(--kb-sl-space-10);
+	width: 100%;
+	box-sizing: border-box;
+	height: 34px;
+	padding: var(--kb-sl-space-05) var(--kb-sl-space-10);
+	background: none;
+	border: 1px solid var(--kb-sl-color-gray-600);
+	cursor: pointer;
+
+	&:disabled {
+		cursor: default;
+		opacity: 0.6;
+	}
+}
+
+.kadence-blocks-style-library__field-token-color-select-swatch,
+.kadence-blocks-style-library__field-token-color-select-option-swatch {
+	flex: 0 0 auto;
+	width: var(--kb-sl-space-20);
+	height: var(--kb-sl-space-20);
+	border: 1px solid var(--kb-sl-color-border);
+	border-radius: var(--kb-sl-radius-full);
+}
+
+.kadence-blocks-style-library__field-token-color-select-label {
+	font-size: var(--kb-sl-font-size-m);
+	color: var(--kb-sl-color-text-primary);
+}
+
+.kadence-blocks-style-library__field-token-color-select-option-label {
+	flex: 1 1 auto;
+}
+
+.kadence-blocks-style-library__field-token-color-select-option-value {
+	margin-left: var(--kb-sl-space-05);
+	color: var(--kb-sl-color-text-muted);
+}

--- a/src/style-library/components/molecules/fields/TokenSelectField.js
+++ b/src/style-library/components/molecules/fields/TokenSelectField.js
@@ -25,6 +25,7 @@ import './TokenSelectField.scss';
  * @param {Object}                              props              The component props.
  * @param {Object}                              field              The field definition.
  * @param {string}                              field.tokenType    The DTCG `$type` to filter the pickable pool to.
+ * @param {?string}                              [field.role]       When given, also narrows the pool to this token role (e.g. `'radius'`).
  * @param {?string}                              [field.label]      The field's own `FieldLabel` text; omitted when the caller supplies its own.
  * @param {?import('@wordpress/icons').IconType} [field.leadingIcon] A glyph rendered before the selected value — schema data, not hardcoded.
  * @param {boolean}                              [field.readOnly]   Whether the control is non-interactive.
@@ -36,7 +37,7 @@ import './TokenSelectField.scss';
  * @return {JSX.Element} The field.
  */
 export function TokenSelectField({ field, value, onChange }) {
-	const tokens = pickableTokensForType(field.tokenType);
+	const tokens = pickableTokensForType(field.tokenType, field.role);
 	const options = tokens.map((token) => ({
 		value: token.id,
 		label: (

--- a/src/style-library/constants/demo-settings-schema.js
+++ b/src/style-library/constants/demo-settings-schema.js
@@ -105,6 +105,7 @@ export const DEMO_SETTINGS_SCHEMA = {
 			initialOpen: true,
 			fields: [
 				{ type: 'color', path: 'background', label: __('Background', 'kadence-blocks') },
+				{ type: 'token-color-select', path: 'tokenColor', label: __('Token Color', 'kadence-blocks') },
 				{
 					type: 'color-list',
 					path: 'stateColors',
@@ -169,6 +170,7 @@ export const DEMO_SETTINGS_VALUES = {
 	letterSpacing: 2,
 	letterSpacingUnit: '0.02em',
 	background: '#2271b1',
+	tokenColor: '',
 	stateColors: { text: '#1e1e1e', bg: '#2271b1' },
 	radius: '',
 	borderWidth: '',

--- a/src/style-library/constants/field-types.js
+++ b/src/style-library/constants/field-types.js
@@ -1,7 +1,7 @@
 /**
  * The settings-field type vocabulary: the single source of truth mapping a schema field's `type`
  * string to the component that renders it. Every per-screen settings schema authors against these
- * twelve strings; `helpers/settings-schema.js`'s `fieldComponentFor` is the only reader.
+ * thirteen strings; `helpers/settings-schema.js`'s `fieldComponentFor` is the only reader.
  */
 
 /**
@@ -17,6 +17,7 @@ import { ShadowField } from '../components/molecules/fields/ShadowField';
 import { StepperField } from '../components/molecules/fields/StepperField';
 import { TextField } from '../components/molecules/fields/TextField';
 import { ToggleField } from '../components/molecules/fields/ToggleField';
+import { TokenColorSelectField } from '../components/molecules/fields/TokenColorSelectField';
 import { TokenSelectField } from '../components/molecules/fields/TokenSelectField';
 import { UnitField } from '../components/molecules/fields/UnitField';
 
@@ -37,6 +38,7 @@ export const FIELD_TYPES = Object.freeze({
 	color: ColorField,
 	'color-list': ColorListField,
 	'token-select': TokenSelectField,
+	'token-color-select': TokenColorSelectField,
 	'box-sides': BoxSidesField,
 	shadow: ShadowField,
 });
@@ -44,9 +46,9 @@ export const FIELD_TYPES = Object.freeze({
 /**
  * The field types a schema may mark `responsive: true`, mirroring the backend's
  * `Schema\Vocabulary\Responsive::is_responsive_capable()` gate (`dimension`/`lineHeight` DTCG
- * types). `token-select`/`box-sides` are excluded — their value is a token reference, not a literal
- * a breakpoint override replaces; the rest are excluded because their DTCG types are never
- * responsive-capable.
+ * types). `token-select`/`token-color-select`/`box-sides` are excluded — their value is a token
+ * reference, not a literal a breakpoint override replaces; the rest are excluded because their DTCG
+ * types are never responsive-capable.
  *
  * @since TBD
  */

--- a/src/style-library/helpers/presets.js
+++ b/src/style-library/helpers/presets.js
@@ -9,6 +9,11 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { nextScaleSlug } from './scale';
@@ -270,4 +275,79 @@ export function overlayPresetRows(rows, itemId, draft, values) {
 	next[index] = overlaid;
 
 	return next;
+}
+
+/**
+ * Resolve the color a `token-color-select` field's swatch should paint for the current value: the
+ * matching pickable option's own resolved value first (it already carries the active library's
+ * literal), then a direct lookup in the feed's resolved value map for an id outside the pool, then
+ * `''` (the caller renders that as transparent).
+ *
+ * @param {Array<{id: string, value: string}>} options The pickable color options (`pickableTokensForType('color')`).
+ * @param {Record<string, string>}             values  The feed's resolved value map.
+ * @param {string}                              id      The field's current value (a bare token id).
+ *
+ * @since TBD
+ *
+ * @return {string} The resolved swatch color, or `''` when unresolvable.
+ */
+export function resolveSwatchColor(options, values, id) {
+	const match = (options ?? []).find((option) => option.id === id);
+
+	if (match?.value) {
+		return match.value;
+	}
+
+	return values?.[id] ?? '';
+}
+
+/**
+ * The Button settings panel's per-tab schema: NAME renders on both tabs (the draft's `label` path
+ * is shared), the Normal tab adds a Radius section, and the Hover tab never does — `button-radius`
+ * has no hover counterpart, so rendering one there would write a property `guard_surface` rejects.
+ *
+ * @param {string} tab The active tab name (`'normal'` or `'hover'`).
+ *
+ * @since TBD
+ *
+ * @return {{panels: Array<Object>}} The settings-form schema for the active tab.
+ */
+export function buttonSettingsSchema(tab) {
+	const namePanel = {
+		id: 'name',
+		fields: [{ type: 'text', path: 'label', label: __('Name', 'kadence-blocks') }],
+	};
+
+	const isHover = tab === 'hover';
+	const textPath = isHover ? 'tokens.button-text-hover' : 'tokens.button-text';
+	const bgPath = isHover ? 'tokens.button-bg-hover' : 'tokens.button-bg';
+
+	const colorPanel = {
+		id: 'color',
+		title: __('Color', 'kadence-blocks'),
+		fields: [
+			{ type: 'token-color-select', path: textPath, label: __('Text', 'kadence-blocks') },
+			{ type: 'token-color-select', path: bgPath, label: __('Background', 'kadence-blocks') },
+		],
+	};
+
+	if (isHover) {
+		return { panels: [namePanel, colorPanel] };
+	}
+
+	const radiusPanel = {
+		id: 'radius',
+		title: __('Radius', 'kadence-blocks'),
+		fields: [
+			{
+				type: 'token-select',
+				tokenType: 'dimension',
+				role: 'radius',
+				path: 'tokens.button-radius',
+				label: __('Radius', 'kadence-blocks'),
+			},
+		],
+	};
+
+	return { panels: [namePanel, colorPanel, radiusPanel] };
 }

--- a/src/style-library/helpers/tokens.js
+++ b/src/style-library/helpers/tokens.js
@@ -32,25 +32,29 @@ export function getPickableTokensPool() {
 
 /**
  * The pickable tokens of one DTCG `$type` (e.g. `dimension`, `color`), each with its resolved
- * literal value from the active library.
+ * literal value from the active library. An optional `role` narrows the pool further (e.g. the
+ * Radius picker wants only `role: 'radius'` dimensions, not every dimension token) — omitted, this
+ * behaves exactly as before.
  *
- * @param {string} type The DTCG token `$type` to filter to.
+ * @param {string}  type   The DTCG token `$type` to filter to.
+ * @param {?string} [role] When given, also require `token.role === role`.
  *
  * @since TBD
  *
- * @return {Array<{id: string, label: string, value: string}>} The pickable tokens for the type.
+ * @return {Array<{id: string, label: string, value: string, role: ?string}>} The pickable tokens for the type.
  */
-export function pickableTokensForType(type) {
+export function pickableTokensForType(type, role) {
 	const pool = getPickableTokensPool();
 	const feed = getDesignTokensFeed();
 	const libraryValues = pool.values?.[feed?.slug] ?? {};
 
 	return (pool.tokens || [])
-		.filter((token) => token.type === type)
+		.filter((token) => token.type === type && (role === undefined || token.role === role))
 		.map((token) => ({
 			id: token.id,
 			label: token.label,
 			value: libraryValues[token.id] ?? '',
+			role: token.role ?? null,
 		}));
 }
 


### PR DESCRIPTION
Adds the `token-color-select` field type and narrows `pickableTokensForType` by an optional token role, so a field only offers tokens from its own role.

## Test instructions

1. Run `npx wp-scripts test-unit-js src/style-library/__tests__/tokens.test.js`.
2. The narrowing is the part to review: confirm passing a role filters the pool, and passing none leaves it unchanged, so existing callers are unaffected.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4083/phase-3a-token-color-select
bun run build-wp
```

The Style Library is at **WP Admin → Kadence → Style Library**. The Button preset screen is under **Block Presets → Button**. Block-editor checks use a **Kadence Single Button** block on any post.
</details>

---

Slice 4 of 23 in the SOFT-4083 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a color token selector with swatches, resolved values, selected states, and read-only support.
  * Added role-based filtering for selectable design tokens.
  * Added reusable button settings panels for Normal and Hover states.
  * Added token color selection to the demo Color panel.

* **Tests**
  * Added coverage for color resolution, button settings, token filtering, and active-library values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->