### PR TITLE
[DTM] SOFT-4083 [8/23]: Preset display-order storage

### DIFF
--- a/includes/resources/Design_Tokens/Document/Preset_Order_Index.php
+++ b/includes/resources/Design_Tokens/Document/Preset_Order_Index.php
@@ -1,0 +1,245 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Document;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+
+/**
+ * Reads and writes the presetOrder map — a per-block ordered preset-slug list — in the module's
+ * $extensions namespace. Authoring metadata only; the effective document builder strips
+ * $extensions, so order never affects rendering. Every mutating method returns the updated
+ * document; the original is not modified.
+ *
+ * {@see Token_Order_Index}'s sibling, keyed per block rather than as one flat list: a preset slug
+ * is only unique WITHIN its block (two different blocks can both define a "primary" preset), unlike
+ * a token id, which is already a stable, globally unique dot-path. Storing slugs directly is safe
+ * here for the same reason {@see Token_Order_Index} avoids storing a UI-schema group label: a
+ * preset slug is a stable, locale-independent identifier, never a translated display string.
+ *
+ * @since TBD
+ */
+final class Preset_Order_Index {
+
+	/**
+	 * The stored order for one block. Read-side fail-soft: a section that is not a sequential list
+	 * is dropped wholesale (degrades to declaration order), and non-string or empty entries inside
+	 * an otherwise-valid list are filtered out, so a hand-corrupted section degrades to "no order"
+	 * instead of a type error downstream.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document The decoded overrides document.
+	 * @param string               $block    The block name.
+	 *
+	 * @return list<string>
+	 */
+	public function for_block( array $document, string $block ): array {
+		$slugs = $this->read_block( $document, $block );
+
+		if ( ! is_array( $slugs ) ) {
+			return [];
+		}
+
+		// The `$slugs === []` check is required, not redundant: `range( 0, -1 )` returns
+		// `[ 0, -1 ]` in PHP, not `[]`, so without this short-circuit an empty order list would be
+		// misclassified as malformed rather than as a valid empty list.
+		$is_list = $slugs === [] || array_keys( $slugs ) === range( 0, count( $slugs ) - 1 );
+
+		if ( ! $is_list ) {
+			return [];
+		}
+
+		return array_values( array_filter( $slugs, fn( $slug ) => is_string( $slug ) && $slug !== '' ) );
+	}
+
+	/**
+	 * Store one block's order wholesale (the endpoint's PUT-replaces contract). Deduplicates the
+	 * incoming slugs, keeping first occurrence.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document The decoded overrides document.
+	 * @param string               $block    The block name.
+	 * @param array<int, string>   $slugs    The block's new ordered preset-slug list.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function set_block( array $document, string $block, array $slugs ): array {
+		return $this->write_block( $document, $block, array_values( array_unique( $slugs ) ) );
+	}
+
+	/**
+	 * Remove one block's stored order — declaration order applies again for that block. No-op
+	 * (the same document is returned) when the block has no order currently stored.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document The decoded overrides document.
+	 * @param string               $block    The block name.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function remove_block( array $document, string $block ): array {
+		$map = $this->read_map( $document );
+
+		if ( ! isset( $map[ $block ] ) ) {
+			return $document;
+		}
+
+		unset( $map[ $block ] );
+
+		if ( $map === [] ) {
+			return $this->unset_section( $document );
+		}
+
+		return $this->write_map( $document, $map );
+	}
+
+	/**
+	 * The single ordering algorithm every read seam applies: stored-and-present slugs first, in
+	 * stored order, then the remaining incoming names in their incoming order. Advisory — a stale
+	 * stored slug that names no incoming preset is skipped silently, and a preset the store has
+	 * never ordered simply appends. Any future listing seam of block presets must route through
+	 * this method rather than reimplement the merge, so the controller, the resolver, and the
+	 * admin feed can never disagree.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document The decoded overrides document.
+	 * @param string               $block    The block name.
+	 * @param array<int, string>   $names    The preset slugs in their unordered (declaration) order.
+	 *
+	 * @return list<string>
+	 */
+	public function apply( array $document, string $block, array $names ): array {
+		$stored  = $this->for_block( $document, $block );
+		$present = array_values( array_intersect( $stored, $names ) );
+		$rest    = array_values( array_diff( $names, $present ) );
+
+		return array_merge( $present, $rest );
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document The decoded overrides document.
+	 * @param string               $block    The block name.
+	 *
+	 * @return mixed
+	 */
+	private function read_block( array $document, string $block ) {
+		return $this->read_map( $document )[ $block ] ?? null;
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document The decoded overrides document.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function read_map( array $document ): array {
+		$ext_data = $document[ Extensions::get_extensions_key() ] ?? null;
+
+		if ( ! is_array( $ext_data ) ) {
+			return [];
+		}
+
+		$ns_data = $ext_data[ Extensions::get_namespace() ] ?? null;
+
+		if ( ! is_array( $ns_data ) ) {
+			return [];
+		}
+
+		$map = $ns_data[ Extensions::get_section_preset_order() ] ?? null;
+
+		return is_array( $map ) ? $map : [];
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document The decoded overrides document.
+	 * @param string               $block    The block name.
+	 * @param array<int, string>   $slugs    The block's ordered preset-slug list.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function write_block( array $document, string $block, array $slugs ): array {
+		$map = $this->read_map( $document );
+
+		$map[ $block ] = $slugs;
+
+		return $this->write_map( $document, $map );
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document The decoded overrides document.
+	 * @param array<string, mixed> $map      The full presetOrder map to store.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function write_map( array $document, array $map ): array {
+		$ext = Extensions::get_extensions_key();
+		$ns  = Extensions::get_namespace();
+		$sec = Extensions::get_section_preset_order();
+
+		/** @var array<string, mixed> $ext_data */
+		$ext_data = isset( $document[ $ext ] ) && is_array( $document[ $ext ] ) ? $document[ $ext ] : [];
+		/** @var array<string, mixed> $ns_data */
+		$ns_data = isset( $ext_data[ $ns ] ) && is_array( $ext_data[ $ns ] ) ? $ext_data[ $ns ] : [];
+
+		$ns_data[ $sec ]  = $map;
+		$ext_data[ $ns ]  = $ns_data;
+		$document[ $ext ] = $ext_data;
+
+		return $document;
+	}
+
+	/**
+	 * Remove the whole presetOrder section, pruning an emptied namespace/extensions node along
+	 * with it so a fully-cleared order leaves no residue in the stored document.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document The decoded overrides document.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function unset_section( array $document ): array {
+		$ext = Extensions::get_extensions_key();
+		$ns  = Extensions::get_namespace();
+		$sec = Extensions::get_section_preset_order();
+
+		if ( ! isset( $document[ $ext ] ) || ! is_array( $document[ $ext ] ) ) {
+			return $document;
+		}
+
+		/** @var array<string, mixed> $ext_data */
+		$ext_data = $document[ $ext ];
+
+		if ( ! isset( $ext_data[ $ns ] ) || ! is_array( $ext_data[ $ns ] ) ) {
+			return $document;
+		}
+
+		/** @var array<string, mixed> $ns_data */
+		$ns_data = $ext_data[ $ns ];
+		unset( $ns_data[ $sec ] );
+
+		if ( $ns_data === [] ) {
+			unset( $ext_data[ $ns ] );
+		} else {
+			$ext_data[ $ns ] = $ns_data;
+		}
+
+		if ( $ext_data === [] ) {
+			unset( $document[ $ext ] );
+		} else {
+			$document[ $ext ] = $ext_data;
+		}
+
+		return $document;
+	}
+}

--- a/includes/resources/Design_Tokens/Document/Preset_Order_Index.php
+++ b/includes/resources/Design_Tokens/Document/Preset_Order_Index.php
@@ -23,8 +23,9 @@ final class Preset_Order_Index {
 	/**
 	 * The stored order for one block. Read-side fail-soft: a section that is not a sequential list
 	 * is dropped wholesale (degrades to declaration order), and non-string or empty entries inside
-	 * an otherwise-valid list are filtered out, so a hand-corrupted section degrades to "no order"
-	 * instead of a type error downstream.
+	 * an otherwise-valid list are filtered out, and repeated slugs collapse to their first
+	 * occurrence, so a hand-corrupted section degrades to "no order" instead of a type error or a
+	 * repeated preset downstream.
 	 *
 	 * @since TBD
 	 *
@@ -49,7 +50,9 @@ final class Preset_Order_Index {
 			return [];
 		}
 
-		return array_values( array_filter( $slugs, fn( $slug ) => is_string( $slug ) && $slug !== '' ) );
+		// Deduplicated here rather than only in `set_block`, because `apply` intersects this list
+		// and would otherwise repeat a preset for any document written outside that setter.
+		return array_values( array_unique( array_filter( $slugs, fn( $slug ) => is_string( $slug ) && $slug !== '' ) ) );
 	}
 
 	/**
@@ -82,7 +85,9 @@ final class Preset_Order_Index {
 	public function remove_block( array $document, string $block ): array {
 		$map = $this->read_map( $document );
 
-		if ( ! isset( $map[ $block ] ) ) {
+		// `array_key_exists`, not `isset`: a stored `null` is malformed but still present, and
+		// `isset` would report it missing and leave the residue in storage permanently.
+		if ( ! array_key_exists( $block, $map ) ) {
 			return $document;
 		}
 

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
@@ -115,6 +115,22 @@ final class Extensions {
 	private const SECTION_TOKEN_ORDER = 'tokenOrder';
 
 	/**
+	 * The per-block preset display-order section: a map of block name => ordered list of preset
+	 * slugs. NOT returned by get_sections() — it is id-keyed authoring metadata, not
+	 * preset-shaped, so the tokens-map walk (and the reference scanner that follows
+	 * get_sections()) must not descend into it; it holds slugs only, never {alias} values. Keyed
+	 * per block, unlike tokenOrder's single flat list, because a preset slug is only unique
+	 * within its block. The stored order is partial and advisory, never authoritative membership:
+	 * readers append unmentioned slugs in declaration order and ignore stale ones, so an order can
+	 * permute the registered set but never hide a preset.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const SECTION_PRESET_ORDER = 'presetOrder';
+
+	/**
 	 * The key naming a group's default preset slug.
 	 *
 	 * @since TBD
@@ -275,6 +291,18 @@ final class Extensions {
 	 */
 	public static function get_section_token_order(): string {
 		return self::SECTION_TOKEN_ORDER;
+	}
+
+	/**
+	 * The per-block preset display-order section name.
+	 * NOT returned by get_sections() — it is id-keyed metadata, not preset-shaped.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_section_preset_order(): string {
+		return self::SECTION_PRESET_ORDER;
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Document/Preset_Order_IndexTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/Preset_Order_IndexTest.php
@@ -117,6 +117,18 @@ final class Preset_Order_IndexTest extends TestCase {
 		];
 	}
 
+	/**
+	 * A repeated slug in a stored order collapses to its first occurrence on read, so a document
+	 * written outside set_block() (which deduplicates on write) cannot surface a preset twice.
+	 *
+	 * @return void
+	 */
+	public function testForBlockDeduplicatesRepeatedSlugs(): void {
+		$doc = $this->doc_with_order( self::BUTTON, [ 'primary', 'primary', 'secondary' ] );
+
+		$this->assertSame( [ 'primary', 'secondary' ], $this->index->for_block( $doc, self::BUTTON ) );
+	}
+
 	// -------------------------------------------------------------------------
 	// set_block()
 	// -------------------------------------------------------------------------
@@ -215,6 +227,32 @@ final class Preset_Order_IndexTest extends TestCase {
 	}
 
 	/**
+	 * remove_block() clears a block whose stored value is null. The entry is malformed but still
+	 * present, so guarding with isset() would report it missing and strand it in storage.
+	 *
+	 * @return void
+	 */
+	public function testRemoveBlockClearsANullEntry(): void {
+		$doc = [
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					Extensions::get_section_preset_order() => [
+						self::BUTTON          => null,
+						'kadence/advancedbtn' => [ 'ghost' ],
+					],
+				],
+			],
+		];
+
+		$result = $this->index->remove_block( $doc, self::BUTTON );
+
+		$section = $result[ Extensions::get_extensions_key() ][ Extensions::get_namespace() ][ Extensions::get_section_preset_order() ];
+
+		$this->assertArrayNotHasKey( self::BUTTON, $section );
+		$this->assertSame( [ 'ghost' ], $this->index->for_block( $result, 'kadence/advancedbtn' ) );
+	}
+
+	/**
 	 * remove_block() prunes the whole presetOrder section once its last block entry is removed, so
 	 * a fully-cleared order leaves no residue in the stored document.
 	 *
@@ -309,6 +347,21 @@ final class Preset_Order_IndexTest extends TestCase {
 	// -------------------------------------------------------------------------
 	// helpers
 	// -------------------------------------------------------------------------
+
+	/**
+	 * A duplicated stored slug does not repeat the preset in the applied order, so apply() keeps
+	 * returning a permutation of the incoming names.
+	 *
+	 * @return void
+	 */
+	public function testApplyDoesNotRepeatADuplicatedStoredSlug(): void {
+		$doc = $this->doc_with_order( self::BUTTON, [ 'primary', 'primary' ] );
+
+		$this->assertSame(
+			[ 'primary', 'secondary' ],
+			$this->index->apply( $doc, self::BUTTON, [ 'secondary', 'primary' ] )
+		);
+	}
 
 	/**
 	 * Build a decoded document carrying one block's presetOrder entry.

--- a/tests/wpunit/Resources/Design_Tokens/Document/Preset_Order_IndexTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/Preset_Order_IndexTest.php
@@ -72,18 +72,20 @@ final class Preset_Order_IndexTest extends TestCase {
 	}
 
 	/**
-	 * A malformed presetOrder entry — a non-list ("map-shaped") value, or non-string/empty slugs
-	 * inside the list — is dropped (or filtered) on read rather than surfaced, so a hand-corrupted
-	 * entry degrades to declaration order instead of a type error downstream.
+	 * A malformed presetOrder entry — a value that is not an array at all, a non-list ("map-shaped")
+	 * value, or non-string/empty slugs inside the list — is dropped (or filtered) on read rather
+	 * than surfaced, so a hand-corrupted entry degrades to declaration order instead of a type error
+	 * downstream. $entry is deliberately untyped: a typed array would make the non-array branch
+	 * unreachable from this provider.
 	 *
 	 * @dataProvider malformedEntryProvider
 	 *
-	 * @param array<int|string, mixed> $entry    The raw decoded presetOrder entry for the block.
-	 * @param list<string>             $expected The expected result of for_block() against that entry.
+	 * @param mixed        $entry    The raw decoded presetOrder entry for the block.
+	 * @param list<string> $expected The expected result of for_block() against that entry.
 	 *
 	 * @return void
 	 */
-	public function testForBlockDropsOrFiltersMalformedEntries( array $entry, array $expected ): void {
+	public function testForBlockDropsOrFiltersMalformedEntries( $entry, array $expected ): void {
 		$doc = [
 			Extensions::get_extensions_key() => [
 				Extensions::get_namespace() => [
@@ -101,6 +103,16 @@ final class Preset_Order_IndexTest extends TestCase {
 	 * @return Generator
 	 */
 	public function malformedEntryProvider(): Generator {
+		yield 'null entry' => [
+			'entry'    => null,
+			'expected' => [],
+		];
+
+		yield 'scalar entry' => [
+			'entry'    => 'primary',
+			'expected' => [],
+		];
+
 		yield 'map-shaped (non-sequential) entry' => [
 			'entry'    => [ 'a' => 'primary' ],
 			'expected' => [],

--- a/tests/wpunit/Resources/Design_Tokens/Document/Preset_Order_IndexTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/Preset_Order_IndexTest.php
@@ -1,0 +1,330 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Document;
+
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Preset_Order_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Covers the presetOrder per-block ordered-slug-list read/write operations of Preset_Order_Index.
+ *
+ * @since TBD
+ */
+final class Preset_Order_IndexTest extends TestCase {
+
+	private const BUTTON = 'kadence/singlebtn';
+
+	/**
+	 * The index under test.
+	 *
+	 * @since TBD
+	 *
+	 * @var Preset_Order_Index
+	 */
+	private Preset_Order_Index $index;
+
+	/**
+	 * Build a fresh index before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->index = new Preset_Order_Index();
+	}
+
+	// -------------------------------------------------------------------------
+	// for_block()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * An empty document has no stored order for any block.
+	 *
+	 * @return void
+	 */
+	public function testForBlockReturnsEmptyArrayForEmptyDocument(): void {
+		$this->assertSame( [], $this->index->for_block( [], self::BUTTON ) );
+	}
+
+	/**
+	 * A document missing the $extensions key has no stored order.
+	 *
+	 * @return void
+	 */
+	public function testForBlockReturnsEmptyArrayWhenExtensionsKeyMissing(): void {
+		$doc = [ 'primitive' => [ 'color' => [] ] ];
+
+		$this->assertSame( [], $this->index->for_block( $doc, self::BUTTON ) );
+	}
+
+	/**
+	 * A well-formed presetOrder entry for a block round-trips through for_block() unchanged.
+	 *
+	 * @return void
+	 */
+	public function testForBlockReturnsStoredEntries(): void {
+		$doc = $this->doc_with_order( self::BUTTON, [ 'secondary', 'primary' ] );
+
+		$this->assertSame( [ 'secondary', 'primary' ], $this->index->for_block( $doc, self::BUTTON ) );
+	}
+
+	/**
+	 * A malformed presetOrder entry — a non-list ("map-shaped") value, or non-string/empty slugs
+	 * inside the list — is dropped (or filtered) on read rather than surfaced, so a hand-corrupted
+	 * entry degrades to declaration order instead of a type error downstream.
+	 *
+	 * @dataProvider malformedEntryProvider
+	 *
+	 * @param array<int|string, mixed> $entry    The raw decoded presetOrder entry for the block.
+	 * @param list<string>             $expected The expected result of for_block() against that entry.
+	 *
+	 * @return void
+	 */
+	public function testForBlockDropsOrFiltersMalformedEntries( array $entry, array $expected ): void {
+		$doc = [
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					Extensions::get_section_preset_order() => [ self::BUTTON => $entry ],
+				],
+			],
+		];
+
+		$this->assertSame( $expected, $this->index->for_block( $doc, self::BUTTON ) );
+	}
+
+	/**
+	 * Malformed presetOrder entry shapes and what for_block() must degrade each to.
+	 *
+	 * @return Generator
+	 */
+	public function malformedEntryProvider(): Generator {
+		yield 'map-shaped (non-sequential) entry' => [
+			'entry'    => [ 'a' => 'primary' ],
+			'expected' => [],
+		];
+
+		yield 'non-string slug inside an otherwise valid list' => [
+			'entry'    => [ 'primary', 42, 'secondary' ],
+			'expected' => [ 'primary', 'secondary' ],
+		];
+
+		yield 'empty-string slug inside an otherwise valid list' => [
+			'entry'    => [ 'primary', '' ],
+			'expected' => [ 'primary' ],
+		];
+	}
+
+	// -------------------------------------------------------------------------
+	// set_block()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * set_block() creates the $extensions/{namespace}/presetOrder path when none of it yet exists.
+	 *
+	 * @return void
+	 */
+	public function testSetBlockCreatesFullPathWhenMissing(): void {
+		$result = $this->index->set_block( [], self::BUTTON, [ 'secondary', 'primary' ] );
+
+		$this->assertSame( [ 'secondary', 'primary' ], $this->index->for_block( $result, self::BUTTON ) );
+	}
+
+	/**
+	 * set_block() replaces a previously stored order for the same block wholesale.
+	 *
+	 * @return void
+	 */
+	public function testSetBlockReplacesExistingOrderWholesale(): void {
+		$doc = $this->doc_with_order( self::BUTTON, [ 'primary', 'secondary' ] );
+
+		$result = $this->index->set_block( $doc, self::BUTTON, [ 'secondary' ] );
+
+		$this->assertSame( [ 'secondary' ], $this->index->for_block( $result, self::BUTTON ) );
+	}
+
+	/**
+	 * set_block() deduplicates submitted slugs, keeping the first occurrence.
+	 *
+	 * @return void
+	 */
+	public function testSetBlockDeduplicatesKeepingFirstOccurrence(): void {
+		$result = $this->index->set_block( [], self::BUTTON, [ 'primary', 'secondary', 'primary' ] );
+
+		$this->assertSame( [ 'primary', 'secondary' ], $this->index->for_block( $result, self::BUTTON ) );
+	}
+
+	/**
+	 * set_block() leaves a sibling block's stored order untouched.
+	 *
+	 * @return void
+	 */
+	public function testSetBlockPreservesSiblingBlocks(): void {
+		$doc = $this->doc_with_order( self::BUTTON, [ 'primary' ] );
+
+		$result = $this->index->set_block( $doc, 'kadence/advancedbtn', [ 'ghost' ] );
+
+		$this->assertSame( [ 'primary' ], $this->index->for_block( $result, self::BUTTON ) );
+		$this->assertSame( [ 'ghost' ], $this->index->for_block( $result, 'kadence/advancedbtn' ) );
+	}
+
+	/**
+	 * set_block() does not modify the document passed in — every mutator returns a new document.
+	 *
+	 * @return void
+	 */
+	public function testSetBlockDoesNotModifyItsInput(): void {
+		$doc = [];
+
+		$this->index->set_block( $doc, self::BUTTON, [ 'primary' ] );
+
+		$this->assertSame( [], $doc );
+	}
+
+	// -------------------------------------------------------------------------
+	// remove_block()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * remove_block() is a no-op (the same document reference is returned) when nothing is stored
+	 * for the block.
+	 *
+	 * @return void
+	 */
+	public function testRemoveBlockIsNoOpWhenAbsent(): void {
+		$doc = [];
+
+		$this->assertSame( $doc, $this->index->remove_block( $doc, self::BUTTON ) );
+	}
+
+	/**
+	 * remove_block() deletes only the targeted block's order, leaving sibling blocks intact.
+	 *
+	 * @return void
+	 */
+	public function testRemoveBlockDeletesTargetBlockOnly(): void {
+		$doc = $this->doc_with_order( self::BUTTON, [ 'primary' ] );
+		$doc = $this->index->set_block( $doc, 'kadence/advancedbtn', [ 'ghost' ] );
+
+		$result = $this->index->remove_block( $doc, self::BUTTON );
+
+		$this->assertSame( [], $this->index->for_block( $result, self::BUTTON ) );
+		$this->assertSame( [ 'ghost' ], $this->index->for_block( $result, 'kadence/advancedbtn' ) );
+	}
+
+	/**
+	 * remove_block() prunes the whole presetOrder section once its last block entry is removed, so
+	 * a fully-cleared order leaves no residue in the stored document.
+	 *
+	 * @return void
+	 */
+	public function testRemoveBlockPrunesTheEmptiedSection(): void {
+		$doc = $this->doc_with_order( self::BUTTON, [ 'primary' ] );
+
+		$result = $this->index->remove_block( $doc, self::BUTTON );
+
+		$this->assertArrayNotHasKey( Extensions::get_extensions_key(), $result );
+	}
+
+	/**
+	 * remove_block() leaves the rest of the document, outside the presetOrder section, unchanged.
+	 *
+	 * @return void
+	 */
+	public function testRemoveBlockLeavesTheRestOfTheDocumentUnchanged(): void {
+		$doc = $this->doc_with_order( self::BUTTON, [ 'primary' ] );
+
+		$doc['primitive'] = [
+			'color' => [
+				'brand' => [
+					'$type'  => 'color',
+					'$value' => '#3182CE',
+				],
+			],
+		];
+
+		$result = $this->index->remove_block( $doc, self::BUTTON );
+
+		$this->assertSame( $doc['primitive'], $result['primitive'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// apply()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * With no stored order, apply() returns the incoming names in their own (declaration) order.
+	 *
+	 * @return void
+	 */
+	public function testApplyWithNoStoredOrderReturnsIncomingOrder(): void {
+		$result = $this->index->apply( [], self::BUTTON, [ 'primary', 'secondary' ] );
+
+		$this->assertSame( [ 'primary', 'secondary' ], $result );
+	}
+
+	/**
+	 * A stored order wins over declaration order for the slugs it names.
+	 *
+	 * @return void
+	 */
+	public function testApplyStoredOrderWinsOverDeclarationOrder(): void {
+		$doc = $this->doc_with_order( self::BUTTON, [ 'secondary', 'primary' ] );
+
+		$result = $this->index->apply( $doc, self::BUTTON, [ 'primary', 'secondary' ] );
+
+		$this->assertSame( [ 'secondary', 'primary' ], $result );
+	}
+
+	/**
+	 * A stored slug the incoming names no longer include (a deleted preset) is skipped silently,
+	 * rather than surfaced as a phantom row.
+	 *
+	 * @return void
+	 */
+	public function testApplySkipsStaleStoredSlugs(): void {
+		$doc = $this->doc_with_order( self::BUTTON, [ 'secondary', 'ghost', 'primary' ] );
+
+		$result = $this->index->apply( $doc, self::BUTTON, [ 'primary', 'secondary' ] );
+
+		$this->assertSame( [ 'secondary', 'primary' ], $result );
+	}
+
+	/**
+	 * A preset the stored order never mentions (a newly created one) appends after the ordered
+	 * slugs, in its incoming position relative to other unordered names.
+	 *
+	 * @return void
+	 */
+	public function testApplyAppendsNamesTheStoredOrderDoesNotMention(): void {
+		$doc = $this->doc_with_order( self::BUTTON, [ 'secondary' ] );
+
+		$result = $this->index->apply( $doc, self::BUTTON, [ 'primary', 'secondary', 'accent' ] );
+
+		$this->assertSame( [ 'secondary', 'primary', 'accent' ], $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Build a decoded document carrying one block's presetOrder entry.
+	 *
+	 * @param string        $block The block name.
+	 * @param list<string>  $slugs The stored ordered preset-slug list.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function doc_with_order( string $block, array $slugs ): array {
+		return [
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					Extensions::get_section_preset_order() => [ $block => $slugs ],
+				],
+			],
+		];
+	}
+}


### PR DESCRIPTION
Per-block preset display-order storage.

## Test instructions

1. Run the wpunit suite for the order index: `slic run wpunit Resources/Design_Tokens/Preset_Order_IndexTest`.
2. Review the apply semantics: a preset missing from the stored order must still appear rather than vanish, which is what keeps a newly added preset visible before any reorder has happened.
3. Nothing reads this yet — the read seams are the next slice.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4083/phase-5a-order-storage
bun run build-wp
```

The Style Library is at **WP Admin → Kadence → Style Library**. The Button preset screen is under **Block Presets → Button**. Block-editor checks use a **Kadence Single Button** block on any post.
</details>

---

Slice 8 of 23 in the SOFT-4083 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for storing and applying custom display ordering for presets on individual blocks.
  * Preset ordering can be updated or removed without affecting other document settings.
  * Invalid, outdated, duplicate, or missing ordering entries are safely handled.
  * Presets not included in a saved order are automatically appended in declaration order.

* **Tests**
  * Added coverage for reading, updating, removing, validating, and applying preset order data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->