### PR TITLE
[DTM] SOFT-4083 [32/38]: update stale preset-union fixtures for border/shadow bindings

### DIFF
--- a/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
@@ -94,7 +94,10 @@ final class Css_BuilderTest extends TestCase {
 				. '--global-palette-btn:var(--kb-token--preset--kadence-singlebtn--secondary--button-text);'
 				. '--global-palette-btn-bg-hover:var(--kb-token--preset--kadence-singlebtn--secondary--button-bg-hover);'
 				. '--global-palette-btn-hover:var(--kb-token--preset--kadence-singlebtn--secondary--button-text-hover);'
-				. '--kb-btn-radius:var(--kb-token--preset--kadence-singlebtn--secondary--button-radius);}',
+				. '--kb-btn-radius:var(--kb-token--preset--kadence-singlebtn--secondary--button-radius);'
+				. '--kb-btn-border-width:var(--kb-token--preset--kadence-singlebtn--secondary--button-border-width);'
+				. '--kb-btn-border-style:var(--kb-token--preset--kadence-singlebtn--secondary--button-border-style);'
+				. '--kb-btn-border-color:var(--kb-token--preset--kadence-singlebtn--secondary--button-border-color);}',
 			$css
 		);
 	}
@@ -114,7 +117,10 @@ final class Css_BuilderTest extends TestCase {
 				. '--global-palette-btn:var(--kb-token--preset--kadence-singlebtn--primary--button-text);'
 				. '--global-palette-btn-bg-hover:var(--kb-token--preset--kadence-singlebtn--primary--button-bg-hover);'
 				. '--global-palette-btn-hover:var(--kb-token--preset--kadence-singlebtn--primary--button-text-hover);'
-				. '--kb-btn-radius:var(--kb-token--preset--kadence-singlebtn--primary--button-radius);}',
+				. '--kb-btn-radius:var(--kb-token--preset--kadence-singlebtn--primary--button-radius);'
+				. '--kb-btn-border-width:var(--kb-token--preset--kadence-singlebtn--primary--button-border-width);'
+				. '--kb-btn-border-style:var(--kb-token--preset--kadence-singlebtn--primary--button-border-style);'
+				. '--kb-btn-border-color:var(--kb-token--preset--kadence-singlebtn--primary--button-border-color);}',
 			$css
 		);
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
@@ -122,7 +122,16 @@ final class Preset_ResolverTest extends TestCase {
 
 		sort( $properties );
 		$this->assertSame(
-			[ 'button-bg', 'button-bg-hover', 'button-radius', 'button-text', 'button-text-hover' ],
+			[
+				'button-bg',
+				'button-bg-hover',
+				'button-border-color',
+				'button-border-style',
+				'button-border-width',
+				'button-radius',
+				'button-text',
+				'button-text-hover',
+			],
 			$properties
 		);
 	}


### PR DESCRIPTION
## Summary
- Phase 21 added `button-border-width`/`-style`/`-color` and `button-shadow` to the Button preset's bindings, but two pre-existing test fixtures elsewhere in the suite were never updated to account for them — undetected until now because a shared `slic` config pointed at the wrong target in this dev environment, silently skipping wpunit on every push in this chain.
- `Preset_ResolverTest::testValuePropertiesAreTheUnionAcrossPresets` now expects the three new border properties in the union.
- `Css_BuilderTest::testItRetargetsButtonSlotsForANamedPreset` / `testItEmitsTheDefaultPresetOnTheBareSelector` now expect the new `--kb-btn-border-width`/`-style`/`-color` vars in the emitted CSS blocks.
- This is a new phase rather than a fold-back onto phase 21, since PR #1317 already has human review.

## Test plan
- [x] `slic run wpunit` — full suite green (2457 tests, 1 pre-existing skip, 0 failures).
- [x] `grep -rn "SOFT-" tests/` — no hits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for button presets to validate border width, style, and color mappings.
  * Updated preset property expectations to include the full set of supported border properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->