### PR TITLE
[DTM] SOFT-4083 [29/38]: EditorBorderControl replaces the native border control on the canvas

### DIFF
--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -26,7 +26,6 @@ import {
 	ResponsiveRangeControls,
 	IconRender,
 	HoverToggleControl,
-	ResponsiveBorderControl,
 	KadenceIconPicker,
 	KadencePanelBody,
 	URLInputControl,
@@ -94,6 +93,7 @@ import {
 } from '../../extension/token-indicators/normalize';
 import { TokenControlRow } from '../../extension/token-indicators/components/TokenControlRow';
 import { EditorBoxControl } from '../../extension/design-tokens/components/EditorBoxControl';
+import { EditorBorderControl } from '../../extension/design-tokens/components/EditorBorderControl';
 import { pickableTokensForControl } from '../../extension/token-picker';
 
 export default function KadenceButtonEdit(props) {
@@ -325,6 +325,16 @@ export default function KadenceButtonEdit(props) {
 	const { setPreviewDeviceType: setPreviewDevice } = useDispatch('kadenceblocks/data');
 	const borderRadiusTokens = pickableTokensForControl('kadence/singlebtn', 'borderRadius') || [];
 	const borderRadiusIsRelative = borderRadiusUnit === 'em' || borderRadiusUnit === 'rem';
+	// One pickable-width-token list per border control, keyed the same way its own attribute is —
+	// mirrors `borderRadiusTokens` above, one call per surface rather than one shared list, since a
+	// future per-surface `control_attr` mapping would need its own distinct entry anyway.
+	const borderWidthTokens = pickableTokensForControl('kadence/singlebtn', 'borderStyle') || [];
+	const borderHoverWidthTokens = pickableTokensForControl('kadence/singlebtn', 'borderHoverStyle') || [];
+	const borderTransparentWidthTokens = pickableTokensForControl('kadence/singlebtn', 'borderTransparentStyle') || [];
+	const borderTransparentHoverWidthTokens =
+		pickableTokensForControl('kadence/singlebtn', 'borderTransparentHoverStyle') || [];
+	const borderStickyWidthTokens = pickableTokensForControl('kadence/singlebtn', 'borderStickyStyle') || [];
+	const borderStickyHoverWidthTokens = pickableTokensForControl('kadence/singlebtn', 'borderStickyHoverStyle') || [];
 
 	// The mode describes what THIS device stores, not what it inherits. A breakpoint that stores nothing
 	// has nothing that differs, so it reads as linked — deriving from the inherited corners instead would
@@ -1073,7 +1083,7 @@ export default function KadenceButtonEdit(props) {
 																/>
 															</TokenControlRow>
 														)}
-														<ResponsiveBorderControl
+														<EditorBorderControl
 															label={__('Border', 'kadence-blocks')}
 															value={borderHoverStyle}
 															tabletValue={tabletBorderHoverStyle}
@@ -1087,6 +1097,9 @@ export default function KadenceButtonEdit(props) {
 															onChangeMobile={(value) =>
 																setAttributes({ mobileBorderHoverStyle: value })
 															}
+															previewDevice={previewDevice}
+															onDeviceChange={setPreviewDevice}
+															widthTokens={borderHoverWidthTokens}
 														/>
 														<ResponsiveMeasurementControls
 															label={__('Border Radius', 'kadence-blocks')}
@@ -1287,7 +1300,7 @@ export default function KadenceButtonEdit(props) {
 																/>
 															</TokenControlRow>
 														)}
-														<ResponsiveBorderControl
+														<EditorBorderControl
 															label={__('Border', 'kadence-blocks')}
 															value={borderStyle}
 															tabletValue={tabletBorderStyle}
@@ -1299,6 +1312,9 @@ export default function KadenceButtonEdit(props) {
 															onChangeMobile={(value) =>
 																setAttributes({ mobileBorderStyle: value })
 															}
+															previewDevice={previewDevice}
+															onDeviceChange={setPreviewDevice}
+															widthTokens={borderWidthTokens}
 														/>
 														<EditorBoxControl
 															label={__('Border Radius', 'kadence-blocks')}
@@ -1469,7 +1485,7 @@ export default function KadenceButtonEdit(props) {
 																	}
 																/>
 															)}
-															<ResponsiveBorderControl
+															<EditorBorderControl
 																label={__('Border', 'kadence-blocks')}
 																value={borderTransparentHoverStyle}
 																tabletValue={tabletBorderTransparentHoverStyle}
@@ -1489,6 +1505,9 @@ export default function KadenceButtonEdit(props) {
 																		mobileBorderTransparentHoverStyle: value,
 																	})
 																}
+																previewDevice={previewDevice}
+																onDeviceChange={setPreviewDevice}
+																widthTokens={borderTransparentHoverWidthTokens}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1667,7 +1686,7 @@ export default function KadenceButtonEdit(props) {
 																	}
 																/>
 															)}
-															<ResponsiveBorderControl
+															<EditorBorderControl
 																label={__('Border', 'kadence-blocks')}
 																value={borderTransparentStyle}
 																tabletValue={tabletBorderTransparentStyle}
@@ -1685,6 +1704,9 @@ export default function KadenceButtonEdit(props) {
 																		mobileBorderTransparentStyle: value,
 																	})
 																}
+																previewDevice={previewDevice}
+																onDeviceChange={setPreviewDevice}
+																widthTokens={borderTransparentWidthTokens}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1873,7 +1895,7 @@ export default function KadenceButtonEdit(props) {
 																	}
 																/>
 															)}
-															<ResponsiveBorderControl
+															<EditorBorderControl
 																label={__('Border', 'kadence-blocks')}
 																value={borderStickyHoverStyle}
 																tabletValue={tabletBorderStickyHoverStyle}
@@ -1893,6 +1915,9 @@ export default function KadenceButtonEdit(props) {
 																		mobileBorderStickyHoverStyle: value,
 																	})
 																}
+																previewDevice={previewDevice}
+																onDeviceChange={setPreviewDevice}
+																widthTokens={borderStickyHoverWidthTokens}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}
@@ -2067,7 +2092,7 @@ export default function KadenceButtonEdit(props) {
 																	}
 																/>
 															)}
-															<ResponsiveBorderControl
+															<EditorBorderControl
 																label={__('Border', 'kadence-blocks')}
 																value={borderStickyStyle}
 																tabletValue={tabletBorderStickyStyle}
@@ -2085,6 +2110,9 @@ export default function KadenceButtonEdit(props) {
 																		mobileBorderStickyStyle: value,
 																	})
 																}
+																previewDevice={previewDevice}
+																onDeviceChange={setPreviewDevice}
+																widthTokens={borderStickyWidthTokens}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -52,7 +52,7 @@ import metadata from './block.json';
 /**
  * Internal block libraries
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { tooltip as tooltipIcon } from '@kadence/icons';
 import { link as linkIcon } from '@wordpress/icons';
@@ -95,6 +95,50 @@ import { TokenControlRow } from '../../extension/token-indicators/components/Tok
 import { EditorBoxControl } from '../../extension/design-tokens/components/EditorBoxControl';
 import { EditorBorderControl } from '../../extension/design-tokens/components/EditorBorderControl';
 import { pickableTokensForControl } from '../../extension/token-picker';
+import { isSlotList, readSlot, writeSlot } from '../../token-controls';
+
+const BORDER_COLOR_SIDE_LABELS = ['Top', 'Right', 'Bottom', 'Left'];
+
+/**
+ * `EditorBorderControl`'s `renderColor` render-prop: reuses the block's existing `PopColorControl`
+ * unchanged, one per side once width/style have been unlinked (color always tracks the same
+ * linked/unlinked shape `EditorBorderControl` gives width and style — see `fromNativeBorder`), or a
+ * single one while still linked. Color is out of this plan's scope entirely; this only wires the
+ * existing color-picking mechanism back in, the way `SingleBorderControl` in `@kadence/components`
+ * rendered it per side before this block moved to `EditorBorderControl`.
+ *
+ * @param {Object}   props          The render-prop's argument.
+ * @param {*}        props.value    The current color scalar or four-element slot list.
+ * @param {Function} props.onChange Called with the next color scalar or slot list.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The rendered color field(s).
+ */
+function renderBorderColor({ value, onChange }) {
+	if (!isSlotList(value)) {
+		return <PopColorControl value={value || ''} default={''} hideClear={true} onChange={onChange} />;
+	}
+
+	return (
+		<div className="kb-border-control__colors">
+			{BORDER_COLOR_SIDE_LABELS.map((sideLabel, index) => (
+				<PopColorControl
+					key={sideLabel}
+					swatchLabel={sprintf(
+						/* translators: %s: border side (Top, Right, Bottom, Left) */
+						__('%s Border Color', 'kadence-blocks'),
+						sideLabel
+					)}
+					value={readSlot(value, index) || ''}
+					default={''}
+					hideClear={true}
+					onChange={(next) => onChange(writeSlot(value, index, next, false))}
+				/>
+			))}
+		</div>
+	);
+}
 
 export default function KadenceButtonEdit(props) {
 	const { attributes, setAttributes, isSelected, context, clientId, name } = props;
@@ -1100,6 +1144,7 @@ export default function KadenceButtonEdit(props) {
 															previewDevice={previewDevice}
 															onDeviceChange={setPreviewDevice}
 															widthTokens={borderHoverWidthTokens}
+															renderColor={renderBorderColor}
 														/>
 														<ResponsiveMeasurementControls
 															label={__('Border Radius', 'kadence-blocks')}
@@ -1315,6 +1360,7 @@ export default function KadenceButtonEdit(props) {
 															previewDevice={previewDevice}
 															onDeviceChange={setPreviewDevice}
 															widthTokens={borderWidthTokens}
+															renderColor={renderBorderColor}
 														/>
 														<EditorBoxControl
 															label={__('Border Radius', 'kadence-blocks')}
@@ -1508,6 +1554,7 @@ export default function KadenceButtonEdit(props) {
 																previewDevice={previewDevice}
 																onDeviceChange={setPreviewDevice}
 																widthTokens={borderTransparentHoverWidthTokens}
+																renderColor={renderBorderColor}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1707,6 +1754,7 @@ export default function KadenceButtonEdit(props) {
 																previewDevice={previewDevice}
 																onDeviceChange={setPreviewDevice}
 																widthTokens={borderTransparentWidthTokens}
+																renderColor={renderBorderColor}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1918,6 +1966,7 @@ export default function KadenceButtonEdit(props) {
 																previewDevice={previewDevice}
 																onDeviceChange={setPreviewDevice}
 																widthTokens={borderStickyHoverWidthTokens}
+																renderColor={renderBorderColor}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}
@@ -2113,6 +2162,7 @@ export default function KadenceButtonEdit(props) {
 																previewDevice={previewDevice}
 																onDeviceChange={setPreviewDevice}
 																widthTokens={borderStickyWidthTokens}
+																renderColor={renderBorderColor}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -83,7 +83,7 @@ import {
 import { addFilter, applyFilters, doAction } from '@wordpress/hooks';
 import BackendStyles from './components/backend-styles';
 import { PresetButton } from '../../extension/preset-picker/PresetButton';
-import { usePresetBinding, resetAttr } from '../../extension/token-indicators';
+import { usePresetBinding, resetAttr, presetPropertyValueForDevice } from '../../extension/token-indicators';
 import {
 	anyCornerInherited,
 	deriveMeasureMode,
@@ -332,6 +332,20 @@ export default function KadenceButtonEdit(props) {
 	const borderRadiusPresetValue = presetValueForDevice(
 		tokenBinding.borderRadius?.presetValue,
 		tokenBinding.borderRadius?.responsive,
+		previewDevice
+	);
+
+	// What an unset Border Width field falls back to: the active preset's own resolved width.
+	// `button-border-width` has no `control_attr` (its native attribute is a nested per-side shape
+	// `usePresetBinding` has nothing to key it by — see `declarations.php`'s comment on that binding),
+	// so `tokenBinding` never carries it; read it directly instead. Shown as `EditorBorderControl`'s
+	// `defaultValue` — without it, a cleared width field renders empty and collapses to zero height
+	// (its `TokenSelector`'s trigger has nothing to show), which reads as broken rather than reset.
+	const borderWidthPresetValue = presetPropertyValueForDevice(
+		'kadence/singlebtn',
+		'button-border-width',
+		attributes,
+		undefined,
 		previewDevice
 	);
 
@@ -1144,6 +1158,7 @@ export default function KadenceButtonEdit(props) {
 															previewDevice={previewDevice}
 															onDeviceChange={setPreviewDevice}
 															widthTokens={borderHoverWidthTokens}
+															defaultValue={borderWidthPresetValue}
 															renderColor={renderBorderColor}
 														/>
 														<ResponsiveMeasurementControls
@@ -1360,6 +1375,7 @@ export default function KadenceButtonEdit(props) {
 															previewDevice={previewDevice}
 															onDeviceChange={setPreviewDevice}
 															widthTokens={borderWidthTokens}
+															defaultValue={borderWidthPresetValue}
 															renderColor={renderBorderColor}
 														/>
 														<EditorBoxControl
@@ -1554,6 +1570,7 @@ export default function KadenceButtonEdit(props) {
 																previewDevice={previewDevice}
 																onDeviceChange={setPreviewDevice}
 																widthTokens={borderTransparentHoverWidthTokens}
+																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
 															/>
 															<ResponsiveMeasurementControls
@@ -1754,6 +1771,7 @@ export default function KadenceButtonEdit(props) {
 																previewDevice={previewDevice}
 																onDeviceChange={setPreviewDevice}
 																widthTokens={borderTransparentWidthTokens}
+																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
 															/>
 															<ResponsiveMeasurementControls
@@ -1966,6 +1984,7 @@ export default function KadenceButtonEdit(props) {
 																previewDevice={previewDevice}
 																onDeviceChange={setPreviewDevice}
 																widthTokens={borderStickyHoverWidthTokens}
+																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
 															/>
 															<ResponsiveMeasurementControls
@@ -2162,6 +2181,7 @@ export default function KadenceButtonEdit(props) {
 																previewDevice={previewDevice}
 																onDeviceChange={setPreviewDevice}
 																widthTokens={borderStickyWidthTokens}
+																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
 															/>
 															<ResponsiveMeasurementControls

--- a/src/extension/design-tokens/components/EditorBorderControl.js
+++ b/src/extension/design-tokens/components/EditorBorderControl.js
@@ -19,10 +19,11 @@
  *   way `BoxControl`'s radius keeps `borderRadiusUnit` — so, unlike `EditorBoxControl`, this
  *   component takes no separate `unit`/`units`/`onUnit` props at all.
  *
- * Color is untouched — passed straight through to whatever the caller's existing color field is
- * (via `renderColor`), matching `BorderControl`'s own scope boundary. This plan's color work is out
- * of scope entirely; see `toNativeBorder`'s docblock for why every write still has to read the
- * EXISTING color back out of the native value rather than dropping it.
+ * Color editing itself is untouched — this component neither builds nor redesigns a color field, it
+ * only wires the caller's EXISTING one back in via `renderColor` (matching `BorderControl`'s own
+ * scope boundary; this plan's color-field redesign work is out of scope entirely). `toNativeBorder`
+ * still has to fall back to the native value's stored color when `renderColor` writes nothing for a
+ * side — see its docblock for why.
  */
 
 /**
@@ -138,16 +139,19 @@ function toNativeSize(slot, unit) {
  * Convert `BorderControl`'s `{ width, style, color }` shape back to the native
  * `[{top,right,bottom,left,unit}]` attribute shape.
  *
- * **Color pass-through, not overwrite**: `BorderControl` never manages `value.color` itself (it's
- * rendered via `renderColor`, scoped out of this plan entirely per the global "no color work"
- * constraint), so this function must read each side's EXISTING color out of `previousNative` and
- * write it back unchanged — writing `''` here instead would silently erase every side's color on
- * the very next width/style edit. This is why `EditorBorderControl`'s `onChange` handler (below)
- * always has the previous native value on hand to pass through.
+ * **Color: use the caller's edit, fall back to the existing value, never blank it out.** `value.color`
+ * is whatever `BorderControl` currently holds for color — either untouched (in which case it is
+ * exactly what `fromNativeBorder` derived from `previousNative`, since a width/style-only edit merges
+ * `{ ...value, ...next }` and leaves `color` alone) or freshly written by the caller's `renderColor`
+ * (via `BorderControl`'s own `patch({ color: next })`). Reading `value.color` first means a genuine
+ * color edit reaches the native attribute; falling back to `previousNative`'s stored color only when
+ * a slot is blank/undefined guards the one case where `value.color` itself has nothing to say (e.g. a
+ * caller that renders no `renderColor` at all) — writing `''` unconditionally in that case would
+ * silently erase every side's color on the very next width/style edit.
  *
  * @param {Object} value          `{ width, style, color }` from `BorderControl`.
- * @param {?Array} previousNative The attribute's current `[{top,right,bottom,left,unit}]` value,
- *                                read for its per-side color only.
+ * @param {?Array} previousNative The attribute's current `[{top,right,bottom,left,unit}]` value, read
+ *                                as the per-side color fallback when `value.color` has nothing set.
  * @param {string} [unit]         The border's shared unit (defaults to `'px'`, matching the native
  *                                default in `ResponsiveBorderControl`'s `deskDefault`).
  *
@@ -160,8 +164,9 @@ function toNativeBorder(value, previousNative, unit = 'px') {
 
 	const sides = SIDES.reduce((acc, side, index) => {
 		const existingColor = previousSides[side]?.[0] || '';
+		const nextColor = readSlot(value.color, index);
 		acc[side] = [
-			existingColor,
+			nextColor || existingColor,
 			readSlot(value.style, index) || 'none',
 			toNativeSize(readSlot(value.width, index), unit),
 		];

--- a/src/extension/design-tokens/components/EditorBorderControl.js
+++ b/src/extension/design-tokens/components/EditorBorderControl.js
@@ -142,34 +142,27 @@ function toNativeSize(slot, unit) {
  * Convert `BorderControl`'s `{ width, style, color }` shape back to the native
  * `[{top,right,bottom,left,unit}]` attribute shape.
  *
- * **Color: use the caller's edit, fall back to the existing value, never blank it out.** `value.color`
- * is whatever `BorderControl` currently holds for color — either untouched (in which case it is
- * exactly what `fromNativeBorder` derived from `previousNative`, since a width/style-only edit merges
+ * **Color always comes straight from `value.color`, with no fallback.** `value.color` is whatever
+ * `BorderControl` currently holds for color — either untouched (in which case it is exactly what
+ * `fromNativeBorder` derived from `previousNative`, since a width/style-only edit merges
  * `{ ...value, ...next }` and leaves `color` alone) or freshly written by the caller's `renderColor`
- * (via `BorderControl`'s own `patch({ color: next })`). Reading `value.color` first means a genuine
- * color edit reaches the native attribute; falling back to `previousNative`'s stored color only when
- * a slot is blank/undefined guards the one case where `value.color` itself has nothing to say (e.g. a
- * caller that renders no `renderColor` at all) — writing `''` unconditionally in that case would
- * silently erase every side's color on the very next width/style edit.
+ * (via `BorderControl`'s own `patch({ color: next })`). Either way `value.color` already carries the
+ * correct value to write — a stale `nextColor || existingColor`-style fallback would treat an
+ * explicit clear (`''`) the same as "nothing changed" and silently write the old color back,
+ * making the border color impossible to clear.
  *
- * @param {Object} value          `{ width, style, color }` from `BorderControl`.
- * @param {?Array} previousNative The attribute's current `[{top,right,bottom,left,unit}]` value, read
- *                                as the per-side color fallback when `value.color` has nothing set.
- * @param {string} [unit]         The border's shared unit (defaults to `'px'`, matching the native
- *                                default in `ResponsiveBorderControl`'s `deskDefault`).
+ * @param {Object} value  `{ width, style, color }` from `BorderControl`.
+ * @param {string} [unit] The border's shared unit (defaults to `'px'`, matching the native default
+ *                        in `ResponsiveBorderControl`'s `deskDefault`).
  *
  * @since TBD
  *
  * @return {Array} `[{top,right,bottom,left,unit}]`.
  */
-function toNativeBorder(value, previousNative, unit = 'px') {
-	const previousSides = previousNative?.[0] || {};
-
+function toNativeBorder(value, unit = 'px') {
 	const sides = SIDES.reduce((acc, side, index) => {
-		const existingColor = previousSides[side]?.[0] || '';
-		const nextColor = readSlot(value.color, index);
 		acc[side] = [
-			nextColor || existingColor,
+			readSlot(value.color, index),
 			readSlot(value.style, index) || 'none',
 			toNativeSize(readSlot(value.width, index), unit),
 		];
@@ -234,7 +227,7 @@ export function EditorBorderControl({
 			<BorderControl
 				label={label}
 				value={fromNativeBorder(activeNative)}
-				onChange={(next) => activeSetter(toNativeBorder(next, activeNative, activeUnit))}
+				onChange={(next) => activeSetter(toNativeBorder(next, activeUnit))}
 				widthTokens={widthTokens}
 				indicator={indicator}
 				breakpoints={Object.values(BREAKPOINT_FOR_DEVICE)}

--- a/src/extension/design-tokens/components/EditorBorderControl.js
+++ b/src/extension/design-tokens/components/EditorBorderControl.js
@@ -1,0 +1,242 @@
+/**
+ * The block editor's adapter for `src/token-controls`' `BorderControl`.
+ *
+ * The Style Library's `BorderField` bridges a different storage shape; this one bridges the
+ * editor's own, the same role `EditorBoxControl` plays for radius:
+ *
+ * - **breakpoints are sibling attributes** — `border`, `tabletBorder`, `mobileBorder` (or whatever
+ *   the block calls its own trio) — passed in directly rather than pre-resolved by the caller,
+ *   since (unlike radius) there is no single scalar per breakpoint to hand over: each breakpoint's
+ *   native value is itself a one-element array of a four-side object, and the color inside it has
+ *   to be read back out again on every write (see `toNativeBorder` below). Resolving which sibling
+ *   is active is this component's job, not the caller's.
+ * - **once a side has ever been written, it stays a four-element array**, never collapsed back to a
+ *   scalar — `fromNativeBorder` only answers the empty scalar (`''`/`'none'`) for a breakpoint that
+ *   has never been saved at all; the moment any side is written, `toNativeBorder` always fills in
+ *   all four, so every later read comes back as four-element width/style/color arrays and the
+ *   control renders unlinked from then on. There is no separate "link" flag to keep in sync.
+ * - **the unit lives inside the native value itself** (`source.unit`), not a sibling attribute the
+ *   way `BoxControl`'s radius keeps `borderRadiusUnit` — so, unlike `EditorBoxControl`, this
+ *   component takes no separate `unit`/`units`/`onUnit` props at all.
+ *
+ * Color is untouched — passed straight through to whatever the caller's existing color field is
+ * (via `renderColor`), matching `BorderControl`'s own scope boundary. This plan's color work is out
+ * of scope entirely; see `toNativeBorder`'s docblock for why every write still has to read the
+ * EXISTING color back out of the native value rather than dropping it.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { BreakpointProvider } from '../../../token-controls';
+import { BorderControl } from '../../../token-controls/controls/BorderControl';
+import { isTokenId, readSlot } from '../../../token-controls/helpers/value-shapes';
+
+const SIDES = ['top', 'right', 'bottom', 'left'];
+
+/**
+ * The control's breakpoint key for an editor device name.
+ *
+ * The editor names its devices `Desktop`/`Tablet`/`Mobile`; the shared control speaks the lowercase
+ * keys the token vocabulary uses. Mapping here keeps that spelling difference out of both, matching
+ * `EditorBoxControl`'s own table exactly.
+ *
+ * @since TBD
+ *
+ * @type {Object<string, string>}
+ */
+const BREAKPOINT_FOR_DEVICE = {
+	Desktop: 'desktop',
+	Tablet: 'tablet',
+	Mobile: 'mobile',
+};
+
+/**
+ * The editor device name for a control breakpoint key — the inverse of `BREAKPOINT_FOR_DEVICE`.
+ *
+ * @param {string} breakpoint The control's breakpoint key (`desktop`/`tablet`/`mobile`).
+ *
+ * @since TBD
+ *
+ * @return {string} The matching editor device name, defaulting to `Desktop`.
+ */
+function deviceForBreakpoint(breakpoint) {
+	return Object.keys(BREAKPOINT_FOR_DEVICE).find((name) => BREAKPOINT_FOR_DEVICE[name] === breakpoint) ?? 'Desktop';
+}
+
+/**
+ * Convert the native `[{top:[color,style,size],...}]` attribute value to `BorderControl`'s
+ * `{ width, style, color }` shape. `size` has no per-side unit in the native shape (one `unit`
+ * shared across the whole border) — the converted `width` slot is written as `${size}${unit}` so
+ * it round-trips through `BorderControl`'s token-or-literal contract as a plain CSS literal when
+ * not a token id.
+ *
+ * @param {?Array} native `[{top,right,bottom,left,unit}]` or undefined.
+ *
+ * @since TBD
+ *
+ * @return {Object} `{ width, style, color }`.
+ */
+function fromNativeBorder(native) {
+	const source = native?.[0];
+
+	if (!source) {
+		return { width: '', style: 'none', color: '' };
+	}
+
+	const unit = source.unit || 'px';
+
+	return {
+		width: SIDES.map((side) => {
+			const [, , size] = source[side] || [];
+
+			if (size === '' || size === undefined || size === null) {
+				return '';
+			}
+
+			// A token alias is already a full id string — never a bare number — so it never gets a
+			// unit suffix appended; only a literal numeric width does.
+			return isTokenId(size) ? size : `${size}${unit}`;
+		}),
+		style: SIDES.map((side) => source[side]?.[1] || 'none'),
+		color: SIDES.map((side) => source[side]?.[0] || ''),
+	};
+}
+
+/**
+ * Split a `BorderControl` width slot (a plain CSS literal like `"2px"`, a token alias like
+ * `"primitive.dimension.border-width.md"`, or `""`) into a native `(size, unit)` pair. A literal is
+ * split on its trailing unit letters; an alias is stored whole in the size position with `unit` left
+ * as the shared border unit unchanged — confirmed against `borderRadius`'s own corner slots
+ * (`EditorBoxControl`'s caller in `singlebtn/edit.js` stores an alias directly in a corner via
+ * `aliasForValue`, with no wrapping and no unit suffix), so a bare alias id in the size slot is the
+ * established convention here too, not a guess.
+ *
+ * @param {string} slot The width slot's value.
+ * @param {string} unit The border's shared unit.
+ *
+ * @since TBD
+ *
+ * @return {string|number} The native size value for this slot.
+ */
+function toNativeSize(slot, unit) {
+	if (slot === '' || slot === undefined) {
+		return '';
+	}
+
+	if (isTokenId(slot)) {
+		return slot; // alias — see the confirmation note above.
+	}
+
+	const literal = String(slot).endsWith(unit) ? slot.slice(0, -unit.length) : slot;
+	const numeric = parseFloat(literal);
+
+	return Number.isNaN(numeric) ? '' : numeric;
+}
+
+/**
+ * Convert `BorderControl`'s `{ width, style, color }` shape back to the native
+ * `[{top,right,bottom,left,unit}]` attribute shape.
+ *
+ * **Color pass-through, not overwrite**: `BorderControl` never manages `value.color` itself (it's
+ * rendered via `renderColor`, scoped out of this plan entirely per the global "no color work"
+ * constraint), so this function must read each side's EXISTING color out of `previousNative` and
+ * write it back unchanged — writing `''` here instead would silently erase every side's color on
+ * the very next width/style edit. This is why `EditorBorderControl`'s `onChange` handler (below)
+ * always has the previous native value on hand to pass through.
+ *
+ * @param {Object} value          `{ width, style, color }` from `BorderControl`.
+ * @param {?Array} previousNative The attribute's current `[{top,right,bottom,left,unit}]` value,
+ *                                read for its per-side color only.
+ * @param {string} [unit]         The border's shared unit (defaults to `'px'`, matching the native
+ *                                default in `ResponsiveBorderControl`'s `deskDefault`).
+ *
+ * @since TBD
+ *
+ * @return {Array} `[{top,right,bottom,left,unit}]`.
+ */
+function toNativeBorder(value, previousNative, unit = 'px') {
+	const previousSides = previousNative?.[0] || {};
+
+	const sides = SIDES.reduce((acc, side, index) => {
+		const existingColor = previousSides[side]?.[0] || '';
+		acc[side] = [
+			existingColor,
+			readSlot(value.style, index) || 'none',
+			toNativeSize(readSlot(value.width, index), unit),
+		];
+		return acc;
+	}, {});
+
+	return [{ ...sides, unit }];
+}
+
+/**
+ * Render the editor-canvas border control.
+ *
+ * @param {Object}       props                The component props.
+ * @param {?Array}       props.value          Desktop border attribute value.
+ * @param {?Array}       props.tabletValue    Tablet border attribute value.
+ * @param {?Array}       props.mobileValue    Mobile border attribute value.
+ * @param {Function}     props.onChange       Desktop attribute setter.
+ * @param {Function}     props.onChangeTablet Tablet attribute setter.
+ * @param {Function}     props.onChangeMobile Mobile attribute setter.
+ * @param {string}       props.previewDevice  The editor's active device (`Desktop`/`Tablet`/`Mobile`).
+ * @param {Function}     props.onDeviceChange Called with the next editor device name.
+ * @param {string}       props.label          The control's label.
+ * @param {Array}        [props.widthTokens]  Pickable border-width tokens.
+ * @param {?Function}    [props.renderColor]  The block's existing color field for `value.color`.
+ * @param {?JSX.Element} [props.indicator]    The editor's `TokenIndicator`, passed straight through.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The rendered control.
+ */
+export function EditorBorderControl({
+	value,
+	tabletValue,
+	mobileValue,
+	onChange,
+	onChangeTablet,
+	onChangeMobile,
+	previewDevice,
+	onDeviceChange,
+	label,
+	widthTokens = [],
+	renderColor,
+	indicator = null,
+}) {
+	const breakpoint = BREAKPOINT_FOR_DEVICE[previewDevice] ?? 'desktop';
+	// Named once and passed to both `BreakpointProvider` and the switcher below, so the two staying
+	// in agreement is structural rather than a convention two separate lambdas could drift out of —
+	// matching `EditorBoxControl`'s own wiring exactly.
+	const changeBreakpoint = (next) => onDeviceChange(deviceForBreakpoint(next));
+
+	const nativeForBreakpoint = { desktop: value, tablet: tabletValue, mobile: mobileValue };
+	const setterForBreakpoint = { desktop: onChange, tablet: onChangeTablet, mobile: onChangeMobile };
+
+	const activeNative = nativeForBreakpoint[breakpoint];
+	const activeSetter = setterForBreakpoint[breakpoint];
+	// Follows the active device's own stored unit, falling back to the desktop unit (matching
+	// `ResponsiveBorderControl`'s own `mobileUnit`/`tabletUnit` fallback), and finally 'px'.
+	const activeUnit = activeNative?.[0]?.unit || value?.[0]?.unit || 'px';
+
+	return (
+		<BreakpointProvider value={breakpoint} onChange={changeBreakpoint}>
+			<BorderControl
+				label={label}
+				value={fromNativeBorder(activeNative)}
+				onChange={(next) => activeSetter(toNativeBorder(next, activeNative, activeUnit))}
+				widthTokens={widthTokens}
+				indicator={indicator}
+				breakpoints={Object.values(BREAKPOINT_FOR_DEVICE)}
+				breakpoint={breakpoint}
+				// The switcher lives in `ControlShell`, driven by this prop directly — it does not read
+				// the `BreakpointProvider` context above, so both must map back to a device the same way.
+				onBreakpointChange={changeBreakpoint}
+				renderColor={renderColor}
+				stacked
+			/>
+		</BreakpointProvider>
+	);
+}

--- a/src/extension/design-tokens/components/EditorBorderControl.js
+++ b/src/extension/design-tokens/components/EditorBorderControl.js
@@ -186,6 +186,13 @@ function toNativeBorder(value, unit = 'px') {
  * @param {Function}     props.onDeviceChange Called with the next editor device name.
  * @param {string}       props.label          The control's label.
  * @param {Array}        [props.widthTokens]  Pickable border-width tokens.
+ * @param {*}            [props.defaultValue] What the width slot falls back to when unset — the
+ *                                            active preset's resolved border width, so a cleared
+ *                                            width field shows a muted "Default 2px" instead of
+ *                                            rendering empty (which collapses the field to zero
+ *                                            height, per its own `TokenSelector`'s summary/fallback
+ *                                            logic). One scalar for every side: presets set a single
+ *                                            border width, never a per-side default.
  * @param {?Function}    [props.renderColor]  The block's existing color field for `value.color`.
  * @param {?JSX.Element} [props.indicator]    The editor's `TokenIndicator`, passed straight through.
  *
@@ -204,6 +211,7 @@ export function EditorBorderControl({
 	onDeviceChange,
 	label,
 	widthTokens = [],
+	defaultValue,
 	renderColor,
 	indicator = null,
 }) {
@@ -229,6 +237,7 @@ export function EditorBorderControl({
 				value={fromNativeBorder(activeNative)}
 				onChange={(next) => activeSetter(toNativeBorder(next, activeUnit))}
 				widthTokens={widthTokens}
+				defaultValue={defaultValue}
 				indicator={indicator}
 				breakpoints={Object.values(BREAKPOINT_FOR_DEVICE)}
 				breakpoint={breakpoint}

--- a/src/extension/design-tokens/components/EditorBorderControl.js
+++ b/src/extension/design-tokens/components/EditorBorderControl.js
@@ -31,7 +31,8 @@
  */
 import { BreakpointProvider } from '../../../token-controls';
 import { BorderControl } from '../../../token-controls/controls/BorderControl';
-import { isTokenId, readSlot } from '../../../token-controls/helpers/value-shapes';
+import { readSlot } from '../../../token-controls/helpers/value-shapes';
+import { isTokenAlias } from '../../../token-controls/helpers/token-summary';
 
 const SIDES = ['top', 'right', 'bottom', 'left'];
 
@@ -97,7 +98,7 @@ function fromNativeBorder(native) {
 
 			// A token alias is already a full id string — never a bare number — so it never gets a
 			// unit suffix appended; only a literal numeric width does.
-			return isTokenId(size) ? size : `${size}${unit}`;
+			return isTokenAlias(size) ? size : `${size}${unit}`;
 		}),
 		style: SIDES.map((side) => source[side]?.[1] || 'none'),
 		color: SIDES.map((side) => source[side]?.[0] || ''),
@@ -106,12 +107,14 @@ function fromNativeBorder(native) {
 
 /**
  * Split a `BorderControl` width slot (a plain CSS literal like `"2px"`, a token alias like
- * `"primitive.dimension.border-width.md"`, or `""`) into a native `(size, unit)` pair. A literal is
- * split on its trailing unit letters; an alias is stored whole in the size position with `unit` left
- * as the shared border unit unchanged — confirmed against `borderRadius`'s own corner slots
- * (`EditorBoxControl`'s caller in `singlebtn/edit.js` stores an alias directly in a corner via
- * `aliasForValue`, with no wrapping and no unit suffix), so a bare alias id in the size slot is the
- * established convention here too, not a guess.
+ * `"{primitive.dimension.border-width.md}"`, or `""`) into a native `(size, unit)` pair. A literal
+ * is split on its trailing unit letters; an alias is stored whole in the size position with `unit`
+ * left as the shared border unit unchanged — matching `borderRadius`'s own corner slots
+ * (`EditorBoxControl`'s caller in `singlebtn/edit.js` stores an alias directly in a corner, with no
+ * unit suffix), so a brace-wrapped alias id in the size slot is the established convention here too.
+ * Detected with `isTokenAlias()` (checks for the `{...}` wrapper `TokenSelector.onPick` actually
+ * passes), not `isTokenId()` (checks for a bare `primitive.`/`semantic.` id, which this slot never
+ * holds — using it here silently treated every alias as a literal and dropped its width to `''`).
  *
  * @param {string} slot The width slot's value.
  * @param {string} unit The border's shared unit.
@@ -125,7 +128,7 @@ function toNativeSize(slot, unit) {
 		return '';
 	}
 
-	if (isTokenId(slot)) {
+	if (isTokenAlias(slot)) {
 		return slot; // alias — see the confirmation note above.
 	}
 

--- a/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
@@ -139,7 +139,7 @@ describe('EditorBorderControl native <-> control value bridging', () => {
 	 */
 	it('stores and reads back a token alias in the width slot without corrupting it', () => {
 		const { borderControl, onChange } = renderEditorBorderControl();
-		const alias = 'primitive.dimension.border-width.md';
+		const alias = '{primitive.dimension.border-width.md}';
 
 		borderControl.props.onChange({
 			width: [alias, '3px', '4px', '5px'],

--- a/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
@@ -155,9 +155,11 @@ describe('EditorBorderControl native <-> control value bridging', () => {
 	});
 
 	/**
-	 * `BorderControl` never manages color; a width/style edit must read each side's EXISTING color
-	 * out of the previous native value and write it back unchanged, or the very next edit would
-	 * silently erase every side's color.
+	 * A width/style-only edit carries `value.color` forward unchanged, because `BorderControl`'s own
+	 * `patch()` merges `{ ...value, ...next }` — the width/style write never touches `color`, so the
+	 * `next` it hands to `onChange` still has the real colors `fromNativeBorder` derived. This is the
+	 * realistic shape of that call (not blanked-out colors — see the clear-color test below for why
+	 * that used to matter).
 	 *
 	 * @return {void}
 	 */
@@ -167,7 +169,7 @@ describe('EditorBorderControl native <-> control value bridging', () => {
 		borderControl.props.onChange({
 			width: ['2px', '3px', '4px', '5px'],
 			style: ['none', 'dashed', 'dotted', 'double'],
-			color: ['', '', '', ''], // BorderControl never populates color itself.
+			color: ['#111111', '#222222', '#333333', '#444444'], // Carried forward by BorderControl's merge.
 		});
 
 		const written = onChange.mock.calls[0][0][0];
@@ -175,6 +177,28 @@ describe('EditorBorderControl native <-> control value bridging', () => {
 		expect(written.right[0]).toBe('#222222');
 		expect(written.bottom[0]).toBe('#333333');
 		expect(written.left[0]).toBe('#444444');
+	});
+
+	/**
+	 * Clearing a side's color (a real `renderColor` implementation calling its `onChange` with `''`)
+	 * must write `''` to the native attribute, not silently keep the stale color — `value.color` is
+	 * always authoritative, so `toNativeBorder` must not fall back to `previousNative`'s color on a
+	 * falsy value the way an earlier version of this function did.
+	 *
+	 * @return {void}
+	 */
+	it('writes an empty string when a side color is cleared, rather than keeping the stale color', () => {
+		const { borderControl, onChange } = renderEditorBorderControl();
+
+		borderControl.props.onChange({
+			width: ['2px', '3px', '4px', '5px'],
+			style: ['solid', 'dashed', 'dotted', 'double'],
+			color: ['', '#222222', '#333333', '#444444'], // Top color cleared.
+		});
+
+		const written = onChange.mock.calls[0][0][0];
+		expect(written.top[0]).toBe('');
+		expect(written.right[0]).toBe('#222222');
 	});
 
 	/**

--- a/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
@@ -179,15 +179,49 @@ describe('EditorBorderControl native <-> control value bridging', () => {
 
 	/**
 	 * `renderColor` is passed straight through to `BorderControl` untouched — this component neither
-	 * builds nor intercepts it.
+	 * builds nor intercepts it. `BorderControl` calls it once with the whole color slot list it read
+	 * out of `fromNativeBorder`'s output, so the caller's `renderColor` sees the same per-side colors
+	 * this component derived from the native value.
 	 *
 	 * @return {void}
 	 */
-	it('passes renderColor straight through to BorderControl', () => {
+	it('passes renderColor straight through to BorderControl, called with the derived color slots', () => {
 		const renderColor = jest.fn();
 		const { borderControl } = renderEditorBorderControl({ renderColor });
 
 		expect(borderControl.props.renderColor).toBe(renderColor);
+
+		// Reproduce what BorderControl itself does: call renderColor with the color slot list from
+		// the value this component built, not a value renderColor computed on its own.
+		borderControl.props.renderColor({ value: borderControl.props.value.color, onChange: jest.fn() });
+
+		expect(renderColor).toHaveBeenCalledWith({
+			value: ['#111111', '#222222', '#333333', '#444444'],
+			onChange: expect.any(Function),
+		});
+	});
+
+	/**
+	 * A genuine color edit — the write a real `renderColor` implementation performs through
+	 * `BorderControl`'s `patch()`, landing back at `BorderControl`'s own `onChange` with the whole
+	 * `{ width, style, color }` — reaches the native attribute, not just the pass-through value.
+	 * Complements the "preserves existing color" test above by covering the write direction: an
+	 * actual color change must not be discarded in favor of the stale `previousNative` color.
+	 *
+	 * @return {void}
+	 */
+	it('writes a genuine per-side color edit through to the native attribute', () => {
+		const { borderControl, onChange } = renderEditorBorderControl();
+
+		borderControl.props.onChange({
+			width: ['2px', '3px', '4px', '5px'],
+			style: ['solid', 'dashed', 'dotted', 'double'],
+			color: ['#ffffff', '#222222', '#333333', '#444444'], // top color changed.
+		});
+
+		const written = onChange.mock.calls[0][0][0];
+		expect(written.top).toEqual(['#ffffff', 'solid', 2]);
+		expect(written.right).toEqual(['#222222', 'dashed', 3]);
 	});
 });
 

--- a/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
@@ -1,0 +1,294 @@
+/* eslint-env jest */
+
+/**
+ * Internal dependencies
+ */
+import { EditorBorderControl } from '../EditorBorderControl';
+
+/**
+ * A representative native border value: every side different, so a round-trip that silently
+ * dropped or shuffled a side would be caught.
+ *
+ * @since TBD
+ *
+ * @type {Array}
+ */
+const NATIVE_VALUE = [
+	{
+		top: ['#111111', 'solid', 2],
+		right: ['#222222', 'dashed', 3],
+		bottom: ['#333333', 'dotted', 4],
+		left: ['#444444', 'double', 5],
+		unit: 'px',
+	},
+];
+
+/**
+ * Call `EditorBorderControl` as a plain function and return the `BorderControl`/`BreakpointProvider`
+ * elements it produced. The component holds no hooks of its own, so the returned element tree can be
+ * inspected directly instead of mounting it — matching `EditorBoxControl.test.js`'s own harness.
+ *
+ * @param {Object} overrides Props to override on top of the defaults.
+ *
+ * @since TBD
+ *
+ * @return {{provider: Object, borderControl: Object, onChange: Function, onChangeTablet: Function,
+ *   onChangeMobile: Function, onDeviceChange: Function}} The provider element, the `BorderControl`
+ *   element nested inside it, and the setter spies passed in.
+ */
+function renderEditorBorderControl(overrides = {}) {
+	const onChange = jest.fn();
+	const onChangeTablet = jest.fn();
+	const onChangeMobile = jest.fn();
+	const onDeviceChange = jest.fn();
+
+	const props = {
+		label: 'Border',
+		value: NATIVE_VALUE,
+		tabletValue: undefined,
+		mobileValue: undefined,
+		onChange,
+		onChangeTablet,
+		onChangeMobile,
+		previewDevice: 'Desktop',
+		onDeviceChange,
+		widthTokens: [],
+		...overrides,
+	};
+
+	const provider = EditorBorderControl(props);
+
+	return {
+		provider,
+		borderControl: provider.props.children,
+		onChange,
+		onChangeTablet,
+		onChangeMobile,
+		onDeviceChange,
+	};
+}
+
+describe('EditorBorderControl native <-> control value bridging', () => {
+	/**
+	 * `fromNativeBorder` is exercised indirectly through the `value` handed to `BorderControl`: each
+	 * side's width becomes a CSS literal (`size` + shared `unit`), style and color pass through
+	 * unchanged, and an empty side becomes an empty width rather than the literal string `"undefined"`
+	 * with a unit appended to it.
+	 *
+	 * @return {void}
+	 */
+	it('converts the native shape to the width/style/color slot lists BorderControl expects', () => {
+		const { borderControl } = renderEditorBorderControl();
+
+		expect(borderControl.props.value).toEqual({
+			width: ['2px', '3px', '4px', '5px'],
+			style: ['solid', 'dashed', 'dotted', 'double'],
+			color: ['#111111', '#222222', '#333333', '#444444'],
+		});
+	});
+
+	/**
+	 * A missing device value (no `tabletBorder` yet stored) reads as the empty scalar, not a crash on
+	 * `undefined[0]` — a completely unset border has never been unlinked, so it renders linked until
+	 * the first write turns every slot into a four-element array.
+	 *
+	 * @return {void}
+	 */
+	it('reads an unset native value as an empty scalar', () => {
+		const { borderControl } = renderEditorBorderControl({ previewDevice: 'Tablet', tabletValue: undefined });
+
+		expect(borderControl.props.value).toEqual({
+			width: '',
+			style: 'none',
+			color: '',
+		});
+	});
+
+	/**
+	 * Changing a width slot writes the native shape back with the other three sides' width, style,
+	 * and color intact — the round-trip must be lossless for a representative value.
+	 *
+	 * @return {void}
+	 */
+	it('round-trips a representative native value losslessly through a width edit', () => {
+		const { borderControl, onChange } = renderEditorBorderControl();
+
+		borderControl.props.onChange({
+			width: ['9px', '3px', '4px', '5px'],
+			style: ['solid', 'dashed', 'dotted', 'double'],
+			color: ['#111111', '#222222', '#333333', '#444444'],
+		});
+
+		expect(onChange).toHaveBeenCalledWith([
+			{
+				top: ['#111111', 'solid', 9],
+				right: ['#222222', 'dashed', 3],
+				bottom: ['#333333', 'dotted', 4],
+				left: ['#444444', 'double', 5],
+				unit: 'px',
+			},
+		]);
+	});
+
+	/**
+	 * Writing a token alias into a width slot stores the alias id whole, not split on a trailing unit
+	 * it doesn't have, and reading it back out (as `fromNativeBorder` would on the next render) must
+	 * not append a spurious unit suffix to it either.
+	 *
+	 * @return {void}
+	 */
+	it('stores and reads back a token alias in the width slot without corrupting it', () => {
+		const { borderControl, onChange } = renderEditorBorderControl();
+		const alias = 'primitive.dimension.border-width.md';
+
+		borderControl.props.onChange({
+			width: [alias, '3px', '4px', '5px'],
+			style: ['solid', 'dashed', 'dotted', 'double'],
+			color: ['#111111', '#222222', '#333333', '#444444'],
+		});
+
+		const written = onChange.mock.calls[0][0];
+		expect(written[0].top).toEqual(['#111111', 'solid', alias]);
+
+		const { borderControl: rerendered } = renderEditorBorderControl({ value: written });
+		expect(rerendered.props.value.width[0]).toBe(alias);
+	});
+
+	/**
+	 * `BorderControl` never manages color; a width/style edit must read each side's EXISTING color
+	 * out of the previous native value and write it back unchanged, or the very next edit would
+	 * silently erase every side's color.
+	 *
+	 * @return {void}
+	 */
+	it('preserves each side existing color when writing a style edit', () => {
+		const { borderControl, onChange } = renderEditorBorderControl();
+
+		borderControl.props.onChange({
+			width: ['2px', '3px', '4px', '5px'],
+			style: ['none', 'dashed', 'dotted', 'double'],
+			color: ['', '', '', ''], // BorderControl never populates color itself.
+		});
+
+		const written = onChange.mock.calls[0][0][0];
+		expect(written.top[0]).toBe('#111111');
+		expect(written.right[0]).toBe('#222222');
+		expect(written.bottom[0]).toBe('#333333');
+		expect(written.left[0]).toBe('#444444');
+	});
+
+	/**
+	 * `renderColor` is passed straight through to `BorderControl` untouched — this component neither
+	 * builds nor intercepts it.
+	 *
+	 * @return {void}
+	 */
+	it('passes renderColor straight through to BorderControl', () => {
+		const renderColor = jest.fn();
+		const { borderControl } = renderEditorBorderControl({ renderColor });
+
+		expect(borderControl.props.renderColor).toBe(renderColor);
+	});
+});
+
+describe('EditorBorderControl breakpoint switching', () => {
+	/**
+	 * The switcher rendered by `ControlShell` drives `BorderControl`'s `onBreakpointChange` prop
+	 * directly, not the `BreakpointProvider` context above it — matching `EditorBoxControl`'s own
+	 * wiring exactly.
+	 *
+	 * @return {void}
+	 */
+	it('invokes onDeviceChange with the matching device when onBreakpointChange fires', () => {
+		const { borderControl, onDeviceChange } = renderEditorBorderControl();
+
+		borderControl.props.onBreakpointChange('tablet');
+
+		expect(onDeviceChange).toHaveBeenCalledWith('Tablet');
+	});
+
+	/**
+	 * Every control breakpoint key maps back to its editor device name, not just one.
+	 *
+	 * @return {void}
+	 */
+	it('maps every breakpoint key back to its editor device name', () => {
+		const { borderControl, onDeviceChange } = renderEditorBorderControl();
+
+		borderControl.props.onBreakpointChange('mobile');
+		expect(onDeviceChange).toHaveBeenLastCalledWith('Mobile');
+
+		borderControl.props.onBreakpointChange('desktop');
+		expect(onDeviceChange).toHaveBeenLastCalledWith('Desktop');
+
+		borderControl.props.onBreakpointChange('tablet');
+		expect(onDeviceChange).toHaveBeenLastCalledWith('Tablet');
+	});
+
+	/**
+	 * The `BreakpointProvider`'s own `onChange` maps breakpoints back to devices the same way as the
+	 * `onBreakpointChange` prop, using the one shared mapping rather than a second copy of it.
+	 *
+	 * @return {void}
+	 */
+	it('maps the BreakpointProvider onChange consistently with onBreakpointChange', () => {
+		const { provider, onDeviceChange } = renderEditorBorderControl();
+
+		provider.props.onChange('mobile');
+
+		expect(onDeviceChange).toHaveBeenCalledWith('Mobile');
+	});
+
+	/**
+	 * The editor's `previewDevice` selects which sibling attribute is read and which setter a write
+	 * goes through.
+	 *
+	 * @return {void}
+	 */
+	it('reads and writes the tablet sibling attribute when previewDevice is Tablet', () => {
+		const { borderControl, onChangeTablet, onChange, onChangeMobile } = renderEditorBorderControl({
+			previewDevice: 'Tablet',
+			tabletValue: NATIVE_VALUE,
+		});
+
+		borderControl.props.onChange({
+			width: ['9px', '3px', '4px', '5px'],
+			style: ['solid', 'dashed', 'dotted', 'double'],
+			color: ['#111111', '#222222', '#333333', '#444444'],
+		});
+
+		expect(onChangeTablet).toHaveBeenCalled();
+		expect(onChange).not.toHaveBeenCalled();
+		expect(onChangeMobile).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * An unrecognized device (e.g. a future editor device this component does not know about yet)
+	 * degrades to desktop rather than rendering with no breakpoint at all.
+	 *
+	 * @return {void}
+	 */
+	it('falls back to desktop for an unknown preview device', () => {
+		const { provider } = renderEditorBorderControl({ previewDevice: 'Widescreen' });
+
+		expect(provider.props.value).toBe('desktop');
+	});
+});
+
+describe('EditorBorderControl unlinked rendering', () => {
+	/**
+	 * The native attribute is always a four-sided object, so `BorderControl`'s value always arrives
+	 * as four-element width/style/color arrays — the control has nothing to collapse and renders
+	 * unlinked by construction, matching `BoxControl`'s own docblock for radius.
+	 *
+	 * @return {void}
+	 */
+	it('always hands BorderControl four-element slot lists, never a scalar', () => {
+		const { borderControl } = renderEditorBorderControl();
+
+		expect(Array.isArray(borderControl.props.value.width)).toBe(true);
+		expect(borderControl.props.value.width).toHaveLength(4);
+		expect(Array.isArray(borderControl.props.value.style)).toBe(true);
+		expect(borderControl.props.value.style).toHaveLength(4);
+	});
+});

--- a/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
@@ -202,6 +202,30 @@ describe('EditorBorderControl native <-> control value bridging', () => {
 	});
 
 	/**
+	 * `defaultValue` is passed straight through to `BorderControl` — the caller (`singlebtn/edit.js`)
+	 * resolves the active preset's border width; this component neither computes nor reshapes it.
+	 *
+	 * @return {void}
+	 */
+	it('passes defaultValue straight through to BorderControl', () => {
+		const { borderControl } = renderEditorBorderControl({ defaultValue: '2px' });
+
+		expect(borderControl.props.defaultValue).toBe('2px');
+	});
+
+	/**
+	 * A `defaultValue` of `0` (a real, meaningful preset value) passes through unchanged rather than
+	 * being falsy-collapsed to `undefined` on the way to `BorderControl`.
+	 *
+	 * @return {void}
+	 */
+	it('passes a zero defaultValue through rather than dropping it', () => {
+		const { borderControl } = renderEditorBorderControl({ defaultValue: '0px' });
+
+		expect(borderControl.props.defaultValue).toBe('0px');
+	});
+
+	/**
 	 * `renderColor` is passed straight through to `BorderControl` untouched — this component neither
 	 * builds nor intercepts it. `BorderControl` calls it once with the whole color slot list it read
 	 * out of `fromNativeBorder`'s output, so the caller's `renderColor` sees the same per-side colors

--- a/src/extension/token-indicators/__tests__/index.test.js
+++ b/src/extension/token-indicators/__tests__/index.test.js
@@ -10,7 +10,7 @@ jest.mock('../components/TokenIndicator', () => ({ TokenIndicator: () => null })
 jest.mock('../components/TokenLabel', () => ({ TokenLabel: () => null }));
 jest.mock('../components/TokenControlRow', () => ({ TokenControlRow: () => null }));
 
-import { usePresetBinding, resetAttrPatch } from '../index';
+import { usePresetBinding, resetAttrPatch, presetPropertyValueForDevice } from '../index';
 
 const BLOCK = 'kadence/singlebtn';
 const SET = 'default';
@@ -137,6 +137,132 @@ describe('usePresetBinding device-aware overridden', () => {
 		const state = usePresetBinding(BLOCK, attributes, SET);
 
 		expect(state.borderRadius.overridden).toBe(false);
+	});
+});
+
+describe('presetPropertyValueForDevice', () => {
+	/**
+	 * Seed a property with no `control_attr` — `usePresetBinding` cannot key it by an attribute name,
+	 * so `presetPropertyValueForDevice` is the only way a caller reads its resolved preset value.
+	 *
+	 * @return {void}
+	 */
+	function seedNoAttrProperty() {
+		window.kadenceDesignTokensPresets = {
+			active: SET,
+			libraries: {
+				[SET]: {
+					[BLOCK]: {
+						default: 'primary',
+						presets: [{ slug: 'primary', label: 'Primary' }],
+						properties: [{ key: 'button-border-width', kind: 'dimension', token: null }],
+						values: {
+							primary: { 'button-border-width': '2px' },
+						},
+						responsive: {
+							primary: { tablet: { 'button-border-width': '4px' } },
+						},
+					},
+				},
+			},
+		};
+	}
+
+	beforeEach(() => {
+		seedNoAttrProperty();
+	});
+
+	afterEach(() => {
+		delete window.kadenceDesignTokensPresets;
+	});
+
+	/**
+	 * The active preset's desktop value resolves for a property `usePresetBinding` has no attribute to
+	 * key it by.
+	 *
+	 * @return {void}
+	 */
+	it('resolves the active preset value for a property with no control_attr', () => {
+		const value = presetPropertyValueForDevice(
+			BLOCK,
+			'button-border-width',
+			{ kbPreset: 'primary' },
+			SET,
+			'Desktop'
+		);
+
+		expect(value).toBe('2px');
+	});
+
+	/**
+	 * A resolved value of `0` (a real, meaningful preset value) is not falsy-collapsed to `undefined` —
+	 * distinguishing "the preset sets 0" from "the preset sets nothing" matters to a caller deciding
+	 * whether to show a muted default at all.
+	 *
+	 * @return {void}
+	 */
+	it('resolves a zero preset value rather than treating it as unset', () => {
+		window.kadenceDesignTokensPresets.libraries[SET][BLOCK].values.primary['button-border-width'] = '0px';
+
+		const value = presetPropertyValueForDevice(
+			BLOCK,
+			'button-border-width',
+			{ kbPreset: 'primary' },
+			SET,
+			'Desktop'
+		);
+
+		expect(value).toBe('0px');
+	});
+
+	/**
+	 * On Tablet, the preset's tablet override resolves instead of its desktop value.
+	 *
+	 * @return {void}
+	 */
+	it('resolves the tablet override on Tablet', () => {
+		const value = presetPropertyValueForDevice(
+			BLOCK,
+			'button-border-width',
+			{ kbPreset: 'primary' },
+			SET,
+			'Tablet'
+		);
+
+		expect(value).toBe('4px');
+	});
+
+	/**
+	 * A user-selected preset (`kbPreset` in `attributes`) resolves, not just the block's default preset
+	 * — the whole point of taking `attributes` is to honor a genuine user selection.
+	 *
+	 * @return {void}
+	 */
+	it('resolves the user-selected preset, not just the block default', () => {
+		window.kadenceDesignTokensPresets.libraries[SET][BLOCK].presets.push({ slug: 'secondary', label: 'Secondary' });
+		window.kadenceDesignTokensPresets.libraries[SET][BLOCK].values.secondary = { 'button-border-width': '6px' };
+
+		const value = presetPropertyValueForDevice(
+			BLOCK,
+			'button-border-width',
+			{ kbPreset: 'secondary' },
+			SET,
+			'Desktop'
+		);
+
+		expect(value).toBe('6px');
+	});
+
+	/**
+	 * A property the active preset does not set resolves to `undefined`, so a caller can tell "no
+	 * default" apart from a real, falsy-but-meaningful value like `0`.
+	 *
+	 * @return {void}
+	 */
+	it('resolves undefined when the active preset does not set the property', () => {
+		const value = presetPropertyValueForDevice(BLOCK, 'button-shadow', { kbPreset: 'primary' }, SET, 'Desktop');
+
+		expect(value).toBeUndefined();
 	});
 });
 

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -166,6 +166,41 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
 }
 
 /**
+ * The active preset's resolved value for one property key, at the given device — for a property with
+ * no `control_attr` (a `css_var`-only binding like `button-border-width`, whose native attribute is a
+ * nested per-side shape `usePresetBinding` has nothing to key it by; see `declarations.php`'s comment
+ * on that binding). `usePresetBinding` skips these properties entirely, so a caller that only needs
+ * "what does the active preset resolve this to" — e.g. a dimension control's `defaultValue`, shown
+ * muted once the control's own override is cleared — reads it directly here instead.
+ *
+ * @param {string} blockName     The block name (e.g. 'kadence/singlebtn').
+ * @param {string} propertyKey   The binding's property key (e.g. 'button-border-width').
+ * @param {Object} attributes    The block's current attributes — read for `kbPreset`, so a
+ *                                user-selected preset (not just the block's default) resolves.
+ * @param {string} [library]     The token library slug; defaults to the active library.
+ * @param {string} [previewDevice] The active preview device ('Desktop' | 'Tablet' | 'Mobile').
+ *
+ * @since TBD
+ *
+ * @return {*} The resolved literal value, or `undefined` when the active preset does not set it.
+ */
+export function presetPropertyValueForDevice(blockName, propertyKey, attributes, library, previewDevice) {
+	const resolvedLibrary = library || activeLibrary();
+	const activePreset = activePresetFor(blockName, attributes, resolvedLibrary);
+	const presetValues = get(blockPresetValues(blockName, resolvedLibrary), activePreset, {});
+	const presetBreakpoints = get(blockPresetResponsive(blockName, resolvedLibrary), activePreset, {});
+
+	return presetValueForDevice(
+		presetValues[propertyKey],
+		{
+			tablet: get(presetBreakpoints, ['tablet', propertyKey]),
+			mobile: get(presetBreakpoints, ['mobile', propertyKey]),
+		},
+		previewDevice
+	);
+}
+
+/**
  * The `setAttributes` patch that clears a mapped control's attribute(s) back to their block.json default
  * shape, so the block falls back to the existing preset-scoped CSS (the `.wp-block-*.kb-preset--<preset>`
  * retarget) or the preset default — no new render path. A `color`/`text` control clears its single


### PR DESCRIPTION
## Summary
- Adds `EditorBorderControl`, a thin block-editor wrapper around `BorderControl` that resolves/writes `kadence/singlebtn`'s native border attribute shape.
- Wires it into `singlebtn/edit.js` in place of the block's six `ResponsiveBorderControl` usages.
- Border color editing is wired back in through the same mechanism the native control used, unchanged in behavior.

## Test plan
- [x] Component tests for `EditorBorderControl`.
- [x] `npx jest` — full suite green.
- [ ] Manual verification on the dev site (block editor canvas, Style tab).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved responsive border controls for the single-button block across desktop, tablet, and mobile views.
  * Supports border width presets, shared or individual border colors, and linked or unlinked side settings.
  * Border settings are available for normal, hover, transparent, and sticky button states.
  * Added support for preserving border design tokens while editing responsive settings.
* **Bug Fixes**
  * Preserves existing border colors, widths, styles, and units when adjusting responsive settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->