### PR TITLE
SOFT-4087 [5/6]: preview the selected block's palette in color-control swatches

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -82,6 +82,7 @@
         "headerfunction",
         "httpheader",
         "iconlist",
+        "iframed",
         "inbetween",
         "infobox",
         "innerblocks",

--- a/src/early-filters.js
+++ b/src/early-filters.js
@@ -19,6 +19,7 @@ import { PalettePicker, selectablePalettes } from './extension/palette-picker';
 import { registerTokenAliasFilters } from './extension/design-tokens/register-filters';
 import { registerColorControlFilters } from './extension/design-tokens/register-color-control-filters';
 import { registerComponentTokenFilters } from './extension/design-tokens/register-component-filters';
+import { registerTokenSwatchPalettePreview } from './extension/design-tokens/palette-swatch-preview';
 
 // Make the @kadence/helpers output helpers design-token aware by resolving `{dot.alias}` values to
 // their `var(--kb-token--<id>)` reference through the library's filter seam.
@@ -31,6 +32,10 @@ registerColorControlFilters();
 // Inject the design-token picker UI into the token-agnostic @kadence/components control seams, so a
 // control that receives a `context` gets the chip/picker without the package knowing about tokens.
 registerComponentTokenFilters();
+
+// Mirror the selected block's per-block palette onto the top-document <html>, so the color-control swatches
+// preview that palette's colors through the projector's existing [data-kb-palette] switch layer.
+registerTokenSwatchPalettePreview();
 
 /**
  * Add animation attributes

--- a/src/extension/design-tokens/__tests__/palette-swatch-preview.test.js
+++ b/src/extension/design-tokens/__tests__/palette-swatch-preview.test.js
@@ -132,6 +132,29 @@ describe('palette-swatch-preview', () => {
 	});
 
 	/**
+	 * The canvas shield is reapplied when the canvas element is replaced while the same palette stays active, so a
+	 * re-mounted non-iframed canvas does not inherit the inspector preview (the root already carrying the palette
+	 * must not short-circuit the shield).
+	 *
+	 * @return {void}
+	 */
+	it('reshields a replaced canvas when the same palette is reapplied', () => {
+		applyPalettePreview('dark');
+		expect(canvas.getAttribute('data-kb-palette')).toBe('default');
+
+		// Replace the canvas element (a re-mount); the fresh one starts with no shield.
+		canvas.remove();
+		canvas = document.createElement('div');
+		canvas.className = 'editor-styles-wrapper';
+		document.body.appendChild(canvas);
+		expect(canvas.hasAttribute('data-kb-palette')).toBe(false);
+
+		// Reapplying the SAME palette (root already 'dark') must still shield the new canvas.
+		applyPalettePreview('dark');
+		expect(canvas.getAttribute('data-kb-palette')).toBe('default');
+	});
+
+	/**
 	 * Registering applies the current selection immediately, then follows selection changes through the
 	 * store subscription, and clears the attribute on deselect.
 	 *

--- a/src/extension/design-tokens/__tests__/palette-swatch-preview.test.js
+++ b/src/extension/design-tokens/__tests__/palette-swatch-preview.test.js
@@ -1,0 +1,135 @@
+/* eslint-env jest */
+/**
+ * The color-control palette-preview sync.
+ *
+ * A block pinned to a palette re-skins its own canvas subtree, but the inspector's color-control swatches
+ * live in the top-document sidebar and keep resolving `var(--kb-token--*)` against the library `$current`.
+ * The projector's `[data-kb-palette]` switch layer is already loaded in the top document, so the sync mirrors
+ * the selected block's effective palette onto `document.documentElement` and the existing CSS does the rest.
+ *
+ * These tests drive `effectivePalette` against a mocked block-editor store (own vs inherited vs none) and
+ * assert `registerTokenSwatchPalettePreview` toggles `data-kb-palette` on `<html>` as the selection changes.
+ */
+import { effectivePalette, applyPalettePreview, registerTokenSwatchPalettePreview } from '../palette-swatch-preview';
+
+let mockSubscriber;
+const mockStore = {
+	getSelectedBlockClientId: jest.fn(),
+	getBlockAttributes: jest.fn(),
+	getBlockParents: jest.fn(),
+};
+
+jest.mock(
+	'@wordpress/data',
+	() => ({
+		select: jest.fn(() => mockStore),
+		subscribe: jest.fn((listener) => {
+			mockSubscriber = listener;
+			return () => {
+				mockSubscriber = undefined;
+			};
+		}),
+	}),
+	{ virtual: true }
+);
+
+/**
+ * Point the mocked store at a selection with an attribute map per client id and a parent chain (outermost
+ * first, matching getBlockParents).
+ *
+ * @param {?string}                     selected The selected block's client id, or null for no selection.
+ * @param {Object<string, Object>}      attrs    A client-id -> attributes map.
+ * @param {Array<string>}               parents  The selected block's ancestors, outermost first.
+ *
+ * @return {void}
+ */
+function setSelection(selected, attrs = {}, parents = []) {
+	mockStore.getSelectedBlockClientId.mockReturnValue(selected);
+	mockStore.getBlockAttributes.mockImplementation((id) => attrs[id] || {});
+	mockStore.getBlockParents.mockReturnValue(parents);
+}
+
+describe('palette-swatch-preview', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockSubscriber = undefined;
+		document.documentElement.removeAttribute('data-kb-palette');
+	});
+
+	/**
+	 * With no block selected there is no override to preview.
+	 *
+	 * @return {void}
+	 */
+	it('resolves to an empty palette when nothing is selected', () => {
+		setSelection(null);
+
+		expect(effectivePalette()).toBe('');
+	});
+
+	/**
+	 * A selected block with its own kbPalette resolves to that palette.
+	 *
+	 * @return {void}
+	 */
+	it('resolves to the selected block own palette', () => {
+		setSelection('a', { a: { kbPalette: 'dark' } });
+
+		expect(effectivePalette()).toBe('dark');
+	});
+
+	/**
+	 * A selected block with no palette follows the nearest pinned ancestor.
+	 *
+	 * @return {void}
+	 */
+	it('resolves to the nearest ancestor palette when the block has none', () => {
+		setSelection('c', { c: {}, b: { kbPalette: 'sunset' }, a: { kbPalette: 'dark' } }, ['a', 'b']);
+
+		expect(effectivePalette()).toBe('sunset');
+	});
+
+	/**
+	 * A selected block with no palette and no pinned ancestor resolves to empty.
+	 *
+	 * @return {void}
+	 */
+	it('resolves to empty when neither the block nor an ancestor is pinned', () => {
+		setSelection('c', { c: {}, a: {} }, ['a']);
+
+		expect(effectivePalette()).toBe('');
+	});
+
+	/**
+	 * applyPalettePreview sets the attribute for a palette id and removes it for the empty id.
+	 *
+	 * @return {void}
+	 */
+	it('sets and clears the data-kb-palette attribute on the document root', () => {
+		applyPalettePreview('dark');
+		expect(document.documentElement.getAttribute('data-kb-palette')).toBe('dark');
+
+		applyPalettePreview('');
+		expect(document.documentElement.hasAttribute('data-kb-palette')).toBe(false);
+	});
+
+	/**
+	 * Registering applies the current selection immediately, then follows selection changes through the
+	 * store subscription, and clears the attribute on deselect.
+	 *
+	 * @return {void}
+	 */
+	it('syncs the attribute to the selection on register and on store changes', () => {
+		setSelection('a', { a: { kbPalette: 'dark' } });
+		registerTokenSwatchPalettePreview();
+		expect(document.documentElement.getAttribute('data-kb-palette')).toBe('dark');
+
+		setSelection('b', { b: { kbPalette: 'sunset' } });
+		mockSubscriber();
+		expect(document.documentElement.getAttribute('data-kb-palette')).toBe('sunset');
+
+		setSelection(null);
+		mockSubscriber();
+		expect(document.documentElement.hasAttribute('data-kb-palette')).toBe(false);
+	});
+});

--- a/src/extension/design-tokens/__tests__/palette-swatch-preview.test.js
+++ b/src/extension/design-tokens/__tests__/palette-swatch-preview.test.js
@@ -132,13 +132,13 @@ describe('palette-swatch-preview', () => {
 	});
 
 	/**
-	 * The canvas shield is reapplied when the canvas element is replaced while the same palette stays active, so a
+	 * The canvas shield is applied again when the canvas element is replaced while the same palette stays active, so a
 	 * re-mounted non-iframed canvas does not inherit the inspector preview (the root already carrying the palette
 	 * must not short-circuit the shield).
 	 *
 	 * @return {void}
 	 */
-	it('reshields a replaced canvas when the same palette is reapplied', () => {
+	it('shields a replaced canvas when the same palette is set again', () => {
 		applyPalettePreview('dark');
 		expect(canvas.getAttribute('data-kb-palette')).toBe('default');
 
@@ -149,7 +149,7 @@ describe('palette-swatch-preview', () => {
 		document.body.appendChild(canvas);
 		expect(canvas.hasAttribute('data-kb-palette')).toBe(false);
 
-		// Reapplying the SAME palette (root already 'dark') must still shield the new canvas.
+		// Setting the SAME palette again (root already 'dark') must still shield the new canvas.
 		applyPalettePreview('dark');
 		expect(canvas.getAttribute('data-kb-palette')).toBe('default');
 	});

--- a/src/extension/design-tokens/__tests__/palette-swatch-preview.test.js
+++ b/src/extension/design-tokens/__tests__/palette-swatch-preview.test.js
@@ -5,10 +5,13 @@
  * A block pinned to a palette re-skins its own canvas subtree, but the inspector's color-control swatches
  * live in the top-document sidebar and keep resolving `var(--kb-token--*)` against the library `$current`.
  * The projector's `[data-kb-palette]` switch layer is already loaded in the top document, so the sync mirrors
- * the selected block's effective palette onto `document.documentElement` and the existing CSS does the rest.
+ * the selected block's effective palette onto `document.documentElement` (`<html>`) — where the swatches and the
+ * portaled pop color popover pick it up — while re-declaring the current palette on the canvas root
+ * (`.editor-styles-wrapper`) so an un-iframed canvas does not inherit the preview.
  *
  * These tests drive `effectivePalette` against a mocked block-editor store (own vs inherited vs none) and
- * assert `registerTokenSwatchPalettePreview` toggles `data-kb-palette` on `<html>` as the selection changes.
+ * assert `registerTokenSwatchPalettePreview` toggles `data-kb-palette` on `<html>` — and the canvas shield — as
+ * the selection changes.
  */
 import { effectivePalette, applyPalettePreview, registerTokenSwatchPalettePreview } from '../palette-swatch-preview';
 
@@ -50,10 +53,22 @@ function setSelection(selected, attrs = {}, parents = []) {
 }
 
 describe('palette-swatch-preview', () => {
+	let canvas;
+
 	beforeEach(() => {
 		jest.clearAllMocks();
 		mockSubscriber = undefined;
+		window.kadenceDesignTokensPalettes = { current: 'default' };
 		document.documentElement.removeAttribute('data-kb-palette');
+		canvas = document.createElement('div');
+		canvas.className = 'editor-styles-wrapper';
+		document.body.appendChild(canvas);
+	});
+
+	afterEach(() => {
+		canvas.remove();
+		document.documentElement.removeAttribute('data-kb-palette');
+		delete window.kadenceDesignTokensPalettes;
 	});
 
 	/**
@@ -101,16 +116,19 @@ describe('palette-swatch-preview', () => {
 	});
 
 	/**
-	 * applyPalettePreview sets the attribute for a palette id and removes it for the empty id.
+	 * applyPalettePreview reflects the palette id onto the document root and holds the canvas on the current
+	 * palette, then clears both for the empty id.
 	 *
 	 * @return {void}
 	 */
-	it('sets and clears the data-kb-palette attribute on the document root', () => {
+	it('previews on the document root and shields the canvas with the current palette', () => {
 		applyPalettePreview('dark');
 		expect(document.documentElement.getAttribute('data-kb-palette')).toBe('dark');
+		expect(canvas.getAttribute('data-kb-palette')).toBe('default');
 
 		applyPalettePreview('');
 		expect(document.documentElement.hasAttribute('data-kb-palette')).toBe(false);
+		expect(canvas.hasAttribute('data-kb-palette')).toBe(false);
 	});
 
 	/**
@@ -123,6 +141,7 @@ describe('palette-swatch-preview', () => {
 		setSelection('a', { a: { kbPalette: 'dark' } });
 		registerTokenSwatchPalettePreview();
 		expect(document.documentElement.getAttribute('data-kb-palette')).toBe('dark');
+		expect(canvas.getAttribute('data-kb-palette')).toBe('default');
 
 		setSelection('b', { b: { kbPalette: 'sunset' } });
 		mockSubscriber();
@@ -131,5 +150,6 @@ describe('palette-swatch-preview', () => {
 		setSelection(null);
 		mockSubscriber();
 		expect(document.documentElement.hasAttribute('data-kb-palette')).toBe(false);
+		expect(canvas.hasAttribute('data-kb-palette')).toBe(false);
 	});
 });

--- a/src/extension/design-tokens/palette-swatch-preview.js
+++ b/src/extension/design-tokens/palette-swatch-preview.js
@@ -114,8 +114,9 @@ function reflect(el, id) {
 /**
  * Reflect an effective palette id onto the top-document `<html>` (so the inspector swatches and the pop color
  * popover preview it), and hold the editor canvas on the library `$current` so an un-iframed canvas does not
- * inherit the preview. A no-op on `<html>` when the value is unchanged, so the shared subscription never thrashes
- * the attribute.
+ * inherit the preview. Per-element writes are skipped when the value is unchanged (see `reflect`), so the shared
+ * subscription never thrashes attributes; the canvas shield is reconciled on every call, so a re-mounted canvas
+ * is re-shielded even when `<html>` already carries the palette.
  *
  * @param {string} id The effective palette id ('' clears the override so swatches follow the set `$current`).
  *
@@ -129,10 +130,6 @@ export function applyPalettePreview(id) {
 	}
 
 	const root = document.documentElement;
-
-	if ((root.getAttribute(SWITCH_ATTR) || '') === id) {
-		return;
-	}
 
 	reflect(root, id);
 

--- a/src/extension/design-tokens/palette-swatch-preview.js
+++ b/src/extension/design-tokens/palette-swatch-preview.js
@@ -2,26 +2,54 @@
  * Preview the selected block's color-palette override in the inspector's color controls.
  *
  * A block pinned to a palette (its `kbPalette`) re-skins its own canvas subtree through the projector's
- * `[data-kb-palette]` switch layer, but the color-control swatches live in the top-document sidebar, outside
+ * `[data-kb-palette]` switch layer, but the color-control swatches live in the top-document inspector, outside
  * that subtree, so they keep resolving `var(--kb-token--<id>)` against the editor `:root` — the library
  * `$current` — no matter which palette the block is pinned to.
  *
- * The same switch-layer CSS is already loaded in the top document: it rides the
- * `kadence-blocks-global-editor-styles` handle, a dependency of `wp-block-library`, alongside the base token
- * vars. So the whole fix is to reflect the selected block's effective palette onto the top-document `<html>` —
- * the existing `[data-kb-palette="<id>"]` rules then re-point the swatch vars (and the picker's computed
- * value, read from `document.documentElement`) to that palette, and clear back to `$current` when nothing is
- * pinned. No new CSS and no per-palette value map: the projector's switch layer stays the single source of
- * truth.
+ * The switch-layer CSS is already loaded in the top document: it rides the `kadence-blocks-global-editor-styles`
+ * handle, a dependency of `wp-block-library`. Reflecting the selected block's effective palette onto the
+ * top-document `<html>` re-points the swatch vars (and the pop color popover, which portals to the body) through
+ * the existing `[data-kb-palette="<id>"]` rules, and clears back to `$current` when nothing is pinned.
+ *
+ * Because a non-iframed editor canvas shares that same top-document root, the `<html>` override would otherwise
+ * cascade into every canvas block that does NOT pin its own palette. To keep the canvas on the library `$current`,
+ * the preview also re-declares `$current` on the canvas root (`.editor-styles-wrapper`) through the same switch
+ * layer — the projector emits a `[data-kb-palette="<current>"]` rule too — so unpinned blocks stay put while
+ * pinned blocks re-override through their own deeper wrapper attribute. In an iframed editor the canvas is a
+ * separate document, so the shield selector matches nothing in the top document and only the iframe's own
+ * per-block attributes apply. No new CSS and no per-palette value map: the projector's switch layer stays the
+ * single source of truth.
  */
 import { select, subscribe } from '@wordpress/data';
 
 /**
- * The wrapper attribute the projector's palette switch layer keys on, mirrored onto the top-document `<html>`.
+ * The wrapper attribute the projector's palette switch layer keys on.
  *
  * @type {string}
  */
 const SWITCH_ATTR = 'data-kb-palette';
+
+/**
+ * The editor canvas root. When the canvas is not iframed it shares the top-document `:root`, so it is re-declared
+ * to the library `$current` while a preview is active to keep unpinned blocks off the previewed palette.
+ *
+ * @type {string}
+ */
+const CANVAS_SELECTOR = '.editor-styles-wrapper';
+
+/**
+ * The library `$current` palette id from the server-localized catalog, defaulting to 'default'. Used to hold the
+ * canvas on the active palette while the inspector previews another.
+ *
+ * @since TBD
+ *
+ * @return {string} The current palette id.
+ */
+function currentPaletteId() {
+	const catalog = (typeof window !== 'undefined' && window.kadenceDesignTokensPalettes) || {};
+
+	return catalog.current || 'default';
+}
 
 /**
  * The selected block's effective palette id: its own `kbPalette`, else the nearest ancestor's — mirroring the
@@ -60,8 +88,34 @@ export function effectivePalette() {
 }
 
 /**
- * Reflect an effective palette id onto the top-document `<html>` via `data-kb-palette`, or remove the attribute
- * when empty. A no-op when the value is unchanged, so the shared subscription never thrashes the attribute.
+ * Set or clear `data-kb-palette` on one element, skipping the write when it already matches.
+ *
+ * @param {Element} el The element to stamp.
+ * @param {string}  id The palette id ('' removes the attribute).
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+function reflect(el, id) {
+	const current = el.getAttribute(SWITCH_ATTR) || '';
+
+	if (id === current) {
+		return;
+	}
+
+	if (id) {
+		el.setAttribute(SWITCH_ATTR, id);
+	} else {
+		el.removeAttribute(SWITCH_ATTR);
+	}
+}
+
+/**
+ * Reflect an effective palette id onto the top-document `<html>` (so the inspector swatches and the pop color
+ * popover preview it), and hold the editor canvas on the library `$current` so an un-iframed canvas does not
+ * inherit the preview. A no-op on `<html>` when the value is unchanged, so the shared subscription never thrashes
+ * the attribute.
  *
  * @param {string} id The effective palette id ('' clears the override so swatches follow the set `$current`).
  *
@@ -75,23 +129,25 @@ export function applyPalettePreview(id) {
 	}
 
 	const root = document.documentElement;
-	const current = root.getAttribute(SWITCH_ATTR) || '';
 
-	if (id === current) {
+	if ((root.getAttribute(SWITCH_ATTR) || '') === id) {
 		return;
 	}
 
-	if (id) {
-		root.setAttribute(SWITCH_ATTR, id);
-	} else {
-		root.removeAttribute(SWITCH_ATTR);
-	}
+	reflect(root, id);
+
+	// Re-declare the current palette on the canvas root so unpinned blocks stay on $current while `<html>` carries
+	// the preview; removing it when the preview clears. Matches nothing in the top document when the canvas is
+	// iframed, which is the correct no-op there.
+	const shield = id ? currentPaletteId() : '';
+
+	document.querySelectorAll(CANVAS_SELECTOR).forEach((canvas) => reflect(canvas, shield));
 }
 
 /**
- * Keep the top-document `<html>` `data-kb-palette` in sync with the selected block's effective palette, so the
- * inspector's color-control swatches preview that palette's colors through the projector's existing switch
- * layer. Applies once immediately, then on every block-editor store change. Returns the unsubscribe handle.
+ * Keep the preview in sync with the selected block's effective palette, so the inspector's color-control swatches
+ * preview that palette's colors through the projector's existing switch layer. Applies once immediately, then on
+ * every block-editor store change. Returns the unsubscribe handle.
  *
  * @since TBD
  *

--- a/src/extension/design-tokens/palette-swatch-preview.js
+++ b/src/extension/design-tokens/palette-swatch-preview.js
@@ -116,7 +116,7 @@ function reflect(el, id) {
  * popover preview it), and hold the editor canvas on the library `$current` so an un-iframed canvas does not
  * inherit the preview. Per-element writes are skipped when the value is unchanged (see `reflect`), so the shared
  * subscription never thrashes attributes; the canvas shield is reconciled on every call, so a re-mounted canvas
- * is re-shielded even when `<html>` already carries the palette.
+ * is shielded again even when `<html>` already carries the palette.
  *
  * @param {string} id The effective palette id ('' clears the override so swatches follow the set `$current`).
  *

--- a/src/extension/design-tokens/palette-swatch-preview.js
+++ b/src/extension/design-tokens/palette-swatch-preview.js
@@ -1,0 +1,106 @@
+/**
+ * Preview the selected block's color-palette override in the inspector's color controls.
+ *
+ * A block pinned to a palette (its `kbPalette`) re-skins its own canvas subtree through the projector's
+ * `[data-kb-palette]` switch layer, but the color-control swatches live in the top-document sidebar, outside
+ * that subtree, so they keep resolving `var(--kb-token--<id>)` against the editor `:root` — the library
+ * `$current` — no matter which palette the block is pinned to.
+ *
+ * The same switch-layer CSS is already loaded in the top document: it rides the
+ * `kadence-blocks-global-editor-styles` handle, a dependency of `wp-block-library`, alongside the base token
+ * vars. So the whole fix is to reflect the selected block's effective palette onto the top-document `<html>` —
+ * the existing `[data-kb-palette="<id>"]` rules then re-point the swatch vars (and the picker's computed
+ * value, read from `document.documentElement`) to that palette, and clear back to `$current` when nothing is
+ * pinned. No new CSS and no per-palette value map: the projector's switch layer stays the single source of
+ * truth.
+ */
+import { select, subscribe } from '@wordpress/data';
+
+/**
+ * The wrapper attribute the projector's palette switch layer keys on, mirrored onto the top-document `<html>`.
+ *
+ * @type {string}
+ */
+const SWITCH_ATTR = 'data-kb-palette';
+
+/**
+ * The selected block's effective palette id: its own `kbPalette`, else the nearest ancestor's — mirroring the
+ * projector's `[data-kb-palette]` cascade to descendants — else '' when no block is selected or none is pinned.
+ *
+ * @since TBD
+ *
+ * @return {string} The effective palette id, or '' when there is no override to preview.
+ */
+export function effectivePalette() {
+	const editor = select('core/block-editor');
+	const clientId = editor && editor.getSelectedBlockClientId && editor.getSelectedBlockClientId();
+
+	if (!clientId) {
+		return '';
+	}
+
+	const own = editor.getBlockAttributes(clientId)?.kbPalette;
+
+	if (own) {
+		return own;
+	}
+
+	// Walk from the nearest ancestor outward, so a child follows the closest pinned ancestor.
+	const parents = editor.getBlockParents(clientId) || [];
+
+	for (let i = parents.length - 1; i >= 0; i--) {
+		const inherited = editor.getBlockAttributes(parents[i])?.kbPalette;
+
+		if (inherited) {
+			return inherited;
+		}
+	}
+
+	return '';
+}
+
+/**
+ * Reflect an effective palette id onto the top-document `<html>` via `data-kb-palette`, or remove the attribute
+ * when empty. A no-op when the value is unchanged, so the shared subscription never thrashes the attribute.
+ *
+ * @param {string} id The effective palette id ('' clears the override so swatches follow the set `$current`).
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+export function applyPalettePreview(id) {
+	if (typeof document === 'undefined' || !document.documentElement) {
+		return;
+	}
+
+	const root = document.documentElement;
+	const current = root.getAttribute(SWITCH_ATTR) || '';
+
+	if (id === current) {
+		return;
+	}
+
+	if (id) {
+		root.setAttribute(SWITCH_ATTR, id);
+	} else {
+		root.removeAttribute(SWITCH_ATTR);
+	}
+}
+
+/**
+ * Keep the top-document `<html>` `data-kb-palette` in sync with the selected block's effective palette, so the
+ * inspector's color-control swatches preview that palette's colors through the projector's existing switch
+ * layer. Applies once immediately, then on every block-editor store change. Returns the unsubscribe handle.
+ *
+ * @since TBD
+ *
+ * @return {Function} The unsubscribe function.
+ */
+export function registerTokenSwatchPalettePreview() {
+	applyPalettePreview(effectivePalette());
+
+	return subscribe(() => {
+		applyPalettePreview(effectivePalette());
+	}, 'core/block-editor');
+}


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4087/color-control-soft-3995-style-token-picker-in-picker-palette-switching
📹  https://www.loom.com/share/0c508363df8841a09bc11b577d113547

Makes the inspector's color-control swatches preview the selected block's per-block palette.

A block pinned to a palette already re-skins its canvas subtree via the projector's `[data-kb-palette]` switch layer, but the color-control swatches live in the top-document sidebar and keep resolving `var(--kb-token--*)` against the library `$current`. That switch-layer CSS (and the base token vars) is **already loaded in the top document** — it rides the `kadence-blocks-global-editor-styles` handle, a dependency of `wp-block-library` — so this simply mirrors the selected block's effective palette (its own `kbPalette`, else the nearest pinned ancestor's) onto the top-document `<html>`. The existing switch layer re-points the swatch vars and the picker's computed value to that palette, and clears back to `$current` on deselect.

No new CSS, no per-palette value map, no PHP: the projector's switch layer stays the single source of truth.

Stacked on #1299.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live palette previews for color swatches in the block editor.
  * Palette previews now reflect the selected block or its inherited palette.
  * Preview styling updates automatically when the selected block changes and clears when no palette applies.

* **Tests**
  * Added coverage for selected, inherited, unconfigured, and deselected palette scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
