### PR TITLE
[DTM] SOFT-4083 [16/23]: Token control shell and slot grid

### DIFF
--- a/src/token-controls/__tests__/control-shell.test.js
+++ b/src/token-controls/__tests__/control-shell.test.js
@@ -1,0 +1,166 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { ControlShell } from '../templates/ControlShell';
+import { BindingIndicator } from '../atoms/BindingIndicator';
+
+// `jest.config.js` maps `@wordpress/components` to the copy nested under
+// `@kadence/components/node_modules`, which resolves its own `react` — a different module instance
+// than the top-level `react-dom/client` this test renders with, which trips React's "Invalid hook
+// call" guard. Stand-ins sidestep that; these tests only need to see which affordances render and
+// whether they are disabled.
+jest.mock('@wordpress/components', () => ({
+	Button: ({ children, icon, showTooltip, isSmall, ...props }) => <button {...props}>{children}</button>,
+	ButtonGroup: ({ children, ...props }) => <div {...props}>{children}</div>,
+	Dashicon: (props) => <span {...props} />,
+	Tooltip: ({ children }) => children,
+}));
+
+jest.mock('@wordpress/icons', () => ({ undo: 'undo', link: 'link', linkOff: 'linkOff' }));
+
+let container;
+let root;
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+/**
+ * Render a component into the test container.
+ *
+ * @param {Function} Component The component to render.
+ * @param {Object}   props     Its props.
+ *
+ * @since TBD
+ *
+ * @return {HTMLElement} The container it rendered into.
+ */
+function render(Component, props) {
+	act(() => root.render(createElement(Component, props)));
+
+	return container;
+}
+
+const resetButton = () => container.querySelector('.kb-token-control__indicator-reset');
+
+describe('BindingIndicator reset button', () => {
+	/**
+	 * A disabled control must not still offer a working reset: every other affordance in the shell
+	 * takes `disabled`, so leaving this one live lets the value change while the rest is inert.
+	 *
+	 * @return {void}
+	 */
+	it('is disabled when the control is disabled', () => {
+		render(BindingIndicator, {
+			status: { bound: true, modified: true },
+			onReset: jest.fn(),
+			disabled: true,
+		});
+
+		expect(resetButton().disabled).toBe(true);
+	});
+
+	/**
+	 * With no reset handler there is nothing to invoke, so the button stays disabled on its own.
+	 *
+	 * @return {void}
+	 */
+	it('is disabled when no reset handler is supplied', () => {
+		render(BindingIndicator, { status: { bound: true, modified: true }, onReset: null });
+
+		expect(resetButton().disabled).toBe(true);
+	});
+
+	/**
+	 * The enabled case, so the two guards above cannot pass by disabling it unconditionally.
+	 *
+	 * @return {void}
+	 */
+	it('is enabled when the control is active and a reset handler exists', () => {
+		render(BindingIndicator, { status: { bound: true, modified: true }, onReset: jest.fn() });
+
+		expect(resetButton().disabled).toBe(false);
+	});
+});
+
+describe('ControlShell header', () => {
+	/**
+	 * `status` is an object, so a plain truthiness check treats `{ bound: false }` as something to
+	 * show — but the indicator renders null for it, leaving an empty header and the gap the shell
+	 * exists to avoid.
+	 *
+	 * @return {void}
+	 */
+	it('renders no header for an unbound status with nothing else to show', () => {
+		render(ControlShell, { status: { bound: false }, children: 'field' });
+
+		expect(container.querySelector('.kb-token-control__header')).toBeNull();
+	});
+
+	/**
+	 * Same gap, reached the other way: a bound but unmodified status renders nothing once the reset
+	 * affordance is switched off.
+	 *
+	 * @return {void}
+	 */
+	it('renders no header for a bound, unmodified status when showReset is off', () => {
+		render(ControlShell, { status: { bound: true, modified: false }, showReset: false, children: 'field' });
+
+		expect(container.querySelector('.kb-token-control__header')).toBeNull();
+	});
+
+	/**
+	 * The header still appears when the indicator has something to say.
+	 *
+	 * @return {void}
+	 */
+	it('renders the header for a bound, modified status', () => {
+		render(ControlShell, { status: { bound: true, modified: true }, onReset: jest.fn(), children: 'field' });
+
+		expect(container.querySelector('.kb-token-control__header')).not.toBeNull();
+	});
+
+	/**
+	 * A label alone is reason enough for a header, independent of the indicator.
+	 *
+	 * @return {void}
+	 */
+	it('renders the header for a label even with no status', () => {
+		render(ControlShell, { label: 'Radius', children: 'field' });
+
+		expect(container.querySelector('.kb-token-control__header')).not.toBeNull();
+	});
+
+	/**
+	 * The shell's own indicator has to inherit the disabled state it passes to every other
+	 * affordance.
+	 *
+	 * @return {void}
+	 */
+	it('forwards disabled to the indicator it renders', () => {
+		render(ControlShell, {
+			status: { bound: true, modified: true },
+			onReset: jest.fn(),
+			disabled: true,
+			children: 'field',
+		});
+
+		expect(resetButton().disabled).toBe(true);
+	});
+});

--- a/src/token-controls/atoms/BindingIndicator.js
+++ b/src/token-controls/atoms/BindingIndicator.js
@@ -1,0 +1,83 @@
+/**
+ * The per-control design-system mark, in three states: a passive glyph when the value still matches
+ * its baseline, a dot plus a reset when it departs from it, and nothing at all when the control is
+ * not bound to a token.
+ *
+ * **Entirely opt-in.** With no `status` this renders nothing, which is the Style Library's case —
+ * there is no preset to override there, so neither the glyph nor the reset has anything to say. The
+ * block editor passes a status and gets the full mark.
+ *
+ * "Baseline" is whatever the host compares against; this never computes it. `status` carries the
+ * answer, so the same mark serves "overrides the selected preset" and any other comparison a host
+ * wants to make.
+ *
+ * The three states mirror the block editor's own `TokenIndicator` so the two can converge: the dot
+ * always shows once modified, while `showReset` gates the glyph and the reset button together — for
+ * a control whose own header already carries a reset.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button, Tooltip } from '@wordpress/components';
+import { undo } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Render the binding indicator.
+ *
+ * @param {Object}    props              The component props.
+ * @param {?Object}   [props.status]     `{ bound, modified }`, or null when the control is unbound
+ *                                       or the host has no baseline to compare against.
+ * @param {?Function} [props.onReset]    Called to clear the value back to its baseline.
+ * @param {boolean}   [props.showReset]  Render the matching glyph and the reset button. False
+ *                                       leaves only the dot, for a control that resets elsewhere.
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The indicator, or null when there is nothing to show.
+ */
+export function BindingIndicator({ status = null, onReset = null, showReset = true }) {
+	if (!status?.bound) {
+		return null;
+	}
+
+	if (!status.modified) {
+		if (!showReset) {
+			return null;
+		}
+
+		return (
+			<Tooltip text={__('Matches the design system value', 'kadence-blocks')}>
+				<span
+					className="kb-token-control__indicator-linked"
+					role="img"
+					aria-label={__('Matches the design system value', 'kadence-blocks')}
+				/>
+			</Tooltip>
+		);
+	}
+
+	return (
+		<span className="kb-token-control__indicator">
+			<Tooltip text={__('Overrides the design system value', 'kadence-blocks')}>
+				<span
+					className="kb-token-control__indicator-dot"
+					role="img"
+					aria-label={__('Overrides the design system value', 'kadence-blocks')}
+				/>
+			</Tooltip>
+			{showReset && (
+				<Button
+					className="kb-token-control__indicator-reset"
+					icon={undo}
+					size="small"
+					onClick={onReset}
+					disabled={!onReset}
+					label={__('Reset to the design system value', 'kadence-blocks')}
+					showTooltip
+				/>
+			)}
+		</span>
+	);
+}

--- a/src/token-controls/atoms/BindingIndicator.js
+++ b/src/token-controls/atoms/BindingIndicator.js
@@ -30,6 +30,8 @@ import { __ } from '@wordpress/i18n';
  * @param {?Object}   [props.status]     `{ bound, modified }`, or null when the control is unbound
  *                                       or the host has no baseline to compare against.
  * @param {?Function} [props.onReset]    Called to clear the value back to its baseline.
+ * @param {boolean}   [props.disabled]   Disable the reset button alongside the control's other
+ *                                          affordances, so a disabled control cannot still be reset.
  * @param {boolean}   [props.showReset]  Render the matching glyph and the reset button. False
  *                                       leaves only the dot, for a control that resets elsewhere.
  *
@@ -37,7 +39,7 @@ import { __ } from '@wordpress/i18n';
  *
  * @return {?JSX.Element} The indicator, or null when there is nothing to show.
  */
-export function BindingIndicator({ status = null, onReset = null, showReset = true }) {
+export function BindingIndicator({ status = null, onReset = null, showReset = true, disabled = false }) {
 	if (!status?.bound) {
 		return null;
 	}
@@ -73,7 +75,7 @@ export function BindingIndicator({ status = null, onReset = null, showReset = tr
 					icon={undo}
 					size="small"
 					onClick={onReset}
-					disabled={!onReset}
+					disabled={disabled || !onReset}
 					label={__('Reset to the design system value', 'kadence-blocks')}
 					showTooltip
 				/>

--- a/src/token-controls/context/breakpoint.js
+++ b/src/token-controls/context/breakpoint.js
@@ -1,0 +1,77 @@
+/**
+ * The active breakpoint, shared by every responsive control under one provider.
+ *
+ * Switching to Tablet on one control switches all of them. The breakpoint is a property of what the
+ * user is currently looking at, not of an individual field, so two responsive controls in the same
+ * panel must never disagree about it — the block editor already behaves this way and this is what
+ * gives the Style Library the same behavior.
+ *
+ * The provider works either way round. Left alone it holds the breakpoint itself, which is all the
+ * Style Library needs. Given `value` and `onChange` it defers to the host instead, which is the seam
+ * the block editor needs: there the active device already lives in the editor's own store, and this
+ * has to follow that rather than compete with it.
+ *
+ * A control with no provider above it falls back to its own local state, so it still works when
+ * rendered standalone.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { createContext, useContext, useMemo, useState } from '@wordpress/element';
+
+/**
+ * The shared breakpoint context. Null when no provider is mounted, which is what tells a consumer to
+ * fall back to local state.
+ *
+ * @since TBD
+ */
+const BreakpointContext = createContext(null);
+
+/**
+ * Share one active breakpoint across every responsive control rendered inside.
+ *
+ * @param {Object}    props              The component props.
+ * @param {Element}   props.children     The subtree whose controls share the breakpoint.
+ * @param {?string}   [props.value]      The active breakpoint, when the host owns it.
+ * @param {?Function} [props.onChange]   Called with the next breakpoint, when the host owns it.
+ * @param {string}    [props.defaultValue] The breakpoint to start on when the provider owns it.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The provider.
+ */
+export function BreakpointProvider({ children, value = null, onChange = null, defaultValue = 'desktop' }) {
+	const [internal, setInternal] = useState(defaultValue);
+	const controlled = value !== null && typeof onChange === 'function';
+	const breakpoint = controlled ? value : internal;
+	const setBreakpoint = controlled ? onChange : setInternal;
+
+	const shared = useMemo(() => ({ breakpoint, setBreakpoint }), [breakpoint, setBreakpoint]);
+
+	return <BreakpointContext.Provider value={shared}>{children}</BreakpointContext.Provider>;
+}
+
+/**
+ * Read and write the active breakpoint, falling back to the caller's own state when no provider is
+ * mounted above it.
+ *
+ * The local fallback is created unconditionally because hooks cannot be called conditionally; it is
+ * simply ignored whenever a provider is present.
+ *
+ * @param {string} [defaultValue] The breakpoint the local fallback starts on.
+ *
+ * @since TBD
+ *
+ * @return {[string, Function]} The active breakpoint and its setter.
+ */
+export function useBreakpoint(defaultValue = 'desktop') {
+	const shared = useContext(BreakpointContext);
+	const [local, setLocal] = useState(defaultValue);
+
+	if (shared) {
+		return [shared.breakpoint, shared.setBreakpoint];
+	}
+
+	return [local, setLocal];
+}

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -282,3 +282,395 @@
 	color: #949494;
 }
 
+/**
+ * The control shell: a header carrying the label and its affordances, above the control body.
+ *
+ * Sibling of `.kadence-token-field` — that styles one value slot, this styles the frame a whole
+ * control sits in. Both are shared between the Style Library and the block editor, so neither may
+ * depend on an app-scoped custom property; the WP admin palette is the common vocabulary.
+ */
+.kb-token-control {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.kb-token-control__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	/*
+	 * No gap: the affordances open with the indicator's dot, which marks the label and has to read as
+	 * attached to it. Spacing here would detach the mark from the thing it marks; the affordances set
+	 * their own internal spacing, and the trailing controls are held apart by the indicator's growth.
+	 */
+	gap: 0;
+	min-height: 24px;
+}
+
+.kb-token-control__label {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	color: #1e1e1e;
+	font-size: 13px;
+	font-weight: 500;
+	line-height: 1.4;
+}
+
+/*
+ * Separates the mark from the affordances that follow it. Scoped to this header rather than set on
+ * `.kb-token-indicator` itself: the same indicator is still used by the block editor's own control
+ * rows, and those are laid out differently — widening the class would shift them too.
+ */
+.kb-token-control__header > .kb-token-indicator {
+	padding-right: 8px;
+}
+
+.kb-token-control__affordances {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	min-width: 0;
+
+	/* Held at the trailing edge; the indicator sits outside this group, against the label. */
+	margin-left: auto;
+}
+
+/**
+ * The affordance buttons: flat and borderless, with a color-only active state.
+ *
+ * WordPress renders `ButtonGroup` as a bordered segmented control and `isPressed` as a solid dark
+ * fill, which reads far heavier than the rest of a settings row. The Style Library's own breakpoint
+ * switcher is borderless with a color-only checked state, so this matches that — in plain CSS, since
+ * shared CSS cannot reach for `--kb-sl-*` custom properties that only exist in one host.
+ */
+/**
+ * The device switcher, ported verbatim from `@kadence/components`' measurement control so the
+ * Style Library and the block editor render one control rather than two lookalikes. The package's
+ * `editor.scss` only ships in the editor bundle, which is why matching class names alone was never
+ * going to be enough — the rules have to live somewhere both hosts load.
+ */
+.kb-token-control__affordances .components-button.kb-responsive-btn {
+	width: auto;
+	height: auto;
+	margin-bottom: 0;
+	padding: 2px 4px;
+	border: 0;
+	background: transparent;
+	box-shadow: none;
+	outline: 0;
+	color: #a0aec0;
+	font-size: 10px;
+
+	&:hover:not(:disabled) {
+		background: transparent;
+		color: #718096;
+	}
+
+	/*
+	 * No ring on click, matching the editor's device switcher. WordPress's own focus style has the same
+	 * specificity as the reset above, so source order decides it — this raises the specificity to settle
+	 * it. Scoped to `:not(:focus-visible)` so the ring still appears for keyboard users, who have nothing
+	 * else telling them where they are.
+	 */
+	&:focus:not(:focus-visible) {
+		box-shadow: none;
+		outline: 0;
+	}
+
+	&.is-active {
+		background: transparent;
+		color: var(--wp-admin-theme-color, #00669b);
+	}
+
+	.dashicon {
+		width: 15px;
+		height: 15px;
+		font-size: 15px;
+	}
+}
+
+.kb-token-control__affordances .kb-measure-responsive-options {
+	display: inline-flex;
+	align-items: center;
+	/* The device buttons sit flush, as they do in the editor's own switcher. */
+	gap: 0;
+	border: 0;
+	border-radius: 0;
+	box-shadow: none;
+}
+
+.kb-token-control__affordances .components-button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 24px;
+	width: 24px;
+	height: 24px;
+	padding: 0;
+	border: 0;
+	border-radius: 2px;
+	background: transparent;
+	box-shadow: none;
+	color: #1e1e1e;
+
+	svg {
+		width: 18px;
+		height: 18px;
+	}
+
+	&:hover:not(:disabled) {
+		background: #f0f0f0;
+		color: #1e1e1e;
+	}
+
+	/* Checked reads as color, not as a filled block — the same signal the app's own switcher uses. */
+	&.is-pressed,
+	&.is-pressed:hover:not(:disabled) {
+		background: transparent;
+		color: #3858e9;
+	}
+
+	&:focus-visible {
+		outline: 2px solid #3858e9;
+		outline-offset: 1px;
+		box-shadow: none;
+	}
+}
+
+.kb-token-control__body {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+/* The unlinked slot grid: two columns, in the display order the control's role decided. */
+.kb-token-control__grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 4px;
+}
+
+/*
+ * A slot in the unlinked grid: a titled cell, the title and the field reading as one box.
+ *
+ * Half the control's width has to carry a token name and its value, and inline they do not fit — at
+ * the panel's width the name alone is about as wide as the whole slot, so side by side the name is
+ * what gets truncated. Stacking gives the name the full width and keeps the value visible under it.
+ */
+.kb-token-control__slot {
+	/* Local to this library on purpose: shared CSS cannot reach for a host's own spacing scale. */
+	--kb-token-control-slot-padding-y: 0.25rem;
+	--kb-token-control-slot-padding-x: 0.5rem;
+	/* Clears the field's 1px border, so the mark reads as inside the box rather than drawn over it. */
+	--kb-token-control-mark-inset: 1px;
+	/* Floored at zero so a field flatter than the inset cannot ask for a negative radius. */
+	--kb-token-control-mark-radius: max(
+		0px,
+		calc(var(--kb-token-control-field-radius, 2px) - var(--kb-token-control-mark-inset))
+	);
+
+	position: relative;
+
+	.kadence-token-field__trigger.components-button {
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0;
+		height: auto;
+		padding: var(--kb-token-control-slot-padding-y) var(--kb-token-control-slot-padding-x);
+		border-radius: var(--kb-token-control-field-radius, 2px);
+		font-size: 12px;
+		text-align: center;
+	}
+
+	.kadence-token-field__label {
+		max-width: 100%;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	/* Set explicitly on the base rule, so it has to be pulled back to the slot's own size here. */
+	.kadence-token-field__value {
+		font-size: inherit;
+	}
+
+	/*
+	 * The position mark hangs off the field itself rather than the cell, so it can sit on the very
+	 * corner (or edge) it names. It is inset by its own border width so it reads as sitting just inside
+	 * the field rather than smudging the field's own border.
+	 */
+	.kadence-token-field {
+		position: relative;
+	}
+
+	.kadence-token-field::before {
+		position: absolute;
+		z-index: 1;
+		box-sizing: border-box;
+		width: 1rem;
+		height: 1rem;
+		border: 0 solid var(--kb-border-dark-color, #6f8094);
+		content: "";
+		pointer-events: none;
+	}
+
+	/*
+	 * One rule set for both geometries, because they are the same idea at different arity: a corner
+	 * sets two adjacent borders, a side sets one. Radius uses the corner classes; border, margin and
+	 * padding use the side ones. Each edge is addressed with its own offset, so a corner simply gets
+	 * two of them and needs no transform to reach the far side.
+	 */
+	&--top-left .kadence-token-field::before,
+	&--top-right .kadence-token-field::before,
+	&--top .kadence-token-field::before {
+		top: var(--kb-token-control-mark-inset);
+		border-top-width: 3px;
+	}
+
+	&--bottom-left .kadence-token-field::before,
+	&--bottom-right .kadence-token-field::before,
+	&--bottom .kadence-token-field::before {
+		bottom: var(--kb-token-control-mark-inset);
+		border-bottom-width: 3px;
+	}
+
+	&--top-left .kadence-token-field::before,
+	&--bottom-left .kadence-token-field::before,
+	&--left .kadence-token-field::before {
+		left: var(--kb-token-control-mark-inset);
+		border-left-width: 3px;
+	}
+
+	&--top-right .kadence-token-field::before,
+	&--bottom-right .kadence-token-field::before,
+	&--right .kadence-token-field::before {
+		right: var(--kb-token-control-mark-inset);
+		border-right-width: 3px;
+	}
+
+	/*
+	 * A corner mark traces the field's own corner, so it follows the same curve — left square, it would
+	 * cut across the rounded edge it is tracing. Inset by the mark's own offset, though: a curve sitting
+	 * 1px inside a 2px one is a 1px curve, so the radius is the field's less the inset rather than the
+	 * field's outright. A side mark is mid-edge and stays straight.
+	 */
+	&--top-left .kadence-token-field::before {
+		border-top-left-radius: var(--kb-token-control-mark-radius);
+	}
+
+	&--top-right .kadence-token-field::before {
+		border-top-right-radius: var(--kb-token-control-mark-radius);
+	}
+
+	&--bottom-right .kadence-token-field::before {
+		border-bottom-right-radius: var(--kb-token-control-mark-radius);
+	}
+
+	&--bottom-left .kadence-token-field::before {
+		border-bottom-left-radius: var(--kb-token-control-mark-radius);
+	}
+
+	/* A side names one edge, so it is centered along that edge rather than pinned to a corner. */
+	&--top .kadence-token-field::before,
+	&--bottom .kadence-token-field::before {
+		left: 50%;
+		transform: translateX(-50%);
+	}
+
+	&--left .kadence-token-field::before,
+	&--right .kadence-token-field::before {
+		top: 50%;
+		transform: translateY(-50%);
+	}
+}
+
+.kb-token-control__indicator {
+	display: inline-flex;
+	align-items: center;
+	gap: 2px;
+}
+
+/* Bound and matching: a quiet mark in the same slot the reset would occupy, so the row's controls
+   do not shift as a value is edited. */
+.kb-token-control__indicator-linked {
+	display: inline-block;
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	background: #3858e9;
+}
+
+.kb-token-control__indicator-dot {
+	display: inline-block;
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	background: #cc1818;
+}
+
+.kb-token-control__indicator-reset.components-button {
+	min-width: 24px;
+	height: 24px;
+	padding: 0;
+	color: #757575;
+
+	&:hover:not(:disabled) {
+		color: #1e1e1e;
+	}
+}
+
+/* An edited control, flagged by a host that offers "highlight edits". */
+.kb-token-control--highlight {
+	border-radius: 2px;
+	background: #fcf9e8;
+	box-shadow: 0 0 0 4px #fcf9e8;
+}
+
+/**
+ * The linked/individual toggle's resting state, ported from `@kadence/components`' `editor.scss`.
+ *
+ * That CSS only ships in the editor bundle, so the toggle arrived here unstyled — WordPress's
+ * own `is-tertiary` gives it a filled grey chip rather than the flat muted glyph the editor shows.
+ * The pressed (linked) fill is handled above, alongside the measure control it matches.
+ */
+.kb-token-control__affordances .components-button.has-icon.kadence-control-toggle {
+	width: auto;
+	min-width: 0;
+	height: auto;
+	margin-bottom: 0;
+	padding: 2px 4px;
+	border: 0;
+	border-radius: 2px;
+	background: transparent;
+	box-shadow: none;
+	outline: 0;
+	color: #a0aec0;
+	font-size: 18px;
+
+	/*
+	 * `:not(.is-pressed)` is load-bearing: this selector is more specific than the pressed rule
+	 * below, so without it a hover while linked would strip the fill back to transparent.
+	 */
+	&:hover:not(:disabled):not(.is-pressed) {
+		background: transparent;
+		color: #718096;
+	}
+
+	/*
+	 * Linked takes the filled treatment, matching the Border control's toggle. Nested rather than
+	 * written as a sibling selector: both states would otherwise carry identical specificity and the
+	 * winner would come down to source order, which is how this rendered grey while linked.
+	 */
+	&.is-pressed,
+	&.is-pressed:hover:not(:disabled) {
+		background: var(--wp-admin-theme-color, #3858e9);
+		color: #fff;
+
+		svg {
+			fill: currentColor;
+		}
+	}
+}

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -320,10 +320,16 @@
 
 /*
  * Separates the mark from the affordances that follow it. Scoped to this header rather than set on
- * `.kb-token-indicator` itself: the same indicator is still used by the block editor's own control
- * rows, and those are laid out differently — widening the class would shift them too.
+ * the indicator classes themselves: the block editor's own `.kb-token-indicator` rows are laid out
+ * differently, so widening the class would shift them too.
+ *
+ * Both indicators are listed because the shell renders either one: `.kb-token-indicator` when the
+ * editor passes its own through the `indicator` prop, and this library's `BindingIndicator`
+ * otherwise, which renders `__indicator` when modified and `__indicator-linked` when not.
  */
-.kb-token-control__header > .kb-token-indicator {
+.kb-token-control__header > .kb-token-indicator,
+.kb-token-control__header > .kb-token-control__indicator,
+.kb-token-control__header > .kb-token-control__indicator-linked {
 	padding-right: 8px;
 }
 

--- a/src/token-controls/templates/ControlShell.js
+++ b/src/token-controls/templates/ControlShell.js
@@ -108,10 +108,15 @@ export function ControlShell({
 	const responsive = Array.isArray(breakpoints) && breakpoints.length > 1;
 	const linkable = typeof onToggleLink === 'function';
 
+	// Whether `BindingIndicator` will actually render something. `status` being an object is not
+	// enough: `{ bound: false }` is truthy but renders null, as does a bound-and-unmodified status
+	// when `showReset` is off.
+	const hasIndicator = Boolean(indicator) || Boolean(status?.bound && (status.modified || showReset));
+
 	// A control that carries its own indicator inline needs no header at all — rendering an empty
 	// one leaves a gap above it. The wrapper then contributes only the highlight tint, which is how
 	// the block editor's rows with and without a header differ.
-	const hasHeader = Boolean(label) || linkable || responsive || Boolean(status) || Boolean(indicator);
+	const hasHeader = Boolean(label) || linkable || responsive || hasIndicator;
 
 	const className = [
 		'kb-token-control',
@@ -126,7 +131,9 @@ export function ControlShell({
 			{hasHeader && (
 				<div className="kb-token-control__header">
 					<span className="kb-token-control__label">{label}</span>
-					{indicator ?? <BindingIndicator status={status} onReset={onReset} showReset={showReset} />}
+					{indicator ?? (
+						<BindingIndicator status={status} onReset={onReset} showReset={showReset} disabled={disabled} />
+					)}
 
 					<div className="kb-token-control__affordances">
 						{responsive && (

--- a/src/token-controls/templates/ControlShell.js
+++ b/src/token-controls/templates/ControlShell.js
@@ -1,0 +1,191 @@
+/**
+ * The chrome a token control wears: its label, and whichever affordances the control opted into — a
+ * breakpoint switcher, a linked/individual toggle, and a binding indicator with reset.
+ *
+ * Every affordance is opt-in by prop. A color control passes none and gets a bare label; a radius
+ * control passes all three.
+ *
+ * Two deliberate non-responsibilities, both so the same shell serves the Style Library and the
+ * block editor:
+ *
+ * - **It does not resolve breakpoints.** It renders the switcher and reports the choice; the caller
+ *   hands it the active breakpoint's value. The two apps store breakpoints differently (one nested
+ *   envelope versus sibling attributes) and neither shape belongs in here.
+ * - **It does not derive the linked state.** `isLinked` is a prop. The block editor's attribute is
+ *   always a four-element array, so shape cannot tell you whether the user is editing sides
+ *   together — that is UI state the caller owns.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button, ButtonGroup, Dashicon } from '@wordpress/components';
+import { link, linkOff } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { BindingIndicator } from '../atoms/BindingIndicator';
+
+/**
+ * The breakpoint switcher's dashicon and item class per breakpoint.
+ *
+ * Both mirror `@kadence/components`' responsive measurement control exactly — same dashicons, same
+ * `kb-desk-tab` / `kb-tablet-tab` / `kb-mobile-tab` hooks — so the two switchers are the same
+ * control rather than two that merely resemble each other. The rules moved into this library's own
+ * CSS, which both hosts load; the package's `editor.scss` only ever reached the editor.
+ *
+ * @since TBD
+ */
+const BREAKPOINT_LABELS = {
+	desktop: __('Desktop', 'kadence-blocks'),
+	tablet: __('Tablet', 'kadence-blocks'),
+	mobile: __('Mobile', 'kadence-blocks'),
+};
+
+/**
+ * The breakpoint switcher's dashicon and item class per breakpoint.
+ *
+ * @since TBD
+ */
+const BREAKPOINTS_UI = {
+	desktop: { icon: 'desktop', itemClass: 'kb-desk-tab' },
+	tablet: { icon: 'tablet', itemClass: 'kb-tablet-tab' },
+	mobile: { icon: 'smartphone', itemClass: 'kb-mobile-tab' },
+};
+
+/**
+ * Render a control's chrome around its body.
+ *
+ * @param {Object}          props                      The component props.
+ * @param {string|Element}  props.label                The control's label; a node when the caller
+ *                                                     supplies its own indicator inline.
+ * @param {Element}         props.children             The control body.
+ * @param {?Object}         [props.status]             `{ bound, modified }` for the indicator.
+ * @param {?Function}       [props.onReset]            Reset handler, shown when `status.modified`.
+ * @param {boolean}         [props.showReset]          Render the matching glyph and reset button; false
+ *                                                     leaves only the modified dot.
+ * @param {?Array}          [props.breakpoints]        Breakpoint keys; omit for a non-responsive control.
+ * @param {?string}         [props.breakpoint]         The active breakpoint (controlled).
+ * @param {?Function}       [props.onBreakpointChange] Breakpoint-change handler.
+ * @param {?boolean}        [props.isLinked]           Whether slots are edited together; omit for a
+ *                                                     control with no link concept.
+ * @param {?Function}       [props.onToggleLink]       Link-toggle handler.
+ * @param {boolean}         [props.stacked]            Put the header above a full-width body instead
+ *                                                     of beside it.
+ * @param {boolean}         [props.highlight]          Tint the whole row, for a host that flags edited
+ *                                                     controls. The host decides when — the editor
+ *                                                     reads its own "highlight edits" setting.
+ * @param {?Element}        [props.indicator]          A host-supplied mark rendered in place of the
+ *                                                     built-in one. The block editor has its own
+ *                                                     indicator that predates this library and is used
+ *                                                     across controls this shell does not wrap, so it
+ *                                                     passes that rather than showing a second mark
+ *                                                     that means the same thing but looks different.
+ * @param {boolean}         [props.disabled]           Whether every affordance is inert.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The wrapped control.
+ */
+export function ControlShell({
+	label,
+	children,
+	status = null,
+	onReset = null,
+	showReset = true,
+	breakpoints = null,
+	breakpoint = null,
+	onBreakpointChange = null,
+	isLinked = null,
+	onToggleLink = null,
+	stacked = false,
+	highlight = false,
+	disabled = false,
+	indicator = null,
+}) {
+	const responsive = Array.isArray(breakpoints) && breakpoints.length > 1;
+	const linkable = typeof onToggleLink === 'function';
+
+	// A control that carries its own indicator inline needs no header at all — rendering an empty
+	// one leaves a gap above it. The wrapper then contributes only the highlight tint, which is how
+	// the block editor's rows with and without a header differ.
+	const hasHeader = Boolean(label) || linkable || responsive || Boolean(status) || Boolean(indicator);
+
+	const className = [
+		'kb-token-control',
+		stacked ? 'kb-token-control--stacked' : '',
+		highlight ? 'kb-token-control--highlight' : '',
+	]
+		.filter(Boolean)
+		.join(' ');
+
+	return (
+		<div className={className}>
+			{hasHeader && (
+				<div className="kb-token-control__header">
+					<span className="kb-token-control__label">{label}</span>
+					{indicator ?? <BindingIndicator status={status} onReset={onReset} showReset={showReset} />}
+
+					<div className="kb-token-control__affordances">
+						{responsive && (
+							<ButtonGroup
+								className="kb-measure-responsive-options"
+								aria-label={__('Device', 'kadence-blocks')}
+							>
+								{breakpoints.map((key) => {
+									const ui = BREAKPOINTS_UI[key] ?? BREAKPOINTS_UI.desktop;
+									const active = key === breakpoint;
+
+									return (
+										<Button
+											key={key}
+											className={`kb-responsive-btn ${ui.itemClass}${active ? ' is-active' : ''}`}
+											isSmall
+											// `aria-pressed` rather than `isPressed`, matching the editor:
+											// `isPressed` adds WordPress's `is-pressed` class and its dark
+											// fill, which then fights the `is-active` color these buttons
+											// actually use.
+											aria-pressed={active}
+											onClick={() => onBreakpointChange?.(key)}
+											disabled={disabled}
+											// Named, but with the tooltip suppressed. The editor passes no label at all,
+											// which leaves a button whose only content is a decorative
+											// dashicon with no accessible name; this keeps the name and
+											// suppresses the tooltip so the two look identical.
+											label={BREAKPOINT_LABELS[key] ?? key}
+											showTooltip={false}
+										>
+											<Dashicon icon={ui.icon} />
+										</Button>
+									);
+								})}
+							</ButtonGroup>
+						)}
+
+						{linkable && (
+							<Button
+								// The class contract `@kadence/components`' measure control uses for this
+								// toggle, so one set of rules dresses both. `is-tertiary` is the unlinked
+								// resting state; `is-pressed` takes the filled treatment.
+								className={`kadence-radio-item kadence-control-toggle radio-custom is-single only-icon${
+									isLinked ? '' : ' is-tertiary'
+								}`}
+								icon={isLinked ? link : linkOff}
+								isSmall
+								isPressed={Boolean(isLinked)}
+								onClick={onToggleLink}
+								disabled={disabled}
+								// Labelled with the state the press moves to, matching the editor's toggle.
+								label={isLinked ? __('Individual', 'kadence-blocks') : __('Linked', 'kadence-blocks')}
+							/>
+						)}
+					</div>
+				</div>
+			)}
+
+			<div className="kb-token-control__body">{children}</div>
+		</div>
+	);
+}

--- a/src/token-controls/templates/SlotGrid.js
+++ b/src/token-controls/templates/SlotGrid.js
@@ -1,0 +1,75 @@
+/**
+ * The arrangement half of a box control: one slot when linked, a 2x2 grid when not.
+ *
+ * Arrangement only — the link *toggle* is chrome and lives in `ControlShell`. Splitting them lets a
+ * control be linkable without being slot-shaped, and slot-shaped without being linkable.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { SLOT_LABELS, readSlot, writeSlot } from '../helpers/value-shapes';
+
+/**
+ * Display order for the unlinked grid, per role.
+ *
+ * Corners walk clockwise (top-left, top-right, bottom-right, bottom-left), which is not reading
+ * order — so the grid renders slots 0, 1, 3, 2 to put each corner in its true visual position.
+ * Sides keep identity order. The stored array order never changes either way.
+ *
+ * @since TBD
+ */
+const GRID_ORDER = {
+	sides: [0, 1, 2, 3],
+	corners: [0, 1, 3, 2],
+};
+
+/**
+ * Render a value as one slot or four.
+ *
+ * @param {Object}   props            The component props.
+ * @param {*}        props.value      A scalar or a `[top, right, bottom, left]` slot list.
+ * @param {Function} props.onChange   Called with the next whole value.
+ * @param {boolean}  props.isLinked   Render one slot rather than the grid.
+ * @param {Function} props.renderSlot `({ value, onChange, label, index }) => Element`.
+ * @param {string}   [props.role]     'sides' or 'corners' — picks labels and grid order.
+ * @param {string}   [props.label]    Fallback label for the linked slot.
+ * @param {boolean}  [props.collapse] Collapse four identical slots to a scalar on write.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The rendered slot or grid.
+ */
+export function SlotGrid({ value, onChange, isLinked, renderSlot, role = 'sides', label, collapse = false }) {
+	const labels = SLOT_LABELS[role] ?? SLOT_LABELS.sides;
+	const order = GRID_ORDER[role] ?? GRID_ORDER.sides;
+
+	if (isLinked) {
+		// Reading slot 0 rather than passing the raw value: a caller whose storage is always an
+		// array (the block editor) still shows one field with a real value in linked mode.
+		return renderSlot({
+			value: readSlot(value, 0),
+			onChange: (next) => onChange(collapse ? next : Array(labels.length).fill(next)),
+			label,
+			index: null,
+		});
+	}
+
+	// Each slot is wrapped and tagged with its position, which is what lets one rule set draw the
+	// "which part of the box is this" mark for both geometries: a corner is two adjacent borders, a
+	// side is one. The suffix is the slot label verbatim, so the classes cannot drift from the order.
+	return (
+		<div className="kb-token-control__grid">
+			{order.map((index) => (
+				<div key={index} className={`kb-token-control__slot kb-token-control__slot--${labels[index]}`}>
+					{renderSlot({
+						value: readSlot(value, index),
+						onChange: (next) => onChange(writeSlot(value, index, next, collapse)),
+						label: labels[index],
+						index,
+					})}
+				</div>
+			))}
+		</div>
+	);
+}


### PR DESCRIPTION
The frame a whole control renders in: control shell, slot grid, binding indicator, breakpoint context, and the remaining half of the stylesheet.

## Test instructions

1. Still not wired to anything — confirm the UI is unchanged on this branch.
2. After this slice the stylesheet is complete; the `.kb-token-control` family added here is what the shell uses.
3. Worth reviewing: `ControlShell` takes each affordance (responsive switcher, linked/individual, dirty state) as an opt-in prop, so a control only gets what it asks for.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4083/phase-10c-token-control-shell
bun run build-wp
```

The Style Library is at **WP Admin → Kadence → Style Library**. The Button preset screen is under **Block Presets → Button**. Block-editor checks use a **Kadence Single Button** block on any post.
</details>

---

Slice 16 of 23 in the SOFT-4083 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token-aware control shells with labels, responsive breakpoint controls, link toggles, status indicators, and disabled or highlighted states.
  * Added linked and unlinked slot layouts for editing side and corner values.
  * Added binding indicators for linked, modified, and resettable values.
  * Added shared breakpoint state for responsive controls.
  * Added styling for token grids, responsive controls, focus states, and edited values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->