### PR TITLE
[DTM] SOFT-4083 [15/23]: Token picker field, popover, and chip

### DIFF
--- a/src/token-controls/__tests__/token-selector.test.js
+++ b/src/token-controls/__tests__/token-selector.test.js
@@ -1,0 +1,87 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { TokenSelector } from '../organisms/TokenSelector';
+
+// `jest.config.js` maps `@wordpress/components` to the copy nested under
+// `@kadence/components/node_modules`, which resolves its own `react` — a different module instance
+// than the top-level `react-dom/client` this test renders with, which trips React's "Invalid hook
+// call" guard. Stand-ins sidestep that; this test only needs the trigger button.
+jest.mock('@wordpress/components', () => ({
+	Button: ({ children, showTooltip, ...props }) => <button {...props}>{children}</button>,
+	Dropdown: ({ renderToggle }) => renderToggle({ isOpen: false, onToggle: () => {} }),
+	Tooltip: ({ children }) => children,
+}));
+
+jest.mock('../molecules/TokenPopover', () => ({ TokenPopover: () => null }));
+jest.mock('../styles/token-controls.scss', () => ({}), { virtual: true });
+
+let container;
+let root;
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+/**
+ * Render `TokenSelector` with the props it needs to draw its trigger.
+ *
+ * @param {Object} props Overrides for the defaults below.
+ *
+ * @since TBD
+ *
+ * @return {HTMLElement} The trigger button.
+ */
+function renderSelector(props = {}) {
+	act(() =>
+		root.render(
+			createElement(TokenSelector, {
+				value: '',
+				tokens: [],
+				onPick: jest.fn(),
+				onClear: jest.fn(),
+				onCustom: jest.fn(),
+				...props,
+			})
+		)
+	);
+
+	return container.querySelector('.kadence-token-field__trigger');
+}
+
+describe('TokenSelector disabled state', () => {
+	/**
+	 * A read-only control has to look and behave read-only. Guarding only the write callbacks leaves
+	 * the trigger clickable, so the popover opens and picks are silently dropped.
+	 *
+	 * @return {void}
+	 */
+	it('disables the trigger when disabled', () => {
+		expect(renderSelector({ disabled: true }).disabled).toBe(true);
+	});
+
+	/**
+	 * The enabled case, so the assertion above cannot pass by disabling unconditionally.
+	 *
+	 * @return {void}
+	 */
+	it('leaves the trigger active by default', () => {
+		expect(renderSelector().disabled).toBe(false);
+	});
+});

--- a/src/token-controls/atoms/TokenChip.js
+++ b/src/token-controls/atoms/TokenChip.js
@@ -1,0 +1,55 @@
+/**
+ * The in-control token display: a bound token's label plus an optional unlink button.
+ *
+ * Used where a control has no per-slot field to turn into a `TokenSelector` trigger — the
+ * whole-value box-shadow control is the case that needs it.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { linkOff } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { findTokenEntry } from '../helpers/token-summary';
+
+/**
+ * The in-control token display: the token's label (dot-path fallback when no matching entry is found)
+ * plus an optional unlink button. Used by the whole-value box-shadow control, which has no per-slot
+ * field to turn into a `TokenFieldControl` trigger.
+ *
+ * @param {Object}   props
+ * @param {string}   props.value     The alias string currently held by the slot.
+ * @param {Array}    [props.tokens]  The pickable-token list, used to resolve the label/preview.
+ * @param {Function} [props.onUnlink] Called with no arguments when the unlink button is pressed; the
+ *                                    button is hidden when this is not provided.
+ *
+ * @since TBD
+ *
+ * @return {Object} The rendered token chip.
+ */
+export function TokenChip({ value, tokens, onUnlink }) {
+	const entry = findTokenEntry(tokens, value);
+	const label = entry ? entry.label : String(value).slice(1, -1);
+
+	return (
+		<span className="kadence-token-chip">
+			<span className="kadence-token-chip__label" title={entry ? entry.value : undefined}>
+				{label}
+			</span>
+			{onUnlink && (
+				<Button
+					className="kadence-token-chip__unlink"
+					icon={linkOff}
+					isSmall
+					label={__('Unlink token', 'kadence-blocks')}
+					onClick={() => onUnlink()}
+				/>
+			)}
+		</span>
+	);
+}

--- a/src/token-controls/molecules/TokenPickerButton.js
+++ b/src/token-controls/molecules/TokenPickerButton.js
@@ -1,0 +1,57 @@
+/**
+ * The in-control picker affordance for a control with no per-slot field: a header button opening
+ * the token list.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { link } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * The in-control picker affordance for the whole-value box-shadow control: a header button opening the
+ * token list; choosing an entry fires `onSelect(entry.alias)`. Renders nothing when the list is
+ * empty/absent or no select handler is provided, so mounting it unconditionally is always safe.
+ *
+ * @param {Object}   props
+ * @param {Array}    [props.tokens]   The pickable-token list.
+ * @param {Function} [props.onSelect] Called with the chosen entry's `alias` when a token is picked.
+ * @param {boolean}  [props.isActive] Whether the toggle should render pressed.
+ *
+ * @since TBD
+ *
+ * @return {?Object} The rendered picker button, or null when there is nothing to pick from.
+ */
+export function TokenPickerButton({ tokens, onSelect, isActive = false }) {
+	if (!tokens || !tokens.length || !onSelect) {
+		return null;
+	}
+
+	return (
+		<DropdownMenu
+			className="kadence-token-picker-toggle"
+			icon={link}
+			label={__('Use design token', 'kadence-blocks')}
+			toggleProps={{ isSmall: true, isPressed: isActive }}
+		>
+			{({ onClose }) => (
+				<MenuGroup>
+					{tokens.map((entry) => (
+						<MenuItem
+							key={entry.id}
+							onClick={() => {
+								onClose();
+								onSelect(entry.alias);
+							}}
+						>
+							{entry.label}
+							<span className="kadence-token-picker__preview">{entry.value}</span>
+						</MenuItem>
+					))}
+				</MenuGroup>
+			)}
+		</DropdownMenu>
+	);
+}

--- a/src/token-controls/molecules/TokenPopover.js
+++ b/src/token-controls/molecules/TokenPopover.js
@@ -1,0 +1,225 @@
+/**
+ * The two-tab picker a token field opens: `Style Library` (pick a token, or reset to the inherited
+ * default) and `Custom` (a literal number, its unit, and a slider).
+ *
+ * Moved verbatim from the block editor's `component-token-ui.js`, which was already pure and
+ * data-free — labels and preview values come from the pickable-token list the caller passes in.
+ * Living here means the Style Library and the editor render the same picker instead of two that
+ * drift apart.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	Icon,
+	RangeControl,
+	SelectControl,
+	TabPanel,
+	__experimentalNumberControl as NumberControl,
+} from '@wordpress/components';
+import { globe, settings, undo } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { hasValue, isTokenAlias } from '../helpers/token-summary';
+
+/**
+ * The `Style Library` tab body: a `Reset` affordance that clears the slot back to its inherited default,
+ * followed by the pickable size tokens (each showing its label and resolved value, the active one
+ * pressed — the `None` size sits among them). Every choice closes the popover.
+ *
+ * @param {Object}   props
+ * @param {*}        props.value        The current slot value, so the active token renders pressed.
+ * @param {Array}    props.tokens       The pickable-token list.
+ * @param {string}   [props.defaultValue] The inherited default's resolved value; its size is tagged
+ *                                      `Default` and marked active while the slot is unset.
+ * @param {boolean}  [props.inherited]  Whether that default comes from another breakpoint, which tags the
+ *                                      row `Inherited` instead.
+ * @param {Function} props.onPick       Called with an entry's `alias` when a token is chosen.
+ * @param {Function} props.onClear      Called when `Reset` is chosen; clears the slot's override.
+ * @param {Function} props.onClose      Closes the popover after a choice.
+ *
+ * @since TBD
+ *
+ * @return {Object} The rendered token list.
+ */
+function StyleLibraryTab({ value, tokens, defaultValue, inherited, onPick, onClear, onClose }) {
+	// Reset clears the slot's override back to the inherited default; it is inert when nothing is set.
+	const hasOverride = isTokenAlias(value) || (value !== '' && value !== undefined && value !== null);
+	// While unset, the size matching the inherited default reads as the active row.
+	const onDefault = !hasOverride && !!defaultValue;
+
+	return (
+		<div className="kadence-token-field__list">
+			<Button
+				className="kadence-token-field__reset"
+				disabled={!hasOverride}
+				onClick={() => {
+					onClear();
+					onClose();
+				}}
+			>
+				<span className="kadence-token-field__reset-label">{__('Reset', 'kadence-blocks')}</span>
+				<Icon className="kadence-token-field__reset-icon" icon={undo} size={20} />
+			</Button>
+			{tokens.map((entry) => {
+				const isDefault = !!defaultValue && entry.value === defaultValue;
+				return (
+					<Button
+						key={entry.id}
+						className="kadence-token-field__item"
+						isPressed={entry.alias === value || (onDefault && isDefault)}
+						onClick={() => {
+							onPick(entry.alias);
+							onClose();
+						}}
+					>
+						<span className="kadence-token-field__item-label">{entry.label}</span>
+						{isDefault && (
+							<span className="kadence-token-field__item-tag">
+								{inherited ? __('Inherited', 'kadence-blocks') : __('Default', 'kadence-blocks')}
+							</span>
+						)}
+						<span className="kadence-token-field__item-value">{entry.value}</span>
+					</Button>
+				);
+			})}
+		</div>
+	);
+}
+
+/**
+ * The `Custom` tab body: a literal number, an optional unit switcher, and a slider when the field
+ * declares an upper bound.
+ *
+ * @param {Object}   props           The component props.
+ * @param {*}        props.number    The current literal, or '' when unset.
+ * @param {string}   [props.unit]    The control's current unit.
+ * @param {Array}    [props.units]   Selectable units; the switcher needs these and `onUnit`.
+ * @param {Function} [props.onUnit]  Writes the control's unit.
+ * @param {number}   [props.min]     Slider and number minimum.
+ * @param {number}   [props.max]     Slider and number maximum; the slider renders when present.
+ * @param {number}   [props.step]    Slider and number step.
+ * @param {Function} props.onNumber  Writes a literal number to the slot.
+ *
+ * @since TBD
+ *
+ * @return {Object} The rendered tab body.
+ */
+export function CustomTab({ number, unit, units, onUnit, min, max, step, onNumber }) {
+	return (
+		<div className="kadence-token-field__custom">
+			<NumberControl
+				className="kadence-token-field__custom-input"
+				label={__('Custom value', 'kadence-blocks')}
+				hideLabelFromVision
+				value={number}
+				min={min}
+				max={max}
+				step={step}
+				onChange={onNumber}
+			/>
+			{units && units.length > 0 && onUnit && (
+				<SelectControl
+					className="kadence-token-field__unit"
+					label={__('Unit', 'kadence-blocks')}
+					hideLabelFromVision
+					value={unit}
+					options={units.map((option) => ({ label: option, value: option }))}
+					onChange={onUnit}
+				/>
+			)}
+			{typeof max === 'number' && (
+				<RangeControl
+					className="kadence-token-field__slider"
+					label={__('Custom value', 'kadence-blocks')}
+					hideLabelFromVision
+					value={number === '' ? undefined : Number(number)}
+					initialPosition={typeof min === 'number' ? min : 0}
+					min={typeof min === 'number' ? min : 0}
+					max={max}
+					step={step}
+					withInputField={false}
+					onChange={(next) => onNumber(next)}
+				/>
+			)}
+		</div>
+	);
+}
+
+/**
+ * Render the picker's tab panel.
+ *
+ * @param {Object}   props                  The component props.
+ * @param {*}        props.value            The current slot value.
+ * @param {Array}    props.tokens           The pickable-token list.
+ * @param {string}   props.resolvedDefault  The inherited default, already resolved to a literal.
+ * @param {boolean}  [props.inherited]      Whether that default came from another breakpoint.
+ * @param {string}   props.initialTab       Which tab opens first.
+ * @param {Object}   props.custom           Props forwarded to the `Custom` tab.
+ * @param {Function} props.onPick           Writes a picked token's alias.
+ * @param {Function} props.onClear          Clears the slot's override.
+ * @param {Function} props.onClose          Closes the popover after a choice.
+ *
+ * @since TBD
+ *
+ * @return {Object} The rendered tabs.
+ */
+export function TokenPopover({
+	value,
+	tokens,
+	resolvedDefault,
+	inherited,
+	initialTab,
+	custom,
+	onPick,
+	onClear,
+	onClose,
+}) {
+	return (
+		<TabPanel
+			className="kadence-token-field__tabs"
+			initialTabName={initialTab}
+			tabs={[
+				{
+					name: 'style-library',
+					title: (
+						<span className="kadence-token-field__tab-title">
+							<Icon icon={globe} size={20} />
+							{__('Style Library', 'kadence-blocks')}
+						</span>
+					),
+				},
+				{
+					name: 'custom',
+					title: (
+						<span className="kadence-token-field__tab-title">
+							<Icon icon={settings} size={20} />
+							{__('Custom', 'kadence-blocks')}
+						</span>
+					),
+				},
+			]}
+		>
+			{(tab) =>
+				tab.name === 'style-library' ? (
+					<StyleLibraryTab
+						value={value}
+						tokens={tokens}
+						defaultValue={resolvedDefault}
+						inherited={inherited}
+						onPick={onPick}
+						onClear={onClear}
+						onClose={onClose}
+					/>
+				) : (
+					<CustomTab {...custom} />
+				)
+			}
+		</TabPanel>
+	);
+}

--- a/src/token-controls/organisms/TokenSelector.js
+++ b/src/token-controls/organisms/TokenSelector.js
@@ -57,6 +57,11 @@ import '../styles/token-controls.scss';
  * @param {Function} props.onPick     Writes a picked token's `alias` to the slot.
  * @param {Function} props.onClear    Clears the slot's override (the `Reset` choice).
  * @param {Function} props.onCustom   Writes a literal number to the slot (used when leaving a token).
+ * @param {boolean}  [props.disabled] Disable the trigger, which is the only control outside the
+ *                                      popover — with it inert the popover cannot open, so nothing
+ *                                      below it is reachable either. Callers that only guard their
+ *                                      write callbacks leave the field looking editable while
+ *                                      silently dropping the writes.
  *
  * @since TBD
  *
@@ -77,6 +82,7 @@ export function TokenSelector({
 	onPick,
 	onClear,
 	onCustom,
+	disabled = false,
 }) {
 	const summary = fieldSummary(value, tokens, unit, __('Custom', 'kadence-blocks'));
 	// The inherited default has to be resolved before it is compared or shown — a raw alias or a unitless
@@ -134,6 +140,7 @@ export function TokenSelector({
 					<Button
 						className="kadence-token-field__trigger"
 						onClick={onToggle}
+						disabled={disabled}
 						aria-expanded={isOpen}
 						label={triggerName}
 						showTooltip

--- a/src/token-controls/organisms/TokenSelector.js
+++ b/src/token-controls/organisms/TokenSelector.js
@@ -1,0 +1,171 @@
+/**
+ * A control's value slot as a token field: a trigger that reads like the control's own input,
+ * opening a popover with a `Style Library` tab and a `Custom` tab.
+ *
+ * Moved from the block editor's `component-token-ui.js`, where it was named `TokenFieldControl`.
+ * That module was already pure and data-free, so nothing had to change to make it shared — the
+ * pickable-token list and every value arrive as props.
+ *
+ * An unset slot shows its inherited default, muted, rather than reading as empty: the field then
+ * names the size actually in effect while still being unset. Keeping "what this slot holds" and
+ * "what it falls back to" apart is the point of the two summaries in `helpers/token-summary.js`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button, Dropdown } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	defaultSummary,
+	fieldSummary,
+	findTokenEntry,
+	isTokenAlias,
+	resolveDefaultValue,
+} from '../helpers/token-summary';
+import { parseCssLength } from '../helpers/parse-css-length';
+import { TokenPopover } from '../molecules/TokenPopover';
+import '../styles/token-controls.scss';
+
+/**
+ * A control's numeric slot as a token field: a corner icon plus a trigger that reads like the control's
+ * input (showing the bound token or the literal), opening a popover with a `Style Library` tab (pick/clear a
+ * token) and a `Custom` tab (edit a literal value + unit with a slider). The `Custom` number seeds from
+ * the token's resolved size when a token is bound, so switching to a custom value drops the alias and
+ * leaves a usable literal.
+ *
+ * @param {Object}   props
+ * @param {*}        props.value      The current slot value (alias string, literal, or empty).
+ * @param {string}   [props.unit]     The control's current unit, for the literal display + switcher.
+ * @param {Array}    [props.units]    The control's selectable units; the `Custom` tab shows a unit
+ *                                    switcher when this and `onUnit` are present.
+ * @param {Function} [props.onUnit]   Writes the control's unit.
+ * @param {string}   [props.defaultValue] The inherited default's resolved value, shown on the trigger and
+ *                                    tagged in the list when the slot is unset.
+ * @param {boolean}  [props.inherited] Whether that default comes from another breakpoint rather than the
+ *                                    preset, which reads as `Inherited` instead of the size name.
+ * @param {*}        [props.icon]     The control's per-slot corner icon (from the default editor), shown
+ *                                    beside the trigger to match the native corner input.
+ * @param {number}   [props.min]      The custom slider/number minimum.
+ * @param {number}   [props.max]      The custom slider/number maximum; the slider renders when present.
+ * @param {number}   [props.step]     The custom slider/number step.
+ * @param {Array}    props.tokens     The pickable-token list.
+ * @param {Function} props.onPick     Writes a picked token's `alias` to the slot.
+ * @param {Function} props.onClear    Clears the slot's override (the `Reset` choice).
+ * @param {Function} props.onCustom   Writes a literal number to the slot (used when leaving a token).
+ *
+ * @since TBD
+ *
+ * @return {Object} The rendered token field.
+ */
+export function TokenSelector({
+	value,
+	unit = '',
+	units,
+	onUnit,
+	defaultValue,
+	inherited,
+	icon,
+	min,
+	max,
+	step,
+	tokens,
+	onPick,
+	onClear,
+	onCustom,
+}) {
+	const summary = fieldSummary(value, tokens, unit, __('Custom', 'kadence-blocks'));
+	// The inherited default has to be resolved before it is compared or shown — a raw alias or a unitless
+	// number would neither match a token row nor read as a value.
+	const resolvedDefault = resolveDefaultValue(defaultValue, tokens, unit, inherited);
+	// A literal fallback is named for the state it is in, not for what it would be called if someone had
+	// typed it. `Custom` is what a value the user actually SET is called, so reusing it here would make
+	// "nothing is set" and "a custom value is set" read the same, with only the muting to tell them
+	// apart. This matches the tooltip below, which has always drawn that distinction.
+	const fallbackState = inherited ? __('Inherited', 'kadence-blocks') : __('Default', 'kadence-blocks');
+	const fallback = defaultSummary(resolvedDefault, tokens, fallbackState);
+	const inheritedName = inherited
+		? sprintf(
+				/* translators: %s: the inherited value, e.g. "8px". */ __('Inherited (%s)', 'kadence-blocks'),
+				resolvedDefault
+			)
+		: sprintf(
+				/* translators: %s: the default value, e.g. "3px". */ __('Default (%s)', 'kadence-blocks'),
+				resolvedDefault
+			);
+	const triggerName = summary.label
+		? `${summary.label}${summary.value ? ` (${summary.value})` : ''}`
+		: resolvedDefault
+			? inheritedName
+			: __('Default', 'kadence-blocks');
+	const aliased = isTokenAlias(value);
+	const entry = aliased ? findTokenEntry(tokens, value) : null;
+	const seed = entry ? parseCssLength(entry.value) : null;
+	// An unset slot seeds the Custom tab from whatever it falls back to, so opening the editor starts
+	// from the value on screen instead of an empty box the user has to guess at.
+	const unset = value === '' || value === undefined || value === null;
+	const fallbackNumber = unset ? parseCssLength(resolvedDefault) : null;
+	const number = aliased ? (seed ? seed.size : '') : unset ? (fallbackNumber?.size ?? '') : value;
+
+	// Only a slot that HOLDS a literal opens on its editor. An unset slot opens on the token list even
+	// when what it falls back to is a literal: the fallback is the block's own value, not a choice the
+	// user made, and landing on the Custom tab would nudge them toward hand-typing a number when picking
+	// a token is the better move. The Custom tab still seeds from that fallback if they go there.
+	const initialTab = !aliased && !unset ? 'custom' : 'style-library';
+
+	const writeNumber = (next) => onCustom(next === '' || next === undefined ? '' : Number(next));
+
+	return (
+		<div className="kadence-token-field">
+			{icon && (
+				<span className="kadence-token-field__icon" aria-hidden="true">
+					{icon}
+				</span>
+			)}
+			<Dropdown
+				className="kadence-token-field__dropdown"
+				contentClassName="kadence-token-field__popover"
+				popoverProps={{ placement: 'left-start' }}
+				renderToggle={({ isOpen, onToggle }) => (
+					<Button
+						className="kadence-token-field__trigger"
+						onClick={onToggle}
+						aria-expanded={isOpen}
+						label={triggerName}
+						showTooltip
+					>
+						{summary.label && <span className="kadence-token-field__label">{summary.label}</span>}
+						{summary.value && <span className="kadence-token-field__value">{summary.value}</span>}
+						{!summary.label && !summary.value && fallback.value && (
+							<>
+								{fallback.label && (
+									<span className="kadence-token-field__label kadence-token-field__label--default">
+										{fallback.label}
+									</span>
+								)}
+								<span className="kadence-token-field__value">{fallback.value}</span>
+							</>
+						)}
+					</Button>
+				)}
+				renderContent={({ onClose }) => (
+					<TokenPopover
+						value={value}
+						tokens={tokens}
+						resolvedDefault={resolvedDefault}
+						inherited={inherited}
+						initialTab={initialTab}
+						custom={{ number, unit, units, onUnit, min, max, step, onNumber: writeNumber }}
+						onPick={onPick}
+						onClear={onClear}
+						onClose={onClose}
+					/>
+				)}
+			/>
+		</div>
+	);
+}

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -1,0 +1,284 @@
+/**
+ * Design-token UI injected into the `@kadence/components` control seams.
+ *
+ * Styles the token field (the corner icon + input-styled trigger that replaces a control's numeric
+ * slot) and its Style Library/Custom popover to the sidebar design, plus the whole-value box-shadow
+ * chip/picker. Values mirror the design tokens: gray-900 #1e1e1e text, gray-600 #949494 borders and
+ * muted values, gray-300 #dddddd dividers, gray-100 #f0f0f0 selection, theme #3858e9 accents, 13px
+ * body type, 2px control radius, 4px popover radius.
+ */
+
+// The token field is a corner icon beside the trigger, filling the slot the numeric input held.
+.kadence-token-field {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+}
+
+// The per-slot corner icon (top-left/right/…) mirrored from the native control, sitting outside the box.
+.kadence-token-field__icon {
+	display: inline-flex;
+	flex: 0 0 auto;
+	align-items: center;
+	justify-content: center;
+	width: 16px;
+	height: 16px;
+	color: #949494;
+
+	svg {
+		width: 16px;
+		height: 16px;
+		fill: currentColor;
+	}
+}
+
+.kadence-token-field__dropdown {
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+// The trigger box: label on the left, resolved value muted on the right — matching a 13px input with a
+// 1px gray-600 border and 2px radius.
+.kadence-token-field__trigger.components-button {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 6px;
+	width: 100%;
+	height: 32px;
+	padding: 0 8px;
+	border: 1px solid #949494;
+	border-radius: var(--kb-token-control-field-radius, 2px);
+	background: #fff;
+	color: #1e1e1e;
+	font-size: 13px;
+	line-height: 1.4;
+
+	&:hover {
+		border-color: #1e1e1e;
+	}
+
+	&[aria-expanded="true"] {
+		border-color: #3858e9;
+		box-shadow: 0 0 0 1px #3858e9;
+	}
+}
+
+.kadence-token-field__label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.kadence-token-field__value {
+	flex: 0 0 auto;
+	color: #949494;
+	font-size: 13px;
+}
+
+// The popover: a 260px white sheet with a 4px radius. WordPress supplies the drop shadow/border chrome.
+.kadence-token-field__popover {
+	.components-popover__content {
+		min-width: 260px;
+		border-radius: 4px;
+	}
+}
+
+// The tab bar: a gray-300 divider under the tabs, a theme-color underline on the active tab, each tab
+// showing its icon beside the label.
+.kadence-token-field__tabs {
+	> .components-tab-panel__tabs {
+		border-bottom: 1px solid #dddddd;
+
+		.components-tab-panel__tabs-item {
+			font-size: 13px;
+			font-weight: 500;
+		}
+	}
+}
+
+// Each tab's icon sits beside its label.
+.kadence-token-field__tab-title {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+
+	svg {
+		width: 20px;
+		height: 20px;
+	}
+}
+
+.kadence-token-field__list {
+	display: flex;
+	flex-direction: column;
+	padding: 4px;
+	max-height: 320px;
+	overflow-y: auto;
+}
+
+// Each row: label left, value (and optional Default tag) right, on a 40px line with a 2px-radius hover.
+.kadence-token-field__item.components-button,
+.kadence-token-field__reset.components-button {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	width: 100%;
+	height: auto;
+	min-height: 40px;
+	padding: 0 8px;
+	border-radius: 2px;
+	color: #1e1e1e;
+	font-size: 13px;
+	text-align: left;
+
+	&:hover:not(:disabled) {
+		background: #f0f0f0;
+		color: #1e1e1e;
+	}
+}
+
+// The active row (a picked token, or None) reads as the soft gray-100 highlight from the design.
+.kadence-token-field__item.components-button.is-pressed {
+	background: #f0f0f0;
+	color: #1e1e1e;
+
+	&:hover:not(:disabled) {
+		background: #e8e8e8;
+	}
+}
+
+// Reset: a muted label on the left with the undo glyph pushed to the far right.
+.kadence-token-field__reset.components-button {
+	color: #949494;
+}
+
+.kadence-token-field__reset-icon {
+	flex: 0 0 auto;
+	color: #949494;
+}
+
+.kadence-token-field__item-label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.kadence-token-field__item-tag {
+	flex: 0 0 auto;
+	margin-left: auto;
+	color: #949494;
+	font-size: 13px;
+}
+
+.kadence-token-field__item-value {
+	flex: 0 0 auto;
+	color: #949494;
+	font-size: 13px;
+}
+
+// The Custom tab: the value input, unit switcher, and slider on a single centered row.
+.kadence-token-field__custom {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 12px;
+
+	.kadence-token-field__custom-input {
+		flex: 0 0 64px;
+		margin-bottom: 0;
+	}
+
+	.kadence-token-field__unit {
+		flex: 0 0 auto;
+		margin-bottom: 0;
+	}
+
+	.kadence-token-field__slider {
+		flex: 1 1 auto;
+		min-width: 0;
+		margin-bottom: 0;
+	}
+}
+
+// A measure control's four corner fields are wider as a token field than as a bare number input, so
+// wrap them into a 2x2 grid (matching the design) instead of cramming four across one row. The linked
+// "all" control has a single field, which still grows to the full width.
+.kadence-controls-content:has(.kadence-token-field) {
+	flex-wrap: wrap;
+	gap: 4px;
+
+	.kadence-token-field {
+		flex: 1 1 calc(50% - 4px);
+		width: auto;
+		min-width: 0;
+	}
+
+	// The control emits the corners clockwise (top-left, top-right, bottom-right, bottom-left), which
+	// lands the bottom row backwards in the 2x2 grid. Swap the last two so each field sits in its true
+	// corner, reading top-left, top-right, bottom-left, bottom-right.
+	.kadence-token-field:nth-child(3) {
+		order: 2;
+	}
+
+	.kadence-token-field:nth-child(4) {
+		order: 1;
+	}
+}
+
+// A token-mapped measure control carries its unit switcher inside the popover's Custom tab, so hide the
+// control's own bottom unit select for those controls only (scoped by the token field's presence).
+.kadence-controls-content:has(.kadence-token-field) .kadence-measure-control-select-wrapper {
+	display: none;
+}
+
+// The measure control's linked/individual toggle ships without a pressed fill, so it reads differently
+// from the Border control's toggle (which fills with the theme color when active). Match that pressed
+// treatment for token-mapped measure controls so the Border Radius header is consistent with Border.
+.kb-responsive-measure-control:has(.kadence-token-field) {
+	.components-button.kadence-control-toggle.is-pressed {
+		background: var(--wp-admin-theme-color, #3858e9);
+		color: #fff;
+
+		svg {
+			fill: currentColor;
+		}
+	}
+}
+
+// The whole-value box-shadow chip: label plus optional unlink button, laid out inline with a small gap.
+.kadence-token-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	min-width: 0;
+}
+
+.kadence-token-chip__label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.kadence-token-chip__unlink.components-button {
+	min-width: 0;
+	padding: 0;
+	height: auto;
+}
+
+// The box-shadow picker dropdown's menu items: the resolved-value preview is pushed to the far right so
+// the label and preview read as two columns instead of butting up against each other.
+.kadence-token-picker__preview {
+	margin-inline-start: auto;
+	padding-inline-start: 12px;
+	color: #949494;
+	font-size: 13px;
+	white-space: nowrap;
+}
+
+.kadence-token-field__label--default {
+	color: #949494;
+}
+


### PR DESCRIPTION
The picker components — the field trigger, its popover, and the chip — plus the stylesheet half they use. Builds on the helpers below.

## Test instructions

1. Nothing renders these yet: the block editor still runs its own copy until slice 18, so **the UI should be unchanged** on this branch. Confirm that.
2. Review the components against the editor's existing `component-token-ui.js` (still present on this branch) — this is the extraction, and the two should agree in behavior.
3. The stylesheet arrives in two halves across this slice and the next; this one carries the `.kadence-token-field` / `.kadence-token-chip` family.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4083/phase-10b-token-picker-components
bun run build-wp
```

The Style Library is at **WP Admin → Kadence → Style Library**. The Button preset screen is under **Block Presets → Button**. Block-editor checks use a **Kadence Single Button** block on any post.
</details>

---

Slice 15 of 23 in the SOFT-4083 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable controls for selecting and displaying design tokens.
  * Added a two-tab token picker supporting library values, inherited/default states, custom numeric values, units, and bounded sliders.
  * Added options to reset, clear, unlink, and preview selected token values.
* **Style**
  * Added responsive styling for token fields, popovers, tabs, token lists, inputs, and value labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->