### PR TITLE
SOFT-4195 [2/4]: ScalarControl, a scalar sibling to BoxControl

### DIFF
--- a/src/token-controls/__tests__/scalar-control.test.js
+++ b/src/token-controls/__tests__/scalar-control.test.js
@@ -1,0 +1,201 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { ScalarControl } from '../controls/ScalarControl';
+
+// `jest.config.js` maps `@wordpress/components` to the copy nested under
+// `@kadence/components/node_modules`, which resolves its own `react` — a different module instance
+// than the top-level `react-dom/client` this test renders with, which trips React's "Invalid hook
+// call" guard. Stand-ins sidestep that; these tests only need the chrome and the field's trigger.
+jest.mock('@wordpress/components', () => ({
+	Button: ({ children, icon, showTooltip, isSmall, ...props }) => <button {...props}>{children}</button>,
+	ButtonGroup: ({ children, ...props }) => <div {...props}>{children}</div>,
+	Dashicon: (props) => <span {...props} />,
+	Dropdown: ({ renderToggle, renderContent }) => (
+		<div>
+			{renderToggle({ isOpen: true, onToggle: () => {} })}
+			{renderContent({ onClose: () => {} })}
+		</div>
+	),
+	Tooltip: ({ children }) => children,
+}));
+
+jest.mock('@wordpress/icons', () => ({ undo: 'undo', link: 'link', linkOff: 'linkOff' }));
+jest.mock('../styles/token-controls.scss', () => ({}), { virtual: true });
+
+// The popover is exercised by its own tests; here it stands in as a set of buttons so each of the
+// field's three write intents can be fired without driving the real tab UI.
+jest.mock('../molecules/TokenPopover', () => ({
+	TokenPopover: ({ onPick, onClear, custom }) => (
+		<div>
+			<button className="test-pick" onClick={() => onPick('{primitive.dimension.icon-size.lg}')} />
+			<button className="test-clear" onClick={() => onClear()} />
+			<button className="test-custom" onClick={() => custom.onNumber('40')} />
+		</div>
+	),
+}));
+
+const TOKENS = [
+	{
+		id: 'primitive.dimension.icon-size.lg',
+		alias: '{primitive.dimension.icon-size.lg}',
+		label: 'LG',
+		value: '2.25rem',
+	},
+];
+
+let container;
+let root;
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+/**
+ * Render `ScalarControl` with the props it needs, overridable per test.
+ *
+ * @param {Object} props Overrides for the defaults below.
+ *
+ * @since TBD
+ *
+ * @return {HTMLElement} The container it rendered into.
+ */
+function renderControl(props = {}) {
+	act(() =>
+		root.render(
+			createElement(ScalarControl, {
+				value: '',
+				onChange: jest.fn(),
+				label: 'Icon Size',
+				tokens: TOKENS,
+				...props,
+			})
+		)
+	);
+
+	return container;
+}
+
+describe('ScalarControl chrome', () => {
+	/**
+	 * The control wears its label and exactly one token field — the whole point of a scalar control is
+	 * that there are no slots to render.
+	 */
+	it('renders the label and a single token field', () => {
+		renderControl();
+
+		expect(container.querySelector('.kb-token-control__label').textContent).toBe('Icon Size');
+		expect(container.querySelectorAll('.kadence-token-field')).toHaveLength(1);
+	});
+
+	/**
+	 * A scalar has nothing to link, so the shell's link toggle must never appear — passing `onToggleLink`
+	 * is the only thing that draws it, and this control passes none.
+	 */
+	it('never renders a linked/individual toggle', () => {
+		renderControl();
+
+		expect(container.querySelector('.kadence-control-toggle')).toBeNull();
+	});
+
+	/**
+	 * The breakpoint switcher is opt-in on the shell, so a control given no `breakpoints` is
+	 * non-responsive and shows none.
+	 */
+	it('renders the breakpoint switcher only when breakpoints are passed', () => {
+		renderControl();
+		expect(container.querySelector('.kb-measure-responsive-options')).toBeNull();
+
+		renderControl({ breakpoints: ['desktop', 'tablet', 'mobile'], breakpoint: 'tablet' });
+		expect(container.querySelectorAll('.kb-measure-responsive-options .kb-responsive-btn')).toHaveLength(3);
+	});
+
+	/**
+	 * The switcher reports the breakpoint the user chose; the shell owns no breakpoint state of its own,
+	 * so the host's handler is what moves the control.
+	 */
+	it('reports a breakpoint change to its handler', () => {
+		const onBreakpointChange = jest.fn();
+
+		renderControl({
+			breakpoints: ['desktop', 'tablet', 'mobile'],
+			breakpoint: 'desktop',
+			onBreakpointChange,
+		});
+
+		act(() => container.querySelector('.kb-tablet-tab').dispatchEvent(new MouseEvent('click', { bubbles: true })));
+
+		expect(onBreakpointChange).toHaveBeenCalledWith('tablet');
+	});
+});
+
+describe('ScalarControl writes', () => {
+	/**
+	 * A pick writes the token's alias, never its resolved literal — the alias is what keeps the value
+	 * following the token after the token's value changes.
+	 */
+	it('writes the picked token alias', () => {
+		const onChange = jest.fn();
+
+		renderControl({ onChange });
+		act(() => container.querySelector('.test-pick').dispatchEvent(new MouseEvent('click', { bubbles: true })));
+
+		expect(onChange).toHaveBeenCalledWith('{primitive.dimension.icon-size.lg}');
+	});
+
+	/**
+	 * Clearing writes an empty string rather than deleting the value, so the host's attribute keeps its
+	 * declared shape and falls back to its own default.
+	 */
+	it('writes an empty string on clear', () => {
+		const onChange = jest.fn();
+
+		renderControl({ onChange, value: '{primitive.dimension.icon-size.lg}' });
+		act(() => container.querySelector('.test-clear').dispatchEvent(new MouseEvent('click', { bubbles: true })));
+
+		expect(onChange).toHaveBeenCalledWith('');
+	});
+
+	/**
+	 * A custom value writes a bare number, not a number-plus-unit string: the unit is the control's and
+	 * lives in the host's own attribute, exactly as `BoxControl` treats it.
+	 */
+	it('writes a bare number for a custom value', () => {
+		const onChange = jest.fn();
+
+		renderControl({ onChange, unit: 'px' });
+		act(() => container.querySelector('.test-custom').dispatchEvent(new MouseEvent('click', { bubbles: true })));
+
+		expect(onChange).toHaveBeenCalledWith(40);
+	});
+
+	/**
+	 * A read-only control drops every write. The field's trigger is disabled too, so in the real UI the
+	 * popover cannot even open — these assertions cover the callbacks behind it.
+	 */
+	it('drops every write when disabled', () => {
+		const onChange = jest.fn();
+
+		renderControl({ onChange, disabled: true });
+		act(() => container.querySelector('.test-pick').dispatchEvent(new MouseEvent('click', { bubbles: true })));
+		act(() => container.querySelector('.test-clear').dispatchEvent(new MouseEvent('click', { bubbles: true })));
+
+		expect(onChange).not.toHaveBeenCalled();
+	});
+});

--- a/src/token-controls/controls/ScalarControl.js
+++ b/src/token-controls/controls/ScalarControl.js
@@ -1,0 +1,119 @@
+/**
+ * The scalar token control: one value, no slots.
+ *
+ * This is `BoxControl` with the two corner-specific parts removed — the `SlotGrid` and the
+ * linked/individual toggle. A property that holds a single dimension (an icon's size, a stroke
+ * width) has one value and nothing to link, so those parts have nothing to do; everything else a
+ * box control wears — the label, the breakpoint switcher, the binding indicator and its reset — is
+ * already opt-in on `ControlShell` and carries over unchanged.
+ *
+ * That is the reason this is a sibling of `BoxControl` rather than a mode of it: the difference is
+ * *shape* (a scalar versus four slots), which decides whether linking exists at all, not a setting
+ * a caller should be able to flip.
+ *
+ * **The binding indicator and its reset are opt-in**, exactly as in `BoxControl`. They exist for the
+ * block editor, where a control can override a selected preset; a host with no preset layer passes
+ * no `status` and gets a bare label.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { ControlShell } from '../templates/ControlShell';
+import { TokenSelector } from '../organisms/TokenSelector';
+
+/**
+ * Render a scalar token control.
+ *
+ * @param {Object}       props                      The component props.
+ * @param {*}            props.value                The current value: an alias, a literal, or empty.
+ * @param {Function}     props.onChange             Called with the next value.
+ * @param {string}       props.label                The control's label.
+ * @param {Array}        [props.tokens]             Pickable tokens, `[{ id, label, value, alias }]`.
+ * @param {string}       [props.unit]               The value's unit.
+ * @param {Array}        [props.units]              Selectable units for the Custom tab. A single-entry
+ *                                                  list pins the unit, which is what a host whose
+ *                                                  attribute stores a bare number in one fixed unit
+ *                                                  wants.
+ * @param {?Function}    [props.onUnit]             Writes the unit.
+ * @param {*}            [props.defaultValue]       What the value falls back to when unset.
+ * @param {boolean}      [props.inherited]          Whether that default came from another breakpoint.
+ * @param {?*}           [props.icon]               A glyph shown beside the field.
+ * @param {?Object}      [props.status]             `{ bound, modified }`; omit for no indicator.
+ * @param {?Function}    [props.onReset]            Reset handler, paired with `status`.
+ * @param {boolean}      [props.showReset]          Render the matching glyph and reset button.
+ * @param {?JSX.Element} [props.indicator]          Rendered in the header in place of the built-in
+ *                                                  indicator, for a host that supplies its own.
+ * @param {?Array}       [props.breakpoints]        Breakpoint keys; omit for a non-responsive control.
+ * @param {?string}      [props.breakpoint]         The active breakpoint.
+ * @param {?Function}    [props.onBreakpointChange] Breakpoint-change handler.
+ * @param {boolean}      [props.stacked]            Header above a full-width body instead of beside it.
+ * @param {boolean}      [props.disabled]           Whether the control is read-only.
+ * @param {?number}      [props.min]                Lowest allowed number on the Custom tab.
+ * @param {?number}      [props.max]                Highest allowed number; the slider needs one.
+ * @param {number}       [props.step]               Custom tab increment.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The rendered control.
+ */
+export function ScalarControl({
+	value,
+	onChange,
+	label,
+	tokens = [],
+	unit = '',
+	units,
+	onUnit,
+	defaultValue,
+	inherited = false,
+	icon = null,
+	status = null,
+	onReset = null,
+	showReset = true,
+	indicator = null,
+	breakpoints = null,
+	breakpoint = null,
+	onBreakpointChange = null,
+	stacked = false,
+	disabled = false,
+	min,
+	max,
+	step,
+}) {
+	return (
+		<ControlShell
+			label={label}
+			status={status}
+			onReset={onReset}
+			showReset={showReset}
+			indicator={indicator}
+			breakpoints={breakpoints}
+			breakpoint={breakpoint}
+			onBreakpointChange={onBreakpointChange}
+			stacked={stacked}
+			disabled={disabled}
+		>
+			<TokenSelector
+				value={value}
+				unit={unit}
+				units={units}
+				onUnit={onUnit}
+				defaultValue={defaultValue}
+				inherited={inherited}
+				icon={icon}
+				tokens={tokens}
+				min={min}
+				max={max}
+				step={step}
+				disabled={disabled}
+				// The field speaks three intents; a scalar stores one value, so they collapse here rather
+				// than in every host. `onCustom` writes a bare number — the unit is the control's, exactly
+				// as `BoxControl` treats it across its four slots.
+				onPick={(alias) => !disabled && onChange(alias)}
+				onClear={() => !disabled && onChange('')}
+				onCustom={(next) => !disabled && onChange(next)}
+			/>
+		</ControlShell>
+	);
+}

--- a/src/token-controls/index.js
+++ b/src/token-controls/index.js
@@ -21,6 +21,7 @@ export { TokenSelector } from './organisms/TokenSelector';
 export { ControlShell } from './templates/ControlShell';
 export { SlotGrid } from './templates/SlotGrid';
 export { BoxControl } from './controls/BoxControl';
+export { ScalarControl } from './controls/ScalarControl';
 
 export { BreakpointProvider, useBreakpoint } from './context/breakpoint';
 


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4195/single-icon-allow-icon-size-to-reference-a-design-token

:video_camera: https://www.loom.com/share/d65fc3fd9a604e74b5584e9148c264fd

Adds a token control for a property that holds **one** dimension rather than four. 2 of 4 in the SOFT-4195 stack; library-only, no consumer yet.

It is `BoxControl` with the two corner-specific parts removed — the `SlotGrid` and the linked/individual toggle — so the label, the breakpoint switcher, the binding indicator and its reset all carry over from `ControlShell` unchanged, and the field is the same `TokenSelector`.

A sibling of `BoxControl` rather than a mode of it: the difference is shape (a scalar versus four slots), which decides whether linking exists at all, not a setting a caller should be able to flip.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
