### PR TITLE
[DTM] SOFT-4083 [12/23]: Button token declarations and bindings

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -245,7 +245,7 @@
 				},
 				"sm": {
 					"$type": "dimension",
-					"$value": "0.1875rem"
+					"$value": "0.25rem"
 				},
 				"md": {
 					"$type": "dimension",
@@ -257,7 +257,15 @@
 				},
 				"xl": {
 					"$type": "dimension",
+					"$value": "0.75rem"
+				},
+				"2xl": {
+					"$type": "dimension",
 					"$value": "1rem"
+				},
+				"3xl": {
+					"$type": "dimension",
+					"$value": "1.5rem"
 				},
 				"full": {
 					"$type": "dimension",
@@ -486,7 +494,7 @@
 		"radius": {
 			"control": {
 				"$type": "dimension",
-				"$value": "{primitive.dimension.radius.sm}"
+				"$value": "0.1875rem"
 			},
 			"media": {
 				"$type": "dimension",

--- a/includes/resources/Design_Tokens/Registry/Preset_Bindings.php
+++ b/includes/resources/Design_Tokens/Registry/Preset_Bindings.php
@@ -364,7 +364,7 @@ final class Preset_Bindings {
 	private static function classify( string $term ): string {
 		$term = strtolower( $term );
 
-		foreach ( [ 'radius', 'width', 'gap', 'spacing', 'space', 'size', 'height', 'dimension' ] as $needle ) {
+		foreach ( [ 'radius', 'width', 'gap', 'spacing', 'space', 'padding', 'margin', 'size', 'height', 'dimension' ] as $needle ) {
 			if ( strpos( $term, $needle ) !== false ) {
 				return self::KIND_DIMENSION;
 			}

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -63,6 +63,8 @@ $radius_labels = [
 	'md'   => __( 'Medium', 'kadence-blocks' ),
 	'lg'   => __( 'Large', 'kadence-blocks' ),
 	'xl'   => __( 'Extra Large', 'kadence-blocks' ),
+	'2xl'  => __( '2X Large', 'kadence-blocks' ),
+	'3xl'  => __( '3X Large', 'kadence-blocks' ),
 	'full' => __( 'Full', 'kadence-blocks' ),
 ];
 

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -501,6 +501,27 @@ return [
 						'mobile' => 'mobileBorderRadius',
 					],
 				],
+				// Padding and margin carry no preset value by default, and that omission is the point: a
+				// button's spacing comes from its size class today, so shipping a value here would restyle
+				// every existing button and take padding away from the Button Size control. The binding
+				// exists so a preset CAN set them; until one does, the property resolves to nothing and no
+				// declaration is emitted.
+				'button-padding'    => [
+					'css_var'          => 'kb-btn-padding',
+					'control_attr'     => 'padding',
+					'responsive_attrs' => [
+						'tablet' => 'tabletPadding',
+						'mobile' => 'mobilePadding',
+					],
+				],
+				'button-margin'     => [
+					'css_var'          => 'kb-btn-margin',
+					'control_attr'     => 'margin',
+					'responsive_attrs' => [
+						'tablet' => 'tabletMargin',
+						'mobile' => 'mobileMargin',
+					],
+				],
 			],
 		],
 		[

--- a/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
@@ -897,9 +897,13 @@ final class Presets_Controller extends Controller {
 					'type'        => 'string',
 				],
 				Extensions::get_tokens_key() => [
-					'description'          => __( 'The preset\'s property => alias-or-literal token map.', 'kadence-blocks' ),
+					'description'          => __( 'The preset\'s property => value map: an alias or literal, a per-corner list, or a responsive envelope.', 'kadence-blocks' ),
 					'type'                 => 'object',
-					'additionalProperties' => [ 'type' => [ 'string', 'number' ] ],
+					// A value is not always scalar. A dimension property can hold a per-corner list, or a
+					// responsive envelope carrying its base value plus per-breakpoint overrides, so the
+					// documented shape has to admit both — the write routes already accept them, and a
+					// schema that says otherwise misleads anything generated from it.
+					'additionalProperties' => [ 'type' => [ 'string', 'number', 'array', 'object' ] ],
 				],
 			],
 		];

--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -302,6 +302,35 @@ describe('presetSaveTokens', () => {
 		});
 	});
 
+	it('omits a bound property the preset leaves unset, rather than sending an empty literal', () => {
+		// `button-padding` and `button-margin` are bound for every button preset, so a preset that
+		// sets neither seeds them as ''. Sending that empty literal fails the server's document
+		// validation and takes the whole save down with it, including a label-only edit.
+		expect(
+			presetSaveTokens({
+				'button-bg': '{semantic.color.action-primary}',
+				'button-padding': '',
+				'button-margin': '',
+			})
+		).toEqual({ 'button-bg': '{semantic.color.action-primary}' });
+	});
+
+	it('omits a per-corner property whose slots are all cleared', () => {
+		expect(presetSaveTokens({ 'button-radius': ['', '', '', ''] })).toEqual({});
+	});
+
+	it('keeps a per-corner property when any slot carries a value', () => {
+		// Asserts only that the property survives the unset guard: how the slots themselves are
+		// wrapped is the aliasing helper's business, and it changes in a later slice.
+		const result = presetSaveTokens({ 'button-radius': ['', 'primitive.dimension.radius.lg', '', ''] });
+
+		expect(Object.keys(result)).toEqual(['button-radius']);
+	});
+
+	it('keeps a zero literal, which is a real value rather than an unset one', () => {
+		expect(presetSaveTokens({ 'button-radius': '0' })).toEqual({ 'button-radius': '0' });
+	});
+
 	it('passes an already-wrapped alias through unchanged', () => {
 		expect(presetSaveTokens({ 'button-bg': '{semantic.color.action-primary}' })).toEqual({
 			'button-bg': '{semantic.color.action-primary}',

--- a/src/style-library/helpers/presets.js
+++ b/src/style-library/helpers/presets.js
@@ -299,6 +299,32 @@ export function presetStoredTokens(payload, slug) {
 }
 
 /**
+ * Whether a preset property's draft value represents "unset" rather than a genuine value to save.
+ *
+ * A bound property the preset has no stored value for seeds as `''`, and a cleared per-corner field
+ * seeds as four `''` slots. Both shapes mean "nothing to write" — see `presetSaveTokens`, which
+ * omits such a property rather than sending the empty literal the server's extension-value
+ * validator rejects (`Dtcg_Validator::validate_extension_value()`).
+ *
+ * @param {*} value The draft property value.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the value carries nothing to save.
+ */
+function isUnsetPresetValue(value) {
+	if (value === '' || value === null || value === undefined) {
+		return true;
+	}
+
+	if (Array.isArray(value)) {
+		return value.every((slot) => slot === '' || slot === null || slot === undefined);
+	}
+
+	return false;
+}
+
+/**
  * Build the write-side token map from a settings-panel draft: a property the draft actually
  * changed from its seed is written as a fresh alias-or-literal; every untouched property is
  * carried over from the preset's raw stored map, byte-for-byte, so a save that only edited the
@@ -306,6 +332,14 @@ export function presetStoredTokens(payload, slug) {
  * the block editor wrote into a bare scalar. A property with no corresponding stored entry (a new
  * preset with `storedTokens` `{}`, or a bound property the draft adds) always counts as touched,
  * since there is nothing to carry over.
+ *
+ * An unset property (see `isUnsetPresetValue`) is omitted from the map entirely rather than sent as
+ * `''`: the server rejects an empty literal outright, and the property's block binding already falls
+ * through to its semantic default when nothing is stored for it. This matters as soon as a property
+ * is bound but most presets leave it alone — `button-padding` and `button-margin` are the first —
+ * because every preset's draft then carries an empty entry for it. Omitting is not the same as
+ * clearing: the write endpoint merges the sent map onto the stored one property by property, so an
+ * omitted property keeps whatever the store already holds.
  *
  * @param {Record<string, string>} draftTokens   The panel's draft token map (bare ids, or a raw
  *                                                 non-scalar entry the field never let the user
@@ -324,6 +358,10 @@ export function presetStoredTokens(payload, slug) {
  */
 export function presetSaveTokens(draftTokens, initialTokens = {}, storedTokens = {}) {
 	return Object.entries(draftTokens ?? {}).reduce((acc, [property, value]) => {
+		if (isUnsetPresetValue(value)) {
+			return acc;
+		}
+
 		const touched = !isEqual(value, initialTokens[property]);
 
 		acc[property] = touched || !(property in storedTokens) ? idToAlias(value) : storedTokens[property];

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -272,6 +272,8 @@ final class Feed_ControllerTest extends TestCase {
 				'primitive.dimension.radius.md',
 				'primitive.dimension.radius.lg',
 				'primitive.dimension.radius.xl',
+				'primitive.dimension.radius.2xl',
+				'primitive.dimension.radius.3xl',
 				'primitive.dimension.radius.full',
 			],
 			$ids
@@ -279,10 +281,12 @@ final class Feed_ControllerTest extends TestCase {
 
 		$this->assertSame( '0', $data['values']['primitive.dimension.radius.none'] );
 		$this->assertSame( '0.125rem', $data['values']['primitive.dimension.radius.xs'] );
-		$this->assertSame( '0.1875rem', $data['values']['primitive.dimension.radius.sm'] );
+		$this->assertSame( '0.25rem', $data['values']['primitive.dimension.radius.sm'] );
 		$this->assertSame( '0.375rem', $data['values']['primitive.dimension.radius.md'] );
 		$this->assertSame( '0.5rem', $data['values']['primitive.dimension.radius.lg'] );
-		$this->assertSame( '1rem', $data['values']['primitive.dimension.radius.xl'] );
+		$this->assertSame( '0.75rem', $data['values']['primitive.dimension.radius.xl'] );
+		$this->assertSame( '1rem', $data['values']['primitive.dimension.radius.2xl'] );
+		$this->assertSame( '1.5rem', $data['values']['primitive.dimension.radius.3xl'] );
 		$this->assertSame( '9999px', $data['values']['primitive.dimension.radius.full'] );
 	}
 


### PR DESCRIPTION
PHP data layer only. Rebuilds the radius scale on Tailwind's steps and values, binds button padding and margin (valued only when a preset sets them), and documents a preset token value as possibly non-scalar.

This sits at the bottom of the remaining stack because the JS slices above bind to it.

## Test instructions

1. Run `vendor/bin/phpstan analyse` and `slic run wpunit Resources/Design_Tokens/Registry/Preset_BindingsTest`.
2. Go to **Style Library → Border Radius** and confirm the scale reads None 0, XS 0.125rem, SM 0.25rem, MD 0.375rem, LG 0.5rem, XL 0.75rem, 2XL 1rem, 3XL 1.5rem, Full 9999px.
3. Confirm a button with no preset spacing set renders **no** padding/margin declarations — the bindings are deliberately valued only when a preset sets them, so this slice should change nothing visually on the front end.
4. **If the site errors after checking this branch out**, the cached baseline is stale: flush it (`lando ssh -s redis -c 'redis-cli flushall'`, or whatever your object cache is). Editing `baseline.json` does not bust that cache on its own.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4083/phase-8-button-token-declarations
bun run build-wp
```

The Style Library is at **WP Admin → Kadence → Style Library**. The Button preset screen is under **Block Presets → Button**. Block-editor checks use a **Kadence Single Button** block on any post.
</details>

---

Slice 12 of 23 in the SOFT-4083 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added extra border-radius options, including `2xl` and `3xl`.
  * Added responsive Button controls for padding and margin across desktop, tablet, and mobile.
  * Expanded preset support for responsive values and per-corner settings.
* **Bug Fixes**
  * Corrected radius values for small and extra-large sizing options.
  * Improved recognition of padding-related settings as dimensional values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->