### PR TITLE
SOFT-4195 [4/4]: mount the token picker on Icon Size

### DIFF
--- a/src/blocks/single-icon/edit.js
+++ b/src/blocks/single-icon/edit.js
@@ -20,8 +20,10 @@ import {
 import { KadenceColorOutput, uniqueIdHelper, getInQueryBlock, getPreviewSize } from '@kadence/helpers';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { EditorScalarControl } from '../../extension/design-tokens/components/EditorScalarControl';
+import { tokenLiteral } from '../../extension/design-tokens/token-literals';
+import { activeLibrary } from '../../extension/preset-picker';
 import { measureAttrsForDevice } from '../../extension/token-indicators/normalize';
-import { pickableTokensForControl } from '../../extension/token-picker';
+import { boundTokenAliasForControl, pickableTokensForControl } from '../../extension/token-picker';
 import { PreviewIcon } from './preview-icon';
 import { AdvancedSettings } from './advanced-settings';
 import { tooltip as tooltipIcon } from '@kadence/icons';
@@ -105,6 +107,19 @@ function KadenceSingleIcon(props) {
 	// Empty when the token registry is inactive, which is what keeps the plain range control below as the
 	// fallback rather than leaving the block with no size control at all.
 	const iconSizeTokens = pickableTokensForControl(name, 'size') || [];
+	// What the active device falls back to when it stores nothing: the breakpoints ABOVE it, in cascade
+	// order, and then the icon-size token the binding names. The device's own value is deliberately left
+	// out — this is what the field reports when it is unset, so including it would just echo the value
+	// already on screen. Tablet and Mobile inherit; Desktop has nothing above it and lands on the token,
+	// which is the value the front end's block-default rule resolves for a cleared size.
+	const inheritedSizeChain = {
+		Tablet: [size],
+		Mobile: [tabletSize, size],
+	};
+	const inheritedSize = (inheritedSizeChain[previewDevice] || []).find(
+		(value) => value !== undefined && value !== null && value !== ''
+	);
+	const iconSizeDefault = inheritedSize ?? tokenLiteral(boundTokenAliasForControl(name, 'size'), activeLibrary());
 
 	useEffect(() => {
 		setAttributes({ inQueryBlock: getInQueryBlock(context, inQueryBlock) });
@@ -230,6 +245,11 @@ function KadenceSingleIcon(props) {
 									previewDevice={previewDevice}
 									onDeviceChange={(device) => setPreviewDeviceType(device)}
 									tokens={iconSizeTokens}
+									// So an unset field names the size actually in effect — "Inherited (50px)" on a
+									// breakpoint taking Desktop's value, "Default (MD)" once the cascade reaches the
+									// token — instead of reading blank after a Reset.
+									defaultValue={iconSizeDefault}
+									inherited={inheritedSize !== undefined}
 									// The size attributes store a bare number and the block declares no unit
 									// attribute of its own, so the front end always renders them as px. Pinning the
 									// Custom tab to px keeps a hand-typed value in the one unit the attribute can

--- a/src/blocks/single-icon/edit.js
+++ b/src/blocks/single-icon/edit.js
@@ -19,6 +19,9 @@ import {
 } from '@kadence/components';
 import { KadenceColorOutput, uniqueIdHelper, getInQueryBlock, getPreviewSize } from '@kadence/helpers';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { EditorScalarControl } from '../../extension/design-tokens/components/EditorScalarControl';
+import { measureAttrsForDevice } from '../../extension/token-indicators/normalize';
+import { pickableTokensForControl } from '../../extension/token-picker';
 import { PreviewIcon } from './preview-icon';
 import { AdvancedSettings } from './advanced-settings';
 import { tooltip as tooltipIcon } from '@kadence/icons';
@@ -88,6 +91,20 @@ function KadenceSingleIcon(props) {
 		undefined !== tabletSize ? tabletSize : undefined,
 		undefined !== mobileSize ? mobileSize : undefined
 	);
+
+	const { setPreviewDeviceType } = useDispatch('kadenceblocks/data');
+	// The Icon Size control writes three sibling attributes but edits one at a time, so it resolves the
+	// active device's attribute up front — reading or writing `size` while the editor is on Tablet would
+	// hit the wrong breakpoint.
+	const sizeForDevice = measureAttrsForDevice(
+		attributes,
+		'size',
+		{ tablet: 'tabletSize', mobile: 'mobileSize' },
+		previewDevice
+	);
+	// Empty when the token registry is inactive, which is what keeps the plain range control below as the
+	// fallback rather than leaving the block with no size control at all.
+	const iconSizeTokens = pickableTokensForControl(name, 'size') || [];
 
 	useEffect(() => {
 		setAttributes({ inQueryBlock: getInQueryBlock(context, inQueryBlock) });
@@ -203,25 +220,48 @@ function KadenceSingleIcon(props) {
 								}}
 							/>
 
-							<ResponsiveRangeControls
-								label={__('Icon Size', 'kadence-blocks')}
-								value={previewSize}
-								onChange={(value) => {
-									setAttributes({ size: value });
-								}}
-								tabletValue={undefined !== tabletSize ? tabletSize : ''}
-								onChangeTablet={(value) => {
-									setAttributes({ tabletSize: value });
-								}}
-								mobileValue={undefined !== mobileSize ? mobileSize : ''}
-								onChangeMobile={(value) => {
-									setAttributes({ mobileSize: value });
-								}}
-								min={0}
-								max={300}
-								step={1}
-								unit={'px'}
-							/>
+							{iconSizeTokens.length ? (
+								<EditorScalarControl
+									label={__('Icon Size', 'kadence-blocks')}
+									value={sizeForDevice.value}
+									onChange={(value) => {
+										setAttributes({ [sizeForDevice.attr]: value });
+									}}
+									previewDevice={previewDevice}
+									onDeviceChange={(device) => setPreviewDeviceType(device)}
+									tokens={iconSizeTokens}
+									// The size attributes store a bare number and the block declares no unit
+									// attribute of its own, so the front end always renders them as px. Pinning the
+									// Custom tab to px keeps a hand-typed value in the one unit the attribute can
+									// actually mean; an em/rem-valued TOKEN is unaffected, since its unit travels
+									// inside the token and reaches output as the var() reference.
+									unit={'px'}
+									units={['px']}
+									min={0}
+									max={300}
+									step={1}
+								/>
+							) : (
+								<ResponsiveRangeControls
+									label={__('Icon Size', 'kadence-blocks')}
+									value={previewSize}
+									onChange={(value) => {
+										setAttributes({ size: value });
+									}}
+									tabletValue={undefined !== tabletSize ? tabletSize : ''}
+									onChangeTablet={(value) => {
+										setAttributes({ tabletSize: value });
+									}}
+									mobileValue={undefined !== mobileSize ? mobileSize : ''}
+									onChangeMobile={(value) => {
+										setAttributes({ mobileSize: value });
+									}}
+									min={0}
+									max={300}
+									step={1}
+									unit={'px'}
+								/>
+							)}
 							{icon && 'fe' === icon.substring(0, 2) && (
 								<RangeControl
 									label={__('Line Width', 'kadence-blocks')}

--- a/src/extension/design-tokens/components/EditorScalarControl.js
+++ b/src/extension/design-tokens/components/EditorScalarControl.js
@@ -1,14 +1,15 @@
 /**
- * The block editor's adapter for `src/token-controls`' `BoxControl`.
+ * The block editor's adapter for `src/token-controls`' `ScalarControl`.
  *
- * The Style Library's adapter bridges a different storage shape; this one bridges the editor's:
+ * The scalar sibling of `EditorBoxControl`, bridging the same editor storage shape for a property
+ * that holds ONE value rather than four:
  *
- * - **breakpoints are sibling attributes**, not one nested envelope — `borderRadius`,
- *   `tabletBorderRadius`, `mobileBorderRadius` — and which one is being edited is the editor's own
- *   device preview, owned by its store rather than by the control;
- * - **a slot is always a four-element array**, never collapsed to a scalar, so the link state cannot
- *   be read off the value's shape and is caller-owned UI state instead;
- * - **the unit lives in its own attribute** beside the value.
+ * - **breakpoints are sibling attributes**, not one nested envelope — `size`, `tabletSize`,
+ *   `mobileSize` — and which one is being edited is the editor's own device preview, owned by its
+ *   store rather than by the control;
+ * - **there is nothing to link**, so no link state crosses this boundary at all;
+ * - **the unit, where a block has one, lives in its own attribute** beside the value. A block whose
+ *   attribute stores a bare number in one fixed unit pins it with a single-entry `units` list.
  *
  * Everything the control needs beyond that — the token pool, the inherited preset default, the
  * binding indicator — the block already computes for its existing control, so this takes them as
@@ -18,39 +19,36 @@
 /**
  * Internal dependencies
  */
-import { BoxControl, BreakpointProvider } from '../../../token-controls';
+import { BreakpointProvider, ScalarControl } from '../../../token-controls';
 import { TokenIndicator } from '../../token-indicators/components/TokenIndicator';
 import { BREAKPOINT_FOR_DEVICE, deviceForBreakpoint } from './breakpoints';
 
 /**
- * Render a box-shaped token control over the editor's per-device attributes.
+ * Render a scalar token control over the editor's per-device attributes.
  *
  * @param {Object}    props                The component props.
  * @param {string}    props.label          The control's label.
- * @param {Array}     props.value          The active device's four-slot value.
- * @param {Function}  props.onChange       Called with the next four-slot value for the active device.
+ * @param {*}         props.value          The active device's value.
+ * @param {Function}  props.onChange       Called with the next value for the active device.
  * @param {string}    props.previewDevice  The editor's active device (`Desktop`/`Tablet`/`Mobile`).
  * @param {Function}  props.onDeviceChange Called with the next editor device name.
  * @param {Array}     props.tokens         The pickable-token list, already resolved by the block.
- * @param {*}         [props.defaultValue] The inherited preset default for this device.
+ * @param {*}         [props.defaultValue] The inherited default for this device.
  * @param {boolean}   [props.inherited]    Whether that default comes from another breakpoint.
  * @param {?Object}   [props.state]        The block's own binding state (`{ bound, overridden }`).
  * @param {?Function} [props.onReset]      Reset handler for the indicator.
- * @param {boolean}   props.isLinked       Whether the slots are edited together.
- * @param {Function}  props.onToggleLink   Toggles the link state.
- * @param {string}    [props.unit]         The unit attribute's current value.
- * @param {Array}     [props.units]        The selectable units.
+ * @param {string}    [props.unit]         The value's unit.
+ * @param {Array}     [props.units]        The selectable units; a single-entry list pins the unit.
  * @param {Function}  [props.onUnit]       Writes the unit attribute.
  * @param {number}    [props.min]          Custom tab minimum.
  * @param {number}    [props.max]          Custom tab maximum.
  * @param {number}    [props.step]         Custom tab increment.
- * @param {string}    [props.role]         'corners' or 'sides' — the control's geometry.
  *
  * @since TBD
  *
  * @return {JSX.Element} The control.
  */
-export function EditorBoxControl({
+export function EditorScalarControl({
 	label,
 	value,
 	onChange,
@@ -61,15 +59,12 @@ export function EditorBoxControl({
 	inherited = false,
 	state = null,
 	onReset = null,
-	isLinked,
-	onToggleLink,
 	unit = '',
 	units,
 	onUnit,
 	min,
 	max,
 	step,
-	role = 'corners',
 }) {
 	const breakpoint = BREAKPOINT_FOR_DEVICE[previewDevice] ?? 'desktop';
 	// Named once and passed to both `BreakpointProvider` and `ControlShell`'s switcher below, so the
@@ -81,7 +76,7 @@ export function EditorBoxControl({
 	// preview is global here, so a switcher that tracked its own would disagree with the canvas.
 	return (
 		<BreakpointProvider value={breakpoint} onChange={changeBreakpoint}>
-			<BoxControl
+			<ScalarControl
 				label={label}
 				value={value}
 				onChange={onChange}
@@ -91,12 +86,6 @@ export function EditorBoxControl({
 				// The editor's own mark, not this library's: it is the same indicator the block's other
 				// controls show, and two marks meaning the same thing should not look different.
 				indicator={<TokenIndicator state={state} onReset={onReset} />}
-				isLinked={isLinked}
-				onToggleLink={onToggleLink}
-				// Never collapse: the attribute is always a four-element array, so folding a uniform
-				// value down to a scalar would write a shape the block cannot read back.
-				collapse={false}
-				role={role}
 				breakpoints={Object.values(BREAKPOINT_FOR_DEVICE)}
 				breakpoint={breakpoint}
 				// The switcher lives in `ControlShell`, driven by this prop directly — it does not read

--- a/src/extension/design-tokens/components/__tests__/EditorScalarControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorScalarControl.test.js
@@ -1,0 +1,158 @@
+/* eslint-env jest */
+
+/**
+ * Internal dependencies
+ */
+import { EditorScalarControl } from '../EditorScalarControl';
+
+/**
+ * Call `EditorScalarControl` as a plain function and return the `ScalarControl`/`BreakpointProvider`
+ * elements it produced. The component holds no hooks of its own, so the returned element tree can
+ * be inspected directly instead of mounting it — matching this file's sibling tests, which inspect
+ * returned element types/props rather than rendering.
+ *
+ * @param {Object} overrides Props to override on top of the defaults.
+ *
+ * @since TBD
+ *
+ * @return {{provider: Object, scalarControl: Object, onDeviceChange: Function}} The provider element,
+ *   the `ScalarControl` element nested inside it, and the `onDeviceChange` spy passed in.
+ */
+function renderEditorScalarControl(overrides = {}) {
+	const onDeviceChange = jest.fn();
+
+	const props = {
+		label: 'Icon Size',
+		value: '',
+		onChange: jest.fn(),
+		previewDevice: 'Desktop',
+		onDeviceChange,
+		tokens: [],
+		...overrides,
+	};
+
+	const provider = EditorScalarControl(props);
+
+	return { provider, scalarControl: provider.props.children, onDeviceChange };
+}
+
+describe('EditorScalarControl breakpoint switching', () => {
+	/**
+	 * The switcher rendered by `ControlShell` drives `ScalarControl`'s `onBreakpointChange` prop
+	 * directly (see `ControlShell`'s `onClick={() => onBreakpointChange?.(key)}`), not the
+	 * `BreakpointProvider` context above it. `EditorScalarControl` must wire that prop itself, or the
+	 * switcher silently no-ops.
+	 *
+	 * @return {void}
+	 */
+	it('invokes onDeviceChange with the matching device when onBreakpointChange fires', () => {
+		const { scalarControl, onDeviceChange } = renderEditorScalarControl();
+
+		scalarControl.props.onBreakpointChange('tablet');
+
+		expect(onDeviceChange).toHaveBeenCalledWith('Tablet');
+	});
+
+	/**
+	 * Every control breakpoint key maps back to its editor device name, not just one.
+	 *
+	 * @return {void}
+	 */
+	it('maps every breakpoint key back to its editor device name', () => {
+		const { scalarControl, onDeviceChange } = renderEditorScalarControl();
+
+		scalarControl.props.onBreakpointChange('mobile');
+		expect(onDeviceChange).toHaveBeenLastCalledWith('Mobile');
+
+		scalarControl.props.onBreakpointChange('desktop');
+		expect(onDeviceChange).toHaveBeenLastCalledWith('Desktop');
+
+		scalarControl.props.onBreakpointChange('tablet');
+		expect(onDeviceChange).toHaveBeenLastCalledWith('Tablet');
+	});
+
+	/**
+	 * The `BreakpointProvider`'s own `onChange` maps breakpoints back to devices the same way as the
+	 * `onBreakpointChange` prop, using the one shared mapping rather than a second copy of it.
+	 *
+	 * @return {void}
+	 */
+	it('maps the BreakpointProvider onChange consistently with onBreakpointChange', () => {
+		const { provider, onDeviceChange } = renderEditorScalarControl();
+
+		provider.props.onChange('mobile');
+
+		expect(onDeviceChange).toHaveBeenCalledWith('Mobile');
+	});
+});
+
+describe('EditorScalarControl device -> breakpoint (forward)', () => {
+	/**
+	 * The editor's `previewDevice` selects the breakpoint both the provider's value and the control
+	 * render at — the direction opposite the switcher callbacks above.
+	 *
+	 * @return {void}
+	 */
+	it.each([
+		['Desktop', 'desktop'],
+		['Tablet', 'tablet'],
+		['Mobile', 'mobile'],
+	])('renders breakpoint %s for previewDevice %s', (previewDevice, breakpoint) => {
+		const { provider, scalarControl } = renderEditorScalarControl({ previewDevice });
+
+		expect(provider.props.value).toBe(breakpoint);
+		expect(scalarControl.props.breakpoint).toBe(breakpoint);
+	});
+
+	/**
+	 * An unrecognized device (e.g. a future editor device this component does not know about yet)
+	 * degrades to desktop rather than rendering with no breakpoint at all.
+	 *
+	 * @return {void}
+	 */
+	it('falls back to desktop for an unknown preview device', () => {
+		const { provider } = renderEditorScalarControl({ previewDevice: 'Widescreen' });
+
+		expect(provider.props.value).toBe('desktop');
+	});
+});
+
+describe('EditorScalarControl shape', () => {
+	/**
+	 * A scalar property has nothing to link, so no link state may cross this boundary — passing either
+	 * prop is what makes `ControlShell` draw the toggle.
+	 *
+	 * @return {void}
+	 */
+	it('passes no link state to the control', () => {
+		const { scalarControl } = renderEditorScalarControl();
+
+		expect(scalarControl.props.isLinked).toBeUndefined();
+		expect(scalarControl.props.onToggleLink).toBeUndefined();
+	});
+
+	/**
+	 * The control is responsive: it offers all three breakpoints, which is what makes `ControlShell`
+	 * render the switcher at all.
+	 *
+	 * @return {void}
+	 */
+	it('offers every editor breakpoint to the switcher', () => {
+		const { scalarControl } = renderEditorScalarControl();
+
+		expect(scalarControl.props.breakpoints).toEqual(['desktop', 'tablet', 'mobile']);
+	});
+
+	/**
+	 * A host that pins the unit (a block whose attribute stores a bare number in one fixed unit) has its
+	 * single-entry unit list reach the control untouched.
+	 *
+	 * @return {void}
+	 */
+	it('passes a pinned unit list straight through', () => {
+		const { scalarControl } = renderEditorScalarControl({ unit: 'px', units: ['px'] });
+
+		expect(scalarControl.props.unit).toBe('px');
+		expect(scalarControl.props.units).toEqual(['px']);
+	});
+});

--- a/src/extension/design-tokens/components/breakpoints.js
+++ b/src/extension/design-tokens/components/breakpoints.js
@@ -1,0 +1,35 @@
+/**
+ * The spelling bridge between the editor's device names and the token vocabulary's breakpoint keys.
+ *
+ * The editor names its devices `Desktop`/`Tablet`/`Mobile` and keeps the active one in its own store;
+ * the shared `token-controls` library speaks the lowercase keys the token vocabulary uses. Every
+ * editor-side adapter over a responsive token control needs the same two-way mapping, so it lives
+ * here rather than being restated per control — two copies is exactly how the switcher and the
+ * provider end up disagreeing about which device is active.
+ */
+
+/**
+ * The control's breakpoint key for an editor device name.
+ *
+ * @since TBD
+ *
+ * @type {Object<string, string>}
+ */
+export const BREAKPOINT_FOR_DEVICE = {
+	Desktop: 'desktop',
+	Tablet: 'tablet',
+	Mobile: 'mobile',
+};
+
+/**
+ * The editor device name for a control breakpoint key — the inverse of `BREAKPOINT_FOR_DEVICE`.
+ *
+ * @param {string} breakpoint The control's breakpoint key (`desktop`/`tablet`/`mobile`).
+ *
+ * @since TBD
+ *
+ * @return {string} The matching editor device name, defaulting to `Desktop`.
+ */
+export function deviceForBreakpoint(breakpoint) {
+	return Object.keys(BREAKPOINT_FOR_DEVICE).find((name) => BREAKPOINT_FOR_DEVICE[name] === breakpoint) ?? 'Desktop';
+}


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4195/single-icon-allow-icon-size-to-reference-a-design-token

:video_camera: https://www.loom.com/share/d65fc3fd9a604e74b5584e9148c264fd

4 of 4 in the SOFT-4195 stack — the feature.

Swaps the Icon Size control for `ScalarControl` through a new `EditorScalarControl` adapter, so the size can be picked from the icon-size token scale (and any custom Icon Size token minted in the Style Library) instead of only typed as a pixel number.

`EditorScalarControl` is the scalar sibling of `EditorBoxControl`, bridging the same editor storage shape — breakpoints as sibling attributes, the device owned by the editor's store — for a property that holds one value rather than four. The device/breakpoint spelling bridge the two share moves into `components/breakpoints.js` rather than being restated: two copies is exactly how the switcher and the provider end up disagreeing about which device is active.

The Custom tab is pinned to px. The size attributes store a bare number and the block declares no unit attribute of its own, so px is the only unit a hand-typed value can mean; an em/rem-valued **token** is unaffected, since its unit travels inside the token and reaches output as the `var()` reference.

The plain range control stays as the fallback for when the token registry is inactive and the pickable list comes back empty, so the block is never left with no size control.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added design-token support for configuring icon sizes in the editor.
  - Icon sizes can now adapt across desktop, tablet, and mobile breakpoints.
  - Token-based size controls include inherited values, reset options, and unit configuration.
  - Existing responsive pixel-based controls remain available when design tokens are not configured.

- **Bug Fixes**
  - Improved consistency when switching preview devices and responsive breakpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->