### PR TITLE
SOFT-4205 [4/4]: reset the default palette on delete, and flag baseline swatches

### DIFF
--- a/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
@@ -403,6 +403,9 @@ final class Palettes_Controller extends Controller {
 	 * removes only overrides, which is why the two cases share one handler. This matches the DELETE semantics
 	 * of the sibling library and preset controllers, where dropping the default resets it to baseline.
 	 *
+	 * Deleting the palette `$current` names hands that pointer to the default palette, so the stored document
+	 * never keeps an id that resolves to nothing.
+	 *
 	 * Idempotent for a baseline palette (a reset with nothing stored changes nothing); a palette the library
 	 * does not define at all is a 404.
 	 *
@@ -421,6 +424,19 @@ final class Palettes_Controller extends Controller {
 		}
 
 		$document = $this->mutator->remove_by_keys( $this->stored_document( $slug ), $this->palette_keys( $id ) );
+
+		// Removing the palette `$current` points at leaves that pointer naming an id that is no longer there.
+		// Nothing renders wrong — every reader fail-softs to `$default` — but the stale id stays in storage,
+		// and it springs back the moment the id exists again: a palette later created under the same id would
+		// go live without anyone activating it. Hand the pointer to the default palette instead. Only for a
+		// palette that actually goes away; deleting a baseline one reverts it and leaves it in the listing,
+		// so a pointer at it stays valid.
+		if ( $this->palettes->current( $slug ) === $id && in_array( $id, $this->palettes->user_created( $slug ), true ) ) {
+			$document = $this->mutator->merge(
+				$document,
+				$this->pointer_partial( Extensions::get_current_key(), $this->palettes->default_palette( $slug ) )
+			);
+		}
 
 		return $this->validate_and_save( $document, $id, $slug );
 	}

--- a/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
@@ -397,8 +397,14 @@ final class Palettes_Controller extends Controller {
 	}
 
 	/**
-	 * Delete a palette (DELETE /palettes/{id}). The library's `$default` palette cannot be deleted, and a
-	 * request for a palette the library does not define is a 404.
+	 * Drop a palette's stored node (DELETE /palettes/{id}). What that leaves behind depends on whether the
+	 * shipped baseline also defines the palette: a user-created one is gone from the listing, while a baseline
+	 * palette — the `default` among them — RESETS to its shipped definition and stays. Either way the request
+	 * removes only overrides, which is why the two cases share one handler. This matches the DELETE semantics
+	 * of the sibling library and preset controllers, where dropping the default resets it to baseline.
+	 *
+	 * Idempotent for a baseline palette (a reset with nothing stored changes nothing); a palette the library
+	 * does not define at all is a 404.
 	 *
 	 * @since TBD
 	 *
@@ -412,17 +418,6 @@ final class Palettes_Controller extends Controller {
 
 		if ( $this->palettes->palette( $id, $slug ) === null ) {
 			return $this->not_found( $id );
-		}
-
-		if ( $id === $this->palettes->default_palette( $slug ) ) {
-			return new WP_Error(
-				'rest_design_tokens_forbidden',
-				__( 'The default palette cannot be deleted.', 'kadence-blocks' ),
-				[
-					'status'       => WP_Http::BAD_REQUEST,
-					self::ID_PARAM => $id,
-				]
-			);
 		}
 
 		$document = $this->mutator->remove_by_keys( $this->stored_document( $slug ), $this->palette_keys( $id ) );
@@ -611,9 +606,18 @@ final class Palettes_Controller extends Controller {
 	/**
 	 * The effective, editable view of a palette: the DEFAULT palette's full group/swatch structure (the field
 	 * template) with each swatch's value taken from the palette's own delta when it defines one, otherwise the
-	 * inherited default value. Each swatch carries an `overridden` flag so the UI can show which are deltas
-	 * versus inherited. This is what the palette editor renders so every field is present even when the palette
-	 * stores only a few deltas.
+	 * inherited default value. This is what the palette editor renders so every field is present even when the
+	 * palette stores only a few deltas.
+	 *
+	 * Two flags per swatch drive the editor's undo affordance, and they answer different questions:
+	 *
+	 *   - `baseline` — whether the shipped palette defines this swatch. A baseline swatch's row is permanent
+	 *     (see {@see guard_baseline_swatches()}), so the editor offers Reset for it and Delete only for the
+	 *     rest.
+	 *   - `overridden` — whether there is anything to undo. On the DEFAULT palette that means the value
+	 *     differs from the shipped one; on any other palette it means the palette stores its own delta rather
+	 *     than inheriting. Measuring the default palette against its own deltas would mark every swatch
+	 *     overridden, since the default stores them all.
 	 *
 	 * @since TBD
 	 *
@@ -626,7 +630,9 @@ final class Palettes_Controller extends Controller {
 		$template = $this->palettes->palette( $this->palettes->default_palette( $slug ), $slug ) ?? [];
 		$deltas   = $this->palettes->swatch_values( $id, $slug );
 		$own      = $this->palettes->palette( $id, $slug ) ?? [];
+		$baseline = $this->palettes->baseline_swatch_values();
 
+		$is_default   = $id === $this->palettes->default_palette( $slug );
 		$token_key    = Extensions::get_swatch_token_key();
 		$label_key    = Extensions::get_label_key();
 		$value_key    = Sentinels::get_value_key();
@@ -651,13 +657,21 @@ final class Palettes_Controller extends Controller {
 					continue;
 				}
 
-				$token      = $swatch[ $token_key ];
-				$overridden = array_key_exists( $token, $deltas );
+				$token   = $swatch[ $token_key ];
+				$has_own = array_key_exists( $token, $deltas );
+				$value   = $has_own ? $deltas[ $token ] : ( $swatch[ $value_key ] ?? '' );
+
+				// The default palette stores every swatch, so "has its own value" is always true there and says
+				// nothing; what can be undone on it is a value that no longer matches the shipped one.
+				$overridden = $is_default
+					? ( array_key_exists( $token, $baseline ) && $baseline[ $token ] !== $value )
+					: $has_own;
 
 				$swatches[] = [
 					$token_key   => $token,
 					$label_key   => $swatch[ $label_key ] ?? $token,
-					$value_key   => $overridden ? $deltas[ $token ] : ( $swatch[ $value_key ] ?? '' ),
+					$value_key   => $value,
+					'baseline'   => array_key_exists( $token, $baseline ),
 					'overridden' => $overridden,
 				];
 			}
@@ -677,7 +691,7 @@ final class Palettes_Controller extends Controller {
 	}
 
 	/**
-	 * Prepare a palette node for storage: drop the presentational-only `overridden` flag the effective view
+	 * Prepare a palette node for storage: drop the presentational-only `overridden` / `baseline` flags the effective view
 	 * adds to every swatch, and — for a non-default palette — reduce it to its deltas by dropping every swatch
 	 * whose `$value` equals the library's default palette value for that token (and any group left empty). So a
 	 * palette persists only the colors it actually changes; the rest are inherited from the default.
@@ -715,7 +729,7 @@ final class Palettes_Controller extends Controller {
 					continue;
 				}
 
-				unset( $swatch['overridden'] );
+				unset( $swatch['overridden'], $swatch['baseline'] );
 
 				$token = $swatch[ $token_key ];
 				$value = $swatch[ $value_key ] ?? null;

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
@@ -155,6 +155,67 @@ final class Palettes_ControllerTest extends TestCase {
 	}
 
 	/**
+	 * Every swatch the shipped palette defines is flagged `baseline`, so the editor can tell a permanent row
+	 * (which it offers to reset) from a user-added one (which it offers to delete).
+	 *
+	 * @return void
+	 */
+	public function testGetItemMarksBaselineSwatches(): void {
+		// primitive.color.neutral.600 is a registered color the shipped palette lists no swatch for, so it stands
+		// in for a user-added color without needing a minted primitive.
+		$this->controller->update_swatch(
+			$this->swatch_request( 'PUT', 'default', 'primitive.color.neutral.600', '#4A5568' )
+		);
+
+		$swatches = $this->view_swatches( 'default' );
+
+		$this->assertTrue( $swatches['primitive.color.brand.button']['baseline'] );
+		$this->assertFalse( $swatches['primitive.color.neutral.600']['baseline'] );
+	}
+
+	/**
+	 * On the DEFAULT palette `overridden` means "differs from the shipped value", not "the palette stores it" —
+	 * the default stores every swatch, so the latter would mark them all overridden and leave the editor unable
+	 * to tell an edited color from an untouched one.
+	 *
+	 * @return void
+	 */
+	public function testGetItemMarksOnlyEditedSwatchesOverriddenOnTheDefaultPalette(): void {
+		$untouched = $this->view_swatches( 'default' );
+
+		$this->assertFalse( $untouched['primitive.color.brand.primary']['overridden'] );
+		$this->assertFalse( $untouched['primitive.color.brand.button']['overridden'] );
+
+		$this->controller->update_swatch(
+			$this->swatch_request( 'PUT', 'default', 'primitive.color.brand.primary', '#0000ff' )
+		);
+
+		$edited = $this->view_swatches( 'default' );
+
+		$this->assertTrue( $edited['primitive.color.brand.primary']['overridden'] );
+		$this->assertFalse( $edited['primitive.color.brand.button']['overridden'], 'Only the edited swatch is overridden.' );
+	}
+
+	/**
+	 * Reverting an edited default swatch clears its `overridden` flag, so the editor's Reset affordance turns
+	 * itself off again.
+	 *
+	 * @return void
+	 */
+	public function testRevertingADefaultSwatchClearsItsOverriddenFlag(): void {
+		$this->controller->update_swatch(
+			$this->swatch_request( 'PUT', 'default', 'primitive.color.brand.primary', '#0000ff' )
+		);
+		$this->assertTrue( $this->view_swatches( 'default' )['primitive.color.brand.primary']['overridden'] );
+
+		$this->controller->delete_swatch(
+			$this->swatch_request( 'DELETE', 'default', 'primitive.color.brand.primary' )
+		);
+
+		$this->assertFalse( $this->view_swatches( 'default' )['primitive.color.brand.primary']['overridden'] );
+	}
+
+	/**
 	 * Writing a non-default palette persists only the swatches that differ from the default; a swatch equal
 	 * to the default is inherited, not stored.
 	 *
@@ -375,18 +436,64 @@ final class Palettes_ControllerTest extends TestCase {
 	 *
 	 * @return void
 	 */
-	public function testDeleteItemRemovesAUserPaletteButNotTheDefault(): void {
+	public function testDeleteItemRemovesAUserPalette(): void {
 		$this->controller->update_item( $this->write_request( 'ocean', 'Ocean', '#0000ff' ) );
 		$this->assertContains( 'ocean', $this->palettes->palette_ids() );
 
 		$delete = new WP_REST_Request( 'DELETE' );
 		$delete->set_param( 'id', 'ocean' );
 		$this->controller->delete_item( $delete );
-		$this->assertNotContains( 'ocean', $this->palettes->palette_ids() );
 
-		$delete_default = new WP_REST_Request( 'DELETE' );
-		$delete_default->set_param( 'id', 'default' );
-		$this->assertSame( WP_Http::BAD_REQUEST, $this->status_of( $this->controller->delete_item( $delete_default ) ) );
+		$this->assertNotContains( 'ocean', $this->palettes->palette_ids() );
+	}
+
+	/**
+	 * Deleting the default palette drops its stored overrides and resets it to the shipped definition rather
+	 * than removing it: it is a baseline palette, so it stays in the listing, rendering from baseline.
+	 *
+	 * @return void
+	 */
+	public function testDeleteItemResetsTheDefaultPaletteToBaseline(): void {
+		$this->controller->update_swatch(
+			$this->swatch_request( 'PUT', 'default', 'primitive.color.brand.primary', '#0000ff' )
+		);
+		$this->controller->update_swatch(
+			$this->swatch_request( 'PUT', 'default', 'primitive.color.brand.button', '#00ff00' )
+		);
+
+		$delete = new WP_REST_Request( 'DELETE' );
+		$delete->set_param( 'id', 'default' );
+
+		$result = $this->controller->delete_item( $delete );
+
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'default', $this->palettes->palette_ids(), 'A baseline palette is reset, never removed.' );
+		$this->assertSame( $this->palettes->baseline_swatch_values(), $this->palettes->swatch_values( 'default' ) );
+	}
+
+	/**
+	 * Resetting the default palette with nothing stored for it changes nothing, so the reset is safe to repeat.
+	 *
+	 * @return void
+	 */
+	public function testDeleteItemOnAnUneditedDefaultPaletteIsANoOp(): void {
+		$delete = new WP_REST_Request( 'DELETE' );
+		$delete->set_param( 'id', 'default' );
+
+		$this->assertNotInstanceOf( WP_Error::class, $this->controller->delete_item( $delete ) );
+		$this->assertSame( $this->palettes->baseline_swatch_values(), $this->palettes->swatch_values( 'default' ) );
+	}
+
+	/**
+	 * Deleting a palette the library does not define at all is a 404.
+	 *
+	 * @return void
+	 */
+	public function testDeleteItemOnAnUnknownPaletteIsNotFound(): void {
+		$delete = new WP_REST_Request( 'DELETE' );
+		$delete->set_param( 'id', 'nope' );
+
+		$this->assertSame( WP_Http::NOT_FOUND, $this->status_of( $this->controller->delete_item( $delete ) ) );
 	}
 
 	/**
@@ -712,6 +819,29 @@ final class Palettes_ControllerTest extends TestCase {
 
 		$this->assertNotInstanceOf( WP_Error::class, $result );
 		$this->assertSame( [ 'primitive.color.brand.primary' => '#DD6B20' ], $this->palettes->swatch_values( 'ocean' ) );
+	}
+
+	/**
+	 * A palette's effective view flattened to `{ token => swatch }`, so a case can assert on one swatch's flags
+	 * without walking the group structure.
+	 *
+	 * @param string $id The palette id to read.
+	 *
+	 * @return array<string, array<string, mixed>> The view's swatches, keyed by token dot-path.
+	 */
+	private function view_swatches( string $id ): array {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+		$request->set_param( 'id', $id );
+
+		$swatches = [];
+
+		foreach ( $this->controller->get_item( $request )->get_data()['groups'] as $group ) {
+			foreach ( $group['swatches'] as $swatch ) {
+				$swatches[ $swatch['token'] ] = $swatch;
+			}
+		}
+
+		return $swatches;
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
@@ -432,7 +432,8 @@ final class Palettes_ControllerTest extends TestCase {
 	}
 
 	/**
-	 * Deleting a user-created palette removes it; deleting the default palette is a 400.
+	 * Deleting a user-created palette removes it from the listing, since the baseline has no definition to
+	 * fall back to.
 	 *
 	 * @return void
 	 */
@@ -445,6 +446,53 @@ final class Palettes_ControllerTest extends TestCase {
 		$this->controller->delete_item( $delete );
 
 		$this->assertNotContains( 'ocean', $this->palettes->palette_ids() );
+	}
+
+	/**
+	 * Deleting the palette `$current` points at hands the pointer to the default palette rather than leaving
+	 * it naming an id that is no longer there.
+	 *
+	 * @return void
+	 */
+	public function testDeleteItemHandsCurrentToTheDefaultPalette(): void {
+		$this->controller->update_item( $this->write_request( 'ocean', 'Ocean', '#0000ff' ) );
+
+		$activate = new WP_REST_Request( 'PUT' );
+		$activate->set_param( 'current', 'ocean' );
+		$this->controller->set_current( $activate );
+		$this->assertSame( 'ocean', $this->palettes->current() );
+
+		$delete = new WP_REST_Request( 'DELETE' );
+		$delete->set_param( 'id', 'ocean' );
+		$this->controller->delete_item( $delete );
+
+		$this->assertSame( 'default', $this->palettes->current() );
+	}
+
+	/**
+	 * Re-creating a palette under an id that used to be `$current` does not silently make it live: the delete
+	 * that removed the previous one already handed the pointer away, so the new palette waits to be activated.
+	 *
+	 * Without that, the stale pointer survives in the stored document — invisible while the id names nothing,
+	 * because the reader fail-softs to `$default` — and springs back the moment the id exists again.
+	 *
+	 * @return void
+	 */
+	public function testRecreatingADeletedCurrentPaletteDoesNotReactivateIt(): void {
+		$this->controller->update_item( $this->write_request( 'ocean', 'Ocean', '#0000ff' ) );
+
+		$activate = new WP_REST_Request( 'PUT' );
+		$activate->set_param( 'current', 'ocean' );
+		$this->controller->set_current( $activate );
+
+		$delete = new WP_REST_Request( 'DELETE' );
+		$delete->set_param( 'id', 'ocean' );
+		$this->controller->delete_item( $delete );
+
+		// A different palette that happens to reuse the id — nobody activated it.
+		$this->controller->update_item( $this->write_request( 'ocean', 'Ocean Two', '#00ff00' ) );
+
+		$this->assertSame( 'default', $this->palettes->current() );
 	}
 
 	/**


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4205/palette-swatch-deletion-lock-baseline-swatches-revert-instead-of

:video_camera:  https://www.loom.com/share/692dba0a66ba48c8a13c4ed53db90c78

Two changes the Style Library's swatch panel needs before it can offer Reset, in [5/5].

**`DELETE /palettes/{id}` resets the default palette.** It refused it with a 400 on the reasoning that the default cannot be removed. It cannot, but the request was never asking to remove a palette — it drops a palette's stored **overrides**, and for a palette the baseline also defines, that is a reset to the shipped definition. The Style Library already labels this action Reset rather than Delete for a baseline palette, and says so in a comment ("does drop its overrides"), so the button has been erroring since it shipped. Both cases now share the one handler: a user-created palette leaves the listing, a baseline one stays and renders from baseline. This is what DELETE already means in the sibling library and preset controllers. An unknown palette is still a 404.

**The effective view carries two flags per swatch**, answering different questions:

- `baseline` — whether the shipped palette defines this swatch. Its row is permanent, so the editor offers Reset for it and Delete only for the rest.
- `overridden` — whether there is anything to undo. Unchanged on a non-default palette (the palette stores its own delta). On the **default** palette it now means the value differs from the shipped one; it previously measured the default palette against its own deltas, and the default stores every swatch, so every one of them read as overridden — no way to tell an edited color from an untouched one.

Both are presentational, so `prepare_for_storage()` strips them on the way back in.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deleting the default palette now restores its shipped baseline settings.
  * User-created palettes can be deleted as before.
  * Palette swatches now indicate baseline values and accurately identify overridden settings.

* **Bug Fixes**
  * Reverting a default palette swatch now clears its overridden status.
  * Deleting an already unedited default palette is safely handled without changes.
  * Unknown palettes continue to return a not-found response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

