### PR TITLE
[DTM] SOFT-4083 [31/38]: render border and shadow from the selected preset

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -147,6 +147,7 @@
         "rowlayout",
         "rrggbb",
         "rrggbbaa",
+        "Sabberworm",
         "scroller",
         "shivammathur",
         "singlebtn",

--- a/includes/blocks/class-kadence-blocks-singlebtn-block.php
+++ b/includes/blocks/class-kadence-blocks-singlebtn-block.php
@@ -127,10 +127,12 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		}
 		$css->render_typography( $attributes, 'typography' );
 		$css->render_measure_output( $attributes, 'borderRadius', 'border-radius', [ 'unit_key' => 'borderRadiusUnit' ] );
+		$this->render_preset_border( $css, $attributes );
 		$css->render_border_styles( $attributes, 'borderStyle', true );
 		$this->render_preset_spacing( $css, $attributes );
 		$css->render_measure_output( $attributes, 'padding', 'padding', [ 'unit_key' => 'paddingUnit' ] );
 		$css->render_measure_output( $attributes, 'margin', 'margin', [ 'unit_key' => 'marginUnit' ] );
+		$this->render_preset_shadow( $css, $attributes );
 		if ( isset( $attributes['displayShadow'] ) && true === $attributes['displayShadow'] ) {
 			if ( isset( $attributes['shadow'] ) && is_array( $attributes['shadow'] ) && isset( $attributes['shadow'][0] ) && is_array( $attributes['shadow'][0] ) ) {
 				$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadow'][0] ) );
@@ -539,6 +541,118 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 
 		if ( isset( $values['button-margin'] ) ) {
 			$css->add_property( 'margin', 'var(--kb-btn-margin)' );
+		}
+	}
+
+	/**
+	 * Point border width/style/color at their preset variables, but only for a property the active
+	 * preset actually resolves.
+	 *
+	 * The gate is the whole point, exactly as in `render_preset_spacing()` — a `var()` pointed at an
+	 * undefined custom property is invalid at computed-value time, so emitting unconditionally would
+	 * blank out the border on a button whose preset sets none of it.
+	 *
+	 * Emitted before `render_border_styles()`'s explicit per-side output so an explicit per-block
+	 * border, which lands later in the same rule, still wins.
+	 *
+	 * @since TBD
+	 *
+	 * @param Kadence_Blocks_CSS   $css        The css object.
+	 * @param array<string, mixed> $attributes The block attributes.
+	 *
+	 * @return void
+	 */
+	private function render_preset_border( Kadence_Blocks_CSS $css, array $attributes ): void {
+		try {
+			$registry = kadence_blocks()->get( Token_Registry::class );
+			$library  = kadence_blocks()->get( Active_Token_Library_Store::class );
+			$resolver = kadence_blocks()->get( Preset_Resolver::class );
+
+			// The container is typed `mixed`, and this runs on every button render, so the services are
+			// checked rather than assumed — a misconfigured container degrades to today's border.
+			if (
+				! $registry instanceof Token_Registry
+				|| ! $library instanceof Active_Token_Library_Store
+				|| ! $resolver instanceof Preset_Resolver
+				|| ! $registry->is_active()
+			) {
+				return;
+			}
+
+			$slug     = $library->get();
+			$selected = Cast::to_string( $attributes['kbPreset'] ?? '' );
+			$preset   = $selected !== '' && $resolver->has_preset( 'kadence/singlebtn', $selected, $slug )
+				? $selected
+				: $resolver->default_preset( 'kadence/singlebtn', $slug );
+			$values   = $resolver->resolve( 'kadence/singlebtn', $preset, $slug );
+		} catch ( Throwable $e ) {
+			// This runs in the render path, so a broken token graph must not take the page down with it —
+			// the button simply keeps the border it has today.
+			return;
+		}
+
+		if ( isset( $values['button-border-width'] ) ) {
+			$css->add_property( 'border-width', 'var(--kb-btn-border-width)' );
+		}
+
+		if ( isset( $values['button-border-style'] ) ) {
+			$css->add_property( 'border-style', 'var(--kb-btn-border-style)' );
+		}
+
+		if ( isset( $values['button-border-color'] ) ) {
+			$css->add_property( 'border-color', 'var(--kb-btn-border-color)' );
+		}
+	}
+
+	/**
+	 * Point the button's box-shadow at its preset variable, but only when the active preset actually
+	 * resolves one.
+	 *
+	 * The gate is the whole point, exactly as in `render_preset_spacing()` — a `var()` pointed at an
+	 * undefined custom property is invalid at computed-value time, so emitting unconditionally would
+	 * blank out the shadow on a button whose preset sets none.
+	 *
+	 * Emitted before the explicit `displayShadow` output below so an explicit per-block shadow, which
+	 * lands later in the same rule, still wins.
+	 *
+	 * @since TBD
+	 *
+	 * @param Kadence_Blocks_CSS   $css        The css object.
+	 * @param array<string, mixed> $attributes The block attributes.
+	 *
+	 * @return void
+	 */
+	private function render_preset_shadow( Kadence_Blocks_CSS $css, array $attributes ): void {
+		try {
+			$registry = kadence_blocks()->get( Token_Registry::class );
+			$library  = kadence_blocks()->get( Active_Token_Library_Store::class );
+			$resolver = kadence_blocks()->get( Preset_Resolver::class );
+
+			// The container is typed `mixed`, and this runs on every button render, so the services are
+			// checked rather than assumed — a misconfigured container degrades to today's shadow.
+			if (
+				! $registry instanceof Token_Registry
+				|| ! $library instanceof Active_Token_Library_Store
+				|| ! $resolver instanceof Preset_Resolver
+				|| ! $registry->is_active()
+			) {
+				return;
+			}
+
+			$slug     = $library->get();
+			$selected = Cast::to_string( $attributes['kbPreset'] ?? '' );
+			$preset   = $selected !== '' && $resolver->has_preset( 'kadence/singlebtn', $selected, $slug )
+				? $selected
+				: $resolver->default_preset( 'kadence/singlebtn', $slug );
+			$values   = $resolver->resolve( 'kadence/singlebtn', $preset, $slug );
+		} catch ( Throwable $e ) {
+			// This runs in the render path, so a broken token graph must not take the page down with it —
+			// the button simply keeps the shadow it has today.
+			return;
+		}
+
+		if ( isset( $values['button-shadow'] ) ) {
+			$css->add_property( 'box-shadow', 'var(--kb-btn-shadow)' );
 		}
 	}
 

--- a/src/blocks/singlebtn/components/backend-styles/__tests__/preset-border-shadow-properties.test.js
+++ b/src/blocks/singlebtn/components/backend-styles/__tests__/preset-border-shadow-properties.test.js
@@ -1,0 +1,133 @@
+/* eslint-env jest */
+
+/**
+ * `presetBorderProperties()`/`presetShadowProperties()` gate the editor-canvas preview's border and
+ * box-shadow `var()` declarations to only the properties the button's active preset actually
+ * resolves — the JS sibling of the front end's `render_preset_border()`/`render_preset_shadow()`.
+ * Mirrors the mocking strategy the block's other preset-picker consumers use: `activePresetFor`/
+ * `blockPresetValues` are mocked directly rather than exercised through the real token registry,
+ * since this module only cares that the gate reads their return value correctly.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { activePresetFor, blockPresetValues } from '../../../../../extension/preset-picker';
+import { presetBorderProperties, presetShadowProperties } from '../index';
+
+// `backend-styles/index.js` imports the `@kadence/helpers` barrel, which eagerly pulls in a
+// REST-fetch helper that has no `@wordpress/api-fetch` module to resolve under Jest (the same
+// constraint documented in `EditorShadowControl.js`). None of `presetBorderProperties`/
+// `presetShadowProperties` call into the helper library, so a bare stub is enough to let the module
+// load without pulling that dependency in.
+jest.mock('@kadence/helpers', () => ({
+	KadenceBlocksCSS: jest.fn(),
+	getPreviewSize: jest.fn(),
+	KadenceColorOutput: jest.fn(),
+	typographyStyle: jest.fn(),
+	getBorderStyle: jest.fn(),
+	getBorderColor: jest.fn(),
+	getSpacingOptionOutput: jest.fn(),
+}));
+
+jest.mock('../../../../../extension/preset-picker', () => ({
+	activePresetFor: jest.fn(),
+	blockPresetValues: jest.fn(),
+}));
+
+/**
+ * Reset the mocked preset-picker helpers before each test so a prior test's stubbed return values
+ * cannot leak into the next one.
+ *
+ * @return {void}
+ */
+beforeEach(() => {
+	activePresetFor.mockReset();
+	blockPresetValues.mockReset();
+});
+
+describe('presetBorderProperties', () => {
+	/**
+	 * A preset that resolves all three border properties reports all three as present.
+	 *
+	 * @return {void}
+	 */
+	it('reports width, style, and color present when the active preset resolves all three', () => {
+		activePresetFor.mockReturnValue('bold');
+		blockPresetValues.mockReturnValue({
+			bold: {
+				'button-border-width': '2px',
+				'button-border-style': 'solid',
+				'button-border-color': '#171717',
+			},
+		});
+
+		expect(presetBorderProperties({ kbPreset: 'bold' })).toEqual({
+			width: true,
+			style: true,
+			color: true,
+		});
+	});
+
+	/**
+	 * A preset that resolves none of the border properties reports none as present, rather than
+	 * defaulting a missing key to `true`.
+	 *
+	 * @return {void}
+	 */
+	it('reports nothing present when the active preset resolves no border property', () => {
+		activePresetFor.mockReturnValue('$default');
+		blockPresetValues.mockReturnValue({ $default: {} });
+
+		expect(presetBorderProperties({ kbPreset: '' })).toEqual({
+			width: false,
+			style: false,
+			color: false,
+		});
+	});
+
+	/**
+	 * A block whose active preset has no entry in the resolved-values map (an unmapped block or
+	 * library) reports nothing present instead of throwing.
+	 *
+	 * @return {void}
+	 */
+	it('reports nothing present when the active preset has no entry in the resolved-values map', () => {
+		activePresetFor.mockReturnValue('missing');
+		blockPresetValues.mockReturnValue({});
+
+		expect(presetBorderProperties({ kbPreset: 'missing' })).toEqual({
+			width: false,
+			style: false,
+			color: false,
+		});
+	});
+});
+
+describe('presetShadowProperties', () => {
+	/**
+	 * A preset that resolves a box-shadow reports it present.
+	 *
+	 * @return {void}
+	 */
+	it('reports true when the active preset resolves a button-shadow', () => {
+		activePresetFor.mockReturnValue('bold');
+		blockPresetValues.mockReturnValue({
+			bold: { 'button-shadow': '0px 2px 8px 0px #1717171f' },
+		});
+
+		expect(presetShadowProperties({ kbPreset: 'bold' })).toBe(true);
+	});
+
+	/**
+	 * A preset that resolves no box-shadow reports false, rather than emitting a dangling `var()`.
+	 *
+	 * @return {void}
+	 */
+	it('reports false when the active preset resolves no button-shadow', () => {
+		activePresetFor.mockReturnValue('$default');
+		blockPresetValues.mockReturnValue({ $default: {} });
+
+		expect(presetShadowProperties({ kbPreset: '' })).toBe(false);
+	});
+});

--- a/src/blocks/singlebtn/components/backend-styles/index.js
+++ b/src/blocks/singlebtn/components/backend-styles/index.js
@@ -33,6 +33,52 @@ function presetSpacingProperties(attributes) {
 	};
 }
 
+/**
+ * Whether the button's active preset resolves a border width, style, and/or color.
+ *
+ * Reads the same preset surface the inspector does, so the canvas and the panel cannot disagree
+ * about whether a preset carries a border. A block with no explicit selection — or one naming a
+ * preset that no longer exists — follows the block's default preset, exactly as the server's
+ * `has_preset()` / `default_preset()` fallback does.
+ *
+ * @param {Object} attributes The block attributes.
+ *
+ * @since TBD
+ *
+ * @return {{width: boolean, style: boolean, color: boolean}} Which border properties the preset defines.
+ */
+export function presetBorderProperties(attributes) {
+	const preset = activePresetFor('kadence/singlebtn', attributes);
+	const tokens = blockPresetValues('kadence/singlebtn')?.[preset] ?? {};
+
+	return {
+		width: 'button-border-width' in tokens,
+		style: 'button-border-style' in tokens,
+		color: 'button-border-color' in tokens,
+	};
+}
+
+/**
+ * Whether the button's active preset resolves a box-shadow.
+ *
+ * Reads the same preset surface the inspector does, so the canvas and the panel cannot disagree
+ * about whether a preset carries a shadow. A block with no explicit selection — or one naming a
+ * preset that no longer exists — follows the block's default preset, exactly as the server's
+ * `has_preset()` / `default_preset()` fallback does.
+ *
+ * @param {Object} attributes The block attributes.
+ *
+ * @since TBD
+ *
+ * @return {boolean} Whether the preset defines a box-shadow.
+ */
+export function presetShadowProperties(attributes) {
+	const preset = activePresetFor('kadence/singlebtn', attributes);
+	const tokens = blockPresetValues('kadence/singlebtn')?.[preset] ?? {};
+
+	return 'button-shadow' in tokens;
+}
+
 export default function BackendStyles(props) {
 	const { attributes, isSelected, previewDevice, currentRef, context } = props;
 
@@ -854,6 +900,25 @@ export default function BackendStyles(props) {
 	if (previewMarginBottom) {
 		css.add_property('margin-bottom', getSpacingOptionOutput(previewMarginBottom, previewMarginUnit));
 	}
+	/*
+	 * Mirrors the front end's gate (`render_preset_border` in the block's PHP): point border
+	 * width/style/color at the preset variables, but only for a property the active preset actually
+	 * resolves. Written before the per-side output below, so an explicit attribute still wins.
+	 */
+	const presetBorder = presetBorderProperties(attributes);
+
+	if (presetBorder.width) {
+		css.add_property('border-width', 'var(--kb-btn-border-width)');
+	}
+
+	if (presetBorder.style) {
+		css.add_property('border-style', 'var(--kb-btn-border-style)');
+	}
+
+	if (presetBorder.color) {
+		css.add_property('border-color', 'var(--kb-btn-border-color)');
+	}
+
 	if (previewBorderTopStyle) {
 		css.add_property('border-top', previewBorderTopStyle);
 	}
@@ -881,6 +946,15 @@ export default function BackendStyles(props) {
 		'border-radius',
 		borderRadiusUnit ? borderRadiusUnit : 'px'
 	);
+	/*
+	 * Mirrors the front end's gate (`render_preset_shadow` in the block's PHP): point box-shadow at
+	 * the preset variable, but only when the active preset actually resolves one. Written before the
+	 * explicit shadow output below, so an explicit per-block shadow still wins.
+	 */
+	if (presetShadowProperties(attributes)) {
+		css.add_property('box-shadow', 'var(--kb-btn-shadow)');
+	}
+
 	css.add_property(
 		'box-shadow',
 		undefined !== displayShadow &&

--- a/tests/helpers/CSSTestHelper.php
+++ b/tests/helpers/CSSTestHelper.php
@@ -97,6 +97,25 @@ class CSSTestHelper {
 	}
 
 	/**
+	 * The declared property names for a selector, in the exact order they were written, excluding
+	 * media queries. A property declared twice (an override) appears twice, in encounter order — the
+	 * ordering `assertCSSPropertiesEqual`'s associative collapse cannot expose, but is exactly what a
+	 * cascade-order assertion (preset var before an explicit override) needs to check directly.
+	 *
+	 * @param string $selector The selector to read, matched exactly as it appears in the source.
+	 *
+	 * @return array<int, string> The property names, in declaration order.
+	 */
+	public function getPropertyOrder($selector): array {
+		return array_map(
+			function ($rule) {
+				return $rule->getRule();
+			},
+			$this->getRulesForSelector($selector)
+		);
+	}
+
+	/**
 	 * Get rules for a selector, excluding media queries
 	 */
 	private function getRulesForSelector($selector) {

--- a/tests/wpunit/Blocks/SinglebtnTest.php
+++ b/tests/wpunit/Blocks/SinglebtnTest.php
@@ -210,8 +210,10 @@ class SinglebtnTest extends KadenceBlocksUnit {
 		);
 
 		// The final computed value is whichever declaration came last — proving the explicit value,
-		// not the preset's, is what the button actually renders.
-		$css_helper->assertCSSPropertiesEqual( $selector, [ 'box-shadow' => '1px 1px 2px 0px #00ff00' ] );
+		// not the preset's, is what the button actually renders. Sabberworm's CSS parser canonicalizes
+		// a 6-digit hex that can shorten to its 3-digit form when re-serializing, so the shorthand is
+		// what assertCSSPropertiesEqual sees even though the block itself renders the literal '#00ff00'.
+		$css_helper->assertCSSPropertiesEqual( $selector, [ 'box-shadow' => '1px 1px 2px 0px #0f0' ] );
 	}
 
 	/**

--- a/tests/wpunit/Blocks/SinglebtnTest.php
+++ b/tests/wpunit/Blocks/SinglebtnTest.php
@@ -2,9 +2,19 @@
 
 namespace Tests\wpunit\Blocks;
 
+use Kadence_Blocks_CSS;
 use Kadence_Blocks_Singlebtn_Block;
+use KadenceWP\KadenceBlocks\App;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Container;
 use Tests\Support\Classes\KadenceBlocksUnit;
+use Tests\helpers\CSSTestHelper;
 
+/**
+ * Covers `render_preset_border()`/`render_preset_shadow()` — the front end's bridge from a button's
+ * selected preset to its rendered border and box-shadow CSS, mirroring `render_preset_spacing()`'s
+ * own coverage shape.
+ */
 class SinglebtnTest extends KadenceBlocksUnit {
 	/**
 	 * Block name.
@@ -20,10 +30,238 @@ class SinglebtnTest extends KadenceBlocksUnit {
 	 */
 	protected $block;
 
+	/**
+	 * CSS instance.
+	 *
+	 * @var Kadence_Blocks_CSS
+	 */
+	protected $css;
+
+	/**
+	 * The service container, used to persist token-library presets ahead of a render.
+	 *
+	 * @var Container
+	 */
+	protected $container;
+
 	protected function setUp(): void {
 		parent::setUp();
-		$this->block = new Kadence_Blocks_Singlebtn_Block();
+
+		$this->block     = new Kadence_Blocks_Singlebtn_Block();
+		$this->css       = new Kadence_Blocks_CSS();
+		$this->container = App::instance()->container();
 	}
 
+	/**
+	 * A named, non-`$default` preset ("secondary") that resolves `button-border-width` emits the
+	 * property pointed at its preset variable.
+	 *
+	 * @return void
+	 */
+	public function testNamedPresetBorderWidthEmitsCssVar(): void {
+		$output = $this->render_button( [ 'kbPreset' => 'secondary' ] );
 
+		$this->assertStringContainsString( 'border-width:var(--kb-btn-border-width)', $output );
+	}
+
+	/**
+	 * The same named preset's `button-border-style` and `button-border-color` are also emitted.
+	 *
+	 * @return void
+	 */
+	public function testNamedPresetBorderStyleAndColorEmitCssVars(): void {
+		$output = $this->render_button( [ 'kbPreset' => 'secondary' ] );
+
+		$this->assertStringContainsString( 'border-style:var(--kb-btn-border-style)', $output );
+		$this->assertStringContainsString( 'border-color:var(--kb-btn-border-color)', $output );
+	}
+
+	/**
+	 * A named preset that resolves `button-shadow` emits box-shadow pointed at its preset variable.
+	 *
+	 * @return void
+	 */
+	public function testNamedPresetShadowEmitsCssVar(): void {
+		$this->seedPreset(
+			'accent',
+			'Accent',
+			[ 'button-shadow' => '0px 2px 8px 0px #1717171f' ]
+		);
+
+		$output = $this->render_button( [ 'kbPreset' => 'accent' ] );
+
+		$this->assertStringContainsString( 'box-shadow:var(--kb-btn-shadow)', $output );
+	}
+
+	/**
+	 * A preset that defines no border property (only an unrelated one) emits none of the border
+	 * `var()` declarations — the `isset()` gate stays closed rather than emitting a dead reference.
+	 *
+	 * @return void
+	 */
+	public function testPresetWithNoBorderPropertyEmitsNoBorderVars(): void {
+		$this->seedPreset( 'bare', 'Bare', [ 'button-bg' => '#ff0000' ] );
+
+		$output = $this->render_button( [ 'kbPreset' => 'bare' ] );
+
+		$this->assertStringNotContainsString( 'border-width:var(--kb-btn-border-width)', $output );
+		$this->assertStringNotContainsString( 'border-style:var(--kb-btn-border-style)', $output );
+		$this->assertStringNotContainsString( 'border-color:var(--kb-btn-border-color)', $output );
+	}
+
+	/**
+	 * A preset that defines no `button-shadow` emits no box-shadow `var()` declaration.
+	 *
+	 * @return void
+	 */
+	public function testPresetWithNoShadowPropertyEmitsNoShadowVar(): void {
+		$this->seedPreset( 'bare', 'Bare', [ 'button-bg' => '#ff0000' ] );
+
+		$output = $this->render_button( [ 'kbPreset' => 'bare' ] );
+
+		$this->assertStringNotContainsString( 'box-shadow:var(--kb-btn-shadow)', $output );
+	}
+
+	/**
+	 * An explicit per-instance border still wins over the selected preset's border: the preset's
+	 * `var()` declaration lands earlier in the generated rule than the explicit per-side output, so
+	 * the plain CSS cascade (same selector, same specificity, later declaration wins) resolves to the
+	 * explicit value. Declaration order is asserted directly, not just the final computed value,
+	 * because order is the actual mechanism that makes the override work.
+	 *
+	 * @return void
+	 */
+	public function testExplicitBorderOverridesPresetBorder(): void {
+		$output = $this->render_button(
+			[
+				'kbPreset'    => 'secondary',
+				'borderStyle' => [
+					[
+						'top'    => [ '#ff0000', 'dashed', 4 ],
+						'right'  => [ '#ff0000', 'dashed', 4 ],
+						'bottom' => [ '#ff0000', 'dashed', 4 ],
+						'left'   => [ '#ff0000', 'dashed', 4 ],
+						'unit'   => 'px',
+					],
+				],
+			]
+		);
+
+		$this->assertStringContainsString( 'border-top:4px dashed #ff0000', $output );
+
+		$order             = ( new CSSTestHelper( $output ) )->getPropertyOrder( '.wp-block-kadence-advancedbtn .kb-btn123.kb-button' );
+		$preset_position   = array_search( 'border-width', $order, true );
+		$explicit_position = array_search( 'border-top', $order, true );
+
+		$this->assertNotFalse( $preset_position, 'The preset border-width var() should still be emitted.' );
+		$this->assertNotFalse( $explicit_position, 'The explicit per-instance border should be emitted.' );
+		$this->assertLessThan(
+			$explicit_position,
+			$preset_position,
+			'The preset border var() must be emitted before the explicit per-instance border, so the explicit value wins the cascade.'
+		);
+	}
+
+	/**
+	 * An explicit per-instance box-shadow still wins over the selected preset's shadow: both declare
+	 * the same `box-shadow` property in the same rule, so the final computed value is whichever comes
+	 * last. This asserts both the winning value AND that the preset's declaration precedes it.
+	 *
+	 * @return void
+	 */
+	public function testExplicitShadowOverridesPresetShadow(): void {
+		$this->seedPreset(
+			'accent',
+			'Accent',
+			[ 'button-shadow' => '0px 2px 8px 0px #1717171f' ]
+		);
+
+		$output = $this->render_button(
+			[
+				'kbPreset'      => 'accent',
+				'displayShadow' => true,
+				'shadow'        => [
+					[
+						'color'   => '#00ff00',
+						'opacity' => 1,
+						'hOffset' => 1,
+						'vOffset' => 1,
+						'blur'    => 2,
+						'spread'  => 0,
+						'inset'   => false,
+					],
+				],
+			]
+		);
+
+		$css_helper = new CSSTestHelper( $output );
+		$selector   = '.wp-block-kadence-advancedbtn .kb-btn123.kb-button';
+
+		// `box-shadow` is declared twice in the same rule (preset, then explicit) — the associative
+		// collapse `assertCSSPropertiesEqual` does elsewhere would hide that, so declaration order is
+		// read directly from the parsed property list instead.
+		$shadow_positions = array_keys( $css_helper->getPropertyOrder( $selector ), 'box-shadow', true );
+
+		$this->assertCount( 2, $shadow_positions, 'Both the preset and the explicit box-shadow should be emitted.' );
+		$this->assertLessThan(
+			$shadow_positions[1],
+			$shadow_positions[0],
+			'The preset box-shadow var() must be emitted before the explicit per-instance shadow, so the explicit value wins the cascade.'
+		);
+
+		// The final computed value is whichever declaration came last — proving the explicit value,
+		// not the preset's, is what the button actually renders.
+		$css_helper->assertCSSPropertiesEqual( $selector, [ 'box-shadow' => '1px 1px 2px 0px #00ff00' ] );
+	}
+
+	/**
+	 * Build the button's rendered CSS for a fixed unique id, filling in the attributes every render
+	 * needs (`uniqueID`) alongside the case-specific ones under test.
+	 *
+	 * @param array<string, mixed> $attributes Attributes to merge over the minimal defaults.
+	 *
+	 * @return string The rendered CSS.
+	 */
+	private function render_button( array $attributes ): string {
+		$unique_id = '123';
+
+		return $this->block->build_css(
+			array_merge( [ 'uniqueID' => $unique_id ], $attributes ),
+			$this->css,
+			$unique_id,
+			$unique_id
+		);
+	}
+
+	/**
+	 * Persist a single button preset into the default token library's overrides document, mirroring
+	 * `Preset_ResolverTest::seedPreset()`.
+	 *
+	 * @param string               $preset The preset slug.
+	 * @param string               $label  The preset label.
+	 * @param array<string, mixed> $tokens The property => value map for the preset.
+	 *
+	 * @return void
+	 */
+	private function seedPreset( string $preset, string $label, array $tokens ): void {
+		/** @var Token_Store $store */
+		$store = $this->container->get( Token_Store::class );
+
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'presets' => [
+						'kadence/singlebtn' => [
+							$preset => [
+								'label'  => $label,
+								'tokens' => $tokens,
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$store->save_document( (string) wp_json_encode( $document ), Token_Store::default_slug() );
+	}
 }


### PR DESCRIPTION
## Summary
- Adds `render_preset_border()`/`render_preset_shadow()` (PHP) and `presetBorderProperties()`/`presetShadowProperties()` (JS), mirroring the existing `render_preset_spacing()`/`presetSpacingProperties()` pattern, so a selected (named, non-default) preset's border and shadow values actually reach rendered CSS on both the front end and the block-editor canvas preview — the same way padding and margin already work.
- An explicit per-instance override still wins over the preset's value, by CSS declaration order (preset emitted first, explicit attribute output after, in the same rule).

## Test plan
- [x] wpunit coverage proving a named, non-default preset changes emitted CSS, and that an explicit per-instance override still wins (declaration order asserted directly).
- [x] `npx jest` — full suite green.
- [ ] Manual verification on the dev site: two Button presets with different border widths render differently, and overriding one specific block instance's border still wins over its own preset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single-button presets now support border width, style, color, and shadow settings.
  * Preset styling is applied automatically when configured.
  * Explicit button border and shadow styles take precedence over preset values.
  * Missing or incomplete preset properties are handled without affecting existing styles.

* **Tests**
  * Added coverage for preset-driven border and shadow styling, fallback behavior, CSS output, and style precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->