### PR TITLE
[DTM] SOFT-4083 [5/23]: Button settings panel

### DIFF
--- a/src/style-library/__tests__/button-settings.test.js
+++ b/src/style-library/__tests__/button-settings.test.js
@@ -1,0 +1,111 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { ButtonSettings } from '../components/pages/ButtonSettings';
+import { useButtonPresets } from '../hooks/use-button-presets';
+
+// Same rationale as `button-screen.test.js`: `use-button-presets.js` pulls in `../api/client`,
+// which imports `@wordpress/api-fetch` (externalized in production, not an installed dependency),
+// so automocking would fail to resolve it. `ButtonSettings` only reads the hook's return value.
+jest.mock('../hooks/use-button-presets', () => ({
+	useButtonPresets: jest.fn(),
+}));
+
+const LIBRARY = { rest: { namespace: 'kb-design-tokens/v1' }, slug: 'default', version: 1, values: {} };
+
+let container;
+let root;
+
+/**
+ * Render `ButtonSettings` with the given `useButtonPresets` stub and route item, returning the
+ * `navigate` spy passed to it.
+ *
+ * @param {Object} presets The `useButtonPresets` return value to stub.
+ * @param {string} item    The route's `item` (`kb-item`) value.
+ *
+ * @since TBD
+ *
+ * @return {Function} The `navigate` jest spy.
+ */
+function renderButtonSettings(presets, item) {
+	useButtonPresets.mockReturnValue(presets);
+	const navigate = jest.fn();
+
+	act(() => {
+		root.render(
+			createElement(ButtonSettings, {
+				route: { screen: 'blocks/kadence/singlebtn', item },
+				navigate,
+				library: LIBRARY,
+			})
+		);
+	});
+
+	return navigate;
+}
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+	useButtonPresets.mockReset();
+});
+
+afterEach(() => {
+	act(() => {
+		root.unmount();
+	});
+	container.remove();
+});
+
+describe('ButtonSettings self-heal guard', () => {
+	/**
+	 * A failed preset fetch must not be mistaken for a stale `kb-item`: the route must survive so a
+	 * retry can still restore the selected preset.
+	 *
+	 * @return {void}
+	 */
+	it('does not clear a valid kb-item when the preset fetch fails', () => {
+		const navigate = renderButtonSettings(
+			{
+				payload: null,
+				isLoading: false,
+				loadError: new Error('Request failed'),
+				rows: [],
+				initialValuesFor: () => null,
+			},
+			'primary'
+		);
+
+		expect(navigate).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * A successful load that resolves to no preset for the given slug is genuinely stale, so the
+	 * self-heal must still clear the route.
+	 *
+	 * @return {void}
+	 */
+	it('clears an unknown kb-item once a successful load finds no matching preset', () => {
+		const navigate = renderButtonSettings(
+			{
+				payload: {},
+				isLoading: false,
+				loadError: null,
+				rows: [],
+				initialValuesFor: () => null,
+			},
+			'does-not-exist'
+		);
+
+		expect(navigate).toHaveBeenCalledWith({ item: '' });
+	});
+});

--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -178,6 +178,14 @@ describe('presetInitialValues', () => {
 	});
 
 	it('seeds real values once the payload lands for a slug that first read null while loading', () => {
+		window.kadenceDesignTokens = {
+			presets: {
+				'kadence/singlebtn': {
+					properties: ['button-bg', 'button-text', 'button-bg-hover', 'button-text-hover', 'button-radius'],
+				},
+			},
+		};
+
 		const slug = 'secondary';
 		const loading = presetInitialValues(null, slug);
 		const loaded = presetInitialValues(

--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -169,6 +169,26 @@ describe('presetInitialValues', () => {
 	it('returns null for an unknown slug', () => {
 		expect(presetInitialValues({ presets: {} }, 'missing')).toBeNull();
 	});
+
+	it('returns null for a null payload, indistinguishable from an unknown slug', () => {
+		// Pins the contract `ButtonSettings` relies on: a still-loading fetch (`payload === null`) and
+		// a genuinely unknown slug both read as null here, which is exactly why the panel gates on
+		// `!isLoading` before treating a null seed as a stale deep link rather than "not landed yet".
+		expect(presetInitialValues(null, 'secondary')).toBeNull();
+	});
+
+	it('seeds real values once the payload lands for a slug that first read null while loading', () => {
+		const slug = 'secondary';
+		const loading = presetInitialValues(null, slug);
+		const loaded = presetInitialValues(
+			{ presets: { secondary: { label: 'Secondary', tokens: { 'button-bg': 'transparent' } } } },
+			slug
+		);
+
+		expect(loading).toBeNull();
+		expect(loaded).not.toBeNull();
+		expect(loaded.label).toBe('Secondary');
+	});
 });
 
 describe('presetSaveTokens', () => {

--- a/src/style-library/__tests__/use-button-presets.test.js
+++ b/src/style-library/__tests__/use-button-presets.test.js
@@ -1,0 +1,146 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { useButtonPresets } from '../hooks/use-button-presets';
+import { fetchBlockPresets } from '../api/client';
+
+// A factory, not automock: `../api/client` imports `@wordpress/api-fetch`, which is externalized to
+// the `wp.apiFetch` global in production and therefore absent from `node_modules`.
+jest.mock('../api/client', () => ({
+	fetchBlockPresets: jest.fn(),
+}));
+
+const LIBRARY_A = { rest: { namespace: 'kb-design-tokens/v1' }, slug: 'default', version: 1, values: {} };
+const LIBRARY_B = { rest: { namespace: 'kb-design-tokens/v1' }, slug: 'brand', version: 1, values: {} };
+
+const PAYLOAD_A = { version: 'a1', default: 'primary', presets: { primary: { label: 'Primary', tokens: {} } } };
+const PAYLOAD_B = { version: 'b1', default: 'primary', presets: { primary: { label: 'Brand Primary', tokens: {} } } };
+
+describe('useButtonPresets library switching', () => {
+	let container;
+	let root;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+		// `initialValuesFor` walks the bound surface off the localized feed, which the Style Library
+		// page inline-scripts before the bundle runs.
+		window.kadenceDesignTokens = {
+			presets: {
+				'kadence/singlebtn': {
+					properties: ['button-bg', 'button-text', 'button-bg-hover', 'button-text-hover', 'button-radius'],
+				},
+			},
+		};
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		delete global.IS_REACT_ACT_ENVIRONMENT;
+		delete window.kadenceDesignTokens;
+	});
+
+	/**
+	 * A single probe component type, so re-rendering with a different library updates the mounted
+	 * hook instead of remounting it — a remount would reset the state this test is about.
+	 *
+	 * @since TBD
+	 *
+	 * @return {{render: Function, latest: Function}} Renders with a library, and reads the hook's
+	 *                                                  most recent return value.
+	 */
+	function mountProbe() {
+		let latest = null;
+
+		function Probe({ library }) {
+			latest = useButtonPresets(library);
+
+			return null;
+		}
+
+		return {
+			render: (library) => act(() => root.render(<Probe library={library} />)),
+			latest: () => latest,
+		};
+	}
+
+	/**
+	 * Switching libraries with the same preset open must drop the previous library's payload right
+	 * away. Holding it would let a settings panel keyed on the preset id alone keep editing the old
+	 * library's draft under the new one.
+	 *
+	 * @return {void}
+	 */
+	it('drops the previous payload as soon as the library changes', async () => {
+		fetchBlockPresets.mockResolvedValueOnce(PAYLOAD_A);
+
+		const probe = mountProbe();
+		await act(async () => probe.render(LIBRARY_A));
+
+		expect(probe.latest().payload).toEqual(PAYLOAD_A);
+		expect(probe.latest().initialValuesFor('primary')).not.toBeNull();
+
+		// The new library's fetch is left pending: this is the window the panel could otherwise
+		// keep the old draft in.
+		let resolveB;
+		fetchBlockPresets.mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolveB = resolve;
+			})
+		);
+
+		probe.render(LIBRARY_B);
+
+		expect(probe.latest().payload).toBeNull();
+		expect(probe.latest().isLoading).toBe(true);
+		expect(probe.latest().initialValuesFor('primary')).toBeNull();
+
+		await act(async () => {
+			resolveB(PAYLOAD_B);
+		});
+
+		expect(probe.latest().payload).toEqual(PAYLOAD_B);
+		expect(probe.latest().isLoading).toBe(false);
+	});
+
+	/**
+	 * A version bump on the same library is a refresh after a write, not a library change, so the
+	 * rows must stay on screen while the re-read is in flight.
+	 *
+	 * @return {void}
+	 */
+	it('keeps the payload while the same library re-reads after a version bump', async () => {
+		fetchBlockPresets.mockResolvedValueOnce(PAYLOAD_A);
+
+		const probe = mountProbe();
+		await act(async () => probe.render(LIBRARY_A));
+
+		let resolveNext;
+		fetchBlockPresets.mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolveNext = resolve;
+			})
+		);
+
+		probe.render({ ...LIBRARY_A, version: 2 });
+
+		expect(probe.latest().payload).toEqual(PAYLOAD_A);
+
+		await act(async () => {
+			resolveNext({ ...PAYLOAD_A, version: 'a2' });
+		});
+
+		expect(probe.latest().payload.version).toBe('a2');
+	});
+});

--- a/src/style-library/components/pages/ButtonScreen.js
+++ b/src/style-library/components/pages/ButtonScreen.js
@@ -23,6 +23,7 @@ import { addFilter } from '@wordpress/hooks';
 import { ScreenHeader } from '../organisms/ScreenHeader';
 import { RowList } from '../templates/RowList';
 import { EmptyState } from '../molecules/EmptyState';
+import { ButtonSettings } from './ButtonSettings';
 import { useButtonPresets } from '../../hooks/use-button-presets';
 import { useDraftChannel } from '../../hooks/use-draft-channel';
 import { BUTTON_BLOCK, overlayPresetRows } from '../../helpers/presets';
@@ -131,6 +132,8 @@ export function ButtonScreen({ label, route, navigate, library }) {
 		</div>
 	);
 }
+
+ButtonScreen.SettingsPanel = ButtonSettings;
 
 /**
  * Register the Button screen for `kadence/singlebtn` on the public preset-screens filter, exactly

--- a/src/style-library/components/pages/ButtonScreen.js
+++ b/src/style-library/components/pages/ButtonScreen.js
@@ -6,7 +6,7 @@
  *
  * This is a bespoke screen, not a `ScaleScreen` config: a preset row carries a five-property map
  * with two states (Normal/Hover), not one scalar token value, so it composes the shared components
- * directly. No settings panel yet — the static lands once the panel exists.
+ * directly. Its settings panel is `ButtonSettings`, assigned below as `ButtonScreen.SettingsPanel`.
  */
 
 /**

--- a/src/style-library/components/pages/ButtonSettings.js
+++ b/src/style-library/components/pages/ButtonSettings.js
@@ -1,9 +1,18 @@
 /**
  * The Button preset's settings panel: the app's first use of `SettingsPanel`'s built-in Normal |
- * Hover tabs. `activeTab` is owned here (view state only — the draft always carries all five bound
- * properties regardless of which tab is active) and drives which schema `helpers/presets.js`'s
+ * Hover tabs. `activeTab` is view state only — the draft always carries all five bound properties
+ * regardless of which tab is active — and drives which schema `helpers/presets.js`'s
  * `buttonSettingsSchema` returns, since `SettingsPanel`'s children render function ignores the tab
  * name (the parent decides what the active tab shows).
+ *
+ * Split into an outer/inner pair because `useButtonPresets`' payload is fetched, not synchronous
+ * like every other screen's `window.kadenceDesignTokens` source: on a cold load `route.item` is
+ * already set at mount while the fetch is still in flight, so a `useSettingsPanel` mounted directly
+ * here would seed its draft from a still-null `initialValues` and never re-seed once the payload
+ * lands (`useSettingsPanel` only re-seeds on an `itemId` change, not on `initialValues` arriving).
+ * `ButtonSettings` owns the fetch, the stale-item self-heal, and the loading/no-data gate;
+ * `ButtonSettingsPanel` — mounted only once real values exist, `key`ed on the preset id — owns
+ * `useSettingsPanel` and the tabs, so switching presets remounts it with a correct seed.
  *
  * The footer is deliberately inert (`onDelete`/`onSave` both null) and nothing publishes to the
  * draft channel yet: registering channel actions whose `save` is a stub would make the
@@ -37,44 +46,22 @@ const TABS = [
 ];
 
 /**
- * Render the Button preset's settings panel.
+ * The panel proper: mounted only once its preset's `initialValues` are known, so `useSettingsPanel`
+ * always seeds from real data. Remounted (via the caller's `key={id}`) on every preset switch,
+ * which both re-seeds the draft and resets the tab to Normal in one step.
  *
- * @param {Object}   props          The component props.
- * @param {Object}   props.route    The current route (`{ screen, item }`).
- * @param {Function} props.navigate The route navigator.
- * @param {Object}   props.library  The design-tokens feed hook's return value.
+ * @param {Object}   props               The component props.
+ * @param {Function} props.navigate      The route navigator.
+ * @param {Object}   props.route         The current route (`{ screen, item }`).
+ * @param {Object}   props.initialValues The seeded draft (`{label, tokens}`) for the open preset.
  *
  * @since TBD
  *
- * @return {?JSX.Element} The panel, or null while a stale `kb-item` self-heals for a tick.
+ * @return {JSX.Element} The panel.
  */
-export function ButtonSettings({ route, navigate, library }) {
-	const presets = useButtonPresets(library);
-	const id = route.item;
-	const initialValues = presets.initialValuesFor(id);
-	const hasInitialValues = Boolean(initialValues);
+function ButtonSettingsPanel({ navigate, route, initialValues }) {
 	const panel = useSettingsPanel({ route, navigate, initialValues });
 	const [activeTab, setActiveTab] = useState(TABS[0].name);
-
-	// Opening a different preset must not start on Hover.
-	useEffect(() => {
-		setActiveTab(TABS[0].name);
-	}, [id]);
-
-	// A `kb-item` naming no preset (a stale deep link, or another screen's token id) closes the
-	// panel instead of rendering broken fields — the `ScaleSettings.js` self-healing idiom. Waiting
-	// on `!presets.isLoading` matters here: while the fetch is in flight, an unknown-slug draft and a
-	// still-loading one look identical (both `null`), so healing eagerly would bounce a valid deep
-	// link straight into the page before its fetch lands.
-	useEffect(() => {
-		if (id && !presets.isLoading && !hasInitialValues) {
-			navigate({ item: '' });
-		}
-	}, [id, presets.isLoading, hasInitialValues, navigate]);
-
-	if (!id || !hasInitialValues) {
-		return null;
-	}
 
 	return (
 		<SettingsPanel
@@ -93,4 +80,41 @@ export function ButtonSettings({ route, navigate, library }) {
 			/>
 		</SettingsPanel>
 	);
+}
+
+/**
+ * Render the Button preset's settings panel.
+ *
+ * @param {Object}   props          The component props.
+ * @param {Object}   props.route    The current route (`{ screen, item }`).
+ * @param {Function} props.navigate The route navigator.
+ * @param {Object}   props.library  The design-tokens feed hook's return value.
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The panel, or null while a stale `kb-item` self-heals for a tick, or while
+ *         a valid one's presets are still loading.
+ */
+export function ButtonSettings({ route, navigate, library }) {
+	const presets = useButtonPresets(library);
+	const id = route.item;
+	const initialValues = presets.initialValuesFor(id);
+	const hasInitialValues = Boolean(initialValues);
+
+	// A `kb-item` naming no preset (a stale deep link, or another screen's token id) closes the
+	// panel instead of rendering broken fields — the `ScaleSettings.js` self-healing idiom. Waiting
+	// on `!presets.isLoading` matters here: while the fetch is in flight, an unknown-slug draft and a
+	// still-loading one look identical (both `null`), so healing eagerly would bounce a valid deep
+	// link straight into the page before its fetch lands.
+	useEffect(() => {
+		if (id && !presets.isLoading && !hasInitialValues) {
+			navigate({ item: '' });
+		}
+	}, [id, presets.isLoading, hasInitialValues, navigate]);
+
+	if (!id || !hasInitialValues) {
+		return null;
+	}
+
+	return <ButtonSettingsPanel key={id} route={route} navigate={navigate} initialValues={initialValues} />;
 }

--- a/src/style-library/components/pages/ButtonSettings.js
+++ b/src/style-library/components/pages/ButtonSettings.js
@@ -1,0 +1,96 @@
+/**
+ * The Button preset's settings panel: the app's first use of `SettingsPanel`'s built-in Normal |
+ * Hover tabs. `activeTab` is owned here (view state only — the draft always carries all five bound
+ * properties regardless of which tab is active) and drives which schema `helpers/presets.js`'s
+ * `buttonSettingsSchema` returns, since `SettingsPanel`'s children render function ignores the tab
+ * name (the parent decides what the active tab shows).
+ *
+ * The footer is deliberately inert (`onDelete`/`onSave` both null) and nothing publishes to the
+ * draft channel yet: registering channel actions whose `save` is a stub would make the
+ * unsaved-changes guard lie about what Save does. Edits are local and discarded on navigation with
+ * no prompt until the mutations flow adds the publish effect and the real handlers.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { SettingsPanel } from '../templates/SettingsPanel';
+import { SettingsForm } from '../organisms/SettingsForm';
+import { useSettingsPanel } from '../../hooks/use-settings-panel';
+import { useButtonPresets } from '../../hooks/use-button-presets';
+import { buttonSettingsSchema } from '../../helpers/presets';
+
+/**
+ * The panel's state tabs, in display order.
+ *
+ * @since TBD
+ */
+const TABS = [
+	{ name: 'normal', title: __('Normal', 'kadence-blocks') },
+	{ name: 'hover', title: __('Hover', 'kadence-blocks') },
+];
+
+/**
+ * Render the Button preset's settings panel.
+ *
+ * @param {Object}   props          The component props.
+ * @param {Object}   props.route    The current route (`{ screen, item }`).
+ * @param {Function} props.navigate The route navigator.
+ * @param {Object}   props.library  The design-tokens feed hook's return value.
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The panel, or null while a stale `kb-item` self-heals for a tick.
+ */
+export function ButtonSettings({ route, navigate, library }) {
+	const presets = useButtonPresets(library);
+	const id = route.item;
+	const initialValues = presets.initialValuesFor(id);
+	const hasInitialValues = Boolean(initialValues);
+	const panel = useSettingsPanel({ route, navigate, initialValues });
+	const [activeTab, setActiveTab] = useState(TABS[0].name);
+
+	// Opening a different preset must not start on Hover.
+	useEffect(() => {
+		setActiveTab(TABS[0].name);
+	}, [id]);
+
+	// A `kb-item` naming no preset (a stale deep link, or another screen's token id) closes the
+	// panel instead of rendering broken fields — the `ScaleSettings.js` self-healing idiom. Waiting
+	// on `!presets.isLoading` matters here: while the fetch is in flight, an unknown-slug draft and a
+	// still-loading one look identical (both `null`), so healing eagerly would bounce a valid deep
+	// link straight into the page before its fetch lands.
+	useEffect(() => {
+		if (id && !presets.isLoading && !hasInitialValues) {
+			navigate({ item: '' });
+		}
+	}, [id, presets.isLoading, hasInitialValues, navigate]);
+
+	if (!id || !hasInitialValues) {
+		return null;
+	}
+
+	return (
+		<SettingsPanel
+			onClose={panel.close}
+			tabs={TABS}
+			activeTab={activeTab}
+			onTabChange={setActiveTab}
+			onDelete={null}
+			onSave={null}
+			isDirty={panel.isDirty}
+		>
+			<SettingsForm
+				schema={buttonSettingsSchema(activeTab)}
+				values={panel.draft}
+				onChange={panel.setFieldValue}
+			/>
+		</SettingsPanel>
+	);
+}

--- a/src/style-library/components/pages/ButtonSettings.js
+++ b/src/style-library/components/pages/ButtonSettings.js
@@ -105,12 +105,15 @@ export function ButtonSettings({ route, navigate, library }) {
 	// panel instead of rendering broken fields — the `ScaleSettings.js` self-healing idiom. Waiting
 	// on `!presets.isLoading` matters here: while the fetch is in flight, an unknown-slug draft and a
 	// still-loading one look identical (both `null`), so healing eagerly would bounce a valid deep
-	// link straight into the page before its fetch lands.
+	// link straight into the page before its fetch lands. Waiting on `!presets.loadError` matters just
+	// as much: a rejected fetch also leaves `initialValuesFor` returning null, and a valid `kb-item`
+	// must not be mistaken for a stale one just because the request failed — that would rewrite the
+	// route and make the deep link unrecoverable even after a successful retry.
 	useEffect(() => {
-		if (id && !presets.isLoading && !hasInitialValues) {
+		if (id && !presets.isLoading && !presets.loadError && !hasInitialValues) {
 			navigate({ item: '' });
 		}
-	}, [id, presets.isLoading, hasInitialValues, navigate]);
+	}, [id, presets.isLoading, presets.loadError, hasInitialValues, navigate]);
 
 	if (!id || !hasInitialValues) {
 		return null;

--- a/src/style-library/hooks/use-button-presets.js
+++ b/src/style-library/hooks/use-button-presets.js
@@ -11,7 +11,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -41,6 +41,21 @@ export function useButtonPresets(library, block = BUTTON_BLOCK) {
 	const namespace = library?.rest?.namespace;
 	const slug = library?.slug;
 	const version = library?.version;
+
+	// Dropped the moment the library changes, not when its replacement arrives: the refetch below
+	// keeps the previous payload on purpose (a version bump after a write must not blank the list),
+	// but across libraries that same payload is another library's data. Callers key their panels on
+	// the preset id alone, so leaving it in place lets a panel opened on the old library keep
+	// editing its draft under the new one. Assigning during render rather than in an effect avoids
+	// a commit that would show the stale rows first.
+	const slugRef = useRef(slug);
+
+	if (slugRef.current !== slug) {
+		slugRef.current = slug;
+		setPayload(null);
+		setIsLoading(true);
+		setLoadError(null);
+	}
 
 	useEffect(() => {
 		if (!namespace || !slug) {


### PR DESCRIPTION
Adds `ButtonSettings` as the Button screen's settings panel, with Normal/Hover tabs and the colour fields. The panel mounts only once real preset values have loaded.

## Test instructions

1. Go to **Style Library → Block Presets → Button** and click the **Primary** row.
2. The settings panel opens with **Normal** and **Hover** tabs, a **Name** field, and Text/Background colour fields.
3. Switch to **Hover** and confirm it shows that state's own values rather than repeating Normal's.
4. Radius is still a plain `Custom` select and the Name field sits *below* the tabs — both change in later slices, so they are correct as-is here.
5. Edge case worth a look: load the screen with a bogus `&kb-item=nope` in the URL. The panel should stay closed rather than render empty fields.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4083/phase-3b-button-settings-panel
bun run build-wp
```

The Style Library is at **WP Admin → Kadence → Style Library**. The Button preset screen is under **Block Presets → Button**. Block-editor checks use a **Kadence Single Button** block on any post.
</details>

## Screenshot

Settings panel with Normal/Hover tabs, colour fields and the radius select
<img width="1512" height="788" alt="phase-3b-button-settings-panel" src="https://github.com/user-attachments/assets/de0addb8-e670-4c43-9ee1-7d47c6a7d4e0" />

---

Slice 5 of 23 in the SOFT-4083 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a button settings panel for editing preset values.
  - Added separate Normal and Hover tabs with context-specific settings.
  - Button screens now expose the settings panel when configuring presets.

- **Bug Fixes**
  - Improved handling of invalid or outdated preset routes while data loads.
  - Preserved valid routes when preset loading fails and cleared unknown routes after successful loading.
  - Improved initialization when preset data is temporarily unavailable, ensuring valid values load correctly afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->