### PR TITLE
SOFT-4205 [3/4]: revert a palette swatch on delete instead of refusing

### DIFF
--- a/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
@@ -39,7 +39,9 @@ use WP_REST_Server;
  *
  * One further guard is specific to the DEFAULT palette: it is the structure template every other palette is
  * projected from, so a write against it may not drop a swatch the shipped baseline defines
- * ({@see guard_baseline_swatches()}). Those rows are permanent — reverted, never removed.
+ * ({@see guard_baseline_swatches()}). Those rows are permanent — reverted, never removed, which is what
+ * {@see delete_swatch()} does with them: restore the shipped color on the default palette, drop the delta
+ * (back to inherited) on any other. Only a user-added swatch's row is actually removable.
  *
  * @since TBD
  */
@@ -477,10 +479,17 @@ final class Palettes_Controller extends Controller {
 	}
 
 	/**
-	 * Revert a single palette swatch to inherited (DELETE /palettes/{id}/swatches/{token}): drop the palette's
-	 * own value for this token so it falls back to the default palette. A token the palette never set is already
-	 * inherited, so the delete is idempotent. The default palette is the base and has nothing to inherit from,
-	 * so reverting one of its swatches is a 400; an unknown palette is a 404.
+	 * Undo a palette's own value for one swatch (DELETE /palettes/{id}/swatches/{token}). What "undo" means
+	 * depends on where the swatch came from, because only one of the two is a row a palette may lose:
+	 *
+	 *   - A swatch the shipped baseline defines is permanent, so this REVERTS its value and keeps the row. On
+	 *     the default palette that means restoring the shipped color; on any other palette it means dropping
+	 *     the delta so the swatch inherits the default palette again.
+	 *   - A user-added swatch has no shipped value to fall back to, so its row is REMOVED. Done on the default
+	 *     palette — which owns the structure every palette is projected from — that retires the color entirely.
+	 *
+	 * Idempotent either way: a token a palette never set is already inherited, and a row already gone stays
+	 * gone. An unknown palette is a 404.
 	 *
 	 * @since TBD
 	 *
@@ -499,18 +508,16 @@ final class Palettes_Controller extends Controller {
 			return $this->not_found( $id );
 		}
 
-		if ( $id === $this->palettes->default_palette( $slug ) ) {
-			return new WP_Error(
-				'rest_design_tokens_forbidden',
-				__( 'A swatch of the default palette cannot be reverted.', 'kadence-blocks' ),
-				[
-					'status'       => WP_Http::BAD_REQUEST,
-					self::ID_PARAM => $id,
-				]
-			);
-		}
+		$baseline = $this->palettes->baseline_swatch_values();
 
-		return $this->write_palette_node( $slug, $id, $this->remove_swatch_from_node( $node, $token ) );
+		// The default palette is the base — it has nothing to inherit from — so a baseline swatch there is
+		// restored to its shipped value rather than dropped. Every other case drops the palette's own entry:
+		// a non-default palette's delta (leaving it inherited) or a user-added row (retiring it).
+		$node = ( $id === $this->palettes->default_palette( $slug ) && array_key_exists( $token, $baseline ) )
+			? $this->set_swatch_in_node( $node, $token, $baseline[ $token ], $slug )
+			: $this->remove_swatch_from_node( $node, $token );
+
+		return $this->write_palette_node( $slug, $id, $node );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
@@ -3,6 +3,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Rest\V1;
 
+use Generator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Palettes;
 use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Palettes_Controller;
 use Tests\Support\Classes\TestCase;
@@ -487,23 +488,116 @@ final class Palettes_ControllerTest extends TestCase {
 		);
 
 		$this->assertArrayNotHasKey( 'primitive.color.brand.primary', $this->palettes->swatch_values( 'ocean' ) );
+
+		// Inherited, not gone: the palette now resolves the token to the default palette's value, and the
+		// default palette itself is untouched.
+		$this->assertSame( '#3182CE', $this->palettes->effective_swatch_values( 'ocean' )['primitive.color.brand.primary'] );
+		$this->assertSame( '#3182CE', $this->palettes->swatch_values( 'default' )['primitive.color.brand.primary'] );
 	}
 
 	/**
-	 * A swatch of the default palette cannot be reverted (there is nothing to inherit from), so a delete is a
-	 * 400.
+	 * Deleting a baseline swatch on the default palette restores its shipped color instead of removing the row:
+	 * the default palette has nothing to inherit from, and the row itself is permanent.
 	 *
 	 * @return void
 	 */
-	public function testDeleteSwatchOnTheDefaultPaletteIsForbidden(): void {
-		$this->assertSame(
-			WP_Http::BAD_REQUEST,
-			$this->status_of(
-				$this->controller->delete_swatch(
-					$this->swatch_request( 'DELETE', 'default', 'primitive.color.brand.primary' )
-				) 
-			)
+	public function testDeleteSwatchOnTheDefaultPaletteRevertsToBaseline(): void {
+		$this->controller->update_swatch(
+			$this->swatch_request( 'PUT', 'default', 'primitive.color.brand.primary', '#0000ff' )
 		);
+		$this->assertSame( '#0000ff', $this->palettes->swatch_values( 'default' )['primitive.color.brand.primary'] );
+
+		$result = $this->controller->delete_swatch(
+			$this->swatch_request( 'DELETE', 'default', 'primitive.color.brand.primary' )
+		);
+
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertSame( '#3182CE', $this->palettes->swatch_values( 'default' )['primitive.color.brand.primary'] );
+	}
+
+	/**
+	 * Reverting one baseline swatch on the default palette leaves the palette's other edits alone.
+	 *
+	 * @return void
+	 */
+	public function testDeleteSwatchOnTheDefaultPaletteLeavesSiblingSwatchesAlone(): void {
+		$this->controller->update_swatch(
+			$this->swatch_request( 'PUT', 'default', 'primitive.color.brand.primary', '#0000ff' )
+		);
+		$this->controller->update_swatch(
+			$this->swatch_request( 'PUT', 'default', 'primitive.color.brand.button', '#00ff00' )
+		);
+
+		$this->controller->delete_swatch(
+			$this->swatch_request( 'DELETE', 'default', 'primitive.color.brand.primary' )
+		);
+
+		$values = $this->palettes->swatch_values( 'default' );
+
+		$this->assertSame( '#3182CE', $values['primitive.color.brand.primary'] );
+		$this->assertSame( '#00ff00', $values['primitive.color.brand.button'], 'Only the reverted swatch may change.' );
+	}
+
+	/**
+	 * A swatch the baseline does NOT define has no shipped value to fall back to, so deleting it on the default
+	 * palette removes the row outright — the true delete of a user-added color.
+	 *
+	 * @return void
+	 */
+	public function testDeleteSwatchRemovesANonBaselineSwatchFromTheDefaultPalette(): void {
+		// primitive.color.neutral.600 is a registered color the shipped palette lists no swatch for, so it stands
+		// in for a user-added color without needing a minted primitive.
+		$this->controller->update_swatch(
+			$this->swatch_request( 'PUT', 'default', 'primitive.color.neutral.600', '#4A5568' )
+		);
+		$this->assertArrayHasKey( 'primitive.color.neutral.600', $this->palettes->swatch_values( 'default' ) );
+
+		$this->controller->delete_swatch(
+			$this->swatch_request( 'DELETE', 'default', 'primitive.color.neutral.600' )
+		);
+
+		$this->assertArrayNotHasKey( 'primitive.color.neutral.600', $this->palettes->swatch_values( 'default' ) );
+	}
+
+	/**
+	 * Reverting a swatch a palette never set changes nothing, so a repeated delete is safe.
+	 *
+	 * @dataProvider idempotentDeleteProvider
+	 *
+	 * @param string $id    The palette id to delete the swatch on.
+	 * @param string $token The swatch token dot-path.
+	 *
+	 * @return void
+	 */
+	public function testDeleteSwatchIsIdempotent( string $id, string $token ): void {
+		$this->controller->update_item( $this->write_request( 'ocean', 'Ocean', '#0000ff' ) );
+
+		$before = $this->palettes->swatch_values( $id );
+
+		$this->controller->delete_swatch( $this->swatch_request( 'DELETE', $id, $token ) );
+		$this->controller->delete_swatch( $this->swatch_request( 'DELETE', $id, $token ) );
+
+		$this->assertSame( $before, $this->palettes->swatch_values( $id ) );
+	}
+
+	/**
+	 * @return Generator
+	 */
+	public function idempotentDeleteProvider(): Generator {
+		yield 'a delta the non-default palette never set' => [
+			'id'    => 'ocean',
+			'token' => 'primitive.color.neutral.900',
+		];
+
+		yield 'an unedited baseline swatch on the default palette' => [
+			'id'    => 'default',
+			'token' => 'primitive.color.brand.accent',
+		];
+
+		yield 'a token no palette carries' => [
+			'id'    => 'default',
+			'token' => 'primitive.color.neutral.600',
+		];
 	}
 
 	/**


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4205/palette-swatch-deletion-lock-baseline-swatches-revert-instead-of

:video_camera:  https://www.loom.com/share/692dba0a66ba48c8a13c4ed53db90c78

`DELETE /palettes/{id}/swatches/{token}` answered 400 on the default palette — "A swatch of the default palette cannot be reverted" — on the reasoning that the base palette has nothing to inherit from. It does have something to fall back to: the shipped baseline value. Refusing left the Style Library with no way to undo a recolor from the swatch panel, which is why its delete rewrote the whole default node instead, taking the row out of every palette at once.

The delete now splits by where the swatch came from, since only one of the two is a row a palette may lose:

| palette | swatch | behavior |
|---|---|---|
| Default | baseline | restore the shipped color, keep the row |
| non-Default | baseline | drop the delta, so it inherits Default (unchanged) |
| any | user-added | remove the row |

Still idempotent in every branch: a token a palette never set is already inherited, and a row already gone stays gone.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a default palette swatch now restores its original baseline value.
  * Custom swatches can still be removed without affecting neighboring swatches.
  * Repeated deletion requests now complete safely without unintended changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

