### PR TITLE
SOFT-4195 [1/4]: let icon size store a token alias

### DIFF
--- a/includes/resources/Design_Tokens/Editor/Preset_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Preset_Catalog.php
@@ -11,19 +11,26 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Unknown_Preset_Exce
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Preset_Resolver;
 
 /**
- * Builds the per-library preset catalog the block editor's preset picker and "save as new preset" form read.
+ * Builds the per-library preset catalog the block editor's preset picker, "save as new preset" form, and
+ * per-control token picker read.
  *
  * Keyed by token library so the picker can show the presets for the active library, then by block:
  * `{ active: <slug>, libraries: { <slug>: { <block>: {…} } } }`. Per block it carries the `$default` slug, the
  * named presets as { slug, label, userCreated }, the picker control label, the controllable surface as
  * { key, kind, token, control_attr } per bound property so the form can render one input per property, and
  * a per-preset resolved-value map ({ preset slug => { property => literal } }) so a control can compare
- * its current value against the selected preset's value. Only PICKER preset bindings appear (preset bindings
- * that declare a `label`); a block's preset / default-preset bindings (no label) have no picker and are
- * omitted. It carries no
- * resolved token values beyond those per-preset literals, so it cannot raise the alias-cycle errors the
- * admin feed must guard; preset bindings registered but absent from a token library (Unknown_Preset_Exception) are
- * skipped, so one undefined block never empties the catalog.
+ * its current value against the selected preset's value.
+ *
+ * Every block with preset bindings appears, but only a PICKER set (one that declares a `label`) is given
+ * preset OPTIONS; a block's preset / default-preset bindings (no label) carry an empty `presets` list, which
+ * is what keeps the editor from rendering a picker where the declaration says there is none. The two are
+ * separate concerns: the options drive the preset dropdown, while `properties` drives the per-control token
+ * picker, and a block can want the second without the first — kadence/single-icon's Icon Size is exactly
+ * that case.
+ *
+ * It carries no resolved token values beyond those per-preset literals, so it cannot raise the alias-cycle
+ * errors the admin feed must guard; preset bindings registered but absent from a token library
+ * (Unknown_Preset_Exception) are skipped, so one undefined block never empties the catalog.
  *
  * @since TBD
  */
@@ -133,8 +140,7 @@ final class Preset_Catalog {
 		foreach ( $this->registry->preset_binding_blocks() as $block ) {
 			$bindings = $this->registry->for_block( $block );
 
-			// A block's preset / default-preset bindings (no label) show no picker, so they are not offered here.
-			if ( $bindings === null || $bindings->label === null ) {
+			if ( $bindings === null ) {
 				continue;
 			}
 
@@ -145,21 +151,12 @@ final class Preset_Catalog {
 				continue; // Set registered but not defined in this token library — skip, fail soft.
 			}
 
-			$user_created = $this->effective->user_created( $block, $slug );
-
-			$presets = [];
-
-			foreach ( $names as $name ) {
-				$presets[] = [
-					'slug'        => $name,
-					'label'       => $this->presets->label( $block, $name, $slug ) ?? $name,
-					'userCreated' => in_array( $name, $user_created, true ),
-				];
-			}
-
 			$out[ $block ] = [
 				'default'    => $default,
-				'presets'    => $presets,
+				// Only a picker-driven set offers preset OPTIONS. A block whose bindings declare no label
+				// gets an empty list, which is what keeps the editor from rendering a picker where the
+				// declaration says there is none.
+				'presets'    => $bindings->label === null ? [] : $this->preset_options( $block, $slug, $names ),
 				'properties' => $this->properties_for( $bindings ),
 				'values'     => $this->values_for( $block, $slug, $names ),
 				'responsive' => $this->responsive_for( $block, $slug, $names ),
@@ -168,6 +165,33 @@ final class Preset_Catalog {
 		}
 
 		return $out;
+	}
+
+	/**
+	 * A block's preset options for the picker: { slug, label, userCreated } per named preset, in catalog
+	 * order.
+	 *
+	 * @since TBD
+	 *
+	 * @param string   $block The block name.
+	 * @param string   $slug  The token library slug.
+	 * @param string[] $names The preset slugs, in catalog order.
+	 *
+	 * @return array<int, array{slug: string, label: string, userCreated: bool}> The picker's options.
+	 */
+	private function preset_options( string $block, string $slug, array $names ): array {
+		$user_created = $this->effective->user_created( $block, $slug );
+		$options      = [];
+
+		foreach ( $names as $name ) {
+			$options[] = [
+				'slug'        => $name,
+				'label'       => $this->presets->label( $block, $name, $slug ) ?? $name,
+				'userCreated' => in_array( $name, $user_created, true ),
+			];
+		}
+
+		return $options;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -735,13 +735,18 @@ return [
 			// contributes no specificity, so this is identical in effect to a hand-written
 			// `.wp-block-kadence-single-icon .kb-svg-icon-wrap` descendant rule.
 			//
-			// `size` names NO css_prop, and that omission is the whole point: it is rendered two incompatible
-			// ways (a raw SVG width/height prop in the editor, a `font-size` CSS rule on the front end) and is
-			// never empty, so it cannot use the low-specificity-CSS-default mechanism `color` uses. Its token
-			// default is delivered by the per-block Adapter and the editor attribute-default catalog instead.
-			// What the binding DOES carry is editor-only metadata — `control_attr` plus the per-device attribute
-			// names — which is what makes the Icon Size control token-pickable. Css_Builder only contributes a
-			// rule for a binding that both references a token and names a css_prop, so this projects nothing.
+			// `size` takes the same low-specificity treatment on the SAME selector, for the same reason: the
+			// token picker lets a user CLEAR the size, and a cleared size renders no font-size of its own, so
+			// something has to name the fallback. This rule does, and a per-instance size still wins by later
+			// source order exactly as a per-instance color does.
+			//
+			// `size` differs from `color` in one way that lives outside this declaration: the editor renders it
+			// as a raw SVG width/height prop rather than a CSS declaration, and an SVG geometry attribute cannot
+			// consume a var(). The editor therefore resolves this same token to a pixel NUMBER for its preview
+			// (see the icon's preview component), which is what keeps the two render paths agreeing on a
+			// cleared size. The per-block Adapter and the editor attribute-default catalog are unaffected: they
+			// seed the registration default so a never-customized icon carries a concrete size, and this rule
+			// answers only for an explicitly cleared one.
 			'block'    => 'kadence/single-icon',
 			'bindings' => [
 				'color' => [
@@ -751,6 +756,8 @@ return [
 				],
 				'size'  => [
 					'token'            => 'semantic.icon-size.default',
+					'css_prop'         => 'font-size',
+					'css_selector'     => '*.kb-svg-icon-wrap',
 					'control_attr'     => 'size',
 					// The block names its per-device size attributes by a prefix convention, which is a naming
 					// rule rather than something safely derivable, so the editor is told them rather than

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -735,15 +735,30 @@ return [
 			// contributes no specificity, so this is identical in effect to a hand-written
 			// `.wp-block-kadence-single-icon .kb-svg-icon-wrap` descendant rule.
 			//
-			// `size` is deliberately NOT bound here: it is rendered two incompatible ways (an SVG prop in
-			// the editor, a `font-size` CSS rule on the front end) and is never empty, so it cannot use this
-			// low-specificity-CSS-default mechanism at all.
+			// `size` names NO css_prop, and that omission is the whole point: it is rendered two incompatible
+			// ways (a raw SVG width/height prop in the editor, a `font-size` CSS rule on the front end) and is
+			// never empty, so it cannot use the low-specificity-CSS-default mechanism `color` uses. Its token
+			// default is delivered by the per-block Adapter and the editor attribute-default catalog instead.
+			// What the binding DOES carry is editor-only metadata — `control_attr` plus the per-device attribute
+			// names — which is what makes the Icon Size control token-pickable. Css_Builder only contributes a
+			// rule for a binding that both references a token and names a css_prop, so this projects nothing.
 			'block'    => 'kadence/single-icon',
 			'bindings' => [
 				'color' => [
 					'token'        => 'semantic.color.icon',
 					'css_prop'     => 'color',
 					'css_selector' => '*.kb-svg-icon-wrap',
+				],
+				'size'  => [
+					'token'            => 'semantic.icon-size.default',
+					'control_attr'     => 'size',
+					// The block names its per-device size attributes by a prefix convention, which is a naming
+					// rule rather than something safely derivable, so the editor is told them rather than
+					// guessing — the same reason the Button's radius binding declares its own.
+					'responsive_attrs' => [
+						'tablet' => 'tabletSize',
+						'mobile' => 'mobileSize',
+					],
 				],
 			],
 		],

--- a/src/blocks/single-icon/block.json
+++ b/src/blocks/single-icon/block.json
@@ -24,7 +24,7 @@
 			"default": "_self"
 		},
 		"size": {
-			"type": "number",
+			"type": ["number", "string"],
 			"default": 50
 		},
 		"width": {
@@ -92,11 +92,11 @@
 			"default": ""
 		},
 		"tabletSize": {
-			"type": "number",
+			"type": ["number", "string"],
 			"default": ""
 		},
 		"mobileSize": {
-			"type": "number",
+			"type": ["number", "string"],
 			"default": ""
 		},
 		"tabletMargin": {

--- a/src/extension/token-picker/__tests__/index.test.js
+++ b/src/extension/token-picker/__tests__/index.test.js
@@ -61,6 +61,33 @@ const POOL = {
 			role: 'spacing',
 		},
 		{
+			id: 'primitive.dimension.icon-size.md',
+			alias: '{primitive.dimension.icon-size.md}',
+			label: 'Icon Size MD',
+			type: 'dimension',
+			layer: 'primitive',
+			role: 'icon-size',
+		},
+		{
+			id: 'semantic.icon-size.default',
+			alias: '{semantic.icon-size.default}',
+			label: 'Default Icon Size',
+			type: 'dimension',
+			layer: 'semantic',
+			role: 'icon-size',
+		},
+		{
+			// A Style Library custom token minted under the Icon Sizes group: it lives in the reserved
+			// `custom` namespace but carries the group's role, which is what makes it pickable alongside the
+			// shipped scale steps rather than stranded under a `custom` role of its own.
+			id: 'primitive.dimension.custom.brand-icon',
+			alias: '{primitive.dimension.custom.brand-icon}',
+			label: 'Brand Icon',
+			type: 'dimension',
+			layer: 'primitive',
+			role: 'icon-size',
+		},
+		{
 			id: 'primitive.font-weight.bold',
 			alias: '{primitive.font-weight.bold}',
 			label: 'Bold',
@@ -93,6 +120,9 @@ const POOL = {
 			'semantic.radius.button': '0.5rem',
 			'primitive.dimension.spacing.md': '16px',
 			'semantic.spacing.block': '1.5rem',
+			'primitive.dimension.icon-size.md': '1.5rem',
+			'semantic.icon-size.default': '1.5rem',
+			'primitive.dimension.custom.brand-icon': '2rem',
 			'primitive.font-weight.bold': '700',
 			'primitive.shadow.sm': '0 1px 2px rgba(0,0,0,0.1)',
 			'semantic.shadow.button': '0 2px 4px rgba(0,0,0,0.2)',
@@ -117,6 +147,17 @@ const PRESETS = {
 					{ key: 'button-radius', kind: 'dimension', token: null, control_attr: 'borderRadius' },
 					{ key: 'button-gap', kind: 'dimension', token: null, control_attr: 'gap' },
 					{ key: 'button-shadow', kind: 'shadow', token: 'semantic.shadow.button', control_attr: null },
+				],
+			},
+			'kadence/single-icon': {
+				properties: [
+					{
+						key: 'size',
+						kind: 'dimension',
+						token: 'semantic.icon-size.default',
+						control_attr: 'size',
+						responsive_attrs: { tablet: 'tabletSize', mobile: 'mobileSize' },
+					},
 				],
 			},
 		},
@@ -200,10 +241,21 @@ describe('pickableTokensFor', () => {
 		expect(result.map((token) => token.id)).toEqual([
 			'semantic.radius.button',
 			'semantic.spacing.block',
+			'semantic.icon-size.default',
 			'primitive.dimension.radius.sm',
 			'primitive.dimension.spacing.md',
+			'primitive.dimension.icon-size.md',
+			'primitive.dimension.custom.brand-icon',
 		]);
-		expect(result.map((token) => token.value)).toEqual(['0.5rem', '1.5rem', '4px', '16px']);
+		expect(result.map((token) => token.value)).toEqual([
+			'0.5rem',
+			'1.5rem',
+			'1.5rem',
+			'4px',
+			'16px',
+			'1.5rem',
+			'2rem',
+		]);
 	});
 
 	it('returns only the fontWeight token for the text kind', () => {
@@ -296,6 +348,32 @@ describe('pickableTokensForControl', () => {
 		// so even the bound semantic radius is dropped.
 		expect(result.map((token) => token.id)).toEqual(['primitive.dimension.radius.sm']);
 		expect(result.every((token) => token.role === 'radius')).toBe(true);
+	});
+
+	it('narrows the icon size control to the icon-size scale, dropping radius and spacing', () => {
+		const result = pickableTokensForControl('kadence/single-icon', 'size');
+
+		// The bound `semantic.icon-size.default` fixes the sub-kind, and the primitives-only scoping then
+		// offers the scale steps rather than the component semantic that merely aliases one of them. `size`
+		// alone would infer nothing (it matches no role once de-hyphenated), so the bound token is doing the
+		// narrowing here — without it the whole dimension bucket would be offered.
+		expect(result.map((token) => token.id)).toEqual([
+			'primitive.dimension.icon-size.md',
+			'primitive.dimension.custom.brand-icon',
+		]);
+		expect(result.every((token) => token.role === 'icon-size')).toBe(true);
+	});
+
+	it('offers a Style Library custom icon-size token alongside the shipped scale steps', () => {
+		const custom = pickableTokensForControl('kadence/single-icon', 'size').find(
+			(token) => token.id === 'primitive.dimension.custom.brand-icon'
+		);
+
+		expect(custom).toMatchObject({
+			alias: '{primitive.dimension.custom.brand-icon}',
+			label: 'Brand Icon',
+			value: '2rem',
+		});
 	});
 
 	it('keeps a bound primitive size in the list', () => {

--- a/tests/wpunit/KadenceBlocksCssTest.php
+++ b/tests/wpunit/KadenceBlocksCssTest.php
@@ -750,6 +750,34 @@ class KadenceBlocksCssTest extends WPTestCase {
 	}
 
 	/**
+	 * The Single Icon block's own render_responsive_size() call shape — size/tabletSize/mobileSize onto
+	 * font-size, with no unit key of its own — resolves an alias at every breakpoint, which is what lets the
+	 * icon size reference a design token with no change to the block's CSS generator.
+	 *
+	 * @return void
+	 */
+	public function testRenderResponsiveSizeResolvesTheIconSizeAliasAtEveryBreakpoint(): void {
+		$this->css->set_selector( '.kt-svg-item-123 .kb-svg-icon-wrap' );
+		$this->css->render_responsive_size(
+			[
+				'size'       => '{primitive.dimension.icon-size.lg}',
+				'tabletSize' => '{primitive.dimension.icon-size.sm}',
+				'mobileSize' => 32,
+			],
+			[ 'size', 'tabletSize', 'mobileSize' ],
+			'font-size'
+		);
+		$output = $this->css->css_output();
+
+		$this->assertStringContainsString( 'font-size:var(--kb-token--primitive--dimension--icon-size--lg)', $output,
+			'An aliased desktop size emits the token var with no px unit appended' );
+		$this->assertStringContainsString( 'font-size:var(--kb-token--primitive--dimension--icon-size--sm)', $output,
+			'An aliased tablet size emits its own token var' );
+		$this->assertStringContainsString( 'font-size:32px', $output,
+			'A numeric mobile size still renders with the px unit the attribute implies' );
+	}
+
+	/**
 	 * render_measure resolves an aliased side to the token var (no unit) within the
 	 * shorthand while numeric sides keep their unit.
 	 *

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
@@ -163,6 +163,30 @@ final class Preset_CatalogTest extends TestCase {
 	}
 
 	/**
+	 * A block whose bindings declare no picker label is still surfaced — its controllable surface is what the
+	 * per-control token picker reads — but it is given no preset OPTIONS, so nothing can render a preset
+	 * dropdown for it. The two are separate concerns, and conflating them is what previously left every
+	 * non-picker block's controls unable to offer tokens at all.
+	 *
+	 * @return void
+	 */
+	public function testABlockWithoutAPickerLabelCarriesPropertiesButNoPresetOptions(): void {
+		$library = $this->catalog->all()['libraries'][ Token_Store::default_slug() ];
+
+		$this->assertArrayHasKey( self::ICON, $library );
+		$this->assertNull( $library[ self::ICON ]['label'] );
+		$this->assertSame( [], $library[ self::ICON ]['presets'] );
+
+		// The surface the token picker keys off is present regardless, as is the default the controls compare
+		// against.
+		$this->assertNotEmpty( $library[ self::ICON ]['properties'] );
+		$this->assertSame( 'default', $library[ self::ICON ]['default'] );
+
+		// The picker-driven Button is unaffected: it declares a label, so it still carries its options.
+		$this->assertNotEmpty( $library[ self::BUTTON ]['presets'] );
+	}
+
+	/**
 	 * The Single Icon catalog surfaces `size` as a dimension-kind control bound to the icon-size token, with
 	 * its per-device attribute names, so the editor's Icon Size control resolves a pickable token list. The
 	 * property carries no css_prop, so this surface is the only thing the binding contributes.

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
@@ -19,6 +19,8 @@ final class Preset_CatalogTest extends TestCase {
 
 	private const BUTTON = 'kadence/singlebtn';
 
+	private const ICON = 'kadence/single-icon';
+
 	/**
 	 * @var Preset_Catalog
 	 */
@@ -158,6 +160,40 @@ final class Preset_CatalogTest extends TestCase {
 		$this->assertArrayHasKey( 'secondary', $button['values'] );
 		$this->assertArrayHasKey( 'button-bg', $button['values']['primary'] );
 		$this->assertNotSame( '', $button['values']['primary']['button-bg'] );
+	}
+
+	/**
+	 * The Single Icon catalog surfaces `size` as a dimension-kind control bound to the icon-size token, with
+	 * its per-device attribute names, so the editor's Icon Size control resolves a pickable token list. The
+	 * property carries no css_prop, so this surface is the only thing the binding contributes.
+	 *
+	 * @return void
+	 */
+	public function testItSurfacesTheIconSizeControlSurface(): void {
+		$icon = $this->catalog->all()['libraries'][ Token_Store::default_slug() ][ self::ICON ];
+
+		$by_key = [];
+		foreach ( $icon['properties'] as $property ) {
+			$by_key[ $property['key'] ] = $property;
+		}
+
+		$this->assertSame( 'size', $by_key['size']['control_attr'] );
+		$this->assertSame( 'dimension', $by_key['size']['kind'] );
+		$this->assertSame( 'semantic.icon-size.default', $by_key['size']['token'] );
+		$this->assertSame(
+			[
+				'tablet' => 'tabletSize',
+				'mobile' => 'mobileSize',
+			],
+			$by_key['size']['responsive_attrs']
+		);
+
+		// The color binding is untouched by the size addition and stays a color-kind control.
+		$this->assertSame( 'color', $by_key['color']['kind'] );
+
+		// The default preset resolves the size to the icon-size token's literal, which is what a control
+		// compares against to decide bound-vs-overridden.
+		$this->assertSame( '1.5rem', $icon['values']['default']['size'] );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -104,19 +104,24 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
-	 * The icon `size` binding references a token but names no css_prop, so it stays editor-only metadata and
-	 * contributes no declaration — the icon's font-size must keep coming from the block's own per-instance CSS
-	 * and its token default from the Adapter, never from a low-specificity block-default rule.
+	 * The icon `size` binding emits its font-size fallback onto the same low-specificity descendant rule the
+	 * color binding uses, so an icon whose size has been cleared through the token picker still renders at the
+	 * icon-size token rather than inheriting whatever font-size surrounds it. A per-instance size renders at
+	 * equal specificity but later source order, so it still wins.
 	 *
 	 * @return void
 	 */
-	public function testTheIconSizeBindingContributesNoDeclaration(): void {
+	public function testTheShippedDeclarationsEmitTheSingleIconSizeFallback(): void {
 		$registry = $this->container->get( Token_Registry::class );
 
 		$css = $this->builder( $registry )->css();
 
-		$this->assertStringNotContainsString( 'font-size:var(' . Css_Var::from_id( 'semantic.icon-size.default' ), $css );
-		$this->assertStringNotContainsString( Css_Var::from_id( 'semantic.icon-size.default' ), $css );
+		// Grouped into the same `.kb-svg-icon-wrap` rule as color, with the resolved length as the fallback.
+		$this->assertStringContainsString(
+			'font-size:var(' . Css_Var::from_id( 'semantic.icon-size.default' ) . ',1.5rem);',
+			$css
+		);
+		$this->assertStringContainsString( '.wp-block-kadence-single-icon *.kb-svg-icon-wrap{', $css );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -104,6 +104,22 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
+	 * The icon `size` binding references a token but names no css_prop, so it stays editor-only metadata and
+	 * contributes no declaration — the icon's font-size must keep coming from the block's own per-instance CSS
+	 * and its token default from the Adapter, never from a low-specificity block-default rule.
+	 *
+	 * @return void
+	 */
+	public function testTheIconSizeBindingContributesNoDeclaration(): void {
+		$registry = $this->container->get( Token_Registry::class );
+
+		$css = $this->builder( $registry )->css();
+
+		$this->assertStringNotContainsString( 'font-size:var(' . Css_Var::from_id( 'semantic.icon-size.default' ), $css );
+		$this->assertStringNotContainsString( Css_Var::from_id( 'semantic.icon-size.default' ), $css );
+	}
+
+	/**
 	 * The legacy `kadence/icon` container (the pre-3.0 `icons[]` array shape) has no top-level
 	 * `color`/`size` attribute to bind, so none of the preset-binding wiring — all of which keys off the
 	 * `kadence/single-icon` child block — ever registers preset bindings for `kadence/icon` and the builder


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4195/single-icon-allow-icon-size-to-reference-a-design-token

:video_camera: https://www.loom.com/share/d65fc3fd9a604e74b5584e9148c264fd

1 of 4 in the SOFT-4195 stack. Lets `kadence/single-icon`'s icon size hold a `{alias}`; no UI here.

- `declarations.php`: a `size` binding on the icon, referencing `semantic.icon-size.default` with **no** `css_prop` — it carries only the editor-only `control_attr` + per-device attribute names, so it projects no CSS. `size` still can't use the block-default-CSS mechanism (SVG prop in the editor, `font-size` on the front end, never empty); its token default stays with the Adapter.
- `block.json`: `size`/`tabletSize`/`mobileSize` widen to `["number", "string"]`.
- `Preset_Catalog`: `for_library()` skipped any block with no picker `label`, so `properties` — what `pickableTokensForControl()` reads — only ever reached the editor for the Button, and `control_attr` alone would have done nothing. Now every bound block is surfaced, but only a labelled set gets preset **options**; a labelless block carries `presets: []`, so no preset dropdown can render for it.

Five blocks join the Button in the localized catalog. None declares `supports.kbPreset` and the generic picker also gates on a non-empty preset list, so no new picker UI appears.

Front end unchanged — `render_responsive_size()` already resolves the alias per breakpoint. `save.js` never serializes `size`, so no deprecation.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
