### PR TITLE
[DTM] SOFT-4083 [36/38]: fix the border-width token's raw-id label fallback

### DIFF
--- a/src/style-library/__tests__/border-shadow-field-rendering.test.js
+++ b/src/style-library/__tests__/border-shadow-field-rendering.test.js
@@ -52,6 +52,12 @@ describe('BorderField', () => {
 		window[PICKABLE_TOKENS_GLOBAL] = {
 			tokens: [
 				{ id: 'primitive.dimension.border-width.sm', label: 'Small', type: 'dimension', role: 'border-width' },
+				{
+					id: 'semantic.border-width.default',
+					label: 'Border Width',
+					type: 'dimension',
+					role: 'border-width',
+				},
 				{ id: 'primitive.dimension.radius.sm', label: 'Radius Small', type: 'dimension', role: 'radius' },
 			],
 			values: { brand: { 'primitive.dimension.border-width.sm': '1px' } },
@@ -78,6 +84,30 @@ describe('BorderField', () => {
 			'primitive.dimension.border-width.sm',
 		]);
 		expect(latestBorderControlProps.widthTokens[0].alias).toBe('{primitive.dimension.border-width.sm}');
+	});
+
+	it('exempts the bound width token from the primitive narrowing, so a bound semantic stays pickable', () => {
+		const field = { label: 'Border', path: 'tokens.button-border' };
+
+		act(() => {
+			root.render(
+				createElement(BorderField, {
+					field,
+					values: { tokens: { 'button-border-width': 'semantic.border-width.default' } },
+					onValueChange: jest.fn(),
+				})
+			);
+		});
+
+		expect(latestBorderControlProps.widthTokens.map((token) => token.id)).toEqual(
+			expect.arrayContaining(['semantic.border-width.default'])
+		);
+
+		const boundToken = latestBorderControlProps.widthTokens.find(
+			(token) => token.id === 'semantic.border-width.default'
+		);
+
+		expect(boundToken.label).toBe('Border Width');
 	});
 
 	it('threads breakpoints only when the field is responsive', () => {

--- a/src/style-library/components/molecules/fields/BorderField.js
+++ b/src/style-library/components/molecules/fields/BorderField.js
@@ -60,6 +60,7 @@ import {
 	writePresetBreakpoint,
 } from '../../../../token-controls/helpers/preset-envelope';
 import { BorderControl } from '../../../../token-controls/controls/BorderControl';
+import { boundTokenIds } from './BoxTokenField';
 import { useBreakpoint } from '../../../../token-controls/context/breakpoint';
 import { parseCssLength } from '../../../../token-controls/helpers/parse-css-length';
 import { isSlotList, readSlot } from '../../../../token-controls/helpers/value-shapes';
@@ -220,10 +221,18 @@ export function BorderField({ field, values, onValueChange }) {
 		onValueChange(stylePath, responsive ? writePresetBreakpoint(rawStyle, breakpoint, next) : next);
 	const writeColor = (next) => onValueChange(colorPath, next);
 
-	const widthTokens = pickableTokensForType('dimension', 'border-width').map((token) => ({
-		...token,
-		alias: `{${token.id}}`,
-	}));
+	// The bound width token(s) are exempt from the primitive narrowing, the same way `BoxTokenField`
+	// exempts a box control's bound corners: without this, the semantic `border-width` token this
+	// role's primitives coexist with is filtered out of the pool whenever it is the one actually
+	// bound, and the field — finding no matching entry — renders the raw id instead of the token's
+	// label. Width is per-slot (a scalar or a four-slot list), which is exactly the shape
+	// `boundTokenIds` already handles.
+	const widthTokens = pickableTokensForType('dimension', 'border-width', boundTokenIds(widthAtBreakpoint)).map(
+		(token) => ({
+			...token,
+			alias: `{${token.id}}`,
+		})
+	);
 
 	// Which breakpoints the user has opened up into per-side editing. Held here rather than inferred
 	// from the stored shape — see the module docblock — and per breakpoint for the same reason

--- a/src/style-library/components/molecules/fields/BoxTokenField.js
+++ b/src/style-library/components/molecules/fields/BoxTokenField.js
@@ -157,7 +157,7 @@ function boundsForUnit(unit, field) {
  *
  * @return {Array<string>} The bound token ids, empty when nothing is bound.
  */
-function boundTokenIds(value) {
+export function boundTokenIds(value) {
 	const slots = isSlotList(value) ? value : [value];
 
 	return slots.filter(


### PR DESCRIPTION
## Summary
- Fixes a display bug on the Style Library's Button preset screen: the Border field's width trigger showed the raw token id `semantic.border-width.default` instead of its real label ("Border Width").
- Root cause: `BorderField.js` called `pickableTokensForType('dimension', 'border-width')` without a `selected` argument, so the primitive-narrowing step (`preferPrimitiveTokens`) dropped the bound semantic token from the pickable list — every other field adapter (e.g. `BoxTokenField.js`) passes `selected` to exempt the currently-bound token from that narrowing, but this one didn't.
- Fix: pass the currently-bound width token id(s) as `selected`, reusing `BoxTokenField`'s existing `boundTokenIds()` helper (now exported) rather than duplicating its logic. Handles both a scalar width and a per-side unlinked width (all four bound tokens exempted).

## Test plan
- [x] `npx jest src/token-controls src/style-library src/extension/design-tokens` — full suite green
- [x] `bun run lint-js`, `bun run build`
- [x] cspell on changed files
- [x] `grep -rn "SOFT-" src/style-library` — no hits
- [ ] Manual verification on the dev site (Button preset screen's Border field width trigger)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Border width fields now keep currently selected semantic width tokens available after filtering.
  - Preserved token labels remain visible when narrowing primitive border-width options.

- **Tests**
  - Added coverage verifying semantic border-width token selection and label preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->