### PR TITLE
SOFT-4205 [2/4]: lock the shipped swatches on the default palette write

### DIFF
--- a/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
@@ -37,6 +37,10 @@ use WP_REST_Server;
  * and `label` must be a string. Because a palette's values live under `$extensions`, the resolver dry-run
  * never sees them, so alias targets are guarded here explicitly.
  *
+ * One further guard is specific to the DEFAULT palette: it is the structure template every other palette is
+ * projected from, so a write against it may not drop a swatch the shipped baseline defines
+ * ({@see guard_baseline_swatches()}). Those rows are permanent — reverted, never removed.
+ *
  * @since TBD
  */
 final class Palettes_Controller extends Controller {
@@ -345,6 +349,9 @@ final class Palettes_Controller extends Controller {
 	 * the shape and swatch guards, replace the palette node in the library's stored overrides, and validate-and-save.
 	 * A single palette node write is create-or-replace either way, so POST and PUT share this handler.
 	 *
+	 * A write against the default palette must additionally keep every baseline swatch: dropping one there
+	 * removes it from every palette, so it is a 403 rather than a structure edit.
+	 *
 	 * @since TBD
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
@@ -368,6 +375,11 @@ final class Palettes_Controller extends Controller {
 		$swatches = $this->guard_swatches( $node, $id );
 		if ( $swatches !== null ) {
 			return $swatches;
+		}
+
+		$locked = $this->guard_baseline_swatches( $node, $id, $slug );
+		if ( $locked !== null ) {
+			return $locked;
 		}
 
 		// The default palette stores every swatch (it is the base). A non-default palette stores only its
@@ -933,6 +945,87 @@ final class Palettes_Controller extends Controller {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Reject a DEFAULT-palette write that drops a swatch the shipped baseline defines. Those swatches are the
+	 * permanent set: the default palette is the structure template every other palette is projected from, so a
+	 * row removed there disappears from every palette at once and can never be recovered. A baseline swatch is
+	 * reverted (DELETE /palettes/{id}/swatches/{token}), never removed; only a user-added swatch is deletable.
+	 *
+	 * Scoped to the default palette on purpose: a non-default palette is stored as DELTAS, so it legitimately
+	 * omits most baseline tokens, and applying this guard there would reject every ordinary palette write.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $node The palette node being written.
+	 * @param string               $id   The palette id, for error context.
+	 * @param string               $slug The token library slug.
+	 *
+	 * @return WP_Error|null A WP_Error when a baseline swatch is missing, null otherwise.
+	 */
+	private function guard_baseline_swatches( array $node, string $id, string $slug ): ?WP_Error {
+		if ( $id !== $this->palettes->default_palette( $slug ) ) {
+			return null;
+		}
+
+		$present = array_flip( $this->swatch_tokens_of_node( $node ) );
+
+		foreach ( array_keys( $this->palettes->baseline_swatch_values() ) as $token ) {
+			if ( isset( $present[ $token ] ) ) {
+				continue;
+			}
+
+			return new WP_Error(
+				'rest_design_tokens_locked',
+				sprintf(
+					/* translators: %s: the token dot-path. */
+					__( 'Swatch "%s" is part of the shipped palette and cannot be removed.', 'kadence-blocks' ),
+					$token
+				),
+				[
+					'status'          => WP_Http::FORBIDDEN,
+					self::ID_PARAM    => $id,
+					self::TOKEN_PARAM => $token,
+				]
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Every swatch token a palette node carries, across all of its groups, in order.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $node The palette node.
+	 *
+	 * @return string[] The swatch token dot-paths.
+	 */
+	private function swatch_tokens_of_node( array $node ): array {
+		$swatches_key = Extensions::get_swatches_key();
+		$token_key    = Extensions::get_swatch_token_key();
+		$groups       = $node[ Extensions::get_groups_key() ] ?? [];
+		$tokens       = [];
+
+		if ( ! is_array( $groups ) ) {
+			return $tokens;
+		}
+
+		foreach ( $groups as $group ) {
+			if ( ! is_array( $group ) || ! isset( $group[ $swatches_key ] ) || ! is_array( $group[ $swatches_key ] ) ) {
+				continue;
+			}
+
+			foreach ( $group[ $swatches_key ] as $swatch ) {
+				if ( is_array( $swatch ) && isset( $swatch[ $token_key ] ) && is_string( $swatch[ $token_key ] ) ) {
+					$tokens[] = $swatch[ $token_key ];
+				}
+			}
+		}
+
+		return $tokens;
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
@@ -533,6 +533,127 @@ final class Palettes_ControllerTest extends TestCase {
 	}
 
 	/**
+	 * A write against the default palette that drops a swatch the shipped baseline defines is refused: the
+	 * default palette is the structure template every other palette is projected from, so removing a row there
+	 * would take that color out of every palette at once.
+	 *
+	 * @return void
+	 */
+	public function testUpdateItemRejectsADefaultPaletteMissingABaselineSwatch(): void {
+		$result = $this->controller->update_item( $this->default_palette_request( 'primitive.color.brand.button' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_locked', $result->get_error_code() );
+		$this->assertSame( WP_Http::FORBIDDEN, $this->status_of( $result ) );
+		$this->assertSame( 'primitive.color.brand.button', $result->get_error_data()['token'] );
+
+		// The refusal is total: nothing about the palette was persisted.
+		$this->assertSame( '#3633e1', $this->palettes->swatch_values( 'default' )['primitive.color.brand.button'] );
+	}
+
+	/**
+	 * A default-palette write that keeps every baseline swatch is accepted, so an ordinary recolor still saves.
+	 *
+	 * @return void
+	 */
+	public function testUpdateItemAcceptsADefaultPaletteThatKeepsEveryBaselineSwatch(): void {
+		$request = $this->default_palette_request();
+		$groups  = $request->get_param( 'groups' );
+
+		$groups[0]['swatches'][3]['$value'] = '#abcdef';
+		$request->set_param( 'groups', $groups );
+
+		$result = $this->controller->update_item( $request );
+
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertSame( '#abcdef', $this->palettes->swatch_values( 'default' )['primitive.color.brand.button'] );
+	}
+
+	/**
+	 * The default palette may still drop a swatch the baseline does NOT define — a user-added color is deletable,
+	 * which is the whole point of scoping the lock to the shipped set.
+	 *
+	 * @return void
+	 */
+	public function testUpdateItemAllowsANonBaselineSwatchToBeDroppedFromTheDefaultPalette(): void {
+		// Built before anything is stored, so it carries the shipped structure without the extra group the next
+		// request adds — the helper reads the EFFECTIVE palette, which would otherwise include it by then.
+		$without = $this->default_palette_request();
+
+		// primitive.color.neutral.600 is a registered color the shipped palette lists no swatch for, so it stands
+		// in for a user-added color without needing a minted primitive.
+		$added  = $this->default_palette_request();
+		$groups = $added->get_param( 'groups' );
+
+		$groups[] = [
+			'id'       => 'extras',
+			'label'    => 'Extras',
+			'swatches' => [
+				[
+					'token'  => 'primitive.color.neutral.600',
+					'label'  => 'Neutral 600',
+					'$value' => '#4A5568',
+				],
+			],
+		];
+
+		$added->set_param( 'groups', $groups );
+
+		$this->assertNotInstanceOf( WP_Error::class, $this->controller->update_item( $added ) );
+		$this->assertArrayHasKey( 'primitive.color.neutral.600', $this->palettes->swatch_values( 'default' ) );
+
+		// Now save the palette back without it: the lock does not apply, so the row goes away for good.
+		$this->assertNotInstanceOf( WP_Error::class, $this->controller->update_item( $without ) );
+		$this->assertArrayNotHasKey( 'primitive.color.neutral.600', $this->palettes->swatch_values( 'default' ) );
+	}
+
+	/**
+	 * The lock is scoped to the default palette: a non-default palette is stored as deltas, so it omits nearly
+	 * every baseline swatch by design and must still save.
+	 *
+	 * @return void
+	 */
+	public function testUpdateItemAllowsANonDefaultPaletteToOmitBaselineSwatches(): void {
+		$result = $this->controller->update_item( $this->write_request( 'ocean', 'Ocean', '#DD6B20' ) );
+
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertSame( [ 'primitive.color.brand.primary' => '#DD6B20' ], $this->palettes->swatch_values( 'ocean' ) );
+	}
+
+	/**
+	 * A write request carrying the default palette's full baseline structure, optionally with one swatch removed
+	 * — the shape the Style Library sends when it saves the palette it is editing.
+	 *
+	 * @param string|null $omit_token A swatch token dot-path to leave out, or null to send the structure intact.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function default_palette_request( ?string $omit_token = null ): WP_REST_Request {
+		$node   = $this->palettes->palette( 'default' ) ?? [];
+		$groups = [];
+
+		foreach ( $node['groups'] ?? [] as $group ) {
+			$swatches = [];
+
+			foreach ( $group['swatches'] ?? [] as $swatch ) {
+				if ( $swatch['token'] !== $omit_token ) {
+					$swatches[] = $swatch;
+				}
+			}
+
+			$group['swatches'] = $swatches;
+			$groups[]          = $group;
+		}
+
+		$request = new WP_REST_Request( 'PUT' );
+		$request->set_param( 'id', 'default' );
+		$request->set_param( 'label', $node['label'] ?? 'Default' );
+		$request->set_param( 'groups', $groups );
+
+		return $request;
+	}
+
+	/**
 	 * Create a non-default "custom" palette (a single brand-primary delta of #DD6B20, labelled "Custom") through
 	 * the controller's own write path, without pointing `$current` at it. The baseline no longer ships a
 	 * non-default palette, so the list / read / $current cases own the one they exercise — and creating it inactive


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4205/palette-swatch-deletion-lock-baseline-swatches-revert-instead-of

:video_camera:  https://www.loom.com/share/692dba0a66ba48c8a13c4ed53db90c78

The default palette is the structure template every other palette is projected from — the effective view renders each palette against the default's groups — so a swatch row removed there disappears from every palette at once, with nothing left to recover it from. Nothing stopped a write from doing that.

`update_item()` now guards a default-palette write against dropping a swatch the shipped baseline defines, answering **403 `rest_design_tokens_locked`** naming the token — the same shape `User_Primitives_Controller` uses to refuse a system primitive. A baseline swatch is reverted, never removed; that revert is the swatch DELETE route, in [3/5].

Scoped to the default palette on purpose: a non-default palette is stored as deltas, so it omits nearly every baseline token by design, and applying the guard there would reject every ordinary palette write. A swatch the baseline does **not** define stays deletable from the default palette too, which is what keeps a user-added color removable.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Protected the default color palette from removing required built-in swatches.
  * Added clear forbidden errors identifying any locked swatch that is missing.
  * Continued allowing custom swatches to be added or removed from the default palette.
  * Non-default palettes can still omit built-in swatches.

* **Bug Fixes**
  * Prevented invalid default-palette changes from being saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

