### PR TITLE
[DTM] SOFT-4083 [26/38]: box-shadow control

### DIFF
--- a/src/token-controls/__tests__/box-shadow-control.test.js
+++ b/src/token-controls/__tests__/box-shadow-control.test.js
@@ -41,18 +41,25 @@ jest.mock('@wordpress/components', () => ({
 			</div>
 		);
 	},
-	__experimentalNumberControl: ({ label, value, onChange }) => (
+	__experimentalNumberControl: ({ label, value, onChange, disabled }) => (
 		<label>
 			{label}
-			<input aria-label={label} type="number" value={value} onChange={(event) => onChange(event.target.value)} />
+			<input
+				aria-label={label}
+				type="number"
+				value={value}
+				disabled={disabled}
+				onChange={(event) => onChange(event.target.value)}
+			/>
 		</label>
 	),
-	ToggleControl: ({ label, checked, onChange }) => (
+	ToggleControl: ({ label, checked, onChange, disabled }) => (
 		<label>
 			<input
 				aria-label={label}
 				type="checkbox"
 				checked={checked}
+				disabled={disabled}
 				onChange={(event) => onChange(event.target.checked)}
 			/>
 			{label}
@@ -259,6 +266,20 @@ describe('BoxShadowControl Custom tab', () => {
 	});
 
 	/**
+	 * A fractional stored value (e.g. a sub-pixel offset) must display intact rather than being
+	 * truncated to its integer part — `parseInt` would silently drop the `.25`.
+	 *
+	 * @return {void}
+	 */
+	it('displays a fractional axis value without truncating it', () => {
+		renderControl({
+			value: { color: '#111111', offsetX: '1.25px', offsetY: '0px', blur: '0px', spread: '0px' },
+		});
+
+		expect(numberInput('X').value).toBe('1.25');
+	});
+
+	/**
 	 * Turning Inset on writes the composite object with `inset: true`.
 	 *
 	 * @return {void}
@@ -387,5 +408,45 @@ describe('BoxShadowControl disabled state', () => {
 		click(insetCheckbox());
 
 		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * The write guard alone leaves the number inputs and Inset toggle interactively enabled, which
+	 * reads as editable even though a write does nothing — `disabled` must reach the underlying
+	 * fields too, not just gate `onChange`.
+	 *
+	 * @return {void}
+	 */
+	it('disables the number inputs and the Inset toggle in the Custom tab', () => {
+		renderControl({
+			value: { color: '#111111', offsetX: '0px', offsetY: '0px', blur: '0px', spread: '0px' },
+			disabled: true,
+		});
+
+		expect(numberInput('X').disabled).toBe(true);
+		expect(numberInput('Y').disabled).toBe(true);
+		expect(numberInput('Blur').disabled).toBe(true);
+		expect(numberInput('Spread').disabled).toBe(true);
+		expect(insetCheckbox().disabled).toBe(true);
+	});
+
+	/**
+	 * `renderColor` receives `disabled` as part of its contract so the caller's color field can
+	 * disable itself too, the same way the number inputs and Inset toggle do.
+	 *
+	 * @return {void}
+	 */
+	it('passes disabled to renderColor', () => {
+		let received;
+		renderControl({
+			value: { color: '#111111', offsetX: '0px', offsetY: '0px', blur: '0px', spread: '0px' },
+			disabled: true,
+			renderColor: (props) => {
+				received = props;
+				return null;
+			},
+		});
+
+		expect(received.disabled).toBe(true);
 	});
 });

--- a/src/token-controls/__tests__/box-shadow-control.test.js
+++ b/src/token-controls/__tests__/box-shadow-control.test.js
@@ -348,4 +348,44 @@ describe('BoxShadowControl disabled state', () => {
 
 		expect(trigger().disabled).toBe(true);
 	});
+
+	/**
+	 * `BoxShadowControl` guards each write path (`onPick`, `onClear`) separately rather than relying
+	 * on the trigger's `disabled` attribute alone — a real popover would still be reachable through
+	 * assistive tech or a stray click on an already-open panel, so the guards inside `TokenPopover`
+	 * are what actually stop a write while disabled. This exercises the Style Library tab's pick and
+	 * reset paths directly and confirms neither fires `onChange`, matching `BorderControl`'s sibling
+	 * "disables every field and fires no onChange from a disabled sub-field" coverage.
+	 *
+	 * @return {void}
+	 */
+	it('fires no onChange from a pick or reset in the Style Library tab while disabled', () => {
+		const onChange = jest.fn();
+		renderControl({ value: '{primitive.shadow.md}', onChange, disabled: true });
+
+		click(tokenItem('Large'));
+		click(resetButton());
+
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * Same guard, exercised on the Custom tab's axis-edit and inset-toggle paths — the third of the
+	 * three `!disabled &&` guards this control relies on.
+	 *
+	 * @return {void}
+	 */
+	it('fires no onChange from an axis edit or the Inset toggle in the Custom tab while disabled', () => {
+		const onChange = jest.fn();
+		renderControl({
+			value: { color: '#111111', offsetX: '0px', offsetY: '0px', blur: '0px', spread: '0px' },
+			onChange,
+			disabled: true,
+		});
+
+		change(numberInput('Blur'), '12');
+		click(insetCheckbox());
+
+		expect(onChange).not.toHaveBeenCalled();
+	});
 });

--- a/src/token-controls/__tests__/box-shadow-control.test.js
+++ b/src/token-controls/__tests__/box-shadow-control.test.js
@@ -238,6 +238,19 @@ describe('BoxShadowControl Style Library tab', () => {
 
 		expect(onChange).toHaveBeenCalledWith('');
 	});
+
+	/**
+	 * Each token row shows its label but not its resolved `box-shadow` value — a shadow's value is a
+	 * long CSS shorthand that would crowd the row.
+	 *
+	 * @return {void}
+	 */
+	it("shows each row's label but not its resolved value", () => {
+		renderControl({ value: '{primitive.shadow.md}' });
+
+		expect(tokenItem('Large')).not.toBeUndefined();
+		expect(container.querySelector('.kadence-token-field__item-value')).toBeNull();
+	});
 });
 
 describe('BoxShadowControl Custom tab', () => {

--- a/src/token-controls/__tests__/box-shadow-control.test.js
+++ b/src/token-controls/__tests__/box-shadow-control.test.js
@@ -1,0 +1,351 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { BoxShadowControl } from '../controls/BoxShadowControl';
+
+// `jest.config.js` maps `@wordpress/components` to the copy nested under
+// `@kadence/components/node_modules`, which resolves its own `react` — a different module instance
+// than the top-level `react-dom/client` this test renders with, which trips React's "Invalid hook
+// call" guard. Stand-ins sidestep that. `Dropdown` always renders both its toggle and its content so
+// the popover's tabs are reachable without simulating a real popover open, and `TabPanel` keeps its
+// own active-tab state so a test can click between `Style Library` and `Custom`.
+jest.mock('@wordpress/components', () => ({
+	Button: ({ children, isPressed, showTooltip, ...props }) => <button {...props}>{children}</button>,
+	Icon: ({ icon, ...props }) => <span {...props}>{icon}</span>,
+	Dropdown: ({ renderToggle, renderContent }) => (
+		<>
+			{renderToggle({ isOpen: true, onToggle: () => {} })}
+			{renderContent({ onClose: () => {} })}
+		</>
+	),
+	TabPanel: ({ children, tabs, initialTabName }) => {
+		const { useState: mockUseState } = require('react');
+		const [active, setActive] = mockUseState(tabs.find((tab) => tab.name === initialTabName) || tabs[0]);
+		return (
+			<div data-testid="tab-panel">
+				<div data-testid="tab-buttons">
+					{tabs.map((tab) => (
+						<button key={tab.name} data-testid={`tab-${tab.name}`} onClick={() => setActive(tab)}>
+							{tab.title}
+						</button>
+					))}
+				</div>
+				{children(active)}
+			</div>
+		);
+	},
+	__experimentalNumberControl: ({ label, value, onChange }) => (
+		<label>
+			{label}
+			<input aria-label={label} type="number" value={value} onChange={(event) => onChange(event.target.value)} />
+		</label>
+	),
+	ToggleControl: ({ label, checked, onChange }) => (
+		<label>
+			<input
+				aria-label={label}
+				type="checkbox"
+				checked={checked}
+				onChange={(event) => onChange(event.target.checked)}
+			/>
+			{label}
+		</label>
+	),
+}));
+
+jest.mock('@wordpress/icons', () => ({ globe: 'globe', settings: 'settings', undo: 'undo' }));
+jest.mock('@wordpress/i18n', () => ({
+	__: (text) => text,
+	sprintf: (format, ...args) => format.replace(/%s/g, () => args.shift()),
+}));
+
+jest.mock('../styles/token-controls.scss', () => ({}), { virtual: true });
+
+let container;
+let root;
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+const TOKENS = [
+	{ id: 'md', label: 'Medium', value: '0px 2px 8px 0px #1717171f', alias: '{primitive.shadow.md}' },
+	{ id: 'lg', label: 'Large', value: '0px 4px 16px 0px #1717172f', alias: '{primitive.shadow.lg}' },
+];
+
+/**
+ * Render `BoxShadowControl` with the props it needs, plus overrides.
+ *
+ * @param {Object} props Overrides for the defaults below.
+ *
+ * @since TBD
+ *
+ * @return {HTMLElement} The container it rendered into.
+ */
+function renderControl(props = {}) {
+	act(() =>
+		root.render(
+			createElement(BoxShadowControl, {
+				value: '',
+				onChange: jest.fn(),
+				label: 'Shadow',
+				tokens: TOKENS,
+				...props,
+			})
+		)
+	);
+
+	return container;
+}
+
+const trigger = () => container.querySelector('.kadence-token-field__trigger');
+const resetButton = () => container.querySelector('.kadence-token-field__reset');
+const tokenItem = (label) =>
+	Array.from(container.querySelectorAll('.kadence-token-field__item')).find((el) => el.textContent.includes(label));
+const numberInput = (label) => container.querySelector(`input[aria-label="${label}"][type="number"]`);
+const insetCheckbox = () => container.querySelector('input[aria-label="Inset"]');
+
+/**
+ * Click a rendered DOM element inside `act`, so React flushes the resulting state/prop updates
+ * before the next assertion reads them.
+ *
+ * @param {HTMLElement} element The element to click.
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+function click(element) {
+	act(() => element.click());
+}
+
+/**
+ * Change a text/number input inside `act`.
+ *
+ * @param {HTMLElement} element The input element.
+ * @param {string}      value   The next value.
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+function change(element, value) {
+	act(() => {
+		const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+		setter.call(element, value);
+		element.dispatchEvent(new Event('input', { bubbles: true }));
+	});
+}
+
+describe('BoxShadowControl trigger', () => {
+	/**
+	 * The trigger shows the bound token's label when the value is that token's alias.
+	 *
+	 * @return {void}
+	 */
+	it('shows the token label when value is a token alias', () => {
+		renderControl({ value: '{primitive.shadow.md}' });
+
+		expect(trigger().textContent).toBe('Medium');
+	});
+
+	/**
+	 * The trigger reads "Custom" when the value is a composite shadow object.
+	 *
+	 * @return {void}
+	 */
+	it('shows "Custom" when value is a composite object', () => {
+		renderControl({ value: { color: '#000000', offsetX: '2px', offsetY: '2px', blur: '4px', spread: '0px' } });
+
+		expect(trigger().textContent).toBe('Custom');
+	});
+});
+
+describe('BoxShadowControl initial tab', () => {
+	/**
+	 * An aliased value opens the popover on the Style Library tab, so the token list is reachable
+	 * without switching tabs.
+	 *
+	 * @return {void}
+	 */
+	it('opens on the Style Library tab for an aliased value', () => {
+		renderControl({ value: '{primitive.shadow.md}' });
+
+		expect(tokenItem('Medium')).not.toBeUndefined();
+	});
+
+	/**
+	 * A composite value opens the popover on the Custom tab, so the axis fields are reachable
+	 * without switching tabs.
+	 *
+	 * @return {void}
+	 */
+	it('opens on the Custom tab for a composite value', () => {
+		renderControl({ value: { color: '#000000', offsetX: '2px', offsetY: '2px', blur: '4px', spread: '0px' } });
+
+		expect(numberInput('X')).not.toBeNull();
+	});
+});
+
+describe('BoxShadowControl Style Library tab', () => {
+	/**
+	 * Picking a token calls onChange with that token's alias.
+	 *
+	 * @return {void}
+	 */
+	it('calls onChange with the picked token alias', () => {
+		const onChange = jest.fn();
+		renderControl({ value: '{primitive.shadow.md}', onChange });
+
+		click(tokenItem('Large'));
+
+		expect(onChange).toHaveBeenCalledWith('{primitive.shadow.lg}');
+	});
+
+	/**
+	 * Reset clears an aliased value back to empty.
+	 *
+	 * @return {void}
+	 */
+	it('calls onChange with an empty string when Reset is clicked', () => {
+		const onChange = jest.fn();
+		renderControl({ value: '{primitive.shadow.md}', onChange });
+
+		click(resetButton());
+
+		expect(onChange).toHaveBeenCalledWith('');
+	});
+});
+
+describe('BoxShadowControl Custom tab', () => {
+	/**
+	 * Editing an axis writes the full composite object with only that axis changed, serialized as a
+	 * px dimension string, and the rest of the value preserved.
+	 *
+	 * @return {void}
+	 */
+	it('calls onChange with the full composite object when an axis changes', () => {
+		const onChange = jest.fn();
+		renderControl({
+			value: { color: '#111111', offsetX: '2px', offsetY: '4px', blur: '8px', spread: '0px' },
+			onChange,
+		});
+
+		change(numberInput('Blur'), '12');
+
+		expect(onChange).toHaveBeenCalledWith({
+			color: '#111111',
+			offsetX: '2px',
+			offsetY: '4px',
+			blur: '12px',
+			spread: '0px',
+		});
+	});
+
+	/**
+	 * Turning Inset on writes the composite object with `inset: true`.
+	 *
+	 * @return {void}
+	 */
+	it('calls onChange with inset true when the Inset toggle is switched on', () => {
+		const onChange = jest.fn();
+		renderControl({
+			value: { color: '#111111', offsetX: '0px', offsetY: '0px', blur: '0px', spread: '0px' },
+			onChange,
+		});
+
+		click(insetCheckbox());
+
+		expect(onChange).toHaveBeenCalledWith({
+			color: '#111111',
+			offsetX: '0px',
+			offsetY: '0px',
+			blur: '0px',
+			spread: '0px',
+			inset: true,
+		});
+	});
+
+	/**
+	 * Turning Inset back off writes the composite object with the `inset` key absent entirely,
+	 * matching `helpers/shadow.js`'s existing convention rather than writing `inset: false`.
+	 *
+	 * @return {void}
+	 */
+	it('calls onChange with the inset key absent when the Inset toggle is switched back off', () => {
+		const onChange = jest.fn();
+		renderControl({
+			value: { color: '#111111', offsetX: '0px', offsetY: '0px', blur: '0px', spread: '0px', inset: true },
+			onChange,
+		});
+
+		click(insetCheckbox());
+
+		const next = onChange.mock.calls[0][0];
+		expect(next).not.toHaveProperty('inset');
+		expect(next).toEqual({ color: '#111111', offsetX: '0px', offsetY: '0px', blur: '0px', spread: '0px' });
+	});
+
+	/**
+	 * `renderColor` is invoked with the shadow's current color and an onChange that patches only the
+	 * color field, leaving every other sub-field untouched.
+	 *
+	 * @return {void}
+	 */
+	it('invokes renderColor with the color value and patches only color on change', () => {
+		const onChange = jest.fn();
+		let received;
+		const renderColor = ({ value, onChange: patch }) => {
+			received = { value, patch };
+			return <div data-testid="color-slot" />;
+		};
+
+		renderControl({
+			value: { color: '#111111', offsetX: '2px', offsetY: '4px', blur: '8px', spread: '0px' },
+			onChange,
+			renderColor,
+		});
+
+		expect(received.value).toBe('#111111');
+		expect(container.querySelector('[data-testid="color-slot"]')).not.toBeNull();
+
+		act(() => received.patch('#ffffff'));
+
+		expect(onChange).toHaveBeenCalledWith({
+			color: '#ffffff',
+			offsetX: '2px',
+			offsetY: '4px',
+			blur: '8px',
+			spread: '0px',
+		});
+	});
+});
+
+describe('BoxShadowControl disabled state', () => {
+	/**
+	 * A disabled control's trigger cannot be interacted with.
+	 *
+	 * @return {void}
+	 */
+	it('disables the trigger', () => {
+		renderControl({ disabled: true });
+
+		expect(trigger().disabled).toBe(true);
+	});
+});

--- a/src/token-controls/__tests__/token-popover.test.js
+++ b/src/token-controls/__tests__/token-popover.test.js
@@ -15,7 +15,10 @@ import { TokenPopover } from '../molecules/TokenPopover';
 // than the top-level `react-dom/client` this test renders with, which trips React's "Invalid hook
 // call" guard. Stand-ins sidestep that; this test only needs the tab panel structure.
 jest.mock('@wordpress/components', () => ({
-	Button: ({ children, ...props }) => <button {...props}>{children}</button>,
+	// `isPressed` is dropped rather than spread: it is a `Button`-only prop, and passing it straight
+	// through to a DOM `<button>` trips React's "unrecognized DOM attribute" warning under
+	// `@wordpress/jest-console`'s strict console assertions.
+	Button: ({ children, isPressed, ...props }) => <button {...props}>{children}</button>,
 	Icon: ({ icon, ...props }) => <span {...props}>{icon}</span>,
 	RangeControl: ({ label }) => <div>{label}</div>,
 	SelectControl: ({ label }) => <div>{label}</div>,
@@ -125,5 +128,37 @@ describe('TokenPopover renderCustom prop', () => {
 		});
 
 		expect(renderCustom).not.toHaveBeenCalled();
+	});
+});
+
+describe('TokenPopover showValue prop', () => {
+	/**
+	 * When `showValue` is omitted — every consumer besides `BoxShadowControl` today — each token row
+	 * still shows its resolved value beside its label. This is the regression check that the additive
+	 * prop leaves existing consumers unchanged.
+	 *
+	 * @return {void}
+	 */
+	it("shows each row's value by default", () => {
+		const tokens = [{ id: 'md', label: 'Medium', value: '8px', alias: '{primitive.radius.md}' }];
+
+		render({ initialTab: 'style-library', tokens });
+
+		expect(container.querySelector('.kadence-token-field__item-value').textContent).toBe('8px');
+	});
+
+	/**
+	 * With `showValue={false}` — `BoxShadowControl`'s own usage — no row renders its resolved value,
+	 * only its label.
+	 *
+	 * @return {void}
+	 */
+	it("hides every row's value when showValue is false", () => {
+		const tokens = [{ id: 'md', label: 'Medium', value: '0px 2px 8px #000', alias: '{primitive.shadow.md}' }];
+
+		render({ initialTab: 'style-library', tokens, showValue: false });
+
+		expect(container.querySelector('.kadence-token-field__item-value')).toBeNull();
+		expect(container.querySelector('.kadence-token-field__item-label').textContent).toBe('Medium');
 	});
 });

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -1,0 +1,163 @@
+/**
+ * The box-shadow token control: a single trigger opening a Style Library tab (pick a shadow token)
+ * and a Custom tab (the composite editor — color, X/Y/blur/spread, inset). The odd one out among
+ * this library's controls: no slots, no link toggle, a shadow isn't sided.
+ *
+ * The Custom tab reuses the exact composite shape `helpers/shadow.js` and `ShadowField` already
+ * define for the Shadow token-library screen (`{ color, offsetX, offsetY, blur, spread, inset }`),
+ * confirmed against the live screen rather than invented fresh — this control is a token-aware
+ * wrapper around that same editing surface, not a new one.
+ *
+ * Color is out of scope here (see `renderColor`) exactly as in `BorderControl` — this control does
+ * not import or build a color picker.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __experimentalNumberControl as NumberControl, Button, Dropdown, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { TokenPopover } from '../molecules/TokenPopover';
+import { isTokenAlias } from '../helpers/token-summary';
+import '../styles/token-controls.scss';
+
+/**
+ * The four length axes of a shadow, in CSS declaration order.
+ *
+ * @since TBD
+ */
+const AXES = [
+	{ key: 'offsetX', label: __('X', 'kadence-blocks') },
+	{ key: 'offsetY', label: __('Y', 'kadence-blocks') },
+	{ key: 'blur', label: __('Blur', 'kadence-blocks') },
+	{ key: 'spread', label: __('Spread', 'kadence-blocks') },
+];
+
+/**
+ * The shadow composite's default shape, matching `ShadowField`'s own fallback.
+ *
+ * @since TBD
+ */
+const DEFAULT_SHADOW = { color: '#000000', offsetX: '0px', offsetY: '0px', blur: '0px', spread: '0px', inset: false };
+
+/**
+ * Apply a patch to the current shadow composite, writing the result through `onChange` with `inset`
+ * omitted entirely when it is not `true` — `helpers/shadow.js`'s `shadowLeafValue()` uses the same
+ * convention (an optional-field map where absent means unset), so a value this control emits is
+ * indistinguishable from one built there.
+ *
+ * @param {Object} shadow The current composite shadow value.
+ * @param {Object} patch  The fields to overwrite.
+ *
+ * @since TBD
+ *
+ * @return {Object} The next composite shadow value, `inset` present only when `true`.
+ */
+function commitShadow(shadow, patch) {
+	const { inset, ...rest } = { ...shadow, ...patch };
+
+	return inset === true ? { ...rest, inset: true } : rest;
+}
+
+/**
+ * The Custom tab body: the shadow composite editor, matching `ShadowField`'s layout — a color row,
+ * four numeric axes, an inset toggle.
+ *
+ * @param {Object}   props              The component props.
+ * @param {Object}   props.shadow       The current composite shadow value (defaults filled).
+ * @param {Function} props.onChange     Called with the next composite shadow value.
+ * @param {Function} [props.renderColor] `({ value, onChange }) => Element` for the color sub-field.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The Custom tab body.
+ */
+function ShadowCustomTab({ shadow, onChange, renderColor }) {
+	const setPart = (key, next) => onChange(commitShadow(shadow, { [key]: next }));
+
+	return (
+		<div className="kadence-token-field__custom kb-box-shadow-control__custom">
+			{renderColor && renderColor({ value: shadow.color, onChange: (next) => setPart('color', next) })}
+			<div className="kb-box-shadow-control__axes">
+				{AXES.map(({ key, label }) => (
+					<NumberControl
+						key={key}
+						label={label}
+						value={parseInt(shadow[key], 10) || 0}
+						onChange={(next) => setPart(key, `${Number(next) || 0}px`)}
+					/>
+				))}
+			</div>
+			<ToggleControl
+				label={__('Inset', 'kadence-blocks')}
+				checked={shadow.inset === true}
+				onChange={(next) => setPart('inset', next)}
+			/>
+		</div>
+	);
+}
+
+/**
+ * Render a box-shadow token control.
+ *
+ * @param {Object}    props               The component props.
+ * @param {*}         props.value         A token alias string, or a composite shadow object.
+ * @param {Function}  props.onChange      Called with the next alias or composite object.
+ * @param {string}    props.label         The control's label.
+ * @param {Array}     [props.tokens]      Pickable `shadow`-type tokens, `[{id, label, value, alias}]`.
+ * @param {Function}  [props.renderColor] `({ value, onChange }) => Element` for the color sub-field.
+ * @param {boolean}   [props.disabled]    Whether the control is read-only.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The rendered control.
+ */
+export function BoxShadowControl({ value, onChange, label, tokens = [], renderColor, disabled = false }) {
+	const aliased = isTokenAlias(value);
+	const shadow = { ...DEFAULT_SHADOW, ...(aliased || !value ? {} : value) };
+	const activeEntry = aliased ? tokens.find((entry) => entry.alias === value) : null;
+	const triggerLabel = activeEntry ? activeEntry.label : aliased ? value : __('Custom', 'kadence-blocks');
+
+	return (
+		<div className="kadence-token-field kb-box-shadow-control">
+			{label && <span className="kadence-token-field__label">{label}</span>}
+			<Dropdown
+				className="kadence-token-field__dropdown"
+				contentClassName="kadence-token-field__popover"
+				renderToggle={({ isOpen, onToggle }) => (
+					<Button
+						className="kadence-token-field__trigger"
+						onClick={onToggle}
+						disabled={disabled}
+						aria-expanded={isOpen}
+					>
+						{triggerLabel}
+					</Button>
+				)}
+				renderContent={({ onClose }) => (
+					<TokenPopover
+						value={value}
+						tokens={tokens}
+						resolvedDefault=""
+						initialTab={aliased || !value ? 'style-library' : 'custom'}
+						custom={{ shadow, renderColor }}
+						renderCustom={(custom) => (
+							<ShadowCustomTab
+								shadow={custom.shadow}
+								renderColor={custom.renderColor}
+								onChange={(next) => !disabled && onChange(next)}
+							/>
+						)}
+						onPick={(alias) => !disabled && onChange(alias)}
+						onClear={() => !disabled && onChange('')}
+						onClose={onClose}
+					/>
+				)}
+			/>
+		</div>
+	);
+}

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -10,6 +10,11 @@
  *
  * Color is out of scope here (see `renderColor`) exactly as in `BorderControl` — this control does
  * not import or build a color picker.
+ *
+ * The token rows also hide their resolved value (`TokenPopover`'s `showValue={false}`) — a shadow's
+ * value is a long CSS shorthand that crowds the row the way a short dimension value does not. Other
+ * `TokenPopover` consumers (Radius, Spacing, Border Width) keep the default `showValue={true}` and
+ * are unaffected.
  */
 
 /**
@@ -159,6 +164,7 @@ export function BoxShadowControl({ value, onChange, label, tokens = [], renderCo
 						onPick={(alias) => !disabled && onChange(alias)}
 						onClear={() => !disabled && onChange('')}
 						onClose={onClose}
+						showValue={false}
 					/>
 				)}
 			/>

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -71,23 +71,25 @@ function commitShadow(shadow, patch) {
  * @param {Object}   props.shadow       The current composite shadow value (defaults filled).
  * @param {Function} props.onChange     Called with the next composite shadow value.
  * @param {Function} [props.renderColor] `({ value, onChange }) => Element` for the color sub-field.
+ * @param {boolean}  [props.disabled]   Whether every sub-field is read-only.
  *
  * @since TBD
  *
  * @return {JSX.Element} The Custom tab body.
  */
-function ShadowCustomTab({ shadow, onChange, renderColor }) {
+function ShadowCustomTab({ shadow, onChange, renderColor, disabled = false }) {
 	const setPart = (key, next) => onChange(commitShadow(shadow, { [key]: next }));
 
 	return (
 		<div className="kadence-token-field__custom kb-box-shadow-control__custom">
-			{renderColor && renderColor({ value: shadow.color, onChange: (next) => setPart('color', next) })}
+			{renderColor && renderColor({ value: shadow.color, onChange: (next) => setPart('color', next), disabled })}
 			<div className="kb-box-shadow-control__axes">
 				{AXES.map(({ key, label }) => (
 					<NumberControl
 						key={key}
 						label={label}
-						value={parseInt(shadow[key], 10) || 0}
+						value={Number.parseFloat(shadow[key]) || 0}
+						disabled={disabled}
 						onChange={(next) => setPart(key, `${Number(next) || 0}px`)}
 					/>
 				))}
@@ -95,6 +97,7 @@ function ShadowCustomTab({ shadow, onChange, renderColor }) {
 			<ToggleControl
 				label={__('Inset', 'kadence-blocks')}
 				checked={shadow.inset === true}
+				disabled={disabled}
 				onChange={(next) => setPart('inset', next)}
 			/>
 		</div>
@@ -144,11 +147,12 @@ export function BoxShadowControl({ value, onChange, label, tokens = [], renderCo
 						tokens={tokens}
 						resolvedDefault=""
 						initialTab={aliased || !value ? 'style-library' : 'custom'}
-						custom={{ shadow, renderColor }}
+						custom={{ shadow, renderColor, disabled }}
 						renderCustom={(custom) => (
 							<ShadowCustomTab
 								shadow={custom.shadow}
 								renderColor={custom.renderColor}
+								disabled={custom.disabled}
 								onChange={(next) => !disabled && onChange(next)}
 							/>
 						)}

--- a/src/token-controls/molecules/TokenPopover.js
+++ b/src/token-controls/molecules/TokenPopover.js
@@ -42,12 +42,16 @@ import { hasValue, isTokenAlias } from '../helpers/token-summary';
  * @param {Function} props.onPick       Called with an entry's `alias` when a token is chosen.
  * @param {Function} props.onClear      Called when `Reset` is chosen; clears the slot's override.
  * @param {Function} props.onClose      Closes the popover after a choice.
+ * @param {boolean}  [props.showValue]  Whether each row shows its resolved value beside its label.
+ *                                      Defaults to `true`; a shadow's resolved value is a long CSS
+ *                                      shorthand that reads awkwardly next to its label the way a
+ *                                      short dimension value does, so `BoxShadowControl` opts out.
  *
  * @since TBD
  *
  * @return {Object} The rendered token list.
  */
-function StyleLibraryTab({ value, tokens, defaultValue, inherited, onPick, onClear, onClose }) {
+function StyleLibraryTab({ value, tokens, defaultValue, inherited, onPick, onClear, onClose, showValue = true }) {
 	// Reset clears the slot's override back to the inherited default; it is inert when nothing is set.
 	const hasOverride = isTokenAlias(value) || (value !== '' && value !== undefined && value !== null);
 	// While unset, the size matching the inherited default reads as the active row.
@@ -84,7 +88,7 @@ function StyleLibraryTab({ value, tokens, defaultValue, inherited, onPick, onCle
 								{inherited ? __('Inherited', 'kadence-blocks') : __('Default', 'kadence-blocks')}
 							</span>
 						)}
-						<span className="kadence-token-field__item-value">{entry.value}</span>
+						{showValue && <span className="kadence-token-field__item-value">{entry.value}</span>}
 					</Button>
 				);
 			})}
@@ -166,6 +170,9 @@ export function CustomTab({ number, unit, units, onUnit, min, max, step, onNumbe
  * @param {Function} props.onPick           Writes a picked token's alias.
  * @param {Function} props.onClear          Clears the slot's override.
  * @param {Function} props.onClose          Closes the popover after a choice.
+ * @param {boolean}  [props.showValue]      Whether each Style Library row shows its resolved value
+ *                                          beside its label. Defaults to `true`; additive only, so
+ *                                          every existing consumer keeps showing values.
  *
  * @since TBD
  *
@@ -182,6 +189,7 @@ export function TokenPopover({
 	onPick,
 	onClear,
 	onClose,
+	showValue = true,
 }) {
 	return (
 		<TabPanel
@@ -218,6 +226,7 @@ export function TokenPopover({
 						onPick={onPick}
 						onClear={onClear}
 						onClose={onClose}
+						showValue={showValue}
 					/>
 				) : renderCustom ? (
 					renderCustom(custom)


### PR DESCRIPTION
## Summary

Adds `BoxShadowControl` (`src/token-controls/controls/BoxShadowControl.js`) — the token-aware box-shadow control for `src/token-controls/`.

- Value: a token alias string, or a composite `{ color, offsetX, offsetY, blur, spread, inset }` — the same shape `helpers/shadow.js`/`ShadowField.js` already use for the Shadow token-library screen, confirmed against the live screen's edit sidebar.
- A single trigger, no slots, no link toggle — a shadow isn't sided.
- Style Library tab lists pickable `shadow`-type tokens; Custom tab reuses the shadow composite editor (color, X/Y/Blur/Spread, Inset), via `TokenPopover`'s new `renderCustom` prop from the previous PR in this stack.
- Color is out of scope for this whole effort — `renderColor` render-prop, same pattern as `BorderControl`.

## Test plan

- [x] `npx jest src/token-controls` — 140/140 passing, no regressions
- [x] cspell clean
- [x] `grep -rn "SOFT-" src/token-controls` — no hits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a box-shadow control with Style Library token selection and Custom editing modes.
  * Supports color, offsets, blur, spread, and inset shadow settings.
  * Added token alias selection, clearing, color previews, and disabled-state handling.

* **Tests**
  * Added comprehensive coverage for shadow editing, token selection, reset behavior, tab selection, inset toggling, color rendering, and disabled controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->