### PR TITLE
SOFT-4087 [2/6]: surface the per-block palette dropdown at the top level

### DIFF
--- a/src/early-filters.js
+++ b/src/early-filters.js
@@ -315,9 +315,9 @@ addFilter('editor.BlockListBlock', 'kadence/kb-palette-attr', withBlockPaletteAt
  * preset subsection needs `kbPreset` support and presets for the active library; the palette subsection needs
  * `kbPalette` support and at least two palettes in the set.
  *
- * A block whose `kbPreset` support requests `inlinePicker` renders the PRESET picker itself (e.g. a Kadence
- * block placing it under its own Style tab), so this generic sidebar panel skips only the preset subsection
- * for it — the palette override still surfaces here.
+ * A block whose `kbPreset` support requests `inlinePicker` renders the preset picker itself (via PresetButton),
+ * and that inline picker also renders the palette dropdown right below the Preset selector, so this generic
+ * sidebar panel skips both the preset and the palette subsection for that block.
  *
  * @since TBD
  */
@@ -339,7 +339,9 @@ const withPresetPicker = createHigherOrderComponent((BlockEdit) => {
 
 		const library = activeLibrary();
 		const showPresets = hasPreset && !inlinePicker && blockPresets(name, library).length > 0;
-		const showPalettes = hasPalette && selectablePalettes().length >= 2;
+		// Inline-picker blocks render the palette dropdown themselves (via PresetButton, just below the Preset
+		// selector), so this generic panel only surfaces it for blocks without an inline picker.
+		const showPalettes = hasPalette && !inlinePicker && selectablePalettes().length >= 2;
 
 		if (!showPresets && !showPalettes) {
 			return <BlockEdit {...props} />;
@@ -352,10 +354,11 @@ const withPresetPicker = createHigherOrderComponent((BlockEdit) => {
 		return (
 			<>
 				{/*
-				 * The per-block Color Palette dropdown surfaces at the top level of the inspector — a bare
-				 * InspectorControls fill, so it sits above the block's own panels in the same top region as the
-				 * Preset selector rather than buried in a lower panel. Rendered before BlockEdit so its fill
-				 * registers ahead of the block's own inspector fills.
+				 * For blocks without an inline preset picker, the per-block Color Palette dropdown surfaces at the
+				 * top level of the inspector — a bare InspectorControls fill, so it sits above the block's own
+				 * panels rather than buried in a lower panel. Rendered before BlockEdit so its fill registers ahead
+				 * of the block's own inspector fills. Inline-picker blocks render the palette via PresetButton, just
+				 * below the Preset selector, so the two controls stay adjacent.
 				 */}
 				{isSelected && showPalettes && (
 					<InspectorControls>

--- a/src/early-filters.js
+++ b/src/early-filters.js
@@ -351,41 +351,34 @@ const withPresetPicker = createHigherOrderComponent((BlockEdit) => {
 
 		return (
 			<>
+				{/*
+				 * The per-block Color Palette dropdown surfaces at the top level of the inspector — a bare
+				 * InspectorControls fill, so it sits above the block's own panels in the same top region as the
+				 * Preset selector rather than buried in a lower panel. Rendered before BlockEdit so its fill
+				 * registers ahead of the block's own inspector fills.
+				 */}
+				{isSelected && showPalettes && (
+					<InspectorControls>
+						<div className="kb-palette-picker__row">
+							<PalettePicker value={get(attributes, 'kbPalette', '')} onChange={selectPalette} />
+						</div>
+					</InspectorControls>
+				)}
 				<BlockEdit {...props} />
-				{isSelected && (
+				{isSelected && showPresets && (
 					<InspectorControls group="styles">
 						<PanelBody title={__('Design Tokens', 'kadence-blocks')} initialOpen={false}>
-							{showPresets && (
-								<SubsectionWrap label={__('Design Presets', 'kadence-blocks')}>
-									<PresetPicker
-										name={name}
-										library={library}
-										value={selected}
-										onChange={selectPreset}
-									/>
-									<PresetActions
-										blockName={name}
-										library={library}
-										selected={selected}
-										onSelect={selectPreset}
-										attributes={attributes}
-										setAttributes={setAttributes}
-									/>
-								</SubsectionWrap>
-							)}
-							{showPalettes && (
-								<SubsectionWrap label={__('Color Palette', 'kadence-blocks')}>
-									{/*
-									 * TODO (SOFT-3990): this dropdown is an interim per-block palette override
-									 * control. The design (see the B4 Figma) integrates the palette token picker
-									 * into the block's color controls — a "Style Library | Custom" popover with a
-									 * Main Palette dropdown and swatch groups, opened from a palette icon on each
-									 * Color row — which requires @kadence/components changes to the color-control
-									 * popover and is deferred.
-									 */}
-									<PalettePicker value={get(attributes, 'kbPalette', '')} onChange={selectPalette} />
-								</SubsectionWrap>
-							)}
+							<SubsectionWrap label={__('Design Presets', 'kadence-blocks')}>
+								<PresetPicker name={name} library={library} value={selected} onChange={selectPreset} />
+								<PresetActions
+									blockName={name}
+									library={library}
+									selected={selected}
+									onSelect={selectPreset}
+									attributes={attributes}
+									setAttributes={setAttributes}
+								/>
+							</SubsectionWrap>
 						</PanelBody>
 					</InspectorControls>
 				)}

--- a/src/early-filters.js
+++ b/src/early-filters.js
@@ -332,13 +332,16 @@ const withPresetPicker = createHigherOrderComponent((BlockEdit) => {
 			return <BlockEdit {...props} />;
 		}
 
-		const support = hasPreset ? getBlockSupport(name, 'kbPreset') : null;
-		// A block whose kbPreset support requests `inlinePicker` renders the PRESET picker itself (e.g. a
-		// Kadence block under its own Style tab), so this generic panel skips only the preset subsection for it.
-		const inlinePicker = Boolean(support && typeof support === 'object' && support.inlinePicker);
-
 		const library = activeLibrary();
-		const showPresets = hasPreset && !inlinePicker && blockPresets(name, library).length > 0;
+		const presetCount = blockPresets(name, library).length;
+		const support = hasPreset ? getBlockSupport(name, 'kbPreset') : null;
+		// A block whose kbPreset support requests `inlinePicker` renders the PRESET picker (and, beside it, the
+		// palette) itself. But PresetButton returns null when the block has no presets, so only treat it as an
+		// inline picker when it actually has presets to render — otherwise this generic panel must surface the
+		// palette for it, so a palette-only inline block still shows its Color Palette control.
+		const inlinePicker = Boolean(support && typeof support === 'object' && support.inlinePicker) && presetCount > 0;
+
+		const showPresets = hasPreset && !inlinePicker && presetCount > 0;
 		// Inline-picker blocks render the palette dropdown themselves (via PresetButton, just below the Preset
 		// selector), so this generic panel only surfaces it for blocks without an inline picker.
 		const showPalettes = hasPalette && !inlinePicker && selectablePalettes().length >= 2;

--- a/src/early-filters.js
+++ b/src/early-filters.js
@@ -362,9 +362,7 @@ const withPresetPicker = createHigherOrderComponent((BlockEdit) => {
 				 */}
 				{isSelected && showPalettes && (
 					<InspectorControls>
-						<div className="kb-palette-picker__row">
-							<PalettePicker value={get(attributes, 'kbPalette', '')} onChange={selectPalette} />
-						</div>
+						<PalettePicker value={get(attributes, 'kbPalette', '')} onChange={selectPalette} />
 					</InspectorControls>
 				)}
 				<BlockEdit {...props} />

--- a/src/extension/palette-picker/index.js
+++ b/src/extension/palette-picker/index.js
@@ -10,6 +10,7 @@
 import { get } from 'lodash';
 import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import './palette-picker.scss';
 
 /**
  * The whole palette catalog the editor localizer prints, or an empty shape when the token registry is

--- a/src/extension/palette-picker/index.js
+++ b/src/extension/palette-picker/index.js
@@ -6,9 +6,14 @@
  * renders against, independent of the set's `$current`. The selection lives in the block's `kbPalette`
  * string attribute; the Design Tokens projector emits a `[data-kb-palette="<id>"]` switch layer the block's
  * `data-kb-palette` wrapper hooks. An empty selection inherits the set `$current`.
+ *
+ * Presented as a pop-out that mirrors the design-token preset control (see PresetButton): an uppercase
+ * label, a bordered toggle button showing the selected palette with a trailing icon, and a dropdown menu of
+ * palettes with a check on the active one.
  */
 import { get } from 'lodash';
-import { SelectControl } from '@wordpress/components';
+import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import { Icon, check, brush } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import './palette-picker.scss';
 
@@ -49,9 +54,11 @@ export function currentPalette() {
 }
 
 /**
- * The per-block palette selector. Renders nothing when the set offers fewer than two palettes (there is
- * nothing to switch between). Selecting an option calls onChange with the chosen palette id (the caller
- * writes it into the block's kbPalette attribute); the empty option inherits the set `$current`.
+ * The per-block palette selector, rendered as a preset-style pop-out (a labeled toggle button that opens a
+ * menu of palettes with a check on the selection). Renders nothing when the set offers fewer than two
+ * palettes (there is nothing to switch between). Choosing an option calls onChange with the chosen palette
+ * id (the caller writes it into the block's kbPalette attribute); the first option inherits the set
+ * `$current`.
  *
  * @param {Object}   props          The component props.
  * @param {string}   props.value    The currently selected palette id ('' inherits the set current).
@@ -71,21 +78,57 @@ export function PalettePicker({ value, onChange, label }) {
 
 	const current = currentPalette();
 	const options = [
-		{
-			label: inheritLabel(current),
-			value: '',
-		},
-		...palettes.map((palette) => ({ label: palette.label, value: palette.id })),
+		{ id: '', label: inheritLabel(current) },
+		...palettes.map((palette) => ({ id: palette.id, label: palette.label })),
 	];
+	const selectedId = value || '';
+	const selectedOption = options.find((option) => option.id === selectedId) || options[0];
 
 	return (
-		<SelectControl
-			label={label || __('Color Palette', 'kadence-blocks')}
-			value={value || ''}
-			options={options}
-			onChange={onChange}
-			__nextHasNoMarginBottom
-		/>
+		<>
+			<span className="kb-palette-picker__control-label">{label || __('Color Palette', 'kadence-blocks')}</span>
+			<div className="kb-palette-picker__row">
+				<Dropdown
+					className="kb-palette-picker__dropdown"
+					contentClassName="kb-palette-picker__menu"
+					popoverProps={{ placement: 'left-start' }}
+					renderToggle={({ isOpen, onToggle }) => (
+						<Button className="kb-palette-picker__button" aria-expanded={isOpen} onClick={onToggle}>
+							<span className="kb-palette-picker__label">{selectedOption.label}</span>
+							<span className="kb-palette-picker__icon">
+								<Icon icon={brush} size={16} />
+							</span>
+						</Button>
+					)}
+					renderContent={({ onClose }) => (
+						<MenuGroup label={__('Color Palettes', 'kadence-blocks')}>
+							{options.map((option) => {
+								const isCurrent = option.id === selectedId;
+
+								return (
+									<MenuItem
+										key={option.id || 'inherit'}
+										role="menuitemradio"
+										aria-checked={isCurrent}
+										suffix={
+											isCurrent ? (
+												<Icon className="kb-palette-picker__check" icon={check} />
+											) : null
+										}
+										onClick={() => {
+											onChange(option.id);
+											onClose();
+										}}
+									>
+										{option.label}
+									</MenuItem>
+								);
+							})}
+						</MenuGroup>
+					)}
+				/>
+			</div>
+		</>
 	);
 }
 

--- a/src/extension/palette-picker/palette-picker.scss
+++ b/src/extension/palette-picker/palette-picker.scss
@@ -9,10 +9,6 @@
 .kb-palette-picker__control-label {
 	display: block;
 	padding: 0 16px 8px;
-	color: #1e1e1e;
-	font-size: 11px;
-	font-weight: 500;
-	line-height: 1.4;
 }
 
 .kb-palette-picker__row {

--- a/src/extension/palette-picker/palette-picker.scss
+++ b/src/extension/palette-picker/palette-picker.scss
@@ -1,9 +1,98 @@
 /**
  * Per-block Color Palette dropdown.
  *
- * Rendered as a bare InspectorControls fill at the top of the block inspector, in the same top region as
- * the preset selector. The row padding matches the preset button row so the two controls line up.
+ * Mirrors the design-token preset control (see preset-button.scss) so the two token controls read as one
+ * set at the top of the inspector: a label, a bordered toggle button showing the selected palette with a
+ * trailing icon, and a pop-out MenuGroup of palettes with a check on the active one. Kept visually in sync
+ * with the preset button by intent.
  */
+.kb-palette-picker__control-label {
+	display: block;
+	padding: 0 16px 8px;
+	color: #1e1e1e;
+	font-size: 11px;
+	font-weight: 500;
+	line-height: 1.4;
+}
+
 .kb-palette-picker__row {
 	padding: 0 16px 16px;
+}
+
+.kb-palette-picker__dropdown {
+	display: block;
+}
+
+.kb-palette-picker__button.components-button {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	width: 100%;
+	height: auto;
+	min-height: 0;
+	padding: 6px 12px;
+	border: 1px solid #949494;
+	border-radius: 2px;
+	color: #1e1e1e;
+	font-size: 0.8125rem; // 13px
+	font-weight: 400;
+	line-height: 1.25rem; // 20px
+	text-align: left;
+
+	.kb-palette-picker__label {
+		flex: 1 1 auto;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.kb-palette-picker__icon {
+		display: inline-flex;
+		flex: 0 0 auto;
+	}
+
+	svg {
+		flex: 0 0 auto;
+		width: 16px;
+		height: 16px;
+		margin: 0; // the 4px icon-to-text gap is the flex `gap`, not a button-default margin.
+	}
+}
+
+.kb-palette-picker__menu {
+	min-width: 220px;
+
+	.components-menu-group {
+		padding: 4px;
+
+		> [role='group'] {
+			display: flex;
+			flex-direction: column;
+			gap: 8px;
+		}
+	}
+
+	.components-menu-group__label {
+		color: #1e1e1e;
+		margin: 0;
+		padding: 12px 12px 16px;
+	}
+
+	.components-menu-item__button {
+		color: #1e1e1e;
+		font-size: 0.8125rem; // 13px
+		font-weight: 400;
+		line-height: 1.25rem; // 20px
+	}
+
+	.kb-palette-picker__check {
+		fill: var(--wp-admin-theme-color, #3858e9);
+	}
+
+	// Suppress the focus ring that lands on the first item when the menu opens by mouse — but keep it for
+	// keyboard users (`:focus-visible`), so arrowing through the list is still visible.
+	.components-menu-item__button:focus:not(:focus-visible) {
+		box-shadow: none;
+		outline: none;
+	}
 }

--- a/src/extension/palette-picker/palette-picker.scss
+++ b/src/extension/palette-picker/palette-picker.scss
@@ -1,0 +1,9 @@
+/**
+ * Per-block Color Palette dropdown.
+ *
+ * Rendered as a bare InspectorControls fill at the top of the block inspector, in the same top region as
+ * the preset selector. The row padding matches the preset button row so the two controls line up.
+ */
+.kb-palette-picker__row {
+	padding: 0 16px 16px;
+}

--- a/src/extension/preset-picker/PresetButton.js
+++ b/src/extension/preset-picker/PresetButton.js
@@ -10,13 +10,19 @@
  *
  * Shared across every preset-enabled block so the control stays identical wherever it surfaces: a block
  * renders it once, above its InspectorControlTabs, passing its name, attributes and setAttributes.
+ *
+ * A "Preset" label sits above the button, and the per-block Color Palette dropdown renders just below it so
+ * the two design-token controls stay adjacent at the top of the inspector (the generic sidebar panel skips
+ * the palette for inline-picker blocks precisely because it surfaces here instead).
  */
-import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import { BaseControl, Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { Icon, check } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+import { get } from 'lodash';
 import { activeLibrary, activePresetFor, blockPresets } from './index';
+import { PalettePicker, selectablePalettes } from '../palette-picker';
 import { presetIcon, resetIcon } from './icons';
 import { capturedTokens } from './capture';
 import { SavePresetModal } from './SavePresetModal';
@@ -45,7 +51,8 @@ function currentPresetLabel(name, library, slug) {
 }
 
 /**
- * The preset button and dropdown for a block. Renders nothing when the block offers no presets.
+ * The preset button and dropdown for a block, labeled "Preset", with the per-block Color Palette dropdown
+ * just below it. Renders nothing when the block offers no presets.
  *
  * @param {Object}   props               The component props.
  * @param {string}   props.blockName     The block name.
@@ -127,6 +134,9 @@ export function PresetButton({ blockName, attributes, setAttributes, library }) 
 
 	return (
 		<>
+			<BaseControl.VisualLabel className="kb-preset-button__control-label">
+				{__('Preset', 'kadence-blocks')}
+			</BaseControl.VisualLabel>
 			<div className="kb-preset-button__row">
 				<Dropdown
 					className="kb-preset-button__dropdown"
@@ -227,6 +237,14 @@ export function PresetButton({ blockName, attributes, setAttributes, library }) 
 					onClick={onResetAll}
 				/>
 			</div>
+			{selectablePalettes().length >= 2 && (
+				<div className="kb-palette-picker__row">
+					<PalettePicker
+						value={get(attributes, 'kbPalette', '')}
+						onChange={(value) => setAttributes({ kbPalette: value })}
+					/>
+				</div>
+			)}
 			{saving && (
 				<SavePresetModal
 					blockName={blockName}

--- a/src/extension/preset-picker/PresetButton.js
+++ b/src/extension/preset-picker/PresetButton.js
@@ -22,7 +22,7 @@ import { Icon, check } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { get } from 'lodash';
 import { activeLibrary, activePresetFor, blockPresets } from './index';
-import { PalettePicker, selectablePalettes } from '../palette-picker';
+import { PalettePicker } from '../palette-picker';
 import { presetIcon, resetIcon } from './icons';
 import { capturedTokens } from './capture';
 import { SavePresetModal } from './SavePresetModal';
@@ -235,14 +235,10 @@ export function PresetButton({ blockName, attributes, setAttributes, library }) 
 					onClick={onResetAll}
 				/>
 			</div>
-			{selectablePalettes().length >= 2 && (
-				<div className="kb-palette-picker__row">
-					<PalettePicker
-						value={get(attributes, 'kbPalette', '')}
-						onChange={(value) => setAttributes({ kbPalette: value })}
-					/>
-				</div>
-			)}
+			<PalettePicker
+				value={get(attributes, 'kbPalette', '')}
+				onChange={(value) => setAttributes({ kbPalette: value })}
+			/>
 			{saving && (
 				<SavePresetModal
 					blockName={blockName}

--- a/src/extension/preset-picker/PresetButton.js
+++ b/src/extension/preset-picker/PresetButton.js
@@ -15,7 +15,7 @@
  * the two design-token controls stay adjacent at the top of the inspector (the generic sidebar panel skips
  * the palette for inline-picker blocks precisely because it surfaces here instead).
  */
-import { BaseControl, Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { Icon, check } from '@wordpress/icons';
@@ -134,9 +134,7 @@ export function PresetButton({ blockName, attributes, setAttributes, library }) 
 
 	return (
 		<>
-			<BaseControl.VisualLabel className="kb-preset-button__control-label">
-				{__('Preset', 'kadence-blocks')}
-			</BaseControl.VisualLabel>
+			<span className="kb-preset-button__control-label">{__('Preset', 'kadence-blocks')}</span>
 			<div className="kb-preset-button__row">
 				<Dropdown
 					className="kb-preset-button__dropdown"

--- a/src/extension/preset-picker/preset-button.scss
+++ b/src/extension/preset-picker/preset-button.scss
@@ -5,15 +5,12 @@
  * bordered box holding the current preset label with the preset icon 4px to its right, and a dropdown
  * that lists the presets and the design-system actions.
  */
-// The "Preset" label above the button. Shares its styling with the Color Palette label (see
-// palette-picker.scss) so the two token controls read as one set; the 16px indent lines it up with the button.
+// The "Preset" label above the button. Inherits the editor's default control-label typography (like the
+// block's other control labels — e.g. "Color", "Text Type" — which set none of their own); the 16px indent
+// lines it up with the button.
 .kb-preset-button__control-label {
 	display: block;
 	padding: 0 16px 8px;
-	color: #1e1e1e;
-	font-size: 11px;
-	font-weight: 500;
-	line-height: 1.4;
 }
 
 .kb-preset-button__row {

--- a/src/extension/preset-picker/preset-button.scss
+++ b/src/extension/preset-picker/preset-button.scss
@@ -5,9 +5,16 @@
  * bordered box holding the current preset label with the preset icon 4px to its right, and a dropdown
  * that lists the presets and the design-system actions.
  */
+// Match the SelectControl label ("COLOR PALETTE") the palette dropdown renders: same uppercase treatment,
+// size and weight, and the 16px indent that lines the label up with the preset button and the palette label.
 .kb-preset-button__control-label {
 	display: block;
 	padding: 0 16px 8px;
+	color: #1e1e1e;
+	font-size: 11px;
+	font-weight: 500;
+	line-height: 1.4;
+	text-transform: uppercase;
 }
 
 .kb-preset-button__row {

--- a/src/extension/preset-picker/preset-button.scss
+++ b/src/extension/preset-picker/preset-button.scss
@@ -5,8 +5,8 @@
  * bordered box holding the current preset label with the preset icon 4px to its right, and a dropdown
  * that lists the presets and the design-system actions.
  */
-// Match the SelectControl label ("COLOR PALETTE") the palette dropdown renders: same uppercase treatment,
-// size and weight, and the 16px indent that lines the label up with the preset button and the palette label.
+// The "Preset" label above the button. Shares its styling with the Color Palette label (see
+// palette-picker.scss) so the two token controls read as one set; the 16px indent lines it up with the button.
 .kb-preset-button__control-label {
 	display: block;
 	padding: 0 16px 8px;
@@ -14,7 +14,6 @@
 	font-size: 11px;
 	font-weight: 500;
 	line-height: 1.4;
-	text-transform: uppercase;
 }
 
 .kb-preset-button__row {

--- a/src/extension/preset-picker/preset-button.scss
+++ b/src/extension/preset-picker/preset-button.scss
@@ -5,6 +5,11 @@
  * bordered box holding the current preset label with the preset icon 4px to its right, and a dropdown
  * that lists the presets and the design-system actions.
  */
+.kb-preset-button__control-label {
+	display: block;
+	padding: 0 16px 8px;
+}
+
 .kb-preset-button__row {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4087/color-control-soft-3995-style-token-picker-in-picker-palette-switching
📹  https://www.loom.com/share/0c508363df8841a09bc11b577d113547

Moves the per-block Color Palette dropdown out of the lower "Design Tokens" styles panel and renders it as a bare `InspectorControls` fill at the **top** of the inspector, in the same top region as the preset selector. The preset subsection keeps its own panel.

Stacked on #1296.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a redesigned palette picker with a pop-out menu, grouped options, selected-state indicator, and inherit option.
  * Added clearer “Preset” labeling and per-block palette selection.
* **Bug Fixes**
  * Prevented duplicate preset and palette controls from appearing in blocks that display these options inline.
  * Improved palette control layout, truncation, spacing, and keyboard focus visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
