### PR TITLE
[DTM] SOFT-4083 [9/23]: Apply preset order at every read seam

### DIFF
--- a/includes/resources/Design_Tokens/Resolver/Preset_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Preset_Resolver.php
@@ -2,6 +2,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Resolver;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Preset_Order_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Unknown_Preset_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
@@ -58,14 +59,25 @@ final class Preset_Resolver {
 	private Token_Resolver $resolver;
 
 	/**
+	 * @var Preset_Order_Index Applies the stored per-block display order to names(), the single seam every
+	 *                          other names()-derived surface (the admin feed, the editor picker) inherits it
+	 *                          through.
+	 *
+	 * @since TBD
+	 */
+	private Preset_Order_Index $order_index;
+
+	/**
 	 * @since TBD
 	 *
-	 * @param Effective_Presets $presets The per-library effective preset definitions.
-	 * @param Token_Resolver    $resolver The token resolver.
+	 * @param Effective_Presets  $presets     The per-library effective preset definitions.
+	 * @param Token_Resolver     $resolver    The token resolver.
+	 * @param Preset_Order_Index $order_index Applies the stored per-block display order to names().
 	 */
-	public function __construct( Effective_Presets $presets, Token_Resolver $resolver ) {
-		$this->presets  = $presets;
-		$this->resolver = $resolver;
+	public function __construct( Effective_Presets $presets, Token_Resolver $resolver, Preset_Order_Index $order_index ) {
+		$this->presets     = $presets;
+		$this->resolver    = $resolver;
+		$this->order_index = $order_index;
 	}
 
 	/**
@@ -258,9 +270,12 @@ final class Preset_Resolver {
 	}
 
 	/**
-	 * The preset slugs a block declares for a library, in document order — the effective library (the
-	 * baseline deep-merged with the library's stored overrides) being the source of truth, so a user-added
-	 * preset in the store appears here alongside the baseline ones.
+	 * The preset slugs a block declares for a library, in DISPLAY order — the effective library (the
+	 * baseline deep-merged with the library's stored overrides) being the source of truth for membership, so
+	 * a user-added preset in the store appears here alongside the baseline ones, and the stored presetOrder
+	 * (when any) determines the sequence. This is the single seam every names()-derived surface (the admin
+	 * feed's presets section, the editor picker, Preset_Nav consumers) inherits the display order through,
+	 * so the Style Library and the editor can never disagree on it.
 	 *
 	 * @since TBD
 	 *
@@ -283,7 +298,7 @@ final class Preset_Resolver {
 			$names[] = (string) $key;
 		}
 
-		return $names;
+		return $this->order_index->apply( $this->presets->raw( $slug ), $block, $names );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
@@ -5,6 +5,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Preset_Order_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Preset_Bindings;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Presets;
@@ -125,6 +126,24 @@ final class Presets_Controller extends Controller {
 	private const LIBRARY_PARAM = 'library';
 
 	/**
+	 * The request parameter that carries the version the client last read, on the order sub-route.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const VERSION_PARAM = 'version';
+
+	/**
+	 * The request parameter that carries the ordered list of preset slugs on an order write.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const ORDER_PARAM = 'order';
+
+	/**
 	 * The block vendor path segment. A slug-safe class with no slash; the block name is the second segment.
 	 *
 	 * @since TBD
@@ -169,6 +188,17 @@ final class Presets_Controller extends Controller {
 	 * @var string
 	 */
 	private const DEFAULT_ROUTE = 'default';
+
+	/**
+	 * The literal sub-route, relative to a block, that sets / clears the block's stored preset
+	 * display order. Registered before the single-preset route so the literal segment is not
+	 * captured as a preset slug — the same trick DEFAULT_ROUTE relies on.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const ORDER_ROUTE = 'order';
 
 	/**
 	 * The sole gateway to the kb_design_tokens table.
@@ -243,6 +273,16 @@ final class Presets_Controller extends Controller {
 	private Preset_Value_Normalizer $normalizer;
 
 	/**
+	 * Reads and writes the presetOrder per-block display-order map, applied at every read seam
+	 * this controller serves.
+	 *
+	 * @since TBD
+	 *
+	 * @var Preset_Order_Index
+	 */
+	private Preset_Order_Index $order_index;
+
+	/**
 	 * Memoised item schema for this request. Null until first built.
 	 *
 	 * @since TBD
@@ -254,14 +294,15 @@ final class Presets_Controller extends Controller {
 	/**
 	 * @since TBD
 	 *
-	 * @param Token_Store                $store     The sole gateway to the kb_design_tokens table.
-	 * @param Mutator                    $mutator   Assembles the candidate overrides document.
-	 * @param Token_Resolver             $resolver  Dry-runs a candidate's token layers before commit.
-	 * @param Dtcg_Validator             $validator Validates the DTCG grammar of a candidate document.
-	 * @param Effective_Presets          $presets   Reads the baseline-merged presets section.
-	 * @param Token_Registry             $registry   Declares which blocks accept presets.
-	 * @param Active_Token_Library_Store $active     Resolves the active library when a request names none.
-	 * @param Preset_Value_Normalizer    $normalizer Rewrites captured literals into semantic aliases.
+	 * @param Token_Store                $store       The sole gateway to the kb_design_tokens table.
+	 * @param Mutator                    $mutator     Assembles the candidate overrides document.
+	 * @param Token_Resolver             $resolver    Dry-runs a candidate's token layers before commit.
+	 * @param Dtcg_Validator             $validator   Validates the DTCG grammar of a candidate document.
+	 * @param Effective_Presets          $presets     Reads the baseline-merged presets section.
+	 * @param Token_Registry             $registry    Declares which blocks accept presets.
+	 * @param Active_Token_Library_Store $active      Resolves the active library when a request names none.
+	 * @param Preset_Value_Normalizer    $normalizer  Rewrites captured literals into semantic aliases.
+	 * @param Preset_Order_Index         $order_index Reads and writes the presetOrder display-order map.
 	 */
 	public function __construct(
 		Token_Store $store,
@@ -271,17 +312,19 @@ final class Presets_Controller extends Controller {
 		Effective_Presets $presets,
 		Token_Registry $registry,
 		Active_Token_Library_Store $active,
-		Preset_Value_Normalizer $normalizer
+		Preset_Value_Normalizer $normalizer,
+		Preset_Order_Index $order_index
 	) {
-		$this->store      = $store;
-		$this->mutator    = $mutator;
-		$this->resolver   = $resolver;
-		$this->validator  = $validator;
-		$this->presets    = $presets;
-		$this->registry   = $registry;
-		$this->active     = $active;
-		$this->normalizer = $normalizer;
-		$this->rest_base  = 'presets';
+		$this->store       = $store;
+		$this->mutator     = $mutator;
+		$this->resolver    = $resolver;
+		$this->validator   = $validator;
+		$this->presets     = $presets;
+		$this->registry    = $registry;
+		$this->active      = $active;
+		$this->normalizer  = $normalizer;
+		$this->order_index = $order_index;
+		$this->rest_base   = 'presets';
 	}
 
 	/**
@@ -289,10 +332,11 @@ final class Presets_Controller extends Controller {
 	 *
 	 * Verb semantics follow the WordPress REST convention: POST creates or merges a single preset, PUT
 	 * replaces the block's whole preset collection, DELETE on a block resets it to baseline, and DELETE on a
-	 * preset removes that one preset. The `$default` is read and set through a dedicated sub-route.
+	 * preset removes that one preset. The `$default` and the display order are each read/set through their
+	 * own dedicated sub-route.
 	 *
-	 * The `default` sub-route is registered before the single-preset route so the literal segment is not
-	 * captured as a preset slug.
+	 * The `default` and `order` sub-routes are registered before the single-preset route so their literal
+	 * segments are not captured as a preset slug.
 	 *
 	 * @since TBD
 	 *
@@ -369,6 +413,31 @@ final class Presets_Controller extends Controller {
 
 		register_rest_route(
 			$this->namespace,
+			'/' . $this->rest_base . '/' . self::BLOCK_ROUTE . '/' . self::ORDER_ROUTE,
+			[
+				[
+					// PUT only: the endpoint replaces the block's whole display order, so there is no
+					// partial-update verb to distinguish from PUT — the labels/order sub-route pattern.
+					'methods'             => 'PUT',
+					'callback'            => [ $this, 'set_order' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_order_params(),
+				],
+				[
+					// DELETE uses the same capability as PUT — clearing a stored order is an update to
+					// the document, not a resource removal, so the two verbs of one operation cannot
+					// diverge on permission.
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => [ $this, 'delete_order' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_order_delete_params(),
+				],
+				'schema' => [ $this, 'get_item_schema' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
 			'/' . $this->rest_base . '/' . self::BLOCK_ROUTE . '/' . self::PRESET_ROUTE,
 			[
 				[
@@ -392,9 +461,10 @@ final class Presets_Controller extends Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		$slug    = $this->slug( $request );
-		$section = $this->presets->section( $slug );
-		$blocks  = [];
+		$slug     = $this->slug( $request );
+		$section  = $this->presets->section( $slug );
+		$document = $this->stored_document( $slug );
+		$blocks   = [];
 
 		foreach ( array_keys( $this->registry->all_preset_bindings() ) as $block ) {
 			$node = $this->set_node( $section, $block );
@@ -402,7 +472,7 @@ final class Presets_Controller extends Controller {
 			$blocks[] = [
 				'block'   => $block,
 				'default' => $this->default_of( $node ),
-				'names'   => $this->preset_names( $node ),
+				'names'   => $this->order_index->apply( $document, $block, $this->preset_names( $node ) ),
 			];
 		}
 
@@ -725,6 +795,89 @@ final class Presets_Controller extends Controller {
 	}
 
 	/**
+	 * Store a block's preset display order wholesale (PUT /presets/{block}/order).
+	 *
+	 * The submitted slugs are pruned to the block's effective preset names, first occurrence wins on
+	 * duplicates — silent by design, mirroring the documents controller's token-order route: the stored
+	 * order is advisory, and a client racing a preset deletion must not fail its whole reorder over one
+	 * vanished slug. Pruning to an empty list clears the stored order entirely, so "no preference" has one
+	 * spelling.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function set_order( $request ) {
+		$block = $this->block_from( $request );
+		$error = $this->guard_block( $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$slug  = $this->slug( $request );
+		$error = $this->guard_client_version( $slug, Cast::to_string( $request->get_param( self::VERSION_PARAM ) ) );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$node  = $this->set_node( $this->presets->section( $slug ), $block );
+		$names = $this->preset_names( $node );
+
+		$submitted = array_map( [ Cast::class, 'to_string' ], (array) $request->get_param( self::ORDER_PARAM ) );
+		$slugs     = array_values( array_unique( array_intersect( $submitted, $names ) ) );
+
+		$stored    = $this->stored_document( $slug );
+		$candidate = $slugs === []
+			? $this->order_index->remove_block( $stored, $block )
+			: $this->order_index->set_block( $stored, $block, $slugs );
+
+		if ( $candidate === $stored ) {
+			return new WP_REST_Response( $this->prepare_item( $block, $slug ), WP_Http::OK );
+		}
+
+		return $this->validate_and_save( $candidate, $block, $slug );
+	}
+
+	/**
+	 * Clear a block's stored preset display order (DELETE /presets/{block}/order), reverting it to merge
+	 * order. Idempotent: a no-op when nothing is stored for the block.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_order( $request ) {
+		$block = $this->block_from( $request );
+		$error = $this->guard_block( $block );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$slug  = $this->slug( $request );
+		$error = $this->guard_client_version( $slug, Cast::to_string( $request->get_param( self::VERSION_PARAM ) ) );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$stored    = $this->stored_document( $slug );
+		$candidate = $this->order_index->remove_block( $stored, $block );
+
+		if ( $candidate === $stored ) {
+			return new WP_REST_Response( $this->prepare_item( $block, $slug ), WP_Http::OK );
+		}
+
+		return $this->validate_and_save( $candidate, $block, $slug );
+	}
+
+	/**
 	 * The JSON Schema for a block's preset collection.
 	 *
 	 * @since TBD
@@ -935,6 +1088,33 @@ final class Presets_Controller extends Controller {
 	}
 
 	/**
+	 * Client-conditional guard for the order sub-route: the stored version must equal what the client last
+	 * read (both '' for a first write), mirroring the documents controller's identical guard for its own
+	 * order route.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug           The token library slug.
+	 * @param string $client_version The version the client last read. Empty only for a first write.
+	 *
+	 * @return WP_Error|null
+	 */
+	private function guard_client_version( string $slug, string $client_version ): ?WP_Error {
+		if ( $this->store->get_version( $slug ) === $client_version ) {
+			return null;
+		}
+
+		return new WP_Error(
+			'rest_design_tokens_conflict',
+			__( 'The token library was modified since you last read it. Reload and try again.', 'kadence-blocks' ),
+			[
+				'status' => WP_Http::CONFLICT,
+				'slug'   => $slug,
+			]
+		);
+	}
+
+	/**
 	 * Reject a preset map whose entries are not well-formed: each named preset must have a non-empty
 	 * slug and be an object, its label (when present) a string and its tokens (when present) an object. The
 	 * alias-or-literal grammar of the token values is left to the DTCG validator.
@@ -991,8 +1171,8 @@ final class Presets_Controller extends Controller {
 
 	/**
 	 * Reject a preset whose slug is reserved. "default" is the literal used by the block's `/default`
-	 * sub-route and by `delete_preset`, so a preset named "default" could never be deleted or set through
-	 * the dedicated route; refuse to create one.
+	 * sub-route and by `delete_preset`, and "order" is the literal used by the block's `/order` sub-route, so
+	 * a preset named either could never be deleted or set through its dedicated route; refuse to create one.
 	 *
 	 * @since TBD
 	 *
@@ -1002,16 +1182,18 @@ final class Presets_Controller extends Controller {
 	 * @return WP_Error|null A WP_Error when a reserved slug is used, null otherwise.
 	 */
 	private function guard_reserved_slugs( array $block_node, string $block ): ?WP_Error {
+		$reserved = [ self::DEFAULT_ROUTE, self::ORDER_ROUTE ];
+
 		foreach ( array_keys( $block_node ) as $slug ) {
 			// $default and any other "$"-prefixed metadata key is not a named preset.
 			if ( is_string( $slug ) && strpos( $slug, '$' ) === 0 ) {
 				continue;
 			}
 
-			if ( (string) $slug === self::DEFAULT_ROUTE ) {
+			if ( in_array( (string) $slug, $reserved, true ) ) {
 				return new WP_Error(
 					'rest_design_tokens_reserved_slug',
-					__( 'The preset slug "default" is reserved.', 'kadence-blocks' ),
+					__( 'That preset slug is reserved.', 'kadence-blocks' ),
 					[
 						'status' => WP_Http::UNPROCESSABLE_ENTITY,
 						'block'  => $block,
@@ -1298,7 +1480,8 @@ final class Presets_Controller extends Controller {
 	 *                              the library defines beyond the baseline).
 	 */
 	private function prepare_item( string $block, string $slug ): array {
-		$node = $this->set_node( $this->presets->section( $slug ), $block );
+		$node    = $this->set_node( $this->presets->section( $slug ), $block );
+		$ordered = $this->order_index->apply( $this->stored_document( $slug ), $block, $this->preset_names( $node ) );
 
 		return [
 			'block'       => $block,
@@ -1306,8 +1489,31 @@ final class Presets_Controller extends Controller {
 			'version'     => $this->store->get_version( $slug ),
 			'default'     => $this->default_of( $node ),
 			'userCreated' => $this->presets->user_created( $block, $slug ),
-			'presets'     => $this->named_presets( $node ),
+			'presets'     => $this->ordered_presets( $this->named_presets( $node ), $ordered ),
 		];
+	}
+
+	/**
+	 * Reorder a slug => preset map to a given slug order. A slug the map does not carry (a stale ordered id
+	 * that has since been removed) is skipped rather than inserted as a hole.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $presets The named presets, keyed by slug.
+	 * @param string[]             $order   The desired slug order.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function ordered_presets( array $presets, array $order ): array {
+		$ordered = [];
+
+		foreach ( $order as $slug ) {
+			if ( array_key_exists( $slug, $presets ) ) {
+				$ordered[ $slug ] = $presets[ $slug ];
+			}
+		}
+
+		return $ordered;
 	}
 
 	/**
@@ -1697,6 +1903,50 @@ final class Presets_Controller extends Controller {
 					'required'          => true,
 					'pattern'           => '^[\w-]+$',
 					'sanitize_callback' => 'sanitize_key',
+				],
+			]
+		);
+	}
+
+	/**
+	 * The arguments accepted by the order-route PUT: the block segments, the ordered slug list and the
+	 * version-conditional guard.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_order_params(): array {
+		return array_merge(
+			$this->get_order_delete_params(),
+			[
+				self::ORDER_PARAM => [
+					'description'          => __( 'The preset slugs in their new display order.', 'kadence-blocks' ),
+					'type'                 => 'array',
+					'required'             => true,
+					'items'                => [ 'type' => 'string' ],
+					'additionalProperties' => false,
+				],
+			]
+		);
+	}
+
+	/**
+	 * The arguments accepted by the order-route DELETE: the block segments plus the version-conditional guard.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_order_delete_params(): array {
+		return array_merge(
+			$this->get_block_params(),
+			[
+				self::VERSION_PARAM => [
+					'description'       => __( 'The version the client last read; empty for a first write. A mismatch is rejected with HTTP 409.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => true,
+					'sanitize_callback' => 'sanitize_text_field',
 				],
 			]
 		);

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Preset/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Preset/ProjectorTest.php
@@ -6,6 +6,7 @@ namespace Tests\wpunit\Resources\Design_Tokens\Projection\Block_Preset;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Preset_Order_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Preset\Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Presets;
@@ -56,7 +57,7 @@ final class ProjectorTest extends TestCase {
 			$this->container->get( Mutator::class )
 		);
 
-		$this->resolver = new Preset_Resolver( $presets, $this->container->get( Token_Resolver::class ) );
+		$this->resolver = new Preset_Resolver( $presets, $this->container->get( Token_Resolver::class ), new Preset_Order_Index() );
 	}
 
 	public function testItMapsThePresetValuesOntoTheBoundBlockAttributes(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
@@ -4,6 +4,7 @@
 namespace Tests\wpunit\Resources\Design_Tokens\Rest\V1;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Preset_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Presets_Controller;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
 use ReflectionClass;
@@ -937,6 +938,160 @@ final class PresetsControllerTest extends TestCase {
 		}
 	}
 
+	// -------------------------------------------------------------------------
+	// preset display order
+	// -------------------------------------------------------------------------
+
+	/**
+	 * The order sub-route is registered with PUT and DELETE, alongside the rest of the block routes.
+	 *
+	 * @return void
+	 */
+	public function testTheOrderRouteIsRegistered(): void {
+		$namespace   = $this->controller_namespace();
+		$base        = $this->controller_rest_base();
+		$block_route = $this->controller_constant( 'BLOCK_ROUTE' );
+		$order_route = $this->controller_constant( 'ORDER_ROUTE' );
+
+		$route = "/$namespace/$base/$block_route/$order_route";
+
+		$this->assertArrayHasKey( $route, $this->rest_server->get_routes() );
+		$this->assertContains( 'PUT', $this->route_methods( $route ) );
+		$this->assertContains( 'DELETE', $this->route_methods( $route ) );
+	}
+
+	/**
+	 * A PUT to the order sub-route persists a new order for two BASELINE preset slugs (primary and
+	 * secondary) — the case fact 5 of the plan overview proves impossible through a PUT-the-collection
+	 * "reorder", since `Effective_Presets` always reads baseline-defined slugs back in baseline order
+	 * regardless of the order overrides were written in.
+	 *
+	 * @return void
+	 */
+	public function testSetOrderMovesBaselineSlugs(): void {
+		$response = $this->controller->set_order( $this->order_request( self::BUTTON, [ 'secondary', 'primary' ] ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( [ 'secondary', 'primary' ], array_keys( $response->get_data()['presets'] ) );
+
+		// The order survives a fresh read.
+		$data = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) )->get_data();
+		$this->assertSame( [ 'secondary', 'primary' ], array_keys( $data['presets'] ) );
+	}
+
+	/**
+	 * A slug the block does not effectively define is pruned from the submitted order silently, rather
+	 * than rejected — the order write is advisory, mirroring the documents controller's token-order route.
+	 *
+	 * @return void
+	 */
+	public function testSetOrderSilentlyPrunesAnUnknownSlug(): void {
+		$response = $this->controller->set_order(
+			$this->order_request( self::BUTTON, [ 'secondary', 'does-not-exist', 'primary' ] )
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( [ 'secondary', 'primary' ], array_keys( $response->get_data()['presets'] ) );
+	}
+
+	/**
+	 * A version that no longer matches the stored version is rejected with HTTP 409, so a client working
+	 * from a stale read cannot silently clobber a concurrent write.
+	 *
+	 * @return void
+	 */
+	public function testSetOrderRejectsAStaleVersionWith409(): void {
+		$result = $this->controller->set_order(
+			$this->order_request( self::BUTTON, [ 'secondary', 'primary' ], 'a-stale-version' )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_conflict', $result->get_error_code() );
+		$this->assertSame( WP_Http::CONFLICT, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * A block with no registered preset bindings is a 404, mirroring every other block sub-route.
+	 *
+	 * @return void
+	 */
+	public function testSetOrderReturns404ForABlockThatAcceptsNoPresets(): void {
+		$result = $this->controller->set_order( $this->order_request( 'kadence/spacer', [ 'anything' ] ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * DELETE on the order sub-route reverts a stored order to merge (baseline) order.
+	 *
+	 * @return void
+	 */
+	public function testDeleteOrderRevertsToMergeOrder(): void {
+		$this->controller->set_order( $this->order_request( self::BUTTON, [ 'secondary', 'primary' ] ) );
+
+		$version  = $this->store->get_version( Token_Store::default_slug() );
+		$response = $this->controller->delete_order( $this->order_request( self::BUTTON, [], $version ) );
+
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertSame( [ 'primary', 'secondary' ], array_keys( $response->get_data()['presets'] ) );
+	}
+
+	/**
+	 * DELETE on the order sub-route is idempotent: a no-op, unchanged-version response when nothing is
+	 * stored for the block.
+	 *
+	 * @return void
+	 */
+	public function testDeleteOrderIsAnIdempotentNoOpWhenAbsent(): void {
+		$version_before = $this->store->get_version( Token_Store::default_slug() );
+
+		$response = $this->controller->delete_order( $this->order_request( self::BUTTON, [], $version_before ) );
+
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertSame( $version_before, $this->store->get_version( Token_Store::default_slug() ) );
+	}
+
+	/**
+	 * Creating a preset named "order" is rejected: the slug is reserved for the block's order sub-route and
+	 * could never be reordered or deleted through the dedicated route.
+	 *
+	 * @return void
+	 */
+	public function testCreatingAPresetNamedOrderIsRejected(): void {
+		$result = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'preset' => 'order',
+					'tokens' => $this->button_tokens(),
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_reserved_slug', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * After a PUT reorders a block's presets, the controller's own read (prepare_item()) and the resolver's
+	 * names() — the seam the admin feed and Preset_Nav consumers read through — agree on the new order, so
+	 * the Style Library and the editor can never disagree.
+	 *
+	 * @return void
+	 */
+	public function testOrderedNamesAgreeBetweenTheControllerAndThePresetResolver(): void {
+		$this->controller->set_order( $this->order_request( self::BUTTON, [ 'secondary', 'primary' ] ) );
+
+		$data     = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) )->get_data();
+		$resolver = $this->container->get( Preset_Resolver::class );
+
+		$this->assertSame( [ 'secondary', 'primary' ], array_keys( $data['presets'] ) );
+		$this->assertSame( [ 'secondary', 'primary' ], $resolver->names( self::BUTTON ) );
+	}
+
 	/**
 	 * Build a request for a single block route, splitting the block name into its two path segments and
 	 * carrying any extra body parameters.
@@ -1024,6 +1179,30 @@ final class PresetsControllerTest extends TestCase {
 	 */
 	private function default_request( string $block, string $default_slug ): WP_REST_Request {
 		return $this->block_request( 'PUT', $block, [ 'default' => $default_slug ] );
+	}
+
+	/**
+	 * Build an order-route request: the block segments plus the ordered slug list and the version guard.
+	 * The version defaults to the library's current stored version, so a call site only needs to pass one
+	 * explicitly when deliberately exercising a mismatch.
+	 *
+	 * @param string   $block The block name.
+	 * @param string[] $order The desired preset slug order.
+	 * @param ?string  $version The version the client last read; defaults to the current stored version.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function order_request( string $block, array $order, ?string $version = null ): WP_REST_Request {
+		$version ??= $this->store->get_version( Token_Store::default_slug() );
+
+		return $this->block_request(
+			'PUT',
+			$block,
+			[
+				'order'   => $order,
+				'version' => $version,
+			] 
+		);
 	}
 
 	/**


### PR DESCRIPTION
Applies and persists the display order wherever presets are read, so every consumer sees the same order.

## Test instructions

1. Run the controller/resolver parity tests: `slic run wpunit Resources/Design_Tokens/Rest/V1/PresetsControllerTest`.
2. Compare the two read paths by hand — `/wp-json/kb-design-tokens/v1/presets/kadence/singlebtn?library=default` and the Style Library screen — and confirm they list presets in the same order.
3. The parity is the point: a reviewer should check the order is applied at *every* seam, not just the REST one.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4083/phase-5b-order-read-seams
bun run build-wp
```

The Style Library is at **WP Admin → Kadence → Style Library**. The Button preset screen is under **Block Presets → Button**. Block-editor checks use a **Kadence Single Button** block on any post.
</details>

---

Slice 9 of 23 in the SOFT-4083 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the display order of presets.
  * Added REST API options to save, update, and clear preset ordering.
  * Preset lists now consistently reflect saved display order.
  * Added version checks to prevent updates based on outdated data.
  * Unknown preset names are safely ignored, and reserved names are protected.

* **Bug Fixes**
  * Clearing a custom order now correctly restores the default order.
  * Unsupported preset collections return an appropriate error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->