### PR TITLE
SOFT-4087 [6/6]: follow the per-block palette for preset color classes

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Palette/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Palette/Css_Builder.php
@@ -21,10 +21,11 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Value;
  * palette, respecting preset selection (a selected preset keeps its own binding, re-tinted).
  *
  * This is the narrow color-only replacement for the cross-library `[data-kb-token-set]` switch removed by the
- * single-active-library pivot: it stays within the single active library and swaps only colors. Accepted v1 limitation: the
- * numbered `--global-palette*` bridges resolve at `:root`, so a `[data-kb-palette]` subtree live-swaps content
- * that reads `--kb-token--*` color vars (directly or through a preset), but not blocks that read a numbered
- * `--global-paletteN` bridge directly.
+ * single-active-library pivot: it stays within the single active library and swaps only colors. A palette that
+ * re-tints a slot-backed color re-declares its numbered `--global-paletteN` bridge too (built in
+ * {@see Projector::palettes_for()}), so a `[data-kb-palette]` subtree live-swaps content that reads a numbered
+ * `--global-paletteN` bridge directly — including the WordPress preset color classes the Projector redirects to
+ * it — as well as content reading `--kb-token--*` color vars (directly or through a preset).
  *
  * Pure: no WordPress calls, no globals, no side effects. The WordPress wiring lives in Projector.
  *

--- a/includes/resources/Design_Tokens/Projection/Palette/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Palette/Projector.php
@@ -304,8 +304,13 @@ final class Projector extends Abstract_Css_Projector {
 	 * Static CSS that redirects a Kadence block's WordPress preset color classes — `has-<slug>-color` and
 	 * `has-<slug>-background-color` — to the numbered `--global-paletteN` variable.
 	 *
-	 * The selector is scoped to `.wp-block-kadence-*`, so only our own blocks are affected: core and third-party
-	 * blocks keep reading WordPress's global `--wp--preset--color--*` variables, which we never touch.
+	 * The selector is scoped to Kadence's own classes (`[class*="kadence-"]`), so only our own blocks are affected
+	 * — core and third-party blocks keep reading WordPress's untouched global `--wp--preset--color--*` variables.
+	 * The broad `kadence-` match (not `wp-block-kadence-`) is deliberate: on the front end the preset class and the
+	 * block's `wp-block-kadence-*` class share one element, but in the editor the preset class lands on an inner
+	 * heading that carries a `kadence-*` class without the `wp-block-kadence-*` wrapper class. The `:root` prefix
+	 * adds specificity, enough to beat both the front-end preset rule and the editor's zero-specificity
+	 * `:where(.editor-styles-wrapper)`-scoped copy of it.
 	 *
 	 * The baseline is unchanged. At `:root`, `--global-paletteN` already equals the color WordPress provides for
 	 * that slot (Kadence feeds both from the same palette). Inside a `[data-kb-palette]` subtree the numbered
@@ -341,11 +346,12 @@ final class Projector extends Abstract_Css_Projector {
 				continue;
 			}
 
-			$var = 'var(--global-' . $slot->slug . ')';
+			$var   = 'var(--global-' . $slot->slug . ')';
+			$scope = ':root [class*="kadence-"]';
 
 			foreach ( [ $kebab, 'theme-' . $kebab ] as $class_slug ) {
-				$css .= '[class*="wp-block-kadence-"].has-' . $class_slug . '-color{color:' . $var . ' !important;}';
-				$css .= '[class*="wp-block-kadence-"].has-' . $class_slug . '-background-color{background-color:' . $var . ' !important;}';
+				$css .= $scope . '.has-' . $class_slug . '-color{color:' . $var . ' !important;}';
+				$css .= $scope . '.has-' . $class_slug . '-background-color{background-color:' . $var . ' !important;}';
 			}
 		}
 

--- a/includes/resources/Design_Tokens/Projection/Palette/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Palette/Projector.php
@@ -5,6 +5,7 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Palette;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts\Abstract_Css_Projector;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Palette_Slot;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Preset\Css_Builder as Preset_Css_Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Palettes;
@@ -201,7 +202,7 @@ final class Projector extends Abstract_Css_Projector {
 		$css = $this->css_builder->css(
 			$this->palettes_for( $active ),
 			$this->presets->canonical_declarations( $active )
-		);
+		) . $this->global_palette_overrides();
 
 		wp_cache_set( $cache_key, $css, self::CACHE_GROUP, DAY_IN_SECONDS );
 
@@ -217,6 +218,10 @@ final class Projector extends Abstract_Css_Projector {
 	 * `[data-kb-palette]` override completely replaces the subtree's colors — semantics and shadow composites
 	 * included — no matter which palette the library `$current` points at. A var no palette changes is identical
 	 * everywhere, so it is left to inherit and never re-declared.
+	 *
+	 * Each slot-backed color additionally re-declares its numbered `--global-paletteN` bridge to the same
+	 * per-palette value, so content that reads the numbered bridge (including the WordPress preset color classes
+	 * redirected to it by {@see global_palette_overrides()}) swaps alongside the `--kb-token--*` vars.
 	 *
 	 * @since TBD
 	 *
@@ -242,6 +247,7 @@ final class Projector extends Abstract_Css_Projector {
 			}
 		}
 
+		$slots    = $this->palette_slot_vars();
 		$palettes = [];
 
 		foreach ( $ids as $id ) {
@@ -250,6 +256,13 @@ final class Projector extends Abstract_Css_Projector {
 			foreach ( array_keys( $changed ) as $var ) {
 				if ( array_key_exists( $var, $resolved[ $id ] ) ) {
 					$declarations[ $var ] = $resolved[ $id ][ $var ];
+
+					// Also swap the numbered --global-paletteN bridge for a slot-backed color, so blocks (and the
+					// WordPress preset color classes redirected to it, see global_palette_overrides()) that read the
+					// numbered bridge follow the palette too — not only content reading --kb-token--* directly.
+					if ( isset( $slots[ $var ] ) ) {
+						$declarations[ '--global-' . $slots[ $var ] ] = $resolved[ $id ][ $var ];
+					}
 				}
 			}
 
@@ -259,5 +272,83 @@ final class Projector extends Abstract_Css_Projector {
 		}
 
 		return $palettes;
+	}
+
+	/**
+	 * The palette-slot tokens' css vars mapped to their slot slug (e.g.
+	 * `--kb-token--primitive--color--brand--secondary` => `palette2`), so palettes_for() can bridge each slot's
+	 * per-palette value onto the numbered `--global-paletteN` variable. Skips any non-palette `kadence_slot`
+	 * (e.g. a font-size slot).
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, string> css var => slot slug.
+	 */
+	private function palette_slot_vars(): array {
+		$slots = [];
+
+		foreach ( $this->registry->by_projection( Kadence_Palette_Slot::get_projection_key() ) as $token ) {
+			$slot = Kadence_Palette_Slot::from_token( $token );
+
+			if ( $slot === null ) {
+				continue;
+			}
+
+			$slots[ $token->css_var ] = $slot->slug;
+		}
+
+		return $slots;
+	}
+
+	/**
+	 * Static CSS that redirects a Kadence block's WordPress preset color classes — `has-<slug>-color` and
+	 * `has-<slug>-background-color` — to the numbered `--global-paletteN` variable.
+	 *
+	 * The selector is scoped to `.wp-block-kadence-*`, so only our own blocks are affected: core and third-party
+	 * blocks keep reading WordPress's global `--wp--preset--color--*` variables, which we never touch.
+	 *
+	 * The baseline is unchanged. At `:root`, `--global-paletteN` already equals the color WordPress provides for
+	 * that slot (Kadence feeds both from the same palette). Inside a `[data-kb-palette]` subtree the numbered
+	 * bridge is re-declared (see palettes_for()), so the redirected color follows the per-block palette.
+	 *
+	 * Why that subtree re-declaration is needed depends on the theme. On a non-Kadence theme `--global-paletteN`
+	 * is itself a `var(--kb-token--*)` reference (set by the Css_Var Legacy_Filter_Bridge), so it already
+	 * re-resolves against a subtree's re-declared token on its own — the re-declaration there is a harmless
+	 * redundancy. Under the Kadence theme `--global-paletteN` is a fixed customizer literal with no token
+	 * reference (and Legacy_Filter_Bridge is a no-op), so re-declaring it in palettes_for() is what makes it swap.
+	 *
+	 * Both slug schemes map to the same bridge: the plugin's own `palette-N` and the Kadence theme's
+	 * `theme-palette-N`. The `theme-palette-N` selectors are simply inert on other themes.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	private function global_palette_overrides(): string {
+		$css = '';
+
+		foreach ( $this->registry->by_projection( Kadence_Palette_Slot::get_projection_key() ) as $token ) {
+			$slot = Kadence_Palette_Slot::from_token( $token );
+
+			if ( $slot === null ) {
+				continue;
+			}
+
+			// WordPress kebab-cases the stored slug ("palette2") for the class/var name ("palette-2").
+			$kebab = preg_replace( '/([a-z])(\d)/', '$1-$2', $slot->slug );
+
+			if ( ! is_string( $kebab ) ) {
+				continue;
+			}
+
+			$var = 'var(--global-' . $slot->slug . ')';
+
+			foreach ( [ $kebab, 'theme-' . $kebab ] as $class_slug ) {
+				$css .= '[class*="wp-block-kadence-"].has-' . $class_slug . '-color{color:' . $var . ' !important;}';
+				$css .= '[class*="wp-block-kadence-"].has-' . $class_slug . '-background-color{background-color:' . $var . ' !important;}';
+			}
+		}
+
+		return $css;
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Palette/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Palette/ProjectorTest.php
@@ -122,6 +122,51 @@ final class ProjectorTest extends TestCase {
 	}
 
 	/**
+	 * Each slot-backed color re-declares its numbered --global-paletteN bridge to the palette's value, so content
+	 * (and the redirected WordPress preset color classes) that reads the numbered bridge swaps with the palette.
+	 *
+	 * @return void
+	 */
+	public function testTheSwitchSelectorBridgesTheNumberedGlobalPalette(): void {
+		$this->store->save_document( (string) wp_json_encode( $this->custom_palette_overrides() ) );
+
+		$css = $this->projector->css();
+
+		$start = strpos( $css, '[data-kb-palette="custom"]{' );
+		$this->assertNotFalse( $start );
+		$block = substr( $css, (int) $start, (int) strpos( $css, '}', (int) $start ) - (int) $start + 1 );
+
+		// brand.primary backs slot palette1, brand.secondary backs slot palette2 (see declarations.php).
+		$this->assertStringContainsString( '--global-palette1:#DD6B20;', $block );
+		$this->assertStringContainsString( '--global-palette2:#C05621;', $block );
+	}
+
+	/**
+	 * The projector emits scoped override rules pointing a Kadence block's WordPress preset color classes at the
+	 * numbered --global-paletteN bridge (so they follow a per-block palette), scoped to .wp-block-kadence-* so core
+	 * blocks reading WordPress's global preset vars are untouched. Covers the plugin's `palette-N` slug and the
+	 * Kadence theme's `theme-palette-N` slug, both mapping to the same bridge.
+	 *
+	 * @return void
+	 */
+	public function testItRedirectsKadencePresetColorClassesToTheGlobalBridge(): void {
+		$css = $this->projector->css();
+
+		$this->assertStringContainsString(
+			'[class*="wp-block-kadence-"].has-palette-1-color{color:var(--global-palette1) !important;}',
+			$css
+		);
+		$this->assertStringContainsString(
+			'[class*="wp-block-kadence-"].has-palette-2-background-color{background-color:var(--global-palette2) !important;}',
+			$css
+		);
+		$this->assertStringContainsString(
+			'[class*="wp-block-kadence-"].has-theme-palette-1-color{color:var(--global-palette1) !important;}',
+			$css
+		);
+	}
+
+	/**
 	 * A deactivated registry projects nothing, so a fail-closed registry leaves KB's behavior untouched.
 	 *
 	 * @return void

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Palette/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Palette/ProjectorTest.php
@@ -143,9 +143,10 @@ final class ProjectorTest extends TestCase {
 
 	/**
 	 * The projector emits scoped override rules pointing a Kadence block's WordPress preset color classes at the
-	 * numbered --global-paletteN bridge (so they follow a per-block palette), scoped to .wp-block-kadence-* so core
-	 * blocks reading WordPress's global preset vars are untouched. Covers the plugin's `palette-N` slug and the
-	 * Kadence theme's `theme-palette-N` slug, both mapping to the same bridge.
+	 * numbered --global-paletteN bridge (so they follow a per-block palette), scoped to `:root [class*="kadence-"]`
+	 * — which matches both the front-end and editor DOM — so only our own blocks are affected while core blocks
+	 * reading WordPress's global preset vars stay untouched. Covers the plugin's `palette-N` slug and the Kadence
+	 * theme's `theme-palette-N` slug, both mapping to the same bridge.
 	 *
 	 * @return void
 	 */

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Palette/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Palette/ProjectorTest.php
@@ -153,15 +153,15 @@ final class ProjectorTest extends TestCase {
 		$css = $this->projector->css();
 
 		$this->assertStringContainsString(
-			'[class*="wp-block-kadence-"].has-palette-1-color{color:var(--global-palette1) !important;}',
+			':root [class*="kadence-"].has-palette-1-color{color:var(--global-palette1) !important;}',
 			$css
 		);
 		$this->assertStringContainsString(
-			'[class*="wp-block-kadence-"].has-palette-2-background-color{background-color:var(--global-palette2) !important;}',
+			':root [class*="kadence-"].has-palette-2-background-color{background-color:var(--global-palette2) !important;}',
 			$css
 		);
 		$this->assertStringContainsString(
-			'[class*="wp-block-kadence-"].has-theme-palette-1-color{color:var(--global-palette1) !important;}',
+			':root [class*="kadence-"].has-theme-palette-1-color{color:var(--global-palette1) !important;}',
 			$css
 		);
 	}


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4087/color-control-soft-3995-style-token-picker-in-picker-palette-switching
📹  https://www.loom.com/share/0c508363df8841a09bc11b577d113547
📹  https://www.loom.com/share/801b11082f3a40d499e9027563d321e5 <- Specific to this PR

Makes a block's WordPress preset color classes (`has-<slug>-color`) follow its per-block palette. Advanced Text and Row Layout can pick colors that render through WordPress preset classes, which read the global `--wp--preset--color--*` variables — variables shared by core and third-party blocks that the switch layer must never re-point.

Instead, the palette switch layer re-declares each slot-backed color's numbered `--global-paletteN` bridge per palette, and the projector emits scoped override rules — `:root [class*="kadence-"].has-<slug>-color` — that point **only our own blocks'** preset color classes at `var(--global-paletteN)`. At `:root` that already equals the value WordPress provides for the slot (Kadence feeds both from the same palette), so the baseline is unchanged; inside a `[data-kb-palette]` subtree the numbered bridge is re-declared, so the color swaps. The `kadence-` scope and `:root` prefix match both the front-end and editor DOM, and it covers the plugin's own `palette-N` slugs and the Kadence theme's `theme-palette-N`.

No per-block edits and no touching WordPress's global preset variables.

Stacked on #1300.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved palette switching with more reliable support for scoped content and nested layouts.
  - Added support for Kadence color and background preset classes across theme and plugin palette naming schemes.
  - Custom palettes now correctly apply their colors to supported WordPress preset classes.

- **Bug Fixes**
  - Fixed palette overrides so preset-based colors remain consistent when palettes are changed or scoped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
