### PR TITLE
SOFT-4205 [5/5]: split the swatch panel into Reset and Delete

### DIFF
--- a/src/style-library/__tests__/palette-flows.test.js
+++ b/src/style-library/__tests__/palette-flows.test.js
@@ -11,6 +11,7 @@ import {
 	renameGroupFlow,
 	renamePaletteFlow,
 	reorderSwatchesFlow,
+	resetSwatchFlow,
 	saveSwatchEditsFlow,
 	writeDefaultPaletteFlow,
 } from '../helpers/palette-flows';
@@ -24,6 +25,7 @@ import * as client from '../api/client';
 jest.mock('../api/client', () => ({
 	createUserPrimitive: jest.fn(),
 	deletePalette: jest.fn(),
+	deleteSwatch: jest.fn(),
 	deleteUserPrimitive: jest.fn(),
 	fetchPalette: jest.fn(),
 	savePalette: jest.fn(),
@@ -827,6 +829,65 @@ describe('renamePaletteFlow', () => {
 
 		expect(onError).toHaveBeenCalledWith({ message: failure.message });
 		expect(onBusy).toHaveBeenLastCalledWith(false);
+	});
+});
+
+describe('resetSwatchFlow', () => {
+	const baseArgs = (overrides) => ({
+		namespace: NAMESPACE,
+		slug: SLUG,
+		editingId: 'ocean',
+		token: 'primitive.color.brand.primary',
+		reload: jest.fn().mockResolvedValue(undefined),
+		refreshFeed: jest.fn().mockResolvedValue({ version: 'v3' }),
+		onBusy: jest.fn(),
+		onError: jest.fn(),
+		...overrides,
+	});
+
+	beforeEach(() => {
+		client.deleteSwatch.mockResolvedValue({});
+	});
+
+	it('reverts the swatch on the palette being EDITED, not the default node', async () => {
+		await resetSwatchFlow(baseArgs());
+
+		expect(client.deleteSwatch).toHaveBeenCalledWith(NAMESPACE, 'ocean', 'primitive.color.brand.primary', SLUG);
+	});
+
+	it('writes no palette structure — a reset changes one palette value, nothing shared', async () => {
+		await resetSwatchFlow(baseArgs());
+
+		expect(client.savePalette).not.toHaveBeenCalled();
+		expect(client.fetchPalette).not.toHaveBeenCalled();
+	});
+
+	it('never deletes the underlying primitive — a baseline swatch keeps its row', async () => {
+		await resetSwatchFlow(baseArgs());
+
+		expect(client.deleteUserPrimitive).not.toHaveBeenCalled();
+	});
+
+	it('reloads and refreshes the feed, since the response carries the listing rather than the view', async () => {
+		const flowArgs = baseArgs();
+
+		await resetSwatchFlow(flowArgs);
+
+		expect(flowArgs.reload).toHaveBeenCalled();
+		expect(flowArgs.refreshFeed).toHaveBeenCalledWith(SLUG);
+		expect(flowArgs.onBusy).toHaveBeenNthCalledWith(1, true);
+		expect(flowArgs.onBusy).toHaveBeenLastCalledWith(false);
+	});
+
+	it('reports and re-throws a failed revert', async () => {
+		client.deleteSwatch.mockRejectedValue({ message: 'nope' });
+		const flowArgs = baseArgs();
+
+		await expect(resetSwatchFlow(flowArgs)).rejects.toBeDefined();
+
+		expect(flowArgs.onError).toHaveBeenCalledWith({ message: 'nope' });
+		expect(flowArgs.onBusy).toHaveBeenLastCalledWith(false);
+		expect(flowArgs.reload).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/style-library/__tests__/palettes.test.js
+++ b/src/style-library/__tests__/palettes.test.js
@@ -6,6 +6,7 @@ import {
 	findSwatch,
 	isCustomColorToken,
 	isDefaultPalette,
+	isDeletableGroup,
 	isDuplicatePaletteLabel,
 	isUserCreatedPalette,
 	mapPaletteToSwatchGroups,
@@ -32,15 +33,33 @@ const effectivePalette = () => ({
 			id: 'accent',
 			label: 'Accent',
 			swatches: [
-				{ token: 'primitive.color.brand.primary', label: 'Main 1', $value: '#112233', overridden: false },
-				{ token: 'primitive.color.brand.secondary', label: 'Main 2', $value: '#445566', overridden: true },
+				{
+					token: 'primitive.color.brand.primary',
+					label: 'Main 1',
+					$value: '#112233',
+					overridden: false,
+					baseline: true,
+				},
+				{
+					token: 'primitive.color.brand.secondary',
+					label: 'Main 2',
+					$value: '#445566',
+					overridden: true,
+					baseline: true,
+				},
 			],
 		},
 		{
 			id: 'contrast',
 			label: 'Contrast',
 			swatches: [
-				{ token: 'primitive.color.neutral.100', label: 'Neutral 100', $value: '#ffffff', overridden: false },
+				{
+					token: 'primitive.color.neutral.100',
+					label: 'Neutral 100',
+					$value: '#ffffff',
+					overridden: false,
+					baseline: true,
+				},
 			],
 		},
 	],
@@ -61,6 +80,7 @@ describe('mapPaletteToSwatchGroups', () => {
 						subLine: '#112233',
 						value: '#112233',
 						overridden: false,
+						baseline: true,
 					},
 					{
 						id: 'primitive.color.brand.secondary',
@@ -68,6 +88,7 @@ describe('mapPaletteToSwatchGroups', () => {
 						subLine: '#445566',
 						value: '#445566',
 						overridden: true,
+						baseline: true,
 					},
 				],
 			},
@@ -81,10 +102,30 @@ describe('mapPaletteToSwatchGroups', () => {
 						subLine: '#ffffff',
 						value: '#ffffff',
 						overridden: false,
+						baseline: true,
 					},
 				],
 			},
 		]);
+	});
+
+	it('carries the baseline flag through, failing closed when the view omits it', () => {
+		const [group] = mapPaletteToSwatchGroups({
+			groups: [
+				{
+					id: 'accent',
+					label: 'Accent',
+					swatches: [
+						{ token: 'primitive.color.custom.a1b2c3', label: 'Brand', $value: '#111', baseline: false },
+						// A view that predates the flag: treated as baseline, never as removable.
+						{ token: 'primitive.color.brand.primary', label: 'Main 1', $value: '#222' },
+					],
+				},
+			],
+		});
+
+		expect(group.items[0].baseline).toBe(false);
+		expect(group.items[1].baseline).toBe(true);
 	});
 
 	it('uses the token as the item id and carries overridden through', () => {
@@ -107,6 +148,7 @@ describe('findSwatch', () => {
 			label: 'Neutral 100',
 			$value: '#ffffff',
 			overridden: false,
+			baseline: true,
 		});
 		expect(findSwatch(effectivePalette(), 'primitive.color.missing')).toBeNull();
 	});
@@ -198,7 +240,7 @@ describe('slugifyPaletteLabel / isDuplicatePaletteLabel', () => {
 });
 
 describe('stripEffectiveFlags', () => {
-	it('removes overridden and nothing else, immutably', () => {
+	it('removes the view-only flags and nothing else, immutably', () => {
 		const groups = effectivePalette().groups;
 		const stripped = stripEffectiveFlags(groups);
 
@@ -491,5 +533,30 @@ describe('isUserCreatedPalette', () => {
 		expect(isUserCreatedPalette({}, 'ocean')).toBe(false);
 		expect(isUserCreatedPalette(undefined, 'ocean')).toBe(false);
 		expect(isUserCreatedPalette(listing, '')).toBe(false);
+	});
+});
+
+describe('isDeletableGroup', () => {
+	const item = (id, baseline) => ({ id, baseline });
+
+	it('reports a group of only user-added swatches as deletable', () => {
+		expect(isDeletableGroup({ items: [item('primitive.color.custom.a1', false)] })).toBe(true);
+	});
+
+	it('refuses a group carrying any baseline swatch', () => {
+		expect(
+			isDeletableGroup({
+				items: [item('primitive.color.custom.a1', false), item('primitive.color.brand.button', true)],
+			})
+		).toBe(false);
+	});
+
+	it('fails closed on a group whose items carry no signal', () => {
+		expect(isDeletableGroup({ items: [{ id: 'primitive.color.brand.button' }] })).toBe(false);
+	});
+
+	it('treats an empty or absent group as deletable, leaving the caller its own guards', () => {
+		expect(isDeletableGroup({ items: [] })).toBe(true);
+		expect(isDeletableGroup(undefined)).toBe(true);
 	});
 });

--- a/src/style-library/__tests__/paths.test.js
+++ b/src/style-library/__tests__/paths.test.js
@@ -6,6 +6,7 @@ import {
 	userPrimitiveRenamePath,
 	palettesPath,
 	palettePath,
+	paletteSwatchPath,
 	paletteCurrentPath,
 	documentsPath,
 	libraryTitlePath,
@@ -38,6 +39,20 @@ describe('palette paths', () => {
 	it('URL-encodes the palette id and library', () => {
 		expect(palettePath('kb-design-tokens/v1', 'my id', 'my set')).toBe(
 			'/kb-design-tokens/v1/palettes/my%20id?library=my%20set'
+		);
+	});
+
+	it('builds a single swatch path from the palette id and token dot-path', () => {
+		expect(paletteSwatchPath('kb-design-tokens/v1', 'dark', 'primitive.color.brand.button', 'default')).toBe(
+			'/kb-design-tokens/v1/palettes/dark/swatches/primitive.color.brand.button?library=default'
+		);
+	});
+
+	it('leaves a token dot-path readable while still encoding the id and library', () => {
+		// encodeURIComponent leaves dots and hyphens alone, which is what keeps the route's own
+		// `[\w.-]+` token capture able to match what the client sends.
+		expect(paletteSwatchPath('kb-design-tokens/v1', 'my id', 'primitive.color.brand.button-hover', 'my set')).toBe(
+			'/kb-design-tokens/v1/palettes/my%20id/swatches/primitive.color.brand.button-hover?library=my%20set'
 		);
 	});
 });

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -31,6 +31,7 @@ import { RenameColorGroupModal } from '../organisms/RenameColorGroupModal';
 import { DeleteColorGroupModal } from '../organisms/DeleteColorGroupModal';
 import { usePalettes } from '../../hooks/use-palettes';
 import {
+	isDeletableGroup,
 	isUserCreatedPalette,
 	mapPaletteToSwatchGroups,
 	paletteDisplayLabel,
@@ -235,10 +236,12 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 											{__('Rename', 'kadence-blocks')}
 										</MenuItem>
 										{/* Absence, not a disabled item, when only one group remains — the server
-										 * rejects an empty `groups` array (`guard_palette_shape()`), and this
-										 * screen's ethos throughout is to hide an affordance it cannot honor rather
-										 * than disable it. */}
-										{gridGroups.length > 1 && (
+										 * rejects an empty `groups` array (`guard_palette_shape()`) — or when the
+										 * group carries a swatch the shipped palette defines, whose row the server
+										 * refuses to drop (`guard_baseline_swatches()`). This screen's ethos
+										 * throughout is to hide an affordance it cannot honor rather than disable
+										 * it. */}
+										{gridGroups.length > 1 && isDeletableGroup(group) && (
 											<MenuItem
 												isDestructive
 												onClick={() => {

--- a/src/style-library/components/pages/ColorPaletteSettings.js
+++ b/src/style-library/components/pages/ColorPaletteSettings.js
@@ -1,8 +1,14 @@
 /**
  * The Color Palette screen's settings panel: edits one swatch — its display name (a structure edit
  * written to the default palette) and its color (a granular value write on the palette being
- * edited) — and deletes it (also a structure edit, with a best-effort token cleanup after). Mounted
- * by the app when a swatch token is the open route item; see `ColorPaletteScreen.SettingsPanel`.
+ * edited) — and offers the matching undo. Mounted by the app when a swatch token is the open route
+ * item; see `ColorPaletteScreen.SettingsPanel`.
+ *
+ * The undo is Reset or Delete depending on where the swatch came from, mirroring the split
+ * `ColorPaletteScreen` already makes at palette scope. A swatch the shipped palette defines has a
+ * permanent row, so its action only undoes this palette's value for it; a user-added swatch has no
+ * shipped value behind it, so its row is removed outright (a structure edit, with a best-effort
+ * token cleanup after).
  */
 
 /**
@@ -76,6 +82,8 @@ export function ColorPaletteSettings({ route, navigate, library }) {
 		return null;
 	}
 
+	const isBaseline = palettes.isBaselineSwatch(token);
+
 	// Deliberately does NOT call `panel.resetDraft()` on success. `resetDraft` closes over
 	// `initialValues` from the render it was created in — by the time this promise resolves, that
 	// closure is the PRE-save values, so calling it would silently revert the panel to what the
@@ -91,14 +99,26 @@ export function ColorPaletteSettings({ route, navigate, library }) {
 		<SettingsPanel
 			onClose={panel.close}
 			onSave={onSave}
-			// Renders for every swatch: what Delete removes is a palette row (user-editable document
-			// data), not the token — `removeSwatch` decides internally whether the underlying token
-			// is user-created and only then best-effort cleans it up (settled decision 8).
+			// Renders for every swatch, but means two different things. For a swatch the shipped palette
+			// defines it is a RESET — the row is permanent, and the action only undoes this palette's
+			// value for it (to the shipped color on the default palette, to inherited elsewhere) — so it
+			// is offered only when there is something to undo. For a user-added swatch it is the DELETE
+			// of a palette row (user-editable document data, not the token); `removeSwatch` routes
+			// between the two and, for a delete, decides internally whether the underlying token is
+			// user-created and only then best-effort cleans it up (settled decision 8).
+			isReset={isBaseline}
+			isDeleteDisabled={isBaseline && !swatch.overridden}
 			onDelete={() =>
 				palettes
 					.removeSwatch(token)
-					.then(() => navigate({ item: '' }))
-					// Swallowed: a row-removal write failure already lands in `saveError`, rendered above.
+					// A reset keeps the row, so the panel stays open on it; only a delete leaves nothing
+					// behind to show.
+					.then(() => {
+						if (!isBaseline) {
+							navigate({ item: '' });
+						}
+					})
+					// Swallowed: the write failure already lands in `saveError`, rendered above.
 					.catch(() => {})
 			}
 			isDirty={panel.isDirty}

--- a/src/style-library/components/templates/SettingsPanel.js
+++ b/src/style-library/components/templates/SettingsPanel.js
@@ -19,6 +19,26 @@ import { closeSmall } from '@wordpress/icons';
 import './SettingsPanel.scss';
 
 /**
+ * The footer's destructive-button label, in each of its four states. Kept out of the JSX so the
+ * resting and in-flight wording stay side by side, and so every string is a whole `__()` call the
+ * translator sees intact.
+ *
+ * @param {boolean} isReset    Whether the action undoes a value rather than removing the item.
+ * @param {boolean} isDeleting Whether the action is in flight.
+ *
+ * @since TBD
+ *
+ * @return {string} The button label.
+ */
+function destructiveLabel(isReset, isDeleting) {
+	if (isReset) {
+		return isDeleting ? __('Resetting…', 'kadence-blocks') : __('Reset', 'kadence-blocks');
+	}
+
+	return isDeleting ? __('Deleting…', 'kadence-blocks') : __('Delete', 'kadence-blocks');
+}
+
+/**
  * Render the settings panel.
  *
  * @param {Object}         props               The component props.
@@ -32,6 +52,12 @@ import './SettingsPanel.scss';
  * @param {JSX.Element}    props.children       The field area content (typically a `SettingsForm`).
  * @param {?Function}      [props.onDelete]     Footer Delete handler; null hides the button (a non-deletable item).
  * @param {?Function}      [props.onSave]       Footer Save handler; null hides the button.
+ * @param {boolean}        [props.isReset]      Labels the destructive button Reset rather than Delete, for an item
+ *                                                whose row is permanent and whose action only undoes a value.
+ *                                                Optional, defaults to false.
+ * @param {boolean}        [props.isDeleteDisabled] Disables the destructive button on its own — for a Reset with
+ *                                                nothing to undo. Optional, defaults to false; `isBusy` still
+ *                                                disables both buttons regardless.
  * @param {boolean}        [props.isDirty]      Enables Save when true.
  * @param {boolean}        [props.isBusy]       Disables both footer buttons while a write is in flight. Optional,
  *                                                defaults to false, so callers that never pass it are unaffected.
@@ -54,6 +80,8 @@ export function SettingsPanel({
 	children,
 	onDelete = null,
 	onSave = null,
+	isReset = false,
+	isDeleteDisabled = false,
 	isDirty = false,
 	isBusy = false,
 	isSaving = false,
@@ -91,8 +119,15 @@ export function SettingsPanel({
 			)}
 			<div className="kadence-blocks-style-library__settings-panel-footer">
 				{onDelete && (
-					<Button variant="secondary" isDestructive isBusy={isDeleting} disabled={isBusy} onClick={onDelete}>
-						{isDeleting ? __('Deleting…', 'kadence-blocks') : __('Delete', 'kadence-blocks')}
+					<Button
+						variant="secondary"
+						// A Reset only undoes a value, so it is not destructive the way removing a row is.
+						isDestructive={!isReset}
+						isBusy={isDeleting}
+						disabled={isBusy || isDeleteDisabled}
+						onClick={onDelete}
+					>
+						{destructiveLabel(isReset, isDeleting)}
 					</Button>
 				)}
 				{onSave && (

--- a/src/style-library/helpers/palette-flows.js
+++ b/src/style-library/helpers/palette-flows.js
@@ -1,7 +1,7 @@
 /**
  * Pure orchestration for the Color Palette screen's write flows: open, activate, create, rename,
- * delete, the settings-panel save (swatch rename + recolor), swatch removal, add color, add color
- * group, and within-group reorder. Extracted out of `hooks/use-palettes` so each flow can be
+ * delete, the settings-panel save (swatch rename + recolor), swatch reset and removal, add color,
+ * add color group, and within-group reorder. Extracted out of `hooks/use-palettes` so each flow can be
  * exercised directly in tests without rendering a component — a flow takes the REST calls it needs
  * (imported here, so a test mocks `api/client`) plus a small set of injected callbacks for the
  * state a caller reacts to (busy, a scoped error slot, and a `reload`/`refreshFeed` pair the hook
@@ -10,8 +10,9 @@
  *
  * `writeDefaultPaletteFlow` is the single place the default-vs-edited write routing (a palette's
  * structure lives only on its `$default` node — see the module's own docblock below) is encoded.
- * Every structural flow in this file funnels through it; only `saveSwatchEditsFlow`'s color half
- * ever writes the palette being edited.
+ * Every structural flow in this file funnels through it; only `saveSwatchEditsFlow`'s color half and
+ * `resetSwatchFlow` ever write the palette being edited — both because they change one palette's
+ * VALUE for a swatch, which is exactly the thing that is not shared structure.
  *
  * The central distinction here mirrors `library-flows.js`: the palette a site *renders with*
  * (`$current`) versus the palette the app is *editing*. Opening is free and reversible — it only
@@ -33,6 +34,7 @@ import { __ } from '@wordpress/i18n';
 import {
 	createUserPrimitive,
 	deletePalette,
+	deleteSwatch,
 	deleteUserPrimitive,
 	fetchPalette,
 	savePalette,
@@ -592,6 +594,53 @@ export function reorderSwatchesFlow({
 		onBusy,
 		onError,
 	});
+}
+
+/**
+ * Reset a swatch the shipped baseline defines: undo the palette's own value for it and keep the row.
+ *
+ * The one flow here that targets `editingId` rather than `defaultId`, and deliberately so — that
+ * single difference is what scopes the undo to the palette on screen. On the default palette the
+ * server restores the shipped color; on any other palette it drops the delta so the swatch inherits
+ * the default palette again, leaving both the default palette and every sibling untouched. Routing
+ * this through the default node instead (the way a structural edit has to) would undo the color for
+ * every palette at once.
+ *
+ * A baseline swatch's row is permanent — the server refuses a default-palette write that drops one —
+ * so there is no primitive to clean up afterwards and no second step. `removeSwatchFlow` is the
+ * counterpart for a user-added swatch, whose row genuinely goes away.
+ *
+ * The server answers with the palette LISTING rather than the palette view, so the `reload` is what
+ * puts the reverted color on screen.
+ *
+ * @param {Object}   args
+ * @param {string}   args.namespace   The REST namespace.
+ * @param {string}   args.slug        The token library slug.
+ * @param {string}   args.editingId   The palette id currently open for editing.
+ * @param {string}   args.token       The swatch token dot-path to reset.
+ * @param {Function} args.reload      Re-reads the listing (and the edited view) from the hook.
+ * @param {Function} args.refreshFeed Replaces the feed for a slug, so its version token matches the
+ *                                    document this write just bumped.
+ * @param {Function} args.onBusy      Called with a boolean as the chain starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once the revert, the reload, and the feed refresh complete;
+ *                          rejects on failure after `onError`/`onBusy` have run.
+ */
+export function resetSwatchFlow({ namespace, slug, editingId, token, reload, refreshFeed, onBusy, onError }) {
+	onBusy(true);
+
+	return deleteSwatch(namespace, editingId, token, slug)
+		.then(() => reload())
+		.then(() => refreshFeed(slug))
+		.then(() => onBusy(false))
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+			throw err;
+		});
 }
 
 /**

--- a/src/style-library/helpers/palettes.js
+++ b/src/style-library/helpers/palettes.js
@@ -35,9 +35,10 @@ const FALLBACK_SWATCH_VALUE = '#000000';
  *
  * @since TBD
  *
- * @return {Array<Object>} `[{ id, label, items: [{ id, name, subLine, value, overridden }] }]` —
+ * @return {Array<Object>} `[{ id, label, items: [{ id, name, subLine, value, overridden, baseline }] }]` —
  *         `id` is the swatch token dot-path (stable, unique per palette, and what `?kb-item=`
- *         carries), `subLine` the raw `$value`.
+ *         carries), `subLine` the raw `$value`, `baseline` whether the shipped palette defines the
+ *         swatch (a permanent row).
  */
 export function mapPaletteToSwatchGroups(palette) {
 	if (!palette || !Array.isArray(palette.groups)) {
@@ -53,8 +54,26 @@ export function mapPaletteToSwatchGroups(palette) {
 			subLine: swatch.$value,
 			value: swatch.$value,
 			overridden: Boolean(swatch.overridden),
+			// Fails CLOSED, like `helpers/token-capabilities`: a view that predates the flag reads as
+			// baseline, so a permanent row is never offered a delete it cannot honor.
+			baseline: swatch.baseline !== false,
 		})),
 	}));
+}
+
+/**
+ * Whether every swatch in a group is user-added, which is what makes the whole group removable: a
+ * group delete takes its swatches out of every palette, and a swatch the shipped palette defines has
+ * a permanent row the server refuses to drop.
+ *
+ * @param {Object} group A `mapPaletteToSwatchGroups()` group, `{ id, label, items }`.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the group carries no baseline swatch.
+ */
+export function isDeletableGroup(group) {
+	return (group?.items ?? []).every((item) => item.baseline === false);
 }
 
 /**
@@ -232,9 +251,10 @@ export function isDuplicatePaletteLabel(label, listing, excludeId) {
 }
 
 /**
- * Strip the view-only `overridden` flag from every swatch, producing write-payload groups. The
- * effective view is read-only data annotated for display; a write payload sends only what the
- * palette node itself stores.
+ * Strip the view-only flags (`overridden`, `baseline`) from every swatch, producing write-payload
+ * groups. The effective view is read-only data annotated for display; a write payload sends only
+ * what the palette node itself stores. Written as a whitelist rather than a delete list, so a flag
+ * the server adds later is dropped here without this needing to know about it.
  *
  * @param {Array<Object>} groups The effective view's `groups` array.
  *

--- a/src/style-library/hooks/use-palettes.js
+++ b/src/style-library/hooks/use-palettes.js
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/el
  */
 import { fetchPalette, fetchPalettes } from '../api/client';
 import { errorMessage } from '../helpers/library-flows';
-import { isCustomColorToken, reorderGroupSwatches, resolveEditingPaletteId } from '../helpers/palettes';
+import { findSwatch, isCustomColorToken, reorderGroupSwatches, resolveEditingPaletteId } from '../helpers/palettes';
 import {
 	activatePaletteFlow,
 	addColorFlow,
@@ -20,6 +20,7 @@ import {
 	renameGroupFlow,
 	renamePaletteFlow,
 	reorderSwatchesFlow,
+	resetSwatchFlow,
 	saveSwatchEditsFlow,
 } from '../helpers/palette-flows';
 import { flattenSchemaTokens } from '../helpers/tokens';
@@ -68,8 +69,8 @@ import { flattenSchemaTokens } from '../helpers/tokens';
  *                  clearOpenError, clearActivateError, clearCreateError, clearRenameError,
  *                  clearDeleteError, clearSaveError, clearStructureError,
  *                  openPalette, activatePalette, createPalette, renamePalette, deletePalette,
- *                  saveSwatchEdits, removeSwatch, addColor, addGroup, reorderSwatches,
- *                  renameGroup, removeGroup }`.
+ *                  saveSwatchEdits, isBaselineSwatch, removeSwatch, addColor, addGroup,
+ *                  reorderSwatches, renameGroup, removeGroup }`.
  */
 export function usePalettes(feed, refreshFeed, route, navigate) {
 	const [listing, setListing] = useState({ defaultId: '', currentId: '', palettes: [], userCreated: [] });
@@ -299,9 +300,31 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 		[namespace, slug, listing, editingId, reload, refreshFeed]
 	);
 
+	// Whether a swatch is one the shipped palette defines, read from the server's own per-swatch flag
+	// on the effective view rather than re-derived from the token id. Fails CLOSED the same way
+	// `helpers/token-capabilities` does: a swatch the view does not carry counts as baseline, so an
+	// unrecognized row is offered a reset rather than a delete that cannot be undone.
+	const isBaselineSwatch = useCallback((token) => findSwatch(palette, token)?.baseline !== false, [palette]);
+
 	const removeSwatch = useCallback(
 		(token) => {
 			setSaveError(null);
+
+			// A swatch the shipped palette defines is permanent — the server refuses a default-palette
+			// write that drops one — so the destructive action on it RESETS its value instead, scoped to
+			// the palette on screen. Only a user-added swatch's row actually goes away.
+			if (isBaselineSwatch(token)) {
+				return resetSwatchFlow({
+					namespace,
+					slug,
+					editingId,
+					token,
+					reload,
+					refreshFeed,
+					onBusy: setIsBusy,
+					onError: setSaveError,
+				});
+			}
 
 			// Trust the feed's own `userCreated` flag when the token has a feed entry (defense in
 			// depth against a token id that merely looks custom-prefixed); fall back to the prefix
@@ -321,7 +344,7 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 				onError: setSaveError,
 			});
 		},
-		[namespace, slug, listing, feedTokens, reload, refreshFeed]
+		[namespace, slug, listing, editingId, isBaselineSwatch, feedTokens, reload, refreshFeed]
 	);
 
 	const addColor = useCallback(
@@ -467,6 +490,7 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 		renamePalette,
 		deletePalette: removePalette,
 		saveSwatchEdits,
+		isBaselineSwatch,
 		removeSwatch,
 		addColor,
 		addGroup,


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4205/palette-swatch-deletion-lock-baseline-swatches-revert-instead-of

:video_camera:  https://www.loom.com/share/692dba0a66ba48c8a13c4ed53db90c78

> [!IMPORTANT]
> **This PR exists primarily so the behavior can be validated, and may be pulled out of the stack
> and closed without merging.** It wires the server work below it up to the Style Library so
> `@d4mation` can exercise the whole Reset/Delete flow in the UI and record a Loom of it — [1/5]–[4/5]
> are server-side only, so there is nothing to click through without this.
>
> `@pauloiankoski` has related changes in flight on another branch. Where the two overlap, that work
> is the one to accept — do not merge this PR without confirming which version of the Style Library
> changes is being taken.
>
> Dropping it costs the rest of the stack nothing. This is the only PR that touches `src/` and it
> sits at the top, so [1/5]–[4/5] stay intact and mergeable on their own. The guards and revert
> semantics below stand regardless of which UI drives them, and the REST contract this PR consumes
> (`baseline` / `overridden` on the effective view, and `DELETE /palettes/{id}/swatches/{token}`)
> lands in [4/5] and [3/5] — so the replacement work can build on it unchanged.

The Color Palette settings panel offered Delete on every swatch, and its handler rewrote the **default** palette node with the row stripped — whatever palette was open. Two problems in one: a swatch the shipped palette defines is not removable at all (its row is the shared structure every palette is projected from), and a delete inside a non-default palette took the color out of every palette instead of dropping that one palette's override.

The panel's destructive action now routes by where the swatch came from, mirroring the Delete/Reset split `ColorPaletteScreen` already makes at palette scope:

- A **baseline** swatch gets **Reset**, through the new `resetSwatchFlow`. It is the one flow besides `saveSwatchEditsFlow`'s color half that targets `editingId` rather than `defaultId`, and that single difference is what scopes the undo to the palette on screen: the shipped color comes back on the default palette, the delta is dropped (back to inherited) on any other. Offered only when there is something to undo, and it leaves the panel open on the row.
- A **user-added** swatch keeps **Delete** and the existing `removeSwatchFlow`, primitive cleanup and all.

This is the first caller of `deleteSwatch`, which the client has exported since the swatch route shipped without a single call site.

`baseline` rides through `mapPaletteToSwatchGroups` so the group overflow menu can gate on it too: a group holding any baseline swatch is no longer deletable, since group delete would otherwise do exactly what swatch delete now refuses. Absence rather than a disabled item, matching the guard already there for the last remaining group. Both the new `isDeletableGroup` and the hook's `isBaselineSwatch` fail **closed** like `helpers/token-capabilities`: an unflagged swatch reads as baseline, so a view that predates the flag is offered a reset, never a delete it cannot undo.

`SettingsPanel` grows `isReset` and `isDeleteDisabled` for the label and the enabled state; a Reset is also not rendered destructive, since it only undoes a value.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reset behavior for baseline swatches, while user-created swatches continue to be deleted.
  * Reset actions now refresh palette data and keep the settings panel open.
  * Added safeguards to prevent deletion of groups containing baseline swatches.
  * Improved action labels and loading states for reset and delete operations.

* **Bug Fixes**
  * Swatch and palette updates now correctly preserve baseline status and handle reset failures with appropriate error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


