### PR TITLE
SOFT-4195 [3/4]: resolve token aliases to px in the editor

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Traits/Converts_Number_To_Px.php
+++ b/includes/resources/Design_Tokens/Projection/Traits/Converts_Number_To_Px.php
@@ -19,12 +19,18 @@ trait Converts_Number_To_Px {
 	 *
 	 * @since TBD
 	 *
+	 * The number grammar is the JS `parseCssLength()` grammar exactly — an optional sign, then digits with
+	 * at most one decimal point and at least one digit after it. A looser `[0-9.]+` would convert
+	 * malformed lengths the JS side declines (`1..2px`, `..px`, `1.2.3rem`), and reject the `+2px` it
+	 * accepts, which is the one way this conversion could render an icon at one size on the front end and
+	 * another in the editor.
+	 *
 	 * @param string $length A resolved CSS length, e.g. "1.5rem", "24px".
 	 *
 	 * @return float|null The pixel value, or null when the unit is not rem/em/px.
 	 */
 	private function to_px( string $length ): ?float {
-		if ( ! preg_match( '/^(-?[0-9.]+)(px|rem|em)$/', trim( $length ), $matches ) ) {
+		if ( ! preg_match( '/^([+-]?\d*\.?\d+)(px|rem|em)$/', trim( $length ), $matches ) ) {
 			return null;
 		}
 

--- a/src/blocks/single-icon/preview-icon.js
+++ b/src/blocks/single-icon/preview-icon.js
@@ -1,6 +1,8 @@
 import { getPreviewSize, KadenceColorOutput, getSpacingOptionOutput } from '@kadence/helpers';
 import { useRef } from '@wordpress/element';
 import { IconRender, Tooltip } from '@kadence/components';
+import { isTokenAlias } from '../../extension/design-tokens/alias';
+import { tokenPx } from '../../extension/design-tokens/token-px';
 export function PreviewIcon({ attributes, previewDevice }) {
 	const ref = useRef();
 	const {
@@ -50,6 +52,13 @@ export function PreviewIcon({ attributes, previewDevice }) {
 		undefined !== tabletSize || tabletSize === 0 ? tabletSize : undefined,
 		undefined !== mobileSize || mobileSize === 0 ? mobileSize : undefined
 	);
+	// The size attribute may hold a design-token alias, which `IconRender` would write verbatim into the
+	// SVG's `width`/`height` presentation attributes — geometry attributes take a number, not a `var()`.
+	// The front end has no such problem: it renders the same attribute as a `font-size` declaration and
+	// resolves the alias there. So resolve to px here, on the same 16px root assumption PHP uses. A plain
+	// number passes through untouched, and an alias that cannot be resolved falls through to `GenIcon`'s
+	// own default rather than a broken attribute.
+	const previewSizePx = isTokenAlias(previewSize) ? (tokenPx(previewSize) ?? undefined) : previewSize;
 	const previewMarginTop = getPreviewSize(
 		previewDevice,
 		margin && undefined !== margin[0] ? margin[0] : undefined,
@@ -114,7 +123,7 @@ export function PreviewIcon({ attributes, previewDevice }) {
 						<IconRender
 							className={`kt-svg-icon kt-svg-icon-${icon}`}
 							name={icon}
-							size={previewSize}
+							size={previewSizePx}
 							strokeWidth={'fe' === icon.substring(0, 2) ? width : undefined}
 							title={title ? title : ''}
 							style={{

--- a/src/blocks/single-icon/preview-icon.js
+++ b/src/blocks/single-icon/preview-icon.js
@@ -1,8 +1,28 @@
 import { getPreviewSize, KadenceColorOutput, getSpacingOptionOutput } from '@kadence/helpers';
 import { useRef } from '@wordpress/element';
 import { IconRender, Tooltip } from '@kadence/components';
-import { isTokenAlias } from '../../extension/design-tokens/alias';
 import { tokenPx } from '../../extension/design-tokens/token-px';
+import { boundTokenAliasForControl } from '../../extension/token-picker';
+import metadata from './block.json';
+
+/**
+ * Whether a size attribute holds a usable raw number.
+ *
+ * The attribute accepts a number or a token alias, and the token picker's Reset writes an empty
+ * string, so "has a value" cannot be a truthiness check: `0` is a real size, while `''` and an alias
+ * the library no longer defines are not numbers at all and would reach the SVG as a broken
+ * `width` attribute.
+ *
+ * @param {*} value The stored size.
+ *
+ * @since TBD
+ *
+ * @return {boolean} Whether the value is a finite number this can render with.
+ */
+function hasIconSize(value) {
+	return value !== '' && value !== null && value !== undefined && Number.isFinite(Number(value));
+}
+
 export function PreviewIcon({ attributes, previewDevice }) {
 	const ref = useRef();
 	const {
@@ -52,13 +72,21 @@ export function PreviewIcon({ attributes, previewDevice }) {
 		undefined !== tabletSize || tabletSize === 0 ? tabletSize : undefined,
 		undefined !== mobileSize || mobileSize === 0 ? mobileSize : undefined
 	);
-	// The size attribute may hold a design-token alias, which `IconRender` would write verbatim into the
-	// SVG's `width`/`height` presentation attributes — geometry attributes take a number, not a `var()`.
-	// The front end has no such problem: it renders the same attribute as a `font-size` declaration and
-	// resolves the alias there. So resolve to px here, on the same 16px root assumption PHP uses. A plain
-	// number passes through untouched, and an alias that cannot be resolved falls through to `GenIcon`'s
-	// own default rather than a broken attribute.
-	const previewSizePx = isTokenAlias(previewSize) ? (tokenPx(previewSize) ?? undefined) : previewSize;
+	// `IconRender` writes the size into the SVG's `width`/`height` presentation attributes, and a geometry
+	// attribute takes a number — not a `var()`, and not an empty string, which produces `width=""` and an
+	// icon with no rendered size at all. The front end has neither problem: it renders the same attribute
+	// as a `font-size` declaration, resolving an alias to the token's var() and a cleared size to the
+	// icon-size token's fallback rule. Both of those become a number here instead, on the same 16px root
+	// assumption PHP uses, so the two render paths agree.
+	//
+	// A cleared size therefore falls back to the very token the block-default CSS names for it, read from
+	// the binding rather than restated. Anything still unresolved after that is left `undefined` so
+	// `GenIcon` applies its own default, which is the one shape that renders rather than breaking.
+	const previewSizePx =
+		tokenPx(previewSize) ??
+		(hasIconSize(previewSize)
+			? previewSize
+			: (tokenPx(boundTokenAliasForControl(metadata.name, 'size')) ?? undefined));
 	const previewMarginTop = getPreviewSize(
 		previewDevice,
 		margin && undefined !== margin[0] ? margin[0] : undefined,

--- a/src/blocks/single-icon/preview-icon.js
+++ b/src/blocks/single-icon/preview-icon.js
@@ -3,24 +3,33 @@ import { useRef } from '@wordpress/element';
 import { IconRender, Tooltip } from '@kadence/components';
 import { tokenPx } from '../../extension/design-tokens/token-px';
 import { boundTokenAliasForControl } from '../../extension/token-picker';
+import { parseCssLength } from '../../token-controls';
 import metadata from './block.json';
 
 /**
- * Whether a size attribute holds a usable raw number.
+ * The raw pixel number a size attribute holds, or null when it holds no usable number.
  *
- * The attribute accepts a number or a token alias, and the token picker's Reset writes an empty
- * string, so "has a value" cannot be a truthiness check: `0` is a real size, while `''` and an alias
- * the library no longer defines are not numbers at all and would reach the SVG as a broken
- * `width` attribute.
+ * The attribute takes a number or a token alias, and the token picker's Reset writes an empty string,
+ * so "has a value" is neither a truthiness check nor a `Number()` coercion: `0` is a real size, while
+ * `''`, an alias the library no longer defines, and the odd non-number that reaches an attribute
+ * (`true`, `[]`, a whitespace string) all coerce to something finite and would land in the SVG's
+ * `width` attribute as garbage.
+ *
+ * `parseCssLength()` draws that line already, so this reuses it rather than inventing a second
+ * grammar — the same reason the pixel conversion is pinned to one shared fixture. A parsed value with
+ * a unit is not this attribute's shape (it stores a bare number, always px), so it is declined and
+ * left to the token fallback.
  *
  * @param {*} value The stored size.
  *
  * @since TBD
  *
- * @return {boolean} Whether the value is a finite number this can render with.
+ * @return {?number} The unitless number, or null when there is none.
  */
-function hasIconSize(value) {
-	return value !== '' && value !== null && value !== undefined && Number.isFinite(Number(value));
+function iconSizeNumber(value) {
+	const parsed = parseCssLength(value);
+
+	return parsed && parsed.unit === '' ? parsed.size : null;
 }
 
 export function PreviewIcon({ attributes, previewDevice }) {
@@ -84,9 +93,9 @@ export function PreviewIcon({ attributes, previewDevice }) {
 	// `GenIcon` applies its own default, which is the one shape that renders rather than breaking.
 	const previewSizePx =
 		tokenPx(previewSize) ??
-		(hasIconSize(previewSize)
-			? previewSize
-			: (tokenPx(boundTokenAliasForControl(metadata.name, 'size')) ?? undefined));
+		iconSizeNumber(previewSize) ??
+		tokenPx(boundTokenAliasForControl(metadata.name, 'size')) ??
+		undefined;
 	const previewMarginTop = getPreviewSize(
 		previewDevice,
 		margin && undefined !== margin[0] ? margin[0] : undefined,

--- a/src/extension/design-tokens/__tests__/fixtures/length-to-px-conformance.json
+++ b/src/extension/design-tokens/__tests__/fixtures/length-to-px-conformance.json
@@ -1,0 +1,13 @@
+{
+	"_comment": "One source of truth for the resolved-CSS-length -> raw pixel number conversion, shared so the JS and PHP implementations can assert against the same pairs and cannot drift. The JS side asserts tokenPx(length) === px; the PHP side (the Converts_Number_To_Px trait's to_px()) must produce the same number for each. Both assume a 16px root font size for rem/em -- the same assumption an unstyled rem makes in a browser -- and both must return null for every 'unconvertible' entry. Note what is deliberately unconvertible: a UNITLESS value (including a bare '0', which CSS accepts as a length) converts in neither language, because neither has a unit to convert from. Inputs are canonical and carry no surrounding whitespace.",
+	"lengths": [
+		{ "length": "24px", "px": 24 },
+		{ "length": "9999px", "px": 9999 },
+		{ "length": "1rem", "px": 16 },
+		{ "length": "1.5rem", "px": 24 },
+		{ "length": "2.25rem", "px": 36 },
+		{ "length": "0.5em", "px": 8 },
+		{ "length": "-1rem", "px": -16 }
+	],
+	"unconvertible": ["0", "50", "50%", "2vw", "auto", "inherit", "clamp(1rem, 2vw, 3rem)", "1rem 2rem", ""]
+}

--- a/src/extension/design-tokens/__tests__/fixtures/length-to-px-conformance.json
+++ b/src/extension/design-tokens/__tests__/fixtures/length-to-px-conformance.json
@@ -7,7 +7,23 @@
 		{ "length": "1.5rem", "px": 24 },
 		{ "length": "2.25rem", "px": 36 },
 		{ "length": "0.5em", "px": 8 },
-		{ "length": "-1rem", "px": -16 }
+		{ "length": "-1rem", "px": -16 },
+		{ "length": "+2px", "px": 2 },
+		{ "length": ".5px", "px": 0.5 }
 	],
-	"unconvertible": ["0", "50", "50%", "2vw", "auto", "inherit", "clamp(1rem, 2vw, 3rem)", "1rem 2rem", ""]
+	"unconvertible": [
+		"0",
+		"50",
+		"50%",
+		"2vw",
+		"auto",
+		"inherit",
+		"clamp(1rem, 2vw, 3rem)",
+		"1rem 2rem",
+		"",
+		"1..2px",
+		"..px",
+		"1.2.3rem",
+		"1.rem"
+	]
 }

--- a/src/extension/design-tokens/__tests__/token-px.test.js
+++ b/src/extension/design-tokens/__tests__/token-px.test.js
@@ -1,0 +1,114 @@
+/* eslint-env jest */
+/**
+ * Alias-to-pixel resolution for the editor render paths that cannot consume a CSS variable, and its
+ * parity with the PHP `Converts_Number_To_Px` trait.
+ *
+ * `kadence/single-icon`'s `size` is written into the SVG's `width`/`height` presentation attributes,
+ * which take a number rather than a `var()`. The front end renders the same attribute as a
+ * `font-size` declaration and resolves the alias in PHP. If the two conversions disagreed, an icon
+ * bound to a token would render one size in the editor and another on the front end — so the numeric
+ * half of this module is pinned to the same JSON fixture a PHP test asserts against.
+ *
+ * The alias-resolution half (reading the localized pool) has no PHP counterpart to match: it is this
+ * module reproducing, in the editor, what the resolver already did on the server.
+ */
+
+// `../token-px` pulls in `../../preset-picker` for `activeLibrary()`, which imports
+// `@kadence/components` (an untransformed ESM module) for its `KadenceRadioButtons` component. This
+// module never renders it, so stub it out.
+jest.mock('@kadence/components', () => ({}));
+
+import { tokenPx } from '../token-px';
+import conformance from './fixtures/length-to-px-conformance.json';
+
+/**
+ * The pickable pool the editor localizer prints, trimmed to the icon-size family plus one token whose
+ * value is a bare `0` — the unitless case both languages decline.
+ */
+const POOL = {
+	tokens: [],
+	values: {
+		default: {
+			'primitive.dimension.icon-size.sm': '1rem',
+			'primitive.dimension.icon-size.md': '1.5rem',
+			'primitive.dimension.icon-size.lg': '2.25rem',
+			'semantic.icon-size.default': '1.5rem',
+			'primitive.dimension.radius.none': '0',
+		},
+		brand: { 'primitive.dimension.icon-size.lg': '48px' },
+	},
+};
+
+beforeEach(() => {
+	window.kadenceDesignTokensPickable = POOL;
+	window.kadenceDesignTokensPresets = { active: 'default', libraries: {} };
+});
+
+afterEach(() => {
+	delete window.kadenceDesignTokensPickable;
+	delete window.kadenceDesignTokensPresets;
+});
+
+describe('tokenPx literal conversion', () => {
+	it.each(conformance.lengths.map(({ length, px }) => [length, px]))('converts %s to %p', (length, px) => {
+		expect(tokenPx(length)).toBe(px);
+	});
+
+	it.each(conformance.unconvertible)('declines the unconvertible %p', (value) => {
+		expect(tokenPx(value)).toBeNull();
+	});
+
+	it.each([null, undefined, true, false, ['1rem'], { size: 1 }])('declines the non-length %p', (value) => {
+		expect(tokenPx(value)).toBeNull();
+	});
+
+	/**
+	 * `parseCssLength` accepts a finite number directly, but a bare number has no unit to convert from,
+	 * so it is declined exactly as the unitless string `'50'` is — and exactly as PHP declines it. The
+	 * caller keeps its own raw pixel value in that case.
+	 */
+	it('declines a bare number, which carries no unit', () => {
+		expect(tokenPx(50)).toBeNull();
+	});
+});
+
+describe('tokenPx alias resolution', () => {
+	it('resolves an alias through the active library, then converts', () => {
+		expect(tokenPx('{primitive.dimension.icon-size.lg}')).toBe(36);
+		expect(tokenPx('{primitive.dimension.icon-size.sm}')).toBe(16);
+		expect(tokenPx('{semantic.icon-size.default}')).toBe(24);
+	});
+
+	it('reads the requested library rather than the active one', () => {
+		expect(tokenPx('{primitive.dimension.icon-size.lg}', 'brand')).toBe(48);
+	});
+
+	it('follows the active library when the catalog names a different one', () => {
+		window.kadenceDesignTokensPresets = { active: 'brand', libraries: {} };
+
+		expect(tokenPx('{primitive.dimension.icon-size.lg}')).toBe(48);
+	});
+
+	/**
+	 * An alias the library does not define resolves to nothing convertible, so the caller falls back to
+	 * its own default instead of writing a `var()` — or a raw alias string — into an SVG attribute.
+	 */
+	it('declines an alias the library does not define', () => {
+		expect(tokenPx('{primitive.dimension.icon-size.xl}')).toBeNull();
+	});
+
+	/**
+	 * A token whose resolved value is a unitless `0` is declined, matching the PHP trait. Pinning the
+	 * gap rather than papering over it on one side is what keeps the two conversions identical.
+	 */
+	it('declines an alias resolving to a unitless value', () => {
+		expect(tokenPx('{primitive.dimension.radius.none}')).toBeNull();
+	});
+
+	it('fails soft when the pool is missing', () => {
+		delete window.kadenceDesignTokensPickable;
+
+		expect(() => tokenPx('{primitive.dimension.icon-size.lg}')).not.toThrow();
+		expect(tokenPx('{primitive.dimension.icon-size.lg}')).toBeNull();
+	});
+});

--- a/src/extension/design-tokens/__tests__/token-px.test.js
+++ b/src/extension/design-tokens/__tests__/token-px.test.js
@@ -63,6 +63,15 @@ describe('tokenPx literal conversion', () => {
 	});
 
 	/**
+	 * The number grammar rejects a malformed decimal rather than salvaging a prefix of it. PHP's converter
+	 * matches this exactly; a looser `[0-9.]+` there would turn `1.2.3rem` into 19.2px on the front end
+	 * while the editor fell back to its default, which is the drift the shared fixture exists to catch.
+	 */
+	it.each(['1..2px', '..px', '1.2.3rem', '1.rem', '1.px'])('declines the malformed decimal %p', (value) => {
+		expect(tokenPx(value)).toBeNull();
+	});
+
+	/**
 	 * `parseCssLength` accepts a finite number directly, but a bare number has no unit to convert from,
 	 * so it is declined exactly as the unitless string `'50'` is — and exactly as PHP declines it. The
 	 * caller keeps its own raw pixel value in that case.

--- a/src/extension/design-tokens/token-px.js
+++ b/src/extension/design-tokens/token-px.js
@@ -1,0 +1,65 @@
+/**
+ * Resolve a design-token alias to a raw pixel number, for the editor render paths that cannot consume
+ * a CSS variable.
+ *
+ * Most bound attributes reach output as a CSS declaration, where `var(--kb-token--<id>)` is the whole
+ * answer. A few do not: `kadence/single-icon`'s `size` is written straight into the SVG's `width` and
+ * `height` presentation attributes by `GenIcon`, and an SVG geometry attribute takes a number, not a
+ * `var()`. Those call sites need the token's value as a number before they render.
+ *
+ * This is the JS mirror of the PHP `Converts_Number_To_Px` trait, deliberately kept exact — including
+ * where it declines. Both accept only `px`, `rem`, and `em`; both assume a 16px root font size, the
+ * same assumption an unstyled `rem` makes in a browser (nothing in this module tracks a site's actual
+ * root font size); and both decline a UNITLESS value, `%`, and any function or keyword. A token whose
+ * value is a bare `0` therefore converts in neither language. Matching the PHP behavior exactly,
+ * gaps included, is the point: the two are pinned to one shared conformance fixture, so a change to
+ * either has to be a deliberate change to both.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { parseCssLength } from '../../token-controls/helpers/parse-css-length';
+import { activeLibrary } from '../preset-picker';
+import { tokenLiteral } from './token-literals';
+
+/**
+ * Pixel-convertible units and their multiplier against the assumed 16px root.
+ *
+ * @since TBD
+ *
+ * @type {Object<string, number>}
+ */
+const PX_PER_UNIT = {
+	px: 1,
+	rem: 16,
+	em: 16,
+};
+
+/**
+ * The pixel number a value resolves to.
+ *
+ * An alias resolves through the library's token map first, so `{primitive.dimension.icon-size.lg}`
+ * becomes `2.25rem` becomes `36`. A literal length converts directly. Anything this cannot safely
+ * convert — a unitless number, a percentage, a `calc()`/`clamp()`, a keyword, or an alias the library
+ * does not define — returns `null`, so the caller falls back to its own default rather than rendering
+ * a guess.
+ *
+ * @param {*}      value     The value to resolve: a `{dot.alias}` or a CSS length literal.
+ * @param {string} [library] The token library slug; defaults to the active library.
+ *
+ * @since TBD
+ *
+ * @return {?number} The pixel value, or `null` when the value cannot be converted.
+ */
+export function tokenPx(value, library) {
+	// `tokenLiteral()` takes an explicit library, so the active-library default is resolved here rather
+	// than left to a caller that has no reason to know which library is selected.
+	const parsed = parseCssLength(tokenLiteral(value, library || activeLibrary()));
+
+	if (!parsed || !Object.prototype.hasOwnProperty.call(PX_PER_UNIT, parsed.unit)) {
+		return null;
+	}
+
+	return parsed.size * PX_PER_UNIT[parsed.unit];
+}

--- a/src/extension/token-picker/__tests__/index.test.js
+++ b/src/extension/token-picker/__tests__/index.test.js
@@ -4,7 +4,13 @@
 // ESM module) for its `PresetPicker` component. This module never renders it, so stub it out.
 jest.mock('@kadence/components', () => ({}));
 
-import { pickableTokenPool, pickableTokensFor, pickableTokensForControl, pickableTokensForKey } from '../index';
+import {
+	boundTokenAliasForControl,
+	pickableTokenPool,
+	pickableTokensFor,
+	pickableTokensForControl,
+	pickableTokensForKey,
+} from '../index';
 
 /**
  * The fixture pickable-token pool: layers are interleaved on purpose to prove the semantic-first
@@ -422,5 +428,37 @@ describe('pickableTokensForKey', () => {
 
 	it('returns an empty array for an unknown block', () => {
 		expect(pickableTokensForKey('kadence/does-not-exist', 'button-shadow')).toEqual([]);
+	});
+});
+
+describe('boundTokenAliasForControl', () => {
+	beforeEach(() => {
+		window.kadenceDesignTokensPickable = POOL;
+		window.kadenceDesignTokensPresets = PRESETS;
+	});
+
+	afterEach(() => {
+		delete window.kadenceDesignTokensPickable;
+		delete window.kadenceDesignTokensPresets;
+	});
+
+	it('returns the bound token as an alias, ready to resolve', () => {
+		expect(boundTokenAliasForControl('kadence/single-icon', 'size')).toBe('{semantic.icon-size.default}');
+	});
+
+	it('returns empty for a control that binds no token', () => {
+		expect(boundTokenAliasForControl('kadence/singlebtn', 'borderRadius')).toBe('');
+	});
+
+	it('returns empty for an unmapped attribute or an unknown block', () => {
+		expect(boundTokenAliasForControl('kadence/singlebtn', 'padding')).toBe('');
+		expect(boundTokenAliasForControl('kadence/does-not-exist', 'size')).toBe('');
+	});
+
+	it('fails soft when the catalog is missing', () => {
+		delete window.kadenceDesignTokensPresets;
+
+		expect(() => boundTokenAliasForControl('kadence/single-icon', 'size')).not.toThrow();
+		expect(boundTokenAliasForControl('kadence/single-icon', 'size')).toBe('');
 	});
 });

--- a/src/extension/token-picker/index.js
+++ b/src/extension/token-picker/index.js
@@ -98,6 +98,30 @@ export function pickableTokensFor(kind, library) {
 }
 
 /**
+ * The alias of the token one block control BINDS, as declared in the preset bindings — the design
+ * system's answer for that control when the block stores nothing of its own.
+ *
+ * A control whose attribute renders as a CSS declaration gets that fallback for free, as the
+ * `var()` the block-default-CSS projector emits. A control whose attribute renders as something a
+ * `var()` cannot reach (a raw SVG geometry attribute, say) has to resolve the same token itself, and
+ * this is where it reads which token that is rather than restating the id the declaration already
+ * owns.
+ *
+ * @param {string} blockName   The block name (e.g. 'kadence/single-icon').
+ * @param {string} controlAttr The attribute the control writes (e.g. 'size').
+ * @param {string} [library]   The token library slug; defaults to the active library.
+ *
+ * @since TBD
+ *
+ * @return {string} The `{dot.alias}` of the bound token, or '' when the control binds none.
+ */
+export function boundTokenAliasForControl(blockName, controlAttr, library) {
+	const property = blockProperties(blockName, library).find((entry) => entry.control_attr === controlAttr);
+
+	return property && property.token ? `{${property.token}}` : '';
+}
+
+/**
  * The role sub-kind of a token id, read from the pool the catalog already tagged (never parsed here) —
  * the discriminator that narrows one $type to the control's sub-kind (a radius control's `dimension`
  * to only radius tokens). Empty when the id is absent from the pool or carries no role.

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Traits/Converts_Number_To_PxConformanceTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Traits/Converts_Number_To_PxConformanceTest.php
@@ -1,0 +1,113 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Projection\Traits;
+
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Converts_Number_To_Px;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Proves the PHP length->pixel conversion stays identical to the JS one by asserting against the SAME
+ * fixture the jest suite reads (never a forked copy). The two exist because `kadence/single-icon`'s
+ * `size` reaches output twice: as a `font-size` declaration on the front end, resolved in PHP, and as
+ * the SVG's `width`/`height` presentation attribute in the editor, resolved in JS. A drift in
+ * `Converts_Number_To_Px::to_px()` here, or in `tokenPx()` on the JS side, would render an icon at one
+ * size in the editor and another on the front end, and fails whichever suite still expects the old
+ * number.
+ *
+ * @since TBD
+ */
+final class Converts_Number_To_PxConformanceTest extends TestCase {
+
+	/**
+	 * Every convertible length in the shared conformance fixture converts to the exact pixel number the
+	 * jest suite also asserts for that entry, on the shared 16px root-font-size assumption.
+	 *
+	 * @dataProvider lengthProvider
+	 *
+	 * @param string $length The resolved CSS length, e.g. "1.5rem".
+	 * @param float  $px     The expected pixel value.
+	 *
+	 * @return void
+	 */
+	public function testLengthsConvertToTheExpectedPixelValue( string $length, float $px ): void {
+		$this->assertSame( $px, $this->converter()->to_px( $length ) );
+	}
+
+	/**
+	 * Every unconvertible entry in the shared conformance fixture is declined, so a caller falls back to
+	 * its own default rather than rendering a guessed number. Note this includes a UNITLESS value: a
+	 * bare "0" is a valid CSS length but carries no unit to convert from, and neither language accepts
+	 * it.
+	 *
+	 * @dataProvider unconvertibleProvider
+	 *
+	 * @param string $value A value the fixture asserts cannot be safely converted.
+	 *
+	 * @return void
+	 */
+	public function testUnconvertibleValuesAreDeclined( string $value ): void {
+		$this->assertNull( $this->converter()->to_px( $value ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function lengthProvider(): Generator {
+		foreach ( $this->load_fixture()['lengths'] as $entry ) {
+			yield $entry['length'] => [
+				'length' => $entry['length'],
+				'px'     => (float) $entry['px'],
+			];
+		}
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function unconvertibleProvider(): Generator {
+		foreach ( $this->load_fixture()['unconvertible'] as $index => $value ) {
+			yield sprintf( 'unconvertible[%d]: %s', $index, wp_json_encode( $value ) ) => [
+				'value' => $value,
+			];
+		}
+	}
+
+	/**
+	 * A throwaway consumer of the trait that exposes `to_px()` publicly. The trait's method is private,
+	 * which is correct for its real consumers (the adapter and the editor-default catalog both call it
+	 * on themselves) but leaves it unreachable from a test without a host class.
+	 *
+	 * @return object An object exposing a public to_px( string $length ): ?float.
+	 */
+	private function converter(): object {
+		return new class() {
+			// Visibility aliasing rather than a wrapper method: a public `to_px()` declared on the class
+			// would OVERRIDE the trait's rather than expose it, and would then be testing the wrapper.
+			use Converts_Number_To_Px {
+				to_px as public;
+			}
+		};
+	}
+
+	/**
+	 * The shared length/pixel conformance fixture, decoded. The SAME file the jest suite reads, so
+	 * neither language can drift without both suites' data changing together.
+	 *
+	 * @return array{lengths: array<int, array{length: string, px: int|float}>, unconvertible: array<int, string>}
+	 */
+	private function load_fixture(): array {
+		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+		return (array) json_decode( (string) file_get_contents( $this->fixture_path() ), true );
+	}
+
+	/**
+	 * Absolute path to the shared conformance fixture, derived from the plugin root so it resolves the
+	 * same way regardless of which working directory slic runs the suite from.
+	 *
+	 * @return string
+	 */
+	private function fixture_path(): string {
+		return KADENCE_BLOCKS_PATH . 'src/extension/design-tokens/__tests__/fixtures/length-to-px-conformance.json';
+	}
+}


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4195/single-icon-allow-icon-size-to-reference-a-design-token

:video_camera: https://www.loom.com/share/d65fc3fd9a604e74b5584e9148c264fd

3 of 4 in the SOFT-4195 stack. No UI here.

`kadence/single-icon`'s `size` reaches output twice: as a `font-size` declaration on the front end, and as the SVG's `width`/`height` presentation attributes in the editor. An SVG geometry attribute takes a number, not a `var()`, so an alias reaching `size` — through REST, copy/paste attributes, or a synced pattern — would be written verbatim into the markup and render nothing.

Adds `tokenPx()`, which resolves an alias through the localized token pool and converts the resulting length to a raw pixel number, and uses it in the icon's editor preview. A plain number passes through untouched; an alias the library does not define falls through to `GenIcon`'s own default rather than a broken attribute.

It is the JS mirror of the PHP `Converts_Number_To_Px` trait, deliberately exact — including where it declines. Both accept only `px`/`rem`/`em`, both assume a 16px root, and both decline a unitless value (a bare `0` included). The two are pinned to one shared conformance fixture that a new wpunit test reads as well, so a change to either conversion has to be a deliberate change to both.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving design-token aliases and CSS length values (`px`, `rem`, and `em`) to pixel sizes.
  * Icon previews now use the correct pixel size, including fallback handling for missing, cleared, or invalid size values.

* **Bug Fixes**
  * Improved icon preview behavior when configured sizes cannot be converted or token references are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->