### PR TITLE
SOFT-4199: Token Picker: order the pickable pool by the stored token sort order

### DIFF
--- a/includes/resources/Design_Tokens/Admin/Feed/Builder.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Builder.php
@@ -2,6 +2,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Sorter;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 
 /**
@@ -39,14 +40,25 @@ final class Builder {
 	private Preset_Nav $preset_nav;
 
 	/**
+	 * The shared stored-order permutation, applied one schema group at a time.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Sorter
+	 */
+	private Token_Sorter $sorter;
+
+	/**
 	 * @since TBD
 	 *
 	 * @param Token_Registry $registry   The token registry.
 	 * @param Preset_Nav     $preset_nav The nav-ready block-presets section builder.
+	 * @param Token_Sorter   $sorter     The shared stored-order permutation.
 	 */
-	public function __construct( Token_Registry $registry, Preset_Nav $preset_nav ) {
+	public function __construct( Token_Registry $registry, Preset_Nav $preset_nav, Token_Sorter $sorter ) {
 		$this->registry   = $registry;
 		$this->preset_nav = $preset_nav;
+		$this->sorter     = $sorter;
 	}
 
 	/**
@@ -121,16 +133,11 @@ final class Builder {
 	}
 
 	/**
-	 * Permute every schema group by the stored flat order. For each group independently: rows
-	 * whose id appears in the flat list come first, sorted by their position in that list; every
-	 * remaining row follows in declaration order — unmentioned ids append rather than sort last so
-	 * a token added after the order was saved (a later release, a newly created primitive) is
-	 * never silently pushed out of view. An id belonging to a different group simply never matches
-	 * one of this group's rows, so cross-group entries in the flat list are ignored naturally —
-	 * no explicit filtering by group is needed. The result of every branch is the same row set the
-	 * registry emitted — a reorder can never hide a token — and an empty stored order returns the
-	 * schema untouched (declaration order), so removing the stored order restores declaration
-	 * order with no other code path involved.
+	 * Permute every schema group by the stored flat order, one group at a time through the shared
+	 * {@see Token_Sorter} — the same permutation the editor's pickable-token pool applies, so the
+	 * picker and this screen can never disagree about where a token sits. Per its contract: listed
+	 * ids first by position, unmentioned ids appended in declaration order (never hidden), an empty
+	 * stored order returning the schema untouched.
 	 *
 	 * @since TBD
 	 *
@@ -144,23 +151,8 @@ final class Builder {
 			return $schema;
 		}
 
-		$positions = array_flip( $order );
-
 		foreach ( $schema['groups'] as $group => $rows ) {
-			$ordered   = [];
-			$unordered = [];
-
-			foreach ( $rows as $row ) {
-				if ( isset( $positions[ $row['id'] ] ) ) {
-					$ordered[] = $row;
-				} else {
-					$unordered[] = $row; // Not in the stored order — declaration order, appended after.
-				}
-			}
-
-			usort( $ordered, fn( array $a, array $b ): int => $positions[ $a['id'] ] <=> $positions[ $b['id'] ] );
-
-			$schema['groups'][ $group ] = array_merge( $ordered, $unordered );
+			$schema['groups'][ $group ] = $this->sorter->sort( $rows, $order );
 		}
 
 		return $schema;

--- a/includes/resources/Design_Tokens/Admin/Feed/Feed_Assembler.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Feed_Assembler.php
@@ -152,7 +152,7 @@ final class Feed_Assembler {
 			$resolved = false; // Corrupt stored document. Fail open: ship structure only.
 		}
 
-		$document = $this->read_document( $slug );
+		$document = $this->store->get_decoded_document( $slug );
 
 		return $this->builder->build(
 			$values,
@@ -203,28 +203,5 @@ final class Feed_Assembler {
 			'namespace' => Controller::namespace(),
 			'nonce'     => wp_create_nonce( 'wp_rest' ),
 		];
-	}
-
-	/**
-	 * Read and decode the stored overrides-only document for a library, empty when absent or
-	 * unreadable. Builder stays pure (no I/O, per its own docblock), so this owns the decode the
-	 * label overlay needs, alongside the store access this class already does for the version.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $slug The token library slug.
-	 *
-	 * @return array<string, mixed>
-	 */
-	private function read_document( string $slug ): array {
-		$raw = $this->store->get_document( $slug );
-
-		if ( $raw === '' ) {
-			return [];
-		}
-
-		$decoded = json_decode( $raw, true );
-
-		return is_array( $decoded ) ? $decoded : [];
 	}
 }

--- a/includes/resources/Design_Tokens/Database/Token_Store.php
+++ b/includes/resources/Design_Tokens/Database/Token_Store.php
@@ -146,6 +146,32 @@ final class Token_Store extends Query {
 	}
 
 	/**
+	 * Read the overrides-only DTCG document for a token library, decoded.
+	 *
+	 * The column holds JSON, so decoding it belongs to the gateway that owns the column rather than to
+	 * each of the callers that read it. Fail-soft the same way {@see self::get_document()} is: a library
+	 * with no row, and a row whose JSON is unreadable or does not decode to an array, both yield an empty
+	 * document, so a caller renders entirely from baseline instead of handling a decode failure itself.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token library slug.
+	 *
+	 * @return array<string, mixed> The decoded document, empty when absent or unreadable.
+	 */
+	public function get_decoded_document( string $slug = self::DEFAULT_SLUG ): array {
+		$raw = $this->get_document( $slug );
+
+		if ( $raw === '' ) {
+			return [];
+		}
+
+		$decoded = json_decode( $raw, true );
+
+		return is_array( $decoded ) ? $decoded : [];
+	}
+
+	/**
 	 * Read the cache-busting version hash for a token library.
 	 *
 	 * Consumed by downstream caches (e.g. the projected-CSS string is keyed on

--- a/includes/resources/Design_Tokens/Document/Token_Sorter.php
+++ b/includes/resources/Design_Tokens/Document/Token_Sorter.php
@@ -1,0 +1,94 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Document;
+
+/**
+ * Applies a library's stored tokenOrder to a set of token rows.
+ *
+ * The permutation every surface that lists tokens shares: rows whose id appears in the flat stored
+ * list come first, sorted by their position in it; every remaining row follows in the order it was
+ * handed over (declaration / registry order). Unmentioned ids append rather than sort last, so a
+ * token added after the order was saved — a later release, a freshly minted user primitive — is
+ * never silently pushed out of view, and the result of every branch is the same row set the caller
+ * passed in: a reorder can never hide a token.
+ *
+ * Callers apply this one group at a time. An id belonging to a different group simply never matches
+ * one of this group's rows, so cross-group entries in the flat list are ignored naturally and no
+ * filtering by group is needed here.
+ *
+ * Reading the raw document out of the store stays with the caller; this class only walks an
+ * already-decoded document (through {@see Token_Order_Index}) and permutes arrays, so it stays free
+ * of WordPress calls and I/O.
+ *
+ * @since TBD
+ */
+final class Token_Sorter {
+
+	/**
+	 * The reader for the stored flat token id list.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Order_Index
+	 */
+	private Token_Order_Index $order_index;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Order_Index $order_index The reader for the stored flat token id list.
+	 */
+	public function __construct( Token_Order_Index $order_index ) {
+		$this->order_index = $order_index;
+	}
+
+	/**
+	 * The flat ordered token id list stored on a decoded library document, empty when it carries none.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document The decoded library document.
+	 *
+	 * @return list<string> The flat ordered token id list.
+	 */
+	public function order_for( array $document ): array {
+		return $this->order_index->all( $document );
+	}
+
+	/**
+	 * Permute one group's rows by the stored flat order.
+	 *
+	 * An empty order returns the rows untouched (declaration order), so removing the stored order
+	 * restores declaration order with no other code path involved.
+	 *
+	 * @since TBD
+	 *
+	 * @template TRow of array<string, mixed>
+	 *
+	 * @param array<int, TRow>   $rows  The group's rows, each carrying an `id` key.
+	 * @param array<int, string> $order The flat ordered token id list.
+	 *
+	 * @return array<int, TRow> The same rows, permuted.
+	 */
+	public function sort( array $rows, array $order ): array {
+		if ( $order === [] ) {
+			return $rows;
+		}
+
+		$positions = array_flip( $order );
+		$ordered   = [];
+		$unordered = [];
+
+		foreach ( $rows as $row ) {
+			if ( isset( $positions[ $row['id'] ] ) ) {
+				$ordered[] = $row;
+			} else {
+				$unordered[] = $row; // Not in the stored order — declaration order, appended after.
+			}
+		}
+
+		usort( $ordered, fn( array $a, array $b ): int => $positions[ $a['id'] ] <=> $positions[ $b['id'] ] );
+
+		return array_merge( $ordered, $unordered );
+	}
+}

--- a/includes/resources/Design_Tokens/Editor/Pickable_Tokens_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Pickable_Tokens_Catalog.php
@@ -2,8 +2,10 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Editor;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Reserved_Namespace;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Sorter;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Dangling_Alias_Exception;
@@ -15,15 +17,22 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Layers;
  * Builds the pickable-token pool the block editor's token picker reads.
  *
  * Two sections: `tokens` is the library-independent STRUCTURE — one { id, alias, label, type, layer, role }
- * entry per registered token, in registry order, where `alias` is the {id} string a pick will later
- * write to a block attribute, `layer` (semantic | primitive) is derived from the id's first
- * dot-segment so the picker can rank semantic tokens before primitives, and `role` is the sub-kind
+ * entry per registered token, in the active library's stored sort order, where `alias` is the {id} string
+ * a pick will later write to a block attribute, `layer` (semantic | primitive) is derived from the id's
+ * first dot-segment so the picker can rank semantic tokens before primitives, and `role` is the sub-kind
  * (radius | spacing | … ) derived from the id so the picker can narrow one `$type` to the control's
  * sub-kind. `values` is the per-library
  * resolved literal map (library slug => ( id => literal )) used ONLY for the picker's preview
  * swatch/number — a pick writes the alias, never the literal. A library whose stored document cannot be
  * resolved (alias cycle / dangling alias from a raw DB write) is skipped, so one corrupt library never
  * empties the pool; structure is registry-driven and always ships.
+ *
+ * Nothing downstream reorders the pool — the picker only filters and partitions it — so the order the
+ * user dragged tokens into on the Style Library screen has to be applied here or not at all. It is
+ * applied group by group through the shared {@see Token_Sorter}, exactly as the admin feed applies it,
+ * and read from the ACTIVE library: `tokens` is one shared structure rather than a per-library one, so
+ * it honors the order of the library the editor renders by default (the same pointer the feed reads),
+ * and a picker opened against another library keeps that ordering.
  *
  * @since TBD
  */
@@ -68,16 +77,44 @@ final class Pickable_Tokens_Catalog {
 	private Token_Store $store;
 
 	/**
+	 * The active-library pointer, naming the library whose stored sort order the pool honors.
+	 *
 	 * @since TBD
 	 *
-	 * @param Token_Registry $registry The token registry.
-	 * @param Token_Resolver $resolver The token resolver.
-	 * @param Token_Store    $store    The persistence gateway.
+	 * @var Active_Token_Library_Store
 	 */
-	public function __construct( Token_Registry $registry, Token_Resolver $resolver, Token_Store $store ) {
+	private Active_Token_Library_Store $active;
+
+	/**
+	 * The shared stored-order permutation, applied one group at a time.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Sorter
+	 */
+	private Token_Sorter $sorter;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry             $registry The token registry.
+	 * @param Token_Resolver             $resolver The token resolver.
+	 * @param Token_Store                $store    The persistence gateway.
+	 * @param Active_Token_Library_Store $active   The active-library pointer.
+	 * @param Token_Sorter               $sorter   The shared stored-order permutation.
+	 */
+	public function __construct(
+		Token_Registry $registry,
+		Token_Resolver $resolver,
+		Token_Store $store,
+		Active_Token_Library_Store $active,
+		Token_Sorter $sorter
+	) {
 		$this->registry = $registry;
 		$this->resolver = $resolver;
 		$this->store    = $store;
+		$this->active   = $active;
+		$this->sorter   = $sorter;
 	}
 
 	/**
@@ -96,7 +133,8 @@ final class Pickable_Tokens_Catalog {
 
 	/**
 	 * The pickable token structure: one { id, alias, label, type, layer, role } entry per registered
-	 * token, in registry insertion order. Library-independent — values live in values().
+	 * token, in the active library's stored sort order within each UI group, registry insertion order
+	 * for the ids that order does not mention. Library-independent — values live in values().
 	 *
 	 * @since TBD
 	 *
@@ -104,8 +142,11 @@ final class Pickable_Tokens_Catalog {
 	 */
 	private function tokens(): array {
 		$tokens = [];
+		$slots  = [];
 
 		foreach ( $this->registry->all() as $token ) {
+			$slots[ $token->group ][] = count( $tokens );
+
 			$tokens[] = [
 				'id'    => $token->id,
 				'alias' => Alias::wrap( $token->id ),
@@ -114,6 +155,48 @@ final class Pickable_Tokens_Catalog {
 				'layer' => $this->layer_of( $token->id ),
 				'role'  => $this->role_of( $token->id, $token->group_key ),
 			];
+		}
+
+		return $this->apply_order( $tokens, $slots );
+	}
+
+	/**
+	 * Permute the flat pool by the active library's stored order, one UI group at a time.
+	 *
+	 * Grouping is by the token's `group` — the very bucket {@see Token_Registry::to_ui_schema()} keys
+	 * the admin feed's schema by, and therefore the bucket the Style Library's per-group reorder writes
+	 * against. That is what makes the pool agree with the screen: a custom token interleaves only among
+	 * the built-ins of its own group, never across the whole pool. The picker's `role` looks like a
+	 * cheaper partition but is a different one — a derivation off the id that can span two groups.
+	 *
+	 * Each group's entries are written back into the very slots they already occupied, so the pool's
+	 * overall sequence is unchanged except within a group. The picker's type-only filter and its
+	 * semantic-before-primitive ranking read the pool as one flat list, and both keep behaving exactly
+	 * as they did before any order was stored.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<int, array{id: string, alias: string, label: string, type: string, layer: string, role: string}> $tokens The pool in registry order.
+	 * @param array<string, array<int, int>>                                                                         $slots  UI group => the pool positions its tokens occupy.
+	 *
+	 * @return array<int, array{id: string, alias: string, label: string, type: string, layer: string, role: string}> The pool, permuted.
+	 */
+	private function apply_order( array $tokens, array $slots ): array {
+		$order = $this->sorter->order_for( $this->store->get_decoded_document( $this->active->get() ) );
+
+		if ( $order === [] ) {
+			return $tokens;
+		}
+
+		foreach ( $slots as $positions ) {
+			$sorted = $this->sorter->sort(
+				array_map( static fn( int $position ): array => $tokens[ $position ], $positions ),
+				$order
+			);
+
+			foreach ( $positions as $slot => $position ) {
+				$tokens[ $position ] = $sorted[ $slot ];
+			}
 		}
 
 		return $tokens;

--- a/includes/resources/Design_Tokens/Foundation_Presets/Selector.php
+++ b/includes/resources/Design_Tokens/Foundation_Presets/Selector.php
@@ -85,7 +85,9 @@ final class Selector {
 		// nothing.
 		$tokens = $this->catalog->tokens_for( $group, $choice );
 
-		$document = $this->current_overrides( $slug );
+		// Tolerates an absent/empty/malformed row as "no overrides yet", so a fresh site seeds onto a
+		// clean slate.
+		$document = $this->store->get_decoded_document( $slug );
 		$original = $document;
 
 		// Clear the group's whole footprint, then write the chosen preset — a clean swap, so a preset the
@@ -120,28 +122,6 @@ final class Selector {
 		}
 
 		$this->store->save_document( $json, $slug );
-	}
-
-	/**
-	 * Decode the library's current overrides document, tolerating an absent/empty/malformed row as "no
-	 * overrides yet" so a fresh site seeds onto a clean slate.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $slug The token library slug.
-	 *
-	 * @return array<string, mixed>
-	 */
-	private function current_overrides( string $slug ): array {
-		$raw = $this->store->get_document( $slug );
-
-		if ( $raw === '' ) {
-			return [];
-		}
-
-		$decoded = json_decode( $raw, true );
-
-		return is_array( $decoded ) ? $decoded : [];
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Registry/User_Primitive_Registrar.php
+++ b/includes/resources/Design_Tokens/Registry/User_Primitive_Registrar.php
@@ -83,7 +83,7 @@ final class User_Primitive_Registrar {
 		}
 
 		foreach ( $this->slugs() as $slug ) {
-			$document = $this->load_document( $slug );
+			$document = $this->store->get_decoded_document( $slug );
 
 			if ( $document === [] ) {
 				continue;
@@ -201,24 +201,5 @@ final class User_Primitive_Registrar {
 		$type = $node[ Token_Type::get_type_key() ] ?? null;
 
 		return is_string( $type ) && $type !== '' ? $type : null;
-	}
-
-	/**
-	 * @since TBD
-	 *
-	 * @param string $slug The token library slug to load.
-	 *
-	 * @return array<string, mixed>
-	 */
-	private function load_document( string $slug ): array {
-		$raw = $this->store->get_document( $slug );
-
-		if ( $raw === '' ) {
-			return [];
-		}
-
-		$decoded = json_decode( $raw, true );
-
-		return is_array( $decoded ) ? $decoded : [];
 	}
 }

--- a/includes/resources/Design_Tokens/Resolver/Effective_Palettes.php
+++ b/includes/resources/Design_Tokens/Resolver/Effective_Palettes.php
@@ -291,15 +291,7 @@ final class Effective_Palettes {
 	 * @return array<string, mixed>
 	 */
 	public function raw( string $slug = 'default' ): array {
-		$raw = $this->store->get_document( $slug );
-
-		if ( $raw === '' ) {
-			return [];
-		}
-
-		$decoded = json_decode( $raw, true );
-
-		return is_array( $decoded ) ? $decoded : [];
+		return $this->store->get_decoded_document( $slug );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Resolver/Effective_Presets.php
+++ b/includes/resources/Design_Tokens/Resolver/Effective_Presets.php
@@ -177,15 +177,7 @@ final class Effective_Presets {
 	 * @return array<string, mixed>
 	 */
 	public function raw( string $slug = 'default' ): array {
-		$raw = $this->store->get_document( $slug );
-
-		if ( $raw === '' ) {
-			return [];
-		}
-
-		$decoded = json_decode( $raw, true );
-
-		return is_array( $decoded ) ? $decoded : [];
+		return $this->store->get_decoded_document( $slug );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
@@ -209,9 +209,7 @@ final class Token_Resolver {
 			return $this->effective_memo[ $cache_key ];
 		}
 
-		$raw     = $this->store->get_document( $slug );
-		$decoded = $raw === '' ? [] : json_decode( $raw, true );
-		$over    = is_array( $decoded ) ? $decoded : [];
+		$over = $this->store->get_decoded_document( $slug );
 
 		$this->effective_memo[ $cache_key ] = $this->apply_palette_overlay(
 			$this->effective->build( $over ),
@@ -254,9 +252,7 @@ final class Token_Resolver {
 			return $cached;
 		}
 
-		$raw     = $this->store->get_document( $slug );
-		$decoded = $raw === '' ? [] : json_decode( $raw, true );
-		$over    = is_array( $decoded ) ? $decoded : [];
+		$over = $this->store->get_decoded_document( $slug );
 
 		$document = $this->apply_palette_overlay(
 			$this->effective->build( $over ),

--- a/includes/resources/Design_Tokens/Rest/V1/Document_Write_Pipeline.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Document_Write_Pipeline.php
@@ -102,15 +102,7 @@ final class Document_Write_Pipeline {
 	 * @return array<string, mixed>
 	 */
 	public function load_document( string $slug ): array {
-		$raw = $this->store->get_document( $slug );
-
-		if ( $raw === '' ) {
-			return [];
-		}
-
-		$decoded = json_decode( $raw, true );
-
-		return is_array( $decoded ) ? $decoded : [];
+		return $this->store->get_decoded_document( $slug );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -729,7 +729,7 @@ final class Documents_Controller extends Controller {
 			$slug = Token_Store::default_slug();
 		}
 
-		$candidate = $this->mutator->merge( $this->read_stored_document( $slug ), $this->read_document_param( $request ) );
+		$candidate = $this->mutator->merge( $this->store->get_decoded_document( $slug ), $this->read_document_param( $request ) );
 
 		return $this->validate_and_save( $candidate, $slug, Cast::to_string( $request->get_param( self::TITLE_PARAM ) ) );
 	}
@@ -753,7 +753,7 @@ final class Documents_Controller extends Controller {
 			return $error;
 		}
 
-		$candidate = $this->mutator->merge( $this->read_stored_document( $slug ), $partial );
+		$candidate = $this->mutator->merge( $this->store->get_decoded_document( $slug ), $partial );
 
 		return $this->validate_and_save( $candidate, $slug, Cast::to_string( $request->get_param( self::TITLE_PARAM ) ) );
 	}
@@ -773,7 +773,7 @@ final class Documents_Controller extends Controller {
 	 */
 	public function update_item( $request ) {
 		$slug   = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
-		$stored = $this->read_stored_document( $slug );
+		$stored = $this->store->get_decoded_document( $slug );
 
 		if ( ! empty( $this->user_primitive_index->all( $stored ) ) ) {
 			return new WP_Error(
@@ -964,7 +964,7 @@ final class Documents_Controller extends Controller {
 			$leaf = [];
 		}
 
-		$stored = $this->read_stored_document( $slug );
+		$stored = $this->store->get_decoded_document( $slug );
 
 		// Build the inspection view with disabled tokens kept (apply_disabled = false): authoring over a
 		// token that an override currently disables must still read its baseline $type and group shape,
@@ -1038,7 +1038,7 @@ final class Documents_Controller extends Controller {
 			);
 		}
 
-		$stored    = $this->read_stored_document( $slug );
+		$stored    = $this->store->get_decoded_document( $slug );
 		$candidate = $this->mutator->remove( $stored, $path );
 
 		if ( $candidate === $stored ) {
@@ -1084,7 +1084,7 @@ final class Documents_Controller extends Controller {
 			return $error;
 		}
 
-		$stored = $this->read_stored_document( $slug );
+		$stored = $this->store->get_decoded_document( $slug );
 
 		if ( $label === '' ) {
 			return $this->persist_label_clear( $stored, $slug, $id );
@@ -1129,7 +1129,7 @@ final class Documents_Controller extends Controller {
 			return $error;
 		}
 
-		return $this->persist_label_clear( $this->read_stored_document( $slug ), $slug, $id );
+		return $this->persist_label_clear( $this->store->get_decoded_document( $slug ), $slug, $id );
 	}
 
 	/**
@@ -1172,7 +1172,7 @@ final class Documents_Controller extends Controller {
 		$submitted = array_map( [ Cast::class, 'to_string' ], (array) $request->get_param( self::ORDER_PARAM ) );
 		$ids       = array_values( array_unique( array_intersect( $submitted, $group_ids ) ) );
 
-		$stored    = $this->read_stored_document( $slug );
+		$stored    = $this->store->get_decoded_document( $slug );
 		$candidate = $ids === []
 			? $this->order_index->remove_group( $stored, $group_ids )
 			: $this->order_index->set_group( $stored, $group_ids, $ids );
@@ -1212,7 +1212,7 @@ final class Documents_Controller extends Controller {
 		}
 
 		$group_ids = array_map( [ Cast::class, 'to_string' ], array_column( $registered, 'id' ) );
-		$stored    = $this->read_stored_document( $slug );
+		$stored    = $this->store->get_decoded_document( $slug );
 		$candidate = $this->order_index->remove_group( $stored, $group_ids );
 
 		if ( $candidate === $stored ) {
@@ -1806,27 +1806,6 @@ final class Documents_Controller extends Controller {
 	}
 
 	/**
-	 * Read and decode the stored overrides-only document for a library.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $slug The token library slug.
-	 *
-	 * @return array<string, mixed> The decoded document, empty when absent or unreadable.
-	 */
-	private function read_stored_document( string $slug ): array {
-		$raw = $this->store->get_document( $slug );
-
-		if ( $raw === '' ) {
-			return [];
-		}
-
-		$decoded = json_decode( $raw, true );
-
-		return is_array( $decoded ) ? $decoded : [];
-	}
-
-	/**
 	 * Read the document body parameter as an array, coercing any non-array to an empty document.
 	 *
 	 * @since TBD
@@ -2106,7 +2085,7 @@ final class Documents_Controller extends Controller {
 			'slug'     => $slug,
 			'title'    => $this->display_title( $slug, $stored ),
 			'version'  => $this->store->get_version( $slug ),
-			'document' => $this->read_stored_document( $slug ),
+			'document' => $this->store->get_decoded_document( $slug ),
 		];
 	}
 

--- a/tests/snapshot/Resources/Design_Tokens/Admin/Feed/Builder_SnapshotTest.php
+++ b/tests/snapshot/Resources/Design_Tokens/Admin/Feed/Builder_SnapshotTest.php
@@ -5,6 +5,8 @@ namespace Tests\snapshot\Resources\Design_Tokens\Admin\Feed;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Preset_Nav;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Order_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Sorter;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use Tests\Support\Classes\SnapshotTestCase;
 
@@ -74,7 +76,9 @@ final class Builder_SnapshotTest extends SnapshotTestCase {
 			'nonce'     => 'test-nonce',
 		];
 
-		$feed = ( new Builder( $this->registry, new Preset_Nav( $this->registry ) ) )->build( $values, true, $presets, $rest, 'v7', 'default' );
+		$builder = new Builder( $this->registry, new Preset_Nav( $this->registry ), new Token_Sorter( new Token_Order_Index() ) );
+
+		$feed = $builder->build( $values, true, $presets, $rest, 'v7', 'default' );
 
 		// Structural assertions that must always hold regardless of snapshot content.
 		$this->assertTrue( $feed['active'] );

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/BuilderTest.php
@@ -5,6 +5,8 @@ namespace Tests\wpunit\Resources\Design_Tokens\Admin\Feed;
 use Generator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Preset_Nav;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Order_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Sorter;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use Tests\Support\Classes\TestCase;
 
@@ -44,7 +46,7 @@ final class BuilderTest extends TestCase {
 	 * @return Builder
 	 */
 	private function builder(): Builder {
-		return new Builder( $this->registry, new Preset_Nav( $this->registry ) );
+		return new Builder( $this->registry, new Preset_Nav( $this->registry ), new Token_Sorter( new Token_Order_Index() ) );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Document/Token_SorterTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/Token_SorterTest.php
@@ -1,0 +1,168 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Document;
+
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Order_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Sorter;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Covers the shared stored-order permutation both the admin feed and the editor's pickable-token pool
+ * apply, so the two surfaces can never disagree about where a token sits.
+ *
+ * @since TBD
+ */
+final class Token_SorterTest extends TestCase {
+
+	/**
+	 * The sorter under test.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Sorter
+	 */
+	private Token_Sorter $sorter;
+
+	/**
+	 * Build a fresh sorter before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->sorter = new Token_Sorter( new Token_Order_Index() );
+	}
+
+	/**
+	 * Permuting rows by a stored order yields the expected id sequence, across the orders a group can
+	 * be handed: none, a full one, a partial one, one naming ids the group does not contain, and one
+	 * that reverses the group.
+	 *
+	 * @dataProvider sortProvider
+	 *
+	 * @param array<int, string> $ids      The row ids in their incoming (declaration) order.
+	 * @param array<int, string> $order    The stored flat ordered token id list.
+	 * @param array<int, string> $expected The id sequence the permutation must produce.
+	 *
+	 * @return void
+	 */
+	public function testSortPermutesRowsByTheStoredOrder( array $ids, array $order, array $expected ): void {
+		$sorted = $this->sorter->sort( $this->rows( $ids ), $order );
+
+		$this->assertSame( $expected, array_column( $sorted, 'id' ) );
+	}
+
+	/**
+	 * A permutation carries every row's other keys through untouched, so sorting a schema row never
+	 * costs it the label, type or projection data the surface renders from.
+	 *
+	 * @return void
+	 */
+	public function testSortPreservesTheRowPayload(): void {
+		$rows = [
+			[
+				'id'    => 'primitive.dimension.radius.sm',
+				'label' => 'Small',
+				'type'  => 'dimension',
+			],
+			[
+				'id'    => 'primitive.dimension.radius.lg',
+				'label' => 'Large',
+				'type'  => 'dimension',
+			],
+		];
+
+		$sorted = $this->sorter->sort( $rows, [ 'primitive.dimension.radius.lg', 'primitive.dimension.radius.sm' ] );
+
+		$this->assertSame( [ $rows[1], $rows[0] ], $sorted );
+	}
+
+	/**
+	 * A permutation never reduces the row set: every incoming row survives exactly once, so a stored
+	 * order can reorder tokens but never hide or duplicate one.
+	 *
+	 * @return void
+	 */
+	public function testSortNeverAddsOrDropsARow(): void {
+		$ids = [ 'a.one', 'a.two', 'a.three', 'a.four' ];
+
+		$sorted = $this->sorter->sort( $this->rows( $ids ), [ 'a.four', 'a.stale', 'a.two' ] );
+
+		$actual = array_column( $sorted, 'id' );
+
+		sort( $ids );
+		sort( $actual );
+
+		$this->assertSame( $ids, $actual );
+	}
+
+	/**
+	 * The order read off a document is the flat list stored in the module's $extensions section, and an
+	 * empty list for a document carrying none — the same fail-soft read the admin feed gets.
+	 *
+	 * @return void
+	 */
+	public function testOrderForReadsTheStoredList(): void {
+		$order = [ 'primitive.dimension.radius.lg', 'primitive.dimension.radius.sm' ];
+
+		$document = [
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					Extensions::get_section_token_order() => $order,
+				],
+			],
+		];
+
+		$this->assertSame( $order, $this->sorter->order_for( $document ) );
+		$this->assertSame( [], $this->sorter->order_for( [] ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function sortProvider(): Generator {
+		yield 'no stored order leaves declaration order' => [
+			'ids'      => [ 'a.one', 'a.two', 'a.three' ],
+			'order'    => [],
+			'expected' => [ 'a.one', 'a.two', 'a.three' ],
+		];
+
+		yield 'a full order sorts every row by position' => [
+			'ids'      => [ 'a.one', 'a.two', 'a.three' ],
+			'order'    => [ 'a.three', 'a.one', 'a.two' ],
+			'expected' => [ 'a.three', 'a.one', 'a.two' ],
+		];
+
+		yield 'unlisted ids append in declaration order' => [
+			'ids'      => [ 'a.one', 'a.two', 'a.three', 'a.four' ],
+			'order'    => [ 'a.three', 'a.one' ],
+			'expected' => [ 'a.three', 'a.one', 'a.two', 'a.four' ],
+		];
+
+		yield 'ids from another group are ignored' => [
+			'ids'      => [ 'a.one', 'a.two' ],
+			'order'    => [ 'b.one', 'a.two', 'b.two', 'a.one' ],
+			'expected' => [ 'a.two', 'a.one' ],
+		];
+
+		yield 'a stale id in the order drops nothing' => [
+			'ids'      => [ 'a.one', 'a.two' ],
+			'order'    => [ 'a.deleted', 'a.two', 'a.one' ],
+			'expected' => [ 'a.two', 'a.one' ],
+		];
+	}
+
+	/**
+	 * Build the minimal rows the sorter reads — it only ever looks at the `id` key.
+	 *
+	 * @param array<int, string> $ids The row ids, in order.
+	 *
+	 * @return array<int, array<string, mixed>> The rows.
+	 */
+	private function rows( array $ids ): array {
+		return array_map( static fn( string $id ): array => [ 'id' => $id ], $ids );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Pickable_Tokens_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Pickable_Tokens_CatalogTest.php
@@ -59,6 +59,11 @@ final class Pickable_Tokens_CatalogTest extends TestCase {
 		$this->catalog  = $this->container->get( Pickable_Tokens_Catalog::class );
 		$this->store    = $this->container->get( Token_Store::class );
 		$this->registry = $this->container->get( Token_Registry::class );
+
+		// The registry lives in the shared container, so a user primitive an earlier test registered
+		// outlives the rollback that removed the document it came from. Syncing against the now-empty
+		// database drops those leftovers, so every test starts from the same pool.
+		$this->container->get( User_Primitive_Registrar::class )->sync();
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Pickable_Tokens_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Pickable_Tokens_CatalogTest.php
@@ -3,8 +3,11 @@
 namespace Tests\wpunit\Resources\Design_Tokens\Editor;
 
 use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Order_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Editor\Pickable_Tokens_Catalog;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\User_Primitive_Registrar;
 use Tests\Support\Classes\TestCase;
 
@@ -25,16 +28,52 @@ final class Pickable_Tokens_CatalogTest extends TestCase {
 	private Token_Store $store;
 
 	/**
-	 * Resolves the catalog and the store from the container so each test exercises the real shipped
-	 * baseline and registered collaborators.
+	 * The token registry, for the UI groups the pool's order is applied within.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * Ids of the user primitives a test registered, deregistered on teardown. The registry lives in the
+	 * shared container rather than the database, so unlike stored rows it is not rolled back between
+	 * tests and a leaked registration would follow the suite into every later case.
+	 *
+	 * @since TBD
+	 *
+	 * @var string[]
+	 */
+	private array $registered = [];
+
+	/**
+	 * Resolves the catalog, the store and the registry from the container so each test exercises the
+	 * real shipped baseline and registered collaborators.
 	 *
 	 * @return void
 	 */
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->catalog = $this->container->get( Pickable_Tokens_Catalog::class );
-		$this->store   = $this->container->get( Token_Store::class );
+		$this->catalog  = $this->container->get( Pickable_Tokens_Catalog::class );
+		$this->store    = $this->container->get( Token_Store::class );
+		$this->registry = $this->container->get( Token_Registry::class );
+	}
+
+	/**
+	 * Drops every user primitive a test registered into the shared in-memory registry.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		foreach ( $this->registered as $id ) {
+			$this->registry->deregister_user_primitive( $id );
+		}
+
+		$this->registered = [];
+
+		parent::tearDown();
 	}
 
 	/**
@@ -261,6 +300,124 @@ final class Pickable_Tokens_CatalogTest extends TestCase {
 	}
 
 	/**
+	 * A library with no stored sort order leaves the pool in registry order, so the picker is unchanged
+	 * until someone actually reorders a scale on the Style Library screen.
+	 *
+	 * @return void
+	 */
+	public function testPoolIsRegistryOrderWithoutAStoredOrder(): void {
+		$this->assertSame(
+			array_keys( $this->registry->all() ),
+			array_column( $this->catalog->all()['tokens'], 'id' )
+		);
+	}
+
+	/**
+	 * A stored order permutes the entries of its own group and leaves every other position in the pool
+	 * holding the token it held before, so a reorder on one scale screen never disturbs another scale.
+	 *
+	 * @return void
+	 */
+	public function testAStoredOrderPermutesOnlyItsOwnGroup(): void {
+		$before = array_column( $this->catalog->all()['tokens'], 'id' );
+
+		[ $ids ] = $this->reorderable_group();
+
+		$slots    = array_map( static fn( string $id ): int => (int) array_search( $id, $before, true ), $ids );
+		$reversed = array_reverse( $ids );
+
+		$this->store_order( Token_Store::default_slug(), $ids, $reversed );
+
+		$after = array_column( $this->catalog->all()['tokens'], 'id' );
+
+		// The group's own slots now spell the stored sequence.
+		$this->assertSame( $reversed, array_map( static fn( int $slot ): string => $after[ $slot ], $slots ) );
+
+		// Every position outside the group is untouched.
+		foreach ( $before as $slot => $id ) {
+			if ( ! in_array( $slot, $slots, true ) ) {
+				$this->assertSame( $id, $after[ $slot ] );
+			}
+		}
+	}
+
+	/**
+	 * A user primitive is registered after the whole baseline, so it lands at the tail of the registry;
+	 * once the stored order places it mid-group it appears there in the pool too, matching the position
+	 * its scale screen shows rather than trailing every other token.
+	 *
+	 * @return void
+	 */
+	public function testAUserPrimitiveListedMidOrderAppearsMidGroup(): void {
+		[ $ids, $group, $type ] = $this->reorderable_group();
+
+		$custom = $this->fixture_id( $ids[0] );
+
+		// Second in its group: after the first built-in, before the one that followed it.
+		$order = array_merge( [ $ids[0], $custom ], array_slice( $ids, 1 ) );
+
+		$this->store_order( Token_Store::default_slug(), array_merge( $ids, [ $custom ] ), $order );
+
+		// After the write, never before: saving a document re-syncs the user primitives, which drops
+		// every user-created registration the document itself does not carry.
+		$this->register_user_primitive( $custom, $group, $type );
+
+		$pool = array_column( $this->catalog->all()['tokens'], 'id' );
+
+		$this->assertGreaterThan( array_search( $ids[0], $pool, true ), array_search( $custom, $pool, true ) );
+		$this->assertLessThan( array_search( $ids[1], $pool, true ), array_search( $custom, $pool, true ) );
+
+		// The symptom the ticket describes: registered last, so it trailed the whole pool.
+		$this->assertNotSame( $custom, end( $pool ) );
+	}
+
+	/**
+	 * The pool honors the ACTIVE library's stored order rather than the default library's, so the picker
+	 * and the Style Library screen — which reads the same pointer — never disagree.
+	 *
+	 * @return void
+	 */
+	public function testPoolFollowsTheActiveLibraryOrder(): void {
+		[ $ids ] = $this->reorderable_group();
+
+		$reversed = array_reverse( $ids );
+		$rotated  = array_merge( [ end( $ids ) ], array_slice( $ids, 0, -1 ) );
+
+		$this->store_order( Token_Store::default_slug(), $ids, $reversed );
+		$this->store_order( 'alternate', $ids, $rotated );
+
+		$this->container->get( Active_Token_Library_Store::class )->set( 'alternate' );
+
+		$pool  = array_column( $this->catalog->all()['tokens'], 'id' );
+		$slots = array_map( static fn( string $id ): int => (int) array_search( $id, $pool, true ), $rotated );
+
+		sort( $slots );
+
+		$this->assertSame( $rotated, array_map( static fn( int $slot ): string => $pool[ $slot ], $slots ) );
+	}
+
+	/**
+	 * A stored order naming an id no token carries — a since-deleted token, a token from a later release
+	 * — neither drops nor duplicates a pool entry, so a stale order can never shrink what the picker offers.
+	 *
+	 * @return void
+	 */
+	public function testAStaleIdInTheStoredOrderDropsNoToken(): void {
+		$before = array_column( $this->catalog->all()['tokens'], 'id' );
+
+		[ $ids ] = $this->reorderable_group();
+
+		$this->store_order( Token_Store::default_slug(), $ids, array_merge( [ 'primitive.gone.away' ], $ids ) );
+
+		$after = array_column( $this->catalog->all()['tokens'], 'id' );
+
+		sort( $before );
+		sort( $after );
+
+		$this->assertSame( $before, $after );
+	}
+
+	/**
 	 * @return Generator
 	 */
 	public function customDimensionRoleProvider(): Generator {
@@ -296,6 +453,72 @@ final class Pickable_Tokens_CatalogTest extends TestCase {
 			'prefix'   => 'primitive.',
 			'expected' => 'primitive',
 		];
+	}
+
+	/**
+	 * A UI group with enough tokens to be worth permuting, read from the same schema the Style Library
+	 * screen and its reorder endpoint address, so the fixture follows the baseline instead of hardcoding
+	 * a group label the declarations may rename.
+	 *
+	 * @return array{0: array<int, string>, 1: string, 2: string} The group's token ids in registry order,
+	 *                                                            the group label, and its tokens' DTCG type.
+	 */
+	private function reorderable_group(): array {
+		foreach ( $this->registry->to_ui_schema()['groups'] as $group => $rows ) {
+			if ( $group !== '' && count( $rows ) >= 3 ) {
+				return [ array_column( $rows, 'id' ), (string) $group, (string) $rows[0]['type'] ];
+			}
+		}
+
+		$this->fail( 'No UI group with at least three tokens in the registry.' );
+	}
+
+	/**
+	 * The id for a user-primitive fixture joining a token's group, derived from that sibling's id so it
+	 * carries the same layer and role as the group it joins.
+	 *
+	 * @param string $sibling The id of a token already in the target group.
+	 *
+	 * @return string The fixture id.
+	 */
+	private function fixture_id( string $sibling ): string {
+		return substr( $sibling, 0, (int) strrpos( $sibling, '.' ) ) . '.pool-order-fixture';
+	}
+
+	/**
+	 * Register a user primitive into the shared registry — appended at the tail, exactly where the
+	 * boot-time sync puts one — and remember it for teardown.
+	 *
+	 * @param string $id    The token id to register.
+	 * @param string $group The group label to register the primitive under.
+	 * @param string $type  The DTCG type to register the primitive as.
+	 *
+	 * @return void
+	 */
+	private function register_user_primitive( string $id, string $group, string $type ): void {
+		$this->registry->register_user_primitive( $id, $type, 'Pool Order Fixture', $group );
+
+		$this->registered[] = $id;
+	}
+
+	/**
+	 * Store one group's sort order on a library, creating the library's row when it has none — the same
+	 * write the Style Library's drag-reorder makes, minus the REST layer.
+	 *
+	 * @param string             $slug      The token library slug.
+	 * @param array<int, string> $group_ids Every token id belonging to the group being ordered.
+	 * @param array<int, string> $ids       The group's ids in their new order.
+	 *
+	 * @return void
+	 */
+	private function store_order( string $slug, array $group_ids, array $ids ): void {
+		$document = ( new Token_Order_Index() )->set_group(
+			$this->store->get_decoded_document( $slug ),
+			$group_ids,
+			$ids
+		);
+
+		$this->store->save_document( (string) wp_json_encode( $document ), $slug );
 	}
 
 	/**


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4199/token-picker-pickable-pool-ignores-the-token-sort-order

:video_camera:  https://www.loom.com/share/3ca51151f2c24880b8428a2be0555882

The editor Token Picker lists tokens in registry-insertion order, so a custom token dragged into the middle of a group on the Style Library screen shows up last in the picker: user primitives register after the baseline, and nothing between the registry and the picker reorders anything.

`Token_Sorter` owns the per-group permutation the admin feed applies (listed ids first by position, unmentioned ids appended in declaration order so a newly added token is never hidden). Both `Admin\Feed\Builder` and `Editor\Pickable_Tokens_Catalog` go through it, so the picker and the Style Library screen cannot drift apart.

The pool groups by each token's UI group, the bucket `to_ui_schema()` keys the feed's schema by and the one the reorder endpoint writes against, permutes each group by the **active** library's stored `tokenOrder`, and writes the result back into the slots that group already occupied. The flat pool therefore only ever moves within a group, leaving the picker's type filter and its semantic-before-primitive ranking untouched. No JS, REST or schema changes.

Also here: `Token_Store::get_decoded_document()` replaces nine copies of the read-then-decode-then-`is_array` body spread across the REST, Resolver, Registry, Admin and Foundation_Presets layers.

Stacked on #1303 (SOFT-4194).

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token groups now follow saved library ordering in the editor and administrative feeds.
  * Active library ordering is applied consistently to available tokens and presets.
  * User-created tokens can appear at their saved positions within groups.

* **Bug Fixes**
  * Unrecognized or outdated ordering entries no longer remove tokens.
  * Missing or invalid token-library documents are handled safely without disrupting results.

* **Refactor**
  * Document loading and token ordering are now handled consistently across editing, resolving, and REST operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
