### PR TITLE
[DTM] SOFT-4083 [37/38]: filter the Shadow field's Style Library tab to match the Shadow screen

### DIFF
--- a/src/style-library/__tests__/border-shadow-field-rendering.test.js
+++ b/src/style-library/__tests__/border-shadow-field-rendering.test.js
@@ -284,8 +284,19 @@ describe('BoxShadowField', () => {
 		document.body.appendChild(container);
 		root = createRoot(container);
 
+		// Mirrors the real pool: three scale primitives plus two `Brand`-group semantics
+		// (`semantic.shadow.media` / `semantic.shadow.button`) that are application-level defaults for
+		// other blocks' default CSS, never meant to be end-user-pickable here. All five share the derived
+		// `role` of "shadow" — `Pickable_Tokens_Catalog::role_of()` reads it off the id's second
+		// dot-segment, which is `shadow` for every one of them.
 		window[PICKABLE_TOKENS_GLOBAL] = {
-			tokens: [{ id: 'semantic.shadow.card', label: 'Card', type: 'shadow' }],
+			tokens: [
+				{ id: 'primitive.shadow.xs', label: 'XS', type: 'shadow', role: 'shadow' },
+				{ id: 'primitive.shadow.sm', label: 'SM', type: 'shadow', role: 'shadow' },
+				{ id: 'primitive.shadow.md', label: 'MD', type: 'shadow', role: 'shadow' },
+				{ id: 'semantic.shadow.media', label: 'Media Shadow', type: 'shadow', role: 'shadow' },
+				{ id: 'semantic.shadow.button', label: 'Button Shadow', type: 'shadow', role: 'shadow' },
+			],
 			values: {},
 		};
 	});
@@ -299,13 +310,53 @@ describe('BoxShadowField', () => {
 		window[PICKABLE_TOKENS_GLOBAL] = originalPool;
 	});
 
-	it("sources tokens via pickableTokensForType('shadow') with an alias attached", () => {
+	it("sources tokens via pickableTokensForType('shadow', 'shadow', ...), excluding the Brand-group semantics", () => {
 		act(() => {
 			root.render(createElement(BoxShadowField, { field: { label: 'Shadow' }, value: '', onChange: jest.fn() }));
 		});
 
-		expect(latestBoxShadowControlProps.tokens).toEqual([
-			{ id: 'semantic.shadow.card', label: 'Card', value: '', role: null, alias: '{semantic.shadow.card}' },
+		expect(latestBoxShadowControlProps.tokens.map((token) => token.id)).toEqual([
+			'primitive.shadow.xs',
+			'primitive.shadow.sm',
+			'primitive.shadow.md',
+		]);
+		expect(latestBoxShadowControlProps.tokens[0].alias).toBe('{primitive.shadow.xs}');
+	});
+
+	it('exempts the bound token from the primitive narrowing when it is a Brand-group semantic', () => {
+		act(() => {
+			root.render(
+				createElement(BoxShadowField, {
+					field: { label: 'Shadow' },
+					value: '{semantic.shadow.button}',
+					onChange: jest.fn(),
+				})
+			);
+		});
+
+		expect(latestBoxShadowControlProps.tokens.map((token) => token.id)).toEqual(
+			expect.arrayContaining(['semantic.shadow.button'])
+		);
+		expect(latestBoxShadowControlProps.tokens).not.toEqual(
+			expect.arrayContaining([expect.objectContaining({ id: 'semantic.shadow.media' })])
+		);
+	});
+
+	it('does not error and exempts nothing when the value is a composite shadow object, not a token reference', () => {
+		act(() => {
+			root.render(
+				createElement(BoxShadowField, {
+					field: { label: 'Shadow' },
+					value: { color: '#000', hOffset: 0, vOffset: 4, blur: 8, spread: 0 },
+					onChange: jest.fn(),
+				})
+			);
+		});
+
+		expect(latestBoxShadowControlProps.tokens.map((token) => token.id)).toEqual([
+			'primitive.shadow.xs',
+			'primitive.shadow.sm',
+			'primitive.shadow.md',
 		]);
 	});
 

--- a/src/style-library/components/molecules/fields/BoxShadowField.js
+++ b/src/style-library/components/molecules/fields/BoxShadowField.js
@@ -29,7 +29,28 @@ import { __ } from '@wordpress/i18n';
  */
 import { pickableTokensForType } from '../../../helpers/tokens';
 import { BoxShadowControl } from '../../../../token-controls/controls/BoxShadowControl';
+import { boundTokenIds } from './BoxTokenField';
+import { isTokenAlias } from '../../../../token-controls/helpers/token-summary';
 import { TokenColorSelectField } from './TokenColorSelectField';
+
+/**
+ * The bound token id, unwrapped from its brace-wrapped alias, or unset when `value` holds a
+ * composite shadow object instead. `boundTokenIds` (shared with `BorderField`) expects the bare
+ * `primitive.`/`semantic.`-prefixed id a preset's own `tokens` map stores; this field's `value`
+ * carries the brace-wrapped alias `BoxShadowControl` matches against instead (see this file's own
+ * docblock — no envelope, no per-slot conversion), so the brace has to come off first. A composite
+ * object is not an alias at all and passes through unwrapped, matching `boundTokenIds`'
+ * non-string, non-list values with an empty exemption set.
+ *
+ * @param {*} value The stored value: a token alias, or a composite shadow object.
+ *
+ * @since TBD
+ *
+ * @return {Array<string>} The bound token ids, empty when nothing is bound.
+ */
+function boundShadowTokenIds(value) {
+	return boundTokenIds(isTokenAlias(value) ? value.slice(1, -1) : value);
+}
 
 /**
  * Render a box-shadow field from a settings schema entry.
@@ -46,7 +67,13 @@ import { TokenColorSelectField } from './TokenColorSelectField';
  * @return {JSX.Element} The field.
  */
 export function BoxShadowField({ field, value, onChange }) {
-	const tokens = pickableTokensForType('shadow').map((token) => ({
+	// A bare `type` filter alone returns every `shadow` token, including the two `Brand`-group
+	// semantics (`semantic.shadow.media`, `semantic.shadow.button`) that back other blocks' own
+	// default CSS and were never meant to be end-user-pickable here. Passing `role: 'shadow'` — every
+	// shadow token's derived role — engages the primitive narrowing, matching the three-entry list the
+	// Shadow screen itself offers. `boundShadowTokenIds` exempts the currently-bound token from that
+	// narrowing so a bound semantic still renders as its own label rather than a raw id.
+	const tokens = pickableTokensForType('shadow', 'shadow', boundShadowTokenIds(value)).map((token) => ({
 		...token,
 		alias: `{${token.id}}`,
 	}));


### PR DESCRIPTION
## Summary
- Fixes a display bug on the Style Library's Button preset screen: the Shadow field's Style Library tab listed more than the Shadow token-library screen itself offers — showing the three shadow primitives (XS/SM/MD) plus two extra Brand-group semantic entries ("Media Shadow", "Button Shadow") that were never meant to be end-user-pickable.
- Root cause: `BoxShadowField.js` called `pickableTokensForType('shadow')` with no `role` argument, which short-circuits to the unfiltered full list.
- Fix: pass `role='shadow'` plus a `selected` exemption for the currently-bound token, mirroring phase 30's identical fix in `BorderField.js` (reuses `boundTokenIds()`, exported from `BoxTokenField.js`). Since `BoxShadowField`'s stored value is a brace-wrapped alias (unlike `BorderField`'s bare id), a small local wrapper unwraps it before delegating.

## Test plan
- [x] `npx jest src/token-controls src/style-library src/extension/design-tokens` — full suite green
- [x] `bun run lint-js`, `bun run build`
- [x] cspell on changed files
- [x] `grep -rn "SOFT-" src/style-library` — no hits
- [ ] Manual verification on the dev site (Button preset screen's Shadow field Style Library tab)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved box shadow token selection by showing relevant shadow options while excluding unrelated semantic defaults.
  - Preserved the currently selected semantic token, even when it falls outside the filtered options.
  - Improved handling of alias-based token bindings and composite shadow values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->