### PR TITLE
[DTM] SOFT-4083 [24/24]: Loading skeletons

### DIFF
--- a/src/style-library/__tests__/preset-screen.test.js
+++ b/src/style-library/__tests__/preset-screen.test.js
@@ -24,9 +24,9 @@ jest.mock('../hooks/use-preset-screen', () => ({
 // `jest.config.js` maps the `@wordpress/components` specifier to the copy nested under
 // `@kadence/components/node_modules`, which resolves its own nested `react`/`react-dom` — a
 // different module instance than the top-level `react-dom/client` this test renders with. Mounting
-// a real `Button`/`Notice`/`Spinner` from that nested copy under the top-level renderer trips
-// React's "Invalid hook call" guard. Simple stand-ins sidestep the cross-copy mismatch; this test
-// only needs to tell the loading/empty/populated states apart, not exercise the real controls.
+// a real `Button`/`Notice` from that nested copy under the top-level renderer trips React's
+// "Invalid hook call" guard. Simple stand-ins sidestep the cross-copy mismatch; this test only
+// needs to tell the loading/empty/populated states apart, not exercise the real controls.
 // The screen reads its draft overlay and its selection guard off this hook. Stubbed per test so
 // the overlay branch (which needs a publication for the open item) and the guard branch are
 // reachable without standing up the real provider.
@@ -37,7 +37,6 @@ jest.mock('../hooks/use-draft-channel', () => ({
 jest.mock('@wordpress/components', () => ({
 	Button: ({ children, ...props }) => <button {...props}>{children}</button>,
 	Notice: ({ children, isDismissible, ...props }) => <div {...props}>{children}</div>,
-	Spinner: (props) => <div className="components-spinner" {...props} />,
 }));
 
 // `@wordpress/primitives` (which `@wordpress/icons`'s `Icon`/`SVG` build on) nests its own `react`
@@ -107,33 +106,33 @@ afterEach(() => {
 
 describe('PresetScreen loading state', () => {
 	/**
-	 * While `usePresetScreen` is still fetching, the screen must show a busy indicator instead of
-	 * the empty state — `usePresetScreen` starts with `isLoading: true` and no rows, and rendering
-	 * the empty state at that point would flash "Add Button" before the presets arrive.
+	 * While `usePresetScreen` is still fetching, the screen must show a row-shaped skeleton instead
+	 * of the empty state — `usePresetScreen` starts with `isLoading: true` and no rows, and
+	 * rendering the empty state at that point would flash "Add Button" before the presets arrive.
 	 *
 	 * @return {void}
 	 */
-	it('renders a spinner instead of the empty state while loading', () => {
+	it('renders a skeleton instead of the empty state while loading', () => {
 		renderPresetScreen({ payload: null, isLoading: true, loadError: null, rows: [], initialValuesFor: () => ({}) });
 
-		expect(container.querySelector('.components-spinner')).not.toBeNull();
+		expect(container.querySelectorAll('.kadence-blocks-style-library__skeleton').length).toBeGreaterThan(0);
 		expect(container.querySelector('.kadence-blocks-style-library__empty-state')).toBeNull();
 	});
 
 	/**
-	 * Once loading finishes with no rows, the empty state renders in place of the spinner.
+	 * Once loading finishes with no rows, the empty state renders in place of the skeleton.
 	 *
 	 * @return {void}
 	 */
 	it('renders the empty state once loading finishes with no rows', () => {
 		renderPresetScreen({ payload: {}, isLoading: false, loadError: null, rows: [], initialValuesFor: () => ({}) });
 
-		expect(container.querySelector('.components-spinner')).toBeNull();
+		expect(container.querySelector('.kadence-blocks-style-library__skeleton')).toBeNull();
 		expect(container.querySelector('.kadence-blocks-style-library__empty-state')).not.toBeNull();
 	});
 
 	/**
-	 * Once loading finishes with rows present, neither the spinner nor the empty state renders.
+	 * Once loading finishes with rows present, neither the skeleton nor the empty state renders.
 	 *
 	 * @return {void}
 	 */
@@ -148,7 +147,7 @@ describe('PresetScreen loading state', () => {
 
 		renderPresetScreen({ payload: {}, isLoading: false, loadError: null, rows, initialValuesFor: () => ({}) });
 
-		expect(container.querySelector('.components-spinner')).toBeNull();
+		expect(container.querySelector('.kadence-blocks-style-library__skeleton')).toBeNull();
 		expect(container.querySelector('.kadence-blocks-style-library__empty-state')).toBeNull();
 		expect(container.querySelector('.kadence-blocks-style-library__row-list')).not.toBeNull();
 	});

--- a/src/style-library/__tests__/preset-screen.test.js
+++ b/src/style-library/__tests__/preset-screen.test.js
@@ -35,7 +35,8 @@ jest.mock('../hooks/use-draft-channel', () => ({
 }));
 
 jest.mock('@wordpress/components', () => ({
-	Button: ({ children, ...props }) => <button {...props}>{children}</button>,
+	// `isBusy` is a `Button` prop, not a DOM attribute — drop it so React does not warn about it.
+	Button: ({ children, isBusy, ...props }) => <button {...props}>{children}</button>,
 	Notice: ({ children, isDismissible, ...props }) => <div {...props}>{children}</div>,
 }));
 

--- a/src/style-library/components/atoms/Skeleton.js
+++ b/src/style-library/components/atoms/Skeleton.js
@@ -1,0 +1,36 @@
+/**
+ * A single shimmering placeholder shape, used to build screen-level loading skeletons (a preset
+ * row, a swatch card, …). Purely decorative — `PresetScreen`/`ColorPaletteScreen` wrap the
+ * composed skeleton in its own `role="status"`/`aria-live` container, so this atom marks itself
+ * `aria-hidden` and carries no accessible name of its own.
+ */
+
+/**
+ * Internal dependencies
+ */
+import './Skeleton.scss';
+
+/**
+ * Render one skeleton placeholder shape.
+ *
+ * @param {Object} [props]           The component props.
+ * @param {string} [props.className] An additional class name — typically a real layout class (e.g.
+ *                                   `list-row-label`) so the shape inherits that column's exact
+ *                                   width instead of a duplicated literal.
+ * @param {Object} [props.style]     Inline style, e.g. a `width`/`height` pinned to a shared size
+ *                                   token (`var(--kb-sl-size-row-preview)`) for a shape with no
+ *                                   layout class of its own to borrow from.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The placeholder shape.
+ */
+export function Skeleton({ className = '', style }) {
+	return (
+		<span
+			className={`kadence-blocks-style-library__skeleton ${className}`.trim()}
+			style={style}
+			aria-hidden="true"
+		/>
+	);
+}

--- a/src/style-library/components/atoms/Skeleton.scss
+++ b/src/style-library/components/atoms/Skeleton.scss
@@ -1,0 +1,42 @@
+// The shimmer sweep. Named locally rather than as a shared root-level keyframe — nothing else in
+// the app animates yet, so there is no existing convention to fold this into.
+@keyframes kadence-blocks-style-library-skeleton-shimmer {
+	100% {
+		transform: translateX(100%);
+	}
+}
+
+.kadence-blocks-style-library__skeleton {
+	position: relative;
+	display: block;
+	overflow: hidden;
+	border-radius: var(--kb-sl-radius-m);
+	background: var(--kb-sl-color-gray-100);
+
+	// The moving highlight, layered on top rather than animating `background-position` on the base
+	// element — a pseudo-element keeps the base fill's own color intact underneath the sweep.
+	&::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		transform: translateX(-100%);
+		background: linear-gradient(90deg, transparent, var(--kb-sl-color-white) 50%, transparent);
+		opacity: 0.5;
+		animation: kadence-blocks-style-library-skeleton-shimmer 1.6s ease-in-out infinite;
+	}
+}
+
+// A deliberately-added animation, so it needs its own reduced-motion guard — nothing else in this
+// app animates today. The base gray fill still communicates "loading" with the motion off.
+@media (prefers-reduced-motion: reduce) {
+	.kadence-blocks-style-library__skeleton::after {
+		animation: none;
+	}
+}
+
+// A text-line-shaped bar, for a skeleton combined with a real column class (e.g. `.list-row-label`,
+// `.swatch-card-name`) so it inherits that class's exact width instead of a duplicated literal —
+// only the height is this modifier's own, reusing the line-height ramp rather than a new value.
+.kadence-blocks-style-library__skeleton--bar {
+	height: var(--kb-sl-line-height-s);
+}

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -10,7 +10,7 @@
  * WordPress dependencies
  */
 import { useMemo, useState } from '@wordpress/element';
-import { Button, DropdownMenu, MenuGroup, MenuItem, Notice, Spinner } from '@wordpress/components';
+import { Button, DropdownMenu, MenuGroup, MenuItem, Notice } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { moreVertical, plus } from '@wordpress/icons';
 
@@ -22,6 +22,7 @@ import { ScreenHeader } from '../organisms/ScreenHeader';
 import { SwatchGrid } from '../organisms/SwatchGrid';
 import { SelectDropdown } from '../molecules/SelectDropdown';
 import { EmptyState } from '../molecules/EmptyState';
+import { Skeleton } from '../atoms/Skeleton';
 import { ActivatePaletteButton } from '../organisms/ActivatePaletteButton';
 import { CreatePaletteModal } from '../organisms/CreatePaletteModal';
 import { RenamePaletteModal } from '../organisms/RenamePaletteModal';
@@ -38,6 +39,56 @@ import {
 } from '../../helpers/palettes';
 import { ColorPaletteSettings } from './ColorPaletteSettings';
 import './ColorPaletteScreen.scss';
+
+// A fixed count, not derived from anything — there is no "expected swatch count" to read before
+// the real palette arrives, so this just needs to fill a group row plausibly.
+const SKELETON_SWATCH_IDS = [0, 1, 2, 3, 4, 5];
+
+/**
+ * The palette loading placeholder: one group heading and a row of swatch-card-shaped skeletons in
+ * the real `SwatchGrid` markup (`.swatch-grid` / `.swatch-group` / `.swatch-card`), so the loading
+ * shape matches the grid it is about to be replaced by instead of collapsing the screen to a
+ * single centered spinner.
+ *
+ * @param {Object} props       The component props.
+ * @param {string} props.label The screen's nav label, used to build the busy-region's accessible name.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The swatch-grid-shaped skeleton.
+ */
+function SwatchGridSkeleton({ label }) {
+	return (
+		<div
+			className="kadence-blocks-style-library__swatch-grid"
+			role="status"
+			aria-live="polite"
+			aria-busy="true"
+			aria-label={sprintf(
+				// translators: %s: the palette screen's label (e.g. "Color Palette").
+				__('Loading %s…', 'kadence-blocks'),
+				label
+			)}
+		>
+			<div className="kadence-blocks-style-library__swatch-group">
+				{/* No real heading class carries a width of its own — `SectionHeading`'s width is
+				 * whatever its text measures — so this bar's width is a plain literal, not a reused
+				 * layout value. */}
+				<Skeleton className="kadence-blocks-style-library__skeleton--bar" style={{ width: '8rem' }} />
+				<div className="kadence-blocks-style-library__swatch-group-row">
+					{SKELETON_SWATCH_IDS.map((id) => (
+						<div key={id} className="kadence-blocks-style-library__swatch-card">
+							<div className="kadence-blocks-style-library__swatch-card-main">
+								<Skeleton className="kadence-blocks-style-library__swatch-card-preview" />
+								<Skeleton className="kadence-blocks-style-library__swatch-card-name kadence-blocks-style-library__skeleton--bar" />
+							</div>
+						</div>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}
 
 /**
  * The fill for a swatch's preview slot: the swatch's raw `$value`, or a neutral gray-100 fallback
@@ -188,7 +239,7 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 				}
 			/>
 			{palettes.isLoading ? (
-				<Spinner />
+				<SwatchGridSkeleton label={label} />
 			) : palettes.palette ? (
 				<>
 					{/* Suppressed while the add-group, rename-group, or delete-group modal is open —

--- a/src/style-library/components/pages/PresetScreen.js
+++ b/src/style-library/components/pages/PresetScreen.js
@@ -15,6 +15,7 @@
  * WordPress dependencies
  */
 import { Button, Notice } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 
@@ -92,23 +93,36 @@ export function PresetScreen({ label, route, navigate, library, preset }) {
 	const screen = usePresetScreen(library, preset);
 	const channel = useDraftChannel();
 
+	const [isAdding, setIsAdding] = useState(false);
+
 	// `createPresetFlow` (`helpers/preset-flows.js`) records the failure via `screen.addError` (the
 	// Notice rendered below) and re-throws pessimistically for callers that need the rejection; this
 	// `.catch()` only stops that rethrow from surfacing as an unhandled promise rejection, it does
-	// not report the error a second time.
-	const mintPreset = () =>
-		screen
+	// not report the error a second time. Disabling the button is a UI guard, not a real one — a
+	// stale click (e.g. a keyboard Enter racing the disabled-attribute repaint) could otherwise
+	// still start a second create.
+	const mintPreset = () => {
+		if (screen.isBusy) {
+			return Promise.resolve();
+		}
+
+		setIsAdding(true);
+
+		return screen
 			.addPreset()
 			.then((id) => navigate({ item: id }))
-			.catch(() => {});
+			.catch(() => {})
+			.finally(() => setIsAdding(false));
+	};
 	const addAction = (
 		<Button
 			icon={plus}
 			variant="secondary"
+			isBusy={isAdding}
 			disabled={screen.isBusy}
 			onClick={() => (channel ? channel.guard(mintPreset) : mintPreset())}
 		>
-			{preset.addLabel}
+			{isAdding ? __('Adding…', 'kadence-blocks') : preset.addLabel}
 		</Button>
 	);
 

--- a/src/style-library/components/pages/PresetScreen.js
+++ b/src/style-library/components/pages/PresetScreen.js
@@ -14,7 +14,8 @@
 /**
  * WordPress dependencies
  */
-import { Button, Notice, Spinner } from '@wordpress/components';
+import { Button, Notice } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 
 /**
@@ -23,10 +24,53 @@ import { plus } from '@wordpress/icons';
 import { ScreenHeader } from '../organisms/ScreenHeader';
 import { RowList } from '../templates/RowList';
 import { EmptyState } from '../molecules/EmptyState';
+import { Skeleton } from '../atoms/Skeleton';
 import { usePresetScreen } from '../../hooks/use-preset-screen';
 import { useDraftChannel } from '../../hooks/use-draft-channel';
 import { overlayPresetRows } from '../../helpers/presets';
 import { useBreakpoint } from '../../../token-controls/context/breakpoint';
+
+// A fixed count, not derived from anything — there is no "expected row count" to read before the
+// real rows arrive, so this just needs to fill the screen plausibly.
+const SKELETON_ROW_IDS = [0, 1, 2, 3];
+
+/**
+ * The preset-list loading placeholder: a few row-shaped skeletons in the real `RowList` markup
+ * (`.row-list` / `.list-row` / `.list-row-main`), so the loading shape matches the rows it is about
+ * to be replaced by instead of collapsing the screen to a single centered spinner.
+ *
+ * @param {Object} props       The component props.
+ * @param {string} props.label The screen's nav label, used to build the busy-region's accessible name.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The row-shaped skeleton list.
+ */
+function PresetRowsSkeleton({ label }) {
+	return (
+		<ul
+			className="kadence-blocks-style-library__row-list"
+			role="status"
+			aria-live="polite"
+			aria-busy="true"
+			aria-label={sprintf(
+				// translators: %s: the preset screen's label (e.g. "Button").
+				__('Loading %s…', 'kadence-blocks'),
+				label
+			)}
+		>
+			{SKELETON_ROW_IDS.map((id) => (
+				<li key={id} className="kadence-blocks-style-library__list-row">
+					<div className="kadence-blocks-style-library__list-row-main">
+						<Skeleton className="kadence-blocks-style-library__list-row-label kadence-blocks-style-library__skeleton--bar" />
+						<Skeleton className="kadence-blocks-style-library__list-row-value kadence-blocks-style-library__skeleton--bar" />
+						<Skeleton className="kadence-blocks-style-library__list-row-preview" />
+					</div>
+				</li>
+			))}
+		</ul>
+	);
+}
 
 /**
  * Render a preset list screen for whichever block the config names.
@@ -112,7 +156,7 @@ export function PresetScreen({ label, route, navigate, library, preset }) {
 				</Notice>
 			)}
 			{screen.isLoading ? (
-				<Spinner />
+				<PresetRowsSkeleton label={label} />
 			) : (
 				<RowList
 					items={items}


### PR DESCRIPTION
Replaces the two screen-level loading spinners in the Style Library with skeleton placeholders that mirror the content they stand in for, so the layout does not jump when data lands.

Adds a shared `Skeleton` atom, then adopts it on the preset row list and the colour swatch grid. Both skeletons reuse the real row/swatch layout classes rather than duplicating their dimensions, so they stay in sync if those change.

The inline `isBusy` spinner in `SelectDropdown` and the app-boot spinners in `StyleLibraryApp`/`AppShell` are deliberately untouched — an inline indicator is not a skeleton case, and a whole-shell skeleton is a separate design decision.

## Test instructions

1. Go to **Style Library → Block Presets → Button** and reload. While the presets fetch, the panel shows row-shaped placeholders rather than a spinner, and the layout does not shift when the rows arrive.
2. Do the same on **Color Palette** — the swatch grid shows card-shaped placeholders.
3. Throttle the network (DevTools → Network → Slow 3G) if the fetch is too fast to see locally.
4. Turn on **Reduce Motion** (macOS: System Settings → Accessibility → Display) and reload. The shimmer stops; the static placeholder remains.
5. With a screen reader, confirm the loading region is announced as busy and the placeholder shapes are not read out as content.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4083/phase-16-ux-polish
bun run build-wp
```

The Style Library is at **WP Admin → Kadence → Style Library**.
</details>

## Screenshot

<!-- Upload `.local/screenshots/SOFT-4083/phase-16-ux-polish.jpg` here and replace the line below. -->
![Preset row skeletons while the presets load](REPLACE_WITH_UPLOADED_IMAGE)

---

Slice 24 of 24 in the SOFT-4083 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.
