### PR TITLE
[DTM] SOFT-4200 [5/7]: Palettes slice — the double-fetch this stack exists to fix

### DIFF
--- a/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
@@ -944,7 +944,7 @@ final class Palettes_Controller extends Controller {
 			);
 		}
 
-		return new WP_REST_Response( $this->prepare_items( $slug ), $status );
+		return new WP_REST_Response( $this->prepare_items_embedded( $slug ), $status );
 	}
 
 	/**
@@ -1367,6 +1367,30 @@ final class Palettes_Controller extends Controller {
 		$candidate = $this->mutator->merge( $document, $this->palette_partial( $id, $node ) );
 
 		return $this->validate_and_save( $candidate, $id, $slug );
+	}
+
+	/**
+	 * The same shape `GET /palettes?_embed` produces, built directly rather than through a request
+	 * object — every write response uses this unconditionally, so the client never needs a follow-up
+	 * GET to see the fresh state a write just produced.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token library slug.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function prepare_items_embedded( string $slug ): array {
+		return array_map(
+			function ( array $row ) use ( $slug ) {
+				$row['_embedded'] = [
+					'self' => [ $this->effective_view( Cast::to_string( $row[ self::ID_PARAM ] ), $slug ) ],
+				];
+
+				return $row;
+			},
+			$this->prepare_items( $slug )
+		);
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
@@ -506,6 +506,20 @@ final class Palettes_Controller extends Controller {
 			}
 
 			$fields['value'] = $value;
+		} elseif ( is_string( $label ) ) {
+			// A label-only write has no new value to guard, so guard the token's CURRENT effective value
+			// instead — a token that is stale or no longer a registered color must still be rejected. A
+			// token this palette has never stored has no current value here; that genuinely-new-token case
+			// is left to the downstream DTCG schema validation, which already rejects it.
+			$current_value = $this->palettes->swatch_values( $id, $slug )[ $token ] ?? null;
+
+			if ( is_string( $current_value ) ) {
+				$guard = $this->guard_swatch_target( $id, $token, $current_value );
+
+				if ( $guard !== null ) {
+					return $guard;
+				}
+			}
 		}
 
 		if ( is_string( $label ) ) {

--- a/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
@@ -578,7 +578,7 @@ final class Palettes_Controller extends Controller {
 		// restored to its shipped value rather than dropped. Every other case drops the palette's own entry:
 		// a non-default palette's delta (leaving it inherited) or a user-added row (retiring it).
 		$node = ( $id === $this->palettes->default_palette( $slug ) && array_key_exists( $token, $baseline ) )
-			? $this->set_swatch_in_node( $node, $token, $baseline[ $token ], $slug )
+			? $this->set_swatch_fields_in_node( $node, $token, [ 'value' => $baseline[ $token ] ], $slug )
 			: $this->remove_swatch_from_node( $node, $token );
 
 		return $this->write_palette_node( $slug, $id, $node );

--- a/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
@@ -314,7 +314,9 @@ final class Palettes_Controller extends Controller {
 	}
 
 	/**
-	 * List a library's palettes: the `$default` / `$current` pointers and each palette's id + label.
+	 * List a library's palettes: a flat row per palette carrying its id, label, and `is_default` /
+	 * `is_current` / `user_created` flags, each with an embeddable `self` link `_embed` resolves into
+	 * the palette's full `effective_view()`.
 	 *
 	 * @since TBD
 	 *
@@ -323,7 +325,13 @@ final class Palettes_Controller extends Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		return new WP_REST_Response( $this->prepare_items( $this->slug( $request ) ), WP_Http::OK );
+		$slug = $this->slug( $request );
+		$rows = array_map(
+			fn( array $row ) => $this->prepare_response_for_collection( $this->prepare_item_for_response( $row, $request ) ),
+			$this->prepare_items( $slug )
+		);
+
+		return new WP_REST_Response( $rows, WP_Http::OK );
 	}
 
 	/**
@@ -617,6 +625,46 @@ final class Palettes_Controller extends Controller {
 		];
 
 		return $this->add_additional_fields_schema( $this->item_schema );
+	}
+
+	/**
+	 * Wrap one listing row in a `WP_REST_Response` carrying its `self` link — what `_embed` resolves
+	 * through `get_item()` into the row's full `effective_view()`, and what the standard
+	 * `prepare_response_for_collection()` call in `get_items()` below merges into the row's own array
+	 * as `_links` (not a nested response object — see `Contracts\Controller` for why this repo's
+	 * controllers otherwise build plain arrays directly).
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $item    The listing row: `{id, label, is_default, is_current, user_created}`.
+	 * @param WP_REST_Request      $request Full details about the request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$response = new WP_REST_Response( $item );
+		$response->add_links( $this->prepare_links( $item ) );
+
+		return $response;
+	}
+
+	/**
+	 * The `self` link for a listing row, targeting `GET /palettes/{id}` — the single-palette route
+	 * `_embed` resolves into the row's full group/swatch data.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $item The listing row.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected function prepare_links( $item ) {
+		return [
+			'self' => [
+				'href'       => rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, Cast::to_string( $item[ self::ID_PARAM ] ) ) ),
+				'embeddable' => true,
+			],
+		];
 	}
 
 	/**
@@ -1276,34 +1324,39 @@ final class Palettes_Controller extends Controller {
 	}
 
 	/**
-	 * The palette listing for a library: the `$default` / `$current` pointers, each palette's id + label, and
-	 * which ids are user-created (the only ones a delete removes rather than reverts to baseline).
+	 * The palette listing for a library: every palette as a flat row carrying its id, label, and which
+	 * of the three per-library facts it represents (`$default`, `$current`, user-created) — a flat
+	 * top-level array, not a wrapper object, because WP core's `_embed` resolution only walks
+	 * TOP-LEVEL collection items, never something nested inside a wrapper key. A row's `is_default`/
+	 * `is_current`/`user_created` flags carry what the old `{$default, $current, palettes,
+	 * userCreated}` wrapper used to convey at the collection level.
 	 *
 	 * @since TBD
 	 *
 	 * @param string $slug The token library slug.
 	 *
-	 * @return array<string, mixed>
+	 * @return array<int, array<string, mixed>>
 	 */
 	private function prepare_items( string $slug ): array {
-		$section  = $this->palettes->section( $slug );
-		$palettes = [];
+		$section      = $this->palettes->section( $slug );
+		$default_id   = $this->palettes->default_palette( $slug );
+		$current_id   = $this->palettes->current( $slug );
+		$user_created = $this->palettes->user_created( $slug );
+		$rows         = [];
 
 		foreach ( $this->palettes->palette_ids( $slug ) as $palette_id ) {
 			$node = $section[ $palette_id ] ?? [];
 
-			$palettes[] = [
+			$rows[] = [
 				self::ID_PARAM    => $palette_id,
 				self::LABEL_PARAM => is_array( $node ) ? ( $node[ Extensions::get_label_key() ] ?? '' ) : '',
+				'is_default'      => $palette_id === $default_id,
+				'is_current'      => $palette_id === $current_id,
+				'user_created'    => in_array( $palette_id, $user_created, true ),
 			];
 		}
 
-		return [
-			Extensions::get_default_key() => $this->palettes->default_palette( $slug ),
-			Extensions::get_current_key() => $this->palettes->current( $slug ),
-			'palettes'                    => $palettes,
-			'userCreated'                 => $this->palettes->user_created( $slug ),
-		];
+		return $rows;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
@@ -613,7 +613,7 @@ final class Palettes_Controller extends Controller {
 			return $saved;
 		}
 
-		return new WP_REST_Response( [ self::CURRENT_PARAM => $this->palettes->current( $slug ) ], $saved->get_status() );
+		return new WP_REST_Response( $this->prepare_items_embedded( $slug ), $saved->get_status() );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
@@ -450,11 +450,13 @@ final class Palettes_Controller extends Controller {
 	}
 
 	/**
-	 * Set a single palette swatch (POST or PUT /palettes/{id}/swatches/{token}): validate just this one token
-	 * and value, upsert it into the palette, and save. Only the sent swatch is guarded, so editing one color
-	 * never depends on the palette's other swatches being valid, and every token the palette does not set falls
-	 * back to the default palette. Setting a non-default palette's swatch to the default value reverts it to
-	 * inherited, the same as a DELETE. A request for a palette the library does not define is a 404.
+	 * Set a single palette swatch's value and/or structural label (POST or PUT /palettes/{id}/swatches/{token}):
+	 * validate just this one token, upsert the sent fields into the palette, and save. Only the sent swatch is
+	 * guarded, so editing one color never depends on the palette's other swatches being valid, and every token
+	 * the palette does not set falls back to the default palette. Setting a non-default palette's swatch value
+	 * to the default value reverts it to inherited, the same as a DELETE. A label is structural — defined once,
+	 * inherited by every palette — so it can only be set on the library's default palette; sending one against
+	 * any other palette id is rejected. A request for a palette the library does not define is a 404.
 	 *
 	 * @since TBD
 	 *
@@ -474,25 +476,50 @@ final class Palettes_Controller extends Controller {
 		}
 
 		$value = $request->get_param( Sentinels::get_value_key() );
+		$label = $request->get_param( self::LABEL_PARAM );
 
-		if ( ! is_string( $value ) || $value === '' ) {
-			return $this->invalid( $id, __( 'A swatch value is required.', 'kadence-blocks' ) );
+		if ( ! is_string( $value ) && ! is_string( $label ) ) {
+			return $this->invalid( $id, __( 'A swatch value or label is required.', 'kadence-blocks' ) );
 		}
 
-		$guard = $this->guard_swatch_target( $id, $token, $value );
-
-		if ( $guard !== null ) {
-			return $guard;
+		if ( is_string( $value ) && $value === '' ) {
+			return $this->invalid( $id, __( 'A swatch value cannot be empty.', 'kadence-blocks' ) );
 		}
 
 		$default_id = $this->palettes->default_palette( $slug );
-		$default    = $this->palettes->swatch_values( $default_id, $slug );
 
-		// A non-default swatch equal to the default value is inherited, not stored, so setting it back to the
-		// default reverts it — identical to a DELETE.
-		$node = ( $id !== $default_id && ( $default[ $token ] ?? null ) === $value )
-			? $this->remove_swatch_from_node( $node, $token )
-			: $this->set_swatch_in_node( $node, $token, $value, $slug );
+		if ( is_string( $label ) && $id !== $default_id ) {
+			return $this->invalid( $id, __( 'A swatch label is structural and can only be set on the library\'s default palette.', 'kadence-blocks' ) );
+		}
+
+		$fields = [];
+
+		if ( is_string( $value ) ) {
+			$guard = $this->guard_swatch_target( $id, $token, $value );
+
+			if ( $guard !== null ) {
+				return $guard;
+			}
+
+			$fields['value'] = $value;
+		}
+
+		if ( is_string( $label ) ) {
+			$fields['label'] = $label;
+		}
+
+		if ( isset( $fields['value'] ) ) {
+			$default = $this->palettes->swatch_values( $default_id, $slug );
+
+			// A non-default swatch equal to the default value is inherited, not stored, so setting it back to
+			// the default reverts it — identical to a DELETE. Only applies to a value write; a label-only
+			// write never reverts anything.
+			$node = ( $id !== $default_id && ( $default[ $token ] ?? null ) === $fields['value'] )
+				? $this->remove_swatch_from_node( $node, $token )
+				: $this->set_swatch_fields_in_node( $node, $token, $fields, $slug );
+		} else {
+			$node = $this->set_swatch_fields_in_node( $node, $token, $fields, $slug );
+		}
 
 		return $this->write_palette_node( $slug, $id, $node );
 	}
@@ -1157,24 +1184,25 @@ final class Palettes_Controller extends Controller {
 	}
 
 	/**
-	 * Upsert a swatch into a palette node: update its value in place if the palette already carries the token,
-	 * otherwise add it to the group the default template places it in (creating that group if the palette does
-	 * not have it yet). Returns the updated node.
+	 * Upsert one or more fields of a swatch into a palette node: update the sent fields in place if the
+	 * palette already carries the token, otherwise add it to the group the default template places it
+	 * in (creating that group if the palette does not have it yet). Returns the updated node.
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, mixed> $node  The palette node.
-	 * @param string               $token The swatch token dot-path.
-	 * @param string               $value The swatch value.
-	 * @param string               $slug  The token library slug.
+	 * @param array<string, mixed>  $node   The palette node.
+	 * @param string                $token  The swatch token dot-path.
+	 * @param array<string, string> $fields The fields to set — `value` and/or `label`, at least one present.
+	 * @param string                $slug   The token library slug.
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function set_swatch_in_node( array $node, string $token, string $value, string $slug ): array {
+	private function set_swatch_fields_in_node( array $node, string $token, array $fields, string $slug ): array {
 		$groups_key   = Extensions::get_groups_key();
 		$swatches_key = Extensions::get_swatches_key();
 		$token_key    = Extensions::get_swatch_token_key();
 		$value_key    = Sentinels::get_value_key();
+		$label_key    = Extensions::get_label_key();
 		$group_id_key = Extensions::get_group_id_key();
 
 		$groups = isset( $node[ $groups_key ] ) && is_array( $node[ $groups_key ] ) ? array_values( $node[ $groups_key ] ) : [];
@@ -1186,21 +1214,29 @@ final class Palettes_Controller extends Controller {
 
 			foreach ( array_values( $group[ $swatches_key ] ) as $si => $swatch ) {
 				if ( is_array( $swatch ) && ( $swatch[ $token_key ] ?? null ) === $token ) {
-					$groups[ $gi ][ $swatches_key ]                      = array_values( $group[ $swatches_key ] );
-					$groups[ $gi ][ $swatches_key ][ $si ][ $value_key ] = $value;
-					$node[ $groups_key ]                                 = $groups;
+					$groups[ $gi ][ $swatches_key ] = array_values( $group[ $swatches_key ] );
+
+					if ( array_key_exists( 'value', $fields ) ) {
+						$groups[ $gi ][ $swatches_key ][ $si ][ $value_key ] = $fields['value'];
+					}
+
+					if ( array_key_exists( 'label', $fields ) ) {
+						$groups[ $gi ][ $swatches_key ][ $si ][ $label_key ] = $fields['label'];
+					}
+
+					$node[ $groups_key ] = $groups;
 
 					return $node;
 				}
 			}
 		}
 
-		[ $group_id, $group_label, $swatch_label ] = $this->template_slot_for( $token, $slug );
+		[ $group_id, $group_label, $template_label ] = $this->template_slot_for( $token, $slug );
 
 		$swatch = [
-			$token_key                  => $token,
-			Extensions::get_label_key() => $swatch_label,
-			$value_key                  => $value,
+			$token_key => $token,
+			$label_key => $fields['label'] ?? $template_label,
+			$value_key => $fields['value'] ?? '',
 		];
 
 		foreach ( $groups as $gi => $group ) {
@@ -1216,9 +1252,9 @@ final class Palettes_Controller extends Controller {
 		}
 
 		$groups[] = [
-			$group_id_key               => $group_id,
-			Extensions::get_label_key() => $group_label,
-			$swatches_key               => [ $swatch ],
+			$group_id_key => $group_id,
+			$label_key    => $group_label,
+			$swatches_key => [ $swatch ],
 		];
 
 		$node[ $groups_key ] = $groups;
@@ -1612,7 +1648,8 @@ final class Palettes_Controller extends Controller {
 	}
 
 	/**
-	 * The arguments for the single-swatch write route: the swatch params plus the required `$value`.
+	 * The arguments for the swatch write route: the value and/or the structural label, each optional
+	 * individually — `update_swatch()` requires at least one to be present.
 	 *
 	 * @since TBD
 	 *
@@ -1625,7 +1662,10 @@ final class Palettes_Controller extends Controller {
 				Sentinels::get_value_key() => [
 					'description' => __( 'The swatch value: a literal color or a {dot.path} alias.', 'kadence-blocks' ),
 					'type'        => 'string',
-					'required'    => true,
+				],
+				self::LABEL_PARAM          => [
+					'description' => __( 'The swatch\'s structural label. Only valid when {id} is the library\'s default palette — labels are defined once, not per palette.', 'kadence-blocks' ),
+					'type'        => 'string',
 				],
 			]
 		);

--- a/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
@@ -632,7 +632,11 @@ final class Palettes_Controller extends Controller {
 	 * through `get_item()` into the row's full `effective_view()`, and what the standard
 	 * `prepare_response_for_collection()` call in `get_items()` below merges into the row's own array
 	 * as `_links` (not a nested response object — see `Contracts\Controller` for why this repo's
-	 * controllers otherwise build plain arrays directly).
+	 * controllers otherwise build plain arrays directly). The `self` link is built against the
+	 * SAME library the listing itself resolved (via `slug()`), not the site's active library —
+	 * otherwise `_embed`'s internal sub-request would silently re-resolve against whatever library
+	 * happens to be active, returning the wrong palette's data for a listing requested against a
+	 * non-active library.
 	 *
 	 * @since TBD
 	 *
@@ -643,25 +647,31 @@ final class Palettes_Controller extends Controller {
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		$response = new WP_REST_Response( $item );
-		$response->add_links( $this->prepare_links( $item ) );
+		$response->add_links( $this->prepare_links( $item, $this->slug( $request ) ) );
 
 		return $response;
 	}
 
 	/**
-	 * The `self` link for a listing row, targeting `GET /palettes/{id}` — the single-palette route
-	 * `_embed` resolves into the row's full group/swatch data.
+	 * The `self` link for a listing row, targeting `GET /palettes/{id}?library={slug}` — the
+	 * single-palette route `_embed` resolves into the row's full group/swatch data. The `library`
+	 * query arg pins the embedded sub-request to the library the listing was requested for; without
+	 * it, `_embed` falls back to the site's active library, which is wrong whenever the listing
+	 * targets a non-active one.
 	 *
 	 * @since TBD
 	 *
 	 * @param array<string, mixed> $item The listing row.
+	 * @param string               $slug The token library slug the listing was resolved for.
 	 *
 	 * @return array<string, array<string, mixed>>
 	 */
-	protected function prepare_links( $item ) {
+	protected function prepare_links( $item, string $slug ) {
+		$href = rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, Cast::to_string( $item[ self::ID_PARAM ] ) ) );
+
 		return [
 			'self' => [
-				'href'       => rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, Cast::to_string( $item[ self::ID_PARAM ] ) ) ),
+				'href'       => add_query_arg( self::LIBRARY_PARAM, $slug, $href ),
 				'embeddable' => true,
 			],
 		];

--- a/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
@@ -486,6 +486,10 @@ final class Palettes_Controller extends Controller {
 			return $this->invalid( $id, __( 'A swatch value cannot be empty.', 'kadence-blocks' ) );
 		}
 
+		if ( is_string( $label ) && $label === '' ) {
+			return $this->invalid( $id, __( 'A swatch label cannot be empty.', 'kadence-blocks' ) );
+		}
+
 		$default_id = $this->palettes->default_palette( $slug );
 
 		if ( is_string( $label ) && $id !== $default_id ) {

--- a/src/style-library/__tests__/palette-flows.test.js
+++ b/src/style-library/__tests__/palette-flows.test.js
@@ -66,8 +66,11 @@ const selectedView = () => ({
 });
 
 // The shape every write response now carries: a flat, fully embedded palette listing — the same
-// wire shape `store/selectors.js`'s `reshapePaletteRows` reshapes. Used as the resolved value for
-// every mocked write call in this file, standing in for what the REST endpoints actually return.
+// RAW wire shape `store/selectors.js`'s `reshapePaletteRows` reshapes on read. Used both as the
+// resolved value for every mocked write call in this file, standing in for what the REST endpoints
+// actually return, AND as the exact value `onReceive` is asserted to have been called with — a
+// flow no longer reshapes its own response before handing it to `onReceive`, it passes it straight
+// through, so the assertion below is byte-for-byte the mocked resolved value.
 const listingRows = (overrides = {}) => [
 	{
 		id: DEFAULT_ID,
@@ -86,16 +89,6 @@ const listingRows = (overrides = {}) => [
 		_embedded: { self: [selectedView()] },
 	},
 ];
-
-const reshapedListing = (overrides = {}) => ({
-	defaultId: DEFAULT_ID,
-	currentId: overrides.currentId ?? DEFAULT_ID,
-	palettes: [
-		{ id: DEFAULT_ID, label: 'Default', groups: defaultView().groups },
-		{ id: 'sunset', label: 'Sunset', groups: selectedView().groups },
-	],
-	userCreated: [],
-});
 
 beforeEach(() => {
 	jest.resetAllMocks();
@@ -133,7 +126,7 @@ describe('writeDefaultPaletteFlow', () => {
 		);
 		const [, , payload] = client.savePalette.mock.calls[0];
 		expect(payload.groups[0].swatches[0].$value).toBe('#111111');
-		expect(onReceive).toHaveBeenCalledWith(reshapedListing());
+		expect(onReceive).toHaveBeenCalledWith(listingRows());
 		expect(refreshFeed).toHaveBeenCalledWith(SLUG);
 		expect(onBusy.mock.calls).toEqual([[true], [false]]);
 		expect(onError).not.toHaveBeenCalled();
@@ -229,7 +222,7 @@ describe('saveSwatchEditsFlow', () => {
 			{ value: '#abcdef' },
 			SLUG
 		);
-		expect(flowArgs.onReceive).toHaveBeenCalledWith(reshapedListing());
+		expect(flowArgs.onReceive).toHaveBeenCalledWith(listingRows());
 		expect(flowArgs.refreshFeed).toHaveBeenCalledTimes(1);
 	});
 
@@ -350,7 +343,7 @@ describe('activatePaletteFlow', () => {
 		});
 
 		expect(client.setCurrentPalette).toHaveBeenCalledWith(NAMESPACE, 'sunset', SLUG);
-		expect(onReceive).toHaveBeenCalledWith(reshapedListing({ currentId: 'sunset' }));
+		expect(onReceive).toHaveBeenCalledWith(listingRows({ currentId: 'sunset' }));
 		expect(refreshFeed).toHaveBeenCalledWith(SLUG);
 		expect(onBusy.mock.calls).toEqual([[true], [false]]);
 	});
@@ -565,7 +558,7 @@ describe('deletePaletteFlow', () => {
 		});
 
 		expect(client.deletePalette).toHaveBeenCalledWith(NAMESPACE, 'sunset', SLUG);
-		expect(onReceive).toHaveBeenCalledWith(reshapedListing());
+		expect(onReceive).toHaveBeenCalledWith(listingRows());
 		expect(refreshFeed).toHaveBeenCalledWith(SLUG);
 		expect(onBusy.mock.calls).toEqual([[true], [false]]);
 		expect(client.setCurrentPalette).not.toHaveBeenCalled();
@@ -628,15 +621,10 @@ describe('deletePaletteFlow', () => {
 
 		expect(order).toEqual(['activate', 'delete']);
 		expect(client.setCurrentPalette).toHaveBeenCalledWith(NAMESPACE, 'forest', SLUG);
-		// The intermediate activation response is discarded — only the FINAL write's (delete's)
+		// The intermediate activation response is discarded — only the FINAL write's (delete's) raw
 		// response is dispatched, since it is the truly fresh post-delete state.
 		expect(onReceive).toHaveBeenCalledTimes(1);
-		expect(onReceive).toHaveBeenCalledWith({
-			defaultId: DEFAULT_ID,
-			currentId: '',
-			palettes: [{ id: DEFAULT_ID, label: 'Default', groups: defaultView().groups }],
-			userCreated: [],
-		});
+		expect(onReceive).toHaveBeenCalledWith(deleteResponse);
 	});
 
 	it('surfaces the default-palette 400 message', async () => {
@@ -784,7 +772,7 @@ describe('renamePaletteFlow', () => {
 		expect(slugArg).toBe(SLUG);
 		expect(payload.label).toBe('Sunset Dusk');
 		expect(payload.groups).toEqual(stripEffectiveFlags(selectedView().groups));
-		expect(onReceive).toHaveBeenCalledWith(reshapedListing());
+		expect(onReceive).toHaveBeenCalledWith(listingRows());
 		expect(onBusy.mock.calls).toEqual([[true], [false]]);
 	});
 
@@ -839,7 +827,7 @@ describe('removeSwatchFlow', () => {
 
 		expect(client.savePalette).toHaveBeenCalled();
 		expect(client.deleteUserPrimitive).toHaveBeenCalledWith(SLUG, 'primitive.color.custom.custom-1', 'v3');
-		expect(flowArgs.onReceive).toHaveBeenCalledWith(reshapedListing());
+		expect(flowArgs.onReceive).toHaveBeenCalledWith(listingRows());
 	});
 
 	it('never calls deleteUserPrimitive for a baseline token', async () => {
@@ -931,7 +919,7 @@ describe('addColorFlow', () => {
 		expect(payload.groups.find((group) => group.id === 'accent').swatches).toContainEqual(
 			expect.objectContaining({ token: 'primitive.color.custom.custom-1' })
 		);
-		expect(onReceive).toHaveBeenCalledWith(reshapedListing());
+		expect(onReceive).toHaveBeenCalledWith(listingRows());
 		expect(token).toBe('primitive.color.custom.custom-1');
 	});
 
@@ -1078,7 +1066,7 @@ describe('renameGroupFlow', () => {
 		// The id-stability assertion: the saved group still carries its original id under the new
 		// label — the regression test for the `template_slot_for()` misfiling hazard.
 		expect(payload.groups.find((group) => group.label === 'Renamed Accent').id).toBe('accent');
-		expect(onReceive).toHaveBeenCalledWith(reshapedListing());
+		expect(onReceive).toHaveBeenCalledWith(listingRows());
 		expect(refreshFeed).toHaveBeenCalledWith(SLUG);
 	});
 

--- a/src/style-library/__tests__/palette-flows.test.js
+++ b/src/style-library/__tests__/palette-flows.test.js
@@ -65,7 +65,7 @@ const selectedView = () => ({
 });
 
 // The shape every write response now carries: a flat, fully embedded palette listing — the same
-// RAW wire shape `store/selectors.js`'s `reshapePaletteRows` reshapes on read. Used both as the
+// RAW wire shape `helpers/palettes.js`'s `reshapePaletteRows` reshapes on read. Used both as the
 // resolved value for every mocked write call in this file, standing in for what the REST endpoints
 // actually return, AND as the exact value `onReceive` is asserted to have been called with — a
 // flow no longer reshapes its own response before handing it to `onReceive`, it passes it straight

--- a/src/style-library/__tests__/palette-flows.test.js
+++ b/src/style-library/__tests__/palette-flows.test.js
@@ -65,15 +65,47 @@ const selectedView = () => ({
 	],
 });
 
+// The shape every write response now carries: a flat, fully embedded palette listing — the same
+// wire shape `store/selectors.js`'s `reshapePaletteRows` reshapes. Used as the resolved value for
+// every mocked write call in this file, standing in for what the REST endpoints actually return.
+const listingRows = (overrides = {}) => [
+	{
+		id: DEFAULT_ID,
+		label: 'Default',
+		is_default: true,
+		is_current: overrides.currentId ? overrides.currentId === DEFAULT_ID : true,
+		user_created: false,
+		_embedded: { self: [defaultView()] },
+	},
+	{
+		id: 'sunset',
+		label: 'Sunset',
+		is_default: false,
+		is_current: overrides.currentId === 'sunset',
+		user_created: false,
+		_embedded: { self: [selectedView()] },
+	},
+];
+
+const reshapedListing = (overrides = {}) => ({
+	defaultId: DEFAULT_ID,
+	currentId: overrides.currentId ?? DEFAULT_ID,
+	palettes: [
+		{ id: DEFAULT_ID, label: 'Default', groups: defaultView().groups },
+		{ id: 'sunset', label: 'Sunset', groups: selectedView().groups },
+	],
+	userCreated: [],
+});
+
 beforeEach(() => {
 	jest.resetAllMocks();
 });
 
 describe('writeDefaultPaletteFlow', () => {
-	it('reads the DEFAULT view, saves the edited default payload, reloads, refreshes the feed, then clears busy', async () => {
+	it('reads the DEFAULT view, saves the edited default payload, dispatches the response, refreshes the feed, then clears busy', async () => {
 		client.fetchPalette.mockResolvedValue(defaultView());
-		client.savePalette.mockResolvedValue({ $default: DEFAULT_ID, $current: DEFAULT_ID, palettes: [] });
-		const reload = jest.fn().mockResolvedValue(undefined);
+		client.savePalette.mockResolvedValue(listingRows());
+		const onReceive = jest.fn();
 		const refreshFeed = jest.fn().mockResolvedValue({ version: 'v2' });
 		const onBusy = jest.fn();
 		const onError = jest.fn();
@@ -84,7 +116,7 @@ describe('writeDefaultPaletteFlow', () => {
 			slug: SLUG,
 			defaultId: DEFAULT_ID,
 			edit,
-			reload,
+			onReceive,
 			refreshFeed,
 			onBusy,
 			onError,
@@ -101,7 +133,7 @@ describe('writeDefaultPaletteFlow', () => {
 		);
 		const [, , payload] = client.savePalette.mock.calls[0];
 		expect(payload.groups[0].swatches[0].$value).toBe('#111111');
-		expect(reload).toHaveBeenCalled();
+		expect(onReceive).toHaveBeenCalledWith(reshapedListing());
 		expect(refreshFeed).toHaveBeenCalledWith(SLUG);
 		expect(onBusy.mock.calls).toEqual([[true], [false]]);
 		expect(onError).not.toHaveBeenCalled();
@@ -119,7 +151,7 @@ describe('writeDefaultPaletteFlow', () => {
 				slug: SLUG,
 				defaultId: DEFAULT_ID,
 				edit: (groups) => groups,
-				reload: jest.fn(),
+				onReceive: jest.fn(),
 				refreshFeed: jest.fn(),
 				onBusy,
 				onError,
@@ -130,57 +162,10 @@ describe('writeDefaultPaletteFlow', () => {
 		expect(onBusy.mock.calls).toEqual([[true], [false]]);
 	});
 
-	it('re-reads on failure, so an optimistically applied edit is put back to the server order', async () => {
-		const failure = new Error('Save failed.');
-		client.fetchPalette.mockResolvedValue(defaultView());
-		client.savePalette.mockRejectedValue(failure);
-		const reload = jest.fn().mockResolvedValue(undefined);
-
-		await expect(
-			writeDefaultPaletteFlow({
-				namespace: NAMESPACE,
-				slug: SLUG,
-				defaultId: DEFAULT_ID,
-				edit: (groups) => groups,
-				reload,
-				refreshFeed: jest.fn(),
-				onBusy: jest.fn(),
-				onError: jest.fn(),
-			})
-		).rejects.toBe(failure);
-
-		// The whole point: reload() is in the success path too, so a version of this flow that only
-		// reloaded there would leave the caller's optimistic edit on screen after a failed write.
-		expect(reload).toHaveBeenCalledTimes(1);
-	});
-
-	it('keeps reporting the write error when the rollback re-read also fails, and still clears busy', async () => {
-		const failure = new Error('Save failed.');
-		client.fetchPalette.mockResolvedValue(defaultView());
-		client.savePalette.mockRejectedValue(failure);
-		const onBusy = jest.fn();
-		const onError = jest.fn();
-
-		await expect(
-			writeDefaultPaletteFlow({
-				namespace: NAMESPACE,
-				slug: SLUG,
-				defaultId: DEFAULT_ID,
-				edit: (groups) => groups,
-				reload: jest.fn().mockRejectedValue(new Error('Re-read failed.')),
-				refreshFeed: jest.fn(),
-				onBusy,
-				onError,
-			})
-		).rejects.toBe(failure);
-
-		expect(onError).toHaveBeenCalledWith({ message: failure.message });
-		expect(onBusy.mock.calls).toEqual([[true], [false]]);
-	});
-
-	it('does not refresh the feed when the write failed', async () => {
+	it('does not call onReceive or refresh the feed when the write failed', async () => {
 		client.fetchPalette.mockResolvedValue(defaultView());
 		client.savePalette.mockRejectedValue(new Error('Save failed.'));
+		const onReceive = jest.fn();
 		const refreshFeed = jest.fn();
 
 		await expect(
@@ -189,13 +174,14 @@ describe('writeDefaultPaletteFlow', () => {
 				slug: SLUG,
 				defaultId: DEFAULT_ID,
 				edit: (groups) => groups,
-				reload: jest.fn().mockResolvedValue(undefined),
+				onReceive,
 				refreshFeed,
 				onBusy: jest.fn(),
 				onError: jest.fn(),
 			})
 		).rejects.toThrow();
 
+		expect(onReceive).not.toHaveBeenCalled();
 		expect(refreshFeed).not.toHaveBeenCalled();
 	});
 });
@@ -207,7 +193,7 @@ describe('saveSwatchEditsFlow', () => {
 		defaultId: DEFAULT_ID,
 		editingId: 'sunset',
 		token: 'primitive.color.brand.primary',
-		reload: jest.fn().mockResolvedValue(undefined),
+		onReceive: jest.fn(),
 		refreshFeed: jest.fn().mockResolvedValue(undefined),
 		onBusy: jest.fn(),
 		onError: jest.fn(),
@@ -222,14 +208,13 @@ describe('saveSwatchEditsFlow', () => {
 
 		await saveSwatchEditsFlow(flowArgs);
 
-		expect(client.fetchPalette).not.toHaveBeenCalled();
 		expect(client.saveSwatch).not.toHaveBeenCalled();
 		expect(flowArgs.onBusy).not.toHaveBeenCalled();
-		expect(flowArgs.reload).not.toHaveBeenCalled();
+		expect(flowArgs.onReceive).not.toHaveBeenCalled();
 	});
 
 	it('writes only the granular swatch (edited palette) for a color-only edit', async () => {
-		client.saveSwatch.mockResolvedValue({});
+		client.saveSwatch.mockResolvedValue(listingRows());
 		const flowArgs = args({
 			draft: { label: 'Main 1', value: '#abcdef' },
 			initial: { label: 'Main 1', value: '#111111' },
@@ -244,15 +229,12 @@ describe('saveSwatchEditsFlow', () => {
 			{ value: '#abcdef' },
 			SLUG
 		);
-		expect(client.fetchPalette).not.toHaveBeenCalled();
-		expect(client.savePalette).not.toHaveBeenCalled();
-		expect(flowArgs.reload).toHaveBeenCalledTimes(1);
+		expect(flowArgs.onReceive).toHaveBeenCalledWith(reshapedListing());
 		expect(flowArgs.refreshFeed).toHaveBeenCalledTimes(1);
 	});
 
-	it('writes only the default node for a label-only edit', async () => {
-		client.fetchPalette.mockResolvedValue(defaultView());
-		client.savePalette.mockResolvedValue({});
+	it('writes the label through the targeted swatch endpoint against the default palette for a label-only edit', async () => {
+		client.saveSwatch.mockResolvedValue(listingRows());
 		const flowArgs = args({
 			draft: { label: 'Renamed', value: '#111111' },
 			initial: { label: 'Main 1', value: '#111111' },
@@ -260,28 +242,22 @@ describe('saveSwatchEditsFlow', () => {
 
 		await saveSwatchEditsFlow(flowArgs);
 
-		expect(client.fetchPalette).toHaveBeenCalledWith(NAMESPACE, DEFAULT_ID, SLUG);
-		expect(client.savePalette).toHaveBeenCalledWith(
+		expect(client.saveSwatch).toHaveBeenCalledWith(
 			NAMESPACE,
 			DEFAULT_ID,
-			expect.objectContaining({ label: 'Default' }),
+			'primitive.color.brand.primary',
+			{ label: 'Renamed' },
 			SLUG
 		);
-		expect(client.saveSwatch).not.toHaveBeenCalled();
+		expect(client.fetchPalette).not.toHaveBeenCalled();
+		expect(client.savePalette).not.toHaveBeenCalled();
 	});
 
-	it('runs rename before the color write when both changed, with one reload and one feed refresh', async () => {
-		client.fetchPalette.mockResolvedValue(defaultView());
-		client.savePalette.mockResolvedValue({});
-		client.saveSwatch.mockResolvedValue({});
+	it('runs the label write before the value write when both changed, with one onReceive and one feed refresh', async () => {
 		const order = [];
-		client.savePalette.mockImplementation(async () => {
-			order.push('savePalette');
-			return {};
-		});
-		client.saveSwatch.mockImplementation(async () => {
-			order.push('saveSwatch');
-			return {};
+		client.saveSwatch.mockImplementation(async (namespace, id) => {
+			order.push(id === DEFAULT_ID ? 'label' : 'value');
+			return listingRows();
 		});
 		const flowArgs = args({
 			draft: { label: 'Renamed', value: '#abcdef' },
@@ -290,8 +266,9 @@ describe('saveSwatchEditsFlow', () => {
 
 		await saveSwatchEditsFlow(flowArgs);
 
-		expect(order).toEqual(['savePalette', 'saveSwatch']);
-		expect(flowArgs.reload).toHaveBeenCalledTimes(1);
+		expect(order).toEqual(['label', 'value']);
+		expect(client.saveSwatch).toHaveBeenCalledTimes(2);
+		expect(flowArgs.onReceive).toHaveBeenCalledTimes(1);
 		expect(flowArgs.refreshFeed).toHaveBeenCalledTimes(1);
 	});
 
@@ -356,27 +333,24 @@ describe('openPaletteFlow', () => {
 });
 
 describe('activatePaletteFlow', () => {
-	it('sets $current, reloads, refreshes the feed pessimistically', async () => {
-		client.setCurrentPalette.mockResolvedValue({ current: 'sunset' });
-		const reload = jest.fn().mockResolvedValue(undefined);
+	it('sets $current and dispatches its own response, then refreshes the feed pessimistically', async () => {
+		client.setCurrentPalette.mockResolvedValue(listingRows({ currentId: 'sunset' }));
+		const onReceive = jest.fn();
 		const refreshFeed = jest.fn().mockResolvedValue(undefined);
 		const onBusy = jest.fn();
-		const onActivated = jest.fn();
 
 		await activatePaletteFlow({
 			namespace: NAMESPACE,
 			slug: SLUG,
 			id: 'sunset',
-			reload,
+			onReceive,
 			refreshFeed,
 			onBusy,
 			onError: jest.fn(),
-			onActivated,
 		});
 
 		expect(client.setCurrentPalette).toHaveBeenCalledWith(NAMESPACE, 'sunset', SLUG);
-		expect(onActivated).toHaveBeenCalledWith('sunset');
-		expect(reload).toHaveBeenCalled();
+		expect(onReceive).toHaveBeenCalledWith(reshapedListing({ currentId: 'sunset' }));
 		expect(refreshFeed).toHaveBeenCalledWith(SLUG);
 		expect(onBusy.mock.calls).toEqual([[true], [false]]);
 	});
@@ -392,11 +366,10 @@ describe('activatePaletteFlow', () => {
 				namespace: NAMESPACE,
 				slug: SLUG,
 				id: 'ghost',
-				reload: jest.fn(),
+				onReceive: jest.fn(),
 				refreshFeed: jest.fn(),
 				onBusy,
 				onError,
-				onActivated: jest.fn(),
 			})
 		).rejects.toBe(failure);
 
@@ -447,7 +420,7 @@ describe('createPaletteFlow', () => {
 
 	it('settles the busy flag on success so the screen leaves its loading state', async () => {
 		client.fetchPalette.mockResolvedValue(defaultView());
-		client.savePalette.mockResolvedValue({});
+		client.savePalette.mockResolvedValue(listingRows());
 		const onBusy = jest.fn();
 
 		await createPaletteFlow({
@@ -455,7 +428,7 @@ describe('createPaletteFlow', () => {
 			slug: SLUG,
 			label: 'Forest',
 			listing: { defaultId: DEFAULT_ID, palettes: [] },
-			reload: jest.fn().mockResolvedValue(undefined),
+			onReceive: jest.fn(),
 			refreshFeed: jest.fn().mockResolvedValue(undefined),
 			openPalette: jest.fn().mockResolvedValue(undefined),
 			onBusy,
@@ -467,9 +440,8 @@ describe('createPaletteFlow', () => {
 
 	it('seeds the new node from the default view, opens it, and never activates it', async () => {
 		client.fetchPalette.mockResolvedValue(defaultView());
-		client.savePalette.mockResolvedValue({});
+		client.savePalette.mockResolvedValue(listingRows());
 		const openPalette = jest.fn().mockResolvedValue(undefined);
-		const reload = jest.fn().mockResolvedValue(undefined);
 		const listing = { defaultId: DEFAULT_ID, palettes: [] };
 
 		await createPaletteFlow({
@@ -477,7 +449,7 @@ describe('createPaletteFlow', () => {
 			slug: SLUG,
 			label: 'Forest',
 			listing,
-			reload,
+			onReceive: jest.fn(),
 			refreshFeed: jest.fn().mockResolvedValue(undefined),
 			openPalette,
 			onBusy: jest.fn(),
@@ -495,12 +467,12 @@ describe('createPaletteFlow', () => {
 		expect(client.setCurrentPalette).not.toHaveBeenCalled();
 	});
 
-	it('reloads the listing before opening the new palette, so the fresh row exists first', async () => {
+	it('dispatches the fresh listing before opening the new palette, so the fresh row exists first', async () => {
 		client.fetchPalette.mockResolvedValue(defaultView());
-		client.savePalette.mockResolvedValue({});
+		client.savePalette.mockResolvedValue(listingRows());
 		const order = [];
-		const reload = jest.fn(async () => {
-			order.push('reload');
+		const onReceive = jest.fn(() => {
+			order.push('onReceive');
 		});
 		const openPalette = jest.fn(async () => {
 			order.push('openPalette');
@@ -512,23 +484,22 @@ describe('createPaletteFlow', () => {
 			slug: SLUG,
 			label: 'Forest',
 			listing,
-			reload,
+			onReceive,
 			refreshFeed: jest.fn().mockResolvedValue(undefined),
 			openPalette,
 			onBusy: jest.fn(),
 			onError: jest.fn(),
 		});
 
-		// `reload()` must land BEFORE `openPalette()`: `hooks/use-palettes.js`'s `reload()` keeps
-		// `editingId` unchanged (it still points at the previously-edited palette, which still
-		// exists), so this ordering means the listing already carries the new row by the time
-		// `editingId` moves onto it — otherwise the dropdown would render the raw id for one tick.
-		expect(order).toEqual(['reload', 'openPalette']);
+		// `onReceive` must land BEFORE `openPalette()`: the fresh listing already carries the new
+		// row by the time `editingId` moves onto it — otherwise the dropdown would render the raw id
+		// for one tick.
+		expect(order).toEqual(['onReceive', 'openPalette']);
 	});
 
 	it('refreshes the feed, so the version token a later write is checked against is not left stale', async () => {
 		client.fetchPalette.mockResolvedValue(defaultView());
-		client.savePalette.mockResolvedValue({});
+		client.savePalette.mockResolvedValue(listingRows());
 		const refreshFeed = jest.fn().mockResolvedValue(undefined);
 
 		await createPaletteFlow({
@@ -536,7 +507,7 @@ describe('createPaletteFlow', () => {
 			slug: SLUG,
 			label: 'Forest',
 			listing: { defaultId: DEFAULT_ID, palettes: [] },
-			reload: jest.fn().mockResolvedValue(undefined),
+			onReceive: jest.fn(),
 			openPalette: jest.fn().mockResolvedValue(undefined),
 			refreshFeed,
 			onBusy: jest.fn(),
@@ -553,7 +524,7 @@ describe('createPaletteFlow', () => {
 		client.fetchPalette.mockRejectedValue(failure);
 		const onBusy = jest.fn();
 		const onError = jest.fn();
-		const reload = jest.fn().mockResolvedValue(undefined);
+		const onReceive = jest.fn();
 		const listing = { defaultId: DEFAULT_ID, palettes: [] };
 
 		await expect(
@@ -562,7 +533,7 @@ describe('createPaletteFlow', () => {
 				slug: SLUG,
 				label: 'Forest',
 				listing,
-				reload,
+				onReceive,
 				openPalette: jest.fn(),
 				onBusy,
 				onError,
@@ -571,14 +542,14 @@ describe('createPaletteFlow', () => {
 
 		expect(onError).toHaveBeenCalledWith({ message: failure.message });
 		expect(onBusy).toHaveBeenLastCalledWith(false);
-		expect(reload).not.toHaveBeenCalled();
+		expect(onReceive).not.toHaveBeenCalled();
 	});
 });
 
 describe('deletePaletteFlow', () => {
 	it('deletes a palette that is not the live one without activating a successor', async () => {
-		client.deletePalette.mockResolvedValue({ $default: DEFAULT_ID, $current: DEFAULT_ID, palettes: [] });
-		const reload = jest.fn().mockResolvedValue(undefined);
+		client.deletePalette.mockResolvedValue(listingRows());
+		const onReceive = jest.fn();
 		const refreshFeed = jest.fn().mockResolvedValue(undefined);
 		const onBusy = jest.fn();
 
@@ -587,16 +558,14 @@ describe('deletePaletteFlow', () => {
 			slug: SLUG,
 			id: 'sunset',
 			currentId: DEFAULT_ID,
-			reload,
+			onReceive,
 			refreshFeed,
 			onBusy,
 			onError: jest.fn(),
 		});
 
 		expect(client.deletePalette).toHaveBeenCalledWith(NAMESPACE, 'sunset', SLUG);
-		// The flow never assumes a fallback id itself — it defers to `reload`, which re-reads the
-		// listing from the server and so always reflects the server's own fallback decision.
-		expect(reload).toHaveBeenCalled();
+		expect(onReceive).toHaveBeenCalledWith(reshapedListing());
 		expect(refreshFeed).toHaveBeenCalledWith(SLUG);
 		expect(onBusy.mock.calls).toEqual([[true], [false]]);
 		expect(client.setCurrentPalette).not.toHaveBeenCalled();
@@ -611,7 +580,7 @@ describe('deletePaletteFlow', () => {
 				slug: SLUG,
 				id: 'sunset',
 				currentId: 'sunset',
-				reload: jest.fn(),
+				onReceive: jest.fn(),
 				refreshFeed: jest.fn(),
 				onBusy: jest.fn(),
 				onError,
@@ -623,17 +592,27 @@ describe('deletePaletteFlow', () => {
 		expect(onError).toHaveBeenCalledWith({ message: expect.stringMatching(/choose which palette/i) });
 	});
 
-	it('activates the chosen successor before deleting the live palette', async () => {
+	it('activates the chosen successor before deleting the live palette, and dispatches the DELETE response, not the activation response', async () => {
 		const order = [];
 		client.setCurrentPalette.mockImplementation(() => {
 			order.push('activate');
-			return Promise.resolve({ current: 'forest' });
+			return Promise.resolve(listingRows({ currentId: 'forest' }));
 		});
+		const deleteResponse = [
+			{
+				id: DEFAULT_ID,
+				label: 'Default',
+				is_default: true,
+				is_current: false,
+				user_created: false,
+				_embedded: { self: [defaultView()] },
+			},
+		];
 		client.deletePalette.mockImplementation(() => {
 			order.push('delete');
-			return Promise.resolve({});
+			return Promise.resolve(deleteResponse);
 		});
-		const onActivated = jest.fn();
+		const onReceive = jest.fn();
 
 		await deletePaletteFlow({
 			namespace: NAMESPACE,
@@ -641,16 +620,23 @@ describe('deletePaletteFlow', () => {
 			id: 'sunset',
 			currentId: 'sunset',
 			successorId: 'forest',
-			reload: jest.fn().mockResolvedValue(undefined),
+			onReceive,
 			refreshFeed: jest.fn().mockResolvedValue(undefined),
 			onBusy: jest.fn(),
 			onError: jest.fn(),
-			onActivated,
 		});
 
 		expect(order).toEqual(['activate', 'delete']);
 		expect(client.setCurrentPalette).toHaveBeenCalledWith(NAMESPACE, 'forest', SLUG);
-		expect(onActivated).toHaveBeenCalledWith('forest');
+		// The intermediate activation response is discarded — only the FINAL write's (delete's)
+		// response is dispatched, since it is the truly fresh post-delete state.
+		expect(onReceive).toHaveBeenCalledTimes(1);
+		expect(onReceive).toHaveBeenCalledWith({
+			defaultId: DEFAULT_ID,
+			currentId: '',
+			palettes: [{ id: DEFAULT_ID, label: 'Default', groups: defaultView().groups }],
+			userCreated: [],
+		});
 	});
 
 	it('surfaces the default-palette 400 message', async () => {
@@ -663,7 +649,7 @@ describe('deletePaletteFlow', () => {
 				namespace: NAMESPACE,
 				slug: SLUG,
 				id: DEFAULT_ID,
-				reload: jest.fn(),
+				onReceive: jest.fn(),
 				refreshFeed: jest.fn(),
 				onBusy: jest.fn(),
 				onError,
@@ -685,7 +671,7 @@ describe('renamePaletteFlow', () => {
 				id: 'sunset',
 				label: '   ',
 				listing: { defaultId: DEFAULT_ID, palettes: [{ id: 'sunset', label: 'Sunset' }] },
-				reload: jest.fn(),
+				onReceive: jest.fn(),
 				refreshFeed: jest.fn().mockResolvedValue(undefined),
 				onBusy: jest.fn(),
 				onError,
@@ -713,7 +699,7 @@ describe('renamePaletteFlow', () => {
 				id: 'sunset',
 				label: 'Forest',
 				listing,
-				reload: jest.fn(),
+				onReceive: jest.fn(),
 				onBusy: jest.fn(),
 				onError,
 			})
@@ -725,8 +711,7 @@ describe('renamePaletteFlow', () => {
 
 	it('allows renaming a palette to its own current label', async () => {
 		client.fetchPalette.mockResolvedValue(selectedView());
-		client.savePalette.mockResolvedValue({});
-		const reload = jest.fn().mockResolvedValue(undefined);
+		client.savePalette.mockResolvedValue(listingRows());
 		const listing = { defaultId: DEFAULT_ID, palettes: [{ id: 'sunset', label: 'Sunset' }] };
 
 		await renamePaletteFlow({
@@ -735,7 +720,7 @@ describe('renamePaletteFlow', () => {
 			id: 'sunset',
 			label: 'Sunset',
 			listing,
-			reload,
+			onReceive: jest.fn(),
 			refreshFeed: jest.fn().mockResolvedValue(undefined),
 			onBusy: jest.fn(),
 			onError: jest.fn(),
@@ -751,7 +736,7 @@ describe('renamePaletteFlow', () => {
 
 	it('refreshes the feed, so a rename does not leave the version token stale', async () => {
 		client.fetchPalette.mockResolvedValue(selectedView());
-		client.savePalette.mockResolvedValue({});
+		client.savePalette.mockResolvedValue(listingRows());
 		const refreshFeed = jest.fn().mockResolvedValue(undefined);
 
 		await renamePaletteFlow({
@@ -760,7 +745,7 @@ describe('renamePaletteFlow', () => {
 			id: 'sunset',
 			label: 'Dusk',
 			listing: { defaultId: DEFAULT_ID, palettes: [{ id: 'sunset', label: 'Sunset' }] },
-			reload: jest.fn().mockResolvedValue(undefined),
+			onReceive: jest.fn(),
 			refreshFeed,
 			onBusy: jest.fn(),
 			onError: jest.fn(),
@@ -770,10 +755,10 @@ describe('renamePaletteFlow', () => {
 		expect(refreshFeed).toHaveBeenCalledWith(SLUG);
 	});
 
-	it('preserves the id, re-sends the palette’s own groups under the new label, and reloads the listing', async () => {
+	it('preserves the id, re-sends the palette’s own groups under the new label, and dispatches the fresh listing', async () => {
 		client.fetchPalette.mockResolvedValue(selectedView());
-		client.savePalette.mockResolvedValue({});
-		const reload = jest.fn().mockResolvedValue(undefined);
+		client.savePalette.mockResolvedValue(listingRows());
+		const onReceive = jest.fn();
 		const onBusy = jest.fn();
 		const listing = { defaultId: DEFAULT_ID, palettes: [{ id: 'sunset', label: 'Sunset' }] };
 
@@ -783,7 +768,7 @@ describe('renamePaletteFlow', () => {
 			id: 'sunset',
 			label: 'Sunset Dusk',
 			listing,
-			reload,
+			onReceive,
 			refreshFeed: jest.fn().mockResolvedValue(undefined),
 			onBusy,
 			onError: jest.fn(),
@@ -799,9 +784,7 @@ describe('renamePaletteFlow', () => {
 		expect(slugArg).toBe(SLUG);
 		expect(payload.label).toBe('Sunset Dusk');
 		expect(payload.groups).toEqual(stripEffectiveFlags(selectedView().groups));
-		expect(reload).toHaveBeenCalled();
-		// No feed refresh: a palette's label never reaches a resolved token value (see the flow's
-		// own docblock), so there is nothing for a refresh to correct.
+		expect(onReceive).toHaveBeenCalledWith(reshapedListing());
 		expect(onBusy.mock.calls).toEqual([[true], [false]]);
 	});
 
@@ -819,7 +802,7 @@ describe('renamePaletteFlow', () => {
 				id: 'sunset',
 				label: 'Sunset Dusk',
 				listing,
-				reload: jest.fn(),
+				onReceive: jest.fn(),
 				onBusy,
 				onError,
 			})
@@ -836,7 +819,7 @@ describe('removeSwatchFlow', () => {
 		slug: SLUG,
 		defaultId: DEFAULT_ID,
 		token: 'primitive.color.custom.custom-1',
-		reload: jest.fn().mockResolvedValue(undefined),
+		onReceive: jest.fn(),
 		refreshFeed: jest.fn().mockResolvedValue({ version: 'v3' }),
 		onBusy: jest.fn(),
 		onError: jest.fn(),
@@ -845,7 +828,7 @@ describe('removeSwatchFlow', () => {
 
 	beforeEach(() => {
 		client.fetchPalette.mockResolvedValue(defaultView());
-		client.savePalette.mockResolvedValue({});
+		client.savePalette.mockResolvedValue(listingRows());
 	});
 
 	it('deletes the user primitive only for a user-created token, after the palette write', async () => {
@@ -856,6 +839,7 @@ describe('removeSwatchFlow', () => {
 
 		expect(client.savePalette).toHaveBeenCalled();
 		expect(client.deleteUserPrimitive).toHaveBeenCalledWith(SLUG, 'primitive.color.custom.custom-1', 'v3');
+		expect(flowArgs.onReceive).toHaveBeenCalledWith(reshapedListing());
 	});
 
 	it('never calls deleteUserPrimitive for a baseline token', async () => {
@@ -871,7 +855,7 @@ describe('removeSwatchFlow', () => {
 		const order = [];
 		client.savePalette.mockImplementation(async () => {
 			order.push('savePalette');
-			return {};
+			return listingRows();
 		});
 		client.deleteUserPrimitive.mockImplementation(async () => {
 			order.push('deleteUserPrimitive');
@@ -879,8 +863,8 @@ describe('removeSwatchFlow', () => {
 		});
 		const flowArgs = baseArgs({
 			isUserCreated: true,
-			reload: jest.fn(async () => {
-				order.push('reload');
+			onReceive: jest.fn(() => {
+				order.push('onReceive');
 			}),
 			refreshFeed: jest.fn(async () => {
 				order.push('refreshFeed');
@@ -890,7 +874,7 @@ describe('removeSwatchFlow', () => {
 
 		await removeSwatchFlow(flowArgs);
 
-		expect(order).toEqual(['savePalette', 'reload', 'refreshFeed', 'deleteUserPrimitive', 'refreshFeed']);
+		expect(order).toEqual(['savePalette', 'onReceive', 'refreshFeed', 'deleteUserPrimitive', 'refreshFeed']);
 	});
 
 	it('resolves — does not reject — when deleteUserPrimitive fails after the row removal already succeeded, and still calls refreshFeed once more', async () => {
@@ -913,6 +897,7 @@ describe('removeSwatchFlow', () => {
 
 		expect(flowArgs.onError).toHaveBeenCalledWith({ message: failure.message });
 		expect(client.deleteUserPrimitive).not.toHaveBeenCalled();
+		expect(flowArgs.onReceive).not.toHaveBeenCalled();
 	});
 });
 
@@ -920,8 +905,8 @@ describe('addColorFlow', () => {
 	it('creates the primitive first, then appends the swatch to the default node, and resolves with the new token id', async () => {
 		client.createUserPrimitive.mockResolvedValue({ id: 'primitive.color.custom.custom-1', version: 'v2' });
 		client.fetchPalette.mockResolvedValue(defaultView());
-		client.savePalette.mockResolvedValue({});
-		const reload = jest.fn().mockResolvedValue(undefined);
+		client.savePalette.mockResolvedValue(listingRows());
+		const onReceive = jest.fn();
 		const refreshFeed = jest.fn().mockResolvedValue(undefined);
 
 		const token = await addColorFlow({
@@ -932,7 +917,7 @@ describe('addColorFlow', () => {
 			tokens: [],
 			palette: selectedView(),
 			feedVersion: 'v1',
-			reload,
+			onReceive,
 			refreshFeed,
 			onBusy: jest.fn(),
 			onError: jest.fn(),
@@ -946,6 +931,7 @@ describe('addColorFlow', () => {
 		expect(payload.groups.find((group) => group.id === 'accent').swatches).toContainEqual(
 			expect.objectContaining({ token: 'primitive.color.custom.custom-1' })
 		);
+		expect(onReceive).toHaveBeenCalledWith(reshapedListing());
 		expect(token).toBe('primitive.color.custom.custom-1');
 	});
 
@@ -963,7 +949,7 @@ describe('addColorFlow', () => {
 				tokens: [],
 				palette: selectedView(),
 				feedVersion: 'v1',
-				reload: jest.fn(),
+				onReceive: jest.fn(),
 				refreshFeed: jest.fn(),
 				onBusy: jest.fn(),
 				onError,
@@ -979,7 +965,7 @@ describe('addGroupFlow', () => {
 	it('creates the group with its first swatch in a single default write', async () => {
 		client.createUserPrimitive.mockResolvedValue({ id: 'primitive.color.custom.custom-1', version: 'v2' });
 		client.fetchPalette.mockResolvedValue(defaultView());
-		client.savePalette.mockResolvedValue({});
+		client.savePalette.mockResolvedValue(listingRows());
 
 		const token = await addGroupFlow({
 			namespace: NAMESPACE,
@@ -989,7 +975,7 @@ describe('addGroupFlow', () => {
 			palette: selectedView(),
 			tokens: [],
 			feedVersion: 'v1',
-			reload: jest.fn().mockResolvedValue(undefined),
+			onReceive: jest.fn(),
 			refreshFeed: jest.fn().mockResolvedValue(undefined),
 			onBusy: jest.fn(),
 			onError: jest.fn(),
@@ -1014,7 +1000,7 @@ describe('addGroupFlow', () => {
 				palette: selectedView(),
 				tokens: [],
 				feedVersion: 'v1',
-				reload: jest.fn(),
+				onReceive: jest.fn(),
 				refreshFeed: jest.fn(),
 				onBusy: jest.fn(),
 				onError,
@@ -1030,7 +1016,7 @@ describe('addGroupFlow', () => {
 				palette: selectedView(),
 				tokens: [],
 				feedVersion: 'v1',
-				reload: jest.fn(),
+				onReceive: jest.fn(),
 				refreshFeed: jest.fn(),
 				onBusy: jest.fn(),
 				onError,
@@ -1044,7 +1030,7 @@ describe('addGroupFlow', () => {
 describe('reorderSwatchesFlow', () => {
 	it('writes the reordered DEFAULT node regardless of the selected palette', async () => {
 		client.fetchPalette.mockResolvedValue(defaultView());
-		client.savePalette.mockResolvedValue({});
+		client.savePalette.mockResolvedValue(listingRows());
 
 		await reorderSwatchesFlow({
 			namespace: NAMESPACE,
@@ -1052,7 +1038,7 @@ describe('reorderSwatchesFlow', () => {
 			defaultId: DEFAULT_ID,
 			groupId: 'accent',
 			orderedTokens: ['primitive.color.brand.secondary', 'primitive.color.brand.primary'],
-			reload: jest.fn().mockResolvedValue(undefined),
+			onReceive: jest.fn(),
 			refreshFeed: jest.fn().mockResolvedValue(undefined),
 			onBusy: jest.fn(),
 			onError: jest.fn(),
@@ -1070,8 +1056,8 @@ describe('reorderSwatchesFlow', () => {
 describe('renameGroupFlow', () => {
 	it('fetches and saves the DEFAULT palette with the relabeled group, keeping its id', async () => {
 		client.fetchPalette.mockResolvedValue(defaultView());
-		client.savePalette.mockResolvedValue({});
-		const reload = jest.fn().mockResolvedValue(undefined);
+		client.savePalette.mockResolvedValue(listingRows());
+		const onReceive = jest.fn();
 		const refreshFeed = jest.fn().mockResolvedValue(undefined);
 
 		await renameGroupFlow({
@@ -1080,7 +1066,7 @@ describe('renameGroupFlow', () => {
 			defaultId: DEFAULT_ID,
 			groupId: 'accent',
 			label: 'Renamed Accent',
-			reload,
+			onReceive,
 			refreshFeed,
 			onBusy: jest.fn(),
 			onError: jest.fn(),
@@ -1092,7 +1078,7 @@ describe('renameGroupFlow', () => {
 		// The id-stability assertion: the saved group still carries its original id under the new
 		// label — the regression test for the `template_slot_for()` misfiling hazard.
 		expect(payload.groups.find((group) => group.label === 'Renamed Accent').id).toBe('accent');
-		expect(reload).toHaveBeenCalled();
+		expect(onReceive).toHaveBeenCalledWith(reshapedListing());
 		expect(refreshFeed).toHaveBeenCalledWith(SLUG);
 	});
 
@@ -1109,7 +1095,7 @@ describe('renameGroupFlow', () => {
 				defaultId: DEFAULT_ID,
 				groupId: 'accent',
 				label: 'Renamed Accent',
-				reload: jest.fn(),
+				onReceive: jest.fn(),
 				refreshFeed: jest.fn(),
 				onBusy,
 				onError,
@@ -1128,7 +1114,7 @@ describe('removeGroupFlow', () => {
 		defaultId: DEFAULT_ID,
 		groupId: 'accent',
 		userCreatedTokens: [],
-		reload: jest.fn().mockResolvedValue(undefined),
+		onReceive: jest.fn(),
 		refreshFeed: jest.fn().mockResolvedValue({ version: 'v3' }),
 		onBusy: jest.fn(),
 		onError: jest.fn(),
@@ -1137,7 +1123,7 @@ describe('removeGroupFlow', () => {
 
 	beforeEach(() => {
 		client.fetchPalette.mockResolvedValue(defaultView());
-		client.savePalette.mockResolvedValue({});
+		client.savePalette.mockResolvedValue(listingRows());
 	});
 
 	it('writes the group removal to the default node from a fresh read before any cleanup delete', async () => {
@@ -1145,7 +1131,7 @@ describe('removeGroupFlow', () => {
 		const order = [];
 		client.savePalette.mockImplementation(async () => {
 			order.push('savePalette');
-			return {};
+			return listingRows();
 		});
 		client.deleteUserPrimitive.mockImplementation(async () => {
 			order.push('deleteUserPrimitive');
@@ -1153,8 +1139,8 @@ describe('removeGroupFlow', () => {
 		});
 		const flowArgs = baseArgs({
 			userCreatedTokens: ['primitive.color.custom.custom-1'],
-			reload: jest.fn(async () => {
-				order.push('reload');
+			onReceive: jest.fn(() => {
+				order.push('onReceive');
 			}),
 			refreshFeed: jest.fn(async () => {
 				order.push('refreshFeed');
@@ -1164,7 +1150,7 @@ describe('removeGroupFlow', () => {
 
 		await removeGroupFlow(flowArgs);
 
-		expect(order).toEqual(['savePalette', 'reload', 'refreshFeed', 'deleteUserPrimitive', 'refreshFeed']);
+		expect(order).toEqual(['savePalette', 'onReceive', 'refreshFeed', 'deleteUserPrimitive', 'refreshFeed']);
 		expect(client.fetchPalette).toHaveBeenCalledWith(NAMESPACE, DEFAULT_ID, SLUG);
 	});
 

--- a/src/style-library/__tests__/palette-flows.test.js
+++ b/src/style-library/__tests__/palette-flows.test.js
@@ -5,7 +5,6 @@ import {
 	addGroupFlow,
 	createPaletteFlow,
 	deletePaletteFlow,
-	openPaletteFlow,
 	removeGroupFlow,
 	removeSwatchFlow,
 	renameGroupFlow,
@@ -277,51 +276,6 @@ describe('saveSwatchEditsFlow', () => {
 
 		expect(flowArgs.onError).toHaveBeenCalledWith({ message: failure.message });
 		expect(flowArgs.onBusy).toHaveBeenLastCalledWith(false);
-	});
-});
-
-describe('openPaletteFlow', () => {
-	it('fetches the effective view and calls onOpened — no write of any kind', async () => {
-		const view = selectedView();
-		client.fetchPalette.mockResolvedValue(view);
-		const onOpened = jest.fn();
-		const onBusy = jest.fn();
-
-		await openPaletteFlow({
-			namespace: NAMESPACE,
-			slug: SLUG,
-			id: 'sunset',
-			onOpened,
-			onBusy,
-			onError: jest.fn(),
-		});
-
-		expect(client.fetchPalette).toHaveBeenCalledWith(NAMESPACE, 'sunset', SLUG);
-		expect(onOpened).toHaveBeenCalledWith(view);
-		expect(client.setCurrentPalette).not.toHaveBeenCalled();
-		expect(client.savePalette).not.toHaveBeenCalled();
-		expect(onBusy.mock.calls).toEqual([[true], [false]]);
-	});
-
-	it('reports through onError and re-throws on failure', async () => {
-		const failure = new Error('That palette does not exist.');
-		client.fetchPalette.mockRejectedValue(failure);
-		const onBusy = jest.fn();
-		const onError = jest.fn();
-
-		await expect(
-			openPaletteFlow({
-				namespace: NAMESPACE,
-				slug: SLUG,
-				id: 'ghost',
-				onOpened: jest.fn(),
-				onBusy,
-				onError,
-			})
-		).rejects.toBe(failure);
-
-		expect(onError).toHaveBeenCalledWith({ message: failure.message });
-		expect(onBusy.mock.calls).toEqual([[true], [false]]);
 	});
 });
 

--- a/src/style-library/__tests__/palette-flows.test.js
+++ b/src/style-library/__tests__/palette-flows.test.js
@@ -241,7 +241,7 @@ describe('saveSwatchEditsFlow', () => {
 			NAMESPACE,
 			'sunset',
 			'primitive.color.brand.primary',
-			'#abcdef',
+			{ value: '#abcdef' },
 			SLUG
 		);
 		expect(client.fetchPalette).not.toHaveBeenCalled();

--- a/src/style-library/__tests__/palettes.test.js
+++ b/src/style-library/__tests__/palettes.test.js
@@ -18,6 +18,7 @@ import {
 	renameGroupInGroups,
 	renameSwatchInGroups,
 	reorderGroupSwatches,
+	reshapePaletteRows,
 	resolveEditingPaletteId,
 	slugifyPaletteLabel,
 	stripEffectiveFlags,
@@ -44,6 +45,50 @@ const effectivePalette = () => ({
 			],
 		},
 	],
+});
+
+describe('reshapePaletteRows', () => {
+	it('reshapes flat is_default/is_current/user_created flags into defaultId/currentId/userCreated pointers', () => {
+		const rows = [
+			{
+				id: 'default',
+				label: 'Default',
+				is_default: true,
+				is_current: false,
+				user_created: false,
+				_embedded: { self: [{ groups: [{ id: 'accent', label: 'Accent', swatches: [] }] }] },
+			},
+			{
+				id: 'brand-b',
+				label: 'Brand B',
+				is_default: false,
+				is_current: true,
+				user_created: true,
+				_embedded: { self: [{ groups: [] }] },
+			},
+		];
+
+		expect(reshapePaletteRows(rows)).toEqual({
+			defaultId: 'default',
+			currentId: 'brand-b',
+			palettes: [
+				{ id: 'default', label: 'Default', groups: [{ id: 'accent', label: 'Accent', swatches: [] }] },
+				{ id: 'brand-b', label: 'Brand B', groups: [] },
+			],
+			userCreated: ['brand-b'],
+		});
+	});
+
+	it('defaults defaultId/currentId to an empty string and groups to [] when a row carries neither flag nor an embedded view', () => {
+		const rows = [{ id: 'default', label: 'Default', is_default: false, is_current: false, user_created: false }];
+
+		expect(reshapePaletteRows(rows)).toEqual({
+			defaultId: '',
+			currentId: '',
+			palettes: [{ id: 'default', label: 'Default', groups: [] }],
+			userCreated: [],
+		});
+	});
 });
 
 describe('mapPaletteToSwatchGroups', () => {

--- a/src/style-library/__tests__/use-palettes.test.js
+++ b/src/style-library/__tests__/use-palettes.test.js
@@ -1,0 +1,401 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * WordPress dependencies
+ */
+import { RegistryProvider } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { usePalettes } from '../hooks/use-palettes';
+import * as client from '../api/client';
+import { createTestRegistry } from '../store/test-utils';
+
+// A factory, not bare automocking: the real module imports `@wordpress/api-fetch`, which is
+// externalized to the `wp.apiFetch` global in production and is not installed as an npm
+// dependency, so automocking (which loads the real module to introspect its shape) would fail to
+// resolve it.
+jest.mock('../api/client', () => ({
+	createUserPrimitive: jest.fn(),
+	deletePalette: jest.fn(),
+	deleteUserPrimitive: jest.fn(),
+	fetchPalette: jest.fn(),
+	fetchPalettes: jest.fn(),
+	savePalette: jest.fn(),
+	saveSwatch: jest.fn(),
+	setCurrentPalette: jest.fn(),
+}));
+
+const NAMESPACE = 'kb-design-tokens/v1';
+const SLUG = 'default';
+const DEFAULT_ID = 'default';
+const SUNSET_ID = 'sunset';
+
+const FEED = { slug: SLUG, version: 'v1', rest: { namespace: NAMESPACE }, schema: {} };
+
+const defaultView = () => ({
+	id: DEFAULT_ID,
+	label: 'Default',
+	groups: [
+		{
+			id: 'accent',
+			label: 'Accent',
+			swatches: [
+				{ token: 'primitive.color.brand.primary', label: 'Main 1', $value: '#111111', overridden: false },
+				{ token: 'primitive.color.brand.secondary', label: 'Main 2', $value: '#222222', overridden: false },
+			],
+		},
+	],
+});
+
+const selectedView = () => ({
+	id: SUNSET_ID,
+	label: 'Sunset',
+	groups: [
+		{
+			id: 'accent',
+			label: 'Accent',
+			swatches: [
+				{ token: 'primitive.color.brand.primary', label: 'Main 1', $value: '#999999', overridden: true },
+				{ token: 'primitive.color.brand.secondary', label: 'Main 2', $value: '#222222', overridden: false },
+			],
+		},
+	],
+});
+
+// The wire shape `getPaletteListing`'s resolver dispatches and every write's own response carries:
+// a flat, fully embedded palette listing. Mirrors `palette-flows.test.js`'s identical fixture.
+const listingRows = (overrides = {}) => [
+	{
+		id: DEFAULT_ID,
+		label: 'Default',
+		is_default: true,
+		is_current: overrides.currentId ? overrides.currentId === DEFAULT_ID : true,
+		user_created: false,
+		_embedded: { self: [overrides.defaultView ? overrides.defaultView() : defaultView()] },
+	},
+	{
+		id: SUNSET_ID,
+		label: 'Sunset',
+		is_default: false,
+		is_current: overrides.currentId === SUNSET_ID,
+		user_created: false,
+		_embedded: { self: [selectedView()] },
+	},
+];
+
+describe('usePalettes', () => {
+	let container;
+	let root;
+	let registry;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		// Fakes `setTimeout`/`setInterval`/`clearTimeout`, so `flushUntil()` below can advance
+		// `@wordpress/data`'s resolver dispatch deterministically instead of racing a real OS timer
+		// tick against whatever else is contending for the CPU. `Date`/`performance` are excluded:
+		// React's own scheduler uses those to make time-slicing decisions, and freezing them (Jest's
+		// default) leaves it unable to ever decide enough time has passed to flush a commit, hanging
+		// real writes that depend on a state update actually landing.
+		jest.useFakeTimers({ doNotFake: ['Date', 'performance', 'queueMicrotask', 'nextTick'] });
+		registry = createTestRegistry();
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		delete global.IS_REACT_ACT_ENVIRONMENT;
+		jest.useRealTimers();
+	});
+
+	// `@wordpress/data`'s resolver dispatch runs off a `setTimeout(fn, 0)` inside the store — a real
+	// timer callback a plain `await act(async () => ...)` does not wait for. `runOnlyPendingTimersAsync`
+	// fires whatever resolver dispatch is currently pending and lets the promise chain it kicks off
+	// drain via the real microtask queue before returning.
+	function flushResolvers() {
+		return act(() => jest.runOnlyPendingTimersAsync());
+	}
+
+	// Bounded by an attempt count, not a wall-clock deadline — fake timers make every hop
+	// deterministic, so this is a fixed number of resolver hops to wait out.
+	async function flushUntil(predicate, maxAttempts = 10) {
+		for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+			await flushResolvers();
+			if (predicate()) {
+				return;
+			}
+		}
+		throw new Error('flushUntil: condition never became true');
+	}
+
+	function mountProbe() {
+		let latest = null;
+
+		function Probe({ feed, refreshFeed, route, navigate }) {
+			latest = usePalettes(feed, refreshFeed, route, navigate);
+			return null;
+		}
+
+		return {
+			render: async ({
+				feed = FEED,
+				refreshFeed = jest.fn().mockResolvedValue(undefined),
+				route = { scope: '' },
+				navigate = jest.fn(),
+			} = {}) => {
+				await act(() =>
+					root.render(
+						<RegistryProvider value={registry}>
+							<Probe feed={feed} refreshFeed={refreshFeed} route={route} navigate={navigate} />
+						</RegistryProvider>
+					)
+				);
+				await flushUntil(() => !latest.isLoading);
+
+				return { refreshFeed, navigate };
+			},
+			latest: () => latest,
+		};
+	}
+
+	it('resolves the listing and derives the edited palette for the $current id', async () => {
+		client.fetchPalettes.mockResolvedValueOnce(listingRows());
+
+		const probe = mountProbe();
+		await probe.render();
+
+		expect(probe.latest().activeId).toBe(DEFAULT_ID);
+		expect(probe.latest().editingId).toBe(DEFAULT_ID);
+		expect(probe.latest().palette).toMatchObject({ id: DEFAULT_ID, label: 'Default' });
+		expect(probe.latest().palette.groups[0].swatches[0].$value).toBe('#111111');
+	});
+
+	it('surfaces a getPaletteListing resolution failure through openError', async () => {
+		client.fetchPalettes.mockRejectedValueOnce(new Error('Something broke'));
+
+		const probe = mountProbe();
+		await probe.render();
+
+		expect(probe.latest().openError).toEqual({ message: 'Something broke' });
+	});
+
+	it('activatePalette dispatches the write response via onReceive, moving activeId and palette together', async () => {
+		client.fetchPalettes.mockResolvedValueOnce(listingRows());
+		client.setCurrentPalette.mockResolvedValueOnce(listingRows({ currentId: SUNSET_ID }));
+
+		const probe = mountProbe();
+		const { refreshFeed } = await probe.render();
+
+		expect(probe.latest().activeId).toBe(DEFAULT_ID);
+
+		await act(async () => probe.latest().activatePalette(SUNSET_ID));
+
+		expect(client.setCurrentPalette).toHaveBeenCalledWith(NAMESPACE, SUNSET_ID, SLUG);
+		expect(refreshFeed).toHaveBeenCalledWith(SLUG);
+		expect(probe.latest().activeId).toBe(SUNSET_ID);
+		// The route's scope is still '' in this test (navigate is mocked, not wired to a real route),
+		// so editingId keeps tracking $current — the same palette activatePalette just moved.
+		expect(probe.latest().palette).toMatchObject({ id: SUNSET_ID });
+	});
+
+	it('createPalette dispatches the new listing via onReceive before navigating to the new palette', async () => {
+		client.fetchPalettes.mockResolvedValueOnce(listingRows());
+		client.fetchPalette.mockResolvedValueOnce(defaultView());
+
+		const createdRows = [
+			...listingRows(),
+			{
+				id: 'brand',
+				label: 'Brand',
+				is_default: false,
+				is_current: false,
+				user_created: true,
+				_embedded: { self: [{ id: 'brand', label: 'Brand', groups: defaultView().groups }] },
+			},
+		];
+		client.savePalette.mockResolvedValueOnce(createdRows);
+
+		const probe = mountProbe();
+		const { navigate } = await probe.render();
+
+		await act(async () => probe.latest().createPalette('Brand'));
+
+		expect(client.savePalette).toHaveBeenCalledWith(
+			NAMESPACE,
+			'brand',
+			expect.objectContaining({ label: 'Brand' }),
+			SLUG
+		);
+		expect(navigate).toHaveBeenCalledWith({ scope: 'brand', item: '' });
+		expect(probe.latest().listing.palettes.map((row) => row.id)).toEqual(
+			expect.arrayContaining(['default', 'sunset', 'brand'])
+		);
+	});
+
+	it('removePalette dispatches the post-delete listing via onReceive, dropping the removed row', async () => {
+		client.fetchPalettes.mockResolvedValueOnce(listingRows());
+		client.deletePalette.mockResolvedValueOnce([listingRows()[0]]);
+
+		const probe = mountProbe();
+		await probe.render();
+
+		expect(probe.latest().listing.palettes).toHaveLength(2);
+
+		await act(async () => probe.latest().deletePalette(SUNSET_ID));
+
+		expect(client.deletePalette).toHaveBeenCalledWith(NAMESPACE, SUNSET_ID, SLUG);
+		expect(probe.latest().listing.palettes.map((row) => row.id)).toEqual([DEFAULT_ID]);
+	});
+
+	it('saveSwatchEdits dispatches the recolored view via onReceive, updating the edited palette', async () => {
+		client.fetchPalettes.mockResolvedValueOnce(listingRows());
+
+		const recoloredRows = listingRows({
+			defaultView: () => ({
+				...defaultView(),
+				groups: [
+					{
+						...defaultView().groups[0],
+						swatches: [
+							{ ...defaultView().groups[0].swatches[0], $value: '#abcabc' },
+							defaultView().groups[0].swatches[1],
+						],
+					},
+				],
+			}),
+		});
+		client.saveSwatch.mockResolvedValueOnce(recoloredRows);
+
+		const probe = mountProbe();
+		await probe.render();
+
+		await act(async () =>
+			probe
+				.latest()
+				.saveSwatchEdits(
+					'primitive.color.brand.primary',
+					{ label: 'Main 1', value: '#abcabc' },
+					{ label: 'Main 1', value: '#111111' }
+				)
+		);
+
+		expect(client.saveSwatch).toHaveBeenCalledWith(
+			NAMESPACE,
+			DEFAULT_ID,
+			'primitive.color.brand.primary',
+			{ value: '#abcabc' },
+			SLUG
+		);
+		expect(probe.latest().palette.groups[0].swatches[0].$value).toBe('#abcabc');
+	});
+
+	it('reorderSwatches applies the new order optimistically, then keeps it once the write resolves', async () => {
+		client.fetchPalettes.mockResolvedValueOnce(listingRows());
+		client.fetchPalette.mockResolvedValueOnce(defaultView());
+
+		const reorderedRows = listingRows({
+			defaultView: () => ({
+				...defaultView(),
+				groups: [
+					{
+						...defaultView().groups[0],
+						swatches: [...defaultView().groups[0].swatches].reverse(),
+					},
+				],
+			}),
+		});
+		client.savePalette.mockResolvedValueOnce(reorderedRows);
+
+		const probe = mountProbe();
+		await probe.render();
+
+		const originalOrder = probe.latest().palette.groups[0].swatches.map((s) => s.token);
+		const newOrder = [...originalOrder].reverse();
+
+		let writePromise;
+		act(() => {
+			writePromise = probe.latest().reorderSwatches('accent', newOrder);
+		});
+
+		// Applied immediately, before the write settles.
+		expect(probe.latest().palette.groups[0].swatches.map((s) => s.token)).toEqual(newOrder);
+
+		await act(async () => writePromise);
+
+		expect(client.savePalette).toHaveBeenCalled();
+		expect(probe.latest().palette.groups[0].swatches.map((s) => s.token)).toEqual(newOrder);
+		expect(probe.latest().structureError).toBeNull();
+	});
+
+	it('reorderSwatches rolls back the optimistic order when the write fails', async () => {
+		client.fetchPalettes.mockResolvedValueOnce(listingRows());
+		client.fetchPalette.mockResolvedValueOnce(defaultView());
+		client.savePalette.mockRejectedValueOnce(new Error('Conflict'));
+
+		const probe = mountProbe();
+		await probe.render();
+
+		const originalOrder = probe.latest().palette.groups[0].swatches.map((s) => s.token);
+		const newOrder = [...originalOrder].reverse();
+
+		let writePromise;
+		act(() => {
+			writePromise = probe
+				.latest()
+				.reorderSwatches('accent', newOrder)
+				.catch(() => {});
+		});
+
+		expect(probe.latest().palette.groups[0].swatches.map((s) => s.token)).toEqual(newOrder);
+
+		await act(async () => writePromise);
+
+		expect(probe.latest().palette.groups[0].swatches.map((s) => s.token)).toEqual(originalOrder);
+		expect(probe.latest().structureError).toEqual({ message: 'Conflict' });
+	});
+
+	it('two mounted instances (a screen and its settings panel) share one listing fetch and stay in sync', async () => {
+		client.fetchPalettes.mockResolvedValueOnce(listingRows());
+		client.setCurrentPalette.mockResolvedValueOnce(listingRows({ currentId: SUNSET_ID }));
+
+		let latestA = null;
+		let latestB = null;
+		const refreshFeed = jest.fn().mockResolvedValue(undefined);
+
+		function ProbeA() {
+			latestA = usePalettes(FEED, refreshFeed, { scope: '' }, jest.fn());
+			return null;
+		}
+		function ProbeB() {
+			latestB = usePalettes(FEED, refreshFeed, { scope: '' }, jest.fn());
+			return null;
+		}
+
+		await act(async () =>
+			root.render(
+				<RegistryProvider value={registry}>
+					<ProbeA />
+					<ProbeB />
+				</RegistryProvider>
+			)
+		);
+		await flushUntil(() => !latestA.isLoading && !latestB.isLoading);
+
+		expect(client.fetchPalettes).toHaveBeenCalledTimes(1);
+
+		await act(async () => latestA.activatePalette(SUNSET_ID));
+
+		expect(latestA.activeId).toBe(SUNSET_ID);
+		expect(latestB.activeId).toBe(SUNSET_ID);
+	});
+});

--- a/src/style-library/__tests__/use-palettes.test.js
+++ b/src/style-library/__tests__/use-palettes.test.js
@@ -180,6 +180,32 @@ describe('usePalettes', () => {
 		expect(probe.latest().palette.groups[0].swatches[0].$value).toBe('#111111');
 	});
 
+	it('isLoading is already true on the very first render, before the resolver dispatch has fired', async () => {
+		client.fetchPalettes.mockResolvedValueOnce(listingRows());
+
+		let latest = null;
+
+		function Probe({ feed, route, navigate }) {
+			latest = usePalettes(feed, jest.fn().mockResolvedValue(undefined), route, navigate);
+			return null;
+		}
+
+		// `@wordpress/data`'s resolver dispatch is scheduled via `setTimeout(fn, 0)`, so this render
+		// happens strictly before that dispatch fires — `isResolving` would still read `false` here,
+		// which is exactly the one-frame "not loading" flash `hasFinishedResolution` must avoid.
+		await act(() =>
+			root.render(
+				<RegistryProvider value={registry}>
+					<Probe feed={FEED} route={{ scope: '' }} navigate={jest.fn()} />
+				</RegistryProvider>
+			)
+		);
+
+		expect(latest.isLoading).toBe(true);
+
+		await flushUntil(() => !latest.isLoading);
+	});
+
 	it('surfaces a getPaletteListing resolution failure through openError', async () => {
 		client.fetchPalettes.mockRejectedValueOnce(new Error('Something broke'));
 

--- a/src/style-library/api/client.js
+++ b/src/style-library/api/client.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -127,16 +128,17 @@ export function setGroupOrder(slug, group, payload) {
 }
 
 /**
- * Fetch the set's color palettes and its `$default` / `$current` pointers.
+ * Fetch the library's palettes: a flat row per palette carrying its id, label, and `is_default` /
+ * `is_current` / `user_created` flags, each embedded (via `_embed`) with its full group/swatch data.
  *
  * @since TBD
  *
  * @param {string} namespace REST namespace.
  * @param {string} slug      Token set slug.
- * @return {Promise<{ '$default': string, '$current': string, palettes: object[] }>} Palette listing.
+ * @return {Promise<object[]>} Flat, fully embedded palette listing.
  */
 export function fetchPalettes(namespace, slug) {
-	return apiFetch({ path: palettesPath(namespace, slug) });
+	return apiFetch({ path: addQueryArgs(palettesPath(namespace, slug), { _embed: true }) });
 }
 
 /**
@@ -191,23 +193,34 @@ export function savePalette(namespace, id, payload, slug) {
 }
 
 /**
- * Set a single palette swatch (the granular per-token write): only this token is sent, and the palette's
- * other swatches are untouched. A token the palette does not set falls back to the default palette.
+ * Set one or both fields of a single palette swatch (the granular per-token write): only the sent
+ * fields are changed, the palette's other swatches are untouched. `label` is only valid when `id`
+ * is the library's default palette — the server rejects it otherwise.
  *
  * @since TBD
  *
  * @param {string} namespace REST namespace.
  * @param {string} id        The palette id.
  * @param {string} token     The swatch token dot-path.
- * @param {string} value     The color value (a literal color or a {dot.path} alias).
+ * @param {{value?: string, label?: string}} fields At least one of `value`/`label`.
  * @param {string} slug      Token set slug.
- * @return {Promise<object>} The updated palette listing.
+ * @return {Promise<object>} The fresh, fully embedded palette listing.
  */
-export function saveSwatch(namespace, id, token, value, slug) {
+export function saveSwatch(namespace, id, token, fields, slug) {
+	const data = {};
+
+	if (fields.value !== undefined) {
+		data.$value = fields.value;
+	}
+
+	if (fields.label !== undefined) {
+		data.label = fields.label;
+	}
+
 	return apiFetch({
 		path: paletteSwatchPath(namespace, id, token, slug),
 		method: 'PUT',
-		data: { $value: value },
+		data,
 	});
 }
 

--- a/src/style-library/api/client.js
+++ b/src/style-library/api/client.js
@@ -131,10 +131,11 @@ export function setGroupOrder(slug, group, payload) {
  * Fetch the library's palettes: a flat row per palette carrying its id, label, and `is_default` /
  * `is_current` / `user_created` flags, each embedded (via `_embed`) with its full group/swatch data.
  *
- * @since TBD
- *
  * @param {string} namespace REST namespace.
  * @param {string} slug      Token set slug.
+ *
+ * @since TBD
+ *
  * @return {Promise<object[]>} Flat, fully embedded palette listing.
  */
 export function fetchPalettes(namespace, slug) {
@@ -163,7 +164,7 @@ export function fetchPalette(namespace, id, slug) {
  * @param {string} namespace REST namespace.
  * @param {string} id        The palette id to make current.
  * @param {string} slug      Token set slug.
- * @return {Promise<{ current: string }>} The resolved current palette.
+ * @return {Promise<Array<{ id: string, label: string, is_default: boolean, is_current: boolean, user_created: boolean, _embedded: object }>>} The fresh, fully embedded palette listing.
  */
 export function setCurrentPalette(namespace, id, slug) {
 	return apiFetch({
@@ -197,13 +198,14 @@ export function savePalette(namespace, id, payload, slug) {
  * fields are changed, the palette's other swatches are untouched. `label` is only valid when `id`
  * is the library's default palette — the server rejects it otherwise.
  *
- * @since TBD
- *
  * @param {string} namespace REST namespace.
  * @param {string} id        The palette id.
  * @param {string} token     The swatch token dot-path.
  * @param {{value?: string, label?: string}} fields At least one of `value`/`label`.
  * @param {string} slug      Token set slug.
+ *
+ * @since TBD
+ *
  * @return {Promise<object>} The fresh, fully embedded palette listing.
  */
 export function saveSwatch(namespace, id, token, fields, slug) {

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -162,7 +162,8 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 				value: row.id,
 				label: paletteDisplayLabel(row),
 				// The Active badge tracks `$current` independently of which row is being edited —
-				// opening a palette never moves it (see `openPaletteFlow`).
+				// opening a palette never moves it (`usePalettes().openPalette` is a pure
+				// navigation that only writes the route's `scope`).
 				badges:
 					row.id === palettes.activeId ? [{ text: __('Active', 'kadence-blocks'), variant: 'state' }] : [],
 			})),
@@ -195,7 +196,8 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 							options={options}
 							// Opens the palette for viewing only — never writes `$current`. A future reader who
 							// "fixes" this to also activate would silently re-tint the live site every time
-							// someone merely looks at a different palette; see `openPaletteFlow`'s own docblock.
+							// someone merely looks at a different palette; see `usePalettes().openPalette`'s
+							// own comment in `hooks/use-palettes.js`.
 							onChange={(id) => palettes.openPalette(id).catch(() => {})}
 							isBusy={palettes.isBusy}
 							isLoading={palettes.isLoading}
@@ -273,7 +275,12 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 						groups={gridGroups}
 						selectedId={route.item}
 						onSelect={(token) => navigate({ item: token })}
-						onReorder={(groupId, orderedTokens) => palettes.reorderSwatches(groupId, orderedTokens)}
+						onReorder={(groupId, orderedTokens) =>
+							palettes
+								.reorderSwatches(groupId, orderedTokens)
+								// Swallowed: a failure already lands in `structureError`, rendered above.
+								.catch(() => {})
+						}
 						onAdd={(groupId) =>
 							palettes
 								.addColor(groupId)

--- a/src/style-library/components/pages/ColorPaletteSettings.js
+++ b/src/style-library/components/pages/ColorPaletteSettings.js
@@ -97,10 +97,11 @@ export function ColorPaletteSettings({ route, navigate, library }) {
 	// closure is the PRE-save values, so calling it would silently revert the panel to what the
 	// user just replaced (confirmed: the write itself lands correctly; only the UI would regress).
 	// Leaving the draft alone is enough: it already holds exactly what was saved, so the picker
-	// keeps showing it, and once `saveSwatchEdits`'s `reload()` refreshes `palettes.palette`, the
-	// next render's `initialValues` recomputes to the same values, `computeIsDirty` sees them as
-	// equal, and the Save button disables itself — no reset step required. On failure the draft
-	// (and the Save button) simply survive, which is what we want anyway.
+	// keeps showing it, and once `saveSwatchEdits`'s write dispatches its own response into the
+	// store (`onReceive`, no follow-up fetch), `palettes.palette` recomputes from the fresh
+	// listing, the next render's `initialValues` recomputes to the same values, `computeIsDirty`
+	// sees them as equal, and the Save button disables itself — no reset step required. On failure
+	// the draft (and the Save button) simply survive, which is what we want anyway.
 	const onSave = () => palettes.saveSwatchEdits(token, panel.draft, initialValues).catch(() => {});
 
 	return (

--- a/src/style-library/helpers/palette-flows.js
+++ b/src/style-library/helpers/palette-flows.js
@@ -187,7 +187,7 @@ export function saveSwatchEditsFlow({
 	}
 
 	if (recolored) {
-		chain = chain.then(() => saveSwatch(namespace, editingId, token, draft.value, slug));
+		chain = chain.then(() => saveSwatch(namespace, editingId, token, { value: draft.value }, slug));
 	}
 
 	return chain

--- a/src/style-library/helpers/palette-flows.js
+++ b/src/style-library/helpers/palette-flows.js
@@ -5,11 +5,14 @@
  * exercised directly in tests without rendering a component — a flow takes the REST calls it needs
  * (imported here, so a test mocks `api/client`) plus a small set of injected callbacks for the
  * state a caller reacts to (busy, a scoped error slot, and an `onReceive`/`refreshFeed` pair the
- * hook provides). Every write's own response is the same flat embedded-array listing shape a
- * `GET /palettes?_embed` would return, so a flow reshapes it (via `reshapePaletteRows`, shared with
- * `store/selectors.js`'s `getPaletteListing`) and hands it straight to `onReceive` — no follow-up
- * fetch is needed to learn the fresh state. Every flow settles pessimistically and re-throws on
- * failure so its caller (a modal, or the settings panel) can tell success from failure; none
+ * hook provides). Every write's own response is the same flat embedded-array wire shape a
+ * `GET /palettes?_embed` would return, so a flow hands it straight to `onReceive` RAW, with no
+ * reshaping and no follow-up fetch needed to learn the fresh state. Reshaping only ever happens in
+ * one place, `store/selectors.js`'s `getPaletteListing` (via its exported `reshapePaletteRows`), the
+ * same as for a resolver-driven GET; a flow reshaping its own response before dispatch would let a write's
+ * dispatched shape drift from a GET's, leaving the store holding two different shapes under the
+ * same key depending on which path last wrote it. Every flow settles pessimistically and re-throws
+ * on failure so its caller (a modal, or the settings panel) can tell success from failure; none
  * reloads the page.
  *
  * `writeDefaultPaletteFlow` is the single place the default-vs-edited write routing (a palette's
@@ -44,7 +47,6 @@ import {
 	setCurrentPalette,
 } from '../api/client';
 import { errorMessage } from './library-flows';
-import { reshapePaletteRows } from '../store';
 import {
 	addGroupToGroups,
 	addSwatchToGroups,
@@ -76,8 +78,8 @@ import {
  * @param {string}   args.slug         The token library slug.
  * @param {string}   args.defaultId    The listing's `$default` palette id.
  * @param {Function} args.edit         Pure `(groups) => groups` transform (from `./palettes`).
- * @param {Function} args.onReceive    Called with the write's own response, reshaped into the
- *                                     internal listing shape, once the write succeeds.
+ * @param {Function} args.onReceive    Called with the write's own raw response (the flat
+ *                                     embedded-array wire rows), once the write succeeds.
  * @param {Function} args.refreshFeed  Replaces the feed for a slug.
  * @param {Function} args.onBusy       Called with a boolean as the chain starts and settles.
  * @param {Function} args.onError      Called with `{ message }` on failure.
@@ -96,7 +98,7 @@ export function writeDefaultPaletteFlow({ namespace, slug, defaultId, edit, onRe
 
 			return savePalette(namespace, defaultId, { label: view.label, groups }, slug);
 		})
-		.then((rows) => onReceive(reshapePaletteRows(rows)))
+		.then((rows) => onReceive(rows))
 		.then(() => refreshFeed(slug))
 		.then(() => onBusy(false))
 		.catch((err) => {
@@ -126,8 +128,8 @@ export function writeDefaultPaletteFlow({ namespace, slug, defaultId, edit, onRe
  * @param {string}   args.token       The swatch token dot-path being edited.
  * @param {Object}   args.draft       The panel's draft values, `{ label, value }`.
  * @param {Object}   args.initial     The values the panel opened with, `{ label, value }`.
- * @param {Function} args.onReceive   Called with the last dirty write's own response, reshaped into
- *                                    the internal listing shape, once every dirty write succeeds.
+ * @param {Function} args.onReceive   Called with the last dirty write's own raw response (the flat
+ *                                    embedded-array wire rows), once every dirty write succeeds.
  * @param {Function} args.refreshFeed Replaces the feed for a slug.
  * @param {Function} args.onBusy      Called with a boolean as the chain starts and settles.
  * @param {Function} args.onError     Called with `{ message }` on failure.
@@ -171,7 +173,7 @@ export function saveSwatchEditsFlow({
 	}
 
 	return chain
-		.then((rows) => onReceive(reshapePaletteRows(rows)))
+		.then((rows) => onReceive(rows))
 		.then(() => refreshFeed(slug))
 		.then(() => onBusy(false))
 		.catch((err) => {
@@ -241,8 +243,8 @@ export function openPaletteFlow({ namespace, slug, id, onOpened, onBusy, onError
  * @param {string}   args.namespace   The REST namespace.
  * @param {string}   args.slug        The token library slug.
  * @param {string}   args.id          The palette id to make current.
- * @param {Function} args.onReceive   Called with the write's own response, reshaped into the
- *                                    internal listing shape — carrying the activated palette
+ * @param {Function} args.onReceive   Called with the write's own raw response (the flat
+ *                                    embedded-array wire rows) — carrying the activated palette
  *                                    already flagged `is_current`, so no separate confirmation
  *                                    step is needed to learn which id the server resolved.
  * @param {Function} args.refreshFeed Replaces the feed for a slug.
@@ -258,7 +260,7 @@ export function activatePaletteFlow({ namespace, slug, id, onReceive, refreshFee
 	onBusy(true);
 
 	return setCurrentPalette(namespace, id, slug)
-		.then((rows) => onReceive(reshapePaletteRows(rows)))
+		.then((rows) => onReceive(rows))
 		.then(() => refreshFeed(slug))
 		.then(() => onBusy(false))
 		.catch((err) => {
@@ -286,10 +288,10 @@ export function activatePaletteFlow({ namespace, slug, id, onReceive, refreshFee
  * @param {string}   args.label       The typed palette label.
  * @param {Object}   args.listing     The current listing (`{ defaultId, palettes }`), for the
  *                                    duplicate-id check.
- * @param {Function} args.onReceive   Called with the write's own response, reshaped into the
- *                                    internal listing shape — run BEFORE `openPalette` so the fresh
- *                                    listing already carries the new row by the time `editingId`
- *                                    moves onto it (see the ordering note below).
+ * @param {Function} args.onReceive   Called with the write's own raw response (the flat
+ *                                    embedded-array wire rows) — run BEFORE `openPalette` so the
+ *                                    fresh listing already carries the new row by the time
+ *                                    `editingId` moves onto it (see the ordering note below).
  * @param {Function} args.openPalette Opens a palette for editing (typically `openPaletteFlow`
  *                                    bound to the new id).
  * @param {Function} args.refreshFeed Replaces the feed for a slug. Required even though a new
@@ -344,7 +346,7 @@ export function createPaletteFlow({
 			// listing already populated, and the dropdown can resolve its label and render it as a real
 			// option instead of falling back to the raw id. Running it after `openPalette` instead would
 			// leave the dropdown showing the new, still-missing-from-the-list id for one render.
-			.then((rows) => refreshFeed(slug).then(() => onReceive(reshapePaletteRows(rows))))
+			.then((rows) => refreshFeed(slug).then(() => onReceive(rows)))
 			.then(() => openPalette(id))
 			.then(() => onBusy(false))
 			.catch((err) => {
@@ -371,10 +373,9 @@ export function createPaletteFlow({
  *                                    successor is required at all.
  * @param {string}   [args.successorId] The palette to make current first. Required only when
  *                                    deleting the current palette.
- * @param {Function} args.onReceive   Called with the FINAL write's own response (the delete's, not
- *                                    the successor activation's — the activation's response would
- *                                    already be stale by the time the delete completes), reshaped
- *                                    into the internal listing shape.
+ * @param {Function} args.onReceive   Called with the FINAL write's own raw response (the delete's,
+ *                                    not the successor activation's — the activation's response
+ *                                    would already be stale by the time the delete completes).
  * @param {Function} args.refreshFeed Replaces the feed for a slug.
  * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
  * @param {Function} args.onError     Called with `{ message }` on failure.
@@ -410,7 +411,7 @@ export function deletePaletteFlow({
 
 	return activation
 		.then(() => deletePalette(namespace, id, slug))
-		.then((rows) => onReceive(reshapePaletteRows(rows)))
+		.then((rows) => onReceive(rows))
 		.then(() => refreshFeed(slug))
 		.then(() => onBusy(false))
 		.catch((err) => {
@@ -449,9 +450,9 @@ export function deletePaletteFlow({
  * @param {string}   args.id        The palette id to rename — unchanged by this flow.
  * @param {string}   args.label     The typed label.
  * @param {Object}   args.listing   The current listing (`{ palettes }`), for the duplicate-label check.
- * @param {Function} args.onReceive   Called with the write's own response, reshaped into the
- *                                    internal listing shape, so the dropdown's label updates
- *                                    immediately.
+ * @param {Function} args.onReceive   Called with the write's own raw response (the flat
+ *                                    embedded-array wire rows), so the dropdown's label
+ *                                    updates immediately.
  * @param {Function} args.refreshFeed Replaces the feed for a slug, so its version token matches the
  *                                    document this write just bumped.
  * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
@@ -482,7 +483,7 @@ export function renamePaletteFlow({ namespace, slug, id, label, listing, onRecei
 
 	return fetchPalette(namespace, id, slug)
 		.then((view) => savePalette(namespace, id, { label: trimmed, groups: stripEffectiveFlags(view.groups) }, slug))
-		.then((rows) => refreshFeed(slug).then(() => onReceive(reshapePaletteRows(rows))))
+		.then((rows) => refreshFeed(slug).then(() => onReceive(rows)))
 		.then(() => onBusy(false))
 		.catch((err) => {
 			onError({ message: errorMessage(err) });
@@ -500,8 +501,8 @@ export function renamePaletteFlow({ namespace, slug, id, label, listing, onRecei
  * @param {string}   args.defaultId   The listing's `$default` palette id.
  * @param {string}   args.token       The swatch token dot-path to rename.
  * @param {string}   args.label       The new label.
- * @param {Function} args.onReceive   Called with the write's own response, reshaped into the
- *                                    internal listing shape, once the write succeeds.
+ * @param {Function} args.onReceive   Called with the write's own raw response (the flat
+ *                                    embedded-array wire rows), once the write succeeds.
  * @param {Function} args.refreshFeed Replaces the feed for a slug.
  * @param {Function} args.onBusy      Called with a boolean as the chain starts and settles.
  * @param {Function} args.onError     Called with `{ message }` on failure.
@@ -544,8 +545,8 @@ export function renameSwatchFlow({
  * @param {string}         args.defaultId     The listing's `$default` palette id.
  * @param {string}         args.groupId       The group being reordered.
  * @param {Array<string>}  args.orderedTokens The new swatch token order.
- * @param {Function}       args.onReceive     Called with the write's own response, reshaped into
- *                                            the internal listing shape, once the write succeeds.
+ * @param {Function}       args.onReceive     Called with the write's own raw response (the flat
+ *                                            embedded-array wire rows), once the write succeeds.
  * @param {Function}       args.refreshFeed   Replaces the feed for a slug.
  * @param {Function}       args.onBusy        Called with a boolean as the chain starts and settles.
  * @param {Function}       args.onError       Called with `{ message }` on failure.
@@ -599,8 +600,8 @@ export function reorderSwatchesFlow({
  * @param {string}   args.token         The swatch token dot-path to remove.
  * @param {boolean}  args.isUserCreated Whether `token` is a user-created custom color — gates
  *                                      ONLY the cleanup step, never the row removal.
- * @param {Function} args.onReceive     Called with the row-removal write's own response, reshaped
- *                                      into the internal listing shape, once the write succeeds.
+ * @param {Function} args.onReceive     Called with the row-removal write's own raw response (the
+ *                                      flat embedded-array wire rows), once the write succeeds.
  * @param {Function} args.refreshFeed   Replaces the feed for a slug; resolves with the fresh feed
  *                                      payload, whose `version` the cleanup step's delete call needs.
  * @param {Function} args.onBusy        Called with a boolean as the chain starts and settles.
@@ -631,7 +632,7 @@ export function removeSwatchFlow({
 
 			return savePalette(namespace, defaultId, { label: view.label, groups }, slug);
 		})
-		.then((rows) => onReceive(reshapePaletteRows(rows)))
+		.then((rows) => onReceive(rows))
 		.then(() => refreshFeed(slug))
 		.then((freshFeed) => {
 			if (!isUserCreated) {
@@ -669,8 +670,8 @@ export function removeSwatchFlow({
  *                                    friendlier starting color (the group's last swatch's value).
  * @param {string}   args.feedVersion The feed's current version, sent as the primitive create's
  *                                    concurrency guard.
- * @param {Function} args.onReceive   Called with the write's own response, reshaped into the
- *                                    internal listing shape, once the write succeeds.
+ * @param {Function} args.onReceive   Called with the write's own raw response (the flat
+ *                                    embedded-array wire rows), once the write succeeds.
  * @param {Function} args.refreshFeed Replaces the feed for a slug.
  * @param {Function} args.onBusy      Called with a boolean as the chain starts and settles.
  * @param {Function} args.onError     Called with `{ message }` on failure.
@@ -737,8 +738,8 @@ export function addColorFlow({
  *                                    colliding with.
  * @param {string}   args.feedVersion The feed's current version, sent as the primitive create's
  *                                    concurrency guard.
- * @param {Function} args.onReceive   Called with the write's own response, reshaped into the
- *                                    internal listing shape, once the write succeeds.
+ * @param {Function} args.onReceive   Called with the write's own raw response (the flat
+ *                                    embedded-array wire rows), once the write succeeds.
  * @param {Function} args.refreshFeed Replaces the feed for a slug.
  * @param {Function} args.onBusy      Called with a boolean as the chain starts and settles.
  * @param {Function} args.onError     Called with `{ message }` on failure or invalid input.
@@ -827,8 +828,8 @@ export function addGroupFlow({
  * @param {string}   args.defaultId   The listing's `$default` palette id.
  * @param {string}   args.groupId     The group id to rename.
  * @param {string}   args.label       The new label.
- * @param {Function} args.onReceive   Called with the write's own response, reshaped into the
- *                                    internal listing shape, once the write succeeds.
+ * @param {Function} args.onReceive   Called with the write's own raw response (the flat
+ *                                    embedded-array wire rows), once the write succeeds.
  * @param {Function} args.refreshFeed Replaces the feed for a slug.
  * @param {Function} args.onBusy      Called with a boolean as the chain starts and settles.
  * @param {Function} args.onError     Called with `{ message }` on failure.
@@ -880,9 +881,9 @@ export function renameGroupFlow({
  * @param {string}        args.groupId           The group id to remove.
  * @param {Array<string>} args.userCreatedTokens The group's user-created swatch tokens — gates
  *                                               ONLY the cleanup steps, never the group removal.
- * @param {Function}      args.onReceive         Called with the group-removal write's own
- *                                               response, reshaped into the internal listing
- *                                               shape, once the write succeeds.
+ * @param {Function}      args.onReceive         Called with the group-removal write's own raw
+ *                                               response (the flat embedded-array wire rows),
+ *                                               once the write succeeds.
  * @param {Function}      args.refreshFeed       Replaces the feed for a slug; resolves with the
  *                                               fresh feed payload, whose `version` each cleanup
  *                                               delete needs.
@@ -915,7 +916,7 @@ export function removeGroupFlow({
 
 			return savePalette(namespace, defaultId, { label: view.label, groups }, slug);
 		})
-		.then((rows) => onReceive(reshapePaletteRows(rows)))
+		.then((rows) => onReceive(rows))
 		.then(() => refreshFeed(slug))
 		.then((freshFeed) => {
 			let chain = Promise.resolve(freshFeed);

--- a/src/style-library/helpers/palette-flows.js
+++ b/src/style-library/helpers/palette-flows.js
@@ -8,7 +8,7 @@
  * hook provides). Every write's own response is the same flat embedded-array wire shape a
  * `GET /palettes?_embed` would return, so a flow hands it straight to `onReceive` RAW, with no
  * reshaping and no follow-up fetch needed to learn the fresh state. Reshaping only ever happens in
- * one place, `store/selectors.js`'s `getPaletteListing` (via its exported `reshapePaletteRows`), the
+ * one place, `store/selectors.js`'s `getPaletteListing` (via `helpers/palettes.js`'s `reshapePaletteRows`), the
  * same as for a resolver-driven GET; a flow reshaping its own response before dispatch would let a write's
  * dispatched shape drift from a GET's, leaving the store holding two different shapes under the
  * same key depending on which path last wrote it. Every flow settles pessimistically and re-throws

--- a/src/style-library/helpers/palette-flows.js
+++ b/src/style-library/helpers/palette-flows.js
@@ -4,9 +4,13 @@
  * group, and within-group reorder. Extracted out of `hooks/use-palettes` so each flow can be
  * exercised directly in tests without rendering a component — a flow takes the REST calls it needs
  * (imported here, so a test mocks `api/client`) plus a small set of injected callbacks for the
- * state a caller reacts to (busy, a scoped error slot, and a `reload`/`refreshFeed` pair the hook
- * provides). Every flow settles pessimistically and re-throws on failure so its caller (a modal,
- * or the settings panel) can tell success from failure; none reloads the page.
+ * state a caller reacts to (busy, a scoped error slot, and an `onReceive`/`refreshFeed` pair the
+ * hook provides). Every write's own response is the same flat embedded-array listing shape a
+ * `GET /palettes?_embed` would return, so a flow reshapes it (via `reshapePaletteRows`, shared with
+ * `store/selectors.js`'s `getPaletteListing`) and hands it straight to `onReceive` — no follow-up
+ * fetch is needed to learn the fresh state. Every flow settles pessimistically and re-throws on
+ * failure so its caller (a modal, or the settings panel) can tell success from failure; none
+ * reloads the page.
  *
  * `writeDefaultPaletteFlow` is the single place the default-vs-edited write routing (a palette's
  * structure lives only on its `$default` node — see the module's own docblock below) is encoded.
@@ -40,6 +44,7 @@ import {
 	setCurrentPalette,
 } from '../api/client';
 import { errorMessage } from './library-flows';
+import { reshapePaletteRows } from '../store';
 import {
 	addGroupToGroups,
 	addSwatchToGroups,
@@ -71,19 +76,18 @@ import {
  * @param {string}   args.slug         The token library slug.
  * @param {string}   args.defaultId    The listing's `$default` palette id.
  * @param {Function} args.edit         Pure `(groups) => groups` transform (from `./palettes`).
- * @param {Function} args.reload       Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.onReceive    Called with the write's own response, reshaped into the
+ *                                     internal listing shape, once the write succeeds.
  * @param {Function} args.refreshFeed  Replaces the feed for a slug.
  * @param {Function} args.onBusy       Called with a boolean as the chain starts and settles.
  * @param {Function} args.onError      Called with `{ message }` on failure.
  *
  * @since TBD
  *
- * @return {Promise<void>} Resolves once the write, the re-reads, and the feed refresh complete;
- *                          rejects on failure after `onError`, a rollback re-read, and `onBusy` have
- *                          run — so a caller that applied its edit optimistically is put back in sync
- *                          with the server whether the write succeeded or not.
+ * @return {Promise<void>} Resolves once the write, `onReceive`, and the feed refresh complete;
+ *                          rejects on failure after `onError`/`onBusy` have run.
  */
-export function writeDefaultPaletteFlow({ namespace, slug, defaultId, edit, reload, refreshFeed, onBusy, onError }) {
+export function writeDefaultPaletteFlow({ namespace, slug, defaultId, edit, onReceive, refreshFeed, onBusy, onError }) {
 	onBusy(true);
 
 	return fetchPalette(namespace, defaultId, slug)
@@ -92,37 +96,24 @@ export function writeDefaultPaletteFlow({ namespace, slug, defaultId, edit, relo
 
 			return savePalette(namespace, defaultId, { label: view.label, groups }, slug);
 		})
-		.then(() => reload())
+		.then((rows) => onReceive(reshapePaletteRows(rows)))
 		.then(() => refreshFeed(slug))
 		.then(() => onBusy(false))
 		.catch((err) => {
 			onError({ message: errorMessage(err) });
+			onBusy(false);
 
-			// Re-read on the way out too, not only on success. A caller may have applied its edit
-			// optimistically — the swatch reorder does, and says so — and depends on this re-read to put
-			// the server's version back when the write fails. Reloading only in the success path leaves a
-			// failed edit sitting on screen next to its own error message.
-			//
-			// A re-read that itself fails is swallowed: the write error is the one worth reporting, and
-			// masking it with a second failure would hide what actually went wrong. `onBusy(false)` runs
-			// either way, so the UI never stays stuck behind a spinner.
-			return Promise.resolve()
-				.then(() => reload())
-				.catch(() => {})
-				.then(() => {
-					onBusy(false);
-
-					throw err;
-				});
+			throw err;
 		});
 }
 
 /**
- * Save the settings panel's edits for a swatch: a label change (a structure edit, written to the
- * default palette node) and/or a value change (written to the palette being edited via the
- * granular per-swatch endpoint) — the only flow in this module that ever targets the edited
- * palette rather than the default node. A label change runs before a value change when both are
- * dirty; either way there is exactly one `reload` and one `refreshFeed` for the whole save.
+ * Save the settings panel's edits for a swatch: a label change (a structure edit, written through
+ * the targeted swatch endpoint against the default palette — the server only accepts a `label`
+ * field when the target id is the default palette) and/or a value change (written to the palette
+ * being edited via the same granular per-swatch endpoint). A label change runs before a value
+ * change when both are dirty; either way there is exactly one `onReceive` and one `refreshFeed` for
+ * the whole save.
  *
  * The color write targets `editingId`, not `$current` — recoloring a swatch on a palette a user
  * is building out must never require that palette to be live first.
@@ -135,7 +126,8 @@ export function writeDefaultPaletteFlow({ namespace, slug, defaultId, edit, relo
  * @param {string}   args.token       The swatch token dot-path being edited.
  * @param {Object}   args.draft       The panel's draft values, `{ label, value }`.
  * @param {Object}   args.initial     The values the panel opened with, `{ label, value }`.
- * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.onReceive   Called with the last dirty write's own response, reshaped into
+ *                                    the internal listing shape, once every dirty write succeeds.
  * @param {Function} args.refreshFeed Replaces the feed for a slug.
  * @param {Function} args.onBusy      Called with a boolean as the chain starts and settles.
  * @param {Function} args.onError     Called with `{ message }` on failure.
@@ -143,7 +135,7 @@ export function writeDefaultPaletteFlow({ namespace, slug, defaultId, edit, relo
  * @since TBD
  *
  * @return {Promise<void>} Resolves immediately, with no request, when neither field changed;
- *                          otherwise resolves once every dirty write, the reload, and the feed
+ *                          otherwise resolves once every dirty write, `onReceive`, and the feed
  *                          refresh complete, or rejects on failure after `onError`/`onBusy` run.
  */
 export function saveSwatchEditsFlow({
@@ -154,7 +146,7 @@ export function saveSwatchEditsFlow({
 	token,
 	draft,
 	initial,
-	reload,
+	onReceive,
 	refreshFeed,
 	onBusy,
 	onError,
@@ -171,19 +163,7 @@ export function saveSwatchEditsFlow({
 	let chain = Promise.resolve();
 
 	if (renamed) {
-		chain = chain
-			.then(() => fetchPalette(namespace, defaultId, slug))
-			.then((view) =>
-				savePalette(
-					namespace,
-					defaultId,
-					{
-						label: view.label,
-						groups: renameSwatchInGroups(stripEffectiveFlags(view.groups), token, draft.label),
-					},
-					slug
-				)
-			);
+		chain = chain.then(() => saveSwatch(namespace, defaultId, token, { label: draft.label }, slug));
 	}
 
 	if (recolored) {
@@ -191,7 +171,7 @@ export function saveSwatchEditsFlow({
 	}
 
 	return chain
-		.then(() => reload())
+		.then((rows) => onReceive(reshapePaletteRows(rows)))
 		.then(() => refreshFeed(slug))
 		.then(() => onBusy(false))
 		.catch((err) => {
@@ -261,37 +241,34 @@ export function openPaletteFlow({ namespace, slug, id, onOpened, onBusy, onError
  * @param {string}   args.namespace   The REST namespace.
  * @param {string}   args.slug        The token library slug.
  * @param {string}   args.id          The palette id to make current.
- * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.onReceive   Called with the write's own response, reshaped into the
+ *                                    internal listing shape — carrying the activated palette
+ *                                    already flagged `is_current`, so no separate confirmation
+ *                                    step is needed to learn which id the server resolved.
  * @param {Function} args.refreshFeed Replaces the feed for a slug.
  * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
  * @param {Function} args.onError     Called with `{ message }` on failure.
- * @param {Function} args.onActivated Called with the id the server resolved as current.
  *
  * @since TBD
  *
- * @return {Promise<void>} Resolves once the pointer has moved, the listing has been re-read, and
- *                          the feed refreshed; rejects on failure after `onError`/`onBusy` have run.
+ * @return {Promise<void>} Resolves once the pointer has moved, `onReceive` has run, and the feed
+ *                          refreshed; rejects on failure after `onError`/`onBusy` have run.
  */
-export function activatePaletteFlow({ namespace, slug, id, reload, refreshFeed, onBusy, onError, onActivated }) {
+export function activatePaletteFlow({ namespace, slug, id, onReceive, refreshFeed, onBusy, onError }) {
 	onBusy(true);
 
-	return (
-		setCurrentPalette(namespace, id, slug)
-			// The resolved id comes from the response rather than the request, mirroring
-			// `activateLibraryFlow` — the server owns which palette ended up current.
-			.then((result) => onActivated(result?.current ?? id))
-			.then(() => reload())
-			.then(() => refreshFeed(slug))
-			.then(() => onBusy(false))
-			.catch((err) => {
-				onError({ message: errorMessage(err) });
-				onBusy(false);
+	return setCurrentPalette(namespace, id, slug)
+		.then((rows) => onReceive(reshapePaletteRows(rows)))
+		.then(() => refreshFeed(slug))
+		.then(() => onBusy(false))
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
 
-				// Re-thrown so the confirmation modal can tell success from failure and knows
-				// whether to close itself.
-				throw err;
-			})
-	);
+			// Re-thrown so the confirmation modal can tell success from failure and knows
+			// whether to close itself.
+			throw err;
+		});
 }
 
 /**
@@ -309,10 +286,10 @@ export function activatePaletteFlow({ namespace, slug, id, reload, refreshFeed, 
  * @param {string}   args.label       The typed palette label.
  * @param {Object}   args.listing     The current listing (`{ defaultId, palettes }`), for the
  *                                    duplicate-id check.
- * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook —
- *                                    run BEFORE `openPalette` so the fresh listing already carries
- *                                    the new row by the time `editingId` moves onto it (see the
- *                                    ordering note below).
+ * @param {Function} args.onReceive   Called with the write's own response, reshaped into the
+ *                                    internal listing shape — run BEFORE `openPalette` so the fresh
+ *                                    listing already carries the new row by the time `editingId`
+ *                                    moves onto it (see the ordering note below).
  * @param {Function} args.openPalette Opens a palette for editing (typically `openPaletteFlow`
  *                                    bound to the new id).
  * @param {Function} args.refreshFeed Replaces the feed for a slug. Required even though a new
@@ -325,7 +302,7 @@ export function activatePaletteFlow({ namespace, slug, id, reload, refreshFeed, 
  *
  * @since TBD
  *
- * @return {Promise<void>} Resolves once the palette is created, the listing reloaded, and the new
+ * @return {Promise<void>} Resolves once the palette is created, `onReceive` has run, and the new
  *                          palette opened for editing; rejects on an empty or duplicate label, or a
  *                          request failure, after `onError` has already run.
  */
@@ -334,7 +311,7 @@ export function createPaletteFlow({
 	slug,
 	label,
 	listing,
-	reload,
+	onReceive,
 	openPalette,
 	refreshFeed,
 	onBusy,
@@ -362,16 +339,12 @@ export function createPaletteFlow({
 	return (
 		fetchPalette(namespace, listing.defaultId, slug)
 			.then((view) => savePalette(namespace, id, { label, groups: stripEffectiveFlags(view.groups) }, slug))
-			// Reloaded BEFORE `openPalette`, not after: `hooks/use-palettes.js`'s `reload()` keeps
-			// `editingId` unchanged when the currently-edited palette still exists in the fresh
-			// listing (true here — nothing about creating a sibling palette removes it), so this
-			// step only refreshes `listing.palettes` with the new row. `openPalette` then moves
-			// `editingId` onto that row with the listing already populated, so the dropdown can
-			// resolve its label and render it as a real option instead of falling back to the raw
-			// id. Reloading after `openPalette` instead would leave the dropdown showing the new,
-			// still-missing-from-the-list id for one render.
-			.then(() => refreshFeed(slug))
-			.then(() => reload())
+			// `onReceive` runs BEFORE `openPalette`, not after: it dispatches the fresh listing — which
+			// already carries the new row — so `openPalette` moves `editingId` onto that row with the
+			// listing already populated, and the dropdown can resolve its label and render it as a real
+			// option instead of falling back to the raw id. Running it after `openPalette` instead would
+			// leave the dropdown showing the new, still-missing-from-the-list id for one render.
+			.then((rows) => refreshFeed(slug).then(() => onReceive(reshapePaletteRows(rows))))
 			.then(() => openPalette(id))
 			.then(() => onBusy(false))
 			.catch((err) => {
@@ -398,17 +371,18 @@ export function createPaletteFlow({
  *                                    successor is required at all.
  * @param {string}   [args.successorId] The palette to make current first. Required only when
  *                                    deleting the current palette.
- * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.onReceive   Called with the FINAL write's own response (the delete's, not
+ *                                    the successor activation's — the activation's response would
+ *                                    already be stale by the time the delete completes), reshaped
+ *                                    into the internal listing shape.
  * @param {Function} args.refreshFeed Replaces the feed for a slug.
  * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
  * @param {Function} args.onError     Called with `{ message }` on failure.
- * @param {Function} [args.onActivated] Called with the id the server reports as current, once the
- *                                    successor is activated.
  *
  * @since TBD
  *
- * @return {Promise<void>} Resolves once the activation, delete, reload, and feed refresh complete;
- *                          rejects on a missing successor or a request failure, after
+ * @return {Promise<void>} Resolves once the activation, delete, `onReceive`, and feed refresh
+ *                          complete; rejects on a missing successor or a request failure, after
  *                          `onError`/`onBusy` have run.
  */
 export function deletePaletteFlow({
@@ -417,11 +391,10 @@ export function deletePaletteFlow({
 	id,
 	currentId,
 	successorId,
-	reload,
+	onReceive,
 	refreshFeed,
 	onBusy,
 	onError,
-	onActivated,
 }) {
 	const needsSuccessor = id === currentId;
 
@@ -433,13 +406,11 @@ export function deletePaletteFlow({
 
 	onBusy(true);
 
-	const activation = needsSuccessor
-		? setCurrentPalette(namespace, successorId, slug).then((result) => onActivated(result?.current ?? successorId))
-		: Promise.resolve();
+	const activation = needsSuccessor ? setCurrentPalette(namespace, successorId, slug) : Promise.resolve();
 
 	return activation
 		.then(() => deletePalette(namespace, id, slug))
-		.then(() => reload())
+		.then((rows) => onReceive(reshapePaletteRows(rows)))
 		.then(() => refreshFeed(slug))
 		.then(() => onBusy(false))
 		.catch((err) => {
@@ -478,8 +449,9 @@ export function deletePaletteFlow({
  * @param {string}   args.id        The palette id to rename — unchanged by this flow.
  * @param {string}   args.label     The typed label.
  * @param {Object}   args.listing   The current listing (`{ palettes }`), for the duplicate-label check.
- * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook, so
- *                                    the dropdown's label updates immediately.
+ * @param {Function} args.onReceive   Called with the write's own response, reshaped into the
+ *                                    internal listing shape, so the dropdown's label updates
+ *                                    immediately.
  * @param {Function} args.refreshFeed Replaces the feed for a slug, so its version token matches the
  *                                    document this write just bumped.
  * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
@@ -487,11 +459,11 @@ export function deletePaletteFlow({
  *
  * @since TBD
  *
- * @return {Promise<void>} Resolves once the rename and the listing reload complete; rejects on an
+ * @return {Promise<void>} Resolves once the rename and `onReceive` complete; rejects on an
  *                          empty or duplicate label, or a request failure, after `onError` has
  *                          already run.
  */
-export function renamePaletteFlow({ namespace, slug, id, label, listing, reload, refreshFeed, onBusy, onError }) {
+export function renamePaletteFlow({ namespace, slug, id, label, listing, onReceive, refreshFeed, onBusy, onError }) {
 	const trimmed = String(label ?? '').trim();
 
 	if (trimmed === '') {
@@ -510,8 +482,7 @@ export function renamePaletteFlow({ namespace, slug, id, label, listing, reload,
 
 	return fetchPalette(namespace, id, slug)
 		.then((view) => savePalette(namespace, id, { label: trimmed, groups: stripEffectiveFlags(view.groups) }, slug))
-		.then(() => refreshFeed(slug))
-		.then(() => reload())
+		.then((rows) => refreshFeed(slug).then(() => onReceive(reshapePaletteRows(rows))))
 		.then(() => onBusy(false))
 		.catch((err) => {
 			onError({ message: errorMessage(err) });
@@ -529,7 +500,8 @@ export function renamePaletteFlow({ namespace, slug, id, label, listing, reload,
  * @param {string}   args.defaultId   The listing's `$default` palette id.
  * @param {string}   args.token       The swatch token dot-path to rename.
  * @param {string}   args.label       The new label.
- * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.onReceive   Called with the write's own response, reshaped into the
+ *                                    internal listing shape, once the write succeeds.
  * @param {Function} args.refreshFeed Replaces the feed for a slug.
  * @param {Function} args.onBusy      Called with a boolean as the chain starts and settles.
  * @param {Function} args.onError     Called with `{ message }` on failure.
@@ -538,13 +510,23 @@ export function renamePaletteFlow({ namespace, slug, id, label, listing, reload,
  *
  * @return {Promise<void>} See `writeDefaultPaletteFlow`.
  */
-export function renameSwatchFlow({ namespace, slug, defaultId, token, label, reload, refreshFeed, onBusy, onError }) {
+export function renameSwatchFlow({
+	namespace,
+	slug,
+	defaultId,
+	token,
+	label,
+	onReceive,
+	refreshFeed,
+	onBusy,
+	onError,
+}) {
 	return writeDefaultPaletteFlow({
 		namespace,
 		slug,
 		defaultId,
 		edit: (groups) => renameSwatchInGroups(groups, token, label),
-		reload,
+		onReceive,
 		refreshFeed,
 		onBusy,
 		onError,
@@ -562,7 +544,8 @@ export function renameSwatchFlow({ namespace, slug, defaultId, token, label, rel
  * @param {string}         args.defaultId     The listing's `$default` palette id.
  * @param {string}         args.groupId       The group being reordered.
  * @param {Array<string>}  args.orderedTokens The new swatch token order.
- * @param {Function}       args.reload        Re-reads the listing (and the edited view) from the hook.
+ * @param {Function}       args.onReceive     Called with the write's own response, reshaped into
+ *                                            the internal listing shape, once the write succeeds.
  * @param {Function}       args.refreshFeed   Replaces the feed for a slug.
  * @param {Function}       args.onBusy        Called with a boolean as the chain starts and settles.
  * @param {Function}       args.onError       Called with `{ message }` on failure.
@@ -577,7 +560,7 @@ export function reorderSwatchesFlow({
 	defaultId,
 	groupId,
 	orderedTokens,
-	reload,
+	onReceive,
 	refreshFeed,
 	onBusy,
 	onError,
@@ -587,7 +570,7 @@ export function reorderSwatchesFlow({
 		slug,
 		defaultId,
 		edit: (groups) => reorderGroupSwatches(groups, groupId, orderedTokens),
-		reload,
+		onReceive,
 		refreshFeed,
 		onBusy,
 		onError,
@@ -616,7 +599,8 @@ export function reorderSwatchesFlow({
  * @param {string}   args.token         The swatch token dot-path to remove.
  * @param {boolean}  args.isUserCreated Whether `token` is a user-created custom color — gates
  *                                      ONLY the cleanup step, never the row removal.
- * @param {Function} args.reload        Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.onReceive     Called with the row-removal write's own response, reshaped
+ *                                      into the internal listing shape, once the write succeeds.
  * @param {Function} args.refreshFeed   Replaces the feed for a slug; resolves with the fresh feed
  *                                      payload, whose `version` the cleanup step's delete call needs.
  * @param {Function} args.onBusy        Called with a boolean as the chain starts and settles.
@@ -634,7 +618,7 @@ export function removeSwatchFlow({
 	defaultId,
 	token,
 	isUserCreated,
-	reload,
+	onReceive,
 	refreshFeed,
 	onBusy,
 	onError,
@@ -647,7 +631,7 @@ export function removeSwatchFlow({
 
 			return savePalette(namespace, defaultId, { label: view.label, groups }, slug);
 		})
-		.then(() => reload())
+		.then((rows) => onReceive(reshapePaletteRows(rows)))
 		.then(() => refreshFeed(slug))
 		.then((freshFeed) => {
 			if (!isUserCreated) {
@@ -685,7 +669,8 @@ export function removeSwatchFlow({
  *                                    friendlier starting color (the group's last swatch's value).
  * @param {string}   args.feedVersion The feed's current version, sent as the primitive create's
  *                                    concurrency guard.
- * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.onReceive   Called with the write's own response, reshaped into the
+ *                                    internal listing shape, once the write succeeds.
  * @param {Function} args.refreshFeed Replaces the feed for a slug.
  * @param {Function} args.onBusy      Called with a boolean as the chain starts and settles.
  * @param {Function} args.onError     Called with `{ message }` on failure.
@@ -703,7 +688,7 @@ export function addColorFlow({
 	tokens,
 	palette,
 	feedVersion,
-	reload,
+	onReceive,
 	refreshFeed,
 	onBusy,
 	onError,
@@ -727,7 +712,7 @@ export function addColorFlow({
 				slug,
 				defaultId,
 				edit: (groups) => addSwatchToGroups(groups, groupId, { token, label, $value: value }),
-				reload,
+				onReceive,
 				refreshFeed,
 				onBusy,
 				onError,
@@ -752,7 +737,8 @@ export function addColorFlow({
  *                                    colliding with.
  * @param {string}   args.feedVersion The feed's current version, sent as the primitive create's
  *                                    concurrency guard.
- * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.onReceive   Called with the write's own response, reshaped into the
+ *                                    internal listing shape, once the write succeeds.
  * @param {Function} args.refreshFeed Replaces the feed for a slug.
  * @param {Function} args.onBusy      Called with a boolean as the chain starts and settles.
  * @param {Function} args.onError     Called with `{ message }` on failure or invalid input.
@@ -771,7 +757,7 @@ export function addGroupFlow({
 	palette,
 	tokens,
 	feedVersion,
-	reload,
+	onReceive,
 	refreshFeed,
 	onBusy,
 	onError,
@@ -820,7 +806,7 @@ export function addGroupFlow({
 						label,
 						swatches: [{ token, label: swatchLabel, $value: value }],
 					}),
-				reload,
+				onReceive,
 				refreshFeed,
 				onBusy,
 				onError,
@@ -841,7 +827,8 @@ export function addGroupFlow({
  * @param {string}   args.defaultId   The listing's `$default` palette id.
  * @param {string}   args.groupId     The group id to rename.
  * @param {string}   args.label       The new label.
- * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.onReceive   Called with the write's own response, reshaped into the
+ *                                    internal listing shape, once the write succeeds.
  * @param {Function} args.refreshFeed Replaces the feed for a slug.
  * @param {Function} args.onBusy      Called with a boolean as the chain starts and settles.
  * @param {Function} args.onError     Called with `{ message }` on failure.
@@ -850,13 +837,23 @@ export function addGroupFlow({
  *
  * @return {Promise<void>} See `writeDefaultPaletteFlow`.
  */
-export function renameGroupFlow({ namespace, slug, defaultId, groupId, label, reload, refreshFeed, onBusy, onError }) {
+export function renameGroupFlow({
+	namespace,
+	slug,
+	defaultId,
+	groupId,
+	label,
+	onReceive,
+	refreshFeed,
+	onBusy,
+	onError,
+}) {
 	return writeDefaultPaletteFlow({
 		namespace,
 		slug,
 		defaultId,
 		edit: (groups) => renameGroupInGroups(groups, groupId, label),
-		reload,
+		onReceive,
 		refreshFeed,
 		onBusy,
 		onError,
@@ -883,7 +880,9 @@ export function renameGroupFlow({ namespace, slug, defaultId, groupId, label, re
  * @param {string}        args.groupId           The group id to remove.
  * @param {Array<string>} args.userCreatedTokens The group's user-created swatch tokens — gates
  *                                               ONLY the cleanup steps, never the group removal.
- * @param {Function}      args.reload            Re-reads the listing (and the edited view).
+ * @param {Function}      args.onReceive         Called with the group-removal write's own
+ *                                               response, reshaped into the internal listing
+ *                                               shape, once the write succeeds.
  * @param {Function}      args.refreshFeed       Replaces the feed for a slug; resolves with the
  *                                               fresh feed payload, whose `version` each cleanup
  *                                               delete needs.
@@ -903,7 +902,7 @@ export function removeGroupFlow({
 	defaultId,
 	groupId,
 	userCreatedTokens,
-	reload,
+	onReceive,
 	refreshFeed,
 	onBusy,
 	onError,
@@ -916,7 +915,7 @@ export function removeGroupFlow({
 
 			return savePalette(namespace, defaultId, { label: view.label, groups }, slug);
 		})
-		.then(() => reload())
+		.then((rows) => onReceive(reshapePaletteRows(rows)))
 		.then(() => refreshFeed(slug))
 		.then((freshFeed) => {
 			let chain = Promise.resolve(freshFeed);

--- a/src/style-library/helpers/palette-flows.js
+++ b/src/style-library/helpers/palette-flows.js
@@ -57,7 +57,6 @@ import {
 	removeGroupFromGroups,
 	removeSwatchFromGroups,
 	renameGroupInGroups,
-	renameSwatchInGroups,
 	reorderGroupSwatches,
 	slugifyPaletteLabel,
 	stripEffectiveFlags,
@@ -184,53 +183,6 @@ export function saveSwatchEditsFlow({
 }
 
 /**
- * Show a palette in the app: fetch its effective view, and nothing else.
- *
- * This never writes `$current`. Choosing a palette from the header dropdown is a navigation act,
- * not a publishing one — editing a palette other than the one the site renders with is the normal
- * case (e.g. building out a dark variant while the site still runs a light one), and the API
- * already supports that split with no new plumbing: `GET /palettes/{id}` returns any palette's
- * effective view without touching `$current`. The site keeps rendering whatever palette is active
- * until someone explicitly activates a different one through `activatePaletteFlow`. A future
- * reader who "fixes" this to also write `$current` would silently re-tint the live site every time
- * someone merely looks at a different palette — don't.
- *
- * Kept as its own flow, thin as it is, rather than a bare fetch inlined in the hook, only so
- * `createPaletteFlow` can chain off it the way `createLibraryFlow` chains off `openLibraryFlow` —
- * see that pair for the shape this mirrors.
- *
- * @param {Object}   args
- * @param {string}   args.namespace The REST namespace.
- * @param {string}   args.slug      The token library slug.
- * @param {string}   args.id        The palette id to open for editing.
- * @param {Function} args.onOpened  Called with the fetched effective view once the read completes.
- * @param {Function} args.onBusy    Called with a boolean as the request starts and settles.
- * @param {Function} args.onError   Called with `{ message }` on failure.
- *
- * @since TBD
- *
- * @return {Promise<void>} Resolves once `onOpened` has run; rejects on failure, after
- *                          `onError`/`onBusy` have already run.
- */
-export function openPaletteFlow({ namespace, slug, id, onOpened, onBusy, onError }) {
-	onBusy(true);
-
-	return fetchPalette(namespace, id, slug)
-		.then((view) => onOpened(view))
-		.then(() => onBusy(false))
-		.catch((err) => {
-			onError({ message: errorMessage(err) });
-			onBusy(false);
-
-			// Re-thrown so a caller chaining off an open (createPaletteFlow, below) can tell a
-			// failed open from a successful one instead of treating this as done. A caller that
-			// only fires a plain open (no chained action) must catch this itself — the error is
-			// already surfaced through `onError` regardless.
-			throw err;
-		});
-}
-
-/**
  * Point the library's `$current` palette pointer at `id` — the one palette-selection operation
  * that changes the live site. Reloads and refreshes the feed for the same reason
  * `writeDefaultPaletteFlow` does: `$current`'s swatch values are overlaid onto the color token
@@ -292,8 +244,9 @@ export function activatePaletteFlow({ namespace, slug, id, onReceive, refreshFee
  *                                    embedded-array wire rows) — run BEFORE `openPalette` so the
  *                                    fresh listing already carries the new row by the time
  *                                    `editingId` moves onto it (see the ordering note below).
- * @param {Function} args.openPalette Opens a palette for editing (typically `openPaletteFlow`
- *                                    bound to the new id).
+ * @param {Function} args.openPalette Opens a palette for editing (`hooks/use-palettes.js`'s
+ *                                    `openPalette`, a pure navigation that writes the new id into
+ *                                    the route's `scope`, bound to the new id).
  * @param {Function} args.refreshFeed Replaces the feed for a slug. Required even though a new
  *                                    palette changes no resolved value: the feed carries the
  *                                    version token every later write is checked against, so
@@ -490,48 +443,6 @@ export function renamePaletteFlow({ namespace, slug, id, label, listing, onRecei
 			onBusy(false);
 			throw err;
 		});
-}
-
-/**
- * Rename a swatch — a structure edit, written to the default palette node.
- *
- * @param {Object}   args
- * @param {string}   args.namespace   The REST namespace.
- * @param {string}   args.slug        The token library slug.
- * @param {string}   args.defaultId   The listing's `$default` palette id.
- * @param {string}   args.token       The swatch token dot-path to rename.
- * @param {string}   args.label       The new label.
- * @param {Function} args.onReceive   Called with the write's own raw response (the flat
- *                                    embedded-array wire rows), once the write succeeds.
- * @param {Function} args.refreshFeed Replaces the feed for a slug.
- * @param {Function} args.onBusy      Called with a boolean as the chain starts and settles.
- * @param {Function} args.onError     Called with `{ message }` on failure.
- *
- * @since TBD
- *
- * @return {Promise<void>} See `writeDefaultPaletteFlow`.
- */
-export function renameSwatchFlow({
-	namespace,
-	slug,
-	defaultId,
-	token,
-	label,
-	onReceive,
-	refreshFeed,
-	onBusy,
-	onError,
-}) {
-	return writeDefaultPaletteFlow({
-		namespace,
-		slug,
-		defaultId,
-		edit: (groups) => renameSwatchInGroups(groups, token, label),
-		onReceive,
-		refreshFeed,
-		onBusy,
-		onError,
-	});
 }
 
 /**

--- a/src/style-library/helpers/palettes.js
+++ b/src/style-library/helpers/palettes.js
@@ -27,6 +27,45 @@ const CUSTOM_COLOR_PREFIX = 'primitive.color.custom.';
 const FALLBACK_SWATCH_VALUE = '#000000';
 
 /**
+ * Reshape the flat embedded-array wire response into the shape every consumer already expects. The
+ * wire shape is a flat array of rows (WP core's `_embed` only resolves top-level collection items,
+ * never something nested inside a wrapper key — see the REST controller's own docblock for why)
+ * with `is_default`/`is_current`/`user_created` flags per row instead of collection-level pointers;
+ * this reshapes those flags back into the pointer-based shape this app's own code was already built
+ * around.
+ *
+ * Used internally by `store/selectors.js`'s `getPaletteListing` only — reshaping the raw wire-format
+ * rows, exactly as the reducer stores them, into the shape the frontend consumes. Nothing else
+ * should call this directly, and specifically not code that writes into the store:
+ * `helpers/palette-flows.js` dispatches every write's response RAW, via `onReceive`, with no
+ * reshaping before dispatch — reshaping a write's response before it reaches the store would
+ * double-reshape it on the next read, since `getPaletteListing` is the one canonical place
+ * reshaping happens. Deliberately kept out of `store/selectors.js` itself, even though it is only
+ * ever called from there: that module is imported wholesale (`import * as selectors`) as the
+ * store's registered selector map, so a plain helper living there would also become a callable
+ * `select(STORE_NAME).reshapePaletteRows()` — which `@wordpress/data` would invoke with `state` as
+ * the first argument instead of `rows`, throwing the moment anything called it that way.
+ *
+ * @param {Array<Object>} rows The flat embedded-array rows.
+ *
+ * @since TBD
+ *
+ * @return {{defaultId: string, currentId: string, palettes: Array<Object>, userCreated: Array<string>}}
+ */
+export function reshapePaletteRows(rows) {
+	return {
+		defaultId: rows.find((row) => row.is_default)?.id ?? '',
+		currentId: rows.find((row) => row.is_current)?.id ?? '',
+		palettes: rows.map((row) => ({
+			id: row.id,
+			label: row.label,
+			groups: row._embedded?.self?.[0]?.groups ?? [],
+		})),
+		userCreated: rows.filter((row) => row.user_created).map((row) => row.id),
+	};
+}
+
+/**
  * Map a palette effective view to the data half of `SwatchGrid`'s `groups` prop. Pure data only —
  * no JSX: the screen supplies each card's `preview` node and drag flags itself, because a React
  * element in a helper would make this untestable under the pure-function policy.

--- a/src/style-library/helpers/palettes.js
+++ b/src/style-library/helpers/palettes.js
@@ -123,15 +123,14 @@ export function isDefaultPalette(listing, id) {
 
 /**
  * Resolve which palette is being edited from the route's generic `scope` arg: `scope` itself when
- * it names a palette in the listing, otherwise the listing's `$current` palette. This is the one
- * fallback rule `hooks/use-palettes.js` needs in two places — once while re-deriving the id to
- * fetch a fresh view for inside `reload()`, and once for the value it hands back to its callers —
- * so it lives here as a single pure rule instead of two copies that could drift apart.
+ * it names a palette in the listing, otherwise the listing's `$current` palette. `hooks/use-palettes.js`
+ * derives `editingId` from this on every render, straight from the already-loaded listing — there is
+ * no separate fetch to re-derive an id for, so this lives here as the one pure rule instead of being
+ * duplicated inline.
  *
  * Also the self-heal for a stale or hand-edited `scope`: a palette id that no longer exists (e.g.
  * the one just deleted, or a copied-and-pasted deep link) falls back to `$current` rather than
- * resolving to nothing, mirroring the fallback `reload()` already applied to its own `editingId`
- * state before that state was replaced by this derivation.
+ * resolving to nothing.
  *
  * @param {string} scope   The route's `scope` value (a palette id, or '').
  * @param {Object} listing The palette listing (`{ currentId, palettes }`).

--- a/src/style-library/hooks/use-palettes.js
+++ b/src/style-library/hooks/use-palettes.js
@@ -1,12 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { useRegistry, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { fetchPalette, fetchPalettes } from '../api/client';
 import { errorMessage } from '../helpers/library-flows';
 import { isCustomColorToken, reorderGroupSwatches, resolveEditingPaletteId } from '../helpers/palettes';
 import {
@@ -23,6 +23,8 @@ import {
 	saveSwatchEditsFlow,
 } from '../helpers/palette-flows';
 import { flattenSchemaTokens } from '../helpers/tokens';
+import { STORE_NAME } from '../store';
+import { EMPTY_LISTING, paletteListingKey } from '../store/constants';
 
 /**
  * Palette state for the Color Palette screen and its settings panel: the listing, the palette
@@ -36,24 +38,27 @@ import { flattenSchemaTokens } from '../helpers/tokens';
  * editing a palette safe: nothing a visitor sees changes until someone explicitly activates one.
  *
  * `editingId` is DERIVED from `route.scope` (via `resolveEditingPaletteId`), not owned as this
- * hook's own state — mirroring the reasoning `hooks/use-libraries.js` already documents for why
- * `editingSlug` comes from the feed rather than a second local copy: "a second copy... could
- * drift." `use-libraries.js` can derive from the feed because opening a library refreshes it;
- * opening a palette deliberately does NOT (decision 5 — it is a pure read, so browsing a palette
- * never re-tints anything), so there is no feed signal to derive from, and the route is the
- * shared source instead. This is not a hypothetical: before this derivation existed, `editingId`
- * WAS a second local `useState` here, and it drifted for real — the screen and its settings panel
- * are separate mounts of this hook, so each held its own copy, and a freshly-mounted panel had no
- * way to learn which palette the screen had already opened; it silently defaulted to `$current`
- * instead, meaning a save from the panel could target the wrong palette. Deriving from the route
- * (shared browser state, not per-instance React state) is what makes it structurally impossible
- * for the two instances to disagree, rather than merely making it less likely.
+ * hook's own state — same reasoning `hooks/use-libraries.js` documents for `editingSlug`: a second
+ * copy of it here could drift, and the screen and its settings panel are separate mounts of this
+ * hook, so each holding its own copy previously meant a freshly-mounted panel had no way to learn
+ * which palette the screen had already opened.
+ *
+ * `palette` is derived directly from `listing.palettes` (the listing selector's own reshape
+ * already embeds each row's `groups` — see `store/selectors.js`'s `reshapePaletteRows`), not from
+ * a second resolver call. There is only one resolver here, `getPaletteListing`, so this hook does
+ * not need the two-hop "wait for the listing, then wait for the palette" loading logic a separate
+ * per-palette read would require.
+ *
+ * `activeId` reads `listing.currentId` directly, with no optimistic override layer: every write
+ * that can move `$current` (`activatePalette`, `removePalette`) dispatches the write's own
+ * response into the store via `onReceive` in the SAME round trip that confirms it, so there is no
+ * window where the UI would otherwise show stale data.
  *
  * Both the screen and its settings panel call this hook as sibling instances; they stay
- * consistent because the state that must agree between them is either server state (the hook
- * re-reads the listing and the edited view whenever the feed identity changes — every write flow
- * ends with `refreshFeed`, which bumps `feed.version` for every instance at once) or route state
- * (the URL's `scope`, read by every instance the same way).
+ * consistent because the state that must agree between them is either server state (both read the
+ * same `getPaletteListing(namespace, slug)` store entry, so a write from either instance updates
+ * both the moment its `onReceive` dispatches) or route state (the URL's `scope`, read by every
+ * instance the same way).
  *
  * @param {Object}   feed        The design-tokens admin feed (slug, version, rest descriptor).
  * @param {Function} refreshFeed Replaces the feed with a fresh REST read for a slug.
@@ -72,9 +77,6 @@ import { flattenSchemaTokens } from '../helpers/tokens';
  *                  renameGroup, removeGroup }`.
  */
 export function usePalettes(feed, refreshFeed, route, navigate) {
-	const [listing, setListing] = useState({ defaultId: '', currentId: '', palettes: [], userCreated: [] });
-	const [palette, setPalette] = useState(null);
-	const [isLoading, setIsLoading] = useState(true);
 	const [isBusy, setIsBusy] = useState(false);
 	const [openError, setOpenError] = useState(null);
 	const [activateError, setActivateError] = useState(null);
@@ -89,8 +91,61 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 	const scope = route?.scope;
 	const feedTokens = useMemo(() => flattenSchemaTokens(feed?.schema), [feed]);
 
+	const registry = useRegistry();
+
+	const listing = useSelect(
+		(select) => (namespace && slug ? select(STORE_NAME).getPaletteListing(namespace, slug) : EMPTY_LISTING),
+		[namespace, slug]
+	);
+
+	// `isListingLoading` is gated on `!listing.palettes.length`, not raw `isResolving` alone — a
+	// write's wrapped `refreshFeed` re-resolves this same selector in the background, which raises
+	// `isResolving` for the duration of that re-fetch too. Once the listing has loaded once, the
+	// store keeps serving those rows while it revalidates, so there is data to keep rendering — a
+	// loading state should only ever show up before the first listing lands.
+	const { isListingLoading, listingFailure } = useSelect(
+		(select) => ({
+			isListingLoading:
+				Boolean(namespace && slug) && select(STORE_NAME).isResolving('getPaletteListing', [namespace, slug]),
+			listingFailure:
+				namespace && slug
+					? select(STORE_NAME).getResolutionError('getPaletteListing', [namespace, slug])
+					: null,
+		}),
+		[namespace, slug]
+	);
+	const isLoading = isListingLoading && !listing.palettes.length;
+
+	// Mirrors `hooks/use-libraries.js`'s identical effect: a resolution failure for
+	// `getPaletteListing` surfaces here the same way a failed write already does via its own
+	// `onError: setOpenError`.
+	useEffect(() => {
+		if (listingFailure) {
+			setOpenError({ message: errorMessage(listingFailure) });
+		}
+	}, [listingFailure]);
+
 	// See this function's own docblock for why this is a derivation, not a second copy of state.
 	const editingId = resolveEditingPaletteId(scope, listing);
+
+	const palette = useMemo(
+		() => listing.palettes.find((row) => row.id === editingId) ?? null,
+		[listing.palettes, editingId]
+	);
+
+	// The local reorder override — see `reorderSwatches` below. Cleared once the real data catches
+	// up (the write's own `onReceive` lands and `palette.groups` changes), mirroring
+	// `hooks/use-scale-screen.js`'s identical `pendingOrder`-clearing effect.
+	const [pendingGroups, setPendingGroups] = useState(null);
+
+	useEffect(() => {
+		setPendingGroups(null);
+	}, [palette?.groups]);
+
+	const displayedPalette = useMemo(
+		() => (pendingGroups && palette ? { ...palette, groups: pendingGroups } : palette),
+		[palette, pendingGroups]
+	);
 
 	// Every mint flow (add color, add group) needs a slug that collides with neither a baseline
 	// nor an already-minted token, wherever that token currently lives — the feed's flattened list
@@ -104,62 +159,18 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 		return [...feedTokens.map((token) => token.id), ...swatchTokens];
 	}, [feedTokens, palette]);
 
-	// Re-reads the listing, then the edited view — resolving `editingId` fresh from the LISTING
-	// THIS CALL JUST FETCHED (not the `editingId` derived above from the outer render's `listing`
-	// state), so a delete that removes the palette named by `scope` self-heals to `$current` on
-	// the very next read, the same way `resolveEditingPaletteId` always would once `listing` state
-	// catches up — this just avoids waiting an extra render for it.
-	const reload = useCallback(() => {
-		return fetchPalettes(namespace, slug).then((response) => {
-			const nextListing = {
-				defaultId: response.$default,
-				currentId: response.$current,
-				palettes: response.palettes ?? [],
-				userCreated: response.userCreated ?? [],
-			};
-
-			setListing(nextListing);
-
-			const nextEditingId = resolveEditingPaletteId(scope, nextListing);
-
-			return fetchPalette(namespace, nextEditingId, slug).then((view) => {
-				setPalette(view);
-				return nextListing;
-			});
-		});
-	}, [namespace, slug, scope]);
-
-	useEffect(() => {
-		setIsLoading(true);
-		reload()
-			.catch((err) => setOpenError({ message: errorMessage(err) }))
-			.finally(() => setIsLoading(false));
-	}, [reload]);
-
-	// The other half of the cross-instance sync the module docblock above describes: a write on a
-	// SIBLING `usePalettes` instance (e.g. the settings panel saving a swatch's color, or deleting
-	// one) never changes THIS instance's own `namespace`/`slug`, so `reload`'s identity — and
-	// therefore the mount effect above — never changes because of it either; without this, a
-	// sibling's write would persist correctly but this instance's `palette` (and whatever renders
-	// from it, e.g. the grid's swatch preview) would keep showing the pre-write value until this
-	// instance happened to reload for an unrelated reason. `refreshFeed` bumps `feed.version` for
-	// every instance at once specifically so this effect has something to react to. Silent — no
-	// `isLoading` toggle — because a write elsewhere is not "this instance is loading" from its own
-	// point of view; the mount effect above is the one spinner-bearing load. Skips the very first
-	// render (the mount effect already covers the cold load) via the ref below, and tolerates one
-	// harmless duplicate fetch on a genuine library switch (`reload`'s identity changing pulls this
-	// effect's deps forward too) rather than adding a second layer of bookkeeping to suppress it.
-	const feedVersion = feed?.version;
-	const hasSyncedOnceRef = useRef(false);
-
-	useEffect(() => {
-		if (!hasSyncedOnceRef.current) {
-			hasSyncedOnceRef.current = true;
-			return;
-		}
-
-		reload().catch((err) => setOpenError({ message: errorMessage(err) }));
-	}, [feedVersion, reload]);
+	// Dispatches a write's own raw response (the flat embedded-array wire rows) straight into the
+	// store under this library's listing key — reused by every write flow below instead of each
+	// one reshaping its own response, so the store only ever gets this shape from one place (see
+	// `store/selectors.js`'s `reshapePaletteRows` docblock).
+	const onReceive = useCallback(
+		(rows) => {
+			if (namespace && slug) {
+				registry.dispatch(STORE_NAME).receivePaletteListing(paletteListingKey(namespace, slug), rows);
+			}
+		},
+		[registry, namespace, slug]
+	);
 
 	const clearOpenError = useCallback(() => setOpenError(null), []);
 	const clearActivateError = useCallback(() => setActivateError(null), []);
@@ -169,23 +180,10 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 	const clearSaveError = useCallback(() => setSaveError(null), []);
 	const clearStructureError = useCallback(() => setStructureError(null), []);
 
-	// Opening a palette is now a pure navigation: write `id` into the route's `scope`, and let the
-	// mount effect above pick it up (its `reload` depends on `scope`, so a scope change gives it a
-	// new identity and the effect re-fires) — the same mechanism every sibling instance already
-	// uses to converge on the listing and feed, applied to the one remaining piece of state that
-	// used to be a per-instance copy (see this hook's own docblock). This is also what makes the
-	// derivation in `helpers/palettes.js` the actual fix for the two-instance divergence: there is
-	// no longer a second code path (a direct `setEditingId`) that could get out of step with it.
-	//
-	// `helpers/palette-flows.js`'s `openPaletteFlow` predates this and is intentionally unused here
-	// now — it fetched and reported success/failure itself, which only made sense when opening had
-	// to update this instance's own state directly. A stale `scope` (naming no known palette) no
-	// longer needs its own error path either: `resolveEditingPaletteId` already falls back instead
-	// of failing, and a genuine request failure surfaces through the reload effects' `openError`
-	// like every other reload does. `id` is always drawn from the already-loaded listing (the
-	// dropdown's own options, or a just-created palette's own id), so this realistically never
-	// needs to reject; kept as a resolved Promise so existing `.then()` callers (e.g.
-	// `createPaletteFlow`, which opens the palette it just created) keep working unchanged.
+	// Opening a palette is a pure navigation: write `id` into the route's `scope`. `editingId`
+	// above re-derives from the already-loaded listing the moment the route changes — there is no
+	// separate fetch, and therefore no failure path of its own; a stale `scope` (naming no known
+	// palette) falls back to `$current` via `resolveEditingPaletteId` rather than erroring.
 	//
 	// Clears `item` as well as setting `scope`. A swatch token is valid on every palette (structure
 	// lives on the default node), so the panel *could* stay open across a switch — but its values
@@ -210,14 +208,13 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 				namespace,
 				slug,
 				id,
-				reload,
+				onReceive,
 				refreshFeed,
 				onBusy: setIsBusy,
 				onError: setActivateError,
-				onActivated: (activatedId) => setListing((prev) => ({ ...prev, currentId: activatedId })),
 			});
 		},
-		[namespace, slug, reload, refreshFeed]
+		[namespace, slug, onReceive, refreshFeed]
 	);
 
 	const addPalette = useCallback(
@@ -228,7 +225,7 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 				slug,
 				label,
 				listing,
-				reload,
+				onReceive,
 				// Reuses `openPalette` directly rather than a create-specific variant — now that
 				// opening is a plain navigation with nothing left to fail (see `openPalette`'s own
 				// comment), there is no separate error/busy path left to route through `createError`
@@ -239,7 +236,7 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 				onError: setCreateError,
 			});
 		},
-		[namespace, slug, listing, reload, refreshFeed, openPalette]
+		[namespace, slug, listing, onReceive, refreshFeed, openPalette]
 	);
 
 	const renamePalette = useCallback(
@@ -251,13 +248,13 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 				id,
 				label,
 				listing,
-				reload,
+				onReceive,
 				refreshFeed,
 				onBusy: setIsBusy,
 				onError: setRenameError,
 			});
 		},
-		[namespace, slug, listing, reload, refreshFeed]
+		[namespace, slug, listing, onReceive, refreshFeed]
 	);
 
 	const removePalette = useCallback(
@@ -269,14 +266,13 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 				id,
 				currentId: listing.currentId,
 				successorId,
-				reload,
+				onReceive,
 				refreshFeed,
 				onBusy: setIsBusy,
 				onError: setDeleteError,
-				onActivated: (activatedId) => setListing((prev) => ({ ...prev, currentId: activatedId })),
 			});
 		},
-		[namespace, slug, listing.currentId, reload, refreshFeed]
+		[namespace, slug, listing.currentId, onReceive, refreshFeed]
 	);
 
 	const saveSwatchEdits = useCallback(
@@ -290,13 +286,13 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 				token,
 				draft,
 				initial,
-				reload,
+				onReceive,
 				refreshFeed,
 				onBusy: setIsBusy,
 				onError: setSaveError,
 			});
 		},
-		[namespace, slug, listing, editingId, reload, refreshFeed]
+		[namespace, slug, listing.defaultId, editingId, onReceive, refreshFeed]
 	);
 
 	const removeSwatch = useCallback(
@@ -315,13 +311,13 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 				defaultId: listing.defaultId,
 				token,
 				isUserCreated,
-				reload,
+				onReceive,
 				refreshFeed,
 				onBusy: setIsBusy,
 				onError: setSaveError,
 			});
 		},
-		[namespace, slug, listing, feedTokens, reload, refreshFeed]
+		[namespace, slug, listing.defaultId, feedTokens, onReceive, refreshFeed]
 	);
 
 	const addColor = useCallback(
@@ -335,13 +331,13 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 				tokens: existingTokenIds,
 				palette,
 				feedVersion: feed?.version,
-				reload,
+				onReceive,
 				refreshFeed,
 				onBusy: setIsBusy,
 				onError: setStructureError,
 			});
 		},
-		[namespace, slug, listing, existingTokenIds, palette, feed?.version, reload, refreshFeed]
+		[namespace, slug, listing.defaultId, existingTokenIds, palette, feed?.version, onReceive, refreshFeed]
 	);
 
 	const addGroup = useCallback(
@@ -355,26 +351,25 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 				palette,
 				tokens: existingTokenIds,
 				feedVersion: feed?.version,
-				reload,
+				onReceive,
 				refreshFeed,
 				onBusy: setIsBusy,
 				onError: setStructureError,
 			});
 		},
-		[namespace, slug, listing, palette, existingTokenIds, feed?.version, reload, refreshFeed]
+		[namespace, slug, listing.defaultId, palette, existingTokenIds, feed?.version, onReceive, refreshFeed]
 	);
 
 	const reorderSwatches = useCallback(
 		(groupId, orderedTokens) => {
 			setStructureError(null);
 
-			// Applied locally at drop time — a drop that snaps back behind a spinner is worse UX than
-			// a rare rollback. `reorderSwatchesFlow`'s `reload()` re-reads the effective view on both
-			// success (a no-op visually) and failure (restores server order), so this optimistic step
-			// never needs its own undo path.
-			setPalette((current) =>
-				current ? { ...current, groups: reorderGroupSwatches(current.groups, groupId, orderedTokens) } : current
-			);
+			if (palette) {
+				// Applied immediately (optimistic), at drop time — a drop that snaps back behind a
+				// spinner is worse UX than a rare rollback. Cleared automatically once `onReceive`'s
+				// dispatch lands and `palette.groups` catches up (see the effect above).
+				setPendingGroups(reorderGroupSwatches(palette.groups, groupId, orderedTokens));
+			}
 
 			return reorderSwatchesFlow({
 				namespace,
@@ -382,13 +377,19 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 				defaultId: listing.defaultId,
 				groupId,
 				orderedTokens,
-				reload,
+				onReceive,
 				refreshFeed,
 				onBusy: setIsBusy,
-				onError: setStructureError,
+				onError: (err) => {
+					// A failed write must not leave the optimistic edit stuck: drop the local
+					// override so the display falls back to the last known-good `palette.groups`
+					// from the store.
+					setPendingGroups(null);
+					setStructureError(err);
+				},
 			});
 		},
-		[namespace, slug, listing, reload, refreshFeed]
+		[namespace, slug, listing.defaultId, palette, onReceive, refreshFeed]
 	);
 
 	const renameGroup = useCallback(
@@ -400,13 +401,13 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 				defaultId: listing.defaultId,
 				groupId,
 				label,
-				reload,
+				onReceive,
 				refreshFeed,
 				onBusy: setIsBusy,
 				onError: setStructureError,
 			});
 		},
-		[namespace, slug, listing, reload, refreshFeed]
+		[namespace, slug, listing.defaultId, onReceive, refreshFeed]
 	);
 
 	const removeGroup = useCallback(
@@ -430,13 +431,13 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 				defaultId: listing.defaultId,
 				groupId,
 				userCreatedTokens,
-				reload,
+				onReceive,
 				refreshFeed,
 				onBusy: setIsBusy,
 				onError: setStructureError,
 			});
 		},
-		[namespace, slug, listing, palette, feedTokens, reload, refreshFeed]
+		[namespace, slug, listing.defaultId, palette, feedTokens, onReceive, refreshFeed]
 	);
 
 	return {
@@ -444,7 +445,7 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 		activeId: listing.currentId,
 		editingId,
 		isEditingActive: editingId === listing.currentId,
-		palette,
+		palette: displayedPalette,
 		isLoading,
 		isBusy,
 		openError,

--- a/src/style-library/hooks/use-palettes.js
+++ b/src/style-library/hooks/use-palettes.js
@@ -44,7 +44,7 @@ import { EMPTY_LISTING, paletteListingKey } from '../store/constants';
  * which palette the screen had already opened.
  *
  * `palette` is derived directly from `listing.palettes` (the listing selector's own reshape
- * already embeds each row's `groups` — see `store/selectors.js`'s `reshapePaletteRows`), not from
+ * already embeds each row's `groups` — see `helpers/palettes.js`'s `reshapePaletteRows`), not from
  * a second resolver call. There is only one resolver here, `getPaletteListing`, so this hook does
  * not need the two-hop "wait for the listing, then wait for the palette" loading logic a separate
  * per-palette read would require.
@@ -169,7 +169,7 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 	// Dispatches a write's own raw response (the flat embedded-array wire rows) straight into the
 	// store under this library's listing key — reused by every write flow below instead of each
 	// one reshaping its own response, so the store only ever gets this shape from one place (see
-	// `store/selectors.js`'s `reshapePaletteRows` docblock).
+	// `helpers/palettes.js`'s `reshapePaletteRows` docblock).
 	const onReceive = useCallback(
 		(rows) => {
 			if (namespace && slug) {

--- a/src/style-library/hooks/use-palettes.js
+++ b/src/style-library/hooks/use-palettes.js
@@ -98,11 +98,12 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 		[namespace, slug]
 	);
 
-	// `isListingLoading` is gated on `!listing.palettes.length`, not raw `isResolving` alone — a
-	// write's wrapped `refreshFeed` re-resolves this same selector in the background, which raises
-	// `isResolving` for the duration of that re-fetch too. Once the listing has loaded once, the
-	// store keeps serving those rows while it revalidates, so there is data to keep rendering — a
-	// loading state should only ever show up before the first listing lands.
+	// `isListingLoading` is gated on `!listing.palettes.length`, not raw `isResolving` alone, so a
+	// re-render never shows a loading state once a listing has already loaded once. This matters
+	// most for a library switch: swapping `namespace`/`slug` starts a genuinely new resolution for
+	// that `(namespace, slug)` args tuple, raising `isResolving` again. Without the `.length` check
+	// this would flash a loading skeleton over the currently-displayed palettes on every switch,
+	// instead of only showing it the very first time this library's listing has never resolved.
 	const { isListingLoading, listingFailure } = useSelect(
 		(select) => ({
 			isListingLoading:

--- a/src/style-library/hooks/use-palettes.js
+++ b/src/style-library/hooks/use-palettes.js
@@ -98,16 +98,22 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 		[namespace, slug]
 	);
 
-	// `isListingLoading` is gated on `!listing.palettes.length`, not raw `isResolving` alone, so a
-	// re-render never shows a loading state once a listing has already loaded once. This matters
-	// most for a library switch: swapping `namespace`/`slug` starts a genuinely new resolution for
-	// that `(namespace, slug)` args tuple, raising `isResolving` again. Without the `.length` check
-	// this would flash a loading skeleton over the currently-displayed palettes on every switch,
-	// instead of only showing it the very first time this library's listing has never resolved.
-	const { isListingLoading, listingFailure } = useSelect(
+	// `hasFinishedListing` uses `hasFinishedResolution`, not `isResolving`: `@wordpress/data` schedules
+	// a resolver's dispatch via a `setTimeout(fn, 0)`, so on the very first render for a given
+	// `(namespace, slug)` tuple `isResolving` can still be `false` — the resolver hasn't been kicked
+	// off yet — even though nothing has loaded. `hasFinishedResolution` stays `false` for that same
+	// render, so `isLoading` below correctly starts `true` instead of flashing `false` for one frame.
+	// It is then gated on `!listing.palettes.length`, so a re-render never shows a loading state once
+	// a listing has already loaded once. This matters most for a library switch: swapping
+	// `namespace`/`slug` starts a genuinely new resolution for that `(namespace, slug)` args tuple,
+	// so `hasFinishedResolution` goes back to `false`. Without the `.length` check this would flash a
+	// loading skeleton over the currently-displayed palettes on every switch, instead of only showing
+	// it the very first time this library's listing has never resolved.
+	const { hasFinishedListing, listingFailure } = useSelect(
 		(select) => ({
-			isListingLoading:
-				Boolean(namespace && slug) && select(STORE_NAME).isResolving('getPaletteListing', [namespace, slug]),
+			hasFinishedListing:
+				!(namespace && slug) ||
+				select(STORE_NAME).hasFinishedResolution('getPaletteListing', [namespace, slug]),
 			listingFailure:
 				namespace && slug
 					? select(STORE_NAME).getResolutionError('getPaletteListing', [namespace, slug])
@@ -115,7 +121,7 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 		}),
 		[namespace, slug]
 	);
-	const isLoading = isListingLoading && !listing.palettes.length;
+	const isLoading = !hasFinishedListing && !listing.palettes.length;
 
 	// Mirrors `hooks/use-libraries.js`'s identical effect: a resolution failure for
 	// `getPaletteListing` surfaces here the same way a failed write already does via its own

--- a/src/style-library/store/actions.js
+++ b/src/style-library/store/actions.js
@@ -29,3 +29,17 @@ export function receiveLibraries(rows) {
 export function receiveBlockPresets(key, payload) {
 	return { type: 'RECEIVE_BLOCK_PRESETS', key, payload };
 }
+
+/**
+ * Store a library's palette listing.
+ *
+ * @param {string}        key  `paletteListingKey()`'s output for this library.
+ * @param {Array<Object>} rows The fetched palette listing rows.
+ *
+ * @since TBD
+ *
+ * @return {Object} The action.
+ */
+export function receivePaletteListing(key, rows) {
+	return { type: 'RECEIVE_PALETTE_LISTING', key, rows };
+}

--- a/src/style-library/store/constants.js
+++ b/src/style-library/store/constants.js
@@ -25,3 +25,24 @@ export const STORE_NAME = 'kadence-blocks/style-library';
 export function presetsKey(namespace, block, slug) {
 	return `${namespace}::${block}::${slug}`;
 }
+
+/**
+ * Build the state key for a library's palette listing.
+ *
+ * @param {string} namespace REST namespace.
+ * @param {string} slug      Token library slug.
+ *
+ * @since TBD
+ *
+ * @return {string} The state key.
+ */
+export function paletteListingKey(namespace, slug) {
+	return `${namespace}::${slug}`;
+}
+
+/**
+ * The shape `getPaletteListing` returns before its palette listing has resolved yet.
+ *
+ * @since TBD
+ */
+export const EMPTY_LISTING = { defaultId: '', currentId: '', palettes: [], userCreated: [] };

--- a/src/style-library/store/index.js
+++ b/src/style-library/store/index.js
@@ -12,6 +12,7 @@ import * as resolvers from './resolvers';
 import * as selectors from './selectors';
 
 export { STORE_NAME } from './constants';
+export { reshapePaletteRows } from './selectors';
 
 import { STORE_NAME } from './constants';
 

--- a/src/style-library/store/index.js
+++ b/src/style-library/store/index.js
@@ -12,7 +12,6 @@ import * as resolvers from './resolvers';
 import * as selectors from './selectors';
 
 export { STORE_NAME } from './constants';
-export { reshapePaletteRows } from './selectors';
 
 import { STORE_NAME } from './constants';
 

--- a/src/style-library/store/reducer.js
+++ b/src/style-library/store/reducer.js
@@ -15,9 +15,17 @@ function presets(state = {}, action) {
 	return { ...state, [action.key]: action.payload };
 }
 
+function paletteListings(state = {}, action) {
+	if (action.type !== 'RECEIVE_PALETTE_LISTING') {
+		return state;
+	}
+
+	return { ...state, [action.key]: action.rows };
+}
+
 /**
  * The Style Library store's root reducer.
  *
  * @since TBD
  */
-export const reducer = combineReducers({ libraries, presets });
+export const reducer = combineReducers({ libraries, presets, paletteListings });

--- a/src/style-library/store/reducer.test.js
+++ b/src/style-library/store/reducer.test.js
@@ -1,12 +1,12 @@
 /* eslint-env jest */
 import { reducer } from './reducer';
-import { receiveLibraries, receiveBlockPresets } from './actions';
+import { receiveLibraries, receiveBlockPresets, receivePaletteListing } from './actions';
 
 describe('reducer', () => {
 	it('starts with empty slices', () => {
 		const state = reducer(undefined, { type: '@@INIT' });
 
-		expect(state).toEqual({ libraries: [], presets: {} });
+		expect(state).toEqual({ libraries: [], presets: {}, paletteListings: {} });
 	});
 
 	it('stores the libraries list on RECEIVE_LIBRARIES', () => {
@@ -21,5 +21,15 @@ describe('reducer', () => {
 		state = reducer(state, receiveBlockPresets('b', { version: 'b1' }));
 
 		expect(state.presets).toEqual({ a: { version: 'a1' }, b: { version: 'b1' } });
+	});
+
+	it('stores a palette listing payload under its key, leaving other keys alone', () => {
+		const rowsA = [{ id: 'default', label: 'Default' }];
+		const rowsB = [{ id: 'custom-1', label: 'Custom' }];
+
+		let state = reducer(undefined, receivePaletteListing('a', rowsA));
+		state = reducer(state, receivePaletteListing('b', rowsB));
+
+		expect(state.paletteListings).toEqual({ a: rowsA, b: rowsB });
 	});
 });

--- a/src/style-library/store/resolvers.js
+++ b/src/style-library/store/resolvers.js
@@ -8,8 +8,8 @@
 /**
  * Internal dependencies
  */
-import { fetchBlockPresets, fetchLibraries } from '../api/client';
-import { presetsKey } from './constants';
+import { fetchBlockPresets, fetchLibraries, fetchPalettes } from '../api/client';
+import { presetsKey, paletteListingKey } from './constants';
 
 /**
  * Resolve `selectors.getLibraries()`.
@@ -41,4 +41,21 @@ export const getBlockPresets =
 	async ({ dispatch }) => {
 		const payload = await fetchBlockPresets(namespace, block, slug);
 		dispatch.receiveBlockPresets(presetsKey(namespace, block, slug), payload);
+	};
+
+/**
+ * Resolve `selectors.getPaletteListing(namespace, slug)`.
+ *
+ * @param {string} namespace REST namespace.
+ * @param {string} slug      Token library slug.
+ *
+ * @since TBD
+ *
+ * @return {Function} A `@wordpress/data` thunk.
+ */
+export const getPaletteListing =
+	(namespace, slug) =>
+	async ({ dispatch }) => {
+		const rows = await fetchPalettes(namespace, slug);
+		dispatch.receivePaletteListing(paletteListingKey(namespace, slug), rows);
 	};

--- a/src/style-library/store/resolvers.test.js
+++ b/src/style-library/store/resolvers.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
-import { getBlockPresets, getLibraries } from './resolvers';
-import { fetchBlockPresets, fetchLibraries } from '../api/client';
+import { getBlockPresets, getLibraries, getPaletteListing } from './resolvers';
+import { fetchBlockPresets, fetchLibraries, fetchPalettes } from '../api/client';
 
 jest.mock('../api/client', () => ({
 	fetchLibraries: jest.fn(),
@@ -34,5 +34,16 @@ describe('resolvers', () => {
 			'kb-design-tokens/v1::kadence/singlebtn::default',
 			payload
 		);
+	});
+
+	it('getPaletteListing() fetches and dispatches receivePaletteListing under the composite key', async () => {
+		const rows = [{ id: 'default', label: 'Default', is_default: true, is_current: true, user_created: false }];
+		fetchPalettes.mockResolvedValueOnce(rows);
+
+		const dispatch = { receivePaletteListing: jest.fn() };
+		await getPaletteListing('kb-design-tokens/v1', 'default')({ dispatch });
+
+		expect(fetchPalettes).toHaveBeenCalledWith('kb-design-tokens/v1', 'default');
+		expect(dispatch.receivePaletteListing).toHaveBeenCalledWith('kb-design-tokens/v1::default', rows);
 	});
 });

--- a/src/style-library/store/selectors.js
+++ b/src/style-library/store/selectors.js
@@ -46,10 +46,12 @@ export function getBlockPresets(state, namespace, block, slug) {
  * this reshapes those flags back into the pointer-based shape this app's own code was already built
  * around.
  *
- * Shared between `getPaletteListing` below (which reshapes STATE already in the store) and
- * `helpers/palette-flows.js` (which reshapes a raw write RESPONSE before it's ever dispatched) —
- * every palette write's own response is the same flat embedded-array shape a `GET /palettes?_embed`
- * returns, so reusing this one reshape avoids the same logic living in two places.
+ * Used internally by `getPaletteListing` below only — reshaping the raw wire-format rows, exactly
+ * as the reducer stores them, into the shape the frontend consumes. Nothing else should call this
+ * directly, and specifically not code that writes into the store: `helpers/palette-flows.js`
+ * dispatches every write's response RAW, via `onReceive`, with no reshaping before dispatch —
+ * reshaping a write's response before it reaches the store would double-reshape it on the next
+ * read, since `getPaletteListing` is the one canonical place reshaping happens.
  *
  * @param {Array<Object>} rows The flat embedded-array rows.
  *

--- a/src/style-library/store/selectors.js
+++ b/src/style-library/store/selectors.js
@@ -7,7 +7,7 @@
 /**
  * Internal dependencies
  */
-import { presetsKey } from './constants';
+import { presetsKey, paletteListingKey, EMPTY_LISTING } from './constants';
 
 /**
  * Read the libraries list.
@@ -36,4 +36,40 @@ export function getLibraries(state) {
  */
 export function getBlockPresets(state, namespace, block, slug) {
 	return state.presets[presetsKey(namespace, block, slug)] ?? null;
+}
+
+/**
+ * Read a library's palette listing, reshaped from the flat embedded-array wire response into the
+ * shape every consumer already expects. The wire shape is a flat array of rows (WP core's `_embed`
+ * only resolves top-level collection items, never something nested inside a wrapper key — see the
+ * REST controller's own docblock for why) with `is_default`/`is_current`/`user_created` flags per
+ * row instead of collection-level pointers; this reshapes those flags back into the pointer-based
+ * shape this app's own code was already built around, so nothing above this selector needs to
+ * change.
+ *
+ * @param {Object} state     The store's state.
+ * @param {string} namespace REST namespace.
+ * @param {string} slug      Token library slug.
+ *
+ * @since TBD
+ *
+ * @return {{defaultId: string, currentId: string, palettes: Array<Object>, userCreated: Array<string>}}
+ */
+export function getPaletteListing(state, namespace, slug) {
+	const rows = state.paletteListings[paletteListingKey(namespace, slug)];
+
+	if (!rows) {
+		return EMPTY_LISTING;
+	}
+
+	return {
+		defaultId: rows.find((row) => row.is_default)?.id ?? '',
+		currentId: rows.find((row) => row.is_current)?.id ?? '',
+		palettes: rows.map((row) => ({
+			id: row.id,
+			label: row.label,
+			groups: row._embedded?.self?.[0]?.groups ?? [],
+		})),
+		userCreated: rows.filter((row) => row.user_created).map((row) => row.id),
+	};
 }

--- a/src/style-library/store/selectors.js
+++ b/src/style-library/store/selectors.js
@@ -39,13 +39,40 @@ export function getBlockPresets(state, namespace, block, slug) {
 }
 
 /**
+ * Reshape the flat embedded-array wire response into the shape every consumer already expects. The
+ * wire shape is a flat array of rows (WP core's `_embed` only resolves top-level collection items,
+ * never something nested inside a wrapper key — see the REST controller's own docblock for why)
+ * with `is_default`/`is_current`/`user_created` flags per row instead of collection-level pointers;
+ * this reshapes those flags back into the pointer-based shape this app's own code was already built
+ * around.
+ *
+ * Shared between `getPaletteListing` below (which reshapes STATE already in the store) and
+ * `helpers/palette-flows.js` (which reshapes a raw write RESPONSE before it's ever dispatched) —
+ * every palette write's own response is the same flat embedded-array shape a `GET /palettes?_embed`
+ * returns, so reusing this one reshape avoids the same logic living in two places.
+ *
+ * @param {Array<Object>} rows The flat embedded-array rows.
+ *
+ * @since TBD
+ *
+ * @return {{defaultId: string, currentId: string, palettes: Array<Object>, userCreated: Array<string>}}
+ */
+export function reshapePaletteRows(rows) {
+	return {
+		defaultId: rows.find((row) => row.is_default)?.id ?? '',
+		currentId: rows.find((row) => row.is_current)?.id ?? '',
+		palettes: rows.map((row) => ({
+			id: row.id,
+			label: row.label,
+			groups: row._embedded?.self?.[0]?.groups ?? [],
+		})),
+		userCreated: rows.filter((row) => row.user_created).map((row) => row.id),
+	};
+}
+
+/**
  * Read a library's palette listing, reshaped from the flat embedded-array wire response into the
- * shape every consumer already expects. The wire shape is a flat array of rows (WP core's `_embed`
- * only resolves top-level collection items, never something nested inside a wrapper key — see the
- * REST controller's own docblock for why) with `is_default`/`is_current`/`user_created` flags per
- * row instead of collection-level pointers; this reshapes those flags back into the pointer-based
- * shape this app's own code was already built around, so nothing above this selector needs to
- * change.
+ * shape every consumer already expects.
  *
  * @param {Object} state     The store's state.
  * @param {string} namespace REST namespace.
@@ -58,18 +85,5 @@ export function getBlockPresets(state, namespace, block, slug) {
 export function getPaletteListing(state, namespace, slug) {
 	const rows = state.paletteListings[paletteListingKey(namespace, slug)];
 
-	if (!rows) {
-		return EMPTY_LISTING;
-	}
-
-	return {
-		defaultId: rows.find((row) => row.is_default)?.id ?? '',
-		currentId: rows.find((row) => row.is_current)?.id ?? '',
-		palettes: rows.map((row) => ({
-			id: row.id,
-			label: row.label,
-			groups: row._embedded?.self?.[0]?.groups ?? [],
-		})),
-		userCreated: rows.filter((row) => row.user_created).map((row) => row.id),
-	};
+	return rows ? reshapePaletteRows(rows) : EMPTY_LISTING;
 }

--- a/src/style-library/store/selectors.js
+++ b/src/style-library/store/selectors.js
@@ -71,6 +71,18 @@ export function reshapePaletteRows(rows) {
 }
 
 /**
+ * Caches `reshapePaletteRows()`'s output per raw `rows` array reference, so `getPaletteListing`
+ * below returns the SAME object on every call until the reducer actually replaces those rows (a
+ * fresh dispatch). Without this, every call reshapes fresh — a new object every time even when
+ * nothing changed — which `useSelect` sees as "the selector's result changed," triggering a
+ * re-render loop and `@wordpress/data`'s "returns different values" dev warning on every render of
+ * any component reading this selector.
+ *
+ * @since TBD
+ */
+const reshapedListingCache = new WeakMap();
+
+/**
  * Read a library's palette listing, reshaped from the flat embedded-array wire response into the
  * shape every consumer already expects.
  *
@@ -85,5 +97,13 @@ export function reshapePaletteRows(rows) {
 export function getPaletteListing(state, namespace, slug) {
 	const rows = state.paletteListings[paletteListingKey(namespace, slug)];
 
-	return rows ? reshapePaletteRows(rows) : EMPTY_LISTING;
+	if (!rows) {
+		return EMPTY_LISTING;
+	}
+
+	if (!reshapedListingCache.has(rows)) {
+		reshapedListingCache.set(rows, reshapePaletteRows(rows));
+	}
+
+	return reshapedListingCache.get(rows);
 }

--- a/src/style-library/store/selectors.js
+++ b/src/style-library/store/selectors.js
@@ -8,6 +8,7 @@
  * Internal dependencies
  */
 import { presetsKey, paletteListingKey, EMPTY_LISTING } from './constants';
+import { reshapePaletteRows } from '../helpers/palettes';
 
 /**
  * Read the libraries list.
@@ -36,40 +37,6 @@ export function getLibraries(state) {
  */
 export function getBlockPresets(state, namespace, block, slug) {
 	return state.presets[presetsKey(namespace, block, slug)] ?? null;
-}
-
-/**
- * Reshape the flat embedded-array wire response into the shape every consumer already expects. The
- * wire shape is a flat array of rows (WP core's `_embed` only resolves top-level collection items,
- * never something nested inside a wrapper key — see the REST controller's own docblock for why)
- * with `is_default`/`is_current`/`user_created` flags per row instead of collection-level pointers;
- * this reshapes those flags back into the pointer-based shape this app's own code was already built
- * around.
- *
- * Used internally by `getPaletteListing` below only — reshaping the raw wire-format rows, exactly
- * as the reducer stores them, into the shape the frontend consumes. Nothing else should call this
- * directly, and specifically not code that writes into the store: `helpers/palette-flows.js`
- * dispatches every write's response RAW, via `onReceive`, with no reshaping before dispatch —
- * reshaping a write's response before it reaches the store would double-reshape it on the next
- * read, since `getPaletteListing` is the one canonical place reshaping happens.
- *
- * @param {Array<Object>} rows The flat embedded-array rows.
- *
- * @since TBD
- *
- * @return {{defaultId: string, currentId: string, palettes: Array<Object>, userCreated: Array<string>}}
- */
-export function reshapePaletteRows(rows) {
-	return {
-		defaultId: rows.find((row) => row.is_default)?.id ?? '',
-		currentId: rows.find((row) => row.is_current)?.id ?? '',
-		palettes: rows.map((row) => ({
-			id: row.id,
-			label: row.label,
-			groups: row._embedded?.self?.[0]?.groups ?? [],
-		})),
-		userCreated: rows.filter((row) => row.user_created).map((row) => row.id),
-	};
 }
 
 /**

--- a/src/style-library/store/selectors.test.js
+++ b/src/style-library/store/selectors.test.js
@@ -77,4 +77,21 @@ describe('selectors', () => {
 			userCreated: [],
 		});
 	});
+
+	it('getPaletteListing() returns the same object reference across calls until the rows array is replaced', () => {
+		const rows = [{ id: 'default', label: 'Default', is_default: true, is_current: true, user_created: false }];
+		const state = { libraries: [], presets: {}, paletteListings: { 'ns::default': rows } };
+
+		const first = getPaletteListing(state, 'ns', 'default');
+		const second = getPaletteListing(state, 'ns', 'default');
+
+		expect(second).toBe(first);
+
+		const nextRows = [{ id: 'default', label: 'Default', is_default: true, is_current: true, user_created: false }];
+		const nextState = { libraries: [], presets: {}, paletteListings: { 'ns::default': nextRows } };
+
+		const third = getPaletteListing(nextState, 'ns', 'default');
+
+		expect(third).not.toBe(first);
+	});
 });

--- a/src/style-library/store/selectors.test.js
+++ b/src/style-library/store/selectors.test.js
@@ -1,9 +1,9 @@
 /* eslint-env jest */
-import { getBlockPresets, getLibraries } from './selectors';
+import { getBlockPresets, getLibraries, getPaletteListing } from './selectors';
 
 describe('selectors', () => {
 	it('getLibraries() returns the libraries slice', () => {
-		const state = { libraries: [{ slug: 'default' }], presets: {}, paletteListings: {}, palettes: {} };
+		const state = { libraries: [{ slug: 'default' }], presets: {}, paletteListings: {} };
 
 		expect(getLibraries(state)).toEqual([{ slug: 'default' }]);
 	});
@@ -13,10 +13,68 @@ describe('selectors', () => {
 			libraries: [],
 			presets: { 'ns::block::slug': { version: 'a1' } },
 			paletteListings: {},
-			palettes: {},
 		};
 
 		expect(getBlockPresets(state, 'ns', 'block', 'slug')).toEqual({ version: 'a1' });
 		expect(getBlockPresets(state, 'ns', 'other-block', 'slug')).toBeNull();
+	});
+
+	it('getPaletteListing() returns EMPTY_LISTING when nothing has resolved yet', () => {
+		const state = { libraries: [], presets: {}, paletteListings: {} };
+
+		expect(getPaletteListing(state, 'ns', 'default')).toEqual({
+			defaultId: '',
+			currentId: '',
+			palettes: [],
+			userCreated: [],
+		});
+	});
+
+	it('getPaletteListing() reshapes the flat embedded-array wire response into the internal shape', () => {
+		const rows = [
+			{
+				id: 'default',
+				label: 'Default',
+				is_default: true,
+				is_current: false,
+				user_created: false,
+				_embedded: {
+					self: [
+						{ id: 'default', label: 'Default', groups: [{ id: 'brand', label: 'Brand', swatches: [] }] },
+					],
+				},
+			},
+			{
+				id: 'custom-1',
+				label: 'Custom',
+				is_default: false,
+				is_current: true,
+				user_created: true,
+				_embedded: { self: [{ id: 'custom-1', label: 'Custom', groups: [] }] },
+			},
+		];
+		const state = { libraries: [], presets: {}, paletteListings: { 'ns::default': rows } };
+
+		expect(getPaletteListing(state, 'ns', 'default')).toEqual({
+			defaultId: 'default',
+			currentId: 'custom-1',
+			palettes: [
+				{ id: 'default', label: 'Default', groups: [{ id: 'brand', label: 'Brand', swatches: [] }] },
+				{ id: 'custom-1', label: 'Custom', groups: [] },
+			],
+			userCreated: ['custom-1'],
+		});
+	});
+
+	it('getPaletteListing() degrades a row with no `_embedded` data to an empty groups array', () => {
+		const rows = [{ id: 'default', label: 'Default', is_default: true, is_current: true, user_created: false }];
+		const state = { libraries: [], presets: {}, paletteListings: { 'ns::default': rows } };
+
+		expect(getPaletteListing(state, 'ns', 'default')).toEqual({
+			defaultId: 'default',
+			currentId: 'default',
+			palettes: [{ id: 'default', label: 'Default', groups: [] }],
+			userCreated: [],
+		});
 	});
 });

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
@@ -175,6 +175,27 @@ final class Palettes_ControllerTest extends TestCase {
 	}
 
 	/**
+	 * Activating a palette returns the full embedded listing, not just the confirmed id — this is what
+	 * lets the frontend skip a follow-up fetch after activation.
+	 *
+	 * @return void
+	 */
+	public function testSetCurrentReturnsTheFullEmbeddedListing(): void {
+		$this->create_custom_palette();
+
+		$request = new WP_REST_Request( 'PUT' );
+		$request->set_param( 'current', 'custom' );
+
+		$data = $this->controller->set_current( $request )->get_data();
+
+		$custom_row = current( array_filter( $data, static fn( array $row ) => $row['id'] === 'custom' ) );
+
+		$this->assertNotFalse( $custom_row, 'The activated palette is present in the response.' );
+		$this->assertTrue( $custom_row['is_current'], 'The activated palette is flagged current in the same response.' );
+		$this->assertArrayHasKey( 'groups', $custom_row['_embedded']['self'][0], 'The response carries full palette detail, not just the pointer.' );
+	}
+
+	/**
 	 * Creating a well-formed palette persists it so a later read and the effective reader both see it, and
 	 * the write response body itself carries the fresh, fully-embedded listing — the same shape
 	 * `GET /palettes?_embed` produces — so the caller never needs a follow-up GET.

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
@@ -51,8 +51,9 @@ final class Palettes_ControllerTest extends TestCase {
 	}
 
 	/**
-	 * The listing returns the library's $default / $current pointers and each palette's id + label — the shipped
-	 * `default` plus a stored non-default palette.
+	 * The listing returns a flat row per palette carrying its id, label, and `is_default` / `is_current` /
+	 * `user_created` flags, each with an embeddable `self` link — the shipped `default` plus a stored
+	 * non-default palette.
 	 *
 	 * @return void
 	 */
@@ -61,12 +62,43 @@ final class Palettes_ControllerTest extends TestCase {
 
 		$data = $this->controller->get_items( new WP_REST_Request( WP_REST_Server::READABLE ) )->get_data();
 
-		$this->assertSame( 'default', $data['$default'] );
-		$this->assertSame( 'default', $data['$current'] );
-
-		$ids = array_column( $data['palettes'], 'id' );
+		$ids = array_column( $data, 'id' );
 		$this->assertContains( 'default', $ids );
 		$this->assertContains( 'custom', $ids );
+
+		$default_row = $data[ array_search( 'default', $ids, true ) ];
+		$custom_row  = $data[ array_search( 'custom', $ids, true ) ];
+
+		$this->assertTrue( $default_row['is_default'] );
+		$this->assertTrue( $default_row['is_current'] );
+		$this->assertFalse( $default_row['user_created'] );
+
+		$this->assertFalse( $custom_row['is_default'] );
+		$this->assertFalse( $custom_row['is_current'] );
+		$this->assertTrue( $custom_row['user_created'] );
+		$this->assertSame( 'Custom', $custom_row['label'] );
+
+		$this->assertArrayHasKey( 'self', $default_row['_links'] );
+		$this->assertTrue( $default_row['_links']['self'][0]['embeddable'] );
+	}
+
+	/**
+	 * `_embed` resolves each row's `self` link into its full `effective_view()` — the whole point of
+	 * flattening the listing in the first place.
+	 *
+	 * @return void
+	 */
+	public function testGetItemsEmbedsEffectiveViewPerRow(): void {
+		$this->create_custom_palette();
+
+		$request = new WP_REST_Request( WP_REST_Server::READABLE, '/kb-design-tokens/v1/palettes' );
+		$request->set_param( 'library', 'default' );
+
+		$response = rest_get_server()->dispatch( $request );
+		$resolved = rest_get_server()->response_to_data( $response, true );
+
+		self::assertArrayHasKey( '_embedded', $resolved[0] );
+		self::assertArrayHasKey( 'groups', $resolved[0]['_embedded']['self'][0] );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
@@ -4,6 +4,7 @@
 namespace Tests\wpunit\Resources\Design_Tokens\Rest\V1;
 
 use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Palettes;
 use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Palettes_Controller;
 use Tests\Support\Classes\TestCase;
@@ -30,6 +31,11 @@ final class Palettes_ControllerTest extends TestCase {
 	private Palettes_Controller $controller;
 
 	/**
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
 	 * @return void
 	 */
 	protected function setUp(): void {
@@ -37,6 +43,7 @@ final class Palettes_ControllerTest extends TestCase {
 
 		$this->palettes   = $this->container->get( Effective_Palettes::class );
 		$this->controller = $this->container->get( Palettes_Controller::class );
+		$this->store      = $this->container->get( Token_Store::class );
 
 		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
 	}
@@ -99,6 +106,32 @@ final class Palettes_ControllerTest extends TestCase {
 
 		self::assertArrayHasKey( '_embedded', $resolved[0] );
 		self::assertArrayHasKey( 'groups', $resolved[0]['_embedded']['self'][0] );
+	}
+
+	/**
+	 * A listing requested for a library other than the active one carries that same library on each
+	 * row's `self` link, and `_embed` resolves against it — not the active library. Without the
+	 * `library` query arg on the link, `_embed`'s internal sub-request would silently fall back to the
+	 * active library and return the wrong palette's data.
+	 *
+	 * @return void
+	 */
+	public function testGetItemsSelfLinkTargetsTheRequestedLibraryNotTheActiveOne(): void {
+		$this->store->save_document( '{}', 'brand-b' );
+		$this->controller->update_item( $this->write_request( 'custom', 'Brand B Custom', '#00FF00', 'brand-b' ) );
+
+		$request = new WP_REST_Request( WP_REST_Server::READABLE, '/kb-design-tokens/v1/palettes' );
+		$request->set_param( 'library', 'brand-b' );
+		$request->set_param( '_embed', true );
+
+		$response = rest_get_server()->dispatch( $request );
+		$resolved = rest_get_server()->response_to_data( $response, true );
+
+		$ids        = array_column( $resolved, 'id' );
+		$custom_row = $resolved[ array_search( 'custom', $ids, true ) ];
+
+		$this->assertStringContainsString( 'library=brand-b', $custom_row['_links']['self'][0]['href'] );
+		$this->assertSame( 'Brand B Custom', $custom_row['_embedded']['self'][0]['label'] );
 	}
 
 	/**
@@ -994,13 +1027,14 @@ final class Palettes_ControllerTest extends TestCase {
 	/**
 	 * A palette write request with a single one-swatch Accent group.
 	 *
-	 * @param string $id    The palette id.
-	 * @param string $label The palette label.
-	 * @param string $value The single swatch's $value.
+	 * @param string      $id      The palette id.
+	 * @param string      $label   The palette label.
+	 * @param string      $value   The single swatch's $value.
+	 * @param string|null $library The library to target, when the write is not for the active library.
 	 *
 	 * @return WP_REST_Request
 	 */
-	private function write_request( string $id, string $label, string $value ): WP_REST_Request {
+	private function write_request( string $id, string $label, string $value, ?string $library = null ): WP_REST_Request {
 		$request = new WP_REST_Request( 'PUT' );
 		$request->set_param( 'id', $id );
 		$request->set_param( 'label', $label );
@@ -1020,6 +1054,10 @@ final class Palettes_ControllerTest extends TestCase {
 				],
 			]
 		);
+
+		if ( $library !== null ) {
+			$request->set_param( 'library', $library );
+		}
 
 		return $request;
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
@@ -765,6 +765,57 @@ final class Palettes_ControllerTest extends TestCase {
 	}
 
 	/**
+	 * A label-only write against a stored swatch whose token is not a registered color is rejected —
+	 * the label-only path must run the same registry guard a value write runs, using the token's current
+	 * stored value, so a stale or non-color token cannot be renamed without ever being validated.
+	 *
+	 * @return void
+	 */
+	public function testUpdateSwatchRejectsALabelOnlyWriteForANonColorToken(): void {
+		// Seeded directly through the store, bypassing the normal write path's own guard, since no
+		// legitimate write can ever get a non-color token into a palette node in the first place.
+		$this->store->save_document(
+			wp_json_encode(
+				[
+					'$extensions' => [
+						'com.kadence.designTokens' => [
+							'colorPalettes' => [
+								'default' => [
+									'groups' => [
+										[
+											'id'       => 'swatch',
+											'label'    => 'swatch',
+											'swatches' => [
+												[
+													'token'  => 'primitive.dimension.spacing.md',
+													'label'  => 'Spacing Md',
+													'$value' => '8px',
+												],
+											],
+										],
+									],
+								],
+							],
+						],
+					],
+				]
+			),
+			'default'
+		);
+
+		$this->assertSame(
+			WP_Http::UNPROCESSABLE_ENTITY,
+			$this->status_of(
+				$this->controller->update_swatch(
+					$this->swatch_request( 'PUT', 'default', 'primitive.dimension.spacing.md', null, 'Renamed' )
+				)
+			)
+		);
+
+		$this->assertSame( 'Spacing Md', $this->swatch_label( 'default', 'primitive.dimension.spacing.md' ), 'The label is left untouched.' );
+	}
+
+	/**
 	 * An empty-string label is rejected — a swatch's label is structural and shared library-wide, so an
 	 * empty write would silently wipe its display name for every palette that inherits it.
 	 *

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
@@ -694,6 +694,56 @@ final class Palettes_ControllerTest extends TestCase {
 	}
 
 	/**
+	 * A label-only write updates the swatch's structural label on the default palette, leaving its
+	 * value untouched.
+	 *
+	 * @return void
+	 */
+	public function testUpdateSwatchAcceptsALabelOnlyWrite(): void {
+		$before = $this->palettes->swatch_values( 'default' )['primitive.color.brand.primary'];
+
+		$this->controller->update_swatch(
+			$this->swatch_request( 'PUT', 'default', 'primitive.color.brand.primary', null, 'Brand One' )
+		);
+
+		$this->assertSame( $before, $this->palettes->swatch_values( 'default' )['primitive.color.brand.primary'] );
+	}
+
+	/**
+	 * A label write against a non-default palette id is rejected — labels are structural, not per-palette.
+	 *
+	 * @return void
+	 */
+	public function testUpdateSwatchRejectsALabelOnANonDefaultPalette(): void {
+		$this->create_custom_palette();
+
+		$this->assertSame(
+			WP_Http::UNPROCESSABLE_ENTITY,
+			$this->status_of(
+				$this->controller->update_swatch(
+					$this->swatch_request( 'PUT', 'custom', 'primitive.color.brand.primary', null, 'Brand One' )
+				)
+			)
+		);
+	}
+
+	/**
+	 * A request with neither value nor label is rejected.
+	 *
+	 * @return void
+	 */
+	public function testUpdateSwatchRequiresAtLeastOneField(): void {
+		$this->assertSame(
+			WP_Http::UNPROCESSABLE_ENTITY,
+			$this->status_of(
+				$this->controller->update_swatch(
+					$this->swatch_request( 'PUT', 'default', 'primitive.color.brand.primary' )
+				)
+			)
+		);
+	}
+
+	/**
 	 * Deleting a swatch through the sub-route drops the palette's own value for that token, reverting it to
 	 * inherited-from-default.
 	 *
@@ -1003,22 +1053,28 @@ final class Palettes_ControllerTest extends TestCase {
 	}
 
 	/**
-	 * A single-swatch request for the sub-route: the palette id, the token dot-path, and (for a write) the value.
+	 * A single-swatch request for the sub-route: the palette id, the token dot-path, and (for a write) the value
+	 * and/or the structural label.
 	 *
 	 * @param string      $method The HTTP method.
 	 * @param string      $id     The palette id.
 	 * @param string      $token  The swatch token dot-path.
 	 * @param string|null $value  The swatch value, for a write.
+	 * @param string|null $label  The swatch's structural label, for a write.
 	 *
 	 * @return WP_REST_Request
 	 */
-	private function swatch_request( string $method, string $id, string $token, ?string $value = null ): WP_REST_Request {
+	private function swatch_request( string $method, string $id, string $token, ?string $value = null, ?string $label = null ): WP_REST_Request {
 		$request = new WP_REST_Request( $method );
 		$request->set_param( 'id', $id );
 		$request->set_param( 'token', $token );
 
 		if ( $value !== null ) {
 			$request->set_param( '$value', $value );
+		}
+
+		if ( $label !== null ) {
+			$request->set_param( 'label', $label );
 		}
 
 		return $request;

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
@@ -759,8 +759,30 @@ final class Palettes_ControllerTest extends TestCase {
 		);
 
 		$this->assertSame( $before, $this->palettes->swatch_values( 'default' )['primitive.color.brand.primary'] );
+		$this->assertSame( 'Brand One', $this->swatch_label( 'default', 'primitive.color.brand.primary' ) );
 
 		$this->assertEmbeddedListingShape( $response->get_data() );
+	}
+
+	/**
+	 * An empty-string label is rejected — a swatch's label is structural and shared library-wide, so an
+	 * empty write would silently wipe its display name for every palette that inherits it.
+	 *
+	 * @return void
+	 */
+	public function testUpdateSwatchRejectsAnEmptyLabel(): void {
+		$before = $this->swatch_label( 'default', 'primitive.color.brand.primary' );
+
+		$this->assertSame(
+			WP_Http::UNPROCESSABLE_ENTITY,
+			$this->status_of(
+				$this->controller->update_swatch(
+					$this->swatch_request( 'PUT', 'default', 'primitive.color.brand.primary', null, '' )
+				)
+			)
+		);
+
+		$this->assertSame( $before, $this->swatch_label( 'default', 'primitive.color.brand.primary' ), 'The label is left untouched.' );
 	}
 
 	/**
@@ -1209,5 +1231,30 @@ final class Palettes_ControllerTest extends TestCase {
 		}
 
 		return $result->get_status();
+	}
+
+	/**
+	 * Read a swatch's current effective label back through `get_item()`, the same read path the frontend uses.
+	 *
+	 * @param string $id    The palette id.
+	 * @param string $token The swatch token dot-path.
+	 *
+	 * @return string|null
+	 */
+	private function swatch_label( string $id, string $token ): ?string {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'id', $id );
+
+		$groups = $this->controller->get_item( $request )->get_data()['groups'] ?? [];
+
+		foreach ( $groups as $group ) {
+			foreach ( $group['swatches'] ?? [] as $swatch ) {
+				if ( ( $swatch['token'] ?? null ) === $token ) {
+					return $swatch['label'] ?? null;
+				}
+			}
+		}
+
+		return null;
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
@@ -175,7 +175,9 @@ final class Palettes_ControllerTest extends TestCase {
 	}
 
 	/**
-	 * Creating a well-formed palette persists it so a later read and the effective reader both see it.
+	 * Creating a well-formed palette persists it so a later read and the effective reader both see it, and
+	 * the write response body itself carries the fresh, fully-embedded listing — the same shape
+	 * `GET /palettes?_embed` produces — so the caller never needs a follow-up GET.
 	 *
 	 * @return void
 	 */
@@ -187,6 +189,29 @@ final class Palettes_ControllerTest extends TestCase {
 
 		$this->assertContains( 'ocean', $this->palettes->palette_ids() );
 		$this->assertSame( '#0000ff', $this->palettes->swatch_values( 'ocean' )['primitive.color.brand.primary'] );
+
+		$this->assertEmbeddedListingShape( $response->get_data() );
+
+		$ids = array_column( $response->get_data(), 'id' );
+		$this->assertContains( 'ocean', $ids );
+	}
+
+	/**
+	 * Renaming a palette (an `update_item` write against its existing id with a new label) responds with the
+	 * fresh embedded listing, so the caller sees the renamed label without a follow-up GET.
+	 *
+	 * @return void
+	 */
+	public function testUpdateItemRenameResponseCarriesTheEmbeddedListing(): void {
+		$this->controller->update_item( $this->write_request( 'ocean', 'Ocean', '#0000ff' ) );
+
+		$response = $this->controller->update_item( $this->write_request( 'ocean', 'Sea', '#0000ff' ) );
+
+		$this->assertEmbeddedListingShape( $response->get_data() );
+
+		$ids       = array_column( $response->get_data(), 'id' );
+		$ocean_row = $response->get_data()[ array_search( 'ocean', $ids, true ) ];
+		$this->assertSame( 'Sea', $ocean_row['label'] );
 	}
 
 	/**
@@ -497,7 +522,8 @@ final class Palettes_ControllerTest extends TestCase {
 	}
 
 	/**
-	 * Deleting a user-created palette removes it from the listing, since the baseline has no definition to
+	 * Deleting a user-created palette removes it from the listing and responds with the fresh embedded
+	 * listing (the deleted palette no longer among its rows), since the baseline has no definition to
 	 * fall back to.
 	 *
 	 * @return void
@@ -508,9 +534,11 @@ final class Palettes_ControllerTest extends TestCase {
 
 		$delete = new WP_REST_Request( 'DELETE' );
 		$delete->set_param( 'id', 'ocean' );
-		$this->controller->delete_item( $delete );
-
+		$response = $this->controller->delete_item( $delete );
 		$this->assertNotContains( 'ocean', $this->palettes->palette_ids() );
+
+		$this->assertEmbeddedListingShape( $response->get_data() );
+		$this->assertNotContains( 'ocean', array_column( $response->get_data(), 'id' ) );
 	}
 
 	/**
@@ -625,7 +653,8 @@ final class Palettes_ControllerTest extends TestCase {
 
 	/**
 	 * Setting one swatch through the sub-route stores just that token and leaves the palette's other swatches
-	 * intact — the caller never sends the full palette, and an untouched token is unaffected.
+	 * intact — the caller never sends the full palette, and an untouched token is unaffected. The write response
+	 * body carries the fresh embedded listing.
 	 *
 	 * @return void
 	 */
@@ -641,6 +670,8 @@ final class Palettes_ControllerTest extends TestCase {
 		$stored = $this->palettes->swatch_values( 'ocean' );
 		$this->assertSame( '#00ff00', $stored['primitive.color.brand.secondary'], 'The set swatch is stored.' );
 		$this->assertSame( '#0000ff', $stored['primitive.color.brand.primary'], 'The untouched swatch is intact.' );
+
+		$this->assertEmbeddedListingShape( $response->get_data() );
 	}
 
 	/**
@@ -694,19 +725,21 @@ final class Palettes_ControllerTest extends TestCase {
 	}
 
 	/**
-	 * A label-only write updates the swatch's structural label on the default palette, leaving its
-	 * value untouched.
+	 * A label-only write updates the swatch's structural label on the default palette, leaving its value
+	 * untouched, and the write response body carries the fresh embedded listing.
 	 *
 	 * @return void
 	 */
 	public function testUpdateSwatchAcceptsALabelOnlyWrite(): void {
 		$before = $this->palettes->swatch_values( 'default' )['primitive.color.brand.primary'];
 
-		$this->controller->update_swatch(
+		$response = $this->controller->update_swatch(
 			$this->swatch_request( 'PUT', 'default', 'primitive.color.brand.primary', null, 'Brand One' )
 		);
 
 		$this->assertSame( $before, $this->palettes->swatch_values( 'default' )['primitive.color.brand.primary'] );
+
+		$this->assertEmbeddedListingShape( $response->get_data() );
 	}
 
 	/**
@@ -1116,6 +1149,30 @@ final class Palettes_ControllerTest extends TestCase {
 		}
 
 		return $request;
+	}
+
+	/**
+	 * Assert a write response body is the same fully-embedded shape `GET /palettes?_embed` produces: a flat
+	 * array of listing rows, each carrying its `is_default` / `is_current` / `user_created` flags and an
+	 * `_embedded.self` entry holding the row's full `effective_view()` (id, label, groups).
+	 *
+	 * @param array<int, array<string, mixed>> $data The write response body.
+	 *
+	 * @return void
+	 */
+	private function assertEmbeddedListingShape( array $data ): void {
+		$this->assertNotEmpty( $data, 'The embedded listing must carry at least one row.' );
+
+		foreach ( $data as $row ) {
+			$this->assertArrayHasKey( 'id', $row );
+			$this->assertArrayHasKey( 'label', $row );
+			$this->assertArrayHasKey( 'is_default', $row );
+			$this->assertArrayHasKey( 'is_current', $row );
+			$this->assertArrayHasKey( 'user_created', $row );
+			$this->assertArrayHasKey( '_embedded', $row );
+			$this->assertArrayHasKey( 'self', $row['_embedded'] );
+			$this->assertArrayHasKey( 'groups', $row['_embedded']['self'][0] );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fetches a full palette listing in one REST request instead of two, and lets every write's own response replace the follow-up refetch that used to run after it.

`GET /palettes` returns a flat array of rows (`id`, `label`, `is_default`, `is_current`, `user_created`), each carrying a `self` link. Requesting `GET /palettes?_embed` resolves each row's full `effective_view()` (its color groups and swatches) under `_embedded`, following WordPress's own REST embedding convention instead of a bespoke shape. The frontend always requests the listing with `_embed`, so opening the palette editor no longer needs a second request per palette — the listing carries everything the screen and its settings panel need.

`PUT /palettes/{id}/swatches/{token}` now accepts an optional `$label` alongside the existing `$value`, so renaming a swatch is a single targeted write instead of fetching the whole default palette and saving it back. A label change is only valid against the library's default palette, since labels are structural and inherited by every palette from there.

Every palette write — create, rename, delete, activate, and both swatch value/label writes — now returns the same embedded listing shape `GET /palettes?_embed` does. `PUT /palettes/current` (activation) previously returned only `{ current: id }`; because it now returns the full listing in the same round trip, the frontend's `pendingActiveId` optimistic-override machinery is gone — there's no window left where the UI would otherwise show stale data while waiting on a slower follow-up fetch.

On the frontend, `usePalettes()` reads the listing through a `@wordpress/data` store slice (`getPaletteListing`), and every write dispatches its own response directly into that store instead of triggering a separate reload. The edited palette is derived straight from the listing (`listing.palettes.find(...)`) rather than through a second per-palette selector. Swatch reordering keeps its optimistic drag feedback through local `pendingGroups` state (mirroring the same pattern already used by the scale screen), clearing once the write's response lands or reverting if the write fails.

## Screenshots

<!-- Drag/paste screenshots (or a short GIF) in over each placeholder line below, then delete the placeholder text. -->

**Color Palette screen, palette list with the "Active" badge:**
_paste screenshot here_

**Activating a different palette — a GIF showing the badge move instantly, before the network round trip completes, would show this better than a static shot:**
_paste screenshot or GIF here_

## Test instructions

1. Go to **Style Library → Color Palette**, throttle the network, open the settings panel for a swatch — confirm only one request loads the palette listing (with `_embed`), and opening a palette for editing needs no further request.
2. Create, rename, delete, and activate palettes; add/remove colors and groups; drag-reorder swatches within a group — confirm everything behaves as expected, including the instant "Active" badge move on activation and the instant reorder feedback while dragging.
3. Rename a swatch (edits the default palette's label) and edit a swatch's color value on a non-default palette — confirm both save correctly and a label edit is rejected with a validation error if attempted against a non-default palette.
4. With the network panel open, confirm every palette write (create/rename/delete/activate/swatch edit) triggers exactly one request, with no follow-up `GET /palettes` afterward.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4200/phase-6-feed-slice
bun install
```

The Style Library is at **WP Admin → Kadence → Style Library**.
</details>

---

Slice 5 of 7 in the SOFT-4200 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Palette listings now update immediately after creating, activating, renaming, deleting, or reordering palettes.
  - Swatches can be edited by changing their value, label, or both.
  - Palette and swatch changes now preserve the latest state across multiple open views.

- **Bug Fixes**
  - Failed reorder operations now restore the previous order.
  - Improved handling of palette loading errors and incomplete palette data.
  - Added validation to prevent empty swatch values and unsupported structural labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
