### PR TITLE
[DTM] SOFT-4083 [27/38]: border and shadow fields in the Button screen

### DIFF
--- a/src/style-library/__tests__/border-field.test.js
+++ b/src/style-library/__tests__/border-field.test.js
@@ -1,0 +1,110 @@
+/* eslint-env jest */
+/**
+ * Internal dependencies
+ */
+import {
+	toControlValue,
+	toControlWidth,
+	toStoredValue,
+	toStoredWidth,
+} from '../components/molecules/fields/BorderField';
+
+describe('toControlWidth', () => {
+	it('wraps a bare token id into the alias the control matches against', () => {
+		expect(toControlWidth('semantic.dimension.border-width-sm')).toBe('{semantic.dimension.border-width-sm}');
+		expect(toControlWidth('primitive.dimension.border-width.md')).toBe('{primitive.dimension.border-width.md}');
+	});
+
+	it('splits a px literal down to its bare number', () => {
+		expect(toControlWidth('2px')).toBe(2);
+	});
+
+	it('reads an unset width as unset', () => {
+		expect(toControlWidth('')).toBe('');
+		expect(toControlWidth(undefined)).toBe('');
+	});
+});
+
+describe('toStoredWidth', () => {
+	it('unwraps an alias back to the bare id a preset stores', () => {
+		expect(toStoredWidth('{semantic.dimension.border-width-sm}')).toBe('semantic.dimension.border-width-sm');
+	});
+
+	it('rejoins a number with px, the only unit border width offers', () => {
+		expect(toStoredWidth(2)).toBe('2px');
+	});
+
+	it('keeps zero unitless', () => {
+		expect(toStoredWidth(0)).toBe('0');
+	});
+
+	it('writes an unset width as empty', () => {
+		expect(toStoredWidth('')).toBe('');
+		expect(toStoredWidth(null)).toBe('');
+	});
+});
+
+describe('toControlValue', () => {
+	it('reads a linked (scalar composite) stored value into a scalar control value', () => {
+		expect(toControlValue({ width: '2px', style: 'solid', color: 'semantic.color.border-default' })).toEqual({
+			width: 2,
+			style: 'solid',
+			color: 'semantic.color.border-default',
+		});
+	});
+
+	it('reads an unlinked (four-slot) stored value into four-slot width/style axes, sharing one color', () => {
+		const stored = [
+			{ width: '1px', style: 'solid', color: '#000' },
+			{ width: '2px', style: 'dashed', color: '#000' },
+			{ width: '1px', style: 'solid', color: '#000' },
+			{ width: '2px', style: 'dashed', color: '#000' },
+		];
+
+		expect(toControlValue(stored)).toEqual({
+			width: [1, 2, 1, 2],
+			style: ['solid', 'dashed', 'solid', 'dashed'],
+			color: '#000',
+		});
+	});
+
+	it('defaults an empty stored value to the unset side', () => {
+		expect(toControlValue('')).toEqual({ width: '', style: 'none', color: '' });
+		expect(toControlValue(undefined)).toEqual({ width: '', style: 'none', color: '' });
+	});
+});
+
+describe('toStoredValue', () => {
+	it('collapses a uniform control value back to a scalar composite', () => {
+		expect(toStoredValue({ width: 2, style: 'solid', color: '#000' })).toEqual({
+			width: '2px',
+			style: 'solid',
+			color: '#000',
+		});
+	});
+
+	it('keeps a non-uniform control value as a four-slot composite list', () => {
+		const next = { width: [1, 1, 1, 2], style: 'solid', color: '#000' };
+
+		expect(toStoredValue(next)).toEqual([
+			{ width: '1px', style: 'solid', color: '#000' },
+			{ width: '1px', style: 'solid', color: '#000' },
+			{ width: '1px', style: 'solid', color: '#000' },
+			{ width: '2px', style: 'solid', color: '#000' },
+		]);
+	});
+
+	it('collapses a four-slot value back to a scalar once every slot matches again', () => {
+		const next = { width: [1, 1, 1, 1], style: ['solid', 'solid', 'solid', 'solid'], color: '#000' };
+
+		expect(toStoredValue(next)).toEqual({ width: '1px', style: 'solid', color: '#000' });
+	});
+});
+
+describe('the conversion pair', () => {
+	it('round-trips a linked border through toStoredValue(toControlValue(...))', () => {
+		const stored = { width: 'semantic.dimension.border-width-sm', style: 'dashed', color: '#171717' };
+
+		expect(toStoredValue(toControlValue(stored))).toEqual(stored);
+	});
+});

--- a/src/style-library/__tests__/border-field.test.js
+++ b/src/style-library/__tests__/border-field.test.js
@@ -3,10 +3,12 @@
  * Internal dependencies
  */
 import {
-	toControlValue,
+	toControlStyleAxis,
 	toControlWidth,
-	toStoredValue,
+	toControlWidthAxis,
+	toStoredStyleAxis,
 	toStoredWidth,
+	toStoredWidthAxis,
 } from '../components/molecules/fields/BorderField';
 
 describe('toControlWidth', () => {
@@ -44,67 +46,59 @@ describe('toStoredWidth', () => {
 	});
 });
 
-describe('toControlValue', () => {
-	it('reads a linked (scalar composite) stored value into a scalar control value', () => {
-		expect(toControlValue({ width: '2px', style: 'solid', color: 'semantic.color.border-default' })).toEqual({
-			width: 2,
-			style: 'solid',
-			color: 'semantic.color.border-default',
-		});
+describe('toControlWidthAxis', () => {
+	it('converts a scalar width axis the same way toControlWidth does', () => {
+		expect(toControlWidthAxis('2px')).toBe(2);
+		expect(toControlWidthAxis('semantic.dimension.border-width-sm')).toBe('{semantic.dimension.border-width-sm}');
 	});
 
-	it('reads an unlinked (four-slot) stored value into four-slot width/style axes, sharing one color', () => {
-		const stored = [
-			{ width: '1px', style: 'solid', color: '#000' },
-			{ width: '2px', style: 'dashed', color: '#000' },
-			{ width: '1px', style: 'solid', color: '#000' },
-			{ width: '2px', style: 'dashed', color: '#000' },
-		];
-
-		expect(toControlValue(stored)).toEqual({
-			width: [1, 2, 1, 2],
-			style: ['solid', 'dashed', 'solid', 'dashed'],
-			color: '#000',
-		});
-	});
-
-	it('defaults an empty stored value to the unset side', () => {
-		expect(toControlValue('')).toEqual({ width: '', style: 'none', color: '' });
-		expect(toControlValue(undefined)).toEqual({ width: '', style: 'none', color: '' });
-	});
-});
-
-describe('toStoredValue', () => {
-	it('collapses a uniform control value back to a scalar composite', () => {
-		expect(toStoredValue({ width: 2, style: 'solid', color: '#000' })).toEqual({
-			width: '2px',
-			style: 'solid',
-			color: '#000',
-		});
-	});
-
-	it('keeps a non-uniform control value as a four-slot composite list', () => {
-		const next = { width: [1, 1, 1, 2], style: 'solid', color: '#000' };
-
-		expect(toStoredValue(next)).toEqual([
-			{ width: '1px', style: 'solid', color: '#000' },
-			{ width: '1px', style: 'solid', color: '#000' },
-			{ width: '1px', style: 'solid', color: '#000' },
-			{ width: '2px', style: 'solid', color: '#000' },
+	it('converts every slot of a four-slot width axis independently', () => {
+		expect(toControlWidthAxis(['1px', '2px', '{semantic.dimension.border-width-sm}', ''])).toEqual([
+			1,
+			2,
+			'{semantic.dimension.border-width-sm}',
+			'',
 		]);
 	});
+});
 
-	it('collapses a four-slot value back to a scalar once every slot matches again', () => {
-		const next = { width: [1, 1, 1, 1], style: ['solid', 'solid', 'solid', 'solid'], color: '#000' };
+describe('toStoredWidthAxis', () => {
+	it('converts a scalar control width the same way toStoredWidth does', () => {
+		expect(toStoredWidthAxis(2)).toBe('2px');
+		expect(toStoredWidthAxis(0)).toBe('0');
+	});
 
-		expect(toStoredValue(next)).toEqual({ width: '1px', style: 'solid', color: '#000' });
+	it('converts every slot of a four-slot control width independently', () => {
+		expect(toStoredWidthAxis([1, 2, '{semantic.dimension.border-width-sm}', ''])).toEqual([
+			'1px',
+			'2px',
+			'semantic.dimension.border-width-sm',
+			'',
+		]);
 	});
 });
 
-describe('the conversion pair', () => {
-	it('round-trips a linked border through toStoredValue(toControlValue(...))', () => {
-		const stored = { width: 'semantic.dimension.border-width-sm', style: 'dashed', color: '#171717' };
+describe('toControlStyleAxis', () => {
+	it('defaults an unset scalar style to none', () => {
+		expect(toControlStyleAxis('')).toBe('none');
+		expect(toControlStyleAxis(undefined)).toBe('none');
+	});
 
-		expect(toStoredValue(toControlValue(stored))).toEqual(stored);
+	it('passes a set scalar style through unchanged', () => {
+		expect(toControlStyleAxis('dashed')).toBe('dashed');
+	});
+
+	it('defaults every unset slot of a four-slot style axis to none', () => {
+		expect(toControlStyleAxis(['solid', '', 'dotted', undefined])).toEqual(['solid', 'none', 'dotted', 'none']);
+	});
+});
+
+describe('toStoredStyleAxis', () => {
+	it('defaults an unset scalar style to none', () => {
+		expect(toStoredStyleAxis('')).toBe('none');
+	});
+
+	it('defaults every unset slot of a four-slot style axis to none', () => {
+		expect(toStoredStyleAxis(['solid', '', 'dotted', undefined])).toEqual(['solid', 'none', 'dotted', 'none']);
 	});
 });

--- a/src/style-library/__tests__/border-shadow-field-rendering.test.js
+++ b/src/style-library/__tests__/border-shadow-field-rendering.test.js
@@ -1,0 +1,211 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { PICKABLE_TOKENS_GLOBAL } from '../constants';
+
+// Stubs, not the real controls: `BorderControl`/`BoxShadowControl` render a deep tree of pickers and
+// popovers that have nothing to do with what this suite is after. Standing in for them exposes
+// exactly the props the adapters compute, which is what these tests drive and assert on.
+let latestBorderControlProps;
+let latestBoxShadowControlProps;
+
+jest.mock('../../token-controls/controls/BorderControl', () => ({
+	BorderControl: (props) => {
+		latestBorderControlProps = props;
+
+		return null;
+	},
+}));
+
+jest.mock('../../token-controls/controls/BoxShadowControl', () => ({
+	BoxShadowControl: (props) => {
+		latestBoxShadowControlProps = props;
+
+		return null;
+	},
+}));
+
+// eslint-disable-next-line import/first -- must follow the jest.mock calls above.
+import { BorderField } from '../components/molecules/fields/BorderField';
+// eslint-disable-next-line import/first -- must follow the jest.mock calls above.
+import { BoxShadowField } from '../components/molecules/fields/BoxShadowField';
+
+describe('BorderField', () => {
+	let container;
+	let root;
+	const originalPool = window[PICKABLE_TOKENS_GLOBAL];
+
+	beforeEach(() => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+
+		window[PICKABLE_TOKENS_GLOBAL] = {
+			tokens: [
+				{ id: 'primitive.dimension.border-width.sm', label: 'Small', type: 'dimension', role: 'border-width' },
+				{ id: 'primitive.dimension.radius.sm', label: 'Radius Small', type: 'dimension', role: 'radius' },
+			],
+			values: { brand: { 'primitive.dimension.border-width.sm': '1px' } },
+		};
+	});
+
+	afterEach(() => {
+		act(() => {
+			root.unmount();
+		});
+		container.remove();
+		latestBorderControlProps = undefined;
+		window[PICKABLE_TOKENS_GLOBAL] = originalPool;
+	});
+
+	it("sources widthTokens from the 'border-width' role only, excluding radius", () => {
+		const field = { label: 'Border', responsive: true };
+
+		act(() => {
+			root.render(createElement(BorderField, { field, value: '', onChange: jest.fn() }));
+		});
+
+		expect(latestBorderControlProps.widthTokens.map((token) => token.id)).toEqual([
+			'primitive.dimension.border-width.sm',
+		]);
+		expect(latestBorderControlProps.widthTokens[0].alias).toBe('{primitive.dimension.border-width.sm}');
+	});
+
+	it('threads breakpoints only when the field is responsive', () => {
+		act(() => {
+			root.render(
+				createElement(BorderField, {
+					field: { label: 'Border', responsive: true },
+					value: '',
+					onChange: jest.fn(),
+				})
+			);
+		});
+		expect(latestBorderControlProps.breakpoints).toEqual(['desktop', 'tablet', 'mobile']);
+
+		act(() => {
+			root.render(createElement(BorderField, { field: { label: 'Border' }, value: '', onChange: jest.fn() }));
+		});
+		expect(latestBorderControlProps.breakpoints).toBeNull();
+	});
+
+	it('writes through onChange with the stored (not control) shape', () => {
+		const onChange = jest.fn();
+
+		act(() => {
+			root.render(createElement(BorderField, { field: { label: 'Border' }, value: '', onChange }));
+		});
+
+		act(() => {
+			latestBorderControlProps.onChange({ width: 2, style: 'solid', color: '#000' });
+		});
+
+		expect(onChange).toHaveBeenCalledWith({ width: '2px', style: 'solid', color: '#000' });
+	});
+
+	it('never calls onChange when the field is read-only', () => {
+		const onChange = jest.fn();
+
+		act(() => {
+			root.render(
+				createElement(BorderField, { field: { label: 'Border', readOnly: true }, value: '', onChange })
+			);
+		});
+
+		act(() => {
+			latestBorderControlProps.onChange({ width: 2, style: 'solid', color: '#000' });
+		});
+
+		expect(onChange).not.toHaveBeenCalled();
+		expect(latestBorderControlProps.disabled).toBe(true);
+	});
+
+	it('renders the color sub-field through the existing TokenColorSelectField, not a new component', () => {
+		act(() => {
+			root.render(createElement(BorderField, { field: { label: 'Border' }, value: '', onChange: jest.fn() }));
+		});
+
+		const element = latestBorderControlProps.renderColor({ value: '', onChange: jest.fn() });
+
+		expect(element.type.name).toBe('TokenColorSelectField');
+	});
+});
+
+describe('BoxShadowField', () => {
+	let container;
+	let root;
+	const originalPool = window[PICKABLE_TOKENS_GLOBAL];
+
+	beforeEach(() => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+
+		window[PICKABLE_TOKENS_GLOBAL] = {
+			tokens: [{ id: 'semantic.shadow.card', label: 'Card', type: 'shadow' }],
+			values: {},
+		};
+	});
+
+	afterEach(() => {
+		act(() => {
+			root.unmount();
+		});
+		container.remove();
+		latestBoxShadowControlProps = undefined;
+		window[PICKABLE_TOKENS_GLOBAL] = originalPool;
+	});
+
+	it("sources tokens via pickableTokensForType('shadow') with an alias attached", () => {
+		act(() => {
+			root.render(createElement(BoxShadowField, { field: { label: 'Shadow' }, value: '', onChange: jest.fn() }));
+		});
+
+		expect(latestBoxShadowControlProps.tokens).toEqual([
+			{ id: 'semantic.shadow.card', label: 'Card', value: '', role: null, alias: '{semantic.shadow.card}' },
+		]);
+	});
+
+	it('passes the value straight through with no envelope/breakpoint handling', () => {
+		act(() => {
+			root.render(
+				createElement(BoxShadowField, {
+					field: { label: 'Shadow' },
+					value: '{semantic.shadow.card}',
+					onChange: jest.fn(),
+				})
+			);
+		});
+
+		expect(latestBoxShadowControlProps.value).toBe('{semantic.shadow.card}');
+		expect(latestBoxShadowControlProps.breakpoints).toBeUndefined();
+	});
+
+	it('never calls onChange when the field is read-only', () => {
+		const onChange = jest.fn();
+
+		act(() => {
+			root.render(
+				createElement(BoxShadowField, { field: { label: 'Shadow', readOnly: true }, value: '', onChange })
+			);
+		});
+
+		act(() => {
+			latestBoxShadowControlProps.onChange('{semantic.shadow.card}');
+		});
+
+		expect(onChange).not.toHaveBeenCalled();
+		expect(latestBoxShadowControlProps.disabled).toBe(true);
+	});
+});

--- a/src/style-library/__tests__/border-shadow-field-rendering.test.js
+++ b/src/style-library/__tests__/border-shadow-field-rendering.test.js
@@ -68,10 +68,10 @@ describe('BorderField', () => {
 	});
 
 	it("sources widthTokens from the 'border-width' role only, excluding radius", () => {
-		const field = { label: 'Border', responsive: true };
+		const field = { label: 'Border', path: 'tokens.button-border', responsive: true };
 
 		act(() => {
-			root.render(createElement(BorderField, { field, value: '', onChange: jest.fn() }));
+			root.render(createElement(BorderField, { field, values: {}, onValueChange: jest.fn() }));
 		});
 
 		expect(latestBorderControlProps.widthTokens.map((token) => token.id)).toEqual([
@@ -84,40 +84,36 @@ describe('BorderField', () => {
 		act(() => {
 			root.render(
 				createElement(BorderField, {
-					field: { label: 'Border', responsive: true },
-					value: '',
-					onChange: jest.fn(),
+					field: { label: 'Border', path: 'tokens.button-border', responsive: true },
+					values: {},
+					onValueChange: jest.fn(),
 				})
 			);
 		});
 		expect(latestBorderControlProps.breakpoints).toEqual(['desktop', 'tablet', 'mobile']);
 
 		act(() => {
-			root.render(createElement(BorderField, { field: { label: 'Border' }, value: '', onChange: jest.fn() }));
+			root.render(
+				createElement(BorderField, {
+					field: { label: 'Border', path: 'tokens.button-border' },
+					values: {},
+					onValueChange: jest.fn(),
+				})
+			);
 		});
 		expect(latestBorderControlProps.breakpoints).toBeNull();
 	});
 
-	it('writes through onChange with the stored (not control) shape', () => {
-		const onChange = jest.fn();
-
-		act(() => {
-			root.render(createElement(BorderField, { field: { label: 'Border' }, value: '', onChange }));
-		});
-
-		act(() => {
-			latestBorderControlProps.onChange({ width: 2, style: 'solid', color: '#000' });
-		});
-
-		expect(onChange).toHaveBeenCalledWith({ width: '2px', style: 'solid', color: '#000' });
-	});
-
-	it('never calls onChange when the field is read-only', () => {
-		const onChange = jest.fn();
+	it('writes each axis to its own sibling path, in the stored (not control) shape', () => {
+		const onValueChange = jest.fn();
 
 		act(() => {
 			root.render(
-				createElement(BorderField, { field: { label: 'Border', readOnly: true }, value: '', onChange })
+				createElement(BorderField, {
+					field: { label: 'Border', path: 'tokens.button-border' },
+					values: {},
+					onValueChange,
+				})
 			);
 		});
 
@@ -125,13 +121,41 @@ describe('BorderField', () => {
 			latestBorderControlProps.onChange({ width: 2, style: 'solid', color: '#000' });
 		});
 
-		expect(onChange).not.toHaveBeenCalled();
+		expect(onValueChange).toHaveBeenCalledWith('tokens.button-border-width', '2px');
+		expect(onValueChange).toHaveBeenCalledWith('tokens.button-border-style', 'solid');
+		expect(onValueChange).toHaveBeenCalledWith('tokens.button-border-color', '#000');
+	});
+
+	it('never calls onValueChange when the field is read-only', () => {
+		const onValueChange = jest.fn();
+
+		act(() => {
+			root.render(
+				createElement(BorderField, {
+					field: { label: 'Border', path: 'tokens.button-border', readOnly: true },
+					values: {},
+					onValueChange,
+				})
+			);
+		});
+
+		act(() => {
+			latestBorderControlProps.onChange({ width: 2, style: 'solid', color: '#000' });
+		});
+
+		expect(onValueChange).not.toHaveBeenCalled();
 		expect(latestBorderControlProps.disabled).toBe(true);
 	});
 
 	it('renders the color sub-field through the existing TokenColorSelectField, not a new component', () => {
 		act(() => {
-			root.render(createElement(BorderField, { field: { label: 'Border' }, value: '', onChange: jest.fn() }));
+			root.render(
+				createElement(BorderField, {
+					field: { label: 'Border', path: 'tokens.button-border' },
+					values: {},
+					onValueChange: jest.fn(),
+				})
+			);
 		});
 
 		const element = latestBorderControlProps.renderColor({ value: '', onChange: jest.fn() });
@@ -139,18 +163,48 @@ describe('BorderField', () => {
 		expect(element.type.name).toBe('TokenColorSelectField');
 	});
 
+	it('a width pick writes only the width path, a style change writes only the style path, color stays where it was', () => {
+		const onValueChange = jest.fn();
+
+		act(() => {
+			root.render(
+				createElement(BorderField, {
+					field: { label: 'Border', path: 'tokens.button-border' },
+					values: { tokens: { 'button-border-color': '#171717' } },
+					onValueChange,
+				})
+			);
+		});
+
+		act(() => {
+			latestBorderControlProps.onChange({
+				width: '{primitive.dimension.border-width.sm}',
+				style: 'none',
+				color: '#171717',
+			});
+		});
+
+		expect(onValueChange).toHaveBeenCalledWith('tokens.button-border-width', 'primitive.dimension.border-width.sm');
+		expect(onValueChange).toHaveBeenCalledWith('tokens.button-border-style', 'none');
+		expect(onValueChange).toHaveBeenCalledWith('tokens.button-border-color', '#171717');
+	});
+
 	it('clicking unlink switches to per-side editing, survives a same-side edit, and leaves the other sides untouched', () => {
 		// A real, stateful host — not a fresh mock per assertion — because the bug this guards against
 		// only shows up across a render cycle: the field re-deriving `linked` from the just-written
 		// value, not from what `onToggleLink` was told.
 		function Harness({ field }) {
-			const [value, setValue] = useState('');
+			const [values, setValues] = useState({});
 
-			return createElement(BorderField, { field, value, onChange: setValue });
+			const onValueChange = (path, next) => {
+				setValues((current) => ({ ...current, tokens: { ...current.tokens, [path.split('.')[1]]: next } }));
+			};
+
+			return createElement(BorderField, { field, values, onValueChange });
 		}
 
 		act(() => {
-			root.render(createElement(Harness, { field: { label: 'Border' } }));
+			root.render(createElement(Harness, { field: { label: 'Border', path: 'tokens.button-border' } }));
 		});
 
 		// Starts linked: nothing stored yet, no unlink chosen.
@@ -177,11 +231,14 @@ describe('BorderField', () => {
 		// Still unlinked after the write — the toggle does not snap back.
 		expect(latestBorderControlProps.isLinked).toBe(false);
 
-		// The stored value reflects only the edited side; the other three are untouched.
+		// The stored value reflects only the edited side; the other three are untouched. Width and style
+		// are independent axes now (each its own sibling path), so the style axis — never diverged in
+		// this edit — stays the scalar it was rather than being forced into a four-slot list just
+		// because width became one.
 		const controlValue = latestBorderControlProps.value;
 
 		expect(controlValue.width).toEqual(['{primitive.dimension.border-width.sm}', '', '', '']);
-		expect(controlValue.style).toEqual(['none', 'none', 'none', 'none']);
+		expect(controlValue.style).toBe('none');
 	});
 });
 

--- a/src/style-library/__tests__/border-shadow-field-rendering.test.js
+++ b/src/style-library/__tests__/border-shadow-field-rendering.test.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { act, createElement } from 'react';
+import { act, createElement, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 
 /**
@@ -137,6 +137,51 @@ describe('BorderField', () => {
 		const element = latestBorderControlProps.renderColor({ value: '', onChange: jest.fn() });
 
 		expect(element.type.name).toBe('TokenColorSelectField');
+	});
+
+	it('clicking unlink switches to per-side editing, survives a same-side edit, and leaves the other sides untouched', () => {
+		// A real, stateful host — not a fresh mock per assertion — because the bug this guards against
+		// only shows up across a render cycle: the field re-deriving `linked` from the just-written
+		// value, not from what `onToggleLink` was told.
+		function Harness({ field }) {
+			const [value, setValue] = useState('');
+
+			return createElement(BorderField, { field, value, onChange: setValue });
+		}
+
+		act(() => {
+			root.render(createElement(Harness, { field: { label: 'Border' } }));
+		});
+
+		// Starts linked: nothing stored yet, no unlink chosen.
+		expect(latestBorderControlProps.isLinked).toBe(true);
+
+		// Click unlink. The stored value is still '' (a scalar), so this must not write anything —
+		// this is exactly the step that used to bounce straight back to linked.
+		act(() => {
+			latestBorderControlProps.onToggleLink();
+		});
+
+		expect(latestBorderControlProps.isLinked).toBe(false);
+
+		// Edit one side only (top's width, via a picked alias), leaving style/color untouched — the
+		// shape a real unlinked `BorderControl` edit produces.
+		act(() => {
+			latestBorderControlProps.onChange({
+				width: ['{primitive.dimension.border-width.sm}', '', '', ''],
+				style: 'none',
+				color: '',
+			});
+		});
+
+		// Still unlinked after the write — the toggle does not snap back.
+		expect(latestBorderControlProps.isLinked).toBe(false);
+
+		// The stored value reflects only the edited side; the other three are untouched.
+		const controlValue = latestBorderControlProps.value;
+
+		expect(controlValue.width).toEqual(['{primitive.dimension.border-width.sm}', '', '', '']);
+		expect(controlValue.style).toEqual(['none', 'none', 'none', 'none']);
 	});
 });
 

--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -646,6 +646,8 @@ describe('BUTTON_PRESET.schemaFor', () => {
 			'tokens.button-text',
 			'tokens.button-bg',
 			'tokens.button-radius',
+			'tokens.button-border',
+			'tokens.button-shadow',
 			'tokens.button-padding',
 			'tokens.button-margin',
 		]);
@@ -655,6 +657,17 @@ describe('BUTTON_PRESET.schemaFor', () => {
 			.find((field) => field.path === 'tokens.button-radius');
 
 		expect(radiusField).toMatchObject({ type: 'radius', tokenType: 'dimension', role: 'radius' });
+	});
+
+	it('lists exactly one border field and one box-shadow field in the Border and Shadow panel, alongside radius', () => {
+		const schema = BUTTON_PRESET.schemaFor('normal');
+		const panel = schema.panels.find((candidate) => candidate.id === 'border-and-shadow');
+
+		expect(panel.fields.map((field) => ({ type: field.type, path: field.path }))).toEqual([
+			{ type: 'radius', path: 'tokens.button-radius' },
+			{ type: 'border', path: 'tokens.button-border' },
+			{ type: 'box-shadow', path: 'tokens.button-shadow' },
+		]);
 	});
 
 	it('lists the hover color fields, with no radius field, on the Hover tab', () => {

--- a/src/style-library/__tests__/settings-schema.test.js
+++ b/src/style-library/__tests__/settings-schema.test.js
@@ -124,6 +124,16 @@ describe('fieldComponentFor', () => {
 	it('returns null for an unknown type', () => {
 		expect(fieldComponentFor('nonsense')).toBeNull();
 	});
+
+	it('resolves "border" and "box-shadow" to distinct, non-null components', () => {
+		expect(fieldComponentFor('border')).not.toBeNull();
+		expect(fieldComponentFor('box-shadow')).not.toBeNull();
+		expect(fieldComponentFor('border')).not.toBe(fieldComponentFor('box-shadow'));
+	});
+
+	it('keeps "shadow" bound to the raw ShadowField the Shadow token-library screen uses, unaffected by "box-shadow"', () => {
+		expect(fieldComponentFor('shadow')).not.toBe(fieldComponentFor('box-shadow'));
+	});
 });
 
 describe('getValueAtPath', () => {

--- a/src/style-library/components/molecules/fields/BorderField.js
+++ b/src/style-library/components/molecules/fields/BorderField.js
@@ -3,17 +3,19 @@
  *
  * Mirrors `BoxTokenField.js` in spirit — bridges the preset's stored shape to the control's plain
  * value contract, owns the breakpoint switcher, and sources `tokens` via `pickableTokensForType` —
- * but the shape being bridged is different. `BorderControl`'s value is `{ width, style, color }`,
- * where `width` and `style` are each independently a scalar or a `[top, right, bottom, left]` slot
- * list, and `color` is always a single value — a border is never a different color per side.
+ * but the shape being bridged is different, and split across three sibling stored keys rather than
+ * one.
  *
- * The preset stores width and style as one composite per side instead of two parallel slot lists: a
- * scalar `{ width, style, color }` when every side matches, or a four-element list of `{ width,
- * style, color }` when they do not. `isUniformSlotList()` decides which on write — the composite
- * counterpart to the `===` collapse `writeSlot()` already does for a plain scalar slot, and the
- * reason that helper exists. `color` is carried in every slot purely so the composite shape is
- * self-contained; it is always identical across slots because `BorderControl` never varies it by
- * side.
+ * PHP declares `button-border-width`/`-style`/`-color` as three separate bound properties (see
+ * `declarations.php`), so the preset's `tokens` map stores three independent flat keys —
+ * `${field.path}-width` / `-style` / `-color` — not one composite value at `field.path` itself.
+ * `BorderControl`'s own value contract already treats width and style as independent axes (each a
+ * scalar or a `[top, right, bottom, left]` slot list) and color as always a single value, so this
+ * split is a closer fit for the control than a shared composite key ever was — width and style no
+ * longer have to share a shape just because they shared a stored key. Because `SettingsForm` only
+ * ever binds one `field.path` to one `value`/`onChange` pair, this adapter reads `values`/writes via
+ * `onValueChange(path, next)` directly — the two additional props `SettingsForm` hands every field
+ * for exactly this case (see its own docblock).
  *
  * Border width has no unit switcher on `BorderControl`'s `Custom` tab — the control passes no
  * `unit`/`units`/`onUnit` to the `TokenSelector` it renders for width, unlike radius/spacing's
@@ -22,18 +24,18 @@
  *
  * Color is out of this plan's scope (see `BorderControl`'s own docblock): `renderColor` wraps the
  * same `TokenColorSelectField` the Button screen's Color panel already renders for text/background,
- * rather than building or importing anything new.
+ * rather than building or importing anything new. Color's own path carries no breakpoint envelope —
+ * a border color has never varied by breakpoint here, so its path always stores the plain value.
  *
  * Link state is owned here, controlled, exactly the way `BoxTokenField` owns it for radius/spacing
  * — not derived from whether the stored value happens to be a scalar or a four-slot list.
  * `BorderControl` left uncontrolled derives `linked` from the data's shape, and this adapter's own
- * `toStoredValue` collapses a uniform four-slot write straight back to a scalar; wired together
- * uncontrolled, unlinking would expand to four identical slots, get collapsed back to a scalar on
- * the very next write, and re-derive as linked before the user could edit a single side — the
- * toggle would visually snap back on every click. Tracking "the user chose the unlinked view" in
- * its own state (per breakpoint, like `BoxTokenField`'s `unlinked`) and passing it down as
- * `isLinked`/`onToggleLink` decouples that choice from what the data looks like, which is what
- * lets an unlinked, still-uniform value stay unlinked until the user actually diverges a side.
+ * axis writes never collapse a four-slot write back to a scalar; wired together uncontrolled,
+ * unlinking would expand to four identical slots and re-derive as linked before the user could edit
+ * a single side — the toggle would visually snap back on every click. Tracking "the user chose the
+ * unlinked view" in its own state (per breakpoint, like `BoxTokenField`'s `unlinked`) and passing it
+ * down as `isLinked`/`onToggleLink` decouples that choice from what the data looks like, which is
+ * what lets an unlinked, still-uniform value stay unlinked until the user actually diverges a side.
  */
 
 /**
@@ -45,6 +47,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { getValueAtPath } from '../../../helpers/settings-schema';
 import { pickableTokensForType } from '../../../helpers/tokens';
 import {
 	PRESET_BREAKPOINTS,
@@ -54,7 +57,7 @@ import {
 import { BorderControl } from '../../../../token-controls/controls/BorderControl';
 import { useBreakpoint } from '../../../../token-controls/context/breakpoint';
 import { parseCssLength } from '../../../../token-controls/helpers/parse-css-length';
-import { isSlotList, isUniformSlotList, toSlotList } from '../../../../token-controls/helpers/value-shapes';
+import { isSlotList, readSlot } from '../../../../token-controls/helpers/value-shapes';
 import { TokenColorSelectField } from './TokenColorSelectField';
 
 /**
@@ -64,13 +67,6 @@ import { TokenColorSelectField } from './TokenColorSelectField';
  * @since TBD
  */
 const WIDTH_UNIT = 'px';
-
-/**
- * One side's default shape, used when nothing is stored yet.
- *
- * @since TBD
- */
-const DEFAULT_SIDE = { width: '', style: 'none', color: '' };
 
 /**
  * Convert one stored width into what the control expects: an alias, a bare number, or ''.
@@ -124,79 +120,100 @@ export function toStoredWidth(next) {
 }
 
 /**
- * Convert a stored border value — one side's composite, or four — into `BorderControl`'s value.
+ * Convert a stored width axis — a scalar side, or a four-slot list of them — into what the control
+ * expects.
  *
- * @param {*} stored The stored value: a `{width, style, color}` composite, or a four-slot list of
- *                    them.
+ * @param {*} stored The stored width axis.
  *
  * @since TBD
  *
- * @return {{width: *, style: *, color: string}} The control-shaped value.
+ * @return {*} The control-shaped width axis.
  */
-export function toControlValue(stored) {
-	if (isSlotList(stored)) {
-		return {
-			width: stored.map((side) => toControlWidth(side?.width ?? '')),
-			style: stored.map((side) => side?.style || 'none'),
-			// Identical in every slot by construction (see the module docblock); the first slot speaks
-			// for all of them.
-			color: stored[0]?.color ?? '',
-		};
-	}
-
-	const side = stored && typeof stored === 'object' ? stored : DEFAULT_SIDE;
-
-	return {
-		width: toControlWidth(side.width ?? ''),
-		style: side.style || 'none',
-		color: side.color ?? '',
-	};
+export function toControlWidthAxis(stored) {
+	return isSlotList(stored) ? stored.map(toControlWidth) : toControlWidth(stored);
 }
 
 /**
- * Convert `BorderControl`'s next value back into what a preset stores.
+ * Convert the control's width axis back into what the width path stores.
  *
- * @param {{width: *, style: *, color: string}} next The control-shaped value.
+ * @param {*} next The control-shaped width axis.
  *
  * @since TBD
  *
- * @return {*} The stored value: a `{width, style, color}` composite, collapsed to a scalar when
- *             every side ends up identical.
+ * @return {*} The stored width axis.
  */
-export function toStoredValue(next) {
-	const widths = toSlotList(next.width).map(toStoredWidth);
-	const styles = toSlotList(next.style).map((style) => style || 'none');
-	const color = next.color ?? '';
+export function toStoredWidthAxis(next) {
+	return isSlotList(next) ? next.map(toStoredWidth) : toStoredWidth(next);
+}
 
-	const slots = widths.map((width, index) => ({ width, style: styles[index], color }));
+/**
+ * Convert a stored style axis — a scalar side, or a four-slot list of them — into what the control
+ * expects. Style needs no other conversion: the stored keyword and the control's keyword are the
+ * same string, only the unset default (`'none'`) needs filling in.
+ *
+ * @param {*} stored The stored style axis.
+ *
+ * @since TBD
+ *
+ * @return {*} The control-shaped style axis.
+ */
+export function toControlStyleAxis(stored) {
+	return isSlotList(stored) ? stored.map((style) => style || 'none') : stored || 'none';
+}
 
-	return isUniformSlotList(slots) ? slots[0] : slots;
+/**
+ * Convert the control's style axis back into what the style path stores.
+ *
+ * @param {*} next The control-shaped style axis.
+ *
+ * @since TBD
+ *
+ * @return {*} The stored style axis.
+ */
+export function toStoredStyleAxis(next) {
+	return isSlotList(next) ? next.map((style) => style || 'none') : next || 'none';
 }
 
 /**
  * Render a border field from a settings schema entry.
  *
- * @param {Object}  props                    The component props.
- * @param {Object}  props.field              The field definition.
- * @param {?string} [props.field.label]      The control's label.
- * @param {boolean} [props.field.readOnly]   Whether the control is non-interactive.
- * @param {boolean} [props.field.responsive] Whether the field offers a breakpoint switcher.
- * @param {*}       props.value              The stored value: a composite, or a four-slot list of them.
- * @param {Function} props.onChange          Called with the next stored value.
+ * @param {Object}   props                    The component props.
+ * @param {Object}   props.field              The field definition.
+ * @param {string}   props.field.path         The base dot path; the width/style/color axes are
+ *                                             stored at `${path}-width` / `-style` / `-color`.
+ * @param {?string}  [props.field.label]      The control's label.
+ * @param {boolean}  [props.field.readOnly]   Whether the control is non-interactive.
+ * @param {boolean}  [props.field.responsive] Whether the field offers a breakpoint switcher.
+ * @param {Object}   props.values             The full draft values, read by dot path.
+ * @param {Function} props.onValueChange      Called with `(path, next)` for any of the three axes.
  *
  * @since TBD
  *
  * @return {JSX.Element} The field.
  */
-export function BorderField({ field, value, onChange }) {
+export function BorderField({ field, values, onValueChange }) {
 	const responsive = field.responsive === true;
 
 	// Shared, not local: switching to Tablet here switches every other responsive control in the panel
 	// with it, matching `BoxTokenField`.
 	const [breakpoint, setBreakpoint] = useBreakpoint(PRESET_BREAKPOINTS[0]);
 
-	const atBreakpoint = responsive ? readPresetBreakpoint(value, breakpoint) : value;
-	const write = (next) => onChange(responsive ? writePresetBreakpoint(value, breakpoint, next) : next);
+	const widthPath = `${field.path}-width`;
+	const stylePath = `${field.path}-style`;
+	const colorPath = `${field.path}-color`;
+
+	const rawWidth = getValueAtPath(values, widthPath);
+	const rawStyle = getValueAtPath(values, stylePath);
+	const rawColor = getValueAtPath(values, colorPath);
+
+	const widthAtBreakpoint = responsive ? readPresetBreakpoint(rawWidth, breakpoint) : rawWidth;
+	const styleAtBreakpoint = responsive ? readPresetBreakpoint(rawStyle, breakpoint) : rawStyle;
+
+	const writeWidth = (next) =>
+		onValueChange(widthPath, responsive ? writePresetBreakpoint(rawWidth, breakpoint, next) : next);
+	const writeStyle = (next) =>
+		onValueChange(stylePath, responsive ? writePresetBreakpoint(rawStyle, breakpoint, next) : next);
+	const writeColor = (next) => onValueChange(colorPath, next);
 
 	const widthTokens = pickableTokensForType('dimension', 'border-width').map((token) => ({
 		...token,
@@ -208,23 +225,36 @@ export function BorderField({ field, value, onChange }) {
 	// `BoxTokenField`'s `unlinked` is: a choice made on one breakpoint must not leak into another that
 	// never made it, keeping the breakpoints independent.
 	const [unlinked, setUnlinked] = useState({});
-	const storedIsList = isSlotList(atBreakpoint);
+	const storedIsList = isSlotList(widthAtBreakpoint) || isSlotList(styleAtBreakpoint);
 	const linked = storedIsList ? false : !unlinked[breakpoint];
 
 	const toggleLink = () => {
 		setUnlinked((current) => ({ ...current, [breakpoint]: linked }));
 
-		// Relinking keeps the first side, matching `BoxTokenField`'s own relink rule; there is nothing
-		// to fold when the breakpoint never actually diverged into a list.
+		// Relinking keeps each axis's first side, matching `BoxTokenField`'s own relink rule; there is
+		// nothing to fold when a breakpoint never actually diverged into a list.
 		if (!linked && storedIsList) {
-			write(atBreakpoint[0]);
+			writeWidth(readSlot(widthAtBreakpoint, 0));
+			writeStyle(readSlot(styleAtBreakpoint, 0));
 		}
 	};
 
 	return (
 		<BorderControl
-			value={toControlValue(atBreakpoint)}
-			onChange={(next) => !field.readOnly && write(toStoredValue(next))}
+			value={{
+				width: toControlWidthAxis(widthAtBreakpoint),
+				style: toControlStyleAxis(styleAtBreakpoint),
+				color: rawColor ?? '',
+			}}
+			onChange={(next) => {
+				if (field.readOnly) {
+					return;
+				}
+
+				writeWidth(toStoredWidthAxis(next.width));
+				writeStyle(toStoredStyleAxis(next.style));
+				writeColor(next.color ?? '');
+			}}
 			label={field.label}
 			widthTokens={widthTokens}
 			renderColor={({ value: color, onChange: onColorChange }) => (

--- a/src/style-library/components/molecules/fields/BorderField.js
+++ b/src/style-library/components/molecules/fields/BorderField.js
@@ -23,11 +23,23 @@
  * Color is out of this plan's scope (see `BorderControl`'s own docblock): `renderColor` wraps the
  * same `TokenColorSelectField` the Button screen's Color panel already renders for text/background,
  * rather than building or importing anything new.
+ *
+ * Link state is owned here, controlled, exactly the way `BoxTokenField` owns it for radius/spacing
+ * — not derived from whether the stored value happens to be a scalar or a four-slot list.
+ * `BorderControl` left uncontrolled derives `linked` from the data's shape, and this adapter's own
+ * `toStoredValue` collapses a uniform four-slot write straight back to a scalar; wired together
+ * uncontrolled, unlinking would expand to four identical slots, get collapsed back to a scalar on
+ * the very next write, and re-derive as linked before the user could edit a single side — the
+ * toggle would visually snap back on every click. Tracking "the user chose the unlinked view" in
+ * its own state (per breakpoint, like `BoxTokenField`'s `unlinked`) and passing it down as
+ * `isLinked`/`onToggleLink` decouples that choice from what the data looks like, which is what
+ * lets an unlinked, still-uniform value stay unlinked until the user actually diverges a side.
  */
 
 /**
  * WordPress dependencies
  */
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -191,6 +203,24 @@ export function BorderField({ field, value, onChange }) {
 		alias: `{${token.id}}`,
 	}));
 
+	// Which breakpoints the user has opened up into per-side editing. Held here rather than inferred
+	// from the stored shape — see the module docblock — and per breakpoint for the same reason
+	// `BoxTokenField`'s `unlinked` is: a choice made on one breakpoint must not leak into another that
+	// never made it, keeping the breakpoints independent.
+	const [unlinked, setUnlinked] = useState({});
+	const storedIsList = isSlotList(atBreakpoint);
+	const linked = storedIsList ? false : !unlinked[breakpoint];
+
+	const toggleLink = () => {
+		setUnlinked((current) => ({ ...current, [breakpoint]: linked }));
+
+		// Relinking keeps the first side, matching `BoxTokenField`'s own relink rule; there is nothing
+		// to fold when the breakpoint never actually diverged into a list.
+		if (!linked && storedIsList) {
+			write(atBreakpoint[0]);
+		}
+	};
+
 	return (
 		<BorderControl
 			value={toControlValue(atBreakpoint)}
@@ -207,6 +237,8 @@ export function BorderField({ field, value, onChange }) {
 			breakpoints={responsive ? PRESET_BREAKPOINTS : null}
 			breakpoint={breakpoint}
 			onBreakpointChange={setBreakpoint}
+			isLinked={linked}
+			onToggleLink={toggleLink}
 			disabled={field.readOnly}
 		/>
 	);

--- a/src/style-library/components/molecules/fields/BorderField.js
+++ b/src/style-library/components/molecules/fields/BorderField.js
@@ -1,0 +1,213 @@
+/**
+ * The Style Library's adapter for `src/token-controls`' `BorderControl`.
+ *
+ * Mirrors `BoxTokenField.js` in spirit — bridges the preset's stored shape to the control's plain
+ * value contract, owns the breakpoint switcher, and sources `tokens` via `pickableTokensForType` —
+ * but the shape being bridged is different. `BorderControl`'s value is `{ width, style, color }`,
+ * where `width` and `style` are each independently a scalar or a `[top, right, bottom, left]` slot
+ * list, and `color` is always a single value — a border is never a different color per side.
+ *
+ * The preset stores width and style as one composite per side instead of two parallel slot lists: a
+ * scalar `{ width, style, color }` when every side matches, or a four-element list of `{ width,
+ * style, color }` when they do not. `isUniformSlotList()` decides which on write — the composite
+ * counterpart to the `===` collapse `writeSlot()` already does for a plain scalar slot, and the
+ * reason that helper exists. `color` is carried in every slot purely so the composite shape is
+ * self-contained; it is always identical across slots because `BorderControl` never varies it by
+ * side.
+ *
+ * Border width has no unit switcher on `BorderControl`'s `Custom` tab — the control passes no
+ * `unit`/`units`/`onUnit` to the `TokenSelector` it renders for width, unlike radius/spacing's
+ * `BoxControl` — so this adapter fixes the unit at `px` (the only unit the `border-width` scale's
+ * tokens use) rather than tracking one the way `BoxTokenField` tracks radius/spacing's unit.
+ *
+ * Color is out of this plan's scope (see `BorderControl`'s own docblock): `renderColor` wraps the
+ * same `TokenColorSelectField` the Button screen's Color panel already renders for text/background,
+ * rather than building or importing anything new.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { pickableTokensForType } from '../../../helpers/tokens';
+import {
+	PRESET_BREAKPOINTS,
+	readPresetBreakpoint,
+	writePresetBreakpoint,
+} from '../../../../token-controls/helpers/preset-envelope';
+import { BorderControl } from '../../../../token-controls/controls/BorderControl';
+import { useBreakpoint } from '../../../../token-controls/context/breakpoint';
+import { parseCssLength } from '../../../../token-controls/helpers/parse-css-length';
+import { isSlotList, isUniformSlotList, toSlotList } from '../../../../token-controls/helpers/value-shapes';
+import { TokenColorSelectField } from './TokenColorSelectField';
+
+/**
+ * The only unit border width is stored in — the `border-width` scale's tokens (`1px`, `2px`,
+ * `4px`) are all pixels, and `BorderControl` offers no switcher to pick another.
+ *
+ * @since TBD
+ */
+const WIDTH_UNIT = 'px';
+
+/**
+ * One side's default shape, used when nothing is stored yet.
+ *
+ * @since TBD
+ */
+const DEFAULT_SIDE = { width: '', style: 'none', color: '' };
+
+/**
+ * Convert one stored width into what the control expects: an alias, a bare number, or ''.
+ *
+ * @param {*} stored The stored width.
+ *
+ * @since TBD
+ *
+ * @return {*} The control-shaped width.
+ */
+export function toControlWidth(stored) {
+	if (typeof stored !== 'string' || stored === '') {
+		return '';
+	}
+
+	if (stored.startsWith('primitive.') || stored.startsWith('semantic.')) {
+		return `{${stored}}`;
+	}
+
+	const parsed = parseCssLength(stored);
+
+	return parsed ? parsed.size : stored;
+}
+
+/**
+ * Convert one control width back into what a preset stores.
+ *
+ * @param {*} next The control-shaped width: an alias, a number, or ''.
+ *
+ * @since TBD
+ *
+ * @return {*} The stored width, in `px`.
+ */
+export function toStoredWidth(next) {
+	if (next === '' || next === undefined || next === null) {
+		return '';
+	}
+
+	if (typeof next === 'string' && next.startsWith('{') && next.endsWith('}')) {
+		return next.slice(1, -1);
+	}
+
+	// Zero stays unitless for the same reason `BoxTokenField`'s `toStoredValue` keeps it unitless: the
+	// `None` token resolves to a bare `'0'`, so appending `px` here would rewrite a clean value on a
+	// no-op round trip.
+	if (Number(next) === 0) {
+		return '0';
+	}
+
+	return `${next}${WIDTH_UNIT}`;
+}
+
+/**
+ * Convert a stored border value — one side's composite, or four — into `BorderControl`'s value.
+ *
+ * @param {*} stored The stored value: a `{width, style, color}` composite, or a four-slot list of
+ *                    them.
+ *
+ * @since TBD
+ *
+ * @return {{width: *, style: *, color: string}} The control-shaped value.
+ */
+export function toControlValue(stored) {
+	if (isSlotList(stored)) {
+		return {
+			width: stored.map((side) => toControlWidth(side?.width ?? '')),
+			style: stored.map((side) => side?.style || 'none'),
+			// Identical in every slot by construction (see the module docblock); the first slot speaks
+			// for all of them.
+			color: stored[0]?.color ?? '',
+		};
+	}
+
+	const side = stored && typeof stored === 'object' ? stored : DEFAULT_SIDE;
+
+	return {
+		width: toControlWidth(side.width ?? ''),
+		style: side.style || 'none',
+		color: side.color ?? '',
+	};
+}
+
+/**
+ * Convert `BorderControl`'s next value back into what a preset stores.
+ *
+ * @param {{width: *, style: *, color: string}} next The control-shaped value.
+ *
+ * @since TBD
+ *
+ * @return {*} The stored value: a `{width, style, color}` composite, collapsed to a scalar when
+ *             every side ends up identical.
+ */
+export function toStoredValue(next) {
+	const widths = toSlotList(next.width).map(toStoredWidth);
+	const styles = toSlotList(next.style).map((style) => style || 'none');
+	const color = next.color ?? '';
+
+	const slots = widths.map((width, index) => ({ width, style: styles[index], color }));
+
+	return isUniformSlotList(slots) ? slots[0] : slots;
+}
+
+/**
+ * Render a border field from a settings schema entry.
+ *
+ * @param {Object}  props                    The component props.
+ * @param {Object}  props.field              The field definition.
+ * @param {?string} [props.field.label]      The control's label.
+ * @param {boolean} [props.field.readOnly]   Whether the control is non-interactive.
+ * @param {boolean} [props.field.responsive] Whether the field offers a breakpoint switcher.
+ * @param {*}       props.value              The stored value: a composite, or a four-slot list of them.
+ * @param {Function} props.onChange          Called with the next stored value.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The field.
+ */
+export function BorderField({ field, value, onChange }) {
+	const responsive = field.responsive === true;
+
+	// Shared, not local: switching to Tablet here switches every other responsive control in the panel
+	// with it, matching `BoxTokenField`.
+	const [breakpoint, setBreakpoint] = useBreakpoint(PRESET_BREAKPOINTS[0]);
+
+	const atBreakpoint = responsive ? readPresetBreakpoint(value, breakpoint) : value;
+	const write = (next) => onChange(responsive ? writePresetBreakpoint(value, breakpoint, next) : next);
+
+	const widthTokens = pickableTokensForType('dimension', 'border-width').map((token) => ({
+		...token,
+		alias: `{${token.id}}`,
+	}));
+
+	return (
+		<BorderControl
+			value={toControlValue(atBreakpoint)}
+			onChange={(next) => !field.readOnly && write(toStoredValue(next))}
+			label={field.label}
+			widthTokens={widthTokens}
+			renderColor={({ value: color, onChange: onColorChange }) => (
+				<TokenColorSelectField
+					field={{ label: __('Color', 'kadence-blocks'), readOnly: field.readOnly }}
+					value={color}
+					onChange={onColorChange}
+				/>
+			)}
+			breakpoints={responsive ? PRESET_BREAKPOINTS : null}
+			breakpoint={breakpoint}
+			onBreakpointChange={setBreakpoint}
+			disabled={field.readOnly}
+		/>
+	);
+}

--- a/src/style-library/components/molecules/fields/BoxShadowField.js
+++ b/src/style-library/components/molecules/fields/BoxShadowField.js
@@ -1,0 +1,70 @@
+/**
+ * The Style Library's adapter for `src/token-controls`' `BoxShadowControl`.
+ *
+ * Named `BoxShadowField` rather than reusing the `shadow` field type or `ShadowField.js`: those
+ * already back the Shadow token-library screen's own settings panel (`ShadowScreen.js`'s
+ * `valueField: { type: 'shadow', ... }`, read through `SettingsForm`/`fieldComponentFor` — the same
+ * `FIELD_TYPES` registry this file's field is added to, via `ScaleSettings`'s
+ * `scaleValueField(config.valueField)`). `ShadowField` is a raw composite editor with no token
+ * concept at all; `BoxShadowControl` is a different, token-aware component. One `FIELD_TYPES` key
+ * can only point at one component, so the Button panel's field is registered under a different
+ * key — `box-shadow` — instead of overwriting `shadow`. `ShadowField.js` and the Shadow screen it
+ * backs are untouched by this change.
+ *
+ * Not responsive: the Button preset's Border and Shadow panel offers no breakpoint switcher for
+ * shadow, so this adapter reads and writes `field.path`'s value directly, with no breakpoint
+ * envelope — unlike `BorderField`/`BoxTokenField`.
+ *
+ * Color is out of this plan's scope, exactly as in `BorderField`: `renderColor` wraps the same
+ * `TokenColorSelectField` the Button screen's Color panel already renders.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { pickableTokensForType } from '../../../helpers/tokens';
+import { BoxShadowControl } from '../../../../token-controls/controls/BoxShadowControl';
+import { TokenColorSelectField } from './TokenColorSelectField';
+
+/**
+ * Render a box-shadow field from a settings schema entry.
+ *
+ * @param {Object}  props                  The component props.
+ * @param {Object}  props.field            The field definition.
+ * @param {?string} [props.field.label]    The control's label.
+ * @param {boolean} [props.field.readOnly] Whether the control is non-interactive.
+ * @param {*}       props.value            The stored value: a token alias, or a composite shadow object.
+ * @param {Function} props.onChange        Called with the next alias or composite object.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The field.
+ */
+export function BoxShadowField({ field, value, onChange }) {
+	const tokens = pickableTokensForType('shadow').map((token) => ({
+		...token,
+		alias: `{${token.id}}`,
+	}));
+
+	return (
+		<BoxShadowControl
+			value={value}
+			onChange={(next) => !field.readOnly && onChange(next)}
+			label={field.label}
+			tokens={tokens}
+			renderColor={({ value: color, onChange: onColorChange }) => (
+				<TokenColorSelectField
+					field={{ label: __('Color', 'kadence-blocks'), readOnly: field.readOnly }}
+					value={color}
+					onChange={onColorChange}
+				/>
+			)}
+			disabled={field.readOnly}
+		/>
+	);
+}

--- a/src/style-library/components/organisms/SettingsForm.js
+++ b/src/style-library/components/organisms/SettingsForm.js
@@ -6,6 +6,12 @@
  * Responsive values are not this component's concern — a `responsive: true` field resolves and
  * writes its own breakpoint slot internally via `hooks/use-responsive-field-value.js`; this
  * component always hands it the plain dot-path `value`/`onChange`.
+ *
+ * A field bound to more than one stored property (`BorderField`'s width/style/color axes are three
+ * sibling `tokens.*` keys, not one composite — see its own docblock) cannot be served by the single
+ * dot-path `value`/`onChange` pair alone, so every field also receives the full draft `values` and
+ * the raw, path-taking `onValueChange(path, next)` this component itself was given — additive, and
+ * ignored by every field that only needs its own `field.path`.
  */
 
 /**
@@ -66,6 +72,8 @@ export function SettingsForm({ schema, values, onChange }) {
 									field={field}
 									value={getValueAtPath(values, field.path)}
 									onChange={(next) => onChange(field.path, next)}
+									values={values}
+									onValueChange={onChange}
 								/>
 							);
 						})}

--- a/src/style-library/constants/demo-settings-schema.js
+++ b/src/style-library/constants/demo-settings-schema.js
@@ -165,7 +165,20 @@ export const DEMO_SETTINGS_SCHEMA = {
 			id: 'shadow',
 			title: __('Shadow', 'kadence-blocks'),
 			initialOpen: true,
-			fields: [{ type: 'shadow', path: 'shadow', label: __('Shadow', 'kadence-blocks') }],
+			fields: [
+				{ type: 'shadow', path: 'shadow', label: __('Shadow', 'kadence-blocks') },
+				{
+					// The token-aware Button-panel counterpart to `box-sides`/`shadow` above.
+					type: 'border',
+					path: 'border',
+					label: __('Border (token control)', 'kadence-blocks'),
+				},
+				{
+					type: 'box-shadow',
+					path: 'boxShadow',
+					label: __('Shadow (token control)', 'kadence-blocks'),
+				},
+			],
 		},
 	],
 };
@@ -193,4 +206,6 @@ export const DEMO_SETTINGS_VALUES = {
 	spacing: '',
 	enabled: true,
 	shadow: { color: '#000000', offsetX: 0, offsetY: 4, blur: 8, spread: 0, inset: false },
+	border: { width: '2px', style: 'solid', color: '#2271b1' },
+	boxShadow: '',
 };

--- a/src/style-library/constants/field-types.js
+++ b/src/style-library/constants/field-types.js
@@ -1,12 +1,14 @@
 /**
  * The settings-field type vocabulary: the single source of truth mapping a schema field's `type`
  * string to the component that renders it. Every per-screen settings schema authors against these
- * fourteen strings; `helpers/settings-schema.js`'s `fieldComponentFor` is the only reader.
+ * sixteen strings; `helpers/settings-schema.js`'s `fieldComponentFor` is the only reader.
  */
 
 /**
  * Internal dependencies
  */
+import { BorderField } from '../components/molecules/fields/BorderField';
+import { BoxShadowField } from '../components/molecules/fields/BoxShadowField';
 import { BoxSidesField } from '../components/molecules/fields/BoxSidesField';
 import { BoxTokenField } from '../components/molecules/fields/BoxTokenField';
 import { ColorField } from '../components/molecules/fields/ColorField';
@@ -51,6 +53,35 @@ const RadiusField = (props) => <BoxTokenField {...props} slots="corners" />;
 const SpacingField = (props) => <BoxTokenField {...props} slots="sides" />;
 
 /**
+ * The `border` field: `BorderControl`'s per-side width/style, color deferred to `renderColor`.
+ *
+ * Bound here for the same reason `radius`/`spacing` are: a schema names the property, this registry
+ * owns which control and geometry render it.
+ *
+ * @param {Object} props The field props from `SettingsForm`.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The field.
+ */
+const BorderTypeField = (props) => <BorderField {...props} />;
+
+/**
+ * The `box-shadow` field: `BoxShadowControl`'s single-value, token-aware shadow.
+ *
+ * A different key from `shadow` — that one is already bound to `ShadowField`, the raw composite
+ * editor the Shadow token-library screen's own settings panel uses (see `BoxShadowField.js`'s
+ * docblock for why the two cannot share a key).
+ *
+ * @param {Object} props The field props from `SettingsForm`.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The field.
+ */
+const BoxShadowTypeField = (props) => <BoxShadowField {...props} />;
+
+/**
  * The field-type registry: `type` string => field component. Frozen so a consumer can't mutate the
  * vocabulary at runtime.
  *
@@ -72,6 +103,8 @@ export const FIELD_TYPES = Object.freeze({
 	radius: RadiusField,
 	spacing: SpacingField,
 	shadow: ShadowField,
+	border: BorderTypeField,
+	'box-shadow': BoxShadowTypeField,
 });
 
 /**
@@ -85,6 +118,10 @@ export const FIELD_TYPES = Object.freeze({
  * their UI could read back; the rest are excluded because their DTCG types are never
  * responsive-capable.
  *
+ * `border` qualifies for the same reason `radius`/`spacing` do: its width is a `dimension` value,
+ * held in the same per-slot shape. `box-shadow` is excluded — the Button panel's shadow field has no
+ * breakpoint switcher (see `BoxShadowField.js`'s docblock).
+ *
  * @since TBD
  */
 export const RESPONSIVE_CAPABLE_FIELD_TYPES = Object.freeze([
@@ -94,4 +131,5 @@ export const RESPONSIVE_CAPABLE_FIELD_TYPES = Object.freeze([
 	'range-number',
 	'stepper',
 	'unit',
+	'border',
 ]);

--- a/src/style-library/constants/field-types.js
+++ b/src/style-library/constants/field-types.js
@@ -1,7 +1,7 @@
 /**
  * The settings-field type vocabulary: the single source of truth mapping a schema field's `type`
  * string to the component that renders it. Every per-screen settings schema authors against these
- * sixteen strings; `helpers/settings-schema.js`'s `fieldComponentFor` is the only reader.
+ * seventeen strings; `helpers/settings-schema.js`'s `fieldComponentFor` is the only reader.
  */
 
 /**

--- a/src/style-library/presets/button-preset.js
+++ b/src/style-library/presets/button-preset.js
@@ -205,11 +205,17 @@ function schemaFor(tab) {
 				responsive: true,
 				path: 'tokens.button-border',
 				label: __('Border', 'kadence-blocks'),
+				// No `defaultValue` here, unlike the radius field above: `BorderField`'s adapter doesn't
+				// read one, because `BorderControl` accepts no `defaultValue`/inherited-value prop the way
+				// `BoxControl` does. Setting one would be a dead key. Add it once `BorderControl` grows that
+				// support, not before.
 			},
 			{
 				type: 'box-shadow',
 				path: 'tokens.button-shadow',
 				label: __('Shadow', 'kadence-blocks'),
+				// Same reason as `border` above: `BoxShadowControl` accepts no `defaultValue` prop, so a
+				// `defaultValue` key here would go unread.
 			},
 		],
 	};

--- a/src/style-library/presets/button-preset.js
+++ b/src/style-library/presets/button-preset.js
@@ -203,6 +203,10 @@ function schemaFor(tab) {
 			{
 				type: 'border',
 				responsive: true,
+				// A base path, not a stored key: PHP declares `button-border-width`/`-style`/`-color` as
+				// three separate bound properties, so `BorderField` derives and reads/writes the three
+				// sibling keys `${path}-width` / `-style` / `-color` itself rather than one composite value
+				// living at this path.
 				path: 'tokens.button-border',
 				label: __('Border', 'kadence-blocks'),
 				// No `defaultValue` here, unlike the radius field above: `BorderField`'s adapter doesn't

--- a/src/style-library/presets/button-preset.js
+++ b/src/style-library/presets/button-preset.js
@@ -155,10 +155,10 @@ function renderPreview(row) {
 }
 
 /**
- * The per-tab settings schema: the Normal tab adds a Radius section and the Hover tab never does —
- * `button-radius` has no hover counterpart, so rendering one there would write a property
- * `guard_surface` rejects. The preset name is not here; it is tab-independent and comes from
- * `presetNameSchema()`.
+ * The per-tab settings schema: the Normal tab adds a Border and Shadow section and the Hover tab
+ * never does — `button-radius`/`button-border`/`button-shadow` have no hover counterpart, so
+ * rendering them there would write a property `guard_surface` rejects. The preset name is not here;
+ * it is tab-independent and comes from `presetNameSchema()`.
  *
  * @param {string} tab The active tab name (`'normal'` or `'hover'`).
  *
@@ -184,7 +184,7 @@ function schemaFor(tab) {
 		return { panels: [colorPanel] };
 	}
 
-	const radiusPanel = {
+	const borderAndShadowPanel = {
 		id: 'border-and-shadow',
 		title: __('Border and Shadow', 'kadence-blocks'),
 		fields: [
@@ -199,6 +199,17 @@ function schemaFor(tab) {
 				// same value `semantic.radius.control` holds. Shown muted when the preset sets nothing, so a
 				// reset field reports the radius the button really has rather than reading as empty.
 				defaultValue: ['0.1875rem', '0.1875rem', '0.1875rem', '0.1875rem'],
+			},
+			{
+				type: 'border',
+				responsive: true,
+				path: 'tokens.button-border',
+				label: __('Border', 'kadence-blocks'),
+			},
+			{
+				type: 'box-shadow',
+				path: 'tokens.button-shadow',
+				label: __('Shadow', 'kadence-blocks'),
 			},
 		],
 	};
@@ -237,7 +248,7 @@ function schemaFor(tab) {
 		],
 	};
 
-	return { panels: [colorPanel, radiusPanel, spacingPanel] };
+	return { panels: [colorPanel, borderAndShadowPanel, spacingPanel] };
 }
 
 /**


### PR DESCRIPTION
## Summary

Wires the new `BorderControl`/`BoxShadowControl` into the Style Library's Button preset screen.

- New `BorderField.js`/`BoxShadowField.js` adapters (mirroring the existing `BoxTokenField.js` pattern for radius/spacing) — breakpoint/link state, `pickableTokensForType` sourcing, path/value bridging.
- Registers `border` and `box-shadow` entries in `FIELD_TYPES` (the existing `shadow` key stays bound to the Shadow token-library screen's raw editor — confirmed that screen routes through the same registry, so a new key avoids the collision rather than overwriting it).
- Adds `border` and `box-shadow` fields to the Button preset's "Border and Shadow" panel, alongside the existing radius field.
- `BorderField`'s link/unlink state is held independently of the stored value's shape (matching `BoxTokenField`'s pattern) so unlinking actually sticks instead of snapping back to linked on the next render.

## Test plan

- [x] `npx jest src/style-library src/token-controls` — 658/658 passing, no regressions
- [x] cspell clean
- [x] `grep -rn "SOFT-" src/style-library` — no hits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added border styling controls with per-side editing, responsive breakpoints, linked and unlinked values, width tokens, and color selection.
  * Added box-shadow controls with token-backed color selection and read-only support.
  * Updated button settings to combine radius, border, and shadow customization in one panel.
* **Tests**
  * Added coverage for border and shadow conversions, rendering behavior, responsive handling, presets, and field registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->