### PR TITLE
fix: pin react and react-dom to matching versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -67,6 +67,8 @@
         "gulp-sass": "^6.0.0",
         "install": "^0.13.0",
         "prettier": "^3.6.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
       },
     },
   },
@@ -3485,8 +3487,6 @@
 
     "@wordpress/primitives/@wordpress/element": ["@wordpress/element@7.0.0", "", { "dependencies": { "@types/react": "^19.2.13", "@types/react-dom": "^19.2.3", "@wordpress/deprecated": "^4.47.0", "@wordpress/escape-html": "^3.47.0", "change-case": "^4.1.2", "is-plain-object": "^5.0.0", "react": "^19.2.4", "react-dom": "^19.2.4" } }, "sha512-iJoc3pzeof0mhwN0gVqDqc64xCRoAij2JynU6YxGSmw5a1uJwi1w3GESX3nPR1eaDdv2V6vwkinMBI+aGG7wxQ=="],
 
-    "@wordpress/primitives/react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
-
     "@wordpress/scripts/@babel/core": ["@babel/core@7.25.7", "", { "dependencies": { "@ampproject/remapping": "^2.2.0", "@babel/code-frame": "^7.25.7", "@babel/generator": "^7.25.7", "@babel/helper-compilation-targets": "^7.25.7", "@babel/helper-module-transforms": "^7.25.7", "@babel/helpers": "^7.25.7", "@babel/parser": "^7.25.7", "@babel/template": "^7.25.7", "@babel/traverse": "^7.25.7", "@babel/types": "^7.25.7", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow=="],
 
     "@wordpress/scripts/json2php": ["json2php@0.0.9", "", {}, "sha512-fQMYwvPsQt8hxRnCGyg1r2JVi6yL8Um0DIIawiKiMK9yhAAkcRNj5UsBWoaFvFzPpcWbgw9L6wzj+UMYA702Mw=="],
@@ -3494,10 +3494,6 @@
     "@wordpress/scripts/prettier": ["wp-prettier@3.0.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA=="],
 
     "@wordpress/theme/@wordpress/element": ["@wordpress/element@7.0.0", "", { "dependencies": { "@types/react": "^19.2.13", "@types/react-dom": "^19.2.3", "@wordpress/deprecated": "^4.47.0", "@wordpress/escape-html": "^3.47.0", "change-case": "^4.1.2", "is-plain-object": "^5.0.0", "react": "^19.2.4", "react-dom": "^19.2.4" } }, "sha512-iJoc3pzeof0mhwN0gVqDqc64xCRoAij2JynU6YxGSmw5a1uJwi1w3GESX3nPR1eaDdv2V6vwkinMBI+aGG7wxQ=="],
-
-    "@wordpress/theme/react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
-
-    "@wordpress/theme/react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
 
     "accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
@@ -3961,6 +3957,8 @@
 
     "@wordpress/primitives/@wordpress/element/change-case": ["change-case@4.1.2", "", { "dependencies": { "camel-case": "^4.1.2", "capital-case": "^1.0.4", "constant-case": "^3.0.4", "dot-case": "^3.0.4", "header-case": "^2.0.4", "no-case": "^3.0.4", "param-case": "^3.0.4", "pascal-case": "^3.1.2", "path-case": "^3.0.4", "sentence-case": "^3.0.4", "snake-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A=="],
 
+    "@wordpress/primitives/@wordpress/element/react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
+
     "@wordpress/primitives/@wordpress/element/react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
 
     "@wordpress/scripts/@babel/core/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -3971,7 +3969,9 @@
 
     "@wordpress/theme/@wordpress/element/change-case": ["change-case@4.1.2", "", { "dependencies": { "camel-case": "^4.1.2", "capital-case": "^1.0.4", "constant-case": "^3.0.4", "dot-case": "^3.0.4", "header-case": "^2.0.4", "no-case": "^3.0.4", "param-case": "^3.0.4", "pascal-case": "^3.1.2", "path-case": "^3.0.4", "sentence-case": "^3.0.4", "snake-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A=="],
 
-    "@wordpress/theme/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+    "@wordpress/theme/@wordpress/element/react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
+
+    "@wordpress/theme/@wordpress/element/react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
 
     "bl/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
@@ -4106,6 +4106,8 @@
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@wordpress/primitives/@wordpress/element/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "@wordpress/theme/@wordpress/element/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "bl/readable-stream/string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,9 @@
 		"gulp-rename": "^2.0.0",
 		"gulp-sass": "^6.0.0",
 		"install": "^0.13.0",
-		"prettier": "^3.6.0"
+		"prettier": "^3.6.0",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1"
 	},
 	"postcss": {},
 	"changelogger": {


### PR DESCRIPTION
## Summary

`react` and `react-dom` were resolving to mismatched versions (`react@19.2.6` vs `react-dom@18.3.1`) because neither is a direct dependency of this plugin — both were purely transitive, pulled in at conflicting version ranges by different `@wordpress/*` packages, and the package manager hoisted them independently. This broke every React-rendering unit test with errors like "Objects are not valid as a React child" and un-`act()`-wrapped state-update warnings.

Pins both as direct `devDependencies` at `^18.3.1`, matching what `@wordpress/element@6.46.0` and `@wordpress/scripts@30.19.0`'s peer dependencies actually expect. `react`/`react-dom` are never bundled at runtime regardless — `DependencyExtractionWebpackPlugin` externalizes every `@wordpress/*` import (and by extension `@wordpress/element`'s own React usage) to WordPress's own runtime globals, so this only affects local tooling resolution (Jest, editor intellisense).

## Test plan

- [x] `npx jest` — 48/48 suites, 800/800 tests passing (previously 10 suites / 36 tests failing with this exact mismatch)
- [x] Confirmed no duplicate nested `react` copy remains under `node_modules/react-dom/node_modules/`