### PR TITLE
[DTM] SOFT-4083 [20/23]: Responsive radius field

### DIFF
--- a/src/style-library/__tests__/box-token-field.test.js
+++ b/src/style-library/__tests__/box-token-field.test.js
@@ -1,0 +1,58 @@
+/* eslint-env jest */
+import { toControlValue, toStoredValue } from '../components/molecules/fields/BoxTokenField';
+
+describe('toControlValue', () => {
+	it('wraps a bare token id into the alias the control matches against', () => {
+		expect(toControlValue('semantic.dimension.radius-sm')).toBe('{semantic.dimension.radius-sm}');
+		expect(toControlValue('primitive.dimension.radius-lg')).toBe('{primitive.dimension.radius-lg}');
+	});
+
+	it('splits a literal down to its bare number, the unit being the control-wide one', () => {
+		expect(toControlValue('0.1875rem')).toBe(0.1875);
+		expect(toControlValue('12px')).toBe(12);
+	});
+
+	it('passes an unparsable literal through rather than blanking it', () => {
+		expect(toControlValue('auto')).toBe('auto');
+	});
+
+	it('reads an unset slot as unset', () => {
+		expect(toControlValue('')).toBe('');
+		expect(toControlValue(undefined)).toBe('');
+	});
+});
+
+describe('toStoredValue', () => {
+	it('unwraps an alias back to the bare id a preset stores', () => {
+		expect(toStoredValue('{semantic.dimension.radius-sm}', 'rem')).toBe('semantic.dimension.radius-sm');
+	});
+
+	it('rejoins a number with the active unit', () => {
+		expect(toStoredValue(0.1875, 'rem')).toBe('0.1875rem');
+		expect(toStoredValue(12, 'px')).toBe('12px');
+	});
+
+	it('keeps zero unitless, so it still equals the None token and does not dirty a clean preset', () => {
+		expect(toStoredValue(0, 'px')).toBe('0');
+		expect(toStoredValue('0', 'rem')).toBe('0');
+	});
+
+	it('writes an unset slot as empty', () => {
+		expect(toStoredValue('', 'px')).toBe('');
+		expect(toStoredValue(null, 'px')).toBe('');
+	});
+});
+
+describe('the conversion pair', () => {
+	it('round-trips every shape a preset slot can hold', () => {
+		for (const [stored, unit] of [
+			['semantic.dimension.radius-sm', 'rem'],
+			['0.1875rem', 'rem'],
+			['12px', 'px'],
+			['0', 'px'],
+			['', 'px'],
+		]) {
+			expect(toStoredValue(toControlValue(stored), unit)).toBe(stored);
+		}
+	});
+});

--- a/src/style-library/__tests__/box-token-field.test.js
+++ b/src/style-library/__tests__/box-token-field.test.js
@@ -1,5 +1,28 @@
 /* eslint-env jest */
-import { toControlValue, toStoredValue } from '../components/molecules/fields/BoxTokenField';
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { BoxTokenField, toControlValue, toStoredValue } from '../components/molecules/fields/BoxTokenField';
+
+// A stub, not the real control: `BoxControl` renders a deep tree of pickers and popovers that have
+// nothing to do with what this suite is after. Standing in for it exposes exactly the props
+// `BoxTokenField` computes — `unit`, `breakpoint`, and the callbacks a real slot/unit/breakpoint pick
+// would invoke — which is what the test drives and asserts on, never the adapter's internal state.
+let latestBoxControlProps;
+
+jest.mock('../../token-controls/controls/BoxControl', () => ({
+	BoxControl: (props) => {
+		latestBoxControlProps = props;
+
+		return null;
+	},
+}));
 
 describe('toControlValue', () => {
 	it('wraps a bare token id into the alias the control matches against', () => {
@@ -54,5 +77,81 @@ describe('the conversion pair', () => {
 		]) {
 			expect(toStoredValue(toControlValue(stored), unit)).toBe(stored);
 		}
+	});
+});
+
+describe('the pending unit', () => {
+	let container;
+	let root;
+	let field;
+	let value;
+	let onChange;
+
+	beforeEach(() => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+
+		field = { tokenType: 'dimension', responsive: true, units: ['px', 'em', 'rem', '%'] };
+		value = '';
+		onChange = jest.fn((next) => {
+			value = next;
+		});
+	});
+
+	afterEach(() => {
+		act(() => {
+			root.unmount();
+		});
+		container.remove();
+		latestBoxControlProps = undefined;
+	});
+
+	/**
+	 * Render `BoxTokenField` with whatever `value` currently holds, refreshing the captured
+	 * `BoxControl` props.
+	 *
+	 * @since TBD
+	 *
+	 * @return {void}
+	 */
+	function renderField() {
+		act(() => {
+			root.render(createElement(BoxTokenField, { field, value, onChange, slots: 'sides' }));
+		});
+	}
+
+	it('does not leak a unit picked with no value on one breakpoint into another breakpoint', () => {
+		renderField();
+
+		// On Desktop, pick `em` without typing a value — the choice has nowhere to persist yet.
+		act(() => {
+			latestBoxControlProps.onUnit('em');
+		});
+		expect(latestBoxControlProps.unit).toBe('em');
+
+		// Switch to Tablet: a fresh breakpoint must not already read as `em`.
+		act(() => {
+			latestBoxControlProps.onBreakpointChange('tablet');
+		});
+		expect(latestBoxControlProps.unit).toBe('px');
+
+		// On Tablet, set the unit to `px` and type `8`.
+		act(() => {
+			latestBoxControlProps.onUnit('px');
+		});
+		act(() => {
+			latestBoxControlProps.onChange(8);
+		});
+		renderField();
+		expect(latestBoxControlProps.unit).toBe('px');
+
+		// Switch back to Desktop: the pending `em` picked there must still be in effect.
+		act(() => {
+			latestBoxControlProps.onBreakpointChange('desktop');
+		});
+		expect(latestBoxControlProps.unit).toBe('em');
 	});
 });

--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -581,7 +581,7 @@ describe('BUTTON_PRESET.schemaFor', () => {
 			.flatMap((panel) => panel.fields)
 			.find((field) => field.path === 'tokens.button-radius');
 
-		expect(radiusField).toMatchObject({ type: 'token-select', tokenType: 'dimension', role: 'radius' });
+		expect(radiusField).toMatchObject({ type: 'radius', tokenType: 'dimension', role: 'radius' });
 	});
 
 	it('lists the hover color fields, with no radius field, on the Hover tab', () => {

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -32,6 +32,7 @@ import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
 import { useLibraries } from '../hooks/use-libraries';
 import { DraftChannelContext, useDraftChannelState } from '../hooks/use-draft-channel';
+import { BreakpointProvider } from '../../token-controls/context/breakpoint';
 import { DEFAULT_SCREEN_ID } from '../constants/screens';
 import { buildBaseStylesNav, buildBlockPresetsNav, resolveScreen } from '../helpers/screens';
 import { libraryDisplayTitle } from '../helpers/libraries';
@@ -154,85 +155,93 @@ export function StyleLibraryApp() {
 
 	return (
 		<DraftChannelContext.Provider value={channel}>
-			<AppShell
-				isBlocked={libraries.isSwappingLibrary}
-				header={
-					<AppHeader
-						librarySlot={
-							<LibrarySelector
-								libraries={libraries.libraries}
-								activeSlug={libraries.activeSlug}
-								editingSlug={libraries.editingSlug}
-								editingTitle={editingTitle}
-								isBusy={libraries.isBusy}
-								isSwapping={libraries.isSwappingLibrary}
-								openError={libraries.openError}
-								createError={libraries.createError}
-								onOpen={libraries.openLibrary}
-								onCreate={libraries.createLibrary}
-								onClearOpenError={libraries.clearOpenError}
-								onClearCreateError={libraries.clearCreateError}
-							/>
-						}
-						actionsSlot={
-							<>
-								<ActivateLibraryButton
-									editingSlug={libraries.editingSlug}
-									editingTitle={editingTitle}
-									activeTitle={activeTitle}
-									isEditingActive={libraries.isEditingActive}
-									isBusy={libraries.isBusy}
-									error={libraries.activateError}
-									onClearError={libraries.clearActivateError}
-									onActivate={libraries.activateLibrary}
-								/>
-								<RenameLibraryModal
-									slug={libraries.editingSlug}
-									currentTitle={editingTitle}
+			{/*
+			 * Mounted here for the same reason as the draft channel above: the screen and its settings
+			 * panel are siblings, and this is the only component that renders both. The row previews
+			 * live in the screen while the breakpoint switcher lives in the panel, so a provider any
+			 * lower would leave the previews unable to see which breakpoint is active.
+			 */}
+			<BreakpointProvider>
+				<AppShell
+					isBlocked={libraries.isSwappingLibrary}
+					header={
+						<AppHeader
+							librarySlot={
+								<LibrarySelector
 									libraries={libraries.libraries}
-									isBusy={libraries.isBusy}
-									error={libraries.renameError}
-									onClearError={libraries.clearRenameError}
-									onRename={libraries.renameLibrary}
-								/>
-								<DeleteLibraryModal
-									editingSlug={libraries.editingSlug}
-									editingTitle={editingTitle}
 									activeSlug={libraries.activeSlug}
-									libraries={libraries.libraries}
+									editingSlug={libraries.editingSlug}
+									editingTitle={editingTitle}
 									isBusy={libraries.isBusy}
-									error={libraries.deleteError}
-									onClearError={libraries.clearDeleteError}
-									onDelete={libraries.deleteLibrary}
+									isSwapping={libraries.isSwappingLibrary}
+									openError={libraries.openError}
+									createError={libraries.createError}
+									onOpen={libraries.openLibrary}
+									onCreate={libraries.createLibrary}
+									onClearOpenError={libraries.clearOpenError}
+									onClearCreateError={libraries.clearCreateError}
 								/>
-							</>
-						}
-					/>
-				}
-				sidebar={
-					<AppSidebar
-						baseStylesNav={baseStylesNav}
-						blockPresetsNav={blockPresetsNav}
-						activeId={activeScreenId}
-						onNavigate={onNavigate}
-					/>
-				}
-				content={<resolution.Component label={label} route={route} navigate={navigate} library={feed} />}
-				settingsPanel={
-					resolution.Component.SettingsPanel && route.item ? (
-						<resolution.Component.SettingsPanel route={route} navigate={navigate} library={feed} />
-					) : null
-				}
-			/>
-			<UnsavedChangesModal
-				isOpen={channel.isGuardOpen}
-				label={channel.publication?.label}
-				isBusy={channel.isGuardBusy}
-				error={channel.guardError}
-				onSave={channel.confirmSave}
-				onDiscard={channel.confirmDiscard}
-				onCancel={channel.cancelGuard}
-			/>
+							}
+							actionsSlot={
+								<>
+									<ActivateLibraryButton
+										editingSlug={libraries.editingSlug}
+										editingTitle={editingTitle}
+										activeTitle={activeTitle}
+										isEditingActive={libraries.isEditingActive}
+										isBusy={libraries.isBusy}
+										error={libraries.activateError}
+										onClearError={libraries.clearActivateError}
+										onActivate={libraries.activateLibrary}
+									/>
+									<RenameLibraryModal
+										slug={libraries.editingSlug}
+										currentTitle={editingTitle}
+										libraries={libraries.libraries}
+										isBusy={libraries.isBusy}
+										error={libraries.renameError}
+										onClearError={libraries.clearRenameError}
+										onRename={libraries.renameLibrary}
+									/>
+									<DeleteLibraryModal
+										editingSlug={libraries.editingSlug}
+										editingTitle={editingTitle}
+										activeSlug={libraries.activeSlug}
+										libraries={libraries.libraries}
+										isBusy={libraries.isBusy}
+										error={libraries.deleteError}
+										onClearError={libraries.clearDeleteError}
+										onDelete={libraries.deleteLibrary}
+									/>
+								</>
+							}
+						/>
+					}
+					sidebar={
+						<AppSidebar
+							baseStylesNav={baseStylesNav}
+							blockPresetsNav={blockPresetsNav}
+							activeId={activeScreenId}
+							onNavigate={onNavigate}
+						/>
+					}
+					content={<resolution.Component label={label} route={route} navigate={navigate} library={feed} />}
+					settingsPanel={
+						resolution.Component.SettingsPanel && route.item ? (
+							<resolution.Component.SettingsPanel route={route} navigate={navigate} library={feed} />
+						) : null
+					}
+				/>
+				<UnsavedChangesModal
+					isOpen={channel.isGuardOpen}
+					label={channel.publication?.label}
+					isBusy={channel.isGuardBusy}
+					error={channel.guardError}
+					onSave={channel.confirmSave}
+					onDiscard={channel.confirmDiscard}
+					onCancel={channel.cancelGuard}
+				/>
+			</BreakpointProvider>
 		</DraftChannelContext.Provider>
 	);
 }

--- a/src/style-library/components/molecules/fields/BoxTokenField.js
+++ b/src/style-library/components/molecules/fields/BoxTokenField.js
@@ -227,9 +227,11 @@ export function BoxTokenField({ field, value, onChange, slots = 'sides' }) {
 	const stored = unitInPlay(atBreakpoint, units[0]);
 
 	// A unit the user picked before typing a number has nowhere to persist — no slot carries it yet
-	// — so it is held here until a value exists to attach it to.
-	const [pendingUnit, setPendingUnit] = useState(null);
-	const unit = pendingUnit ?? stored;
+	// — so it is held here until a value exists to attach it to. Keyed per breakpoint for the same
+	// reason `unlinked` below is: a pending unit picked on one breakpoint must not leak into another
+	// that never chose it, which is what keeps the breakpoints independent.
+	const [pendingUnit, setPendingUnit] = useState({});
+	const unit = pendingUnit[breakpoint] ?? stored;
 	const bounds = boundsForUnit(unit, field);
 
 	// Which breakpoints the user has opened up into slots. Held here rather than inferred from the
@@ -272,7 +274,7 @@ export function BoxTokenField({ field, value, onChange, slots = 'sides' }) {
 			unit={unit}
 			units={units}
 			onUnit={(next) => {
-				setPendingUnit(next);
+				setPendingUnit((current) => ({ ...current, [breakpoint]: next }));
 
 				// Retype whatever is already set, so switching unit moves every literal slot at
 				// once rather than leaving a mix behind the single shared switcher.

--- a/src/style-library/components/molecules/fields/BoxTokenField.js
+++ b/src/style-library/components/molecules/fields/BoxTokenField.js
@@ -1,0 +1,305 @@
+/**
+ * The Style Library's adapter for `src/token-controls`' `BoxControl`.
+ *
+ * The control is host-agnostic by design, which means it speaks the block editor's storage
+ * contract: a slot holds a brace-wrapped alias (`{semantic.dimension.radius-sm}`) or a bare number,
+ * with the unit kept alongside as its own value. This app stores neither — a preset slot is one
+ * composed string, either a bare token id (`semantic.dimension.radius-sm`, as
+ * `presetInitialValues` seeds it) or a literal with its unit baked in (`0.1875rem`).
+ *
+ * Bridging that is this file's whole job, and it is the reason the adapter exists rather than the
+ * registry pointing at `BoxControl` directly:
+ *
+ * - **reading** wraps a bare id into an alias, and splits a literal into its number;
+ * - **writing** unwraps an alias back to a bare id, and rejoins a number with the active unit;
+ * - **the unit** has nowhere of its own to live here, so it is read from whichever slot already
+ *   carries one and re-applied on write. All four slots share it, exactly as the editor's
+ *   measurement control treats a single unit for four sides.
+ *
+ * Note the two meanings of "role" that meet here: `field.role` narrows the *token pool* (only the
+ * radius scale, say), while `slots` picks the control's *geometry*. The registry binds `slots`; a
+ * schema sets `role`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { pickableTokensForType } from '../../../helpers/tokens';
+import {
+	PRESET_BREAKPOINTS,
+	readPresetBreakpoint,
+	resolvePresetBreakpoint,
+	writePresetBreakpoint,
+} from '../../../../token-controls/helpers/preset-envelope';
+import { BoxControl } from '../../../../token-controls/controls/BoxControl';
+import { useBreakpoint } from '../../../../token-controls/context/breakpoint';
+import { parseCssLength } from '../../../../token-controls/helpers/parse-css-length';
+import { isSlotList, readSlot } from '../../../../token-controls/helpers/value-shapes';
+import './BoxTokenField.scss';
+
+/**
+ * The unit a slot list already uses, so a write does not silently retype every other slot.
+ *
+ * @param {*}      value    A scalar or slot list of stored values.
+ * @param {string} fallback The unit to assume when nothing carries one yet.
+ *
+ * @since TBD
+ *
+ * @return {string} The unit in play.
+ */
+function unitInPlay(value, fallback) {
+	const slots = isSlotList(value) ? value : [value];
+
+	for (const slot of slots) {
+		const parsed = parseCssLength(slot);
+
+		if (parsed?.unit) {
+			return parsed.unit;
+		}
+	}
+
+	return fallback;
+}
+
+/**
+ * Convert one stored slot into what the control expects: an alias, a bare number, or ''.
+ *
+ * @param {*} stored The stored slot value.
+ *
+ * @since TBD
+ *
+ * @return {*} The control-shaped value.
+ */
+export function toControlValue(stored) {
+	if (typeof stored !== 'string' || stored === '') {
+		return '';
+	}
+
+	// A bare token id becomes the alias the control matches its pickable list against.
+	if (stored.startsWith('primitive.') || stored.startsWith('semantic.')) {
+		return `{${stored}}`;
+	}
+
+	const parsed = parseCssLength(stored);
+
+	return parsed ? parsed.size : stored;
+}
+
+/**
+ * Convert one control slot back into what a preset stores.
+ *
+ * @param {*}      next The control-shaped value: an alias, a number, or ''.
+ * @param {string} unit The unit to rejoin a bare number with.
+ *
+ * @since TBD
+ *
+ * @return {*} The stored value.
+ */
+export function toStoredValue(next, unit) {
+	if (next === '' || next === undefined || next === null) {
+		return '';
+	}
+
+	if (typeof next === 'string' && next.startsWith('{') && next.endsWith('}')) {
+		return next.slice(1, -1);
+	}
+
+	// Zero stays unitless. The `None` token resolves to a bare `'0'`, so appending a unit here would
+	// rewrite a stored value on a no-op round trip — marking a clean preset dirty and breaking the
+	// equality that decides whether a slot still matches the design system.
+	if (Number(next) === 0) {
+		return '0';
+	}
+
+	return `${next}${unit || ''}`;
+}
+
+/**
+ * The numeric bounds a length field offers, which depend on the unit in play.
+ *
+ * Lifted from how `ResponsiveMeasurementControls` is called for a border radius in the block
+ * editor: a relative unit tops out far lower and steps far finer than an absolute one, so a slider
+ * calibrated for `px` is unusable in `rem`. A schema may override any of the three.
+ *
+ * @param {string} unit  The unit currently in play.
+ * @param {Object} field The field definition, whose own bounds win when given.
+ *
+ * @since TBD
+ *
+ * @return {{min: number, max: number, step: number}} The bounds for this unit.
+ */
+function boundsForUnit(unit, field) {
+	const relative = unit === 'em' || unit === 'rem';
+
+	return {
+		min: field.min ?? 0,
+		max: field.max ?? (relative ? 24 : 500),
+		step: field.step ?? (relative ? 0.1 : 1),
+	};
+}
+
+/**
+ * Every token id a value has bound, so the pool narrowing knows what it must not drop.
+ *
+ * All of them, not just the first: unlinking gives each corner its own slot, so pointing one at a
+ * primitive while the rest still hold a semantic is an ordinary thing to do. Exempting only the first
+ * would drop the semantic from the pool, and the corners still holding it would render their raw
+ * dot-path instead of the token's name.
+ *
+ * @param {*} value The stored scalar or slot list.
+ *
+ * @since TBD
+ *
+ * @return {Array<string>} The bound token ids, empty when nothing is bound.
+ */
+function boundTokenIds(value) {
+	const slots = isSlotList(value) ? value : [value];
+
+	return slots.filter(
+		(slot) => typeof slot === 'string' && (slot.startsWith('primitive.') || slot.startsWith('semantic.'))
+	);
+}
+
+/**
+ * Map a whole value — scalar or slot list — through a per-slot converter.
+ *
+ * @param {*}        value   The scalar or slot list.
+ * @param {Function} convert The per-slot converter.
+ *
+ * @since TBD
+ *
+ * @return {*} The converted value, in the same shape.
+ */
+function mapSlots(value, convert) {
+	return isSlotList(value) ? value.map(convert) : convert(value);
+}
+
+/**
+ * Render a box-shaped token field from a settings schema entry.
+ *
+ * @param {Object}   props                  The component props.
+ * @param {Object}   props.field            The field definition.
+ * @param {string}   props.field.tokenType  The DTCG `$type` the pickable pool is filtered to.
+ * @param {?string}  [props.field.role]     Narrows the pool further to one token role.
+ * @param {?string}  [props.field.label]    The control's label.
+ * @param {boolean}  [props.field.readOnly] Whether the control is non-interactive.
+ * @param {boolean}  [props.field.responsive] Whether the field offers a breakpoint switcher.
+ * @param {?Array}   [props.field.units]    Units the Custom tab offers.
+ * @param {?number}  [props.field.min]      Lowest allowed number on the Custom tab.
+ * @param {?number}  [props.field.max]      Highest allowed number; the slider needs one.
+ * @param {?number}  [props.field.step]     Custom tab increment.
+ * @param {*}        props.value            The stored value: a scalar or a four-slot list.
+ * @param {Function} props.onChange         Called with the next stored value.
+ * @param {string}   [props.slots]          'corners' or 'sides' — the control's geometry.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The field.
+ */
+export function BoxTokenField({ field, value, onChange, slots = 'sides' }) {
+	const units = field.units ?? ['px', 'em', 'rem', '%'];
+	const responsive = field.responsive === true;
+
+	// Shared, not local: switching to Tablet here switches every other responsive control in the panel
+	// with it, matching the block editor.
+	const [breakpoint, setBreakpoint] = useBreakpoint(PRESET_BREAKPOINTS[0]);
+
+	// The breakpoint unwrap wraps the slot conversion rather than sitting inside it: the envelope
+	// holds one whole value per breakpoint — scalar or slot list — so a breakpoint is resolved first
+	// and the four slots are read out of whatever that breakpoint holds.
+	const atBreakpoint = responsive ? readPresetBreakpoint(value, breakpoint) : value;
+	const write = (next) => (responsive ? writePresetBreakpoint(value, breakpoint, next) : next);
+
+	// An unset breakpoint shows what is actually in effect rather than reading as empty, and it inherits
+	// from the next breakpoint up, not straight from desktop: mobile shows the tablet value whenever
+	// tablet is set, because the projected tablet media query also covers mobile widths. Desktop has
+	// nothing above it — a preset's base value is the root of that chain.
+	const onDesktop = !responsive || breakpoint === PRESET_BREAKPOINTS[0];
+	const inheritedFrom = onDesktop
+		? null
+		: resolvePresetBreakpoint(value, PRESET_BREAKPOINTS[PRESET_BREAKPOINTS.indexOf(breakpoint) - 1]);
+
+	const stored = unitInPlay(atBreakpoint, units[0]);
+
+	// A unit the user picked before typing a number has nowhere to persist — no slot carries it yet
+	// — so it is held here until a value exists to attach it to.
+	const [pendingUnit, setPendingUnit] = useState(null);
+	const unit = pendingUnit ?? stored;
+	const bounds = boundsForUnit(unit, field);
+
+	// Which breakpoints the user has opened up into slots. Held here rather than inferred from the
+	// stored shape, because a breakpoint that inherits stores nothing to infer from: unlinking there
+	// produces four empty slots, and an override that sets nothing is not written at all. Tracking the
+	// choice per breakpoint is also what keeps the breakpoints independent — tablet can be edited as
+	// four corners while mobile is still a single value.
+	const [unlinked, setUnlinked] = useState({});
+	const storedIsList = isSlotList(atBreakpoint);
+	const linked = storedIsList ? false : !unlinked[breakpoint];
+
+	const toggleLink = () => {
+		setUnlinked((current) => ({ ...current, [breakpoint]: linked }));
+
+		// Relinking keeps the first slot, matching the control's own rule; there is nothing to fold
+		// when the breakpoint never held a list.
+		if (!linked && storedIsList) {
+			onChange(write(readSlot(atBreakpoint, 0)));
+		}
+	};
+
+	return (
+		<BoxControl
+			value={mapSlots(atBreakpoint, toControlValue)}
+			onChange={(next) => !field.readOnly && onChange(write(mapSlots(next, (slot) => toStoredValue(slot, unit))))}
+			label={field.label}
+			// The inherited value's token has to be exempt from the narrowing too, not just this
+			// breakpoint's own. A breakpoint that inherits binds nothing itself, so without this the
+			// semantic it falls back to is filtered out of the pool and the field, finding no entry for
+			// it, shows nothing at all instead of the value actually in effect.
+			tokens={pickableTokensForType(field.tokenType, field.role, [
+				...boundTokenIds(atBreakpoint),
+				...boundTokenIds(inheritedFrom),
+			]).map((token) => ({
+				...token,
+				alias: `{${token.id}}`,
+			}))}
+			defaultValue={inheritedFrom === null ? undefined : mapSlots(inheritedFrom, toControlValue)}
+			inherited={!onDesktop}
+			unit={unit}
+			units={units}
+			onUnit={(next) => {
+				setPendingUnit(next);
+
+				// Retype whatever is already set, so switching unit moves every literal slot at
+				// once rather than leaving a mix behind the single shared switcher.
+				onChange(
+					write(
+						mapSlots(atBreakpoint, (slot) => {
+							const parsed = parseCssLength(slot);
+
+							return parsed ? `${parsed.size}${next}` : slot;
+						})
+					)
+				);
+			}}
+			role={slots}
+			isLinked={linked}
+			onToggleLink={toggleLink}
+			// Passed explicitly because supplying `onToggleLink` makes the control's link state
+			// caller-owned, which would otherwise turn collapsing off — and this app does collapse: a
+			// uniform slot list round-trips as a scalar, the shape a preset uses for "every slot".
+			collapse
+			breakpoints={responsive ? PRESET_BREAKPOINTS : null}
+			breakpoint={breakpoint}
+			onBreakpointChange={setBreakpoint}
+			disabled={field.readOnly}
+			min={bounds.min}
+			max={bounds.max}
+			step={bounds.step}
+		/>
+	);
+}

--- a/src/style-library/components/molecules/fields/BoxTokenField.scss
+++ b/src/style-library/components/molecules/fields/BoxTokenField.scss
@@ -1,0 +1,12 @@
+@use '../../../styles/mixins' as *;
+
+// `src/token-controls` stays host-agnostic, so `ControlShell` ships its label with layout only and no
+// type treatment. Here that label sits directly beside `FieldLabel`'s (NAME, and every other field in
+// the panel), so it has to read as the same kind of label — via the shared mixin rather than a copy of
+// its values.
+//
+// Scoped to the page body class on purpose: the block editor is expected to adopt the same shell, and
+// an unscoped rule would restyle every editor control label the moment it does.
+body.kadence-blocks-style-library-page .kb-token-control__label {
+	@include small-uppercase-label;
+}

--- a/src/style-library/components/molecules/fields/BoxTokenField.scss
+++ b/src/style-library/components/molecules/fields/BoxTokenField.scss
@@ -3,10 +3,8 @@
 // `src/token-controls` stays host-agnostic, so `ControlShell` ships its label with layout only and no
 // type treatment. Here that label sits directly beside `FieldLabel`'s (NAME, and every other field in
 // the panel), so it has to read as the same kind of label — via the shared mixin rather than a copy of
-// its values.
-//
-// Scoped to the page body class on purpose: the block editor is expected to adopt the same shell, and
-// an unscoped rule would restyle every editor control label the moment it does.
+// its values. Scoped to the page body class on purpose: the block editor is expected to adopt the same
+// shell, and an unscoped rule would restyle every editor control label the moment it does.
 body.kadence-blocks-style-library-page .kb-token-control__label {
 	@include small-uppercase-label;
 }

--- a/src/style-library/components/pages/PresetScreen.js
+++ b/src/style-library/components/pages/PresetScreen.js
@@ -26,6 +26,7 @@ import { EmptyState } from '../molecules/EmptyState';
 import { usePresetScreen } from '../../hooks/use-preset-screen';
 import { useDraftChannel } from '../../hooks/use-draft-channel';
 import { overlayPresetRows } from '../../helpers/presets';
+import { useBreakpoint } from '../../../token-controls/context/breakpoint';
 
 /**
  * Render a preset list screen for whichever block the config names.
@@ -72,7 +73,8 @@ export function PresetScreen({ label, route, navigate, library, preset }) {
 	// this screen's rows.
 	const draft =
 		channel && channel.publication && channel.publication.itemId === route.item ? channel.publication.draft : null;
-	const rows = overlayPresetRows(screen.rows, route.item, draft, library?.values, preset.preview);
+	const [breakpoint] = useBreakpoint();
+	const rows = overlayPresetRows(screen.rows, route.item, draft, library?.values, preset.preview, breakpoint);
 
 	const items = rows.map((row) => ({
 		id: row.id,

--- a/src/style-library/constants/demo-settings-schema.js
+++ b/src/style-library/constants/demo-settings-schema.js
@@ -130,6 +130,14 @@ export const DEMO_SETTINGS_SCHEMA = {
 					leadingIcon: cornerAll,
 				},
 				{
+					// The token-controls `BoxControl` in corner geometry — the replacement for the
+					// `box-sides` entry above, kept alongside it while both exist.
+					type: 'radius',
+					path: 'tokenRadius',
+					label: __('Radius (token control)', 'kadence-blocks'),
+					tokenType: 'dimension',
+				},
+				{
 					// Same shape as Radius, different leading glyph — proving the glyph is schema data.
 					type: 'box-sides',
 					path: 'borderWidth',

--- a/src/style-library/constants/field-types.js
+++ b/src/style-library/constants/field-types.js
@@ -8,6 +8,7 @@
  * Internal dependencies
  */
 import { BoxSidesField } from '../components/molecules/fields/BoxSidesField';
+import { BoxTokenField } from '../components/molecules/fields/BoxTokenField';
 import { ColorField } from '../components/molecules/fields/ColorField';
 import { ColorListField } from '../components/molecules/fields/ColorListField';
 import { NumberUnitField } from '../components/molecules/fields/NumberUnitField';
@@ -20,6 +21,20 @@ import { ToggleField } from '../components/molecules/fields/ToggleField';
 import { TokenColorSelectField } from '../components/molecules/fields/TokenColorSelectField';
 import { TokenSelectField } from '../components/molecules/fields/TokenSelectField';
 import { UnitField } from '../components/molecules/fields/UnitField';
+
+/**
+ * The `radius` field: a box control whose four slots are corners.
+ *
+ * Bound here rather than in a schema so a schema names the property (`type: 'radius'`) instead of
+ * describing an arrangement — geometry is this registry's job, not the author's.
+ *
+ * @param {Object} props The field props from `SettingsForm`.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The field.
+ */
+const RadiusField = (props) => <BoxTokenField {...props} slots="corners" />;
 
 /**
  * The field-type registry: `type` string => field component. Frozen so a consumer can't mutate the
@@ -40,16 +55,27 @@ export const FIELD_TYPES = Object.freeze({
 	'token-select': TokenSelectField,
 	'token-color-select': TokenColorSelectField,
 	'box-sides': BoxSidesField,
+	radius: RadiusField,
 	shadow: ShadowField,
 });
 
 /**
  * The field types a schema may mark `responsive: true`, mirroring the backend's
  * `Schema\Vocabulary\Responsive::is_responsive_capable()` gate (`dimension`/`lineHeight` DTCG
- * types). `token-select`/`token-color-select`/`box-sides` are excluded — their value is a token
- * reference, not a literal a breakpoint override replaces; the rest are excluded because their DTCG
- * types are never responsive-capable.
+ * types). `radius` qualifies: its slots hold `dimension` values, and the envelope stores whatever a
+ * slot holds — an alias overrides per breakpoint just as a literal does.
+ *
+ * `token-select`/`token-color-select`/`box-sides` remain excluded. Those render a single picker with
+ * no breakpoint switcher to drive one, so marking them responsive would write an override no part of
+ * their UI could read back; the rest are excluded because their DTCG types are never
+ * responsive-capable.
  *
  * @since TBD
  */
-export const RESPONSIVE_CAPABLE_FIELD_TYPES = Object.freeze(['number-unit', 'range-number', 'stepper', 'unit']);
+export const RESPONSIVE_CAPABLE_FIELD_TYPES = Object.freeze([
+	'number-unit',
+	'radius',
+	'range-number',
+	'stepper',
+	'unit',
+]);

--- a/src/style-library/hooks/use-presets.js
+++ b/src/style-library/hooks/use-presets.js
@@ -18,6 +18,7 @@ import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
  */
 import { fetchBlockPresets } from '../api/client';
 import { presetInitialValues, presetRows } from '../helpers/presets';
+import { useBreakpoint } from '../../token-controls/context/breakpoint';
 
 /**
  * Fetch a block's preset collection and bind it to row view models.
@@ -93,7 +94,13 @@ export function usePresets(library, preset) {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [namespace, block, slug, version]);
 
-	const rows = useMemo(() => presetRows(payload, library?.values, preview), [payload, library?.values, preview]);
+	// The row previews resolve at the active breakpoint, so switching the panel to Tablet re-renders
+	// every chip with its tablet value rather than leaving them all showing desktop.
+	const [breakpoint] = useBreakpoint();
+	const rows = useMemo(
+		() => presetRows(payload, library?.values, preview, breakpoint),
+		[payload, library?.values, preview, breakpoint]
+	);
 
 	const initialValuesFor = (presetSlug) => presetInitialValues(payload, presetSlug, preset.properties);
 

--- a/src/style-library/presets/button-preset.js
+++ b/src/style-library/presets/button-preset.js
@@ -36,11 +36,13 @@ const TABS = [
  * Another block's rows would preview something else entirely, which is why the generic row mapper
  * takes this as a function rather than reading fixed keys.
  *
- * @param {Record<string, *>}      tokens     The preset's stored token map.
- * @param {Record<string, string>} values     The feed's resolved value map.
- * @param {string}                 breakpoint The breakpoint the row is previewing, so a responsive
- *                                              value resolves to the step being viewed rather than
- *                                              always to desktop.
+ * @param {Record<string, *>}      tokens       The preset's stored token map.
+ * @param {Record<string, string>} values       The feed's resolved value map.
+ * @param {string}                 [breakpoint] The breakpoint to resolve responsive values at —
+ *                                              defaults to desktop. Passed through by both the row
+ *                                              preview and the draft-overlay chip, so either one
+ *                                              shows the step currently being viewed/edited rather
+ *                                              than always falling back to desktop.
  *
  * @since TBD
  *
@@ -115,13 +117,14 @@ function schemaFor(tab) {
 	}
 
 	const radiusPanel = {
-		id: 'radius',
-		title: __('Radius', 'kadence-blocks'),
+		id: 'border-and-shadow',
+		title: __('Border and Shadow', 'kadence-blocks'),
 		fields: [
 			{
-				type: 'token-select',
+				type: 'radius',
 				tokenType: 'dimension',
 				role: 'radius',
+				responsive: true,
 				path: 'tokens.button-radius',
 				label: __('Radius', 'kadence-blocks'),
 			},


### PR DESCRIPTION
Replaces the radius select with the responsive radius field backed by the shared box control, and shares one active breakpoint across the panel and its row previews.

## Test instructions

1. Open a Button preset. Radius is now a **2x2 corner grid** with a breakpoint switcher and a linked/individual toggle.
2. Set different values per corner, save, reload, confirm they persisted.
3. Switch the breakpoint to Tablet and set a different value; confirm Desktop keeps its own, and that Mobile falls back to Tablet rather than jumping to Desktop.
4. Confirm the **row preview updates to the breakpoint you are editing** — the panel and the previews share one active breakpoint, which is the second half of this slice.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4083/phase-12-responsive-radius-field
bun run build-wp
```

The Style Library is at **WP Admin → Kadence → Style Library**. The Button preset screen is under **Block Presets → Button**. Block-editor checks use a **Kadence Single Button** block on any post.
</details>

## Screenshot

Radius as a 2x2 corner box control with breakpoint switcher and link toggle
<img width="1512" height="788" alt="phase-12-responsive-radius-field" src="https://github.com/user-attachments/assets/c0cdb506-47cf-4923-98f9-68f6a0f85c88" />

---

Slice 20 of 23 in the SOFT-4083 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive radius controls for configuring individual or linked corners.
  * Added support for radius tokens, CSS length values, unit changes, and breakpoint-specific overrides.
  * Updated the button preset’s radius settings within the combined “Border and Shadow” panel.
* **Enhancements**
  * Preset previews now update according to the active responsive breakpoint.
  * Improved labels and presentation for token-based controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->