### PR TITLE
[DTM] SOFT-4200 [6/7]: Design-token feed slice, folding every scale-type screen in

### DIFF
--- a/src/style-library.js
+++ b/src/style-library.js
@@ -3,6 +3,7 @@
  */
 import { createRoot } from '@wordpress/element';
 import { StyleLibraryApp } from './style-library/app/StyleLibraryApp';
+import { seedDesignTokensFeed } from './style-library/hooks/use-design-tokens-feed';
 import './style-library/styles/_primitives.scss';
 import './style-library/styles/_semantic.scss';
 import './style-library/styles/_shell.scss';
@@ -14,6 +15,11 @@ wp.domReady(() => {
 	if (!container) {
 		return;
 	}
+
+	// Seeds the store BEFORE React starts rendering, so `useDesignTokensFeed()`'s very first render
+	// already has `isReady: true` for the active library — see the function's own docblock for why
+	// this can't happen inside the render itself.
+	seedDesignTokensFeed();
 
 	createRoot(container).render(<StyleLibraryApp />);
 });

--- a/src/style-library/__tests__/tokens.test.js
+++ b/src/style-library/__tests__/tokens.test.js
@@ -4,7 +4,6 @@ import {
 	flattenSchemaTokens,
 	isResponsiveType,
 	pickableTokensForType,
-	refreshFeedFlow,
 	tokenTypeIdSegment,
 } from '../helpers/tokens';
 import { PICKABLE_TOKENS_GLOBAL } from '../constants';
@@ -222,28 +221,5 @@ describe('pickableTokensForType', () => {
 		expect(tokens).toEqual([
 			{ id: 'semantic.color.action-primary', label: 'Action Primary', value: '#3633e1', role: null },
 		]);
-	});
-});
-
-describe('refreshFeedFlow', () => {
-	it('fetches the feed for the given slug and applies it', async () => {
-		const feed = { slug: 'brand-b', active: true };
-		const fetchFeed = jest.fn().mockResolvedValue(feed);
-		const applyFeed = jest.fn();
-
-		const result = await refreshFeedFlow('brand-b', applyFeed, fetchFeed);
-
-		expect(fetchFeed).toHaveBeenCalledWith('brand-b');
-		expect(applyFeed).toHaveBeenCalledWith(feed);
-		expect(result).toBe(feed);
-	});
-
-	it('rejects and does not apply anything when the fetch fails', async () => {
-		const error = new Error('network down');
-		const fetchFeed = jest.fn().mockRejectedValue(error);
-		const applyFeed = jest.fn();
-
-		await expect(refreshFeedFlow('brand-b', applyFeed, fetchFeed)).rejects.toBe(error);
-		expect(applyFeed).not.toHaveBeenCalled();
 	});
 });

--- a/src/style-library/__tests__/use-design-tokens-feed.test.js
+++ b/src/style-library/__tests__/use-design-tokens-feed.test.js
@@ -1,0 +1,88 @@
+/* eslint-env jest */
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { RegistryProvider } from '@wordpress/data';
+import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
+import { fetchDesignTokensFeed, configureRestClient } from '../api/client';
+import { createTestRegistry } from '../store/test-utils';
+
+jest.mock('../api/client', () => ({
+	fetchDesignTokensFeed: jest.fn(),
+	configureRestClient: jest.fn(),
+}));
+
+const LOCALIZED_FEED = { slug: 'default', version: 'v1', rest: { root: 'x', nonce: 'y' }, schema: { groups: {} } };
+const BRAND_FEED = { slug: 'brand', version: 'b1', rest: { root: 'x', nonce: 'y' }, schema: { groups: {} } };
+
+describe('useDesignTokensFeed', () => {
+	let container;
+	let root;
+	let registry;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		registry = createTestRegistry();
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+		window.kadenceDesignTokens = LOCALIZED_FEED;
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		delete global.IS_REACT_ACT_ENVIRONMENT;
+		delete window.kadenceDesignTokens;
+	});
+
+	function mountProbe() {
+		let latest = null;
+
+		function Probe() {
+			latest = useDesignTokensFeed();
+			return null;
+		}
+
+		return {
+			render: () =>
+				act(() =>
+					root.render(
+						<RegistryProvider value={registry}>
+							<Probe />
+						</RegistryProvider>
+					)
+				),
+			latest: () => latest,
+		};
+	}
+
+	it('is ready on the very first render, with no fetch for the localized slug', async () => {
+		const probe = mountProbe();
+		await probe.render();
+
+		expect(probe.latest().isReady).toBe(true);
+		expect(probe.latest().feed).toEqual(LOCALIZED_FEED);
+		expect(fetchDesignTokensFeed).not.toHaveBeenCalled();
+	});
+
+	it('refreshFeed() switches to a fetched library and always forces a fresh read', async () => {
+		fetchDesignTokensFeed.mockResolvedValueOnce(BRAND_FEED);
+
+		const probe = mountProbe();
+		await probe.render();
+
+		await act(async () => probe.latest().refreshFeed('brand'));
+
+		expect(fetchDesignTokensFeed).toHaveBeenCalledWith('brand');
+		expect(probe.latest().feed).toEqual(BRAND_FEED);
+		expect(probe.latest().slug).toBe('brand');
+	});
+
+	it('configures the REST client once the feed carries a rest descriptor', async () => {
+		const probe = mountProbe();
+		await probe.render();
+
+		expect(configureRestClient).toHaveBeenCalledWith(LOCALIZED_FEED.rest);
+	});
+});

--- a/src/style-library/__tests__/use-design-tokens-feed.test.js
+++ b/src/style-library/__tests__/use-design-tokens-feed.test.js
@@ -2,7 +2,7 @@
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RegistryProvider } from '@wordpress/data';
-import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
+import { seedDesignTokensFeed, useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { fetchDesignTokensFeed, configureRestClient } from '../api/client';
 import { createTestRegistry } from '../store/test-utils';
 
@@ -25,6 +25,11 @@ describe('useDesignTokensFeed', () => {
 		registry = createTestRegistry();
 		global.IS_REACT_ACT_ENVIRONMENT = true;
 		window.kadenceDesignTokens = LOCALIZED_FEED;
+
+		// Mirrors `style-library.js`'s bootstrap: seeds the (isolated, test) registry BEFORE
+		// mounting, the same way production seeds the default registry before `createRoot(...).render()`.
+		seedDesignTokensFeed(registry.dispatch);
+
 		container = document.createElement('div');
 		document.body.appendChild(container);
 		root = createRoot(container);
@@ -57,6 +62,16 @@ describe('useDesignTokensFeed', () => {
 			latest: () => latest,
 		};
 	}
+
+	it('seedDesignTokensFeed() is a no-op when there is no localized feed', () => {
+		delete window.kadenceDesignTokens;
+
+		const dispatch = jest.fn(() => ({ receiveDesignTokensFeed: jest.fn(), finishResolution: jest.fn() }));
+
+		seedDesignTokensFeed(dispatch);
+
+		expect(dispatch).not.toHaveBeenCalled();
+	});
 
 	it('is ready on the very first render, with no fetch for the localized slug', async () => {
 		const probe = mountProbe();

--- a/src/style-library/__tests__/use-design-tokens-feed.test.js
+++ b/src/style-library/__tests__/use-design-tokens-feed.test.js
@@ -117,9 +117,10 @@ describe('useDesignTokensFeed', () => {
 		let refreshPromise;
 		await act(async () => {
 			refreshPromise = probe.latest().refreshFeed('brand');
-			// The resolver's own fetch call is scheduled via `setTimeout(0)` internally by
-			// `@wordpress/data`, so a real timer tick is needed before `fetchDesignTokensFeed`
-			// has actually been called and `resolveFetch` is assigned.
+			// `refreshFeed` calls `fetchDesignTokensFeed` synchronously (it no longer routes through
+			// the store's resolver framework, whose own dispatch is scheduled via `setTimeout(0)`
+			// internally by `@wordpress/data`) — this tick just lets the surrounding `act()` settle
+			// before the assertions below read state.
 			await new Promise((resolve) => setTimeout(resolve, 0));
 		});
 
@@ -172,9 +173,8 @@ describe('useDesignTokensFeed', () => {
 		let refreshPromise;
 		await act(async () => {
 			refreshPromise = probe.latest().refreshFeed('default');
-			// See the previous test: the resolver's fetch call is scheduled via `setTimeout(0)`
-			// internally, so a real timer tick is needed before `fetchDesignTokensFeed` has
-			// actually run and `resolveFetch` is assigned.
+			// See the previous test: `fetchDesignTokensFeed` runs synchronously inside `refreshFeed`
+			// now; this tick just lets the surrounding `act()` settle.
 			await new Promise((resolve) => setTimeout(resolve, 0));
 		});
 
@@ -240,5 +240,69 @@ describe('useDesignTokensFeed', () => {
 
 		expect(probe.latest().slug).toBe('third');
 		expect(probe.latest().feed).toEqual(THIRD_FEED);
+	});
+
+	// Two overlapping refreshes of the SAME slug (unlike the previous test's different-slug race —
+	// this is the shape every write flow's own `refreshFeed(slug)` produces when a sibling instance,
+	// e.g. a screen and its settings panel, both write close together). Before this was fixed, an
+	// older call's promise resolved the moment ANY call for the same tuple finished — including a
+	// newer sibling's — so it could settle with stale data before its own fetch had even landed, and
+	// code chaining logic off it (every write flow does) would act on that stale read.
+	it('an older refreshFeed() call for the SAME slug settles on its own fetch, not a newer sibling call finishing first', async () => {
+		let resolveOlder;
+		let resolveNewer;
+		fetchDesignTokensFeed
+			.mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						resolveOlder = resolve;
+					})
+			)
+			.mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						resolveNewer = resolve;
+					})
+			);
+
+		const probe = mountProbe();
+		await probe.render();
+
+		let olderCall;
+		let newerCall;
+		let olderSettled = false;
+		let olderResolvedWith = null;
+		await act(async () => {
+			olderCall = probe.latest().refreshFeed('brand');
+			olderCall.then((resolvedFeed) => {
+				olderSettled = true;
+				olderResolvedWith = resolvedFeed;
+			});
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			newerCall = probe.latest().refreshFeed('brand');
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		// The newer call resolves first — it must win, and the older call must still be pending,
+		// not resolved early by the newer call finishing the same (slug-only) tuple.
+		await act(async () => {
+			resolveNewer({ ...BRAND_FEED, version: 'newer' });
+			await newerCall;
+		});
+
+		expect(probe.latest().feed).toEqual({ ...BRAND_FEED, version: 'newer' });
+		expect(olderSettled).toBe(false);
+
+		// The older call's own fetch finally lands, with stale data — its promise settles now (not
+		// before, on the newer call's own resolution), with its OWN fetch's payload, and its stale
+		// response must not overwrite the newer feed already in the store.
+		await act(async () => {
+			resolveOlder({ ...BRAND_FEED, version: 'older' });
+			await olderCall;
+		});
+
+		expect(olderSettled).toBe(true);
+		expect(olderResolvedWith).toEqual({ ...BRAND_FEED, version: 'older' });
+		expect(probe.latest().feed).toEqual({ ...BRAND_FEED, version: 'newer' });
 	});
 });

--- a/src/style-library/__tests__/use-design-tokens-feed.test.js
+++ b/src/style-library/__tests__/use-design-tokens-feed.test.js
@@ -13,6 +13,7 @@ jest.mock('../api/client', () => ({
 
 const LOCALIZED_FEED = { slug: 'default', version: 'v1', rest: { root: 'x', nonce: 'y' }, schema: { groups: {} } };
 const BRAND_FEED = { slug: 'brand', version: 'b1', rest: { root: 'x', nonce: 'y' }, schema: { groups: {} } };
+const THIRD_FEED = { slug: 'third', version: 't1', rest: { root: 'x', nonce: 'y' }, schema: { groups: {} } };
 
 describe('useDesignTokensFeed', () => {
 	let container;
@@ -84,5 +85,145 @@ describe('useDesignTokensFeed', () => {
 		await probe.render();
 
 		expect(configureRestClient).toHaveBeenCalledWith(LOCALIZED_FEED.rest);
+	});
+
+	it('does not advance slug/feed until refreshFeed()s fresh read actually resolves', async () => {
+		let resolveFetch;
+		fetchDesignTokensFeed.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					resolveFetch = resolve;
+				})
+		);
+
+		const probe = mountProbe();
+		await probe.render();
+
+		let refreshPromise;
+		await act(async () => {
+			refreshPromise = probe.latest().refreshFeed('brand');
+			// The resolver's own fetch call is scheduled via `setTimeout(0)` internally by
+			// `@wordpress/data`, so a real timer tick is needed before `fetchDesignTokensFeed`
+			// has actually been called and `resolveFetch` is assigned.
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		// The fetch is still in flight: `slug`/`feed`/`isReady` must not have moved yet, or every
+		// consumer (including `StyleLibraryApp`, which gates its whole render on `isReady`) would
+		// already be showing nothing for a library switch that hasn't resolved.
+		expect(probe.latest().slug).toBe('default');
+		expect(probe.latest().isReady).toBe(true);
+		expect(probe.latest().feed).toEqual(LOCALIZED_FEED);
+
+		await act(async () => {
+			resolveFetch(BRAND_FEED);
+			await refreshPromise;
+		});
+
+		expect(probe.latest().slug).toBe('brand');
+		expect(probe.latest().isReady).toBe(true);
+		expect(probe.latest().feed).toEqual(BRAND_FEED);
+	});
+
+	it('keeps showing the previous library when refreshFeed()s fresh read rejects', async () => {
+		fetchDesignTokensFeed.mockRejectedValueOnce(new Error('network down'));
+
+		const probe = mountProbe();
+		await probe.render();
+
+		await act(async () => {
+			await expect(probe.latest().refreshFeed('brand')).rejects.toThrow('network down');
+		});
+
+		// `slug` never advanced onto 'brand', so the app keeps rendering the old library's feed
+		// instead of getting stuck on a permanent spinner behind a `slug` no feed ever resolved for.
+		expect(probe.latest().slug).toBe('default');
+		expect(probe.latest().isReady).toBe(true);
+		expect(probe.latest().feed).toEqual(LOCALIZED_FEED);
+	});
+
+	it('refreshFeed() with the current slug always forces a fresh read, without ever dropping readiness', async () => {
+		let resolveFetch;
+		fetchDesignTokensFeed.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					resolveFetch = resolve;
+				})
+		);
+
+		const probe = mountProbe();
+		await probe.render();
+
+		let refreshPromise;
+		await act(async () => {
+			refreshPromise = probe.latest().refreshFeed('default');
+			// See the previous test: the resolver's fetch call is scheduled via `setTimeout(0)`
+			// internally, so a real timer tick is needed before `fetchDesignTokensFeed` has
+			// actually run and `resolveFetch` is assigned.
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		// A write must always force a fresh read, never serve a cached value — even for the slug
+		// already showing.
+		expect(fetchDesignTokensFeed).toHaveBeenCalledWith('default');
+		expect(probe.latest().isReady).toBe(true);
+		expect(probe.latest().feed).toEqual(LOCALIZED_FEED);
+
+		const updatedFeed = { ...LOCALIZED_FEED, version: 'v2' };
+		await act(async () => {
+			resolveFetch(updatedFeed);
+			await refreshPromise;
+		});
+
+		expect(probe.latest().isReady).toBe(true);
+		expect(probe.latest().feed).toEqual(updatedFeed);
+	});
+
+	it('a slower first refreshFeed() call never overwrites a faster, later call', async () => {
+		let resolveBrand;
+		let resolveThird;
+		fetchDesignTokensFeed
+			.mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						resolveBrand = resolve;
+					})
+			)
+			.mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						resolveThird = resolve;
+					})
+			);
+
+		const probe = mountProbe();
+		await probe.render();
+
+		let firstCall;
+		let secondCall;
+		await act(async () => {
+			firstCall = probe.latest().refreshFeed('brand');
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			secondCall = probe.latest().refreshFeed('third');
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		// The second, later call resolves FIRST — its result must win.
+		await act(async () => {
+			resolveThird(THIRD_FEED);
+			await secondCall;
+		});
+
+		expect(probe.latest().slug).toBe('third');
+		expect(probe.latest().feed).toEqual(THIRD_FEED);
+
+		// The first, earlier call resolves LAST — it must not be allowed to overwrite the newer slug.
+		await act(async () => {
+			resolveBrand(BRAND_FEED);
+			await firstCall;
+		});
+
+		expect(probe.latest().slug).toBe('third');
+		expect(probe.latest().feed).toEqual(THIRD_FEED);
 	});
 });

--- a/src/style-library/helpers/tokens.js
+++ b/src/style-library/helpers/tokens.js
@@ -120,28 +120,6 @@ export function pickableTokensForType(type, role, selected) {
 }
 
 /**
- * Fetch the feed for a library and apply it. Pulled out of `use-design-tokens-feed` so the
- * refresh behavior can be exercised directly in a test without rendering the hook — the same
- * shape the hook's `refreshFeed` exposes to its callers. `fetchFeed` is injected (the hook passes
- * `fetchDesignTokensFeed` from `api/client`) rather than imported here, so this pure-helpers
- * module carries no REST dependency of its own and a test can pass a plain mock.
- *
- * @param {string}   slug      The token library slug to read the feed for.
- * @param {Function} applyFeed Called with the fetched feed payload once it resolves.
- * @param {Function} fetchFeed Fetches the feed payload for a slug (`fetchDesignTokensFeed`).
- *
- * @since TBD
- *
- * @return {Promise<object>} The fetched feed payload.
- */
-export function refreshFeedFlow(slug, applyFeed, fetchFeed) {
-	return fetchFeed(slug).then((nextFeed) => {
-		applyFeed(nextFeed);
-		return nextFeed;
-	});
-}
-
-/**
  * Flatten schema groups into a single token list.
  *
  * User-created primitives have no server-assigned group (empty string); they

--- a/src/style-library/hooks/use-design-tokens-feed.js
+++ b/src/style-library/hooks/use-design-tokens-feed.js
@@ -7,10 +7,11 @@ import { dispatch as defaultDispatch, useSelect, useRegistry } from '@wordpress/
 /**
  * Internal dependencies
  */
-import { configureRestClient } from '../api/client';
+import { configureRestClient, fetchDesignTokensFeed } from '../api/client';
 import { flattenSchemaTokens, getDesignTokensFeed as readLocalizedFeed } from '../helpers/tokens';
 import { DEFAULT_LIBRARY_SLUG } from '../constants';
 import { STORE_NAME } from '../store';
+import { bumpFeedRevision, isFeedRevisionCurrent } from '../store/resolvers';
 
 /**
  * Seed the store with the localized design-token feed. Call this BEFORE React starts rendering —
@@ -104,6 +105,31 @@ export function useDesignTokensFeed() {
 	 * tags each call with an ever-increasing id at the moment it starts, and only the call still
 	 * holding the latest id when its read resolves is allowed to advance `slug`.
 	 *
+	 * Fetches and dispatches directly, deliberately NOT through `registry.resolveSelect(STORE_NAME)`:
+	 * that promise settles once the store's resolver framework marks the ARGS TUPLE
+	 * (`['getDesignTokensFeed', [targetSlug]]`) finished — a flag shared by every caller of that
+	 * same tuple, not one scoped to this specific call's own fetch. Two overlapping refreshes of the
+	 * SAME slug (the expected case — sibling instances, e.g. a screen and its settings panel, writing
+	 * close together) would let an OLDER, slower call's "this response is stale, skip it" early
+	 * return still finish the shared tuple — resolving BOTH callers' promises with whatever the store
+	 * already held, before the newer call's real data has landed; a caller chaining logic off the
+	 * older promise (as every write flow does) would read stale data. The same sharing means one
+	 * call's fetch REJECTING could reject a sibling call that was about to succeed on its own. Calling
+	 * `fetchDesignTokensFeed` here directly, and dispatching conditionally on `isFeedRevisionCurrent`
+	 * (shared with the `getDesignTokensFeed` resolver in `store/resolvers.js`, which still fetches and
+	 * dispatches through the normal resolver path for any consumer that reaches this tuple without
+	 * going through `refreshFeed` first), ties this call's promise to its OWN fetch alone.
+	 *
+	 * Deliberately does NOT call `invalidateResolution` first, unlike this function's own earlier
+	 * version — this dispatches `receiveDesignTokensFeed` and `finishResolution` itself once its
+	 * fetch lands, so the tuple's resolution status ends up correct without ever needing to mark it
+	 * invalid first. Invalidating would re-arm this same hook's own passive `useSelect` read of this
+	 * tuple (see `feed` above) to auto-trigger the resolver on its very next evaluation — which
+	 * fires within the same tick, racing this function's own direct fetch with a second, unwanted
+	 * one, and reintroducing the exact shared-tuple problem this rewrite exists to remove. Nothing in
+	 * this app reads `isResolving`/`getResolutionError` for this tuple, so there is no consumer that
+	 * needs the "invalid" state to exist even transiently.
+	 *
 	 * @param {string} targetSlug The token library slug to read the feed for.
 	 *
 	 * @since TBD
@@ -113,18 +139,20 @@ export function useDesignTokensFeed() {
 	const refreshFeed = useCallback(
 		(targetSlug) => {
 			const requestId = ++latestRequestRef.current;
+			const revision = bumpFeedRevision(targetSlug);
 
-			registry.dispatch(STORE_NAME).invalidateResolution('getDesignTokensFeed', [targetSlug]);
+			return fetchDesignTokensFeed(targetSlug).then((nextFeed) => {
+				if (isFeedRevisionCurrent(targetSlug, revision)) {
+					registry.dispatch(STORE_NAME).receiveDesignTokensFeed(targetSlug, nextFeed);
+					registry.dispatch(STORE_NAME).finishResolution('getDesignTokensFeed', [targetSlug]);
+				}
 
-			return registry
-				.resolveSelect(STORE_NAME)
-				.getDesignTokensFeed(targetSlug)
-				.then((nextFeed) => {
-					if (requestId === latestRequestRef.current) {
-						setSlug(targetSlug);
-					}
-					return nextFeed;
-				});
+				if (requestId === latestRequestRef.current) {
+					setSlug(targetSlug);
+				}
+
+				return nextFeed;
+			});
 		},
 		[registry]
 	);

--- a/src/style-library/hooks/use-design-tokens-feed.js
+++ b/src/style-library/hooks/use-design-tokens-feed.js
@@ -139,10 +139,10 @@ export function useDesignTokensFeed() {
 	const refreshFeed = useCallback(
 		(targetSlug) => {
 			const requestId = ++latestRequestRef.current;
-			const revision = bumpFeedRevision(targetSlug);
+			const revision = bumpFeedRevision(registry, targetSlug);
 
 			return fetchDesignTokensFeed(targetSlug).then((nextFeed) => {
-				if (isFeedRevisionCurrent(targetSlug, revision)) {
+				if (isFeedRevisionCurrent(registry, targetSlug, revision)) {
 					registry.dispatch(STORE_NAME).receiveDesignTokensFeed(targetSlug, nextFeed);
 					registry.dispatch(STORE_NAME).finishResolution('getDesignTokensFeed', [targetSlug]);
 				}

--- a/src/style-library/hooks/use-design-tokens-feed.js
+++ b/src/style-library/hooks/use-design-tokens-feed.js
@@ -7,7 +7,7 @@ import { useSelect, useRegistry } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { configureRestClient, fetchDesignTokensFeed } from '../api/client';
+import { configureRestClient } from '../api/client';
 import { flattenSchemaTokens, getDesignTokensFeed as readLocalizedFeed } from '../helpers/tokens';
 import { DEFAULT_LIBRARY_SLUG } from '../constants';
 import { STORE_NAME } from '../store';
@@ -45,6 +45,14 @@ export function useDesignTokensFeed() {
 	if (!hydratedRef.current) {
 		hydratedRef.current = true;
 
+		// Deliberate dispatch-during-render: seeds the store synchronously so the very first render
+		// already has `isReady: true` for the localized slug, rather than waiting one render for an
+		// async resolver to run. This is only safe here because nothing is subscribed to the store yet
+		// on this first render (the `useSelect` below hasn't mounted its subscription) — dispatching
+		// during render in any later render, once subscribers exist, would be the usual React pitfall.
+		// That invariant holds today because `StyleLibraryApp.js` is this hook's only call site and
+		// calls it before any other store-reading hook (`useLibraries`, etc.) mounts; a second call
+		// site, or moving this hook below another one that already subscribes, would break it silently.
 		if (initialFeed) {
 			registry.dispatch(STORE_NAME).receiveDesignTokensFeed(initialSlug, initialFeed);
 			registry.dispatch(STORE_NAME).finishResolution('getDesignTokensFeed', [initialSlug]);
@@ -52,6 +60,10 @@ export function useDesignTokensFeed() {
 	}
 
 	const [slug, setSlug] = useState(initialSlug);
+
+	// Identifies the most recently STARTED `refreshFeed` call, so an earlier call's slower read can't
+	// win a race against a later one and leave `slug` on stale data — see `refreshFeed` below.
+	const latestRequestRef = useRef(0);
 
 	const feed = useSelect((select) => select(STORE_NAME).getDesignTokensFeed(slug), [slug]);
 	const tokens = useMemo(() => flattenSchemaTokens(feed?.schema), [feed]);
@@ -68,6 +80,21 @@ export function useDesignTokensFeed() {
 	 * call site either just switched libraries (must see that library's real current state) or just
 	 * wrote to the current one (a cached pre-write value would be stale by definition).
 	 *
+	 * `slug` (and therefore `feed`/`isReady`) only advances once this read actually succeeds — not
+	 * synchronously on call. Advancing it eagerly would make `getDesignTokensFeed(state, targetSlug)`
+	 * return `null` (so `isReady` goes false) the instant this runs, for every consumer, for the
+	 * whole duration of the fetch; a failure would then leave `slug` pointing at a library whose feed
+	 * never resolved, with `isReady` false and no way back short of a page reload. Staying on the OLD
+	 * slug until the new read lands means a failure just leaves the previous feed on screen, where its
+	 * caller's own error state (already tracked per flow, e.g. `openError`) can still be shown.
+	 *
+	 * Two overlapping calls (a second library switch fired before the first one's read has settled)
+	 * resolve in whichever order their network requests happen to land, not necessarily the order
+	 * they were called in — without a guard, a slower first call resolving after a faster second call
+	 * would win and leave `slug` pointing at the wrong (earlier-requested) library. `latestRequestRef`
+	 * tags each call with an ever-increasing id at the moment it starts, and only the call still
+	 * holding the latest id when its read resolves is allowed to advance `slug`.
+	 *
 	 * @param {string} targetSlug The token library slug to read the feed for.
 	 *
 	 * @since TBD
@@ -76,9 +103,19 @@ export function useDesignTokensFeed() {
 	 */
 	const refreshFeed = useCallback(
 		(targetSlug) => {
-			setSlug(targetSlug);
+			const requestId = ++latestRequestRef.current;
+
 			registry.dispatch(STORE_NAME).invalidateResolution('getDesignTokensFeed', [targetSlug]);
-			return registry.resolveSelect(STORE_NAME).getDesignTokensFeed(targetSlug);
+
+			return registry
+				.resolveSelect(STORE_NAME)
+				.getDesignTokensFeed(targetSlug)
+				.then((nextFeed) => {
+					if (requestId === latestRequestRef.current) {
+						setSlug(targetSlug);
+					}
+					return nextFeed;
+				});
 		},
 		[registry]
 	);

--- a/src/style-library/hooks/use-design-tokens-feed.js
+++ b/src/style-library/hooks/use-design-tokens-feed.js
@@ -1,33 +1,59 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useSelect, useRegistry } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { configureRestClient, fetchDesignTokensFeed } from '../api/client';
-import { flattenSchemaTokens, getDesignTokensFeed, refreshFeedFlow } from '../helpers/tokens';
+import { flattenSchemaTokens, getDesignTokensFeed as readLocalizedFeed } from '../helpers/tokens';
 import { DEFAULT_LIBRARY_SLUG } from '../constants';
+import { STORE_NAME } from '../store';
 
 /**
- * Read and normalize the localized design-token feed, with a way to refresh it in place.
+ * Read and normalize the design-token feed from the store, with a way to refresh it in place.
  *
  * `slug` is the token library the feed's schema/values/version were actually resolved against — the
  * active library, not necessarily the default one (see `Admin\Feed\Localizer`). Every write this page
  * makes must target that same slug, or an edit lands in a document other than the one being shown.
  *
  * The first paint always reads the server-printed `window.kadenceDesignTokens` global rather than
- * fetching — a fetch-on-mount would regress startup and reintroduce a flash of default content
- * before the real feed arrives. `refreshFeed` is the one path that replaces the feed with a fresh
- * REST read, for after the active library changes without a page reload (see `hooks/use-libraries`).
+ * fetching, exactly as before — that value is seeded into the store SYNCHRONOUSLY on first render
+ * (not through the store's async resolver, which would otherwise leave `isReady` false for one
+ * render) and its resolution is marked finished immediately, so a fetch is never issued for the
+ * slug the page already loaded with. `refreshFeed` is the one path that always forces a fresh REST
+ * read through the store, for after the active library changes, or after a write on the current
+ * library, without a page reload.
  *
  * @since TBD
  *
  * @return {{ feed: object|null, tokens: object[], isReady: boolean, isActive: boolean, isResolved: boolean, values: Record<string, string>, responsive: Record<string, object>, rest: object|null, version: string, slug: string, title: string, refreshFeed: Function }}
  */
 export function useDesignTokensFeed() {
-	const [feed, setFeed] = useState(() => getDesignTokensFeed());
+	const registry = useRegistry();
+
+	const initialFeedRef = useRef();
+	if (initialFeedRef.current === undefined) {
+		initialFeedRef.current = readLocalizedFeed();
+	}
+	const initialFeed = initialFeedRef.current;
+	const initialSlug = initialFeed?.slug ?? DEFAULT_LIBRARY_SLUG;
+
+	const hydratedRef = useRef(false);
+	if (!hydratedRef.current) {
+		hydratedRef.current = true;
+
+		if (initialFeed) {
+			registry.dispatch(STORE_NAME).receiveDesignTokensFeed(initialSlug, initialFeed);
+			registry.dispatch(STORE_NAME).finishResolution('getDesignTokensFeed', [initialSlug]);
+		}
+	}
+
+	const [slug, setSlug] = useState(initialSlug);
+
+	const feed = useSelect((select) => select(STORE_NAME).getDesignTokensFeed(slug), [slug]);
 	const tokens = useMemo(() => flattenSchemaTokens(feed?.schema), [feed]);
 
 	useEffect(() => {
@@ -38,15 +64,24 @@ export function useDesignTokensFeed() {
 
 	/**
 	 * Replace the feed with a fresh REST read for the given library, so every consumer re-renders
-	 * against the newly active library without a page reload.
+	 * against the newly active library without a page reload. Always forces a fresh read — every
+	 * call site either just switched libraries (must see that library's real current state) or just
+	 * wrote to the current one (a cached pre-write value would be stale by definition).
 	 *
-	 * @param {string} slug The token library slug to read the feed for.
+	 * @param {string} targetSlug The token library slug to read the feed for.
 	 *
 	 * @since TBD
 	 *
 	 * @return {Promise<object>} The fresh feed payload.
 	 */
-	const refreshFeed = useCallback((slug) => refreshFeedFlow(slug, setFeed, fetchDesignTokensFeed), []);
+	const refreshFeed = useCallback(
+		(targetSlug) => {
+			setSlug(targetSlug);
+			registry.dispatch(STORE_NAME).invalidateResolution('getDesignTokensFeed', [targetSlug]);
+			return registry.resolveSelect(STORE_NAME).getDesignTokensFeed(targetSlug);
+		},
+		[registry]
+	);
 
 	return {
 		feed,

--- a/src/style-library/hooks/use-design-tokens-feed.js
+++ b/src/style-library/hooks/use-design-tokens-feed.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
-import { useSelect, useRegistry } from '@wordpress/data';
+import { dispatch as defaultDispatch, useSelect, useRegistry } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -13,6 +13,39 @@ import { DEFAULT_LIBRARY_SLUG } from '../constants';
 import { STORE_NAME } from '../store';
 
 /**
+ * Seed the store with the localized design-token feed. Call this BEFORE React starts rendering —
+ * from the bootstrap entry point (`style-library.js`), ahead of `createRoot(...).render()` — so the
+ * very first render already has `isReady: true` for the active library, without a render-phase
+ * mutation of this external store: a component's render body must stay pure (React can replay or
+ * discard a render before it commits), and that purity requirement applies to an external store
+ * exactly the way it applies to component state — a null-guarded "run once" ref check is only a
+ * supported exception for LOCAL ref values, not for mutating shared state outside React entirely.
+ *
+ * Marks the resolution finished immediately alongside the raw write, so the store's resolver
+ * framework doesn't also auto-trigger `getDesignTokensFeed`'s REST fetch for a slug this already
+ * has fresh data for.
+ *
+ * @param {Function} dispatch A `@wordpress/data` registry's `dispatch` (defaults to the default
+ *                              registry's, for production; tests pass an isolated test registry's).
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+export function seedDesignTokensFeed(dispatch = defaultDispatch) {
+	const feed = readLocalizedFeed();
+
+	if (!feed) {
+		return;
+	}
+
+	const slug = feed.slug ?? DEFAULT_LIBRARY_SLUG;
+
+	dispatch(STORE_NAME).receiveDesignTokensFeed(slug, feed);
+	dispatch(STORE_NAME).finishResolution('getDesignTokensFeed', [slug]);
+}
+
+/**
  * Read and normalize the design-token feed from the store, with a way to refresh it in place.
  *
  * `slug` is the token library the feed's schema/values/version were actually resolved against — the
@@ -20,12 +53,10 @@ import { STORE_NAME } from '../store';
  * makes must target that same slug, or an edit lands in a document other than the one being shown.
  *
  * The first paint always reads the server-printed `window.kadenceDesignTokens` global rather than
- * fetching, exactly as before — that value is seeded into the store SYNCHRONOUSLY on first render
- * (not through the store's async resolver, which would otherwise leave `isReady` false for one
- * render) and its resolution is marked finished immediately, so a fetch is never issued for the
- * slug the page already loaded with. `refreshFeed` is the one path that always forces a fresh REST
- * read through the store, for after the active library changes, or after a write on the current
- * library, without a page reload.
+ * fetching, exactly as before — `seedDesignTokensFeed()` above puts that same value into the store
+ * before this hook ever renders, so a fetch is never issued for the slug the page already loaded
+ * with. `refreshFeed` is the one path that always forces a fresh REST read through the store, for
+ * after the active library changes, or after a write on the current library, without a page reload.
  *
  * @since TBD
  *
@@ -34,32 +65,10 @@ import { STORE_NAME } from '../store';
 export function useDesignTokensFeed() {
 	const registry = useRegistry();
 
-	const initialFeedRef = useRef();
-	if (initialFeedRef.current === undefined) {
-		initialFeedRef.current = readLocalizedFeed();
-	}
-	const initialFeed = initialFeedRef.current;
-	const initialSlug = initialFeed?.slug ?? DEFAULT_LIBRARY_SLUG;
-
-	const hydratedRef = useRef(false);
-	if (!hydratedRef.current) {
-		hydratedRef.current = true;
-
-		// Deliberate dispatch-during-render: seeds the store synchronously so the very first render
-		// already has `isReady: true` for the localized slug, rather than waiting one render for an
-		// async resolver to run. This is only safe here because nothing is subscribed to the store yet
-		// on this first render (the `useSelect` below hasn't mounted its subscription) — dispatching
-		// during render in any later render, once subscribers exist, would be the usual React pitfall.
-		// That invariant holds today because `StyleLibraryApp.js` is this hook's only call site and
-		// calls it before any other store-reading hook (`useLibraries`, etc.) mounts; a second call
-		// site, or moving this hook below another one that already subscribes, would break it silently.
-		if (initialFeed) {
-			registry.dispatch(STORE_NAME).receiveDesignTokensFeed(initialSlug, initialFeed);
-			registry.dispatch(STORE_NAME).finishResolution('getDesignTokensFeed', [initialSlug]);
-		}
-	}
-
-	const [slug, setSlug] = useState(initialSlug);
+	// The lazy-initializer form of `useState` — called once, on mount, to compute a value — is a
+	// supported exception to "no side effects during render" (unlike `seedDesignTokensFeed`'s own
+	// dispatch, this reads the same static global rather than mutating anything).
+	const [slug, setSlug] = useState(() => readLocalizedFeed()?.slug ?? DEFAULT_LIBRARY_SLUG);
 
 	// Identifies the most recently STARTED `refreshFeed` call, so an earlier call's slower read can't
 	// win a race against a later one and leave `slug` on stale data — see `refreshFeed` below.

--- a/src/style-library/store/actions.js
+++ b/src/style-library/store/actions.js
@@ -43,3 +43,17 @@ export function receiveBlockPresets(key, payload) {
 export function receivePaletteListing(key, rows) {
 	return { type: 'RECEIVE_PALETTE_LISTING', key, rows };
 }
+
+/**
+ * Store a library's design-token feed.
+ *
+ * @param {string} slug The library slug the feed was resolved for.
+ * @param {Object} feed The feed payload.
+ *
+ * @since TBD
+ *
+ * @return {Object} The action.
+ */
+export function receiveDesignTokensFeed(slug, feed) {
+	return { type: 'RECEIVE_DESIGN_TOKENS_FEED', slug, feed };
+}

--- a/src/style-library/store/reducer.js
+++ b/src/style-library/store/reducer.js
@@ -23,9 +23,17 @@ function paletteListings(state = {}, action) {
 	return { ...state, [action.key]: action.rows };
 }
 
+function feeds(state = {}, action) {
+	if (action.type !== 'RECEIVE_DESIGN_TOKENS_FEED') {
+		return state;
+	}
+
+	return { ...state, [action.slug]: action.feed };
+}
+
 /**
  * The Style Library store's root reducer.
  *
  * @since TBD
  */
-export const reducer = combineReducers({ libraries, presets, paletteListings });
+export const reducer = combineReducers({ libraries, presets, paletteListings, feeds });

--- a/src/style-library/store/reducer.test.js
+++ b/src/style-library/store/reducer.test.js
@@ -1,12 +1,12 @@
 /* eslint-env jest */
 import { reducer } from './reducer';
-import { receiveLibraries, receiveBlockPresets, receivePaletteListing } from './actions';
+import { receiveLibraries, receiveBlockPresets, receivePaletteListing, receiveDesignTokensFeed } from './actions';
 
 describe('reducer', () => {
 	it('starts with empty slices', () => {
 		const state = reducer(undefined, { type: '@@INIT' });
 
-		expect(state).toEqual({ libraries: [], presets: {}, paletteListings: {} });
+		expect(state).toEqual({ libraries: [], presets: {}, paletteListings: {}, feeds: {} });
 	});
 
 	it('stores the libraries list on RECEIVE_LIBRARIES', () => {
@@ -31,5 +31,11 @@ describe('reducer', () => {
 		state = reducer(state, receivePaletteListing('b', rowsB));
 
 		expect(state.paletteListings).toEqual({ a: rowsA, b: rowsB });
+	});
+
+	it('stores a feed payload under its slug', () => {
+		const state = reducer(undefined, receiveDesignTokensFeed('default', { version: 'v1' }));
+
+		expect(state.feeds).toEqual({ default: { version: 'v1' } });
 	});
 });

--- a/src/style-library/store/resolvers.js
+++ b/src/style-library/store/resolvers.js
@@ -61,18 +61,55 @@ export const getPaletteListing =
 	};
 
 /**
- * Tracks each slug's most recent `getDesignTokensFeed` resolver invocation. `refreshFeed`
- * (`hooks/use-design-tokens-feed.js`) always invalidates before re-resolving, even for the SAME
- * slug already showing — every write flow across the app (scale, typography, palettes, presets)
- * ends in a same-slug refresh, and two sibling instances writing close together (e.g. the screen
- * and its settings panel) can each trigger one. Without this, a slower earlier fetch's response
- * landing after a faster later one would silently overwrite the newer feed with stale data — this
- * store-level guard is the same defense `use-design-tokens-feed.js`'s `latestRequestRef` already
- * applies for a slug SWITCH, applied here to an overlapping refresh of the SAME slug.
+ * Tracks each slug's most recent in-flight design-tokens feed fetch, whether started by THIS
+ * resolver or by `hooks/use-design-tokens-feed.js`'s `refreshFeed` (which bumps and checks this
+ * same counter directly — see `bumpFeedRevision`/`isFeedRevisionCurrent` below — rather than
+ * going through this resolver's own thunk; that hook's own docblock explains why). Every write
+ * flow across the app (scale, typography, palettes, presets) ends in a same-slug refresh, and two
+ * sibling instances writing close together (e.g. a screen and its settings panel) can each trigger
+ * one — without a shared guard, a slower earlier fetch's response landing after a faster later one
+ * would silently overwrite the newer feed with stale data. This is the store-data-level half of
+ * that defense; `use-design-tokens-feed.js`'s `latestRequestRef` is the separate, unrelated guard
+ * for a slug SWITCH (which slug the UI ends up pointing at), not an overlapping same-slug refresh.
  *
  * @since TBD
  */
 const feedRevisionBySlug = new Map();
+
+/**
+ * Advance a slug's feed revision, marking any still-in-flight fetch for it stale. Call once, at
+ * the moment a new fetch for that slug starts — every caller (this resolver, and `refreshFeed`)
+ * shares this one counter, so whichever of two overlapping fetches for the same slug started LAST
+ * is the only one `isFeedRevisionCurrent` will still say yes to once it lands.
+ *
+ * @param {string} slug Token library slug.
+ *
+ * @since TBD
+ *
+ * @return {number} The new current revision for this slug — pass this to `isFeedRevisionCurrent`
+ *         once the fetch this call started resolves.
+ */
+export function bumpFeedRevision(slug) {
+	const revision = (feedRevisionBySlug.get(slug) ?? 0) + 1;
+	feedRevisionBySlug.set(slug, revision);
+	return revision;
+}
+
+/**
+ * Whether `revision` is still the current one for `slug` — false the moment a later call has
+ * bumped past it, meaning the fetch this revision belongs to is stale and its response must not
+ * be dispatched.
+ *
+ * @param {string} slug     Token library slug.
+ * @param {number} revision The revision `bumpFeedRevision` returned when this fetch started.
+ *
+ * @since TBD
+ *
+ * @return {boolean} Whether this revision's response may still be dispatched.
+ */
+export function isFeedRevisionCurrent(slug, revision) {
+	return feedRevisionBySlug.get(slug) === revision;
+}
 
 /**
  * Resolve `selectors.getDesignTokensFeed(slug)`.
@@ -86,14 +123,12 @@ const feedRevisionBySlug = new Map();
 export const getDesignTokensFeed =
 	(slug) =>
 	async ({ dispatch }) => {
-		const revision = (feedRevisionBySlug.get(slug) ?? 0) + 1;
-		feedRevisionBySlug.set(slug, revision);
-
+		const revision = bumpFeedRevision(slug);
 		const feed = await fetchDesignTokensFeed(slug);
 
 		// A newer fetch for this same slug started (and will dispatch its own response) after this
 		// one did — this response is stale and must not overwrite it.
-		if (feedRevisionBySlug.get(slug) !== revision) {
+		if (!isFeedRevisionCurrent(slug, revision)) {
 			return;
 		}
 

--- a/src/style-library/store/resolvers.js
+++ b/src/style-library/store/resolvers.js
@@ -61,6 +61,20 @@ export const getPaletteListing =
 	};
 
 /**
+ * Tracks each slug's most recent `getDesignTokensFeed` resolver invocation. `refreshFeed`
+ * (`hooks/use-design-tokens-feed.js`) always invalidates before re-resolving, even for the SAME
+ * slug already showing — every write flow across the app (scale, typography, palettes, presets)
+ * ends in a same-slug refresh, and two sibling instances writing close together (e.g. the screen
+ * and its settings panel) can each trigger one. Without this, a slower earlier fetch's response
+ * landing after a faster later one would silently overwrite the newer feed with stale data — this
+ * store-level guard is the same defense `use-design-tokens-feed.js`'s `latestRequestRef` already
+ * applies for a slug SWITCH, applied here to an overlapping refresh of the SAME slug.
+ *
+ * @since TBD
+ */
+const feedRevisionBySlug = new Map();
+
+/**
  * Resolve `selectors.getDesignTokensFeed(slug)`.
  *
  * @param {string} slug Token library slug.
@@ -72,6 +86,16 @@ export const getPaletteListing =
 export const getDesignTokensFeed =
 	(slug) =>
 	async ({ dispatch }) => {
+		const revision = (feedRevisionBySlug.get(slug) ?? 0) + 1;
+		feedRevisionBySlug.set(slug, revision);
+
 		const feed = await fetchDesignTokensFeed(slug);
+
+		// A newer fetch for this same slug started (and will dispatch its own response) after this
+		// one did — this response is stale and must not overwrite it.
+		if (feedRevisionBySlug.get(slug) !== revision) {
+			return;
+		}
+
 		dispatch.receiveDesignTokensFeed(slug, feed);
 	};

--- a/src/style-library/store/resolvers.js
+++ b/src/style-library/store/resolvers.js
@@ -61,45 +61,58 @@ export const getPaletteListing =
 	};
 
 /**
- * Tracks each slug's most recent in-flight design-tokens feed fetch, whether started by THIS
- * resolver or by `hooks/use-design-tokens-feed.js`'s `refreshFeed` (which bumps and checks this
- * same counter directly — see `bumpFeedRevision`/`isFeedRevisionCurrent` below — rather than
- * going through this resolver's own thunk; that hook's own docblock explains why). Every write
- * flow across the app (scale, typography, palettes, presets) ends in a same-slug refresh, and two
+ * Tracks each slug's most recent in-flight design-tokens feed fetch, scoped per registry and
+ * shared by THIS resolver and `hooks/use-design-tokens-feed.js`'s `refreshFeed` (which bumps and
+ * checks it directly via `bumpFeedRevision`/`isFeedRevisionCurrent` below, rather than going
+ * through this resolver's own thunk; that hook's own docblock explains why). Every write flow
+ * across the app (scale, typography, palettes, presets) ends in a same-slug refresh, and two
  * sibling instances writing close together (e.g. a screen and its settings panel) can each trigger
  * one — without a shared guard, a slower earlier fetch's response landing after a faster later one
  * would silently overwrite the newer feed with stale data. This is the store-data-level half of
  * that defense; `use-design-tokens-feed.js`'s `latestRequestRef` is the separate, unrelated guard
  * for a slug SWITCH (which slug the UI ends up pointing at), not an overlapping same-slug refresh.
  *
+ * This app can have multiple independent `@wordpress/data` registries alive at once (see
+ * `store/test-utils.js`'s `createTestRegistry()`, one per test). A plain module-global `Map` would
+ * let a request in one registry bump the shared revision counter and wrongly discard an unrelated
+ * request in a different registry as "stale", even though the two have no ordering relationship.
+ * Keying a `WeakMap` on the caller's `registry` object scopes the revision tracking to the
+ * registry it actually belongs to.
+ *
  * @since TBD
  */
-const feedRevisionBySlug = new Map();
+const feedRevisionByRegistry = new WeakMap();
 
 /**
- * Advance a slug's feed revision, marking any still-in-flight fetch for it stale. Call once, at
- * the moment a new fetch for that slug starts — every caller (this resolver, and `refreshFeed`)
- * shares this one counter, so whichever of two overlapping fetches for the same slug started LAST
- * is the only one `isFeedRevisionCurrent` will still say yes to once it lands.
+ * Advance a slug's feed revision within a registry, marking any still-in-flight fetch for it
+ * stale. Call once, at the moment a new fetch for that slug starts — every caller (this resolver,
+ * and `refreshFeed`) sharing a registry shares this one counter for it, so whichever of two
+ * overlapping fetches for the same slug started LAST is the only one `isFeedRevisionCurrent` will
+ * still say yes to once it lands.
  *
- * @param {string} slug Token library slug.
+ * @param {Object} registry The `@wordpress/data` registry this fetch belongs to.
+ * @param {string} slug     Token library slug.
  *
  * @since TBD
  *
  * @return {number} The new current revision for this slug — pass this to `isFeedRevisionCurrent`
  *         once the fetch this call started resolves.
  */
-export function bumpFeedRevision(slug) {
-	const revision = (feedRevisionBySlug.get(slug) ?? 0) + 1;
-	feedRevisionBySlug.set(slug, revision);
+export function bumpFeedRevision(registry, slug) {
+	const revisionBySlug = feedRevisionByRegistry.get(registry) ?? new Map();
+	feedRevisionByRegistry.set(registry, revisionBySlug);
+
+	const revision = (revisionBySlug.get(slug) ?? 0) + 1;
+	revisionBySlug.set(slug, revision);
 	return revision;
 }
 
 /**
- * Whether `revision` is still the current one for `slug` — false the moment a later call has
- * bumped past it, meaning the fetch this revision belongs to is stale and its response must not
- * be dispatched.
+ * Whether `revision` is still the current one for `slug` within `registry` — false the moment a
+ * later call has bumped past it, meaning the fetch this revision belongs to is stale and its
+ * response must not be dispatched.
  *
+ * @param {Object} registry The `@wordpress/data` registry this fetch belongs to.
  * @param {string} slug     Token library slug.
  * @param {number} revision The revision `bumpFeedRevision` returned when this fetch started.
  *
@@ -107,8 +120,8 @@ export function bumpFeedRevision(slug) {
  *
  * @return {boolean} Whether this revision's response may still be dispatched.
  */
-export function isFeedRevisionCurrent(slug, revision) {
-	return feedRevisionBySlug.get(slug) === revision;
+export function isFeedRevisionCurrent(registry, slug, revision) {
+	return feedRevisionByRegistry.get(registry)?.get(slug) === revision;
 }
 
 /**
@@ -122,13 +135,13 @@ export function isFeedRevisionCurrent(slug, revision) {
  */
 export const getDesignTokensFeed =
 	(slug) =>
-	async ({ dispatch }) => {
-		const revision = bumpFeedRevision(slug);
+	async ({ dispatch, registry }) => {
+		const revision = bumpFeedRevision(registry, slug);
 		const feed = await fetchDesignTokensFeed(slug);
 
-		// A newer fetch for this same slug started (and will dispatch its own response) after this
-		// one did — this response is stale and must not overwrite it.
-		if (!isFeedRevisionCurrent(slug, revision)) {
+		// A newer fetch for this same slug, in this same registry, started (and will dispatch its
+		// own response) after this one did — this response is stale and must not overwrite it.
+		if (!isFeedRevisionCurrent(registry, slug, revision)) {
 			return;
 		}
 

--- a/src/style-library/store/resolvers.js
+++ b/src/style-library/store/resolvers.js
@@ -8,7 +8,7 @@
 /**
  * Internal dependencies
  */
-import { fetchBlockPresets, fetchLibraries, fetchPalettes } from '../api/client';
+import { fetchBlockPresets, fetchLibraries, fetchPalettes, fetchDesignTokensFeed } from '../api/client';
 import { presetsKey, paletteListingKey } from './constants';
 
 /**
@@ -58,4 +58,20 @@ export const getPaletteListing =
 	async ({ dispatch }) => {
 		const rows = await fetchPalettes(namespace, slug);
 		dispatch.receivePaletteListing(paletteListingKey(namespace, slug), rows);
+	};
+
+/**
+ * Resolve `selectors.getDesignTokensFeed(slug)`.
+ *
+ * @param {string} slug Token library slug.
+ *
+ * @since TBD
+ *
+ * @return {Function} A `@wordpress/data` thunk.
+ */
+export const getDesignTokensFeed =
+	(slug) =>
+	async ({ dispatch }) => {
+		const feed = await fetchDesignTokensFeed(slug);
+		dispatch.receiveDesignTokensFeed(slug, feed);
 	};

--- a/src/style-library/store/resolvers.test.js
+++ b/src/style-library/store/resolvers.test.js
@@ -57,4 +57,53 @@ describe('resolvers', () => {
 		expect(fetchDesignTokensFeed).toHaveBeenCalledWith('brand');
 		expect(dispatch.receiveDesignTokensFeed).toHaveBeenCalledWith('brand', feed);
 	});
+
+	/**
+	 * Two sibling instances (e.g. a scale screen and its settings panel) can each write and call
+	 * `refreshFeed` for the SAME slug close together — `refreshFeed` always invalidates before
+	 * re-resolving, even for the slug already showing, so both trigger their own resolver run. If
+	 * the FIRST call's network response lands AFTER the second's, only the second's (newer) response
+	 * may reach the store; the first's must be discarded as stale.
+	 *
+	 * @return {void}
+	 */
+	it('a slower first getDesignTokensFeed() call never overwrites a faster, later call for the same slug', async () => {
+		let resolveFirst;
+		let resolveSecond;
+
+		fetchDesignTokensFeed
+			.mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						resolveFirst = resolve;
+					})
+			)
+			.mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						resolveSecond = resolve;
+					})
+			);
+
+		const dispatch = { receiveDesignTokensFeed: jest.fn() };
+
+		const firstCall = getDesignTokensFeed('race-slug')({ dispatch });
+		const secondCall = getDesignTokensFeed('race-slug')({ dispatch });
+
+		// The second, later call resolves FIRST — its result must win.
+		resolveSecond({ slug: 'race-slug', version: 'newer' });
+		await secondCall;
+
+		expect(dispatch.receiveDesignTokensFeed).toHaveBeenCalledTimes(1);
+		expect(dispatch.receiveDesignTokensFeed).toHaveBeenCalledWith('race-slug', {
+			slug: 'race-slug',
+			version: 'newer',
+		});
+
+		// The first, earlier call resolves LAST — it must not be allowed to overwrite the newer feed.
+		resolveFirst({ slug: 'race-slug', version: 'older' });
+		await firstCall;
+
+		expect(dispatch.receiveDesignTokensFeed).toHaveBeenCalledTimes(1);
+	});
 });

--- a/src/style-library/store/resolvers.test.js
+++ b/src/style-library/store/resolvers.test.js
@@ -1,12 +1,12 @@
 /* eslint-env jest */
-import { getBlockPresets, getLibraries, getPaletteListing } from './resolvers';
-import { fetchBlockPresets, fetchLibraries, fetchPalettes } from '../api/client';
+import { getBlockPresets, getLibraries, getPaletteListing, getDesignTokensFeed } from './resolvers';
+import { fetchBlockPresets, fetchLibraries, fetchPalettes, fetchDesignTokensFeed } from '../api/client';
 
 jest.mock('../api/client', () => ({
 	fetchLibraries: jest.fn(),
 	fetchBlockPresets: jest.fn(),
 	fetchPalettes: jest.fn(),
-	fetchPalette: jest.fn(),
+	fetchDesignTokensFeed: jest.fn(),
 }));
 
 describe('resolvers', () => {
@@ -45,5 +45,16 @@ describe('resolvers', () => {
 
 		expect(fetchPalettes).toHaveBeenCalledWith('kb-design-tokens/v1', 'default');
 		expect(dispatch.receivePaletteListing).toHaveBeenCalledWith('kb-design-tokens/v1::default', rows);
+	});
+
+	it('getDesignTokensFeed() fetches and dispatches receiveDesignTokensFeed under the slug', async () => {
+		const feed = { slug: 'brand', version: 'b1' };
+		fetchDesignTokensFeed.mockResolvedValueOnce(feed);
+
+		const dispatch = { receiveDesignTokensFeed: jest.fn() };
+		await getDesignTokensFeed('brand')({ dispatch });
+
+		expect(fetchDesignTokensFeed).toHaveBeenCalledWith('brand');
+		expect(dispatch.receiveDesignTokensFeed).toHaveBeenCalledWith('brand', feed);
 	});
 });

--- a/src/style-library/store/resolvers.test.js
+++ b/src/style-library/store/resolvers.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 import { getBlockPresets, getLibraries, getPaletteListing, getDesignTokensFeed } from './resolvers';
 import { fetchBlockPresets, fetchLibraries, fetchPalettes, fetchDesignTokensFeed } from '../api/client';
+import { createTestRegistry } from './test-utils';
 
 jest.mock('../api/client', () => ({
 	fetchLibraries: jest.fn(),
@@ -52,7 +53,7 @@ describe('resolvers', () => {
 		fetchDesignTokensFeed.mockResolvedValueOnce(feed);
 
 		const dispatch = { receiveDesignTokensFeed: jest.fn() };
-		await getDesignTokensFeed('brand')({ dispatch });
+		await getDesignTokensFeed('brand')({ dispatch, registry: createTestRegistry() });
 
 		expect(fetchDesignTokensFeed).toHaveBeenCalledWith('brand');
 		expect(dispatch.receiveDesignTokensFeed).toHaveBeenCalledWith('brand', feed);
@@ -87,9 +88,12 @@ describe('resolvers', () => {
 			);
 
 		const dispatch = { receiveDesignTokensFeed: jest.fn() };
+		// The thunk context's `registry` object — both calls share it because they are the SAME
+		// registry racing against itself.
+		const registry = createTestRegistry();
 
-		const firstCall = getDesignTokensFeed('race-slug')({ dispatch });
-		const secondCall = getDesignTokensFeed('race-slug')({ dispatch });
+		const firstCall = getDesignTokensFeed('race-slug')({ dispatch, registry });
+		const secondCall = getDesignTokensFeed('race-slug')({ dispatch, registry });
 
 		// The second, later call resolves FIRST — its result must win.
 		resolveSecond({ slug: 'race-slug', version: 'newer' });
@@ -106,5 +110,65 @@ describe('resolvers', () => {
 		await firstCall;
 
 		expect(dispatch.receiveDesignTokensFeed).toHaveBeenCalledTimes(1);
+	});
+
+	/**
+	 * Two INDEPENDENT registries (e.g. two isolated app instances, as `createTestRegistry()`
+	 * builds for tests) requesting the same slug concurrently have no ordering relationship to
+	 * each other. A fast response landing in one registry must never cause the other, unrelated
+	 * registry's own slower-resolving request to be discarded as "stale" — each registry's
+	 * revision tracking must stay scoped to that registry.
+	 *
+	 * @return {void}
+	 */
+	it('a slow getDesignTokensFeed() call in one registry is not discarded by a fast call in a different registry', async () => {
+		let resolveSlow;
+		let resolveFast;
+
+		fetchDesignTokensFeed
+			.mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						resolveSlow = resolve;
+					})
+			)
+			.mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						resolveFast = resolve;
+					})
+			);
+
+		const dispatchA = { receiveDesignTokensFeed: jest.fn() };
+		const dispatchB = { receiveDesignTokensFeed: jest.fn() };
+		// Two SEPARATE, real `@wordpress/data` registries — like two isolated app instances — used
+		// here as the stand-in for the thunk context's `registry` object, so the revision map is
+		// keyed on genuinely distinct registry identities, not look-alike plain objects.
+		const registryA = createTestRegistry();
+		const registryB = createTestRegistry();
+
+		const slowCall = getDesignTokensFeed('shared-slug')({ dispatch: dispatchA, registry: registryA });
+		const fastCall = getDesignTokensFeed('shared-slug')({ dispatch: dispatchB, registry: registryB });
+
+		// Registry B's request resolves first — it has no bearing on registry A's own request.
+		resolveFast({ slug: 'shared-slug', version: 'b' });
+		await fastCall;
+
+		expect(dispatchB.receiveDesignTokensFeed).toHaveBeenCalledTimes(1);
+		expect(dispatchB.receiveDesignTokensFeed).toHaveBeenCalledWith('shared-slug', {
+			slug: 'shared-slug',
+			version: 'b',
+		});
+
+		// Registry A's request resolves last, but it is the ONLY request registry A ever made, so
+		// it must still be dispatched — it is not "stale" relative to a different registry.
+		resolveSlow({ slug: 'shared-slug', version: 'a' });
+		await slowCall;
+
+		expect(dispatchA.receiveDesignTokensFeed).toHaveBeenCalledTimes(1);
+		expect(dispatchA.receiveDesignTokensFeed).toHaveBeenCalledWith('shared-slug', {
+			slug: 'shared-slug',
+			version: 'a',
+		});
 	});
 });

--- a/src/style-library/store/resolvers.test.js
+++ b/src/style-library/store/resolvers.test.js
@@ -59,11 +59,12 @@ describe('resolvers', () => {
 	});
 
 	/**
-	 * Two sibling instances (e.g. a scale screen and its settings panel) can each write and call
-	 * `refreshFeed` for the SAME slug close together — `refreshFeed` always invalidates before
-	 * re-resolving, even for the slug already showing, so both trigger their own resolver run. If
-	 * the FIRST call's network response lands AFTER the second's, only the second's (newer) response
-	 * may reach the store; the first's must be discarded as stale.
+	 * This resolver's own `bumpFeedRevision`/`isFeedRevisionCurrent` guard is shared with
+	 * `use-design-tokens-feed.js`'s `refreshFeed`, which now fetches and dispatches directly rather
+	 * than routing through this resolver — see that hook's own docblock. Two organic resolver runs
+	 * for the SAME slug close together (this test's scenario) still need to coordinate through the
+	 * same counter: if the FIRST call's network response lands AFTER the second's, only the second's
+	 * (newer) response may reach the store; the first's must be discarded as stale.
 	 *
 	 * @return {void}
 	 */

--- a/src/style-library/store/selectors.js
+++ b/src/style-library/store/selectors.js
@@ -76,3 +76,17 @@ export function getPaletteListing(state, namespace, slug) {
 
 	return reshapedListingCache.get(rows);
 }
+
+/**
+ * Read a library's design-token feed.
+ *
+ * @param {Object} state The store's state.
+ * @param {string} slug  Token library slug.
+ *
+ * @since TBD
+ *
+ * @return {?Object} The feed, or `null` if not yet resolved.
+ */
+export function getDesignTokensFeed(state, slug) {
+	return state.feeds[slug] ?? null;
+}

--- a/src/style-library/store/selectors.test.js
+++ b/src/style-library/store/selectors.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { getBlockPresets, getLibraries, getPaletteListing } from './selectors';
+import { getBlockPresets, getLibraries, getPaletteListing, getDesignTokensFeed } from './selectors';
 
 describe('selectors', () => {
 	it('getLibraries() returns the libraries slice', () => {
@@ -93,5 +93,17 @@ describe('selectors', () => {
 		const third = getPaletteListing(nextState, 'ns', 'default');
 
 		expect(third).not.toBe(first);
+	});
+
+	it('getDesignTokensFeed() reads a slug’s feed, or null when unresolved', () => {
+		const state = {
+			libraries: [],
+			presets: {},
+			paletteListings: {},
+			feeds: { default: { version: 'v1' } },
+		};
+
+		expect(getDesignTokensFeed(state, 'default')).toEqual({ version: 'v1' });
+		expect(getDesignTokensFeed(state, 'brand')).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary

Adds a `feeds` slice to the store and migrates `useDesignTokensFeed()` — the single hook called from `StyleLibraryApp.js` and threaded down as the `library` prop everywhere else — to read through it. Because of that single call site, every scale-type screen (Border Radius, Border Width, Spacing, Icon Sizes, Typography, Shadow) and their write flows (`scale-flows.js`, `font-flows.js`) needed **zero changes** — they already just consume `library.feed`/`library.refreshFeed` as a prop, which is now transparently store-backed.

The first paint stays fetch-free exactly as before: `seedDesignTokensFeed()` writes the localized `window.kadenceDesignTokens` global into the store — and marks its resolution finished — from `style-library.js`'s bootstrap, BEFORE React starts rendering at all, so the very first render already has `isReady: true` for the active library with no fetch issued for it. This runs ahead of `createRoot(...).render()` rather than inside the hook's own render body: a component's render can be replayed or discarded by React (concurrent rendering, Strict Mode's mount-unmount-remount cycle), and that purity requirement applies to an external store exactly the way it applies to component state.

Also fixes a regression this migration's first draft introduced and a whole-branch review caught: `refreshFeed()` originally advanced to the new library slug before its read resolved, which meant a *failed* library switch left `isReady` `false` — and `StyleLibraryApp.js` gates the entire app's render on `isReady`, so a failed open, a failed delete-successor-swap, or a failed create-then-open left the app permanently blank with no way to see the error or retry short of a page reload. The slug now only advances once the read actually succeeds, restoring the pre-branch behavior where the previous library's content stays on screen through a failure.

Two further races are guarded against, both from the same root cause — overlapping refreshes resolving out of call order:

- **Switching libraries twice quickly**: `refreshFeed()` tags each call with an ever-increasing request id, so a slower earlier switch's response can't overwrite a faster later one and leave the app showing the wrong library.
- **Two sibling instances writing to the same library close together** (e.g. a scale screen and its settings panel, or any two of the writes that all end in a same-slug `refreshFeed`): the store's `getDesignTokensFeed` resolver now tracks a revision per slug, so a slower earlier fetch's response can't overwrite a faster later one's — even when both requests target the identical slug.

## Screenshots

<!-- Drag/paste screenshots in over each placeholder line below, then delete the placeholder text. -->

**Normal library switch — the loading scrim over existing content, not a blank screen:**
_paste screenshot here_

**Failed library switch — the app still showing the previous library's content, not a permanent blank screen:**
_paste screenshot here_

## Test instructions

1. Go to **Style Library**, confirm every scale-type screen (Border Radius, Border Width, Spacing, Icon Sizes, Typography, Shadow) still loads and edits exactly as before — first paint has no loading flash.
2. Switch libraries — confirm the app shows the loading scrim over existing content rather than unmounting, and lands on the new library correctly.
3. Simulate a failed library switch (e.g. throttle + block the feed request in DevTools) — confirm the app stays showing the *previous* library rather than going permanently blank.
4. With Redux DevTools installed, confirm `kadence-blocks/style-library`'s `feeds` slice populates and `wp.data.select('kadence-blocks/style-library').getLibraries()` and the feed selectors all work from the console.

<details>
<summary>Setup (same for every slice in this stack)</summary>

```bash
git checkout SOFT-4200/phase-6-feed-slice
bun install
```

The Style Library is at **WP Admin → Kadence → Style Library**.
</details>

---

Slice 6 of 7 in the SOFT-4200 stack. Read bottom-up: this PR is understandable from its own diff plus the slice below it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Design-token feeds are initialized from localized data when the style library loads.
  - Library selection and feed updates are synchronized with the shared data store.
  - Added support for retrieving block presets, palette listings, and design-token feeds.
- **Bug Fixes**
  - Improved feed refresh behavior, including pending and failed requests.
  - Prevented outdated responses from overwriting newer feed data during overlapping refreshes.
  - Same-library refreshes now correctly update displayed token data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
