### PR TITLE
[DTM] SOFT-4083 [35/38]: BoxShadowControl adopts the shared row anatomy

### DIFF
--- a/src/token-controls/__tests__/box-shadow-control.test.js
+++ b/src/token-controls/__tests__/box-shadow-control.test.js
@@ -162,14 +162,26 @@ function change(element, value) {
 
 describe('BoxShadowControl trigger', () => {
 	/**
-	 * The trigger shows the bound token's label when the value is that token's alias.
+	 * The trigger shows the bound token's label when the value is that token's alias, matching
+	 * `TokenSelector`'s own label-then-value split rather than one concatenated string.
 	 *
 	 * @return {void}
 	 */
 	it('shows the token label when value is a token alias', () => {
 		renderControl({ value: '{primitive.shadow.md}' });
 
-		expect(trigger().textContent).toBe('Medium');
+		expect(trigger().querySelector('.kadence-token-field__label').textContent).toBe('Medium');
+	});
+
+	/**
+	 * The trigger shows the token's resolved value alongside its label.
+	 *
+	 * @return {void}
+	 */
+	it('shows the token value alongside its label', () => {
+		renderControl({ value: '{primitive.shadow.md}' });
+
+		expect(trigger().querySelector('.kadence-token-field__value').textContent).toBe('0px 2px 8px 0px #1717171f');
 	});
 
 	/**
@@ -180,7 +192,60 @@ describe('BoxShadowControl trigger', () => {
 	it('shows "Custom" when value is a composite object', () => {
 		renderControl({ value: { color: '#000000', offsetX: '2px', offsetY: '2px', blur: '4px', spread: '0px' } });
 
-		expect(trigger().textContent).toBe('Custom');
+		expect(trigger().querySelector('.kadence-token-field__label').textContent).toBe('Custom');
+	});
+
+	/**
+	 * A composite value's trigger shows its own resolved shorthand as the value, not the alias'
+	 * literal display — so the field reads the same "label, then value" way for either value shape.
+	 *
+	 * @return {void}
+	 */
+	it('shows the composite shadow resolved as CSS shorthand alongside "Custom"', () => {
+		renderControl({ value: { color: '#000000', offsetX: '2px', offsetY: '2px', blur: '4px', spread: '0px' } });
+
+		expect(trigger().querySelector('.kadence-token-field__value').textContent).toBe('2px 2px 4px 0px #000000');
+	});
+});
+
+describe('BoxShadowControl row anatomy', () => {
+	/**
+	 * The control renders exactly one control-box row — matching Border Radius's row anatomy — since
+	 * a shadow is a single value with nothing sided to grid.
+	 *
+	 * @return {void}
+	 */
+	it('renders exactly one control-box row', () => {
+		renderControl();
+
+		expect(container.querySelectorAll('.kb-token-control__row')).toHaveLength(1);
+	});
+
+	/**
+	 * The row carries no glyph element — a shadow has nothing spatial to point at, unlike a bordered
+	 * side or a rounded corner.
+	 *
+	 * @return {void}
+	 */
+	it('renders no glyph element', () => {
+		renderControl();
+
+		expect(container.querySelector('.kb-token-control__glyph')).toBeNull();
+	});
+
+	/**
+	 * `ControlShell`'s own header renders the field's label exactly once — the control no longer
+	 * builds its own ad-hoc `<span>` label alongside it.
+	 *
+	 * @return {void}
+	 */
+	it('renders the label once, via ControlShell’s header', () => {
+		renderControl({ label: 'Shadow' });
+
+		const headerLabels = container.querySelectorAll('.kb-token-control__label');
+
+		expect(headerLabels).toHaveLength(1);
+		expect(headerLabels[0].textContent).toBe('Shadow');
 	});
 });
 

--- a/src/token-controls/__tests__/box-shadow-control.test.js
+++ b/src/token-controls/__tests__/box-shadow-control.test.js
@@ -196,32 +196,16 @@ describe('BoxShadowControl trigger', () => {
 	});
 
 	/**
-	 * A composite value's trigger shows its own resolved shorthand as the value, not the alias'
-	 * literal display — so the field reads the same "label, then value" way for either value shape.
+	 * A composite value's trigger shows bare "Custom" with no value text — the Custom tab itself is
+	 * one click away and already shows every sub-field, so the trigger does not also spell out a CSS
+	 * shorthand alongside the label the way the aliased branch does.
 	 *
 	 * @return {void}
 	 */
-	it('shows the composite shadow resolved as CSS shorthand alongside "Custom"', () => {
+	it('shows no value text alongside "Custom" for a composite value', () => {
 		renderControl({ value: { color: '#000000', offsetX: '2px', offsetY: '2px', blur: '4px', spread: '0px' } });
 
-		expect(trigger().querySelector('.kadence-token-field__value').textContent).toBe('2px 2px 4px 0px #000000');
-	});
-
-	/**
-	 * An inset composite's value reads the literal lowercase `inset` CSS keyword, matching
-	 * `shadowCss()`'s own convention, rather than a translated UI word mixed into an otherwise
-	 * verbatim CSS string.
-	 *
-	 * @return {void}
-	 */
-	it('prefixes the shorthand with the literal "inset" keyword when the composite is inset', () => {
-		renderControl({
-			value: { color: '#000000', offsetX: '2px', offsetY: '2px', blur: '4px', spread: '0px', inset: true },
-		});
-
-		expect(trigger().querySelector('.kadence-token-field__value').textContent).toBe(
-			'inset 2px 2px 4px 0px #000000'
-		);
+		expect(trigger().querySelector('.kadence-token-field__value')).toBeNull();
 	});
 
 	/**
@@ -502,6 +486,55 @@ describe('BoxShadowControl Custom tab', () => {
 			blur: '8px',
 			spread: '0px',
 		});
+	});
+
+	/**
+	 * The Custom tab's color row sits in its own wrapper, above the axes — matching the Style
+	 * Library's `ShadowField` layout — rather than sitting inline with the axis fields the way it
+	 * did before this row anatomy existed. `renderColor`'s own rendered element (a bare
+	 * `data-testid="color-slot"` stand-in here, standing in for the real swatch-plus-label toggle) is
+	 * asserted as a child of that row, proving the wrapper does not alter or replace what the render
+	 * prop returns.
+	 *
+	 * @return {void}
+	 */
+	it('renders renderColor’s output inside its own color row, above the axes', () => {
+		const renderColor = () => <div data-testid="color-slot" />;
+
+		renderControl({
+			value: { color: '#111111', offsetX: '2px', offsetY: '4px', blur: '8px', spread: '0px' },
+			renderColor,
+		});
+
+		const colorRow = container.querySelector('.kb-box-shadow-control__color-row');
+
+		expect(colorRow).not.toBeNull();
+		expect(colorRow.querySelector('[data-testid="color-slot"]')).not.toBeNull();
+
+		// The color row renders above the axes: its section index in the Custom tab's own children
+		// comes before the axes row's.
+		const sections = Array.from(container.querySelector('.kb-box-shadow-control__custom').children);
+
+		expect(sections.indexOf(colorRow)).toBeLessThan(
+			sections.indexOf(container.querySelector('.kb-box-shadow-control__axes'))
+		);
+	});
+
+	/**
+	 * The four axis fields render together inside one `.kb-box-shadow-control__axes` row, in X, Y,
+	 * Blur, Spread order — the horizontal row anatomy `ShadowField` uses, not a stack.
+	 *
+	 * @return {void}
+	 */
+	it('renders the four axis fields together, in X/Y/Blur/Spread order', () => {
+		renderControl({
+			value: { color: '#111111', offsetX: '2px', offsetY: '4px', blur: '8px', spread: '1px' },
+		});
+
+		const axes = container.querySelector('.kb-box-shadow-control__axes');
+		const inputs = Array.from(axes.querySelectorAll('input[type="number"]'));
+
+		expect(inputs.map((input) => input.getAttribute('aria-label'))).toEqual(['X', 'Y', 'Blur', 'Spread']);
 	});
 });
 

--- a/src/token-controls/__tests__/box-shadow-control.test.js
+++ b/src/token-controls/__tests__/box-shadow-control.test.js
@@ -67,7 +67,7 @@ jest.mock('@wordpress/components', () => ({
 	),
 }));
 
-jest.mock('@wordpress/icons', () => ({ globe: 'globe', settings: 'settings', undo: 'undo' }));
+jest.mock('@wordpress/icons', () => ({ globe: 'globe', settings: 'settings', undo: 'undo', shadow: 'shadow-glyph' }));
 jest.mock('@wordpress/i18n', () => ({
 	__: (text) => text,
 	sprintf: (format, ...args) => format.replace(/%s/g, () => args.shift()),
@@ -162,8 +162,19 @@ function change(element, value) {
 
 describe('BoxShadowControl trigger', () => {
 	/**
-	 * The trigger shows the bound token's label when the value is that token's alias, matching
-	 * `TokenSelector`'s own label-then-value split rather than one concatenated string.
+	 * The trigger always shows a leading glyph, in every value state — the field's own visible
+	 * identity, independent of whether anything is set yet.
+	 *
+	 * @return {void}
+	 */
+	it('shows a leading icon glyph', () => {
+		renderControl({ value: '{primitive.shadow.md}' });
+
+		expect(trigger().querySelector('.kadence-token-field__icon')).not.toBeNull();
+	});
+
+	/**
+	 * The trigger shows the bound token's label when the value is that token's alias.
 	 *
 	 * @return {void}
 	 */
@@ -174,14 +185,15 @@ describe('BoxShadowControl trigger', () => {
 	});
 
 	/**
-	 * The trigger shows the token's resolved value alongside its label.
+	 * The trigger shows no value text alongside the bound token's label — unlike every other field's
+	 * `TokenSelector` trigger, this control shows a label only, never a resolved value/shorthand.
 	 *
 	 * @return {void}
 	 */
-	it('shows the token value alongside its label', () => {
+	it('shows no value text alongside the token label', () => {
 		renderControl({ value: '{primitive.shadow.md}' });
 
-		expect(trigger().querySelector('.kadence-token-field__value').textContent).toBe('0px 2px 8px 0px #1717171f');
+		expect(trigger().querySelector('.kadence-token-field__value')).toBeNull();
 	});
 
 	/**
@@ -196,9 +208,9 @@ describe('BoxShadowControl trigger', () => {
 	});
 
 	/**
-	 * A composite value's trigger shows bare "Custom" with no value text — the Custom tab itself is
-	 * one click away and already shows every sub-field, so the trigger does not also spell out a CSS
-	 * shorthand alongside the label the way the aliased branch does.
+	 * A composite value's trigger shows no value text alongside "Custom" either — the Custom tab
+	 * itself is one click away and already shows every sub-field, so the trigger does not also spell
+	 * out a CSS shorthand.
 	 *
 	 * @return {void}
 	 */
@@ -210,24 +222,24 @@ describe('BoxShadowControl trigger', () => {
 
 	/**
 	 * An unset value (the field's actual starting state before a token or a custom shadow is chosen)
-	 * renders an empty trigger — no label, no fabricated all-zero shorthand — matching every other
-	 * control's unset-slot behavior and `fieldSummary()`'s own unset branch.
+	 * renders no label text — no fabricated all-zero shorthand, matching every other control's
+	 * unset-slot behavior and `fieldSummary()`'s own unset branch — though the leading glyph still
+	 * renders, giving the trigger a visible identity even while empty.
 	 *
 	 * @return {void}
 	 */
-	it('renders an empty trigger when the value is unset', () => {
+	it('renders no label text when the value is unset', () => {
 		renderControl({ value: '' });
 
 		expect(trigger().querySelector('.kadence-token-field__label')).toBeNull();
-		expect(trigger().querySelector('.kadence-token-field__value')).toBeNull();
-		expect(trigger().textContent).toBe('');
+		expect(trigger().querySelector('.kadence-token-field__icon')).not.toBeNull();
 	});
 
 	/**
-	 * An unset trigger has no visible text, so it needs an `aria-label` naming it — otherwise a
-	 * screen reader announces the button with no accessible name at all. `ControlShell` renders the
-	 * field's `label` prop in a separate header span, not as this button's name, so the trigger has
-	 * to carry its own.
+	 * An unset trigger has no visible label text, so it needs an `aria-label` naming it — otherwise a
+	 * screen reader announces the button with nothing but a decorative, `aria-hidden` glyph to go on.
+	 * `ControlShell` renders the field's `label` prop in a separate header span, not as this button's
+	 * name, so the trigger has to carry its own.
 	 *
 	 * @return {void}
 	 */
@@ -238,8 +250,8 @@ describe('BoxShadowControl trigger', () => {
 	});
 
 	/**
-	 * A trigger with visible label/value text names itself through that text, so no `aria-label` is
-	 * added on top of it — avoiding a redundant or conflicting accessible name.
+	 * A trigger with visible label text names itself through that text, so no `aria-label` is added on
+	 * top of it — avoiding a redundant or conflicting accessible name.
 	 *
 	 * @return {void}
 	 */
@@ -250,7 +262,7 @@ describe('BoxShadowControl trigger', () => {
 	});
 
 	/**
-	 * Same guard for a composite (Custom) value, the other value shape with visible text.
+	 * Same guard for a composite (Custom) value, the other value shape with visible label text.
 	 *
 	 * @return {void}
 	 */

--- a/src/token-controls/__tests__/box-shadow-control.test.js
+++ b/src/token-controls/__tests__/box-shadow-control.test.js
@@ -206,6 +206,38 @@ describe('BoxShadowControl trigger', () => {
 
 		expect(trigger().querySelector('.kadence-token-field__value').textContent).toBe('2px 2px 4px 0px #000000');
 	});
+
+	/**
+	 * An inset composite's value reads the literal lowercase `inset` CSS keyword, matching
+	 * `shadowCss()`'s own convention, rather than a translated UI word mixed into an otherwise
+	 * verbatim CSS string.
+	 *
+	 * @return {void}
+	 */
+	it('prefixes the shorthand with the literal "inset" keyword when the composite is inset', () => {
+		renderControl({
+			value: { color: '#000000', offsetX: '2px', offsetY: '2px', blur: '4px', spread: '0px', inset: true },
+		});
+
+		expect(trigger().querySelector('.kadence-token-field__value').textContent).toBe(
+			'inset 2px 2px 4px 0px #000000'
+		);
+	});
+
+	/**
+	 * An unset value (the field's actual starting state before a token or a custom shadow is chosen)
+	 * renders an empty trigger — no label, no fabricated all-zero shorthand — matching every other
+	 * control's unset-slot behavior and `fieldSummary()`'s own unset branch.
+	 *
+	 * @return {void}
+	 */
+	it('renders an empty trigger when the value is unset', () => {
+		renderControl({ value: '' });
+
+		expect(trigger().querySelector('.kadence-token-field__label')).toBeNull();
+		expect(trigger().querySelector('.kadence-token-field__value')).toBeNull();
+		expect(trigger().textContent).toBe('');
+	});
 });
 
 describe('BoxShadowControl row anatomy', () => {

--- a/src/token-controls/__tests__/box-shadow-control.test.js
+++ b/src/token-controls/__tests__/box-shadow-control.test.js
@@ -238,6 +238,43 @@ describe('BoxShadowControl trigger', () => {
 		expect(trigger().querySelector('.kadence-token-field__value')).toBeNull();
 		expect(trigger().textContent).toBe('');
 	});
+
+	/**
+	 * An unset trigger has no visible text, so it needs an `aria-label` naming it — otherwise a
+	 * screen reader announces the button with no accessible name at all. `ControlShell` renders the
+	 * field's `label` prop in a separate header span, not as this button's name, so the trigger has
+	 * to carry its own.
+	 *
+	 * @return {void}
+	 */
+	it('has an aria-label when the value is unset', () => {
+		renderControl({ value: '' });
+
+		expect(trigger().getAttribute('aria-label')).toBe('Choose shadow');
+	});
+
+	/**
+	 * A trigger with visible label/value text names itself through that text, so no `aria-label` is
+	 * added on top of it — avoiding a redundant or conflicting accessible name.
+	 *
+	 * @return {void}
+	 */
+	it('has no aria-label when a token alias value is set', () => {
+		renderControl({ value: '{primitive.shadow.md}' });
+
+		expect(trigger().hasAttribute('aria-label')).toBe(false);
+	});
+
+	/**
+	 * Same guard for a composite (Custom) value, the other value shape with visible text.
+	 *
+	 * @return {void}
+	 */
+	it('has no aria-label when a composite value is set', () => {
+		renderControl({ value: { color: '#000000', offsetX: '2px', offsetY: '2px', blur: '4px', spread: '0px' } });
+
+		expect(trigger().hasAttribute('aria-label')).toBe(false);
+	});
 });
 
 describe('BoxShadowControl row anatomy', () => {

--- a/src/token-controls/__tests__/box-shadow-control.test.js
+++ b/src/token-controls/__tests__/box-shadow-control.test.js
@@ -369,6 +369,36 @@ describe('BoxShadowControl Style Library tab', () => {
 		expect(tokenItem('Large')).not.toBeUndefined();
 		expect(container.querySelector('.kadence-token-field__item-value')).toBeNull();
 	});
+
+	/**
+	 * The Style Library tab shows a live preview square above `Reset`, with the currently bound
+	 * token's resolved `box-shadow` value applied — giving a visual sense of the shadow before it is
+	 * picked.
+	 *
+	 * @return {void}
+	 */
+	it('shows a preview square carrying the bound token’s resolved shadow', () => {
+		renderControl({ value: '{primitive.shadow.md}' });
+
+		const preview = container.querySelector('.kadence-token-field__preview .kb-box-shadow-control__preview');
+
+		expect(preview).not.toBeNull();
+		expect(preview.style.boxShadow).toBe('0px 2px 8px 0px #1717171f');
+	});
+
+	/**
+	 * With nothing set yet, the preview square carries no shadow rather than a fabricated one.
+	 *
+	 * @return {void}
+	 */
+	it('shows a shadow-less preview square when the value is unset', () => {
+		renderControl({ value: '' });
+
+		const preview = container.querySelector('.kadence-token-field__preview .kb-box-shadow-control__preview');
+
+		expect(preview).not.toBeNull();
+		expect(preview.style.boxShadow).toBe('none');
+	});
 });
 
 describe('BoxShadowControl Custom tab', () => {

--- a/src/token-controls/__tests__/box-shadow-control.test.js
+++ b/src/token-controls/__tests__/box-shadow-control.test.js
@@ -411,6 +411,75 @@ describe('BoxShadowControl Style Library tab', () => {
 		expect(preview).not.toBeNull();
 		expect(preview.style.boxShadow).toBe('none');
 	});
+
+	/**
+	 * Hovering a different token row previews that row's shadow instead of the bound value's — the
+	 * live-hover behavior this control opts into via `TokenPopover`'s `hoveredEntry`.
+	 *
+	 * @return {void}
+	 */
+	it('previews the hovered token row’s shadow instead of the bound value', () => {
+		renderControl({ value: '{primitive.shadow.md}' });
+
+		const preview = () => container.querySelector('.kadence-token-field__preview .kb-box-shadow-control__preview');
+
+		expect(preview().style.boxShadow).toBe('0px 2px 8px 0px #1717171f');
+
+		act(() => tokenItem('Large').dispatchEvent(new MouseEvent('mouseover', { bubbles: true })));
+
+		expect(preview().style.boxShadow).toBe('0px 4px 16px 0px #1717172f');
+	});
+
+	/**
+	 * Leaving hover on a token row falls back to the bound value's own shadow again — the preview
+	 * does not stay pinned to whatever was last hovered.
+	 *
+	 * @return {void}
+	 */
+	it('falls back to the bound value’s shadow once hover leaves the token row', () => {
+		renderControl({ value: '{primitive.shadow.md}' });
+
+		const preview = () => container.querySelector('.kadence-token-field__preview .kb-box-shadow-control__preview');
+		const large = tokenItem('Large');
+
+		act(() => large.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })));
+		expect(preview().style.boxShadow).toBe('0px 4px 16px 0px #1717172f');
+
+		act(() => large.dispatchEvent(new MouseEvent('mouseout', { bubbles: true })));
+		expect(preview().style.boxShadow).toBe('0px 2px 8px 0px #1717171f');
+	});
+
+	/**
+	 * Focusing a token row (keyboard navigation) previews it exactly like a mouse hover — the field
+	 * stays keyboard-accessible, not mouse-only.
+	 *
+	 * @return {void}
+	 */
+	it('previews the focused token row’s shadow instead of the bound value', () => {
+		renderControl({ value: '{primitive.shadow.md}' });
+
+		const preview = () => container.querySelector('.kadence-token-field__preview .kb-box-shadow-control__preview');
+
+		act(() => tokenItem('Large').dispatchEvent(new window.FocusEvent('focusin', { bubbles: true })));
+
+		expect(preview().style.boxShadow).toBe('0px 4px 16px 0px #1717172f');
+	});
+
+	/**
+	 * Hovering the Reset row previews the cleared state — shadow-less here, since this control has
+	 * no inherited default for Reset to fall back to.
+	 *
+	 * @return {void}
+	 */
+	it('previews a shadow-less square while hovering Reset', () => {
+		renderControl({ value: '{primitive.shadow.md}' });
+
+		const preview = () => container.querySelector('.kadence-token-field__preview .kb-box-shadow-control__preview');
+
+		act(() => resetButton().dispatchEvent(new MouseEvent('mouseover', { bubbles: true })));
+
+		expect(preview().style.boxShadow).toBe('none');
+	});
 });
 
 describe('BoxShadowControl Custom tab', () => {

--- a/src/token-controls/__tests__/token-popover.test.js
+++ b/src/token-controls/__tests__/token-popover.test.js
@@ -162,3 +162,58 @@ describe('TokenPopover showValue prop', () => {
 		expect(container.querySelector('.kadence-token-field__item-label').textContent).toBe('Medium');
 	});
 });
+
+describe('TokenPopover renderPreview prop', () => {
+	/**
+	 * When `renderPreview` is absent — every consumer besides `BoxShadowControl` today, including
+	 * radius/spacing/border — no extra preview markup renders on the Style Library tab. This is the
+	 * regression check that the additive prop leaves existing consumers unchanged.
+	 *
+	 * @return {void}
+	 */
+	it('renders no preview slot when renderPreview is omitted', () => {
+		render({ initialTab: 'style-library', tokens: [], renderPreview: undefined });
+
+		expect(container.querySelector('.kadence-token-field__preview')).toBeNull();
+	});
+
+	/**
+	 * When `renderPreview` is provided, its output renders inside `.kadence-token-field__preview`,
+	 * above the `Reset` button, on the Style Library tab.
+	 *
+	 * @return {void}
+	 */
+	it('renders renderPreview output above Reset when provided', () => {
+		const renderPreview = () => createElement('div', { 'data-testid': 'preview-square' });
+
+		render({ initialTab: 'style-library', tokens: [], renderPreview });
+
+		const list = container.querySelector('.kadence-token-field__list');
+		const preview = list.querySelector('.kadence-token-field__preview');
+		const reset = list.querySelector('.kadence-token-field__reset');
+
+		expect(preview).not.toBeNull();
+		expect(preview.querySelector('[data-testid="preview-square"]')).not.toBeNull();
+
+		const children = Array.from(list.children);
+		expect(children.indexOf(preview)).toBeLessThan(children.indexOf(reset));
+	});
+
+	/**
+	 * `renderPreview` is called with the current slot value and the pickable-token list, so a caller
+	 * can resolve either shape (an alias or a literal) into a preview.
+	 *
+	 * @return {void}
+	 */
+	it('calls renderPreview with the current value and token list', () => {
+		const renderPreview = jest.fn(() => null);
+		// An empty pickable list avoids rendering a token row: the mocked `Button` passes `isPressed`
+		// straight through to a DOM `<button>`, which React warns about for an unknown DOM attribute —
+		// a pre-existing quirk of this test file's stand-in, unrelated to what this assertion checks.
+		const tokens = [];
+
+		render({ initialTab: 'style-library', value: '{primitive.shadow.md}', tokens, renderPreview });
+
+		expect(renderPreview).toHaveBeenCalledWith({ value: '{primitive.shadow.md}', tokens });
+	});
+});

--- a/src/token-controls/__tests__/token-popover.test.js
+++ b/src/token-controls/__tests__/token-popover.test.js
@@ -214,6 +214,103 @@ describe('TokenPopover renderPreview prop', () => {
 
 		render({ initialTab: 'style-library', value: '{primitive.shadow.md}', tokens, renderPreview });
 
-		expect(renderPreview).toHaveBeenCalledWith({ value: '{primitive.shadow.md}', tokens });
+		expect(renderPreview).toHaveBeenCalledWith({ value: '{primitive.shadow.md}', tokens, hoveredEntry: null });
+	});
+
+	/**
+	 * With nothing hovered or focused yet, `renderPreview` receives `hoveredEntry: null` so the
+	 * caller falls back to the bound value — the regression check for the pre-hover state.
+	 *
+	 * @return {void}
+	 */
+	it('calls renderPreview with a null hoveredEntry before any row is hovered or focused', () => {
+		const renderPreview = jest.fn(() => null);
+		// An empty pickable list avoids rendering a token row, sidestepping the same mocked-`Button`
+		// `isPressed`-on-DOM quirk noted above.
+		const tokens = [];
+
+		render({ initialTab: 'style-library', tokens, renderPreview });
+
+		expect(renderPreview).toHaveBeenLastCalledWith({ value: '', tokens, hoveredEntry: null });
+	});
+
+	/**
+	 * Hovering a token row (mouse enter) passes that entry to `renderPreview` as `{ kind: 'token',
+	 * entry }`; leaving it (mouse leave) falls back to `hoveredEntry: null` again.
+	 *
+	 * @return {void}
+	 */
+	it('updates hoveredEntry to the token row on mouse enter, and back to null on mouse leave', () => {
+		const renderPreview = jest.fn(() => null);
+		const entry = { id: 'md', label: 'Medium', value: '0px 2px 8px #000', alias: '{primitive.shadow.md}' };
+
+		render({ initialTab: 'style-library', tokens: [entry], renderPreview });
+
+		const item = container.querySelector('.kadence-token-field__item');
+
+		act(() => item.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })));
+		expect(renderPreview).toHaveBeenLastCalledWith({
+			value: '',
+			tokens: [entry],
+			hoveredEntry: { kind: 'token', entry },
+		});
+
+		act(() => item.dispatchEvent(new MouseEvent('mouseout', { bubbles: true })));
+		expect(renderPreview).toHaveBeenLastCalledWith({ value: '', tokens: [entry], hoveredEntry: null });
+	});
+
+	/**
+	 * Focusing a token row (keyboard navigation) previews it exactly like a mouse hover does, and
+	 * blurring it falls back to `hoveredEntry: null` — so tabbing through the list, not only
+	 * pointing at it, drives the live preview.
+	 *
+	 * @return {void}
+	 */
+	it('updates hoveredEntry to the token row on focus, and back to null on blur', () => {
+		const renderPreview = jest.fn(() => null);
+		const entry = { id: 'md', label: 'Medium', value: '0px 2px 8px #000', alias: '{primitive.shadow.md}' };
+
+		render({ initialTab: 'style-library', tokens: [entry], renderPreview });
+
+		const item = container.querySelector('.kadence-token-field__item');
+
+		act(() => item.dispatchEvent(new window.FocusEvent('focusin', { bubbles: true })));
+		expect(renderPreview).toHaveBeenLastCalledWith({
+			value: '',
+			tokens: [entry],
+			hoveredEntry: { kind: 'token', entry },
+		});
+
+		act(() => item.dispatchEvent(new window.FocusEvent('focusout', { bubbles: true })));
+		expect(renderPreview).toHaveBeenLastCalledWith({ value: '', tokens: [entry], hoveredEntry: null });
+	});
+
+	/**
+	 * Hovering the `Reset` row previews the cleared state as `{ kind: 'reset' }`, distinct from a
+	 * token-row hover, so a caller can render what the field looks like once cleared.
+	 *
+	 * @return {void}
+	 */
+	it('updates hoveredEntry to the reset kind on hovering the Reset row', () => {
+		const renderPreview = jest.fn(() => null);
+		const tokens = [{ id: 'md', label: 'Medium', value: '0px 2px 8px #000', alias: '{primitive.shadow.md}' }];
+
+		render({ initialTab: 'style-library', value: '{primitive.shadow.md}', tokens, renderPreview });
+
+		const reset = container.querySelector('.kadence-token-field__reset');
+
+		act(() => reset.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })));
+		expect(renderPreview).toHaveBeenLastCalledWith({
+			value: '{primitive.shadow.md}',
+			tokens,
+			hoveredEntry: { kind: 'reset' },
+		});
+
+		act(() => reset.dispatchEvent(new MouseEvent('mouseout', { bubbles: true })));
+		expect(renderPreview).toHaveBeenLastCalledWith({
+			value: '{primitive.shadow.md}',
+			tokens,
+			hoveredEntry: null,
+		});
 	});
 });

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -22,6 +22,10 @@
  * `TokenPopover` consumers (Radius, Spacing, Border Width) keep the default `showValue={true}` and
  * are unaffected.
  *
+ * The Style Library tab shows a live preview square above `Reset`, via `TokenPopover`'s optional
+ * `renderPreview` prop — additive there, so every other `TokenPopover` consumer that does not pass
+ * it renders unchanged. Only this control opts in for now, per explicit scope.
+ *
  * The wrapper composes `ControlShell` exactly as `BoxControl`/`BorderControl` do, minus the props
  * neither applies to a shadow: no `breakpoints`/`onBreakpointChange` (a shadow field isn't
  * responsive here), no `isLinked`/`onToggleLink` (a shadow is one value, not sided, so there is
@@ -81,6 +85,36 @@ function commitShadow(shadow, patch) {
 	const { inset, ...rest } = { ...shadow, ...patch };
 
 	return inset === true ? { ...rest, inset: true } : rest;
+}
+
+/**
+ * Resolve the current slot value into `box-shadow` CSS for the Style Library tab's preview square: a
+ * bound token's own resolved value string when aliased, or the composite's own shorthand (matching
+ * the dimension order and literal `inset` keyword `Css_Renderer`/`shadowCss()` emit) when a literal
+ * composite is set. Empty when nothing is set yet, so the preview renders a plain, shadow-less box.
+ *
+ * @param {*}      value  The current slot value (alias string, composite object, or empty).
+ * @param {Array}  tokens The pickable-token list, used to resolve an alias.
+ * @param {Object} shadow The composite value with defaults already filled (ignored for an alias).
+ *
+ * @since TBD
+ *
+ * @return {string} The resolved `box-shadow` CSS, or '' when unset.
+ */
+function resolvePreviewCss(value, tokens, shadow) {
+	if (isTokenAlias(value)) {
+		const entry = tokens.find((candidate) => candidate.alias === value);
+
+		return entry ? entry.value : '';
+	}
+
+	if (!hasValue(value)) {
+		return '';
+	}
+
+	const shorthand = `${shadow.offsetX} ${shadow.offsetY} ${shadow.blur} ${shadow.spread} ${shadow.color}`;
+
+	return shadow.inset === true ? `inset ${shorthand}` : shorthand;
 }
 
 /**
@@ -206,6 +240,15 @@ export function BoxShadowControl({ value, onChange, label, tokens = [], renderCo
 								onClear={() => !disabled && onChange('')}
 								onClose={onClose}
 								showValue={false}
+								renderPreview={({ value: previewValue, tokens: previewTokens }) => (
+									<div
+										className="kb-box-shadow-control__preview"
+										style={{
+											boxShadow: resolvePreviewCss(previewValue, previewTokens, shadow) || 'none',
+										}}
+										aria-hidden="true"
+									/>
+								)}
 							/>
 						)}
 					/>

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -26,6 +26,12 @@
  * `renderPreview` prop — additive there, so every other `TokenPopover` consumer that does not pass
  * it renders unchanged. Only this control opts in for now, per explicit scope.
  *
+ * The trigger itself is icon-plus-label only, never a value — a leading glyph (the `@wordpress/icons`
+ * package's own `shadow` artwork, which draws as a sun) followed by the bound token's label or bare
+ * "Custom", with no resolved value/shorthand text shown alongside either. Every other field's trigger
+ * (`TokenSelector`'s) keeps its label-then-value split; this is a deliberate, shadow-only departure,
+ * not a shared-trigger-style change.
+ *
  * The wrapper composes `ControlShell` exactly as `BoxControl`/`BorderControl` do, minus the props
  * neither applies to a shadow: no `breakpoints`/`onBreakpointChange` (a shadow field isn't
  * responsive here), no `isLinked`/`onToggleLink` (a shadow is one value, not sided, so there is
@@ -39,6 +45,10 @@
  * WordPress dependencies
  */
 import { __experimentalNumberControl as NumberControl, Button, Dropdown, ToggleControl } from '@wordpress/components';
+// `shadow` (renamed to avoid colliding with this file's own `shadow` composite-value variable) draws
+// as a sun-with-rays glyph in `@wordpress/icons`' own artwork — an odd name for that shape, but it is
+// the package's dedicated "shadow" icon, so it is the intended one rather than a generic substitute.
+import { shadow as shadowGlyph } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -184,23 +194,20 @@ function ShadowCustomTab({ shadow, onChange, renderColor, disabled = false }) {
 export function BoxShadowControl({ value, onChange, label, tokens = [], renderColor, disabled = false }) {
 	const aliased = isTokenAlias(value);
 	const shadow = { ...DEFAULT_SHADOW, ...(aliased || !value ? {} : value) };
-	// Aliased reads the bound token's label/value split exactly as `TokenSelector`'s own trigger does;
-	// an unset slot reads as empty, matching `fieldSummary()`'s own unset branch and `TokenSelector`'s
-	// resulting empty trigger, rather than fabricating a value for a field that holds nothing; a
-	// genuine composite reads bare "Custom" with no value text — the Custom tab itself is one click
-	// away and already shows every sub-field, so the trigger does not also spell out a shorthand.
+	// The trigger shows a label only, never a value — for either shape. Aliased still reads
+	// `fieldSummary()`'s bound-token label (dropping the `value` half it also returns, which does not
+	// fit this control's icon-plus-label trigger); a genuine composite reads bare "Custom"; unset
+	// reads as empty text (the leading glyph below still gives it a visible, accessible identity).
 	const summary = aliased
-		? fieldSummary(value, tokens, '', __('Custom', 'kadence-blocks'))
+		? { ...fieldSummary(value, tokens, '', __('Custom', 'kadence-blocks')), value: '' }
 		: !hasValue(value)
 			? { label: '', value: '' }
 			: { label: __('Custom', 'kadence-blocks'), value: '' };
-	// The unset trigger renders no visible label/value (so the field reads as genuinely empty, not a
-	// fabricated custom shadow — see the summary derivation above), which would otherwise leave the
-	// Button with no accessible name at all: `ControlShell` renders `label` as a separate header span,
-	// not as this button's name. An `aria-label` fills that gap only while the trigger is visibly
-	// empty; a set value already names itself through the visible label/value text, so adding one
-	// there would be redundant.
-	const emptyTriggerLabel = !summary.label && !summary.value ? __('Choose shadow', 'kadence-blocks') : undefined;
+	// An unset trigger has no visible label text, which would otherwise leave the Button with no
+	// accessible name at all: `ControlShell` renders `label` as a separate header span, not as this
+	// button's name. An `aria-label` fills that gap only while unset; a bound token or a composite
+	// already names itself through its visible label text, so adding one there would be redundant.
+	const emptyTriggerLabel = !summary.label ? __('Choose shadow', 'kadence-blocks') : undefined;
 
 	return (
 		<ControlShell label={label} disabled={disabled}>
@@ -211,14 +218,16 @@ export function BoxShadowControl({ value, onChange, label, tokens = [], renderCo
 						contentClassName="kadence-token-field__popover"
 						renderToggle={({ isOpen, onToggle }) => (
 							<Button
-								className="kadence-token-field__trigger"
+								className="kadence-token-field__trigger kb-box-shadow-control__trigger"
 								onClick={onToggle}
 								disabled={disabled}
 								aria-expanded={isOpen}
 								aria-label={emptyTriggerLabel}
 							>
+								<span className="kadence-token-field__icon" aria-hidden="true">
+									{shadowGlyph}
+								</span>
 								{summary.label && <span className="kadence-token-field__label">{summary.label}</span>}
-								{summary.value && <span className="kadence-token-field__value">{summary.value}</span>}
 							</Button>
 						)}
 						renderContent={({ onClose }) => (

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -36,7 +36,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { ControlShell } from '../templates/ControlShell';
 import { TokenPopover } from '../molecules/TokenPopover';
-import { fieldSummary, isTokenAlias } from '../helpers/token-summary';
+import { fieldSummary, hasValue, isTokenAlias } from '../helpers/token-summary';
 import '../styles/token-controls.scss';
 
 /**
@@ -79,7 +79,9 @@ function commitShadow(shadow, patch) {
 
 /**
  * Render a composite shadow's `box-shadow` CSS shorthand for the trigger's value text, matching the
- * dimension order `Css_Renderer` emits.
+ * dimension order and literal `inset` keyword `Css_Renderer`/`shadowCss()` emit — the value span is
+ * otherwise verbatim CSS (units, hex, rgba), so this stays untranslated rather than mixing in a UI
+ * word.
  *
  * @param {Object} shadow The composite shadow value, defaults already filled.
  *
@@ -90,7 +92,7 @@ function commitShadow(shadow, patch) {
 function shadowShorthand(shadow) {
 	const shorthand = `${shadow.offsetX} ${shadow.offsetY} ${shadow.blur} ${shadow.spread} ${shadow.color}`;
 
-	return shadow.inset === true ? `${__('Inset', 'kadence-blocks')} ${shorthand}` : shorthand;
+	return shadow.inset === true ? `inset ${shorthand}` : shorthand;
 }
 
 /**
@@ -153,16 +155,20 @@ export function BoxShadowControl({ value, onChange, label, tokens = [], renderCo
 	const aliased = isTokenAlias(value);
 	const shadow = { ...DEFAULT_SHADOW, ...(aliased || !value ? {} : value) };
 	// Aliased reads the bound token's label/value split exactly as `TokenSelector`'s own trigger does;
-	// a composite has no token entry to look up, so it reads "Custom" plus its own resolved shorthand
-	// instead of `fieldSummary()`'s literal-plus-unit shape, which does not fit an object value.
+	// an unset slot reads as empty, matching `fieldSummary()`'s own unset branch and `TokenSelector`'s
+	// resulting empty trigger, rather than fabricating a value for a field that holds nothing; only a
+	// genuine composite reads "Custom" plus its own resolved shorthand, which `fieldSummary()`'s
+	// literal-plus-unit shape does not fit (it is built for scalars, not an object value).
 	const summary = aliased
 		? fieldSummary(value, tokens, '', __('Custom', 'kadence-blocks'))
-		: { label: __('Custom', 'kadence-blocks'), value: shadowShorthand(shadow) };
+		: !hasValue(value)
+			? { label: '', value: '' }
+			: { label: __('Custom', 'kadence-blocks'), value: shadowShorthand(shadow) };
 
 	return (
 		<ControlShell label={label} disabled={disabled}>
 			<div className="kb-token-control__row">
-				<div className="kadence-token-field kb-box-shadow-control">
+				<div className="kadence-token-field">
 					<Dropdown
 						className="kadence-token-field__dropdown"
 						contentClassName="kadence-token-field__popover"

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -164,6 +164,13 @@ export function BoxShadowControl({ value, onChange, label, tokens = [], renderCo
 		: !hasValue(value)
 			? { label: '', value: '' }
 			: { label: __('Custom', 'kadence-blocks'), value: shadowShorthand(shadow) };
+	// The unset trigger renders no visible label/value (so the field reads as genuinely empty, not a
+	// fabricated custom shadow — see the summary derivation above), which would otherwise leave the
+	// Button with no accessible name at all: `ControlShell` renders `label` as a separate header span,
+	// not as this button's name. An `aria-label` fills that gap only while the trigger is visibly
+	// empty; a set value already names itself through the visible label/value text, so adding one
+	// there would be redundant.
+	const emptyTriggerLabel = !summary.label && !summary.value ? __('Choose shadow', 'kadence-blocks') : undefined;
 
 	return (
 		<ControlShell label={label} disabled={disabled}>
@@ -178,6 +185,7 @@ export function BoxShadowControl({ value, onChange, label, tokens = [], renderCo
 								onClick={onToggle}
 								disabled={disabled}
 								aria-expanded={isOpen}
+								aria-label={emptyTriggerLabel}
 							>
 								{summary.label && <span className="kadence-token-field__label">{summary.label}</span>}
 								{summary.value && <span className="kadence-token-field__value">{summary.value}</span>}

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -24,7 +24,9 @@
  *
  * The Style Library tab shows a live preview square above `Reset`, via `TokenPopover`'s optional
  * `renderPreview` prop — additive there, so every other `TokenPopover` consumer that does not pass
- * it renders unchanged. Only this control opts in for now, per explicit scope.
+ * it renders unchanged. Only this control opts in for now, per explicit scope. The square tracks
+ * whichever row is currently hovered or keyboard-focused (`resolveHoverPreviewCss()`), falling back
+ * to the bound value's own shadow (`resolvePreviewCss()`) once hover/focus leaves the list.
  *
  * The trigger itself is icon-plus-label only, never a value — a leading glyph (the `@wordpress/icons`
  * package's own `shadow` artwork, which draws as a sun) followed by the bound token's label or bare
@@ -125,6 +127,30 @@ function resolvePreviewCss(value, tokens, shadow) {
 	const shorthand = `${shadow.offsetX} ${shadow.offsetY} ${shadow.blur} ${shadow.spread} ${shadow.color}`;
 
 	return shadow.inset === true ? `inset ${shorthand}` : shorthand;
+}
+
+/**
+ * Resolve the preview square's `box-shadow` CSS for a given hover/focus state: whichever token row
+ * the pointer or keyboard focus currently sits on, the "Reset" row's cleared state (this control has
+ * no inherited default to fall back to, so cleared reads as shadow-less), or — while nothing is
+ * hovered/focused — the bound slot's own resolved shadow via `resolvePreviewCss()`.
+ *
+ * @param {?Object} hoveredEntry The `TokenPopover` hover/focus state: `null`, `{ kind: 'reset' }`, or
+ *                                `{ kind: 'token', entry }`.
+ * @param {*}       value        The current slot value, used when nothing is hovered/focused.
+ * @param {Array}   tokens       The pickable-token list, used when nothing is hovered/focused.
+ * @param {Object}  shadow       The composite value with defaults already filled.
+ *
+ * @since TBD
+ *
+ * @return {string} The resolved `box-shadow` CSS, or '' for a shadow-less preview.
+ */
+function resolveHoverPreviewCss(hoveredEntry, value, tokens, shadow) {
+	if (!hoveredEntry) {
+		return resolvePreviewCss(value, tokens, shadow);
+	}
+
+	return hoveredEntry.kind === 'token' ? hoveredEntry.entry.value : '';
 }
 
 /**
@@ -249,11 +275,17 @@ export function BoxShadowControl({ value, onChange, label, tokens = [], renderCo
 								onClear={() => !disabled && onChange('')}
 								onClose={onClose}
 								showValue={false}
-								renderPreview={({ value: previewValue, tokens: previewTokens }) => (
+								renderPreview={({ value: previewValue, tokens: previewTokens, hoveredEntry }) => (
 									<div
 										className="kb-box-shadow-control__preview"
 										style={{
-											boxShadow: resolvePreviewCss(previewValue, previewTokens, shadow) || 'none',
+											boxShadow:
+												resolveHoverPreviewCss(
+													hoveredEntry,
+													previewValue,
+													previewTokens,
+													shadow
+												) || 'none',
 										}}
 										aria-hidden="true"
 									/>

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -6,10 +6,16 @@
  * The Custom tab reuses the exact composite shape `helpers/shadow.js` and `ShadowField` already
  * define for the Shadow token-library screen (`{ color, offsetX, offsetY, blur, spread, inset }`),
  * confirmed against the live screen rather than invented fresh — this control is a token-aware
- * wrapper around that same editing surface, not a new one.
+ * wrapper around that same editing surface, not a new one. Its visual layout mirrors that same
+ * `ShadowField` too — a color row, then the four axes side by side, then Inset — built as plain
+ * markup here rather than importing `ShadowField`/its SCSS, since `token-controls` cannot depend on
+ * `style-library` (this control also runs in the block editor canvas, which has none of the
+ * `--kb-sl-*` custom properties `style-library`'s own SCSS resolves against).
  *
  * Color is out of scope here (see `renderColor`) exactly as in `BorderControl` — this control does
- * not import or build a color picker.
+ * not import or build a color picker. The Custom tab's color row wraps whatever `renderColor`
+ * renders (the Style Library's swatch-plus-label toggle, the block editor's `PopColorControl`) in
+ * plain layout chrome; it does not touch what that render prop returns.
  *
  * The token rows also hide their resolved value (`TokenPopover`'s `showValue={false}`) — a shadow's
  * value is a long CSS shorthand that crowds the row the way a short dimension value does not. Other
@@ -78,24 +84,6 @@ function commitShadow(shadow, patch) {
 }
 
 /**
- * Render a composite shadow's `box-shadow` CSS shorthand for the trigger's value text, matching the
- * dimension order and literal `inset` keyword `Css_Renderer`/`shadowCss()` emit — the value span is
- * otherwise verbatim CSS (units, hex, rgba), so this stays untranslated rather than mixing in a UI
- * word.
- *
- * @param {Object} shadow The composite shadow value, defaults already filled.
- *
- * @since TBD
- *
- * @return {string} The shorthand string, `inset`-prefixed when the composite is inset.
- */
-function shadowShorthand(shadow) {
-	const shorthand = `${shadow.offsetX} ${shadow.offsetY} ${shadow.blur} ${shadow.spread} ${shadow.color}`;
-
-	return shadow.inset === true ? `inset ${shorthand}` : shorthand;
-}
-
-/**
  * The Custom tab body: the shadow composite editor, matching `ShadowField`'s layout — a color row,
  * four numeric axes, an inset toggle.
  *
@@ -114,7 +102,15 @@ function ShadowCustomTab({ shadow, onChange, renderColor, disabled = false }) {
 
 	return (
 		<div className="kadence-token-field__custom kb-box-shadow-control__custom">
-			{renderColor && renderColor({ value: shadow.color, onChange: (next) => setPart('color', next), disabled })}
+			{renderColor && (
+				// A plain wrapper, not a rebuilt picker: whatever the caller's `renderColor` already renders
+				// (the Style Library's `TokenColorSelectField` swatch-plus-"Color"-label toggle, the block
+				// editor's `PopColorControl`) keeps its own click-to-open mechanism and chrome untouched;
+				// this only gives it its own row above the axes instead of sitting inline with them.
+				<div className="kb-box-shadow-control__color-row">
+					{renderColor({ value: shadow.color, onChange: (next) => setPart('color', next), disabled })}
+				</div>
+			)}
 			<div className="kb-box-shadow-control__axes">
 				{AXES.map(({ key, label }) => (
 					<NumberControl
@@ -156,14 +152,14 @@ export function BoxShadowControl({ value, onChange, label, tokens = [], renderCo
 	const shadow = { ...DEFAULT_SHADOW, ...(aliased || !value ? {} : value) };
 	// Aliased reads the bound token's label/value split exactly as `TokenSelector`'s own trigger does;
 	// an unset slot reads as empty, matching `fieldSummary()`'s own unset branch and `TokenSelector`'s
-	// resulting empty trigger, rather than fabricating a value for a field that holds nothing; only a
-	// genuine composite reads "Custom" plus its own resolved shorthand, which `fieldSummary()`'s
-	// literal-plus-unit shape does not fit (it is built for scalars, not an object value).
+	// resulting empty trigger, rather than fabricating a value for a field that holds nothing; a
+	// genuine composite reads bare "Custom" with no value text — the Custom tab itself is one click
+	// away and already shows every sub-field, so the trigger does not also spell out a shorthand.
 	const summary = aliased
 		? fieldSummary(value, tokens, '', __('Custom', 'kadence-blocks'))
 		: !hasValue(value)
 			? { label: '', value: '' }
-			: { label: __('Custom', 'kadence-blocks'), value: shadowShorthand(shadow) };
+			: { label: __('Custom', 'kadence-blocks'), value: '' };
 	// The unset trigger renders no visible label/value (so the field reads as genuinely empty, not a
 	// fabricated custom shadow — see the summary derivation above), which would otherwise leave the
 	// Button with no accessible name at all: `ControlShell` renders `label` as a separate header span,

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -15,6 +15,14 @@
  * value is a long CSS shorthand that crowds the row the way a short dimension value does not. Other
  * `TokenPopover` consumers (Radius, Spacing, Border Width) keep the default `showValue={true}` and
  * are unaffected.
+ *
+ * The wrapper composes `ControlShell` exactly as `BoxControl`/`BorderControl` do, minus the props
+ * neither applies to a shadow: no `breakpoints`/`onBreakpointChange` (a shadow field isn't
+ * responsive here), no `isLinked`/`onToggleLink` (a shadow is one value, not sided, so there is
+ * nothing to link). The body renders one `.kb-token-control__row` — the same control-box chrome
+ * `SlotGrid` gives Radius/Spacing's rows — but built directly rather than through `SlotGrid`,
+ * because `SlotGrid` always pairs a row with a glyph and a shadow has no side/corner for a glyph to
+ * point at.
  */
 
 /**
@@ -26,8 +34,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { ControlShell } from '../templates/ControlShell';
 import { TokenPopover } from '../molecules/TokenPopover';
-import { isTokenAlias } from '../helpers/token-summary';
+import { fieldSummary, isTokenAlias } from '../helpers/token-summary';
 import '../styles/token-controls.scss';
 
 /**
@@ -66,6 +75,22 @@ function commitShadow(shadow, patch) {
 	const { inset, ...rest } = { ...shadow, ...patch };
 
 	return inset === true ? { ...rest, inset: true } : rest;
+}
+
+/**
+ * Render a composite shadow's `box-shadow` CSS shorthand for the trigger's value text, matching the
+ * dimension order `Css_Renderer` emits.
+ *
+ * @param {Object} shadow The composite shadow value, defaults already filled.
+ *
+ * @since TBD
+ *
+ * @return {string} The shorthand string, `inset`-prefixed when the composite is inset.
+ */
+function shadowShorthand(shadow) {
+	const shorthand = `${shadow.offsetX} ${shadow.offsetY} ${shadow.blur} ${shadow.spread} ${shadow.color}`;
+
+	return shadow.inset === true ? `${__('Inset', 'kadence-blocks')} ${shorthand}` : shorthand;
 }
 
 /**
@@ -127,47 +152,55 @@ function ShadowCustomTab({ shadow, onChange, renderColor, disabled = false }) {
 export function BoxShadowControl({ value, onChange, label, tokens = [], renderColor, disabled = false }) {
 	const aliased = isTokenAlias(value);
 	const shadow = { ...DEFAULT_SHADOW, ...(aliased || !value ? {} : value) };
-	const activeEntry = aliased ? tokens.find((entry) => entry.alias === value) : null;
-	const triggerLabel = activeEntry ? activeEntry.label : aliased ? value : __('Custom', 'kadence-blocks');
+	// Aliased reads the bound token's label/value split exactly as `TokenSelector`'s own trigger does;
+	// a composite has no token entry to look up, so it reads "Custom" plus its own resolved shorthand
+	// instead of `fieldSummary()`'s literal-plus-unit shape, which does not fit an object value.
+	const summary = aliased
+		? fieldSummary(value, tokens, '', __('Custom', 'kadence-blocks'))
+		: { label: __('Custom', 'kadence-blocks'), value: shadowShorthand(shadow) };
 
 	return (
-		<div className="kadence-token-field kb-box-shadow-control">
-			{label && <span className="kadence-token-field__label">{label}</span>}
-			<Dropdown
-				className="kadence-token-field__dropdown"
-				contentClassName="kadence-token-field__popover"
-				renderToggle={({ isOpen, onToggle }) => (
-					<Button
-						className="kadence-token-field__trigger"
-						onClick={onToggle}
-						disabled={disabled}
-						aria-expanded={isOpen}
-					>
-						{triggerLabel}
-					</Button>
-				)}
-				renderContent={({ onClose }) => (
-					<TokenPopover
-						value={value}
-						tokens={tokens}
-						resolvedDefault=""
-						initialTab={aliased || !value ? 'style-library' : 'custom'}
-						custom={{ shadow, renderColor, disabled }}
-						renderCustom={(custom) => (
-							<ShadowCustomTab
-								shadow={custom.shadow}
-								renderColor={custom.renderColor}
-								disabled={custom.disabled}
-								onChange={(next) => !disabled && onChange(next)}
+		<ControlShell label={label} disabled={disabled}>
+			<div className="kb-token-control__row">
+				<div className="kadence-token-field kb-box-shadow-control">
+					<Dropdown
+						className="kadence-token-field__dropdown"
+						contentClassName="kadence-token-field__popover"
+						renderToggle={({ isOpen, onToggle }) => (
+							<Button
+								className="kadence-token-field__trigger"
+								onClick={onToggle}
+								disabled={disabled}
+								aria-expanded={isOpen}
+							>
+								{summary.label && <span className="kadence-token-field__label">{summary.label}</span>}
+								{summary.value && <span className="kadence-token-field__value">{summary.value}</span>}
+							</Button>
+						)}
+						renderContent={({ onClose }) => (
+							<TokenPopover
+								value={value}
+								tokens={tokens}
+								resolvedDefault=""
+								initialTab={aliased || !value ? 'style-library' : 'custom'}
+								custom={{ shadow, renderColor, disabled }}
+								renderCustom={(custom) => (
+									<ShadowCustomTab
+										shadow={custom.shadow}
+										renderColor={custom.renderColor}
+										disabled={custom.disabled}
+										onChange={(next) => !disabled && onChange(next)}
+									/>
+								)}
+								onPick={(alias) => !disabled && onChange(alias)}
+								onClear={() => !disabled && onChange('')}
+								onClose={onClose}
+								showValue={false}
 							/>
 						)}
-						onPick={(alias) => !disabled && onChange(alias)}
-						onClear={() => !disabled && onChange('')}
-						onClose={onClose}
-						showValue={false}
 					/>
-				)}
-			/>
-		</div>
+				</div>
+			</div>
+		</ControlShell>
 	);
 }

--- a/src/token-controls/molecules/TokenPopover.js
+++ b/src/token-controls/molecules/TokenPopover.js
@@ -21,6 +21,7 @@ import {
 } from '@wordpress/components';
 import { globe, settings, undo } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -46,9 +47,13 @@ import { hasValue, isTokenAlias } from '../helpers/token-summary';
  *                                      Defaults to `true`; a shadow's resolved value is a long CSS
  *                                      shorthand that reads awkwardly next to its label the way a
  *                                      short dimension value does, so `BoxShadowControl` opts out.
- * @param {?Function} [props.renderPreview] `({ value, tokens }) => Element`, rendered above `Reset`
- *                                      when supplied. Omit for no preview — every consumer that
- *                                      does not pass it renders exactly as before.
+ * @param {?Function} [props.renderPreview] `({ value, tokens, hoveredEntry }) => Element`, rendered
+ *                                      above `Reset` when supplied. Omit for no preview — every
+ *                                      consumer that does not pass it renders exactly as before.
+ *                                      `hoveredEntry` is `null` while nothing in the list carries
+ *                                      hover/focus (the preview should fall back to `value`),
+ *                                      `{ kind: 'reset' }` while the `Reset` row does, or
+ *                                      `{ kind: 'token', entry }` while a token row does.
  *
  * @since TBD
  *
@@ -69,10 +74,17 @@ function StyleLibraryTab({
 	const hasOverride = isTokenAlias(value) || (value !== '' && value !== undefined && value !== null);
 	// While unset, the size matching the inherited default reads as the active row.
 	const onDefault = !hasOverride && !!defaultValue;
+	// Which row currently carries hover or keyboard focus, so `renderPreview` (today, only the shadow
+	// field's live preview square) can show that option instead of the bound value. This state is
+	// cheap to keep even for consumers that never pass `renderPreview` — nothing reads it then.
+	const [hoveredEntry, setHoveredEntry] = useState(null);
+	const clearHover = () => setHoveredEntry(null);
 
 	return (
 		<div className="kadence-token-field__list">
-			{renderPreview && <div className="kadence-token-field__preview">{renderPreview({ value, tokens })}</div>}
+			{renderPreview && (
+				<div className="kadence-token-field__preview">{renderPreview({ value, tokens, hoveredEntry })}</div>
+			)}
 			<Button
 				className="kadence-token-field__reset"
 				disabled={!hasOverride}
@@ -80,6 +92,10 @@ function StyleLibraryTab({
 					onClear();
 					onClose();
 				}}
+				onMouseEnter={() => setHoveredEntry({ kind: 'reset' })}
+				onMouseLeave={clearHover}
+				onFocus={() => setHoveredEntry({ kind: 'reset' })}
+				onBlur={clearHover}
 			>
 				<span className="kadence-token-field__reset-label">{__('Reset', 'kadence-blocks')}</span>
 				<Icon className="kadence-token-field__reset-icon" icon={undo} size={20} />
@@ -95,6 +111,10 @@ function StyleLibraryTab({
 							onPick(entry.alias);
 							onClose();
 						}}
+						onMouseEnter={() => setHoveredEntry({ kind: 'token', entry })}
+						onMouseLeave={clearHover}
+						onFocus={() => setHoveredEntry({ kind: 'token', entry })}
+						onBlur={clearHover}
 					>
 						<span className="kadence-token-field__item-label">{entry.label}</span>
 						{isDefault && (
@@ -187,12 +207,14 @@ export function CustomTab({ number, unit, units, onUnit, min, max, step, onNumbe
  * @param {boolean}  [props.showValue]      Whether each Style Library row shows its resolved value
  *                                          beside its label. Defaults to `true`; additive only, so
  *                                          every existing consumer keeps showing values.
- * @param {?Function} [props.renderPreview] `({ value, tokens }) => Element`, rendered above the
- *                                          Style Library tab's `Reset` button when supplied — a
- *                                          shadow field's live preview square, for example. Omit
- *                                          for no preview; additive only, so every existing
- *                                          `TokenPopover` consumer that does not pass it is
- *                                          unaffected.
+ * @param {?Function} [props.renderPreview] `({ value, tokens, hoveredEntry }) => Element`, rendered
+ *                                          above the Style Library tab's `Reset` button when
+ *                                          supplied — a shadow field's live preview square, for
+ *                                          example, that tracks whichever row is hovered/focused
+ *                                          via `hoveredEntry` and falls back to `value` while
+ *                                          `hoveredEntry` is `null`. Omit for no preview; additive
+ *                                          only, so every existing `TokenPopover` consumer that
+ *                                          does not pass it is unaffected.
  *
  * @since TBD
  *

--- a/src/token-controls/molecules/TokenPopover.js
+++ b/src/token-controls/molecules/TokenPopover.js
@@ -46,12 +46,25 @@ import { hasValue, isTokenAlias } from '../helpers/token-summary';
  *                                      Defaults to `true`; a shadow's resolved value is a long CSS
  *                                      shorthand that reads awkwardly next to its label the way a
  *                                      short dimension value does, so `BoxShadowControl` opts out.
+ * @param {?Function} [props.renderPreview] `({ value, tokens }) => Element`, rendered above `Reset`
+ *                                      when supplied. Omit for no preview — every consumer that
+ *                                      does not pass it renders exactly as before.
  *
  * @since TBD
  *
  * @return {Object} The rendered token list.
  */
-function StyleLibraryTab({ value, tokens, defaultValue, inherited, onPick, onClear, onClose, showValue = true }) {
+function StyleLibraryTab({
+	value,
+	tokens,
+	defaultValue,
+	inherited,
+	onPick,
+	onClear,
+	onClose,
+	showValue = true,
+	renderPreview,
+}) {
 	// Reset clears the slot's override back to the inherited default; it is inert when nothing is set.
 	const hasOverride = isTokenAlias(value) || (value !== '' && value !== undefined && value !== null);
 	// While unset, the size matching the inherited default reads as the active row.
@@ -59,6 +72,7 @@ function StyleLibraryTab({ value, tokens, defaultValue, inherited, onPick, onCle
 
 	return (
 		<div className="kadence-token-field__list">
+			{renderPreview && <div className="kadence-token-field__preview">{renderPreview({ value, tokens })}</div>}
 			<Button
 				className="kadence-token-field__reset"
 				disabled={!hasOverride}
@@ -173,6 +187,12 @@ export function CustomTab({ number, unit, units, onUnit, min, max, step, onNumbe
  * @param {boolean}  [props.showValue]      Whether each Style Library row shows its resolved value
  *                                          beside its label. Defaults to `true`; additive only, so
  *                                          every existing consumer keeps showing values.
+ * @param {?Function} [props.renderPreview] `({ value, tokens }) => Element`, rendered above the
+ *                                          Style Library tab's `Reset` button when supplied — a
+ *                                          shadow field's live preview square, for example. Omit
+ *                                          for no preview; additive only, so every existing
+ *                                          `TokenPopover` consumer that does not pass it is
+ *                                          unaffected.
  *
  * @since TBD
  *
@@ -190,6 +210,7 @@ export function TokenPopover({
 	onClear,
 	onClose,
 	showValue = true,
+	renderPreview,
 }) {
 	return (
 		<TabPanel
@@ -227,6 +248,7 @@ export function TokenPopover({
 						onClear={onClear}
 						onClose={onClose}
 						showValue={showValue}
+						renderPreview={renderPreview}
 					/>
 				) : renderCustom ? (
 					renderCustom(custom)

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -142,6 +142,18 @@
 	background: #f0f0f0;
 }
 
+/*
+ * `BoxShadowControl`'s own trigger shows a leading glyph and its label only, never a value — unlike
+ * every other field's trigger, which the shared `.kadence-token-field__trigger` rule's
+ * `justify-content: space-between` pushes a label and a value to opposite ends of. With no value to
+ * balance against, that would strand the icon and label at opposite ends instead, so this scopes an
+ * override to the extra `kb-box-shadow-control__trigger` class this control alone adds — every other
+ * consumer of the shared trigger class is untouched.
+ */
+.kadence-token-field__trigger.kb-box-shadow-control__trigger {
+	justify-content: flex-start;
+}
+
 // Each row: label left, value (and optional Default tag) right, on a 40px line with a 2px-radius hover.
 .kadence-token-field__item.components-button,
 .kadence-token-field__reset.components-button {

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -118,6 +118,30 @@
 	overflow-y: auto;
 }
 
+/*
+ * The Style Library tab's optional preview slot (`TokenPopover`'s `renderPreview`), sitting above
+ * `Reset` inside the same list container. Centers whatever square the caller renders; only
+ * `BoxShadowControl` opts in today.
+ */
+.kadence-token-field__preview {
+	display: flex;
+	justify-content: center;
+	padding: 8px 4px 4px;
+}
+
+/*
+ * `BoxShadowControl`'s preview square: a plain gray-100 box with the active shadow's CSS applied, so
+ * a shadow reads at a glance before it is picked. Reuses this file's own established gray-100
+ * selection background and 2px control radius rather than new values.
+ */
+.kb-box-shadow-control__preview {
+	flex: 0 0 auto;
+	width: 48px;
+	height: 48px;
+	border-radius: 2px;
+	background: #f0f0f0;
+}
+
 // Each row: label left, value (and optional Default tag) right, on a 40px line with a 2px-radius hover.
 .kadence-token-field__item.components-button,
 .kadence-token-field__reset.components-button {

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -203,6 +203,45 @@
 	}
 }
 
+/*
+ * `BoxShadowControl`'s Custom tab: unlike the single-row layout above (one scalar plus its unit and
+ * slider), a shadow composite stacks three sections — the color row, the four axes, the Inset toggle
+ * — so this overrides the base rule's row direction rather than adding a second unrelated class.
+ * Reuses the base rule's own `8px`/`12px` spacing instead of introducing new values.
+ */
+.kadence-token-field__custom.kb-box-shadow-control__custom {
+	flex-direction: column;
+	align-items: stretch;
+}
+
+/*
+ * The color row: a plain full-width wrapper around whatever `renderColor` renders (see the render
+ * function's own comment on why this does not rebuild that markup). Margin only, no border/padding
+ * of its own — the Style Library's `TokenColorSelectField` and the block editor's `PopColorControl`
+ * already draw their own bordered, clickable swatch-plus-label toggle, and adding a second border
+ * around it would double up the chrome the reference `ShadowField` only draws once.
+ */
+.kb-box-shadow-control__color-row {
+	width: 100%;
+	margin-bottom: 4px;
+}
+
+/*
+ * The four axis fields (X/Y/Blur/Spread), side by side rather than stacked — each field's own label
+ * already renders above its input via `NumberControl`'s built-in `label` prop (the same field-level
+ * markup `TokenSelector`'s Custom tab number input already uses elsewhere in this file), so this rule
+ * only has to arrange the four fields, not draw a second label.
+ */
+.kb-box-shadow-control__axes {
+	display: flex;
+	gap: 8px;
+
+	> * {
+		flex: 1 1 auto;
+		min-width: 0;
+	}
+}
+
 // A measure control's four corner fields are wider as a token field than as a bare number input, so
 // wrap them into a 2x2 grid (matching the design) instead of cramming four across one row. The linked
 // "all" control has a single field, which still grows to the full width.


### PR DESCRIPTION
## Summary
- `BoxShadowControl` now composes `ControlShell` the same way `BoxControl`/`BorderControl` do (minus breakpoints/link props, since shadow is a single value with no sides), replacing the bespoke top-level wrapper and its ad-hoc field-level label.
- Renders one row using the shared control-box anatomy, with no glyph — shadow has nothing spatial to point at, matching Border Radius's row minus its unlinked/multi-slot support.
- The trigger's label and value are split the way `TokenSelector` already splits every other field, instead of one concatenated string.
- An unset shadow value now renders an empty/placeholder trigger instead of a fabricated default composite.
- The inset prefix in the composite summary uses the literal CSS `inset` keyword (matching `shadowCss()`'s own convention) instead of a translated word.
- Style Library tab / Custom tab mechanics, `renderCustom`/`ShadowCustomTab`, the `renderColor` contract, and the underlying value shape are all unchanged — this is a visual-wrapper-only change.

## Test plan
- [x] `npx jest src/token-controls src/style-library src/extension/design-tokens` — full suite green
- [x] `bun run lint-js`, `bun run build`
- [x] cspell on changed files
- [x] `grep -rn "SOFT-" src/token-controls` — no hits
- [ ] Manual verification on the dev site (Button preset screen's Shadow field)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated the box shadow control with a clearer, structured layout.
  - Added live shadow previews for token, composite, reset, hover, and focus states.
  - Displays shadow labels and resolved values separately in concise CSS shorthand.
  - Distinguishes unset, aliased, and custom shadow values more clearly.
  - Improved accessibility naming for unset values.
  - Refined the Custom tab with organized color and axis controls.
  - Preserves token-aware editing and disabled-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->