### PR TITLE
[DTM] SOFT-4083 [21/23]: Editor canvas radius control

### DIFF
--- a/src/blocks/singlebtn/components/backend-styles/index.js
+++ b/src/blocks/singlebtn/components/backend-styles/index.js
@@ -172,31 +172,6 @@ export default function BackendStyles(props) {
 	);
 	const previewPaddingUnit = paddingUnit ? paddingUnit : 'px';
 
-	const previewRadiusTop = getPreviewSize(
-		previewDevice,
-		undefined !== borderRadius ? borderRadius[0] : '',
-		undefined !== tabletBorderRadius ? tabletBorderRadius[0] : '',
-		undefined !== mobileBorderRadius ? mobileBorderRadius[0] : ''
-	);
-	const previewRadiusRight = getPreviewSize(
-		previewDevice,
-		undefined !== borderRadius ? borderRadius[1] : '',
-		undefined !== tabletBorderRadius ? tabletBorderRadius[1] : '',
-		undefined !== mobileBorderRadius ? mobileBorderRadius[1] : ''
-	);
-	const previewRadiusBottom = getPreviewSize(
-		previewDevice,
-		undefined !== borderRadius ? borderRadius[2] : '',
-		undefined !== tabletBorderRadius ? tabletBorderRadius[2] : '',
-		undefined !== mobileBorderRadius ? mobileBorderRadius[2] : ''
-	);
-	const previewRadiusLeft = getPreviewSize(
-		previewDevice,
-		undefined !== borderRadius ? borderRadius[3] : '',
-		undefined !== tabletBorderRadius ? tabletBorderRadius[3] : '',
-		undefined !== mobileBorderRadius ? mobileBorderRadius[3] : ''
-	);
-
 	const previewFixedWidth = getPreviewSize(
 		previewDevice,
 		undefined !== width?.[0] ? width[0] : '',
@@ -846,30 +821,21 @@ export default function BackendStyles(props) {
 	if (previewBorderBottomStyle) {
 		css.add_property('border-bottom', previewBorderBottomStyle);
 	}
-	if ('' !== previewRadiusTop) {
-		css.add_property(
-			'border-top-left-radius',
-			css.render_size(previewRadiusTop, borderRadiusUnit ? borderRadiusUnit : 'px')
-		);
-	}
-	if ('' !== previewRadiusRight) {
-		css.add_property(
-			'border-top-right-radius',
-			css.render_size(previewRadiusRight, borderRadiusUnit ? borderRadiusUnit : 'px')
-		);
-	}
-	if ('' !== previewRadiusLeft) {
-		css.add_property(
-			'border-bottom-left-radius',
-			css.render_size(previewRadiusLeft, borderRadiusUnit ? borderRadiusUnit : 'px')
-		);
-	}
-	if ('' !== previewRadiusBottom) {
-		css.add_property(
-			'border-bottom-right-radius',
-			css.render_size(previewRadiusBottom, borderRadiusUnit ? borderRadiusUnit : 'px')
-		);
-	}
+	// `render_measure_output` rather than four manual `render_size` calls: a corner can now be a
+	// design-token alias (the box control's token-pick path), and `render_size` only knows how to
+	// concatenate a number with a unit — it would emit `{alias}px`, invalid CSS, for a picked corner.
+	// `render_measure_output` runs every side through the `kadence.helpers.dimensionValue` filter
+	// first, the same alias-to-`var(--kb-token--…)` resolution the real (PHP-rendered) frontend
+	// already uses via `render_measure_side`, so the editor preview stops disagreeing with the page
+	// it is previewing.
+	css.render_measure_output(
+		borderRadius,
+		tabletBorderRadius,
+		mobileBorderRadius,
+		previewDevice,
+		'border-radius',
+		borderRadiusUnit ? borderRadiusUnit : 'px'
+	);
 	css.add_property(
 		'box-shadow',
 		undefined !== displayShadow &&

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -86,6 +86,7 @@ import BackendStyles from './components/backend-styles';
 import { PresetButton } from '../../extension/preset-picker/PresetButton';
 import { usePresetBinding, resetAttr } from '../../extension/token-indicators';
 import {
+	anyCornerInherited,
 	deriveMeasureMode,
 	inheritedMeasureSlots,
 	measureAttrsForDevice,
@@ -1307,7 +1308,9 @@ export default function KadenceButtonEdit(props) {
 															onDeviceChange={setPreviewDevice}
 															tokens={borderRadiusTokens}
 															defaultValue={inheritedBorderRadius.values}
-															inherited={!!inheritedBorderRadius.inherited}
+															inherited={anyCornerInherited(
+																inheritedBorderRadius.inherited
+															)}
 															state={tokenBinding.borderRadius}
 															onReset={() => resetToken('borderRadius')}
 															isLinked={borderRadiusIsLinked}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -91,8 +91,9 @@ import {
 	measureAttrsForDevice,
 	presetValueForDevice,
 } from '../../extension/token-indicators/normalize';
-import { TokenLabel } from '../../extension/token-indicators/components/TokenLabel';
 import { TokenControlRow } from '../../extension/token-indicators/components/TokenControlRow';
+import { EditorBoxControl } from '../../extension/design-tokens/components/EditorBoxControl';
+import { pickableTokensForControl } from '../../extension/token-picker';
 
 export default function KadenceButtonEdit(props) {
 	const { attributes, setAttributes, isSelected, context, clientId, name } = props;
@@ -317,6 +318,85 @@ export default function KadenceButtonEdit(props) {
 	// Keyed by device: the responsive control keeps ONE mode but writes three attributes, so a choice
 	// made on Tablet must not flip Desktop's corners (and vice versa).
 	const [borderRadiusModeOverride, setBorderRadiusModeOverride] = useState({});
+
+	// Everything the new box control needs that the block already knows, gathered in one place rather
+	// than inlined into the JSX.
+	const { setPreviewDeviceType: setPreviewDevice } = useDispatch('kadenceblocks/data');
+	const borderRadiusTokens = pickableTokensForControl('kadence/singlebtn', 'borderRadius') || [];
+	const borderRadiusIsRelative = borderRadiusUnit === 'em' || borderRadiusUnit === 'rem';
+
+	// The mode describes what THIS device stores, not what it inherits. A breakpoint that stores nothing
+	// has nothing that differs, so it reads as linked — deriving from the inherited corners instead would
+	// split an all-empty Tablet into four identical blank fields, showing a difference the user cannot
+	// see. Where the value comes from is surfaced by the field's popover, not by the link toggle.
+	const borderRadiusIsLinked =
+		'linked' ===
+		(borderRadiusModeOverride[previewDevice] ??
+			deriveMeasureMode(borderRadiusForDevice.value, borderRadiusPresetValue));
+
+	// What the corners inherit, and whether that inheritance is uniform. A per-corner inheritance is the
+	// case where linking is a real change rather than a no-op.
+	const inheritedCorners = Array.isArray(borderRadiusPresetValue)
+		? borderRadiusPresetValue
+		: inheritedBorderRadius.values;
+	const inheritedCornersDiffer =
+		Array.isArray(inheritedCorners) && inheritedCorners.some((corner) => corner !== inheritedCorners[0]);
+	// The preset surface carries resolved literals, not aliases (`blockPresetValues` flattens them so the
+	// overridden-check can be a plain compare), so the literal is matched back to the token that produced
+	// it. Writing the alias keeps the collapsed corner bound to `None` rather than landing as a custom
+	// `0px` that merely happens to look the same.
+	const aliasForValue = (value) => borderRadiusTokens.find((token) => token.value === value)?.alias ?? value ?? '';
+	const inheritedFirstCorner = Array.isArray(inheritedCorners) ? aliasForValue(inheritedCorners[0]) : '';
+
+	const toggleBorderRadiusLink = () => {
+		if (!borderRadiusIsLinked) {
+			const corners = borderRadiusForDevice.value ?? [];
+			const corner = corners[0] ?? '';
+			const isEmpty = corners.every((value) => '' === value || undefined === value);
+
+			if (isEmpty) {
+				// Nothing stored on this device, so ordinarily there is nothing to collapse — the corners
+				// are empty because they inherit, and writing the inherited value would silently pin
+				// Tablet/Mobile to Desktop's current radius. Remember the choice instead.
+				//
+				// Unless what is inherited differs corner to corner: then "link" genuinely changes the
+				// result, and storing nothing would leave the control showing one value while the button
+				// still renders four, with the indicator insisting it matches the preset. Collapsing to
+				// the first corner is the write that makes the three agree.
+				if (!inheritedCornersDiffer) {
+					setBorderRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
+
+					return;
+				}
+
+				setAttributes({
+					[borderRadiusForDevice.attr]: [
+						inheritedFirstCorner,
+						inheritedFirstCorner,
+						inheritedFirstCorner,
+						inheritedFirstCorner,
+					],
+				});
+				setBorderRadiusModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
+
+				return;
+			}
+
+			// Every corner matches the top-left, blank included, and only on the ACTIVE device.
+			setAttributes({ [borderRadiusForDevice.attr]: [corner, corner, corner, corner] });
+			// Equal corners derive linked on their own — except blank ones under a per-corner preset.
+			setBorderRadiusModeOverride((current) => ({
+				...current,
+				[previewDevice]: '' === corner ? 'linked' : undefined,
+			}));
+
+			return;
+		}
+
+		// Unlinking equal corners leaves the values untouched, so remember the choice for this session
+		// AND this device; a differing corner would derive individual on its own.
+		setBorderRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
+	};
 	// The override records a choice made about the PREVIOUS preset's corners, so selecting another preset
 	// drops it — otherwise an explicit "link" would stick and hide a new preset's per-corner radius.
 	useEffect(() => {
@@ -1217,145 +1297,30 @@ export default function KadenceButtonEdit(props) {
 																setAttributes({ mobileBorderStyle: value })
 															}
 														/>
-														<TokenControlRow
-															attr="borderRadius"
-															binding={tokenBinding}
-															stacked
-														>
-															<ResponsiveMeasurementControls
-																label={
-																	<TokenLabel
-																		text={__('Border Radius', 'kadence-blocks')}
-																		attr="borderRadius"
-																		binding={tokenBinding}
-																		onReset={resetToken}
-																		showReset
-																	/>
-																}
-																context={{
-																	blockName: 'kadence/singlebtn',
-																	attribute: 'borderRadius',
-																	defaultValue: inheritedBorderRadius.values,
-																	inheritedDefault: inheritedBorderRadius.inherited,
-																	unit: borderRadiusUnit,
-																	units: ['px', 'em', 'rem', '%'],
-																	onUnit: (value) =>
-																		setAttributes({ borderRadiusUnit: value }),
-																	min: 0,
-																	max:
-																		borderRadiusUnit === 'em' ||
-																		borderRadiusUnit === 'rem'
-																			? 24
-																			: 500,
-																	step:
-																		borderRadiusUnit === 'em' ||
-																		borderRadiusUnit === 'rem'
-																			? 0.1
-																			: 1,
-																}}
-																// The mode describes what THIS device stores, not what it
-																// inherits. A breakpoint that stores nothing has nothing
-																// that differs, so it reads as linked — deriving from the
-																// inherited corners instead would split an all-empty Tablet
-																// into four identical blank fields, showing a difference the
-																// user cannot see. Where the value comes from is surfaced by
-																// the field's popover, not by the link toggle.
-																control={
-																	borderRadiusModeOverride[previewDevice] ??
-																	deriveMeasureMode(
-																		borderRadiusForDevice.value,
-																		borderRadiusPresetValue
-																	)
-																}
-																onChangeControl={(mode) => {
-																	if ('linked' === mode) {
-																		const corners =
-																			borderRadiusForDevice.value ?? [];
-																		const corner = corners[0] ?? '';
-																		const isEmpty = corners.every(
-																			(value) =>
-																				'' === value || undefined === value
-																		);
-
-																		if (isEmpty) {
-																			// Nothing stored on this device, so there is
-																			// nothing to collapse — the corners are empty
-																			// because they inherit, and writing the
-																			// inherited value here would silently pin
-																			// Tablet/Mobile to Desktop's current radius.
-																			// Remember the choice instead, so the control
-																			// links without the corners leaving inherit.
-																			setBorderRadiusModeOverride((current) => ({
-																				...current,
-																				[previewDevice]: 'linked',
-																			}));
-
-																			return;
-																		}
-
-																		// Every corner matches the top-left, blank
-																		// included, and only on the ACTIVE device.
-																		setAttributes({
-																			[borderRadiusForDevice.attr]: [
-																				corner,
-																				corner,
-																				corner,
-																				corner,
-																			],
-																		});
-																		// Equal corners derive linked on their own —
-																		// except blank ones under a per-corner preset.
-																		setBorderRadiusModeOverride((current) => ({
-																			...current,
-																			[previewDevice]:
-																				'' === corner ? 'linked' : undefined,
-																		}));
-																	} else {
-																		// Unlinking equal corners leaves the values
-																		// untouched, so remember the choice for this
-																		// session AND this device; a differing corner
-																		// would derive individual on its own.
-																		setBorderRadiusModeOverride((current) => ({
-																			...current,
-																			[previewDevice]: 'individual',
-																		}));
-																	}
-																}}
-																reset={false}
-																value={borderRadius}
-																tabletValue={tabletBorderRadius}
-																mobileValue={mobileBorderRadius}
-																onChange={(value) =>
-																	setAttributes({ borderRadius: value })
-																}
-																onChangeTablet={(value) =>
-																	setAttributes({ tabletBorderRadius: value })
-																}
-																onChangeMobile={(value) =>
-																	setAttributes({ mobileBorderRadius: value })
-																}
-																unit={borderRadiusUnit}
-																units={['px', 'em', 'rem', '%']}
-																onUnit={(value) =>
-																	setAttributes({ borderRadiusUnit: value })
-																}
-																max={
-																	borderRadiusUnit === 'em' ||
-																	borderRadiusUnit === 'rem'
-																		? 24
-																		: 500
-																}
-																step={
-																	borderRadiusUnit === 'em' ||
-																	borderRadiusUnit === 'rem'
-																		? 0.1
-																		: 1
-																}
-																min={0}
-																isBorderRadius={true}
-																allowEmpty={true}
-															/>
-														</TokenControlRow>
+														<EditorBoxControl
+															label={__('Border Radius', 'kadence-blocks')}
+															value={borderRadiusForDevice.value}
+															onChange={(next) =>
+																setAttributes({ [borderRadiusForDevice.attr]: next })
+															}
+															previewDevice={previewDevice}
+															onDeviceChange={setPreviewDevice}
+															tokens={borderRadiusTokens}
+															defaultValue={inheritedBorderRadius.values}
+															inherited={!!inheritedBorderRadius.inherited}
+															state={tokenBinding.borderRadius}
+															onReset={() => resetToken('borderRadius')}
+															isLinked={borderRadiusIsLinked}
+															onToggleLink={toggleBorderRadiusLink}
+															unit={borderRadiusUnit}
+															units={['px', 'em', 'rem', '%']}
+															onUnit={(value) =>
+																setAttributes({ borderRadiusUnit: value })
+															}
+															min={0}
+															max={borderRadiusIsRelative ? 24 : 500}
+															step={borderRadiusIsRelative ? 0.1 : 1}
+														/>
 														<BoxShadowControl
 															label={__('Box Shadow', 'kadence-blocks')}
 															enable={undefined !== displayShadow ? displayShadow : false}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -282,7 +282,7 @@ export default function KadenceButtonEdit(props) {
 
 	// Design-token indicators: the per-attribute bound/overridden state for the selected preset, plus a
 	// reset that clears the mapped attribute back to the preset value (served by the existing scoped CSS).
-	const tokenBinding = usePresetBinding('kadence/singlebtn', attributes);
+	const tokenBinding = usePresetBinding('kadence/singlebtn', attributes, undefined, previewDevice);
 	const resetToken = (attr) => resetAttr(attr, setAttributes, tokenBinding[attr]?.kind);
 
 	const borderRadiusPresetValue = presetValueForDevice(

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -336,10 +336,12 @@ export default function KadenceButtonEdit(props) {
 			deriveMeasureMode(borderRadiusForDevice.value, borderRadiusPresetValue));
 
 	// What the corners inherit, and whether that inheritance is uniform. A per-corner inheritance is the
-	// case where linking is a real change rather than a no-op.
-	const inheritedCorners = Array.isArray(borderRadiusPresetValue)
-		? borderRadiusPresetValue
-		: inheritedBorderRadius.values;
+	// case where linking is a real change rather than a no-op. Always `inheritedBorderRadius.values`,
+	// never the raw preset value directly: `inheritedMeasureSlots()` already falls through to the
+	// preset's own per-corner slots (`presetSlotAt`) once the device's stored corners run out, so
+	// reading the preset array straight through here would drop any corner this device DOES store —
+	// silently discarding the desktop/tablet cascade for a preset that happens to be per-corner.
+	const inheritedCorners = inheritedBorderRadius.values;
 	const inheritedCornersDiffer =
 		Array.isArray(inheritedCorners) && inheritedCorners.some((corner) => corner !== inheritedCorners[0]);
 	// The preset surface carries resolved literals, not aliases (`blockPresetValues` flattens them so the

--- a/src/extension/design-tokens/components/EditorBoxControl.js
+++ b/src/extension/design-tokens/components/EditorBoxControl.js
@@ -100,11 +100,15 @@ export function EditorBoxControl({
 	role = 'corners',
 }) {
 	const breakpoint = BREAKPOINT_FOR_DEVICE[previewDevice] ?? 'desktop';
+	// Named once and passed to both `BreakpointProvider` and `ControlShell`'s switcher below, so the
+	// two staying in agreement is structural rather than a convention two separate lambdas could drift
+	// out of.
+	const changeBreakpoint = (next) => onDeviceChange(deviceForBreakpoint(next));
 
 	// The provider is handed the editor's device rather than holding one of its own: the device
 	// preview is global here, so a switcher that tracked its own would disagree with the canvas.
 	return (
-		<BreakpointProvider value={breakpoint} onChange={(next) => onDeviceChange(deviceForBreakpoint(next))}>
+		<BreakpointProvider value={breakpoint} onChange={changeBreakpoint}>
 			<BoxControl
 				label={label}
 				value={value}
@@ -125,7 +129,7 @@ export function EditorBoxControl({
 				breakpoint={breakpoint}
 				// The switcher lives in `ControlShell`, driven by this prop directly — it does not read
 				// the `BreakpointProvider` context above, so both must map back to a device the same way.
-				onBreakpointChange={(next) => onDeviceChange(deviceForBreakpoint(next))}
+				onBreakpointChange={changeBreakpoint}
 				unit={unit}
 				units={units}
 				onUnit={onUnit}

--- a/src/extension/design-tokens/components/EditorBoxControl.js
+++ b/src/extension/design-tokens/components/EditorBoxControl.js
@@ -38,6 +38,19 @@ const BREAKPOINT_FOR_DEVICE = {
 };
 
 /**
+ * The editor device name for a control breakpoint key — the inverse of `BREAKPOINT_FOR_DEVICE`.
+ *
+ * @param {string} breakpoint The control's breakpoint key (`desktop`/`tablet`/`mobile`).
+ *
+ * @since TBD
+ *
+ * @return {string} The matching editor device name, defaulting to `Desktop`.
+ */
+function deviceForBreakpoint(breakpoint) {
+	return Object.keys(BREAKPOINT_FOR_DEVICE).find((name) => BREAKPOINT_FOR_DEVICE[name] === breakpoint) ?? 'Desktop';
+}
+
+/**
  * Render a box-shaped token control over the editor's per-device attributes.
  *
  * @param {Object}    props                The component props.
@@ -91,14 +104,7 @@ export function EditorBoxControl({
 	// The provider is handed the editor's device rather than holding one of its own: the device
 	// preview is global here, so a switcher that tracked its own would disagree with the canvas.
 	return (
-		<BreakpointProvider
-			value={breakpoint}
-			onChange={(next) => {
-				const device = Object.keys(BREAKPOINT_FOR_DEVICE).find((name) => BREAKPOINT_FOR_DEVICE[name] === next);
-
-				onDeviceChange(device ?? 'Desktop');
-			}}
-		>
+		<BreakpointProvider value={breakpoint} onChange={(next) => onDeviceChange(deviceForBreakpoint(next))}>
 			<BoxControl
 				label={label}
 				value={value}
@@ -117,6 +123,9 @@ export function EditorBoxControl({
 				role={role}
 				breakpoints={Object.values(BREAKPOINT_FOR_DEVICE)}
 				breakpoint={breakpoint}
+				// The switcher lives in `ControlShell`, driven by this prop directly — it does not read
+				// the `BreakpointProvider` context above, so both must map back to a device the same way.
+				onBreakpointChange={(next) => onDeviceChange(deviceForBreakpoint(next))}
 				unit={unit}
 				units={units}
 				onUnit={onUnit}

--- a/src/extension/design-tokens/components/EditorBoxControl.js
+++ b/src/extension/design-tokens/components/EditorBoxControl.js
@@ -1,0 +1,130 @@
+/**
+ * The block editor's adapter for `src/token-controls`' `BoxControl`.
+ *
+ * The Style Library's adapter bridges a different storage shape; this one bridges the editor's:
+ *
+ * - **breakpoints are sibling attributes**, not one nested envelope — `borderRadius`,
+ *   `tabletBorderRadius`, `mobileBorderRadius` — and which one is being edited is the editor's own
+ *   device preview, owned by its store rather than by the control;
+ * - **a slot is always a four-element array**, never collapsed to a scalar, so the link state cannot
+ *   be read off the value's shape and is caller-owned UI state instead;
+ * - **the unit lives in its own attribute** beside the value.
+ *
+ * Everything the control needs beyond that — the token pool, the inherited preset default, the
+ * binding indicator — the block already computes for its existing control, so this takes them as
+ * props rather than resolving them again and risking a second answer.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { BoxControl, BreakpointProvider } from '../../../token-controls';
+import { TokenIndicator } from '../../token-indicators/components/TokenIndicator';
+
+/**
+ * The control's breakpoint key for an editor device name.
+ *
+ * The editor names its devices `Desktop`/`Tablet`/`Mobile`; the shared control speaks the lowercase
+ * keys the token vocabulary uses. Mapping here keeps that spelling difference out of both.
+ *
+ * @since TBD
+ *
+ * @type {Object<string, string>}
+ */
+const BREAKPOINT_FOR_DEVICE = {
+	Desktop: 'desktop',
+	Tablet: 'tablet',
+	Mobile: 'mobile',
+};
+
+/**
+ * Render a box-shaped token control over the editor's per-device attributes.
+ *
+ * @param {Object}    props                The component props.
+ * @param {string}    props.label          The control's label.
+ * @param {Array}     props.value          The active device's four-slot value.
+ * @param {Function}  props.onChange       Called with the next four-slot value for the active device.
+ * @param {string}    props.previewDevice  The editor's active device (`Desktop`/`Tablet`/`Mobile`).
+ * @param {Function}  props.onDeviceChange Called with the next editor device name.
+ * @param {Array}     props.tokens         The pickable-token list, already resolved by the block.
+ * @param {*}         [props.defaultValue] The inherited preset default for this device.
+ * @param {boolean}   [props.inherited]    Whether that default comes from another breakpoint.
+ * @param {?Object}   [props.state]        The block's own binding state (`{ bound, overridden }`).
+ * @param {?Function} [props.onReset]      Reset handler for the indicator.
+ * @param {boolean}   props.isLinked       Whether the slots are edited together.
+ * @param {Function}  props.onToggleLink   Toggles the link state.
+ * @param {string}    [props.unit]         The unit attribute's current value.
+ * @param {Array}     [props.units]        The selectable units.
+ * @param {Function}  [props.onUnit]       Writes the unit attribute.
+ * @param {number}    [props.min]          Custom tab minimum.
+ * @param {number}    [props.max]          Custom tab maximum.
+ * @param {number}    [props.step]         Custom tab increment.
+ * @param {string}    [props.role]         'corners' or 'sides' — the control's geometry.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The control.
+ */
+export function EditorBoxControl({
+	label,
+	value,
+	onChange,
+	previewDevice,
+	onDeviceChange,
+	tokens,
+	defaultValue,
+	inherited = false,
+	state = null,
+	onReset = null,
+	isLinked,
+	onToggleLink,
+	unit = '',
+	units,
+	onUnit,
+	min,
+	max,
+	step,
+	role = 'corners',
+}) {
+	const breakpoint = BREAKPOINT_FOR_DEVICE[previewDevice] ?? 'desktop';
+
+	// The provider is handed the editor's device rather than holding one of its own: the device
+	// preview is global here, so a switcher that tracked its own would disagree with the canvas.
+	return (
+		<BreakpointProvider
+			value={breakpoint}
+			onChange={(next) => {
+				const device = Object.keys(BREAKPOINT_FOR_DEVICE).find((name) => BREAKPOINT_FOR_DEVICE[name] === next);
+
+				onDeviceChange(device ?? 'Desktop');
+			}}
+		>
+			<BoxControl
+				label={label}
+				value={value}
+				onChange={onChange}
+				tokens={tokens}
+				defaultValue={defaultValue}
+				inherited={inherited}
+				// The editor's own mark, not this library's: it is the same indicator the block's other
+				// controls show, and two marks meaning the same thing should not look different.
+				indicator={<TokenIndicator state={state} onReset={onReset} />}
+				isLinked={isLinked}
+				onToggleLink={onToggleLink}
+				// Never collapse: the attribute is always a four-element array, so folding a uniform
+				// value down to a scalar would write a shape the block cannot read back.
+				collapse={false}
+				role={role}
+				breakpoints={Object.values(BREAKPOINT_FOR_DEVICE)}
+				breakpoint={breakpoint}
+				unit={unit}
+				units={units}
+				onUnit={onUnit}
+				min={min}
+				max={max}
+				step={step}
+				stacked
+			/>
+		</BreakpointProvider>
+	);
+}

--- a/src/extension/design-tokens/components/__tests__/EditorBoxControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorBoxControl.test.js
@@ -1,0 +1,89 @@
+/* eslint-env jest */
+
+/**
+ * Internal dependencies
+ */
+import { EditorBoxControl } from '../EditorBoxControl';
+
+/**
+ * Call `EditorBoxControl` as a plain function and return the `BoxControl`/`BreakpointProvider`
+ * elements it produced. The component holds no hooks of its own, so the returned element tree can
+ * be inspected directly instead of mounting it — matching this file's sibling tests, which inspect
+ * returned element types/props rather than rendering.
+ *
+ * @param {Object} overrides Props to override on top of the defaults.
+ *
+ * @since TBD
+ *
+ * @return {{provider: Object, boxControl: Object, onDeviceChange: Function}} The provider element,
+ *   the `BoxControl` element nested inside it, and the `onDeviceChange` spy passed in.
+ */
+function renderEditorBoxControl(overrides = {}) {
+	const onDeviceChange = jest.fn();
+
+	const props = {
+		label: 'Border Radius',
+		value: ['', '', '', ''],
+		onChange: jest.fn(),
+		previewDevice: 'Desktop',
+		onDeviceChange,
+		tokens: [],
+		isLinked: true,
+		onToggleLink: jest.fn(),
+		...overrides,
+	};
+
+	const provider = EditorBoxControl(props);
+
+	return { provider, boxControl: provider.props.children, onDeviceChange };
+}
+
+describe('EditorBoxControl breakpoint switching', () => {
+	/**
+	 * The switcher rendered by `ControlShell` drives `BoxControl`'s `onBreakpointChange` prop
+	 * directly (see `ControlShell`'s `onClick={() => onBreakpointChange?.(key)}`), not the
+	 * `BreakpointProvider` context above it. `EditorBoxControl` must wire that prop itself, or the
+	 * switcher silently no-ops.
+	 *
+	 * @return {void}
+	 */
+	it('invokes onDeviceChange with the matching device when onBreakpointChange fires', () => {
+		const { boxControl, onDeviceChange } = renderEditorBoxControl();
+
+		boxControl.props.onBreakpointChange('tablet');
+
+		expect(onDeviceChange).toHaveBeenCalledWith('Tablet');
+	});
+
+	/**
+	 * Every control breakpoint key maps back to its editor device name, not just one.
+	 *
+	 * @return {void}
+	 */
+	it('maps every breakpoint key back to its editor device name', () => {
+		const { boxControl, onDeviceChange } = renderEditorBoxControl();
+
+		boxControl.props.onBreakpointChange('mobile');
+		expect(onDeviceChange).toHaveBeenLastCalledWith('Mobile');
+
+		boxControl.props.onBreakpointChange('desktop');
+		expect(onDeviceChange).toHaveBeenLastCalledWith('Desktop');
+
+		boxControl.props.onBreakpointChange('tablet');
+		expect(onDeviceChange).toHaveBeenLastCalledWith('Tablet');
+	});
+
+	/**
+	 * The `BreakpointProvider`'s own `onChange` maps breakpoints back to devices the same way as the
+	 * `onBreakpointChange` prop, using the one shared mapping rather than a second copy of it.
+	 *
+	 * @return {void}
+	 */
+	it('maps the BreakpointProvider onChange consistently with onBreakpointChange', () => {
+		const { provider, onDeviceChange } = renderEditorBoxControl();
+
+		provider.props.onChange('mobile');
+
+		expect(onDeviceChange).toHaveBeenCalledWith('Mobile');
+	});
+});

--- a/src/extension/design-tokens/components/__tests__/EditorBoxControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorBoxControl.test.js
@@ -87,3 +87,48 @@ describe('EditorBoxControl breakpoint switching', () => {
 		expect(onDeviceChange).toHaveBeenCalledWith('Mobile');
 	});
 });
+
+describe('EditorBoxControl device -> breakpoint (forward)', () => {
+	/**
+	 * The editor's `previewDevice` selects the breakpoint both the provider's value and the control
+	 * render at — the direction opposite the switcher callbacks above.
+	 *
+	 * @return {void}
+	 */
+	it.each([
+		['Desktop', 'desktop'],
+		['Tablet', 'tablet'],
+		['Mobile', 'mobile'],
+	])('renders breakpoint %s for previewDevice %s', (previewDevice, breakpoint) => {
+		const { provider, boxControl } = renderEditorBoxControl({ previewDevice });
+
+		expect(provider.props.value).toBe(breakpoint);
+		expect(boxControl.props.breakpoint).toBe(breakpoint);
+	});
+
+	/**
+	 * An unrecognized device (e.g. a future editor device this component does not know about yet)
+	 * degrades to desktop rather than rendering with no breakpoint at all.
+	 *
+	 * @return {void}
+	 */
+	it('falls back to desktop for an unknown preview device', () => {
+		const { provider } = renderEditorBoxControl({ previewDevice: 'Widescreen' });
+
+		expect(provider.props.value).toBe('desktop');
+	});
+});
+
+describe('EditorBoxControl collapse', () => {
+	/**
+	 * The block attribute is always a four-element array, so `BoxControl` must never fold a uniform
+	 * value down to a scalar the block cannot read back.
+	 *
+	 * @return {void}
+	 */
+	it('never collapses a uniform value to a scalar', () => {
+		const { boxControl } = renderEditorBoxControl();
+
+		expect(boxControl.props.collapse).toBe(false);
+	});
+});

--- a/src/extension/token-indicators/__tests__/index.test.js
+++ b/src/extension/token-indicators/__tests__/index.test.js
@@ -1,0 +1,167 @@
+/* eslint-env jest */
+
+// `index.js` also re-exports the indicator store and components, which pull in `@wordpress/data` and
+// the full `@wordpress/components` tree — neither installed/resolvable here and neither exercised by
+// these tests (they only cover the plain functions `index.js` defines directly). Stub the re-exported
+// modules out so loading `index.js` doesn't drag that chain in.
+jest.mock('@kadence/components', () => ({}));
+jest.mock('../store', () => ({ TOKEN_INDICATORS_STORE: 'kadence/token-indicators' }));
+jest.mock('../components/TokenIndicator', () => ({ TokenIndicator: () => null }));
+jest.mock('../components/TokenLabel', () => ({ TokenLabel: () => null }));
+jest.mock('../components/TokenControlRow', () => ({ TokenControlRow: () => null }));
+
+import { usePresetBinding, resetAttrPatch } from '../index';
+
+const BLOCK = 'kadence/singlebtn';
+const SET = 'default';
+
+/**
+ * Seed the localized design-token catalog with one dimension property (`button-radius` ->
+ * `borderRadius`) whose `primary` preset carries a desktop value and a tablet override.
+ *
+ * @return {void}
+ */
+function seedCatalog() {
+	window.kadenceDesignTokensPresets = {
+		active: SET,
+		libraries: {
+			[SET]: {
+				[BLOCK]: {
+					default: 'primary',
+					presets: [{ slug: 'primary', label: 'Primary' }],
+					properties: [
+						{ key: 'button-radius', kind: 'dimension', token: null, control_attr: 'borderRadius' },
+					],
+					values: {
+						primary: { 'button-radius': '4px' },
+					},
+					responsive: {
+						primary: { tablet: { 'button-radius': '8px' } },
+					},
+				},
+			},
+		},
+	};
+}
+
+describe('usePresetBinding device-aware overridden', () => {
+	beforeEach(() => {
+		seedCatalog();
+	});
+
+	afterEach(() => {
+		delete window.kadenceDesignTokensPresets;
+	});
+
+	/**
+	 * On Desktop, a stored value matching the preset's base value reads as bound, not overridden.
+	 *
+	 * @return {void}
+	 */
+	it('reports not overridden when the desktop value matches the preset base value', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			borderRadius: ['4', '4', '4', '4'],
+			borderRadiusUnit: 'px',
+		};
+
+		const state = usePresetBinding(BLOCK, attributes, SET, 'Desktop');
+
+		expect(state.borderRadius.overridden).toBe(false);
+	});
+
+	/**
+	 * On Tablet, the compare uses the tablet attribute against the preset's tablet override, not the
+	 * (empty) desktop attribute against the preset's desktop value — so a tablet-only edit that matches
+	 * the preset's desktop value but not its tablet override is still caught as overridden.
+	 *
+	 * @return {void}
+	 */
+	it('reports overridden when the tablet value differs from the preset tablet override', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			tabletBorderRadius: ['4', '4', '4', '4'],
+			borderRadiusUnit: 'px',
+		};
+
+		const state = usePresetBinding(BLOCK, attributes, SET, 'Tablet');
+
+		expect(state.borderRadius.overridden).toBe(true);
+	});
+
+	/**
+	 * On Tablet, a stored tablet value matching the preset's tablet override reads as bound, not
+	 * overridden.
+	 *
+	 * @return {void}
+	 */
+	it('reports not overridden when the tablet value matches the preset tablet override', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			tabletBorderRadius: ['8', '8', '8', '8'],
+			borderRadiusUnit: 'px',
+		};
+
+		const state = usePresetBinding(BLOCK, attributes, SET, 'Tablet');
+
+		expect(state.borderRadius.overridden).toBe(false);
+	});
+
+	/**
+	 * The returned state is always keyed by the desktop attribute name, even when the compare ran
+	 * against a different device's attribute.
+	 *
+	 * @return {void}
+	 */
+	it('keys the state by the desktop attribute name regardless of the active device', () => {
+		const attributes = { kbPreset: 'primary', tabletBorderRadius: ['8', '8', '8', '8'] };
+
+		const state = usePresetBinding(BLOCK, attributes, SET, 'Tablet');
+
+		expect(Object.keys(state)).toEqual(['borderRadius']);
+	});
+
+	/**
+	 * With no `previewDevice` argument, the compare falls back to the desktop attribute, preserving the
+	 * pre-existing behavior for a caller with no device context (e.g. a block-wide summary).
+	 *
+	 * @return {void}
+	 */
+	it('falls back to the desktop attribute when no previewDevice is given', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			borderRadius: ['4', '4', '4', '4'],
+			borderRadiusUnit: 'px',
+		};
+
+		const state = usePresetBinding(BLOCK, attributes, SET);
+
+		expect(state.borderRadius.overridden).toBe(false);
+	});
+});
+
+describe('resetAttrPatch', () => {
+	/**
+	 * A dimension reset clears the primary, unit, and both responsive companion attributes to their
+	 * block.json default shape, using the same device-attribute spelling `usePresetBinding` reads.
+	 *
+	 * @return {void}
+	 */
+	it('clears the primary, unit, and responsive companions for a dimension', () => {
+		expect(resetAttrPatch('borderRadius', 'dimension')).toEqual({
+			borderRadius: ['', '', '', ''],
+			borderRadiusUnit: 'px',
+			tabletBorderRadius: ['', '', '', ''],
+			mobileBorderRadius: ['', '', '', ''],
+		});
+	});
+
+	/**
+	 * A non-dimension kind clears only its single attribute.
+	 *
+	 * @return {void}
+	 */
+	it('clears only the primary attribute for a non-dimension kind', () => {
+		expect(resetAttrPatch('background', 'color')).toEqual({ background: '' });
+	});
+});

--- a/src/extension/token-indicators/__tests__/normalize.test.js
+++ b/src/extension/token-indicators/__tests__/normalize.test.js
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 import {
+	anyCornerInherited,
 	deriveMeasureMode,
 	inheritedMeasureSlots,
 	measureAttrsForDevice,
@@ -201,6 +202,47 @@ describe('inheritedMeasureSlots', () => {
 		const read = inheritedMeasureSlots('Desktop', { desktop: DESKTOP }, '3px');
 
 		expect(read.values).toEqual(['3px', '3px', '3px', '3px']);
+	});
+});
+
+describe('anyCornerInherited', () => {
+	/**
+	 * On Desktop every corner resolves straight to the preset, so the row-level label must read as
+	 * "Default" rather than "Inherited" — a bare `!!inherited` on the four-element array would report
+	 * `true` here regardless of its contents, which is the bug this guards against.
+	 *
+	 * @return {void}
+	 */
+	it('is false when no corner is inherited', () => {
+		expect(anyCornerInherited([false, false, false, false])).toBe(false);
+	});
+
+	/**
+	 * A mixed row — one corner pulled from another breakpoint, the rest resolved to the preset — still
+	 * counts as inherited, since the control shows only one label for all four corners.
+	 *
+	 * @return {void}
+	 */
+	it('is true when only some corners are inherited', () => {
+		expect(anyCornerInherited([true, false, true, false])).toBe(true);
+	});
+
+	/**
+	 * Every corner inheriting is also reported as inherited.
+	 *
+	 * @return {void}
+	 */
+	it('is true when every corner is inherited', () => {
+		expect(anyCornerInherited([true, true, true, true])).toBe(true);
+	});
+
+	/**
+	 * A missing or malformed array degrades to "not inherited" instead of throwing.
+	 *
+	 * @return {void}
+	 */
+	it('is false for a non-array input', () => {
+		expect(anyCornerInherited(undefined)).toBe(false);
 	});
 });
 

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -20,13 +20,36 @@ import {
 	blockPresetValues,
 	blockPresetResponsive,
 } from '../preset-picker';
-import { isEmptyValue, matchesPreset } from './normalize';
+import { isEmptyValue, matchesPreset, presetValueForDevice } from './normalize';
 import './token-indicators.scss';
 
 export { TOKEN_INDICATORS_STORE } from './store';
 export { TokenIndicator } from './components/TokenIndicator';
 export { TokenLabel } from './components/TokenLabel';
 export { TokenControlRow } from './components/TokenControlRow';
+
+/**
+ * The device-specific attribute name for a dimension control, by the same `tablet${Capitalized}` /
+ * `mobile${Capitalized}` convention `resetAttrPatch` clears — the single spelling, so a reader that
+ * only checks the desktop attribute cannot silently disagree with the one that resets all three.
+ *
+ * @param {string} attr   The desktop attribute name.
+ * @param {string} device The active preview device ('Desktop' | 'Tablet' | 'Mobile'); defaults to
+ *                          desktop for a caller with no device context.
+ *
+ * @since TBD
+ *
+ * @return {string} The attribute the given device stores its value in.
+ */
+function deviceAttrFor(attr, device) {
+	if ('Tablet' !== device && 'Mobile' !== device) {
+		return attr;
+	}
+
+	const capitalized = attr.charAt(0).toUpperCase() + attr.slice(1);
+
+	return `${device.toLowerCase()}${capitalized}`;
+}
 
 /**
  * The companion unit attribute for a dimension control, by convention `${attr}Unit` (e.g. `borderRadius`
@@ -64,16 +87,24 @@ export function mappedAttrsFor(blockName, library) {
 /**
  * The design-token binding state for a block's mapped controls, keyed by the control's attribute name.
  *
- * @param {string} blockName  The block name (e.g. 'kadence/singlebtn').
- * @param {Object} attributes The block's current attributes.
- * @param {string} [library]  The token library slug; defaults to the active library — pass the caller's
- *                            resolved library so the binding can't disagree with the rest of its UI.
+ * @param {string} blockName     The block name (e.g. 'kadence/singlebtn').
+ * @param {Object} attributes    The block's current attributes.
+ * @param {string} [library]     The token library slug; defaults to the active library — pass the
+ *                                caller's resolved library so the binding can't disagree with the
+ *                                rest of its UI.
+ * @param {string} [previewDevice] The active preview device ('Desktop' | 'Tablet' | 'Mobile'); a
+ *                                dimension control reads and reports `overridden` for THIS device's
+ *                                own attribute (`tabletBorderRadius`, not `borderRadius`, on Tablet) —
+ *                                omit it only for a caller with no device context, e.g. a block-wide
+ *                                "is anything overridden" summary that doesn't distinguish devices.
  *
  * @since TBD
  *
  * @return {Object} attrName => { property, token, kind, presetValue, responsive, bound, overridden }.
+ *                   Keyed by the DESKTOP attribute name even when `overridden` reflects another
+ *                   device, so a caller can still look a control up by its one stable key.
  */
-export function usePresetBinding(blockName, attributes, library) {
+export function usePresetBinding(blockName, attributes, library, previewDevice) {
 	const resolvedLibrary = library || activeLibrary();
 	const selected = get(attributes, 'kbPreset', '');
 	const properties = blockProperties(blockName, resolvedLibrary);
@@ -102,21 +133,31 @@ export function usePresetBinding(blockName, attributes, library) {
 
 		const kind = property.kind;
 		const presetValue = presetValues[property.key];
-		const value = get(attributes, attr, '');
+		const propertyBreakpoints = {
+			tablet: get(presetBreakpoints, ['tablet', property.key]),
+			mobile: get(presetBreakpoints, ['mobile', property.key]),
+		};
+
+		// `overridden` compares like against like: a dimension control reads its OWN device's stored
+		// attribute (`tabletBorderRadius` on Tablet), against the preset value in effect at that same
+		// device (its tablet override where the preset declares one, else the base). Comparing a
+		// Tablet-stored value to the desktop preset value — or reporting the desktop attribute's state
+		// while Tablet is open — would show the wrong mark for the device actually being edited.
+		const deviceAttr = kind === 'dimension' ? deviceAttrFor(attr, previewDevice) : attr;
+		const devicePresetValue =
+			kind === 'dimension' ? presetValueForDevice(presetValue, propertyBreakpoints, previewDevice) : presetValue;
+		const value = get(attributes, deviceAttr, '');
 		const unit = unitAttrFor(kind, attr) ? get(attributes, unitAttrFor(kind, attr), '') : '';
 
 		const empty = isEmptyValue(kind, value);
-		const overridden = !empty && !matchesPreset(kind, value, unit, presetValue);
+		const overridden = !empty && !matchesPreset(kind, value, unit, devicePresetValue);
 
 		state[attr] = {
 			property: property.key,
 			token: property.token,
 			kind,
 			presetValue,
-			responsive: {
-				tablet: get(presetBreakpoints, ['tablet', property.key]),
-				mobile: get(presetBreakpoints, ['mobile', property.key]),
-			},
+			responsive: propertyBreakpoints,
 			bound: true,
 			overridden,
 		};
@@ -150,14 +191,13 @@ export function resetAttrPatch(attr, kind) {
 		return { [attr]: '' };
 	}
 
-	const capitalized = attr.charAt(0).toUpperCase() + attr.slice(1);
 	const emptySides = ['', '', '', ''];
 
 	return {
 		[attr]: emptySides,
 		[`${attr}Unit`]: 'px',
-		[`tablet${capitalized}`]: emptySides,
-		[`mobile${capitalized}`]: emptySides,
+		[deviceAttrFor(attr, 'Tablet')]: emptySides,
+		[deviceAttrFor(attr, 'Mobile')]: emptySides,
 	};
 }
 

--- a/src/extension/token-indicators/normalize.js
+++ b/src/extension/token-indicators/normalize.js
@@ -215,6 +215,26 @@ export function inheritedMeasureSlots(device, values = {}, presetValue) {
 }
 
 /**
+ * Whether a measure control's single row-level "Inherited" label should show, given each corner's
+ * own inherited flag from `inheritedMeasureSlots()`.
+ *
+ * The control renders one label for all four corners, so "any corner inherited" is the safer read
+ * than "every corner inherited": a mixed row — one corner pulled from another breakpoint, the rest
+ * resolved straight to the preset — is no longer a plain preset default, and reporting "Default"
+ * would understate that. `inherited` is always a four-element array, so a bare truthiness check on
+ * the array itself is always `true`; this reduces it to the actual per-corner flags instead.
+ *
+ * @param {boolean[]} inherited Per-corner inherited flags, i.e. `inheritedMeasureSlots().inherited`.
+ *
+ * @since TBD
+ *
+ * @return {boolean} Whether any corner inherits from another breakpoint rather than the preset.
+ */
+export function anyCornerInherited(inherited) {
+	return Array.isArray(inherited) && inherited.some(Boolean);
+}
+
+/**
  * The linked/individual mode a measure control should open in, derived from the corners the user would
  * actually see: each stored corner where one is set, otherwise the value that corner inherits from the
  * selected preset.


### PR DESCRIPTION
Renders Border Radius in the block editor with the same shared box control the Style Library uses, so both hosts present the control identically.

## Test instructions

1. In the block editor, select a **Kadence Single Button** and open **Style**.
2. Border Radius now renders as the corner grid with token names and values, matching the Style Library.
3. Set a corner to a token, then to a custom value, and confirm both render on the canvas.
4. Compare side by side with the Style Library's radius field — presenting the same control in both hosts is the point of the slice.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4083/phase-13-editor-radius-box-control
bun run build-wp
```

The Style Library is at **WP Admin → Kadence → Style Library**. The Button preset screen is under **Block Presets → Button**. Block-editor checks use a **Kadence Single Button** block on any post.
</details>

## Screenshot

Border Radius in the block editor, rendered by the shared box control
<img width="1512" height="788" alt="phase-13-editor-radius-box-control" src="https://github.com/user-attachments/assets/c18d21a6-62ca-457e-a145-6899f9eaaa41" />

---

Slice 21 of 23 in the SOFT-4083 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive border-radius controls with linked or individual corner editing.
  * Added token selection, inherited values, units, reset options, and device-specific settings.
  * Improved handling of inherited values across responsive breakpoints.

* **Bug Fixes**
  * Preserved per-device overrides when linking or changing border-radius values.

* **Tests**
  * Added coverage for responsive breakpoint switching and inherited corner values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->