### PR TITLE
[DTM] SOFT-4083 [38/38]: fix the empty Border/Shadow token pickers in the block editor canvas

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Preset_Bindings.php
+++ b/includes/resources/Design_Tokens/Registry/Preset_Bindings.php
@@ -68,6 +68,15 @@ final class Preset_Bindings {
 	private const KIND_TEXT = 'text';
 
 	/**
+	 * The coarse input kind for a shadow-valued property.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const KIND_SHADOW = 'shadow';
+
+	/**
 	 * The block name, e.g. "kadence/advancedbtn".
 	 *
 	 * @since TBD
@@ -246,16 +255,29 @@ final class Preset_Bindings {
 	}
 
 	/**
-	 * A coarse input kind for a bound property — "color", "dimension" or "text" — so the editor's preset
-	 * form can render the right control per property. Read from the referenced token's group segment when the
-	 * binding is a token reference (e.g. `semantic.radius.media` => "dimension"), otherwise inferred from the
-	 * property name (e.g. `button-bg` => "color", `button-radius` => "dimension"). Falls back to "text".
+	 * The coarse input kind for a shadow-valued property. Read by the editor's token-picker lookup,
+	 * which cannot compare against the constant directly.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_kind_shadow(): string {
+		return self::KIND_SHADOW;
+	}
+
+	/**
+	 * A coarse input kind for a bound property — "color", "dimension", "shadow" or "text" — so the editor's
+	 * preset form can render the right control per property. Read from the referenced token's group segment
+	 * when the binding is a token reference (e.g. `semantic.radius.media` => "dimension",
+	 * `semantic.shadow.button` => "shadow"), otherwise inferred from the property name (e.g. `button-bg` =>
+	 * "color", `button-radius` => "dimension"). Falls back to "text".
 	 *
 	 * @since TBD
 	 *
 	 * @param string $property The bound property, e.g. "button-bg".
 	 *
-	 * @return string One of "color", "dimension" or "text".
+	 * @return string One of "color", "dimension", "shadow" or "text".
 	 */
 	public function kind( string $property ): string {
 		$binding = $this->binding( $property );
@@ -352,17 +374,22 @@ final class Preset_Bindings {
 
 	/**
 	 * Classify a term (a token group segment or a property name) into a coarse input kind, or "" when it
-	 * matches neither a dimension nor a color. Dimension terms are checked first so "borderRadius" resolves to
-	 * "dimension" rather than matching the "border" color term.
+	 * matches none of shadow, dimension or color. Shadow is checked first since it collides with neither of
+	 * the other lists; dimension is checked before color so "borderRadius" resolves to "dimension" rather
+	 * than matching the "border" color term.
 	 *
 	 * @since TBD
 	 *
 	 * @param string $term The term to classify.
 	 *
-	 * @return string "color", "dimension" or "".
+	 * @return string "shadow", "dimension", "color" or "".
 	 */
 	private static function classify( string $term ): string {
 		$term = strtolower( $term );
+
+		if ( strpos( $term, 'shadow' ) !== false ) {
+			return self::KIND_SHADOW;
+		}
 
 		foreach ( [ 'radius', 'width', 'gap', 'spacing', 'space', 'padding', 'margin', 'size', 'height', 'dimension' ] as $needle ) {
 			if ( strpos( $term, $needle ) !== false ) {

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -98,7 +98,7 @@ import {
 	combineColorOpacity,
 	splitColorOpacity,
 } from '../../extension/design-tokens/components/EditorShadowControl';
-import { pickableTokensForControl } from '../../extension/token-picker';
+import { pickableTokensForControl, pickableTokensForKey } from '../../extension/token-picker';
 
 /**
  * `EditorBorderControl`'s `renderColor` render-prop: reuses the block's existing `PopColorControl`
@@ -413,24 +413,24 @@ export default function KadenceButtonEdit(props) {
 	const { setPreviewDeviceType: setPreviewDevice } = useDispatch('kadenceblocks/data');
 	const borderRadiusTokens = pickableTokensForControl('kadence/singlebtn', 'borderRadius') || [];
 	const borderRadiusIsRelative = borderRadiusUnit === 'em' || borderRadiusUnit === 'rem';
-	// One pickable-width-token list per border control, keyed the same way its own attribute is —
-	// mirrors `borderRadiusTokens` above, one call per surface rather than one shared list, since a
-	// future per-surface `control_attr` mapping would need its own distinct entry anyway.
-	const borderWidthTokens = pickableTokensForControl('kadence/singlebtn', 'borderStyle') || [];
-	const borderHoverWidthTokens = pickableTokensForControl('kadence/singlebtn', 'borderHoverStyle') || [];
-	const borderTransparentWidthTokens = pickableTokensForControl('kadence/singlebtn', 'borderTransparentStyle') || [];
-	const borderTransparentHoverWidthTokens =
-		pickableTokensForControl('kadence/singlebtn', 'borderTransparentHoverStyle') || [];
-	const borderStickyWidthTokens = pickableTokensForControl('kadence/singlebtn', 'borderStickyStyle') || [];
-	const borderStickyHoverWidthTokens = pickableTokensForControl('kadence/singlebtn', 'borderStickyHoverStyle') || [];
-	// One pickable shadow-token list per shadow control, keyed the same way its own attribute is —
-	// mirrors the border width tokens above.
-	const shadowTokens = pickableTokensForControl('kadence/singlebtn', 'shadow') || [];
-	const shadowHoverTokens = pickableTokensForControl('kadence/singlebtn', 'shadowHover') || [];
-	const shadowTransparentTokens = pickableTokensForControl('kadence/singlebtn', 'shadowTransparent') || [];
-	const shadowTransparentHoverTokens = pickableTokensForControl('kadence/singlebtn', 'shadowTransparentHover') || [];
-	const shadowStickyTokens = pickableTokensForControl('kadence/singlebtn', 'shadowSticky') || [];
-	const shadowStickyHoverTokens = pickableTokensForControl('kadence/singlebtn', 'shadowStickyHover') || [];
+	// Border width and shadow bind through their bindings KEY, not a `control_attr` — the native border
+	// and shadow attributes are nested per-side/composite shapes, not a single scalar a `control_attr`
+	// lookup can target, so their PHP bindings declare no `control_attr` at all (see declarations.php's
+	// `kadence/singlebtn` block). One PHP binding exists per property (`button-border-width`,
+	// `button-shadow`) — there is one border-width scale and one shadow scale, not a separate one per
+	// state — so every hover/sticky/transparent variant below resolves to the same key on purpose.
+	const borderWidthTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width') || [];
+	const borderHoverWidthTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width') || [];
+	const borderTransparentWidthTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width') || [];
+	const borderTransparentHoverWidthTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width') || [];
+	const borderStickyWidthTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width') || [];
+	const borderStickyHoverWidthTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width') || [];
+	const shadowTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow') || [];
+	const shadowHoverTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow') || [];
+	const shadowTransparentTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow') || [];
+	const shadowTransparentHoverTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow') || [];
+	const shadowStickyTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow') || [];
+	const shadowStickyHoverTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow') || [];
 
 	// The mode describes what THIS device stores, not what it inherits. A breakpoint that stores nothing
 	// has nothing that differs, so it reads as linked — deriving from the inherited corners instead would

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -418,19 +418,22 @@ export default function KadenceButtonEdit(props) {
 	// lookup can target, so their PHP bindings declare no `control_attr` at all (see declarations.php's
 	// `kadence/singlebtn` block). One PHP binding exists per property (`button-border-width`,
 	// `button-shadow`) — there is one border-width scale and one shadow scale, not a separate one per
-	// state — so every hover/sticky/transparent variant below resolves to the same key on purpose.
-	const borderWidthTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width') || [];
-	const borderHoverWidthTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width') || [];
-	const borderTransparentWidthTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width') || [];
-	const borderTransparentHoverWidthTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width') || [];
-	const borderStickyWidthTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width') || [];
-	const borderStickyHoverWidthTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width') || [];
-	const shadowTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow') || [];
-	const shadowHoverTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow') || [];
-	const shadowTransparentTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow') || [];
-	const shadowTransparentHoverTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow') || [];
-	const shadowStickyTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow') || [];
-	const shadowStickyHoverTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow') || [];
+	// state — so every hover/sticky/transparent variant below reuses the same resolved list rather than
+	// re-filtering the pool per state.
+	const borderWidthPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width');
+	const borderWidthTokens = borderWidthPickableTokens;
+	const borderHoverWidthTokens = borderWidthPickableTokens;
+	const borderTransparentWidthTokens = borderWidthPickableTokens;
+	const borderTransparentHoverWidthTokens = borderWidthPickableTokens;
+	const borderStickyWidthTokens = borderWidthPickableTokens;
+	const borderStickyHoverWidthTokens = borderWidthPickableTokens;
+	const shadowPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow');
+	const shadowTokens = shadowPickableTokens;
+	const shadowHoverTokens = shadowPickableTokens;
+	const shadowTransparentTokens = shadowPickableTokens;
+	const shadowTransparentHoverTokens = shadowPickableTokens;
+	const shadowStickyTokens = shadowPickableTokens;
+	const shadowStickyHoverTokens = shadowPickableTokens;
 
 	// The mode describes what THIS device stores, not what it inherits. A breakpoint that stores nothing
 	// has nothing that differs, so it reads as linked — deriving from the inherited corners instead would

--- a/src/extension/token-picker/__tests__/index.test.js
+++ b/src/extension/token-picker/__tests__/index.test.js
@@ -328,9 +328,14 @@ describe('pickableTokensForKey', () => {
 		expect(result.every((token) => token.role === 'shadow')).toBe(true);
 	});
 
-	it('leaves pickableTokensForControl returning empty for the same control_attr-less property, proving the paths are independent', () => {
-		expect(pickableTokensForControl('kadence/singlebtn', 'shadow')).toEqual([]);
+	it('succeeds by key on the exact same property that pickableTokensForControl cannot reach by any control_attr guess, proving the two lookup paths are genuinely independent', () => {
+		// Not a vacuous "no control_attr matches, so both return []" comparison: pickableTokensForKey
+		// resolves real tokens for this property (asserted above), while pickableTokensForControl fails to
+		// find it under its own key used AS a controlAttr, or under the attribute the real control writes
+		// ('shadow') — because the property carries no control_attr at all, not because the guess is wrong.
 		expect(pickableTokensForControl('kadence/singlebtn', 'button-shadow')).toEqual([]);
+		expect(pickableTokensForControl('kadence/singlebtn', 'shadow')).toEqual([]);
+		expect(pickableTokensForKey('kadence/singlebtn', 'button-shadow').length).toBeGreaterThan(0);
 	});
 
 	it('returns an empty array for an unmapped key', () => {

--- a/src/extension/token-picker/__tests__/index.test.js
+++ b/src/extension/token-picker/__tests__/index.test.js
@@ -4,7 +4,7 @@
 // ESM module) for its `PresetPicker` component. This module never renders it, so stub it out.
 jest.mock('@kadence/components', () => ({}));
 
-import { pickableTokenPool, pickableTokensFor, pickableTokensForControl } from '../index';
+import { pickableTokenPool, pickableTokensFor, pickableTokensForControl, pickableTokensForKey } from '../index';
 
 /**
  * The fixture pickable-token pool: layers are interleaved on purpose to prove the semantic-first
@@ -68,6 +68,22 @@ const POOL = {
 			layer: 'primitive',
 			role: 'font-weight',
 		},
+		{
+			id: 'primitive.shadow.sm',
+			alias: '{primitive.shadow.sm}',
+			label: 'Shadow SM',
+			type: 'shadow',
+			layer: 'primitive',
+			role: 'shadow',
+		},
+		{
+			id: 'semantic.shadow.button',
+			alias: '{semantic.shadow.button}',
+			label: 'Button Shadow',
+			type: 'shadow',
+			layer: 'semantic',
+			role: 'shadow',
+		},
 	],
 	values: {
 		default: {
@@ -78,6 +94,8 @@ const POOL = {
 			'primitive.dimension.spacing.md': '16px',
 			'semantic.spacing.block': '1.5rem',
 			'primitive.font-weight.bold': '700',
+			'primitive.shadow.sm': '0 1px 2px rgba(0,0,0,0.1)',
+			'semantic.shadow.button': '0 2px 4px rgba(0,0,0,0.2)',
 		},
 		brand: { 'semantic.color.button-primary-bg': '#000000' },
 	},
@@ -85,7 +103,10 @@ const POOL = {
 
 /**
  * The fixture preset catalog: enough for `activeLibrary()` and `blockProperties()` to resolve a single
- * mapped control (`borderRadius` -> `dimension`) for `kadence/singlebtn`.
+ * mapped control (`borderRadius` -> `dimension`) for `kadence/singlebtn`. `button-shadow` mirrors the
+ * real PHP binding: it has a `key` and a bound `token`, but no `control_attr` at all — the native shadow
+ * attribute is a composite shape, not a scalar a `control_attr` lookup can target — which is exactly the
+ * case `pickableTokensForKey` exists to reach.
  */
 const PRESETS = {
 	active: 'default',
@@ -95,6 +116,7 @@ const PRESETS = {
 				properties: [
 					{ key: 'button-radius', kind: 'dimension', token: null, control_attr: 'borderRadius' },
 					{ key: 'button-gap', kind: 'dimension', token: null, control_attr: 'gap' },
+					{ key: 'button-shadow', kind: 'shadow', token: 'semantic.shadow.button', control_attr: null },
 				],
 			},
 		},
@@ -283,5 +305,39 @@ describe('pickableTokensForControl', () => {
 
 		// A bound primitive is itself a size, so it survives the primitives-only scoping and is pinned first.
 		expect(result.map((token) => token.id)).toEqual(['primitive.dimension.radius.sm']);
+	});
+});
+
+describe('pickableTokensForKey', () => {
+	beforeEach(() => {
+		window.kadenceDesignTokensPickable = POOL;
+		window.kadenceDesignTokensPresets = PRESETS;
+	});
+
+	afterEach(() => {
+		delete window.kadenceDesignTokensPickable;
+		delete window.kadenceDesignTokensPresets;
+	});
+
+	it('finds a property with no control_attr by its key and narrows to the bound token sub-kind', () => {
+		const result = pickableTokensForKey('kadence/singlebtn', 'button-shadow');
+
+		// The bound token fixes the shadow role; with a primitive shadow present the picker offers only
+		// the size scale (mirroring the radius narrowing above), so even the bound semantic drops out.
+		expect(result.map((token) => token.id)).toEqual(['primitive.shadow.sm']);
+		expect(result.every((token) => token.role === 'shadow')).toBe(true);
+	});
+
+	it('leaves pickableTokensForControl returning empty for the same control_attr-less property, proving the paths are independent', () => {
+		expect(pickableTokensForControl('kadence/singlebtn', 'shadow')).toEqual([]);
+		expect(pickableTokensForControl('kadence/singlebtn', 'button-shadow')).toEqual([]);
+	});
+
+	it('returns an empty array for an unmapped key', () => {
+		expect(pickableTokensForKey('kadence/singlebtn', 'button-does-not-exist')).toEqual([]);
+	});
+
+	it('returns an empty array for an unknown block', () => {
+		expect(pickableTokensForKey('kadence/does-not-exist', 'button-shadow')).toEqual([]);
 	});
 });

--- a/src/extension/token-picker/index.js
+++ b/src/extension/token-picker/index.js
@@ -143,27 +143,23 @@ function inferRoleFromControl(controlAttr, tokens) {
 }
 
 /**
- * The pickable tokens for one block control, keyed by the attribute the control writes: resolves
- * the control's kind from the preset catalog's { key, kind, token, control_attr } surface, then
- * filters and ranks the pool for that kind. When the control binds a role token, the list is further
- * narrowed to that token's sub-kind (a radius control's `dimension` to only radius tokens, never
- * spacing) and the bound token is pinned to the top. Without a bound token the sub-kind is inferred
- * from the control attribute (`borderRadius` -> radius), narrowing all the same; only when no single
- * role can be inferred does it stay the coarse kind list (type filter + semantic-first). Empty when the
- * block maps no such control in the library — an unmapped control offers no tokens, which is the
- * "selectable only where it makes sense" guarantee at the per-control call site.
+ * The pickable tokens for an already-resolved bound property: filters and ranks the pool for the
+ * property's kind, narrows to the bound (or inferred) role's sub-kind with that role's primitive scale
+ * steps preferred, and pins the bound token first. Shared by every lookup path
+ * (`pickableTokensForControl`'s `control_attr` match, `pickableTokensForKey`'s `key` match) once each
+ * has found its own `property` entry, so the narrowing logic exists once.
  *
- * @param {string} blockName   The block name (e.g. 'kadence/singlebtn').
- * @param {string} controlAttr The attribute the control writes (e.g. 'borderRadius').
+ * @param {Object} property    The resolved bound property ({ key, kind, token, control_attr }).
+ * @param {string} controlAttr The attribute to infer a role from when the property binds no token
+ *                              (e.g. 'borderRadius'); pass '' when the caller has no such attribute
+ *                              (e.g. a key-based lookup for a property with no `control_attr`).
  * @param {string} [library]   The token library slug; defaults to the active library.
  *
  * @since TBD
  *
  * @return {Array} The pickable list ([{ id, alias, label, value, type, role }]), empty when unmapped.
  */
-export function pickableTokensForControl(blockName, controlAttr, library) {
-	const property = blockProperties(blockName, library).find((entry) => entry.control_attr === controlAttr);
-
+function pickableTokensForProperty(property, controlAttr, library) {
 	if (!property || !property.kind) {
 		return [];
 	}
@@ -189,4 +185,51 @@ export function pickableTokensForControl(blockName, controlAttr, library) {
 		...scoped.filter((token) => token.id === property.token),
 		...scoped.filter((token) => token.id !== property.token),
 	];
+}
+
+/**
+ * The pickable tokens for one block control, keyed by the attribute the control writes: resolves
+ * the control's kind from the preset catalog's { key, kind, token, control_attr } surface, then
+ * defers to the shared narrowing helper. Empty when the block maps no such control in the library —
+ * an unmapped control offers no tokens, which is the "selectable only where it makes sense" guarantee
+ * at the per-control call site.
+ *
+ * Only reaches properties that DO carry a `control_attr` — a property bound to a nested/composite
+ * native attribute (border, shadow) is declared with no `control_attr` at all and is invisible to this
+ * lookup by design; use `pickableTokensForKey` for those.
+ *
+ * @param {string} blockName   The block name (e.g. 'kadence/singlebtn').
+ * @param {string} controlAttr The attribute the control writes (e.g. 'borderRadius').
+ * @param {string} [library]   The token library slug; defaults to the active library.
+ *
+ * @since TBD
+ *
+ * @return {Array} The pickable list ([{ id, alias, label, value, type, role }]), empty when unmapped.
+ */
+export function pickableTokensForControl(blockName, controlAttr, library) {
+	const property = blockProperties(blockName, library).find((entry) => entry.control_attr === controlAttr);
+
+	return pickableTokensForProperty(property, controlAttr, library);
+}
+
+/**
+ * The pickable tokens for one bound property, keyed by the property's stable `key` (the PHP bindings
+ * array key, e.g. 'button-shadow') rather than its `control_attr`. Exists for properties whose native
+ * block attribute is a nested/composite shape (border, shadow) and so is declared with no
+ * `control_attr` at all — `pickableTokensForControl` can never find them, since it has no other way to
+ * locate a property. Otherwise identical to `pickableTokensForControl`: defers to the same shared
+ * narrowing helper once the property is found.
+ *
+ * @param {string} blockName The block name (e.g. 'kadence/singlebtn').
+ * @param {string} key       The property's bindings key (e.g. 'button-shadow').
+ * @param {string} [library] The token library slug; defaults to the active library.
+ *
+ * @since TBD
+ *
+ * @return {Array} The pickable list ([{ id, alias, label, value, type, role }]), empty when unmapped.
+ */
+export function pickableTokensForKey(blockName, key, library) {
+	const property = blockProperties(blockName, library).find((entry) => entry.key === key);
+
+	return pickableTokensForProperty(property, '', library);
 }

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Preset_BindingsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Preset_BindingsTest.php
@@ -238,6 +238,11 @@ final class Preset_BindingsTest extends TestCase {
 	 * "semantic.shadow.button" => "shadow"), matching the real `kadence/singlebtn` `button-shadow`
 	 * binding, which has no `control_attr` and so is classified purely from its bound token.
 	 *
+	 * The bound property is deliberately named "button-example", not "button-shadow": `kind()` falls
+	 * back to classifying the property NAME itself when the token's own group doesn't resolve, and
+	 * "button-shadow" would then match the "shadow" needle by name alone — masking whether the
+	 * "unrecognized group falls back to text" case is really exercising that fallback.
+	 *
 	 * @dataProvider tokenGroupKindProvider
 	 *
 	 * @param string $token    The bound token id.
@@ -249,11 +254,11 @@ final class Preset_BindingsTest extends TestCase {
 		$bindings = Preset_Bindings::from_array(
 			[
 				'block'    => 'kadence/singlebtn',
-				'bindings' => [ 'button-shadow' => [ 'token' => $token ] ],
+				'bindings' => [ 'button-example' => [ 'token' => $token ] ],
 			]
 		);
 
-		$this->assertSame( $expected, $bindings->kind( 'button-shadow' ) );
+		$this->assertSame( $expected, $bindings->kind( 'button-example' ) );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Preset_BindingsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Preset_BindingsTest.php
@@ -232,4 +232,69 @@ final class Preset_BindingsTest extends TestCase {
 
 		yield 'null' => [ 'label' => null ];
 	}
+
+	/**
+	 * A token-reference binding's coarse kind is read from its token's group segment (e.g.
+	 * "semantic.shadow.button" => "shadow"), matching the real `kadence/singlebtn` `button-shadow`
+	 * binding, which has no `control_attr` and so is classified purely from its bound token.
+	 *
+	 * @dataProvider tokenGroupKindProvider
+	 *
+	 * @param string $token    The bound token id.
+	 * @param string $expected The expected coarse kind.
+	 *
+	 * @return void
+	 */
+	public function testKindClassifiesATokenReferenceBindingByItsTokenGroup( string $token, string $expected ): void {
+		$bindings = Preset_Bindings::from_array(
+			[
+				'block'    => 'kadence/singlebtn',
+				'bindings' => [ 'button-shadow' => [ 'token' => $token ] ],
+			]
+		);
+
+		$this->assertSame( $expected, $bindings->kind( 'button-shadow' ) );
+	}
+
+	/**
+	 * Token groups covering every coarse kind `kind()` distinguishes: dimension, color, shadow, and
+	 * the text fallback for a group `classify()` matches neither list.
+	 *
+	 * @return Generator
+	 */
+	public function tokenGroupKindProvider(): Generator {
+		yield 'dimension group' => [
+			'token'    => 'semantic.radius.media',
+			'expected' => 'dimension',
+		];
+
+		yield 'color group' => [
+			'token'    => 'semantic.color.button-bg',
+			'expected' => 'color',
+		];
+
+		yield 'shadow group' => [
+			'token'    => 'semantic.shadow.button',
+			'expected' => 'shadow',
+		];
+
+		yield 'unrecognized group falls back to text' => [
+			'token'    => 'semantic.font-weight.bold',
+			'expected' => 'text',
+		];
+	}
+
+	/**
+	 * An inline (non-token-reference) binding, or an undeclared property, falls back to classifying the
+	 * property NAME itself — the shape `button-border-width`'s sibling color/style bindings rely on.
+	 *
+	 * @return void
+	 */
+	public function testKindClassifiesAnUnboundPropertyByItsOwnName(): void {
+		$bindings = Preset_Bindings::from_array( $this->declaration() );
+
+		$this->assertSame( 'dimension', $bindings->kind( 'button-radius' ) );
+		$this->assertSame( 'color', $bindings->kind( 'button-bg-color' ) );
+		$this->assertSame( 'text', $bindings->kind( 'button-label' ) );
+	}
 }


### PR DESCRIPTION
## Summary
- Manual verification in the block editor (`kadence/singlebtn`'s Style tab) showed the Border and Shadow token pickers' Style Library tab as completely empty, unlike the Style Library page (which already works after phase 30/31's fixes) — a different, pre-existing bug in a different code path.
- Root cause 1 (JS): `pickableTokensForControl()` looks up a block's bound property by matching `control_attr`, but `button-border-width`/`-style`/`-color`/`button-shadow` were deliberately declared with no `control_attr` (the native attributes are nested/composite, not a scalar a control_attr-style consumer can target). Added `pickableTokensForKey()`, a sibling lookup matching by the stable PHP binding key instead, sharing the existing narrowing/scoping/pinning logic. `singlebtn/edit.js`'s border-width/shadow token calls now use it.
- Root cause 2 (PHP): even with the JS fix, `button-shadow`'s `kind` classification resolved to `text`, not `shadow` — `Preset_Bindings::classify()` had no `shadow` needle in its dimension/color needle lists. Added a `KIND_SHADOW` constant, `get_kind_shadow()` accessor, and a shadow check in `classify()`.
- This is a new phase rather than a fold-back onto phase 21/22/23, since those PRs already have human review.

## Test plan
- [x] `npx jest src/token-controls src/style-library src/extension/design-tokens src/blocks/singlebtn src/extension/token-picker` — full suite green.
- [x] `slic run wpunit` — full suite green.
- [x] `vendor/bin/phpstan analyse`, `vendor/bin/phpcs` — clean.
- [x] cspell on changed files.
- [x] `grep -rn "SOFT-" src/extension/token-picker src/blocks/singlebtn` — no hits.
- [ ] Manual verification on the dev site (block editor canvas, Border and Shadow Style Library tabs now list real tokens).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for shadow design tokens in preset bindings.
  * Improved token selection for border widths, shadows, nested properties, and composite attributes.
  * Added key-based token lookup for more accurate styling options.

* **Bug Fixes**
  * Improved classification of shadow tokens and fallback handling for other token types.
  * Ensured token selection remains consistent across responsive and interactive states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->