### PR TITLE
[DTM] SOFT-4083 [10/23]: Drag-to-reorder UI

### DIFF
--- a/src/style-library/__tests__/button-screen.test.js
+++ b/src/style-library/__tests__/button-screen.test.js
@@ -39,6 +39,16 @@ jest.mock('@wordpress/components', () => ({
 	Spinner: (props) => <div className="components-spinner" {...props} />,
 }));
 
+// `DragHandle` renders an `Icon` from `@wordpress/icons`, which pulls its `<SVG>` primitive from
+// `@wordpress/primitives` — a package with its own nested `react` copy (unlike `@wordpress/icons`
+// itself). Mounting it under this test's top-level `react-dom/client` renderer trips the same
+// cross-copy element-identity mismatch the `@wordpress/components` mock above sidesteps. The rows
+// this test renders always come back with `isDraggable: true`, so a bare stand-in keeps the row
+// list mountable without exercising the drag affordance.
+jest.mock('../components/atoms/DragHandle', () => ({
+	DragHandle: () => null,
+}));
+
 const LIBRARY = { rest: { namespace: 'kb-design-tokens/v1' }, slug: 'default', version: 1, values: {} };
 
 let container;

--- a/src/style-library/__tests__/preset-flows.test.js
+++ b/src/style-library/__tests__/preset-flows.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { createPresetFlow, deletePresetFlow, savePresetFlow } from '../helpers/preset-flows';
+import { createPresetFlow, deletePresetFlow, reorderPresetsFlow, savePresetFlow } from '../helpers/preset-flows';
 import * as client from '../api/client';
 
 // A factory, not bare automocking — see scale-flows.test.js's identical note: the real module
@@ -8,6 +8,7 @@ jest.mock('../api/client', () => ({
 	fetchBlockPresets: jest.fn(),
 	saveBlockPreset: jest.fn(),
 	deleteBlockPreset: jest.fn(),
+	setBlockPresetOrder: jest.fn(),
 }));
 
 beforeEach(() => {
@@ -283,6 +284,61 @@ describe('deletePresetFlow', () => {
 				namespace: 'kb-design-tokens/v1',
 				block: 'kadence/singlebtn',
 				preset: 'primary',
+				slug: 'default',
+				refreshFeed,
+				onBusy,
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(refreshFeed).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+});
+
+describe('reorderPresetsFlow', () => {
+	it('PUTs the full ordered slug list with the version and refreshes', async () => {
+		client.setBlockPresetOrder.mockResolvedValue({});
+		const refreshFeed = jest.fn().mockResolvedValue({});
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await reorderPresetsFlow({
+			namespace: 'kb-design-tokens/v1',
+			block: 'kadence/singlebtn',
+			orderedIds: ['secondary', 'primary'],
+			feedVersion: 'v1',
+			slug: 'default',
+			refreshFeed,
+			onBusy,
+			onError,
+		});
+
+		expect(client.setBlockPresetOrder).toHaveBeenCalledWith(
+			'kb-design-tokens/v1',
+			'kadence/singlebtn',
+			{ order: ['secondary', 'primary'], version: 'v1' },
+			'default'
+		);
+		expect(refreshFeed).toHaveBeenCalledWith('default');
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it('surfaces the error, clears busy, and re-throws on failure', async () => {
+		const failure = new Error('Boom');
+		client.setBlockPresetOrder.mockRejectedValue(failure);
+		const refreshFeed = jest.fn();
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			reorderPresetsFlow({
+				namespace: 'kb-design-tokens/v1',
+				block: 'kadence/singlebtn',
+				orderedIds: ['secondary', 'primary'],
+				feedVersion: 'v1',
 				slug: 'default',
 				refreshFeed,
 				onBusy,

--- a/src/style-library/__tests__/use-button-screen.test.js
+++ b/src/style-library/__tests__/use-button-screen.test.js
@@ -1,0 +1,140 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { useButtonScreen } from '../hooks/use-button-screen';
+import { reorderPresetsFlow } from '../helpers/preset-flows';
+import { useButtonPresets } from '../hooks/use-button-presets';
+
+// A factory, not automock: `helpers/preset-flows.js` reaches `../api/client`, which imports
+// `@wordpress/api-fetch` — externalized to the `wp.apiFetch` global in production and therefore
+// absent from `node_modules`, so automocking would fail to resolve it.
+jest.mock('../helpers/preset-flows', () => ({
+	createPresetFlow: jest.fn(),
+	deletePresetFlow: jest.fn(),
+	reorderPresetsFlow: jest.fn(),
+	savePresetFlow: jest.fn(),
+}));
+
+// Stubbed for the same reason, and so the fetched payload can be pinned to a version that never
+// advances — the state this regression is about.
+jest.mock('../hooks/use-button-presets', () => ({
+	useButtonPresets: jest.fn(),
+}));
+
+const LIBRARY = {
+	rest: { namespace: 'kb-design-tokens/v1' },
+	slug: 'default',
+	version: 1,
+	refreshFeed: jest.fn().mockResolvedValue({}),
+};
+
+describe('useButtonScreen reorder version handling', () => {
+	let container;
+	let root;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+
+		useButtonPresets.mockReturnValue({
+			payload: { version: 'v1' },
+			isLoading: false,
+			loadError: null,
+			rows: [],
+			initialValuesFor: () => null,
+		});
+
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		delete global.IS_REACT_ACT_ENVIRONMENT;
+	});
+
+	/**
+	 * Render `useButtonScreen` and hand back its latest return value.
+	 *
+	 * @since TBD
+	 *
+	 * @return {Function} Returns the hook's most recent return value when called.
+	 */
+	function renderScreen() {
+		let latest = null;
+
+		function Probe() {
+			latest = useButtonScreen(LIBRARY);
+
+			return null;
+		}
+
+		act(() => root.render(<Probe />));
+
+		return () => latest;
+	}
+
+	it('sends the version the previous write returned when a second drop follows the first', async () => {
+		const sentVersions = [];
+
+		// The payload's version stays 'v1' throughout: `useButtonPresets` re-reads it in a later
+		// effect, and the point of this test is the window before that read lands.
+		reorderPresetsFlow.mockImplementation(({ feedVersion, onVersion }) => {
+			sentVersions.push(feedVersion);
+			onVersion('v2');
+
+			return Promise.resolve();
+		});
+
+		const screen = renderScreen();
+
+		await act(async () => {
+			screen().reorderPresets(['secondary', 'primary']);
+			await screen().reorderPresets(['primary', 'secondary']);
+		});
+
+		expect(sentVersions).toEqual(['v1', 'v2']);
+	});
+
+	it('keeps using the payload version once the re-read catches up to the written one', async () => {
+		const sentVersions = [];
+
+		reorderPresetsFlow.mockImplementation(({ feedVersion, onVersion }) => {
+			sentVersions.push(feedVersion);
+			onVersion('v2');
+
+			return Promise.resolve();
+		});
+
+		const screen = renderScreen();
+
+		await act(async () => {
+			await screen().reorderPresets(['secondary', 'primary']);
+		});
+
+		// The re-read lands, carrying the same version the write reported.
+		useButtonPresets.mockReturnValue({
+			payload: { version: 'v2' },
+			isLoading: false,
+			loadError: null,
+			rows: [],
+			initialValuesFor: () => null,
+		});
+		renderScreen();
+
+		await act(async () => {
+			await screen().reorderPresets(['primary', 'secondary']);
+		});
+
+		expect(sentVersions).toEqual(['v1', 'v2']);
+	});
+});

--- a/src/style-library/__tests__/use-button-screen.test.js
+++ b/src/style-library/__tests__/use-button-screen.test.js
@@ -63,11 +63,14 @@ describe('useButtonScreen reorder version handling', () => {
 	});
 
 	/**
-	 * Render `useButtonScreen` and hand back its latest return value.
+	 * Mount `useButtonScreen` behind a single probe component type, so a re-render updates the
+	 * mounted hook rather than replacing it. A fresh component type per render would remount and
+	 * reset the version refs these tests are about.
 	 *
 	 * @since TBD
 	 *
-	 * @return {Function} Returns the hook's most recent return value when called.
+	 * @return {{rerender: Function, latest: Function}} Re-renders the mounted probe, and reads the
+	 *                                                    hook's most recent return value.
 	 */
 	function renderScreen() {
 		let latest = null;
@@ -78,9 +81,11 @@ describe('useButtonScreen reorder version handling', () => {
 			return null;
 		}
 
-		act(() => root.render(<Probe />));
+		const rerender = () => act(() => root.render(<Probe />));
 
-		return () => latest;
+		rerender();
+
+		return { rerender, latest: () => latest };
 	}
 
 	it('sends the version the previous write returned when a second drop follows the first', async () => {
@@ -98,8 +103,8 @@ describe('useButtonScreen reorder version handling', () => {
 		const screen = renderScreen();
 
 		await act(async () => {
-			screen().reorderPresets(['secondary', 'primary']);
-			await screen().reorderPresets(['primary', 'secondary']);
+			screen.latest().reorderPresets(['secondary', 'primary']);
+			await screen.latest().reorderPresets(['primary', 'secondary']);
 		});
 
 		expect(sentVersions).toEqual(['v1', 'v2']);
@@ -118,10 +123,10 @@ describe('useButtonScreen reorder version handling', () => {
 		const screen = renderScreen();
 
 		await act(async () => {
-			await screen().reorderPresets(['secondary', 'primary']);
+			await screen.latest().reorderPresets(['secondary', 'primary']);
 		});
 
-		// The re-read lands, carrying the same version the write reported.
+		// The re-read lands on the mounted hook, carrying the version the write reported.
 		useButtonPresets.mockReturnValue({
 			payload: { version: 'v2' },
 			isLoading: false,
@@ -129,12 +134,90 @@ describe('useButtonScreen reorder version handling', () => {
 			rows: [],
 			initialValuesFor: () => null,
 		});
-		renderScreen();
+		screen.rerender();
 
 		await act(async () => {
-			await screen().reorderPresets(['primary', 'secondary']);
+			await screen.latest().reorderPresets(['primary', 'secondary']);
 		});
 
 		expect(sentVersions).toEqual(['v1', 'v2']);
+	});
+
+	/**
+	 * A rejected write leaves no new version behind, so a drop already queued must fall back to the
+	 * payload rather than resend the previous write's override and fail the same way.
+	 *
+	 * @return {void}
+	 */
+	it('falls back to the payload version for the next drop after a failed write', async () => {
+		const sentVersions = [];
+		let call = 0;
+
+		reorderPresetsFlow.mockImplementation(({ feedVersion, onVersion }) => {
+			sentVersions.push(feedVersion);
+			call += 1;
+
+			if (call === 1) {
+				onVersion('v2');
+
+				return Promise.resolve();
+			}
+
+			// The second write conflicts: no version is reported.
+			return Promise.reject(new Error('Conflict'));
+		});
+
+		const screen = renderScreen();
+
+		await act(async () => {
+			await screen.latest().reorderPresets(['secondary', 'primary']);
+			await screen.latest().reorderPresets(['primary', 'secondary']);
+			await screen.latest().reorderPresets(['secondary', 'primary']);
+		});
+
+		// v1 from the payload, v2 from the first write's response, then back to the payload's v1
+		// because the failed write retired the override.
+		expect(sentVersions).toEqual(['v1', 'v2', 'v1']);
+		expect(LIBRARY.refreshFeed).toHaveBeenCalled();
+	});
+
+	/**
+	 * A re-read carrying a version this screen never wrote — another client's write — supersedes the
+	 * override, which must not keep being sent afterwards.
+	 *
+	 * @return {void}
+	 */
+	it('retires the write override when a later read supersedes it', async () => {
+		const sentVersions = [];
+
+		reorderPresetsFlow.mockImplementation(({ feedVersion, onVersion }) => {
+			sentVersions.push(feedVersion);
+			onVersion('v2');
+
+			return Promise.resolve();
+		});
+
+		const screen = renderScreen();
+
+		await act(async () => {
+			await screen.latest().reorderPresets(['secondary', 'primary']);
+		});
+
+		// Not 'v2': someone else wrote in between, so the payload moved somewhere the override
+		// cannot describe.
+		useButtonPresets.mockReturnValue({
+			payload: { version: 'v9' },
+			isLoading: false,
+			loadError: null,
+			rows: [],
+			initialValuesFor: () => null,
+		});
+		screen.rerender();
+
+		await act(async () => {
+			await screen.latest().reorderPresets(['primary', 'secondary']);
+		});
+
+		expect(sentVersions).toEqual(['v1', 'v9']);
 	});
 });

--- a/src/style-library/api/client.js
+++ b/src/style-library/api/client.js
@@ -27,6 +27,7 @@ import {
 	feedPath,
 	blockPresetsPath,
 	blockPresetPath,
+	blockPresetOrderPath,
 } from './paths';
 import { DEFAULT_LIBRARY_SLUG } from '../constants';
 
@@ -464,6 +465,25 @@ export function deleteBlockPreset(namespace, block, preset, slug) {
 	return apiFetch({
 		path: blockPresetPath(namespace, block, preset, slug),
 		method: 'DELETE',
+	});
+}
+
+/**
+ * Persist a block's full preset display order.
+ *
+ * @since TBD
+ *
+ * @param {string}                                 namespace REST namespace.
+ * @param {string}                                 block     The block name, e.g. `kadence/singlebtn`.
+ * @param {{ order: string[], version: string }}    payload   Request body.
+ * @param {string}                                 slug      Token library slug.
+ * @return {Promise<object>} The updated preset collection.
+ */
+export function setBlockPresetOrder(namespace, block, payload, slug) {
+	return apiFetch({
+		path: blockPresetOrderPath(namespace, block, slug),
+		method: 'PUT',
+		data: payload,
 	});
 }
 

--- a/src/style-library/api/paths.js
+++ b/src/style-library/api/paths.js
@@ -285,3 +285,17 @@ export function blockPresetsPath(namespace, block, slug = DEFAULT_LIBRARY_SLUG) 
 export function blockPresetPath(namespace, block, preset, slug = DEFAULT_LIBRARY_SLUG) {
 	return `${blockPresetsBasePath(namespace, block)}/${encodeURIComponent(preset)}?library=${encodeURIComponent(slug)}`;
 }
+
+/**
+ * Build a REST path for a block's preset display-order resource.
+ *
+ * @since TBD
+ *
+ * @param {string} namespace REST namespace (e.g. kb-design-tokens/v1).
+ * @param {string} block     The block name, e.g. `kadence/singlebtn`.
+ * @param {string} slug      Token library slug.
+ * @return {string} REST path relative to wp-json root.
+ */
+export function blockPresetOrderPath(namespace, block, slug = DEFAULT_LIBRARY_SLUG) {
+	return `${blockPresetsBasePath(namespace, block)}/order?library=${encodeURIComponent(slug)}`;
+}

--- a/src/style-library/components/pages/ButtonScreen.js
+++ b/src/style-library/components/pages/ButtonScreen.js
@@ -107,7 +107,7 @@ export function ButtonScreen({ label, route, navigate, library }) {
 		id: row.id,
 		label: row.label,
 		preview: renderButtonPreview(row),
-		isDraggable: false,
+		isDraggable: true,
 	}));
 
 	// Selecting the already-open preset is a no-op bypassing the guard entirely (the draft
@@ -135,6 +135,11 @@ export function ButtonScreen({ label, route, navigate, library }) {
 					{screen.addError.message}
 				</Notice>
 			)}
+			{screen.orderError && (
+				<Notice status="error" isDismissible onRemove={screen.clearOrderError}>
+					{screen.orderError.message}
+				</Notice>
+			)}
 			{screen.isLoading ? (
 				<Spinner />
 			) : (
@@ -142,7 +147,7 @@ export function ButtonScreen({ label, route, navigate, library }) {
 					items={items}
 					selectedId={route.item}
 					onSelect={selectPreset}
-					onReorder={() => {}}
+					onReorder={screen.reorderPresets}
 					empty={
 						<EmptyState title={label} description={__('Add Button', 'kadence-blocks')} action={addAction} />
 					}

--- a/src/style-library/helpers/preset-flows.js
+++ b/src/style-library/helpers/preset-flows.js
@@ -1,11 +1,13 @@
 /**
- * Pure orchestration for the Button preset screen's three write flows: create, save (which also
- * covers rename — a preset's label and token map are always written together), and delete. Same
+ * Pure orchestration for the Button preset screen's write flows: create, save (which also covers
+ * rename — a preset's label and token map are always written together), delete, and reorder. Same
  * `scale-flows.js` discipline: the REST call is imported here (so a test mocks `api/client`), the
  * caller supplies busy/error callbacks and a feed refresh, and every flow settles pessimistically
- * and re-throws on failure. Unlike the scale flows, no write here carries a `version` parameter —
- * the preset write routes have no optimistic-concurrency check (fact 15 of the plan overview), so
- * there is no 409 handling to thread through.
+ * and re-throws on failure. Create/save/delete carry no `version` parameter — the preset write
+ * routes have no optimistic-concurrency check for those verbs (fact 15 of the plan overview) — but
+ * reorder is the one exception: the display-order sub-route DOES guard the client version (the
+ * `reorderScaleTokensFlow` shape), since two rapid drags racing each other's refresh is exactly the
+ * case that guard exists to catch.
  */
 
 /**
@@ -16,7 +18,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { deleteBlockPreset, saveBlockPreset } from '../api/client';
+import { deleteBlockPreset, saveBlockPreset, setBlockPresetOrder } from '../api/client';
 import { isEqual } from './settings-schema';
 import { nextPresetSlug, presetSaveTokens } from './presets';
 
@@ -158,6 +160,41 @@ export function deletePresetFlow({ namespace, block, preset, slug, refreshFeed, 
 	onBusy(true);
 
 	return deleteBlockPreset(namespace, block, preset, slug)
+		.then(() => refreshFeed(slug))
+		.then(() => onBusy(false))
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+
+			throw err;
+		});
+}
+
+/**
+ * Persist a block's full preset display order: PUT the ordered slug list with the version the
+ * caller last read, then refresh the feed. The `reorderScaleTokensFlow` shape — the caller is
+ * responsible for serializing concurrent calls (see `hooks/use-button-screen.js`'s reorder chain)
+ * so a second rapid drop's write always carries the first drop's refreshed version.
+ *
+ * @param {Object}   args
+ * @param {string}   args.namespace   REST namespace.
+ * @param {string}   args.block       The block name, e.g. `kadence/singlebtn`.
+ * @param {string[]} args.orderedIds  The preset slugs in their new display order.
+ * @param {string}   args.feedVersion The version the client last read.
+ * @param {string}   args.slug        Token library slug.
+ * @param {Function} args.refreshFeed Replaces the feed with a fresh REST read for a slug.
+ * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once the write and the feed refresh complete; rejects on
+ *                          failure, after `onError`/`onBusy` have already run.
+ */
+export function reorderPresetsFlow({ namespace, block, orderedIds, feedVersion, slug, refreshFeed, onBusy, onError }) {
+	onBusy(true);
+
+	return setBlockPresetOrder(namespace, block, { order: orderedIds, version: feedVersion }, slug)
 		.then(() => refreshFeed(slug))
 		.then(() => onBusy(false))
 		.catch((err) => {

--- a/src/style-library/helpers/preset-flows.js
+++ b/src/style-library/helpers/preset-flows.js
@@ -107,6 +107,9 @@ export function createPresetFlow({
  * @param {Function} args.refreshFeed Replaces the feed with a fresh REST read for a slug.
  * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
  * @param {Function} args.onError     Called with `{ message }` on failure.
+ * @param {Function} args.onVersion   Called with the version the write returned, before the feed
+ *                                      refresh, so a caller serializing drops can hand the next
+ *                                      one a current version without waiting for a re-read.
  *
  * @since TBD
  *
@@ -191,10 +194,28 @@ export function deletePresetFlow({ namespace, block, preset, slug, refreshFeed, 
  * @return {Promise<void>} Resolves once the write and the feed refresh complete; rejects on
  *                          failure, after `onError`/`onBusy` have already run.
  */
-export function reorderPresetsFlow({ namespace, block, orderedIds, feedVersion, slug, refreshFeed, onBusy, onError }) {
+export function reorderPresetsFlow({
+	namespace,
+	block,
+	orderedIds,
+	feedVersion,
+	slug,
+	refreshFeed,
+	onBusy,
+	onError,
+	onVersion,
+}) {
 	onBusy(true);
 
 	return setBlockPresetOrder(namespace, block, { order: orderedIds, version: feedVersion }, slug)
+		.then((response) => {
+			// Reported straight off the write. The feed refresh below only bumps the library
+			// version; the preset payload that carries this one arrives in a later re-read, which
+			// a queued second drop would otherwise overtake and 409 against itself.
+			if (response && response.version) {
+				onVersion(response.version);
+			}
+		})
 		.then(() => refreshFeed(slug))
 		.then(() => onBusy(false))
 		.catch((err) => {

--- a/src/style-library/hooks/use-button-screen.js
+++ b/src/style-library/hooks/use-button-screen.js
@@ -47,14 +47,26 @@ export function useButtonScreen(library) {
 	const refreshFeed = library?.refreshFeed;
 	const payloadVersion = presets.payload?.version;
 
-	// Holds the version the last reorder write returned, until the preset payload catches up to it.
+	// Read inside the queued continuations below, which are created once per `useCallback` identity
+	// and would otherwise close over the version from the render that made them.
+	const payloadVersionRef = useRef(payloadVersion);
+	payloadVersionRef.current = payloadVersion;
+
+	// Holds the version the last reorder write returned, until the preset payload catches up.
 	// Unlike `use-scale-screen.js`, whose version comes from the feed the awaited refresh replaces,
 	// this screen reads its version from a payload that `useButtonPresets` re-fetches in a later
 	// effect. A second drop queued behind the first would otherwise dereference the pre-write
 	// version and 409 against itself.
 	const writtenVersionRef = useRef(null);
 
-	if (payloadVersion === writtenVersionRef.current) {
+	// The payload version at the moment the override was recorded. The override is retired as soon
+	// as the payload moves off it at all, rather than only on an exact match with what the write
+	// returned: a re-read that carries a newer version — someone else's write, or a response this
+	// screen never saw — supersedes the override, and holding on to it would keep sending a version
+	// the server has already replaced.
+	const payloadAtWriteRef = useRef(payloadVersion);
+
+	if (writtenVersionRef.current !== null && payloadVersion !== payloadAtWriteRef.current) {
 		writtenVersionRef.current = null;
 	}
 
@@ -174,6 +186,7 @@ export function useButtonScreen(library) {
 					// commits one, and it reads `feedVersionRef` directly.
 					onVersion: (version) => {
 						writtenVersionRef.current = version;
+						payloadAtWriteRef.current = payloadVersionRef.current;
 						feedVersionRef.current = version;
 					},
 				})
@@ -181,6 +194,15 @@ export function useButtonScreen(library) {
 						// Caught here, not re-thrown — every link must settle so the chain is never left
 						// permanently rejected. Snap the optimistic order back to the last confirmed one.
 						setPendingOrder(null);
+
+						// A failed write returned no version, so the override is meaningless now, and a
+						// drop already queued behind this one would otherwise resend it and fail the same
+						// way. Fall back to the payload and re-read it, so the next link in the chain
+						// carries whatever the server actually holds.
+						writtenVersionRef.current = null;
+						feedVersionRef.current = payloadVersionRef.current;
+
+						return refreshFeed ? refreshFeed(slug).catch(() => {}) : undefined;
 					})
 					.then(() => {
 						reorderPendingCountRef.current -= 1;

--- a/src/style-library/hooks/use-button-screen.js
+++ b/src/style-library/hooks/use-button-screen.js
@@ -3,10 +3,10 @@
  * `useScaleScreen` role, applied to a fetched-not-localized payload): wraps `useButtonPresets`
  * and adds the four preset write flows. Create/save/delete carry no version parameter
  * (`helpers/preset-flows.js`'s module docblock), so only reorder needs the serialized-chain
- * machinery — copied from `use-scale-screen.js`'s `reorderTokens`, with `feedVersionRef` mirroring
- * the fetched preset payload's own `version` (not the localized feed's — this screen's data source
- * is `useButtonPresets`, not the feed in hand) so two rapid drags cannot race the re-fetch into a
- * spurious 409 against themselves.
+ * machinery — copied from `use-scale-screen.js`'s `reorderTokens`. This screen's data source is
+ * `useButtonPresets`, not the feed in hand, and that payload's `version` only refreshes on a later
+ * re-read, so the chain carries the version each write returns until the payload catches up. Two
+ * rapid drags therefore cannot race the re-read into a spurious 409 against themselves.
  */
 
 /**
@@ -47,11 +47,22 @@ export function useButtonScreen(library) {
 	const refreshFeed = library?.refreshFeed;
 	const payloadVersion = presets.payload?.version;
 
-	// Mirrors the fetched preset payload's version so the queued reorder continuation below always
-	// dereferences the live version at execution time, never a value captured when the drop was
-	// enqueued — see `use-scale-screen.js`'s identical comment for why.
+	// Holds the version the last reorder write returned, until the preset payload catches up to it.
+	// Unlike `use-scale-screen.js`, whose version comes from the feed the awaited refresh replaces,
+	// this screen reads its version from a payload that `useButtonPresets` re-fetches in a later
+	// effect. A second drop queued behind the first would otherwise dereference the pre-write
+	// version and 409 against itself.
+	const writtenVersionRef = useRef(null);
+
+	if (payloadVersion === writtenVersionRef.current) {
+		writtenVersionRef.current = null;
+	}
+
+	// Mirrors the version the queued reorder continuation below must send, so it always
+	// dereferences the live value at execution time, never one captured when the drop was enqueued
+	// — see `use-scale-screen.js`'s identical comment for why.
 	const feedVersionRef = useRef(payloadVersion);
-	feedVersionRef.current = payloadVersion;
+	feedVersionRef.current = writtenVersionRef.current ?? payloadVersion;
 
 	// One in-flight reorder promise, the `use-scale-screen.js` shape: each call chains onto the
 	// previous reorder's settled promise so a second drop's write waits for the first drop's flow
@@ -159,6 +170,12 @@ export function useButtonScreen(library) {
 					refreshFeed,
 					onBusy: setIsBusy,
 					onError: setOrderError,
+					// Assigned outside a render on purpose: the next queued link may run before React
+					// commits one, and it reads `feedVersionRef` directly.
+					onVersion: (version) => {
+						writtenVersionRef.current = version;
+						feedVersionRef.current = version;
+					},
 				})
 					.catch(() => {
 						// Caught here, not re-thrown — every link must settle so the chain is never left

--- a/src/style-library/hooks/use-button-screen.js
+++ b/src/style-library/hooks/use-button-screen.js
@@ -1,32 +1,36 @@
 /**
  * The state binding both `ButtonScreen` and `ButtonSettings` call as siblings (the
  * `useScaleScreen` role, applied to a fetched-not-localized payload): wraps `useButtonPresets`
- * and adds the three preset write flows. No reorder chain here (that is a separate concern) and
- * no `feedVersionRef` — preset writes carry no version parameter (`helpers/preset-flows.js`'s
- * module docblock), so there is nothing to serialize against.
+ * and adds the four preset write flows. Create/save/delete carry no version parameter
+ * (`helpers/preset-flows.js`'s module docblock), so only reorder needs the serialized-chain
+ * machinery — copied from `use-scale-screen.js`'s `reorderTokens`, with `feedVersionRef` mirroring
+ * the fetched preset payload's own `version` (not the localized feed's — this screen's data source
+ * is `useButtonPresets`, not the feed in hand) so two rapid drags cannot race the re-fetch into a
+ * spurious 409 against themselves.
  */
 
 /**
  * WordPress dependencies
  */
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { createPresetFlow, deletePresetFlow, savePresetFlow } from '../helpers/preset-flows';
+import { applyRowOrder } from '../helpers/scale';
+import { createPresetFlow, deletePresetFlow, reorderPresetsFlow, savePresetFlow } from '../helpers/preset-flows';
 import { BUTTON_BLOCK, presetInitialValues } from '../helpers/presets';
 import { useButtonPresets } from './use-button-presets';
 
 /**
- * Bind the Button preset screen's config to the fetched preset collection and its three write
+ * Bind the Button preset screen's config to the fetched preset collection and its four write
  * flows.
  *
  * @param {Object} library The design-tokens feed hook's return value (`useDesignTokensFeed()`).
  *
  * @since TBD
  *
- * @return {{payload: ?object, isLoading: boolean, loadError: ?Error, rows: Array<Object>, initialValuesFor: Function, isBusy: boolean, addError: ?Object, saveError: ?Object, deleteError: ?Object, clearAddError: Function, clearSaveError: Function, clearDeleteError: Function, addPreset: Function, savePreset: Function, deletePreset: Function, isDeletable: Function}}
+ * @return {{payload: ?object, isLoading: boolean, loadError: ?Error, rows: Array<Object>, initialValuesFor: Function, isBusy: boolean, addError: ?Object, saveError: ?Object, deleteError: ?Object, orderError: ?Object, clearAddError: Function, clearSaveError: Function, clearDeleteError: Function, clearOrderError: Function, addPreset: Function, savePreset: Function, deletePreset: Function, reorderPresets: Function, isDeletable: Function}}
  */
 export function useButtonScreen(library) {
 	const presets = useButtonPresets(library);
@@ -35,14 +39,46 @@ export function useButtonScreen(library) {
 	const [addError, setAddError] = useState(null);
 	const [saveError, setSaveError] = useState(null);
 	const [deleteError, setDeleteError] = useState(null);
+	const [orderError, setOrderError] = useState(null);
+	const [pendingOrder, setPendingOrder] = useState(null);
 
 	const namespace = library?.rest?.namespace;
 	const slug = library?.slug;
 	const refreshFeed = library?.refreshFeed;
+	const payloadVersion = presets.payload?.version;
+
+	// Mirrors the fetched preset payload's version so the queued reorder continuation below always
+	// dereferences the live version at execution time, never a value captured when the drop was
+	// enqueued — see `use-scale-screen.js`'s identical comment for why.
+	const feedVersionRef = useRef(payloadVersion);
+	feedVersionRef.current = payloadVersion;
+
+	// One in-flight reorder promise, the `use-scale-screen.js` shape: each call chains onto the
+	// previous reorder's settled promise so a second drop's write waits for the first drop's flow
+	// (including its own refresh) before reading the refreshed version.
+	const reorderChainRef = useRef(Promise.resolve());
+	const reorderPendingCountRef = useRef(0);
+
+	// The local reorder override clears itself once the fetched payload catches up — but only
+	// while the reorder chain is idle, or the first drop's refresh would visually revert the
+	// second drop while its write is still queued. A failed link clears it itself, inline, in its
+	// own catch below.
+	useEffect(() => {
+		if (reorderPendingCountRef.current === 0) {
+			setPendingOrder(null);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [payloadVersion]);
+
+	const rows = useMemo(
+		() => (pendingOrder ? applyRowOrder(presets.rows, pendingOrder) : presets.rows),
+		[presets.rows, pendingOrder]
+	);
 
 	const clearAddError = useCallback(() => setAddError(null), []);
 	const clearSaveError = useCallback(() => setSaveError(null), []);
 	const clearDeleteError = useCallback(() => setDeleteError(null), []);
+	const clearOrderError = useCallback(() => setOrderError(null), []);
 
 	const addPreset = useCallback(() => {
 		setAddError(null);
@@ -103,22 +139,63 @@ export function useButtonScreen(library) {
 		[presets.rows]
 	);
 
+	const reorderPresets = useCallback(
+		(orderedIds) => {
+			// Applied immediately (optimistic), at drop time, before the write is even queued — see
+			// `use-scale-screen.js`'s identical comment.
+			setPendingOrder(orderedIds);
+			reorderPendingCountRef.current += 1;
+
+			const run = () => {
+				setOrderError(null);
+
+				return reorderPresetsFlow({
+					namespace,
+					block: BUTTON_BLOCK,
+					orderedIds,
+					// Dereferenced here, inside the queued continuation — never a value captured earlier.
+					feedVersion: feedVersionRef.current,
+					slug,
+					refreshFeed,
+					onBusy: setIsBusy,
+					onError: setOrderError,
+				})
+					.catch(() => {
+						// Caught here, not re-thrown — every link must settle so the chain is never left
+						// permanently rejected. Snap the optimistic order back to the last confirmed one.
+						setPendingOrder(null);
+					})
+					.then(() => {
+						reorderPendingCountRef.current -= 1;
+					});
+			};
+
+			reorderChainRef.current = reorderChainRef.current.then(run);
+
+			return reorderChainRef.current;
+		},
+		[namespace, slug, refreshFeed]
+	);
+
 	return {
 		payload: presets.payload,
 		isLoading: presets.isLoading,
 		loadError: presets.loadError,
-		rows: presets.rows,
+		rows,
 		initialValuesFor: presets.initialValuesFor,
 		isBusy,
 		addError,
 		saveError,
 		deleteError,
+		orderError,
 		clearAddError,
 		clearSaveError,
 		clearDeleteError,
+		clearOrderError,
 		addPreset,
 		savePreset,
 		deletePreset,
+		reorderPresets,
 		isDeletable,
 	};
 }


### PR DESCRIPTION
Serialized drag-to-reorder for button presets, backed by the storage and read seams below.

## Test instructions

1. On **Block Presets → Button**, drag a preset row by its handle to a new position.
2. Reload the page and confirm the new order persisted.
3. Drag two rows in quick succession — the writes are serialized, so the final order should match what you see, with no lost reorder.
4. Confirm the order also holds in the block editor's preset dropdown on a Single Button block.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4083/phase-5e-drag-reorder-ui
bun run build-wp
```

The Style Library is at **WP Admin → Kadence → Style Library**. The Button preset screen is under **Block Presets → Button**. Block-editor checks use a **Kadence Single Button** block on any post.
</details>

## Screenshot

Preset rows with drag handles
<img width="1512" height="788" alt="phase-5e-drag-reorder-ui" src="https://github.com/user-attachments/assets/cab815db-73aa-4de9-85be-f8f79c44c26e" />

---

Slice 10 of 23 in the SOFT-4083 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Button presets can now be reordered by dragging and dropping rows.
  * New ordering is saved automatically and preserved after refreshing the library.
  * Reordering remains responsive while updates are being saved.
  * Consecutive reorder changes are handled reliably while saving is in progress.
* **Bug Fixes**
  * Added clearer handling for ordering conflicts and save failures.
  * Failed reorder attempts now restore the previous order and display an error.
  * Ordering errors can be cleared after they are addressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->