### PR TITLE
[DTM] SOFT-4083 [34/38]: BorderControl adopts the one-row anatomy

### DIFF
--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -99,69 +99,41 @@ import {
 	splitColorOpacity,
 } from '../../extension/design-tokens/components/EditorShadowControl';
 import { pickableTokensForControl } from '../../extension/token-picker';
-import { isSlotList, readSlot, writeSlot } from '../../token-controls';
-
-const BORDER_COLOR_SIDE_LABELS = ['Top', 'Right', 'Bottom', 'Left'];
 
 /**
  * `EditorBorderControl`'s `renderColor` render-prop: reuses the block's existing `PopColorControl`
- * unchanged, one per side once width/style have been unlinked (color always tracks the same
- * linked/unlinked shape `EditorBorderControl` gives width and style — see `fromNativeBorder`), or a
- * single one while still linked. Color is out of this plan's scope entirely; this only wires the
- * existing color-picking mechanism back in, the way `SingleBorderControl` in `@kadence/components`
- * rendered it per side before this block moved to `EditorBorderControl`.
+ * unchanged. `BorderControl`'s row anatomy always calls this once per row with that row's own
+ * resolved color scalar (via `readSlot()`), never the whole four-element axis, so this only ever
+ * renders one swatch per call — the same way it already reads `width`/`style` per row. Color is out
+ * of this plan's scope entirely; this only wires the existing color-picking mechanism back in.
  *
  * @param {Object}   props          The render-prop's argument.
- * @param {*}        props.value    The current color scalar or four-element slot list.
- * @param {Function} props.onChange Called with the next color scalar or slot list.
+ * @param {*}        props.value    The row's own resolved color scalar.
+ * @param {Function} props.onChange Called with the next color scalar.
  * @param {?string}  [props.label]  The row's own bare side name (e.g. "top"), or `null` while
- *                                  linked, from `BorderControl`'s per-row `renderColor` call. Built
- *                                  into the same "%s Border Color" wording the old array branch
- *                                  below used, so unlinked mode's four swatches — one per row now
- *                                  instead of stacked in one cluster — keep distinct names.
+ *                                  linked, from `BorderControl`'s per-row `renderColor` call.
  *
  * @since TBD
  *
- * @return {JSX.Element} The rendered color field(s).
+ * @return {JSX.Element} The rendered color field.
  */
 function renderBorderColor({ value, onChange, label }) {
-	if (!isSlotList(value)) {
-		return (
-			<PopColorControl
-				swatchLabel={
-					label
-						? sprintf(
-								/* translators: %s: border side (Top, Right, Bottom, Left) */
-								__('%s Border Color', 'kadence-blocks'),
-								upperFirst(label)
-							)
-						: undefined
-				}
-				value={value || ''}
-				default={''}
-				hideClear={true}
-				onChange={onChange}
-			/>
-		);
-	}
-
 	return (
-		<div className="kb-border-control__colors">
-			{BORDER_COLOR_SIDE_LABELS.map((sideLabel, index) => (
-				<PopColorControl
-					key={sideLabel}
-					swatchLabel={sprintf(
-						/* translators: %s: border side (Top, Right, Bottom, Left) */
-						__('%s Border Color', 'kadence-blocks'),
-						sideLabel
-					)}
-					value={readSlot(value, index) || ''}
-					default={''}
-					hideClear={true}
-					onChange={(next) => onChange(writeSlot(value, index, next, false))}
-				/>
-			))}
-		</div>
+		<PopColorControl
+			swatchLabel={
+				label
+					? sprintf(
+							/* translators: %s: border side (Top, Right, Bottom, Left) */
+							__('%s Border Color', 'kadence-blocks'),
+							upperFirst(label)
+						)
+					: undefined
+			}
+			value={value || ''}
+			default={''}
+			hideClear={true}
+			onChange={onChange}
+		/>
 	);
 }
 

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -45,7 +45,7 @@ import {
 	Tooltip,
 } from '@kadence/components';
 import classnames from 'classnames';
-import { times, filter, map, uniqueId, get } from 'lodash';
+import { times, filter, map, uniqueId, get, upperFirst } from 'lodash';
 
 import metadata from './block.json';
 /**
@@ -114,14 +114,35 @@ const BORDER_COLOR_SIDE_LABELS = ['Top', 'Right', 'Bottom', 'Left'];
  * @param {Object}   props          The render-prop's argument.
  * @param {*}        props.value    The current color scalar or four-element slot list.
  * @param {Function} props.onChange Called with the next color scalar or slot list.
+ * @param {?string}  [props.label]  The row's own bare side name (e.g. "top"), or `null` while
+ *                                  linked, from `BorderControl`'s per-row `renderColor` call. Built
+ *                                  into the same "%s Border Color" wording the old array branch
+ *                                  below used, so unlinked mode's four swatches — one per row now
+ *                                  instead of stacked in one cluster — keep distinct names.
  *
  * @since TBD
  *
  * @return {JSX.Element} The rendered color field(s).
  */
-function renderBorderColor({ value, onChange }) {
+function renderBorderColor({ value, onChange, label }) {
 	if (!isSlotList(value)) {
-		return <PopColorControl value={value || ''} default={''} hideClear={true} onChange={onChange} />;
+		return (
+			<PopColorControl
+				swatchLabel={
+					label
+						? sprintf(
+								/* translators: %s: border side (Top, Right, Bottom, Left) */
+								__('%s Border Color', 'kadence-blocks'),
+								upperFirst(label)
+							)
+						: undefined
+				}
+				value={value || ''}
+				default={''}
+				hideClear={true}
+				onChange={onChange}
+			/>
+		);
 	}
 
 	return (

--- a/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
@@ -227,25 +227,47 @@ describe('EditorBorderControl native <-> control value bridging', () => {
 
 	/**
 	 * `renderColor` is passed straight through to `BorderControl` untouched — this component neither
-	 * builds nor intercepts it. `BorderControl` calls it once with the whole color slot list it read
-	 * out of `fromNativeBorder`'s output, so the caller's `renderColor` sees the same per-side colors
-	 * this component derived from the native value.
+	 * builds nor intercepts it. `BorderControl` calls it once per row (not once with the whole color
+	 * slot list) with that row's own scalar color and its bare side name as `label`, so the caller's
+	 * `renderColor` sees the same per-side colors this component derived from the native value, one
+	 * side at a time.
 	 *
 	 * @return {void}
 	 */
-	it('passes renderColor straight through to BorderControl, called with the derived color slots', () => {
+	it("passes renderColor straight through to BorderControl, called once per row with that row's own color and side label", () => {
 		const renderColor = jest.fn();
 		const { borderControl } = renderEditorBorderControl({ renderColor });
 
 		expect(borderControl.props.renderColor).toBe(renderColor);
 
-		// Reproduce what BorderControl itself does: call renderColor with the color slot list from
-		// the value this component built, not a value renderColor computed on its own.
-		borderControl.props.renderColor({ value: borderControl.props.value.color, onChange: jest.fn() });
+		// Reproduce what BorderControl itself does per row (see BorderControl.js's `renderSlot`): call
+		// renderColor once per side with that side's own scalar out of the color slot list this
+		// component built, plus the bare side name as `label`, rather than one call with the whole
+		// four-element list.
+		const colors = borderControl.props.value.color;
+		['top', 'right', 'bottom', 'left'].forEach((side, index) => {
+			borderControl.props.renderColor({ value: colors[index], onChange: jest.fn(), label: side });
+		});
 
-		expect(renderColor).toHaveBeenCalledWith({
-			value: ['#111111', '#222222', '#333333', '#444444'],
+		expect(renderColor).toHaveBeenNthCalledWith(1, {
+			value: '#111111',
 			onChange: expect.any(Function),
+			label: 'top',
+		});
+		expect(renderColor).toHaveBeenNthCalledWith(2, {
+			value: '#222222',
+			onChange: expect.any(Function),
+			label: 'right',
+		});
+		expect(renderColor).toHaveBeenNthCalledWith(3, {
+			value: '#333333',
+			onChange: expect.any(Function),
+			label: 'bottom',
+		});
+		expect(renderColor).toHaveBeenNthCalledWith(4, {
+			value: '#444444',
+			onChange: expect.any(Function),
+			label: 'left',
 		});
 	});
 

--- a/src/style-library/components/molecules/fields/BorderField.js
+++ b/src/style-library/components/molecules/fields/BorderField.js
@@ -39,6 +39,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import { upperFirst } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
@@ -225,17 +230,24 @@ export function BorderField({ field, values, onValueChange }) {
 	// `BoxTokenField`'s `unlinked` is: a choice made on one breakpoint must not leak into another that
 	// never made it, keeping the breakpoints independent.
 	const [unlinked, setUnlinked] = useState({});
-	const storedIsList = isSlotList(widthAtBreakpoint) || isSlotList(styleAtBreakpoint);
+	// `color` can now diverge per side too (`BorderControl` writes it through the same per-slot axis
+	// width/style already use), so a list-shaped color has to force the unlinked view exactly like a
+	// list-shaped width/style does — otherwise the panel would show one linked swatch while the
+	// stored value still carries four different colors.
+	const storedIsList = isSlotList(widthAtBreakpoint) || isSlotList(styleAtBreakpoint) || isSlotList(rawColor);
 	const linked = storedIsList ? false : !unlinked[breakpoint];
 
 	const toggleLink = () => {
 		setUnlinked((current) => ({ ...current, [breakpoint]: linked }));
 
 		// Relinking keeps each axis's first side, matching `BoxTokenField`'s own relink rule; there is
-		// nothing to fold when a breakpoint never actually diverged into a list.
+		// nothing to fold when a breakpoint never actually diverged into a list. `color` folds
+		// alongside width/style — `readSlot` on an already-scalar color is a no-op, so this is safe to
+		// call unconditionally once any axis diverged.
 		if (!linked && storedIsList) {
 			writeWidth(readSlot(widthAtBreakpoint, 0));
 			writeStyle(readSlot(styleAtBreakpoint, 0));
+			writeColor(readSlot(rawColor, 0));
 		}
 	};
 
@@ -257,9 +269,17 @@ export function BorderField({ field, values, onValueChange }) {
 			}}
 			label={field.label}
 			widthTokens={widthTokens}
-			renderColor={({ value: color, onChange: onColorChange }) => (
+			renderColor={({ value: color, onChange: onColorChange, label: sideLabel }) => (
 				<TokenColorSelectField
-					field={{ label: __('Color', 'kadence-blocks'), readOnly: field.readOnly }}
+					// `sideLabel` is the row's bare side name ("top", "right", …), or `null` while linked.
+					// Capitalized and used as the field's own name so unlinked mode's four swatches — one
+					// per row now instead of sharing the linked "Color" name — read as distinct fields to
+					// a screen reader, matching `styleLabel`'s per-side naming a few lines up in
+					// `BorderControl`.
+					field={{
+						label: sideLabel ? upperFirst(sideLabel) : __('Color', 'kadence-blocks'),
+						readOnly: field.readOnly,
+					}}
 					value={color}
 					onChange={onColorChange}
 				/>

--- a/src/token-controls/__tests__/border-control.test.js
+++ b/src/token-controls/__tests__/border-control.test.js
@@ -269,12 +269,12 @@ describe('BorderControl link toggle (uncontrolled)', () => {
 	});
 
 	/**
-	 * Toggling while unlinked collapses both axes back to slot 0's value, and does not touch
-	 * color, even when the four slots differ.
+	 * Toggling while unlinked collapses all three axes back to slot 0's value — a scalar color
+	 * folds to itself, a no-op.
 	 *
 	 * @return {void}
 	 */
-	it('collapses width and style to slot 0 when toggled while unlinked', () => {
+	it('collapses width, style, and color to slot 0 when toggled while unlinked', () => {
 		const onChange = jest.fn();
 		renderControl({
 			value: {
@@ -291,6 +291,33 @@ describe('BorderControl link toggle (uncontrolled)', () => {
 			width: 'a',
 			style: 'solid',
 			color: 'semantic.color.border',
+		});
+	});
+
+	/**
+	 * A `color` axis a caller's `renderColor` widened into a four-slot list (via `applyToAxis`,
+	 * exactly as `width`/`style` already can be) folds back to slot 0 on relink too, rather than
+	 * staying a stale four-element list underneath a linked view that only ever reads slot 0.
+	 *
+	 * @return {void}
+	 */
+	it('folds a list-shaped color to slot 0 when toggled while unlinked', () => {
+		const onChange = jest.fn();
+		renderControl({
+			value: {
+				width: ['a', 'b', 'c', 'd'],
+				style: ['solid', 'dashed', 'dotted', 'double'],
+				color: ['red', 'green', 'blue', 'yellow'],
+			},
+			onChange,
+		});
+
+		click(linkToggle());
+
+		expect(onChange).toHaveBeenCalledWith({
+			width: 'a',
+			style: 'solid',
+			color: 'red',
 		});
 	});
 });
@@ -471,6 +498,7 @@ describe('BorderControl row anatomy', () => {
 		expect(container.querySelectorAll('.kb-border-control__box')).toHaveLength(4);
 		expect(container.querySelectorAll('.kb-border-control__swatch')).toHaveLength(4);
 		expect(container.querySelectorAll('.kb-border-control__style-preview')).toHaveLength(4);
+		expect(container.querySelectorAll('.kb-border-control__box .stub-token-selector')).toHaveLength(4);
 	});
 
 	/**
@@ -535,6 +563,34 @@ describe('BorderControl row anatomy', () => {
 			style: 'solid',
 			color: ['semantic.color.border', 'semantic.color.border', 'semantic.color.accent', 'semantic.color.border'],
 		});
+	});
+
+	/**
+	 * `renderColor` receives the row's own bare side name as `label`, `null` while linked — so an
+	 * unlinked caller can give each of the four swatches its own accessible name, the way the width
+	 * field's per-slot icon and the style select's own `styleLabel` already do.
+	 *
+	 * @return {void}
+	 */
+	it('passes the row side name as label, null while linked', () => {
+		const receivedLinked = [];
+		renderControl({
+			renderColor: (props) => {
+				receivedLinked.push(props.label);
+				return null;
+			},
+		});
+		expect(receivedLinked).toEqual([null]);
+
+		const receivedUnlinked = [];
+		renderControl({
+			value: { width: ['a', 'b', 'c', 'd'], style: 'solid', color: '' },
+			renderColor: (props) => {
+				receivedUnlinked.push(props.label);
+				return null;
+			},
+		});
+		expect(receivedUnlinked).toEqual(['top', 'right', 'bottom', 'left']);
 	});
 });
 

--- a/src/token-controls/__tests__/border-control.test.js
+++ b/src/token-controls/__tests__/border-control.test.js
@@ -435,6 +435,109 @@ describe('BorderControl disabled', () => {
 	});
 });
 
+describe('BorderControl row anatomy', () => {
+	/**
+	 * The linked row bundles the swatch, style preview, and width field into one control box.
+	 *
+	 * @return {void}
+	 */
+	it('renders one control box containing the swatch, style preview, and width field when linked', () => {
+		renderControl({
+			value: { width: '', style: 'solid', color: 'semantic.color.border' },
+			renderColor: ({ value }) => <span className="stub-swatch" data-value={value ?? ''} />,
+		});
+
+		const boxes = container.querySelectorAll('.kb-border-control__box');
+		expect(boxes).toHaveLength(1);
+
+		const box = boxes[0];
+		expect(box.querySelector('.kb-border-control__swatch .stub-swatch')).not.toBeNull();
+		expect(box.querySelector('.kb-border-control__style-preview')).not.toBeNull();
+		expect(box.querySelector('.stub-token-selector')).not.toBeNull();
+	});
+
+	/**
+	 * Unlinked mode renders one control box per side, each with its own swatch/style-preview/width
+	 * triple.
+	 *
+	 * @return {void}
+	 */
+	it('renders four control boxes, each with a swatch and style preview, when unlinked', () => {
+		renderControl({
+			value: { width: ['a', 'b', 'c', 'd'], style: 'solid', color: '' },
+			renderColor: ({ value }) => <span className="stub-swatch" data-value={value ?? ''} />,
+		});
+
+		expect(container.querySelectorAll('.kb-border-control__box')).toHaveLength(4);
+		expect(container.querySelectorAll('.kb-border-control__swatch')).toHaveLength(4);
+		expect(container.querySelectorAll('.kb-border-control__style-preview')).toHaveLength(4);
+	});
+
+	/**
+	 * The style preview's rule carries a modifier class naming the side's current style, and the
+	 * style picker's own select sits inside the preview box rather than as a separate field.
+	 *
+	 * @return {void}
+	 */
+	it('marks the style preview with the current style and keeps the picker select inside it', () => {
+		renderControl({ value: { width: '', style: 'dashed', color: '' } });
+
+		const preview = container.querySelector('.kb-border-control__style-preview');
+
+		expect(preview.querySelector('.kb-border-control__style-preview-rule--dashed')).not.toBeNull();
+		expect(preview.querySelector('select')).not.toBeNull();
+	});
+
+	/**
+	 * `none` hides the preview's rule rather than drawing a muted line.
+	 *
+	 * @return {void}
+	 */
+	it('hides the style preview rule when style is none', () => {
+		renderControl({ value: { width: '', style: 'none', color: '' } });
+
+		const rule = container.querySelector('.kb-border-control__style-preview-rule');
+
+		expect(rule.classList.contains('kb-border-control__style-preview-rule--none')).toBe(true);
+	});
+
+	/**
+	 * `renderColor` is called once per row with that row's own color value, and its `onChange`
+	 * writes back through the same axis the width/style fields already use — a linked write stays a
+	 * scalar, an unlinked write touches only that row's slot.
+	 *
+	 * @return {void}
+	 */
+	it('calls renderColor once per row and writes the touched slot when unlinked', () => {
+		const onChange = jest.fn();
+		renderControl({
+			value: { width: ['a', 'b', 'c', 'd'], style: 'solid', color: 'semantic.color.border' },
+			onChange,
+			renderColor: ({ value, onChange: onColorChange }) => (
+				<button
+					className="stub-color-write"
+					data-value={value ?? ''}
+					onClick={() => onColorChange('semantic.color.accent')}
+				>
+					swatch
+				</button>
+			),
+		});
+
+		const swatches = container.querySelectorAll('.stub-color-write');
+		expect(swatches).toHaveLength(4);
+		expect(Array.from(swatches).every((el) => el.dataset.value === 'semantic.color.border')).toBe(true);
+
+		click(swatches[2]);
+
+		expect(onChange).toHaveBeenCalledWith({
+			width: ['a', 'b', 'c', 'd'],
+			style: 'solid',
+			color: ['semantic.color.border', 'semantic.color.border', 'semantic.color.accent', 'semantic.color.border'],
+		});
+	});
+});
+
 describe('BorderControl style select accessible labels', () => {
 	/**
 	 * Linked mode has one style field standing for every side, so the generic label is accurate.

--- a/src/token-controls/__tests__/border-control.test.js
+++ b/src/token-controls/__tests__/border-control.test.js
@@ -72,8 +72,13 @@ jest.mock('@wordpress/icons', () => ({
 // `TokenSelector` already has coverage for. The stand-in exposes `onPick`/`onClear`/`onCustom`
 // directly as buttons so a click can trigger each without driving the popover open first.
 jest.mock('../organisms/TokenSelector', () => ({
-	TokenSelector: ({ value, disabled, onPick, onClear, onCustom }) => (
-		<div className="stub-token-selector" data-value={value ?? ''}>
+	TokenSelector: ({ value, disabled, onPick, onClear, onCustom, defaultValue, inherited }) => (
+		<div
+			className="stub-token-selector"
+			data-value={value ?? ''}
+			data-default-value={defaultValue ?? ''}
+			data-inherited={String(Boolean(inherited))}
+		>
 			<button
 				className="stub-pick"
 				disabled={disabled}
@@ -454,6 +459,61 @@ describe('BorderControl color', () => {
 	 */
 	it('renders nothing and does not throw without renderColor', () => {
 		expect(() => renderControl({ renderColor: undefined })).not.toThrow();
+	});
+});
+
+describe('BorderControl width default', () => {
+	/**
+	 * `defaultValue` reaches the width `TokenSelector` — without it, an unset width field shows
+	 * nothing and the row collapses to zero height.
+	 *
+	 * @return {void}
+	 */
+	it('passes defaultValue through to the width TokenSelector', () => {
+		renderControl({ defaultValue: '2px' });
+
+		expect(widthSelectors()[0].dataset.defaultValue).toBe('2px');
+	});
+
+	/**
+	 * A `defaultValue` of `0` (a real, meaningful preset value) reaches the width `TokenSelector`
+	 * unchanged rather than being coalesced away as if nothing were set.
+	 *
+	 * @return {void}
+	 */
+	it('passes a zero defaultValue through rather than dropping it', () => {
+		renderControl({ defaultValue: '0px' });
+
+		expect(widthSelectors()[0].dataset.defaultValue).toBe('0px');
+	});
+
+	/**
+	 * Every row — not just the linked one — gets the same `defaultValue`, since a border has one
+	 * default width regardless of how many sides are currently showing.
+	 *
+	 * @return {void}
+	 */
+	it('passes the same defaultValue to every row when unlinked', () => {
+		renderControl({
+			value: { width: ['', '', '', ''], style: 'solid', color: '' },
+			defaultValue: '2px',
+		});
+
+		widthSelectors().forEach((selector) => {
+			expect(selector.dataset.defaultValue).toBe('2px');
+		});
+	});
+
+	/**
+	 * `inherited` reaches the width `TokenSelector` too, so it can tag the default `Inherited` instead
+	 * of `Default`.
+	 *
+	 * @return {void}
+	 */
+	it('passes inherited through to the width TokenSelector', () => {
+		renderControl({ defaultValue: '2px', inherited: true });
+
+		expect(widthSelectors()[0].dataset.inherited).toBe('true');
 	});
 });
 

--- a/src/token-controls/__tests__/border-control.test.js
+++ b/src/token-controls/__tests__/border-control.test.js
@@ -13,30 +13,59 @@ import { BorderControl } from '../controls/BorderControl';
 // `jest.config.js` maps `@wordpress/components` to the copy nested under
 // `@kadence/components/node_modules`, which resolves its own `react` — a different module instance
 // than the top-level `react-dom/client` this test renders with, which trips React's "Invalid hook
-// call" guard. Stand-ins sidestep that; these tests only need the link toggle and a plain select.
-jest.mock('@wordpress/components', () => ({
-	Button: ({ children, icon, showTooltip, isSmall, isPressed, ...props }) => <button {...props}>{children}</button>,
-	ButtonGroup: ({ children, ...props }) => <div {...props}>{children}</div>,
-	Dashicon: (props) => <span {...props} />,
-	Tooltip: ({ children }) => children,
-	SelectControl: ({ label, hideLabelFromVision, options, value, onChange, disabled, ...props }) => (
-		<select
-			aria-label={label}
-			value={value}
-			disabled={disabled}
-			onChange={(event) => onChange(event.target.value)}
-			{...props}
-		>
-			{options.map((option) => (
-				<option key={option.value} value={option.value}>
-					{option.label}
-				</option>
-			))}
-		</select>
-	),
-}));
+// call" guard. Stand-ins sidestep that; these tests only need the link toggle and the style picker's
+// `Dropdown`/`MenuGroup`/`MenuItem`/`NavigableMenu` shells.
+//
+// `Dropdown` keeps real open/closed state (via its own `useState`, from this same file's already-safe
+// top-level `react` import) rather than always rendering its content like `box-shadow-control.test.js`'s
+// stand-in does, because `BorderControl`'s style picker specifically needs "closed until clicked" and
+// "closes after picking" to be real, observable behavior for the tests below — not something a
+// permanently-open mock could exercise. `NavigableMenu` only forwards `role="menu"` — the actual
+// arrow-key roving focus that role wires up in production comes from WordPress's own
+// `NavigableContainer` (see `BorderStyleSelect.js`'s docblock), which this mock necessarily bypasses
+// along with the rest of `@wordpress/components`; the tests below can only verify the structural wiring
+// (a real `role="menu"` container holding real, focusable `role="menuitemradio"` buttons), not simulate
+// the roving focus itself.
+jest.mock('@wordpress/components', () => {
+	const { useState } = require('react');
 
-jest.mock('@wordpress/icons', () => ({ undo: 'undo', link: 'link', linkOff: 'linkOff' }));
+	return {
+		Button: ({ children, icon, showTooltip, isSmall, isPressed, ...props }) => (
+			<button {...props}>{children}</button>
+		),
+		ButtonGroup: ({ children, ...props }) => <div {...props}>{children}</div>,
+		Dashicon: (props) => <span {...props} />,
+		Tooltip: ({ children }) => children,
+		Dropdown: ({ className, contentClassName, renderToggle, renderContent }) => {
+			const [isOpen, setIsOpen] = useState(false);
+
+			return (
+				<div className={className}>
+					{renderToggle({ isOpen, onToggle: () => setIsOpen((open) => !open) })}
+					{isOpen && (
+						<div className={contentClassName}>{renderContent({ onClose: () => setIsOpen(false) })}</div>
+					)}
+				</div>
+			);
+		},
+		MenuGroup: ({ children }) => <div role="group">{children}</div>,
+		NavigableMenu: ({ children, role }) => <div role={role}>{children}</div>,
+		MenuItem: ({ children, role, suffix, onClick, ...props }) => (
+			<button role={role} onClick={onClick} {...props}>
+				{children}
+				{suffix}
+			</button>
+		),
+	};
+});
+
+jest.mock('@wordpress/icons', () => ({
+	undo: 'undo',
+	link: 'link',
+	linkOff: 'linkOff',
+	check: 'check',
+	Icon: ({ icon, ...props }) => <span {...props}>{icon}</span>,
+}));
 
 // `TokenSelector` opens a real popover through `@wordpress/components`' `Dropdown`, which is out of
 // scope for these tests — they exercise `BorderControl`'s own width-axis wiring, not the picker
@@ -103,9 +132,9 @@ function renderControl(props = {}) {
 }
 
 const widthSelectors = () => container.querySelectorAll('.stub-token-selector');
-// Matches both the linked label ("Border style") and each unlinked, side-named label
-// ("Border style (top)", etc.) — the prefix is what every style select shares.
-const styleSelects = () => container.querySelectorAll('select[aria-label^="Border style"]');
+// One per row, whether linked (one, generically labeled "Border style") or unlinked (four, each
+// side-named — "Border style (top)", etc.).
+const styleTriggers = () => container.querySelectorAll('.kb-border-control__style-trigger');
 const linkToggle = () => container.querySelector('.kadence-control-toggle');
 
 /**
@@ -122,17 +151,42 @@ function click(element) {
 	act(() => element.click());
 }
 
+/**
+ * Open a row's style picker and pick the option matching `styleValue`, driving the mocked
+ * `Dropdown`/`MenuGroup`/`MenuItem` exactly as a user would: click the trigger to open the menu,
+ * then click the option whose rule carries that style's modifier class.
+ *
+ * @param {HTMLElement} trigger    The row's `.kb-border-control__style-trigger` button.
+ * @param {string}      styleValue The style keyword to pick — matches `STYLES`' `value` and the
+ *                                 option's `kb-border-control__style-preview-rule--{styleValue}`
+ *                                 modifier class.
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+function pickStyle(trigger, styleValue) {
+	click(trigger);
+
+	const option = trigger
+		.closest('.kb-border-control__style-preview')
+		.querySelector(`.kb-border-control__style-preview-rule--${styleValue}`)
+		.closest('[role="menuitemradio"]');
+
+	click(option);
+}
+
 describe('BorderControl slot rendering', () => {
 	/**
 	 * The default, all-scalar value is linked, so only one width/style pair renders.
 	 *
 	 * @return {void}
 	 */
-	it('renders one width TokenSelector and one style SelectControl when value is all-scalar', () => {
+	it('renders one width TokenSelector and one style trigger when value is all-scalar', () => {
 		renderControl();
 
 		expect(widthSelectors()).toHaveLength(1);
-		expect(styleSelects()).toHaveLength(1);
+		expect(styleTriggers()).toHaveLength(1);
 	});
 
 	/**
@@ -146,7 +200,7 @@ describe('BorderControl slot rendering', () => {
 		});
 
 		expect(widthSelectors()).toHaveLength(4);
-		expect(styleSelects()).toHaveLength(4);
+		expect(styleTriggers()).toHaveLength(4);
 	});
 
 	/**
@@ -164,7 +218,28 @@ describe('BorderControl slot rendering', () => {
 		});
 
 		expect(widthSelectors()).toHaveLength(4);
-		expect(styleSelects()).toHaveLength(4);
+		expect(styleTriggers()).toHaveLength(4);
+	});
+
+	/**
+	 * A 4-list on `color` alone — width and style both still scalar — also means the control is
+	 * unlinked. `color` can diverge on its own through a caller's `renderColor` writing per row
+	 * (via `applyToAxis`), so deriving `linked` from width/style only would render this value as
+	 * linked and read just slot 0 of `color`, hiding the other three sides' colors.
+	 *
+	 * @return {void}
+	 */
+	it('renders four of each when color is a 4-list, even with scalar width and style', () => {
+		renderControl({
+			value: {
+				width: 'primitive.dimension.border-width.md',
+				style: 'solid',
+				color: ['red', 'green', 'blue', 'yellow'],
+			},
+		});
+
+		expect(widthSelectors()).toHaveLength(4);
+		expect(styleTriggers()).toHaveLength(4);
 	});
 });
 
@@ -192,23 +267,19 @@ describe('BorderControl width and style writes', () => {
 	});
 
 	/**
-	 * Changing the style select while linked writes the scalar directly to `style` and leaves
+	 * Picking a style option while linked writes the scalar directly to `style` and leaves
 	 * `width`/`color` untouched.
 	 *
 	 * @return {void}
 	 */
-	it('calls onChange with only style changed when changing the style select', () => {
+	it('calls onChange with only style changed when picking a style option', () => {
 		const onChange = jest.fn();
 		renderControl({
 			value: { width: 'primitive.dimension.border-width.sm', style: 'none', color: 'semantic.color.border' },
 			onChange,
 		});
 
-		act(() => {
-			const select = styleSelects()[0];
-			select.value = 'dashed';
-			select.dispatchEvent(new Event('change', { bubbles: true }));
-		});
+		pickStyle(styleTriggers()[0], 'dashed');
 
 		expect(onChange).toHaveBeenCalledWith({
 			width: 'primitive.dimension.border-width.sm',
@@ -388,7 +459,7 @@ describe('BorderControl color', () => {
 
 describe('BorderControl disabled', () => {
 	/**
-	 * Every sub-field — the width stand-in's buttons and the style select — is disabled, and
+	 * Every sub-field — the width stand-in's buttons and the style trigger — is disabled, and
 	 * clicking/changing them fires no `onChange`.
 	 *
 	 * @return {void}
@@ -406,7 +477,7 @@ describe('BorderControl disabled', () => {
 		expect(selector.querySelector('.stub-pick').disabled).toBe(true);
 		expect(selector.querySelector('.stub-clear').disabled).toBe(true);
 		expect(selector.querySelector('.stub-custom').disabled).toBe(true);
-		expect(styleSelects()[0].disabled).toBe(true);
+		expect(styleTriggers()[0].disabled).toBe(true);
 
 		click(selector.querySelector('.stub-pick'));
 		click(selector.querySelector('.stub-clear'));
@@ -503,17 +574,17 @@ describe('BorderControl row anatomy', () => {
 
 	/**
 	 * The style preview's rule carries a modifier class naming the side's current style, and the
-	 * style picker's own select sits inside the preview box rather than as a separate field.
+	 * style picker's own trigger sits inside the preview box rather than as a separate field.
 	 *
 	 * @return {void}
 	 */
-	it('marks the style preview with the current style and keeps the picker select inside it', () => {
+	it('marks the style preview with the current style and keeps the picker trigger inside it', () => {
 		renderControl({ value: { width: '', style: 'dashed', color: '' } });
 
 		const preview = container.querySelector('.kb-border-control__style-preview');
 
 		expect(preview.querySelector('.kb-border-control__style-preview-rule--dashed')).not.toBeNull();
-		expect(preview.querySelector('select')).not.toBeNull();
+		expect(preview.querySelector('.kb-border-control__style-trigger')).not.toBeNull();
 	});
 
 	/**
@@ -594,7 +665,103 @@ describe('BorderControl row anatomy', () => {
 	});
 });
 
-describe('BorderControl style select accessible labels', () => {
+describe('BorderControl style picker', () => {
+	/**
+	 * The menu does not exist in the DOM until the trigger opens it — clicking anywhere on the
+	 * preview box before that has nothing to click into.
+	 *
+	 * @return {void}
+	 */
+	it('does not render the style menu until the trigger is clicked', () => {
+		renderControl();
+
+		expect(container.querySelector('.kb-border-control__style-menu')).toBeNull();
+
+		click(styleTriggers()[0]);
+
+		expect(container.querySelector('.kb-border-control__style-menu')).not.toBeNull();
+	});
+
+	/**
+	 * All five curated styles are listed, each as its own focusable option showing its own rule —
+	 * not plain text, which is the whole reason this isn't a native `<select>`.
+	 *
+	 * @return {void}
+	 */
+	it('lists all five style options, each with its own rule', () => {
+		renderControl();
+
+		click(styleTriggers()[0]);
+
+		const options = container.querySelectorAll('.kb-border-control__style-menu [role="menuitemradio"]');
+		expect(options).toHaveLength(5);
+
+		['none', 'solid', 'dashed', 'dotted', 'double'].forEach((styleValue) => {
+			expect(
+				container.querySelector(
+					`.kb-border-control__style-menu .kb-border-control__style-preview-rule--${styleValue}`
+				)
+			).not.toBeNull();
+		});
+	});
+
+	/**
+	 * The options sit inside a real `role="menu"` container — the integration point WordPress's own
+	 * `NavigableMenu`/`NavigableContainer` uses to wire up arrow-key roving focus between them in
+	 * production. This file mocks `NavigableMenu` down to a plain `<div role="menu">` (see the
+	 * `@wordpress/components` mock's docblock above) alongside the rest of `@wordpress/components`,
+	 * so the actual roving-focus keyboard behavior — implemented entirely inside WordPress's own
+	 * component, not this one — cannot be driven or re-verified from here; this asserts the
+	 * structural wiring `BorderStyleSelect` is responsible for instead.
+	 *
+	 * @return {void}
+	 */
+	it('wraps the options in a role="menu" container for arrow-key navigation', () => {
+		renderControl();
+
+		click(styleTriggers()[0]);
+
+		const menu = container.querySelector('.kb-border-control__style-menu [role="menu"]');
+		expect(menu).not.toBeNull();
+		expect(menu.querySelectorAll('[role="menuitemradio"]')).toHaveLength(5);
+	});
+
+	/**
+	 * Picking an option calls `onChange` with that option's value and closes the menu — clicking an
+	 * option is a complete pick-and-dismiss action, not just a write.
+	 *
+	 * @return {void}
+	 */
+	it('picking an option calls onChange and closes the menu', () => {
+		const onChange = jest.fn();
+		renderControl({ value: { width: '', style: 'solid', color: '' }, onChange });
+
+		pickStyle(styleTriggers()[0], 'dotted');
+
+		expect(onChange).toHaveBeenCalledWith({ width: '', style: 'dotted', color: '' });
+		expect(container.querySelector('.kb-border-control__style-menu')).toBeNull();
+	});
+
+	/**
+	 * The active option is marked `aria-checked`, matching the same `role="menuitemradio"` idiom
+	 * `TokenColorSelectField` already uses for its own token list.
+	 *
+	 * @return {void}
+	 */
+	it('marks the current style option as checked', () => {
+		renderControl({ value: { width: '', style: 'dotted', color: '' } });
+
+		click(styleTriggers()[0]);
+
+		const current = container
+			.querySelector('.kb-border-control__style-menu .kb-border-control__style-preview-rule--dotted')
+			.closest('[role="menuitemradio"]');
+
+		expect(current.getAttribute('aria-checked')).toBe('true');
+	});
+});
+
+describe('BorderControl style trigger accessible labels', () => {
 	/**
 	 * Linked mode has one style field standing for every side, so the generic label is accurate.
 	 *
@@ -603,7 +770,7 @@ describe('BorderControl style select accessible labels', () => {
 	it('uses the generic label when linked', () => {
 		renderControl();
 
-		expect(styleSelects()[0].getAttribute('aria-label')).toBe('Border style');
+		expect(styleTriggers()[0].getAttribute('aria-label')).toBe('Border style');
 	});
 
 	/**
@@ -617,7 +784,7 @@ describe('BorderControl style select accessible labels', () => {
 			value: { width: ['', '', '', ''], style: ['none', 'none', 'none', 'none'], color: '' },
 		});
 
-		const labels = Array.from(styleSelects()).map((select) => select.getAttribute('aria-label'));
+		const labels = Array.from(styleTriggers()).map((trigger) => trigger.getAttribute('aria-label'));
 
 		expect(labels).toEqual([
 			'Border style (top)',

--- a/src/token-controls/atoms/BorderStyleSelect.js
+++ b/src/token-controls/atoms/BorderStyleSelect.js
@@ -1,0 +1,101 @@
+/**
+ * The border-style picker: a trigger that reads as the row's style-preview box — a short rule drawn
+ * in the side's current `border-style` — opening a menu of the same options, each showing its own
+ * rule next to its name.
+ *
+ * A native `<select>` can only render plain-text `<option>`s, so it cannot show what "dashed" or
+ * "dotted" actually look like; this exists because the reference wants each option's own line style
+ * visible in the list, not just its name. Built on the same `Dropdown` + `MenuGroup`/`MenuItem`
+ * (`role="menuitemradio"`/`aria-checked`, a `check` suffix on the active option) idiom
+ * `TokenColorSelectField` already established in this codebase, rather than the vendor package's
+ * `DropdownMenu` — this stays dependency-free (`@wordpress/components`/`@wordpress/icons` only, no
+ * store or global coupling), matching what the rest of `token-controls`/`style-library` already use.
+ * `MenuGroup`/`MenuItem` alone give no keyboard roving between options (that is what `DropdownMenu`
+ * gets from wrapping its menu in `NavigableMenu` internally — see
+ * `@wordpress/components/src/dropdown-menu/index.tsx`), so the options here are wrapped in the same
+ * `NavigableMenu` directly for arrow-key navigation; `Popover`'s own focus trap already provides
+ * Escape-to-close and returns focus to the trigger on close, so neither of those needed reimplementing.
+ *
+ * Each rule — the trigger's and every option's — reuses `token-controls.scss`'s own
+ * `.kb-border-control__style-preview-rule--*` modifier classes, the same ones the row's control box
+ * always drew its preview with, so the line each option shows is the identical border-style CSS the
+ * row itself uses, not a re-invented set.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Dropdown, MenuGroup, MenuItem, NavigableMenu } from '@wordpress/components';
+import { Icon, check } from '@wordpress/icons';
+
+/**
+ * Render a border-style picker.
+ *
+ * @param {Object}   props            The component props.
+ * @param {string}   props.value      The current style keyword (`'none'`, `'solid'`, …).
+ * @param {Array}    props.options    `[{ value, label }]` — the pickable styles, in menu order.
+ * @param {string}   [props.label]    The trigger's accessible name (e.g. "Border style (top)").
+ * @param {boolean}  [props.disabled] Whether the trigger is inert.
+ * @param {Function} props.onChange   Called with the picked style's `value`.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The rendered picker.
+ */
+export function BorderStyleSelect({ value, options, label, disabled = false, onChange }) {
+	return (
+		<Dropdown
+			className="kb-border-control__style-preview"
+			contentClassName="kb-border-control__style-menu"
+			popoverProps={{ placement: 'left-start' }}
+			renderToggle={({ isOpen, onToggle }) => (
+				<button
+					type="button"
+					className="kb-border-control__style-trigger"
+					aria-label={label}
+					aria-expanded={isOpen}
+					disabled={disabled}
+					onClick={onToggle}
+				>
+					<span
+						className={`kb-border-control__style-preview-rule kb-border-control__style-preview-rule--${value}`}
+						aria-hidden="true"
+					/>
+				</button>
+			)}
+			renderContent={({ onClose }) => (
+				<NavigableMenu role="menu">
+					<MenuGroup>
+						{options.map((option) => {
+							const isCurrent = option.value === value;
+
+							return (
+								<MenuItem
+									key={option.value}
+									role="menuitemradio"
+									aria-checked={isCurrent}
+									suffix={isCurrent ? <Icon icon={check} /> : null}
+									onClick={() => {
+										onClose();
+
+										if (!disabled && !isCurrent) {
+											onChange(option.value);
+										}
+									}}
+								>
+									<span className="kb-border-control__style-menu-swatch">
+										<span
+											className={`kb-border-control__style-preview-rule kb-border-control__style-preview-rule--${option.value}`}
+											aria-hidden="true"
+										/>
+									</span>
+									<span className="kb-border-control__style-menu-label">{option.label}</span>
+								</MenuItem>
+							);
+						})}
+					</MenuGroup>
+				</NavigableMenu>
+			)}
+		/>
+	);
+}

--- a/src/token-controls/controls/BorderControl.js
+++ b/src/token-controls/controls/BorderControl.js
@@ -26,8 +26,9 @@
  *
  * Each row shares one control box — a 20px color swatch, a style-preview box, then the width
  * field's label/value — matching Padding/Margin/Radius's row anatomy except for the two pickers up
- * front. `renderColor` keeps its existing `({ value, onChange, disabled }) => Element` contract;
- * this control simply calls it once per row (once for the linked row, once per side when unlinked)
+ * front. `renderColor` keeps its existing `({ value, onChange, label, disabled }) => Element`
+ * contract; this control simply calls it once per row (once for the linked row, once per side
+ * when unlinked)
  * with that row's own resolved color scalar instead of the whole axis, the same way it already
  * reads `width`/`style` per row. A caller's existing `renderColor` — whether it renders a bare
  * swatch or a small swatch-plus-label field like the Style Library's `TokenColorSelectField` —
@@ -104,11 +105,15 @@ function applyToAxis(axis, index, next) {
  * @param {?Function} [props.onBreakpointChange]  Breakpoint-change handler.
  * @param {?boolean}  [props.isLinked]            Linked state, when the host controls it.
  * @param {?Function} [props.onToggleLink]        Link-toggle handler; omit to let this own the state.
- * @param {?Function} [props.renderColor]         `({ value, onChange, disabled }) => Element` —
- *                                                the caller's existing color field for one side's
- *                                                color. Called once per row with that row's own
- *                                                resolved scalar (the linked row reads slot 0).
- *                                                Renders nothing when omitted.
+ * @param {?Function} [props.renderColor]         `({ value, onChange, label, disabled }) =>
+ *                                                Element` — the caller's existing color field for
+ *                                                one side's color. Called once per row with that
+ *                                                row's own resolved scalar (the linked row reads
+ *                                                slot 0) and that row's bare side name as `label`
+ *                                                (`null` while linked) so an unlinked caller can
+ *                                                give each of the four swatches a distinct
+ *                                                accessible name; ignoring `label` is fine. Renders
+ *                                                nothing when omitted.
  * @param {boolean}   [props.stacked]             Header above a full-width body instead of beside it.
  * @param {boolean}   [props.disabled]            Whether the control is read-only.
  *
@@ -152,7 +157,11 @@ export function BorderControl({
 
 				// Relinking reads slot 0 of each axis — "the first side wins" is predictable, matching
 				// BoxControl's own relink rule. It does not require the four slots to already match.
-				patch({ width: readSlot(width, 0), style: readSlot(style, 0) });
+				// `color` folds the same way even though this control never promotes it to a list itself
+				// (`toSlotList` above only touches width/style) — a caller's `renderColor` can still widen
+				// it into one through `applyToAxis`, and leaving it unfolded here would relink the visible
+				// width/style fields while `color` stayed a stale four-element list underneath.
+				patch({ width: readSlot(width, 0), style: readSlot(style, 0), color: readSlot(color, 0) });
 			};
 
 	return (
@@ -205,6 +214,13 @@ export function BorderControl({
 										value: colorSlot,
 										onChange: (next) =>
 											!disabled && patch({ color: applyToAxis(color, index, next) }),
+										// The bare side name (e.g. "top"), or `null` while linked -- additive, so a
+										// caller ignoring it keeps its own default name. Passed unformatted (unlike
+										// `styleLabel` below) because each caller already has its own established
+										// wording for naming a color field (`singlebtn/edit.js`'s "%s Border Color",
+										// `BorderField.js`'s plain field name) and composing a sentence here would
+										// fight both.
+										label: index === null ? null : slotLabel,
 										disabled,
 									})}
 								</span>

--- a/src/token-controls/controls/BorderControl.js
+++ b/src/token-controls/controls/BorderControl.js
@@ -20,9 +20,11 @@
  * on the very next render.
  *
  * Border style has no token library (`Style Library`'s Base Styles nav has no "Border Style"
- * screen — only one semantic default exists), so the style field is a plain closed-enum select,
- * not a `TokenSelector`/`TokenPopover` pair. Width reuses `TokenSelector` exactly as radius/spacing
- * do. Color is entirely out of this control's scope — the caller renders it via `renderColor`.
+ * screen — only one semantic default exists), so the style field is a closed enum, rendered by
+ * `BorderStyleSelect` — a small custom picker rather than a native `<select>`, since the reference
+ * wants each option to show its own line style, not just its name (a native `<select>` can only
+ * render plain-text `<option>`s). Width reuses `TokenSelector` exactly as radius/spacing do. Color is
+ * entirely out of this control's scope — the caller renders it via `renderColor`.
  *
  * Each row shares one control box — a 20px color swatch, a style-preview box, then the width
  * field's label/value — matching Padding/Margin/Radius's row anatomy except for the two pickers up
@@ -39,12 +41,12 @@
 /**
  * WordPress dependencies
  */
-import { SelectControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { BorderStyleSelect } from '../atoms/BorderStyleSelect';
 import { ControlShell } from '../templates/ControlShell';
 import { SlotGrid } from '../templates/SlotGrid';
 import { TokenSelector } from '../organisms/TokenSelector';
@@ -143,7 +145,12 @@ export function BorderControl({
 	const { width = '', style = 'none', color = '' } = value;
 
 	const controlled = typeof onToggleLink === 'function';
-	const linked = controlled ? Boolean(isLinked) : !isSlotList(width) && !isSlotList(style);
+	// `color` has to be checked alongside width/style: a caller's `renderColor` can widen it into a
+	// four-slot list on its own (via `applyToAxis`, in the per-row write below) without width or
+	// style ever leaving scalar. Deriving `linked` from width/style only would then render that
+	// value as linked and read just slot 0 of `color`, hiding the other three sides' colors
+	// entirely even though they're still stored.
+	const linked = controlled ? Boolean(isLinked) : !isSlotList(width) && !isSlotList(style) && !isSlotList(color);
 
 	const patch = (next) => onChange({ ...value, ...next });
 
@@ -225,21 +232,13 @@ export function BorderControl({
 									})}
 								</span>
 							)}
-							<span className="kb-border-control__style-preview">
-								<span
-									className={`kb-border-control__style-preview-rule kb-border-control__style-preview-rule--${styleSlot}`}
-									aria-hidden="true"
-								/>
-								<SelectControl
-									className="kb-border-control__style-select"
-									label={styleLabel}
-									hideLabelFromVision
-									value={styleSlot}
-									options={STYLES}
-									disabled={disabled}
-									onChange={(next) => !disabled && patch({ style: applyToAxis(style, index, next) })}
-								/>
-							</span>
+							<BorderStyleSelect
+								value={styleSlot}
+								options={STYLES}
+								label={styleLabel}
+								disabled={disabled}
+								onChange={(next) => !disabled && patch({ style: applyToAxis(style, index, next) })}
+							/>
 							<TokenSelector
 								value={widthSlot}
 								icon={slotIcons?.[slotIndex]}

--- a/src/token-controls/controls/BorderControl.js
+++ b/src/token-controls/controls/BorderControl.js
@@ -5,14 +5,14 @@
  * Border is not a `BoxControl` the way radius and spacing are — it carries two properties per side
  * (width, style) instead of one, and a third (color) this control deliberately does not touch
  * (color is being reworked separately; see `renderColor`). `SlotGrid` still applies unmodified: its
- * `renderSlot` render-prop was already generic, so this control renders a two-field row per slot
+ * `renderSlot` render-prop was already generic, so this control renders a one-box row per slot
  * instead of `BoxControl`'s single `TokenSelector`.
  *
  * `SlotGrid`'s own `value`/`onChange` props only drive its slot *arrangement* (linked-vs-grid,
  * corner display order, labels) — the `onChange` it would call from inside `renderSlot`'s `onChange`
  * argument is dead here because this `renderSlot` ignores that argument entirely and writes through
- * the `patch` closure instead, since a slot needs to update two parallel arrays (width and style),
- * not the one `SlotGrid` knows how to collapse. That also means `SlotGrid`'s own linked-mode
+ * the `patch` closure instead, since a slot needs to update three parallel axes (width, style, and
+ * color), not the one `SlotGrid` knows how to collapse. That also means `SlotGrid`'s own linked-mode
  * behavior — filling every slot with the written value, or returning a bare scalar when `collapse`
  * is set — never runs; this control has to reproduce "write the scalar directly while linked" itself
  * (`applyToAxis` below), or every write while linked would silently turn a scalar axis into a
@@ -23,6 +23,16 @@
  * screen — only one semantic default exists), so the style field is a plain closed-enum select,
  * not a `TokenSelector`/`TokenPopover` pair. Width reuses `TokenSelector` exactly as radius/spacing
  * do. Color is entirely out of this control's scope — the caller renders it via `renderColor`.
+ *
+ * Each row shares one control box — a 20px color swatch, a style-preview box, then the width
+ * field's label/value — matching Padding/Margin/Radius's row anatomy except for the two pickers up
+ * front. `renderColor` keeps its existing `({ value, onChange, disabled }) => Element` contract;
+ * this control simply calls it once per row (once for the linked row, once per side when unlinked)
+ * with that row's own resolved color scalar instead of the whole axis, the same way it already
+ * reads `width`/`style` per row. A caller's existing `renderColor` — whether it renders a bare
+ * swatch or a small swatch-plus-label field like the Style Library's `TokenColorSelectField` —
+ * already renders something compact enough to sit in that slot once it only ever receives a scalar
+ * (never a four-element list), so no new render-prop was needed.
  */
 
 /**
@@ -55,7 +65,7 @@ const STYLES = [
 ];
 
 /**
- * Write one axis (`width` or `style`) at a slot position, keeping a linked axis a scalar.
+ * Write one axis (`width`, `style`, or `color`) at a slot position, keeping a linked axis a scalar.
  *
  * `writeSlot()` always returns an array unless every slot ends up identical and `collapse` is on —
  * neither fits the linked case here, where `SlotGrid` reports the write as slot index `null` and the
@@ -94,8 +104,10 @@ function applyToAxis(axis, index, next) {
  * @param {?Function} [props.onBreakpointChange]  Breakpoint-change handler.
  * @param {?boolean}  [props.isLinked]            Linked state, when the host controls it.
  * @param {?Function} [props.onToggleLink]        Link-toggle handler; omit to let this own the state.
- * @param {?Function} [props.renderColor]         `({ value, onChange, disabled }) => Element` — the
- *                                                caller's existing color field for `value.color`.
+ * @param {?Function} [props.renderColor]         `({ value, onChange, disabled }) => Element` —
+ *                                                the caller's existing color field for one side's
+ *                                                color. Called once per row with that row's own
+ *                                                resolved scalar (the linked row reads slot 0).
  *                                                Renders nothing when omitted.
  * @param {boolean}   [props.stacked]             Header above a full-width body instead of beside it.
  * @param {boolean}   [props.disabled]            Whether the control is read-only.
@@ -169,6 +181,7 @@ export function BorderControl({
 					const slotIndex = index ?? 0;
 					const widthSlot = readSlot(width, slotIndex);
 					const styleSlot = readSlot(style, slotIndex) || 'none';
+					const colorSlot = readSlot(color, slotIndex);
 					// Linked mode has one field standing for every side, so the generic label is
 					// accurate; unlinked mode names the side so screen readers can tell the four
 					// style selectors apart, matching what the width TokenSelector's icon already
@@ -185,7 +198,32 @@ export function BorderControl({
 								);
 
 					return (
-						<div className="kb-border-control__slot" key={index ?? 'linked'}>
+						<div className="kb-border-control__box" key={index ?? 'linked'}>
+							{renderColor && (
+								<span className="kb-border-control__swatch">
+									{renderColor({
+										value: colorSlot,
+										onChange: (next) =>
+											!disabled && patch({ color: applyToAxis(color, index, next) }),
+										disabled,
+									})}
+								</span>
+							)}
+							<span className="kb-border-control__style-preview">
+								<span
+									className={`kb-border-control__style-preview-rule kb-border-control__style-preview-rule--${styleSlot}`}
+									aria-hidden="true"
+								/>
+								<SelectControl
+									className="kb-border-control__style-select"
+									label={styleLabel}
+									hideLabelFromVision
+									value={styleSlot}
+									options={STYLES}
+									disabled={disabled}
+									onChange={(next) => !disabled && patch({ style: applyToAxis(style, index, next) })}
+								/>
+							</span>
 							<TokenSelector
 								value={widthSlot}
 								icon={slotIcons?.[slotIndex]}
@@ -195,20 +233,10 @@ export function BorderControl({
 								onClear={() => !disabled && patch({ width: applyToAxis(width, index, '') })}
 								onCustom={(next) => !disabled && patch({ width: applyToAxis(width, index, next) })}
 							/>
-							<SelectControl
-								label={styleLabel}
-								hideLabelFromVision
-								value={styleSlot}
-								options={STYLES}
-								disabled={disabled}
-								onChange={(next) => !disabled && patch({ style: applyToAxis(style, index, next) })}
-							/>
 						</div>
 					);
 				}}
 			/>
-			{renderColor &&
-				renderColor({ value: color, onChange: (next) => !disabled && patch({ color: next }), disabled })}
 		</ControlShell>
 	);
 }

--- a/src/token-controls/controls/BorderControl.js
+++ b/src/token-controls/controls/BorderControl.js
@@ -96,6 +96,14 @@ function applyToAxis(axis, index, next) {
  * @param {Function}  props.onChange              Called with the next `{ width, style, color }`.
  * @param {string}    props.label                 The control's label.
  * @param {Array}     [props.widthTokens]         Pickable border-width tokens.
+ * @param {*}         [props.defaultValue]        What the width field falls back to when unset —
+ *                                                shown muted in every row (linked or per-side; a
+ *                                                border's width has one default regardless of how
+ *                                                many sides are showing). Without this, an unset
+ *                                                width `TokenSelector` renders nothing at all and
+ *                                                the row collapses to zero height.
+ * @param {boolean}   [props.inherited]           Whether that default comes from another breakpoint,
+ *                                                which tags it `Inherited` instead of `Default`.
  * @param {?Array}    [props.slotIcons]            Per-slot glyphs, in stored order (matches
  *                                                `BoxControl`'s prop).
  * @param {?Object}   [props.status]              `{ bound, modified }`; omit for no indicator.
@@ -128,6 +136,8 @@ export function BorderControl({
 	onChange,
 	label,
 	widthTokens = [],
+	defaultValue,
+	inherited = false,
 	slotIcons = null,
 	status = null,
 	onReset = null,
@@ -243,6 +253,8 @@ export function BorderControl({
 								value={widthSlot}
 								icon={slotIcons?.[slotIndex]}
 								tokens={widthTokens}
+								defaultValue={defaultValue}
+								inherited={inherited}
 								disabled={disabled}
 								onPick={(alias) => !disabled && patch({ width: applyToAxis(width, index, alias) })}
 								onClear={() => !disabled && patch({ width: applyToAxis(width, index, '') })}

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -742,15 +742,24 @@
 	.kadence-pop-color-label {
 		display: none;
 	}
+}
 
-	// `@kadence/components`' `SinglePopColorControl` draws its own swatch button
-	// (`.kadence-pop-color-indicate`, `pop-color-control/editor.scss`) at a fixed 28x28 — 8px bigger
-	// than this slot — so it has to be forced down to 20x20 rather than just having its wrapper's
-	// chrome stripped like the rules above.
-	.kadence-pop-color-indicate {
-		width: 20px;
-		height: 20px;
-	}
+/*
+ * `@kadence/components`' `SinglePopColorControl` draws its own swatch (`.kadence-pop-color-indicate`,
+ * inside `.kadence-pop-color-icon-indicate`, inside `.kadence-pop-color-control` — see
+ * `single-pop-color-control/index.js:305-312` and `pop-color-control/index.js:55`) at a fixed 28x28,
+ * via `pop-color-control/editor.scss`'s own
+ * `.kadence-pop-color-control .kadence-pop-color-icon-indicate .kadence-pop-color-indicate` rule —
+ * three classes, (0,3,0). Nesting the override inside `.kb-border-control__swatch` alone only adds
+ * one class on top of that same three-class chain's tail, tying rather than beating it — a tie a
+ * later-loaded CSS file could still lose depending on enqueue order. Written here as a standalone
+ * rule qualified by both `.kb-border-control__box` and `.kb-border-control__swatch` (both real
+ * ancestors — see `BorderControl.js`'s row markup) reaches four classes, (0,4,0), which wins outright
+ * regardless of load order.
+ */
+.kb-border-control__box .kb-border-control__swatch .kadence-pop-color-icon-indicate .kadence-pop-color-indicate {
+	width: 20px;
+	height: 20px;
 }
 
 /*

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -668,6 +668,7 @@
 	align-items: center;
 	gap: 8px;
 	width: 100%;
+
 	// Tighter on the left than the `7px 10px` other box fields use — the reference seats the
 	// swatch and style preview flush against that edge.
 	padding: 5px 10px 5px 6px;
@@ -764,12 +765,11 @@
 
 /*
  * The style preview: a 26x20px box with a 16px horizontal rule styled to match the side's current
- * `border-style` value. The native `<select>` the style picker already is sits on top, sized to
- * cover the box and invisible — clicking anywhere on the preview opens the same picker, without
- * building a new one.
+ * `border-style` value. `Dropdown` (from `BorderStyleSelect`) renders this as its own wrapping
+ * `<div>` via its `className` prop, with the real trigger `<button>` inside — see
+ * `.kb-border-control__style-trigger` below.
  */
 .kb-border-control__style-preview {
-	position: relative;
 	display: flex;
 	flex: 0 0 auto;
 	align-items: center;
@@ -779,14 +779,33 @@
 	border: 1px solid #dddddd;
 	border-radius: 3px;
 	background: #fff;
+}
 
-	// The real `<select>` inside is kept at `opacity: 0` (see `.kb-border-control__style-select`
-	// below) rather than replaced with a fake trigger, so keyboard focus lands on it invisibly.
-	// `:focus-within` gives the box itself the outline the trigger would otherwise show, matching
-	// the width trigger's own `:focus-visible` a few pixels away in the same row.
-	&:focus-within {
+/*
+ * The trigger itself: a real, focusable `<button>` filling the preview box — unlike the earlier
+ * native-`<select>`-underneath approach, `BorderStyleSelect` is custom UI top to bottom, so its own
+ * focus state has to be drawn explicitly rather than relying on a hidden native control's outline.
+ */
+.kb-border-control__style-trigger {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: 100%;
+	padding: 0;
+	border: 0;
+	border-radius: inherit;
+	background: transparent;
+	cursor: pointer;
+
+	&:focus-visible {
 		outline: 2px solid #3858e9;
 		outline-offset: 1px;
+	}
+
+	&:disabled {
+		cursor: default;
+		opacity: 0.5;
 	}
 }
 
@@ -814,22 +833,23 @@
 	visibility: hidden;
 }
 
-.kb-border-control__style-select.components-base-control {
-	position: absolute;
-	inset: 0;
-	margin: 0;
-
-	.components-base-control__field {
-		margin-bottom: 0;
-		height: 100%;
+// The popover's menu: a 4px-radius white sheet, matching the token field's own popover.
+.kb-border-control__style-menu {
+	.components-popover__content {
+		min-width: 180px;
+		border-radius: 4px;
 	}
+}
 
-	.components-select-control__input {
-		width: 100%;
-		height: 100%;
-		padding: 0;
-		border: 0;
-		opacity: 0;
-		cursor: pointer;
-	}
+// Each option's own rule sits in a fixed-width swatch column so every label starts at the same
+// indent regardless of which style (and therefore how wide a `--double` rule's border gets) it draws.
+.kb-border-control__style-menu-swatch {
+	display: inline-flex;
+	flex: 0 0 24px;
+	align-items: center;
+	justify-content: center;
+}
+
+.kb-border-control__style-menu-label {
+	flex: 1 1 auto;
 }

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -652,3 +652,158 @@
 		}
 	}
 }
+
+/**
+ * `BorderControl`'s row anatomy: a color swatch, a style-preview box, then the width field's
+ * label/value, all sharing one control box — the two pickers Padding/Margin/Radius's row doesn't
+ * carry.
+ *
+ * The box's own border/radius/padding lives here rather than on `TokenSelector`'s trigger (which
+ * `.kb-token-control__row`'s shared rule styles for every other box field): Border's box wraps
+ * three siblings, not one, so the width trigger's own border is stripped down to nothing and only
+ * the outer box's edge shows.
+ */
+.kb-border-control__box {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	// Tighter on the left than the `7px 10px` other box fields use — the reference seats the
+	// swatch and style preview flush against that edge.
+	padding: 5px 10px 5px 6px;
+	border: 1px solid #dddddd;
+	border-radius: 5px;
+
+	.kadence-token-field {
+		flex: 1 1 auto;
+		min-width: 0;
+	}
+}
+
+/*
+ * Strips the width trigger's own border/radius/padding when it sits inside Border's box — the box
+ * itself now draws that chrome. Scoped through `:has()` off the box's own class (rather than a
+ * class on `.kb-token-control__row` itself, which `SlotGrid` renders and this control does not
+ * touch) so Radius/Spacing's rows, which have no `.kb-border-control__box`, are untouched. Higher
+ * specificity than the shared row rule's `:where()`-wrapped selector wins regardless of source
+ * order.
+ */
+.kb-token-control__row:has(.kb-border-control__box) .kadence-token-field__trigger.components-button {
+	padding: 0;
+	border: 0;
+	border-radius: 0;
+
+	&[aria-expanded="true"] {
+		box-shadow: none;
+	}
+}
+
+/*
+ * The color swatch: sized and rounded to a 20px circle around whatever `renderColor` returns.
+ * `renderColor`'s own chrome (padding, border, a visible name label) is stripped back here — the
+ * row already carries the box border, and the reference row shows only the swatch, not a labeled
+ * field. This only reaches for the swatch's already-established markup (the block editor's
+ * `@kadence/components` `PopColorControl`/`SinglePopColorControl` and the Style Library's
+ * `TokenColorSelectField`); it does not add any new color-picking UI.
+ */
+.kb-border-control__swatch {
+	display: inline-flex;
+	flex: 0 0 auto;
+	align-items: center;
+	justify-content: center;
+	width: 20px;
+	height: 20px;
+
+	// The Style Library's `TokenColorSelectField`: drop its bordered/padded toggle chrome and its
+	// visible name label, leaving just the round swatch it already draws at 20px.
+	.kadence-blocks-style-library__field-token-color-select-toggle {
+		width: 20px;
+		height: 20px;
+		padding: 0;
+		border: 0;
+		gap: 0;
+	}
+
+	.kadence-blocks-style-library__field-token-color-select-label {
+		display: none;
+	}
+
+	// The block editor's `PopColorControl`: drop the base-control wrapper's own margin/padding so
+	// the swatch button it renders (`SinglePopColorControl`, via `.single-pop-color`) is the only
+	// thing that takes up space.
+	.components-base-control.kadence-pop-color-control {
+		margin: 0;
+	}
+
+	.kadence-pop-color-container {
+		gap: 0;
+	}
+
+	.kadence-pop-color-label {
+		display: none;
+	}
+}
+
+/*
+ * The style preview: a 26x20px box with a 16px horizontal rule styled to match the side's current
+ * `border-style` value. The native `<select>` the style picker already is sits on top, sized to
+ * cover the box and invisible — clicking anywhere on the preview opens the same picker, without
+ * building a new one.
+ */
+.kb-border-control__style-preview {
+	position: relative;
+	display: flex;
+	flex: 0 0 auto;
+	align-items: center;
+	justify-content: center;
+	width: 26px;
+	height: 20px;
+	border: 1px solid #dddddd;
+	border-radius: 3px;
+	background: #fff;
+}
+
+.kb-border-control__style-preview-rule {
+	width: 16px;
+	height: 0;
+	border-top: 2px solid #1e1e1e;
+	border-top-style: solid;
+}
+
+.kb-border-control__style-preview-rule--dashed {
+	border-top-style: dashed;
+}
+
+.kb-border-control__style-preview-rule--dotted {
+	border-top-style: dotted;
+}
+
+.kb-border-control__style-preview-rule--double {
+	border-top-style: double;
+	border-top-width: 3px;
+}
+
+// `none` shows no rule at all, rather than a muted line — there is nothing to preview.
+.kb-border-control__style-preview-rule--none {
+	visibility: hidden;
+}
+
+.kb-border-control__style-select.components-base-control {
+	position: absolute;
+	inset: 0;
+	margin: 0;
+
+	.components-base-control__field {
+		margin-bottom: 0;
+		height: 100%;
+	}
+
+	.components-select-control__input {
+		width: 100%;
+		height: 100%;
+		padding: 0;
+		border: 0;
+		opacity: 0;
+		cursor: pointer;
+	}
+}

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -670,10 +670,11 @@
 	width: 100%;
 
 	// Tighter on the left than the `7px 10px` other box fields use — the reference seats the
-	// swatch and style preview flush against that edge.
+	// swatch and style preview flush against that edge. Border-color and radius match the base
+	// trigger's original values, not the reference's control-box values.
 	padding: 5px 10px 5px 6px;
-	border: 1px solid #dddddd;
-	border-radius: 5px;
+	border: 1px solid #949494;
+	border-radius: 2px;
 
 	.kadence-token-field {
 		flex: 1 1 auto;

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -835,6 +835,7 @@
 
 // The popover's menu: a 4px-radius white sheet, matching the token field's own popover.
 .kb-border-control__style-menu {
+
 	.components-popover__content {
 		min-width: 180px;
 		border-radius: 4px;

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -742,6 +742,15 @@
 	.kadence-pop-color-label {
 		display: none;
 	}
+
+	// `@kadence/components`' `SinglePopColorControl` draws its own swatch button
+	// (`.kadence-pop-color-indicate`, `pop-color-control/editor.scss`) at a fixed 28x28 — 8px bigger
+	// than this slot — so it has to be forced down to 20x20 rather than just having its wrapper's
+	// chrome stripped like the rules above.
+	.kadence-pop-color-indicate {
+		width: 20px;
+		height: 20px;
+	}
 }
 
 /*
@@ -761,13 +770,21 @@
 	border: 1px solid #dddddd;
 	border-radius: 3px;
 	background: #fff;
+
+	// The real `<select>` inside is kept at `opacity: 0` (see `.kb-border-control__style-select`
+	// below) rather than replaced with a fake trigger, so keyboard focus lands on it invisibly.
+	// `:focus-within` gives the box itself the outline the trigger would otherwise show, matching
+	// the width trigger's own `:focus-visible` a few pixels away in the same row.
+	&:focus-within {
+		outline: 2px solid #3858e9;
+		outline-offset: 1px;
+	}
 }
 
 .kb-border-control__style-preview-rule {
 	width: 16px;
 	height: 0;
 	border-top: 2px solid #1e1e1e;
-	border-top-style: solid;
 }
 
 .kb-border-control__style-preview-rule--dashed {


### PR DESCRIPTION
## Summary
- Restructures `BorderControl`'s per-side rendering from two separate widgets (a width `TokenSelector` and a style `SelectControl`) into one control box per side: a 20px circular color swatch, a 26×20px style-preview box, and the width token's label/value inline — matching the shared row anatomy Padding/Margin/Radius already use.
- Color and style pickers keep their existing mechanisms unchanged (`renderColor`'s contract, the style `SelectControl`'s popover) — only where their triggers render moved into the shared box.
- Adds a per-side accessible label to the color swatch (`renderColor`'s optional `label` key) so four unlinked swatches don't share one accessible name.
- Folds `color` into both link-fold paths (`BorderControl`'s uncontrolled relink and `BorderField`'s controlled `toggleLink`/`storedIsList`) so relinking after per-side color edits doesn't leave a stale four-slot value behind.
- Border's control box uses its own `5px 10px 5px 6px` padding, scoped so it doesn't affect Radius/Spacing/Margin's shared `7px 10px`.

## Test plan
- [x] `npx jest src/token-controls src/style-library src/extension/design-tokens` — full suite green
- [x] `bun run lint-js`, `bun run build`
- [x] cspell on changed files
- [x] `grep -rn "SOFT-" src/token-controls` — no hits
- [ ] Manual verification on the dev site (Button preset screen's Border field)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Border controls now display width, style, and color together for each side.
  - Added compact color swatches and visual previews for solid, dashed, dotted, double, and hidden border styles.
  - Unlinked border sides show localized, side-specific color labels.
  - Added an accessible border-style picker with selectable previews and active-state indicators.
  - Linked borders retain synchronized values and relink consistently across all sides.

- **Bug Fixes**
  - Improved handling of color values when switching between linked and unlinked border settings.
  - Added clearer focus styling and more consistent border-control layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->