### PR TITLE
SOFT-4194: Token Picker: tag custom dimension tokens with their real role

### DIFF
--- a/includes/resources/Design_Tokens/Document/Reserved_Namespace.php
+++ b/includes/resources/Design_Tokens/Document/Reserved_Namespace.php
@@ -78,6 +78,20 @@ final class Reserved_Namespace {
 	}
 
 	/**
+	 * The reserved namespace segment that marks a user-created primitive: the `custom` in
+	 * `primitive.<type>.custom.<slug>`. Exposed so a consumer keying off the segment (e.g. deriving a
+	 * custom token's real sub-kind from its group) references this single source of truth instead of
+	 * repeating the literal.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_segment(): string {
+		return self::SEGMENT;
+	}
+
+	/**
 	 * Whether a terminal slug (not a full id) is valid kebab-case.
 	 *
 	 * @since TBD

--- a/includes/resources/Design_Tokens/Editor/Pickable_Tokens_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Pickable_Tokens_Catalog.php
@@ -3,6 +3,7 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Editor;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Reserved_Namespace;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
@@ -111,7 +112,7 @@ final class Pickable_Tokens_Catalog {
 				'label' => $token->label,
 				'type'  => $token->type,
 				'layer' => $this->layer_of( $token->id ),
-				'role'  => $this->role_of( $token->id ),
+				'role'  => $this->role_of( $token->id, $token->group_key ),
 			];
 		}
 
@@ -127,17 +128,31 @@ final class Pickable_Tokens_Catalog {
 	 * (`primitive.dimension.<role>.<step>`), which is normalized away so a semantic and a primitive
 	 * token of the same sub-kind report the same role. An id with no role segment yields "".
 	 *
+	 * A user-minted scale token nests `custom` where the sub-kind would be
+	 * (`primitive.dimension.custom.<slug>`), so the id alone reports the literal `custom`. In that one
+	 * case the real sub-kind is taken from the token's `group_key` — the group the "+ Add …" flow minted
+	 * it into, whose vocabulary is the role vocabulary — falling back to the id-derived `custom` when the
+	 * token carries no group_key. Only `primitive.dimension.custom.*` derives role `custom`, so no other
+	 * token (colors included, which carry no machine group_key) is affected.
+	 *
 	 * @since TBD
 	 *
-	 * @param string $id The token id (a dot-path).
+	 * @param string $id        The token id (a dot-path).
+	 * @param string $group_key The token's group_key, used to recover a custom dimension token's sub-kind.
 	 *
 	 * @return string The role sub-kind, or "" when the id carries none.
 	 */
-	private function role_of( string $id ): string {
+	private function role_of( string $id, string $group_key ): string {
 		$segments = explode( '.', $id );
 
 		if ( ( $segments[0] ?? '' ) === Layers::get_primitive() && ( $segments[1] ?? '' ) === self::DIMENSION_GROUP ) {
-			return $segments[2] ?? '';
+			$role = $segments[2] ?? '';
+
+			if ( $role === Reserved_Namespace::get_segment() && $group_key !== '' ) {
+				return $group_key;
+			}
+
+			return $role;
 		}
 
 		return $segments[1] ?? '';

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -76,7 +76,7 @@ foreach ( $radius_labels as $slug => $label ) {
 		'type'      => 'dimension',
 		'label'     => $label,
 		'group'     => __( 'Border Radius', 'kadence-blocks' ),
-		'group_key' => 'border-radius',
+		'group_key' => 'radius',
 	];
 }
 
@@ -115,7 +115,7 @@ $icon_size_tokens = array_map(
 			'type'      => 'dimension',
 			'label'     => strtoupper( $slug ),
 			'group'     => __( 'Icon Sizes', 'kadence-blocks' ),
-			'group_key' => 'icon-sizes',
+			'group_key' => 'icon-size',
 		];
 	},
 	$icon_size_slugs

--- a/src/style-library/__tests__/scale-flows.test.js
+++ b/src/style-library/__tests__/scale-flows.test.js
@@ -29,7 +29,7 @@ describe('addScaleTokenFlow', () => {
 		const onError = jest.fn();
 
 		const result = await addScaleTokenFlow({
-			groupKey: 'border-radius',
+			groupKey: 'radius',
 			tokenType: 'dimension',
 			slugBase: 'radius',
 			label: 'New Radius',
@@ -47,7 +47,7 @@ describe('addScaleTokenFlow', () => {
 			$type: 'dimension',
 			$value: '0.5rem',
 			label: 'New Radius',
-			group: 'border-radius',
+			group: 'radius',
 			version: 'v1',
 		});
 		expect(refreshFeed).toHaveBeenCalledWith('default');
@@ -65,7 +65,7 @@ describe('addScaleTokenFlow', () => {
 
 		await expect(
 			addScaleTokenFlow({
-				groupKey: 'border-radius',
+				groupKey: 'radius',
 				tokenType: 'dimension',
 				slugBase: 'radius',
 				label: 'New Radius',

--- a/src/style-library/components/pages/BorderRadiusScreen.js
+++ b/src/style-library/components/pages/BorderRadiusScreen.js
@@ -44,7 +44,7 @@ export const BORDER_RADIUS_CONFIG = {
 	title: __('Corner Radius', 'kadence-blocks'),
 	addLabel: __('Add Border Radius', 'kadence-blocks'),
 	group: __('Border Radius', 'kadence-blocks'),
-	groupKey: 'border-radius',
+	groupKey: 'radius',
 	tokenType: 'dimension',
 	slugBase: 'radius',
 	newTokenLabel: __('New Radius', 'kadence-blocks'),

--- a/src/style-library/components/pages/IconSizesScreen.js
+++ b/src/style-library/components/pages/IconSizesScreen.js
@@ -59,7 +59,7 @@ export const ICON_SIZES_CONFIG = {
 	title: __('Icon Sizes', 'kadence-blocks'),
 	addLabel: __('Add Icon Size', 'kadence-blocks'),
 	group: __('Icon Sizes', 'kadence-blocks'),
-	groupKey: 'icon-sizes',
+	groupKey: 'icon-size',
 	tokenType: 'dimension',
 	slugBase: 'icon-size',
 	newTokenLabel: __('New Icon Size', 'kadence-blocks'),

--- a/tests/wpunit/Resources/Design_Tokens/Document/User_Primitive_Document_ValidatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/User_Primitive_Document_ValidatorTest.php
@@ -463,7 +463,7 @@ final class User_Primitive_Document_ValidatorTest extends TestCase {
 	public function testEntryWithAKebabCaseGroupReturnsNoErrors(): void {
 		$id  = 'primitive.color.custom.brand';
 		$doc = $this->doc_with_color_entry( $id, 'Brand', '#3182CE' );
-		$doc = $this->index->add( $doc, $id, 'Brand', 'border-radius' );
+		$doc = $this->index->add( $doc, $id, 'Brand', 'radius' );
 
 		$this->assertSame( [], $this->validator->validate( $doc ) );
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Document/User_Primitive_IndexTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/User_Primitive_IndexTest.php
@@ -163,11 +163,11 @@ final class User_Primitive_IndexTest extends TestCase {
 	 */
 	public function testAddWithNullGroupPreservesTheExistingStoredGroup(): void {
 		$id  = 'primitive.dimension.custom.radius-md';
-		$doc = $this->doc_with_entry( $id, 'Radius MD', 'border-radius' );
+		$doc = $this->doc_with_entry( $id, 'Radius MD', 'radius' );
 
 		$result = $this->index->add( $doc, $id, 'Renamed Radius' );
 
-		$this->assertSame( 'border-radius', $this->index->all( $result )[ $id ]['group'] );
+		$this->assertSame( 'radius', $this->index->all( $result )[ $id ]['group'] );
 	}
 
 	/**
@@ -179,9 +179,9 @@ final class User_Primitive_IndexTest extends TestCase {
 		$id  = 'primitive.dimension.custom.radius-md';
 		$doc = $this->doc_with_entry( $id, 'Radius MD', 'old-group' );
 
-		$result = $this->index->add( $doc, $id, 'Radius MD', 'border-radius' );
+		$result = $this->index->add( $doc, $id, 'Radius MD', 'radius' );
 
-		$this->assertSame( 'border-radius', $this->index->all( $result )[ $id ]['group'] );
+		$this->assertSame( 'radius', $this->index->all( $result )[ $id ]['group'] );
 	}
 
 	/**
@@ -193,7 +193,7 @@ final class User_Primitive_IndexTest extends TestCase {
 	 */
 	public function testAddWithAnEmptyStringGroupClearsItAndOmitsTheKey(): void {
 		$id  = 'primitive.dimension.custom.radius-md';
-		$doc = $this->doc_with_entry( $id, 'Radius MD', 'border-radius' );
+		$doc = $this->doc_with_entry( $id, 'Radius MD', 'radius' );
 
 		$result = $this->index->add( $doc, $id, 'Radius MD', '' );
 
@@ -285,11 +285,11 @@ final class User_Primitive_IndexTest extends TestCase {
 	public function testRenameCarriesTheOldStoredGroupToTheNewId(): void {
 		$old_id = 'primitive.dimension.custom.radius-md';
 		$new_id = 'primitive.dimension.custom.radius-medium';
-		$doc    = $this->doc_with_entry( $old_id, 'Radius MD', 'border-radius' );
+		$doc    = $this->doc_with_entry( $old_id, 'Radius MD', 'radius' );
 
 		$result = $this->index->rename( $doc, $old_id, $new_id, 'Radius Medium' );
 
-		$this->assertSame( 'border-radius', $this->index->all( $result )[ $new_id ]['group'] );
+		$this->assertSame( 'radius', $this->index->all( $result )[ $new_id ]['group'] );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Pickable_Tokens_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Pickable_Tokens_CatalogTest.php
@@ -5,6 +5,7 @@ namespace Tests\wpunit\Resources\Design_Tokens\Editor;
 use Generator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Editor\Pickable_Tokens_Catalog;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\User_Primitive_Registrar;
 use Tests\Support\Classes\TestCase;
 
 /**
@@ -202,6 +203,87 @@ final class Pickable_Tokens_CatalogTest extends TestCase {
 	}
 
 	/**
+	 * A custom dimension token reports the sub-kind of the group it was minted into, not the literal
+	 * `custom` its id segment carries, so it narrows into the same control as its declared siblings.
+	 *
+	 * @dataProvider customDimensionRoleProvider
+	 *
+	 * @param string $group    The group_key the custom token is minted into.
+	 * @param string $slug     The custom token's slug.
+	 * @param string $expected The role the pool must report for it.
+	 *
+	 * @return void
+	 */
+	public function testACustomDimensionTokenTakesItsRoleFromItsGroupKey( string $group, string $slug, string $expected ): void {
+		$id = 'primitive.dimension.custom.' . $slug;
+
+		$this->store->save_document( $this->encode_custom_primitive_document( $id, 'dimension', '0.75rem', $group ) );
+		$this->container->get( User_Primitive_Registrar::class )->sync();
+
+		$entry = $this->first_with_prefix( $this->catalog->all()['tokens'], $id );
+
+		$this->assertSame( $expected, $entry['role'] );
+	}
+
+	/**
+	 * A custom dimension token minted into no group falls back to its id-derived role (`custom`), so an
+	 * ungrouped token degrades gracefully rather than reporting an empty role.
+	 *
+	 * @return void
+	 */
+	public function testABlankedGroupKeyFallsBackToTheIdDerivedRole(): void {
+		$id = 'primitive.dimension.custom.orphan';
+
+		$this->store->save_document( $this->encode_custom_primitive_document( $id, 'dimension', '0.75rem' ) );
+		$this->container->get( User_Primitive_Registrar::class )->sync();
+
+		$entry = $this->first_with_prefix( $this->catalog->all()['tokens'], $id );
+
+		$this->assertSame( 'custom', $entry['role'] );
+	}
+
+	/**
+	 * A custom color token keeps role `color`: only a `primitive.dimension.custom.*` id derives role
+	 * `custom`, so the group_key remap never touches a color (whose grouping is a display label, not a
+	 * role), and a color control's narrowing still surfaces it.
+	 *
+	 * @return void
+	 */
+	public function testACustomColorTokenKeepsTheColorRole(): void {
+		$id = 'primitive.color.custom.brand-teal';
+
+		$this->store->save_document( $this->encode_custom_primitive_document( $id, 'color', '#0d9488' ) );
+		$this->container->get( User_Primitive_Registrar::class )->sync();
+
+		$entry = $this->first_with_prefix( $this->catalog->all()['tokens'], $id );
+
+		$this->assertSame( 'color', $entry['role'] );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function customDimensionRoleProvider(): Generator {
+		yield 'radius' => [
+			'group'    => 'radius',
+			'slug'     => 'radius-md',
+			'expected' => 'radius',
+		];
+
+		yield 'icon size' => [
+			'group'    => 'icon-size',
+			'slug'     => 'icon-lg',
+			'expected' => 'icon-size',
+		];
+
+		yield 'spacing identity' => [
+			'group'    => 'spacing',
+			'slug'     => 'gap-2',
+			'expected' => 'spacing',
+		];
+	}
+
+	/**
 	 * @return Generator
 	 */
 	public function layerProvider(): Generator {
@@ -274,5 +356,48 @@ final class Pickable_Tokens_CatalogTest extends TestCase {
 		}
 
 		$this->fail( sprintf( 'No token of type "%s" with a matching resolved value in the pool.', $type ) );
+	}
+
+	/**
+	 * Encode a stored document with one user primitive: the tree leaf plus the userPrimitives envelope
+	 * entry the registrar reads, carrying a stable group key when one is given (omitted otherwise, so the
+	 * token registers ungrouped).
+	 *
+	 * @param string $id    The custom token's dot-path id.
+	 * @param string $type  The DTCG `$type`.
+	 * @param string $value The DTCG `$value`.
+	 * @param string $group The group_key stored in the envelope, or "" to register ungrouped.
+	 *
+	 * @return string The JSON-encoded document.
+	 */
+	private function encode_custom_primitive_document( string $id, string $type, string $value, string $group = '' ): string {
+		$segments = explode( '.', $id );
+
+		$tree = [
+			'$type'  => $type,
+			'$value' => $value,
+		];
+
+		for ( $i = count( $segments ) - 1; $i >= 0; $i-- ) {
+			$tree = [ $segments[ $i ] => $tree ];
+		}
+
+		$provenance = [ 'label' => 'Seeded ' . $id ];
+
+		if ( $group !== '' ) {
+			$provenance['group'] = $group;
+		}
+
+		$envelope = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'userPrimitives' => [
+						$id => $provenance,
+					],
+				],
+			],
+		];
+
+		return (string) wp_json_encode( array_merge( $tree, $envelope ) );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Token_RegistryTest.php
@@ -311,11 +311,11 @@ final class Token_RegistryTest extends TestCase {
 				'type'      => 'dimension',
 				'label'     => 'SM',
 				'group'     => 'Border Radius',
-				'group_key' => 'border-radius',
+				'group_key' => 'radius',
 			]
 		);
 
-		$this->assertSame( 'Border Radius', $this->registry->group_label_for( 'border-radius' ) );
+		$this->assertSame( 'Border Radius', $this->registry->group_label_for( 'radius' ) );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Registry/User_Primitive_RegistrarTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/User_Primitive_RegistrarTest.php
@@ -135,12 +135,12 @@ final class User_Primitive_RegistrarTest extends TestCase {
 				'type'      => 'dimension',
 				'label'     => 'SM',
 				'group'     => 'Border Radius',
-				'group_key' => 'border-radius',
+				'group_key' => 'radius',
 			]
 		);
 
 		$store->save_document(
-			$this->encode_document_with_group( 'primitive.dimension.custom.radius-md', 'dimension', 'Radius MD', 'border-radius' )
+			$this->encode_document_with_group( 'primitive.dimension.custom.radius-md', 'dimension', 'Radius MD', 'radius' )
 		);
 
 		$this->make_registrar( $registry, $logger )->sync();

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerLabelsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerLabelsTest.php
@@ -298,14 +298,14 @@ final class DocumentsControllerLabelsTest extends TestCase {
 		$slug = Token_Store::default_slug();
 		$id   = 'primitive.dimension.custom.radius-md';
 
-		$this->seed_user_primitive( $slug, $id, 'Radius MD', 'border-radius' );
+		$this->seed_user_primitive( $slug, $id, 'Radius MD', 'radius' );
 
 		$response = $this->controller->set_label( $this->label_request( 'PUT', $slug, $id, $this->store->get_version( $slug ), 'Custom Radius' ) );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
 
 		$stored = json_decode( $this->store->get_document( $slug ), true );
-		$this->assertSame( 'border-radius', $this->user_primitive_index->all( $stored )[ $id ]['group'] );
+		$this->assertSame( 'radius', $this->user_primitive_index->all( $stored )[ $id ]['group'] );
 
 		$this->sync_registrar();
 
@@ -325,14 +325,14 @@ final class DocumentsControllerLabelsTest extends TestCase {
 		$slug = Token_Store::default_slug();
 		$id   = 'primitive.dimension.custom.radius-md';
 
-		$this->seed_user_primitive( $slug, $id, 'Radius MD', 'border-radius' );
+		$this->seed_user_primitive( $slug, $id, 'Radius MD', 'radius' );
 
 		$response = $this->controller->delete_label( $this->label_request( 'DELETE', $slug, $id, $this->store->get_version( $slug ) ) );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
 
 		$stored = json_decode( $this->store->get_document( $slug ), true );
-		$this->assertSame( 'border-radius', $this->user_primitive_index->all( $stored )[ $id ]['group'] );
+		$this->assertSame( 'radius', $this->user_primitive_index->all( $stored )[ $id ]['group'] );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerOrderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerOrderTest.php
@@ -471,7 +471,7 @@ final class DocumentsControllerOrderTest extends TestCase {
 						'userPrimitives' => [
 							$id => [
 								'label' => 'Radius MD',
-								'group' => 'border-radius',
+								'group' => 'radius',
 							],
 						],
 					],

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -558,7 +558,7 @@ final class Feed_ControllerTest extends TestCase {
 						'userPrimitives' => [
 							$id => [
 								'label' => 'New Icon Size',
-								'group' => 'icon-sizes',
+								'group' => 'icon-size',
 							],
 						],
 					],

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/User_Primitives_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/User_Primitives_ControllerTest.php
@@ -576,7 +576,7 @@ final class User_Primitives_ControllerTest extends TestCase {
 		$this->store->save_document( '{}' );
 		$version = $this->store->get_version( $slug );
 
-		$request = $this->make_create_request( $slug, 'radius-md', 'dimension', '0.75rem', $version, 'Radius MD', 'border-radius' );
+		$request = $this->make_create_request( $slug, 'radius-md', 'dimension', '0.75rem', $version, 'Radius MD', 'radius' );
 		$result  = $this->controller->create_item( $request );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $result );
@@ -585,7 +585,7 @@ final class User_Primitives_ControllerTest extends TestCase {
 		$doc = $result->get_data()['document'];
 		$ext = $doc[ Extensions::get_extensions_key() ][ Extensions::get_namespace() ][ Extensions::get_section_user_primitives() ];
 
-		$this->assertSame( 'border-radius', $ext['primitive.dimension.custom.radius-md']['group'] );
+		$this->assertSame( 'radius', $ext['primitive.dimension.custom.radius-md']['group'] );
 	}
 
 	/**
@@ -1494,7 +1494,7 @@ final class User_Primitives_ControllerTest extends TestCase {
 		$version = $this->store->get_version( $slug );
 
 		$create = $this->controller->create_item(
-			$this->make_create_request( $slug, 'radius-md', 'dimension', '0.75rem', $version, 'Radius MD', 'border-radius' )
+			$this->make_create_request( $slug, 'radius-md', 'dimension', '0.75rem', $version, 'Radius MD', 'radius' )
 		);
 		$this->assertInstanceOf( WP_REST_Response::class, $create );
 
@@ -1508,7 +1508,7 @@ final class User_Primitives_ControllerTest extends TestCase {
 		$doc = $result->get_data()['document'];
 		$ext = $doc[ Extensions::get_extensions_key() ][ Extensions::get_namespace() ][ Extensions::get_section_user_primitives() ];
 
-		$this->assertSame( 'border-radius', $ext['primitive.dimension.custom.radius-medium']['group'] );
+		$this->assertSame( 'radius', $ext['primitive.dimension.custom.radius-medium']['group'] );
 		$this->assertArrayNotHasKey( 'primitive.dimension.custom.radius-md', $ext );
 	}
 


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4194/token-picker-tag-custom-dimension-tokens-with-their-real-role
📹 https://www.loom.com/share/003bcdd2c4b14362a1d7af29ebceaa8e

Custom dimension tokens are minted as `primitive.dimension.custom.<slug>`, so `Pickable_Tokens_Catalog::role_of()` tagged them role `custom` and the Token Picker's role narrowing dropped them.

- Align the two mismatched dimension `group_key`s with the role vocabulary (`border-radius` -> `radius`, `icon-sizes` -> `icon-size`) on both sides of the JS<->PHP mint contract.
- Derive a custom dimension token's role from its `group_key`; colors and shipped tokens keep their id-derived role. The `custom` segment is read via a new `Reserved_Namespace::get_segment()` accessor.

Groundwork only -- no picker UI is mounted.

**Note (colors):** the Token-Picker path (`kadenceDesignTokensPickable`) already exposes every color token -- all palette groups plus custom colors -- so a color control migrated to the picker inherits the full set natively; the standard color control's incomplete swatches are only because it reads the 9-slot `kadenceDesignTokensPalettes` source. Swatch *names* are a separate matter: the picker carries the registry label (e.g. "Brand Primary") while the Color Palette screen shows the palette-document label (e.g. "Main 1"), so matching them is a label-vocabulary reconciliation tracked in https://linear.app/nexcess/issue/SOFT-4196

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role assignment for custom dimension tokens based on their group.
  * Preserved fallback behavior for ungrouped tokens and color token roles.
* **Improvements**
  * Standardized border-radius and icon-size group keys for more consistent token handling.
  * Exposed the reserved custom namespace segment for reliable integration.
* **Tests**
  * Expanded coverage for custom token roles, grouping, renaming, ordering, and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->