### PR TITLE
[DTM] SOFT-4083 [6/23]: Preset create, save, and delete flows

### DIFF
--- a/src/style-library/__tests__/preset-flows.test.js
+++ b/src/style-library/__tests__/preset-flows.test.js
@@ -1,0 +1,297 @@
+/* eslint-env jest */
+import { createPresetFlow, deletePresetFlow, savePresetFlow } from '../helpers/preset-flows';
+import * as client from '../api/client';
+
+// A factory, not bare automocking — see scale-flows.test.js's identical note: the real module
+// imports `@wordpress/api-fetch`, externalized in production and not an npm dependency here.
+jest.mock('../api/client', () => ({
+	fetchBlockPresets: jest.fn(),
+	saveBlockPreset: jest.fn(),
+	deleteBlockPreset: jest.fn(),
+}));
+
+beforeEach(() => {
+	jest.resetAllMocks();
+});
+
+describe('createPresetFlow', () => {
+	const defaultTokens = {
+		'button-bg': 'semantic.color.action-primary',
+		'button-text': 'semantic.color.on-primary',
+		'button-bg-hover': 'semantic.color.action-primary-hover',
+		'button-text-hover': 'semantic.color.on-primary',
+		'button-radius': 'semantic.dimension.radius-md',
+	};
+
+	it('mints the base slug, posts the translated label and the default tokens wrapped as aliases, refreshes the feed, and resolves the slug', async () => {
+		client.saveBlockPreset.mockResolvedValue({});
+		const refreshFeed = jest.fn().mockResolvedValue({});
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		const result = await createPresetFlow({
+			namespace: 'kb-design-tokens/v1',
+			block: 'kadence/singlebtn',
+			existingSlugs: ['primary', 'secondary'],
+			defaultTokens,
+			slug: 'default',
+			refreshFeed,
+			onBusy,
+			onError,
+		});
+
+		expect(client.saveBlockPreset).toHaveBeenCalledWith(
+			'kb-design-tokens/v1',
+			'kadence/singlebtn',
+			{
+				preset: 'button',
+				label: 'New Button',
+				tokens: {
+					'button-bg': '{semantic.color.action-primary}',
+					'button-text': '{semantic.color.on-primary}',
+					'button-bg-hover': '{semantic.color.action-primary-hover}',
+					'button-text-hover': '{semantic.color.on-primary}',
+					'button-radius': '{semantic.dimension.radius-md}',
+				},
+			},
+			'default'
+		);
+		expect(refreshFeed).toHaveBeenCalledWith('default');
+		expect(result).toBe('button');
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it('mints button-2 when button is already taken', async () => {
+		client.saveBlockPreset.mockResolvedValue({});
+		const refreshFeed = jest.fn().mockResolvedValue({});
+
+		const result = await createPresetFlow({
+			namespace: 'kb-design-tokens/v1',
+			block: 'kadence/singlebtn',
+			existingSlugs: ['primary', 'secondary', 'button'],
+			defaultTokens,
+			slug: 'default',
+			refreshFeed,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(client.saveBlockPreset).toHaveBeenCalledWith(
+			'kb-design-tokens/v1',
+			'kadence/singlebtn',
+			expect.objectContaining({ preset: 'button-2' }),
+			'default'
+		);
+		expect(result).toBe('button-2');
+	});
+
+	it('surfaces the error, clears busy, and re-throws on failure', async () => {
+		const failure = new Error('Boom');
+		client.saveBlockPreset.mockRejectedValue(failure);
+		const refreshFeed = jest.fn();
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			createPresetFlow({
+				namespace: 'kb-design-tokens/v1',
+				block: 'kadence/singlebtn',
+				existingSlugs: [],
+				defaultTokens,
+				slug: 'default',
+				refreshFeed,
+				onBusy,
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(refreshFeed).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+});
+
+describe('savePresetFlow', () => {
+	const baseArgs = {
+		namespace: 'kb-design-tokens/v1',
+		block: 'kadence/singlebtn',
+		preset: 'primary',
+		slug: 'default',
+	};
+
+	it('skips the request entirely for an unchanged draft', async () => {
+		const refreshFeed = jest.fn();
+		const draft = {
+			label: 'Primary',
+			tokens: { 'button-bg': 'semantic.color.action-primary' },
+		};
+
+		await savePresetFlow({
+			...baseArgs,
+			draft,
+			initialValues: { label: 'Primary', tokens: { 'button-bg': 'semantic.color.action-primary' } },
+			refreshFeed,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(client.saveBlockPreset).not.toHaveBeenCalled();
+		expect(refreshFeed).not.toHaveBeenCalled();
+	});
+
+	it('posts the label and all five wrapped tokens when the draft is dirty, and refreshes the feed', async () => {
+		client.saveBlockPreset.mockResolvedValue({});
+		const refreshFeed = jest.fn().mockResolvedValue({});
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await savePresetFlow({
+			...baseArgs,
+			draft: {
+				label: 'Main Action',
+				tokens: {
+					'button-bg': 'semantic.color.action-primary',
+					'button-text': 'semantic.color.on-primary',
+					'button-bg-hover': 'semantic.color.action-primary-hover',
+					'button-text-hover': 'semantic.color.on-primary',
+					'button-radius': 'semantic.dimension.radius-md',
+				},
+			},
+			initialValues: {
+				label: 'Primary',
+				tokens: {
+					'button-bg': 'semantic.color.action-primary',
+					'button-text': 'semantic.color.on-primary',
+					'button-bg-hover': 'semantic.color.action-primary-hover',
+					'button-text-hover': 'semantic.color.on-primary',
+					'button-radius': 'semantic.dimension.radius-md',
+				},
+			},
+			refreshFeed,
+			onBusy,
+			onError,
+		});
+
+		expect(client.saveBlockPreset).toHaveBeenCalledWith(
+			'kb-design-tokens/v1',
+			'kadence/singlebtn',
+			{
+				preset: 'primary',
+				label: 'Main Action',
+				tokens: {
+					'button-bg': '{semantic.color.action-primary}',
+					'button-text': '{semantic.color.on-primary}',
+					'button-bg-hover': '{semantic.color.action-primary-hover}',
+					'button-text-hover': '{semantic.color.on-primary}',
+					'button-radius': '{semantic.dimension.radius-md}',
+				},
+			},
+			'default'
+		);
+		expect(refreshFeed).toHaveBeenCalledWith('default');
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it('posts the full token map even for a label-only rename, leaving the stored map intact', async () => {
+		client.saveBlockPreset.mockResolvedValue({});
+		const refreshFeed = jest.fn().mockResolvedValue({});
+		const tokens = { 'button-bg': 'semantic.color.action-primary' };
+
+		await savePresetFlow({
+			...baseArgs,
+			draft: { label: 'Renamed', tokens },
+			initialValues: { label: 'Primary', tokens },
+			refreshFeed,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(client.saveBlockPreset).toHaveBeenCalledWith(
+			'kb-design-tokens/v1',
+			'kadence/singlebtn',
+			{
+				preset: 'primary',
+				label: 'Renamed',
+				tokens: { 'button-bg': '{semantic.color.action-primary}' },
+			},
+			'default'
+		);
+	});
+
+	it('surfaces the error, clears busy, and re-throws on failure', async () => {
+		const failure = new Error('Boom');
+		client.saveBlockPreset.mockRejectedValue(failure);
+		const refreshFeed = jest.fn();
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			savePresetFlow({
+				...baseArgs,
+				draft: { label: 'Renamed', tokens: { 'button-bg': 'semantic.color.action-primary' } },
+				initialValues: { label: 'Primary', tokens: { 'button-bg': 'semantic.color.action-primary' } },
+				refreshFeed,
+				onBusy,
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(refreshFeed).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+});
+
+describe('deletePresetFlow', () => {
+	it('deletes and refreshes the feed', async () => {
+		client.deleteBlockPreset.mockResolvedValue({});
+		const refreshFeed = jest.fn().mockResolvedValue({});
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await deletePresetFlow({
+			namespace: 'kb-design-tokens/v1',
+			block: 'kadence/singlebtn',
+			preset: 'button-2',
+			slug: 'default',
+			refreshFeed,
+			onBusy,
+			onError,
+		});
+
+		expect(client.deleteBlockPreset).toHaveBeenCalledWith(
+			'kb-design-tokens/v1',
+			'kadence/singlebtn',
+			'button-2',
+			'default'
+		);
+		expect(refreshFeed).toHaveBeenCalledWith('default');
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+
+	it('surfaces the server 422 message and re-throws, leaving the row for the guard-modal contract', async () => {
+		const failure = new Error('The default preset must name an existing preset.');
+		client.deleteBlockPreset.mockRejectedValue(failure);
+		const refreshFeed = jest.fn();
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			deletePresetFlow({
+				namespace: 'kb-design-tokens/v1',
+				block: 'kadence/singlebtn',
+				preset: 'primary',
+				slug: 'default',
+				refreshFeed,
+				onBusy,
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(refreshFeed).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+});

--- a/src/style-library/helpers/preset-flows.js
+++ b/src/style-library/helpers/preset-flows.js
@@ -1,0 +1,169 @@
+/**
+ * Pure orchestration for the Button preset screen's three write flows: create, save (which also
+ * covers rename — a preset's label and token map are always written together), and delete. Same
+ * `scale-flows.js` discipline: the REST call is imported here (so a test mocks `api/client`), the
+ * caller supplies busy/error callbacks and a feed refresh, and every flow settles pessimistically
+ * and re-throws on failure. Unlike the scale flows, no write here carries a `version` parameter —
+ * the preset write routes have no optimistic-concurrency check (fact 15 of the plan overview), so
+ * there is no 409 handling to thread through.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { deleteBlockPreset, saveBlockPreset } from '../api/client';
+import { isEqual } from './settings-schema';
+import { nextPresetSlug, presetSaveTokens } from './presets';
+
+/**
+ * Read the message off a REST error, falling back to a generic string when the error carries
+ * none. Duplicated from `scale-flows.js`'s identical helper rather than imported — the flow
+ * modules stay independent on purpose.
+ *
+ * @param {*} error The rejected value from an `apiFetch` call.
+ *
+ * @since TBD
+ *
+ * @return {string} A user-facing message.
+ */
+function errorMessage(error) {
+	return error?.message || __('Something went wrong. Please try again.', 'kadence-blocks');
+}
+
+/**
+ * Mint a new button preset as a visible, editable copy of the default preset: pick the first free
+ * slug, POST it with the default preset's five bound properties, refresh the feed, and resolve
+ * the new preset's slug so the caller can open its settings panel.
+ *
+ * @param {Object}                 args
+ * @param {string}                 args.namespace     REST namespace.
+ * @param {string}                 args.block         The block name, e.g. `kadence/singlebtn`.
+ * @param {string[]}               args.existingSlugs The preset slugs already taken.
+ * @param {Record<string, string>} args.defaultTokens  The `$default` preset's seeded id map
+ *                                                       (bare ids, as `presetInitialValues` returns).
+ * @param {string}                 args.slug          Token library slug.
+ * @param {Function}               args.refreshFeed   Replaces the feed with a fresh REST read for a slug.
+ * @param {Function}               args.onBusy        Called with a boolean as the request starts and settles.
+ * @param {Function}               args.onError       Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<string>} Resolves with the new preset's slug; rejects on failure, after
+ *                            `onError`/`onBusy` have already run.
+ */
+export function createPresetFlow({
+	namespace,
+	block,
+	existingSlugs,
+	defaultTokens,
+	slug,
+	refreshFeed,
+	onBusy,
+	onError,
+}) {
+	onBusy(true);
+
+	const preset = nextPresetSlug(existingSlugs, 'button');
+
+	return saveBlockPreset(
+		namespace,
+		block,
+		{ preset, label: __('New Button', 'kadence-blocks'), tokens: presetSaveTokens(defaultTokens) },
+		slug
+	)
+		.then(() => refreshFeed(slug))
+		.then(() => {
+			onBusy(false);
+			return preset;
+		})
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+
+			throw err;
+		});
+}
+
+/**
+ * Save a preset's label and token map in one write — the panel's Save button and a NAME rename
+ * both go through this flow. Skips the request entirely when the draft is unchanged; otherwise
+ * always sends the full label + token map together, so a rename never has to omit `tokens` to
+ * avoid clobbering it.
+ *
+ * @param {Object} args
+ * @param {string} args.namespace     REST namespace.
+ * @param {string} args.block         The block name, e.g. `kadence/singlebtn`.
+ * @param {string} args.preset        The preset slug being saved.
+ * @param {Object} args.draft         The panel's current draft (`{ label, tokens }`).
+ * @param {Object} args.initialValues The values the draft is compared against (`{ label, tokens }`).
+ * @param {string} args.slug          Token library slug.
+ * @param {Function} args.refreshFeed Replaces the feed with a fresh REST read for a slug.
+ * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once an unchanged draft is skipped, or the write and feed
+ *                          refresh complete; rejects on failure, after `onError`/`onBusy` have
+ *                          already run.
+ */
+export function savePresetFlow({ namespace, block, preset, draft, initialValues, slug, refreshFeed, onBusy, onError }) {
+	if (isEqual(draft, initialValues)) {
+		return Promise.resolve();
+	}
+
+	onBusy(true);
+
+	return saveBlockPreset(
+		namespace,
+		block,
+		{ preset, label: draft.label, tokens: presetSaveTokens(draft.tokens) },
+		slug
+	)
+		.then(() => refreshFeed(slug))
+		.then(() => onBusy(false))
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+
+			throw err;
+		});
+}
+
+/**
+ * Delete a user-created button preset. The server rejects deleting whatever the effective
+ * `$default` names with a 422 (`guard_default_present`) — that response's own message is
+ * surfaced through `onError` unchanged, never swallowed.
+ *
+ * @param {Object}   args
+ * @param {string}   args.namespace   REST namespace.
+ * @param {string}   args.block       The block name, e.g. `kadence/singlebtn`.
+ * @param {string}   args.preset      The preset slug to delete.
+ * @param {string}   args.slug        Token library slug.
+ * @param {Function} args.refreshFeed Replaces the feed with a fresh REST read for a slug.
+ * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once the delete and the feed refresh complete; rejects on
+ *                          failure, after `onError`/`onBusy` have already run.
+ */
+export function deletePresetFlow({ namespace, block, preset, slug, refreshFeed, onBusy, onError }) {
+	onBusy(true);
+
+	return deleteBlockPreset(namespace, block, preset, slug)
+		.then(() => refreshFeed(slug))
+		.then(() => onBusy(false))
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+
+			throw err;
+		});
+}


### PR DESCRIPTION
The pure create/save/delete flows, wired to nothing yet.

## Test instructions

1. Run `npx wp-scripts test-unit-js src/style-library/__tests__/preset-flows.test.js`.
2. Review what each flow sends: the create flow seeds from the library default, and the save flow posts the whole token map. Nothing calls these yet, so they cannot affect the running app at this slice.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4083/phase-4a-preset-flow-helpers
bun run build-wp
```

The Style Library is at **WP Admin → Kadence → Style Library**. The Button preset screen is under **Block Presets → Button**. Block-editor checks use a **Kadence Single Button** block on any post.
</details>

---

Slice 6 of 23 in the SOFT-4083 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flows for creating, saving, renaming, and deleting button presets.
  * New presets automatically receive available names and default styling tokens.
  * Saving supports label-only and token changes while skipping unchanged drafts.
  * Preset lists refresh after successful updates.

* **Bug Fixes**
  * Improved busy-state handling and server error reporting during preset operations.
  * Preserves server-provided error messages when deletion fails.

* **Tests**
  * Added comprehensive coverage for preset creation, updates, deletion, errors, and refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->