### PR TITLE
[DTM] SOFT-4207 [1/15]: favoriteFonts document section

### DIFF
--- a/includes/resources/Design_Tokens/Document/Favorite_Font_Index.php
+++ b/includes/resources/Design_Tokens/Document/Favorite_Font_Index.php
@@ -19,6 +19,14 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
  * order is the display order every picker renders — the family a site added first sits first.
  * add() is therefore idempotent on an existing entry and never reorders it.
  *
+ * Membership is decided case-insensitively, because a family name is a proper noun rather than an
+ * identifier: `Inter` and `INTER` name one face, and the catalog gate the REST routes run in front of
+ * this already accepts either spelling. Matching case-sensitively here would let those two spellings
+ * both pass that gate and store two entries for one font — and neither picker would show the second,
+ * since both collapse the list case-insensitively before rendering, leaving an entry no one can see
+ * or remove. Only the comparison folds case; the stored name keeps whatever casing it arrived with,
+ * which is what a picker displays.
+ *
  * @since TBD
  */
 final class Favorite_Font_Index {
@@ -27,8 +35,9 @@ final class Favorite_Font_Index {
 	 * Every stored favorite family, in display order. Read-side fail-soft: a section that is not a
 	 * sequential list is dropped wholesale (degrades to "no favorites"), and non-string or empty
 	 * entries inside an otherwise-valid list are filtered out, so a hand-corrupted section degrades
-	 * to an empty list instead of a type error downstream. Duplicates are collapsed, keeping first
-	 * occurrence, so a hand-written repeat cannot render the same family twice.
+	 * to an empty list instead of a type error downstream. Duplicates are collapsed case-insensitively,
+	 * keeping first occurrence, so neither a hand-written repeat nor a pair of spellings can render the
+	 * same family twice.
 	 *
 	 * @since TBD
 	 *
@@ -54,10 +63,26 @@ final class Favorite_Font_Index {
 
 		$valid = array_filter( $families, fn( $family ) => is_string( $family ) && trim( $family ) !== '' );
 
-		return array_values( array_unique( array_map( 'trim', $valid ) ) );
+		$seen   = [];
+		$unique = [];
+
+		foreach ( array_map( 'trim', $valid ) as $family ) {
+			$key = $this->fold( $family );
+
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+
+			$seen[ $key ] = true;
+			$unique[]     = $family;
+		}
+
+		return $unique;
 	}
 
 	/**
+	 * Whether a family is already a favorite, matched case-insensitively.
+	 *
 	 * @since TBD
 	 *
 	 * @param array<string, mixed> $document
@@ -66,7 +91,15 @@ final class Favorite_Font_Index {
 	 * @return bool
 	 */
 	public function has( array $document, string $family ): bool {
-		return in_array( trim( $family ), $this->all( $document ), true );
+		$key = $this->fold( trim( $family ) );
+
+		foreach ( $this->all( $document ) as $stored ) {
+			if ( $this->fold( $stored ) === $key ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -95,8 +128,10 @@ final class Favorite_Font_Index {
 	}
 
 	/**
-	 * Remove a family from the list, leaving every other favorite's relative order untouched.
-	 * No-op (the same document is returned) when the family is not in the list.
+	 * Remove a family from the list, leaving every other favorite's relative order untouched. Matched
+	 * case-insensitively, so a family can be cleared through the spelling a client has rather than only
+	 * through the one that happens to be stored. No-op (the same document is returned) when the family
+	 * is not in the list.
 	 *
 	 * @since TBD
 	 *
@@ -106,16 +141,33 @@ final class Favorite_Font_Index {
 	 * @return array<string, mixed>
 	 */
 	public function remove( array $document, string $family ): array {
-		$family  = trim( $family );
+		$key     = $this->fold( trim( $family ) );
 		$current = $this->all( $document );
 
-		$remaining = array_values( array_filter( $current, fn( string $stored ) => $stored !== $family ) );
+		$remaining = array_values(
+			array_filter( $current, fn( string $stored ) => $this->fold( $stored ) !== $key )
+		);
 
 		if ( $remaining === $current ) {
 			return $document;
 		}
 
 		return $this->write_list( $document, $remaining );
+	}
+
+	/**
+	 * The comparison key for a family name. ASCII lowercasing, matching both the `strcasecmp()` the
+	 * REST catalog gate uses and the `toLowerCase()` both pickers collapse their lists with, so the
+	 * three agree on what counts as the same font.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $family The family name.
+	 *
+	 * @return string The comparison key.
+	 */
+	private function fold( string $family ): string {
+		return strtolower( $family );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Document/Favorite_Font_Index.php
+++ b/includes/resources/Design_Tokens/Document/Favorite_Font_Index.php
@@ -1,0 +1,206 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Document;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+
+/**
+ * Reads and writes the favoriteFonts list — the library's ordered favorite font families — in the
+ * module's $extensions namespace. Authoring metadata only; the effective document builder strips
+ * $extensions, so a favorite never reaches projected CSS. Every mutating method returns the
+ * updated document; the original is not modified.
+ *
+ * A favorite is a plain catalog family name, never a token id and never an {alias}. It carries no
+ * indirection: nothing resolves through it, no CSS variable is emitted for it, and re-pointing one
+ * site-wide is not a capability that exists. Its only job is to pin a family to the top of a font
+ * picker so a site is not searching a ~1,900-name catalog for the same face every time.
+ *
+ * Membership is a set, but the storage shape is an ordered list rather than a map because insertion
+ * order is the display order every picker renders — the family a site added first sits first.
+ * add() is therefore idempotent on an existing entry and never reorders it.
+ *
+ * @since TBD
+ */
+final class Favorite_Font_Index {
+
+	/**
+	 * Every stored favorite family, in display order. Read-side fail-soft: a section that is not a
+	 * sequential list is dropped wholesale (degrades to "no favorites"), and non-string or empty
+	 * entries inside an otherwise-valid list are filtered out, so a hand-corrupted section degrades
+	 * to an empty list instead of a type error downstream. Duplicates are collapsed, keeping first
+	 * occurrence, so a hand-written repeat cannot render the same family twice.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 *
+	 * @return list<string>
+	 */
+	public function all( array $document ): array {
+		$families = $this->read_list( $document );
+
+		if ( ! is_array( $families ) ) {
+			return [];
+		}
+
+		// The `$families === []` check is required, not redundant: `range( 0, -1 )` returns
+		// `[ 0, -1 ]` in PHP, not `[]`, so without this short-circuit an empty favorites list would
+		// be misclassified as malformed rather than as a valid empty list.
+		$is_list = $families === [] || array_keys( $families ) === range( 0, count( $families ) - 1 );
+
+		if ( ! $is_list ) {
+			return [];
+		}
+
+		$valid = array_filter( $families, fn( $family ) => is_string( $family ) && trim( $family ) !== '' );
+
+		return array_values( array_unique( array_map( 'trim', $valid ) ) );
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param string               $family The catalog family name.
+	 *
+	 * @return bool
+	 */
+	public function has( array $document, string $family ): bool {
+		return in_array( trim( $family ), $this->all( $document ), true );
+	}
+
+	/**
+	 * Append a family to the end of the list. Idempotent: a family already in the list returns the
+	 * same document, keeping its existing position rather than moving to the end — a picker's
+	 * display order must not shuffle because a client replayed a write.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param string               $family The catalog family name.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function add( array $document, string $family ): array {
+		$family = trim( $family );
+
+		if ( $family === '' || $this->has( $document, $family ) ) {
+			return $document;
+		}
+
+		$families   = $this->all( $document );
+		$families[] = $family;
+
+		return $this->write_list( $document, $families );
+	}
+
+	/**
+	 * Remove a family from the list, leaving every other favorite's relative order untouched.
+	 * No-op (the same document is returned) when the family is not in the list.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param string               $family The catalog family name.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function remove( array $document, string $family ): array {
+		$family  = trim( $family );
+		$current = $this->all( $document );
+
+		$remaining = array_values( array_filter( $current, fn( string $stored ) => $stored !== $family ) );
+
+		if ( $remaining === $current ) {
+			return $document;
+		}
+
+		return $this->write_list( $document, $remaining );
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 *
+	 * @return mixed
+	 */
+	private function read_list( array $document ) {
+		$ext_data = $document[ Extensions::get_extensions_key() ] ?? null;
+
+		if ( ! is_array( $ext_data ) ) {
+			return null;
+		}
+
+		$ns_data = $ext_data[ Extensions::get_namespace() ] ?? null;
+
+		if ( ! is_array( $ns_data ) ) {
+			return null;
+		}
+
+		return $ns_data[ Extensions::get_section_favorite_fonts() ] ?? null;
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 * @param array<int, string>   $families
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function write_list( array $document, array $families ): array {
+		$document = $this->ensure_path( $document );
+
+		$ext = Extensions::get_extensions_key();
+		$ns  = Extensions::get_namespace();
+		$sec = Extensions::get_section_favorite_fonts();
+
+		/** @var array<string, mixed> $ext_data */
+		$ext_data = $document[ $ext ];
+		/** @var array<string, mixed> $ns_data */
+		$ns_data = $ext_data[ $ns ];
+
+		$ns_data[ $sec ]  = $families;
+		$ext_data[ $ns ]  = $ns_data;
+		$document[ $ext ] = $ext_data;
+
+		return $document;
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function ensure_path( array $document ): array {
+		$ext = Extensions::get_extensions_key();
+		$ns  = Extensions::get_namespace();
+		$sec = Extensions::get_section_favorite_fonts();
+
+		if ( ! isset( $document[ $ext ] ) || ! is_array( $document[ $ext ] ) ) {
+			$document[ $ext ] = [];
+		}
+
+		/** @var array<string, mixed> $ext_data */
+		$ext_data = $document[ $ext ];
+
+		if ( ! isset( $ext_data[ $ns ] ) || ! is_array( $ext_data[ $ns ] ) ) {
+			$ext_data[ $ns ]  = [];
+			$document[ $ext ] = $ext_data;
+		}
+
+		/** @var array<string, mixed> $ns_data */
+		$ns_data = $ext_data[ $ns ];
+
+		if ( ! isset( $ns_data[ $sec ] ) || ! is_array( $ns_data[ $sec ] ) ) {
+			$ns_data[ $sec ]  = [];
+			$ext_data[ $ns ]  = $ns_data;
+			$document[ $ext ] = $ext_data;
+		}
+
+		return $document;
+	}
+}

--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -642,6 +642,18 @@ final class Dtcg_Validator {
 			);
 		}
 
+		// favoriteFonts is a flat ordered list of font family names — not preset-shaped and not a
+		// { key => value } map, so the tokens-map walk (driven by get_sections(), which excludes
+		// it) never covers it. Without this branch it would pass through with no validation at all.
+		$favorites_section = Extensions::get_section_favorite_fonts();
+
+		if ( isset( $namespace[ $favorites_section ] ) && is_array( $namespace[ $favorites_section ] ) ) {
+			$errors = array_merge(
+				$errors,
+				$this->validate_favorite_fonts( $namespace[ $favorites_section ], $base . '.' . $favorites_section )
+			);
+		}
+
 		return $errors;
 	}
 
@@ -770,6 +782,50 @@ final class Dtcg_Validator {
 					$prefix . '.' . Cast::to_string( $index ),
 					Validation_Error::get_code_value_invalid(),
 					'tokenOrder must be a sequential list of non-empty string token ids.'
+				);
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Validate a favoriteFonts section: it must be a sequential list of non-empty string font
+	 * family names. Whether a name is present in the site's font catalog is the REST write guard's
+	 * concern — a family that a theme or plugin has since stopped registering is data drift, not a
+	 * grammar error, and read-side consumers already ignore what they cannot render.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<int|string, mixed> $favorites The decoded favoriteFonts section.
+	 * @param string                   $prefix    Dot-path to the section, for error messages.
+	 *
+	 * @return Validation_Error[]
+	 */
+	private function validate_favorite_fonts( array $favorites, string $prefix ): array {
+		// The `$favorites === []` check is required, not redundant: `range( 0, -1 )` returns
+		// `[ 0, -1 ]` in PHP, not `[]`, so without this short-circuit an empty favorites list would
+		// be misclassified as malformed rather than as a valid empty list.
+		$is_list = $favorites === [] || array_keys( $favorites ) === range( 0, count( $favorites ) - 1 );
+
+		if ( ! $is_list ) {
+			return [
+				new Validation_Error(
+					$prefix,
+					Validation_Error::get_code_value_invalid(),
+					'favoriteFonts must be a sequential list of non-empty font family names.'
+				),
+			];
+		}
+
+		$errors = [];
+
+		foreach ( $favorites as $index => $family ) {
+			if ( ! is_string( $family ) || trim( $family ) === '' ) {
+				$errors[] = new Validation_Error(
+					$prefix . '.' . Cast::to_string( $index ),
+					Validation_Error::get_code_value_invalid(),
+					'favoriteFonts must be a sequential list of non-empty font family names.'
 				);
 			}
 		}

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Extensions.php
@@ -19,6 +19,9 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary;
  *                           metadata only. Flat rather than group-keyed so the stored order stays
  *                           locale-independent — a UI-schema group name is a translated display
  *                           label, not a stable identifier (see Token_Order_Index).
+ *   - "favoriteFonts"     → the library's favorite font families: an ordered list of catalog family
+ *                           names. Not a token layer — a favorite carries no indirection and no CSS
+ *                           variable; it only pins a family to the top of a font picker.
  *
  * The preset sections hold named groups; each group is a map of preset-slug =>
  * { "label": …, "tokens": … } alongside a "$default" key naming the group's default preset. A color palette
@@ -129,6 +132,25 @@ final class Extensions {
 	 * @var string
 	 */
 	private const SECTION_PRESET_ORDER = 'presetOrder';
+
+	/**
+	 * The library's favorite font families: an ordered list of catalog family names, the fonts a
+	 * site reaches for often pinned to the top of every font picker. NOT returned by
+	 * get_sections() — it is neither preset-shaped nor a tokens map, so the tokens-map walk (and
+	 * the reference scanner that follows get_sections()) must not descend into it; it holds
+	 * family-name strings only, never {alias} values. The validator covers it with its own
+	 * explicit branch instead.
+	 *
+	 * Deliberately not a token layer. A favorite carries no indirection: it never resolves through
+	 * an alias, never emits a CSS variable, and re-pointing one site-wide is not a capability that
+	 * exists. Storing families as tokens would imply all three, and would offer a narrower set than
+	 * the font catalog a block's own picker already lists.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const SECTION_FAVORITE_FONTS = 'favoriteFonts';
 
 	/**
 	 * The key naming a group's default preset slug.
@@ -303,6 +325,18 @@ final class Extensions {
 	 */
 	public static function get_section_preset_order(): string {
 		return self::SECTION_PRESET_ORDER;
+	}
+
+	/**
+	 * The favorite-font-families section name.
+	 * NOT returned by get_sections() — it is a flat name list, not preset-shaped.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_section_favorite_fonts(): string {
+		return self::SECTION_FAVORITE_FONTS;
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Document/Favorite_Font_IndexTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/Favorite_Font_IndexTest.php
@@ -157,9 +157,69 @@ final class Favorite_Font_IndexTest extends TestCase {
 		$this->assertTrue( $this->index->has( $doc, '  Inter  ' ) );
 	}
 
+	/**
+	 * A family name is a proper noun, not an identifier, so membership folds case. The REST catalog
+	 * gate in front of this already accepts either spelling, so matching case-sensitively here would
+	 * let both through and store two entries for one font.
+	 *
+	 * @dataProvider caseVariantProvider
+	 *
+	 * @param string $stored  The family as stored.
+	 * @param string $queried The same family, spelled differently.
+	 *
+	 * @return void
+	 */
+	public function testHasMatchesRegardlessOfCase( string $stored, string $queried ): void {
+		$this->assertTrue( $this->index->has( $this->doc_with_favorites( [ $stored ] ), $queried ) );
+	}
+
+	/**
+	 * Spellings of one family name, for the membership, add and remove cases below.
+	 *
+	 * @return Generator
+	 */
+	public function caseVariantProvider(): Generator {
+		yield 'upper queried against title' => [
+			'stored'  => 'Inter',
+			'queried' => 'INTER',
+		];
+		yield 'lower queried against title' => [
+			'stored'  => 'Inter',
+			'queried' => 'inter',
+		];
+		yield 'title queried against lower' => [
+			'stored'  => 'inter',
+			'queried' => 'Inter',
+		];
+		yield 'mixed multi-word' => [
+			'stored'  => 'Abril Fatface',
+			'queried' => 'abril FATFACE',
+		];
+	}
+
 	// -------------------------------------------------------------------------
 	// add()
 	// -------------------------------------------------------------------------
+
+	/**
+	 * The consequence of the rule above on the write path: a second spelling of a family already
+	 * favorited is the same idempotent no-op an exact repeat is, rather than a second entry that
+	 * neither picker would render — both collapse the list case-insensitively before display, so such
+	 * an entry could not be seen or cleared through the UI.
+	 *
+	 * @dataProvider caseVariantProvider
+	 *
+	 * @param string $stored  The family as stored.
+	 * @param string $queried The same family, spelled differently.
+	 *
+	 * @return void
+	 */
+	public function testAddDoesNotStoreASecondSpellingOfAFamily( string $stored, string $queried ): void {
+		$doc = $this->doc_with_favorites( [ $stored ] );
+
+		$this->assertSame( $doc, $this->index->add( $doc, $queried ) );
+		$this->assertSame( [ $stored ], $this->index->all( $this->index->add( $doc, $queried ) ) );
+	}
 
 	/**
 	 * add() creates the $extensions/{namespace}/favoriteFonts path when none of it yet exists.
@@ -301,6 +361,36 @@ final class Favorite_Font_IndexTest extends TestCase {
 	// -------------------------------------------------------------------------
 	// helpers
 	// -------------------------------------------------------------------------
+
+	/**
+	 * A favorite can be cleared through the spelling a client holds rather than only through the one
+	 * that happens to be stored — otherwise a favorite added before this rule existed could be
+	 * unreachable from a picker that lowercases what it sends.
+	 *
+	 * @dataProvider caseVariantProvider
+	 *
+	 * @param string $stored  The family as stored.
+	 * @param string $queried The same family, spelled differently.
+	 *
+	 * @return void
+	 */
+	public function testRemoveMatchesRegardlessOfCase( string $stored, string $queried ): void {
+		$doc = $this->doc_with_favorites( [ $stored, 'Georgia' ] );
+
+		$this->assertSame( [ 'Georgia' ], $this->index->all( $this->index->remove( $doc, $queried ) ) );
+	}
+
+	/**
+	 * A section hand-written with two spellings of one family renders once, keeping the first — the
+	 * same collapse both pickers apply, so the Style Library and a block agree on the list.
+	 *
+	 * @return void
+	 */
+	public function testAllCollapsesCaseVariantDuplicates(): void {
+		$doc = $this->doc_with_favorites( [ 'Inter', 'INTER', 'Georgia', 'inter' ] );
+
+		$this->assertSame( [ 'Inter', 'Georgia' ], $this->index->all( $doc ) );
+	}
 
 	/**
 	 * Build a decoded document carrying a favoriteFonts family list.

--- a/tests/wpunit/Resources/Design_Tokens/Document/Favorite_Font_IndexTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/Favorite_Font_IndexTest.php
@@ -1,0 +1,321 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Document;
+
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Favorite_Font_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Covers the favoriteFonts ordered-family-list read/write operations of Favorite_Font_Index.
+ *
+ * @since TBD
+ */
+final class Favorite_Font_IndexTest extends TestCase {
+
+	/**
+	 * The index under test.
+	 *
+	 * @since TBD
+	 *
+	 * @var Favorite_Font_Index
+	 */
+	private Favorite_Font_Index $index;
+
+	/**
+	 * Build a fresh index before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->index = new Favorite_Font_Index();
+	}
+
+	// -------------------------------------------------------------------------
+	// all()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * An empty document has no favorites.
+	 *
+	 * @return void
+	 */
+	public function testAllReturnsEmptyArrayForEmptyDocument(): void {
+		$this->assertSame( [], $this->index->all( [] ) );
+	}
+
+	/**
+	 * A document missing the $extensions key has no favorites.
+	 *
+	 * @return void
+	 */
+	public function testAllReturnsEmptyArrayWhenExtensionsKeyMissing(): void {
+		$doc = [ 'primitive' => [ 'color' => [] ] ];
+
+		$this->assertSame( [], $this->index->all( $doc ) );
+	}
+
+	/**
+	 * A well-formed favoriteFonts section round-trips through all() in its stored order.
+	 *
+	 * @return void
+	 */
+	public function testAllReturnsStoredFamiliesInOrder(): void {
+		$doc = $this->doc_with_favorites( [ 'Inter', 'Abril Fatface' ] );
+
+		$this->assertSame( [ 'Inter', 'Abril Fatface' ], $this->index->all( $doc ) );
+	}
+
+	/**
+	 * A malformed favoriteFonts section — a non-list ("map-shaped") value, or non-string, empty or
+	 * duplicated families inside the list — is dropped (or filtered) on read rather than surfaced,
+	 * so a hand-corrupted section degrades to "no favorites" instead of a type error downstream.
+	 *
+	 * @dataProvider malformedSectionProvider
+	 *
+	 * @param array<int|string, mixed> $section  The raw decoded favoriteFonts section.
+	 * @param list<string>             $expected The expected result of all() against that section.
+	 *
+	 * @return void
+	 */
+	public function testAllDropsOrFiltersMalformedEntries( array $section, array $expected ): void {
+		$doc = [
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					Extensions::get_section_favorite_fonts() => $section,
+				],
+			],
+		];
+
+		$this->assertSame( $expected, $this->index->all( $doc ) );
+	}
+
+	/**
+	 * Malformed favoriteFonts section shapes and what all() must degrade each to.
+	 *
+	 * @return Generator
+	 */
+	public function malformedSectionProvider(): Generator {
+		yield 'map-shaped (non-sequential) section value' => [
+			'section'  => [ 'a' => 'Inter' ],
+			'expected' => [],
+		];
+
+		yield 'non-string family inside an otherwise valid list' => [
+			'section'  => [ 'Inter', 42, 'Georgia' ],
+			'expected' => [ 'Inter', 'Georgia' ],
+		];
+
+		yield 'empty-string family inside an otherwise valid list' => [
+			'section'  => [ 'Inter', '' ],
+			'expected' => [ 'Inter' ],
+		];
+
+		yield 'whitespace-only family inside an otherwise valid list' => [
+			'section'  => [ 'Inter', '   ' ],
+			'expected' => [ 'Inter' ],
+		];
+
+		yield 'surrounding whitespace is trimmed' => [
+			'section'  => [ '  Inter  ' ],
+			'expected' => [ 'Inter' ],
+		];
+
+		yield 'duplicate family collapses to first occurrence' => [
+			'section'  => [ 'Inter', 'Georgia', 'Inter' ],
+			'expected' => [ 'Inter', 'Georgia' ],
+		];
+	}
+
+	// -------------------------------------------------------------------------
+	// has()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * has() reports a stored family, and reports a family that is not stored as absent.
+	 *
+	 * @return void
+	 */
+	public function testHasReportsMembership(): void {
+		$doc = $this->doc_with_favorites( [ 'Inter' ] );
+
+		$this->assertTrue( $this->index->has( $doc, 'Inter' ) );
+		$this->assertFalse( $this->index->has( $doc, 'Georgia' ) );
+	}
+
+	/**
+	 * has() trims the family it is asked about, matching how all() stores one.
+	 *
+	 * @return void
+	 */
+	public function testHasTrimsTheQueriedFamily(): void {
+		$doc = $this->doc_with_favorites( [ 'Inter' ] );
+
+		$this->assertTrue( $this->index->has( $doc, '  Inter  ' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// add()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * add() creates the $extensions/{namespace}/favoriteFonts path when none of it yet exists.
+	 *
+	 * @return void
+	 */
+	public function testAddCreatesFullPathWhenMissing(): void {
+		$result = $this->index->add( [], 'Inter' );
+
+		$this->assertSame( [ 'Inter' ], $this->index->all( $result ) );
+	}
+
+	/**
+	 * add() appends to the end, so insertion order is the display order a picker renders.
+	 *
+	 * @return void
+	 */
+	public function testAddAppendsToTheEnd(): void {
+		$doc = $this->doc_with_favorites( [ 'Inter' ] );
+
+		$result = $this->index->add( $doc, 'Georgia' );
+
+		$this->assertSame( [ 'Inter', 'Georgia' ], $this->index->all( $result ) );
+	}
+
+	/**
+	 * add() is idempotent on a family already in the list: the same document comes back, so a
+	 * replayed write neither duplicates the entry nor moves it to the end of the list.
+	 *
+	 * @return void
+	 */
+	public function testAddIsIdempotentAndPreservesPosition(): void {
+		$doc = $this->doc_with_favorites( [ 'Inter', 'Georgia' ] );
+
+		$result = $this->index->add( $doc, 'Inter' );
+
+		$this->assertSame( $doc, $result );
+	}
+
+	/**
+	 * add() refuses an empty or whitespace-only family, returning the document untouched — all()
+	 * would filter such an entry out anyway, so it must not be storable in the first place.
+	 *
+	 * @dataProvider blankFamilyProvider
+	 *
+	 * @param string $family The blank family name.
+	 *
+	 * @return void
+	 */
+	public function testAddRefusesABlankFamily( string $family ): void {
+		$doc = $this->doc_with_favorites( [ 'Inter' ] );
+
+		$this->assertSame( $doc, $this->index->add( $doc, $family ) );
+	}
+
+	/**
+	 * Family names that carry no name at all.
+	 *
+	 * @return Generator
+	 */
+	public function blankFamilyProvider(): Generator {
+		yield 'empty string' => [ 'family' => '' ];
+		yield 'spaces only' => [ 'family' => '   ' ];
+	}
+
+	/**
+	 * add() trims the family before storing it, so the same face cannot enter the list twice under
+	 * two spellings that differ only in whitespace.
+	 *
+	 * @return void
+	 */
+	public function testAddTrimsTheFamily(): void {
+		$result = $this->index->add( [], '  Inter  ' );
+
+		$this->assertSame( [ 'Inter' ], $this->index->all( $result ) );
+	}
+
+	/**
+	 * add() does not modify the document passed in — every mutator returns a new document.
+	 *
+	 * @return void
+	 */
+	public function testAddDoesNotModifyItsInput(): void {
+		$doc = [];
+
+		$this->index->add( $doc, 'Inter' );
+
+		$this->assertSame( [], $doc );
+	}
+
+	// -------------------------------------------------------------------------
+	// remove()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * remove() is a no-op (the same document is returned) when the family is not in the list.
+	 *
+	 * @return void
+	 */
+	public function testRemoveIsNoOpWhenAbsent(): void {
+		$this->assertSame( [], $this->index->remove( [], 'Inter' ) );
+	}
+
+	/**
+	 * remove() deletes only the named family, leaving every other favorite's relative order intact.
+	 *
+	 * @return void
+	 */
+	public function testRemoveDeletesTargetFamilyOnly(): void {
+		$doc = $this->doc_with_favorites( [ 'Inter', 'Georgia', 'Abril Fatface' ] );
+
+		$result = $this->index->remove( $doc, 'Georgia' );
+
+		$this->assertSame( [ 'Inter', 'Abril Fatface' ], $this->index->all( $result ) );
+	}
+
+	/**
+	 * remove() leaves the rest of the document, outside the favoriteFonts section, unchanged.
+	 *
+	 * @return void
+	 */
+	public function testRemoveLeavesTheRestOfTheDocumentUnchanged(): void {
+		$doc = $this->doc_with_favorites( [ 'Inter' ] );
+
+		$doc['primitive'] = [
+			'color' => [
+				'brand' => [
+					'$type'  => 'color',
+					'$value' => '#3182CE',
+				],
+			],
+		];
+
+		$result = $this->index->remove( $doc, 'Inter' );
+
+		$this->assertSame( $doc['primitive'], $result['primitive'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Build a decoded document carrying a favoriteFonts family list.
+	 *
+	 * @param list<string> $families The stored favorite families.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function doc_with_favorites( array $families ): array {
+		return [
+			Extensions::get_extensions_key() => [
+				Extensions::get_namespace() => [
+					Extensions::get_section_favorite_fonts() => $families,
+				],
+			],
+		];
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Document/Favorite_Font_IndexTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Document/Favorite_Font_IndexTest.php
@@ -202,8 +202,8 @@ final class Favorite_Font_IndexTest extends TestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * The consequence of the rule above on the write path: a second spelling of a family already
-	 * favorited is the same idempotent no-op an exact repeat is, rather than a second entry that
+	 * The consequence of the rule above on the write path: a second spelling of a family already in
+	 * the list is the same idempotent no-op an exact repeat is, rather than a second entry that
 	 * neither picker would render — both collapse the list case-insensitively before display, so such
 	 * an entry could not be seen or cleared through the UI.
 	 *

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
@@ -171,6 +171,47 @@ final class Dtcg_ValidatorTest extends TestCase {
 	}
 
 	/**
+	 * A well-formed favoriteFonts section validates: a sequential list of non-empty family names.
+	 *
+	 * @return void
+	 */
+	public function testAWellFormedFavoriteFontsSectionValidates(): void {
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'favoriteFonts' => [ 'Inter', 'Abril Fatface' ],
+				],
+			],
+		];
+
+		$result = $this->validator->validate( $document, Dtcg_Validator::get_context_overrides() );
+
+		$this->assertTrue( $result->is_valid(), $this->describe( $result->errors() ) );
+	}
+
+	/**
+	 * A stored favorite naming a family the site's catalog does not carry does not fail validation:
+	 * a theme switch stranding a favorite is data drift, enforced by the REST write guard, not
+	 * full-document grammar — and the removal path deliberately accepts such a family so it can be
+	 * cleared.
+	 *
+	 * @return void
+	 */
+	public function testAFavoriteFontNamingAnUncataloguedFamilyStillValidates(): void {
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'favoriteFonts' => [ 'A Font No Catalog Carries' ],
+				],
+			],
+		];
+
+		$result = $this->validator->validate( $document, Dtcg_Validator::get_context_overrides() );
+
+		$this->assertTrue( $result->is_valid(), $this->describe( $result->errors() ) );
+	}
+
+	/**
 	 * A document without a tokenOrder section produces no new errors, and a non-Kadence extension
 	 * namespace alongside it is passed through untouched.
 	 *
@@ -502,6 +543,44 @@ final class Dtcg_ValidatorTest extends TestCase {
 			'context'  => Dtcg_Validator::get_context_overrides(),
 			'code'     => Validation_Error::get_code_value_invalid(),
 			'path'     => '$extensions.com.kadence.designTokens.tokenOrder.0',
+		];
+		// favoriteFonts is an ordered list of family names, so a map-shaped value is rejected
+		// wholesale and a non-string or blank family is rejected per entry.
+		yield 'map-shaped (non-sequential) favoriteFonts value' => [
+			'document' => [
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'favoriteFonts' => [ 'a' => 'Inter' ],
+					],
+				],
+			],
+			'context'  => Dtcg_Validator::get_context_overrides(),
+			'code'     => Validation_Error::get_code_value_invalid(),
+			'path'     => '$extensions.com.kadence.designTokens.favoriteFonts',
+		];
+		yield 'non-string favoriteFonts family' => [
+			'document' => [
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'favoriteFonts' => [ 'Inter', 42 ],
+					],
+				],
+			],
+			'context'  => Dtcg_Validator::get_context_overrides(),
+			'code'     => Validation_Error::get_code_value_invalid(),
+			'path'     => '$extensions.com.kadence.designTokens.favoriteFonts.1',
+		];
+		yield 'whitespace-only favoriteFonts family' => [
+			'document' => [
+				'$extensions' => [
+					'com.kadence.designTokens' => [
+						'favoriteFonts' => [ '   ' ],
+					],
+				],
+			],
+			'context'  => Dtcg_Validator::get_context_overrides(),
+			'code'     => Validation_Error::get_code_value_invalid(),
+			'path'     => '$extensions.com.kadence.designTokens.favoriteFonts.0',
 		];
 		yield 'responsive on non-capable type' => [
 			'document' => [


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4207/font-families-become-favorites-not-tokens
:video_camera:  https://www.loom.com/share/2cde91916171494694080f3b7beda6e9

Adds `favoriteFonts` to the module's `$extensions` namespace: an ordered list of catalog font family names, the storage a site's favorite fonts will live in.

A favorite is deliberately not a token. It carries no indirection: nothing resolves through it, no CSS variable is emitted for it, and re-pointing one site-wide is not a capability that exists. Storing families as tokens would imply all three while offering a narrower set than the font catalog a block's own picker already lists.

- `Favorite_Font_Index` reads and writes the section, modeled on `Token_Order_Index`. Fail-soft on read: a map-shaped section degrades to an empty list, and blank or non-string entries are filtered out. `add()` is idempotent and preserves an existing entry's position, since insertion order is the display order every picker renders.
- The section is excluded from `get_sections()`, like `tokenLabels` and `tokenOrder`: it holds family-name strings, never `{alias}` values, so the tokens-map walk and the reference scanner must not descend into it. It gets its own explicit validator branch instead, which is the only thing that would otherwise validate it at all.

Nothing reads or writes the section yet.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for storing and managing favorite font families.
  * Favorite fonts can be viewed, added, checked, and removed while preserving their order.
  * Font names are trimmed, deduplicated, and blank entries are ignored.

* **Bug Fixes**
  * Added validation to identify malformed favorite-font data and invalid entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

