### PR TITLE
[DTM] SOFT-4200 [3/7]: Store scaffold + libraries slice

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,7 @@
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.25.1",
+        "@wordpress/data": "^10.53.0",
         "@wordpress/dependency-extraction-webpack-plugin": "^6.26.0",
         "@wordpress/eslint-plugin": "^22.12.0",
         "@wordpress/i18n": "^5.26.0",
@@ -863,6 +864,8 @@
 
     "@tannin/postfix": ["@tannin/postfix@1.1.0", "", {}, "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="],
 
+    "@tannin/sprintf": ["@tannin/sprintf@1.3.3", "", {}, "sha512-RwARl+hFwhzy0tg9atWcchLFvoQiOh4rrP7uG2N5E4W80BPCUX0ElcUR9St43fxB9EfjsW2df9Qp+UsTbvQDjA=="],
+
     "@tootallnate/once": ["@tootallnate/once@2.0.1", "", {}, "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ=="],
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
@@ -914,6 +917,8 @@
     "@types/mime": ["@types/mime@1.3.5", "", {}, "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="],
 
     "@types/minimist": ["@types/minimist@1.2.5", "", {}, "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag=="],
+
+    "@types/mousetrap": ["@types/mousetrap@1.6.15", "", {}, "sha512-qL0hyIMNPow317QWW/63RvL1x5MVMV+Ru3NaY9f/CuEpCqrmb7WeuK2071ZY5hczOnm38qExWM2i2WtkXLSqFw=="],
 
     "@types/mysql": ["@types/mysql@2.15.26", "", { "dependencies": { "@types/node": "*" } }, "sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ=="],
 
@@ -1073,15 +1078,21 @@
 
     "@wordpress/browserslist-config": ["@wordpress/browserslist-config@6.47.0", "", {}, "sha512-ogoxvjDH6lH369uc1SLZkVWVkM/lFTQ9hkhzgn7egWigycdFydG7T76iUw0CvOkHlcxTJGIVaBXEUq7Y3oRqjQ=="],
 
+    "@wordpress/compose": ["@wordpress/compose@8.6.0", "", { "dependencies": { "@types/mousetrap": "^1.6.8", "@wordpress/deprecated": "^4.53.0", "@wordpress/dom": "^4.53.0", "@wordpress/element": "^8.5.0", "@wordpress/is-shallow-equal": "^5.53.0", "@wordpress/keycodes": "^4.53.0", "@wordpress/priority-queue": "^3.53.0", "@wordpress/private-apis": "^1.53.0", "@wordpress/undo-manager": "^1.53.0", "change-case": "^4.1.2", "mousetrap": "^1.6.5", "use-memo-one": "^1.1.1" }, "peerDependencies": { "@types/react": "^18 || ^19", "react": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-aurjKO5vgnKl3p4iRM/maMEB3z36e0FdAuJOvPTHKMUjd0OUk8n2M/n2mfRS68QxVHv8mmDm1IEg8zKobwIDmA=="],
+
+    "@wordpress/data": ["@wordpress/data@10.53.0", "", { "dependencies": { "@wordpress/compose": "^8.6.0", "@wordpress/deprecated": "^4.53.0", "@wordpress/element": "^8.5.0", "@wordpress/is-shallow-equal": "^5.53.0", "@wordpress/priority-queue": "^3.53.0", "@wordpress/private-apis": "^1.53.0", "@wordpress/redux-routine": "^5.53.0", "deepmerge": "^4.3.1", "equivalent-key-map": "^0.2.2", "is-plain-object": "^5.0.0", "is-promise": "^4.0.0", "redux": "^5.0.1", "rememo": "^4.0.2", "use-memo-one": "^1.1.1" }, "peerDependencies": { "@types/react": "^18 || ^19", "react": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-J/TnOBv1pJaeHs0Wk+11jL0kvEf05ocOm1cA24KNbOsdysUpcCh2FKEokyfZaEVJOXjWoiuYFyAtpdXVr/tt+g=="],
+
     "@wordpress/dependency-extraction-webpack-plugin": ["@wordpress/dependency-extraction-webpack-plugin@6.47.0", "", { "dependencies": { "json2php": "^0.0.7" }, "peerDependencies": { "webpack": "^5.0.0" } }, "sha512-fY8yFrvrj7c/tVmoaxm0TcHtsMYGh7nNxB1YTl2NOLUUGCVudby+ts1TWKTttN7vXY3TkRKsEuUL+4X3ToV1WQ=="],
 
-    "@wordpress/deprecated": ["@wordpress/deprecated@4.47.0", "", { "dependencies": { "@wordpress/hooks": "^4.47.0" } }, "sha512-SPmYu3Ihqfaqve4xEKf8+SAhae9UuYLncFovXHHEHeNrKwldYyNy3fm+3Aifd/RK5r7Vc7nr0zONYkuhWkDlNw=="],
+    "@wordpress/deprecated": ["@wordpress/deprecated@4.53.0", "", { "dependencies": { "@wordpress/hooks": "^4.53.0" } }, "sha512-JaIWiGVoKEmsiWP4XwAZvrET44T34EtPG+xCJe9vPIs9O3DHPyB83VHV4WxVRxddaf1osTmR6iPLx0sBvVTjZw=="],
+
+    "@wordpress/dom": ["@wordpress/dom@4.53.0", "", { "dependencies": { "@wordpress/deprecated": "^4.53.0" } }, "sha512-cf+WkRxuXtPLmAWXYShsbitUIkPOjIgiScUJQztA4OSqy9vfSPvrOgb6pUqijPiIo9+fhBSoyryOFCOg7xABOQ=="],
 
     "@wordpress/e2e-test-utils-playwright": ["@wordpress/e2e-test-utils-playwright@1.47.0", "", { "dependencies": { "change-case": "^4.1.2", "get-port": "^5.1.1", "lighthouse": "^12.2.2", "mime": "^3.0.0", "web-vitals": "^4.2.1" }, "peerDependencies": { "@playwright/test": ">=1", "@types/node": "^20.17.10" } }, "sha512-ddDmuW+QaK9g2jsbZi/WWTEDIY3BaO17XLEIIw2vAXksiFTffFlaWh13f85Tl8Md68qZQvG89hEJ++y8DRmNKQ=="],
 
-    "@wordpress/element": ["@wordpress/element@6.46.0", "", { "dependencies": { "@types/react": "^18.3.27", "@types/react-dom": "^18.3.1", "@wordpress/escape-html": "^3.46.0", "change-case": "^4.1.2", "is-plain-object": "^5.0.0", "react": "^18.3.0", "react-dom": "^18.3.0" } }, "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA=="],
+    "@wordpress/element": ["@wordpress/element@8.5.0", "", { "dependencies": { "@wordpress/deprecated": "^4.53.0", "@wordpress/escape-html": "^3.53.0", "change-case": "^4.1.2", "is-plain-object": "^5.0.0" }, "peerDependencies": { "@types/react": "^18 || ^19", "@types/react-dom": "^18 || ^19", "react": "^18 || ^19", "react-dom": "^18 || ^19" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-d6Ct+JETXRoGjfAxu5kSPjportHloZ3auAPLguQOLEoNBiZJp60fslYYd6LeVw7M7dUR3lArwcYVK0x0G06c9Q=="],
 
-    "@wordpress/escape-html": ["@wordpress/escape-html@3.47.0", "", {}, "sha512-3D3dlMxpfc3rTrxASc5osqIR3gp+WgQSn8aqN+1zP8VctM0hm7HdzIix0LwPbyw64DfLiG/jnlRBrtHF6S9UQw=="],
+    "@wordpress/escape-html": ["@wordpress/escape-html@3.53.0", "", {}, "sha512-6EE4hOsd0kUp4bO9voTsIeK0oa80FYMbxvJkjN9Vitnf0ZTRVB7Iz2IviaYorhGUDemlRy3kOPEZdP9DA/CoCA=="],
 
     "@wordpress/eslint-plugin": ["@wordpress/eslint-plugin@22.22.0", "", { "dependencies": { "@babel/eslint-parser": "7.25.7", "@typescript-eslint/eslint-plugin": "^6.4.1", "@typescript-eslint/parser": "^6.4.1", "@wordpress/babel-preset-default": "^8.36.0", "@wordpress/prettier-config": "^4.36.0", "cosmiconfig": "^7.0.0", "eslint-config-prettier": "^8.3.0", "eslint-import-resolver-typescript": "^4.4.4", "eslint-plugin-import": "^2.25.2", "eslint-plugin-jest": "^27.4.3", "eslint-plugin-jsdoc": "^46.4.6", "eslint-plugin-jsx-a11y": "^6.5.1", "eslint-plugin-playwright": "^0.15.3", "eslint-plugin-prettier": "^5.0.0", "eslint-plugin-react": "^7.27.0", "eslint-plugin-react-hooks": "^4.3.0", "globals": "^13.12.0", "requireindex": "^1.2.0" }, "peerDependencies": { "@babel/core": ">=7", "eslint": ">=8", "prettier": ">=3", "typescript": ">=5" }, "optionalPeers": ["prettier", "typescript"] }, "sha512-DLGm5i8Gn0vjkZGKF49U2pYME5Jl9AvmoMJB2G508d+sB/oTSkPmM0baUP7G5zxbd1aqfNTaD0KjdyGyWFFKOA=="],
 
@@ -1091,9 +1102,13 @@
 
     "@wordpress/icons": ["@wordpress/icons@10.32.0", "", { "dependencies": { "@babel/runtime": "7.25.7", "@wordpress/element": "^6.32.0", "@wordpress/primitives": "^4.32.0" } }, "sha512-1WvJdT361X1LnetYBpBWUjAVXZzl+pBdIwHbYRAp8ej47EI/igPmNxmq81nFd40s8fer/9qtipielcqSI6H2rA=="],
 
+    "@wordpress/is-shallow-equal": ["@wordpress/is-shallow-equal@5.53.0", "", {}, "sha512-NHhvEnqi82Vzon458Jz6nzmbAPWM1zy9k6rBXQTc+9PsRiWHWpqXqldKAeTFVrl0vspZf4PwmLlsxqP3ckCLWw=="],
+
     "@wordpress/jest-console": ["@wordpress/jest-console@8.47.0", "", { "dependencies": { "jest-matcher-utils": "^29.6.2", "jest-mock": "^29.6.2" }, "peerDependencies": { "jest": ">=29" } }, "sha512-FM1ySjABL6kdmDWPkEhy12CFiD/GH1OXSH5hUKXssIkrPvWrygrVMU38Yi4DKeWD82C8UZ92VEO2RHOZwCiSLg=="],
 
     "@wordpress/jest-preset-default": ["@wordpress/jest-preset-default@12.47.0", "", { "dependencies": { "@wordpress/jest-console": "^8.47.0", "babel-jest": "29.7.0" }, "peerDependencies": { "@babel/core": ">=7", "jest": ">=29" } }, "sha512-L9JIFxRCnMr5G/CR+Npdva2pj7o/Yh629QX9W+rT4dW4Oq+yXqZE64T0eva/V8brz6//0FLrNNKtYXdXXtD+ZQ=="],
+
+    "@wordpress/keycodes": ["@wordpress/keycodes@4.53.0", "", { "dependencies": { "@wordpress/i18n": "^6.26.0" }, "peerDependencies": { "@types/react": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-e2o0NjkyGpPUGz8sfRd1OeEHdeOk3UVlL1J8P4Y9/fgQQJumTjulbiwps6yheE5kRNqbrh2o424QLdMaODu9Kw=="],
 
     "@wordpress/npm-package-json-lint-config": ["@wordpress/npm-package-json-lint-config@5.47.0", "", { "peerDependencies": { "npm-package-json-lint": ">=6.0.0" } }, "sha512-Xn8hqvwDGKAv6VxsNbsLU/+y60vJjhh/8XlSSMJtx/mfGCC6d6W7p8JEdSji4oixbBI4aXg3zRX3zNpvKKKqHg=="],
 
@@ -1103,7 +1118,11 @@
 
     "@wordpress/primitives": ["@wordpress/primitives@4.47.0", "", { "dependencies": { "@wordpress/element": "^7.0.0", "clsx": "^2.1.1" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-Y1uhC6BiLFzORtXnMa07o3DVXG0z+q2KV6g48ClpZJ9aDiehBfdThBHwa6oa7HbYX/yAoMuCkuA7fWbm3zYxNw=="],
 
-    "@wordpress/private-apis": ["@wordpress/private-apis@1.47.0", "", {}, "sha512-DfwLsmencI2LUZhY6u1aZCwZYO1ILuyJf7Cn15G/gVbPlA7pBJp9YVFk+3FR5U35I0e0infNMDDn8u5632urmQ=="],
+    "@wordpress/priority-queue": ["@wordpress/priority-queue@3.53.0", "", { "dependencies": { "requestidlecallback": "^0.3.0" } }, "sha512-HQ5AatN1QWimFHQnhhhzrfgNoiVWTqwhUEv5326hhTnyUxvh5SOYxg46IBGow+zj/VJjIPyaxv1ftuqzVxgRMQ=="],
+
+    "@wordpress/private-apis": ["@wordpress/private-apis@1.53.0", "", {}, "sha512-xXW2yeBC0n/doFLsv6chEl3Qs5phqmRH7wcUyil+Xvh3msVGzUJxvyo0szmKpQcmoYafASpkQux82HCtNp6jxQ=="],
+
+    "@wordpress/redux-routine": ["@wordpress/redux-routine@5.53.0", "", { "dependencies": { "is-plain-object": "^5.0.0", "is-promise": "^4.0.0", "rungen": "^0.3.2" }, "peerDependencies": { "redux": ">=4" } }, "sha512-brrkZHfYSLUFYKrDkxJLTTRXmZbKNAS8iJnWPOWxjBf4QGeOoBPaVaiGHsMjzQZL98lHox8vHeytUW0Id2Px1g=="],
 
     "@wordpress/scripts": ["@wordpress/scripts@30.27.0", "", { "dependencies": { "@babel/core": "7.25.7", "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11", "@svgr/webpack": "^8.0.1", "@wordpress/babel-preset-default": "^8.34.0", "@wordpress/browserslist-config": "^6.34.0", "@wordpress/dependency-extraction-webpack-plugin": "^6.34.0", "@wordpress/e2e-test-utils-playwright": "^1.34.0", "@wordpress/eslint-plugin": "^22.20.0", "@wordpress/jest-preset-default": "^12.34.0", "@wordpress/npm-package-json-lint-config": "^5.34.0", "@wordpress/postcss-plugins-preset": "^5.34.0", "@wordpress/prettier-config": "^4.34.0", "@wordpress/stylelint-config": "^23.26.0", "adm-zip": "^0.5.9", "babel-jest": "29.7.0", "babel-loader": "9.2.1", "browserslist": "^4.21.10", "chalk": "^4.0.0", "check-node-version": "^4.1.0", "copy-webpack-plugin": "^10.2.0", "cross-spawn": "^7.0.6", "css-loader": "^6.2.0", "cssnano": "^6.0.1", "cwd": "^0.10.0", "dir-glob": "^3.0.1", "eslint": "^8.3.0", "expect-puppeteer": "^4.4.0", "fast-glob": "^3.2.7", "filenamify": "^4.2.0", "jest": "^29.6.2", "jest-dev-server": "^10.1.4", "jest-environment-jsdom": "^29.6.2", "jest-environment-node": "^29.6.2", "json2php": "^0.0.9", "markdownlint-cli": "^0.31.1", "merge-deep": "^3.0.3", "mini-css-extract-plugin": "^2.9.2", "minimist": "^1.2.0", "npm-package-json-lint": "^6.4.0", "npm-packlist": "^3.0.0", "postcss": "^8.4.5", "postcss-loader": "^6.2.1", "prettier": "npm:wp-prettier@3.0.3", "puppeteer-core": "^23.10.1", "react-refresh": "^0.14.0", "read-pkg-up": "^7.0.1", "resolve-bin": "^0.4.0", "rtlcss": "^4.3.0", "sass": "^1.54.0", "sass-loader": "^16.0.3", "schema-utils": "^4.2.0", "source-map-loader": "^3.0.0", "stylelint": "^16.8.2", "terser-webpack-plugin": "^5.3.10", "url-loader": "^4.1.1", "webpack": "^5.97.0", "webpack-bundle-analyzer": "^4.9.1", "webpack-cli": "^5.1.4", "webpack-dev-server": "^4.15.1" }, "peerDependencies": { "@playwright/test": "^1.56.1", "@wordpress/env": "^10.0.0", "react": "^18.0.0", "react-dom": "^18.0.0" }, "optionalPeers": ["@wordpress/env"], "bin": { "wp-scripts": "./bin/wp-scripts.js" } }, "sha512-gXGptazCxAaR7g8kcN5joj7B5fCm0VeBHOmnDBs2dbQ4W4F3tfzdg6CTEj8LonF9bWQXlSy3ku8EqWCdkSG9Xw=="],
 
@@ -1112,6 +1131,8 @@
     "@wordpress/stylelint-config": ["@wordpress/stylelint-config@23.39.0", "", { "dependencies": { "@stylistic/stylelint-plugin": "^3.0.1", "@wordpress/theme": "^0.14.0", "stylelint-config-recommended": "^14.0.1", "stylelint-config-recommended-scss": "^14.1.0" }, "peerDependencies": { "stylelint": "^16.8.2", "stylelint-scss": "^6.4.0" } }, "sha512-JnEn92PHqgmDo9+ddtauFvUgJhDVKZQLBgDv8DR28nEGtALrIRK63bd2ZK0EyF7JK7jRaUMFAJ4ryPeoy1VdMw=="],
 
     "@wordpress/theme": ["@wordpress/theme@0.14.0", "", { "dependencies": { "@wordpress/element": "^7.0.0", "@wordpress/private-apis": "^1.47.0", "@wordpress/style-runtime": "^0.3.0", "colorjs.io": "^0.6.0", "memize": "^2.1.0" }, "peerDependencies": { "react": "^19.2.4", "react-dom": "^19.2.4", "stylelint": "^16.8.2" }, "optionalPeers": ["stylelint"] }, "sha512-Z03kSyK7k1mSWgUE64/Grg7O3EdYIDqkbBjv0f91keb7b/asZgfIHynNhdyg05FQXcRHn8NJhP/cZOVwnyII8A=="],
+
+    "@wordpress/undo-manager": ["@wordpress/undo-manager@1.53.0", "", { "dependencies": { "@wordpress/is-shallow-equal": "^5.53.0" } }, "sha512-0MtlfeCa0uFWAGubP2rAJ1NoWQOWOuzW0kTwZgqfFFg81HEgNIBb8LU3eXMbMxERjdZYpCrqUL3MbVPl7ExiGw=="],
 
     "@wordpress/url": ["@wordpress/url@4.47.0", "", { "dependencies": { "remove-accents": "^0.5.0" } }, "sha512-34UAKyzb7R4JhNgSFVQa9hu1aojlK6EtWsHWq9yEgz925PJ//EV6sfqHXFT5I6eKx+k5PNMjkrk4VxFYP6MZcg=="],
 
@@ -1679,6 +1700,8 @@
 
     "envinfo": ["envinfo@7.21.0", "", { "bin": { "envinfo": "dist/cli.js" } }, "sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow=="],
 
+    "equivalent-key-map": ["equivalent-key-map@0.2.2", "", {}, "sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew=="],
+
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
     "error-stack-parser": ["error-stack-parser@2.1.4", "", { "dependencies": { "stackframe": "^1.3.4" } }, "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ=="],
@@ -2141,6 +2164,8 @@
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
     "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
 
     "is-relative": ["is-relative@1.0.0", "", { "dependencies": { "is-unc-path": "^1.0.0" } }, "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA=="],
@@ -2444,6 +2469,8 @@
     "mixin-object": ["mixin-object@2.0.1", "", { "dependencies": { "for-in": "^0.1.3", "is-extendable": "^0.1.1" } }, "sha512-ALGF1Jt9ouehcaXaHhn6t1yGWRqGaHkPFndtFVHfZXOvkIZ/yoGaSi0AHVTafb3ZBGg4dr/bDwnaEKqCXzchMA=="],
 
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
+
+    "mousetrap": ["mousetrap@1.6.5", "", {}, "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA=="],
 
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
 
@@ -2831,6 +2858,8 @@
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
     "regenerate": ["regenerate@1.4.2", "", {}, "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="],
@@ -2847,6 +2876,8 @@
 
     "regjsparser": ["regjsparser@0.13.1", "", { "dependencies": { "jsesc": "~3.1.0" }, "bin": { "regjsparser": "bin/parser" } }, "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw=="],
 
+    "rememo": ["rememo@4.0.2", "", {}, "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ=="],
+
     "remove-accents": ["remove-accents@0.5.0", "", {}, "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A=="],
 
     "remove-trailing-separator": ["remove-trailing-separator@1.1.0", "", {}, "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw=="],
@@ -2854,6 +2885,8 @@
     "replace-ext": ["replace-ext@2.0.0", "", {}, "sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug=="],
 
     "replace-homedir": ["replace-homedir@2.0.0", "", {}, "sha512-bgEuQQ/BHW0XkkJtawzrfzHFSN70f/3cNOiHa2QsYxqrjaC30X1k74FJ6xswVBP0sr0SpGIdVFuPwfrYziVeyw=="],
+
+    "requestidlecallback": ["requestidlecallback@0.3.0", "", {}, "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
@@ -2894,6 +2927,8 @@
     "run-con": ["run-con@1.2.12", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~3.0.0", "minimist": "^1.2.8", "strip-json-comments": "~3.1.1" }, "bin": { "run-con": "cli.js" } }, "sha512-5257ILMYIF4RztL9uoZ7V9Q97zHtNHn5bN3NobeAnzB1P3ASLgg8qocM2u+R18ttp+VEM78N2LK8XcNVtnSRrg=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "rungen": ["rungen@0.3.2", "", {}, "sha512-zWl10xu2D7zoR8zSC2U6bg5bYF6T/Wk7rxwp8IPaJH7f0Ge21G03kNHVgHR7tyVkSSfAOG0Rqf/Cl38JftSmtw=="],
 
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
@@ -3243,6 +3278,8 @@
 
     "use-isomorphic-layout-effect": ["use-isomorphic-layout-effect@1.2.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA=="],
 
+    "use-memo-one": ["use-memo-one@1.1.3", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0" } }, "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ=="],
+
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
@@ -3479,11 +3516,19 @@
 
     "@wordpress/babel-preset-default/react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
 
+    "@wordpress/compose/change-case": ["change-case@4.1.2", "", { "dependencies": { "camel-case": "^4.1.2", "capital-case": "^1.0.4", "constant-case": "^3.0.4", "dot-case": "^3.0.4", "header-case": "^2.0.4", "no-case": "^3.0.4", "param-case": "^3.0.4", "pascal-case": "^3.1.2", "path-case": "^3.0.4", "sentence-case": "^3.0.4", "snake-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A=="],
+
+    "@wordpress/deprecated/@wordpress/hooks": ["@wordpress/hooks@4.53.0", "", {}, "sha512-YU30rweJCTu5g7X8bc+w6QyoxJBYLEHH++Wwo/IbbROHUC/4I7e+ZtxnPWls8BTtMP4d28JJ74s+UoKpzd2J7w=="],
+
     "@wordpress/e2e-test-utils-playwright/change-case": ["change-case@4.1.2", "", { "dependencies": { "camel-case": "^4.1.2", "capital-case": "^1.0.4", "constant-case": "^3.0.4", "dot-case": "^3.0.4", "header-case": "^2.0.4", "no-case": "^3.0.4", "param-case": "^3.0.4", "pascal-case": "^3.1.2", "path-case": "^3.0.4", "sentence-case": "^3.0.4", "snake-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A=="],
 
     "@wordpress/element/change-case": ["change-case@4.1.2", "", { "dependencies": { "camel-case": "^4.1.2", "capital-case": "^1.0.4", "constant-case": "^3.0.4", "dot-case": "^3.0.4", "header-case": "^2.0.4", "no-case": "^3.0.4", "param-case": "^3.0.4", "pascal-case": "^3.1.2", "path-case": "^3.0.4", "sentence-case": "^3.0.4", "snake-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A=="],
 
     "@wordpress/eslint-plugin/@babel/eslint-parser": ["@babel/eslint-parser@7.25.7", "", { "dependencies": { "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1", "eslint-visitor-keys": "^2.1.0", "semver": "^6.3.1" }, "peerDependencies": { "@babel/core": "^7.11.0", "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0" } }, "sha512-B+BO9x86VYsQHimucBAL1fxTJKF4wyKY6ZVzee9QgzdZOUfs3BaR6AQrgoGrRI+7IFS1wUz/VyQ+SoBcSpdPbw=="],
+
+    "@wordpress/icons/@wordpress/element": ["@wordpress/element@6.46.0", "", { "dependencies": { "@types/react": "^18.3.27", "@types/react-dom": "^18.3.1", "@wordpress/escape-html": "^3.46.0", "change-case": "^4.1.2", "is-plain-object": "^5.0.0", "react": "^18.3.0", "react-dom": "^18.3.0" } }, "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA=="],
+
+    "@wordpress/keycodes/@wordpress/i18n": ["@wordpress/i18n@6.26.0", "", { "dependencies": { "@tannin/sprintf": "^1.3.2", "@wordpress/hooks": "^4.53.0", "gettext-parser": "^1.3.1", "tannin": "^1.2.0" }, "bin": { "pot-to-php": "tools/pot-to-php.js" } }, "sha512-v/LzeB7T5YKIfBgmLM0jYG8zOuu81biZ90j8RY9pHIVu+jdRE+DSmt55S3FvtXRo5J2X9FoigFRzYPKXLbitWA=="],
 
     "@wordpress/primitives/@wordpress/element": ["@wordpress/element@7.0.0", "", { "dependencies": { "@types/react": "^19.2.13", "@types/react-dom": "^19.2.3", "@wordpress/deprecated": "^4.47.0", "@wordpress/escape-html": "^3.47.0", "change-case": "^4.1.2", "is-plain-object": "^5.0.0", "react": "^19.2.4", "react-dom": "^19.2.4" } }, "sha512-iJoc3pzeof0mhwN0gVqDqc64xCRoAij2JynU6YxGSmw5a1uJwi1w3GESX3nPR1eaDdv2V6vwkinMBI+aGG7wxQ=="],
 
@@ -3494,6 +3539,8 @@
     "@wordpress/scripts/prettier": ["wp-prettier@3.0.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA=="],
 
     "@wordpress/theme/@wordpress/element": ["@wordpress/element@7.0.0", "", { "dependencies": { "@types/react": "^19.2.13", "@types/react-dom": "^19.2.3", "@wordpress/deprecated": "^4.47.0", "@wordpress/escape-html": "^3.47.0", "change-case": "^4.1.2", "is-plain-object": "^5.0.0", "react": "^19.2.4", "react-dom": "^19.2.4" } }, "sha512-iJoc3pzeof0mhwN0gVqDqc64xCRoAij2JynU6YxGSmw5a1uJwi1w3GESX3nPR1eaDdv2V6vwkinMBI+aGG7wxQ=="],
+
+    "@wordpress/theme/@wordpress/private-apis": ["@wordpress/private-apis@1.47.0", "", {}, "sha512-DfwLsmencI2LUZhY6u1aZCwZYO1ILuyJf7Cn15G/gVbPlA7pBJp9YVFk+3FR5U35I0e0infNMDDn8u5632urmQ=="],
 
     "accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
@@ -3951,9 +3998,19 @@
 
     "@wordpress/babel-preset-default/@babel/core/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "@wordpress/icons/@wordpress/element/@wordpress/escape-html": ["@wordpress/escape-html@3.47.0", "", {}, "sha512-3D3dlMxpfc3rTrxASc5osqIR3gp+WgQSn8aqN+1zP8VctM0hm7HdzIix0LwPbyw64DfLiG/jnlRBrtHF6S9UQw=="],
+
+    "@wordpress/icons/@wordpress/element/change-case": ["change-case@4.1.2", "", { "dependencies": { "camel-case": "^4.1.2", "capital-case": "^1.0.4", "constant-case": "^3.0.4", "dot-case": "^3.0.4", "header-case": "^2.0.4", "no-case": "^3.0.4", "param-case": "^3.0.4", "pascal-case": "^3.1.2", "path-case": "^3.0.4", "sentence-case": "^3.0.4", "snake-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A=="],
+
+    "@wordpress/keycodes/@wordpress/i18n/@wordpress/hooks": ["@wordpress/hooks@4.53.0", "", {}, "sha512-YU30rweJCTu5g7X8bc+w6QyoxJBYLEHH++Wwo/IbbROHUC/4I7e+ZtxnPWls8BTtMP4d28JJ74s+UoKpzd2J7w=="],
+
     "@wordpress/primitives/@wordpress/element/@types/react": ["@types/react@19.2.15", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q=="],
 
     "@wordpress/primitives/@wordpress/element/@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@wordpress/primitives/@wordpress/element/@wordpress/deprecated": ["@wordpress/deprecated@4.47.0", "", { "dependencies": { "@wordpress/hooks": "^4.47.0" } }, "sha512-SPmYu3Ihqfaqve4xEKf8+SAhae9UuYLncFovXHHEHeNrKwldYyNy3fm+3Aifd/RK5r7Vc7nr0zONYkuhWkDlNw=="],
+
+    "@wordpress/primitives/@wordpress/element/@wordpress/escape-html": ["@wordpress/escape-html@3.47.0", "", {}, "sha512-3D3dlMxpfc3rTrxASc5osqIR3gp+WgQSn8aqN+1zP8VctM0hm7HdzIix0LwPbyw64DfLiG/jnlRBrtHF6S9UQw=="],
 
     "@wordpress/primitives/@wordpress/element/change-case": ["change-case@4.1.2", "", { "dependencies": { "camel-case": "^4.1.2", "capital-case": "^1.0.4", "constant-case": "^3.0.4", "dot-case": "^3.0.4", "header-case": "^2.0.4", "no-case": "^3.0.4", "param-case": "^3.0.4", "pascal-case": "^3.1.2", "path-case": "^3.0.4", "sentence-case": "^3.0.4", "snake-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A=="],
 
@@ -3966,6 +4023,10 @@
     "@wordpress/theme/@wordpress/element/@types/react": ["@types/react@19.2.15", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q=="],
 
     "@wordpress/theme/@wordpress/element/@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@wordpress/theme/@wordpress/element/@wordpress/deprecated": ["@wordpress/deprecated@4.47.0", "", { "dependencies": { "@wordpress/hooks": "^4.47.0" } }, "sha512-SPmYu3Ihqfaqve4xEKf8+SAhae9UuYLncFovXHHEHeNrKwldYyNy3fm+3Aifd/RK5r7Vc7nr0zONYkuhWkDlNw=="],
+
+    "@wordpress/theme/@wordpress/element/@wordpress/escape-html": ["@wordpress/escape-html@3.47.0", "", {}, "sha512-3D3dlMxpfc3rTrxASc5osqIR3gp+WgQSn8aqN+1zP8VctM0hm7HdzIix0LwPbyw64DfLiG/jnlRBrtHF6S9UQw=="],
 
     "@wordpress/theme/@wordpress/element/change-case": ["change-case@4.1.2", "", { "dependencies": { "camel-case": "^4.1.2", "capital-case": "^1.0.4", "constant-case": "^3.0.4", "dot-case": "^3.0.4", "header-case": "^2.0.4", "no-case": "^3.0.4", "param-case": "^3.0.4", "pascal-case": "^3.1.2", "path-case": "^3.0.4", "sentence-case": "^3.0.4", "snake-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A=="],
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
 	},
 	"devDependencies": {
 		"@babel/eslint-parser": "^7.25.1",
+		"@wordpress/data": "^10.53.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.26.0",
 		"@wordpress/eslint-plugin": "^22.12.0",
 		"@wordpress/i18n": "^5.26.0",

--- a/src/style-library/__tests__/library-flows.test.js
+++ b/src/style-library/__tests__/library-flows.test.js
@@ -493,6 +493,36 @@ describe('deleteLibraryFlow', () => {
 		expect(refreshFeed).toHaveBeenCalledWith('default');
 	});
 
+	it('resolves and clears busy even when the post-delete list refetch fails, so a successful delete never reports as a failure', async () => {
+		// The delete itself, and the feed refresh for wherever the app lands, both succeed —
+		// `loadLibraries()` (the list refetch) is the only thing that fails, e.g. a transient GET
+		// error after the DELETE has already gone through.
+		client.deleteLibrary.mockResolvedValue({ deleted: true });
+		const refreshFeed = jest.fn().mockResolvedValue({ slug: 'default' });
+		const loadLibraries = jest.fn().mockRejectedValue(new Error('Network error'));
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			deleteLibraryFlow({
+				slug: 'brand-b',
+				activeSlug: 'default',
+				refreshFeed,
+				loadLibraries,
+				onBusy,
+				onError,
+				onActiveChanged: jest.fn(),
+			})
+		).resolves.toBeUndefined();
+
+		expect(client.deleteLibrary).toHaveBeenCalledWith('brand-b');
+		expect(loadLibraries).toHaveBeenCalled();
+		// Neither surfaces: a stale list is already reported separately, through
+		// `getResolutionError('getLibraries', [])` feeding the library dropdown's own `openError`.
+		expect(onError).not.toHaveBeenCalled();
+		expect(onBusy).toHaveBeenLastCalledWith(false);
+	});
+
 	it('surfaces the error, clears busy, and rejects when the delete request fails', async () => {
 		const failure = new Error('The design token library could not be deleted.');
 		client.deleteLibrary.mockRejectedValue(failure);

--- a/src/style-library/__tests__/use-libraries.test.js
+++ b/src/style-library/__tests__/use-libraries.test.js
@@ -24,6 +24,14 @@ describe('useLibraries', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
+		// Fakes `setTimeout`/`setInterval`/`clearTimeout`, so `flushResolvers()` below can advance
+		// `@wordpress/data`'s resolver dispatch deterministically instead of racing a real OS timer
+		// tick against whatever else is contending for the CPU. `Date`/`performance` are excluded:
+		// React's own scheduler uses those to make time-slicing decisions, and freezing them (Jest's
+		// default) leaves it unable to ever decide enough time has passed to flush a commit, hanging
+		// real writes that depend on a state update actually landing. See `use-palettes.test.js` for
+		// the same setup and the investigation behind it.
+		jest.useFakeTimers({ doNotFake: ['Date', 'performance', 'queueMicrotask', 'nextTick'] });
 		registry = createTestRegistry();
 		global.IS_REACT_ACT_ENVIRONMENT = true;
 		container = document.createElement('div');
@@ -35,37 +43,69 @@ describe('useLibraries', () => {
 		act(() => root.unmount());
 		container.remove();
 		delete global.IS_REACT_ACT_ENVIRONMENT;
+		jest.useRealTimers();
 	});
 
 	// `@wordpress/data`'s resolver dispatch runs off a `setTimeout(fn, 0)` inside the store
 	// (see `mapSelectorWithResolver` in `@wordpress/data`'s redux store), a real timer callback that
 	// a plain `await act(async () => render())` does not wait for — that promise settles as soon as
-	// the synchronous render returns. Flushing one real timer tick after each render/dispatch gives
-	// the resolver's callback a turn to run before assertions read the store.
+	// the synchronous render returns. `runOnlyPendingTimersAsync` fires whatever resolver dispatch is
+	// currently pending and lets the promise chain it kicks off (the mocked fetch resolving, its
+	// `.then()`, the store dispatch) drain via the real microtask queue before returning, so one call
+	// reliably carries a resolver all the way to "dispatched," deterministically — see
+	// `use-palettes.test.js`'s identical helper for why `advanceTimersByTimeAsync(0)` doesn't work
+	// here (a resolver's callback can itself schedule a second resolver's timer from deeper inside a
+	// promise chain, which that API doesn't reliably pick up within the same call).
 	function flushResolvers() {
-		return act(() => new Promise((resolve) => setTimeout(resolve, 0)));
+		return act(() => jest.runOnlyPendingTimersAsync());
 	}
 
-	// A single fixed `flushResolvers()` call assumes the resolution lands within one real timer
-	// tick — true under `--runInBand`, but under parallel jest workers, CPU contention from the
-	// other worker processes can delay a `setTimeout(0)` callback by an amount a fixed count can't
-	// bound. Polling against a wall-clock deadline survives that contention; a genuine regression
-	// still fails, just after the deadline instead of after one tick.
+	// Bounded by an attempt count, not a wall-clock deadline — fake timers make every hop
+	// deterministic, so this is a fixed number of resolver hops to wait out, not a "did enough real
+	// time pass" question.
 	//
 	// Flushes at least once before ever checking `predicate` — `isLoading` (the usual predicate
 	// here) is `isResolving && !rows.length`, which reads `false` both once resolution has genuinely
 	// finished AND before it has even started (nothing is resolving yet at the very first render,
-	// since the resolver's own dispatch is itself scheduled via a real timer). Checking first would
-	// exit on that pre-start `false` without ever giving the resolver a turn to run.
-	async function flushUntil(predicate, timeoutMs = 3000) {
-		const deadline = Date.now() + timeoutMs;
-		do {
+	// since the resolver's own dispatch is itself scheduled via a timer). Checking first would exit
+	// on that pre-start `false` without ever giving the resolver a turn to run.
+	async function flushUntil(predicate, maxAttempts = 10) {
+		for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
 			await flushResolvers();
 			if (predicate()) {
 				return;
 			}
-		} while (Date.now() < deadline);
+		}
 		throw new Error('flushUntil: condition never became true');
+	}
+
+	// A bare `await` on a promise that depends on a store resolver settling (e.g.
+	// `resolveSelect(...).getLibraries()`) relied, under REAL timers, on Node's event loop
+	// opportunistically servicing the pending `setTimeout(0)` while the test awaited — invisible
+	// there, but a permanent hang under fake timers, which advance only when explicitly told to. This
+	// starts from the given promise, advances fake timers until it settles, then returns it so the
+	// caller can still inspect its resolved value or rejection. See `use-palettes.test.js`'s identical
+	// helper.
+	async function settleWithTimers(promise, maxAttempts = 20) {
+		let settled = false;
+		promise.then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			}
+		);
+
+		for (let attempt = 0; !settled && attempt < maxAttempts; attempt += 1) {
+			await jest.runOnlyPendingTimersAsync();
+		}
+
+		if (!settled) {
+			throw new Error(`settleWithTimers: promise never settled after ${maxAttempts} attempts`);
+		}
+
+		return promise;
 	}
 
 	function mountProbe() {
@@ -187,7 +227,7 @@ describe('useLibraries', () => {
 
 		const registryDispatch = registry.dispatch('kadence-blocks/style-library');
 		registryDispatch.invalidateResolution('getLibraries', []);
-		await act(async () => registry.resolveSelect('kadence-blocks/style-library').getLibraries());
+		await act(() => settleWithTimers(registry.resolveSelect('kadence-blocks/style-library').getLibraries()));
 
 		expect(probe.latest().libraries).toHaveLength(2);
 	});

--- a/src/style-library/__tests__/use-libraries.test.js
+++ b/src/style-library/__tests__/use-libraries.test.js
@@ -111,6 +111,50 @@ describe('useLibraries', () => {
 		expect(fetchLibraries).toHaveBeenCalledTimes(1);
 	});
 
+	it('keeps isLoading false during a write-triggered background reload once the list has loaded once', async () => {
+		fetchLibraries.mockResolvedValueOnce([ROW_A]);
+
+		const probe = mountProbe();
+		await probe.render({ slug: 'default' }, jest.fn());
+
+		expect(probe.latest().libraries).toHaveLength(1);
+		expect(probe.latest().isLoading).toBe(false);
+
+		let resolveReload;
+		fetchLibraries.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					resolveReload = resolve;
+				})
+		);
+
+		const registryDispatch = registry.dispatch('kadence-blocks/style-library');
+		let reloadPromise;
+		await act(async () => {
+			registryDispatch.invalidateResolution('getLibraries', []);
+			reloadPromise = registry.resolveSelect('kadence-blocks/style-library').getLibraries();
+		});
+		// `resolveSelect()` re-runs the same instrumented selector `select()` uses, which schedules its
+		// resolver fulfillment on a real `setTimeout(fn, 0)` (see the `flushResolvers()` comment above) —
+		// one real timer tick gets `fetchLibraries` actually called and `isResolving` flipped true before
+		// the fetch itself settles.
+		await flushResolvers();
+
+		// The reload is genuinely in flight here (`isResolving` is true), but the list already has the
+		// one row from the first load, so the dropdown must keep rendering it, not a skeleton.
+		expect(fetchLibraries).toHaveBeenCalledTimes(2);
+		expect(probe.latest().libraries).toHaveLength(1);
+		expect(probe.latest().isLoading).toBe(false);
+
+		await act(async () => {
+			resolveReload([ROW_A, ROW_B]);
+			await reloadPromise;
+		});
+
+		expect(probe.latest().libraries).toHaveLength(2);
+		expect(probe.latest().isLoading).toBe(false);
+	});
+
 	it('a create flow that calls loadLibraries() sees the refreshed list', async () => {
 		fetchLibraries.mockResolvedValueOnce([ROW_A]).mockResolvedValueOnce([ROW_A, ROW_B]);
 

--- a/src/style-library/__tests__/use-libraries.test.js
+++ b/src/style-library/__tests__/use-libraries.test.js
@@ -79,6 +79,15 @@ describe('useLibraries', () => {
 		expect(probe.latest().libraries.map((row) => row.slug)).toEqual(expect.arrayContaining(['default', 'brand']));
 	});
 
+	it('surfaces a getLibraries resolution failure through openError, same as the old mount-effect .catch() did', async () => {
+		fetchLibraries.mockRejectedValueOnce(new Error('Something broke'));
+
+		const probe = mountProbe();
+		await probe.render({ slug: 'default' }, jest.fn());
+
+		expect(probe.latest().openError).toEqual({ message: 'Something broke' });
+	});
+
 	it('two mounted instances share one fetch — the resolver runs once per argument tuple', async () => {
 		fetchLibraries.mockResolvedValueOnce([ROW_A]);
 

--- a/src/style-library/__tests__/use-libraries.test.js
+++ b/src/style-library/__tests__/use-libraries.test.js
@@ -46,6 +46,28 @@ describe('useLibraries', () => {
 		return act(() => new Promise((resolve) => setTimeout(resolve, 0)));
 	}
 
+	// A single fixed `flushResolvers()` call assumes the resolution lands within one real timer
+	// tick — true under `--runInBand`, but under parallel jest workers, CPU contention from the
+	// other worker processes can delay a `setTimeout(0)` callback by an amount a fixed count can't
+	// bound. Polling against a wall-clock deadline survives that contention; a genuine regression
+	// still fails, just after the deadline instead of after one tick.
+	//
+	// Flushes at least once before ever checking `predicate` — `isLoading` (the usual predicate
+	// here) is `isResolving && !rows.length`, which reads `false` both once resolution has genuinely
+	// finished AND before it has even started (nothing is resolving yet at the very first render,
+	// since the resolver's own dispatch is itself scheduled via a real timer). Checking first would
+	// exit on that pre-start `false` without ever giving the resolver a turn to run.
+	async function flushUntil(predicate, timeoutMs = 3000) {
+		const deadline = Date.now() + timeoutMs;
+		do {
+			await flushResolvers();
+			if (predicate()) {
+				return;
+			}
+		} while (Date.now() < deadline);
+		throw new Error('flushUntil: condition never became true');
+	}
+
 	function mountProbe() {
 		let latest = null;
 
@@ -63,7 +85,7 @@ describe('useLibraries', () => {
 						</RegistryProvider>
 					)
 				);
-				await flushResolvers();
+				await flushUntil(() => !latest.isLoading);
 			},
 			latest: () => latest,
 		};
@@ -106,7 +128,7 @@ describe('useLibraries', () => {
 				</RegistryProvider>
 			)
 		);
-		await flushResolvers();
+		await flushUntil(() => fetchLibraries.mock.calls.length >= 1);
 
 		expect(fetchLibraries).toHaveBeenCalledTimes(1);
 	});
@@ -136,9 +158,9 @@ describe('useLibraries', () => {
 		});
 		// `resolveSelect()` re-runs the same instrumented selector `select()` uses, which schedules its
 		// resolver fulfillment on a real `setTimeout(fn, 0)` (see the `flushResolvers()` comment above) —
-		// one real timer tick gets `fetchLibraries` actually called and `isResolving` flipped true before
-		// the fetch itself settles.
-		await flushResolvers();
+		// polling gets `fetchLibraries` actually called and `isResolving` flipped true before the fetch
+		// itself settles, regardless of how many real ticks that takes under load.
+		await flushUntil(() => fetchLibraries.mock.calls.length >= 2);
 
 		// The reload is genuinely in flight here (`isResolving` is true), but the list already has the
 		// one row from the first load, so the dropdown must keep rendering it, not a skeleton.

--- a/src/style-library/__tests__/use-libraries.test.js
+++ b/src/style-library/__tests__/use-libraries.test.js
@@ -1,0 +1,119 @@
+/* eslint-env jest */
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { RegistryProvider } from '@wordpress/data';
+import { useLibraries } from '../hooks/use-libraries';
+import { fetchLibraries } from '../api/client';
+import { createTestRegistry } from '../store/test-utils';
+
+jest.mock('../api/client', () => ({
+	fetchLibraries: jest.fn(),
+	createLibrary: jest.fn(),
+	renameLibrary: jest.fn(),
+	deleteLibrary: jest.fn(),
+	setActiveLibrary: jest.fn(),
+}));
+
+const ROW_A = { slug: 'default', title: '', version: 'v1', document: {} };
+const ROW_B = { slug: 'brand', title: 'Brand', version: 'v1', document: {} };
+
+describe('useLibraries', () => {
+	let container;
+	let root;
+	let registry;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		registry = createTestRegistry();
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		delete global.IS_REACT_ACT_ENVIRONMENT;
+	});
+
+	// `@wordpress/data`'s resolver dispatch runs off a `setTimeout(fn, 0)` inside the store
+	// (see `mapSelectorWithResolver` in `@wordpress/data`'s redux store), a real timer callback that
+	// a plain `await act(async () => render())` does not wait for — that promise settles as soon as
+	// the synchronous render returns. Flushing one real timer tick after each render/dispatch gives
+	// the resolver's callback a turn to run before assertions read the store.
+	function flushResolvers() {
+		return act(() => new Promise((resolve) => setTimeout(resolve, 0)));
+	}
+
+	function mountProbe() {
+		let latest = null;
+
+		function Probe({ feed, refreshFeed }) {
+			latest = useLibraries(feed, refreshFeed);
+			return null;
+		}
+
+		return {
+			render: async (feed, refreshFeed) => {
+				await act(() =>
+					root.render(
+						<RegistryProvider value={registry}>
+							<Probe feed={feed} refreshFeed={refreshFeed} />
+						</RegistryProvider>
+					)
+				);
+				await flushResolvers();
+			},
+			latest: () => latest,
+		};
+	}
+
+	it('resolves the libraries list on first read, with no fetch-on-mount effect required', async () => {
+		fetchLibraries.mockResolvedValueOnce([ROW_A, ROW_B]);
+
+		const probe = mountProbe();
+		await probe.render({ slug: 'default' }, jest.fn());
+
+		expect(probe.latest().isLoading).toBe(false);
+		expect(probe.latest().libraries.map((row) => row.slug)).toEqual(expect.arrayContaining(['default', 'brand']));
+	});
+
+	it('two mounted instances share one fetch — the resolver runs once per argument tuple', async () => {
+		fetchLibraries.mockResolvedValueOnce([ROW_A]);
+
+		function ProbeA() {
+			return useLibraries({ slug: 'default' }, jest.fn()) && null;
+		}
+		function ProbeB() {
+			return useLibraries({ slug: 'default' }, jest.fn()) && null;
+		}
+
+		await act(async () =>
+			root.render(
+				<RegistryProvider value={registry}>
+					<ProbeA />
+					<ProbeB />
+				</RegistryProvider>
+			)
+		);
+		await flushResolvers();
+
+		expect(fetchLibraries).toHaveBeenCalledTimes(1);
+	});
+
+	it('a create flow that calls loadLibraries() sees the refreshed list', async () => {
+		fetchLibraries.mockResolvedValueOnce([ROW_A]).mockResolvedValueOnce([ROW_A, ROW_B]);
+
+		const probe = mountProbe();
+		await probe.render({ slug: 'default' }, jest.fn());
+
+		expect(probe.latest().libraries).toHaveLength(1);
+
+		const registryDispatch = registry.dispatch('kadence-blocks/style-library');
+		registryDispatch.invalidateResolution('getLibraries', []);
+		await act(async () => registry.resolveSelect('kadence-blocks/style-library').getLibraries());
+
+		expect(probe.latest().libraries).toHaveLength(2);
+	});
+});

--- a/src/style-library/helpers/library-flows.js
+++ b/src/style-library/helpers/library-flows.js
@@ -294,7 +294,16 @@ export function deleteLibraryFlow({
 	return activation
 		.then(() => deleteLibrary(slug))
 		.then(() => refreshFeed(nextSlug))
-		.then(() => loadLibraries())
+		.then(() =>
+			// A failed refetch here must not undo a delete that already succeeded — by this point
+			// `deleteLibrary(slug)` has already resolved. A stale list is already surfaced
+			// separately, via `getResolutionError('getLibraries', [])` feeding `openError` in
+			// `use-libraries.js`, which the header's own library dropdown renders. Letting this
+			// rejection propagate into the `.catch()` below would report "delete failed" for a
+			// delete that worked, leaving the modal open and a retry 404ing against the row that is
+			// already gone.
+			loadLibraries().catch(() => {})
+		)
 		.then(() => onBusy(false))
 		.catch((err) => {
 			onError({ message: errorMessage(err) });

--- a/src/style-library/hooks/use-libraries.js
+++ b/src/style-library/hooks/use-libraries.js
@@ -79,7 +79,10 @@ export function useLibraries(feed, refreshFeed) {
 	// re-resolves after create/rename/delete) — the store keeps serving the previous rows while that
 	// re-fetch is in flight, so there is already data to render and no loading state to show for it.
 	const { libraryRows, isLoading, loadFailure } = useSelect((select) => {
-		const rows = select(STORE_NAME).getLibraries();
+		// Guarded the same way `sortLibraries(libraryRows ?? [])` below already is — the selector's
+		// raw result is trusted nowhere else in this hook, and a throw here would crash the render
+		// instead of leaving the empty-list rendering `sortLibraries`'s own guard already handles.
+		const rows = select(STORE_NAME).getLibraries() ?? [];
 		return {
 			libraryRows: rows,
 			isLoading: select(STORE_NAME).isResolving('getLibraries', []) && rows.length === 0,

--- a/src/style-library/hooks/use-libraries.js
+++ b/src/style-library/hooks/use-libraries.js
@@ -74,14 +74,18 @@ export function useLibraries(feed, refreshFeed) {
 	const [activeSlug, setActiveSlug] = useState(editingSlug);
 
 	const registry = useRegistry();
-	const { libraryRows, isLoading, loadFailure } = useSelect(
-		(select) => ({
-			libraryRows: select(STORE_NAME).getLibraries(),
-			isLoading: select(STORE_NAME).isResolving('getLibraries', []),
+	// `isLoading` only reflects a cold load with nothing to show yet. `isResolving` alone would also
+	// flip true for every write-triggered background reload (`loadLibraries()`, below, invalidates and
+	// re-resolves after create/rename/delete) — the store keeps serving the previous rows while that
+	// re-fetch is in flight, so there is already data to render and no loading state to show for it.
+	const { libraryRows, isLoading, loadFailure } = useSelect((select) => {
+		const rows = select(STORE_NAME).getLibraries();
+		return {
+			libraryRows: rows,
+			isLoading: select(STORE_NAME).isResolving('getLibraries', []) && rows.length === 0,
 			loadFailure: select(STORE_NAME).getResolutionError('getLibraries', []),
-		}),
-		[]
-	);
+		};
+	}, []);
 	const libraries = useMemo(() => sortLibraries(libraryRows ?? []), [libraryRows]);
 
 	// The original hook's mount-effect `.catch()` wrote a failed list fetch into the SAME `openError`

--- a/src/style-library/hooks/use-libraries.js
+++ b/src/style-library/hooks/use-libraries.js
@@ -1,12 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { useSelect, useRegistry } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { fetchLibraries } from '../api/client';
 import { DEFAULT_LIBRARY_SLUG } from '../constants';
 import { sortLibraries } from '../helpers/libraries';
 import {
@@ -17,6 +17,7 @@ import {
 	openLibraryFlow,
 	renameLibraryFlow,
 } from '../helpers/library-flows';
+import { STORE_NAME } from '../store';
 
 /**
  * The library management surface for the Style Library header: the list, the two slugs, and the
@@ -54,8 +55,6 @@ import {
  *                  the functions that clear them, and the five operations.
  */
 export function useLibraries(feed, refreshFeed) {
-	const [libraries, setLibraries] = useState([]);
-	const [isLoading, setIsLoading] = useState(true);
 	const [isBusy, setIsBusy] = useState(false);
 	const [openError, setOpenError] = useState(null);
 	const [activateError, setActivateError] = useState(null);
@@ -74,16 +73,37 @@ export function useLibraries(feed, refreshFeed) {
 	// pointer goes through a flow that reports the server's resolved slug back here.
 	const [activeSlug, setActiveSlug] = useState(editingSlug);
 
-	const loadLibraries = useCallback(() => {
-		return fetchLibraries()
-			.then((rows) => setLibraries(sortLibraries(rows)))
-			.catch((err) => setOpenError({ message: errorMessage(err) }));
-	}, []);
+	const registry = useRegistry();
+	const { libraryRows, isLoading, loadFailure } = useSelect(
+		(select) => ({
+			libraryRows: select(STORE_NAME).getLibraries(),
+			isLoading: select(STORE_NAME).isResolving('getLibraries', []),
+			loadFailure: select(STORE_NAME).getResolutionError('getLibraries', []),
+		}),
+		[]
+	);
+	const libraries = useMemo(() => sortLibraries(libraryRows ?? []), [libraryRows]);
 
+	// The original hook's mount-effect `.catch()` wrote a failed list fetch into the SAME `openError`
+	// slot `openLibrary` (below) also writes to — `LibrarySelector.js` renders one `openError` prop for
+	// both cases. This effect preserves that: a resolution failure for `getLibraries` surfaces here the
+	// same way a failed `openLibrary` call already does via its own `onError: setOpenError`.
 	useEffect(() => {
-		setIsLoading(true);
-		loadLibraries().finally(() => setIsLoading(false));
-	}, [loadLibraries]);
+		if (loadFailure) {
+			setOpenError({ message: errorMessage(loadFailure) });
+		}
+	}, [loadFailure]);
+
+	// The flows in `helpers/library-flows.js` call this after create/rename/delete to refresh the list —
+	// unchanged from their point of view. Internally: `invalidateResolution` clears the "this selector
+	// call is already resolved" flag the framework tracks per argument tuple, and `resolveSelect` then
+	// re-runs the `getLibraries` resolver (rather than returning the now-invalidated cached result),
+	// resolving once the fresh rows land in the store — every mounted `useLibraries` instance re-renders
+	// from the same updated state automatically.
+	const loadLibraries = useCallback(() => {
+		registry.dispatch(STORE_NAME).invalidateResolution('getLibraries', []);
+		return registry.resolveSelect(STORE_NAME).getLibraries();
+	}, [registry]);
 
 	const clearOpenError = useCallback(() => setOpenError(null), []);
 	const clearActivateError = useCallback(() => setActivateError(null), []);

--- a/src/style-library/store/actions.js
+++ b/src/style-library/store/actions.js
@@ -1,0 +1,59 @@
+/**
+ * Plain action creators for the Style Library store's four RECEIVE_* actions. Every one of them is
+ * dispatched from a resolver in `resolvers.js` once its matching REST read resolves.
+ */
+
+/**
+ * Store the libraries list.
+ *
+ * @param {Array<Object>} rows The library rows.
+ *
+ * @since TBD
+ *
+ * @return {Object} The action.
+ */
+export function receiveLibraries(rows) {
+	return { type: 'RECEIVE_LIBRARIES', rows };
+}
+
+/**
+ * Store a block's preset collection.
+ *
+ * @param {string} key     `presetsKey()`'s output for this block/library.
+ * @param {Object} payload The fetched preset collection.
+ *
+ * @since TBD
+ *
+ * @return {Object} The action.
+ */
+export function receiveBlockPresets(key, payload) {
+	return { type: 'RECEIVE_BLOCK_PRESETS', key, payload };
+}
+
+/**
+ * Store a library's raw palette-listing response.
+ *
+ * @param {string} key      `paletteListingKey()`'s output for this library.
+ * @param {Object} listing The fetched listing response (`{$default, $current, palettes, userCreated}`).
+ *
+ * @since TBD
+ *
+ * @return {Object} The action.
+ */
+export function receivePaletteListing(key, listing) {
+	return { type: 'RECEIVE_PALETTE_LISTING', key, listing };
+}
+
+/**
+ * Store a single palette's effective view.
+ *
+ * @param {string} key  `paletteKey()`'s output for this palette.
+ * @param {Object} view The fetched palette view.
+ *
+ * @since TBD
+ *
+ * @return {Object} The action.
+ */
+export function receivePalette(key, view) {
+	return { type: 'RECEIVE_PALETTE', key, view };
+}

--- a/src/style-library/store/actions.js
+++ b/src/style-library/store/actions.js
@@ -1,5 +1,5 @@
 /**
- * Plain action creators for the Style Library store's four RECEIVE_* actions. Every one of them is
+ * Plain action creators for the Style Library store's RECEIVE_* actions. Every one of them is
  * dispatched from a resolver in `resolvers.js` once its matching REST read resolves.
  */
 
@@ -14,46 +14,4 @@
  */
 export function receiveLibraries(rows) {
 	return { type: 'RECEIVE_LIBRARIES', rows };
-}
-
-/**
- * Store a block's preset collection.
- *
- * @param {string} key     `presetsKey()`'s output for this block/library.
- * @param {Object} payload The fetched preset collection.
- *
- * @since TBD
- *
- * @return {Object} The action.
- */
-export function receiveBlockPresets(key, payload) {
-	return { type: 'RECEIVE_BLOCK_PRESETS', key, payload };
-}
-
-/**
- * Store a library's raw palette-listing response.
- *
- * @param {string} key      `paletteListingKey()`'s output for this library.
- * @param {Object} listing The fetched listing response (`{$default, $current, palettes, userCreated}`).
- *
- * @since TBD
- *
- * @return {Object} The action.
- */
-export function receivePaletteListing(key, listing) {
-	return { type: 'RECEIVE_PALETTE_LISTING', key, listing };
-}
-
-/**
- * Store a single palette's effective view.
- *
- * @param {string} key  `paletteKey()`'s output for this palette.
- * @param {Object} view The fetched palette view.
- *
- * @since TBD
- *
- * @return {Object} The action.
- */
-export function receivePalette(key, view) {
-	return { type: 'RECEIVE_PALETTE', key, view };
 }

--- a/src/style-library/store/constants.js
+++ b/src/style-library/store/constants.js
@@ -1,6 +1,5 @@
 /**
- * The Style Library app's `@wordpress/data` store name, and the key builders every resolver/
- * selector in this store uses to address a specific resource instance.
+ * The Style Library app's `@wordpress/data` store name.
  */
 
 /**
@@ -10,47 +9,3 @@
  * @since TBD
  */
 export const STORE_NAME = 'kadence-blocks/style-library';
-
-/**
- * Build the state key for a block's preset collection.
- *
- * @param {string} namespace REST namespace.
- * @param {string} block     The block name, e.g. `kadence/singlebtn`.
- * @param {string} slug      Token library slug.
- *
- * @since TBD
- *
- * @return {string} The state key.
- */
-export function presetsKey(namespace, block, slug) {
-	return `${namespace}::${block}::${slug}`;
-}
-
-/**
- * Build the state key for a library's palette listing.
- *
- * @param {string} namespace REST namespace.
- * @param {string} slug      Token library slug.
- *
- * @since TBD
- *
- * @return {string} The state key.
- */
-export function paletteListingKey(namespace, slug) {
-	return `${namespace}::${slug}::listing`;
-}
-
-/**
- * Build the state key for a single palette's effective view.
- *
- * @param {string} namespace REST namespace.
- * @param {string} slug      Token library slug.
- * @param {string} id        The palette id.
- *
- * @since TBD
- *
- * @return {string} The state key.
- */
-export function paletteKey(namespace, slug, id) {
-	return `${namespace}::${slug}::palette::${id}`;
-}

--- a/src/style-library/store/constants.js
+++ b/src/style-library/store/constants.js
@@ -1,0 +1,56 @@
+/**
+ * The Style Library app's `@wordpress/data` store name, and the key builders every resolver/
+ * selector in this store uses to address a specific resource instance.
+ */
+
+/**
+ * The registered store name — visible in Redux DevTools and via
+ * `wp.data.select('kadence-blocks/style-library')` in the browser console.
+ *
+ * @since TBD
+ */
+export const STORE_NAME = 'kadence-blocks/style-library';
+
+/**
+ * Build the state key for a block's preset collection.
+ *
+ * @param {string} namespace REST namespace.
+ * @param {string} block     The block name, e.g. `kadence/singlebtn`.
+ * @param {string} slug      Token library slug.
+ *
+ * @since TBD
+ *
+ * @return {string} The state key.
+ */
+export function presetsKey(namespace, block, slug) {
+	return `${namespace}::${block}::${slug}`;
+}
+
+/**
+ * Build the state key for a library's palette listing.
+ *
+ * @param {string} namespace REST namespace.
+ * @param {string} slug      Token library slug.
+ *
+ * @since TBD
+ *
+ * @return {string} The state key.
+ */
+export function paletteListingKey(namespace, slug) {
+	return `${namespace}::${slug}::listing`;
+}
+
+/**
+ * Build the state key for a single palette's effective view.
+ *
+ * @param {string} namespace REST namespace.
+ * @param {string} slug      Token library slug.
+ * @param {string} id        The palette id.
+ *
+ * @since TBD
+ *
+ * @return {string} The state key.
+ */
+export function paletteKey(namespace, slug, id) {
+	return `${namespace}::${slug}::palette::${id}`;
+}

--- a/src/style-library/store/index.js
+++ b/src/style-library/store/index.js
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { createReduxStore, register } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { reducer } from './reducer';
+import * as actions from './actions';
+import * as resolvers from './resolvers';
+import * as selectors from './selectors';
+
+export { STORE_NAME, presetsKey, paletteListingKey, paletteKey } from './constants';
+
+import { STORE_NAME } from './constants';
+
+/**
+ * The store's config, exported separately from registration so `test-utils.js` can build the exact
+ * same store fresh inside an isolated registry per test, instead of every test sharing the process-
+ * wide default registry this module registers into below.
+ *
+ * @since TBD
+ */
+export const storeConfig = { reducer, actions, resolvers, selectors };
+
+register(createReduxStore(STORE_NAME, storeConfig));

--- a/src/style-library/store/index.js
+++ b/src/style-library/store/index.js
@@ -11,7 +11,7 @@ import * as actions from './actions';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
 
-export { STORE_NAME, presetsKey, paletteListingKey, paletteKey } from './constants';
+export { STORE_NAME } from './constants';
 
 import { STORE_NAME } from './constants';
 

--- a/src/style-library/store/reducer.js
+++ b/src/style-library/store/reducer.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { combineReducers } from '@wordpress/data';
+
+function libraries(state = [], action) {
+	return action.type === 'RECEIVE_LIBRARIES' ? action.rows : state;
+}
+
+function presets(state = {}, action) {
+	if (action.type !== 'RECEIVE_BLOCK_PRESETS') {
+		return state;
+	}
+
+	return { ...state, [action.key]: action.payload };
+}
+
+function paletteListings(state = {}, action) {
+	if (action.type !== 'RECEIVE_PALETTE_LISTING') {
+		return state;
+	}
+
+	return { ...state, [action.key]: action.listing };
+}
+
+function palettes(state = {}, action) {
+	if (action.type !== 'RECEIVE_PALETTE') {
+		return state;
+	}
+
+	return { ...state, [action.key]: action.view };
+}
+
+/**
+ * The Style Library store's root reducer.
+ *
+ * @since TBD
+ */
+export const reducer = combineReducers({ libraries, presets, paletteListings, palettes });

--- a/src/style-library/store/reducer.js
+++ b/src/style-library/store/reducer.js
@@ -7,33 +7,9 @@ function libraries(state = [], action) {
 	return action.type === 'RECEIVE_LIBRARIES' ? action.rows : state;
 }
 
-function presets(state = {}, action) {
-	if (action.type !== 'RECEIVE_BLOCK_PRESETS') {
-		return state;
-	}
-
-	return { ...state, [action.key]: action.payload };
-}
-
-function paletteListings(state = {}, action) {
-	if (action.type !== 'RECEIVE_PALETTE_LISTING') {
-		return state;
-	}
-
-	return { ...state, [action.key]: action.listing };
-}
-
-function palettes(state = {}, action) {
-	if (action.type !== 'RECEIVE_PALETTE') {
-		return state;
-	}
-
-	return { ...state, [action.key]: action.view };
-}
-
 /**
  * The Style Library store's root reducer.
  *
  * @since TBD
  */
-export const reducer = combineReducers({ libraries, presets, paletteListings, palettes });
+export const reducer = combineReducers({ libraries });

--- a/src/style-library/store/reducer.test.js
+++ b/src/style-library/store/reducer.test.js
@@ -1,12 +1,12 @@
 /* eslint-env jest */
 import { reducer } from './reducer';
-import { receiveLibraries, receiveBlockPresets, receivePaletteListing, receivePalette } from './actions';
+import { receiveLibraries } from './actions';
 
 describe('reducer', () => {
 	it('starts with empty slices', () => {
 		const state = reducer(undefined, { type: '@@INIT' });
 
-		expect(state).toEqual({ libraries: [], presets: {}, paletteListings: {}, palettes: {} });
+		expect(state).toEqual({ libraries: [] });
 	});
 
 	it('stores the libraries list on RECEIVE_LIBRARIES', () => {
@@ -14,24 +14,5 @@ describe('reducer', () => {
 		const state = reducer(undefined, receiveLibraries(rows));
 
 		expect(state.libraries).toBe(rows);
-	});
-
-	it('stores a block presets payload under its key, leaving other keys alone', () => {
-		let state = reducer(undefined, receiveBlockPresets('a', { version: 'a1' }));
-		state = reducer(state, receiveBlockPresets('b', { version: 'b1' }));
-
-		expect(state.presets).toEqual({ a: { version: 'a1' }, b: { version: 'b1' } });
-	});
-
-	it('stores a palette listing under its key', () => {
-		const state = reducer(undefined, receivePaletteListing('k', { $default: 'default' }));
-
-		expect(state.paletteListings).toEqual({ k: { $default: 'default' } });
-	});
-
-	it('stores a palette view under its key', () => {
-		const state = reducer(undefined, receivePalette('k', { id: 'default', groups: [] }));
-
-		expect(state.palettes).toEqual({ k: { id: 'default', groups: [] } });
 	});
 });

--- a/src/style-library/store/reducer.test.js
+++ b/src/style-library/store/reducer.test.js
@@ -1,0 +1,37 @@
+/* eslint-env jest */
+import { reducer } from './reducer';
+import { receiveLibraries, receiveBlockPresets, receivePaletteListing, receivePalette } from './actions';
+
+describe('reducer', () => {
+	it('starts with empty slices', () => {
+		const state = reducer(undefined, { type: '@@INIT' });
+
+		expect(state).toEqual({ libraries: [], presets: {}, paletteListings: {}, palettes: {} });
+	});
+
+	it('stores the libraries list on RECEIVE_LIBRARIES', () => {
+		const rows = [{ slug: 'default', title: '', version: 'v1', document: {} }];
+		const state = reducer(undefined, receiveLibraries(rows));
+
+		expect(state.libraries).toBe(rows);
+	});
+
+	it('stores a block presets payload under its key, leaving other keys alone', () => {
+		let state = reducer(undefined, receiveBlockPresets('a', { version: 'a1' }));
+		state = reducer(state, receiveBlockPresets('b', { version: 'b1' }));
+
+		expect(state.presets).toEqual({ a: { version: 'a1' }, b: { version: 'b1' } });
+	});
+
+	it('stores a palette listing under its key', () => {
+		const state = reducer(undefined, receivePaletteListing('k', { $default: 'default' }));
+
+		expect(state.paletteListings).toEqual({ k: { $default: 'default' } });
+	});
+
+	it('stores a palette view under its key', () => {
+		const state = reducer(undefined, receivePalette('k', { id: 'default', groups: [] }));
+
+		expect(state.palettes).toEqual({ k: { id: 'default', groups: [] } });
+	});
+});

--- a/src/style-library/store/resolvers.js
+++ b/src/style-library/store/resolvers.js
@@ -1,0 +1,25 @@
+/**
+ * Thunk resolvers for the Style Library store: each one is auto-invoked by `@wordpress/data` the
+ * first time its matching selector is read with a given argument tuple, and the framework tracks
+ * `isResolving`/resolution-finished state per tuple on its own — nothing here manages loading state
+ * directly.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { fetchLibraries } from '../api/client';
+
+/**
+ * Resolve `selectors.getLibraries()`.
+ *
+ * @since TBD
+ *
+ * @return {Function} A `@wordpress/data` thunk.
+ */
+export const getLibraries =
+	() =>
+	async ({ dispatch }) => {
+		const rows = await fetchLibraries();
+		dispatch.receiveLibraries(rows);
+	};

--- a/src/style-library/store/resolvers.test.js
+++ b/src/style-library/store/resolvers.test.js
@@ -1,0 +1,24 @@
+/* eslint-env jest */
+import { getLibraries } from './resolvers';
+import { fetchLibraries } from '../api/client';
+
+jest.mock('../api/client', () => ({
+	fetchLibraries: jest.fn(),
+	fetchBlockPresets: jest.fn(),
+	fetchPalettes: jest.fn(),
+	fetchPalette: jest.fn(),
+}));
+
+describe('resolvers', () => {
+	beforeEach(() => jest.clearAllMocks());
+
+	it('getLibraries() fetches the list and dispatches receiveLibraries', async () => {
+		const rows = [{ slug: 'default', title: '', version: 'v1', document: {} }];
+		fetchLibraries.mockResolvedValueOnce(rows);
+
+		const dispatch = { receiveLibraries: jest.fn() };
+		await getLibraries()({ dispatch });
+
+		expect(dispatch.receiveLibraries).toHaveBeenCalledWith(rows);
+	});
+});

--- a/src/style-library/store/selectors.js
+++ b/src/style-library/store/selectors.js
@@ -1,0 +1,18 @@
+/**
+ * Plain state readers for the Style Library store. `state` is always the first, implicit argument —
+ * `@wordpress/data` injects it; every other parameter is what a caller passes to
+ * `select(STORE_NAME).getX(...)`.
+ */
+
+/**
+ * Read the libraries list.
+ *
+ * @param {Object} state The store's state.
+ *
+ * @since TBD
+ *
+ * @return {Array<Object>} The library rows.
+ */
+export function getLibraries(state) {
+	return state.libraries;
+}

--- a/src/style-library/store/selectors.test.js
+++ b/src/style-library/store/selectors.test.js
@@ -1,0 +1,10 @@
+/* eslint-env jest */
+import { getLibraries } from './selectors';
+
+describe('selectors', () => {
+	it('getLibraries() returns the libraries slice', () => {
+		const state = { libraries: [{ slug: 'default' }], presets: {}, paletteListings: {}, palettes: {} };
+
+		expect(getLibraries(state)).toEqual([{ slug: 'default' }]);
+	});
+});

--- a/src/style-library/store/test-utils.js
+++ b/src/style-library/store/test-utils.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { createRegistry, createReduxStore } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_NAME, storeConfig } from './index';
+
+/**
+ * Build an isolated `@wordpress/data` registry with the Style Library store registered fresh. Every
+ * hook test in this app uses this instead of the default registry `index.js` registers into at
+ * import time — the default registry is a process-wide singleton, so sharing it across tests would
+ * let one test's writes leak into the next test's reads.
+ *
+ * @since TBD
+ *
+ * @return {Object} A registry with only this store registered.
+ */
+export function createTestRegistry() {
+	const registry = createRegistry();
+	registry.register(createReduxStore(STORE_NAME, storeConfig));
+	return registry;
+}


### PR DESCRIPTION
## Summary

Adds a real `@wordpress/data` store for the Style Library page (`kadence-blocks/style-library`) — a plain reducer, action creators, thunk resolvers that call the existing REST client functions, and selectors — registered so it's inspectable in Redux DevTools and via `wp.data.select('kadence-blocks/style-library')` from the console.

Migrates the first resource, `useLibraries()`, to read through the store instead of local `useState`/`useEffect`. Reads go through `useSelect`; the framework auto-triggers a resolver the first time its selector is read and tracks `isResolving`/resolution-finished state per exact argument tuple — no manual fetch-on-mount effect needed. `isLoading` is deliberately gated on "no data yet," not raw `isResolving` alone, so a write-triggered background reload never re-flashes the loading skeleton once data has already loaded.

`helpers/library-flows.js` — the existing write orchestration (create/rename/delete/activate) — is **not modified**. It already takes a `loadLibraries`/`refreshFeed` callback as its invalidation signal; only what `useLibraries()` passes into that slot changed, from a local re-fetch to `registry.dispatch(STORE_NAME).invalidateResolution(...)` + `registry.resolveSelect(STORE_NAME)...`.

`@wordpress/data` is added as a `devDependency` only — it's externalized to WordPress's own runtime global at build time like every other `@wordpress/*` import in this plugin, so this only affects local tooling resolution, never the shipped bundle.

## Test instructions

1. Go to **Style Library**, open the library dropdown — confirm the list loads and behaves exactly as before (open/create/rename/delete a library).
2. With Redux DevTools installed, confirm `kadence-blocks/style-library` appears as a store and `RECEIVE_LIBRARIES` fires as the list loads.
3. In the browser console: `wp.data.select('kadence-blocks/style-library').getLibraries()` returns the current list.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4200/phase-6-feed-slice
bun install
```

The Style Library is at **WP Admin → Kadence → Style Library**.
</details>

---

Slice 3 of 7 in the SOFT-4200 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Style Library loading and refresh behavior.
  * Library data now stays synchronized across multiple views, reducing duplicate loading requests.
  * Background updates refresh results without unnecessarily showing a loading state.
  * Library changes now trigger refreshed results automatically.

* **Bug Fixes**
  * Improved error handling when Style Library data cannot be loaded.

* **Tests**
  * Added coverage for loading, refreshing, deduplication, invalidation, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
