### PR TITLE
[DTM] SOFT-4083 [25/38]: border control

### DIFF
--- a/src/token-controls/__tests__/border-control.test.js
+++ b/src/token-controls/__tests__/border-control.test.js
@@ -103,7 +103,9 @@ function renderControl(props = {}) {
 }
 
 const widthSelectors = () => container.querySelectorAll('.stub-token-selector');
-const styleSelects = () => container.querySelectorAll('select[aria-label="Border style"]');
+// Matches both the linked label ("Border style") and each unlinked, side-named label
+// ("Border style (top)", etc.) — the prefix is what every style select shares.
+const styleSelects = () => container.querySelectorAll('select[aria-label^="Border style"]');
 const linkToggle = () => container.querySelector('.kadence-control-toggle');
 
 /**
@@ -384,5 +386,64 @@ describe('BorderControl disabled', () => {
 		click(selector.querySelector('.stub-custom'));
 
 		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * `renderColor`'s `onChange` is a write path `BorderControl` doesn't render a disabled
+	 * attribute on (the caller owns that field), so it needs its own `disabled` guard — otherwise
+	 * a disabled control could still mutate color.
+	 *
+	 * @return {void}
+	 */
+	it('fires no onChange from renderColor while disabled', () => {
+		const onChange = jest.fn();
+		let received;
+		renderControl({
+			value: { width: '', style: 'none', color: 'semantic.color.border' },
+			onChange,
+			disabled: true,
+			renderColor: (props) => {
+				received = props;
+				return null;
+			},
+		});
+
+		received.onChange('semantic.color.accent');
+
+		expect(onChange).not.toHaveBeenCalled();
+	});
+});
+
+describe('BorderControl style select accessible labels', () => {
+	/**
+	 * Linked mode has one style field standing for every side, so the generic label is accurate.
+	 *
+	 * @return {void}
+	 */
+	it('uses the generic label when linked', () => {
+		renderControl();
+
+		expect(styleSelects()[0].getAttribute('aria-label')).toBe('Border style');
+	});
+
+	/**
+	 * Unlinked mode has four independent style fields; each needs its own side name so a screen
+	 * reader can tell them apart, matching the width field's per-slot icon.
+	 *
+	 * @return {void}
+	 */
+	it('names each side when unlinked', () => {
+		renderControl({
+			value: { width: ['', '', '', ''], style: ['none', 'none', 'none', 'none'], color: '' },
+		});
+
+		const labels = Array.from(styleSelects()).map((select) => select.getAttribute('aria-label'));
+
+		expect(labels).toEqual([
+			'Border style (top)',
+			'Border style (right)',
+			'Border style (bottom)',
+			'Border style (left)',
+		]);
 	});
 });

--- a/src/token-controls/__tests__/border-control.test.js
+++ b/src/token-controls/__tests__/border-control.test.js
@@ -412,6 +412,27 @@ describe('BorderControl disabled', () => {
 
 		expect(onChange).not.toHaveBeenCalled();
 	});
+
+	/**
+	 * `renderColor` receives the control's own `disabled` state, so a caller's color field can
+	 * disable itself the same way the width/style fields do rather than staying interactive while
+	 * every write it makes is silently discarded.
+	 *
+	 * @return {void}
+	 */
+	it('passes disabled through to renderColor', () => {
+		let received;
+		renderControl({
+			value: { width: '', style: 'none', color: 'semantic.color.border' },
+			disabled: true,
+			renderColor: (props) => {
+				received = props;
+				return null;
+			},
+		});
+
+		expect(received.disabled).toBe(true);
+	});
 });
 
 describe('BorderControl style select accessible labels', () => {

--- a/src/token-controls/__tests__/border-control.test.js
+++ b/src/token-controls/__tests__/border-control.test.js
@@ -1,0 +1,388 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { BorderControl } from '../controls/BorderControl';
+
+// `jest.config.js` maps `@wordpress/components` to the copy nested under
+// `@kadence/components/node_modules`, which resolves its own `react` — a different module instance
+// than the top-level `react-dom/client` this test renders with, which trips React's "Invalid hook
+// call" guard. Stand-ins sidestep that; these tests only need the link toggle and a plain select.
+jest.mock('@wordpress/components', () => ({
+	Button: ({ children, icon, showTooltip, isSmall, isPressed, ...props }) => <button {...props}>{children}</button>,
+	ButtonGroup: ({ children, ...props }) => <div {...props}>{children}</div>,
+	Dashicon: (props) => <span {...props} />,
+	Tooltip: ({ children }) => children,
+	SelectControl: ({ label, hideLabelFromVision, options, value, onChange, disabled, ...props }) => (
+		<select
+			aria-label={label}
+			value={value}
+			disabled={disabled}
+			onChange={(event) => onChange(event.target.value)}
+			{...props}
+		>
+			{options.map((option) => (
+				<option key={option.value} value={option.value}>
+					{option.label}
+				</option>
+			))}
+		</select>
+	),
+}));
+
+jest.mock('@wordpress/icons', () => ({ undo: 'undo', link: 'link', linkOff: 'linkOff' }));
+
+// `TokenSelector` opens a real popover through `@wordpress/components`' `Dropdown`, which is out of
+// scope for these tests — they exercise `BorderControl`'s own width-axis wiring, not the picker
+// `TokenSelector` already has coverage for. The stand-in exposes `onPick`/`onClear`/`onCustom`
+// directly as buttons so a click can trigger each without driving the popover open first.
+jest.mock('../organisms/TokenSelector', () => ({
+	TokenSelector: ({ value, disabled, onPick, onClear, onCustom }) => (
+		<div className="stub-token-selector" data-value={value ?? ''}>
+			<button
+				className="stub-pick"
+				disabled={disabled}
+				onClick={() => onPick('primitive.dimension.border-width.md')}
+			>
+				pick
+			</button>
+			<button className="stub-clear" disabled={disabled} onClick={() => onClear()}>
+				clear
+			</button>
+			<button className="stub-custom" disabled={disabled} onClick={() => onCustom('2px')}>
+				custom
+			</button>
+		</div>
+	),
+}));
+
+let container;
+let root;
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+/**
+ * Render `BorderControl` with the props it needs, plus overrides.
+ *
+ * @param {Object} props Overrides for the defaults below.
+ *
+ * @since TBD
+ *
+ * @return {HTMLElement} The container it rendered into.
+ */
+function renderControl(props = {}) {
+	act(() =>
+		root.render(
+			createElement(BorderControl, {
+				value: { width: '', style: 'none', color: '' },
+				onChange: jest.fn(),
+				label: 'Border',
+				...props,
+			})
+		)
+	);
+
+	return container;
+}
+
+const widthSelectors = () => container.querySelectorAll('.stub-token-selector');
+const styleSelects = () => container.querySelectorAll('select[aria-label="Border style"]');
+const linkToggle = () => container.querySelector('.kadence-control-toggle');
+
+/**
+ * Click a rendered DOM element inside `act`, so React flushes the resulting state/prop updates
+ * before the next assertion reads them.
+ *
+ * @param {HTMLElement} element The element to click.
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+function click(element) {
+	act(() => element.click());
+}
+
+describe('BorderControl slot rendering', () => {
+	/**
+	 * The default, all-scalar value is linked, so only one width/style pair renders.
+	 *
+	 * @return {void}
+	 */
+	it('renders one width TokenSelector and one style SelectControl when value is all-scalar', () => {
+		renderControl();
+
+		expect(widthSelectors()).toHaveLength(1);
+		expect(styleSelects()).toHaveLength(1);
+	});
+
+	/**
+	 * A 4-list on either axis means the control is unlinked, regardless of which axis carries it.
+	 *
+	 * @return {void}
+	 */
+	it('renders four of each when width is a 4-list', () => {
+		renderControl({
+			value: { width: ['a', 'b', 'c', 'd'], style: 'solid', color: '' },
+		});
+
+		expect(widthSelectors()).toHaveLength(4);
+		expect(styleSelects()).toHaveLength(4);
+	});
+
+	/**
+	 * Same as above, reached through the style axis instead of width.
+	 *
+	 * @return {void}
+	 */
+	it('renders four of each when style is a 4-list', () => {
+		renderControl({
+			value: {
+				width: 'primitive.dimension.border-width.md',
+				style: ['solid', 'dashed', 'solid', 'solid'],
+				color: '',
+			},
+		});
+
+		expect(widthSelectors()).toHaveLength(4);
+		expect(styleSelects()).toHaveLength(4);
+	});
+});
+
+describe('BorderControl width and style writes', () => {
+	/**
+	 * Picking a width token while linked writes the scalar directly to `width` and leaves
+	 * `style`/`color` untouched.
+	 *
+	 * @return {void}
+	 */
+	it('calls onChange with only width changed when picking a width token', () => {
+		const onChange = jest.fn();
+		renderControl({
+			value: { width: '', style: 'solid', color: 'semantic.color.border' },
+			onChange,
+		});
+
+		click(widthSelectors()[0].querySelector('.stub-pick'));
+
+		expect(onChange).toHaveBeenCalledWith({
+			width: 'primitive.dimension.border-width.md',
+			style: 'solid',
+			color: 'semantic.color.border',
+		});
+	});
+
+	/**
+	 * Changing the style select while linked writes the scalar directly to `style` and leaves
+	 * `width`/`color` untouched.
+	 *
+	 * @return {void}
+	 */
+	it('calls onChange with only style changed when changing the style select', () => {
+		const onChange = jest.fn();
+		renderControl({
+			value: { width: 'primitive.dimension.border-width.sm', style: 'none', color: 'semantic.color.border' },
+			onChange,
+		});
+
+		act(() => {
+			const select = styleSelects()[0];
+			select.value = 'dashed';
+			select.dispatchEvent(new Event('change', { bubbles: true }));
+		});
+
+		expect(onChange).toHaveBeenCalledWith({
+			width: 'primitive.dimension.border-width.sm',
+			style: 'dashed',
+			color: 'semantic.color.border',
+		});
+	});
+
+	/**
+	 * Writing one slot of an unlinked width axis updates only that position, leaving the other
+	 * three and the style axis untouched.
+	 *
+	 * @return {void}
+	 */
+	it('writes only the touched slot when unlinked', () => {
+		const onChange = jest.fn();
+		renderControl({
+			value: { width: ['a', 'b', 'c', 'd'], style: 'solid', color: '' },
+			onChange,
+		});
+
+		click(widthSelectors()[2].querySelector('.stub-pick'));
+
+		expect(onChange).toHaveBeenCalledWith({
+			width: ['a', 'b', 'primitive.dimension.border-width.md', 'd'],
+			style: 'solid',
+			color: '',
+		});
+	});
+});
+
+describe('BorderControl link toggle (uncontrolled)', () => {
+	/**
+	 * Toggling while linked promotes both width and style to 4-lists via `toSlotList`, and does
+	 * not touch color.
+	 *
+	 * @return {void}
+	 */
+	it('promotes width and style to 4-lists when toggled while linked', () => {
+		const onChange = jest.fn();
+		renderControl({
+			value: { width: 'primitive.dimension.border-width.sm', style: 'dashed', color: 'semantic.color.border' },
+			onChange,
+		});
+
+		click(linkToggle());
+
+		expect(onChange).toHaveBeenCalledWith({
+			width: [
+				'primitive.dimension.border-width.sm',
+				'primitive.dimension.border-width.sm',
+				'primitive.dimension.border-width.sm',
+				'primitive.dimension.border-width.sm',
+			],
+			style: ['dashed', 'dashed', 'dashed', 'dashed'],
+			color: 'semantic.color.border',
+		});
+	});
+
+	/**
+	 * Toggling while unlinked collapses both axes back to slot 0's value, and does not touch
+	 * color, even when the four slots differ.
+	 *
+	 * @return {void}
+	 */
+	it('collapses width and style to slot 0 when toggled while unlinked', () => {
+		const onChange = jest.fn();
+		renderControl({
+			value: {
+				width: ['a', 'b', 'c', 'd'],
+				style: ['solid', 'dashed', 'dotted', 'double'],
+				color: 'semantic.color.border',
+			},
+			onChange,
+		});
+
+		click(linkToggle());
+
+		expect(onChange).toHaveBeenCalledWith({
+			width: 'a',
+			style: 'solid',
+			color: 'semantic.color.border',
+		});
+	});
+});
+
+describe('BorderControl link toggle (controlled)', () => {
+	/**
+	 * With `onToggleLink` supplied, clicking the link toggle calls it instead of computing and
+	 * writing a new value directly.
+	 *
+	 * @return {void}
+	 */
+	it('calls onToggleLink instead of mutating value directly', () => {
+		const onChange = jest.fn();
+		const onToggleLink = jest.fn();
+		renderControl({
+			value: { width: '', style: 'none', color: '' },
+			onChange,
+			isLinked: true,
+			onToggleLink,
+		});
+
+		click(linkToggle());
+
+		expect(onToggleLink).toHaveBeenCalledTimes(1);
+		expect(onChange).not.toHaveBeenCalled();
+	});
+});
+
+describe('BorderControl color', () => {
+	/**
+	 * `renderColor` receives the current color value and a `onChange` that patches only `color`
+	 * on the outer value.
+	 *
+	 * @return {void}
+	 */
+	it('calls renderColor with the color value and patches only color on change', () => {
+		const onChange = jest.fn();
+		let received;
+		renderControl({
+			value: { width: '', style: 'none', color: 'semantic.color.border' },
+			onChange,
+			renderColor: (props) => {
+				received = props;
+				return null;
+			},
+		});
+
+		expect(received.value).toBe('semantic.color.border');
+
+		received.onChange('semantic.color.accent');
+
+		expect(onChange).toHaveBeenCalledWith({
+			width: '',
+			style: 'none',
+			color: 'semantic.color.accent',
+		});
+	});
+
+	/**
+	 * Without `renderColor`, nothing color-related renders and nothing throws.
+	 *
+	 * @return {void}
+	 */
+	it('renders nothing and does not throw without renderColor', () => {
+		expect(() => renderControl({ renderColor: undefined })).not.toThrow();
+	});
+});
+
+describe('BorderControl disabled', () => {
+	/**
+	 * Every sub-field — the width stand-in's buttons and the style select — is disabled, and
+	 * clicking/changing them fires no `onChange`.
+	 *
+	 * @return {void}
+	 */
+	it('disables every field and fires no onChange from a disabled sub-field', () => {
+		const onChange = jest.fn();
+		renderControl({
+			value: { width: '', style: 'none', color: '' },
+			onChange,
+			disabled: true,
+		});
+
+		const selector = widthSelectors()[0];
+
+		expect(selector.querySelector('.stub-pick').disabled).toBe(true);
+		expect(selector.querySelector('.stub-clear').disabled).toBe(true);
+		expect(selector.querySelector('.stub-custom').disabled).toBe(true);
+		expect(styleSelects()[0].disabled).toBe(true);
+
+		click(selector.querySelector('.stub-pick'));
+		click(selector.querySelector('.stub-clear'));
+		click(selector.querySelector('.stub-custom'));
+
+		expect(onChange).not.toHaveBeenCalled();
+	});
+});

--- a/src/token-controls/controls/BorderControl.js
+++ b/src/token-controls/controls/BorderControl.js
@@ -94,9 +94,9 @@ function applyToAxis(axis, index, next) {
  * @param {?Function} [props.onBreakpointChange]  Breakpoint-change handler.
  * @param {?boolean}  [props.isLinked]            Linked state, when the host controls it.
  * @param {?Function} [props.onToggleLink]        Link-toggle handler; omit to let this own the state.
- * @param {?Function} [props.renderColor]         `({ value, onChange }) => Element` — the caller's
- *                                                existing color field for `value.color`. Renders
- *                                                nothing when omitted.
+ * @param {?Function} [props.renderColor]         `({ value, onChange, disabled }) => Element` — the
+ *                                                caller's existing color field for `value.color`.
+ *                                                Renders nothing when omitted.
  * @param {boolean}   [props.stacked]             Header above a full-width body instead of beside it.
  * @param {boolean}   [props.disabled]            Whether the control is read-only.
  *
@@ -207,7 +207,8 @@ export function BorderControl({
 					);
 				}}
 			/>
-			{renderColor && renderColor({ value: color, onChange: (next) => !disabled && patch({ color: next }) })}
+			{renderColor &&
+				renderColor({ value: color, onChange: (next) => !disabled && patch({ color: next }), disabled })}
 		</ControlShell>
 	);
 }

--- a/src/token-controls/controls/BorderControl.js
+++ b/src/token-controls/controls/BorderControl.js
@@ -1,0 +1,199 @@
+/**
+ * The border token control: width and style per side, one link toggle, color supplied by the
+ * caller.
+ *
+ * Border is not a `BoxControl` the way radius and spacing are — it carries two properties per side
+ * (width, style) instead of one, and a third (color) this control deliberately does not touch
+ * (color is being reworked separately; see `renderColor`). `SlotGrid` still applies unmodified: its
+ * `renderSlot` render-prop was already generic, so this control renders a two-field row per slot
+ * instead of `BoxControl`'s single `TokenSelector`.
+ *
+ * `SlotGrid`'s own `value`/`onChange` props only drive its slot *arrangement* (linked-vs-grid,
+ * corner display order, labels) — the `onChange` it would call from inside `renderSlot`'s `onChange`
+ * argument is dead here because this `renderSlot` ignores that argument entirely and writes through
+ * the `patch` closure instead, since a slot needs to update two parallel arrays (width and style),
+ * not the one `SlotGrid` knows how to collapse. That also means `SlotGrid`'s own linked-mode
+ * behavior — filling every slot with the written value, or returning a bare scalar when `collapse`
+ * is set — never runs; this control has to reproduce "write the scalar directly while linked" itself
+ * (`applyToAxis` below), or every write while linked would silently turn a scalar axis into a
+ * four-element array of identical values, which would then make `isSlotList()` see it as unlinked
+ * on the very next render.
+ *
+ * Border style has no token library (`Style Library`'s Base Styles nav has no "Border Style"
+ * screen — only one semantic default exists), so the style field is a plain closed-enum select,
+ * not a `TokenSelector`/`TokenPopover` pair. Width reuses `TokenSelector` exactly as radius/spacing
+ * do. Color is entirely out of this control's scope — the caller renders it via `renderColor`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ControlShell } from '../templates/ControlShell';
+import { SlotGrid } from '../templates/SlotGrid';
+import { TokenSelector } from '../organisms/TokenSelector';
+import { isSlotList, readSlot, toSlotList, writeSlot } from '../helpers/value-shapes';
+
+/**
+ * The border styles offered. The backend accepts all 10 CSS `border-style` keywords
+ * (`Literals.php`'s `BORDER_STYLE_KEYWORDS`), but this control deliberately offers a curated 5 —
+ * `groove`/`ridge`/`inset`/`outset`/`hidden` are legacy 3D effects nobody designs with here.
+ *
+ * @since TBD
+ */
+const STYLES = [
+	{ value: 'none', label: __('None', 'kadence-blocks') },
+	{ value: 'solid', label: __('Solid', 'kadence-blocks') },
+	{ value: 'dashed', label: __('Dashed', 'kadence-blocks') },
+	{ value: 'dotted', label: __('Dotted', 'kadence-blocks') },
+	{ value: 'double', label: __('Double', 'kadence-blocks') },
+];
+
+/**
+ * Write one axis (`width` or `style`) at a slot position, keeping a linked axis a scalar.
+ *
+ * `writeSlot()` always returns an array unless every slot ends up identical and `collapse` is on —
+ * neither fits the linked case here, where `SlotGrid` reports the write as slot index `null` and the
+ * only correct result is the scalar itself, not a four-element array that merely looks uniform.
+ *
+ * @param {*}      axis  The axis's current scalar or slot list.
+ * @param {?number} index The slot `SlotGrid` reported (`null` while linked).
+ * @param {*}      next  The value to write.
+ *
+ * @since TBD
+ *
+ * @return {*} The axis's next scalar or slot list.
+ */
+function applyToAxis(axis, index, next) {
+	return index === null ? next : writeSlot(axis, index, next, false);
+}
+
+/**
+ * Render a border token control.
+ *
+ * @param {Object}    props                      The component props.
+ * @param {Object}    props.value                `{ width, style, color }`; width and style are
+ *                                                independently a scalar or a
+ *                                                `[top, right, bottom, left]` slot list.
+ * @param {Function}  props.onChange              Called with the next `{ width, style, color }`.
+ * @param {string}    props.label                 The control's label.
+ * @param {Array}     [props.widthTokens]         Pickable border-width tokens.
+ * @param {?Array}    [props.slotIcons]            Per-slot glyphs, in stored order (matches
+ *                                                `BoxControl`'s prop).
+ * @param {?Object}   [props.status]              `{ bound, modified }`; omit for no indicator.
+ * @param {?JSX.Element} [props.indicator]        Rendered in the header instead of the built-in one.
+ * @param {?Function} [props.onReset]             Reset handler, paired with `status`.
+ * @param {boolean}   [props.showReset]           Render the matching glyph and reset button.
+ * @param {?Array}    [props.breakpoints]         Breakpoint keys; omit for non-responsive.
+ * @param {?string}   [props.breakpoint]          The active breakpoint.
+ * @param {?Function} [props.onBreakpointChange]  Breakpoint-change handler.
+ * @param {?boolean}  [props.isLinked]            Linked state, when the host controls it.
+ * @param {?Function} [props.onToggleLink]        Link-toggle handler; omit to let this own the state.
+ * @param {?Function} [props.renderColor]         `({ value, onChange }) => Element` — the caller's
+ *                                                existing color field for `value.color`. Renders
+ *                                                nothing when omitted.
+ * @param {boolean}   [props.stacked]             Header above a full-width body instead of beside it.
+ * @param {boolean}   [props.disabled]            Whether the control is read-only.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The rendered control.
+ */
+export function BorderControl({
+	value = {},
+	onChange,
+	label,
+	widthTokens = [],
+	slotIcons = null,
+	status = null,
+	onReset = null,
+	showReset = true,
+	indicator = null,
+	breakpoints = null,
+	breakpoint = null,
+	onBreakpointChange = null,
+	isLinked = null,
+	onToggleLink = null,
+	renderColor,
+	stacked = false,
+	disabled = false,
+}) {
+	const { width = '', style = 'none', color = '' } = value;
+
+	const controlled = typeof onToggleLink === 'function';
+	const linked = controlled ? Boolean(isLinked) : !isSlotList(width) && !isSlotList(style);
+
+	const patch = (next) => onChange({ ...value, ...next });
+
+	const toggleLink = controlled
+		? onToggleLink
+		: () => {
+				if (linked) {
+					patch({ width: toSlotList(width), style: toSlotList(style) });
+					return;
+				}
+
+				// Relinking reads slot 0 of each axis — "the first side wins" is predictable, matching
+				// BoxControl's own relink rule. It does not require the four slots to already match.
+				patch({ width: readSlot(width, 0), style: readSlot(style, 0) });
+			};
+
+	return (
+		<ControlShell
+			label={label}
+			status={status}
+			onReset={onReset}
+			showReset={showReset}
+			indicator={indicator}
+			breakpoints={breakpoints}
+			breakpoint={breakpoint}
+			onBreakpointChange={onBreakpointChange}
+			isLinked={linked}
+			onToggleLink={toggleLink}
+			stacked={stacked}
+			disabled={disabled}
+		>
+			<SlotGrid
+				value={width}
+				onChange={() => {}}
+				isLinked={linked}
+				role="sides"
+				label={label}
+				collapse={false}
+				renderSlot={({ index }) => {
+					const slotIndex = index ?? 0;
+					const widthSlot = readSlot(width, slotIndex);
+					const styleSlot = readSlot(style, slotIndex) || 'none';
+
+					return (
+						<div className="kb-border-control__slot" key={index ?? 'linked'}>
+							<TokenSelector
+								value={widthSlot}
+								icon={slotIcons?.[slotIndex]}
+								tokens={widthTokens}
+								disabled={disabled}
+								onPick={(alias) => !disabled && patch({ width: applyToAxis(width, index, alias) })}
+								onClear={() => !disabled && patch({ width: applyToAxis(width, index, '') })}
+								onCustom={(next) => !disabled && patch({ width: applyToAxis(width, index, next) })}
+							/>
+							<SelectControl
+								label={__('Border style', 'kadence-blocks')}
+								hideLabelFromVision
+								value={styleSlot}
+								options={STYLES}
+								disabled={disabled}
+								onChange={(next) => !disabled && patch({ style: applyToAxis(style, index, next) })}
+							/>
+						</div>
+					);
+				}}
+			/>
+			{renderColor && renderColor({ value: color, onChange: (next) => patch({ color: next }) })}
+		</ControlShell>
+	);
+}

--- a/src/token-controls/controls/BorderControl.js
+++ b/src/token-controls/controls/BorderControl.js
@@ -29,7 +29,7 @@
  * WordPress dependencies
  */
 import { SelectControl } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -165,10 +165,24 @@ export function BorderControl({
 				role="sides"
 				label={label}
 				collapse={false}
-				renderSlot={({ index }) => {
+				renderSlot={({ index, label: slotLabel }) => {
 					const slotIndex = index ?? 0;
 					const widthSlot = readSlot(width, slotIndex);
 					const styleSlot = readSlot(style, slotIndex) || 'none';
+					// Linked mode has one field standing for every side, so the generic label is
+					// accurate; unlinked mode names the side so screen readers can tell the four
+					// style selectors apart, matching what the width TokenSelector's icon already
+					// does visually via `slotIcons`.
+					const styleLabel =
+						index === null
+							? __('Border style', 'kadence-blocks')
+							: sprintf(
+									/* translators: %s: the side name, e.g. "top". */ __(
+										'Border style (%s)',
+										'kadence-blocks'
+									),
+									slotLabel
+								);
 
 					return (
 						<div className="kb-border-control__slot" key={index ?? 'linked'}>
@@ -182,7 +196,7 @@ export function BorderControl({
 								onCustom={(next) => !disabled && patch({ width: applyToAxis(width, index, next) })}
 							/>
 							<SelectControl
-								label={__('Border style', 'kadence-blocks')}
+								label={styleLabel}
 								hideLabelFromVision
 								value={styleSlot}
 								options={STYLES}
@@ -193,7 +207,7 @@ export function BorderControl({
 					);
 				}}
 			/>
-			{renderColor && renderColor({ value: color, onChange: (next) => patch({ color: next }) })}
+			{renderColor && renderColor({ value: color, onChange: (next) => !disabled && patch({ color: next }) })}
 		</ControlShell>
 	);
 }


### PR DESCRIPTION
## Summary

Adds `BorderControl` (`src/token-controls/controls/BorderControl.js`) — the token-aware border control for the `src/token-controls/` library, sibling to the existing `BoxControl` (radius/spacing).

- Value shape: `{ width, style, color }`, each axis independently a scalar or a `[top, right, bottom, left]` slot list, one link toggle spanning width + style.
- **Width** reuses the existing `TokenSelector`/`TokenPopover` dimension pattern unchanged.
- **Style** is a plain 5-option `SelectControl` (`none/solid/dashed/dotted/double`) — no token library exists for border style, so this deliberately isn't a token picker.
- **Color** is out of scope for this whole effort (being reworked separately) — the control accepts a `renderColor` render-prop and never imports a color component itself.

## Test plan

- [x] `npx jest src/token-controls` — 127/127 passing, no regressions
- [x] cspell clean
- [x] `grep -rn "SOFT-" src/token-controls` — no hits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added border controls for editing width and style independently on each side.
  - Supports linked or individual side editing, responsive settings, reset/status controls, width tokens, and disabled states.
  - Added optional color rendering and customizable control icons.

- **Tests**
  - Added comprehensive coverage for border rendering, updates, linking behavior, colors, and disabled fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->