### PR TITLE
SOFT-4205 [1/4]: let a stored palette's groups replace the baseline's

### DIFF
--- a/includes/resources/Design_Tokens/Resolver/Effective_Palettes.php
+++ b/includes/resources/Design_Tokens/Resolver/Effective_Palettes.php
@@ -18,6 +18,11 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Sentinels;
  * subtree, and delegates the merge. The sibling {@see Effective_Document} deliberately strips "$extensions",
  * so it cannot be reused here — palettes are read through this seam instead.
  *
+ * One thing is deliberately NOT merged: a palette's `groups`. A stored palette node owns its structure
+ * outright and REPLACES the baseline's list rather than being merged onto it, because the merge descends
+ * lists positionally and would otherwise leave the baseline's tail entries behind whenever a stored list is
+ * shorter. See {@see without_superseded_groups()} for the failure that guards against.
+ *
  * Beyond the raw section it exposes the two things the resolver and projection need: the library's `$current`
  * pointer (which palette is active at `:root`), and a palette flattened to a `{ token => $value }` overlay
  * (its groups' swatches collapsed) so the resolver can re-tint the color tokens before alias flattening.
@@ -103,7 +108,9 @@ final class Effective_Palettes {
 	 * @return array<string, mixed>
 	 */
 	public function for_overrides( array $overrides ): array {
-		return $this->mutator->merge( $this->palettes_of( $this->baseline->document() ), $this->palettes_of( $overrides ) );
+		$stored = $this->palettes_of( $overrides );
+
+		return $this->mutator->merge( $this->without_superseded_groups( $this->palettes_of( $this->baseline->document() ), $stored ), $stored );
 	}
 
 	/**
@@ -295,6 +302,78 @@ final class Effective_Palettes {
 	}
 
 	/**
+	 * The shipped baseline `$default` palette flattened to a `{ token => $value }` map — the colors the
+	 * plugin ships, independent of any stored library.
+	 *
+	 * This is the authoritative answer to "is this swatch part of the shipped palette?", which no other
+	 * seam can give: {@see Baseline_Document::has()} indexes only the primitive/semantic token layers and
+	 * deliberately skips "$extensions", so it never sees a palette swatch at all.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, string> token dot-path => the shipped literal-or-alias value.
+	 */
+	public function baseline_swatch_values(): array {
+		$section = $this->palettes_of( $this->baseline->document() );
+
+		return $this->swatch_values_of( $section, $this->pointer_of( $section, Extensions::get_default_key() ) );
+	}
+
+	/**
+	 * Whether a token is a swatch the shipped baseline palette defines — the permanent set, whose rows a
+	 * palette write may never drop and whose values a delete reverts rather than removes.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $token The swatch token dot-path.
+	 *
+	 * @return bool
+	 */
+	public function is_baseline_swatch( string $token ): bool {
+		return array_key_exists( $token, $this->baseline_swatch_values() );
+	}
+
+	/**
+	 * Strip the `groups` list from every baseline palette node the overrides also define groups for, so the
+	 * stored list REPLACES the baseline's instead of being merged onto it.
+	 *
+	 * {@see Mutator::merge()} descends a `groups` / `swatches` list as a group, merging the two lists
+	 * POSITIONALLY — only an individual swatch is a leaf (it carries "$value") and replaces wholesale. The
+	 * default palette is in the baseline and stores every swatch, so any write that SHRINKS it (removing a
+	 * swatch, removing a group) leaves the baseline's tail entries un-overwritten: the removed swatch
+	 * reappears as a duplicate of its successor, and the duplicate then fails the palette write's own
+	 * no-repeated-token guard, wedging every later save.
+	 *
+	 * Dropping the baseline `groups` first makes the stored structure authoritative, which is what it
+	 * already is everywhere else — the palette write assembles a complete node and
+	 * {@see Palettes_Controller::write_palette_node()} removes-then-merges for exactly this reason one
+	 * layer down. Sibling keys (`label`) still merge normally, and a baseline palette the overrides only
+	 * relabel keeps its baseline groups.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $baseline The baseline colorPalettes section.
+	 * @param array<string, mixed> $stored   The stored overrides' colorPalettes section.
+	 *
+	 * @return array<string, mixed> The baseline section with superseded groups lists removed.
+	 */
+	private function without_superseded_groups( array $baseline, array $stored ): array {
+		$groups_key = Extensions::get_groups_key();
+
+		foreach ( $stored as $id => $node ) {
+			if ( ! is_array( $node ) || ! isset( $node[ $groups_key ] ) || ! is_array( $node[ $groups_key ] ) ) {
+				continue;
+			}
+
+			if ( isset( $baseline[ $id ] ) && is_array( $baseline[ $id ] ) ) {
+				unset( $baseline[ $id ][ $groups_key ] );
+			}
+		}
+
+		return $baseline;
+	}
+
+	/**
 	 * Reduce a `{ token => value }` map to the entries that differ from the baseline default palette.
 	 *
 	 * @since TBD
@@ -304,7 +383,7 @@ final class Effective_Palettes {
 	 * @return array<string, string>
 	 */
 	private function diff_against_baseline( array $values ): array {
-		$baseline = $this->baseline_default_swatch_values();
+		$baseline = $this->baseline_swatch_values();
 		$overlay  = [];
 
 		foreach ( $values as $token => $value ) {
@@ -316,20 +395,6 @@ final class Effective_Palettes {
 		}
 
 		return $overlay;
-	}
-
-	/**
-	 * The baseline `$default` palette flattened to a `{ token => $value }` map — the shipped baseline color
-	 * values, the reference the resolve-time overlay diffs against.
-	 *
-	 * @since TBD
-	 *
-	 * @return array<string, string>
-	 */
-	private function baseline_default_swatch_values(): array {
-		$section = $this->palettes_of( $this->baseline->document() );
-
-		return $this->swatch_values_of( $section, $this->pointer_of( $section, Extensions::get_default_key() ) );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Resolver/Effective_Palettes.php
+++ b/includes/resources/Design_Tokens/Resolver/Effective_Palettes.php
@@ -305,9 +305,14 @@ final class Effective_Palettes {
 	 * The shipped baseline `$default` palette flattened to a `{ token => $value }` map — the colors the
 	 * plugin ships, independent of any stored library.
 	 *
-	 * This is the authoritative answer to "is this swatch part of the shipped palette?", which no other
-	 * seam can give: {@see Baseline_Document::has()} indexes only the primitive/semantic token layers and
+	 * Both halves are load-bearing. Its KEYS are the permanent swatch set, whose rows a palette write may
+	 * never drop; its VALUES are what a delete reverts one of those swatches to. No other seam can answer
+	 * either question: {@see Baseline_Document::has()} indexes only the primitive/semantic token layers and
 	 * deliberately skips "$extensions", so it never sees a palette swatch at all.
+	 *
+	 * Returned whole rather than behind a per-token predicate because every caller needs the values too,
+	 * or walks the whole set — and the flatten re-walks the baseline document, so a predicate would redo it
+	 * once per swatch.
 	 *
 	 * @since TBD
 	 *
@@ -317,20 +322,6 @@ final class Effective_Palettes {
 		$section = $this->palettes_of( $this->baseline->document() );
 
 		return $this->swatch_values_of( $section, $this->pointer_of( $section, Extensions::get_default_key() ) );
-	}
-
-	/**
-	 * Whether a token is a swatch the shipped baseline palette defines — the permanent set, whose rows a
-	 * palette write may never drop and whose values a delete reverts rather than removes.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $token The swatch token dot-path.
-	 *
-	 * @return bool
-	 */
-	public function is_baseline_swatch( string $token ): bool {
-		return array_key_exists( $token, $this->baseline_swatch_values() );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_PalettesTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_PalettesTest.php
@@ -3,7 +3,6 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Resolver;
 
-use Generator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Palettes;
 use Tests\Support\Classes\TestCase;
@@ -234,7 +233,8 @@ final class Effective_PalettesTest extends TestCase {
 	}
 
 	/**
-	 * The baseline swatch values expose the shipped colors regardless of what a library has stored over them.
+	 * The baseline swatch values expose the shipped colors regardless of what a library has stored over them —
+	 * a palette edited away from the baseline, or one with the swatch removed outright, does not move them.
 	 *
 	 * @return void
 	 */
@@ -252,44 +252,21 @@ final class Effective_PalettesTest extends TestCase {
 	}
 
 	/**
-	 * A token counts as a baseline swatch only when the shipped default palette actually lists it — being a
-	 * registered color token is not enough.
-	 *
-	 * @dataProvider baselineSwatchProvider
-	 *
-	 * @param string $token    The token dot-path.
-	 * @param bool   $expected Whether the shipped palette defines a swatch for it.
+	 * The key set is the shipped palette's SWATCHES, not the registered color tokens: a color the registry
+	 * knows but the shipped palette lists no swatch for is absent, which is what keeps such a swatch
+	 * deletable rather than permanent.
 	 *
 	 * @return void
 	 */
-	public function testIsBaselineSwatchIdentifiesTheShippedSwatches( string $token, bool $expected ): void {
-		$this->assertSame( $expected, $this->palettes->is_baseline_swatch( $token ) );
-	}
+	public function testBaselineSwatchValuesCoversOnlyTheShippedSwatches(): void {
+		$baseline = $this->palettes->baseline_swatch_values();
 
-	/**
-	 * @return Generator
-	 */
-	public function baselineSwatchProvider(): Generator {
-		yield 'shipped brand swatch' => [
-			'token'    => 'primitive.color.brand.button',
-			'expected' => true,
-		];
+		$this->assertArrayHasKey( 'primitive.color.brand.button', $baseline );
+		$this->assertArrayHasKey( 'primitive.color.neutral.0', $baseline );
 
-		yield 'shipped neutral swatch' => [
-			'token'    => 'primitive.color.neutral.0',
-			'expected' => true,
-		];
-
-		// Registered and projected, but the shipped palette lists no swatch for it.
-		yield 'registered token with no swatch' => [
-			'token'    => 'primitive.color.neutral.600',
-			'expected' => false,
-		];
-
-		yield 'unknown token' => [
-			'token'    => 'primitive.color.custom.abc123',
-			'expected' => false,
-		];
+		// Registered and projected into a palette slot, but the shipped palette lists no swatch for it.
+		$this->assertArrayNotHasKey( 'primitive.color.neutral.600', $baseline );
+		$this->assertArrayNotHasKey( 'primitive.color.custom.abc123', $baseline );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_PalettesTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_PalettesTest.php
@@ -3,6 +3,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Resolver;
 
+use Generator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Palettes;
 use Tests\Support\Classes\TestCase;
@@ -149,6 +150,233 @@ final class Effective_PalettesTest extends TestCase {
 		$this->assertContains( 'midnight', $this->palettes->palette_ids() );
 		$this->assertSame( 'midnight', $this->palettes->current() );
 		$this->assertSame( '#0b1020', $this->palettes->current_swatch_values()['primitive.color.brand.primary'] );
+	}
+
+	/**
+	 * A stored default palette whose groups list is SHORTER than the baseline's replaces it wholesale: the
+	 * removed swatch is gone, and the baseline's tail swatch is not left behind as a duplicate of its
+	 * successor.
+	 *
+	 * The merge descends a swatches list positionally, so without the structure replace, dropping the
+	 * fourth of five swatches shifts the fifth onto index 3 and leaves the baseline's index 4 untouched —
+	 * the removed swatch reappears, the survivor is listed twice, and the duplicate then trips the palette
+	 * write's own no-repeated-token guard, wedging every later save.
+	 *
+	 * @return void
+	 */
+	public function testAStoredDefaultPaletteReplacesTheBaselineGroups(): void {
+		$this->store->save_document(
+			(string) wp_json_encode( $this->default_palette_overrides( [ $this->accent_group_without_the_button_swatch() ] ) ),
+			'default'
+		);
+
+		$tokens = $this->swatch_tokens_of_group( 'default', 'accent' );
+
+		$this->assertNotContains( 'primitive.color.brand.button', $tokens, 'A removed swatch must not survive the baseline merge.' );
+		$this->assertSame( array_unique( $tokens ), $tokens, 'The baseline tail swatch must not be left behind as a duplicate.' );
+		$this->assertSame(
+			[
+				'primitive.color.brand.primary',
+				'primitive.color.brand.secondary',
+				'primitive.color.brand.accent',
+				'primitive.color.brand.button-hover',
+			],
+			$tokens
+		);
+	}
+
+	/**
+	 * The same structure replace applies to whole groups: a stored default palette carrying fewer groups than
+	 * the baseline does not leak the baseline's trailing groups back into the effective section.
+	 *
+	 * @return void
+	 */
+	public function testAStoredDefaultPaletteDroppingGroupsDoesNotLeakTheBaselineTail(): void {
+		$this->store->save_document(
+			(string) wp_json_encode( $this->default_palette_overrides( [ $this->accent_group_without_the_button_swatch() ] ) ),
+			'default'
+		);
+
+		$node   = $this->palettes->palette( 'default' ) ?? [];
+		$groups = $node['groups'] ?? [];
+
+		$this->assertIsArray( $groups );
+		$this->assertCount( 1, $groups, 'Only the stored group may survive; the baseline groups after it are superseded.' );
+		$this->assertSame( 'accent', $groups[0]['id'] );
+	}
+
+	/**
+	 * An override that only relabels a baseline palette keeps that palette's baseline groups — the structure
+	 * replace is scoped to a stored node that actually defines `groups`.
+	 *
+	 * @return void
+	 */
+	public function testRelabelingABaselinePaletteKeepsItsBaselineGroups(): void {
+		$this->store->save_document(
+			(string) wp_json_encode(
+				[
+					'$extensions' => [
+						'com.kadence.designTokens' => [
+							'colorPalettes' => [
+								'default' => [ 'label' => 'Renamed' ],
+							],
+						],
+					],
+				]
+			),
+			'default'
+		);
+
+		$node = $this->palettes->palette( 'default' ) ?? [];
+
+		$this->assertSame( 'Renamed', $node['label'] );
+		$this->assertSame( '#3633e1', $this->palettes->swatch_values( 'default' )['primitive.color.brand.button'] );
+	}
+
+	/**
+	 * The baseline swatch values expose the shipped colors regardless of what a library has stored over them.
+	 *
+	 * @return void
+	 */
+	public function testBaselineSwatchValuesExposesTheShippedColors(): void {
+		$this->store->save_document(
+			(string) wp_json_encode( $this->default_palette_overrides( [ $this->accent_group_without_the_button_swatch() ] ) ),
+			'default'
+		);
+
+		$baseline = $this->palettes->baseline_swatch_values();
+
+		$this->assertSame( '#3633e1', $baseline['primitive.color.brand.button'] );
+		$this->assertSame( '#3182CE', $baseline['primitive.color.brand.primary'] );
+		$this->assertSame( '#ffffff', $baseline['primitive.color.neutral.0'] );
+	}
+
+	/**
+	 * A token counts as a baseline swatch only when the shipped default palette actually lists it — being a
+	 * registered color token is not enough.
+	 *
+	 * @dataProvider baselineSwatchProvider
+	 *
+	 * @param string $token    The token dot-path.
+	 * @param bool   $expected Whether the shipped palette defines a swatch for it.
+	 *
+	 * @return void
+	 */
+	public function testIsBaselineSwatchIdentifiesTheShippedSwatches( string $token, bool $expected ): void {
+		$this->assertSame( $expected, $this->palettes->is_baseline_swatch( $token ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function baselineSwatchProvider(): Generator {
+		yield 'shipped brand swatch' => [
+			'token'    => 'primitive.color.brand.button',
+			'expected' => true,
+		];
+
+		yield 'shipped neutral swatch' => [
+			'token'    => 'primitive.color.neutral.0',
+			'expected' => true,
+		];
+
+		// Registered and projected, but the shipped palette lists no swatch for it.
+		yield 'registered token with no swatch' => [
+			'token'    => 'primitive.color.neutral.600',
+			'expected' => false,
+		];
+
+		yield 'unknown token' => [
+			'token'    => 'primitive.color.custom.abc123',
+			'expected' => false,
+		];
+	}
+
+	/**
+	 * A stored-overrides document that replaces the default palette's structure with the given groups.
+	 *
+	 * @param array<int, mixed> $groups The groups list to store on the default palette.
+	 *
+	 * @return array<string, mixed> The decoded overrides document.
+	 */
+	private function default_palette_overrides( array $groups ): array {
+		return [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'colorPalettes' => [
+						'default' => [
+							'label'  => 'Default',
+							'groups' => $groups,
+						],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * The baseline's Accent group with its fourth swatch (Button) removed — a group one shorter than the
+	 * baseline's, which is what makes the positional merge observable.
+	 *
+	 * @return array<string, mixed> The group node.
+	 */
+	private function accent_group_without_the_button_swatch(): array {
+		return [
+			'id'       => 'accent',
+			'label'    => 'Accent',
+			'swatches' => [
+				[
+					'token'  => 'primitive.color.brand.primary',
+					'label'  => 'Main 1',
+					'$value' => '#3182CE',
+				],
+				[
+					'token'  => 'primitive.color.brand.secondary',
+					'label'  => 'Main 2',
+					'$value' => '#2B6CB0',
+				],
+				[
+					'token'  => 'primitive.color.brand.accent',
+					'label'  => 'Main 3',
+					'$value' => '#ED8936',
+				],
+				[
+					'token'  => 'primitive.color.brand.button-hover',
+					'label'  => 'Button Hover',
+					'$value' => '#2f2ffc',
+				],
+			],
+		];
+	}
+
+	/**
+	 * The ordered swatch tokens of one group in a palette's effective node.
+	 *
+	 * @param string $palette_id The palette id.
+	 * @param string $group_id   The group id.
+	 *
+	 * @return string[] The swatch token dot-paths, in order.
+	 */
+	private function swatch_tokens_of_group( string $palette_id, string $group_id ): array {
+		$node   = $this->palettes->palette( $palette_id ) ?? [];
+		$groups = $node['groups'] ?? [];
+		$tokens = [];
+
+		if ( ! is_array( $groups ) ) {
+			return $tokens;
+		}
+
+		foreach ( $groups as $group ) {
+			if ( ! is_array( $group ) || ( $group['id'] ?? null ) !== $group_id ) {
+				continue;
+			}
+
+			foreach ( $group['swatches'] ?? [] as $swatch ) {
+				$tokens[] = (string) $swatch['token'];
+			}
+		}
+
+		return $tokens;
 	}
 
 	/**


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4205/palette-swatch-deletion-lock-baseline-swatches-revert-instead-of

:video_camera:  https://www.loom.com/share/692dba0a66ba48c8a13c4ed53db90c78

The effective palette section is the baseline `colorPalettes` deep-merged with a library's stored overrides, and `Mutator::merge()` descends a `groups` / `swatches` list as a group — merging the two lists **positionally**. Only an individual swatch is a leaf (it carries `$value`) and replaces wholesale.

The default palette is in the baseline and stores every one of its swatches, so any write that **shrinks** it left the baseline's tail entries un-overwritten. Removing the fourth of the Accent group's five swatches shifted the fifth onto index 3 and left the baseline's index 4 in place:

```
0 brand.primary  1 brand.secondary  2 brand.accent  3 brand.button-hover  4 brand.button-hover
```

The removed swatch reappeared, its successor was listed twice, and the duplicate then failed the palette write's own no-repeated-token guard — wedging every later save of that palette. Dropping a whole color group leaked the baseline's trailing groups back the same way.

This drops the baseline node's `groups` for any palette the overrides also define groups for, so the stored structure is authoritative — what it already is one layer down, where `write_palette_node()` removes-then-merges for exactly this reason. Sibling keys still merge, so a palette the overrides only relabel keeps its baseline groups.

Also promotes the private baseline swatch flattener to a public `baseline_swatch_values()`, which the rest of the stack builds on: its KEYS are the permanent swatch set, whose rows a palette write may never drop, and its VALUES are what a delete reverts one of those swatches to. `Baseline_Document::has()` cannot answer either question: it indexes only the primitive/semantic token layers and deliberately skips `$extensions`, so it never sees a palette swatch.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated palette overrides so stored group lists fully replace baseline groups instead of merging unexpectedly.
  * Prevented baseline groups and swatches from appearing in customized palettes when they have been removed.
  * Preserved baseline groups when only a palette label is changed.
  * Ensured baseline color values remain independent of stored palette edits.

* **Tests**
  * Added coverage for palette replacement, removal, relabeling, and baseline swatch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


