### PR TITLE
[DTM] SOFT-4083 [39/51]: shadow preview square styling

### DIFF
--- a/src/style-library/components/pages/ShadowScreen.scss
+++ b/src/style-library/components/pages/ShadowScreen.scss
@@ -10,14 +10,14 @@
 	background: transparent;
 }
 
-// The shadowed square itself: fixed 48px inside the 80px slot, centered by the slot's own flex
-// layout, giving 16px of clearance on every side for the cast shadow to read — matching the board's
-// light square sitting proud of the row.
+// The shadowed square itself: 80px, filling the 80px slot (`--kb-sl-size-row-preview`) exactly, so no
+// clearance remains inside the row for the cast shadow to read — it is only visible where it extends
+// past the row into the surrounding page background.
 .kadence-blocks-style-library__shadow-preview {
 	box-sizing: border-box;
 	display: block;
-	width: 3rem;
-	height: 3rem;
+	width: 5rem;
+	height: 5rem;
 	border: var(--kb-sl-border-width-input) solid var(--kb-sl-color-gray-200);
 	border-radius: var(--kb-sl-radius-s);
 	background: var(--kb-sl-color-white);

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -4,8 +4,8 @@
  * Styles the token field (the corner icon + input-styled trigger that replaces a control's numeric
  * slot) and its Style Library/Custom popover to the sidebar design, plus the whole-value box-shadow
  * chip/picker. Values mirror the design tokens: gray-900 #1e1e1e text, gray-600 #949494 borders and
- * muted values, gray-300 #dddddd dividers, gray-100 #f0f0f0 selection, theme #3858e9 accents, 13px
- * body type, 2px control radius, 4px popover radius.
+ * muted values, gray-400 #cccccc borders, gray-300 #dddddd dividers, gray-100 #f0f0f0 selection,
+ * theme #3858e9 accents, 13px body type, 2px control radius, 4px popover radius.
  */
 
 // The token field is a corner icon beside the trigger, filling the slot the numeric input held.
@@ -130,16 +130,19 @@
 }
 
 /*
- * `BoxShadowControl`'s preview square: a plain gray-100 box with the active shadow's CSS applied, so
- * a shadow reads at a glance before it is picked. Reuses this file's own established gray-100
- * selection background and 2px control radius rather than new values.
+ * `BoxShadowControl`'s preview square: a white box with the active shadow's CSS applied, so a shadow
+ * reads at a glance before it is picked — white rather than this file's own gray-100 selection
+ * background so a dark shadow shows up clearly against it. The gray-400 border (`#cccccc`, mirroring
+ * the design tokens the way this file's other hardcoded colors do — see its header comment) keeps the
+ * square's own edge visible even when the active shadow is empty.
  */
 .kb-box-shadow-control__preview {
 	flex: 0 0 auto;
-	width: 48px;
-	height: 48px;
+	width: 6rem;
+	height: 6rem;
+	border: 1px solid #cccccc;
 	border-radius: 2px;
-	background: #f0f0f0;
+	background: #fff;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Resizes the box-shadow control's preview square to 6rem with a white background and a gray-400 border.
- Resizes the Shadow screen's preview square to 5rem so it matches the row slot.

## Screenshots
| BEFORE | AFTER |
|---|---|
| <img width="362" height="513" alt="CleanShot 2026-08-26 at 20 28 04" src="https://github.com/user-attachments/assets/f9800734-b8c6-4cff-ad62-97cb413883fc" /> | <img width="386" height="518" alt="CleanShot 2026-08-26 at 20 29 48" src="https://github.com/user-attachments/assets/cea0d502-6a91-4ff2-b76d-97a96d979323" /> |
| <img width="296" height="333" alt="CleanShot 2026-08-26 at 20 28 26" src="https://github.com/user-attachments/assets/fec88ad0-0f3a-42ae-940c-8d0df7c2ce5d" /> | <img width="297" height="388" alt="CleanShot 2026-08-26 at 20 29 37" src="https://github.com/user-attachments/assets/d6b1b0ec-32df-43d6-b418-0e4e35d361ae" /> |

## Test plan

- [ ] Open the Button preset's Shadow field and confirm the preview square renders at 6rem with a white background and gray-400 border.
- [ ] Open the Shadow screen and confirm its preview square renders at 5rem, aligned with the row slot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated shadow previews to fill the available preview area.
  * Improved shadow preview contrast with a white background and gray border.
  * Documented the gray-400 color token (`#cccccc`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->