### PR TITLE
[DTM] SOFT-4083 [22/23]: Button preset padding and margin

### DIFF
--- a/includes/blocks/class-kadence-blocks-singlebtn-block.php
+++ b/includes/blocks/class-kadence-blocks-singlebtn-block.php
@@ -15,6 +15,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Palette\Renders_Palette_Attribute;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Identifier;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Preset\Renders_Preset_Classes;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Preset_Resolver;
 use KadenceWP\KadenceBlocks\Utils\Cast;
 
 /**
@@ -131,6 +134,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$css->render_typography( $attributes, 'typography' );
 		$css->render_measure_output( $attributes, 'borderRadius', 'border-radius', [ 'unit_key' => 'borderRadiusUnit' ] );
 		$css->render_border_styles( $attributes, 'borderStyle', true );
+		$this->render_preset_spacing( $css, $attributes );
 		$css->render_measure_output( $attributes, 'padding', 'padding', [ 'unit_key' => 'paddingUnit' ] );
 		$css->render_measure_output( $attributes, 'margin', 'margin', [ 'unit_key' => 'marginUnit' ] );
 		if ( isset( $attributes['displayShadow'] ) && true === $attributes['displayShadow'] ) {
@@ -494,6 +498,64 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		wp_register_script( 'kadence-blocks-glight-video-init', KADENCE_BLOCKS_URL . 'includes/assets/js/kb-glight-video-init.min.js', [ 'kadence-glightbox' ], KADENCE_BLOCKS_VERSION, true );
 		wp_register_script( 'kadence-blocks-popper', KADENCE_BLOCKS_URL . 'includes/assets/js/popper.min.js', [], KADENCE_BLOCKS_VERSION, true );
 		wp_register_script( 'kadence-blocks-tippy', KADENCE_BLOCKS_URL . 'includes/assets/js/kb-tippy.min.js', [ 'kadence-blocks-popper' ], KADENCE_BLOCKS_VERSION, true );
+	}
+
+	/**
+	 * Point padding and margin at their preset variables, but only for a property the active preset
+	 * actually resolves.
+	 *
+	 * The gate is the whole point. `padding: var(--kb-btn-padding)` is not inert when the variable is
+	 * undefined — it is invalid at computed-value time, which resets padding to `0` rather than letting
+	 * the button's size class supply it. Emitting only when the property resolves is what keeps a button
+	 * whose preset sets no spacing looking exactly as it does today.
+	 *
+	 * Emitted before the attribute output so an explicit per-block value, which lands later in the same
+	 * rule, still wins. Responsiveness needs nothing here: a per-breakpoint override redeclares the
+	 * canonical preset variable inside a media query, and this bridge follows it.
+	 *
+	 * @since TBD
+	 *
+	 * @param Kadence_Blocks_CSS   $css        The css object.
+	 * @param array<string, mixed> $attributes The block attributes.
+	 *
+	 * @return void
+	 */
+	private function render_preset_spacing( Kadence_Blocks_CSS $css, array $attributes ): void {
+		try {
+			$registry = kadence_blocks()->get( Token_Registry::class );
+			$library  = kadence_blocks()->get( Active_Token_Library_Store::class );
+			$resolver = kadence_blocks()->get( Preset_Resolver::class );
+
+			// The container is typed `mixed`, and this runs on every button render, so the services are
+			// checked rather than assumed — a misconfigured container degrades to today's spacing.
+			if (
+				! $registry instanceof Token_Registry
+				|| ! $library instanceof Active_Token_Library_Store
+				|| ! $resolver instanceof Preset_Resolver
+				|| ! $registry->is_active()
+			) {
+				return;
+			}
+
+			$slug     = $library->get();
+			$selected = Cast::to_string( $attributes['kbPreset'] ?? '' );
+			$preset   = $selected !== '' && $resolver->has_preset( 'kadence/singlebtn', $selected, $slug )
+				? $selected
+				: $resolver->default_preset( 'kadence/singlebtn', $slug );
+			$values   = $resolver->resolve( 'kadence/singlebtn', $preset, $slug );
+		} catch ( Throwable $e ) {
+			// This runs in the render path, so a broken token graph must not take the page down with it —
+			// the button simply keeps the spacing it has today.
+			return;
+		}
+
+		if ( isset( $values['button-padding'] ) ) {
+			$css->add_property( 'padding', 'var(--kb-btn-padding)' );
+		}
+
+		if ( isset( $values['button-margin'] ) ) {
+			$css->add_property( 'margin', 'var(--kb-btn-margin)' );
+		}
 	}
 
 	/**

--- a/src/blocks/singlebtn/components/backend-styles/index.js
+++ b/src/blocks/singlebtn/components/backend-styles/index.js
@@ -7,6 +7,30 @@ import {
 	getBorderColor,
 	getSpacingOptionOutput,
 } from '@kadence/helpers';
+import { blockDefaultPreset, blockPresetValues } from '../../../../extension/preset-picker';
+
+/**
+ * Whether the button's active preset resolves a padding and/or a margin.
+ *
+ * Reads the same preset surface the inspector does, so the canvas and the panel cannot disagree about
+ * whether a preset carries spacing. A block with no explicit selection follows the block's default
+ * preset, exactly as the server does.
+ *
+ * @param {Object} attributes The block attributes.
+ *
+ * @since TBD
+ *
+ * @return {{padding: boolean, margin: boolean}} Which spacing properties the preset defines.
+ */
+function presetSpacingProperties(attributes) {
+	const preset = attributes?.kbPreset || blockDefaultPreset('kadence/singlebtn');
+	const tokens = blockPresetValues('kadence/singlebtn')?.[preset] ?? {};
+
+	return {
+		padding: 'button-padding' in tokens,
+		margin: 'button-margin' in tokens,
+	};
+}
 
 export default function BackendStyles(props) {
 	const { attributes, isSelected, previewDevice, currentRef, context } = props;
@@ -784,6 +808,26 @@ export default function BackendStyles(props) {
 	}
 	//standard styles
 	css.set_selector(`.kb-single-btn-${uniqueID} .kt-button-${uniqueID}`);
+
+	/*
+	 * Mirrors the front end's gate (`render_preset_spacing` in the block's PHP): point spacing at the
+	 * preset variable, but only for a property the active preset actually resolves.
+	 *
+	 * The condition is load-bearing rather than defensive. `padding: var(--kb-btn-padding)` with the
+	 * variable undefined is invalid at computed-value time, which resets padding to 0 instead of letting
+	 * the button's size class supply it — so emitting unconditionally would flatten every button that has
+	 * no preset spacing. Written before the per-side output below, so an explicit attribute still wins.
+	 */
+	const presetSpacing = presetSpacingProperties(attributes);
+
+	if (presetSpacing.padding) {
+		css.add_property('padding', 'var(--kb-btn-padding)');
+	}
+
+	if (presetSpacing.margin) {
+		css.add_property('margin', 'var(--kb-btn-margin)');
+	}
+
 	if (previewPaddingTop) {
 		css.add_property('padding-top', getSpacingOptionOutput(previewPaddingTop, previewPaddingUnit));
 	}

--- a/src/blocks/singlebtn/components/backend-styles/index.js
+++ b/src/blocks/singlebtn/components/backend-styles/index.js
@@ -7,14 +7,15 @@ import {
 	getBorderColor,
 	getSpacingOptionOutput,
 } from '@kadence/helpers';
-import { blockDefaultPreset, blockPresetValues } from '../../../../extension/preset-picker';
+import { activePresetFor, blockPresetValues } from '../../../../extension/preset-picker';
 
 /**
  * Whether the button's active preset resolves a padding and/or a margin.
  *
  * Reads the same preset surface the inspector does, so the canvas and the panel cannot disagree about
- * whether a preset carries spacing. A block with no explicit selection follows the block's default
- * preset, exactly as the server does.
+ * whether a preset carries spacing. A block with no explicit selection — or one naming a preset that no
+ * longer exists — follows the block's default preset, exactly as the server's `has_preset()` /
+ * `default_preset()` fallback does.
  *
  * @param {Object} attributes The block attributes.
  *
@@ -23,7 +24,7 @@ import { blockDefaultPreset, blockPresetValues } from '../../../../extension/pre
  * @return {{padding: boolean, margin: boolean}} Which spacing properties the preset defines.
  */
 function presetSpacingProperties(attributes) {
-	const preset = attributes?.kbPreset || blockDefaultPreset('kadence/singlebtn');
+	const preset = activePresetFor('kadence/singlebtn', attributes);
 	const tokens = blockPresetValues('kadence/singlebtn')?.[preset] ?? {};
 
 	return {

--- a/src/extension/preset-picker/PresetButton.js
+++ b/src/extension/preset-picker/PresetButton.js
@@ -16,8 +16,7 @@ import { useEffect, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { Icon, check } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
-import { get } from 'lodash';
-import { activeLibrary, blockPresets, blockDefaultPreset } from './index';
+import { activeLibrary, activePresetFor, blockPresets } from './index';
 import { presetIcon, resetIcon } from './icons';
 import { capturedTokens } from './capture';
 import { SavePresetModal } from './SavePresetModal';
@@ -28,19 +27,18 @@ import { mappedAttrsFor, resetAttrPatch, usePresetBinding } from '../token-indic
 import './preset-button.scss';
 
 /**
- * The label for the block's current preset: the selected preset's label, the library's default preset
- * label when none is selected, or a generic "Default" fallback.
+ * The label for a block's resolved preset slug, or a generic "Default" fallback when the slug names no
+ * preset (the default look, or a slug the block does not declare).
  *
- * @param {string} name     The block name.
- * @param {string} library  The token library slug.
- * @param {string} selected The selected preset slug ('' for the default look).
+ * @param {string} name The block name.
+ * @param {string} library The token library slug.
+ * @param {string} slug The resolved preset slug (see `activePresetFor()`), not a raw `kbPreset` value.
  *
  * @since TBD
  *
  * @return {string} The preset label.
  */
-function currentPresetLabel(name, library, selected) {
-	const slug = selected || blockDefaultPreset(name, library);
+function currentPresetLabel(name, library, slug) {
 	const preset = blockPresets(name, library).find((candidate) => candidate.slug === slug);
 
 	return preset?.label || __('Default', 'kadence-blocks');
@@ -82,9 +80,8 @@ export function PresetButton({ blockName, attributes, setAttributes, library }) 
 		return null;
 	}
 
-	const selected = get(attributes, 'kbPreset', '');
-	const currentSlug = selected || blockDefaultPreset(blockName, resolvedLibrary);
-	const label = currentPresetLabel(blockName, resolvedLibrary, selected);
+	const currentSlug = activePresetFor(blockName, attributes, resolvedLibrary);
+	const label = currentPresetLabel(blockName, resolvedLibrary, currentSlug);
 
 	/**
 	 * The setAttributes patch that clears every mapped override back to its preset value, so a control

--- a/src/extension/preset-picker/__tests__/active-preset.test.js
+++ b/src/extension/preset-picker/__tests__/active-preset.test.js
@@ -1,0 +1,74 @@
+/* eslint-env jest */
+
+// `index.js` imports `@kadence/components` (an untransformed ESM module) for its `PresetPicker`
+// component. This file never renders it, so stub the module out.
+jest.mock('@kadence/components', () => ({}));
+
+import { activePresetFor } from '../index';
+
+const BLOCK = 'kadence/singlebtn';
+const SET = 'default';
+
+/**
+ * Seed the localized design-token catalog with a block whose `primary` preset is the declared default
+ * and whose `ghost` preset is a second, non-default option.
+ *
+ * @return {void}
+ */
+function seedCatalog() {
+	window.kadenceDesignTokensPresets = {
+		active: SET,
+		libraries: {
+			[SET]: {
+				[BLOCK]: {
+					default: 'primary',
+					presets: [
+						{ slug: 'primary', label: 'Primary' },
+						{ slug: 'ghost', label: 'Ghost' },
+					],
+					properties: [],
+					values: { primary: {}, ghost: {} },
+				},
+			},
+		},
+	};
+}
+
+describe('activePresetFor', () => {
+	beforeEach(() => {
+		seedCatalog();
+	});
+
+	afterEach(() => {
+		delete window.kadenceDesignTokensPresets;
+	});
+
+	/**
+	 * A `kbPreset` naming a preset the block still declares is trusted as-is.
+	 *
+	 * @return {void}
+	 */
+	it('resolves the explicit selection when it still exists', () => {
+		expect(activePresetFor(BLOCK, { kbPreset: 'ghost' }, SET)).toBe('ghost');
+	});
+
+	/**
+	 * No selection at all falls back to the library's declared default preset.
+	 *
+	 * @return {void}
+	 */
+	it('falls back to the default preset when kbPreset is unset', () => {
+		expect(activePresetFor(BLOCK, {}, SET)).toBe('primary');
+	});
+
+	/**
+	 * A `kbPreset` naming a preset the block no longer declares (e.g. it was deleted) falls back to the
+	 * default, mirroring the PHP resolver's `has_preset()` / `default_preset()` fallback instead of
+	 * being trusted at face value.
+	 *
+	 * @return {void}
+	 */
+	it('falls back to the default preset when kbPreset names a deleted preset', () => {
+		expect(activePresetFor(BLOCK, { kbPreset: 'deleted-preset' }, SET)).toBe('primary');
+	});
+});

--- a/src/extension/preset-picker/capture.js
+++ b/src/extension/preset-picker/capture.js
@@ -8,7 +8,7 @@
  */
 import { get } from 'lodash';
 import { KADENCE_TOKEN_NAMESPACE } from '../../token-controls/helpers/preset-envelope';
-import { activeLibrary, blockProperties, blockPresetValues, blockDefaultPreset } from './index';
+import { activeLibrary, activePresetFor, blockProperties, blockPresetValues } from './index';
 import {
 	normalizeColor,
 	normalizeDimension,
@@ -223,8 +223,7 @@ export function capturedCatalogValues(tokens, library) {
  */
 export function capturedTokens(blockName, library, attributes) {
 	const resolvedLibrary = library || activeLibrary();
-	const selected = get(attributes, 'kbPreset', '');
-	const currentSlug = selected || blockDefaultPreset(blockName, resolvedLibrary);
+	const currentSlug = activePresetFor(blockName, attributes, resolvedLibrary);
 	const presetValues = get(blockPresetValues(blockName, resolvedLibrary), currentSlug, {});
 
 	return blockProperties(blockName, resolvedLibrary).reduce((tokens, property) => {

--- a/src/extension/preset-picker/index.js
+++ b/src/extension/preset-picker/index.js
@@ -134,6 +134,29 @@ export function blockDefaultPreset(name, library) {
 }
 
 /**
+ * The block's active preset slug for a set of attributes: the explicit `kbPreset` selection when it
+ * still names a preset the block declares, otherwise the library's default preset. Mirrors the PHP
+ * resolver's `has_preset()` / `default_preset()` fallback (`Preset_Resolver`), so a `kbPreset` left
+ * over from a deleted preset degrades here the same way it does server-side, instead of every caller
+ * trusting a non-empty string at face value.
+ *
+ * @param {string} name       The block name.
+ * @param {Object} attributes The block's current attributes.
+ * @param {string} [library]  The token library slug; defaults to the active library.
+ *
+ * @since TBD
+ *
+ * @return {string} The resolved preset slug, or '' when the block declares no default either.
+ */
+export function activePresetFor(name, attributes, library) {
+	const resolvedLibrary = library || activeLibrary();
+	const selected = get(attributes, 'kbPreset', '');
+	const exists = selected && blockPresets(name, resolvedLibrary).some((preset) => preset.slug === selected);
+
+	return exists ? selected : blockDefaultPreset(name, resolvedLibrary);
+}
+
+/**
  * Whether a preset slug is a user-created one for a block's library (editable and deletable). A baseline
  * preset, or one that only shadows a baseline preset, is not.
  *

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -15,7 +15,7 @@
 import { get } from 'lodash';
 import {
 	activeLibrary,
-	blockDefaultPreset,
+	activePresetFor,
 	blockProperties,
 	blockPresetValues,
 	blockPresetResponsive,
@@ -106,16 +106,15 @@ export function mappedAttrsFor(blockName, library) {
  */
 export function usePresetBinding(blockName, attributes, library, previewDevice) {
 	const resolvedLibrary = library || activeLibrary();
-	const selected = get(attributes, 'kbPreset', '');
 	const properties = blockProperties(blockName, resolvedLibrary);
 	const values = blockPresetValues(blockName, resolvedLibrary);
 	const responsive = blockPresetResponsive(blockName, resolvedLibrary);
 
 	// The preset whose surface drives the indicators: the explicit selection, or the set's authoritative
-	// default preset when none is chosen (kbPreset is '' on every freshly inserted block, so this
-	// fallback runs constantly and must use the catalog's declared default, not JSON key order). When
-	// neither resolves, no control is bound.
-	const activePreset = selected || blockDefaultPreset(blockName, resolvedLibrary);
+	// default preset when none is chosen or the selection no longer exists (kbPreset is '' on every
+	// freshly inserted block, so this fallback runs constantly and must use the catalog's declared
+	// default, not JSON key order). When neither resolves, no control is bound.
+	const activePreset = activePresetFor(blockName, attributes, resolvedLibrary);
 	const presetValues = get(values, activePreset, {});
 	const presetBreakpoints = get(responsive, activePreset, {});
 

--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -261,7 +261,15 @@ describe('presetInitialValues', () => {
 		window.kadenceDesignTokens = {
 			presets: {
 				'kadence/singlebtn': {
-					properties: ['button-bg', 'button-text', 'button-bg-hover', 'button-text-hover', 'button-radius'],
+					properties: [
+						'button-bg',
+						'button-text',
+						'button-bg-hover',
+						'button-text-hover',
+						'button-radius',
+						'button-padding',
+						'button-margin',
+					],
 				},
 			},
 		};
@@ -271,7 +279,7 @@ describe('presetInitialValues', () => {
 		delete window.kadenceDesignTokens;
 	});
 
-	it('seeds all five bound properties as bare ids', () => {
+	it('seeds every bound property as a bare id', () => {
 		const payload = {
 			presets: {
 				primary: {
@@ -295,6 +303,10 @@ describe('presetInitialValues', () => {
 				'button-bg-hover': 'semantic.color.action-primary-hover',
 				'button-text-hover': 'semantic.color.on-primary',
 				'button-radius': '0.5rem',
+				// Bound but unvalued by this preset, so they seed empty — the shape that keeps a button's
+				// spacing owned by its size class until someone sets one.
+				'button-padding': '',
+				'button-margin': '',
 			},
 		});
 	});
@@ -575,7 +587,13 @@ describe('BUTTON_PRESET.schemaFor', () => {
 		const schema = BUTTON_PRESET.schemaFor('normal');
 		const paths = schema.panels.flatMap((panel) => panel.fields.map((field) => field.path));
 
-		expect(paths).toEqual(['tokens.button-text', 'tokens.button-bg', 'tokens.button-radius']);
+		expect(paths).toEqual([
+			'tokens.button-text',
+			'tokens.button-bg',
+			'tokens.button-radius',
+			'tokens.button-padding',
+			'tokens.button-margin',
+		]);
 
 		const radiusField = schema.panels
 			.flatMap((panel) => panel.fields)

--- a/src/style-library/constants/demo-settings-schema.js
+++ b/src/style-library/constants/demo-settings-schema.js
@@ -138,6 +138,13 @@ export const DEMO_SETTINGS_SCHEMA = {
 					tokenType: 'dimension',
 				},
 				{
+					// The same control in side geometry, which is what padding and margin use.
+					type: 'spacing',
+					path: 'tokenSpacing',
+					label: __('Spacing (token control)', 'kadence-blocks'),
+					tokenType: 'dimension',
+				},
+				{
 					// Same shape as Radius, different leading glyph — proving the glyph is schema data.
 					type: 'box-sides',
 					path: 'borderWidth',
@@ -181,6 +188,7 @@ export const DEMO_SETTINGS_VALUES = {
 	tokenColor: '',
 	stateColors: { text: '#1e1e1e', bg: '#2271b1' },
 	radius: '',
+	tokenSpacing: '',
 	borderWidth: '',
 	spacing: '',
 	enabled: true,

--- a/src/style-library/constants/field-types.js
+++ b/src/style-library/constants/field-types.js
@@ -1,7 +1,7 @@
 /**
  * The settings-field type vocabulary: the single source of truth mapping a schema field's `type`
  * string to the component that renders it. Every per-screen settings schema authors against these
- * thirteen strings; `helpers/settings-schema.js`'s `fieldComponentFor` is the only reader.
+ * fourteen strings; `helpers/settings-schema.js`'s `fieldComponentFor` is the only reader.
  */
 
 /**
@@ -37,6 +37,20 @@ import { UnitField } from '../components/molecules/fields/UnitField';
 const RadiusField = (props) => <BoxTokenField {...props} slots="corners" />;
 
 /**
+ * The `spacing` field: a box control whose four slots are sides.
+ *
+ * Same control as `radius`, different geometry — padding and margin name edges where a radius names
+ * corners. Bound here for the same reason: a schema names the property, not the arrangement.
+ *
+ * @param {Object} props The field props from `SettingsForm`.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The field.
+ */
+const SpacingField = (props) => <BoxTokenField {...props} slots="sides" />;
+
+/**
  * The field-type registry: `type` string => field component. Frozen so a consumer can't mutate the
  * vocabulary at runtime.
  *
@@ -56,14 +70,15 @@ export const FIELD_TYPES = Object.freeze({
 	'token-color-select': TokenColorSelectField,
 	'box-sides': BoxSidesField,
 	radius: RadiusField,
+	spacing: SpacingField,
 	shadow: ShadowField,
 });
 
 /**
  * The field types a schema may mark `responsive: true`, mirroring the backend's
  * `Schema\Vocabulary\Responsive::is_responsive_capable()` gate (`dimension`/`lineHeight` DTCG
- * types). `radius` qualifies: its slots hold `dimension` values, and the envelope stores whatever a
- * slot holds — an alias overrides per breakpoint just as a literal does.
+ * types). `radius` and `spacing` qualify: their slots hold `dimension` values, and the envelope stores
+ * whatever a slot holds — an alias overrides per breakpoint just as a literal does.
  *
  * `token-select`/`token-color-select`/`box-sides` remain excluded. Those render a single picker with
  * no breakpoint switcher to drive one, so marking them responsive would write an override no part of
@@ -75,6 +90,7 @@ export const FIELD_TYPES = Object.freeze({
 export const RESPONSIVE_CAPABLE_FIELD_TYPES = Object.freeze([
 	'number-unit',
 	'radius',
+	'spacing',
 	'range-number',
 	'stepper',
 	'unit',

--- a/src/style-library/presets/button-preset.js
+++ b/src/style-library/presets/button-preset.js
@@ -131,7 +131,32 @@ function schemaFor(tab) {
 		],
 	};
 
-	return { panels: [colorPanel, radiusPanel] };
+	// Normal only, like the radius panel: neither property has a hover counterpart, so a field on the
+	// Hover tab would write something `guard_surface` rejects.
+	const spacingPanel = {
+		id: 'spacing',
+		title: __('Spacing', 'kadence-blocks'),
+		fields: [
+			{
+				type: 'spacing',
+				tokenType: 'dimension',
+				role: 'spacing',
+				responsive: true,
+				path: 'tokens.button-padding',
+				label: __('Padding', 'kadence-blocks'),
+			},
+			{
+				type: 'spacing',
+				tokenType: 'dimension',
+				role: 'spacing',
+				responsive: true,
+				path: 'tokens.button-margin',
+				label: __('Margin', 'kadence-blocks'),
+			},
+		],
+	};
+
+	return { panels: [colorPanel, radiusPanel, spacingPanel] };
 }
 
 /**


### PR DESCRIPTION
Adds the responsive Padding and Margin fields to the button preset and renders them on the block, only when the preset sets them. Binds to the declarations in the PHP slice at the bottom of this stack.

## Test instructions

1. Open a Button preset — **Spacing** now has Padding and Margin, both responsive, both empty.
2. Set a padding, save, and confirm the button changes **both in the editor canvas and on the front end**.
3. Clear it again and confirm the button returns to its size/style padding rather than to zero — spacing is rendered *only* when the preset sets it, which is the part most likely to break.
4. Repeat for Margin, and check one non-desktop breakpoint.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4083/phase-14-button-spacing
bun run build-wp
```

The Style Library is at **WP Admin → Kadence → Style Library**. The Button preset screen is under **Block Presets → Button**. Block-editor checks use a **Kadence Single Button** block on any post.
</details>

## Screenshot

Spacing section with Padding and Margin fields, both unset
<img width="1512" height="788" alt="phase-14-button-spacing" src="https://github.com/user-attachments/assets/c9f846a2-c6e4-47ac-b762-42fb2196208e" />

---

Slice 22 of 23 in the SOFT-4083 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added responsive spacing controls for button presets, including padding and margin.
  - Button styles now support preset-defined spacing while preserving explicit per-side overrides.
  - Added spacing token support to the style library and demo settings.
  - Preset spacing can automatically apply to buttons in both editing and published views.
  - Added safeguards so invalid or unavailable preset data leaves existing spacing unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->