### PR TITLE
[DTM] SOFT-4083 [28/38]: button border and shadow token declarations

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -658,6 +658,16 @@
 					"blur": "0px",
 					"spread": "0px"
 				}
+			},
+			"button": {
+				"$type": "shadow",
+				"$value": {
+					"color": "{primitive.color.transparent}",
+					"offsetX": "0px",
+					"offsetY": "0px",
+					"blur": "0px",
+					"spread": "0px"
+				}
 			}
 		}
 	},
@@ -814,7 +824,10 @@
 							"button-text": "{semantic.color.button-primary-text}",
 							"button-bg-hover": "{semantic.color.button-primary-bg-hover}",
 							"button-text-hover": "{semantic.color.button-primary-text-hover}",
-							"button-radius": "{semantic.radius.control}"
+							"button-radius": "{semantic.radius.control}",
+							"button-border-width": "{semantic.border-width.default}",
+							"button-border-style": "{semantic.border-style.default}",
+							"button-border-color": "{semantic.color.border}"
 						}
 					},
 					"secondary": {
@@ -824,7 +837,10 @@
 							"button-text": "{semantic.color.button-secondary-text}",
 							"button-bg-hover": "{semantic.color.button-secondary-bg-hover}",
 							"button-text-hover": "{semantic.color.button-secondary-text-hover}",
-							"button-radius": "{semantic.radius.control}"
+							"button-radius": "{semantic.radius.control}",
+							"button-border-width": "{semantic.border-width.default}",
+							"button-border-style": "{semantic.border-style.default}",
+							"button-border-color": "{semantic.color.border}"
 						}
 					}
 				},

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -594,30 +594,35 @@ return [
 						'mobile' => 'mobileMargin',
 					],
 				],
-				// Border and shadow reuse the brand-wide tokens (and, for shadow, a button-scoped one) the
-				// same way Advanced Text's border/shadow surface does, mirroring its token/css_prop shape
-				// (declarations.php's Advanced Heading entry below) rather than the css_var shape the other
-				// button-* properties above use — there is no existing ownable button border/shadow variable
-				// to point at, so the block-default-CSS projector's low-specificity rule is the delivery
-				// mechanism here.
+				// Border and shadow reuse the brand-wide tokens (and, for shadow, a button-scoped one),
+				// mirroring button-padding/button-margin/button-radius's css_var shape above rather than a
+				// css_prop shape: a css_prop binding only ever reaches Block_Default_Css\Css_Builder, which
+				// resolves exclusively the block's $default preset and can never reflect a *selected*
+				// preset's value. css_var is what lets Preset\Css_Builder (the named-preset projector) emit a
+				// scoped variable a selected preset can actually vary. No control_attr — unlike padding/
+				// margin/radius, the native block attributes for border ([{top:[color,style,size],...},unit])
+				// and shadow ([{color,opacity,hOffset,vOffset,blur,spread,inset}]) are nested per-side/
+				// composite shapes, not a single scalar value, so there is no attribute for a picker/capture
+				// consumer of control_attr (token-picker, preset-picker/capture.js, token-indicators) to
+				// target here.
 				'button-border-width' => [
-					'token'    => 'semantic.border-width.default',
-					'css_prop' => 'border-width',
+					'token'   => 'semantic.border-width.default',
+					'css_var' => 'kb-btn-border-width',
 				],
 				'button-border-style' => [
-					'token'    => 'semantic.border-style.default',
-					'css_prop' => 'border-style',
+					'token'   => 'semantic.border-style.default',
+					'css_var' => 'kb-btn-border-style',
 				],
 				'button-border-color' => [
-					'token'    => 'semantic.color.border',
-					'css_prop' => 'border-color',
+					'token'   => 'semantic.color.border',
+					'css_var' => 'kb-btn-border-color',
 				],
 				// No baseline default: an unstyled button carries no shadow, so the preset's $default omits
 				// this property entirely and the projector emits no box-shadow rule until a preset (or the
 				// user) sets one.
 				'button-shadow'       => [
-					'token'    => 'semantic.shadow.button',
-					'css_prop' => 'box-shadow',
+					'token'   => 'semantic.shadow.button',
+					'css_var' => 'kb-btn-shadow',
 				],
 			],
 		],

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -493,6 +493,16 @@ return [
 				'label' => __( 'Button Margin Left', 'kadence-blocks' ),
 				'group' => __( 'Brand', 'kadence-blocks' ),
 			],
+			[
+				// Button shadow default for the block-default CSS projector, mirroring semantic.shadow.media.
+				// Registered so Css_Var emits --kb-token--semantic--shadow--button; the projector points
+				// kadence/singlebtn's box-shadow at it. Resolves to an invisible (transparent, zero) shadow,
+				// matching KB's default (a button carries no shadow until a preset or the user sets one).
+				'id'    => 'semantic.shadow.button',
+				'type'  => 'shadow',
+				'label' => __( 'Button Shadow', 'kadence-blocks' ),
+				'group' => __( 'Brand', 'kadence-blocks' ),
+			],
 		],
 		$button_color_tokens,
 		$notice_color_tokens,
@@ -536,23 +546,23 @@ return [
 				'label' => __( 'Button', 'kadence-blocks' ),
 			],
 			'bindings'      => [
-				'button-bg'         => [
+				'button-bg'           => [
 					'kadence_slot' => 'palette-btn-bg',
 					'control_attr' => 'background',
 				],
-				'button-text'       => [
+				'button-text'         => [
 					'kadence_slot' => 'palette-btn',
 					'control_attr' => 'color',
 				],
-				'button-bg-hover'   => [
+				'button-bg-hover'     => [
 					'kadence_slot' => 'palette-btn-bg-hover',
 					'control_attr' => 'backgroundHover',
 				],
-				'button-text-hover' => [
+				'button-text-hover'   => [
 					'kadence_slot' => 'palette-btn-hover',
 					'control_attr' => 'colorHover',
 				],
-				'button-radius'     => [
+				'button-radius'       => [
 					'css_var'          => 'kb-btn-radius', // drives --kb-btn-radius so a preset can vary the radius.
 					'control_attr'     => 'borderRadius',
 					// The block names its per-device radius attributes by a prefix convention, which is a naming
@@ -568,7 +578,7 @@ return [
 				// every existing button and take padding away from the Button Size control. The binding
 				// exists so a preset CAN set them; until one does, the property resolves to nothing and no
 				// declaration is emitted.
-				'button-padding'    => [
+				'button-padding'      => [
 					'css_var'          => 'kb-btn-padding',
 					'control_attr'     => 'padding',
 					'responsive_attrs' => [
@@ -576,13 +586,38 @@ return [
 						'mobile' => 'mobilePadding',
 					],
 				],
-				'button-margin'     => [
+				'button-margin'       => [
 					'css_var'          => 'kb-btn-margin',
 					'control_attr'     => 'margin',
 					'responsive_attrs' => [
 						'tablet' => 'tabletMargin',
 						'mobile' => 'mobileMargin',
 					],
+				],
+				// Border and shadow reuse the brand-wide tokens (and, for shadow, a button-scoped one) the
+				// same way Advanced Text's border/shadow surface does, mirroring its token/css_prop shape
+				// (declarations.php's Advanced Heading entry below) rather than the css_var shape the other
+				// button-* properties above use — there is no existing ownable button border/shadow variable
+				// to point at, so the block-default-CSS projector's low-specificity rule is the delivery
+				// mechanism here.
+				'button-border-width' => [
+					'token'    => 'semantic.border-width.default',
+					'css_prop' => 'border-width',
+				],
+				'button-border-style' => [
+					'token'    => 'semantic.border-style.default',
+					'css_prop' => 'border-style',
+				],
+				'button-border-color' => [
+					'token'    => 'semantic.color.border',
+					'css_prop' => 'border-color',
+				],
+				// No baseline default: an unstyled button carries no shadow, so the preset's $default omits
+				// this property entirely and the projector emits no box-shadow rule until a preset (or the
+				// user) sets one.
+				'button-shadow'       => [
+					'token'    => 'semantic.shadow.button',
+					'css_prop' => 'box-shadow',
 				],
 			],
 		],

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -3,6 +3,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Projection\Block_Default_Css;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css\Css_Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
@@ -293,6 +294,77 @@ final class Css_BuilderTest extends TestCase {
 
 		$this->assertStringContainsString( '.wp-block-kadence-image img{border-radius:var(' . $var . ',0);}', $css );
 		$this->assertStringNotContainsString( '.wp-block-kadence-imageimg', $css ); // cspell:disable-line -- Checking for invalid selector.
+	}
+
+	/**
+	 * The shipped Button declarations bind border-width/border-style/border-color to the same brand-wide
+	 * tokens Advanced Text reuses, projected as one grouped, low-specificity rule on the block root — the
+	 * button's own kadence_slot/css_var properties (background, text, radius) declare no css_prop, so they
+	 * contribute nothing here. box-shadow is absent from the rule: the baseline `$default` for both button
+	 * presets omits `button-shadow` entirely, so the projector has no value to emit a declaration for.
+	 *
+	 * @return void
+	 */
+	public function testTheShippedDeclarationsEmitTheButtonBorderSurfaceRule(): void {
+		$registry = $this->container->get( Token_Registry::class );
+
+		$css = $this->builder( $registry )->css();
+
+		$this->assertStringContainsString(
+			'.wp-block-kadence-singlebtn{border-width:var(' . Css_Var::from_id( 'semantic.border-width.default' ) . ',1px);',
+			$css
+		);
+		$this->assertStringContainsString( 'border-style:var(' . Css_Var::from_id( 'semantic.border-style.default' ) . ',none);', $css );
+		// The closing brace directly after border-color (rather than a further box-shadow declaration)
+		// proves the rule carries no box-shadow — the shipped $default omits button-shadow entirely.
+		$this->assertStringContainsString( 'border-color:var(' . Css_Var::from_id( 'semantic.color.border' ) . ',#E2E8F0);}', $css );
+	}
+
+	/**
+	 * A `button-shadow` binding that DOES resolve a value (unlike the shipped baseline, which omits the
+	 * property) projects through the same token/css_prop mechanism as border, emitting a `box-shadow`
+	 * declaration whose var() fallback is the fully rendered shadow shorthand — proving the composite
+	 * `shadow` $type reaches this projector end to end via a real stored preset override. The shorthand's
+	 * own field order/inset handling is covered by
+	 * {@see \Tests\wpunit\Resources\Design_Tokens\Resolver\Css_RendererTest}, so this only checks that the
+	 * rule is emitted with the right property and var name.
+	 *
+	 * @return void
+	 */
+	public function testAButtonShadowBindingWithAResolvedValueEmitsABoxShadowRule(): void {
+		/** @var Token_Store $store */
+		$store = $this->container->get( Token_Store::class );
+
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'presets' => [
+						'kadence/singlebtn' => [
+							'primary' => [
+								'tokens' => [
+									'button-shadow' => '{primitive.shadow.md}',
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$store->save_document( (string) wp_json_encode( $document ), Token_Store::default_slug() );
+
+		$registry = $this->container->get( Token_Registry::class );
+
+		$css = $this->builder( $registry )->css();
+
+		// Not anchored to the opening brace: the merged property order (border-width/style/color from the
+		// baseline default, plus this override's button-shadow) is an implementation detail of the merge,
+		// not something this test pins.
+		$this->assertStringContainsString(
+			'box-shadow:var(' . Css_Var::from_id( 'semantic.shadow.button' ) . ',0px 2px 8px 0px #1717171f);',
+			$css
+		);
+		$this->assertStringContainsString( '.wp-block-kadence-singlebtn{', $css );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -3,7 +3,6 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Projection\Block_Default_Css;
 
-use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css\Css_Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
@@ -294,77 +293,6 @@ final class Css_BuilderTest extends TestCase {
 
 		$this->assertStringContainsString( '.wp-block-kadence-image img{border-radius:var(' . $var . ',0);}', $css );
 		$this->assertStringNotContainsString( '.wp-block-kadence-imageimg', $css ); // cspell:disable-line -- Checking for invalid selector.
-	}
-
-	/**
-	 * The shipped Button declarations bind border-width/border-style/border-color to the same brand-wide
-	 * tokens Advanced Text reuses, projected as one grouped, low-specificity rule on the block root — the
-	 * button's own kadence_slot/css_var properties (background, text, radius) declare no css_prop, so they
-	 * contribute nothing here. box-shadow is absent from the rule: the baseline `$default` for both button
-	 * presets omits `button-shadow` entirely, so the projector has no value to emit a declaration for.
-	 *
-	 * @return void
-	 */
-	public function testTheShippedDeclarationsEmitTheButtonBorderSurfaceRule(): void {
-		$registry = $this->container->get( Token_Registry::class );
-
-		$css = $this->builder( $registry )->css();
-
-		$this->assertStringContainsString(
-			'.wp-block-kadence-singlebtn{border-width:var(' . Css_Var::from_id( 'semantic.border-width.default' ) . ',1px);',
-			$css
-		);
-		$this->assertStringContainsString( 'border-style:var(' . Css_Var::from_id( 'semantic.border-style.default' ) . ',none);', $css );
-		// The closing brace directly after border-color (rather than a further box-shadow declaration)
-		// proves the rule carries no box-shadow — the shipped $default omits button-shadow entirely.
-		$this->assertStringContainsString( 'border-color:var(' . Css_Var::from_id( 'semantic.color.border' ) . ',#E2E8F0);}', $css );
-	}
-
-	/**
-	 * A `button-shadow` binding that DOES resolve a value (unlike the shipped baseline, which omits the
-	 * property) projects through the same token/css_prop mechanism as border, emitting a `box-shadow`
-	 * declaration whose var() fallback is the fully rendered shadow shorthand — proving the composite
-	 * `shadow` $type reaches this projector end to end via a real stored preset override. The shorthand's
-	 * own field order/inset handling is covered by
-	 * {@see \Tests\wpunit\Resources\Design_Tokens\Resolver\Css_RendererTest}, so this only checks that the
-	 * rule is emitted with the right property and var name.
-	 *
-	 * @return void
-	 */
-	public function testAButtonShadowBindingWithAResolvedValueEmitsABoxShadowRule(): void {
-		/** @var Token_Store $store */
-		$store = $this->container->get( Token_Store::class );
-
-		$document = [
-			'$extensions' => [
-				'com.kadence.designTokens' => [
-					'presets' => [
-						'kadence/singlebtn' => [
-							'primary' => [
-								'tokens' => [
-									'button-shadow' => '{primitive.shadow.md}',
-								],
-							],
-						],
-					],
-				],
-			],
-		];
-
-		$store->save_document( (string) wp_json_encode( $document ), Token_Store::default_slug() );
-
-		$registry = $this->container->get( Token_Registry::class );
-
-		$css = $this->builder( $registry )->css();
-
-		// Not anchored to the opening brace: the merged property order (border-width/style/color from the
-		// baseline default, plus this override's button-shadow) is an implementation detail of the merge,
-		// not something this test pins.
-		$this->assertStringContainsString(
-			'box-shadow:var(' . Css_Var::from_id( 'semantic.shadow.button' ) . ',0px 2px 8px 0px #1717171f);',
-			$css
-		);
-		$this->assertStringContainsString( '.wp-block-kadence-singlebtn{', $css );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
@@ -761,6 +761,43 @@ final class PresetsControllerTest extends TestCase {
 	}
 
 	/**
+	 * The button's border and shadow properties are bound (declarations.php), so `guard_surface()` accepts
+	 * a preset that sets all four alongside the pre-existing surface — the same acceptance path
+	 * `testAnUnboundPropertyIsRejected` proves rejects a name the block does not bind.
+	 *
+	 * @return void
+	 */
+	public function testTheButtonBorderAndShadowPropertiesAreAccepted(): void {
+		$response = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'preset' => 'outline',
+					'tokens' => $this->button_tokens(
+						[
+							'button-border-width' => '2px',
+							'button-border-style' => 'solid',
+							'button-border-color' => '#000000',
+							'button-shadow'       => '{primitive.shadow.md}',
+						]
+					),
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::CREATED, $response->get_status() );
+
+		$tokens = $response->get_data()['presets']['outline']['tokens'];
+
+		$this->assertSame( '2px', $tokens['button-border-width'] );
+		$this->assertSame( 'solid', $tokens['button-border-style'] );
+		$this->assertSame( '#000000', $tokens['button-border-color'] );
+		$this->assertSame( '{primitive.shadow.md}', $tokens['button-shadow'] );
+	}
+
+	/**
 	 * A preset may define a SUBSET of the block's bound surface: a preset that leaves a bound property
 	 * unset is accepted and stored with exactly the properties it defines. The property it omits is inherited
 	 * from the block $default through the cascade rather than being required here.


### PR DESCRIPTION
## Summary

PHP declarations for the four new button-scoped properties, mirroring PR #1279's `button-radius`/`button-padding`/`button-margin` pattern:

- `button-border-width` (`dimension`), `button-border-style` (`borderStyle`), `button-border-color` (`color`) — bound via `token`+`css_prop` (matching the existing four border-color/width/radius/style bindings on `kadence/advancedheading`, since there's no ownable button-border CSS variable to expose — a deliberate deviation from `button-radius`'s `css_var`/`control_attr` shape, verified against precedent).
- `button-shadow` (`shadow`) — a new `semantic.shadow.button` token registered, matching `semantic.shadow.media`'s shape. Omitted from both baseline presets by default (no Figma access to confirm a default shadow; matches how `button-padding`/`button-margin` handle an unset property).
- `guard_surface()` needed no change — it derives its allow-list live from the binding declarations, not a hardcoded list.

## Test plan

- [x] `vendor/bin/phpstan analyse` — clean, level max, baseline untouched
- [x] `composer phpcs` — 0 errors/warnings
- [x] cspell — 0 issues
- [x] New wpunit test cases added to `Css_BuilderTest`/`PresetsControllerTest` (execution deferred — `slic`'s shared config in this environment doesn't resolve to this worktree; static checks above are green)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added default button shadow styling through design tokens.
  * Button presets now support configurable border width, style, color, and shadow properties.
  * Custom button shadow overrides are reflected in generated styles.
* **Improvements**
  * Button styling continues to support existing color, radius, spacing, and margin settings.
  * Preset creation now accepts and preserves the expanded button border and shadow settings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->