### PR TITLE
SOFT-4087 [4/6]: apply per-block palette and preset markup generically for dynamic blocks

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -96,6 +96,7 @@
         "ktanimate",
         "ktanimateadd",
         "ktanimatepreview",
+        "ktanimatereveal",
         "ktanimateswipe",
         "ktdynamic",
         "ktgooglefonts",

--- a/includes/blocks/class-kadence-blocks-abstract-block.php
+++ b/includes/blocks/class-kadence-blocks-abstract-block.php
@@ -358,8 +358,9 @@ class Kadence_Blocks_Abstract_Block {
 	 * `kbPalette` attribute (via `kbPalette` block support) and needs no per-block PHP. A no-op when no palette
 	 * is pinned, the content is empty, or it has no opening tag to carry the attribute.
 	 *
-	 * Only the opening tag is touched: the tag processor stops at the first tag, so a block with many nested
-	 * children is not walked, and the whole method short-circuits before any parsing when nothing is pinned.
+	 * The attribute lands on the block's own root element (the tag carrying its `wp-block-<namespace>-<name>`
+	 * class), not an outer wrapper such as an animation `data-aos` div, and the whole method short-circuits
+	 * before any parsing when nothing is pinned.
 	 *
 	 * @since TBD
 	 *
@@ -381,7 +382,7 @@ class Kadence_Blocks_Abstract_Block {
 
 		$tags = new WP_HTML_Tag_Processor( $content );
 
-		if ( ! $tags->next_tag() ) {
+		if ( ! $tags->next_tag( [ 'class_name' => 'wp-block-' . $this->namespace . '-' . $this->block_name ] ) ) {
 			return $content;
 		}
 
@@ -397,8 +398,10 @@ class Kadence_Blocks_Abstract_Block {
 	 * no per-block PHP. A no-op when no preset is selected, the content is empty, or it has no opening tag to
 	 * carry the class.
 	 *
-	 * Only the opening tag is touched: the tag processor stops at the first tag, so a block with many nested
-	 * children is not walked, and the whole method short-circuits before any parsing when nothing is selected.
+	 * The class lands on the block's own root element (the tag carrying its `wp-block-<namespace>-<name>` class),
+	 * not an outer wrapper such as an animation `data-aos` div — the scoped preset selector is compound on the
+	 * block class (`.wp-block-<name>.kb-preset--<slug>`), so a class on a wrapper never matches. The whole method
+	 * short-circuits before any parsing when nothing is selected.
 	 *
 	 * @since TBD
 	 *
@@ -420,7 +423,7 @@ class Kadence_Blocks_Abstract_Block {
 
 		$tags = new WP_HTML_Tag_Processor( $content );
 
-		if ( ! $tags->next_tag() ) {
+		if ( ! $tags->next_tag( [ 'class_name' => 'wp-block-' . $this->namespace . '-' . $this->block_name ] ) ) {
 			return $content;
 		}
 

--- a/includes/blocks/class-kadence-blocks-abstract-block.php
+++ b/includes/blocks/class-kadence-blocks-abstract-block.php
@@ -10,12 +10,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Palette\Renders_Palette_Attribute;
+
 /**
  * Abstract class to register blocks, build CSS, and enqueue scripts.
  *
  * @category class
  */
 class Kadence_Blocks_Abstract_Block {
+
+	use Renders_Palette_Attribute;
 
 	/**
 	 * Block namespace.
@@ -289,6 +293,7 @@ class Kadence_Blocks_Abstract_Block {
 			$attributes = apply_filters( 'kadence_blocks_' . str_replace( '-', '_', $this->block_name ) . '_render_block_attributes', $attributes, $block_instance );
 
 			$content = $this->build_html( $attributes, $unique_id, $content, $block_instance );
+			$content = $this->render_palette_attribute( $attributes, $content );
 			if ( ! $css_class->has_styles( 'kb-' . $this->block_name . $unique_style_id ) && ! is_feed() && apply_filters( 'kadence_blocks_render_inline_css', true, $this->block_name, $unique_id ) ) {
 				$css = $this->build_css( $attributes, $css_class, $unique_id, $unique_style_id );
 				if ( ! empty( $css ) && ! wp_is_block_theme() ) {
@@ -341,6 +346,45 @@ class Kadence_Blocks_Abstract_Block {
 	 */
 	public function build_html( $attributes, $unique_id, $content, $block_instance ) {
 		return $content;
+	}
+
+	/**
+	 * Reflect a block's per-block color-palette override onto its rendered root element as
+	 * data-kb-palette="<id>", so the Design Tokens projector's `[data-kb-palette]` switch layer re-skins the
+	 * block's colors on the front end. Generic across every dynamic block: a block opts in by registering the
+	 * `kbPalette` attribute (via `kbPalette` block support) and needs no per-block PHP. A no-op when no palette
+	 * is pinned, the content is empty, or it has no opening tag to carry the attribute.
+	 *
+	 * Only the opening tag is touched: the tag processor stops at the first tag, so a block with many nested
+	 * children is not walked, and the whole method short-circuits before any parsing when nothing is pinned.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $attributes The block attributes.
+	 * @param mixed $content    The block's rendered HTML.
+	 *
+	 * @return mixed The HTML, with data-kb-palette set on the root element when a palette is pinned.
+	 */
+	protected function render_palette_attribute( $attributes, $content ) {
+		if ( ! is_array( $attributes ) || ! is_string( $content ) || $content === '' ) {
+			return $content;
+		}
+
+		$palette = $this->palette_attributes( $attributes['kbPalette'] ?? '' );
+
+		if ( ! isset( $palette['data-kb-palette'] ) ) {
+			return $content;
+		}
+
+		$tags = new WP_HTML_Tag_Processor( $content );
+
+		if ( ! $tags->next_tag() ) {
+			return $content;
+		}
+
+		$tags->set_attribute( 'data-kb-palette', $palette['data-kb-palette'] );
+
+		return $tags->get_updated_html();
 	}
 
 	/**

--- a/includes/blocks/class-kadence-blocks-abstract-block.php
+++ b/includes/blocks/class-kadence-blocks-abstract-block.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Palette\Renders_Palette_Attribute;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Preset\Renders_Preset_Classes;
 
 /**
  * Abstract class to register blocks, build CSS, and enqueue scripts.
@@ -20,6 +21,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Palette\Renders_Palette_Att
 class Kadence_Blocks_Abstract_Block {
 
 	use Renders_Palette_Attribute;
+	use Renders_Preset_Classes;
 
 	/**
 	 * Block namespace.
@@ -294,6 +296,7 @@ class Kadence_Blocks_Abstract_Block {
 
 			$content = $this->build_html( $attributes, $unique_id, $content, $block_instance );
 			$content = $this->render_palette_attribute( $attributes, $content );
+			$content = $this->render_preset_class( $attributes, $content );
 			if ( ! $css_class->has_styles( 'kb-' . $this->block_name . $unique_style_id ) && ! is_feed() && apply_filters( 'kadence_blocks_render_inline_css', true, $this->block_name, $unique_id ) ) {
 				$css = $this->build_css( $attributes, $css_class, $unique_id, $unique_style_id );
 				if ( ! empty( $css ) && ! wp_is_block_theme() ) {
@@ -383,6 +386,47 @@ class Kadence_Blocks_Abstract_Block {
 		}
 
 		$tags->set_attribute( 'data-kb-palette', $palette['data-kb-palette'] );
+
+		return $tags->get_updated_html();
+	}
+
+	/**
+	 * Add a block's selected design-token preset class (`kb-preset--<slug>`) to its rendered root element, so
+	 * the Design Tokens projector's scoped preset CSS applies on the front end. Generic across every dynamic
+	 * block: a block opts in by registering the `kbPreset` attribute (via `kbPreset` block support) and needs
+	 * no per-block PHP. A no-op when no preset is selected, the content is empty, or it has no opening tag to
+	 * carry the class.
+	 *
+	 * Only the opening tag is touched: the tag processor stops at the first tag, so a block with many nested
+	 * children is not walked, and the whole method short-circuits before any parsing when nothing is selected.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $attributes The block attributes.
+	 * @param mixed $content    The block's rendered HTML.
+	 *
+	 * @return mixed The HTML, with the kb-preset--<slug> class added to the root element when a preset is set.
+	 */
+	protected function render_preset_class( $attributes, $content ) {
+		if ( ! is_array( $attributes ) || ! is_string( $content ) || $content === '' ) {
+			return $content;
+		}
+
+		$classes = $this->preset_classes( $attributes['kbPreset'] ?? '' );
+
+		if ( $classes === [] ) {
+			return $content;
+		}
+
+		$tags = new WP_HTML_Tag_Processor( $content );
+
+		if ( ! $tags->next_tag() ) {
+			return $content;
+		}
+
+		foreach ( $classes as $preset_class ) {
+			$tags->add_class( $preset_class );
+		}
 
 		return $tags->get_updated_html();
 	}

--- a/includes/blocks/class-kadence-blocks-singlebtn-block.php
+++ b/includes/blocks/class-kadence-blocks-singlebtn-block.php
@@ -12,9 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Palette\Renders_Palette_Attribute;
-use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Identifier;
-use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Preset\Renders_Preset_Classes;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Preset_Resolver;
@@ -26,9 +23,6 @@ use KadenceWP\KadenceBlocks\Utils\Cast;
  * @category class
  */
 class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
-	use Renders_Palette_Attribute;
-	use Sanitizes_Css_Identifier;
-	use Renders_Preset_Classes;
 
 	/**
 	 * Instance of this class
@@ -374,10 +368,6 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$classes[] = ! empty( $attributes['text'] ) ? 'kt-btn-has-text-true' : 'kt-btn-has-text-false';
 		$classes[] = ! empty( $attributes['icon'] ) ? 'kt-btn-has-svg-true' : 'kt-btn-has-svg-false';
 		$classes[] = ! empty( $attributes['iconReveal'] ) && ! empty( $attributes['icon'] ) ? 'icon-reveal' : '';
-		// A selected design-token preset outputs a kb-preset--<slug> class the Design Tokens preset
-		// projector's scoped CSS hooks. This is a dynamic block, so the class is added here rather than by
-		// the editor save filter.
-		$classes = array_merge( $classes, $this->preset_classes( $attributes['kbPreset'] ?? '' ) );
 
 		if ( ! empty( $attributes['target'] ) && 'video' === $attributes['target'] ) {
 			$classes[] = 'ktblocksvideopop';
@@ -385,13 +375,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		if ( ! empty( $attributes['inheritStyles'] ) && ( 'inherit' === $attributes['inheritStyles'] || 'inherit-secondary' === $attributes['inheritStyles'] ) ) {
 			$classes[] = 'wp-block-button__link';
 		}
-		// A per-block color-palette override outputs a data-kb-palette="<id>" attribute the Design Tokens
-		// projector's [data-kb-palette] switch layer re-points the block's canonical color vars through. This is
-		// a dynamic block, so the attribute is added here rather than by the editor save filter.
-		$wrapper_args = array_merge(
-			[ 'class' => implode( ' ', $classes ) ],
-			$this->palette_attributes( $attributes['kbPalette'] ?? '' )
-		);
+		$wrapper_args = [ 'class' => implode( ' ', $classes ) ];
 		if ( ! empty( $attributes['anchor'] ) ) {
 			$wrapper_args['id'] = Cast::to_string( $attributes['anchor'] );
 		}

--- a/src/blocks/advancedheading/block.json
+++ b/src/blocks/advancedheading/block.json
@@ -666,6 +666,7 @@
 		"ktanimatepreview": true,
 		"ktdynamic": true,
 		"kbMetadata": true,
-		"kbContentLabel": "content"
+		"kbContentLabel": "content",
+		"kbPalette": true
 	}
 }

--- a/src/blocks/rowlayout/block.json
+++ b/src/blocks/rowlayout/block.json
@@ -794,6 +794,7 @@
 		"ktdynamic": true,
 		"kbcss": true,
 		"html": false,
-		"kbMetadata": true
+		"kbMetadata": true,
+		"kbPalette": true
 	}
 }


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4087/color-control-soft-3995-style-token-picker-in-picker-palette-switching
📹  https://www.loom.com/share/0c508363df8841a09bc11b577d113547

Applies a block's per-block design-token selections to dynamic blocks **generically**, in the abstract block's `render_css()`:

- `render_palette_attribute()` sets `data-kb-palette="<id>"` from `kbPalette`.
- `render_preset_class()` adds the `kb-preset--<slug>` class from `kbPreset`.

Kept as two methods since palette and preset are distinct concerns. Each uses `WP_HTML_Tag_Processor`, stops at the opening tag (nested children are not walked), and short-circuits before any parsing when nothing is pinned. A dynamic block now opts in with just a `block.json` support line — no per-block PHP.

Opts Row Layout (`kadence/rowlayout`) and Advanced Text (`kadence/advancedheading`) into the palette override this way, and `kadence/singlebtn` drops its per-block palette/preset merges to render through the generic path.

Stacked on #1298.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Advanced Heading blocks now support color palette settings.
  * Row Layout blocks now support color palettes and enhanced block metadata.
  * Block styling information is applied consistently during dynamic rendering.

* **Bug Fixes**
  * Improved handling of palette and preset styling so invalid or empty values do not affect rendered content.
  * Button blocks no longer receive unintended palette or preset styling attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
