### PR TITLE
[DTM] SOFT-4083 [19/23]: Preset value aliasing

### DIFF
--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -549,7 +549,7 @@ describe('BUTTON_PRESET.schemaFor', () => {
 			.flatMap((panel) => panel.fields)
 			.find((field) => field.path === 'tokens.button-radius');
 
-		expect(radiusField).toMatchObject({ type: 'radius', tokenType: 'dimension', role: 'radius' });
+		expect(radiusField).toMatchObject({ type: 'token-select', tokenType: 'dimension', role: 'radius' });
 	});
 
 	it('lists the hover color fields, with no radius field, on the Hover tab', () => {

--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -195,6 +195,38 @@ describe('presetRows', () => {
 		expect(rows[1].preview).toEqual({ background: 'transparent', color: '#3633e1', borderRadius: '0.25rem' });
 	});
 
+	it('resolves a responsive preview at the breakpoint being viewed', () => {
+		// The row and overlay paths both pass a breakpoint through to the preview callback. Ignoring
+		// it renders every step with the desktop value, so Tablet and Mobile silently preview wrong.
+		const responsiveValues = { ...values, 'semantic.color.action-secondary': '#00ff00' };
+		const payload = {
+			userCreated: [],
+			presets: {
+				primary: {
+					label: 'Primary',
+					tokens: {
+						'button-bg': {
+							$value: '{semantic.color.action-primary}',
+							$extensions: {
+								'com.kadence.designTokens': {
+									responsive: { tablet: '{semantic.color.action-secondary}' },
+								},
+							},
+						},
+						'button-text': '{semantic.color.on-primary}',
+						'button-radius': '0.5rem',
+					},
+				},
+			},
+		};
+
+		const desktop = presetRows(payload, responsiveValues, BUTTON_PRESET.preview, 'desktop');
+		const tablet = presetRows(payload, responsiveValues, BUTTON_PRESET.preview, 'tablet');
+
+		expect(desktop[0].preview.background).toBe('#3633e1');
+		expect(tablet[0].preview.background).toBe('#00ff00');
+	});
+
 	it('falls back to the slug for a label-less preset', () => {
 		const payload = { userCreated: [], presets: { outline: { tokens: {} } } };
 

--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -549,7 +549,7 @@ describe('BUTTON_PRESET.schemaFor', () => {
 			.flatMap((panel) => panel.fields)
 			.find((field) => field.path === 'tokens.button-radius');
 
-		expect(radiusField).toMatchObject({ type: 'token-select', tokenType: 'dimension', role: 'radius' });
+		expect(radiusField).toMatchObject({ type: 'radius', tokenType: 'dimension', role: 'radius' });
 	});
 
 	it('lists the hover color fields, with no radius field, on the Hover tab', () => {
@@ -568,5 +568,146 @@ describe('BUTTON_PRESET.schemaFor', () => {
 
 			expect(paths).not.toContain('label');
 		}
+	});
+});
+
+describe('presetSaveTokens with non-scalar values', () => {
+	const NS = 'com.kadence.designTokens';
+
+	it('aliases the ids inside a responsive envelope, not just a bare scalar', () => {
+		const draft = {
+			'button-radius': {
+				$value: 'primitive.dimension.radius-sm',
+				$extensions: { [NS]: { responsive: { tablet: 'primitive.dimension.radius-xs' } } },
+			},
+		};
+
+		const written = presetSaveTokens(draft, {}, {});
+
+		expect(written['button-radius'].$value).toBe('{primitive.dimension.radius-sm}');
+		expect(written['button-radius'].$extensions[NS].responsive.tablet).toBe('{primitive.dimension.radius-xs}');
+	});
+
+	it('aliases every id in a per-corner slot list', () => {
+		const draft = {
+			'button-radius': ['semantic.dimension.control-radius', '0.5rem', 'primitive.dimension.radius-sm', ''],
+		};
+
+		expect(presetSaveTokens(draft, {}, {})['button-radius']).toEqual([
+			'{semantic.dimension.control-radius}',
+			'0.5rem',
+			'{primitive.dimension.radius-sm}',
+			'',
+		]);
+	});
+
+	it('leaves an untouched non-scalar exactly as it was stored', () => {
+		const stored = { $value: '{primitive.dimension.radius-lg}' };
+		const seeded = { $value: '{primitive.dimension.radius-lg}' };
+
+		const written = presetSaveTokens(
+			{ 'button-radius': seeded },
+			{ 'button-radius': seeded },
+			{
+				'button-radius': stored,
+			}
+		);
+
+		expect(written['button-radius']).toBe(stored);
+	});
+});
+
+describe('seed/save round trip', () => {
+	const NS = 'com.kadence.designTokens';
+
+	it('seeds a responsive envelope as bare ids so a saved draft stops being dirty', () => {
+		const stored = {
+			$value: '{primitive.dimension.radius-sm}',
+			$extensions: { [NS]: { responsive: { tablet: '{primitive.dimension.radius-lg}' } } },
+		};
+
+		const seeded = presetInitialValues(
+			{ presets: { primary: { label: 'Primary', tokens: { 'button-radius': stored } } } },
+			'primary',
+			['button-radius']
+		);
+
+		// What the panel compares its draft against: every nested alias unwrapped, matching exactly
+		// what the field writes back into the draft.
+		expect(seeded.tokens['button-radius']).toEqual({
+			$value: 'primitive.dimension.radius-sm',
+			$extensions: { [NS]: { responsive: { tablet: 'primitive.dimension.radius-lg' } } },
+		});
+
+		// And re-aliasing that seed reproduces the stored shape, so an untouched draft is byte-identical
+		// to what is already on the server.
+		expect(presetSaveTokens({ 'button-radius': seeded.tokens['button-radius'] }, {}, {})).toEqual({
+			'button-radius': stored,
+		});
+	});
+
+	it('seeds a per-corner slot list as bare ids', () => {
+		const seeded = presetInitialValues(
+			{
+				presets: {
+					primary: {
+						tokens: {
+							'button-radius': [
+								'{primitive.dimension.radius-sm}',
+								'0.5rem',
+								'',
+								'{semantic.dimension.control-radius}',
+							],
+						},
+					},
+				},
+			},
+			'primary',
+			['button-radius']
+		);
+
+		expect(seeded.tokens['button-radius']).toEqual([
+			'primitive.dimension.radius-sm',
+			'0.5rem',
+			'',
+			'semantic.dimension.control-radius',
+		]);
+	});
+});
+
+describe('resolveTokenValue at a breakpoint', () => {
+	const NS = 'com.kadence.designTokens';
+	const values = { 'radius.sm': '0.1875rem', 'radius.lg': '0.5rem', 'radius.none': '0' };
+
+	const envelope = {
+		$value: '{radius.sm}',
+		$extensions: { [NS]: { responsive: { tablet: '{radius.lg}' } } },
+	};
+
+	it('resolves the breakpoint override when one exists', () => {
+		expect(resolveTokenValue(values, envelope, 'tablet')).toBe('0.5rem');
+	});
+
+	it('steps an unset mobile down to the tablet override, not to desktop', () => {
+		// The projected tablet media query covers mobile widths, so tablet is what actually renders here.
+		expect(resolveTokenValue(values, envelope, 'mobile')).toBe('0.5rem');
+	});
+
+	it('falls through to the base value when no breakpoint above is set either', () => {
+		expect(resolveTokenValue(values, { $value: '{radius.sm}' }, 'mobile')).toBe('0.1875rem');
+	});
+
+	it('resolves the base value at desktop, and by default', () => {
+		expect(resolveTokenValue(values, envelope, 'desktop')).toBe('0.1875rem');
+		expect(resolveTokenValue(values, envelope)).toBe('0.1875rem');
+	});
+
+	it('resolves a slot list held at a breakpoint into the shorthand', () => {
+		const perCorner = {
+			$value: '{radius.sm}',
+			$extensions: { [NS]: { responsive: { tablet: ['{radius.lg}', '{radius.none}', '{radius.lg}', '0'] } } },
+		};
+
+		expect(resolveTokenValue(values, perCorner, 'tablet')).toBe('0.5rem 0 0.5rem 0');
 	});
 });

--- a/src/style-library/__tests__/token-select-field.test.js
+++ b/src/style-library/__tests__/token-select-field.test.js
@@ -1,0 +1,62 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { TokenSelectField } from '../components/molecules/fields/TokenSelectField';
+import { pickableTokensForType } from '../helpers/tokens';
+
+// A factory, not automock: `helpers/tokens.js` reaches the localized feed, and this test only cares
+// about the arguments the field hands it.
+jest.mock('../helpers/tokens', () => ({
+	pickableTokensForType: jest.fn(() => []),
+}));
+
+jest.mock('../components/molecules/SelectDropdown', () => ({ SelectDropdown: () => null }));
+jest.mock('../components/molecules/fields/FieldLabel', () => ({ FieldLabel: ({ children }) => children }));
+jest.mock('../components/molecules/fields/TokenSelectField.scss', () => ({}), { virtual: true });
+
+let container;
+let root;
+
+beforeEach(() => {
+	jest.clearAllMocks();
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+describe('TokenSelectField token pool', () => {
+	/**
+	 * The field's current value is handed to the pool as `selected`, which exempts it from the
+	 * primitive narrowing. Without it a bound semantic token is filtered out of its own picker, so
+	 * the field renders with its current value absent from the list.
+	 *
+	 * @return {void}
+	 */
+	it('passes the bound value through as the selected token', () => {
+		act(() =>
+			root.render(
+				createElement(TokenSelectField, {
+					field: { tokenType: 'dimension', role: 'radius', label: 'Radius' },
+					value: 'semantic.dimension.radius-control',
+					onChange: jest.fn(),
+				})
+			)
+		);
+
+		expect(pickableTokensForType).toHaveBeenCalledWith('dimension', 'radius', 'semantic.dimension.radius-control');
+	});
+});

--- a/src/style-library/__tests__/tokens.test.js
+++ b/src/style-library/__tests__/tokens.test.js
@@ -199,6 +199,23 @@ describe('pickableTokensForType', () => {
 		expect(tokens[0]).toMatchObject({ id: 'primitive.dimension.radius.sm', value: '4px', role: 'radius' });
 	});
 
+	it('keeps the token the field is already bound to, even when it loses the primitive narrowing', () => {
+		// The bound value is passed through as `selected`. Without it the narrowing drops a semantic
+		// token from its own picker, so the field renders with its current value missing.
+		window[PICKABLE_TOKENS_GLOBAL].tokens.push({
+			id: 'semantic.dimension.radius-control',
+			label: 'Control Radius',
+			type: 'dimension',
+			role: 'radius',
+		});
+
+		const withoutSelected = pickableTokensForType('dimension', 'radius');
+		const withSelected = pickableTokensForType('dimension', 'radius', 'semantic.dimension.radius-control');
+
+		expect(withoutSelected.map((token) => token.id)).not.toContain('semantic.dimension.radius-control');
+		expect(withSelected.map((token) => token.id)).toContain('semantic.dimension.radius-control');
+	});
+
 	it('resolves the active-library value for a color type', () => {
 		const tokens = pickableTokensForType('color');
 

--- a/src/style-library/components/molecules/fields/TokenSelectField.js
+++ b/src/style-library/components/molecules/fields/TokenSelectField.js
@@ -37,7 +37,9 @@ import './TokenSelectField.scss';
  * @return {JSX.Element} The field.
  */
 export function TokenSelectField({ field, value, onChange }) {
-	const tokens = pickableTokensForType(field.tokenType, field.role);
+	// `value` is passed as `selected` so the token this field is already bound to survives the
+	// primitive narrowing — without it a bound semantic token is filtered out of its own picker.
+	const tokens = pickableTokensForType(field.tokenType, field.role, value);
 	const options = tokens.map((token) => ({
 		value: token.id,
 		label: (

--- a/src/style-library/helpers/presets.js
+++ b/src/style-library/helpers/presets.js
@@ -17,18 +17,15 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { isEqual } from './settings-schema';
+import {
+	isPresetEnvelope,
+	PRESET_BREAKPOINTS,
+	readPresetBreakpoint,
+	resolvePresetBreakpoint,
+	writePresetBreakpoint,
+} from '../../token-controls/helpers/preset-envelope';
 import { nextScaleSlug } from './scale';
 import { getDesignTokensFeed } from './tokens';
-
-/**
- * The `$value` sentinel key a responsive preset-value envelope wraps its base value in, mirroring
- * the sibling per-corner/responsive-value work's `Sentinels::get_value_key()`. Presence of this key
- * on an object (never an array — a slot list is a plain array) is what distinguishes an envelope
- * from a bare per-corner slot list.
- *
- * @since TBD
- */
-const ENVELOPE_VALUE_KEY = '$value';
 
 /**
  * The number of corners a per-corner slot list carries (top-left, top-right, bottom-right,
@@ -130,23 +127,6 @@ export function idToAlias(value) {
 }
 
 /**
- * Whether a stored preset token entry is a responsive envelope: `{ $value, $extensions: {
- * "com.kadence.designTokens": { responsive: { tablet, mobile } } } }`. Only the base `$value` is
- * read here — the breakpoint overrides are an editor concern, out of scope for the Style Library's
- * single-value preview/picker surface. An object is checked rather than any array, since a slot
- * list (see `isSlotList`) is a plain array and never carries a `$value` key.
- *
- * @param {*} value The stored token entry.
- *
- * @since TBD
- *
- * @return {boolean} True when `value` is a responsive envelope.
- */
-function isPresetEnvelope(value) {
-	return Boolean(value) && typeof value === 'object' && !Array.isArray(value) && ENVELOPE_VALUE_KEY in value;
-}
-
-/**
  * Whether a stored preset token entry is a per-corner slot list: exactly four entries, each
  * independently an alias or a literal.
  *
@@ -179,25 +159,35 @@ export function isNonScalarPresetValue(value) {
 /**
  * Resolve a stored preset token value against the feed's resolved value map, tolerant of every
  * shape a preset property's value can carry: a bare alias or literal (unchanged from the original
- * contract), a responsive envelope (resolved from its base `$value`, breakpoint overrides ignored —
- * this is a single preview/picker value, not a responsive editor), or a per-corner slot list (each
- * corner resolved independently and joined with a space, the CSS `border-radius` shorthand order).
- * Anything else unresolvable degrades to `''` rather than a stringified object or array.
+ * contract), a responsive envelope (resolved at `breakpoint`, stepping down the cascade to whatever is
+ * actually in effect there), or
+ * a per-corner slot list (each corner resolved independently and joined with a space, the CSS
+ * `border-radius` shorthand order). Anything else unresolvable degrades to `''` rather than a
+ * stringified object or array.
  *
- * @param {Record<string, string>} values The feed's resolved value map (`feed.values`).
- * @param {*}                       value  The stored token entry (alias, literal, envelope, or slot list).
+ * `breakpoint` is what lets a row preview show what the user is actually looking at: switching the
+ * panel to Tablet has to re-render the chip with the tablet override, not keep showing desktop.
+ *
+ * @param {Record<string, string>} values       The feed's resolved value map (`feed.values`).
+ * @param {*}                      value        The stored token entry (alias, literal, envelope, or
+ *                                              slot list).
+ * @param {string}                 [breakpoint] The breakpoint to resolve at; defaults to desktop.
  *
  * @since TBD
  *
  * @return {string} The resolved value, or `''` when unresolvable.
  */
-export function resolveTokenValue(values, value) {
+export function resolveTokenValue(values, value, breakpoint = PRESET_BREAKPOINTS[0]) {
 	if (isPresetEnvelope(value)) {
-		return resolveTokenValue(values, value[ENVELOPE_VALUE_KEY]);
+		// Stepped, not flat: an unset mobile renders the tablet value and only falls through to desktop
+		// when tablet is unset too, because the projected tablet media query covers mobile widths.
+		return resolveTokenValue(values, resolvePresetBreakpoint(value, breakpoint), breakpoint);
 	}
 
 	if (isSlotList(value)) {
-		const slots = value.map((slot) => (typeof slot === 'string' ? resolveTokenValue(values, slot) : ''));
+		const slots = value.map((slot) =>
+			typeof slot === 'string' ? resolveTokenValue(values, slot, breakpoint) : ''
+		);
 
 		// All four slots or none: joining a partial resolution emits a valid-looking shorthand
 		// (`1rem  1rem 1rem`) that silently renders a different radius than the one stored, which is
@@ -227,13 +217,14 @@ export function resolveTokenValue(values, value) {
  *
  * @param {{presets?: Record<string, {label?: string, tokens?: Record<string, string>}>, userCreated?: string[]}} payload The preset GET payload.
  * @param {Record<string, string>}                                                                                 values  The feed's resolved value map.
- * @param {Function}                                                                                               preview `(tokens, values) => object` — the block's own row preview.
+ * @param {Function}                                                                                               preview `(tokens, values, breakpoint) => object` — the block's own row preview.
+ * @param {string}                                                                                                 [breakpoint] The breakpoint the preview resolves at; defaults to desktop.
  *
  * @since TBD
  *
  * @return {Array<{id: string, label: string, userCreated: boolean, preview: Object}>} The preset rows.
  */
-export function presetRows(payload, values, preview) {
+export function presetRows(payload, values, preview, breakpoint = PRESET_BREAKPOINTS[0]) {
 	const presets = payload?.presets ?? {};
 	const userCreated = Array.isArray(payload?.userCreated) ? payload.userCreated : [];
 
@@ -244,7 +235,7 @@ export function presetRows(payload, values, preview) {
 			id: slug,
 			label: preset?.label ?? slug,
 			userCreated: userCreated.includes(slug),
-			preview: preview(tokens, values),
+			preview: preview(tokens, values, breakpoint),
 		};
 	});
 }
@@ -274,7 +265,7 @@ export function presetInitialValues(payload, slug, properties) {
 	return {
 		label: preset.label ?? slug,
 		tokens: properties.reduce((acc, property) => {
-			acc[property] = aliasToId(tokens[property] ?? '');
+			acc[property] = aliasToIdDeep(tokens[property] ?? '');
 			return acc;
 		}, {}),
 	};
@@ -324,6 +315,61 @@ function isUnsetPresetValue(value) {
 }
 
 /**
+ * Alias every token id inside a value, whatever shape holds it.
+ *
+ * `idToAlias` only understands a bare string, which was enough while every editable property was a
+ * scalar. A per-corner slot list and a responsive envelope both carry ids *inside* them, and passing
+ * either through unchanged writes bare dot-paths where the server expects `{aliases}`. Keys are left
+ * alone — only values are candidates — and a non-id string (a literal, a clamp expression) is
+ * returned untouched by `idToAlias` itself.
+ *
+ * @param {*} value A scalar, a slot list, or a responsive envelope.
+ *
+ * @since TBD
+ *
+ * @return {*} The same shape, with every token id alias-wrapped.
+ */
+function aliasDeep(value) {
+	if (Array.isArray(value)) {
+		return value.map(aliasDeep);
+	}
+
+	if (value !== null && typeof value === 'object') {
+		return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, aliasDeep(entry)]));
+	}
+
+	return idToAlias(value);
+}
+
+/**
+ * Unwrap every alias inside a value back to its bare id, whatever shape holds it.
+ *
+ * The read-side mirror of `aliasDeep`, and it has to reach just as deep for the panel's dirty bit to
+ * ever clear. `isDirty` compares the draft against these seeded values, and the two sides disagree on
+ * a nested id unless both are unwrapped: the field writes a bare id into the draft while the stored
+ * envelope still carries `{braces}`, so a shallow unwrap leaves them permanently unequal and Save
+ * stays enabled forever after a successful write. Both shapes happen to render identically, which is
+ * what makes the mismatch invisible until the button never goes quiet.
+ *
+ * @param {*} value A scalar, a slot list, or a responsive envelope.
+ *
+ * @since TBD
+ *
+ * @return {*} The same shape, with every alias unwrapped to a bare id.
+ */
+function aliasToIdDeep(value) {
+	if (Array.isArray(value)) {
+		return value.map(aliasToIdDeep);
+	}
+
+	if (value !== null && typeof value === 'object') {
+		return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, aliasToIdDeep(entry)]));
+	}
+
+	return aliasToId(value);
+}
+
+/**
  * Build the write-side token map from a settings-panel draft: a property the draft actually
  * changed from its seed is written as a fresh alias-or-literal; every untouched property is
  * carried over from the preset's raw stored map, byte-for-byte, so a save that only edited the
@@ -363,7 +409,7 @@ export function presetSaveTokens(draftTokens, initialTokens = {}, storedTokens =
 
 		const touched = !isEqual(value, initialTokens[property]);
 
-		acc[property] = touched || !(property in storedTokens) ? idToAlias(value) : storedTokens[property];
+		acc[property] = touched || !(property in storedTokens) ? aliasDeep(value) : storedTokens[property];
 
 		return acc;
 	}, {});
@@ -397,15 +443,16 @@ export function nextPresetSlug(existingSlugs, base) {
  * @param {string}                                              itemId  The open route item id.
  * @param {?{label?: string, tokens?: Record<string, string>}}  draft   The open panel's live draft, or null.
  * @param {Record<string, string>}                              values  The feed's resolved value map.
- * @param {Function}                                            preview `(tokens, values) => object` — the same
- *                                                                      builder `presetRows` used, so an overlaid
- *                                                                      row and a fetched one cannot drift.
+ * @param {Function}                                            preview `(tokens, values, breakpoint) => object` —
+ *                                                                      the same builder `presetRows` used, so an
+ *                                                                      overlaid row and a fetched one cannot drift.
+ * @param {string} [breakpoint] The breakpoint the preview resolves at; defaults to desktop.
  *
  * @since TBD
  *
  * @return {Array<Object>} The rows, with the matching row's label/preview overlaid.
  */
-export function overlayPresetRows(rows, itemId, draft, values, preview) {
+export function overlayPresetRows(rows, itemId, draft, values, preview, breakpoint = PRESET_BREAKPOINTS[0]) {
 	if (!draft || !itemId) {
 		return rows;
 	}
@@ -427,11 +474,11 @@ export function overlayPresetRows(rows, itemId, draft, values, preview) {
 		// stored alias shape, same as a fetched payload. Re-wrapping here means both paths run the
 		// identical builder, so a live overlay can never resolve differently from what lands on save.
 		const asStored = Object.entries(draft.tokens).reduce((acc, [property, value]) => {
-			acc[property] = idToAlias(value ?? '');
+			acc[property] = aliasDeep(value ?? '');
 			return acc;
 		}, {});
 
-		overlaid.preview = preview(asStored, values);
+		overlaid.preview = preview(asStored, values, breakpoint);
 	}
 
 	const next = [...rows];
@@ -484,3 +531,5 @@ export function presetNameSchema() {
 		],
 	};
 }
+
+export { isPresetEnvelope, PRESET_BREAKPOINTS, readPresetBreakpoint, writePresetBreakpoint };

--- a/src/style-library/helpers/tokens.js
+++ b/src/style-library/helpers/tokens.js
@@ -31,24 +31,79 @@ export function getPickableTokensPool() {
 }
 
 /**
+ * Narrow a role-scoped token list to its primitive-layer entries, when it has any. A role's
+ * primitives are its scale steps (e.g. the radius sizes); its semantic tokens merely alias them, so
+ * a picker that already knows the role offers only the steps rather than duplicating them with the
+ * component-specific aliases. A role with no primitives (only semantics) falls back to the full list
+ * unchanged.
+ *
+ * The narrowing can never drop a currently-bound token from the list, though: a stored preset value
+ * is often a semantic alias by design (e.g. `{semantic.radius.control}`), and a semantic id the
+ * primitive narrowing would otherwise remove is kept — the field would otherwise find no matching
+ * entry and mistake a valid token for a literal, rendering the raw dot-path as if it were text.
+ *
+ * Every bound id is exempt, not just one. A box control's four corners can each hold a different
+ * token, so exempting only the first would drop the others the moment one corner is pointed at a
+ * primitive — and the corners still holding the semantic would render as raw ids.
+ *
+ * @param {Array<{id: string}>}   tokens   The role-narrowed token list.
+ * @param {?(string|Array)}       selected The currently-bound token id, or ids, exempt from the
+ *                                         narrowing.
+ *
+ * @since TBD
+ *
+ * @return {Array<{id: string}>} The primitive-only list plus any exempted selections, in the pool's
+ * own order, or `tokens` unchanged when it has no primitives.
+ */
+export function preferPrimitiveTokens(tokens, selected) {
+	const primitives = tokens.filter((token) => token.id.startsWith('primitive.'));
+
+	if (!primitives.length) {
+		return tokens;
+	}
+
+	const exempt = new Set(
+		(Array.isArray(selected) ? selected : [selected]).filter(
+			(id) => id && !primitives.some((token) => token.id === id)
+		)
+	);
+
+	if (!exempt.size) {
+		return primitives;
+	}
+
+	// Filtered from the full list rather than appended to the primitives, so an exempted semantic keeps
+	// its place in the pool's order instead of being pushed to the end.
+	return tokens.filter((token) => token.id.startsWith('primitive.') || exempt.has(token.id));
+}
+
+/**
  * The pickable tokens of one DTCG `$type` (e.g. `dimension`, `color`), each with its resolved
  * literal value from the active library. An optional `role` narrows the pool further (e.g. the
  * Radius picker wants only `role: 'radius'` dimensions, not every dimension token) — omitted, this
- * behaves exactly as before.
+ * behaves exactly as before. When a `role` is given, the pool also prefers that role's primitive
+ * scale (see `preferPrimitiveTokens`, exempting `selectedId` from the narrowing).
  *
- * @param {string}  type   The DTCG token `$type` to filter to.
- * @param {?string} [role] When given, also require `token.role === role`.
+ * The order is the pool's own, which is the order its scale screen lists — a picker that reshuffled
+ * by what happens to be bound would read differently every time the value changed.
+ *
+ * @param {string}            type       The DTCG token `$type` to filter to.
+ * @param {?string}           [role]     When given, also require `token.role === role` and prefer
+ *                                       that role's primitives.
+ * @param {?(string|Array)}   [selected] The currently-bound token id, or ids, exempt from the
+ *                                       primitive narrowing so a bound semantic alias is never
+ *                                       filtered out of its own picker.
  *
  * @since TBD
  *
  * @return {Array<{id: string, label: string, value: string, role: ?string}>} The pickable tokens for the type.
  */
-export function pickableTokensForType(type, role) {
+export function pickableTokensForType(type, role, selected) {
 	const pool = getPickableTokensPool();
 	const feed = getDesignTokensFeed();
 	const libraryValues = pool.values?.[feed?.slug] ?? {};
 
-	return (pool.tokens || [])
+	const matched = (pool.tokens || [])
 		.filter((token) => token.type === type && (role === undefined || token.role === role))
 		.map((token) => ({
 			id: token.id,
@@ -56,6 +111,12 @@ export function pickableTokensForType(type, role) {
 			value: libraryValues[token.id] ?? '',
 			role: token.role ?? null,
 		}));
+
+	if (role === undefined) {
+		return matched;
+	}
+
+	return preferPrimitiveTokens(matched, selected);
 }
 
 /**
@@ -105,14 +166,11 @@ export function flattenSchemaTokens(schema) {
 	);
 }
 
-/**
- * The vendor-extension namespace the module owns (mirrors Schema\Vocabulary\Extensions::NAMESPACE).
- *
- * @since TBD
- *
- * @type {string}
- */
-export const KADENCE_TOKEN_NAMESPACE = 'com.kadence.designTokens';
+// Re-exported, not redeclared: the envelope contract owns the spelling, and this module both
+// uses it and keeps the name available to existing importers.
+import { KADENCE_TOKEN_NAMESPACE } from '../../token-controls/helpers/preset-envelope';
+
+export { KADENCE_TOKEN_NAMESPACE };
 
 /**
  * The stepped responsive breakpoint keys, in cascade order (mirrors Schema\Vocabulary\Responsive).

--- a/src/style-library/presets/button-preset.js
+++ b/src/style-library/presets/button-preset.js
@@ -36,18 +36,21 @@ const TABS = [
  * Another block's rows would preview something else entirely, which is why the generic row mapper
  * takes this as a function rather than reading fixed keys.
  *
- * @param {Record<string, *>}      tokens The preset's stored token map.
- * @param {Record<string, string>} values The feed's resolved value map.
+ * @param {Record<string, *>}      tokens     The preset's stored token map.
+ * @param {Record<string, string>} values     The feed's resolved value map.
+ * @param {string}                 breakpoint The breakpoint the row is previewing, so a responsive
+ *                                              value resolves to the step being viewed rather than
+ *                                              always to desktop.
  *
  * @since TBD
  *
  * @return {{background: string, color: string, borderRadius: string}} The preview.
  */
-function preview(tokens, values) {
+function preview(tokens, values, breakpoint) {
 	return {
-		background: resolveTokenValue(values, tokens['button-bg']),
-		color: resolveTokenValue(values, tokens['button-text']),
-		borderRadius: resolveTokenValue(values, tokens['button-radius']),
+		background: resolveTokenValue(values, tokens['button-bg'], breakpoint),
+		color: resolveTokenValue(values, tokens['button-text'], breakpoint),
+		borderRadius: resolveTokenValue(values, tokens['button-radius'], breakpoint),
 	};
 }
 


### PR DESCRIPTION
Aliases every token id inside a preset value in both directions, and exempts bound tokens from the primitive narrowing.

Sits above the token-control library because it reads the envelope helper introduced there.

## Test instructions

1. Run `npx wp-scripts test-unit-js src/style-library/__tests__/presets.test.js`.
2. Round-trip check: set a preset value to a token, save, reload, and confirm it still reads as that token rather than as a literal — that is both directions of the aliasing working.
3. Confirm a token bound by the preset still appears in the picker even when the narrowing would otherwise filter it out; without the exemption the field shows nothing at all.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4083/phase-11-preset-value-aliasing
bun run build-wp
```

The Style Library is at **WP Admin → Kadence → Style Library**. The Button preset screen is under **Block Presets → Button**. Block-editor checks use a **Kadence Single Button** block on any post.
</details>

---

Slice 19 of 23 in the SOFT-4083 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added breakpoint-aware responsive preset previews and token resolution.
  * Improved handling of nested token aliases in arrays and objects during preset saving, loading, and draft editing.
  * Added smarter token selection that prioritizes primitive tokens while retaining selected semantic tokens.

* **Bug Fixes**
  * Preserved existing stored values when updating only part of a preset.
  * Improved responsive fallback and slot-list resolution across breakpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->