### PR TITLE
fix(ci): restore write access for workflows that write

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -24,6 +24,7 @@
         "alignleft",
         "alignright",
         "autoplay",
+        "axios",
         "blocksy",
         "bloginfo",
         "britner",

--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -27,6 +27,12 @@ jobs:
     # The proper name for the job being run.
     name: Deploy to WP.org
 
+    # Attaching the zip to the release writes to the repository. A job with no permissions block
+    # inherits the default from the Actions settings, which live outside this file and are
+    # currently read, so the upload step below has to ask for write access explicitly.
+    permissions:
+      contents: write
+
     # The environment this job should run on. In the context of WordPress, ubuntu-latest is
     # pretty typical. Since we are only interacting with git and subversion, Ubuntu is perfect
     # for this.

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -5,10 +5,6 @@ on:
   push:
   # pull_request:
 
-# permissions:
-#   contents: write
-#   pull-requests: write
-
 jobs:
   run-linters:
     name: Run linters
@@ -44,5 +40,8 @@ jobs:
       - name: Run linters
         uses: wearerequired/lint-action@v2
         with:
+          # The bot's token rather than the default one, so auto-fix commits are attributed to it
+          # and still trigger the workflows that a commit pushed by the default token would not.
+          github_token: ${{ secrets.GH_BOT_TOKEN }}
           auto_fix: true
           eslint: true

--- a/.github/workflows/google-fonts.yml
+++ b/.github/workflows/google-fonts.yml
@@ -8,6 +8,12 @@ jobs:
   update-fonts:
     runs-on: ubuntu-latest
 
+    # Opening the update PR writes to the repository. A job with no permissions block inherits the
+    # default from the Actions settings, which live outside this file and are currently read.
+    permissions:
+      contents: write
+      pull-requests: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/stellar-zip.yml
+++ b/.github/workflows/stellar-zip.yml
@@ -73,6 +73,12 @@ on:
 jobs:
   generate-zip:
     runs-on: ubuntu-latest
+    # The PR status comment needs write access. A caller may only narrow these further, so any
+    # workflow calling this one has to grant at least as much.
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       # ------------------------------------------------------------------------------
       # Checkout the repo.

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -55,6 +55,12 @@ jobs:
 
     zip:
         uses: ./.github/workflows/stellar-zip.yml
+        # The PR status comment needs write access. Declared here rather than relying on the
+        # organization's default workflow permissions, which can be changed outside this repo.
+        permissions:
+            contents: read
+            issues: write
+            pull-requests: write
         needs:
             - set_vars
         with:

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -55,8 +55,8 @@ jobs:
 
     zip:
         uses: ./.github/workflows/stellar-zip.yml
-        # The PR status comment needs write access. Declared here rather than relying on the
-        # organization's default workflow permissions, which can be changed outside this repo.
+        # The PR status comment needs write access. A job with no permissions block inherits the
+        # default from the Actions settings, which live outside this file and are currently read.
         permissions:
             contents: read
             issues: write

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -22,6 +22,10 @@ on:
                 description: 'Slack thread to post to'
                 required: false
 
+# No token access by default. The zip job below grants itself what it needs; set_vars only writes
+# to $GITHUB_OUTPUT and never touches the API, so it gets nothing.
+permissions: {}
+
 jobs:
     set_vars:
         runs-on: ubuntu-latest


### PR DESCRIPTION
🎫  N/A

Workflows that write to the repository are failing with `Resource not accessible by integration`. None of them declared a `permissions:` block, so the token inherits the default from the repository's Actions settings, and that default is now read-only:

```
$ gh api repos/stellarwp/kadence-blocks/actions/permissions/workflow
{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}
```

Four workflows were affected. The zip one fails on every PR; the other three fail the next time they run.

### Two approaches, and why each one is used here

**A `permissions:` block** grants the default token exactly the scope that job needs. It is least-privilege, scoped to the single run, and never expires. This is the fix for `zip.yml`, `deploy-on-release.yml`, and `google-fonts.yml`, which just need to comment, attach a release asset, and open a PR.

**The bot's PAT** is used for `eslint.yml` instead, because a permissions block would not be enough there. `lint-action` runs with `auto_fix: true`, and GitHub deliberately does not trigger workflows for commits pushed by the default token — an auto-fix commit would land with no CI. A PAT-pushed commit does trigger them, and is attributed to the bot rather than to `github-actions`.

### Changes

- `zip.yml` — `issues: write` + `pull-requests: write` on the job calling the reusable workflow. PR comments are issue comments, so the comment actions need `issues`. This has to live on the caller: a called workflow inherits the caller's token and [can only reduce it, never elevate it](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows).
- `stellar-zip.yml` — the same block on `generate-zip`, so the reusable workflow states what it requires instead of depending on whatever its caller happens to grant.
- `deploy-on-release.yml` — `contents: write` for `Upload release asset`. Note the step reads `secrets.GITHUB_TOKEN`, which is the automatic token and not the bot PAT; secret names cannot start with `GITHUB_`.
- `google-fonts.yml` — `contents: write` + `pull-requests: write` for `create-pull-request`.
- `eslint.yml` — `github_token: ${{ secrets.GH_BOT_TOKEN }}` on `lint-action`, and the commented-out permissions block removed as the alternative that was not taken.

Left alone: `m26-release-branches.yml`, `replace-since-tbd.yml`, and `update-pot.yml` already declare what they need. Everything else either writes nothing or authenticates with `GH_BOT_TOKEN`, which is unaffected by the default.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated release deployments so generated packages can be uploaded successfully.
  * Updated automation permissions to support repository maintenance, font updates, packaging, and issue or pull request updates.
  * Strengthened workflow security by using explicit, narrowly scoped access permissions.
  * Improved linting workflow reliability by using the appropriate authentication credentials.
  * Added support for recognizing “axios” in spelling checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->