### PR TITLE
[DTM] SOFT-4083 [7/23]: Wire the preset flows into the screen

### DIFF
--- a/src/style-library/__tests__/button-screen.test.js
+++ b/src/style-library/__tests__/button-screen.test.js
@@ -9,15 +9,15 @@ import { createRoot } from 'react-dom/client';
  * Internal dependencies
  */
 import { ButtonScreen } from '../components/pages/ButtonScreen';
-import { useButtonPresets } from '../hooks/use-button-presets';
+import { useButtonScreen } from '../hooks/use-button-screen';
 import { useDraftChannel } from '../hooks/use-draft-channel';
 
-// A factory: `use-button-presets.js` pulls in `../api/client`, which imports `@wordpress/api-fetch`
-// (externalized to the `wp.apiFetch` global in production, not an installed npm dependency), so
-// automocking would fail to resolve it. The screen only reads the hook's return value, so a bare
-// jest.fn() stand-in is enough.
-jest.mock('../hooks/use-button-presets', () => ({
-	useButtonPresets: jest.fn(),
+// A factory: `use-button-screen.js` pulls in `helpers/preset-flows.js` -> `../api/client`, which
+// imports `@wordpress/api-fetch` (externalized to the `wp.apiFetch` global in production, not an
+// installed npm dependency), so automocking would fail to resolve it. The screen only reads the
+// hook's return value, so a bare jest.fn() stand-in is enough.
+jest.mock('../hooks/use-button-screen', () => ({
+	useButtonScreen: jest.fn(),
 }));
 
 // `jest.config.js` maps the `@wordpress/components` specifier to the copy nested under
@@ -45,9 +45,9 @@ let container;
 let root;
 
 /**
- * Render `ButtonScreen` with the given `useButtonPresets` stub and return the mounted container.
+ * Render `ButtonScreen` with the given `useButtonScreen` stub and return the mounted container.
  *
- * @param {Object}   presets    The `useButtonPresets` return value to stub.
+ * @param {Object}   screen     The `useButtonScreen` return value to stub.
  * @param {Object}   [options]  Overrides for the props the selection and overlay paths read.
  * @param {string}   [options.item]     The route's open `kb-item`.
  * @param {Function} [options.navigate] The navigate spy.
@@ -56,8 +56,8 @@ let root;
  *
  * @return {HTMLElement} The container the screen was rendered into.
  */
-function renderButtonScreen(presets, { item = '', navigate = () => {} } = {}) {
-	useButtonPresets.mockReturnValue(presets);
+function renderButtonScreen(screen, { item = '', navigate = () => {} } = {}) {
+	useButtonScreen.mockReturnValue(screen);
 
 	act(() => {
 		root.render(
@@ -78,7 +78,7 @@ beforeEach(() => {
 	container = document.createElement('div');
 	document.body.appendChild(container);
 	root = createRoot(container);
-	useButtonPresets.mockReset();
+	useButtonScreen.mockReset();
 	useDraftChannel.mockReset();
 	useDraftChannel.mockReturnValue(null);
 });
@@ -92,14 +92,24 @@ afterEach(() => {
 
 describe('ButtonScreen loading state', () => {
 	/**
-	 * While `useButtonPresets` is still fetching, the screen must show a busy indicator instead of
-	 * the empty state — `useButtonPresets` starts with `isLoading: true` and no rows, and rendering
+	 * While `useButtonScreen` is still fetching, the screen must show a busy indicator instead of
+	 * the empty state — `useButtonScreen` starts with `isLoading: true` and no rows, and rendering
 	 * the empty state at that point would flash "Add Button" before the presets arrive.
 	 *
 	 * @return {void}
 	 */
 	it('renders a spinner instead of the empty state while loading', () => {
-		renderButtonScreen({ payload: null, isLoading: true, loadError: null, rows: [], initialValuesFor: () => ({}) });
+		renderButtonScreen({
+			payload: null,
+			isLoading: true,
+			loadError: null,
+			rows: [],
+			initialValuesFor: () => ({}),
+			isBusy: false,
+			addError: null,
+			clearAddError: () => {},
+			addPreset: () => Promise.resolve(),
+		});
 
 		expect(container.querySelector('.components-spinner')).not.toBeNull();
 		expect(container.querySelector('.kadence-blocks-style-library__empty-state')).toBeNull();
@@ -111,7 +121,17 @@ describe('ButtonScreen loading state', () => {
 	 * @return {void}
 	 */
 	it('renders the empty state once loading finishes with no rows', () => {
-		renderButtonScreen({ payload: {}, isLoading: false, loadError: null, rows: [], initialValuesFor: () => ({}) });
+		renderButtonScreen({
+			payload: {},
+			isLoading: false,
+			loadError: null,
+			rows: [],
+			initialValuesFor: () => ({}),
+			isBusy: false,
+			addError: null,
+			clearAddError: () => {},
+			addPreset: () => Promise.resolve(),
+		});
 
 		expect(container.querySelector('.components-spinner')).toBeNull();
 		expect(container.querySelector('.kadence-blocks-style-library__empty-state')).not.toBeNull();
@@ -131,7 +151,17 @@ describe('ButtonScreen loading state', () => {
 			},
 		];
 
-		renderButtonScreen({ payload: {}, isLoading: false, loadError: null, rows, initialValuesFor: () => ({}) });
+		renderButtonScreen({
+			payload: {},
+			isLoading: false,
+			loadError: null,
+			rows,
+			initialValuesFor: () => ({}),
+			isBusy: false,
+			addError: null,
+			clearAddError: () => {},
+			addPreset: () => Promise.resolve(),
+		});
 
 		expect(container.querySelector('.components-spinner')).toBeNull();
 		expect(container.querySelector('.kadence-blocks-style-library__empty-state')).toBeNull();

--- a/src/style-library/__tests__/button-settings.test.js
+++ b/src/style-library/__tests__/button-settings.test.js
@@ -9,13 +9,15 @@ import { createRoot } from 'react-dom/client';
  * Internal dependencies
  */
 import { ButtonSettings } from '../components/pages/ButtonSettings';
-import { useButtonPresets } from '../hooks/use-button-presets';
+import { useButtonScreen } from '../hooks/use-button-screen';
 
-// Same rationale as `button-screen.test.js`: `use-button-presets.js` pulls in `../api/client`,
-// which imports `@wordpress/api-fetch` (externalized in production, not an installed dependency),
-// so automocking would fail to resolve it. `ButtonSettings` only reads the hook's return value.
-jest.mock('../hooks/use-button-presets', () => ({
-	useButtonPresets: jest.fn(),
+// Same rationale as `button-screen.test.js`: `use-button-screen.js` pulls in
+// `helpers/preset-flows.js` -> `../api/client`, which imports `@wordpress/api-fetch`
+// (externalized in production, not an installed dependency), so automocking would fail to
+// resolve it. Both cases below resolve to no initial values, so `ButtonSettings` returns null
+// before mounting `ButtonSettingsPanel` — the hook's write-flow fields never need stubbing.
+jest.mock('../hooks/use-button-screen', () => ({
+	useButtonScreen: jest.fn(),
 }));
 
 const LIBRARY = { rest: { namespace: 'kb-design-tokens/v1' }, slug: 'default', version: 1, values: {} };
@@ -24,18 +26,18 @@ let container;
 let root;
 
 /**
- * Render `ButtonSettings` with the given `useButtonPresets` stub and route item, returning the
+ * Render `ButtonSettings` with the given `useButtonScreen` stub and route item, returning the
  * `navigate` spy passed to it.
  *
- * @param {Object} presets The `useButtonPresets` return value to stub.
- * @param {string} item    The route's `item` (`kb-item`) value.
+ * @param {Object} screen The `useButtonScreen` return value to stub.
+ * @param {string} item   The route's `item` (`kb-item`) value.
  *
  * @since TBD
  *
  * @return {Function} The `navigate` jest spy.
  */
-function renderButtonSettings(presets, item) {
-	useButtonPresets.mockReturnValue(presets);
+function renderButtonSettings(screen, item) {
+	useButtonScreen.mockReturnValue(screen);
 	const navigate = jest.fn();
 
 	act(() => {
@@ -56,7 +58,7 @@ beforeEach(() => {
 	container = document.createElement('div');
 	document.body.appendChild(container);
 	root = createRoot(container);
-	useButtonPresets.mockReset();
+	useButtonScreen.mockReset();
 });
 
 afterEach(() => {

--- a/src/style-library/components/pages/ButtonScreen.js
+++ b/src/style-library/components/pages/ButtonScreen.js
@@ -127,7 +127,7 @@ export function ButtonScreen({ label, route, navigate, library }) {
 					{screen.addError.message}
 				</Notice>
 			)}
-			{presets.isLoading ? (
+			{screen.isLoading ? (
 				<Spinner />
 			) : (
 				<RowList

--- a/src/style-library/components/pages/ButtonScreen.js
+++ b/src/style-library/components/pages/ButtonScreen.js
@@ -76,7 +76,15 @@ export function ButtonScreen({ label, route, navigate, library }) {
 
 	// Guarded exactly like the scale mint (`ScaleScreen.js`): a dirty draft in the open panel
 	// prompts before a new preset navigates it away.
-	const mintPreset = () => screen.addPreset().then((id) => navigate({ item: id }));
+	// `createPresetFlow` (`helpers/preset-flows.js`) records the failure via `screen.addError` (the
+	// Notice rendered below) and re-throws pessimistically for callers that need the rejection; this
+	// `.catch()` only stops that rethrow from surfacing as an unhandled promise rejection, it does
+	// not report the error a second time.
+	const mintPreset = () =>
+		screen
+			.addPreset()
+			.then((id) => navigate({ item: id }))
+			.catch(() => {});
 	const addAction = (
 		<Button
 			icon={plus}

--- a/src/style-library/components/pages/ButtonScreen.js
+++ b/src/style-library/components/pages/ButtonScreen.js
@@ -1,8 +1,8 @@
 /**
  * The Button preset screen: self-registers for `kadence/singlebtn` on the preset-screens filter,
  * exactly as a third party would (`constants/screens.js`'s `PRESET_SCREENS_FILTER` docblock). A
- * header with a (for now inert) "+ Add Button" action over a `RowList` of preset rows, each showing
- * a live-rendered Button chip resolved from the preset's bound color and radius tokens.
+ * header with a "+ Add Button" action over a `RowList` of preset rows, each showing a
+ * live-rendered Button chip resolved from the preset's bound color and radius tokens.
  *
  * This is a bespoke screen, not a `ScaleScreen` config: a preset row carries a five-property map
  * with two states (Normal/Hover), not one scalar token value, so it composes the shared components
@@ -24,7 +24,7 @@ import { ScreenHeader } from '../organisms/ScreenHeader';
 import { RowList } from '../templates/RowList';
 import { EmptyState } from '../molecules/EmptyState';
 import { ButtonSettings } from './ButtonSettings';
-import { useButtonPresets } from '../../hooks/use-button-presets';
+import { useButtonScreen } from '../../hooks/use-button-screen';
 import { useDraftChannel } from '../../hooks/use-draft-channel';
 import { BUTTON_BLOCK, overlayPresetRows } from '../../helpers/presets';
 import { PRESET_SCREENS_FILTER } from '../../constants/screens';
@@ -71,13 +71,19 @@ function renderButtonPreview(row) {
  * @return {JSX.Element} The screen body.
  */
 export function ButtonScreen({ label, route, navigate, library }) {
-	const presets = useButtonPresets(library);
+	const screen = useButtonScreen(library);
 	const channel = useDraftChannel();
 
-	// Disabled with no handler until the mutations flow lands (decision 11): visible intent, not a
-	// hidden affordance.
+	// Guarded exactly like the scale mint (`ScaleScreen.js`): a dirty draft in the open panel
+	// prompts before a new preset navigates it away.
+	const mintPreset = () => screen.addPreset().then((id) => navigate({ item: id }));
 	const addAction = (
-		<Button icon={plus} variant="secondary" disabled>
+		<Button
+			icon={plus}
+			variant="secondary"
+			disabled={screen.isBusy}
+			onClick={() => (channel ? channel.guard(mintPreset) : mintPreset())}
+		>
 			{__('Add Button', 'kadence-blocks')}
 		</Button>
 	);
@@ -87,7 +93,7 @@ export function ButtonScreen({ label, route, navigate, library }) {
 	// this screen's rows.
 	const draft =
 		channel && channel.publication && channel.publication.itemId === route.item ? channel.publication.draft : null;
-	const rows = overlayPresetRows(presets.rows, route.item, draft, library?.values);
+	const rows = overlayPresetRows(screen.rows, route.item, draft, library?.values);
 
 	const items = rows.map((row) => ({
 		id: row.id,
@@ -111,9 +117,14 @@ export function ButtonScreen({ label, route, navigate, library }) {
 	return (
 		<div className="kadence-blocks-style-library__button-screen">
 			<ScreenHeader title={label} primaryAction={addAction} />
-			{presets.loadError && (
+			{screen.loadError && (
 				<Notice status="error" isDismissible={false}>
-					{presets.loadError.message}
+					{screen.loadError.message}
+				</Notice>
+			)}
+			{screen.addError && (
+				<Notice status="error" isDismissible onRemove={screen.clearAddError}>
+					{screen.addError.message}
 				</Notice>
 			)}
 			{presets.isLoading ? (

--- a/src/style-library/components/pages/ButtonSettings.js
+++ b/src/style-library/components/pages/ButtonSettings.js
@@ -93,6 +93,20 @@ function ButtonSettingsPanel({ navigate, route, screen, initialValues, presetLab
 		return () => clearPublication();
 	}, [publish, clearPublication, id, presetLabel, panel.draft, panel.isDirty]);
 
+	// `screen.saveError`/`screen.deleteError` live on the outer `useButtonScreen` instance, not on
+	// this per-preset panel, so a failed write's error otherwise survives past the preset it
+	// happened on. This component is remounted (the caller's `key={id}`) on every preset switch and
+	// on close (the parent returns null once `route.item` clears), so a cleanup that clears both
+	// errors fires exactly when this panel stops representing the preset the error belongs to.
+	const { clearSaveError, clearDeleteError } = screen;
+
+	useEffect(() => {
+		return () => {
+			clearSaveError();
+			clearDeleteError();
+		};
+	}, [clearSaveError, clearDeleteError]);
+
 	// Reassigned every render, never held in state (the `ScaleSettings.js` posture): these close
 	// over the current `panel.draft`, so storing them in state would either loop the publish effect
 	// above or hand the guard modal a stale draft. `save` is the raw promise, rejection intact — the

--- a/src/style-library/components/pages/ButtonSettings.js
+++ b/src/style-library/components/pages/ButtonSettings.js
@@ -68,6 +68,11 @@ function ButtonSettingsPanel({ navigate, route, screen, initialValues, presetLab
 	const id = route.item;
 	const panel = useSettingsPanel({ route, navigate, initialValues });
 	const [activeTab, setActiveTab] = useState(TABS[0].name);
+	// `screen.isBusy` covers all three write flows (add/save/delete) with a single flag, but the
+	// footer needs to show the busy animation on only the button the user actually clicked — a save
+	// must not make Delete look like it is deleting, and vice versa. Tracked locally rather than
+	// added to the hook because only this panel's footer needs the distinction.
+	const [pendingAction, setPendingAction] = useState(null);
 	const channel = useDraftChannel();
 
 	// Pulled out of `channel` rather than depending on `channel` itself — see `ScaleSettings.js`'s
@@ -99,15 +104,33 @@ function ButtonSettingsPanel({ navigate, route, screen, initialValues, presetLab
 		};
 	}
 
+	// Disabling the footer buttons is a UI guard, not a real one — the handlers refuse to start a
+	// second write while `screen.isBusy` is already true, since the flag covers add/save/delete
+	// together and a stale click (e.g. a keyboard Enter racing the disabled-attribute repaint) could
+	// otherwise still fire.
 	const handleSave = () => {
-		screen.savePreset(id, panel.draft, initialValues).catch(() => {});
+		if (screen.isBusy) {
+			return;
+		}
+
+		setPendingAction('save');
+		screen
+			.savePreset(id, panel.draft, initialValues)
+			.catch(() => {})
+			.finally(() => setPendingAction(null));
 	};
 
 	const handleDelete = () => {
+		if (screen.isBusy) {
+			return;
+		}
+
+		setPendingAction('delete');
 		screen
 			.deletePreset(id)
 			.then(() => navigate({ item: '' }))
-			.catch(() => {});
+			.catch(() => {})
+			.finally(() => setPendingAction(null));
 	};
 
 	// Close becomes guarded now that the panel publishes a real draft — the `ScaleSettings.js`
@@ -124,6 +147,9 @@ function ButtonSettingsPanel({ navigate, route, screen, initialValues, presetLab
 			onDelete={screen.isDeletable(id) ? handleDelete : null}
 			onSave={handleSave}
 			isDirty={panel.isDirty}
+			isBusy={screen.isBusy}
+			isSaving={pendingAction === 'save'}
+			isDeleting={pendingAction === 'delete'}
 		>
 			{screen.saveError && (
 				<Notice status="error" isDismissible onRemove={screen.clearSaveError}>

--- a/src/style-library/components/pages/ButtonSettings.js
+++ b/src/style-library/components/pages/ButtonSettings.js
@@ -12,18 +12,20 @@
  * lands (`useSettingsPanel` only re-seeds on an `itemId` change, not on `initialValues` arriving).
  * `ButtonSettings` owns the fetch, the stale-item self-heal, and the loading/no-data gate;
  * `ButtonSettingsPanel` — mounted only once real values exist, `key`ed on the preset id — owns
- * `useSettingsPanel` and the tabs, so switching presets remounts it with a correct seed.
+ * `useSettingsPanel`, the tabs, and the write flows, so switching presets remounts it with a
+ * correct seed.
  *
- * The footer is deliberately inert (`onDelete`/`onSave` both null) and nothing publishes to the
- * draft channel yet: registering channel actions whose `save` is a stub would make the
- * unsaved-changes guard lie about what Save does. Edits are local and discarded on navigation with
- * no prompt until the mutations flow adds the publish effect and the real handlers.
+ * Save writes the label and the full token map together (a rename is just a Save with only the
+ * label changed), so a saved draft always equals the refreshed `initialValues` and `isDirty`
+ * settles to false on its own — no extra re-seed is needed after a save (see the module's sibling
+ * `ScaleSettings.js` for the same posture on scale tokens).
  */
 
 /**
  * WordPress dependencies
  */
 import { useEffect, useState } from '@wordpress/element';
+import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -32,7 +34,8 @@ import { __ } from '@wordpress/i18n';
 import { SettingsPanel } from '../templates/SettingsPanel';
 import { SettingsForm } from '../organisms/SettingsForm';
 import { useSettingsPanel } from '../../hooks/use-settings-panel';
-import { useButtonPresets } from '../../hooks/use-button-presets';
+import { useButtonScreen } from '../../hooks/use-button-screen';
+import { useDraftChannel } from '../../hooks/use-draft-channel';
 import { buttonSettingsSchema } from '../../helpers/presets';
 
 /**
@@ -53,26 +56,85 @@ const TABS = [
  * @param {Object}   props               The component props.
  * @param {Function} props.navigate      The route navigator.
  * @param {Object}   props.route         The current route (`{ screen, item }`).
+ * @param {Object}   props.screen        The `useButtonScreen` binding.
  * @param {Object}   props.initialValues The seeded draft (`{label, tokens}`) for the open preset.
+ * @param {string}   props.presetLabel   The open preset's persisted label, for the channel publication.
  *
  * @since TBD
  *
  * @return {JSX.Element} The panel.
  */
-function ButtonSettingsPanel({ navigate, route, initialValues }) {
+function ButtonSettingsPanel({ navigate, route, screen, initialValues, presetLabel }) {
+	const id = route.item;
 	const panel = useSettingsPanel({ route, navigate, initialValues });
 	const [activeTab, setActiveTab] = useState(TABS[0].name);
+	const channel = useDraftChannel();
+
+	// Pulled out of `channel` rather than depending on `channel` itself — see `ScaleSettings.js`'s
+	// identical comment: `publish`/`clearPublication` are individually stable, while
+	// `useDraftChannelState()` returns a fresh object literal on every app render, so depending on
+	// `channel` would re-fire this effect's cleanup (nulling the pending guard action) on every
+	// unrelated re-render, including the one `guard()` itself triggers.
+	const publish = channel?.publish;
+	const clearPublication = channel?.clearPublication;
+
+	useEffect(() => {
+		if (!publish || !clearPublication || !id) {
+			return undefined;
+		}
+
+		publish({ itemId: id, label: presetLabel, draft: panel.draft, isDirty: panel.isDirty });
+
+		return () => clearPublication();
+	}, [publish, clearPublication, id, presetLabel, panel.draft, panel.isDirty]);
+
+	// Reassigned every render, never held in state (the `ScaleSettings.js` posture): these close
+	// over the current `panel.draft`, so storing them in state would either loop the publish effect
+	// above or hand the guard modal a stale draft. `save` is the raw promise, rejection intact — the
+	// modal's own Save button is the one place that needs to see a failure.
+	if (channel) {
+		channel.actionsRef.current = {
+			save: () => screen.savePreset(id, panel.draft, initialValues),
+			discard: panel.resetDraft,
+		};
+	}
+
+	const handleSave = () => {
+		screen.savePreset(id, panel.draft, initialValues).catch(() => {});
+	};
+
+	const handleDelete = () => {
+		screen
+			.deletePreset(id)
+			.then(() => navigate({ item: '' }))
+			.catch(() => {});
+	};
+
+	// Close becomes guarded now that the panel publishes a real draft — the `ScaleSettings.js`
+	// pattern. Delete is never guarded and never confirmed beyond the click: prompting to save a
+	// draft on a preset being destroyed is nonsense.
+	const handleClose = () => (channel ? channel.guard(panel.close) : panel.close());
 
 	return (
 		<SettingsPanel
-			onClose={panel.close}
+			onClose={handleClose}
 			tabs={TABS}
 			activeTab={activeTab}
 			onTabChange={setActiveTab}
-			onDelete={null}
-			onSave={null}
+			onDelete={screen.isDeletable(id) ? handleDelete : null}
+			onSave={handleSave}
 			isDirty={panel.isDirty}
 		>
+			{screen.saveError && (
+				<Notice status="error" isDismissible onRemove={screen.clearSaveError}>
+					{screen.saveError.message}
+				</Notice>
+			)}
+			{screen.deleteError && (
+				<Notice status="error" isDismissible onRemove={screen.clearDeleteError}>
+					{screen.deleteError.message}
+				</Notice>
+			)}
 			<SettingsForm
 				schema={buttonSettingsSchema(activeTab)}
 				values={panel.draft}
@@ -96,28 +158,38 @@ function ButtonSettingsPanel({ navigate, route, initialValues }) {
  *         a valid one's presets are still loading.
  */
 export function ButtonSettings({ route, navigate, library }) {
-	const presets = useButtonPresets(library);
+	const screen = useButtonScreen(library);
 	const id = route.item;
-	const initialValues = presets.initialValuesFor(id);
+	const initialValues = screen.initialValuesFor(id);
 	const hasInitialValues = Boolean(initialValues);
+	const presetLabel = screen.payload?.presets?.[id]?.label ?? id;
 
 	// A `kb-item` naming no preset (a stale deep link, or another screen's token id) closes the
 	// panel instead of rendering broken fields — the `ScaleSettings.js` self-healing idiom. Waiting
-	// on `!presets.isLoading` matters here: while the fetch is in flight, an unknown-slug draft and a
+	// on `!screen.isLoading` matters here: while the fetch is in flight, an unknown-slug draft and a
 	// still-loading one look identical (both `null`), so healing eagerly would bounce a valid deep
-	// link straight into the page before its fetch lands. Waiting on `!presets.loadError` matters just
+	// link straight into the page before its fetch lands. Waiting on `!screen.loadError` matters just
 	// as much: a rejected fetch also leaves `initialValuesFor` returning null, and a valid `kb-item`
 	// must not be mistaken for a stale one just because the request failed — that would rewrite the
 	// route and make the deep link unrecoverable even after a successful retry.
 	useEffect(() => {
-		if (id && !presets.isLoading && !presets.loadError && !hasInitialValues) {
+		if (id && !screen.isLoading && !screen.loadError && !hasInitialValues) {
 			navigate({ item: '' });
 		}
-	}, [id, presets.isLoading, presets.loadError, hasInitialValues, navigate]);
+	}, [id, screen.isLoading, screen.loadError, hasInitialValues, navigate]);
 
 	if (!id || !hasInitialValues) {
 		return null;
 	}
 
-	return <ButtonSettingsPanel key={id} route={route} navigate={navigate} initialValues={initialValues} />;
+	return (
+		<ButtonSettingsPanel
+			key={id}
+			route={route}
+			navigate={navigate}
+			screen={screen}
+			initialValues={initialValues}
+			presetLabel={presetLabel}
+		/>
+	);
 }

--- a/src/style-library/components/templates/SettingsPanel.js
+++ b/src/style-library/components/templates/SettingsPanel.js
@@ -30,6 +30,13 @@ import './SettingsPanel.scss';
  * @param {?Function}      [props.onDelete]     Footer Delete handler; null hides the button (a non-deletable item).
  * @param {?Function}      [props.onSave]       Footer Save handler; null hides the button.
  * @param {boolean}        [props.isDirty]      Enables Save when true.
+ * @param {boolean}        [props.isBusy]       Disables both footer buttons while a write is in flight. Optional,
+ *                                                defaults to false, so callers that never pass it are unaffected.
+ * @param {boolean}        [props.isSaving]     Shows the Save button's busy animation and a "Saving…" label.
+ *                                                Optional, defaults to false; distinct from `isBusy` so a delete in
+ *                                                flight does not make Save look like it is saving.
+ * @param {boolean}        [props.isDeleting]   Shows the Delete button's busy animation and a "Deleting…" label.
+ *                                                Optional, defaults to false, for the same reason as `isSaving`.
  *
  * @since TBD
  *
@@ -44,6 +51,9 @@ export function SettingsPanel({
 	onDelete = null,
 	onSave = null,
 	isDirty = false,
+	isBusy = false,
+	isSaving = false,
+	isDeleting = false,
 }) {
 	const fieldArea = <div className="kadence-blocks-style-library__settings-panel-fields">{children}</div>;
 
@@ -76,13 +86,13 @@ export function SettingsPanel({
 			)}
 			<div className="kadence-blocks-style-library__settings-panel-footer">
 				{onDelete && (
-					<Button variant="secondary" isDestructive onClick={onDelete}>
-						{__('Delete', 'kadence-blocks')}
+					<Button variant="secondary" isDestructive isBusy={isDeleting} disabled={isBusy} onClick={onDelete}>
+						{isDeleting ? __('Deleting…', 'kadence-blocks') : __('Delete', 'kadence-blocks')}
 					</Button>
 				)}
 				{onSave && (
-					<Button variant="primary" disabled={!isDirty} onClick={onSave}>
-						{__('Save', 'kadence-blocks')}
+					<Button variant="primary" isBusy={isSaving} disabled={!isDirty || isBusy} onClick={onSave}>
+						{isSaving ? __('Saving…', 'kadence-blocks') : __('Save', 'kadence-blocks')}
 					</Button>
 				)}
 			</div>

--- a/src/style-library/hooks/use-button-screen.js
+++ b/src/style-library/hooks/use-button-screen.js
@@ -1,0 +1,124 @@
+/**
+ * The state binding both `ButtonScreen` and `ButtonSettings` call as siblings (the
+ * `useScaleScreen` role, applied to a fetched-not-localized payload): wraps `useButtonPresets`
+ * and adds the three preset write flows. No reorder chain here (that is a separate concern) and
+ * no `feedVersionRef` — preset writes carry no version parameter (`helpers/preset-flows.js`'s
+ * module docblock), so there is nothing to serialize against.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { createPresetFlow, deletePresetFlow, savePresetFlow } from '../helpers/preset-flows';
+import { BUTTON_BLOCK, presetInitialValues } from '../helpers/presets';
+import { useButtonPresets } from './use-button-presets';
+
+/**
+ * Bind the Button preset screen's config to the fetched preset collection and its three write
+ * flows.
+ *
+ * @param {Object} library The design-tokens feed hook's return value (`useDesignTokensFeed()`).
+ *
+ * @since TBD
+ *
+ * @return {{payload: ?object, isLoading: boolean, loadError: ?Error, rows: Array<Object>, initialValuesFor: Function, isBusy: boolean, addError: ?Object, saveError: ?Object, deleteError: ?Object, clearAddError: Function, clearSaveError: Function, clearDeleteError: Function, addPreset: Function, savePreset: Function, deletePreset: Function, isDeletable: Function}}
+ */
+export function useButtonScreen(library) {
+	const presets = useButtonPresets(library);
+
+	const [isBusy, setIsBusy] = useState(false);
+	const [addError, setAddError] = useState(null);
+	const [saveError, setSaveError] = useState(null);
+	const [deleteError, setDeleteError] = useState(null);
+
+	const namespace = library?.rest?.namespace;
+	const slug = library?.slug;
+	const refreshFeed = library?.refreshFeed;
+
+	const clearAddError = useCallback(() => setAddError(null), []);
+	const clearSaveError = useCallback(() => setSaveError(null), []);
+	const clearDeleteError = useCallback(() => setDeleteError(null), []);
+
+	const addPreset = useCallback(() => {
+		setAddError(null);
+
+		const existingSlugs = Object.keys(presets.payload?.presets ?? {});
+		const defaultTokens = presetInitialValues(presets.payload, presets.payload?.default)?.tokens ?? {};
+
+		return createPresetFlow({
+			namespace,
+			block: BUTTON_BLOCK,
+			existingSlugs,
+			defaultTokens,
+			slug,
+			refreshFeed,
+			onBusy: setIsBusy,
+			onError: setAddError,
+		});
+	}, [namespace, presets.payload, slug, refreshFeed]);
+
+	const savePreset = useCallback(
+		(id, draft, initialValues) => {
+			setSaveError(null);
+
+			return savePresetFlow({
+				namespace,
+				block: BUTTON_BLOCK,
+				preset: id,
+				draft,
+				initialValues,
+				slug,
+				refreshFeed,
+				onBusy: setIsBusy,
+				onError: setSaveError,
+			});
+		},
+		[namespace, presets.payload, slug, refreshFeed]
+	);
+
+	const deletePreset = useCallback(
+		(id) => {
+			setDeleteError(null);
+
+			return deletePresetFlow({
+				namespace,
+				block: BUTTON_BLOCK,
+				preset: id,
+				slug,
+				refreshFeed,
+				onBusy: setIsBusy,
+				onError: setDeleteError,
+			});
+		},
+		[namespace, presets.payload, slug, refreshFeed]
+	);
+
+	const isDeletable = useCallback(
+		(id) => presets.rows.find((row) => row.id === id)?.userCreated ?? false,
+		[presets.rows]
+	);
+
+	return {
+		payload: presets.payload,
+		isLoading: presets.isLoading,
+		loadError: presets.loadError,
+		rows: presets.rows,
+		initialValuesFor: presets.initialValuesFor,
+		isBusy,
+		addError,
+		saveError,
+		deleteError,
+		clearAddError,
+		clearSaveError,
+		clearDeleteError,
+		addPreset,
+		savePreset,
+		deletePreset,
+		isDeletable,
+	};
+}


### PR DESCRIPTION
Connects the flows from the slice below to the screen and settings panel.

## Test instructions

1. On **Block Presets → Button**, confirm **Add Button** is now enabled and **Save** appears in the panel.
2. Click **Add Button** — a new preset appears and its panel opens.
3. Rename it, change a colour, hit **Save**, then reload the page and confirm both stuck.
4. Delete the preset you just made and confirm it disappears after a reload.
5. Confirm the presets that ship with the library cannot be deleted.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4083/phase-4b-preset-flow-wiring
bun run build-wp
```

The Style Library is at **WP Admin → Kadence → Style Library**. The Button preset screen is under **Block Presets → Button**. Block-editor checks use a **Kadence Single Button** block on any post.
</details>

## Screenshot
Add Button enabled and Save present once the flows are wired
<img width="1512" height="788" alt="phase-4b-preset-flow-wiring" src="https://github.com/user-attachments/assets/524698ab-fa8e-41c8-ade9-6667d17cf1fd" />

---

Slice 7 of 23 in the SOFT-4083 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streamlined button preset management, including creating, saving, and deleting presets.
  * Added loading, busy, and operation-specific error states with dismissible notifications.
  * Added safeguards for draft publication, closing, and navigation.
  * Added support for determining whether user-created presets can be deleted.
  * Added clear “Saving…” and “Deleting…” indicators while operations are in progress.
* **Bug Fixes**
  * Improved handling of stale preset routes and loading states in button settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->