### PR TITLE
[DTM] SOFT-4200 [2/7]: Loading skeletons, everywhere a real fetch is in flight

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,15 @@
  * `@wordpress/components` is not an installed top-level dependency (production externalizes it to
  * `wp.components`), but jest still needs to resolve it wherever a module references it. Mapped to
  * the copy nested under `@kadence/components` rather than adding a new top-level dependency.
+ *
+ * That nested `@wordpress/components` copy resolves its own `react`/`react-dom` imports to the
+ * `react`/`react-dom` bundled inside `@kadence/components`'s own `node_modules` (Node's normal
+ * upward resolution finds the nearer copy first). A test that mounts the top-level `react-dom/client`
+ * root and then renders one of its components — `Dropdown`/`Popover`, the only ones this app opens
+ * outside a mock — ends up with two separate React module instances in the same tree, which throws
+ * "Invalid hook call" the moment the nested copy's hook runs against the top-level renderer. Forcing
+ * both to the top-level copies keeps every `react`/`react-dom` import, direct or through the nested
+ * `@wordpress/components`, resolving to the same module instance.
  */
 const path = require('path');
 const baseConfig = require('@wordpress/scripts/config/jest-unit.config.js');
@@ -28,5 +37,9 @@ module.exports = {
 			__dirname,
 			'node_modules/@kadence/components/node_modules/@wordpress/components/build/index.js'
 		),
+		'^react$': require.resolve('react'),
+		'^react-dom$': require.resolve('react-dom'),
+		'^react-dom/client$': require.resolve('react-dom/client'),
+		'^react/jsx-runtime$': require.resolve('react/jsx-runtime'),
 	},
 };

--- a/src/style-library/__tests__/preset-screen.test.js
+++ b/src/style-library/__tests__/preset-screen.test.js
@@ -24,9 +24,9 @@ jest.mock('../hooks/use-preset-screen', () => ({
 // `jest.config.js` maps the `@wordpress/components` specifier to the copy nested under
 // `@kadence/components/node_modules`, which resolves its own nested `react`/`react-dom` — a
 // different module instance than the top-level `react-dom/client` this test renders with. Mounting
-// a real `Button`/`Notice`/`Spinner` from that nested copy under the top-level renderer trips
-// React's "Invalid hook call" guard. Simple stand-ins sidestep the cross-copy mismatch; this test
-// only needs to tell the loading/empty/populated states apart, not exercise the real controls.
+// a real `Button`/`Notice` from that nested copy under the top-level renderer trips React's
+// "Invalid hook call" guard. Simple stand-ins sidestep the cross-copy mismatch; this test only
+// needs to tell the loading/empty/populated states apart, not exercise the real controls.
 // The screen reads its draft overlay and its selection guard off this hook. Stubbed per test so
 // the overlay branch (which needs a publication for the open item) and the guard branch are
 // reachable without standing up the real provider.
@@ -37,7 +37,6 @@ jest.mock('../hooks/use-draft-channel', () => ({
 jest.mock('@wordpress/components', () => ({
 	Button: ({ children, ...props }) => <button {...props}>{children}</button>,
 	Notice: ({ children, isDismissible, ...props }) => <div {...props}>{children}</div>,
-	Spinner: (props) => <div className="components-spinner" {...props} />,
 }));
 
 // `@wordpress/primitives` (which `@wordpress/icons`'s `Icon`/`SVG` build on) nests its own `react`
@@ -107,33 +106,33 @@ afterEach(() => {
 
 describe('PresetScreen loading state', () => {
 	/**
-	 * While `usePresetScreen` is still fetching, the screen must show a busy indicator instead of
-	 * the empty state — `usePresetScreen` starts with `isLoading: true` and no rows, and rendering
-	 * the empty state at that point would flash "Add Button" before the presets arrive.
+	 * While `usePresetScreen` is still fetching, the screen must show a row-shaped skeleton instead
+	 * of the empty state — `usePresetScreen` starts with `isLoading: true` and no rows, and
+	 * rendering the empty state at that point would flash "Add Button" before the presets arrive.
 	 *
 	 * @return {void}
 	 */
-	it('renders a spinner instead of the empty state while loading', () => {
+	it('renders a skeleton instead of the empty state while loading', () => {
 		renderPresetScreen({ payload: null, isLoading: true, loadError: null, rows: [], initialValuesFor: () => ({}) });
 
-		expect(container.querySelector('.components-spinner')).not.toBeNull();
+		expect(container.querySelectorAll('.kadence-blocks-style-library__skeleton').length).toBeGreaterThan(0);
 		expect(container.querySelector('.kadence-blocks-style-library__empty-state')).toBeNull();
 	});
 
 	/**
-	 * Once loading finishes with no rows, the empty state renders in place of the spinner.
+	 * Once loading finishes with no rows, the empty state renders in place of the skeleton.
 	 *
 	 * @return {void}
 	 */
 	it('renders the empty state once loading finishes with no rows', () => {
 		renderPresetScreen({ payload: {}, isLoading: false, loadError: null, rows: [], initialValuesFor: () => ({}) });
 
-		expect(container.querySelector('.components-spinner')).toBeNull();
+		expect(container.querySelector('.kadence-blocks-style-library__skeleton')).toBeNull();
 		expect(container.querySelector('.kadence-blocks-style-library__empty-state')).not.toBeNull();
 	});
 
 	/**
-	 * Once loading finishes with rows present, neither the spinner nor the empty state renders.
+	 * Once loading finishes with rows present, neither the skeleton nor the empty state renders.
 	 *
 	 * @return {void}
 	 */
@@ -148,7 +147,7 @@ describe('PresetScreen loading state', () => {
 
 		renderPresetScreen({ payload: {}, isLoading: false, loadError: null, rows, initialValuesFor: () => ({}) });
 
-		expect(container.querySelector('.components-spinner')).toBeNull();
+		expect(container.querySelector('.kadence-blocks-style-library__skeleton')).toBeNull();
 		expect(container.querySelector('.kadence-blocks-style-library__empty-state')).toBeNull();
 		expect(container.querySelector('.kadence-blocks-style-library__row-list')).not.toBeNull();
 	});

--- a/src/style-library/__tests__/preset-screen.test.js
+++ b/src/style-library/__tests__/preset-screen.test.js
@@ -35,7 +35,8 @@ jest.mock('../hooks/use-draft-channel', () => ({
 }));
 
 jest.mock('@wordpress/components', () => ({
-	Button: ({ children, ...props }) => <button {...props}>{children}</button>,
+	// `isBusy` is a `Button` prop, not a DOM attribute — drop it so React does not warn about it.
+	Button: ({ children, isBusy, ...props }) => <button {...props}>{children}</button>,
 	Notice: ({ children, isDismissible, ...props }) => <div {...props}>{children}</div>,
 }));
 

--- a/src/style-library/__tests__/select-dropdown.test.js
+++ b/src/style-library/__tests__/select-dropdown.test.js
@@ -1,0 +1,60 @@
+/* eslint-env jest */
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { SelectDropdown } from '../components/molecules/SelectDropdown';
+
+describe('SelectDropdown loading state', () => {
+	let container;
+	let root;
+
+	beforeEach(() => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		delete global.IS_REACT_ACT_ENVIRONMENT;
+	});
+
+	it('shows skeleton rows in the open menu instead of an empty list while loading', async () => {
+		await act(async () =>
+			root.render(<SelectDropdown value="" options={[]} onChange={() => {}} isLoading valueLabel="Loading…" />)
+		);
+
+		const toggle = container.querySelector('.kadence-blocks-style-library__select-dropdown-toggle');
+		await act(async () => toggle.click());
+
+		// The open menu renders through `Popover`'s own portal, appended to `document.body` as a
+		// sibling of `container` rather than a descendant of it — the menu content is looked up
+		// against `document` for that reason, while the toggle above (rendered in place) stays a
+		// `container` lookup.
+		const skeletonRows = document.querySelectorAll('.kadence-blocks-style-library__select-dropdown-skeleton-row');
+		expect(skeletonRows.length).toBeGreaterThan(0);
+		expect(document.querySelectorAll('[role="menuitemradio"]').length).toBe(0);
+	});
+
+	it('shows real options once loaded, never skeleton rows', async () => {
+		await act(async () =>
+			root.render(
+				<SelectDropdown
+					value="a"
+					options={[{ value: 'a', label: 'Option A' }]}
+					onChange={() => {}}
+					isLoading={false}
+				/>
+			)
+		);
+
+		const toggle = container.querySelector('.kadence-blocks-style-library__select-dropdown-toggle');
+		await act(async () => toggle.click());
+
+		// See the note in the test above — the open menu is looked up against `document`, not
+		// `container`, because `Popover` portals it to `document.body`.
+		expect(document.querySelectorAll('.kadence-blocks-style-library__select-dropdown-skeleton-row').length).toBe(0);
+		expect(document.querySelectorAll('[role="menuitemradio"]').length).toBe(1);
+	});
+});

--- a/src/style-library/__tests__/select-dropdown.test.js
+++ b/src/style-library/__tests__/select-dropdown.test.js
@@ -35,6 +35,17 @@ describe('SelectDropdown loading state', () => {
 		const skeletonRows = document.querySelectorAll('.kadence-blocks-style-library__select-dropdown-skeleton-row');
 		expect(skeletonRows.length).toBeGreaterThan(0);
 		expect(document.querySelectorAll('[role="menuitemradio"]').length).toBe(0);
+
+		// A screen-reader user opening the menu while it loads must be told content is on the
+		// way — the skeleton rows sit inside a status region, not silently in place of the
+		// options.
+		const statusRegion = document.querySelector('.kadence-blocks-style-library__select-dropdown-skeleton-group');
+		expect(statusRegion).not.toBeNull();
+		expect(statusRegion.getAttribute('role')).toBe('status');
+		expect(statusRegion.getAttribute('aria-live')).toBe('polite');
+		expect(statusRegion.getAttribute('aria-busy')).toBe('true');
+		expect(statusRegion.getAttribute('aria-label')).toBe('Loading options…');
+		expect(statusRegion.contains(skeletonRows[0])).toBe(true);
 	});
 
 	it('shows real options once loaded, never skeleton rows', async () => {

--- a/src/style-library/__tests__/use-loading-announcement.test.js
+++ b/src/style-library/__tests__/use-loading-announcement.test.js
@@ -1,0 +1,98 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { useLoadingAnnouncement } from '../hooks/use-loading-announcement';
+
+describe('useLoadingAnnouncement', () => {
+	let container;
+	let root;
+
+	beforeEach(() => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		delete global.IS_REACT_ACT_ENVIRONMENT;
+	});
+
+	/**
+	 * Mount `useLoadingAnnouncement` behind a single probe component type, so a re-render updates
+	 * the mounted hook (and its `isLoading` transition) rather than remounting it.
+	 *
+	 * @since TBD
+	 *
+	 * @return {{rerender: Function}} Re-renders the mounted probe with new props.
+	 */
+	function mountProbe() {
+		function Probe({ isLoading, message }) {
+			useLoadingAnnouncement(isLoading, message);
+			return null;
+		}
+
+		const rerender = (props) => act(() => root.render(<Probe {...props} />));
+
+		return { rerender };
+	}
+
+	/**
+	 * Find the live-region node this hook appends directly to `document.body`.
+	 *
+	 * @since TBD
+	 *
+	 * @return {?Element} The node, or null if none is mounted.
+	 */
+	function announcerNode() {
+		return document.body.querySelector('.screen-reader-text[aria-live="polite"]');
+	}
+
+	it('appends a visually-hidden, polite live region on mount, empty until a load completes', () => {
+		const { rerender } = mountProbe();
+
+		rerender({ isLoading: true, message: 'Color Palette loaded.' });
+
+		const node = announcerNode();
+		expect(node).not.toBeNull();
+		expect(node.getAttribute('role')).toBe('status');
+		expect(node.textContent).toBe('');
+	});
+
+	it('writes the message once isLoading flips from true to false', () => {
+		const { rerender } = mountProbe();
+
+		rerender({ isLoading: true, message: 'Color Palette loaded.' });
+		expect(announcerNode().textContent).toBe('');
+
+		rerender({ isLoading: false, message: 'Color Palette loaded.' });
+		expect(announcerNode().textContent).toBe('Color Palette loaded.');
+	});
+
+	it('does not write anything on mount already idle — only a true→false transition announces', () => {
+		const { rerender } = mountProbe();
+
+		rerender({ isLoading: false, message: 'Color Palette loaded.' });
+
+		expect(announcerNode().textContent).toBe('');
+	});
+
+	it('removes its live-region node on unmount', () => {
+		mountProbe().rerender({ isLoading: true, message: 'Color Palette loaded.' });
+
+		expect(announcerNode()).not.toBeNull();
+
+		act(() => root.unmount());
+
+		expect(announcerNode()).toBeNull();
+	});
+});

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -173,6 +173,7 @@ export function StyleLibraryApp() {
 									editingSlug={libraries.editingSlug}
 									editingTitle={editingTitle}
 									isBusy={libraries.isBusy}
+									isLoading={libraries.isLoading}
 									isSwapping={libraries.isSwappingLibrary}
 									openError={libraries.openError}
 									createError={libraries.createError}

--- a/src/style-library/components/atoms/Skeleton.js
+++ b/src/style-library/components/atoms/Skeleton.js
@@ -1,0 +1,36 @@
+/**
+ * A single shimmering placeholder shape, used to build screen-level loading skeletons (a preset
+ * row, a swatch card, …). Purely decorative — `PresetScreen`/`ColorPaletteScreen` wrap the
+ * composed skeleton in its own `role="status"`/`aria-live` container, so this atom marks itself
+ * `aria-hidden` and carries no accessible name of its own.
+ */
+
+/**
+ * Internal dependencies
+ */
+import './Skeleton.scss';
+
+/**
+ * Render one skeleton placeholder shape.
+ *
+ * @param {Object} [props]           The component props.
+ * @param {string} [props.className] An additional class name — typically a real layout class (e.g.
+ *                                   `list-row-label`) so the shape inherits that column's exact
+ *                                   width instead of a duplicated literal.
+ * @param {Object} [props.style]     Inline style, e.g. a `width`/`height` pinned to a shared size
+ *                                   token (`var(--kb-sl-size-row-preview)`) for a shape with no
+ *                                   layout class of its own to borrow from.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The placeholder shape.
+ */
+export function Skeleton({ className = '', style }) {
+	return (
+		<span
+			className={`kadence-blocks-style-library__skeleton ${className}`.trim()}
+			style={style}
+			aria-hidden="true"
+		/>
+	);
+}

--- a/src/style-library/components/atoms/Skeleton.scss
+++ b/src/style-library/components/atoms/Skeleton.scss
@@ -40,3 +40,13 @@
 .kadence-blocks-style-library__skeleton--bar {
 	height: var(--kb-sl-line-height-s);
 }
+
+// A settings-panel field placeholder (`PresetSidebar`/`ColorPaletteSettings`, before their real
+// `initialValues` land): sized as a text-input-shaped bar, reusing the same 40px height every real
+// input in this app already uses (`--kb-sl-space-50`, e.g. `SelectDropdown`'s toggle) and the
+// panel header's own horizontal/vertical padding rhythm, rather than inventing new dimensions.
+.kadence-blocks-style-library__settings-panel-field {
+	width: 100%;
+	height: var(--kb-sl-space-50);
+	margin: 0 0 var(--kb-sl-space-15);
+}

--- a/src/style-library/components/atoms/Skeleton.scss
+++ b/src/style-library/components/atoms/Skeleton.scss
@@ -1,0 +1,42 @@
+// The shimmer sweep. Named locally rather than as a shared root-level keyframe — nothing else in
+// the app animates yet, so there is no existing convention to fold this into.
+@keyframes kadence-blocks-style-library-skeleton-shimmer {
+	100% {
+		transform: translateX(100%);
+	}
+}
+
+.kadence-blocks-style-library__skeleton {
+	position: relative;
+	display: block;
+	overflow: hidden;
+	border-radius: var(--kb-sl-radius-m);
+	background: var(--kb-sl-color-gray-100);
+
+	// The moving highlight, layered on top rather than animating `background-position` on the base
+	// element — a pseudo-element keeps the base fill's own color intact underneath the sweep.
+	&::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		transform: translateX(-100%);
+		background: linear-gradient(90deg, transparent, var(--kb-sl-color-white) 50%, transparent);
+		opacity: 0.5;
+		animation: kadence-blocks-style-library-skeleton-shimmer 1.6s ease-in-out infinite;
+	}
+}
+
+// A deliberately-added animation, so it needs its own reduced-motion guard — nothing else in this
+// app animates today. The base gray fill still communicates "loading" with the motion off.
+@media (prefers-reduced-motion: reduce) {
+	.kadence-blocks-style-library__skeleton::after {
+		animation: none;
+	}
+}
+
+// A text-line-shaped bar, for a skeleton combined with a real column class (e.g. `.list-row-label`,
+// `.swatch-card-name`) so it inherits that class's exact width instead of a duplicated literal —
+// only the height is this modifier's own, reusing the line-height ramp rather than a new value.
+.kadence-blocks-style-library__skeleton--bar {
+	height: var(--kb-sl-line-height-s);
+}

--- a/src/style-library/components/molecules/SelectDropdown.js
+++ b/src/style-library/components/molecules/SelectDropdown.js
@@ -23,6 +23,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import { Skeleton } from '../atoms/Skeleton';
+import { useLoadingAnnouncement } from '../../hooks/use-loading-announcement';
 import './SelectDropdown.scss';
 
 // A fixed placeholder-row count — there is no "expected row count" to read before the real options
@@ -83,6 +84,11 @@ export function SelectDropdown({
 }) {
 	const activeOption = options.find((option) => option.value === value);
 	const activeLabel = activeOption?.label ?? valueLabel ?? value;
+
+	// The skeleton rows below live inside their own `role="status"` region, which only announces
+	// "Loading options…" while it is actually mounted — the moment it is replaced by the real list,
+	// that region is gone too, and nothing is left to tell a screen reader the load finished.
+	useLoadingAnnouncement(isLoading, __('Options loaded.', 'kadence-blocks'));
 
 	return (
 		<div className={classnames('kadence-blocks-style-library__select-dropdown', className)}>

--- a/src/style-library/components/molecules/SelectDropdown.js
+++ b/src/style-library/components/molecules/SelectDropdown.js
@@ -11,6 +11,7 @@
  * WordPress dependencies
  */
 import { Button, Dropdown, MenuGroup, MenuItem, Notice, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { Icon, check, chevronDown } from '@wordpress/icons';
 
 /**
@@ -118,72 +119,82 @@ export function SelectDropdown({
 				renderContent={({ onClose }) => (
 					<>
 						<MenuGroup>
-							{isLoading
-								? SKELETON_ROW_IDS.map((id) => (
+							{isLoading ? (
+								<div
+									className="kadence-blocks-style-library__select-dropdown-skeleton-group"
+									role="status"
+									aria-live="polite"
+									aria-busy="true"
+									aria-label={__('Loading options…', 'kadence-blocks')}
+								>
+									{SKELETON_ROW_IDS.map((id) => (
 										<div
 											key={id}
 											className="kadence-blocks-style-library__select-dropdown-skeleton-row"
 										>
 											<Skeleton className="kadence-blocks-style-library__select-dropdown-skeleton-label" />
 										</div>
-									))
-								: options.map((option) => {
-										const isCurrent = option.value === value;
+									))}
+								</div>
+							) : (
+								options.map((option) => {
+									const isCurrent = option.value === value;
 
-										return (
-											<MenuItem
-												key={option.value}
-												role="menuitemradio"
-												aria-checked={isCurrent}
-												disabled={isBusy}
-												// Badges ride in the suffix rather than beside the label, so they and
-												// the check are siblings of the label's own box and the button's
-												// single `gap` spaces all three identically — no margins of their
-												// own to keep in step with it.
-												//
-												// The check slot is always rendered, empty on the rows without a
-												// check, so every row reserves the same trailing column. Without it
-												// the check's width exists on one row only, and everything to its
-												// left sits at a different right edge there than on its neighbors.
-												suffix={
-													<>
-														{option.badges?.length > 0 && (
-															<span className="kadence-blocks-style-library__select-dropdown-badges">
-																{option.badges.map((badge) => (
-																	<span
-																		key={badge.text}
-																		className={classnames(
-																			'kadence-blocks-style-library__select-dropdown-badge',
-																			`kadence-blocks-style-library__select-dropdown-badge--${badge.variant ?? 'muted'}`
-																		)}
-																	>
-																		{badge.text}
-																	</span>
-																))}
-															</span>
-														)}
-														<span className="kadence-blocks-style-library__select-dropdown-check-slot">
-															{isCurrent && (
-																<Icon
-																	className="kadence-blocks-style-library__select-dropdown-check"
-																	icon={check}
-																/>
-															)}
+									return (
+										<MenuItem
+											key={option.value}
+											role="menuitemradio"
+											aria-checked={isCurrent}
+											disabled={isBusy}
+											// Badges ride in the suffix rather than beside the label, so they and
+											// the check are siblings of the label's own box and the button's
+											// single `gap` spaces all three identically — no margins of their
+											// own to keep in step with it.
+											//
+											// The check slot is always rendered, empty on the rows without a
+											// check, so every row reserves the same trailing column. Without it
+											// the check's width exists on one row only, and everything to its
+											// left sits at a different right edge there than on its neighbors.
+											suffix={
+												<>
+													{option.badges?.length > 0 && (
+														<span className="kadence-blocks-style-library__select-dropdown-badges">
+															{option.badges.map((badge) => (
+																<span
+																	key={badge.text}
+																	className={classnames(
+																		'kadence-blocks-style-library__select-dropdown-badge',
+																		`kadence-blocks-style-library__select-dropdown-badge--${badge.variant ?? 'muted'}`
+																	)}
+																>
+																	{badge.text}
+																</span>
+															))}
 														</span>
-													</>
-												}
-												onClick={() => {
-													onClose();
+													)}
+													<span className="kadence-blocks-style-library__select-dropdown-check-slot">
+														{isCurrent && (
+															<Icon
+																className="kadence-blocks-style-library__select-dropdown-check"
+																icon={check}
+															/>
+														)}
+													</span>
+												</>
+											}
+											onClick={() => {
+												onClose();
 
-													if (!isCurrent) {
-														onChange(option.value);
-													}
-												}}
-											>
-												{option.label}
-											</MenuItem>
-										);
-									})}
+												if (!isCurrent) {
+													onChange(option.value);
+												}
+											}}
+										>
+											{option.label}
+										</MenuItem>
+									);
+								})
+							)}
 						</MenuGroup>
 						{trailingAction && (
 							<>

--- a/src/style-library/components/molecules/SelectDropdown.js
+++ b/src/style-library/components/molecules/SelectDropdown.js
@@ -21,7 +21,12 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
+import { Skeleton } from '../atoms/Skeleton';
 import './SelectDropdown.scss';
+
+// A fixed placeholder-row count — there is no "expected row count" to read before the real options
+// arrive, so this is a plain visual approximation, not a value derived from real data.
+const SKELETON_ROW_IDS = [0, 1, 2];
 
 /**
  * Render the selector dropdown.
@@ -37,6 +42,11 @@ import './SelectDropdown.scss';
  *                                                                       badge means.
  * @param {Function}                              props.onChange        Called with a value when a different option is chosen.
  * @param {boolean}                               [props.isBusy]        Whether a change is in flight.
+ * @param {boolean}                               [props.isLoading]     Whether the option list itself is still
+ *                                                                       loading (as opposed to `isBusy`, which
+ *                                                                       covers a write in flight). While true and
+ *                                                                       the menu is open, skeleton rows render in
+ *                                                                       place of `options`.
  * @param {boolean}                               [props.showSpinner]   Whether the inline busy spinner is drawn. Defaults to true; a caller that
  *                                                                       already shows progress for the same wait elsewhere passes false to avoid a
  *                                                                       second indicator. Independent of `isBusy`, which still disables the control.
@@ -61,6 +71,7 @@ export function SelectDropdown({
 	options,
 	onChange,
 	isBusy,
+	isLoading = false,
 	showSpinner = true,
 	error,
 	onClearError,
@@ -107,63 +118,72 @@ export function SelectDropdown({
 				renderContent={({ onClose }) => (
 					<>
 						<MenuGroup>
-							{options.map((option) => {
-								const isCurrent = option.value === value;
+							{isLoading
+								? SKELETON_ROW_IDS.map((id) => (
+										<div
+											key={id}
+											className="kadence-blocks-style-library__select-dropdown-skeleton-row"
+										>
+											<Skeleton className="kadence-blocks-style-library__select-dropdown-skeleton-label" />
+										</div>
+									))
+								: options.map((option) => {
+										const isCurrent = option.value === value;
 
-								return (
-									<MenuItem
-										key={option.value}
-										role="menuitemradio"
-										aria-checked={isCurrent}
-										disabled={isBusy}
-										// Badges ride in the suffix rather than beside the label, so they and
-										// the check are siblings of the label's own box and the button's
-										// single `gap` spaces all three identically — no margins of their
-										// own to keep in step with it.
-										//
-										// The check slot is always rendered, empty on the rows without a
-										// check, so every row reserves the same trailing column. Without it
-										// the check's width exists on one row only, and everything to its
-										// left sits at a different right edge there than on its neighbors.
-										suffix={
-											<>
-												{option.badges?.length > 0 && (
-													<span className="kadence-blocks-style-library__select-dropdown-badges">
-														{option.badges.map((badge) => (
-															<span
-																key={badge.text}
-																className={classnames(
-																	'kadence-blocks-style-library__select-dropdown-badge',
-																	`kadence-blocks-style-library__select-dropdown-badge--${badge.variant ?? 'muted'}`
-																)}
-															>
-																{badge.text}
+										return (
+											<MenuItem
+												key={option.value}
+												role="menuitemradio"
+												aria-checked={isCurrent}
+												disabled={isBusy}
+												// Badges ride in the suffix rather than beside the label, so they and
+												// the check are siblings of the label's own box and the button's
+												// single `gap` spaces all three identically — no margins of their
+												// own to keep in step with it.
+												//
+												// The check slot is always rendered, empty on the rows without a
+												// check, so every row reserves the same trailing column. Without it
+												// the check's width exists on one row only, and everything to its
+												// left sits at a different right edge there than on its neighbors.
+												suffix={
+													<>
+														{option.badges?.length > 0 && (
+															<span className="kadence-blocks-style-library__select-dropdown-badges">
+																{option.badges.map((badge) => (
+																	<span
+																		key={badge.text}
+																		className={classnames(
+																			'kadence-blocks-style-library__select-dropdown-badge',
+																			`kadence-blocks-style-library__select-dropdown-badge--${badge.variant ?? 'muted'}`
+																		)}
+																	>
+																		{badge.text}
+																	</span>
+																))}
 															</span>
-														))}
-													</span>
-												)}
-												<span className="kadence-blocks-style-library__select-dropdown-check-slot">
-													{isCurrent && (
-														<Icon
-															className="kadence-blocks-style-library__select-dropdown-check"
-															icon={check}
-														/>
-													)}
-												</span>
-											</>
-										}
-										onClick={() => {
-											onClose();
+														)}
+														<span className="kadence-blocks-style-library__select-dropdown-check-slot">
+															{isCurrent && (
+																<Icon
+																	className="kadence-blocks-style-library__select-dropdown-check"
+																	icon={check}
+																/>
+															)}
+														</span>
+													</>
+												}
+												onClick={() => {
+													onClose();
 
-											if (!isCurrent) {
-												onChange(option.value);
-											}
-										}}
-									>
-										{option.label}
-									</MenuItem>
-								);
-							})}
+													if (!isCurrent) {
+														onChange(option.value);
+													}
+												}}
+											>
+												{option.label}
+											</MenuItem>
+										);
+									})}
 						</MenuGroup>
 						{trailingAction && (
 							<>

--- a/src/style-library/components/molecules/SelectDropdown.scss
+++ b/src/style-library/components/molecules/SelectDropdown.scss
@@ -337,6 +337,20 @@
 	color: var(--kb-sl-color-text-muted);
 }
 
+// Matches `.components-menu-item__button`'s own padding/min-height above, so a skeleton row
+// occupies the exact same box a real `MenuItem` would.
+.kadence-blocks-style-library__select-dropdown-skeleton-row {
+	display: flex;
+	align-items: center;
+	padding: var(--kb-sl-space-10) var(--kb-sl-space-15);
+	min-height: var(--kb-sl-space-30);
+}
+
+.kadence-blocks-style-library__select-dropdown-skeleton-label {
+	width: 60%;
+	height: 1em;
+}
+
 .kadence-blocks-style-library__select-dropdown-error {
 	margin: 0;
 }

--- a/src/style-library/components/organisms/LibrarySelector.js
+++ b/src/style-library/components/organisms/LibrarySelector.js
@@ -35,6 +35,7 @@ import { CreateLibraryModal } from './CreateLibraryModal';
  * @param {string}        props.editingSlug        The slug the app is showing.
  * @param {string}        props.editingTitle       That library's display title, already resolved by the caller.
  * @param {boolean}       props.isBusy             Whether a library operation is in flight.
+ * @param {boolean}       [props.isLoading]        Whether the libraries list is still loading.
  * @param {boolean}       props.isSwapping         Whether the app is being repopulated for a different library.
  * @param {?{message: string}} props.openError     The current open error, if any.
  * @param {?{message: string}} props.createError   The current create error, if any.
@@ -53,6 +54,7 @@ export function LibrarySelector({
 	editingSlug,
 	editingTitle,
 	isBusy,
+	isLoading,
 	isSwapping,
 	openError,
 	createError,
@@ -104,6 +106,7 @@ export function LibrarySelector({
 				// silently correcting itself when the list request lands.
 				valueLabel={editingTitle}
 				isBusy={isBusy}
+				isLoading={isLoading}
 				// The app draws its own scrim while a library is being opened, so the dropdown's
 				// inline spinner would be a second progress indicator for the same wait — and one
 				// sitting underneath the scrim at that. The control still disables via `isBusy`.

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -181,6 +181,7 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 							// someone merely looks at a different palette; see `openPaletteFlow`'s own docblock.
 							onChange={(id) => palettes.openPalette(id).catch(() => {})}
 							isBusy={palettes.isBusy}
+							isLoading={palettes.isLoading}
 							error={palettes.openError}
 							onClearError={palettes.clearOpenError}
 							trailingAction={{

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -10,7 +10,7 @@
  * WordPress dependencies
  */
 import { useMemo, useState } from '@wordpress/element';
-import { Button, DropdownMenu, MenuGroup, MenuItem, Notice, Spinner } from '@wordpress/components';
+import { Button, DropdownMenu, MenuGroup, MenuItem, Notice } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { moreVertical, plus } from '@wordpress/icons';
 
@@ -22,6 +22,7 @@ import { ScreenHeader } from '../organisms/ScreenHeader';
 import { SwatchGrid } from '../organisms/SwatchGrid';
 import { SelectDropdown } from '../molecules/SelectDropdown';
 import { EmptyState } from '../molecules/EmptyState';
+import { Skeleton } from '../atoms/Skeleton';
 import { ActivatePaletteButton } from '../organisms/ActivatePaletteButton';
 import { CreatePaletteModal } from '../organisms/CreatePaletteModal';
 import { RenamePaletteModal } from '../organisms/RenamePaletteModal';
@@ -38,6 +39,56 @@ import {
 } from '../../helpers/palettes';
 import { ColorPaletteSettings } from './ColorPaletteSettings';
 import './ColorPaletteScreen.scss';
+
+// A fixed count, not derived from anything — there is no "expected swatch count" to read before
+// the real palette arrives, so this just needs to fill a group row plausibly.
+const SKELETON_SWATCH_IDS = [0, 1, 2, 3, 4, 5];
+
+/**
+ * The palette loading placeholder: one group heading and a row of swatch-card-shaped skeletons in
+ * the real `SwatchGrid` markup (`.swatch-grid` / `.swatch-group` / `.swatch-card`), so the loading
+ * shape matches the grid it is about to be replaced by instead of collapsing the screen to a
+ * single centered spinner.
+ *
+ * @param {Object} props       The component props.
+ * @param {string} props.label The screen's nav label, used to build the busy-region's accessible name.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The swatch-grid-shaped skeleton.
+ */
+function SwatchGridSkeleton({ label }) {
+	return (
+		<div
+			className="kadence-blocks-style-library__swatch-grid"
+			role="status"
+			aria-live="polite"
+			aria-busy="true"
+			aria-label={sprintf(
+				// translators: %s: the palette screen's label (e.g. "Color Palette").
+				__('Loading %s…', 'kadence-blocks'),
+				label
+			)}
+		>
+			<div className="kadence-blocks-style-library__swatch-group">
+				{/* No real heading class carries a width of its own — `SectionHeading`'s width is
+				 * whatever its text measures — so this bar's width is a plain literal, not a reused
+				 * layout value. */}
+				<Skeleton className="kadence-blocks-style-library__skeleton--bar" style={{ width: '8rem' }} />
+				<div className="kadence-blocks-style-library__swatch-group-row">
+					{SKELETON_SWATCH_IDS.map((id) => (
+						<div key={id} className="kadence-blocks-style-library__swatch-card">
+							<div className="kadence-blocks-style-library__swatch-card-main">
+								<Skeleton className="kadence-blocks-style-library__swatch-card-preview" />
+								<Skeleton className="kadence-blocks-style-library__swatch-card-name kadence-blocks-style-library__skeleton--bar" />
+							</div>
+						</div>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}
 
 /**
  * The fill for a swatch's preview slot: the swatch's raw `$value`, or a neutral gray-100 fallback
@@ -188,7 +239,7 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 				}
 			/>
 			{palettes.isLoading ? (
-				<Spinner />
+				<SwatchGridSkeleton label={label} />
 			) : palettes.palette ? (
 				<>
 					{/* Suppressed while the add-group, rename-group, or delete-group modal is open —

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -31,6 +31,7 @@ import { AddColorGroupModal } from '../organisms/AddColorGroupModal';
 import { RenameColorGroupModal } from '../organisms/RenameColorGroupModal';
 import { DeleteColorGroupModal } from '../organisms/DeleteColorGroupModal';
 import { usePalettes } from '../../hooks/use-palettes';
+import { useLoadingAnnouncement } from '../../hooks/use-loading-announcement';
 import {
 	isUserCreatedPalette,
 	mapPaletteToSwatchGroups,
@@ -80,7 +81,14 @@ function SwatchGridSkeleton({ label }) {
 						<div key={id} className="kadence-blocks-style-library__swatch-card">
 							<div className="kadence-blocks-style-library__swatch-card-main">
 								<Skeleton className="kadence-blocks-style-library__swatch-card-preview" />
-								<Skeleton className="kadence-blocks-style-library__swatch-card-name kadence-blocks-style-library__skeleton--bar" />
+								{/* `.swatch-card-name` only declares `max-width: 100%`, never a `width` — a real
+								 * swatch name gets its width from its own text, but this shape has none, and its
+								 * `align-items: flex-start` parent collapses an unsized block to 0 width without
+								 * one. Same fix as the group heading bar above: pin a plausible literal width. */}
+								<Skeleton
+									className="kadence-blocks-style-library__swatch-card-name kadence-blocks-style-library__skeleton--bar"
+									style={{ width: '70%' }}
+								/>
 							</div>
 						</div>
 					))}
@@ -125,6 +133,15 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 	// route, not another `useState`, has to be the source of truth shared with the settings panel's
 	// own separate instance below.
 	const palettes = usePalettes(library.feed, library.refreshFeed, route, navigate);
+
+	// The skeleton below lives inside its own `role="status"` region, which only announces "Loading
+	// X…" while it is actually mounted — the moment it is replaced by the real grid, that region is
+	// gone too, and nothing is left to tell a screen reader the load finished.
+	useLoadingAnnouncement(
+		palettes.isLoading,
+		// translators: %s: the palette screen's label (e.g. "Color Palette").
+		sprintf(__('%s loaded.', 'kadence-blocks'), label)
+	);
 
 	// Plain UI state, not route state — a half-typed modal must not enter browser history.
 	const [isCreateOpen, setIsCreateOpen] = useState(false);

--- a/src/style-library/components/pages/ColorPaletteSettings.js
+++ b/src/style-library/components/pages/ColorPaletteSettings.js
@@ -19,6 +19,7 @@ import { SettingsPanel } from '../templates/SettingsPanel';
 import { SettingsForm } from '../organisms/SettingsForm';
 import { usePalettes } from '../../hooks/use-palettes';
 import { useSettingsPanel } from '../../hooks/use-settings-panel';
+import { useLoadingAnnouncement } from '../../hooks/use-loading-announcement';
 import { findSwatch, swatchInitialValues } from '../../helpers/palettes';
 import { Skeleton } from '../atoms/Skeleton';
 
@@ -62,6 +63,11 @@ export function ColorPaletteSettings({ route, navigate, library }) {
 	// seeding empty at mount and never re-seeding. See that hook's own docblock for the contract.
 	const initialValues = palettes.palette ? swatchInitialValues(palettes.palette, token) : null;
 	const panel = useSettingsPanel({ route, navigate, initialValues });
+
+	// The skeleton below lives inside its own `role="status"` region, which only announces "Loading…"
+	// while it is actually mounted — the moment it is replaced by the real panel, that region is
+	// gone too, and nothing is left to tell a screen reader the load finished.
+	useLoadingAnnouncement(Boolean(token && palettes.isLoading), __('Settings loaded.', 'kadence-blocks'));
 
 	// Self-heal a stale item the same way the app's unknown-screen route does: a token that does not
 	// resolve in the current palette's view (a leftover from another palette, or a hand-edited URL)

--- a/src/style-library/components/pages/ColorPaletteSettings.js
+++ b/src/style-library/components/pages/ColorPaletteSettings.js
@@ -20,6 +20,7 @@ import { SettingsForm } from '../organisms/SettingsForm';
 import { usePalettes } from '../../hooks/use-palettes';
 import { useSettingsPanel } from '../../hooks/use-settings-panel';
 import { findSwatch, swatchInitialValues } from '../../helpers/palettes';
+import { Skeleton } from '../atoms/Skeleton';
 
 /**
  * The swatch panel's schema: a NAME text field and a color-only picker. `colorOnly: true` keeps the
@@ -71,6 +72,15 @@ export function ColorPaletteSettings({ route, navigate, library }) {
 			navigate({ item: '' });
 		}
 	}, [palettes.isLoading, palettes.palette, swatch, navigate]);
+
+	if (token && palettes.isLoading) {
+		return (
+			<div className="kadence-blocks-style-library__settings-panel" role="status" aria-busy="true">
+				<Skeleton className="kadence-blocks-style-library__settings-panel-field" />
+				<Skeleton className="kadence-blocks-style-library__settings-panel-field" />
+			</div>
+		);
+	}
 
 	if (!swatch) {
 		return null;

--- a/src/style-library/components/pages/PresetScreen.js
+++ b/src/style-library/components/pages/PresetScreen.js
@@ -15,6 +15,7 @@
  * WordPress dependencies
  */
 import { Button, Notice } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 
@@ -92,23 +93,36 @@ export function PresetScreen({ label, route, navigate, library, preset }) {
 	const screen = usePresetScreen(library, preset);
 	const channel = useDraftChannel();
 
+	const [isAdding, setIsAdding] = useState(false);
+
 	// `createPresetFlow` (`helpers/preset-flows.js`) records the failure via `screen.addError` (the
 	// Notice rendered below) and re-throws pessimistically for callers that need the rejection; this
 	// `.catch()` only stops that rethrow from surfacing as an unhandled promise rejection, it does
-	// not report the error a second time.
-	const mintPreset = () =>
-		screen
+	// not report the error a second time. Disabling the button is a UI guard, not a real one — a
+	// stale click (e.g. a keyboard Enter racing the disabled-attribute repaint) could otherwise
+	// still start a second create.
+	const mintPreset = () => {
+		if (screen.isBusy) {
+			return Promise.resolve();
+		}
+
+		setIsAdding(true);
+
+		return screen
 			.addPreset()
 			.then((id) => navigate({ item: id }))
-			.catch(() => {});
+			.catch(() => {})
+			.finally(() => setIsAdding(false));
+	};
 	const addAction = (
 		<Button
 			icon={plus}
 			variant="secondary"
+			isBusy={isAdding}
 			disabled={screen.isBusy}
 			onClick={() => (channel ? channel.guard(mintPreset) : mintPreset())}
 		>
-			{preset.addLabel}
+			{isAdding ? __('Adding…', 'kadence-blocks') : preset.addLabel}
 		</Button>
 	);
 

--- a/src/style-library/components/pages/PresetScreen.js
+++ b/src/style-library/components/pages/PresetScreen.js
@@ -14,7 +14,8 @@
 /**
  * WordPress dependencies
  */
-import { Button, Notice, Spinner } from '@wordpress/components';
+import { Button, Notice } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 
 /**
@@ -23,10 +24,53 @@ import { plus } from '@wordpress/icons';
 import { ScreenHeader } from '../organisms/ScreenHeader';
 import { RowList } from '../templates/RowList';
 import { EmptyState } from '../molecules/EmptyState';
+import { Skeleton } from '../atoms/Skeleton';
 import { usePresetScreen } from '../../hooks/use-preset-screen';
 import { useDraftChannel } from '../../hooks/use-draft-channel';
 import { overlayPresetRows } from '../../helpers/presets';
 import { useBreakpoint } from '../../../token-controls/context/breakpoint';
+
+// A fixed count, not derived from anything — there is no "expected row count" to read before the
+// real rows arrive, so this just needs to fill the screen plausibly.
+const SKELETON_ROW_IDS = [0, 1, 2, 3];
+
+/**
+ * The preset-list loading placeholder: a few row-shaped skeletons in the real `RowList` markup
+ * (`.row-list` / `.list-row` / `.list-row-main`), so the loading shape matches the rows it is about
+ * to be replaced by instead of collapsing the screen to a single centered spinner.
+ *
+ * @param {Object} props       The component props.
+ * @param {string} props.label The screen's nav label, used to build the busy-region's accessible name.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The row-shaped skeleton list.
+ */
+function PresetRowsSkeleton({ label }) {
+	return (
+		<ul
+			className="kadence-blocks-style-library__row-list"
+			role="status"
+			aria-live="polite"
+			aria-busy="true"
+			aria-label={sprintf(
+				// translators: %s: the preset screen's label (e.g. "Button").
+				__('Loading %s…', 'kadence-blocks'),
+				label
+			)}
+		>
+			{SKELETON_ROW_IDS.map((id) => (
+				<li key={id} className="kadence-blocks-style-library__list-row">
+					<div className="kadence-blocks-style-library__list-row-main">
+						<Skeleton className="kadence-blocks-style-library__list-row-label kadence-blocks-style-library__skeleton--bar" />
+						<Skeleton className="kadence-blocks-style-library__list-row-value kadence-blocks-style-library__skeleton--bar" />
+						<Skeleton className="kadence-blocks-style-library__list-row-preview" />
+					</div>
+				</li>
+			))}
+		</ul>
+	);
+}
 
 /**
  * Render a preset list screen for whichever block the config names.
@@ -112,7 +156,7 @@ export function PresetScreen({ label, route, navigate, library, preset }) {
 				</Notice>
 			)}
 			{screen.isLoading ? (
-				<Spinner />
+				<PresetRowsSkeleton label={label} />
 			) : (
 				<RowList
 					items={items}

--- a/src/style-library/components/pages/PresetScreen.js
+++ b/src/style-library/components/pages/PresetScreen.js
@@ -28,6 +28,7 @@ import { EmptyState } from '../molecules/EmptyState';
 import { Skeleton } from '../atoms/Skeleton';
 import { usePresetScreen } from '../../hooks/use-preset-screen';
 import { useDraftChannel } from '../../hooks/use-draft-channel';
+import { useLoadingAnnouncement } from '../../hooks/use-loading-announcement';
 import { overlayPresetRows } from '../../helpers/presets';
 import { useBreakpoint } from '../../../token-controls/context/breakpoint';
 
@@ -92,6 +93,15 @@ export function PresetScreen({ label, route, navigate, library, preset }) {
 	const { renderPreview, className = '' } = preset;
 	const screen = usePresetScreen(library, preset);
 	const channel = useDraftChannel();
+
+	// The skeleton below lives inside its own `role="status"` region, which only announces "Loading
+	// X…" while it is actually mounted — the moment it is replaced by the real list, that region is
+	// gone too, and nothing is left to tell a screen reader the load finished.
+	useLoadingAnnouncement(
+		screen.isLoading,
+		// translators: %s: the preset screen's label (e.g. "Button").
+		sprintf(__('%s loaded.', 'kadence-blocks'), label)
+	);
 
 	const [isAdding, setIsAdding] = useState(false);
 

--- a/src/style-library/components/pages/PresetSidebar.js
+++ b/src/style-library/components/pages/PresetSidebar.js
@@ -18,6 +18,7 @@
  */
 import { useEffect, useState } from '@wordpress/element';
 import { Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -26,6 +27,7 @@ import { SettingsPanel } from '../templates/SettingsPanel';
 import { SettingsForm } from '../organisms/SettingsForm';
 import { useSettingsPanel } from '../../hooks/use-settings-panel';
 import { useDraftChannel } from '../../hooks/use-draft-channel';
+import { useLoadingAnnouncement } from '../../hooks/use-loading-announcement';
 import { presetNameSchema } from '../../helpers/presets';
 import { Skeleton } from '../atoms/Skeleton';
 
@@ -181,8 +183,8 @@ function PresetSidebarBody({ navigate, route, screen, initialValues, presetLabel
  *
  * @since TBD
  *
- * @return {?JSX.Element} The panel, or null while a stale `kb-item` self-heals for a tick, or while
- *         a valid one's presets are still loading.
+ * @return {?JSX.Element} The panel, a loading skeleton while a valid `kb-item`'s presets are still
+ *         loading, or null while a stale one self-heals for a tick.
  */
 export function PresetSidebar({ route, navigate, screen, preset }) {
 	const { tabs, schemaFor } = preset;
@@ -190,6 +192,11 @@ export function PresetSidebar({ route, navigate, screen, preset }) {
 	const initialValues = screen.initialValuesFor(id);
 	const hasInitialValues = Boolean(initialValues);
 	const presetLabel = screen.payload?.presets?.[id]?.label ?? id;
+
+	// The skeleton below lives inside its own `role="status"` region, which only announces "Loading…"
+	// while it is actually mounted — the moment it is replaced by the real panel, that region is
+	// gone too, and nothing is left to tell a screen reader the load finished.
+	useLoadingAnnouncement(Boolean(id && screen.isLoading), __('Settings loaded.', 'kadence-blocks'));
 
 	// A `kb-item` naming no preset (a stale deep link, or another screen's token id) closes the
 	// panel instead of rendering broken fields — the `ScaleSettings.js` self-healing idiom. Waiting

--- a/src/style-library/components/pages/PresetSidebar.js
+++ b/src/style-library/components/pages/PresetSidebar.js
@@ -27,6 +27,7 @@ import { SettingsForm } from '../organisms/SettingsForm';
 import { useSettingsPanel } from '../../hooks/use-settings-panel';
 import { useDraftChannel } from '../../hooks/use-draft-channel';
 import { presetNameSchema } from '../../helpers/presets';
+import { Skeleton } from '../atoms/Skeleton';
 
 /**
  * The panel proper: mounted only once its preset's `initialValues` are known, so `useSettingsPanel`
@@ -203,6 +204,15 @@ export function PresetSidebar({ route, navigate, screen, preset }) {
 			navigate({ item: '' });
 		}
 	}, [id, screen.isLoading, screen.loadError, hasInitialValues, navigate]);
+
+	if (id && screen.isLoading) {
+		return (
+			<div className="kadence-blocks-style-library__settings-panel" role="status" aria-busy="true">
+				<Skeleton className="kadence-blocks-style-library__settings-panel-field" />
+				<Skeleton className="kadence-blocks-style-library__settings-panel-field" />
+			</div>
+		);
+	}
 
 	if (!id || !hasInitialValues) {
 		return null;

--- a/src/style-library/hooks/use-loading-announcement.js
+++ b/src/style-library/hooks/use-loading-announcement.js
@@ -1,0 +1,51 @@
+/**
+ * Announce a loading skeleton's completion to screen readers. Every skeleton in this app already
+ * lives inside its own `role="status"` region, so its "Loading X…" label is announced while it is
+ * showing — but the moment the real content replaces it, that region is gone from the DOM too,
+ * leaving nothing to tell a screen reader user the load actually finished. This hook holds its own
+ * persistent, visually-hidden live-region node (created on mount, removed on unmount) so the
+ * completion announcement survives the skeleton's own unmount.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+
+/**
+ * Announce once the loading state this hook is paired with flips from busy to idle. Call
+ * unconditionally near the top of a component — before any early return — the same as any other
+ * hook; the message is only ever written to the DOM on a true→false transition, never on mount
+ * with an already-idle state and never while still loading.
+ *
+ * @param {boolean} isLoading Whether the paired skeleton is currently showing.
+ * @param {string}  message   The exact text to announce once loading finishes (e.g. "Color Palette loaded.").
+ *
+ * @since TBD
+ */
+export function useLoadingAnnouncement(isLoading, message) {
+	const nodeRef = useRef(null);
+	const wasLoading = useRef(isLoading);
+
+	useEffect(() => {
+		const node = document.createElement('div');
+		node.className = 'screen-reader-text';
+		node.setAttribute('role', 'status');
+		node.setAttribute('aria-live', 'polite');
+		document.body.appendChild(node);
+		nodeRef.current = node;
+
+		return () => {
+			document.body.removeChild(node);
+			nodeRef.current = null;
+		};
+	}, []);
+
+	useEffect(() => {
+		if (wasLoading.current && !isLoading && nodeRef.current) {
+			nodeRef.current.textContent = message;
+		}
+
+		wasLoading.current = isLoading;
+	}, [isLoading, message]);
+}


### PR DESCRIPTION
## Summary

Replaces spinners with skeleton placeholders across the Style Library page, scoped to exactly the controls that do a real, awaitable fetch — and nowhere else.

Adds a shared `Skeleton` atom, then adopts it on the preset row list and the color-palette swatch grid, replacing their screen-level spinners. A generic `isLoading` capability is added to the shared `SelectDropdown` molecule (skeleton rows in the open menu instead of an empty list) and wired into the library-picker dropdown and the color-palette picker. Both preset and palette settings panels also gain a loading skeleton for their cold-load state.

Deliberately does **not** touch any of the six "scale-type" screens (Border Radius, Border Width, Spacing, Icon Sizes, Typography, Shadow) — they read synchronously off the already-loaded design-token feed and never fetch, so a loading state there would be theater. The inline `isBusy` spinner in `SelectDropdown` and the app-boot spinners in `StyleLibraryApp`/`AppShell` are also untouched — an inline write-in-flight indicator and a whole-shell boot state are different design decisions.

## Screenshots

<!-- Drag/paste screenshots in over each placeholder line below, then delete the placeholder text. -->

**Block Presets panel — spinner (before) vs. skeleton rows (after), network throttled:**
_paste screenshot here_

**Color Palette swatch grid — skeleton cards, network throttled:**
_paste screenshot here_

**Library / Color Palette dropdown — skeleton rows in the open menu:**
_paste screenshot here_

## Test instructions

1. Go to **Style Library → Block Presets → Button** and reload with the network throttled (DevTools → Slow 3G). The panel shows row-shaped placeholders instead of a spinner.
2. Do the same on **Color Palette** — the swatch grid shows card-shaped placeholders.
3. Open the library dropdown, and the Color Palette picker, before either has loaded this session — confirm skeleton rows instead of an empty menu.
4. Open a preset's settings panel, and a palette swatch's settings panel, before the data has loaded — confirm skeleton fields.
5. Un-throttle, reload, and repeat each — confirm real content shows immediately once already loaded, no skeleton flash on warm data.
6. Turn on **Reduce Motion** (macOS: System Settings → Accessibility → Display) and reload — the shimmer stops, the static placeholder remains.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4200/phase-6-feed-slice
bun install
```

The Style Library is at **WP Admin → Kadence → Style Library**.
</details>

---

Slice 2 of 7 in the SOFT-4200 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added skeleton loading placeholders across style library screens, dropdowns, preset panels, and color palette settings.
  * Added accessible loading states with localized status text.
  * Added busy-state feedback when creating presets, preventing duplicate submissions.

* **Bug Fixes**
  * Improved loading behavior and accessibility for library and preset selection interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
