### PR TITLE
SOFT-4087 [1/6]: decouple per-block palette support from presets

### DIFF
--- a/src/blocks/singlebtn/block.json
+++ b/src/blocks/singlebtn/block.json
@@ -775,7 +775,8 @@
 		"kbContentLabel": "text",
 		"kbPreset": {
 			"inlinePicker": true
-		}
+		},
+		"kbPalette": true
 	},
 	"usesContext": [
 		"postId",

--- a/src/early-filters.js
+++ b/src/early-filters.js
@@ -89,30 +89,15 @@ function convertArrayTitleToString(arr) {
 addFilter('blocks.registerBlockType', 'kadence/block-label', blockMetadataAttribute);
 
 /**
- * Whether a block opts into the design-token per-block controls — either `kbPreset` support (block presets
- * plus the palette override) or `kbPalette` support (the palette override only). Accepts a block name or a
- * block type / settings object, mirroring hasBlockSupport, so the attribute, save, canvas, and inspector
- * filters can share one gate.
- *
- * @param {string|Object} nameOrType The block name, or the block type / settings object.
- *
- * @since TBD
- *
- * @return {boolean} True when the block supports kbPreset or kbPalette.
- */
-function supportsDesignTokenControls(nameOrType) {
-	return hasBlockSupport(nameOrType, 'kbPreset') || hasBlockSupport(nameOrType, 'kbPalette');
-}
-
-/**
- * Add the kbPreset and kbPalette attributes to any block that opts into the matching block support.
+ * Add the kbPreset and/or kbPalette attributes to a block, each gated on its own block support so the two
+ * controls stay independent.
  *
  * kbPreset (added for `kbPreset`-support blocks) is the selected preset slug (e.g. "ghost"); an empty value
- * means the block keeps its $default look (the block preset). kbPalette (added for `kbPreset`- OR
- * `kbPalette`-support blocks) holds the id of a per-block color-palette override (e.g. "dark"); empty means
- * the block follows the set's `$current` palette. A color-only block declares `kbPalette` support to get the
- * palette override without registering an unused `kbPreset` attribute. Both the scoped preset CSS and the
- * palette switch layer are emitted server-side by the Design Tokens projector.
+ * means the block keeps its $default look (the block preset). kbPalette (added for `kbPalette`-support blocks)
+ * holds the id of a per-block color-palette override (e.g. "dark"); empty means the block follows the set's
+ * `$current` palette. A palette only changes which colors the tokens resolve to, so it is orthogonal to
+ * presets — a block can support either, both, or neither. Both the scoped preset CSS and the palette switch
+ * layer are emitted server-side by the Design Tokens projector.
  *
  * @param {Object} settings The block settings.
  *
@@ -121,10 +106,7 @@ function supportsDesignTokenControls(nameOrType) {
  * @return {Object} The block settings with the kbPreset and/or kbPalette attributes added.
  */
 export function blockPresetAttribute(settings) {
-	const hasPreset = hasBlockSupport(settings, 'kbPreset');
-	const hasPalette = hasBlockSupport(settings, 'kbPalette');
-
-	if (hasPreset) {
+	if (hasBlockSupport(settings, 'kbPreset')) {
 		settings.attributes = assign(settings.attributes, {
 			kbPreset: {
 				type: 'string',
@@ -133,7 +115,7 @@ export function blockPresetAttribute(settings) {
 		});
 	}
 
-	if (hasPreset || hasPalette) {
+	if (hasBlockSupport(settings, 'kbPalette')) {
 		settings.attributes = assign(settings.attributes, {
 			kbPalette: {
 				type: 'string',
@@ -254,7 +236,7 @@ addFilter('blocks.getSaveContent.extraProps', 'kadence/kb-preset-save-class', bl
  * @return {Object} The props, with the data attribute appended when a palette is pinned.
  */
 export function blockPaletteSaveAttr(props, blockType, attributes) {
-	if (!supportsDesignTokenControls(blockType)) {
+	if (!hasBlockSupport(blockType, 'kbPalette')) {
 		return props;
 	}
 
@@ -306,7 +288,7 @@ const withBlockPaletteAttr = createHigherOrderComponent((BlockListBlock) => {
 	return (props) => {
 		const { name, attributes } = props;
 
-		if (!supportsDesignTokenControls(name)) {
+		if (!hasBlockSupport(name, 'kbPalette')) {
 			return <BlockListBlock {...props} />;
 		}
 
@@ -329,8 +311,9 @@ addFilter('editor.BlockListBlock', 'kadence/kb-palette-attr', withBlockPaletteAt
  * the kbPreset attribute, which the save/preview filters turn into the kb-preset--<slug> class the projector's
  * scoped CSS hooks; an empty preset selects the block's $default preset look. Selecting a palette writes the
  * kbPalette attribute, which the save/preview filters turn into the data-kb-palette switch the projector's
- * `[data-kb-palette]` layer re-skins. The preset subsection is skipped when the block has no presets for the
- * active library; the palette subsection is skipped when the set offers fewer than two palettes.
+ * `[data-kb-palette]` layer re-skins. The two controls gate independently on their own block support: the
+ * preset subsection needs `kbPreset` support and presets for the active library; the palette subsection needs
+ * `kbPalette` support and at least two palettes in the set.
  *
  * A block whose `kbPreset` support requests `inlinePicker` renders the PRESET picker itself (e.g. a Kadence
  * block placing it under its own Style tab), so this generic sidebar panel skips only the preset subsection
@@ -343,20 +326,20 @@ const withPresetPicker = createHigherOrderComponent((BlockEdit) => {
 		const { name, attributes, setAttributes, isSelected } = props;
 
 		const hasPreset = hasBlockSupport(name, 'kbPreset');
+		const hasPalette = hasBlockSupport(name, 'kbPalette');
 
-		if (!supportsDesignTokenControls(name)) {
+		if (!hasPreset && !hasPalette) {
 			return <BlockEdit {...props} />;
 		}
 
 		const support = hasPreset ? getBlockSupport(name, 'kbPreset') : null;
 		// A block whose kbPreset support requests `inlinePicker` renders the PRESET picker itself (e.g. a
-		// Kadence block under its own Style tab), so this generic panel skips only the preset subsection for
-		// it — the per-block Color Palette override still surfaces here for every kbPreset/kbPalette block.
+		// Kadence block under its own Style tab), so this generic panel skips only the preset subsection for it.
 		const inlinePicker = Boolean(support && typeof support === 'object' && support.inlinePicker);
 
 		const library = activeLibrary();
 		const showPresets = hasPreset && !inlinePicker && blockPresets(name, library).length > 0;
-		const showPalettes = selectablePalettes().length >= 2;
+		const showPalettes = hasPalette && selectablePalettes().length >= 2;
 
 		if (!showPresets && !showPalettes) {
 			return <BlockEdit {...props} />;

--- a/src/early-filters.js
+++ b/src/early-filters.js
@@ -89,26 +89,52 @@ function convertArrayTitleToString(arr) {
 addFilter('blocks.registerBlockType', 'kadence/block-label', blockMetadataAttribute);
 
 /**
- * Add the kbPreset and kbPalette attributes to any block that opts in via the `kbPreset` block support.
+ * Whether a block opts into the design-token per-block controls — either `kbPreset` support (block presets
+ * plus the palette override) or `kbPalette` support (the palette override only). Accepts a block name or a
+ * block type / settings object, mirroring hasBlockSupport, so the attribute, save, canvas, and inspector
+ * filters can share one gate.
  *
- * kbPreset is the selected preset slug (e.g. "ghost"); an empty value means the block keeps its $default
- * look (the block preset). kbPalette holds the id of a per-block color-palette override (e.g. "dark"); empty
- * means the block follows the set's `$current` palette. Both the scoped preset CSS and the palette switch
- * layer are emitted server-side by the Design Tokens projector.
+ * @param {string|Object} nameOrType The block name, or the block type / settings object.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the block supports kbPreset or kbPalette.
+ */
+function supportsDesignTokenControls(nameOrType) {
+	return hasBlockSupport(nameOrType, 'kbPreset') || hasBlockSupport(nameOrType, 'kbPalette');
+}
+
+/**
+ * Add the kbPreset and kbPalette attributes to any block that opts into the matching block support.
+ *
+ * kbPreset (added for `kbPreset`-support blocks) is the selected preset slug (e.g. "ghost"); an empty value
+ * means the block keeps its $default look (the block preset). kbPalette (added for `kbPreset`- OR
+ * `kbPalette`-support blocks) holds the id of a per-block color-palette override (e.g. "dark"); empty means
+ * the block follows the set's `$current` palette. A color-only block declares `kbPalette` support to get the
+ * palette override without registering an unused `kbPreset` attribute. Both the scoped preset CSS and the
+ * palette switch layer are emitted server-side by the Design Tokens projector.
  *
  * @param {Object} settings The block settings.
  *
  * @since TBD
  *
- * @return {Object} The block settings with the kbPreset and kbPalette attributes added.
+ * @return {Object} The block settings with the kbPreset and/or kbPalette attributes added.
  */
 export function blockPresetAttribute(settings) {
-	if (hasBlockSupport(settings, 'kbPreset')) {
+	const hasPreset = hasBlockSupport(settings, 'kbPreset');
+	const hasPalette = hasBlockSupport(settings, 'kbPalette');
+
+	if (hasPreset) {
 		settings.attributes = assign(settings.attributes, {
 			kbPreset: {
 				type: 'string',
 				default: '',
 			},
+		});
+	}
+
+	if (hasPreset || hasPalette) {
+		settings.attributes = assign(settings.attributes, {
 			kbPalette: {
 				type: 'string',
 				default: '',
@@ -228,7 +254,7 @@ addFilter('blocks.getSaveContent.extraProps', 'kadence/kb-preset-save-class', bl
  * @return {Object} The props, with the data attribute appended when a palette is pinned.
  */
 export function blockPaletteSaveAttr(props, blockType, attributes) {
-	if (!hasBlockSupport(blockType, 'kbPreset')) {
+	if (!supportsDesignTokenControls(blockType)) {
 		return props;
 	}
 
@@ -280,7 +306,7 @@ const withBlockPaletteAttr = createHigherOrderComponent((BlockListBlock) => {
 	return (props) => {
 		const { name, attributes } = props;
 
-		if (!hasBlockSupport(name, 'kbPreset')) {
+		if (!supportsDesignTokenControls(name)) {
 			return <BlockListBlock {...props} />;
 		}
 
@@ -298,14 +324,17 @@ const withBlockPaletteAttr = createHigherOrderComponent((BlockListBlock) => {
 addFilter('editor.BlockListBlock', 'kadence/kb-palette-attr', withBlockPaletteAttr);
 
 /**
- * Add the design-token preset picker to the inspector of any block that opts into kbPreset support, under
- * a "Design Tokens" panel with a "Design Presets" subsection. Selecting a preset writes the kbPreset
- * attribute, which the save/preview filters turn into the kb-preset--<slug> class the projector's scoped
- * CSS hooks. An empty preset selects the block's $default preset look. The panel is skipped when the block
- * has no presets for the active library.
+ * Add the design-token preset picker and the per-block Color Palette override to the inspector of any block
+ * that opts into `kbPreset` or `kbPalette` support, under a "Design Tokens" panel. Selecting a preset writes
+ * the kbPreset attribute, which the save/preview filters turn into the kb-preset--<slug> class the projector's
+ * scoped CSS hooks; an empty preset selects the block's $default preset look. Selecting a palette writes the
+ * kbPalette attribute, which the save/preview filters turn into the data-kb-palette switch the projector's
+ * `[data-kb-palette]` layer re-skins. The preset subsection is skipped when the block has no presets for the
+ * active library; the palette subsection is skipped when the set offers fewer than two palettes.
  *
- * A block whose `kbPreset` support requests `inlinePicker` renders the picker itself (e.g. a Kadence
- * block placing it under its own Style tab), so this generic sidebar panel skips it to avoid a duplicate.
+ * A block whose `kbPreset` support requests `inlinePicker` renders the PRESET picker itself (e.g. a Kadence
+ * block placing it under its own Style tab), so this generic sidebar panel skips only the preset subsection
+ * for it — the palette override still surfaces here.
  *
  * @since TBD
  */
@@ -313,18 +342,20 @@ const withPresetPicker = createHigherOrderComponent((BlockEdit) => {
 	return (props) => {
 		const { name, attributes, setAttributes, isSelected } = props;
 
-		if (!hasBlockSupport(name, 'kbPreset')) {
+		const hasPreset = hasBlockSupport(name, 'kbPreset');
+
+		if (!supportsDesignTokenControls(name)) {
 			return <BlockEdit {...props} />;
 		}
 
-		const support = getBlockSupport(name, 'kbPreset');
+		const support = hasPreset ? getBlockSupport(name, 'kbPreset') : null;
 		// A block whose kbPreset support requests `inlinePicker` renders the PRESET picker itself (e.g. a
 		// Kadence block under its own Style tab), so this generic panel skips only the preset subsection for
-		// it — the per-block Color Palette override still surfaces here for every kbPreset block.
+		// it — the per-block Color Palette override still surfaces here for every kbPreset/kbPalette block.
 		const inlinePicker = Boolean(support && typeof support === 'object' && support.inlinePicker);
 
 		const library = activeLibrary();
-		const showPresets = !inlinePicker && blockPresets(name, library).length > 0;
+		const showPresets = hasPreset && !inlinePicker && blockPresets(name, library).length > 0;
 		const showPalettes = selectablePalettes().length >= 2;
 
 		if (!showPresets && !showPalettes) {


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4087/color-control-soft-3995-style-token-picker-in-picker-palette-switching
📹  https://www.loom.com/share/0c508363df8841a09bc11b577d113547

Introduces a dedicated `kbPalette` block support so a color-only block can carry the per-block Color Palette override without registering an unused `kbPreset` attribute. The `kbPalette` attribute, the `data-kb-palette` save/canvas filters, and the inspector picker now gate on `kbPreset` **or** `kbPalette` through a shared `supportsDesignTokenControls()` helper.

No block opts into `kbPalette` yet, so this is a no-op enabler; `kadence/singlebtn` keeps working through its existing `kbPreset` support.

First of a stacked series for SOFT-4087 (per-step PRs).

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added color palette support to the Single Button block.
  - Preset and palette options can now be enabled independently.
  - The block settings panel displays the relevant controls based on supported features.

- **Bug Fixes**
  - Improved palette handling in the editor and saved block output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
