### PR TITLE
[DTM] SOFT-4083 [30/38]: EditorShadowControl replaces the native box-shadow control on the canvas

### DIFF
--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -35,7 +35,6 @@ import {
 	URLInputInline,
 	ResponsiveAlignControls,
 	GradientControl,
-	BoxShadowControl,
 	InspectorControlTabs,
 	KadenceBlockDefaults,
 	ResponsiveMeasureRangeControl,
@@ -94,6 +93,11 @@ import {
 import { TokenControlRow } from '../../extension/token-indicators/components/TokenControlRow';
 import { EditorBoxControl } from '../../extension/design-tokens/components/EditorBoxControl';
 import { EditorBorderControl } from '../../extension/design-tokens/components/EditorBorderControl';
+import {
+	EditorShadowControl,
+	combineColorOpacity,
+	splitColorOpacity,
+} from '../../extension/design-tokens/components/EditorShadowControl';
 import { pickableTokensForControl } from '../../extension/token-picker';
 import { isSlotList, readSlot, writeSlot } from '../../token-controls';
 
@@ -137,6 +141,39 @@ function renderBorderColor({ value, onChange }) {
 				/>
 			))}
 		</div>
+	);
+}
+
+/**
+ * `EditorShadowControl`'s `renderColor` render-prop: reuses the block's existing `PopColorControl`
+ * unchanged, wired through its own two-channel `opacityValue`/`onArrayChange` props so the swatch's
+ * opacity slider keeps working exactly as it did on the native `@kadence/components` `BoxShadowControl`
+ * (see `node_modules/@kadence/components/src/box-shadow-control/index.js`). The composite's `color`
+ * slot arrives combined (`combineColorOpacity`); this is the one place that has to split it apart for
+ * `PopColorControl` and recombine on every write, using the exact same rules `EditorShadowControl`
+ * itself uses to read/write the native attribute, so both directions agree.
+ *
+ * @param {Object}   props          The render-prop's argument.
+ * @param {string}   props.value    The composite's combined color slot (a plain hex, or `rgba(...)`).
+ * @param {Function} props.onChange Called with the next combined color slot.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The rendered color field.
+ */
+function renderShadowColor({ value, onChange }) {
+	const { color, opacity } = splitColorOpacity(value);
+
+	return (
+		<PopColorControl
+			value={color || ''}
+			default={'#000000'}
+			hideClear={true}
+			opacityValue={opacity}
+			onChange={(next) => onChange(combineColorOpacity(next, opacity))}
+			onOpacityChange={(next) => onChange(combineColorOpacity(color, next))}
+			onArrayChange={(next, nextOpacity) => onChange(combineColorOpacity(next, nextOpacity))}
+		/>
 	);
 }
 
@@ -393,6 +430,14 @@ export default function KadenceButtonEdit(props) {
 		pickableTokensForControl('kadence/singlebtn', 'borderTransparentHoverStyle') || [];
 	const borderStickyWidthTokens = pickableTokensForControl('kadence/singlebtn', 'borderStickyStyle') || [];
 	const borderStickyHoverWidthTokens = pickableTokensForControl('kadence/singlebtn', 'borderStickyHoverStyle') || [];
+	// One pickable shadow-token list per shadow control, keyed the same way its own attribute is —
+	// mirrors the border width tokens above.
+	const shadowTokens = pickableTokensForControl('kadence/singlebtn', 'shadow') || [];
+	const shadowHoverTokens = pickableTokensForControl('kadence/singlebtn', 'shadowHover') || [];
+	const shadowTransparentTokens = pickableTokensForControl('kadence/singlebtn', 'shadowTransparent') || [];
+	const shadowTransparentHoverTokens = pickableTokensForControl('kadence/singlebtn', 'shadowTransparentHover') || [];
+	const shadowStickyTokens = pickableTokensForControl('kadence/singlebtn', 'shadowSticky') || [];
+	const shadowStickyHoverTokens = pickableTokensForControl('kadence/singlebtn', 'shadowStickyHover') || [];
 
 	// The mode describes what THIS device stores, not what it inherits. A breakpoint that stores nothing
 	// has nothing that differs, so it reads as linked — deriving from the inherited corners instead would
@@ -518,73 +563,6 @@ export default function KadenceButtonEdit(props) {
 		});
 		setAttributes({
 			typography: newUpdate,
-		});
-	};
-	const saveShadow = (value) => {
-		const newUpdate = shadow.map((item, index) => {
-			if (0 === index) {
-				item = { ...item, ...value };
-			}
-			return item;
-		});
-		setAttributes({
-			shadow: newUpdate,
-		});
-	};
-	const saveShadowHover = (value) => {
-		const newItems = shadowHover.map((item, thisIndex) => {
-			if (0 === thisIndex) {
-				item = { ...item, ...value };
-			}
-
-			return item;
-		});
-		setAttributes({
-			shadowHover: newItems,
-		});
-	};
-	const saveShadowTransparent = (value) => {
-		const newUpdate = shadowTransparent.map((item, index) => {
-			if (0 === index) {
-				item = { ...item, ...value };
-			}
-			return item;
-		});
-		setAttributes({
-			shadowTransparent: newUpdate,
-		});
-	};
-	const saveShadowTransparentHover = (value) => {
-		const newUpdate = shadowTransparentHover.map((item, index) => {
-			if (0 === index) {
-				item = { ...item, ...value };
-			}
-			return item;
-		});
-		setAttributes({
-			shadowTransparentHover: newUpdate,
-		});
-	};
-	const saveShadowSticky = (value) => {
-		const newUpdate = shadowSticky.map((item, index) => {
-			if (0 === index) {
-				item = { ...item, ...value };
-			}
-			return item;
-		});
-		setAttributes({
-			shadowSticky: newUpdate,
-		});
-	};
-	const saveShadowStickyHover = (value) => {
-		const newUpdate = shadowStickyHover.map((item, index) => {
-			if (0 === index) {
-				item = { ...item, ...value };
-			}
-			return item;
-		});
-		setAttributes({
-			shadowStickyHover: newUpdate,
 		});
 	};
 	const btnSizes = [
@@ -1196,92 +1174,20 @@ export default function KadenceButtonEdit(props) {
 															isBorderRadius={true}
 															allowEmpty={true}
 														/>
-														<BoxShadowControl
+														<EditorShadowControl
 															label={__('Box Shadow', 'kadence-blocks')}
+															value={shadowHover}
+															onChange={(value) => setAttributes({ shadowHover: value })}
 															enable={
 																undefined !== displayHoverShadow
 																	? displayHoverShadow
 																	: false
 															}
-															color={
-																undefined !== shadowHover &&
-																undefined !== shadowHover[0] &&
-																undefined !== shadowHover[0].color
-																	? shadowHover[0].color
-																	: '#000000'
+															onEnableChange={(value) =>
+																setAttributes({ displayHoverShadow: value })
 															}
-															colorDefault={'#000000'}
-															onArrayChange={(color, opacity) => {
-																saveShadowHover({ color, opacity });
-															}}
-															opacity={
-																undefined !== shadowHover &&
-																undefined !== shadowHover[0] &&
-																undefined !== shadowHover[0].opacity
-																	? shadowHover[0].opacity
-																	: 0.2
-															}
-															hOffset={
-																undefined !== shadowHover &&
-																undefined !== shadowHover[0] &&
-																undefined !== shadowHover[0].hOffset
-																	? shadowHover[0].hOffset
-																	: 0
-															}
-															vOffset={
-																undefined !== shadowHover &&
-																undefined !== shadowHover[0] &&
-																undefined !== shadowHover[0].vOffset
-																	? shadowHover[0].vOffset
-																	: 0
-															}
-															blur={
-																undefined !== shadowHover &&
-																undefined !== shadowHover[0] &&
-																undefined !== shadowHover[0].blur
-																	? shadowHover[0].blur
-																	: 14
-															}
-															spread={
-																undefined !== shadowHover &&
-																undefined !== shadowHover[0] &&
-																undefined !== shadowHover[0].spread
-																	? shadowHover[0].spread
-																	: 0
-															}
-															inset={
-																undefined !== shadowHover &&
-																undefined !== shadowHover[0] &&
-																undefined !== shadowHover[0].inset
-																	? shadowHover[0].inset
-																	: false
-															}
-															onEnableChange={(value) => {
-																setAttributes({
-																	displayHoverShadow: value,
-																});
-															}}
-															onColorChange={(value) => {
-																saveShadowHover({ color: value });
-															}}
-															onOpacityChange={(value) => {
-																saveShadowHover({ opacity: value });
-															}}
-															onHOffsetChange={(value) => {
-																saveShadowHover({ hOffset: value });
-															}}
-															onVOffsetChange={(value) => {
-																saveShadowHover({ vOffset: value });
-															}}
-															onBlurChange={(value) => {
-																saveShadowHover({ blur: value });
-															}}
-															onSpreadChange={(value) => {
-																saveShadowHover({ spread: value });
-															}}
-															onInsetChange={(value) => {
-																saveShadowHover({ inset: value });
-															}}
+															tokens={shadowHoverTokens}
+															renderColor={renderShadowColor}
 														/>
 													</>
 												}
@@ -1404,88 +1310,16 @@ export default function KadenceButtonEdit(props) {
 															max={borderRadiusIsRelative ? 24 : 500}
 															step={borderRadiusIsRelative ? 0.1 : 1}
 														/>
-														<BoxShadowControl
+														<EditorShadowControl
 															label={__('Box Shadow', 'kadence-blocks')}
+															value={shadow}
+															onChange={(value) => setAttributes({ shadow: value })}
 															enable={undefined !== displayShadow ? displayShadow : false}
-															color={
-																undefined !== shadow &&
-																undefined !== shadow[0] &&
-																undefined !== shadow[0].color
-																	? shadow[0].color
-																	: '#000000'
+															onEnableChange={(value) =>
+																setAttributes({ displayShadow: value })
 															}
-															colorDefault={'#000000'}
-															onArrayChange={(color, opacity) => {
-																saveShadow({ color, opacity });
-															}}
-															opacity={
-																undefined !== shadow &&
-																undefined !== shadow[0] &&
-																undefined !== shadow[0].opacity
-																	? shadow[0].opacity
-																	: 0.2
-															}
-															hOffset={
-																undefined !== shadow &&
-																undefined !== shadow[0] &&
-																undefined !== shadow[0].hOffset
-																	? shadow[0].hOffset
-																	: 0
-															}
-															vOffset={
-																undefined !== shadow &&
-																undefined !== shadow[0] &&
-																undefined !== shadow[0].vOffset
-																	? shadow[0].vOffset
-																	: 0
-															}
-															blur={
-																undefined !== shadow &&
-																undefined !== shadow[0] &&
-																undefined !== shadow[0].blur
-																	? shadow[0].blur
-																	: 14
-															}
-															spread={
-																undefined !== shadow &&
-																undefined !== shadow[0] &&
-																undefined !== shadow[0].spread
-																	? shadow[0].spread
-																	: 0
-															}
-															inset={
-																undefined !== shadow &&
-																undefined !== shadow[0] &&
-																undefined !== shadow[0].inset
-																	? shadow[0].inset
-																	: false
-															}
-															onEnableChange={(value) => {
-																setAttributes({
-																	displayShadow: value,
-																});
-															}}
-															onColorChange={(value) => {
-																saveShadow({ color: value });
-															}}
-															onOpacityChange={(value) => {
-																saveShadow({ opacity: value });
-															}}
-															onHOffsetChange={(value) => {
-																saveShadow({ hOffset: value });
-															}}
-															onVOffsetChange={(value) => {
-																saveShadow({ vOffset: value });
-															}}
-															onBlurChange={(value) => {
-																saveShadow({ blur: value });
-															}}
-															onSpreadChange={(value) => {
-																saveShadow({ spread: value });
-															}}
-															onInsetChange={(value) => {
-																saveShadow({ inset: value });
-															}}
+															tokens={shadowTokens}
+															renderColor={renderShadowColor}
 														/>
 													</>
 												}
@@ -1616,92 +1450,24 @@ export default function KadenceButtonEdit(props) {
 																isBorderRadius={true}
 																allowEmpty={true}
 															/>
-															<BoxShadowControl
+															<EditorShadowControl
 																label={__('Box Shadow', 'kadence-blocks')}
+																value={shadowTransparentHover}
+																onChange={(value) =>
+																	setAttributes({ shadowTransparentHover: value })
+																}
 																enable={
 																	undefined !== displayHoverShadowTransparent
 																		? displayHoverShadowTransparent
 																		: false
 																}
-																color={
-																	undefined !== shadowTransparentHover &&
-																	undefined !== shadowTransparentHover[0] &&
-																	undefined !== shadowTransparentHover[0].color
-																		? shadowTransparentHover[0].color
-																		: '#000000'
-																}
-																colorDefault={'#000000'}
-																onArrayChange={(color, opacity) => {
-																	saveShadowTransparentHover({ color, opacity });
-																}}
-																opacity={
-																	undefined !== shadowTransparentHover &&
-																	undefined !== shadowTransparentHover[0] &&
-																	undefined !== shadowTransparentHover[0].opacity
-																		? shadowTransparentHover[0].opacity
-																		: 0.2
-																}
-																hOffset={
-																	undefined !== shadowTransparentHover &&
-																	undefined !== shadowTransparentHover[0] &&
-																	undefined !== shadowTransparentHover[0].hOffset
-																		? shadowTransparentHover[0].hOffset
-																		: 0
-																}
-																vOffset={
-																	undefined !== shadowTransparentHover &&
-																	undefined !== shadowTransparentHover[0] &&
-																	undefined !== shadowTransparentHover[0].vOffset
-																		? shadowTransparentHover[0].vOffset
-																		: 0
-																}
-																blur={
-																	undefined !== shadowTransparentHover &&
-																	undefined !== shadowTransparentHover[0] &&
-																	undefined !== shadowTransparentHover[0].blur
-																		? shadowTransparentHover[0].blur
-																		: 14
-																}
-																spread={
-																	undefined !== shadowTransparentHover &&
-																	undefined !== shadowTransparentHover[0] &&
-																	undefined !== shadowTransparentHover[0].spread
-																		? shadowTransparentHover[0].spread
-																		: 0
-																}
-																inset={
-																	undefined !== shadowTransparentHover &&
-																	undefined !== shadowTransparentHover[0] &&
-																	undefined !== shadowTransparentHover[0].inset
-																		? shadowTransparentHover[0].inset
-																		: false
-																}
-																onEnableChange={(value) => {
+																onEnableChange={(value) =>
 																	setAttributes({
 																		displayHoverShadowTransparent: value,
-																	});
-																}}
-																onColorChange={(value) => {
-																	saveShadowTransparentHover({ color: value });
-																}}
-																onOpacityChange={(value) => {
-																	saveShadowTransparentHover({ opacity: value });
-																}}
-																onHOffsetChange={(value) => {
-																	saveShadowTransparentHover({ hOffset: value });
-																}}
-																onVOffsetChange={(value) => {
-																	saveShadowTransparentHover({ vOffset: value });
-																}}
-																onBlurChange={(value) => {
-																	saveShadowTransparentHover({ blur: value });
-																}}
-																onSpreadChange={(value) => {
-																	saveShadowTransparentHover({ spread: value });
-																}}
-																onInsetChange={(value) => {
-																	saveShadowTransparentHover({ inset: value });
-																}}
+																	})
+																}
+																tokens={shadowTransparentHoverTokens}
+																renderColor={renderShadowColor}
 															/>
 														</>
 													}
@@ -1815,92 +1581,22 @@ export default function KadenceButtonEdit(props) {
 																isBorderRadius={true}
 																allowEmpty={true}
 															/>
-															<BoxShadowControl
+															<EditorShadowControl
 																label={__('Box Shadow', 'kadence-blocks')}
+																value={shadowTransparent}
+																onChange={(value) =>
+																	setAttributes({ shadowTransparent: value })
+																}
 																enable={
 																	undefined !== displayShadowTransparent
 																		? displayShadowTransparent
 																		: false
 																}
-																color={
-																	undefined !== shadowTransparent &&
-																	undefined !== shadowTransparent[0] &&
-																	undefined !== shadowTransparent[0].color
-																		? shadowTransparent[0].color
-																		: '#000000'
+																onEnableChange={(value) =>
+																	setAttributes({ displayShadowTransparent: value })
 																}
-																colorDefault={'#000000'}
-																onArrayChange={(color, opacity) => {
-																	saveShadowTransparent({ color, opacity });
-																}}
-																opacity={
-																	undefined !== shadowTransparent &&
-																	undefined !== shadowTransparent[0] &&
-																	undefined !== shadowTransparent[0].opacity
-																		? shadowTransparent[0].opacity
-																		: 0.2
-																}
-																hOffset={
-																	undefined !== shadowTransparent &&
-																	undefined !== shadowTransparent[0] &&
-																	undefined !== shadowTransparent[0].hOffset
-																		? shadowTransparent[0].hOffset
-																		: 0
-																}
-																vOffset={
-																	undefined !== shadowTransparent &&
-																	undefined !== shadowTransparent[0] &&
-																	undefined !== shadowTransparent[0].vOffset
-																		? shadow[0].vOffset
-																		: 0
-																}
-																blur={
-																	undefined !== shadowTransparent &&
-																	undefined !== shadowTransparent[0] &&
-																	undefined !== shadowTransparent[0].blur
-																		? shadowTransparent[0].blur
-																		: 14
-																}
-																spread={
-																	undefined !== shadowTransparent &&
-																	undefined !== shadowTransparent[0] &&
-																	undefined !== shadowTransparent[0].spread
-																		? shadowTransparent[0].spread
-																		: 0
-																}
-																inset={
-																	undefined !== shadowTransparent &&
-																	undefined !== shadowTransparent[0] &&
-																	undefined !== shadowTransparent[0].inset
-																		? shadowTransparent[0].inset
-																		: false
-																}
-																onEnableChange={(value) => {
-																	setAttributes({
-																		displayShadowTransparent: value,
-																	});
-																}}
-																onColorChange={(value) => {
-																	saveShadowTransparent({ color: value });
-																}}
-																onOpacityChange={(value) => {
-																	saveShadowTransparent({ opacity: value });
-																}}
-																onHOffsetChange={(value) => {
-																	saveShadowTransparent({ hOffset: value });
-																}}
-																onVOffsetChange={(value) => {
-																	saveShadowTransparent({ vOffset: value });
-																}}
-																onBlurChange={(value) => {
-																	saveShadowTransparent({ blur: value });
-																}}
-																onSpreadChange={(value) => {
-																	saveShadowTransparent({ spread: value });
-																}}
-																onInsetChange={(value) => {
-																	saveShadowTransparent({ inset: value });
-																}}
+																tokens={shadowTransparentTokens}
+																renderColor={renderShadowColor}
 															/>
 														</>
 													}
@@ -2030,92 +1726,22 @@ export default function KadenceButtonEdit(props) {
 																isBorderRadius={true}
 																allowEmpty={true}
 															/>
-															<BoxShadowControl
+															<EditorShadowControl
 																label={__('Box Shadow', 'kadence-blocks')}
+																value={shadowStickyHover}
+																onChange={(value) =>
+																	setAttributes({ shadowStickyHover: value })
+																}
 																enable={
 																	undefined !== displayHoverShadowSticky
 																		? displayHoverShadowSticky
 																		: false
 																}
-																color={
-																	undefined !== shadowStickyHover &&
-																	undefined !== shadowStickyHover[0] &&
-																	undefined !== shadowStickyHover[0].color
-																		? shadowStickyHover[0].color
-																		: '#000000'
+																onEnableChange={(value) =>
+																	setAttributes({ displayHoverShadowSticky: value })
 																}
-																colorDefault={'#000000'}
-																onArrayChange={(color, opacity) => {
-																	saveShadowStickyHover({ color, opacity });
-																}}
-																opacity={
-																	undefined !== shadowStickyHover &&
-																	undefined !== shadowStickyHover[0] &&
-																	undefined !== shadowStickyHover[0].opacity
-																		? shadowStickyHover[0].opacity
-																		: 0.2
-																}
-																hOffset={
-																	undefined !== shadowStickyHover &&
-																	undefined !== shadowStickyHover[0] &&
-																	undefined !== shadowStickyHover[0].hOffset
-																		? shadowStickyHover[0].hOffset
-																		: 0
-																}
-																vOffset={
-																	undefined !== shadowStickyHover &&
-																	undefined !== shadowStickyHover[0] &&
-																	undefined !== shadowStickyHover[0].vOffset
-																		? shadowStickyHover[0].vOffset
-																		: 0
-																}
-																blur={
-																	undefined !== shadowStickyHover &&
-																	undefined !== shadowStickyHover[0] &&
-																	undefined !== shadowStickyHover[0].blur
-																		? shadowStickyHover[0].blur
-																		: 14
-																}
-																spread={
-																	undefined !== shadowStickyHover &&
-																	undefined !== shadowStickyHover[0] &&
-																	undefined !== shadowStickyHover[0].spread
-																		? shadowStickyHover[0].spread
-																		: 0
-																}
-																inset={
-																	undefined !== shadowStickyHover &&
-																	undefined !== shadowStickyHover[0] &&
-																	undefined !== shadowStickyHover[0].inset
-																		? shadowStickyHover[0].inset
-																		: false
-																}
-																onEnableChange={(value) => {
-																	setAttributes({
-																		displayHoverShadowSticky: value,
-																	});
-																}}
-																onColorChange={(value) => {
-																	saveShadowStickyHover({ color: value });
-																}}
-																onOpacityChange={(value) => {
-																	saveShadowStickyHover({ opacity: value });
-																}}
-																onHOffsetChange={(value) => {
-																	saveShadowStickyHover({ hOffset: value });
-																}}
-																onVOffsetChange={(value) => {
-																	saveShadowStickyHover({ vOffset: value });
-																}}
-																onBlurChange={(value) => {
-																	saveShadowStickyHover({ blur: value });
-																}}
-																onSpreadChange={(value) => {
-																	saveShadowStickyHover({ spread: value });
-																}}
-																onInsetChange={(value) => {
-																	saveShadowStickyHover({ inset: value });
-																}}
+																tokens={shadowStickyHoverTokens}
+																renderColor={renderShadowColor}
 															/>
 														</>
 													}
@@ -2225,92 +1851,22 @@ export default function KadenceButtonEdit(props) {
 																isBorderRadius={true}
 																allowEmpty={true}
 															/>
-															<BoxShadowControl
+															<EditorShadowControl
 																label={__('Box Shadow', 'kadence-blocks')}
+																value={shadowSticky}
+																onChange={(value) =>
+																	setAttributes({ shadowSticky: value })
+																}
 																enable={
 																	undefined !== displayShadowSticky
 																		? displayShadowSticky
 																		: false
 																}
-																color={
-																	undefined !== shadowSticky &&
-																	undefined !== shadowSticky[0] &&
-																	undefined !== shadowSticky[0].color
-																		? shadowSticky[0].color
-																		: '#000000'
+																onEnableChange={(value) =>
+																	setAttributes({ displayShadowSticky: value })
 																}
-																colorDefault={'#000000'}
-																onArrayChange={(color, opacity) => {
-																	saveShadowSticky({ color, opacity });
-																}}
-																opacity={
-																	undefined !== shadowSticky &&
-																	undefined !== shadowSticky[0] &&
-																	undefined !== shadowSticky[0].opacity
-																		? shadowSticky[0].opacity
-																		: 0.2
-																}
-																hOffset={
-																	undefined !== shadowSticky &&
-																	undefined !== shadowSticky[0] &&
-																	undefined !== shadowSticky[0].hOffset
-																		? shadowSticky[0].hOffset
-																		: 0
-																}
-																vOffset={
-																	undefined !== shadowSticky &&
-																	undefined !== shadowSticky[0] &&
-																	undefined !== shadowSticky[0].vOffset
-																		? shadow[0].vOffset
-																		: 0
-																}
-																blur={
-																	undefined !== shadowSticky &&
-																	undefined !== shadowSticky[0] &&
-																	undefined !== shadowSticky[0].blur
-																		? shadowSticky[0].blur
-																		: 14
-																}
-																spread={
-																	undefined !== shadowSticky &&
-																	undefined !== shadowSticky[0] &&
-																	undefined !== shadowSticky[0].spread
-																		? shadowSticky[0].spread
-																		: 0
-																}
-																inset={
-																	undefined !== shadowSticky &&
-																	undefined !== shadowSticky[0] &&
-																	undefined !== shadowSticky[0].inset
-																		? shadowSticky[0].inset
-																		: false
-																}
-																onEnableChange={(value) => {
-																	setAttributes({
-																		displayShadowSticky: value,
-																	});
-																}}
-																onColorChange={(value) => {
-																	saveShadowSticky({ color: value });
-																}}
-																onOpacityChange={(value) => {
-																	saveShadowSticky({ opacity: value });
-																}}
-																onHOffsetChange={(value) => {
-																	saveShadowSticky({ hOffset: value });
-																}}
-																onVOffsetChange={(value) => {
-																	saveShadowSticky({ vOffset: value });
-																}}
-																onBlurChange={(value) => {
-																	saveShadowSticky({ blur: value });
-																}}
-																onSpreadChange={(value) => {
-																	saveShadowSticky({ spread: value });
-																}}
-																onInsetChange={(value) => {
-																	saveShadowSticky({ inset: value });
-																}}
+																tokens={shadowStickyTokens}
+																renderColor={renderShadowColor}
 															/>
 														</>
 													}

--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -75,6 +75,14 @@ const DEFAULT_COMPOSITE = {
 const RGBA_PATTERN = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+))?\s*\)$/i;
 
 /**
+ * A 3-, 6-, or 8-digit hex color, with or without a leading `#` — the only shapes `hexToRgba` can
+ * safely convert. The 8-digit form's trailing pair is its own embedded alpha.
+ *
+ * @since TBD
+ */
+const HEX_PATTERN = /^#?([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
+/**
  * A single 0-255 channel as two hex digits.
  *
  * @param {number} channel The channel value.
@@ -124,7 +132,9 @@ function hexToRgba(hex, alpha) {
  *
  * @since TBD
  *
- * @return {string} The combined color, `rgba(...)` when partially transparent.
+ * @return {string} The combined color, `rgba(...)` when partially transparent and `color` is a hex
+ * literal `hexToRgba` can parse; any other CSS color literal (`var(...)`, `transparent`, an existing
+ * `rgba(...)`) passes through unchanged rather than being corrupted into black.
  */
 export function combineColorOpacity(color, opacity) {
 	if (!color) {
@@ -132,6 +142,10 @@ export function combineColorOpacity(color, opacity) {
 	}
 
 	if (opacity === undefined || opacity === null || Number(opacity) >= 1) {
+		return color;
+	}
+
+	if (!HEX_PATTERN.test(color)) {
 		return color;
 	}
 
@@ -155,18 +169,28 @@ export function splitColorOpacity(combined) {
 		return { color: '', opacity: 1 };
 	}
 
-	const match = combined.match(RGBA_PATTERN);
+	const rgbaMatch = combined.match(RGBA_PATTERN);
 
-	if (!match) {
-		return { color: combined, opacity: 1 };
+	if (rgbaMatch) {
+		const [, r, g, b, a] = rgbaMatch;
+
+		return {
+			color: `#${channelToHex(Number(r))}${channelToHex(Number(g))}${channelToHex(Number(b))}`,
+			opacity: a !== undefined ? Number(a) : 1,
+		};
 	}
 
-	const [, r, g, b, a] = match;
+	// An 8-digit hex (`#RRGGBBAA`) carries its own alpha in the trailing pair — decode it rather than
+	// reading the whole 8-digit string as an opaque color, which `PopColorControl` cannot render.
+	const hexAlphaMatch = combined.match(/^#?([0-9a-f]{6})([0-9a-f]{2})$/i);
 
-	return {
-		color: `#${channelToHex(Number(r))}${channelToHex(Number(g))}${channelToHex(Number(b))}`,
-		opacity: a !== undefined ? Number(a) : 1,
-	};
+	if (hexAlphaMatch) {
+		const [, rgb, alphaHex] = hexAlphaMatch;
+
+		return { color: `#${rgb}`, opacity: parseInt(alphaHex, 16) / 255 };
+	}
+
+	return { color: combined, opacity: 1 };
 }
 
 /**

--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -1,0 +1,312 @@
+/**
+ * The block editor's adapter for `src/token-controls`' `BoxShadowControl`.
+ *
+ * `kadence/singlebtn`'s native shadow attribute (`shadow`, `shadowHover`, `shadowTransparent`, …) is
+ * a one-element array — `[{ color, opacity, hOffset, vOffset, blur, spread, inset }]` — confirmed
+ * against `src/blocks/singlebtn/block.json` and the six existing `BoxShadowControl` call sites in
+ * `src/blocks/singlebtn/edit.js` rather than assumed. `BoxShadowControl`'s (phase 19) own contract is
+ * a *single* value that is either a token alias string or the composite shape `{ color, offsetX,
+ * offsetY, blur, spread, inset }` `helpers/shadow.js`/`ShadowField` already use on the Shadow
+ * token-library screen. Three shape differences this bridges:
+ *
+ * - **field names**: native `hOffset`/`vOffset` become the composite's `offsetX`/`offsetY`; native's
+ *   unitless numbers become the composite's `"Npx"` strings, matching `ShadowField`'s own convention.
+ * - **no `opacity` field in the composite** — the Shadow screen's `ColorPicker` carries alpha inside
+ *   the color itself. Folding native's separate `opacity` into the composite's `color` (as an
+ *   `rgba(...)` string when opacity is less than fully opaque, a plain hex otherwise) is what lets a
+ *   caller's `renderColor` edit both through one `PopColorControl`, unchanged, via its existing
+ *   `opacityValue`/`onArrayChange` props — the same two-channel mechanism the native
+ *   `@kadence/components` `BoxShadowControl` already wires it through
+ *   (`node_modules/@kadence/components/src/box-shadow-control/index.js`). `combineColorOpacity`/
+ *   `splitColorOpacity` below are exported so a caller's `renderColor` can do that combine/split with
+ *   the exact same rules this component uses to read/write the native attribute, keeping both
+ *   directions symmetric.
+ * - **`enable` lives outside the value entirely** — it is a separate sibling boolean attribute
+ *   (`displayShadow`, `displayHoverShadow`, …), not a key inside the shadow array's item. This wrapper
+ *   keeps it a plain `ToggleControl` rendered beside `BoxShadowControl`, matching how the native
+ *   control also renders its enable toggle as an independent affordance next to the label, hiding the
+ *   rest of the control's body while off.
+ *
+ * A whole-shadow token pick (the Style Library tab) has no home in the native item's existing keys —
+ * unlike border, where an alias replaces a single side's width slot, a shadow alias replaces the
+ * *entire* value. It is stored as an added `alias` key on the native item (`toNativeShadow` keeps the
+ * previous literal fields alongside it as a CSS fallback, never dropping them, so `render_shadow()`
+ * still emits valid — if stale until resolved — CSS rather than corrupt placeholder text). Picking a
+ * literal value again drops `alias`, returning the item to its original plain shape.
+ *
+ * Color is out of scope for redesign here, exactly as in `EditorBorderControl` — this component
+ * neither builds nor intercepts a color field, it only wires the caller's EXISTING one back in via
+ * `renderColor`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { ToggleControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { BoxShadowControl } from '../../../token-controls/controls/BoxShadowControl';
+
+/**
+ * The composite's default shape, matching `BoxShadowControl`'s own `DEFAULT_SHADOW` fallback.
+ *
+ * @since TBD
+ */
+const DEFAULT_COMPOSITE = {
+	color: '#000000',
+	offsetX: '0px',
+	offsetY: '0px',
+	blur: '0px',
+	spread: '0px',
+	inset: false,
+};
+
+/**
+ * A CSS `rgba(r, g, b, a)` string, matching `hexToRGBA`'s own output format exactly (comma-space
+ * separated, no leading zero normalization) so `splitColorOpacity` can parse back what this component
+ * writes without a separate, potentially drifting, format.
+ *
+ * @since TBD
+ */
+const RGBA_PATTERN = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+))?\s*\)$/i;
+
+/**
+ * A single 0-255 channel as two hex digits.
+ *
+ * @param {number} channel The channel value.
+ *
+ * @since TBD
+ *
+ * @return {string} Two lowercase hex digits.
+ */
+function channelToHex(channel) {
+	return Math.max(0, Math.min(255, Math.round(channel)))
+		.toString(16)
+		.padStart(2, '0');
+}
+
+/**
+ * A hex color and an alpha number as an `rgba(r, g, b, a)` string — the format `render_color()`'s own
+ * `hexToRGBA` helper (`@kadence/helpers`) produces, matched here rather than imported so this module
+ * does not pull in that package's barrel export (which also loads its REST-fetch helper, unusable
+ * under Jest) for one small, dependency-free conversion.
+ *
+ * @param {string} hex   A 3- or 6-digit hex color, with or without a leading `#`.
+ * @param {number} alpha The alpha value (0-1).
+ *
+ * @since TBD
+ *
+ * @return {string} The `rgba(...)` string.
+ */
+function hexToRgba(hex, alpha) {
+	const stripped = hex.replace('#', '');
+	const long = stripped.length === 3 ? stripped.replace(/(.)/g, '$1$1') : stripped;
+	const r = parseInt(long.slice(0, 2), 16) || 0;
+	const g = parseInt(long.slice(2, 4), 16) || 0;
+	const b = parseInt(long.slice(4, 6), 16) || 0;
+
+	return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+/**
+ * Fold a native hex color and a separate opacity number into the single string `BoxShadowControl`'s
+ * composite color slot carries, so a caller's `renderColor` can hand both to one `PopColorControl` via
+ * its `value`/`opacityValue` props. Fully opaque (or unset) opacity stays a plain hex literal — no
+ * `rgba(...)` wrapping — so the common case round-trips as the same hex string a plain `PopColorControl`
+ * without opacity support would also produce.
+ *
+ * @param {string}  color   The native hex color (or any CSS color literal).
+ * @param {?number} opacity The native opacity (0-1), or undefined for fully opaque.
+ *
+ * @since TBD
+ *
+ * @return {string} The combined color, `rgba(...)` when partially transparent.
+ */
+export function combineColorOpacity(color, opacity) {
+	if (!color) {
+		return color || '';
+	}
+
+	if (opacity === undefined || opacity === null || Number(opacity) >= 1) {
+		return color;
+	}
+
+	return hexToRgba(color, Number(opacity));
+}
+
+/**
+ * Split a combined color (a plain hex/CSS literal, or the `rgba(...)` string `combineColorOpacity`
+ * produces) back into the native `(color, opacity)` pair. Anything that is not an `rgba(...)` string —
+ * a plain hex, a `var(...)` reference, an empty string — passes through as fully opaque, matching
+ * `combineColorOpacity`'s own choice not to wrap the opaque case.
+ *
+ * @param {string} combined The composite's color slot value.
+ *
+ * @since TBD
+ *
+ * @return {{color: string, opacity: number}} The native color and opacity.
+ */
+export function splitColorOpacity(combined) {
+	if (typeof combined !== 'string' || !combined) {
+		return { color: '', opacity: 1 };
+	}
+
+	const match = combined.match(RGBA_PATTERN);
+
+	if (!match) {
+		return { color: combined, opacity: 1 };
+	}
+
+	const [, r, g, b, a] = match;
+
+	return {
+		color: `#${channelToHex(Number(r))}${channelToHex(Number(g))}${channelToHex(Number(b))}`,
+		opacity: a !== undefined ? Number(a) : 1,
+	};
+}
+
+/**
+ * A native numeric axis (`hOffset`, `vOffset`, `blur`, `spread`) as the composite's `"Npx"` string.
+ *
+ * @param {?number} axis The native axis value.
+ *
+ * @since TBD
+ *
+ * @return {string} The composite's px string for this axis.
+ */
+function axisToComposite(axis) {
+	return `${Number(axis) || 0}px`;
+}
+
+/**
+ * A composite axis slot (a `"Npx"` string, matching `ShadowCustomTab`'s own `NumberControl` writes)
+ * back to the native unitless number.
+ *
+ * @param {*} slot The composite's axis value.
+ *
+ * @since TBD
+ *
+ * @return {number} The native axis value.
+ */
+function axisToNative(slot) {
+	return parseFloat(slot) || 0;
+}
+
+/**
+ * Convert the native `[{ color, opacity, hOffset, vOffset, blur, spread, inset, alias? }]` attribute
+ * value to `BoxShadowControl`'s alias-or-composite contract.
+ *
+ * @param {?Array} native The native shadow attribute value.
+ *
+ * @since TBD
+ *
+ * @return {string|Object} A token alias string, when the item carries one, otherwise the composite
+ *                          `{ color, offsetX, offsetY, blur, spread, inset }` shape.
+ */
+export function fromNativeShadow(native) {
+	const source = native?.[0];
+
+	if (!source) {
+		return { ...DEFAULT_COMPOSITE };
+	}
+
+	if (source.alias) {
+		return source.alias;
+	}
+
+	return {
+		color: combineColorOpacity(source.color || DEFAULT_COMPOSITE.color, source.opacity),
+		offsetX: axisToComposite(source.hOffset),
+		offsetY: axisToComposite(source.vOffset),
+		blur: axisToComposite(source.blur),
+		spread: axisToComposite(source.spread),
+		inset: source.inset === true,
+	};
+}
+
+/**
+ * Convert `BoxShadowControl`'s alias-or-composite value back to the native
+ * `[{ color, opacity, hOffset, vOffset, blur, spread, inset }]` attribute shape.
+ *
+ * @param {string|Object} value          The value `BoxShadowControl` reports through `onChange`.
+ * @param {?Array}        previousNative The attribute's current value, kept as the literal CSS
+ *                                       fallback when `value` is a freshly-picked alias.
+ *
+ * @since TBD
+ *
+ * @return {Array} `[{ color, opacity, hOffset, vOffset, blur, spread, inset, alias? }]`.
+ */
+export function toNativeShadow(value, previousNative) {
+	if (typeof value === 'string') {
+		const previous = previousNative?.[0] || {};
+
+		// Keep the previous literal fields as the CSS fallback — `render_shadow()` does not resolve
+		// `alias` and would otherwise have nothing to render until the value is picked again.
+		return [{ ...previous, alias: value }];
+	}
+
+	const { color, opacity } = splitColorOpacity(value?.color);
+
+	return [
+		{
+			color: color || DEFAULT_COMPOSITE.color,
+			opacity,
+			hOffset: axisToNative(value?.offsetX),
+			vOffset: axisToNative(value?.offsetY),
+			blur: axisToNative(value?.blur),
+			spread: axisToNative(value?.spread),
+			inset: value?.inset === true,
+		},
+	];
+}
+
+/**
+ * Render the editor-canvas box-shadow control: an `enable` toggle (the native attribute's own
+ * sibling boolean, kept independent of the shadow value) beside `BoxShadowControl`, shown only while
+ * enabled — matching the native `@kadence/components` `BoxShadowControl`'s own layout.
+ *
+ * @param {Object}    props                The component props.
+ * @param {string}    props.label          The control's label.
+ * @param {?Array}    props.value          The native shadow attribute value.
+ * @param {Function}  props.onChange       Called with the next native shadow attribute value.
+ * @param {boolean}   props.enable         Whether the shadow is enabled (the sibling boolean attribute).
+ * @param {Function}  props.onEnableChange Called with the next enabled state.
+ * @param {Array}     [props.tokens]       Pickable `shadow`-type tokens, `[{id, label, value, alias}]`.
+ * @param {?Function} [props.renderColor]  The block's existing color field for the composite's `color`.
+ * @param {boolean}   [props.disabled]     Whether the control is read-only.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The rendered control.
+ */
+export function EditorShadowControl({
+	label,
+	value,
+	onChange,
+	enable,
+	onEnableChange,
+	tokens = [],
+	renderColor,
+	disabled = false,
+}) {
+	return (
+		<div className="kb-editor-shadow-control">
+			<div className="kb-editor-shadow-control__header">
+				{label && <span className="kb-editor-shadow-control__label">{label}</span>}
+				<ToggleControl checked={!!enable} onChange={onEnableChange} disabled={disabled} />
+			</div>
+			{enable && (
+				<BoxShadowControl
+					label={undefined}
+					value={fromNativeShadow(value)}
+					onChange={(next) => onChange(toNativeShadow(next, value))}
+					tokens={tokens}
+					renderColor={renderColor}
+					disabled={disabled}
+				/>
+			)}
+		</div>
+	);
+}

--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -45,6 +45,7 @@
  * WordPress dependencies
  */
 import { ToggleControl } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -127,14 +128,19 @@ function hexToRgba(hex, alpha) {
  * `rgba(...)` wrapping — so the common case round-trips as the same hex string a plain `PopColorControl`
  * without opacity support would also produce.
  *
- * @param {string}  color   The native hex color (or any CSS color literal).
+ * @param {string}  color   The native hex color, an `rgb(...)`/`rgba(...)` literal, or any other CSS
+ *                          color literal.
  * @param {?number} opacity The native opacity (0-1), or undefined for fully opaque.
  *
  * @since TBD
  *
  * @return {string} The combined color, `rgba(...)` when partially transparent and `color` is a hex
- * literal `hexToRgba` can parse; any other CSS color literal (`var(...)`, `transparent`, an existing
- * `rgba(...)`) passes through unchanged rather than being corrupted into black.
+ * or `rgb(...)`/`rgba(...)` literal (both channel-decodable, so the opacity can be folded in
+ * losslessly). A CSS color this module cannot decode into channels — `var(...)`, a named color like
+ * `transparent`, `currentColor` — passes through unchanged rather than being corrupted into black;
+ * the separate opacity is lost in that one case, a known, accepted limitation (there is no lossless
+ * single-string encoding for "an opaque reference plus a multiplier" without `color-mix()`, which
+ * `PopColorControl`/`splitColorOpacity` do not parse) — see `splitColorOpacity`'s matching fallback.
  */
 export function combineColorOpacity(color, opacity) {
 	if (!color) {
@@ -145,11 +151,19 @@ export function combineColorOpacity(color, opacity) {
 		return color;
 	}
 
-	if (!HEX_PATTERN.test(color)) {
-		return color;
+	if (HEX_PATTERN.test(color)) {
+		return hexToRgba(color, Number(opacity));
 	}
 
-	return hexToRgba(color, Number(opacity));
+	const rgbMatch = color.match(RGBA_PATTERN);
+
+	if (rgbMatch) {
+		const [, r, g, b] = rgbMatch;
+
+		return `rgba(${r}, ${g}, ${b}, ${Number(opacity)})`;
+	}
+
+	return color;
 }
 
 /**
@@ -374,7 +388,23 @@ export function EditorShadowControl({
 		<div className="kb-editor-shadow-control">
 			<div className="kb-editor-shadow-control__header">
 				{label && <span className="kb-editor-shadow-control__label">{label}</span>}
-				<ToggleControl checked={!!enable} onChange={onEnableChange} disabled={disabled} />
+				<ToggleControl
+					label={
+						label
+							? sprintf(
+									/* translators: %s: the field's own label, e.g. "Shadow". */ __(
+										'Enable %s',
+										'kadence-blocks'
+									),
+									label
+								)
+							: __('Enable shadow', 'kadence-blocks')
+					}
+					hideLabelFromVision
+					checked={!!enable}
+					onChange={onEnableChange}
+					disabled={disabled}
+				/>
 			</div>
 			{enable && (
 				<BoxShadowControl

--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -28,11 +28,13 @@
  *   rest of the control's body while off.
  *
  * A whole-shadow token pick (the Style Library tab) has no home in the native item's existing keys —
- * unlike border, where an alias replaces a single side's width slot, a shadow alias replaces the
- * *entire* value. It is stored as an added `alias` key on the native item (`toNativeShadow` keeps the
- * previous literal fields alongside it as a CSS fallback, never dropping them, so `render_shadow()`
- * still emits valid — if stale until resolved — CSS rather than corrupt placeholder text). Picking a
- * literal value again drops `alias`, returning the item to its original plain shape.
+ * unlike border, where an alias replaces a single side's width slot, a shadow alias would replace the
+ * *entire* value. Rather than invent a spot to carry a live alias, a pick resolves to its literal
+ * composite value immediately, at pick time, using the same `tokens` list `BoxShadowControl` already
+ * offers for its trigger label (`[{ id, alias, label, value, type, role }]`). `toNativeShadow` looks
+ * up the picked alias's resolved `value` (the feed's `box-shadow` shorthand string) and writes the
+ * parsed composite straight into the native item's plain fields — no alias key, no live link back to
+ * the token, matching how a per-instance color pick is already handled everywhere else in this plan.
  *
  * Color is out of scope for redesign here, exactly as in `EditorBorderControl` — this component
  * neither builds nor intercepts a color field, it only wires the caller's EXISTING one back in via
@@ -195,25 +197,79 @@ function axisToNative(slot) {
 }
 
 /**
- * Convert the native `[{ color, opacity, hOffset, vOffset, blur, spread, inset, alias? }]` attribute
- * value to `BoxShadowControl`'s alias-or-composite contract.
+ * The feed's resolved `box-shadow` shorthand grammar, matching what `Css_Renderer::shadow()`
+ * produces: an optional leading `inset `, four space-separated dimension tokens (offsetX, offsetY,
+ * blur, spread), then the color as the remainder of the string. Capturing the color as "everything
+ * after the fourth dimension" (rather than a fifth token) keeps a color with internal spaces —
+ * `rgba(23, 23, 23, 0.12)` — intact.
+ *
+ * @since TBD
+ */
+const SHADOW_SHORTHAND_PATTERN = /^(inset\s+)?(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.+)$/;
+
+/**
+ * Parse a resolved `box-shadow` shorthand string into the composite `{ color, offsetX, offsetY, blur,
+ * spread, inset }` shape `BoxShadowControl` edits.
+ *
+ * @param {*} css The resolved shorthand (e.g. `"0px 2px 8px 0px #1717171f"`, with an optional
+ *                `inset ` prefix), or anything that fails to parse as one.
+ *
+ * @since TBD
+ *
+ * @return {Object} The parsed composite, or the field's default shape when `css` is empty or does
+ *                   not match the shorthand grammar.
+ */
+function parseResolvedShadow(css) {
+	const match = typeof css === 'string' ? css.trim().match(SHADOW_SHORTHAND_PATTERN) : null;
+
+	if (!match) {
+		return { ...DEFAULT_COMPOSITE };
+	}
+
+	const [, insetPrefix, offsetX, offsetY, blur, spread, color] = match;
+
+	return {
+		color,
+		offsetX,
+		offsetY,
+		blur,
+		spread,
+		inset: Boolean(insetPrefix),
+	};
+}
+
+/**
+ * Resolve a picked token alias to its literal composite value, via the same `tokens` list
+ * `BoxShadowControl` already offers for its trigger label.
+ *
+ * @param {string} alias  The picked token alias.
+ * @param {Array}  tokens Pickable `shadow`-type tokens, `[{id, label, value, alias}]`.
+ *
+ * @since TBD
+ *
+ * @return {?Object} The resolved composite, or `null` when the alias matches no pickable token.
+ */
+function resolveShadowAlias(alias, tokens) {
+	const entry = (tokens || []).find((token) => token.alias === alias);
+
+	return entry ? parseResolvedShadow(entry.value) : null;
+}
+
+/**
+ * Convert the native `[{ color, opacity, hOffset, vOffset, blur, spread, inset }]` attribute value to
+ * the composite `BoxShadowControl` edits.
  *
  * @param {?Array} native The native shadow attribute value.
  *
  * @since TBD
  *
- * @return {string|Object} A token alias string, when the item carries one, otherwise the composite
- *                          `{ color, offsetX, offsetY, blur, spread, inset }` shape.
+ * @return {Object} The composite `{ color, offsetX, offsetY, blur, spread, inset }` shape.
  */
 export function fromNativeShadow(native) {
 	const source = native?.[0];
 
 	if (!source) {
 		return { ...DEFAULT_COMPOSITE };
-	}
-
-	if (source.alias) {
-		return source.alias;
 	}
 
 	return {
@@ -227,37 +283,36 @@ export function fromNativeShadow(native) {
 }
 
 /**
- * Convert `BoxShadowControl`'s alias-or-composite value back to the native
+ * Convert `BoxShadowControl`'s value back to the native
  * `[{ color, opacity, hOffset, vOffset, blur, spread, inset }]` attribute shape.
  *
- * @param {string|Object} value          The value `BoxShadowControl` reports through `onChange`.
- * @param {?Array}        previousNative The attribute's current value, kept as the literal CSS
- *                                       fallback when `value` is a freshly-picked alias.
+ * A token alias string (a pick from the Style Library tab) resolves to its literal composite value
+ * immediately, through `tokens`, rather than being stored as a live link back to the token — an
+ * alias that resolves to nothing (a stale or unmapped id) falls back to the composite default so the
+ * write never corrupts the attribute.
+ *
+ * @param {string|Object} value    The value `BoxShadowControl` reports through `onChange`.
+ * @param {Array}         [tokens] Pickable `shadow`-type tokens, `[{id, label, value, alias}]`, used
+ *                                 to resolve a picked alias to its literal value.
  *
  * @since TBD
  *
- * @return {Array} `[{ color, opacity, hOffset, vOffset, blur, spread, inset, alias? }]`.
+ * @return {Array} `[{ color, opacity, hOffset, vOffset, blur, spread, inset }]`.
  */
-export function toNativeShadow(value, previousNative) {
-	if (typeof value === 'string') {
-		const previous = previousNative?.[0] || {};
+export function toNativeShadow(value, tokens = []) {
+	const composite = typeof value === 'string' ? resolveShadowAlias(value, tokens) || DEFAULT_COMPOSITE : value;
 
-		// Keep the previous literal fields as the CSS fallback — `render_shadow()` does not resolve
-		// `alias` and would otherwise have nothing to render until the value is picked again.
-		return [{ ...previous, alias: value }];
-	}
-
-	const { color, opacity } = splitColorOpacity(value?.color);
+	const { color, opacity } = splitColorOpacity(composite?.color);
 
 	return [
 		{
 			color: color || DEFAULT_COMPOSITE.color,
 			opacity,
-			hOffset: axisToNative(value?.offsetX),
-			vOffset: axisToNative(value?.offsetY),
-			blur: axisToNative(value?.blur),
-			spread: axisToNative(value?.spread),
-			inset: value?.inset === true,
+			hOffset: axisToNative(composite?.offsetX),
+			vOffset: axisToNative(composite?.offsetY),
+			blur: axisToNative(composite?.blur),
+			spread: axisToNative(composite?.spread),
+			inset: composite?.inset === true,
 		},
 	];
 }
@@ -301,7 +356,7 @@ export function EditorShadowControl({
 				<BoxShadowControl
 					label={undefined}
 					value={fromNativeShadow(value)}
-					onChange={(next) => onChange(toNativeShadow(next, value))}
+					onChange={(next) => onChange(toNativeShadow(next, tokens))}
 					tokens={tokens}
 					renderColor={renderColor}
 					disabled={disabled}

--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -260,6 +260,31 @@ describe('EditorShadowControl enable toggle', () => {
 
 		expect(shadowControl).toBeNull();
 	});
+
+	/**
+	 * The toggle has no visible text of its own (the field's label sits in a separate, unassociated
+	 * sibling `<span>`), so it needs its own accessible name rather than relying on that span.
+	 *
+	 * @return {void}
+	 */
+	it('gives the toggle an accessible name derived from the field label, hidden visually', () => {
+		const { toggle } = renderEditorShadowControl({ label: 'Box Shadow' });
+
+		expect(toggle.props.label).toBe('Enable Box Shadow');
+		expect(toggle.props.hideLabelFromVision).toBe(true);
+	});
+
+	/**
+	 * A caller that omits `label` entirely still gets a usable, generic accessible name rather than an
+	 * empty or undefined one.
+	 *
+	 * @return {void}
+	 */
+	it('falls back to a generic accessible name when no label is given', () => {
+		const { toggle } = renderEditorShadowControl({ label: undefined });
+
+		expect(toggle.props.label).toBe('Enable shadow');
+	});
 });
 
 describe('EditorShadowControl renderColor wiring', () => {
@@ -329,10 +354,23 @@ describe('combineColorOpacity / splitColorOpacity', () => {
 	 *
 	 * @return {void}
 	 */
-	it('leaves a non-hex color unconverted rather than corrupting it to black', () => {
+	it('leaves a color it cannot decode into channels unconverted rather than corrupting it to black', () => {
 		expect(combineColorOpacity('var(--palette-color)', 0.5)).toBe('var(--palette-color)');
 		expect(combineColorOpacity('transparent', 0.5)).toBe('transparent');
-		expect(combineColorOpacity('rgb(10, 20, 30)', 0.5)).toBe('rgb(10, 20, 30)');
+	});
+
+	/**
+	 * Unlike `var(...)`/named colors, `rgb(...)` already carries decodable channels, so its opacity
+	 * is not lost the way a genuinely opaque-reference color's is — it round-trips through combine and
+	 * split exactly like a hex color does.
+	 *
+	 * @return {void}
+	 */
+	it('folds opacity into an rgb(...) color and round-trips it losslessly', () => {
+		const combined = combineColorOpacity('rgb(10, 20, 30)', 0.5);
+
+		expect(combined).toBe('rgba(10, 20, 30, 0.5)');
+		expect(splitColorOpacity(combined)).toEqual({ color: '#0a141e', opacity: 0.5 });
 	});
 
 	/**

--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -1,0 +1,344 @@
+/* eslint-env jest */
+
+/**
+ * Internal dependencies
+ */
+import { EditorShadowControl, combineColorOpacity, splitColorOpacity } from '../EditorShadowControl';
+
+/**
+ * A representative native shadow value — every field a different, distinguishable number/string, so a
+ * round-trip that silently dropped or shuffled a field would be caught.
+ *
+ * @since TBD
+ *
+ * @type {Array}
+ */
+const NATIVE_VALUE = [
+	{
+		color: '#111111',
+		opacity: 0.4,
+		hOffset: 2,
+		vOffset: 3,
+		blur: 4,
+		spread: 5,
+		inset: false,
+	},
+];
+
+/**
+ * Call `EditorShadowControl` as a plain function and return the `BoxShadowControl`/`ToggleControl`
+ * elements it produced. The component holds no hooks of its own, so the returned element tree can be
+ * inspected directly instead of mounting it — matching `EditorBorderControl.test.js`'s own harness.
+ *
+ * @param {Object} overrides Props to override on top of the defaults.
+ *
+ * @since TBD
+ *
+ * @return {{root: Object, header: Object, toggle: Object, shadowControl: ?Object, onChange: Function,
+ *   onEnableChange: Function}} The root element, the header row, the enable toggle, the
+ *   `BoxShadowControl` element (or `null` when `enable` is false), and the setter spies passed in.
+ */
+function renderEditorShadowControl(overrides = {}) {
+	const onChange = jest.fn();
+	const onEnableChange = jest.fn();
+
+	const props = {
+		label: 'Box Shadow',
+		value: NATIVE_VALUE,
+		onChange,
+		enable: true,
+		onEnableChange,
+		tokens: [],
+		...overrides,
+	};
+
+	const root = EditorShadowControl(props);
+	const [header, shadowControl] = root.props.children;
+
+	return {
+		root,
+		header,
+		toggle: header.props.children[1],
+		shadowControl: shadowControl || null,
+		onChange,
+		onEnableChange,
+	};
+}
+
+describe('EditorShadowControl native <-> BoxShadowControl value bridging', () => {
+	/**
+	 * `fromNativeShadow` is exercised indirectly through the `value` handed to `BoxShadowControl`: field
+	 * names are translated (`hOffset`/`vOffset` to `offsetX`/`offsetY`), numbers become `"Npx"` strings,
+	 * and a partially-transparent color folds its `opacity` into an `rgba(...)` string.
+	 *
+	 * @return {void}
+	 */
+	it('converts the native shape to the composite BoxShadowControl expects, folding opacity into color', () => {
+		const { shadowControl } = renderEditorShadowControl();
+
+		expect(shadowControl.props.value).toEqual({
+			color: 'rgba(17, 17, 17, 0.4)',
+			offsetX: '2px',
+			offsetY: '3px',
+			blur: '4px',
+			spread: '5px',
+			inset: false,
+		});
+	});
+
+	/**
+	 * A fully opaque native color is passed through as a plain hex literal, never wrapped in
+	 * `rgba(...)`, matching what a plain `PopColorControl` without opacity would already produce.
+	 *
+	 * @return {void}
+	 */
+	it('keeps a fully-opaque color as a plain hex literal, unwrapped', () => {
+		const { shadowControl } = renderEditorShadowControl({
+			value: [{ color: '#222222', opacity: 1, hOffset: 0, vOffset: 0, blur: 0, spread: 0, inset: false }],
+		});
+
+		expect(shadowControl.props.value.color).toBe('#222222');
+	});
+
+	/**
+	 * A missing native value reads as the composite's default shape rather than crashing on
+	 * `undefined[0]`.
+	 *
+	 * @return {void}
+	 */
+	it('reads an unset native value as the composite default', () => {
+		const { shadowControl } = renderEditorShadowControl({ value: undefined });
+
+		expect(shadowControl.props.value).toEqual({
+			color: '#000000',
+			offsetX: '0px',
+			offsetY: '0px',
+			blur: '0px',
+			spread: '0px',
+			inset: false,
+		});
+	});
+
+	/**
+	 * Editing the composite writes the native shape back with every field translated to its native
+	 * name/type — the round-trip must be lossless for a representative value, including the
+	 * color/opacity fold-back.
+	 *
+	 * @return {void}
+	 */
+	it('round-trips a representative native value losslessly through a composite edit', () => {
+		const { shadowControl, onChange } = renderEditorShadowControl();
+
+		shadowControl.props.onChange({
+			color: 'rgba(17, 17, 17, 0.4)',
+			offsetX: '9px',
+			offsetY: '3px',
+			blur: '4px',
+			spread: '5px',
+			inset: false,
+		});
+
+		expect(onChange).toHaveBeenCalledWith([
+			{
+				color: '#111111',
+				opacity: 0.4,
+				hOffset: 9,
+				vOffset: 3,
+				blur: 4,
+				spread: 5,
+				inset: false,
+			},
+		]);
+	});
+
+	/**
+	 * Toggling `inset` on writes it through unchanged, alongside the rest of the value.
+	 *
+	 * @return {void}
+	 */
+	it('writes an inset edit through to the native attribute', () => {
+		const { shadowControl, onChange } = renderEditorShadowControl();
+
+		shadowControl.props.onChange({
+			color: 'rgba(17, 17, 17, 0.4)',
+			offsetX: '2px',
+			offsetY: '3px',
+			blur: '4px',
+			spread: '5px',
+			inset: true,
+		});
+
+		const written = onChange.mock.calls[0][0][0];
+		expect(written.inset).toBe(true);
+	});
+
+	/**
+	 * Picking a token alias in the Style Library tab writes the alias id into the native item, keeping
+	 * the previous literal fields alongside it as a CSS fallback rather than dropping them.
+	 *
+	 * @return {void}
+	 */
+	it('stores a picked token alias alongside the previous literal fields, not in place of them', () => {
+		const { shadowControl, onChange } = renderEditorShadowControl();
+		const alias = 'primitive.shadow.md';
+
+		shadowControl.props.onChange(alias);
+
+		expect(onChange).toHaveBeenCalledWith([
+			{
+				color: '#111111',
+				opacity: 0.4,
+				hOffset: 2,
+				vOffset: 3,
+				blur: 4,
+				spread: 5,
+				inset: false,
+				alias,
+			},
+		]);
+	});
+
+	/**
+	 * Reading a native item that carries an `alias` reports the alias string straight back to
+	 * `BoxShadowControl`, not the literal fallback fields kept alongside it.
+	 *
+	 * @return {void}
+	 */
+	it('reads a native item carrying an alias back as the alias string', () => {
+		const alias = 'primitive.shadow.md';
+		const { shadowControl } = renderEditorShadowControl({
+			value: [{ ...NATIVE_VALUE[0], alias }],
+		});
+
+		expect(shadowControl.props.value).toBe(alias);
+	});
+
+	/**
+	 * Picking a literal composite value again after an alias drops the `alias` key, returning the
+	 * native item to its plain shape.
+	 *
+	 * @return {void}
+	 */
+	it('drops the alias key when a literal composite value is written after an alias', () => {
+		const { shadowControl, onChange } = renderEditorShadowControl({
+			value: [{ ...NATIVE_VALUE[0], alias: 'primitive.shadow.md' }],
+		});
+
+		shadowControl.props.onChange({
+			color: '#111111',
+			offsetX: '2px',
+			offsetY: '3px',
+			blur: '4px',
+			spread: '5px',
+			inset: false,
+		});
+
+		const written = onChange.mock.calls[0][0][0];
+		expect(written).not.toHaveProperty('alias');
+	});
+});
+
+describe('EditorShadowControl enable toggle', () => {
+	/**
+	 * The enable toggle reads and writes the sibling boolean attribute independently of the shadow
+	 * value's shape — it stays functional whether the value is a token or a composite literal.
+	 *
+	 * @return {void}
+	 */
+	it('reflects the enable prop and writes through onEnableChange, independent of the value shape', () => {
+		const { toggle, onEnableChange } = renderEditorShadowControl({ enable: false });
+
+		expect(toggle.props.checked).toBe(false);
+
+		toggle.props.onChange(true);
+		expect(onEnableChange).toHaveBeenCalledWith(true);
+	});
+
+	/**
+	 * The toggle stays functional when the current value is an aliased token, not just a composite.
+	 *
+	 * @return {void}
+	 */
+	it('keeps the enable toggle independent when the value is a token alias', () => {
+		const { toggle, onEnableChange } = renderEditorShadowControl({
+			enable: true,
+			value: [{ ...NATIVE_VALUE[0], alias: 'primitive.shadow.md' }],
+		});
+
+		toggle.props.onChange(false);
+		expect(onEnableChange).toHaveBeenCalledWith(false);
+	});
+
+	/**
+	 * `BoxShadowControl` renders only while enabled, matching the native control's own layout — a
+	 * caller should not be able to edit a shadow value that is currently switched off.
+	 *
+	 * @return {void}
+	 */
+	it('hides BoxShadowControl while disabled', () => {
+		const { shadowControl } = renderEditorShadowControl({ enable: false });
+
+		expect(shadowControl).toBeNull();
+	});
+});
+
+describe('EditorShadowControl renderColor wiring', () => {
+	/**
+	 * `renderColor` is passed straight through to `BoxShadowControl` untouched — this component neither
+	 * builds nor intercepts it. `BoxShadowControl` calls it with the composite's `color` slot this
+	 * component derived from the native value, so the caller's `renderColor` sees the combined
+	 * color/opacity string, not the raw native pair.
+	 *
+	 * @return {void}
+	 */
+	it('passes renderColor straight through to BoxShadowControl, called with the derived color', () => {
+		const renderColor = jest.fn();
+		const { shadowControl } = renderEditorShadowControl({ renderColor });
+
+		expect(shadowControl.props.renderColor).toBe(renderColor);
+
+		shadowControl.props.renderColor({ value: shadowControl.props.value.color, onChange: jest.fn() });
+
+		expect(renderColor).toHaveBeenCalledWith({
+			value: 'rgba(17, 17, 17, 0.4)',
+			onChange: expect.any(Function),
+		});
+	});
+});
+
+describe('combineColorOpacity / splitColorOpacity', () => {
+	/**
+	 * A partially-transparent color combines into an `rgba(...)` string that `splitColorOpacity`
+	 * reads back apart into the exact same hex/opacity pair — the two directions must agree with each
+	 * other, not just with `EditorShadowControl`'s own internal use of them.
+	 *
+	 * @return {void}
+	 */
+	it('round-trips a partially-transparent color through combine and split', () => {
+		const combined = combineColorOpacity('#3182ce', 0.5);
+
+		expect(combined).toBe('rgba(49, 130, 206, 0.5)');
+		expect(splitColorOpacity(combined)).toEqual({ color: '#3182ce', opacity: 0.5 });
+	});
+
+	/**
+	 * A fully opaque color is never wrapped, and splitting a plain hex back reports full opacity.
+	 *
+	 * @return {void}
+	 */
+	it('leaves a fully-opaque color unwrapped and reports full opacity on split', () => {
+		expect(combineColorOpacity('#3182ce', 1)).toBe('#3182ce');
+		expect(splitColorOpacity('#3182ce')).toEqual({ color: '#3182ce', opacity: 1 });
+	});
+
+	/**
+	 * An empty color combines/splits to an empty color rather than throwing, so a not-yet-set shadow
+	 * value renders without a crash.
+	 *
+	 * @return {void}
+	 */
+	it('handles an empty color without throwing', () => {
+		expect(combineColorOpacity('', 0.5)).toBe('');
+		expect(splitColorOpacity('')).toEqual({ color: '', opacity: 1 });
+	});
+});

--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -321,4 +321,28 @@ describe('combineColorOpacity / splitColorOpacity', () => {
 		expect(combineColorOpacity('', 0.5)).toBe('');
 		expect(splitColorOpacity('')).toEqual({ color: '', opacity: 1 });
 	});
+
+	/**
+	 * A non-hex CSS color literal (a custom property reference, `transparent`, or an existing
+	 * `rgba(...)` string) is never routed through `hexToRgba` — combining it with a partial opacity
+	 * would otherwise read every RGB channel as `NaN || 0` and silently produce black.
+	 *
+	 * @return {void}
+	 */
+	it('leaves a non-hex color unconverted rather than corrupting it to black', () => {
+		expect(combineColorOpacity('var(--palette-color)', 0.5)).toBe('var(--palette-color)');
+		expect(combineColorOpacity('transparent', 0.5)).toBe('transparent');
+		expect(combineColorOpacity('rgb(10, 20, 30)', 0.5)).toBe('rgb(10, 20, 30)');
+	});
+
+	/**
+	 * An 8-digit hex (`#RRGGBBAA`) — the shape a resolved shadow token's color can arrive as — carries
+	 * its own alpha in the trailing pair. Splitting it must decode that alpha rather than reporting the
+	 * whole 8-digit string as an opaque color.
+	 *
+	 * @return {void}
+	 */
+	it('decodes an 8-digit hex color into its base color and embedded alpha', () => {
+		expect(splitColorOpacity('#1717171f')).toEqual({ color: '#171717', opacity: 0x1f / 255 });
+	});
 });

--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -173,68 +173,63 @@ describe('EditorShadowControl native <-> BoxShadowControl value bridging', () =>
 	});
 
 	/**
-	 * Picking a token alias in the Style Library tab writes the alias id into the native item, keeping
-	 * the previous literal fields alongside it as a CSS fallback rather than dropping them.
+	 * Picking a token alias in the Style Library tab resolves it to its literal composite value
+	 * immediately, via the `tokens` list, and writes that literal into the native item — no `alias`
+	 * key, no live link back to the token.
 	 *
 	 * @return {void}
 	 */
-	it('stores a picked token alias alongside the previous literal fields, not in place of them', () => {
-		const { shadowControl, onChange } = renderEditorShadowControl();
-		const alias = 'primitive.shadow.md';
+	it('resolves a picked token alias to its literal composite value, not an alias marker', () => {
+		const { shadowControl, onChange } = renderEditorShadowControl({
+			tokens: [
+				{
+					id: 'primitive.shadow.md',
+					alias: 'primitive.shadow.md',
+					label: 'Medium',
+					value: '2px 3px 4px 5px #111111',
+					type: 'shadow',
+				},
+			],
+		});
 
-		shadowControl.props.onChange(alias);
+		shadowControl.props.onChange('primitive.shadow.md');
 
 		expect(onChange).toHaveBeenCalledWith([
 			{
 				color: '#111111',
-				opacity: 0.4,
+				opacity: 1,
 				hOffset: 2,
 				vOffset: 3,
 				blur: 4,
 				spread: 5,
 				inset: false,
-				alias,
 			},
 		]);
+		expect(onChange.mock.calls[0][0][0]).not.toHaveProperty('alias');
 	});
 
 	/**
-	 * Reading a native item that carries an `alias` reports the alias string straight back to
-	 * `BoxShadowControl`, not the literal fallback fields kept alongside it.
+	 * An alias that resolves to nothing (a stale or unmapped token id) falls back to the composite
+	 * default rather than corrupting the native item or leaving it unwritten.
 	 *
 	 * @return {void}
 	 */
-	it('reads a native item carrying an alias back as the alias string', () => {
-		const alias = 'primitive.shadow.md';
-		const { shadowControl } = renderEditorShadowControl({
-			value: [{ ...NATIVE_VALUE[0], alias }],
-		});
+	it('falls back to the composite default when a picked alias matches no pickable token', () => {
+		const { shadowControl, onChange } = renderEditorShadowControl({ tokens: [] });
 
-		expect(shadowControl.props.value).toBe(alias);
-	});
+		shadowControl.props.onChange('primitive.shadow.unknown');
 
-	/**
-	 * Picking a literal composite value again after an alias drops the `alias` key, returning the
-	 * native item to its plain shape.
-	 *
-	 * @return {void}
-	 */
-	it('drops the alias key when a literal composite value is written after an alias', () => {
-		const { shadowControl, onChange } = renderEditorShadowControl({
-			value: [{ ...NATIVE_VALUE[0], alias: 'primitive.shadow.md' }],
-		});
-
-		shadowControl.props.onChange({
-			color: '#111111',
-			offsetX: '2px',
-			offsetY: '3px',
-			blur: '4px',
-			spread: '5px',
-			inset: false,
-		});
-
-		const written = onChange.mock.calls[0][0][0];
-		expect(written).not.toHaveProperty('alias');
+		expect(onChange).toHaveBeenCalledWith([
+			{
+				color: '#000000',
+				opacity: 1,
+				hOffset: 0,
+				vOffset: 0,
+				blur: 0,
+				spread: 0,
+				inset: false,
+			},
+		]);
 	});
 });
 
@@ -252,21 +247,6 @@ describe('EditorShadowControl enable toggle', () => {
 
 		toggle.props.onChange(true);
 		expect(onEnableChange).toHaveBeenCalledWith(true);
-	});
-
-	/**
-	 * The toggle stays functional when the current value is an aliased token, not just a composite.
-	 *
-	 * @return {void}
-	 */
-	it('keeps the enable toggle independent when the value is a token alias', () => {
-		const { toggle, onEnableChange } = renderEditorShadowControl({
-			enable: true,
-			value: [{ ...NATIVE_VALUE[0], alias: 'primitive.shadow.md' }],
-		});
-
-		toggle.props.onChange(false);
-		expect(onEnableChange).toHaveBeenCalledWith(false);
 	});
 
 	/**


### PR DESCRIPTION
## Summary
- Adds `EditorShadowControl`, a thin block-editor wrapper around `BoxShadowControl` that resolves/writes `kadence/singlebtn`'s native box-shadow attribute shape.
- Wires it into `singlebtn/edit.js` in place of the block's native box-shadow control.
- A Style-Library-tab token pick resolves to its literal composite value immediately (matching how per-instance color is already handled everywhere else in this plan), rather than tracking a live alias.

## Test plan
- [x] Component tests for `EditorShadowControl`.
- [x] `npx jest` — full suite green.
- [ ] Manual verification on the dev site (block editor canvas, Style tab) — note the shadow preview is only fully correct once the `kadence-helpers` fix (separate repo, https://github.com/stellarwp/kadence-helpers/pull/8) merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated button shadow controls for normal, hover, transparent, and sticky states.
  - Added support for design-token-based shadow presets and reusable shadow values.
  - Improved editing of shadow colors and opacity as independent settings.
  - Added clearer controls for enabling, disabling, and configuring shadows.
  - Preserved inset shadows, axis units, and existing shadow settings during edits.

- **Bug Fixes**
  - Improved handling of unsupported or unresolved shadow presets by safely falling back to default values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->