### PR TITLE
[DTM] SOFT-4083 [33/38]: box fields adopt the one-row anatomy

### DIFF
--- a/src/token-controls/__tests__/slot-grid.test.js
+++ b/src/token-controls/__tests__/slot-grid.test.js
@@ -1,0 +1,141 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { SlotGrid } from '../templates/SlotGrid';
+
+let container;
+let root;
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+/**
+ * Render a `SlotGrid` with a bare-bones `renderSlot` that just tags its output with the index it
+ * received, and return the container to assert against.
+ *
+ * @param {Object} props Props to merge over the defaults.
+ *
+ * @since TBD
+ *
+ * @return {HTMLElement} The container `SlotGrid` rendered into.
+ */
+function renderSlotGrid(props = {}) {
+	act(() => {
+		root.render(
+			createElement(SlotGrid, {
+				value: '4px',
+				onChange: () => {},
+				isLinked: false,
+				role: 'sides',
+				renderSlot: ({ index }) =>
+					createElement('div', { className: 'stub-slot', 'data-index': index ?? 'linked' }),
+				...props,
+			})
+		);
+	});
+
+	return container;
+}
+
+describe('SlotGrid glyph', () => {
+	it('renders a row per slot, each holding a glyph before the field', () => {
+		renderSlotGrid();
+
+		const rows = container.querySelectorAll('.kb-token-control__row');
+
+		expect(rows).toHaveLength(4);
+		rows.forEach((row) => {
+			const glyph = row.querySelector('.kb-token-control__glyph');
+
+			expect(glyph).not.toBeNull();
+			expect(row.querySelector('.stub-slot')).not.toBeNull();
+			// The glyph precedes the field within the row.
+			expect(row.firstElementChild).toBe(glyph);
+		});
+	});
+
+	it('highlights the single matching edge for a sides slot', () => {
+		renderSlotGrid({ role: 'sides' });
+
+		const glyphs = [...container.querySelectorAll('.kb-token-control__glyph')];
+		const positions = glyphs.map((glyph) => glyph.className);
+
+		expect(positions[0]).toContain('kb-token-control__glyph--top');
+		expect(positions[1]).toContain('kb-token-control__glyph--right');
+		expect(positions[2]).toContain('kb-token-control__glyph--bottom');
+		expect(positions[3]).toContain('kb-token-control__glyph--left');
+	});
+
+	it('highlights the corner-named position for a corners slot, in visual (not stored) order', () => {
+		renderSlotGrid({ role: 'corners' });
+
+		const glyphs = [...container.querySelectorAll('.kb-token-control__glyph')];
+		const positions = glyphs.map((glyph) => glyph.className);
+
+		// GRID_ORDER for corners is [0, 1, 3, 2]: top-left, top-right, bottom-left, bottom-right.
+		expect(positions[0]).toContain('kb-token-control__glyph--top-left');
+		expect(positions[1]).toContain('kb-token-control__glyph--top-right');
+		expect(positions[2]).toContain('kb-token-control__glyph--bottom-left');
+		expect(positions[3]).toContain('kb-token-control__glyph--bottom-right');
+	});
+
+	it('tags every glyph with its role', () => {
+		renderSlotGrid({ role: 'corners' });
+
+		container.querySelectorAll('.kb-token-control__glyph').forEach((glyph) => {
+			expect(glyph.className).toContain('kb-token-control__glyph--corners');
+		});
+	});
+
+	it('renders one row with the "all" glyph variant while linked, for the sides role', () => {
+		renderSlotGrid({ isLinked: true, role: 'sides' });
+
+		const rows = container.querySelectorAll('.kb-token-control__row');
+
+		expect(rows).toHaveLength(1);
+
+		const glyph = rows[0].querySelector('.kb-token-control__glyph');
+
+		expect(glyph.className).toContain('kb-token-control__glyph--sides');
+		expect(glyph.className).toContain('kb-token-control__glyph--all');
+		expect(rows[0].querySelector('.stub-slot').dataset.index).toBe('linked');
+	});
+
+	it('renders one row with the "all" glyph variant while linked, for the corners role', () => {
+		renderSlotGrid({ isLinked: true, role: 'corners' });
+
+		const glyph = container.querySelector('.kb-token-control__glyph');
+
+		expect(glyph.className).toContain('kb-token-control__glyph--corners');
+		expect(glyph.className).toContain('kb-token-control__glyph--all');
+	});
+
+	it('wraps unlinked rows in the flex-column grid container', () => {
+		renderSlotGrid({ isLinked: false });
+
+		expect(container.querySelector('.kb-token-control__grid')).not.toBeNull();
+	});
+
+	it('does not wrap the single linked row in the grid container', () => {
+		renderSlotGrid({ isLinked: true });
+
+		expect(container.querySelector('.kb-token-control__grid')).toBeNull();
+	});
+});

--- a/src/token-controls/__tests__/slot-grid.test.js
+++ b/src/token-controls/__tests__/slot-grid.test.js
@@ -83,17 +83,18 @@ describe('SlotGrid glyph', () => {
 		expect(positions[3]).toContain('kb-token-control__glyph--left');
 	});
 
-	it('highlights the corner-named position for a corners slot, in visual (not stored) order', () => {
+	it('highlights the corner-named position for a corners slot, walking clockwise', () => {
 		renderSlotGrid({ role: 'corners' });
 
 		const glyphs = [...container.querySelectorAll('.kb-token-control__glyph')];
 		const positions = glyphs.map((glyph) => glyph.className);
 
-		// GRID_ORDER for corners is [0, 1, 3, 2]: top-left, top-right, bottom-left, bottom-right.
+		// SLOT_LABELS.corners is already clockwise, and the stacked-row grid renders that order
+		// directly: top-left, top-right, bottom-right, bottom-left.
 		expect(positions[0]).toContain('kb-token-control__glyph--top-left');
 		expect(positions[1]).toContain('kb-token-control__glyph--top-right');
-		expect(positions[2]).toContain('kb-token-control__glyph--bottom-left');
-		expect(positions[3]).toContain('kb-token-control__glyph--bottom-right');
+		expect(positions[2]).toContain('kb-token-control__glyph--bottom-right');
+		expect(positions[3]).toContain('kb-token-control__glyph--bottom-left');
 	});
 
 	it('tags every glyph with its role', () => {

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -455,7 +455,7 @@
 .kb-token-control__grid {
 	display: flex;
 	flex-direction: column;
-	gap: 10px;
+	gap: 8px;
 }
 
 /*
@@ -470,13 +470,26 @@
 
 	/*
 	 * The row's own control-box chrome. Unlinked rows previously centered/stacked the trigger's text
-	 * at a smaller size here; that override is gone; what is left is sizing the trigger as the row's
-	 * control box, not restyling its type — font-size/color stay the base trigger's.
+	 * at a smaller size here; that override is gone. Border-color and border-radius are box-model
+	 * properties, not typography, so they follow the reference's control-box values (reusing this
+	 * file's own `#dddddd` gray-300 divider color rather than the reference's literal `#d8dade`,
+	 * since it is already the established "light gray border" in this style sheet); font-size, weight
+	 * and color are left alone, inherited from the base trigger rule.
+	 *
+	 * `:where()` wraps the row scoping so this rule's specificity comes only from
+	 * `.kadence-token-field__trigger.components-button` itself (two classes) — level with that base
+	 * rule's own resting border-color, but still below its `:hover`/`[aria-expanded="true"]` states
+	 * (two classes plus a pseudo-class/attribute selector). Written as a plain descendant selector,
+	 * this override's extra class would tie those interactive states on specificity and — being
+	 * declared later in the file — win over them, so hovering or opening a row's popover would stop
+	 * changing its border color.
 	 */
-	.kadence-token-field__trigger.components-button {
+	:where(&) .kadence-token-field__trigger.components-button {
 		flex: 1 1 auto;
 		height: auto;
 		padding: 7px 10px;
+		border-color: #dddddd;
+		border-radius: 5px;
 	}
 }
 

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -451,146 +451,107 @@
 	gap: 4px;
 }
 
-/* The unlinked slot grid: two columns, in the display order the control's role decided. */
+/* The unlinked rows: one column, stacked, in the display order the control's role decided. */
 .kb-token-control__grid {
-	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
-	gap: 4px;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
 }
 
 /*
- * A slot in the unlinked grid: a titled cell, the title and the field reading as one box.
- *
- * Half the control's width has to carry a token name and its value, and inline they do not fit — at
- * the panel's width the name alone is about as wide as the whole slot, so side by side the name is
- * what gets truncated. Stacking gives the name the full width and keeps the value visible under it.
+ * One row: the glyph, then the control box (the field renderSlot() supplies). Shared by the single
+ * linked row and every unlinked row, so linked mode gets the same anatomy — glyph included — instead
+ * of a bare field.
  */
-.kb-token-control__slot {
-	/* Local to this library on purpose: shared CSS cannot reach for a host's own spacing scale. */
-	--kb-token-control-slot-padding-y: 0.25rem;
-	--kb-token-control-slot-padding-x: 0.5rem;
-	/* Clears the field's 1px border, so the mark reads as inside the box rather than drawn over it. */
-	--kb-token-control-mark-inset: 1px;
-	/* Floored at zero so a field flatter than the inset cannot ask for a negative radius. */
-	--kb-token-control-mark-radius: max(
-		0px,
-		calc(var(--kb-token-control-field-radius, 2px) - var(--kb-token-control-mark-inset))
-	);
+.kb-token-control__row {
+	display: flex;
+	align-items: center;
+	gap: 10px;
 
-	position: relative;
-
+	/*
+	 * The row's own control-box chrome. Unlinked rows previously centered/stacked the trigger's text
+	 * at a smaller size here; that override is gone; what is left is sizing the trigger as the row's
+	 * control box, not restyling its type — font-size/color stay the base trigger's.
+	 */
 	.kadence-token-field__trigger.components-button {
-		flex-direction: column;
-		align-items: center;
-		justify-content: center;
-		gap: 0;
+		flex: 1 1 auto;
 		height: auto;
-		padding: var(--kb-token-control-slot-padding-y) var(--kb-token-control-slot-padding-x);
-		border-radius: var(--kb-token-control-field-radius, 2px);
-		font-size: 12px;
-		text-align: center;
+		padding: 7px 10px;
 	}
+}
 
-	.kadence-token-field__label {
-		max-width: 100%;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
+/*
+ * The row's leading glyph: a small standalone box marking which edge(s) the row names, rather than a
+ * `::before` overlay on the field's own border. Base state is a plain 1px square; the modifiers below
+ * thicken and re-color one or more of its own edges (and, for a corner, round it) to point at the
+ * position the row is for. Border color reuses the same `--kb-border-dark-color` custom property the
+ * previous `::before` mark used, so the highlighted edge keeps its established color.
+ */
+.kb-token-control__glyph {
+	box-sizing: border-box;
+	flex: none;
+	width: 15px;
+	height: 15px;
+	border: 1px solid #949494;
+	border-radius: 2px;
+}
 
-	/* Set explicitly on the base rule, so it has to be pulled back to the slot's own size here. */
-	.kadence-token-field__value {
-		font-size: inherit;
-	}
+.kb-token-control__glyph--top,
+.kb-token-control__glyph--top-left,
+.kb-token-control__glyph--top-right,
+.kb-token-control__glyph--all {
+	border-top-width: 2px;
+	border-top-color: var(--kb-border-dark-color, #6f8094);
+}
 
-	/*
-	 * The position mark hangs off the field itself rather than the cell, so it can sit on the very
-	 * corner (or edge) it names. It is inset by its own border width so it reads as sitting just inside
-	 * the field rather than smudging the field's own border.
-	 */
-	.kadence-token-field {
-		position: relative;
-	}
+.kb-token-control__glyph--right,
+.kb-token-control__glyph--top-right,
+.kb-token-control__glyph--bottom-right,
+.kb-token-control__glyph--all {
+	border-right-width: 2px;
+	border-right-color: var(--kb-border-dark-color, #6f8094);
+}
 
-	.kadence-token-field::before {
-		position: absolute;
-		z-index: 1;
-		box-sizing: border-box;
-		width: 1rem;
-		height: 1rem;
-		border: 0 solid var(--kb-border-dark-color, #6f8094);
-		content: "";
-		pointer-events: none;
-	}
+.kb-token-control__glyph--bottom,
+.kb-token-control__glyph--bottom-right,
+.kb-token-control__glyph--bottom-left,
+.kb-token-control__glyph--all {
+	border-bottom-width: 2px;
+	border-bottom-color: var(--kb-border-dark-color, #6f8094);
+}
 
-	/*
-	 * One rule set for both geometries, because they are the same idea at different arity: a corner
-	 * sets two adjacent borders, a side sets one. Radius uses the corner classes; border, margin and
-	 * padding use the side ones. Each edge is addressed with its own offset, so a corner simply gets
-	 * two of them and needs no transform to reach the far side.
-	 */
-	&--top-left .kadence-token-field::before,
-	&--top-right .kadence-token-field::before,
-	&--top .kadence-token-field::before {
-		top: var(--kb-token-control-mark-inset);
-		border-top-width: 3px;
-	}
+.kb-token-control__glyph--left,
+.kb-token-control__glyph--top-left,
+.kb-token-control__glyph--bottom-left,
+.kb-token-control__glyph--all {
+	border-left-width: 2px;
+	border-left-color: var(--kb-border-dark-color, #6f8094);
+}
 
-	&--bottom-left .kadence-token-field::before,
-	&--bottom-right .kadence-token-field::before,
-	&--bottom .kadence-token-field::before {
-		bottom: var(--kb-token-control-mark-inset);
-		border-bottom-width: 3px;
-	}
+/*
+ * A corner glyph also rounds the one corner it names, matching the four-corner rounding the previous
+ * `::before` mark drew via `--kb-token-control-mark-radius`, reapplied here to a real element instead.
+ */
+.kb-token-control__glyph--top-left {
+	border-top-left-radius: 5px;
+}
 
-	&--top-left .kadence-token-field::before,
-	&--bottom-left .kadence-token-field::before,
-	&--left .kadence-token-field::before {
-		left: var(--kb-token-control-mark-inset);
-		border-left-width: 3px;
-	}
+.kb-token-control__glyph--top-right {
+	border-top-right-radius: 5px;
+}
 
-	&--top-right .kadence-token-field::before,
-	&--bottom-right .kadence-token-field::before,
-	&--right .kadence-token-field::before {
-		right: var(--kb-token-control-mark-inset);
-		border-right-width: 3px;
-	}
+.kb-token-control__glyph--bottom-right {
+	border-bottom-right-radius: 5px;
+}
 
-	/*
-	 * A corner mark traces the field's own corner, so it follows the same curve — left square, it would
-	 * cut across the rounded edge it is tracing. Inset by the mark's own offset, though: a curve sitting
-	 * 1px inside a 2px one is a 1px curve, so the radius is the field's less the inset rather than the
-	 * field's outright. A side mark is mid-edge and stays straight.
-	 */
-	&--top-left .kadence-token-field::before {
-		border-top-left-radius: var(--kb-token-control-mark-radius);
-	}
+.kb-token-control__glyph--bottom-left {
+	border-bottom-left-radius: 5px;
+}
 
-	&--top-right .kadence-token-field::before {
-		border-top-right-radius: var(--kb-token-control-mark-radius);
-	}
-
-	&--bottom-right .kadence-token-field::before {
-		border-bottom-right-radius: var(--kb-token-control-mark-radius);
-	}
-
-	&--bottom-left .kadence-token-field::before {
-		border-bottom-left-radius: var(--kb-token-control-mark-radius);
-	}
-
-	/* A side names one edge, so it is centered along that edge rather than pinned to a corner. */
-	&--top .kadence-token-field::before,
-	&--bottom .kadence-token-field::before {
-		left: 50%;
-		transform: translateX(-50%);
-	}
-
-	&--left .kadence-token-field::before,
-	&--right .kadence-token-field::before {
-		top: 50%;
-		transform: translateY(-50%);
-	}
+/* Linked mode's "all corners" glyph rounds every corner, standing in for "every corner is this one
+   value" the way the unlinked grid otherwise shows one corner at a time. */
+.kb-token-control__glyph--corners.kb-token-control__glyph--all {
+	border-radius: 5px;
 }
 
 .kb-token-control__indicator {

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -470,11 +470,11 @@
 
 	/*
 	 * The row's own control-box chrome. Unlinked rows previously centered/stacked the trigger's text
-	 * at a smaller size here; that override is gone. Border-color and border-radius are box-model
-	 * properties, not typography, so they follow the reference's control-box values (reusing this
-	 * file's own `#dddddd` gray-300 divider color rather than the reference's literal `#d8dade`,
-	 * since it is already the established "light gray border" in this style sheet); font-size, weight
-	 * and color are left alone, inherited from the base trigger rule.
+	 * at a smaller size here; that override is gone. Border-color and border-radius are left as the
+	 * base trigger rule's own values (`#949494`, 2px) rather than the reference's control-box values
+	 * — the row's arrangement changes (glyph, stacked layout), but the trigger itself keeps its
+	 * established appearance; font-size, weight and color are also left alone, inherited from the
+	 * base trigger rule.
 	 *
 	 * `:where()` wraps the row scoping so this rule's specificity comes only from
 	 * `.kadence-token-field__trigger.components-button` itself (two classes) — level with that base
@@ -488,8 +488,6 @@
 		flex: 1 1 auto;
 		height: auto;
 		padding: 7px 10px;
-		border-color: #dddddd;
-		border-radius: 5px;
 	}
 }
 

--- a/src/token-controls/templates/SlotGrid.js
+++ b/src/token-controls/templates/SlotGrid.js
@@ -25,6 +25,54 @@ const GRID_ORDER = {
 };
 
 /**
+ * The position label a glyph keys its highlighted edge(s) on: the slot's own label, or `'all'` for
+ * the linked, every-edge state — a state the grid never rendered before this row anatomy.
+ *
+ * @param {string}  role  'sides' or 'corners' — picks the label set.
+ * @param {?number} index The slot index, or `null` while linked.
+ *
+ * @since TBD
+ *
+ * @return {string} The position the glyph's modifier class keys on.
+ */
+function glyphPosition(role, index) {
+	if (index === null) {
+		return 'all';
+	}
+
+	const labels = SLOT_LABELS[role] ?? SLOT_LABELS.sides;
+
+	return labels[index] ?? 'all';
+}
+
+/**
+ * The row's leading glyph: a small box marking which edge(s) a slot names.
+ *
+ * A real element rather than a border overlay on the field, so its edges are independent of the
+ * field's own border/radius. Role-agnostic geometry — `sides` highlights one edge, `corners`
+ * highlights two adjacent edges and rounds the corner they meet at, and the linked `all` state
+ * highlights every edge (and, for corners, rounds every corner) — so the same helper serves any
+ * future role built on the same `sides`/`corners` distinction.
+ *
+ * @param {string}  role  'sides' or 'corners'.
+ * @param {?number} index The slot index, or `null` while linked.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The glyph element.
+ */
+function renderGlyph(role, index) {
+	const position = glyphPosition(role, index);
+
+	return (
+		<span
+			className={`kb-token-control__glyph kb-token-control__glyph--${role} kb-token-control__glyph--${position}`}
+			aria-hidden="true"
+		/>
+	);
+}
+
+/**
  * Render a value as one slot or four.
  *
  * @param {Object}   props            The component props.
@@ -32,13 +80,13 @@ const GRID_ORDER = {
  * @param {Function} props.onChange   Called with the next whole value.
  * @param {boolean}  props.isLinked   Render one slot rather than the grid.
  * @param {Function} props.renderSlot `({ value, onChange, label, index }) => Element`.
- * @param {string}   [props.role]     'sides' or 'corners' — picks labels and grid order.
+ * @param {string}   [props.role]     'sides' or 'corners' — picks labels, grid order, and glyph shape.
  * @param {string}   [props.label]    Fallback label for the linked slot.
  * @param {boolean}  [props.collapse] Collapse four identical slots to a scalar on write.
  *
  * @since TBD
  *
- * @return {JSX.Element} The rendered slot or grid.
+ * @return {JSX.Element} The rendered slot or grid, each row led by its glyph.
  */
 export function SlotGrid({ value, onChange, isLinked, renderSlot, role = 'sides', label, collapse = false }) {
 	const labels = SLOT_LABELS[role] ?? SLOT_LABELS.sides;
@@ -46,22 +94,29 @@ export function SlotGrid({ value, onChange, isLinked, renderSlot, role = 'sides'
 
 	if (isLinked) {
 		// Reading slot 0 rather than passing the raw value: a caller whose storage is always an
-		// array (the block editor) still shows one field with a real value in linked mode.
-		return renderSlot({
-			value: readSlot(value, 0),
-			onChange: (next) => onChange(collapse ? next : Array(labels.length).fill(next)),
-			label,
-			index: null,
-		});
+		// array (the block editor) still shows one field with a real value in linked mode. The row
+		// still gets a glyph — the "all edges"/"all corners" variant — where linked mode used to
+		// render no mark at all.
+		return (
+			<div className="kb-token-control__row">
+				{renderGlyph(role, null)}
+				{renderSlot({
+					value: readSlot(value, 0),
+					onChange: (next) => onChange(collapse ? next : Array(labels.length).fill(next)),
+					label,
+					index: null,
+				})}
+			</div>
+		);
 	}
 
-	// Each slot is wrapped and tagged with its position, which is what lets one rule set draw the
-	// "which part of the box is this" mark for both geometries: a corner is two adjacent borders, a
-	// side is one. The suffix is the slot label verbatim, so the classes cannot drift from the order.
+	// Each row is tagged with its position for identification/testing; the glyph inside it (not a
+	// CSS rule keyed on this class) is what actually draws the highlighted edge(s).
 	return (
 		<div className="kb-token-control__grid">
 			{order.map((index) => (
-				<div key={index} className={`kb-token-control__slot kb-token-control__slot--${labels[index]}`}>
+				<div key={index} className={`kb-token-control__row kb-token-control__row--${labels[index]}`}>
+					{renderGlyph(role, index)}
 					{renderSlot({
 						value: readSlot(value, index),
 						onChange: (next) => onChange(writeSlot(value, index, next, collapse)),

--- a/src/token-controls/templates/SlotGrid.js
+++ b/src/token-controls/templates/SlotGrid.js
@@ -13,15 +13,18 @@ import { SLOT_LABELS, readSlot, writeSlot } from '../helpers/value-shapes';
 /**
  * Display order for the unlinked grid, per role.
  *
- * Corners walk clockwise (top-left, top-right, bottom-right, bottom-left), which is not reading
- * order — so the grid renders slots 0, 1, 3, 2 to put each corner in its true visual position.
- * Sides keep identity order. The stored array order never changes either way.
+ * `SLOT_LABELS.corners` is already stored clockwise (top-left, top-right, bottom-right,
+ * bottom-left), so identity order *is* visual order for the single-column stacked rows this grid
+ * renders. (The old 2x2 spatial grid needed slots 0, 1, 3, 2 to put each corner in its true
+ * on-screen quadrant — row-major reading of a 2x2 square isn't clockwise — but a one-column list
+ * has no quadrants to match, so it reads the stored clockwise order directly.) Sides also keep
+ * identity order. The stored array order never changes either way.
  *
  * @since TBD
  */
 const GRID_ORDER = {
 	sides: [0, 1, 2, 3],
-	corners: [0, 1, 3, 2],
+	corners: [0, 1, 2, 3],
 };
 
 /**


### PR DESCRIPTION
## Summary
- Replaces the shared box-control arrangement — a 2-column grid where each cell centered a stacked label/value and drew its position mark as a `::before` overlay — with a single-column stacked-row anatomy shared by all box fields: Padding, Margin, Border, and Border Radius.
- The position glyph (side or corner) is now a real element `SlotGrid` renders per row, including a new "all sides/corners" variant for linked mode (previously no mark at all).
- Trigger border-color and radius keep their original values — only the row's arrangement changed (glyph, stacked layout), not the trigger's own chrome.

## Test plan
- [x] `npx jest` — full suite green, including regression coverage for the two already-shipped consumers (Radius, Spacing).
- [x] `bun run lint-js`, `bun run build`.
- [ ] Manual verification on the dev site: unlinking Radius and Spacing's Padding/Margin renders stacked rows with a glyph per row; linking collapses to one row with an "all" glyph.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Updated token controls with a consistent row-based layout for linked and unlinked modes.
  * Added clearer, accessible indicators for top, right, bottom, left, corner, and all-edge states.
  * Improved visual highlighting and corner styling for active positions.
* **Quality**
  * Expanded automated coverage for slot arrangement, positioning, linked states, and grid behavior.
  * Strengthened validation of button preset border styling and color properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->