### PR TITLE
[DTM] SOFT-4083 [11/23]: Shape-tolerant preset values

### DIFF
--- a/src/style-library/__tests__/preset-flows.test.js
+++ b/src/style-library/__tests__/preset-flows.test.js
@@ -243,6 +243,101 @@ describe('savePresetFlow', () => {
 		expect(onError).toHaveBeenCalledWith({ message: failure.message });
 		expect(onBusy.mock.calls).toEqual([[true], [false]]);
 	});
+
+	// The sibling per-corner-values and responsive-values work widens a stored preset property's
+	// value to a per-corner slot list or a responsive envelope. Today's base can only produce a
+	// scalar, so these shapes are constructed by hand — pinning the save flow's forward-compatible
+	// contract against data this screen cannot itself author yet.
+	describe('non-scalar button-radius (per-corner / responsive shapes)', () => {
+		const nonScalarRadius = {
+			$value: ['{radius.lg}', '{radius.none}', '{radius.lg}', '{radius.none}'],
+			$extensions: {
+				'com.kadence.designTokens': {
+					responsive: { tablet: ['{radius.sm}', '0', '{radius.sm}', '0'] },
+				},
+			},
+		};
+
+		it('leaves a non-scalar button-radius untouched in the POST body when only the label changes', async () => {
+			client.saveBlockPreset.mockResolvedValue({});
+			const refreshFeed = jest.fn().mockResolvedValue({});
+			const storedTokens = {
+				'button-bg': '{semantic.color.action-primary}',
+				'button-radius': nonScalarRadius,
+			};
+			// initialValues.tokens mirrors presetInitialValues' seed: scalar properties as bare ids,
+			// a non-scalar property passed through unchanged (aliasToId is a no-op on non-strings).
+			const initialTokens = {
+				'button-bg': 'semantic.color.action-primary',
+				'button-radius': nonScalarRadius,
+			};
+
+			await savePresetFlow({
+				...baseArgs,
+				draft: { label: 'Renamed', tokens: initialTokens },
+				initialValues: { label: 'Primary', tokens: initialTokens },
+				storedTokens,
+				refreshFeed,
+				onBusy: jest.fn(),
+				onError: jest.fn(),
+			});
+
+			expect(client.saveBlockPreset).toHaveBeenCalledWith(
+				'kb-design-tokens/v1',
+				'kadence/singlebtn',
+				{
+					preset: 'primary',
+					label: 'Renamed',
+					tokens: {
+						'button-bg': '{semantic.color.action-primary}',
+						'button-radius': nonScalarRadius,
+					},
+				},
+				'default'
+			);
+		});
+
+		it('writes an edited color and still preserves the untouched non-scalar radius', async () => {
+			client.saveBlockPreset.mockResolvedValue({});
+			const refreshFeed = jest.fn().mockResolvedValue({});
+			const storedTokens = {
+				'button-bg': '{semantic.color.action-primary}',
+				'button-radius': nonScalarRadius,
+			};
+			const initialTokens = {
+				'button-bg': 'semantic.color.action-primary',
+				'button-radius': nonScalarRadius,
+			};
+			const draftTokens = {
+				'button-bg': 'semantic.color.action-primary-hover',
+				'button-radius': nonScalarRadius,
+			};
+
+			await savePresetFlow({
+				...baseArgs,
+				draft: { label: 'Primary', tokens: draftTokens },
+				initialValues: { label: 'Primary', tokens: initialTokens },
+				storedTokens,
+				refreshFeed,
+				onBusy: jest.fn(),
+				onError: jest.fn(),
+			});
+
+			expect(client.saveBlockPreset).toHaveBeenCalledWith(
+				'kb-design-tokens/v1',
+				'kadence/singlebtn',
+				{
+					preset: 'primary',
+					label: 'Primary',
+					tokens: {
+						'button-bg': '{semantic.color.action-primary-hover}',
+						'button-radius': nonScalarRadius,
+					},
+				},
+				'default'
+			);
+		});
+	});
 });
 
 describe('deletePresetFlow', () => {

--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -7,6 +7,7 @@ import {
 	presetRows,
 	presetInitialValues,
 	presetSaveTokens,
+	presetStoredTokens,
 	nextPresetSlug,
 	getButtonPresetProperties,
 	overlayPresetRows,
@@ -286,6 +287,59 @@ describe('presetSaveTokens', () => {
 
 	it('passes a literal value through unchanged', () => {
 		expect(presetSaveTokens({ 'button-bg': 'transparent' })).toEqual({ 'button-bg': 'transparent' });
+	});
+
+	it('with no initialTokens/storedTokens, treats every entry as touched (the create-flow shape)', () => {
+		const slots = ['{radius.lg}', '0', '{radius.lg}', '0'];
+
+		expect(presetSaveTokens({ 'button-radius': slots })).toEqual({ 'button-radius': slots });
+	});
+
+	it('carries an untouched non-scalar property over from storedTokens byte-for-byte', () => {
+		const storedRadius = {
+			$value: '{semantic.dimension.radius-md}',
+			$extensions: { 'com.kadence.designTokens': { responsive: { tablet: '{semantic.dimension.radius-sm}' } } },
+		};
+		const draftTokens = { 'button-radius': storedRadius };
+		const initialTokens = { 'button-radius': storedRadius };
+		const storedTokens = { 'button-radius': storedRadius };
+
+		const result = presetSaveTokens(draftTokens, initialTokens, storedTokens);
+
+		expect(result['button-radius']).toBe(storedRadius);
+	});
+
+	it('writes a fresh alias for a property the draft changed, even with storedTokens present', () => {
+		const initialTokens = { 'button-bg': 'semantic.color.action-primary' };
+		const storedTokens = { 'button-bg': '{semantic.color.action-primary}' };
+		const draftTokens = { 'button-bg': 'semantic.color.action-primary-hover' };
+
+		expect(presetSaveTokens(draftTokens, initialTokens, storedTokens)).toEqual({
+			'button-bg': '{semantic.color.action-primary-hover}',
+		});
+	});
+
+	it('falls back to a fresh alias when a draft property has no stored counterpart', () => {
+		const result = presetSaveTokens({ 'button-radius': 'semantic.dimension.radius-md' }, {}, {});
+
+		expect(result).toEqual({ 'button-radius': '{semantic.dimension.radius-md}' });
+	});
+});
+
+describe('presetStoredTokens', () => {
+	it("reads the preset's raw stored token map, unmodified", () => {
+		const tokens = { 'button-bg': '{semantic.color.action-primary}', 'button-radius': ['1rem', '0', '1rem', '0'] };
+		const payload = { presets: { primary: { tokens } } };
+
+		expect(presetStoredTokens(payload, 'primary')).toBe(tokens);
+	});
+
+	it('returns an empty object for an unknown slug', () => {
+		expect(presetStoredTokens({ presets: {} }, 'missing')).toEqual({});
+	});
+
+	it('returns an empty object for a null payload', () => {
+		expect(presetStoredTokens(null, 'primary')).toEqual({});
 	});
 });
 

--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -94,6 +94,29 @@ describe('resolveTokenValue', () => {
 		expect(resolveTokenValue(dimensionValues, slots)).toBe('1rem 4px 1rem 4px');
 	});
 
+	it('resolves a slot list with a dangling alias to an empty string, not a partial shorthand', () => {
+		const dimensionValues = { 'radius.lg': '1rem' };
+		const slots = ['{radius.lg}', '{radius.does-not-exist}', '{radius.lg}', '{radius.lg}'];
+
+		// Joining the resolved slots would emit `1rem  1rem 1rem` — valid CSS, but a different
+		// radius than the one stored.
+		expect(resolveTokenValue(dimensionValues, slots)).toBe('');
+	});
+
+	it('resolves a slot list holding a non-string slot to an empty string', () => {
+		const dimensionValues = { 'radius.lg': '1rem' };
+
+		expect(resolveTokenValue(dimensionValues, ['{radius.lg}', 4, '{radius.lg}', '{radius.lg}'])).toBe('');
+		expect(resolveTokenValue(dimensionValues, [1, 2, 3, 4])).toBe('');
+	});
+
+	it('keeps a zero-valued slot, which resolves to a real value rather than nothing', () => {
+		const dimensionValues = { 'radius.none': '0' };
+		const slots = ['{radius.none}', '{radius.none}', '{radius.none}', '{radius.none}'];
+
+		expect(resolveTokenValue(dimensionValues, slots)).toBe('0 0 0 0');
+	});
+
 	it('unwraps an envelope whose base $value is a per-corner slot list', () => {
 		const dimensionValues = { 'radius.lg': '1rem' };
 		const envelope = {

--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -3,6 +3,7 @@ import {
 	aliasToId,
 	idToAlias,
 	resolveTokenValue,
+	isNonScalarPresetValue,
 	presetRows,
 	presetInitialValues,
 	presetSaveTokens,
@@ -54,6 +55,77 @@ describe('resolveTokenValue', () => {
 
 	it('resolves a dangling alias to an empty string', () => {
 		expect(resolveTokenValue(values, '{semantic.color.does-not-exist}')).toBe('');
+	});
+
+	it('unwraps a responsive envelope to its base $value, ignoring breakpoint overrides', () => {
+		const envelope = {
+			$value: '{semantic.color.action-primary}',
+			$extensions: {
+				'com.kadence.designTokens': {
+					responsive: { tablet: '#000000', mobile: '#111111' },
+				},
+			},
+		};
+
+		expect(resolveTokenValue(values, envelope)).toBe('#3633e1');
+	});
+
+	it('unwraps an envelope whose base $value is itself a literal', () => {
+		const envelope = {
+			$value: '4px',
+			$extensions: { 'com.kadence.designTokens': { responsive: { tablet: '2px' } } },
+		};
+
+		expect(resolveTokenValue(values, envelope)).toBe('4px');
+	});
+
+	it('resolves a per-corner slot list to a space-joined CSS value', () => {
+		const dimensionValues = { 'radius.lg': '1rem', 'radius.none': '0' };
+		const slots = ['{radius.lg}', '{radius.none}', '{radius.lg}', '{radius.none}'];
+
+		expect(resolveTokenValue(dimensionValues, slots)).toBe('1rem 0 1rem 0');
+	});
+
+	it('resolves a per-corner slot list of mixed aliases and literals', () => {
+		const dimensionValues = { 'radius.lg': '1rem' };
+		const slots = ['{radius.lg}', '4px', '{radius.lg}', '4px'];
+
+		expect(resolveTokenValue(dimensionValues, slots)).toBe('1rem 4px 1rem 4px');
+	});
+
+	it('unwraps an envelope whose base $value is a per-corner slot list', () => {
+		const dimensionValues = { 'radius.lg': '1rem' };
+		const envelope = {
+			$value: ['{radius.lg}', '0', '{radius.lg}', '0'],
+			$extensions: { 'com.kadence.designTokens': { responsive: { tablet: ['0', '0', '0', '0'] } } },
+		};
+
+		expect(resolveTokenValue(dimensionValues, envelope)).toBe('1rem 0 1rem 0');
+	});
+
+	it('degrades an unresolvable non-string, non-array, non-envelope entry to an empty string rather than garbage', () => {
+		expect(resolveTokenValue(values, null)).toBe('');
+		expect(resolveTokenValue(values, undefined)).toBe('');
+	});
+});
+
+describe('isNonScalarPresetValue', () => {
+	it('is true for a responsive envelope', () => {
+		expect(isNonScalarPresetValue({ $value: '4px' })).toBe(true);
+	});
+
+	it('is true for a four-entry per-corner slot list', () => {
+		expect(isNonScalarPresetValue(['1rem', '0', '1rem', '0'])).toBe(true);
+	});
+
+	it('is false for a bare alias or literal', () => {
+		expect(isNonScalarPresetValue('{semantic.dimension.radius-md}')).toBe(false);
+		expect(isNonScalarPresetValue('4px')).toBe(false);
+	});
+
+	it('is false for an empty or non-four-entry array (not a valid slot list)', () => {
+		expect(isNonScalarPresetValue([])).toBe(false);
+		expect(isNonScalarPresetValue(['1rem', '0'])).toBe(false);
 	});
 });
 

--- a/src/style-library/helpers/preset-flows.js
+++ b/src/style-library/helpers/preset-flows.js
@@ -103,6 +103,13 @@ export function createPresetFlow({
  * @param {string} args.preset        The preset slug being saved.
  * @param {Object} args.draft         The panel's current draft (`{ label, tokens }`).
  * @param {Object} args.initialValues The values the draft is compared against (`{ label, tokens }`).
+ * @param {Record<string, *>} [args.storedTokens] The preset's raw stored token map
+ *                                                 (`presetStoredTokens`); an untouched property is
+ *                                                 carried over from here byte-for-byte rather than
+ *                                                 rebuilt from the draft's bare-id seed, so a save
+ *                                                 that only edits, say, the label never flattens a
+ *                                                 per-corner slot list or a responsive envelope into
+ *                                                 a plain alias. Defaults to `{}`.
  * @param {string} args.slug          Token library slug.
  * @param {Function} args.refreshFeed Replaces the feed with a fresh REST read for a slug.
  * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
@@ -117,7 +124,18 @@ export function createPresetFlow({
  *                          refresh complete; rejects on failure, after `onError`/`onBusy` have
  *                          already run.
  */
-export function savePresetFlow({ namespace, block, preset, draft, initialValues, slug, refreshFeed, onBusy, onError }) {
+export function savePresetFlow({
+	namespace,
+	block,
+	preset,
+	draft,
+	initialValues,
+	storedTokens = {},
+	slug,
+	refreshFeed,
+	onBusy,
+	onError,
+}) {
 	if (isEqual(draft, initialValues)) {
 		return Promise.resolve();
 	}
@@ -127,7 +145,7 @@ export function savePresetFlow({ namespace, block, preset, draft, initialValues,
 	return saveBlockPreset(
 		namespace,
 		block,
-		{ preset, label: draft.label, tokens: presetSaveTokens(draft.tokens) },
+		{ preset, label: draft.label, tokens: presetSaveTokens(draft.tokens, initialValues?.tokens, storedTokens) },
 		slug
 	)
 		.then(() => refreshFeed(slug))

--- a/src/style-library/helpers/presets.js
+++ b/src/style-library/helpers/presets.js
@@ -20,6 +20,24 @@ import { nextScaleSlug } from './scale';
 import { getDesignTokensFeed } from './tokens';
 
 /**
+ * The `$value` sentinel key a responsive preset-value envelope wraps its base value in, mirroring
+ * the sibling per-corner/responsive-value work's `Sentinels::get_value_key()`. Presence of this key
+ * on an object (never an array — a slot list is a plain array) is what distinguishes an envelope
+ * from a bare per-corner slot list.
+ *
+ * @since TBD
+ */
+const ENVELOPE_VALUE_KEY = '$value';
+
+/**
+ * The number of corners a per-corner slot list carries (top-left, top-right, bottom-right,
+ * bottom-left) — the sibling per-corner-values work's `Dtcg_Validator::SLOT_LIST_SIDES`.
+ *
+ * @since TBD
+ */
+const SLOT_LIST_SIDES = 4;
+
+/**
  * The block name the Button preset screen edits — the single JS spelling, so the preset-screens
  * filter registration, the fetch-and-bind hook, and any future preset screen reusing this contract
  * never risk a typo'd duplicate.
@@ -110,20 +128,82 @@ export function idToAlias(value) {
 }
 
 /**
- * Resolve a stored preset token value against the feed's resolved value map: an alias resolves to
- * its target's resolved value, a literal is returned as-is, and an alias pointing at nothing
- * resolves to an empty string.
+ * Whether a stored preset token entry is a responsive envelope: `{ $value, $extensions: {
+ * "com.kadence.designTokens": { responsive: { tablet, mobile } } } }`. Only the base `$value` is
+ * read here — the breakpoint overrides are an editor concern, out of scope for the Style Library's
+ * single-value preview/picker surface. An object is checked rather than any array, since a slot
+ * list (see `isSlotList`) is a plain array and never carries a `$value` key.
  *
- * @param {Record<string, string>} values The feed's resolved value map (`feed.values`).
- * @param {string}                 value  The stored token value (alias or literal).
+ * @param {*} value The stored token entry.
  *
  * @since TBD
  *
- * @return {string} The resolved value, or `''` for a dangling alias.
+ * @return {boolean} True when `value` is a responsive envelope.
+ */
+function isPresetEnvelope(value) {
+	return Boolean(value) && typeof value === 'object' && !Array.isArray(value) && ENVELOPE_VALUE_KEY in value;
+}
+
+/**
+ * Whether a stored preset token entry is a per-corner slot list: exactly four entries, each
+ * independently an alias or a literal.
+ *
+ * @param {*} value The stored token entry.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when `value` is a per-corner slot list.
+ */
+function isSlotList(value) {
+	return Array.isArray(value) && value.length === SLOT_LIST_SIDES;
+}
+
+/**
+ * Whether a stored preset token entry is one of the shapes the single-value token picker cannot
+ * represent — a responsive envelope or a per-corner slot list. Both carry more than the picker's
+ * one alias-or-literal slot, so editing them through it would silently flatten the value on save;
+ * callers use this to render the field read-only instead.
+ *
+ * @param {*} value The stored (or draft-seeded) token entry.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when `value` is non-scalar.
+ */
+export function isNonScalarPresetValue(value) {
+	return isPresetEnvelope(value) || isSlotList(value);
+}
+
+/**
+ * Resolve a stored preset token value against the feed's resolved value map, tolerant of every
+ * shape a preset property's value can carry: a bare alias or literal (unchanged from the original
+ * contract), a responsive envelope (resolved from its base `$value`, breakpoint overrides ignored —
+ * this is a single preview/picker value, not a responsive editor), or a per-corner slot list (each
+ * corner resolved independently and joined with a space, the CSS `border-radius` shorthand order).
+ * Anything else unresolvable degrades to `''` rather than a stringified object or array.
+ *
+ * @param {Record<string, string>} values The feed's resolved value map (`feed.values`).
+ * @param {*}                       value  The stored token entry (alias, literal, envelope, or slot list).
+ *
+ * @since TBD
+ *
+ * @return {string} The resolved value, or `''` when unresolvable.
  */
 export function resolveTokenValue(values, value) {
-	if (typeof value !== 'string' || !value.startsWith('{') || !value.endsWith('}')) {
-		return value ?? '';
+	if (isPresetEnvelope(value)) {
+		return resolveTokenValue(values, value[ENVELOPE_VALUE_KEY]);
+	}
+
+	if (isSlotList(value)) {
+		return value.map((slot) => resolveTokenValue(values, slot)).join(' ');
+	}
+
+	if (typeof value !== 'string') {
+		return '';
+	}
+
+	if (!value.startsWith('{') || !value.endsWith('}')) {
+		return value;
 	}
 
 	return values?.[aliasToId(value)] ?? '';

--- a/src/style-library/helpers/presets.js
+++ b/src/style-library/helpers/presets.js
@@ -196,7 +196,14 @@ export function resolveTokenValue(values, value) {
 	}
 
 	if (isSlotList(value)) {
-		return value.map((slot) => resolveTokenValue(values, slot)).join(' ');
+		const slots = value.map((slot) => (typeof slot === 'string' ? resolveTokenValue(values, slot) : ''));
+
+		// All four slots or none: joining a partial resolution emits a valid-looking shorthand
+		// (`1rem  1rem 1rem`) that silently renders a different radius than the one stored, which is
+		// worse than the empty fallback every other unresolvable shape degrades to. Kept here rather
+		// than in `isSlotList`, which also decides whether the single-value picker may edit the
+		// entry — narrowing that would make a malformed slot list look editable.
+		return slots.some((slot) => slot === '') ? '' : slots.join(' ');
 	}
 
 	if (typeof value !== 'string') {

--- a/src/style-library/helpers/presets.js
+++ b/src/style-library/helpers/presets.js
@@ -16,6 +16,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { isEqual } from './settings-schema';
 import { nextScaleSlug } from './scale';
 import { getDesignTokensFeed } from './tokens';
 
@@ -274,19 +275,52 @@ export function presetInitialValues(payload, slug) {
 }
 
 /**
- * Build the write-side token map from a settings-panel draft: each present entry wrapped as an
- * alias (or passed through when already an alias or a literal). Only the keys present in the
- * draft are sent.
+ * The preset's raw stored token map — the exact entries `presets.php`'s payload carries for a
+ * slug, in whatever shape each property was last written (scalar, per-corner slot list, or
+ * responsive envelope). `presetInitialValues` is not a substitute for this: it converts every
+ * scalar to a bare id for the picker, which is the wrong shape to write back verbatim.
  *
- * @param {Record<string, string>} draftTokens The panel's draft token map (bare ids).
+ * @param {{presets?: Record<string, {tokens?: Record<string, *>}>}} payload The preset GET payload.
+ * @param {string}                                                    slug    The preset slug.
  *
  * @since TBD
  *
- * @return {Record<string, string>} The property => alias-or-literal map ready for the write.
+ * @return {Record<string, *>} The property => stored-value map, or `{}` for an unknown slug.
  */
-export function presetSaveTokens(draftTokens) {
+export function presetStoredTokens(payload, slug) {
+	return payload?.presets?.[slug]?.tokens ?? {};
+}
+
+/**
+ * Build the write-side token map from a settings-panel draft: a property the draft actually
+ * changed from its seed is written as a fresh alias-or-literal; every untouched property is
+ * carried over from the preset's raw stored map, byte-for-byte, so a save that only edited the
+ * label (or a different property) never flattens a per-corner slot list or a responsive envelope
+ * the block editor wrote into a bare scalar. A property with no corresponding stored entry (a new
+ * preset with `storedTokens` `{}`, or a bound property the draft adds) always counts as touched,
+ * since there is nothing to carry over.
+ *
+ * @param {Record<string, string>} draftTokens   The panel's draft token map (bare ids, or a raw
+ *                                                 non-scalar entry the field never let the user
+ *                                                 touch — see `isNonScalarPresetValue`).
+ * @param {Record<string, string>} [initialTokens] The draft's seed (`presetInitialValues`'s bare-id
+ *                                                 map), compared against `draftTokens` to detect a
+ *                                                 genuine edit. Defaults to `{}`, under which every
+ *                                                 property counts as touched — the create-flow shape.
+ * @param {Record<string, *>}      [storedTokens]  The preset's raw stored token map
+ *                                                 (`presetStoredTokens`), read verbatim for any
+ *                                                 property the draft did not change.
+ *
+ * @since TBD
+ *
+ * @return {Record<string, *>} The property => value map ready for the write.
+ */
+export function presetSaveTokens(draftTokens, initialTokens = {}, storedTokens = {}) {
 	return Object.entries(draftTokens ?? {}).reduce((acc, [property, value]) => {
-		acc[property] = idToAlias(value);
+		const touched = !isEqual(value, initialTokens[property]);
+
+		acc[property] = touched || !(property in storedTokens) ? idToAlias(value) : storedTokens[property];
+
 		return acc;
 	}, {});
 }

--- a/src/style-library/hooks/use-button-screen.js
+++ b/src/style-library/hooks/use-button-screen.js
@@ -19,7 +19,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/el
  */
 import { applyRowOrder } from '../helpers/scale';
 import { createPresetFlow, deletePresetFlow, reorderPresetsFlow, savePresetFlow } from '../helpers/preset-flows';
-import { BUTTON_BLOCK, presetInitialValues } from '../helpers/presets';
+import { BUTTON_BLOCK, presetInitialValues, presetStoredTokens } from '../helpers/presets';
 import { useButtonPresets } from './use-button-presets';
 
 /**
@@ -131,6 +131,7 @@ export function useButtonScreen(library) {
 				preset: id,
 				draft,
 				initialValues,
+				storedTokens: presetStoredTokens(presets.payload, id),
 				slug,
 				refreshFeed,
 				onBusy: setIsBusy,


### PR DESCRIPTION
Resolves responsive-envelope and per-corner preset values instead of stringifying them, and preserves untouched non-scalar properties on save rather than flattening them.

## Test instructions

1. Run `npx wp-scripts test-unit-js src/style-library/__tests__/presets.test.js`.
2. The important check is the save path: open a preset, change **one** field, save, then inspect the stored document and confirm the properties you did not touch kept their original shape rather than being flattened to a string.
3. This is what stops a richer value written by another ticket from being destroyed by an unrelated save here.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4083/phase-6a-shape-tolerant-reads
bun run build-wp
```

The Style Library is at **WP Admin → Kadence → Style Library**. The Button preset screen is under **Block Presets → Button**. Block-editor checks use a **Kadence Single Button** block on any post.
</details>

---

Slice 11 of 23 in the SOFT-4083 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preset saves now preserve responsive and per-corner values when unrelated settings are edited.
  * Improved handling of non-scalar token values during preset updates.
  * Unsupported token formats are handled safely without corrupting saved data.

* **Tests**
  * Added coverage for responsive, per-corner, invalid, and unchanged preset values.
  * Added coverage for creating and updating presets while preserving stored token structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->