### PR TITLE
[DTM] SOFT-4200 [4/7]: Presets slice

### DIFF
--- a/src/style-library/__tests__/use-preset-screen.test.js
+++ b/src/style-library/__tests__/use-preset-screen.test.js
@@ -28,6 +28,16 @@ jest.mock('../hooks/use-presets', () => ({
 	usePresets: jest.fn(),
 }));
 
+// `usePresetScreen`'s wrapped `refreshFeed` reaches the store, whose resolvers import `../api/client`
+// directly — same `@wordpress/api-fetch` reason as above. `usePresets` above already stubs out the
+// hook's own read of the store, so this mock only needs to keep the store module loadable; the
+// wrapped `refreshFeed`'s own store round trip through this stub resolves to `undefined` and is
+// otherwise inert for these tests.
+jest.mock('../api/client', () => ({
+	fetchBlockPresets: jest.fn(),
+	fetchLibraries: jest.fn(),
+}));
+
 // Inline rather than the real `BUTTON_PRESET`, which reads its properties from the localized feed.
 // `usePresets` is mocked here, so the hook only needs the three keys it reads itself.
 const PRESET = { block: 'kadence/singlebtn', properties: ['color'], slugBase: 'preset' };

--- a/src/style-library/__tests__/use-preset-screen.test.js
+++ b/src/style-library/__tests__/use-preset-screen.test.js
@@ -45,7 +45,7 @@ const PRESET = { block: 'kadence/singlebtn', properties: ['color'], slugBase: 'p
 const LIBRARY = {
 	rest: { namespace: 'kb-design-tokens/v1' },
 	slug: 'default',
-	version: 1,
+	version: 'v1',
 	refreshFeed: jest.fn().mockResolvedValue({}),
 };
 
@@ -56,6 +56,11 @@ describe('usePresetScreen reorder version handling', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		global.IS_REACT_ACT_ENVIRONMENT = true;
+
+		// Reset the shared fixture: several tests below mutate `LIBRARY.version` in place to
+		// simulate the feed advancing (see `renderScreen()`'s docblock for why the object stays
+		// the same reference across a test's re-renders).
+		LIBRARY.version = 'v1';
 
 		usePresets.mockReturnValue({
 			payload: { version: 'v1' },
@@ -105,8 +110,9 @@ describe('usePresetScreen reorder version handling', () => {
 	it('sends the version the previous write returned when a second drop follows the first', async () => {
 		const sentVersions = [];
 
-		// The payload's version stays 'v1' throughout: `usePresets` re-reads it in a later
-		// effect, and the point of this test is the window before that read lands.
+		// `LIBRARY.version` stays 'v1' throughout — both drops are queued within the same `act`,
+		// with no re-render between them — and the point of this test is the window before a
+		// refresh lands.
 		reorderPresetsFlow.mockImplementation(({ feedVersion, onVersion }) => {
 			sentVersions.push(feedVersion);
 			onVersion('v2');
@@ -124,7 +130,7 @@ describe('usePresetScreen reorder version handling', () => {
 		expect(sentVersions).toEqual(['v1', 'v2']);
 	});
 
-	it('keeps using the payload version once the re-read catches up to the written one', async () => {
+	it('keeps using the feed version once it catches up to the written one', async () => {
 		const sentVersions = [];
 
 		reorderPresetsFlow.mockImplementation(({ feedVersion, onVersion }) => {
@@ -140,14 +146,9 @@ describe('usePresetScreen reorder version handling', () => {
 			await screen.latest().reorderPresets(['secondary', 'primary']);
 		});
 
-		// The re-read lands on the mounted hook, carrying the version the write reported.
-		usePresets.mockReturnValue({
-			payload: { version: 'v2' },
-			isLoading: false,
-			loadError: null,
-			rows: [],
-			initialValuesFor: () => null,
-		});
+		// The write's own wrapped `refreshFeed` lands on the mounted hook, carrying the version
+		// the write reported — same as any OTHER screen's write would too.
+		LIBRARY.version = 'v2';
 		screen.rerender();
 
 		await act(async () => {
@@ -159,11 +160,11 @@ describe('usePresetScreen reorder version handling', () => {
 
 	/**
 	 * A rejected write leaves no new version behind, so a drop already queued must fall back to the
-	 * payload rather than resend the previous write's override and fail the same way.
+	 * feed's own version rather than resend the previous write's override and fail the same way.
 	 *
 	 * @return {void}
 	 */
-	it('falls back to the payload version for the next drop after a failed write', async () => {
+	it('falls back to the feed version for the next drop after a failed write', async () => {
 		const sentVersions = [];
 		let call = 0;
 
@@ -189,19 +190,20 @@ describe('usePresetScreen reorder version handling', () => {
 			await screen.latest().reorderPresets(['secondary', 'primary']);
 		});
 
-		// v1 from the payload, v2 from the first write's response, then back to the payload's v1
-		// because the failed write retired the override.
+		// v1 from the feed's initial version, v2 from the first write's response, then back to
+		// the feed's still-unmoved v1 because the failed write retired the override.
 		expect(sentVersions).toEqual(['v1', 'v2', 'v1']);
 		expect(LIBRARY.refreshFeed).toHaveBeenCalled();
 	});
 
 	/**
-	 * A re-read carrying a version this screen never wrote — another client's write — supersedes the
-	 * override, which must not keep being sent afterwards.
+	 * A refresh carrying a version this screen never wrote — another screen's write, on any
+	 * resource in the same library — supersedes the override, which must not keep being sent
+	 * afterwards.
 	 *
 	 * @return {void}
 	 */
-	it('retires the write override when a later read supersedes it', async () => {
+	it('retires the write override when a later refresh supersedes it', async () => {
 		const sentVersions = [];
 
 		reorderPresetsFlow.mockImplementation(({ feedVersion, onVersion }) => {
@@ -217,15 +219,9 @@ describe('usePresetScreen reorder version handling', () => {
 			await screen.latest().reorderPresets(['secondary', 'primary']);
 		});
 
-		// Not 'v2': someone else wrote in between, so the payload moved somewhere the override
-		// cannot describe.
-		usePresets.mockReturnValue({
-			payload: { version: 'v9' },
-			isLoading: false,
-			loadError: null,
-			rows: [],
-			initialValuesFor: () => null,
-		});
+		// Not 'v2': a write on another screen (scale, typography, palettes) landed in between and
+		// moved the shared feed version somewhere the override cannot describe.
+		LIBRARY.version = 'v9';
 		screen.rerender();
 
 		await act(async () => {
@@ -233,5 +229,46 @@ describe('usePresetScreen reorder version handling', () => {
 		});
 
 		expect(sentVersions).toEqual(['v1', 'v9']);
+	});
+
+	/**
+	 * A write on a completely different screen (scale, typography, palettes) bumps the shared
+	 * feed version via its own `library.refreshFeed`, without ever touching this screen's cached
+	 * preset payload — this hook was never mounted, so it had no `refreshFeed` wrapper in the
+	 * loop to invalidate `getBlockPresets`. The first reorder here, after mounting, must still
+	 * send the CURRENT server version (`library.version`), not the stale one still sitting in the
+	 * payload from whenever it was last fetched.
+	 *
+	 * @return {void}
+	 */
+	it('sends the current feed version, not a stale cached payload version, on first mount', async () => {
+		const sentVersions = [];
+
+		// The payload was fetched before another screen's write bumped the library — its own
+		// version never moved, exactly as `getBlockPresets` would look if nothing here ever
+		// invalidated it.
+		usePresets.mockReturnValue({
+			payload: { version: 'v1' },
+			isLoading: false,
+			loadError: null,
+			rows: [],
+			initialValuesFor: () => null,
+		});
+		LIBRARY.version = 'v5';
+
+		reorderPresetsFlow.mockImplementation(({ feedVersion, onVersion }) => {
+			sentVersions.push(feedVersion);
+			onVersion('v6');
+
+			return Promise.resolve();
+		});
+
+		const screen = renderScreen();
+
+		await act(async () => {
+			await screen.latest().reorderPresets(['secondary', 'primary']);
+		});
+
+		expect(sentVersions).toEqual(['v5']);
 	});
 });

--- a/src/style-library/__tests__/use-presets.test.js
+++ b/src/style-library/__tests__/use-presets.test.js
@@ -60,11 +60,25 @@ describe('usePresets', () => {
 	// `@wordpress/data`'s resolver dispatch runs off a `setTimeout(fn, 0)` inside the store (see
 	// `mapSelectorWithResolver` in `@wordpress/data`'s redux store), a real timer callback that a
 	// plain `await act(async () => render())` does not wait for — that promise settles as soon as the
-	// synchronous render returns. Flushing one real timer tick after each render/dispatch gives the
+	// synchronous render returns. Flushing a real timer tick after each render/dispatch gives the
 	// resolver's callback a turn to run before assertions read the store. See `use-libraries.test.js`
 	// for the same pattern.
-	function flushResolvers() {
-		return act(() => new Promise((resolve) => setTimeout(resolve, 0)));
+	//
+	// Several ticks, not one: this helper is called from contexts that deliberately expect the
+	// resolution to still be pending (e.g. "switching to a not-yet-resolved library shows loading
+	// with no stale data" below), so it can't poll a "the resolution has finished" predicate the way
+	// `use-libraries.test.js`/`use-palettes.test.js` do — there is no single terminal state every
+	// caller is waiting for. A single `setTimeout(0)` assumes the resolver's callback fires within
+	// one real tick, which is true under `--runInBand` but not guaranteed under parallel jest workers
+	// with other processes contending for the CPU; chaining several real ticks gives the callback a
+	// much larger wall-clock window to actually run, without changing behavior for a deliberately
+	// still-pending mock (extra ticks with nothing to advance are a no-op).
+	function flushResolvers(ticks = 3) {
+		return act(async () => {
+			for (let tick = 0; tick < ticks; tick += 1) {
+				await new Promise((resolve) => setTimeout(resolve, 0));
+			}
+		});
 	}
 
 	function mountProbe() {

--- a/src/style-library/__tests__/use-presets.test.js
+++ b/src/style-library/__tests__/use-presets.test.js
@@ -6,33 +6,38 @@ import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 
 /**
+ * WordPress dependencies
+ */
+import { RegistryProvider } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
 import { usePresets } from '../hooks/use-presets';
 import { BUTTON_PRESET } from '../presets/button-preset';
 import { fetchBlockPresets } from '../api/client';
+import { createTestRegistry } from '../store/test-utils';
+import { STORE_NAME } from '../store';
 
-// A factory, not automock: `../api/client` imports `@wordpress/api-fetch`, which is externalized to
-// the `wp.apiFetch` global in production and therefore absent from `node_modules`.
 jest.mock('../api/client', () => ({
 	fetchBlockPresets: jest.fn(),
 }));
 
-const LIBRARY_A = { rest: { namespace: 'kb-design-tokens/v1' }, slug: 'default', version: 1, values: {} };
-const LIBRARY_B = { rest: { namespace: 'kb-design-tokens/v1' }, slug: 'brand', version: 1, values: {} };
+const LIBRARY_A = { rest: { namespace: 'kb-design-tokens/v1' }, slug: 'default', values: {} };
+const LIBRARY_B = { rest: { namespace: 'kb-design-tokens/v1' }, slug: 'brand', values: {} };
 
 const PAYLOAD_A = { version: 'a1', default: 'primary', presets: { primary: { label: 'Primary', tokens: {} } } };
 const PAYLOAD_B = { version: 'b1', default: 'primary', presets: { primary: { label: 'Brand Primary', tokens: {} } } };
 
-describe('usePresets library switching', () => {
+describe('usePresets', () => {
 	let container;
 	let root;
+	let registry;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
+		registry = createTestRegistry();
 		global.IS_REACT_ACT_ENVIRONMENT = true;
-		// `initialValuesFor` walks the bound surface off the localized feed, which the Style Library
-		// page inline-scripts before the bundle runs.
 		window.kadenceDesignTokens = {
 			presets: {
 				'kadence/singlebtn': {
@@ -52,48 +57,55 @@ describe('usePresets library switching', () => {
 		delete window.kadenceDesignTokens;
 	});
 
-	/**
-	 * A single probe component type, so re-rendering with a different library updates the mounted
-	 * hook instead of remounting it — a remount would reset the state this test is about.
-	 *
-	 * @since TBD
-	 *
-	 * @return {{render: Function, latest: Function}} Renders with a library, and reads the hook's
-	 *                                                  most recent return value.
-	 */
+	// `@wordpress/data`'s resolver dispatch runs off a `setTimeout(fn, 0)` inside the store (see
+	// `mapSelectorWithResolver` in `@wordpress/data`'s redux store), a real timer callback that a
+	// plain `await act(async () => render())` does not wait for — that promise settles as soon as the
+	// synchronous render returns. Flushing one real timer tick after each render/dispatch gives the
+	// resolver's callback a turn to run before assertions read the store. See `use-libraries.test.js`
+	// for the same pattern.
+	function flushResolvers() {
+		return act(() => new Promise((resolve) => setTimeout(resolve, 0)));
+	}
+
 	function mountProbe() {
 		let latest = null;
 
 		function Probe({ library }) {
 			latest = usePresets(library, BUTTON_PRESET);
-
 			return null;
 		}
 
 		return {
-			render: (library) => act(() => root.render(<Probe library={library} />)),
+			render: async (library) => {
+				await act(() =>
+					root.render(
+						<RegistryProvider value={registry}>
+							<Probe library={library} />
+						</RegistryProvider>
+					)
+				);
+				await flushResolvers();
+			},
 			latest: () => latest,
 		};
 	}
 
-	/**
-	 * Switching libraries with the same preset open must drop the previous library's payload right
-	 * away. Holding it would let a settings panel keyed on the preset id alone keep editing the old
-	 * library's draft under the new one.
-	 *
-	 * @return {void}
-	 */
-	it('drops the previous payload as soon as the library changes', async () => {
+	it('resolves a library’s presets and exposes them', async () => {
 		fetchBlockPresets.mockResolvedValueOnce(PAYLOAD_A);
 
 		const probe = mountProbe();
-		await act(async () => probe.render(LIBRARY_A));
+		await probe.render(LIBRARY_A);
 
 		expect(probe.latest().payload).toEqual(PAYLOAD_A);
 		expect(probe.latest().initialValuesFor('primary')).not.toBeNull();
+	});
 
-		// The new library's fetch is left pending: this is the window the panel could otherwise
-		// keep the old draft in.
+	it('switching to a not-yet-resolved library shows loading with no stale data', async () => {
+		fetchBlockPresets.mockResolvedValueOnce(PAYLOAD_A);
+
+		const probe = mountProbe();
+		await probe.render(LIBRARY_A);
+
 		let resolveB;
 		fetchBlockPresets.mockReturnValueOnce(
 			new Promise((resolve) => {
@@ -101,31 +113,23 @@ describe('usePresets library switching', () => {
 			})
 		);
 
-		probe.render(LIBRARY_B);
+		await probe.render(LIBRARY_B);
 
 		expect(probe.latest().payload).toBeNull();
 		expect(probe.latest().isLoading).toBe(true);
 		expect(probe.latest().initialValuesFor('primary')).toBeNull();
 
-		await act(async () => {
-			resolveB(PAYLOAD_B);
-		});
+		await act(async () => resolveB(PAYLOAD_B));
 
 		expect(probe.latest().payload).toEqual(PAYLOAD_B);
 		expect(probe.latest().isLoading).toBe(false);
 	});
 
-	/**
-	 * A version bump on the same library is a refresh after a write, not a library change, so the
-	 * rows must stay on screen while the re-read is in flight.
-	 *
-	 * @return {void}
-	 */
-	it('keeps the payload while the same library re-reads after a version bump', async () => {
+	it('keeps the payload on screen while an invalidation re-resolves the same library', async () => {
 		fetchBlockPresets.mockResolvedValueOnce(PAYLOAD_A);
 
 		const probe = mountProbe();
-		await act(async () => probe.render(LIBRARY_A));
+		await probe.render(LIBRARY_A);
 
 		let resolveNext;
 		fetchBlockPresets.mockReturnValueOnce(
@@ -134,14 +138,46 @@ describe('usePresets library switching', () => {
 			})
 		);
 
-		probe.render({ ...LIBRARY_A, version: 2 });
-
-		expect(probe.latest().payload).toEqual(PAYLOAD_A);
-
-		await act(async () => {
-			resolveNext({ ...PAYLOAD_A, version: 'a2' });
+		// Simulates what `usePresetScreen`'s wrapped `refreshFeed` now does after a write.
+		act(() => {
+			registry
+				.dispatch(STORE_NAME)
+				.invalidateResolution('getBlockPresets', ['kb-design-tokens/v1', 'kadence/singlebtn', 'default']);
+			registry.resolveSelect(STORE_NAME).getBlockPresets('kb-design-tokens/v1', 'kadence/singlebtn', 'default');
 		});
 
+		expect(probe.latest().payload).toEqual(PAYLOAD_A);
+		expect(probe.latest().isLoading).toBe(false);
+
+		// The invalidated selector's re-fetch is itself scheduled on a `setTimeout(fn, 0)` (same
+		// mechanism as `flushResolvers()` above), so resolving the mock's promise first and then
+		// flushing lets `fetchBlockPresets` actually be called and its already-resolved result land.
+		resolveNext({ ...PAYLOAD_A, version: 'a2' });
+		await flushResolvers();
+
 		expect(probe.latest().payload.version).toBe('a2');
+	});
+
+	it('two mounted instances (a screen and its settings panel) share one fetch', async () => {
+		fetchBlockPresets.mockResolvedValueOnce(PAYLOAD_A);
+
+		function ProbeA() {
+			return usePresets(LIBRARY_A, BUTTON_PRESET) && null;
+		}
+		function ProbeB() {
+			return usePresets(LIBRARY_A, BUTTON_PRESET) && null;
+		}
+
+		await act(async () =>
+			root.render(
+				<RegistryProvider value={registry}>
+					<ProbeA />
+					<ProbeB />
+				</RegistryProvider>
+			)
+		);
+		await flushResolvers();
+
+		expect(fetchBlockPresets).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/style-library/__tests__/use-presets.test.js
+++ b/src/style-library/__tests__/use-presets.test.js
@@ -116,6 +116,33 @@ describe('usePresets', () => {
 		expect(probe.latest().initialValuesFor('primary')).not.toBeNull();
 	});
 
+	it('isLoading is already true on the very first render, before the resolver dispatch has fired', async () => {
+		fetchBlockPresets.mockResolvedValueOnce(PAYLOAD_A);
+
+		let latest = null;
+
+		function Probe({ library }) {
+			latest = usePresets(library, BUTTON_PRESET);
+			return null;
+		}
+
+		// `@wordpress/data`'s resolver dispatch is scheduled via `setTimeout(fn, 0)`, so this render
+		// happens strictly before that dispatch fires — `isResolving` would still read `false` here,
+		// which is exactly the one-frame "not loading" flash `hasFinishedResolution` must avoid.
+		await act(() =>
+			root.render(
+				<RegistryProvider value={registry}>
+					<Probe library={LIBRARY_A} />
+				</RegistryProvider>
+			)
+		);
+
+		expect(latest.isLoading).toBe(true);
+		expect(latest.payload).toBeNull();
+
+		await act(() => jest.runOnlyPendingTimersAsync());
+	});
+
 	it('switching to a not-yet-resolved library shows loading with no stale data', async () => {
 		fetchBlockPresets.mockResolvedValueOnce(PAYLOAD_A);
 

--- a/src/style-library/__tests__/use-presets.test.js
+++ b/src/style-library/__tests__/use-presets.test.js
@@ -158,6 +158,47 @@ describe('usePresets', () => {
 		expect(probe.latest().payload.version).toBe('a2');
 	});
 
+	it('stays out of loading during a write-triggered background re-resolve once data has loaded', async () => {
+		fetchBlockPresets.mockResolvedValueOnce(PAYLOAD_A);
+
+		const probe = mountProbe();
+		await probe.render(LIBRARY_A);
+
+		expect(probe.latest().payload).toEqual(PAYLOAD_A);
+		expect(probe.latest().isLoading).toBe(false);
+
+		let resolveNext;
+		fetchBlockPresets.mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolveNext = resolve;
+			})
+		);
+
+		// Simulates what `usePresetScreen`'s wrapped `refreshFeed` does after a create/save/delete/
+		// reorder write.
+		act(() => {
+			registry
+				.dispatch(STORE_NAME)
+				.invalidateResolution('getBlockPresets', ['kb-design-tokens/v1', 'kadence/singlebtn', 'default']);
+			registry.resolveSelect(STORE_NAME).getBlockPresets('kb-design-tokens/v1', 'kadence/singlebtn', 'default');
+		});
+
+		// Flushed so the resolver's `setTimeout(fn, 0)` actually fires and `isResolving` genuinely
+		// flips `true` for the in-flight re-fetch — the exact window the regression is about. Without
+		// this flush the assertions below would trivially pass even against the buggy code, because
+		// resolution wouldn't have started yet.
+		await flushResolvers();
+
+		expect(fetchBlockPresets).toHaveBeenCalledTimes(2);
+		expect(probe.latest().payload).toEqual(PAYLOAD_A);
+		expect(probe.latest().isLoading).toBe(false);
+
+		await act(async () => resolveNext({ ...PAYLOAD_A, version: 'a2' }));
+
+		expect(probe.latest().payload.version).toBe('a2');
+		expect(probe.latest().isLoading).toBe(false);
+	});
+
 	it('two mounted instances (a screen and its settings panel) share one fetch', async () => {
 		fetchBlockPresets.mockResolvedValueOnce(PAYLOAD_A);
 

--- a/src/style-library/__tests__/use-presets.test.js
+++ b/src/style-library/__tests__/use-presets.test.js
@@ -36,6 +36,14 @@ describe('usePresets', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
+		// Fakes `setTimeout`/`setInterval`/`clearTimeout`, so `flushResolvers()` below can advance
+		// `@wordpress/data`'s resolver dispatch deterministically instead of racing a real OS timer
+		// tick against whatever else is contending for the CPU. `Date`/`performance` are excluded:
+		// React's own scheduler uses those to make time-slicing decisions, and freezing them (Jest's
+		// default) leaves it unable to ever decide enough time has passed to flush a commit, hanging
+		// real writes that depend on a state update actually landing. See `use-palettes.test.js` for
+		// the same setup and the investigation behind it.
+		jest.useFakeTimers({ doNotFake: ['Date', 'performance', 'queueMicrotask', 'nextTick'] });
 		registry = createTestRegistry();
 		global.IS_REACT_ACT_ENVIRONMENT = true;
 		window.kadenceDesignTokens = {
@@ -55,30 +63,24 @@ describe('usePresets', () => {
 		container.remove();
 		delete global.IS_REACT_ACT_ENVIRONMENT;
 		delete window.kadenceDesignTokens;
+		jest.useRealTimers();
 	});
 
 	// `@wordpress/data`'s resolver dispatch runs off a `setTimeout(fn, 0)` inside the store (see
 	// `mapSelectorWithResolver` in `@wordpress/data`'s redux store), a real timer callback that a
-	// plain `await act(async () => render())` does not wait for — that promise settles as soon as the
-	// synchronous render returns. Flushing a real timer tick after each render/dispatch gives the
-	// resolver's callback a turn to run before assertions read the store. See `use-libraries.test.js`
-	// for the same pattern.
-	//
-	// Several ticks, not one: this helper is called from contexts that deliberately expect the
-	// resolution to still be pending (e.g. "switching to a not-yet-resolved library shows loading
-	// with no stale data" below), so it can't poll a "the resolution has finished" predicate the way
-	// `use-libraries.test.js`/`use-palettes.test.js` do — there is no single terminal state every
-	// caller is waiting for. A single `setTimeout(0)` assumes the resolver's callback fires within
-	// one real tick, which is true under `--runInBand` but not guaranteed under parallel jest workers
-	// with other processes contending for the CPU; chaining several real ticks gives the callback a
-	// much larger wall-clock window to actually run, without changing behavior for a deliberately
-	// still-pending mock (extra ticks with nothing to advance are a no-op).
-	function flushResolvers(ticks = 3) {
-		return act(async () => {
-			for (let tick = 0; tick < ticks; tick += 1) {
-				await new Promise((resolve) => setTimeout(resolve, 0));
-			}
-		});
+	// plain `await act(async () => render())` does not wait for. `runOnlyPendingTimersAsync` fires
+	// whatever resolver dispatch is currently pending and lets the promise chain it kicks off (the
+	// mocked fetch resolving, its `.then()`, the store dispatch) drain via the real microtask queue
+	// before returning — deterministically, with no dependency on real wall-clock time. This helper
+	// is called from contexts that deliberately expect the resolution to still be pending (e.g.
+	// "switching to a not-yet-resolved library shows loading with no stale data" below, where the
+	// mock is a promise that never resolves) — calling it there is a safe no-op past the one pending
+	// timer it does find and fire. See `use-palettes.test.js`'s identical helper for why
+	// `advanceTimersByTimeAsync(0)` doesn't work here instead (a resolver's callback can itself
+	// schedule a second resolver's timer from deeper inside a promise chain, which that API doesn't
+	// reliably pick up within the same call).
+	function flushResolvers() {
+		return act(() => jest.runOnlyPendingTimersAsync());
 	}
 
 	function mountProbe() {

--- a/src/style-library/hooks/use-preset-screen.js
+++ b/src/style-library/hooks/use-preset-screen.js
@@ -18,7 +18,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { useRegistry } from '@wordpress/data';
 
 /**
@@ -81,35 +81,40 @@ export function usePresetScreen(library, preset) {
 		[library, registry, namespace, block, slug]
 	);
 
-	// Mirrors `library.version` for reads inside the queued continuations below, which are created
-	// once per `useCallback` identity and would otherwise close over the version from the render
-	// that made them.
+	// `feedVersionSnapshotRef` mirrors `library.version` for reads inside the queued continuations
+	// below, which are created once per `useCallback` identity and would otherwise close over the
+	// version from the render that made them. `writtenVersionRef` holds the version the last reorder
+	// write returned, until the feed's own version — bumped by every write everywhere in the
+	// library, not just this screen's — catches up; a second drop queued behind the first would
+	// otherwise dereference the pre-write version and 409 against itself. `feedVersionAtWriteRef` is
+	// the feed version at the moment that override was recorded, so the retirement check below can
+	// tell whether the feed has moved since. `feedVersionRef` mirrors the version the queued reorder
+	// continuation below must send — see `use-scale-screen.js`'s identical comment for why, and the
+	// module docblock for why this is sourced from `library.version`, not the store's cached preset
+	// payload.
 	const feedVersionSnapshotRef = useRef(feedVersion);
-	feedVersionSnapshotRef.current = feedVersion;
-
-	// Holds the version the last reorder write returned, until the feed's own version — bumped by
-	// every write everywhere in the library, not just this screen's — catches up. A second drop
-	// queued behind the first would otherwise dereference the pre-write version and 409 against
-	// itself.
 	const writtenVersionRef = useRef(null);
-
-	// The feed version at the moment the override was recorded. The override is retired as soon as
-	// the feed version moves off it at all, rather than only on an exact match with what the write
-	// returned: a refresh that carries a newer version — someone else's write, or a response this
-	// screen never saw — supersedes the override, and holding on to it would keep sending a version
-	// the server has already replaced.
 	const feedVersionAtWriteRef = useRef(feedVersion);
-
-	if (writtenVersionRef.current !== null && feedVersion !== feedVersionAtWriteRef.current) {
-		writtenVersionRef.current = null;
-	}
-
-	// Mirrors the version the queued reorder continuation below must send, so it always
-	// dereferences the live value at execution time, never one captured when the drop was enqueued
-	// — see `use-scale-screen.js`'s identical comment for why. See the module docblock for why this
-	// is sourced from `library.version`, not the store's cached preset payload.
 	const feedVersionRef = useRef(feedVersion);
-	feedVersionRef.current = writtenVersionRef.current ?? feedVersion;
+
+	// Synchronized from a layout effect, not the render body: React can replay or discard a render
+	// before it commits, and a ref write inside the render body itself would leak a value from a
+	// render that never actually happened. A layout effect still runs before the browser paints and
+	// before any user-triggered event handler (e.g. a drop that calls `reorderPresets`), so nothing
+	// that reads these refs can ever observe a value from a discarded render.
+	useLayoutEffect(() => {
+		feedVersionSnapshotRef.current = feedVersion;
+
+		// The override is retired as soon as the feed version moves off it at all, rather than only
+		// on an exact match with what the write returned: a refresh that carries a newer version —
+		// someone else's write, or a response this screen never saw — supersedes the override, and
+		// holding on to it would keep sending a version the server has already replaced.
+		if (writtenVersionRef.current !== null && feedVersion !== feedVersionAtWriteRef.current) {
+			writtenVersionRef.current = null;
+		}
+
+		feedVersionRef.current = writtenVersionRef.current ?? feedVersion;
+	}, [feedVersion]);
 
 	// One in-flight reorder promise, the `use-scale-screen.js` shape: each call chains onto the
 	// previous reorder's settled promise so a second drop's write waits for the first drop's flow

--- a/src/style-library/hooks/use-preset-screen.js
+++ b/src/style-library/hooks/use-preset-screen.js
@@ -5,10 +5,14 @@
  *
  * Create/save/delete carry no version parameter (`helpers/preset-flows.js`'s module docblock), so
  * only reorder needs the serialized-chain machinery — copied from `use-scale-screen.js`'s
- * `reorderTokens`. This screen's data source is `usePresets`, not the feed in hand, and that
- * payload's `version` only refreshes on a later re-read, so the chain carries the version each
- * write returns until the payload catches up. Two rapid drags therefore cannot race the re-read
- * into a spurious 409 against themselves.
+ * `reorderTokens`. Reorder's version tracking is sourced from the shared feed (`library.version`),
+ * not from `usePresets`'s own payload: every write anywhere in the library — scale, typography,
+ * palettes, and presets itself — ends in `library.refreshFeed`, which always bumps `library.version`
+ * to the server's current value, while the store's cached preset payload only catches up when this
+ * screen's own wrapped `refreshFeed` (below) explicitly invalidates it. A reorder here that trusted
+ * the payload's version instead would 409 the moment a write on any OTHER screen moved the server
+ * past it. The chain carries the version each write returns until `library.version` catches up, so
+ * two rapid drags cannot race the re-read into a spurious 409 against themselves.
  */
 
 /**
@@ -55,6 +59,7 @@ export function usePresetScreen(library, preset) {
 	const namespace = library?.rest?.namespace;
 	const slug = library?.slug;
 	const payloadVersion = presets.payload?.version;
+	const feedVersion = library?.version;
 
 	const registry = useRegistry();
 
@@ -76,34 +81,35 @@ export function usePresetScreen(library, preset) {
 		[library, registry, namespace, block, slug]
 	);
 
-	// Read inside the queued continuations below, which are created once per `useCallback` identity
-	// and would otherwise close over the version from the render that made them.
-	const payloadVersionRef = useRef(payloadVersion);
-	payloadVersionRef.current = payloadVersion;
+	// Mirrors `library.version` for reads inside the queued continuations below, which are created
+	// once per `useCallback` identity and would otherwise close over the version from the render
+	// that made them.
+	const feedVersionSnapshotRef = useRef(feedVersion);
+	feedVersionSnapshotRef.current = feedVersion;
 
-	// Holds the version the last reorder write returned, until the preset payload catches up.
-	// Unlike `use-scale-screen.js`, whose version comes from the feed the awaited refresh replaces,
-	// this screen reads its version from a payload that `usePresets` re-fetches in a later
-	// effect. A second drop queued behind the first would otherwise dereference the pre-write
-	// version and 409 against itself.
+	// Holds the version the last reorder write returned, until the feed's own version — bumped by
+	// every write everywhere in the library, not just this screen's — catches up. A second drop
+	// queued behind the first would otherwise dereference the pre-write version and 409 against
+	// itself.
 	const writtenVersionRef = useRef(null);
 
-	// The payload version at the moment the override was recorded. The override is retired as soon
-	// as the payload moves off it at all, rather than only on an exact match with what the write
-	// returned: a re-read that carries a newer version — someone else's write, or a response this
+	// The feed version at the moment the override was recorded. The override is retired as soon as
+	// the feed version moves off it at all, rather than only on an exact match with what the write
+	// returned: a refresh that carries a newer version — someone else's write, or a response this
 	// screen never saw — supersedes the override, and holding on to it would keep sending a version
 	// the server has already replaced.
-	const payloadAtWriteRef = useRef(payloadVersion);
+	const feedVersionAtWriteRef = useRef(feedVersion);
 
-	if (writtenVersionRef.current !== null && payloadVersion !== payloadAtWriteRef.current) {
+	if (writtenVersionRef.current !== null && feedVersion !== feedVersionAtWriteRef.current) {
 		writtenVersionRef.current = null;
 	}
 
 	// Mirrors the version the queued reorder continuation below must send, so it always
 	// dereferences the live value at execution time, never one captured when the drop was enqueued
-	// — see `use-scale-screen.js`'s identical comment for why.
-	const feedVersionRef = useRef(payloadVersion);
-	feedVersionRef.current = writtenVersionRef.current ?? payloadVersion;
+	// — see `use-scale-screen.js`'s identical comment for why. See the module docblock for why this
+	// is sourced from `library.version`, not the store's cached preset payload.
+	const feedVersionRef = useRef(feedVersion);
+	feedVersionRef.current = writtenVersionRef.current ?? feedVersion;
 
 	// One in-flight reorder promise, the `use-scale-screen.js` shape: each call chains onto the
 	// previous reorder's settled promise so a second drop's write waits for the first drop's flow
@@ -219,7 +225,7 @@ export function usePresetScreen(library, preset) {
 					// commits one, and it reads `feedVersionRef` directly.
 					onVersion: (version) => {
 						writtenVersionRef.current = version;
-						payloadAtWriteRef.current = payloadVersionRef.current;
+						feedVersionAtWriteRef.current = feedVersionSnapshotRef.current;
 						feedVersionRef.current = version;
 					},
 				})
@@ -230,10 +236,10 @@ export function usePresetScreen(library, preset) {
 
 						// A failed write returned no version, so the override is meaningless now, and a
 						// drop already queued behind this one would otherwise resend it and fail the same
-						// way. Fall back to the payload and re-read it, so the next link in the chain
-						// carries whatever the server actually holds.
+						// way. Fall back to the feed's own version and re-read it, so the next link in the
+						// chain carries whatever the server actually holds.
 						writtenVersionRef.current = null;
-						feedVersionRef.current = payloadVersionRef.current;
+						feedVersionRef.current = feedVersionSnapshotRef.current;
 
 						return refreshFeed ? refreshFeed(slug).catch(() => {}) : undefined;
 					})

--- a/src/style-library/hooks/use-preset-screen.js
+++ b/src/style-library/hooks/use-preset-screen.js
@@ -15,6 +15,7 @@
  * WordPress dependencies
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useRegistry } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -23,6 +24,7 @@ import { applyRowOrder } from '../helpers/scale';
 import { createPresetFlow, deletePresetFlow, reorderPresetsFlow, savePresetFlow } from '../helpers/preset-flows';
 import { presetInitialValues, presetStoredTokens } from '../helpers/presets';
 import { usePresets } from './use-presets';
+import { STORE_NAME } from '../store';
 
 /**
  * Bind a preset screen to its block's fetched preset collection and the four write flows.
@@ -52,8 +54,27 @@ export function usePresetScreen(library, preset) {
 
 	const namespace = library?.rest?.namespace;
 	const slug = library?.slug;
-	const refreshFeed = library?.refreshFeed;
 	const payloadVersion = presets.payload?.version;
+
+	const registry = useRegistry();
+
+	// Every write flow below still calls `refreshFeed(slug)` — this wraps that same call so a preset
+	// write also re-resolves the store's `getBlockPresets` selector, instead of relying on a `version`
+	// bump (no longer part of `usePresets`'s own logic) to trigger a re-read.
+	const refreshFeed = useCallback(
+		(targetSlug) => {
+			const feedRefresh = library?.refreshFeed?.(targetSlug) ?? Promise.resolve();
+
+			let storeRefresh = Promise.resolve();
+			if (namespace && block && slug) {
+				registry.dispatch(STORE_NAME).invalidateResolution('getBlockPresets', [namespace, block, slug]);
+				storeRefresh = registry.resolveSelect(STORE_NAME).getBlockPresets(namespace, block, slug);
+			}
+
+			return Promise.all([feedRefresh, storeRefresh]);
+		},
+		[library, registry, namespace, block, slug]
+	);
 
 	// Read inside the queued continuations below, which are created once per `useCallback` identity
 	// and would otherwise close over the version from the render that made them.

--- a/src/style-library/hooks/use-preset-screen.js
+++ b/src/style-library/hooks/use-preset-screen.js
@@ -78,7 +78,11 @@ export function usePresetScreen(library, preset) {
 
 			return Promise.all([feedRefresh, storeRefresh]);
 		},
-		[library, registry, namespace, block, slug]
+		// `library.refreshFeed`, not `library` — this only ever calls that one function off it, and
+		// `library` is a fresh object literal every render (`useDesignTokensFeed()`'s own return
+		// value), so depending on the whole object would rebuild this callback (and everything that
+		// depends on its identity) on every render instead of only when the function itself changes.
+		[library?.refreshFeed, registry, namespace, block, slug]
 	);
 
 	// `feedVersionSnapshotRef` mirrors `library.version` for reads inside the queued continuations

--- a/src/style-library/hooks/use-presets.js
+++ b/src/style-library/hooks/use-presets.js
@@ -45,9 +45,15 @@ export function usePresets(library, preset) {
 	const { payload, isLoading, loadError } = useSelect(
 		(select) => ({
 			payload: namespace && block && slug ? select(STORE_NAME).getBlockPresets(namespace, block, slug) : null,
+			// Gated on `!payload`, not raw `isResolving` alone: a write's wrapped `refreshFeed`
+			// (`use-preset-screen.js`) invalidates and re-resolves this same selector, which raises
+			// `isResolving` for the duration of that background re-fetch too. Once the presets list has
+			// loaded once, the store keeps serving that payload while it revalidates, so there is data to
+			// keep rendering — a loading state should only ever show up before the first payload lands.
 			isLoading:
 				Boolean(namespace && block && slug) &&
-				select(STORE_NAME).isResolving('getBlockPresets', [namespace, block, slug]),
+				select(STORE_NAME).isResolving('getBlockPresets', [namespace, block, slug]) &&
+				!select(STORE_NAME).getBlockPresets(namespace, block, slug),
 			loadError:
 				namespace && block && slug
 					? select(STORE_NAME).getResolutionError('getBlockPresets', [namespace, block, slug])

--- a/src/style-library/hooks/use-presets.js
+++ b/src/style-library/hooks/use-presets.js
@@ -43,22 +43,38 @@ export function usePresets(library, preset) {
 	const slug = library?.slug;
 
 	const { payload, isLoading, loadError } = useSelect(
-		(select) => ({
-			payload: namespace && block && slug ? select(STORE_NAME).getBlockPresets(namespace, block, slug) : null,
-			// Gated on `!payload`, not raw `isResolving` alone: a write's wrapped `refreshFeed`
-			// (`use-preset-screen.js`) invalidates and re-resolves this same selector, which raises
-			// `isResolving` for the duration of that background re-fetch too. Once the presets list has
-			// loaded once, the store keeps serving that payload while it revalidates, so there is data to
-			// keep rendering — a loading state should only ever show up before the first payload lands.
-			isLoading:
-				Boolean(namespace && block && slug) &&
-				select(STORE_NAME).isResolving('getBlockPresets', [namespace, block, slug]) &&
-				!select(STORE_NAME).getBlockPresets(namespace, block, slug),
-			loadError:
-				namespace && block && slug
-					? select(STORE_NAME).getResolutionError('getBlockPresets', [namespace, block, slug])
-					: null,
-		}),
+		(select) => {
+			const currentPayload =
+				namespace && block && slug ? select(STORE_NAME).getBlockPresets(namespace, block, slug) : null;
+
+			// `hasFinishedResolution`, not `isResolving`: `@wordpress/data` schedules a resolver's
+			// dispatch via a `setTimeout(fn, 0)`, so on the very first render for a given
+			// `(namespace, block, slug)` tuple `isResolving` can still be `false` — the resolver hasn't
+			// been kicked off yet — even though nothing has loaded. `isLoading` below would then read
+			// `false` for that one frame, with `payload` still `null`; a caller that self-heals a
+			// `?kb-item=` deep link off "not loading and no matching preset" (see `use-preset-screen.js`)
+			// would read that frame as "this preset was deleted" and rewrite the route away from a
+			// perfectly valid link before its fetch even started. `hasFinishedResolution` stays `false`
+			// for that same render, so `isLoading` correctly starts `true` instead.
+			const hasFinishedPresets =
+				!(namespace && block && slug) ||
+				select(STORE_NAME).hasFinishedResolution('getBlockPresets', [namespace, block, slug]);
+
+			return {
+				payload: currentPayload,
+				// Gated on `!currentPayload`, not `hasFinishedPresets` alone: a write's wrapped
+				// `refreshFeed` (`use-preset-screen.js`) invalidates and re-resolves this same selector,
+				// which flips `hasFinishedPresets` back to `false` for the duration of that background
+				// re-fetch too. Once the presets list has loaded once, the store keeps serving that
+				// payload while it revalidates, so there is data to keep rendering — a loading state
+				// should only ever show up before the first payload lands.
+				isLoading: !hasFinishedPresets && !currentPayload,
+				loadError:
+					namespace && block && slug
+						? select(STORE_NAME).getResolutionError('getBlockPresets', [namespace, block, slug])
+						: null,
+			};
+		},
 		[namespace, block, slug]
 	);
 

--- a/src/style-library/hooks/use-presets.js
+++ b/src/style-library/hooks/use-presets.js
@@ -1,8 +1,7 @@
 /**
- * Fetch-and-bind hook for a block's preset collection — the `use-libraries.js` shape (a state slot
- * plus an effect that re-fetches), not `useScaleScreen`'s live-feed-in-hand shape, because presets
- * have no counterpart in the localized feed: there is no group to map, so the payload has to be
- * fetched on its own.
+ * Fetch-and-bind hook for a block's preset collection — reads it from the Style Library store, so a
+ * screen and its settings panel calling this hook for the same block/library share one underlying
+ * fetch instead of each running its own.
  *
  * Takes the block name as an argument (default the Button block) so a later preset screen built on
  * the same contract can reuse this hook unchanged.
@@ -11,24 +10,25 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { fetchBlockPresets } from '../api/client';
 import { presetInitialValues, presetRows } from '../helpers/presets';
 import { useBreakpoint } from '../../token-controls/context/breakpoint';
+import { STORE_NAME } from '../store';
 
 /**
- * Fetch a block's preset collection and bind it to row view models.
+ * Read a block's preset collection from the store and bind it to row view models.
  *
- * Re-fetches whenever the library slug or version changes — the version bumps on every preset
- * write's `refreshFeed`, which is the cross-slot invalidation signal a sibling settings panel's
- * save relies on to make this hook's rows current again.
+ * A screen and its settings panel are separate mounts of this hook (see `usePresetScreen` and
+ * `PresetSidebar`), and both read the same selector call when they share a `namespace`/`block`/
+ * `slug`, so only one of them ever triggers the resolver.
  *
  * @param {Object} library The design-tokens feed hook's return value (`useDesignTokensFeed()`).
- * @param {string} block   The block name whose presets are fetched.
+ * @param {Object} preset  The block's preset config.
  *
  * @since TBD
  *
@@ -38,61 +38,23 @@ export function usePresets(library, preset) {
 	// See `use-preset-screen.js`: `properties` is a throwing getter on the preset configs, so it is
 	// read where it is used rather than destructured at render scope.
 	const { block, preview } = preset;
-	const [payload, setPayload] = useState(null);
-	const [isLoading, setIsLoading] = useState(true);
-	const [loadError, setLoadError] = useState(null);
 
 	const namespace = library?.rest?.namespace;
 	const slug = library?.slug;
-	const version = library?.version;
 
-	// Dropped the moment the library changes, not when its replacement arrives: the refetch below
-	// keeps the previous payload on purpose (a version bump after a write must not blank the list),
-	// but across libraries that same payload is another library's data. Callers key their panels on
-	// the preset id alone, so leaving it in place lets a panel opened on the old library keep
-	// editing its draft under the new one. Assigning during render rather than in an effect avoids
-	// a commit that would show the stale rows first.
-	const slugRef = useRef(slug);
-
-	if (slugRef.current !== slug) {
-		slugRef.current = slug;
-		setPayload(null);
-		setIsLoading(true);
-		setLoadError(null);
-	}
-
-	useEffect(() => {
-		if (!namespace || !slug) {
-			return;
-		}
-
-		let cancelled = false;
-
-		setIsLoading(true);
-		setLoadError(null);
-
-		fetchBlockPresets(namespace, block, slug)
-			.then((result) => {
-				if (!cancelled) {
-					setPayload(result);
-				}
-			})
-			.catch((err) => {
-				if (!cancelled) {
-					setLoadError(err);
-				}
-			})
-			.finally(() => {
-				if (!cancelled) {
-					setIsLoading(false);
-				}
-			});
-
-		return () => {
-			cancelled = true;
-		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [namespace, block, slug, version]);
+	const { payload, isLoading, loadError } = useSelect(
+		(select) => ({
+			payload: namespace && block && slug ? select(STORE_NAME).getBlockPresets(namespace, block, slug) : null,
+			isLoading:
+				Boolean(namespace && block && slug) &&
+				select(STORE_NAME).isResolving('getBlockPresets', [namespace, block, slug]),
+			loadError:
+				namespace && block && slug
+					? select(STORE_NAME).getResolutionError('getBlockPresets', [namespace, block, slug])
+					: null,
+		}),
+		[namespace, block, slug]
+	);
 
 	// The row previews resolve at the active breakpoint, so switching the panel to Tablet re-renders
 	// every chip with its tablet value rather than leaving them all showing desktop.

--- a/src/style-library/store/actions.js
+++ b/src/style-library/store/actions.js
@@ -15,3 +15,17 @@
 export function receiveLibraries(rows) {
 	return { type: 'RECEIVE_LIBRARIES', rows };
 }
+
+/**
+ * Store a block's preset collection.
+ *
+ * @param {string} key     `presetsKey()`'s output for this block/library.
+ * @param {Object} payload The fetched preset collection.
+ *
+ * @since TBD
+ *
+ * @return {Object} The action.
+ */
+export function receiveBlockPresets(key, payload) {
+	return { type: 'RECEIVE_BLOCK_PRESETS', key, payload };
+}

--- a/src/style-library/store/constants.js
+++ b/src/style-library/store/constants.js
@@ -1,5 +1,6 @@
 /**
- * The Style Library app's `@wordpress/data` store name.
+ * The Style Library app's `@wordpress/data` store name, and the key builders every resolver/
+ * selector in this store uses to address a specific resource instance.
  */
 
 /**
@@ -9,3 +10,18 @@
  * @since TBD
  */
 export const STORE_NAME = 'kadence-blocks/style-library';
+
+/**
+ * Build the state key for a block's preset collection.
+ *
+ * @param {string} namespace REST namespace.
+ * @param {string} block     The block name, e.g. `kadence/singlebtn`.
+ * @param {string} slug      Token library slug.
+ *
+ * @since TBD
+ *
+ * @return {string} The state key.
+ */
+export function presetsKey(namespace, block, slug) {
+	return `${namespace}::${block}::${slug}`;
+}

--- a/src/style-library/store/reducer.js
+++ b/src/style-library/store/reducer.js
@@ -7,9 +7,17 @@ function libraries(state = [], action) {
 	return action.type === 'RECEIVE_LIBRARIES' ? action.rows : state;
 }
 
+function presets(state = {}, action) {
+	if (action.type !== 'RECEIVE_BLOCK_PRESETS') {
+		return state;
+	}
+
+	return { ...state, [action.key]: action.payload };
+}
+
 /**
  * The Style Library store's root reducer.
  *
  * @since TBD
  */
-export const reducer = combineReducers({ libraries });
+export const reducer = combineReducers({ libraries, presets });

--- a/src/style-library/store/reducer.test.js
+++ b/src/style-library/store/reducer.test.js
@@ -1,12 +1,12 @@
 /* eslint-env jest */
 import { reducer } from './reducer';
-import { receiveLibraries } from './actions';
+import { receiveLibraries, receiveBlockPresets } from './actions';
 
 describe('reducer', () => {
 	it('starts with empty slices', () => {
 		const state = reducer(undefined, { type: '@@INIT' });
 
-		expect(state).toEqual({ libraries: [] });
+		expect(state).toEqual({ libraries: [], presets: {} });
 	});
 
 	it('stores the libraries list on RECEIVE_LIBRARIES', () => {
@@ -14,5 +14,12 @@ describe('reducer', () => {
 		const state = reducer(undefined, receiveLibraries(rows));
 
 		expect(state.libraries).toBe(rows);
+	});
+
+	it('stores a block presets payload under its key, leaving other keys alone', () => {
+		let state = reducer(undefined, receiveBlockPresets('a', { version: 'a1' }));
+		state = reducer(state, receiveBlockPresets('b', { version: 'b1' }));
+
+		expect(state.presets).toEqual({ a: { version: 'a1' }, b: { version: 'b1' } });
 	});
 });

--- a/src/style-library/store/resolvers.js
+++ b/src/style-library/store/resolvers.js
@@ -8,7 +8,8 @@
 /**
  * Internal dependencies
  */
-import { fetchLibraries } from '../api/client';
+import { fetchBlockPresets, fetchLibraries } from '../api/client';
+import { presetsKey } from './constants';
 
 /**
  * Resolve `selectors.getLibraries()`.
@@ -22,4 +23,22 @@ export const getLibraries =
 	async ({ dispatch }) => {
 		const rows = await fetchLibraries();
 		dispatch.receiveLibraries(rows);
+	};
+
+/**
+ * Resolve `selectors.getBlockPresets(namespace, block, slug)`.
+ *
+ * @param {string} namespace REST namespace.
+ * @param {string} block     The block name, e.g. `kadence/singlebtn`.
+ * @param {string} slug      Token library slug.
+ *
+ * @since TBD
+ *
+ * @return {Function} A `@wordpress/data` thunk.
+ */
+export const getBlockPresets =
+	(namespace, block, slug) =>
+	async ({ dispatch }) => {
+		const payload = await fetchBlockPresets(namespace, block, slug);
+		dispatch.receiveBlockPresets(presetsKey(namespace, block, slug), payload);
 	};

--- a/src/style-library/store/resolvers.test.js
+++ b/src/style-library/store/resolvers.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
-import { getLibraries } from './resolvers';
-import { fetchLibraries } from '../api/client';
+import { getBlockPresets, getLibraries } from './resolvers';
+import { fetchBlockPresets, fetchLibraries } from '../api/client';
 
 jest.mock('../api/client', () => ({
 	fetchLibraries: jest.fn(),
@@ -20,5 +20,19 @@ describe('resolvers', () => {
 		await getLibraries()({ dispatch });
 
 		expect(dispatch.receiveLibraries).toHaveBeenCalledWith(rows);
+	});
+
+	it('getBlockPresets() fetches and dispatches receiveBlockPresets under the composite key', async () => {
+		const payload = { version: 'a1', presets: {} };
+		fetchBlockPresets.mockResolvedValueOnce(payload);
+
+		const dispatch = { receiveBlockPresets: jest.fn() };
+		await getBlockPresets('kb-design-tokens/v1', 'kadence/singlebtn', 'default')({ dispatch });
+
+		expect(fetchBlockPresets).toHaveBeenCalledWith('kb-design-tokens/v1', 'kadence/singlebtn', 'default');
+		expect(dispatch.receiveBlockPresets).toHaveBeenCalledWith(
+			'kb-design-tokens/v1::kadence/singlebtn::default',
+			payload
+		);
 	});
 });

--- a/src/style-library/store/selectors.js
+++ b/src/style-library/store/selectors.js
@@ -5,6 +5,11 @@
  */
 
 /**
+ * Internal dependencies
+ */
+import { presetsKey } from './constants';
+
+/**
  * Read the libraries list.
  *
  * @param {Object} state The store's state.
@@ -15,4 +20,20 @@
  */
 export function getLibraries(state) {
 	return state.libraries;
+}
+
+/**
+ * Read a block's preset collection.
+ *
+ * @param {Object} state     The store's state.
+ * @param {string} namespace REST namespace.
+ * @param {string} block     The block name, e.g. `kadence/singlebtn`.
+ * @param {string} slug      Token library slug.
+ *
+ * @since TBD
+ *
+ * @return {?Object} The preset collection, or `null` if not yet resolved.
+ */
+export function getBlockPresets(state, namespace, block, slug) {
+	return state.presets[presetsKey(namespace, block, slug)] ?? null;
 }

--- a/src/style-library/store/selectors.test.js
+++ b/src/style-library/store/selectors.test.js
@@ -1,10 +1,22 @@
 /* eslint-env jest */
-import { getLibraries } from './selectors';
+import { getBlockPresets, getLibraries } from './selectors';
 
 describe('selectors', () => {
 	it('getLibraries() returns the libraries slice', () => {
 		const state = { libraries: [{ slug: 'default' }], presets: {}, paletteListings: {}, palettes: {} };
 
 		expect(getLibraries(state)).toEqual([{ slug: 'default' }]);
+	});
+
+	it('getBlockPresets() reads the payload under its composite key, or null when absent', () => {
+		const state = {
+			libraries: [],
+			presets: { 'ns::block::slug': { version: 'a1' } },
+			paletteListings: {},
+			palettes: {},
+		};
+
+		expect(getBlockPresets(state, 'ns', 'block', 'slug')).toEqual({ version: 'a1' });
+		expect(getBlockPresets(state, 'ns', 'other-block', 'slug')).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary

Adds the presets slice to the store (`getBlockPresets(namespace, block, slug)` resolver + selector) and migrates `usePresets()`/`usePresetScreen()` to read through it.

This is a genuine bug fix, not just a refactor: `ButtonScreen.js` and `ButtonSettings.js` each independently called `usePresetScreen()` today, so opening a preset's settings panel triggered its own separate REST fetch of the same preset collection the list screen had already loaded. Both now read the same store selector call, so only one of them ever issues the request, and a write from either instance updates what both render.

`helpers/preset-flows.js` is **not modified**. `usePresetScreen()`'s `refreshFeed` wrapper now does both the existing feed refresh (still needed — preset row previews read token values off the feed) and a store invalidate + re-resolve, but every write flow's own call site is unchanged.

Reorder's version tracking (the client-sent `version` a preset reorder must match, to guard against a stale concurrent write) is sourced from the shared feed's own `library.version`, not from the store's cached preset payload — every write anywhere in the library (scale, typography, palettes, presets) bumps `library.version` via `refreshFeed`, while the cached payload only catches up when this screen's own wrapped `refreshFeed` explicitly invalidates it. A write on any OTHER screen would otherwise leave the payload's version stale, and the next preset reorder would 409 against a version the server had already moved past. The refs this tracking depends on sync from a `useLayoutEffect` keyed on the feed version, not the render body, so a discarded or replayed render (React 18 concurrent rendering) can't leak a stale value into a queued reorder.

## Test instructions

1. Go to **Style Library → Block Presets → Button**, throttle the network, open a preset's settings panel — confirm it doesn't re-fetch the list you can already see (only one network request for presets total).
2. Create, save, delete, and reorder presets — confirm everything behaves exactly as before.
3. With Redux DevTools installed, confirm `RECEIVE_BLOCK_PRESETS` fires once per library/block combination, not once per panel open.
4. On **Block Presets → Button**, change a value on a different screen that shares this library (e.g. **Border Radius**), then go back and reorder a preset — confirm the reorder succeeds instead of failing with a version conflict.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4200/phase-6-feed-slice
bun install
```

The Style Library is at **WP Admin → Kadence → Style Library**.
</details>

---

Slice 4 of 7 in the SOFT-4200 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized loading and caching for block presets.
  * Preset data remains visible during background refreshes.
  * Multiple views requesting the same presets share a single fetch.
  * Preset updates from other screens are detected and reflected automatically.

* **Bug Fixes**
  * Switching libraries clears stale preset data and displays the appropriate loading state.
  * Improved preset refresh behavior, version tracking, and handling of missing or unresolved data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
