### PR TITLE
[DTM] SOFT-4083 [40/40]: collapse the Border field's Linked view when every side matches

### DIFF
--- a/src/extension/design-tokens/components/EditorBorderControl.js
+++ b/src/extension/design-tokens/components/EditorBorderControl.js
@@ -13,8 +13,14 @@
  * - **once a side has ever been written, it stays a four-element array**, never collapsed back to a
  *   scalar — `fromNativeBorder` only answers the empty scalar (`''`/`'none'`) for a breakpoint that
  *   has never been saved at all; the moment any side is written, `toNativeBorder` always fills in
- *   all four, so every later read comes back as four-element width/style/color arrays and the
- *   control renders unlinked from then on. There is no separate "link" flag to keep in sync.
+ *   all four. So the linked/unlinked view cannot be read off storage the way `BorderControl`'s own
+ *   uncontrolled fallback tries to (it only checks "is this an array", not "do the four elements
+ *   agree") — this component owns that view as UI state instead, seeded from whether the stored
+ *   sides currently agree (`isUniformBorder`) and overridden per breakpoint once the user explicitly
+ *   links or unlinks. This mirrors `singlebtn/edit.js`'s own `borderRadiusModeOverride` for radius,
+ *   just owned locally: border's `defaultValue` is always one scalar for every side (see its own
+ *   docblock below), so there is no per-side preset difference an early "uniform" read could hide
+ *   the way an empty radius corner could.
  * - **the unit lives inside the native value itself** (`source.unit`), not a sibling attribute the
  *   way `BoxControl`'s radius keeps `borderRadiusUnit` — so, unlike `EditorBoxControl`, this
  *   component takes no separate `unit`/`units`/`onUnit` props at all.
@@ -25,6 +31,11 @@
  * still has to fall back to the native value's stored color when `renderColor` writes nothing for a
  * side — see its docblock for why.
  */
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -64,6 +75,35 @@ const BREAKPOINT_FOR_DEVICE = {
  */
 function deviceForBreakpoint(breakpoint) {
 	return Object.keys(BREAKPOINT_FOR_DEVICE).find((name) => BREAKPOINT_FOR_DEVICE[name] === breakpoint) ?? 'Desktop';
+}
+
+/**
+ * Whether a native border value shows the same color, style, and width on every side — the state a
+ * linked view can honestly represent. A breakpoint that has never been written reads as uniform too:
+ * there is nothing stored to differ side to side, and (unlike radius corners) a border preset only
+ * ever sets one width for every side, so there is no per-side preset difference an early "uniform"
+ * read could hide.
+ *
+ * @param {?Array} native `[{top,right,bottom,left,unit}]` or undefined.
+ *
+ * @since TBD
+ *
+ * @return {boolean} Whether every side currently matches.
+ */
+function isUniformBorder(native) {
+	const source = native?.[0];
+
+	if (!source) {
+		return true;
+	}
+
+	const uniform = (values) => values.every((entry) => entry === values[0]);
+
+	return (
+		uniform(SIDES.map((side) => source[side]?.[0] || '')) &&
+		uniform(SIDES.map((side) => source[side]?.[1] || 'none')) &&
+		uniform(SIDES.map((side) => source[side]?.[2]))
+	);
 }
 
 /**
@@ -230,6 +270,36 @@ export function EditorBorderControl({
 	// `ResponsiveBorderControl`'s own `mobileUnit`/`tabletUnit` fallback), and finally 'px'.
 	const activeUnit = activeNative?.[0]?.unit || value?.[0]?.unit || 'px';
 
+	// Per-breakpoint UI override for the linked view — see this file's own docblock for why storage
+	// cannot answer it alone. Keyed by breakpoint so switching devices does not carry one device's
+	// explicit choice onto another; resets on remount, matching `singlebtn/edit.js`'s
+	// `borderRadiusModeOverride` for radius.
+	const [linkOverride, setLinkOverride] = useState({});
+	const linked = linkOverride[breakpoint] ?? isUniformBorder(activeNative);
+
+	const toggleLink = () => {
+		if (linked) {
+			setLinkOverride((current) => ({ ...current, [breakpoint]: false }));
+			return;
+		}
+
+		// Relinking collapses every side to slot 0's value — "the first side wins" is predictable,
+		// matching `BorderControl`'s own uncontrolled relink rule and `BoxControl`'s relink comment.
+		const current = fromNativeBorder(activeNative);
+
+		activeSetter(
+			toNativeBorder(
+				{
+					width: readSlot(current.width, 0),
+					style: readSlot(current.style, 0),
+					color: readSlot(current.color, 0),
+				},
+				activeUnit
+			)
+		);
+		setLinkOverride((next) => ({ ...next, [breakpoint]: true }));
+	};
+
 	return (
 		<BreakpointProvider value={breakpoint} onChange={changeBreakpoint}>
 			<BorderControl
@@ -245,6 +315,8 @@ export function EditorBorderControl({
 				// the `BreakpointProvider` context above, so both must map back to a device the same way.
 				onBreakpointChange={changeBreakpoint}
 				renderColor={renderColor}
+				isLinked={linked}
+				onToggleLink={toggleLink}
 				stacked
 			/>
 		</BreakpointProvider>

--- a/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
@@ -1,9 +1,30 @@
 /* eslint-env jest */
 
 /**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
  * Internal dependencies
  */
 import { EditorBorderControl } from '../EditorBorderControl';
+
+// `BorderControl` now gains its `isLinked`/`onToggleLink` props from state this component owns, so
+// it can no longer be exercised by calling `EditorBorderControl` as a plain function the way this file
+// used to — hooks only work inside a real render. `BorderControl` itself is stood in for here (rather
+// than mocking `@wordpress/components`, the way `border-control.test.js` has to) because these tests
+// only care what props reach it, not how it renders them; capturing props on every render keeps the
+// rest of this file's assertions the same shape they were before.
+let latestBorderControlProps = null;
+
+jest.mock('../../../../token-controls/controls/BorderControl', () => ({
+	BorderControl: (props) => {
+		latestBorderControlProps = props;
+		return null;
+	},
+}));
 
 /**
  * A representative native border value: every side different, so a round-trip that silently
@@ -24,17 +45,53 @@ const NATIVE_VALUE = [
 ];
 
 /**
- * Call `EditorBorderControl` as a plain function and return the `BorderControl`/`BreakpointProvider`
- * elements it produced. The component holds no hooks of its own, so the returned element tree can be
- * inspected directly instead of mounting it — matching `EditorBoxControl.test.js`'s own harness.
+ * A representative native border value with every side identical — the shape `isUniformBorder`
+ * reads as linked.
+ *
+ * @since TBD
+ *
+ * @type {Array}
+ */
+const UNIFORM_NATIVE_VALUE = [
+	{
+		top: ['#111111', 'solid', 2],
+		right: ['#111111', 'solid', 2],
+		bottom: ['#111111', 'solid', 2],
+		left: ['#111111', 'solid', 2],
+		unit: 'px',
+	},
+];
+
+let container;
+let root;
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+	latestBorderControlProps = null;
+});
+
+afterEach(() => {
+	act(() => {
+		root.unmount();
+	});
+	container.remove();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+/**
+ * Render `EditorBorderControl` and return the props its (stood-in) `BorderControl` received, plus
+ * the setter spies passed in.
  *
  * @param {Object} overrides Props to override on top of the defaults.
  *
  * @since TBD
  *
- * @return {{provider: Object, borderControl: Object, onChange: Function, onChangeTablet: Function,
- *   onChangeMobile: Function, onDeviceChange: Function}} The provider element, the `BorderControl`
- *   element nested inside it, and the setter spies passed in.
+ * @return {{borderControl: {props: Object}, onChange: Function, onChangeTablet: Function,
+ *   onChangeMobile: Function, onDeviceChange: Function}} The captured `BorderControl` props (wrapped
+ *   to match this file's previous `element.props` shape) and the setter spies passed in.
  */
 function renderEditorBorderControl(overrides = {}) {
 	const onChange = jest.fn();
@@ -56,11 +113,12 @@ function renderEditorBorderControl(overrides = {}) {
 		...overrides,
 	};
 
-	const provider = EditorBorderControl(props);
+	act(() => {
+		root.render(createElement(EditorBorderControl, props));
+	});
 
 	return {
-		provider,
-		borderControl: provider.props.children,
+		borderControl: { props: latestBorderControlProps },
 		onChange,
 		onChangeTablet,
 		onChangeMobile,
@@ -113,10 +171,12 @@ describe('EditorBorderControl native <-> control value bridging', () => {
 	it('round-trips a representative native value losslessly through a width edit', () => {
 		const { borderControl, onChange } = renderEditorBorderControl();
 
-		borderControl.props.onChange({
-			width: ['9px', '3px', '4px', '5px'],
-			style: ['solid', 'dashed', 'dotted', 'double'],
-			color: ['#111111', '#222222', '#333333', '#444444'],
+		act(() => {
+			borderControl.props.onChange({
+				width: ['9px', '3px', '4px', '5px'],
+				style: ['solid', 'dashed', 'dotted', 'double'],
+				color: ['#111111', '#222222', '#333333', '#444444'],
+			});
 		});
 
 		expect(onChange).toHaveBeenCalledWith([
@@ -141,10 +201,12 @@ describe('EditorBorderControl native <-> control value bridging', () => {
 		const { borderControl, onChange } = renderEditorBorderControl();
 		const alias = '{primitive.dimension.border-width.md}';
 
-		borderControl.props.onChange({
-			width: [alias, '3px', '4px', '5px'],
-			style: ['solid', 'dashed', 'dotted', 'double'],
-			color: ['#111111', '#222222', '#333333', '#444444'],
+		act(() => {
+			borderControl.props.onChange({
+				width: [alias, '3px', '4px', '5px'],
+				style: ['solid', 'dashed', 'dotted', 'double'],
+				color: ['#111111', '#222222', '#333333', '#444444'],
+			});
 		});
 
 		const written = onChange.mock.calls[0][0];
@@ -166,10 +228,12 @@ describe('EditorBorderControl native <-> control value bridging', () => {
 	it('preserves each side existing color when writing a style edit', () => {
 		const { borderControl, onChange } = renderEditorBorderControl();
 
-		borderControl.props.onChange({
-			width: ['2px', '3px', '4px', '5px'],
-			style: ['none', 'dashed', 'dotted', 'double'],
-			color: ['#111111', '#222222', '#333333', '#444444'], // Carried forward by BorderControl's merge.
+		act(() => {
+			borderControl.props.onChange({
+				width: ['2px', '3px', '4px', '5px'],
+				style: ['none', 'dashed', 'dotted', 'double'],
+				color: ['#111111', '#222222', '#333333', '#444444'], // Carried forward by BorderControl's merge.
+			});
 		});
 
 		const written = onChange.mock.calls[0][0][0];
@@ -190,10 +254,12 @@ describe('EditorBorderControl native <-> control value bridging', () => {
 	it('writes an empty string when a side color is cleared, rather than keeping the stale color', () => {
 		const { borderControl, onChange } = renderEditorBorderControl();
 
-		borderControl.props.onChange({
-			width: ['2px', '3px', '4px', '5px'],
-			style: ['solid', 'dashed', 'dotted', 'double'],
-			color: ['', '#222222', '#333333', '#444444'], // Top color cleared.
+		act(() => {
+			borderControl.props.onChange({
+				width: ['2px', '3px', '4px', '5px'],
+				style: ['solid', 'dashed', 'dotted', 'double'],
+				color: ['', '#222222', '#333333', '#444444'], // Top color cleared.
+			});
 		});
 
 		const written = onChange.mock.calls[0][0][0];
@@ -283,10 +349,12 @@ describe('EditorBorderControl native <-> control value bridging', () => {
 	it('writes a genuine per-side color edit through to the native attribute', () => {
 		const { borderControl, onChange } = renderEditorBorderControl();
 
-		borderControl.props.onChange({
-			width: ['2px', '3px', '4px', '5px'],
-			style: ['solid', 'dashed', 'dotted', 'double'],
-			color: ['#ffffff', '#222222', '#333333', '#444444'], // top color changed.
+		act(() => {
+			borderControl.props.onChange({
+				width: ['2px', '3px', '4px', '5px'],
+				style: ['solid', 'dashed', 'dotted', 'double'],
+				color: ['#ffffff', '#222222', '#333333', '#444444'], // top color changed.
+			});
 		});
 
 		const written = onChange.mock.calls[0][0][0];
@@ -297,16 +365,18 @@ describe('EditorBorderControl native <-> control value bridging', () => {
 
 describe('EditorBorderControl breakpoint switching', () => {
 	/**
-	 * The switcher rendered by `ControlShell` drives `BorderControl`'s `onBreakpointChange` prop
-	 * directly, not the `BreakpointProvider` context above it — matching `EditorBoxControl`'s own
-	 * wiring exactly.
+	 * `BorderControl`'s `onBreakpointChange` and the `BreakpointProvider` context above it are wired
+	 * to the same `changeBreakpoint` function, so exercising one exercises the other; invoking it maps
+	 * the control breakpoint key back to the matching editor device name.
 	 *
 	 * @return {void}
 	 */
 	it('invokes onDeviceChange with the matching device when onBreakpointChange fires', () => {
 		const { borderControl, onDeviceChange } = renderEditorBorderControl();
 
-		borderControl.props.onBreakpointChange('tablet');
+		act(() => {
+			borderControl.props.onBreakpointChange('tablet');
+		});
 
 		expect(onDeviceChange).toHaveBeenCalledWith('Tablet');
 	});
@@ -319,28 +389,20 @@ describe('EditorBorderControl breakpoint switching', () => {
 	it('maps every breakpoint key back to its editor device name', () => {
 		const { borderControl, onDeviceChange } = renderEditorBorderControl();
 
-		borderControl.props.onBreakpointChange('mobile');
+		act(() => {
+			borderControl.props.onBreakpointChange('mobile');
+		});
 		expect(onDeviceChange).toHaveBeenLastCalledWith('Mobile');
 
-		borderControl.props.onBreakpointChange('desktop');
+		act(() => {
+			borderControl.props.onBreakpointChange('desktop');
+		});
 		expect(onDeviceChange).toHaveBeenLastCalledWith('Desktop');
 
-		borderControl.props.onBreakpointChange('tablet');
+		act(() => {
+			borderControl.props.onBreakpointChange('tablet');
+		});
 		expect(onDeviceChange).toHaveBeenLastCalledWith('Tablet');
-	});
-
-	/**
-	 * The `BreakpointProvider`'s own `onChange` maps breakpoints back to devices the same way as the
-	 * `onBreakpointChange` prop, using the one shared mapping rather than a second copy of it.
-	 *
-	 * @return {void}
-	 */
-	it('maps the BreakpointProvider onChange consistently with onBreakpointChange', () => {
-		const { provider, onDeviceChange } = renderEditorBorderControl();
-
-		provider.props.onChange('mobile');
-
-		expect(onDeviceChange).toHaveBeenCalledWith('Mobile');
 	});
 
 	/**
@@ -355,10 +417,12 @@ describe('EditorBorderControl breakpoint switching', () => {
 			tabletValue: NATIVE_VALUE,
 		});
 
-		borderControl.props.onChange({
-			width: ['9px', '3px', '4px', '5px'],
-			style: ['solid', 'dashed', 'dotted', 'double'],
-			color: ['#111111', '#222222', '#333333', '#444444'],
+		act(() => {
+			borderControl.props.onChange({
+				width: ['9px', '3px', '4px', '5px'],
+				style: ['solid', 'dashed', 'dotted', 'double'],
+				color: ['#111111', '#222222', '#333333', '#444444'],
+			});
 		});
 
 		expect(onChangeTablet).toHaveBeenCalled();
@@ -373,17 +437,17 @@ describe('EditorBorderControl breakpoint switching', () => {
 	 * @return {void}
 	 */
 	it('falls back to desktop for an unknown preview device', () => {
-		const { provider } = renderEditorBorderControl({ previewDevice: 'Widescreen' });
+		const { borderControl } = renderEditorBorderControl({ previewDevice: 'Widescreen' });
 
-		expect(provider.props.value).toBe('desktop');
+		expect(borderControl.props.breakpoint).toBe('desktop');
 	});
 });
 
 describe('EditorBorderControl unlinked rendering', () => {
 	/**
 	 * The native attribute is always a four-sided object, so `BorderControl`'s value always arrives
-	 * as four-element width/style/color arrays — the control has nothing to collapse and renders
-	 * unlinked by construction, matching `BoxControl`'s own docblock for radius.
+	 * as four-element width/style/color arrays — collapsing them to one row is `isLinked`'s job now,
+	 * not a shape the value itself can ever take on.
 	 *
 	 * @return {void}
 	 */
@@ -394,5 +458,133 @@ describe('EditorBorderControl unlinked rendering', () => {
 		expect(borderControl.props.value.width).toHaveLength(4);
 		expect(Array.isArray(borderControl.props.value.style)).toBe(true);
 		expect(borderControl.props.value.style).toHaveLength(4);
+	});
+});
+
+describe('EditorBorderControl linked view', () => {
+	/**
+	 * A breakpoint that has never stored anything has nothing to differ side to side, so it opens
+	 * linked — matching an unlinked-but-uniform value below, and the unset-value test in the bridging
+	 * suite above.
+	 *
+	 * @return {void}
+	 */
+	it('reads an unset value as linked', () => {
+		const { borderControl } = renderEditorBorderControl({ previewDevice: 'Tablet', tabletValue: undefined });
+
+		expect(borderControl.props.isLinked).toBe(true);
+	});
+
+	/**
+	 * Four sides that already agree on color, style, and width read as linked, even though the native
+	 * shape storing them is the same four-element arrays an actually-diverging value would use —
+	 * `isLinked` is derived from whether the sides agree, not from the shape alone.
+	 *
+	 * @return {void}
+	 */
+	it('reads a uniform four-sided value as linked', () => {
+		const { borderControl } = renderEditorBorderControl({ value: UNIFORM_NATIVE_VALUE });
+
+		expect(borderControl.props.isLinked).toBe(true);
+	});
+
+	/**
+	 * Four sides that disagree on any of color, style, or width read as unlinked.
+	 *
+	 * @return {void}
+	 */
+	it('reads a diverging four-sided value as unlinked', () => {
+		const { borderControl } = renderEditorBorderControl({ value: NATIVE_VALUE });
+
+		expect(borderControl.props.isLinked).toBe(false);
+	});
+
+	/**
+	 * Toggling link while unlinked collapses every side to the top side's value — matching
+	 * `BorderControl`'s own uncontrolled relink rule — and the control reports linked afterward.
+	 *
+	 * @return {void}
+	 */
+	it('collapses every side to the top side value when relinking a diverging border', () => {
+		const { borderControl, onChange } = renderEditorBorderControl({ value: NATIVE_VALUE });
+
+		expect(borderControl.props.isLinked).toBe(false);
+
+		act(() => {
+			borderControl.props.onToggleLink();
+		});
+
+		expect(onChange).toHaveBeenCalledWith([
+			{
+				top: ['#111111', 'solid', 2],
+				right: ['#111111', 'solid', 2],
+				bottom: ['#111111', 'solid', 2],
+				left: ['#111111', 'solid', 2],
+				unit: 'px',
+			},
+		]);
+		expect(latestBorderControlProps.isLinked).toBe(true);
+	});
+
+	/**
+	 * Toggling link while a uniform border is linked switches the view to unlinked without writing
+	 * anything — the four sides already agree, so there is nothing to collapse; only the view changes,
+	 * exactly the behavior Border Radius's own link toggle already has and this control lacked before.
+	 *
+	 * @return {void}
+	 */
+	it('unlinks a uniform border into the per-side grid without writing a change', () => {
+		const { borderControl, onChange } = renderEditorBorderControl({ value: UNIFORM_NATIVE_VALUE });
+
+		expect(borderControl.props.isLinked).toBe(true);
+
+		act(() => {
+			borderControl.props.onToggleLink();
+		});
+
+		expect(onChange).not.toHaveBeenCalled();
+		expect(latestBorderControlProps.isLinked).toBe(false);
+	});
+
+	/**
+	 * The unlinked view, once explicitly chosen, survives an incidental re-render with the same
+	 * uniform value (e.g. a parent re-render that changes an unrelated prop) — an explicit choice is
+	 * not something a value that merely stayed the same should silently revert.
+	 *
+	 * @return {void}
+	 */
+	it('keeps an explicit unlink across a re-render with the same uniform value', () => {
+		const { borderControl } = renderEditorBorderControl({ value: UNIFORM_NATIVE_VALUE });
+
+		act(() => {
+			borderControl.props.onToggleLink();
+		});
+
+		renderEditorBorderControl({ value: UNIFORM_NATIVE_VALUE, label: 'Border' });
+
+		expect(latestBorderControlProps.isLinked).toBe(false);
+	});
+
+	/**
+	 * Each breakpoint's explicit link choice is independent — unlinking Desktop must not leave Tablet
+	 * stuck unlinked too, since the two are edited through entirely separate control instances in
+	 * practice and only share this component's state because a test re-renders the same instance.
+	 *
+	 * @return {void}
+	 */
+	it('tracks the linked override per breakpoint independently', () => {
+		const { borderControl } = renderEditorBorderControl({ value: UNIFORM_NATIVE_VALUE });
+
+		act(() => {
+			borderControl.props.onToggleLink();
+		});
+		expect(latestBorderControlProps.isLinked).toBe(false);
+
+		renderEditorBorderControl({
+			previewDevice: 'Tablet',
+			value: UNIFORM_NATIVE_VALUE,
+			tabletValue: UNIFORM_NATIVE_VALUE,
+		});
+		expect(latestBorderControlProps.isLinked).toBe(true);
 	});
 });


### PR DESCRIPTION
Supersedes #1345, which auto-closed when its branch was renamed.

## Summary
- Follow-up to review feedback on #1334: `EditorBorderControl`'s Linked toggle never collapsed the Border field to one row, because the native attribute always stores four sides once written, so `BorderControl`'s own shape-based fallback (`isSlotList`) could never tell "every side happens to match" from "the user is editing them individually."
- `EditorBorderControl` now owns the linked/unlinked view as its own UI state, seeded from whether the stored sides currently agree and overridden per breakpoint once the user explicitly links or unlinks — the same pairing `singlebtn/edit.js`'s `borderRadiusModeOverride` already uses for Border Radius.
- Relinking collapses every side to the top side's value, matching `BorderControl`'s own uncontrolled relink rule ("the first side wins").

## Test plan
- [ ] Open the Button preset's Border field with all four sides matching and confirm it renders as one row.
- [ ] Click Unlink and confirm it expands into four independently-editable rows without changing the stored value.
- [ ] Diverge one side's width, style, or color, then click Link and confirm every side collapses to the top side's value and the field returns to one row.
- [ ] Switch breakpoints (Desktop/Tablet/Mobile) and confirm each one remembers its own linked/unlinked choice independently.