### PR TITLE
[DTM] SOFT-4207 [5/15]: Typography screen saves favorites, not font tokens

### DIFF
--- a/src/style-library/__tests__/font-flows.test.js
+++ b/src/style-library/__tests__/font-flows.test.js
@@ -1,28 +1,28 @@
 /* eslint-env jest */
-// cspell:ignore Abril Fatface abril fatface .
-import { addFontFlow } from '../helpers/font-flows';
+// cspell:ignore Abril Fatface .
+import { addFavoriteFontFlow, removeFavoriteFontFlow } from '../helpers/font-flows';
 import * as client from '../api/client';
 
 // A factory, not bare automocking — see scale-flows.test.js's identical note: the real module
 // imports `@wordpress/api-fetch`, externalized in production and not an npm dependency here.
 jest.mock('../api/client', () => ({
-	createUserPrimitive: jest.fn(),
+	addFavoriteFont: jest.fn(),
+	removeFavoriteFont: jest.fn(),
 }));
 
 beforeEach(() => {
 	jest.resetAllMocks();
 });
 
-describe('addFontFlow', () => {
-	it('posts the derived slug, label, single-family stack, and font-family group, refreshes the feed, and resolves the kebab canonical id', async () => {
-		client.createUserPrimitive.mockResolvedValue({ version: 'v2' });
+describe('addFavoriteFontFlow', () => {
+	it('sends the family name verbatim with the client version, refreshes the feed, and resolves the name', async () => {
+		client.addFavoriteFont.mockResolvedValue({ version: 'v2' });
 		const refreshFeed = jest.fn().mockResolvedValue({});
 		const onBusy = jest.fn();
 		const onError = jest.fn();
 
-		const result = await addFontFlow({
+		const result = await addFavoriteFontFlow({
 			name: 'Abril Fatface',
-			existingIds: [],
 			slug: 'default',
 			feedVersion: 'v1',
 			refreshFeed,
@@ -30,49 +30,70 @@ describe('addFontFlow', () => {
 			onError,
 		});
 
-		expect(client.createUserPrimitive).toHaveBeenCalledWith('default', {
-			id: 'abril-fatface',
-			$type: 'fontFamily',
-			$value: ['Abril Fatface'],
-			label: 'Abril Fatface',
-			group: 'font-family',
-			version: 'v1',
-		});
+		expect(client.addFavoriteFont).toHaveBeenCalledWith('default', 'Abril Fatface', { version: 'v1' });
 		expect(refreshFeed).toHaveBeenCalledWith('default');
-		expect(result).toBe('primitive.font-family.custom.abril-fatface');
+		expect(result).toBe('Abril Fatface');
 		expect(onBusy.mock.calls).toEqual([[true], [false]]);
 		expect(onError).not.toHaveBeenCalled();
 	});
 
-	it('suffixes the derived slug on collision with an existing id', async () => {
-		client.createUserPrimitive.mockResolvedValue({ version: 'v2' });
-		const refreshFeed = jest.fn().mockResolvedValue({});
-
-		const result = await addFontFlow({
-			name: 'Abel',
-			existingIds: ['primitive.font-family.custom.abel'],
-			slug: 'default',
-			feedVersion: 'v1',
-			refreshFeed,
-			onBusy: jest.fn(),
-			onError: jest.fn(),
-		});
-
-		expect(client.createUserPrimitive).toHaveBeenCalledWith('default', expect.objectContaining({ id: 'abel-2' }));
-		expect(result).toBe('primitive.font-family.custom.abel-2');
-	});
-
 	it('surfaces the error, clears busy, and re-throws on failure', async () => {
 		const failure = new Error('Boom');
-		client.createUserPrimitive.mockRejectedValue(failure);
+		client.addFavoriteFont.mockRejectedValue(failure);
 		const refreshFeed = jest.fn();
 		const onBusy = jest.fn();
 		const onError = jest.fn();
 
 		await expect(
-			addFontFlow({
+			addFavoriteFontFlow({
 				name: 'Abel',
-				existingIds: [],
+				slug: 'default',
+				feedVersion: 'v1',
+				refreshFeed,
+				onBusy,
+				onError,
+			})
+		).rejects.toBe(failure);
+
+		expect(refreshFeed).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith({ message: failure.message });
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+});
+
+describe('removeFavoriteFontFlow', () => {
+	it('sends the family name with the client version, refreshes the feed, and resolves the name', async () => {
+		client.removeFavoriteFont.mockResolvedValue({ version: 'v2' });
+		const refreshFeed = jest.fn().mockResolvedValue({});
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		const result = await removeFavoriteFontFlow({
+			name: 'Abril Fatface',
+			slug: 'default',
+			feedVersion: 'v1',
+			refreshFeed,
+			onBusy,
+			onError,
+		});
+
+		expect(client.removeFavoriteFont).toHaveBeenCalledWith('default', 'Abril Fatface', { version: 'v1' });
+		expect(refreshFeed).toHaveBeenCalledWith('default');
+		expect(result).toBe('Abril Fatface');
+		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it('surfaces the error, clears busy, and re-throws on failure', async () => {
+		const failure = new Error('Boom');
+		client.removeFavoriteFont.mockRejectedValue(failure);
+		const refreshFeed = jest.fn();
+		const onBusy = jest.fn();
+		const onError = jest.fn();
+
+		await expect(
+			removeFavoriteFontFlow({
+				name: 'Abel',
 				slug: 'default',
 				feedVersion: 'v1',
 				refreshFeed,

--- a/src/style-library/__tests__/typography.test.js
+++ b/src/style-library/__tests__/typography.test.js
@@ -33,6 +33,19 @@ describe('fontOptions', () => {
 		expect(fontOptions({ favoriteFonts: ['"Inter"'] })).toEqual([{ id: 'Inter', label: 'Inter', stack: 'Inter' }]);
 	});
 
+	// The store deduplicates before unquoting, so these are two entries there and one font here.
+	it('drops a duplicate that differs only by quoting or case', () => {
+		expect(fontOptions({ favoriteFonts: ['Inter', '"Inter"', 'INTER'] })).toEqual([
+			{ id: 'Inter', label: 'Inter', stack: 'Inter' },
+		]);
+	});
+
+	it('drops an entry that unquotes to nothing', () => {
+		expect(fontOptions({ favoriteFonts: ['""', 'Inter'] })).toEqual([
+			{ id: 'Inter', label: 'Inter', stack: 'Inter' },
+		]);
+	});
+
 	it('drops non-string and blank entries rather than rendering a nameless option', () => {
 		expect(fontOptions({ favoriteFonts: ['Inter', 42, '', '   ', null] })).toEqual([
 			{ id: 'Inter', label: 'Inter', stack: 'Inter' },

--- a/src/style-library/__tests__/typography.test.js
+++ b/src/style-library/__tests__/typography.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 // cspell:ignore Abril Fatface .
 import {
+	familyStack,
 	findFontByFamily,
 	fontActionFor,
 	fontOptions,
@@ -36,6 +37,26 @@ describe('fontOptions', () => {
 		expect(fontOptions({ favoriteFonts: ['Inter', 42, '', '   ', null] })).toEqual([
 			{ id: 'Inter', label: 'Inter', stack: 'Inter' },
 		]);
+	});
+});
+
+describe('familyStack', () => {
+	it('leaves a single-word family bare', () => {
+		expect(familyStack('Inter')).toBe('Inter');
+	});
+
+	it('quotes a family carrying whitespace so it reads as one family', () => {
+		expect(familyStack('Abril Fatface')).toBe('"Abril Fatface"');
+	});
+
+	it('unquotes and trims before deciding, so a quoted name is not double-quoted', () => {
+		expect(familyStack('  "Inter"  ')).toBe('Inter');
+	});
+
+	it('returns an empty string for a blank or missing family', () => {
+		expect(familyStack('')).toBe('');
+		expect(familyStack('   ')).toBe('');
+		expect(familyStack(undefined)).toBe('');
 	});
 });
 

--- a/src/style-library/__tests__/typography.test.js
+++ b/src/style-library/__tests__/typography.test.js
@@ -1,84 +1,41 @@
 /* eslint-env jest */
-// cspell:ignore Abril Fatface abril fatface Écriture ecriture .
+// cspell:ignore Abril Fatface .
 import {
 	findFontByFamily,
 	fontActionFor,
-	fontFamilySlug,
 	fontOptions,
 	fontSizeDisplayValue,
 	getFontCatalog,
 } from '../helpers/typography';
 
 describe('fontOptions', () => {
-	it('returns [] for a missing schema or unknown group', () => {
-		expect(fontOptions(undefined, {}, 'Font Family')).toEqual([]);
-		expect(fontOptions({ groups: {} }, {}, 'Font Family')).toEqual([]);
-		expect(fontOptions({ groups: { Other: [] } }, {}, 'Font Family')).toEqual([]);
+	it('returns [] for a missing feed or a feed carrying no favorites', () => {
+		expect(fontOptions(undefined)).toEqual([]);
+		expect(fontOptions({})).toEqual([]);
+		expect(fontOptions({ favoriteFonts: 'not-an-array' })).toEqual([]);
 	});
 
-	it('maps id, first-family label, and the full stack in feed order', () => {
-		const schema = {
-			groups: {
-				'Font Family': [
-					{ id: 'primitive.font-family.sans' },
-					{ id: 'primitive.font-family.serif' },
-					{ id: 'primitive.font-family.mono' },
-				],
-			},
-		};
-		const values = {
-			'primitive.font-family.sans': 'Inter, system-ui, sans-serif',
-			'primitive.font-family.serif': 'Georgia, Cambria, serif',
-			'primitive.font-family.mono': 'Menlo, Consolas, monospace',
-		};
-
-		expect(fontOptions(schema, values, 'Font Family')).toEqual([
-			{
-				id: 'primitive.font-family.sans',
-				label: 'Inter',
-				stack: 'Inter, system-ui, sans-serif',
-				userCreated: false,
-			},
-			{
-				id: 'primitive.font-family.serif',
-				label: 'Georgia',
-				stack: 'Georgia, Cambria, serif',
-				userCreated: false,
-			},
-			{
-				id: 'primitive.font-family.mono',
-				label: 'Menlo',
-				stack: 'Menlo, Consolas, monospace',
-				userCreated: false,
-			},
+	it('maps each favorite to an option keyed by its own family name, in stored order', () => {
+		expect(fontOptions({ favoriteFonts: ['Inter', 'Georgia'] })).toEqual([
+			{ id: 'Inter', label: 'Inter', stack: 'Inter' },
+			{ id: 'Georgia', label: 'Georgia', stack: 'Georgia' },
 		]);
 	});
 
-	it('strips wrapping quotes from a quoted first family', () => {
-		const schema = { groups: { 'Font Family': [{ id: 'primitive.font-family.sans' }] } };
-		const values = { 'primitive.font-family.sans': '"Inter", system-ui, sans-serif' };
-
-		expect(fontOptions(schema, values, 'Font Family')[0].label).toBe('Inter');
+	it('quotes a multi-word family in the stack so it is one family, not several', () => {
+		expect(fontOptions({ favoriteFonts: ['Abril Fatface'] })).toEqual([
+			{ id: 'Abril Fatface', label: 'Abril Fatface', stack: '"Abril Fatface"' },
+		]);
 	});
 
-	it('passes userCreated through from the feed entry', () => {
-		const schema = {
-			groups: {
-				'Font Family': [
-					{ id: 'primitive.font-family.sans' },
-					{ id: 'primitive.font-family.custom.abel', userCreated: true },
-				],
-			},
-		};
-		const values = {
-			'primitive.font-family.sans': 'Inter, system-ui, sans-serif',
-			'primitive.font-family.custom.abel': 'Abel',
-		};
+	it('strips wrapping quotes from a stored family before using it as label and id', () => {
+		expect(fontOptions({ favoriteFonts: ['"Inter"'] })).toEqual([{ id: 'Inter', label: 'Inter', stack: 'Inter' }]);
+	});
 
-		const options = fontOptions(schema, values, 'Font Family');
-
-		expect(options[0].userCreated).toBe(false);
-		expect(options[1].userCreated).toBe(true);
+	it('drops non-string and blank entries rather than rendering a nameless option', () => {
+		expect(fontOptions({ favoriteFonts: ['Inter', 42, '', '   ', null] })).toEqual([
+			{ id: 'Inter', label: 'Inter', stack: 'Inter' },
+		]);
 	});
 });
 
@@ -132,7 +89,7 @@ describe('findFontByFamily', () => {
 		{ id: 'primitive.font-family.serif', label: 'Georgia' },
 	];
 
-	it('matches a design-system font case-insensitively', () => {
+	it('matches a favorite case-insensitively', () => {
 		expect(findFontByFamily(fonts, 'inter')).toEqual(fonts[0]);
 		expect(findFontByFamily(fonts, 'INTER')).toEqual(fonts[0]);
 	});
@@ -142,48 +99,25 @@ describe('findFontByFamily', () => {
 		expect(findFontByFamily([{ id: 'x', label: '"Inter"' }], 'Inter')).toEqual({ id: 'x', label: '"Inter"' });
 	});
 
-	it('returns null when no font matches', () => {
+	it('returns null when no favorite matches', () => {
 		expect(findFontByFamily(fonts, 'Abel')).toBeNull();
 	});
 });
 
-describe('fontFamilySlug', () => {
-	it('lowercases and hyphenates spaces', () => {
-		expect(fontFamilySlug('Abril Fatface')).toBe('abril-fatface');
-	});
-
-	it('strips diacritics', () => {
-		expect(fontFamilySlug('Écriture')).toBe('ecriture');
-	});
-
-	it('collapses any run of non alphanumeric characters to a single hyphen and trims the edges', () => {
-		expect(fontFamilySlug('  Foo!!  Bar__Baz  ')).toBe('foo-bar-baz');
-	});
-
-	it('falls back to "font" for a name that yields nothing (fully non-Latin)', () => {
-		expect(fontFamilySlug('日本語')).toBe('font');
-	});
-
-	it('falls back to "font" for an empty or missing name', () => {
-		expect(fontFamilySlug('')).toBe('font');
-		expect(fontFamilySlug(undefined)).toBe('font');
-	});
-});
-
 describe('fontActionFor', () => {
-	const baselineFont = { id: 'primitive.font-family.sans', label: 'Inter', userCreated: false };
-	const customFont = { id: 'primitive.font-family.custom.abel', label: 'Abel', userCreated: true };
-	const fonts = [baselineFont, customFont];
+	const favorite = { id: 'Inter', label: 'Inter' };
+	const fonts = [favorite];
 
-	it('returns an enabled add action when the pick matches no design-system font', () => {
+	it('returns an enabled add action when the pick is not yet a favorite', () => {
 		expect(fontActionFor(fonts, 'Abril Fatface')).toEqual({ type: 'add', disabled: false, font: null });
 	});
 
-	it('returns an enabled delete action when the pick matches a user-created font', () => {
-		expect(fontActionFor(fonts, 'Abel')).toEqual({ type: 'delete', disabled: false, font: customFont });
+	it('returns a remove action when the pick is already a favorite', () => {
+		expect(fontActionFor(fonts, 'Inter')).toEqual({ type: 'remove', disabled: false, font: favorite });
 	});
 
-	it('returns a disabled add action when the pick matches a baseline font', () => {
-		expect(fontActionFor(fonts, 'Inter')).toEqual({ type: 'add', disabled: true, font: baselineFont });
+	it('disables the add action when the dropdown holds nothing to add', () => {
+		expect(fontActionFor(fonts, '')).toEqual({ type: 'add', disabled: true, font: null });
+		expect(fontActionFor(fonts, '   ')).toEqual({ type: 'add', disabled: true, font: null });
 	});
 });

--- a/src/style-library/components/pages/TypographyScreen.js
+++ b/src/style-library/components/pages/TypographyScreen.js
@@ -32,7 +32,7 @@ import { SearchableSelectDropdown } from '../molecules/SearchableSelectDropdown'
 import { addFavoriteFontFlow, removeFavoriteFontFlow } from '../../helpers/font-flows';
 import { useGoogleFontLoader } from '../../hooks/use-google-font-loader';
 import {
-	findFontByFamily,
+	familyStack,
 	fontActionFor,
 	fontOptions,
 	fontSizeDisplayValue,
@@ -228,12 +228,14 @@ export const TYPOGRAPHY_CONFIG = {
 
 /**
  * The Typography screen body: the base config extended per render with the font-dependent
- * `renderPreview`/`renderToolbar` keys, and the selected-font state (plus the catalog dropdown's
- * pending pick and the favorite-write flow state) they close over. The font SELECTION is view-only,
- * session-scoped React state (never persisted) — only the favorites list itself is stored. It
- * self-heals to the first favorite whenever the selected family leaves the list, the same
- * stale-item idiom the rest of the app uses, so a family dropped from the list out from under an open
- * selection never leaves the toolbar pointing at nothing.
+ * `renderPreview`/`renderToolbar` keys, and the selected-family and favorite-write state they close
+ * over. The font SELECTION is view-only, session-scoped React state (never persisted) — only the
+ * favorites list itself is stored.
+ *
+ * The selection is a plain family name, not a favorite's id, so the sample previews any pick from the
+ * catalog rather than only the handful a site keeps. Previewing IS what this screen's font
+ * selector is for: gating it on favorite status left the sample stuck on the previous font for every
+ * other pick, which reads as the control being broken.
  *
  * @param {Object} props The props `ScaleScreen` accepts (`{ label, route, navigate, library }`).
  *
@@ -249,49 +251,25 @@ export function TypographyScreen(props) {
 	// Rebuilt whenever the favorites change, since they are pinned to the top of the same list.
 	const catalogOptions = useMemo(() => buildCatalogOptions(fonts), [fonts]);
 
-	const [selectedFontId, setSelectedFontId] = useState(() => fonts[0]?.id ?? '');
-	// The catalog dropdown's pending pick: null while it mirrors the previewed font, or a catalog
-	// family name once a pick matches no favorite (armed for "Add Favorite" but not yet previewed:
-	// previewing a family the library has not kept would fetch a webfont for a face that may
-	// never be kept).
-	const [pendingFontName, setPendingFontName] = useState(null);
+	// The previewed family, as a plain catalog name. One piece of state, not a favorite id plus a
+	// pending pick: the sample previews whatever the dropdown holds, favorite or not. Splitting the
+	// two is what left every non-favorite pick showing the previous font, since only a favorite had
+	// an id to select by.
+	const [selectedFamily, setSelectedFamily] = useState(() => fonts[0]?.label ?? '');
 	const [fontBusy, setFontBusy] = useState(false);
 	const [fontError, setFontError] = useState(null);
 
+	// Seed the preview from the first favorite once the feed arrives, and only then: a family the
+	// user picked is left alone even when it is not a favorite, which is the whole point.
 	useEffect(() => {
-		if (fonts.length > 0 && !fonts.some((font) => font.id === selectedFontId)) {
-			setSelectedFontId(fonts[0].id);
-			setPendingFontName(null);
+		if (selectedFamily === '' && fonts.length > 0) {
+			setSelectedFamily(fonts[0].label);
 		}
-	}, [fonts, selectedFontId]);
+	}, [fonts, selectedFamily]);
 
-	const selectedFont = fonts.find((font) => font.id === selectedFontId) ?? null;
+	useGoogleFontLoader(selectedFamily);
 
-	useGoogleFontLoader(selectedFont?.label ?? '');
-
-	// A catalog pick that matches a favorite always clears a pending pick, so the dropdown goes back
-	// to mirroring the preview.
-	const selectPreviewFont = useCallback((id) => {
-		setPendingFontName(null);
-		setSelectedFontId(id);
-	}, []);
-
-	const dropdownValue = pendingFontName ?? selectedFont?.label ?? '';
-
-	const pickCatalogFont = useCallback(
-		(name) => {
-			const matched = findFontByFamily(fonts, name);
-
-			if (matched) {
-				selectPreviewFont(matched.id);
-			} else {
-				setPendingFontName(name);
-			}
-		},
-		[fonts, selectPreviewFont]
-	);
-
-	const fontAction = fontActionFor(fonts, dropdownValue);
+	const fontAction = fontActionFor(fonts, selectedFamily);
 
 	// Adding or removing a favorite is deliberately never guarded (unlike selecting a row or
 	// navigating away with a dirty draft): neither touches the size-panel draft, and the post-write
@@ -300,7 +278,7 @@ export function TypographyScreen(props) {
 		setFontError(null);
 
 		const flowArgs = {
-			name: fontAction.font?.label ?? dropdownValue,
+			name: fontAction.font?.label ?? selectedFamily,
 			slug: library.slug,
 			feedVersion: library.version,
 			refreshFeed: library.refreshFeed,
@@ -308,20 +286,12 @@ export function TypographyScreen(props) {
 			onError: setFontError,
 		};
 
-		if (fontAction.type === 'remove') {
-			removeFavoriteFontFlow(flowArgs)
-				.then(() => setPendingFontName(null))
-				.catch(() => {});
+		// Neither flow touches the preview: the family stays selected whether it was just added to the
+		// favorites or just taken out of them, so the sample does not jump under the user's cursor.
+		const flow = fontAction.type === 'remove' ? removeFavoriteFontFlow : addFavoriteFontFlow;
 
-			return;
-		}
-
-		// The picked family becomes the previewed one: it is a favorite now, so the self-heal effect
-		// would otherwise leave the preview on whichever family happened to sit first.
-		addFavoriteFontFlow(flowArgs)
-			.then((name) => selectPreviewFont(name))
-			.catch(() => {});
-	}, [fontAction, dropdownValue, library, selectPreviewFont]);
+		flow(flowArgs).catch(() => {});
+	}, [fontAction, selectedFamily, library]);
 
 	// `useScaleScreen`'s addToken/saveToken/reorderTokens list the whole config in their deps, so an
 	// inline object would rebuild all three every render. The catalog toolbar widens what the config
@@ -330,11 +300,11 @@ export function TypographyScreen(props) {
 	const config = useMemo(
 		() => ({
 			...TYPOGRAPHY_CONFIG,
-			renderPreview: samplePreviewRenderer(selectedFont?.stack ?? ''),
+			renderPreview: samplePreviewRenderer(familyStack(selectedFamily)),
 			renderToolbar: typographyToolbarRenderer({
 				catalogOptions,
-				dropdownValue,
-				onPickCatalog: pickCatalogFont,
+				dropdownValue: selectedFamily,
+				onPickCatalog: setSelectedFamily,
 				fontAction,
 				onFontAction: handleFontAction,
 				fontBusy,
@@ -342,16 +312,7 @@ export function TypographyScreen(props) {
 				onClearFontError: () => setFontError(null),
 			}),
 		}),
-		[
-			selectedFont?.stack,
-			catalogOptions,
-			dropdownValue,
-			pickCatalogFont,
-			fontAction,
-			handleFontAction,
-			fontBusy,
-			fontError,
-		]
+		[selectedFamily, catalogOptions, fontAction, handleFontAction, fontBusy, fontError]
 	);
 
 	return <ScaleScreen config={config} {...props} />;

--- a/src/style-library/components/pages/TypographyScreen.js
+++ b/src/style-library/components/pages/TypographyScreen.js
@@ -3,11 +3,16 @@
  * renderer, and the two thin wrappers that plug into the shared `ScaleScreen`/`ScaleSettings`
  * contract (see `ScaleScreen.js`'s module docblock). Two things make this screen genuinely
  * different from its siblings: a toolbar between the header and the list (the FONT catalog
- * dropdown, the contextual Add/Delete Font button, font tabs, and the "+ Add Size" action) built
- * on `ScaleScreen`'s optional `renderToolbar` seam, and screen-level preview state (the currently
- * previewed font, plus the font catalog's Add/Delete flow) that `renderPreview` and the toolbar
- * close over — absorbed entirely at this screen's own boundary, with no change to the shared hook
- * or flows.
+ * dropdown, the contextual Add/Remove Favorite button, and the "+ Add Size" action) built on
+ * `ScaleScreen`'s optional `renderToolbar` seam, and screen-level preview state (the currently
+ * previewed font, plus the favorite-font flows) that `renderPreview` and the toolbar close over —
+ * absorbed entirely at this screen's own boundary, with no change to the shared hook or flows.
+ *
+ * The screen's fonts are the library's FAVORITES, not tokens. A favorite carries no indirection and
+ * emits no CSS variable; it exists so a family a site uses often sits at the top of this dropdown
+ * and of every block's font picker, instead of being searched for in a ~1,900-name catalog each
+ * time. Font family is therefore the one thing on this screen that is not a design token — the
+ * font-size steps below it still are.
  */
 
 /**
@@ -16,12 +21,7 @@
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, Notice } from '@wordpress/components';
-import { plus } from '@wordpress/icons';
-
-/**
- * External dependencies
- */
-import classnames from 'classnames';
+import { starEmpty, starFilled } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -29,8 +29,7 @@ import classnames from 'classnames';
 import { ScaleScreen } from './ScaleScreen';
 import { ScaleSettings } from './ScaleSettings';
 import { SearchableSelectDropdown } from '../molecules/SearchableSelectDropdown';
-import { deleteScaleTokenFlow } from '../../helpers/scale-flows';
-import { addFontFlow } from '../../helpers/font-flows';
+import { addFavoriteFontFlow, removeFavoriteFontFlow } from '../../helpers/font-flows';
 import { useGoogleFontLoader } from '../../hooks/use-google-font-loader';
 import {
 	findFontByFamily,
@@ -50,20 +49,19 @@ import './TypographyScreen.scss';
 const SAMPLE_TEXT = __('Visualize your font', 'kadence-blocks');
 
 /**
- * The translated `Font Family` feed group label — display and request addressing only, mirroring
- * `config.group`'s role for the `Font Size` group this screen edits.
- *
- * @since TBD
- */
-const FONT_FAMILY_GROUP = __('Font Family', 'kadence-blocks');
-
-/**
  * The muted badge a catalog custom font carries in the dropdown menu, matching the `SelectDropdown`
  * badge treatment used elsewhere in the app.
  *
  * @since TBD
  */
 const CUSTOM_BADGE = __('Custom', 'kadence-blocks');
+
+/**
+ * The muted badge a favorite carries where it sits pinned above the catalog.
+ *
+ * @since TBD
+ */
+const FAVORITE_BADGE = __('Favorite', 'kadence-blocks');
 
 /**
  * Build a `renderPreview` closing over the currently selected font's resolved stack. `row.value` is
@@ -93,52 +91,57 @@ function samplePreviewRenderer(fontStack) {
 }
 
 /**
- * Build the catalog dropdown's option list: every Google family name, then every custom family
- * name, each carrying its catalog family name as `value` (never a token id — see
- * `SearchableSelectDropdown`'s module docblock) and custom names tagged with the muted `Custom`
- * badge.
+ * Build the catalog dropdown's option list: the library's favorites first, then every Google family
+ * name, then every custom family name — each carrying its catalog family name as `value` (never a
+ * token id — see `SearchableSelectDropdown`'s module docblock), favorites tagged with the muted
+ * `Favorite` badge and custom names with `Custom`.
+ *
+ * Pinning favorites to the top IS the feature: it is what replaces the font tabs this screen used
+ * to carry, and it matches how the block editor's font picker surfaces the same list. A favorite
+ * family is filtered out of the catalog runs below so it appears exactly once, keeping its pinned
+ * position rather than showing again mid-list.
+ *
+ * @param {Array<{label: string}>} fonts The library's favorites (`fontOptions()`).
  *
  * @since TBD
  *
  * @return {Array<{value: string, label: string, badge?: string}>} The dropdown's option list.
  */
-function buildCatalogOptions() {
+function buildCatalogOptions(fonts) {
 	const { google, custom } = getFontCatalog();
+	const favorites = fonts.map((font) => font.label);
+	const pinned = new Set(favorites.map((name) => name.toLowerCase()));
+	const unpinned = (name) => !pinned.has(name.toLowerCase());
 
 	return [
-		...google.map((name) => ({ value: name, label: name })),
-		...custom.map((name) => ({ value: name, label: name, badge: CUSTOM_BADGE })),
+		...favorites.map((name) => ({ value: name, label: name, badge: FAVORITE_BADGE })),
+		...google.filter(unpinned).map((name) => ({ value: name, label: name })),
+		...custom.filter(unpinned).map((name) => ({ value: name, label: name, badge: CUSTOM_BADGE })),
 	];
 }
 
 /**
- * Build the `renderToolbar( { addAction, isBusy } )` implementation: font tabs (only when more than
- * one family exists), the FONT label, the searchable catalog dropdown with its contextual
- * Add/Delete Font button, and the passed-in add-size action positioned at the row's right edge —
- * the toolbar positions `addAction`, it never re-implements it, so the shared guard/busy discipline
- * cannot fork between this screen and its siblings.
+ * Build the `renderToolbar( { addAction, isBusy } )` implementation: the FONT label, the searchable
+ * catalog dropdown (favorites pinned at its top) with its contextual Add/Remove Favorite button,
+ * and the passed-in add-size action positioned at the row's right edge — the toolbar positions
+ * `addAction`, it never re-implements it, so the shared guard/busy discipline cannot fork between
+ * this screen and its siblings.
  *
- * @param {Object}                                              args
- * @param {Array<{id: string, label: string, stack: string}>}   args.fonts           The FONT options, in feed order.
- * @param {string}                                              args.selectedFontId  The currently previewed font's id.
- * @param {Function}                                             args.onSelectFont    Called with a font id when the tabs or a matching catalog pick change the preview.
- * @param {Array<{value: string, label: string, badge?: string}>} args.catalogOptions The catalog dropdown's option list.
+ * @param {Array<{value: string, label: string, badge?: string}>} args                 The toolbar's inputs.
+ * @param {Array<{value: string, label: string, badge?: string}>} args.catalogOptions  The catalog dropdown's option list.
  * @param {string}                                               args.dropdownValue   The catalog dropdown's current value (a catalog family name).
- * @param {Function}                                              args.onPickCatalog   Called with a catalog family name when a dropdown option is chosen.
- * @param {{type: ('add'|'delete'), disabled: boolean, font: ?Object}} args.fontAction The contextual button's state ({@see fontActionFor}).
- * @param {Function}                                              args.onFontAction    Invokes the Add Font or Delete Font flow for the current `fontAction`.
- * @param {boolean}                                               args.fontBusy        Whether an Add/Delete Font request is in flight.
- * @param {?{message: string}}                                    args.fontError       The current Add/Delete Font error, if any.
- * @param {Function}                                              args.onClearFontError Dismisses `fontError`.
+ * @param {Function}                                             args.onPickCatalog   Called with a catalog family name when a dropdown option is chosen.
+ * @param {{type: ('add'|'remove'), disabled: boolean, font: ?Object}} args.fontAction The contextual button's state ({@see fontActionFor}).
+ * @param {Function}                                             args.onFontAction    Invokes the add- or remove-favorite flow for the current `fontAction`.
+ * @param {boolean}                                              args.fontBusy        Whether a favorite request is in flight.
+ * @param {?{message: string}}                                   args.fontError       The current favorite-write error, if any.
+ * @param {Function}                                             args.onClearFontError Dismisses `fontError`.
  *
  * @since TBD
  *
  * @return {Function} The `config.renderToolbar` implementation.
  */
 function typographyToolbarRenderer({
-	fonts,
-	selectedFontId,
-	onSelectFont,
 	catalogOptions,
 	dropdownValue,
 	onPickCatalog,
@@ -153,26 +156,6 @@ function typographyToolbarRenderer({
 
 		return (
 			<div className="kadence-blocks-style-library__typography-toolbar">
-				{fonts.length > 1 && (
-					<div className="kadence-blocks-style-library__typography-font-tabs" role="tablist">
-						{fonts.map((font) => (
-							<button
-								key={font.id}
-								type="button"
-								role="tab"
-								aria-selected={font.id === selectedFontId}
-								disabled={controlsBusy}
-								className={classnames('kadence-blocks-style-library__typography-font-tab', {
-									'kadence-blocks-style-library__typography-font-tab--active':
-										font.id === selectedFontId,
-								})}
-								onClick={() => onSelectFont(font.id)}
-							>
-								{font.label}
-							</button>
-						))}
-					</div>
-				)}
 				{fontError && (
 					<Notice status="error" isDismissible onRemove={onClearFontError}>
 						{fontError.message}
@@ -193,15 +176,14 @@ function typographyToolbarRenderer({
 							/>
 							<Button
 								className="kadence-blocks-style-library__typography-font-action"
-								variant={fontAction.type === 'delete' ? 'tertiary' : 'secondary'}
-								icon={fontAction.type === 'delete' ? undefined : plus}
-								isDestructive={fontAction.type === 'delete'}
+								variant={fontAction.type === 'remove' ? 'tertiary' : 'secondary'}
+								icon={fontAction.type === 'remove' ? starFilled : starEmpty}
 								disabled={controlsBusy || fontAction.disabled}
 								onClick={onFontAction}
 							>
-								{fontAction.type === 'delete'
-									? __('Delete', 'kadence-blocks')
-									: __('Add Font', 'kadence-blocks')}
+								{fontAction.type === 'remove'
+									? __('Remove Favorite', 'kadence-blocks')
+									: __('Add Favorite', 'kadence-blocks')}
 							</Button>
 						</div>
 					</div>
@@ -247,11 +229,11 @@ export const TYPOGRAPHY_CONFIG = {
 /**
  * The Typography screen body: the base config extended per render with the font-dependent
  * `renderPreview`/`renderToolbar` keys, and the selected-font state (plus the catalog dropdown's
- * pending pick and the Add/Delete Font flow state) they close over. The font selection is
- * view-only, session-scoped React state (never persisted) — it self-heals to the group's first
- * font whenever the selected id leaves the feed, the same stale-item idiom the rest of the app
- * uses, so a font deleted or renamed out from under an open selection never leaves the toolbar
- * pointing at nothing.
+ * pending pick and the favorite-write flow state) they close over. The font SELECTION is view-only,
+ * session-scoped React state (never persisted) — only the favorites list itself is stored. It
+ * self-heals to the first favorite whenever the selected family leaves the list, the same
+ * stale-item idiom the rest of the app uses, so a family dropped from the list out from under an open
+ * selection never leaves the toolbar pointing at nothing.
  *
  * @param {Object} props The props `ScaleScreen` accepts (`{ label, route, navigate, library }`).
  *
@@ -262,18 +244,16 @@ export const TYPOGRAPHY_CONFIG = {
 export function TypographyScreen(props) {
 	const { library } = props;
 
-	const fonts = useMemo(
-		() => fontOptions(library.feed?.schema, library.feed?.values, FONT_FAMILY_GROUP),
-		[library.feed]
-	);
+	const fonts = useMemo(() => fontOptions(library.feed), [library.feed]);
 
-	const catalogOptions = useMemo(buildCatalogOptions, []);
+	// Rebuilt whenever the favorites change, since they are pinned to the top of the same list.
+	const catalogOptions = useMemo(() => buildCatalogOptions(fonts), [fonts]);
 
 	const [selectedFontId, setSelectedFontId] = useState(() => fonts[0]?.id ?? '');
 	// The catalog dropdown's pending pick: null while it mirrors the previewed font, or a catalog
-	// family name once a pick matches no design-system font (armed for "+ Add Font" but not yet
-	// previewed: previewing a font the library does not own would need a webfont load for a token
-	// that may never be created).
+	// family name once a pick matches no favorite (armed for "Add Favorite" but not yet previewed:
+	// previewing a family the library has not kept would fetch a webfont for a face that may
+	// never be kept).
 	const [pendingFontName, setPendingFontName] = useState(null);
 	const [fontBusy, setFontBusy] = useState(false);
 	const [fontError, setFontError] = useState(null);
@@ -289,8 +269,8 @@ export function TypographyScreen(props) {
 
 	useGoogleFontLoader(selectedFont?.label ?? '');
 
-	// Switching tabs (or a catalog pick that matches a design-system font) always clears a pending
-	// catalog pick, so the dropdown goes back to mirroring the preview.
+	// A catalog pick that matches a favorite always clears a pending pick, so the dropdown goes back
+	// to mirroring the preview.
 	const selectPreviewFont = useCallback((id) => {
 		setPendingFontName(null);
 		setSelectedFontId(id);
@@ -313,37 +293,33 @@ export function TypographyScreen(props) {
 
 	const fontAction = fontActionFor(fonts, dropdownValue);
 
-	// Add/Delete Font is deliberately never guarded (unlike selecting a row or navigating away with
-	// a dirty draft): neither touches the size-panel draft, and the post-write `refreshFeed`
-	// re-overlays it exactly as every sibling write does.
+	// Adding or removing a favorite is deliberately never guarded (unlike selecting a row or
+	// navigating away with a dirty draft): neither touches the size-panel draft, and the post-write
+	// `refreshFeed` re-overlays it exactly as every sibling write does.
 	const handleFontAction = useCallback(() => {
 		setFontError(null);
 
-		if (fontAction.type === 'delete') {
-			deleteScaleTokenFlow({
-				slug: library.slug,
-				tokenId: fontAction.font.id,
-				feedVersion: library.version,
-				refreshFeed: library.refreshFeed,
-				onBusy: setFontBusy,
-				onError: setFontError,
-			})
+		const flowArgs = {
+			name: fontAction.font?.label ?? dropdownValue,
+			slug: library.slug,
+			feedVersion: library.version,
+			refreshFeed: library.refreshFeed,
+			onBusy: setFontBusy,
+			onError: setFontError,
+		};
+
+		if (fontAction.type === 'remove') {
+			removeFavoriteFontFlow(flowArgs)
 				.then(() => setPendingFontName(null))
 				.catch(() => {});
 
 			return;
 		}
 
-		addFontFlow({
-			name: dropdownValue,
-			existingIds: library.tokens.map((token) => token.id),
-			slug: library.slug,
-			feedVersion: library.version,
-			refreshFeed: library.refreshFeed,
-			onBusy: setFontBusy,
-			onError: setFontError,
-		})
-			.then((id) => selectPreviewFont(id))
+		// The picked family becomes the previewed one: it is a favorite now, so the self-heal effect
+		// would otherwise leave the preview on whichever family happened to sit first.
+		addFavoriteFontFlow(flowArgs)
+			.then((name) => selectPreviewFont(name))
 			.catch(() => {});
 	}, [fontAction, dropdownValue, library, selectPreviewFont]);
 
@@ -356,9 +332,6 @@ export function TypographyScreen(props) {
 			...TYPOGRAPHY_CONFIG,
 			renderPreview: samplePreviewRenderer(selectedFont?.stack ?? ''),
 			renderToolbar: typographyToolbarRenderer({
-				fonts,
-				selectedFontId,
-				onSelectFont: selectPreviewFont,
 				catalogOptions,
 				dropdownValue,
 				onPickCatalog: pickCatalogFont,
@@ -371,9 +344,6 @@ export function TypographyScreen(props) {
 		}),
 		[
 			selectedFont?.stack,
-			fonts,
-			selectedFontId,
-			selectPreviewFont,
 			catalogOptions,
 			dropdownValue,
 			pickCatalogFont,

--- a/src/style-library/components/pages/TypographyScreen.scss
+++ b/src/style-library/components/pages/TypographyScreen.scss
@@ -62,26 +62,6 @@
 	margin: var(--kb-sl-space-20) 0;
 }
 
-.kadence-blocks-style-library__typography-font-tabs {
-	@include flex-row(var(--kb-sl-space-10));
-}
-
-.kadence-blocks-style-library__typography-font-tab {
-	padding: var(--kb-sl-space-10) var(--kb-sl-space-15);
-	border: 0;
-	border-radius: var(--kb-sl-radius-s);
-	background: transparent;
-	color: var(--kb-sl-color-text-secondary);
-	font-size: var(--kb-sl-font-size-s);
-	cursor: pointer;
-
-	&--active {
-		background: var(--kb-sl-color-gray-100);
-		color: var(--kb-sl-color-text-primary);
-		font-weight: var(--kb-sl-font-weight-semibold);
-	}
-}
-
 .kadence-blocks-style-library__typography-toolbar-row {
 	display: flex;
 	align-items: flex-end;
@@ -97,7 +77,7 @@
 	@include small-uppercase-label;
 }
 
-// The catalog dropdown and its contextual Add/Delete Font button sit side by side, beneath the
+// The catalog dropdown and its contextual Add/Remove Favorite button sit side by side, beneath the
 // FONT label — the board's slot for both.
 .kadence-blocks-style-library__typography-font-picker {
 	@include flex-row(var(--kb-sl-space-10));

--- a/src/style-library/helpers/font-flows.js
+++ b/src/style-library/helpers/font-flows.js
@@ -1,10 +1,12 @@
 /**
- * Pure orchestration for the Typography screen's font-catalog write flow: adding a picked catalog
- * family as a user primitive. Font deletion needs no font-specific flow — it reuses
- * `deleteScaleTokenFlow` verbatim, since deletion is token-generic. Same `scale-flows.js`
- * discipline: the REST call is imported here (so a test mocks `api/client`), the caller supplies
- * busy/error callbacks and a feed refresh, and the flow settles pessimistically and re-throws on
- * failure.
+ * Pure orchestration for the Typography screen's favorite-font write flows: adding a picked catalog
+ * family to the library's favorites, and removing one. Same `scale-flows.js` discipline: the REST
+ * call is imported here (so a test mocks `api/client`), the caller supplies busy/error callbacks and
+ * a feed refresh, and each flow settles pessimistically and re-throws on failure.
+ *
+ * A favorite is not a token, so neither flow mints or deletes anything in the registry — the family
+ * name is stored verbatim in the document's `favoriteFonts` section and read back by every font
+ * picker. That is the whole model: no alias, no CSS variable, no indirection to re-point.
  */
 
 /**
@@ -15,24 +17,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { createUserPrimitive } from '../api/client';
-import { customScaleTokenId, nextScaleSlug } from './scale';
-import { fontFamilySlug } from './typography';
-
-/**
- * The DTCG `$type` every minted font uses.
- *
- * @since TBD
- */
-const FONT_FAMILY_TYPE = 'fontFamily';
-
-/**
- * The stable group key every minted font is filed under (mirrors `declarations.php`'s
- * `group_key: 'font-family'`).
- *
- * @since TBD
- */
-const FONT_FAMILY_GROUP_KEY = 'font-family';
+import { addFavoriteFont, removeFavoriteFont } from '../api/client';
 
 /**
  * Read the message off a REST error, falling back to a generic string when the error carries none.
@@ -50,16 +35,11 @@ function errorMessage(error) {
 }
 
 /**
- * Mint a picked catalog family as a user `fontFamily` primitive: derive a kebab slug from the
- * family name (suffixing on collision, the `nextScaleSlug` idiom applied to the derived stem),
- * create it as a single-family stack with no invented generic fallback (the shipped font arrays
- * carry no category data, so appending one would be a guess), refresh the feed, and resolve the
- * new token's canonical id via the segment-aware `customScaleTokenId` so the caller can preview it
- * immediately.
+ * Add a picked catalog family to the library's favorites, then refresh the feed so every reader of
+ * `feed.favoriteFonts` sees it.
  *
  * @param {Object}   args
- * @param {string}   args.name        The picked catalog family name, verbatim (becomes the label).
- * @param {string[]} args.existingIds Every canonical id already registered, for slug collision.
+ * @param {string}   args.name        The picked catalog family name, verbatim.
  * @param {string}   args.slug        Token library slug.
  * @param {string}   args.feedVersion The version token the client last read.
  * @param {Function} args.refreshFeed Replaces the feed with a fresh REST read for a slug.
@@ -68,28 +48,50 @@ function errorMessage(error) {
  *
  * @since TBD
  *
- * @return {Promise<string>} Resolves with the new font's canonical id; rejects on failure, after
+ * @return {Promise<string>} Resolves with the added family name; rejects on failure, after
  *                            `onError`/`onBusy` have already run.
  */
-export function addFontFlow({ name, existingIds, slug, feedVersion, refreshFeed, onBusy, onError }) {
+export function addFavoriteFontFlow({ name, slug, feedVersion, refreshFeed, onBusy, onError }) {
 	onBusy(true);
 
-	const stem = fontFamilySlug(name);
-	const terminalSlug = nextScaleSlug(existingIds, stem);
-	const id = customScaleTokenId(FONT_FAMILY_TYPE, terminalSlug);
-
-	return createUserPrimitive(slug, {
-		id: terminalSlug,
-		$type: FONT_FAMILY_TYPE,
-		$value: [name],
-		label: name,
-		group: FONT_FAMILY_GROUP_KEY,
-		version: feedVersion,
-	})
+	return addFavoriteFont(slug, name, { version: feedVersion })
 		.then(() => refreshFeed(slug))
 		.then(() => {
 			onBusy(false);
-			return id;
+			return name;
+		})
+		.catch((err) => {
+			onError({ message: errorMessage(err) });
+			onBusy(false);
+
+			throw err;
+		});
+}
+
+/**
+ * Remove a family from the library's favorites, then refresh the feed.
+ *
+ * @param {Object}   args
+ * @param {string}   args.name        The family name to un-star, verbatim.
+ * @param {string}   args.slug        Token library slug.
+ * @param {string}   args.feedVersion The version token the client last read.
+ * @param {Function} args.refreshFeed Replaces the feed with a fresh REST read for a slug.
+ * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError     Called with `{ message }` on failure.
+ *
+ * @since TBD
+ *
+ * @return {Promise<string>} Resolves with the removed family name; rejects on failure, after
+ *                            `onError`/`onBusy` have already run.
+ */
+export function removeFavoriteFontFlow({ name, slug, feedVersion, refreshFeed, onBusy, onError }) {
+	onBusy(true);
+
+	return removeFavoriteFont(slug, name, { version: feedVersion })
+		.then(() => refreshFeed(slug))
+		.then(() => {
+			onBusy(false);
+			return name;
 		})
 		.catch((err) => {
 			onError({ message: errorMessage(err) });

--- a/src/style-library/helpers/typography.js
+++ b/src/style-library/helpers/typography.js
@@ -41,6 +41,10 @@ function unquoteFamily(family) {
  *
  * @since TBD
  *
+ * Blank and duplicate entries are dropped. The store already trims and deduplicates on exact
+ * strings, but it compares before unquoting: `Inter` and `\"Inter\"` are two entries there and one
+ * font here, and both would otherwise render as separate pinned rows.
+ *
  * @return {Array<{id: string, label: string, stack: string}>} The font options, or `[]` when the
  *         library has no favorites.
  */
@@ -51,13 +55,27 @@ export function fontOptions(feed) {
 		return [];
 	}
 
-	return favorites
-		.filter((family) => typeof family === 'string' && family.trim() !== '')
-		.map((family) => {
-			const label = unquoteFamily(family.trim());
+	const seen = new Set();
 
-			return { id: label, label, stack: familyStack(label) };
-		});
+	return favorites.reduce((options, family) => {
+		if (typeof family !== 'string') {
+			return options;
+		}
+
+		const label = unquoteFamily(family.trim()).trim();
+		// Matched the way `findFontByFamily` matches, so a name that would select an existing option
+		// never renders as a second one.
+		const key = label.toLowerCase();
+
+		if (label === '' || seen.has(key)) {
+			return options;
+		}
+
+		seen.add(key);
+		options.push({ id: label, label, stack: familyStack(label) });
+
+		return options;
+	}, []);
 }
 
 /**

--- a/src/style-library/helpers/typography.js
+++ b/src/style-library/helpers/typography.js
@@ -56,12 +56,33 @@ export function fontOptions(feed) {
 		.map((family) => {
 			const label = unquoteFamily(family.trim());
 
-			return {
-				id: label,
-				label,
-				stack: /[\s"']/.test(label) ? `"${label.replace(/"/g, '\\"')}"` : label,
-			};
+			return { id: label, label, stack: familyStack(label) };
 		});
+}
+
+/**
+ * The `font-family` CSS value for a single family: quoted when the name carries whitespace or a
+ * quote, bare otherwise. No generic fallback is appended — the shipped font arrays carry no category
+ * data, so guessing one would put the wrong face behind a failed load.
+ *
+ * Shared because the preview has to render a family the site has NOT kept just as faithfully as
+ * one it has; deriving the stack only inside `fontOptions()` is what left every non-favorite pick
+ * with no preview at all.
+ *
+ * @param {string} family A single family name, already unquoted and trimmed.
+ *
+ * @since TBD
+ *
+ * @return {string} The `font-family` value.
+ */
+export function familyStack(family) {
+	const name = unquoteFamily(String(family ?? '').trim());
+
+	if (name === '') {
+		return '';
+	}
+
+	return /[\s"']/.test(name) ? `"${name.replace(/"/g, '\\"')}"` : name;
 }
 
 /**

--- a/src/style-library/helpers/typography.js
+++ b/src/style-library/helpers/typography.js
@@ -1,17 +1,15 @@
 /**
- * The Typography screen's pure helpers: mapping the `Font Family` feed group into the FONT
+ * The Typography screen's pure helpers: mapping the library's favorite families into the FONT
  * selector's options, reading a fluid font-size step's authored scalar out of its resolved
- * `clamp(...)` CSS, and the font-catalog capability (reading the page-load catalog global,
- * matching a catalog pick against a design-system font, deriving a slug that can be minted, and deciding the
- * contextual Add/Delete button's state). No React, no JSX, no REST — see
- * `components/pages/TypographyScreen.js` for where these plug into the scale-screen contract and
- * `helpers/font-flows.js` for the Add Font write flow.
+ * `clamp(...)` CSS, and the font-catalog capability (reading the page-load catalog global, matching
+ * a catalog pick against a favorite, and deciding the contextual Add/Remove button's state). No
+ * React, no JSX, no REST — see `components/pages/TypographyScreen.js` for where these plug into the
+ * scale-screen contract and `helpers/font-flows.js` for the favorite write flows.
+ *
+ * A favorite is a plain catalog family name, not a token: nothing resolves through it and no CSS
+ * variable is emitted for it. It only pins a family to the top of a font picker, here and in the
+ * block editor, so a site is not searching a ~1,900-name catalog for the same face every time.
  */
-
-/**
- * Internal dependencies
- */
-import { isDeletable } from './token-capabilities';
 
 /**
  * Strip a pair of wrapping quotes (single or double) from a font-family name, the same trimming a
@@ -31,37 +29,39 @@ function unquoteFamily(family) {
 }
 
 /**
- * Map the feed's `Font Family` UI-schema group to the FONT selector's options, in feed order.
+ * Map the feed's stored favorite families to the FONT selector's options, in stored order.
  *
- * @param {{ groups?: Record<string, Array<Object>> }} schema The feed's UI schema.
- * @param {Record<string, string>}                      values The feed's resolved value map.
- * @param {string}                                       group  The UI-schema group label to list
- *                                                                (the translated `Font Family` group).
+ * `id` is the family name itself. A favorite has no token id to key on — there is nothing in the
+ * registry to point at — and the family name is already unique within the list, so it doubles as
+ * the option's identity. `stack` is the family quoted when it needs to be, which is what a preview
+ * assigns to `font-family`; no generic fallback is invented, since the shipped font arrays carry no
+ * category data and guessing one would put the wrong face behind a failed load.
+ *
+ * @param {{ favoriteFonts?: string[] }} feed The design-tokens feed.
  *
  * @since TBD
  *
- * @return {Array<{id: string, label: string, stack: string, userCreated: boolean}>} The font
- *         options, or `[]` for a missing schema or an unknown group. `userCreated` passes through
- *         the feed entry verbatim so `fontActionFor` can gate on it without re-reading the schema.
+ * @return {Array<{id: string, label: string, stack: string}>} The font options, or `[]` when the
+ *         library has no favorites.
  */
-export function fontOptions(schema, values, group) {
-	const entries = schema?.groups?.[group];
+export function fontOptions(feed) {
+	const favorites = feed?.favoriteFonts;
 
-	if (!Array.isArray(entries)) {
+	if (!Array.isArray(favorites)) {
 		return [];
 	}
 
-	return entries.map((entry) => {
-		const stack = values?.[entry.id] ?? '';
-		const firstFamily = stack.split(',')[0]?.trim() ?? '';
+	return favorites
+		.filter((family) => typeof family === 'string' && family.trim() !== '')
+		.map((family) => {
+			const label = unquoteFamily(family.trim());
 
-		return {
-			id: entry.id,
-			label: unquoteFamily(firstFamily),
-			stack,
-			userCreated: entry.userCreated === true,
-		};
-	});
+			return {
+				id: label,
+				label,
+				stack: /[\s"']/.test(label) ? `"${label.replace(/"/g, '\\"')}"` : label,
+			};
+		});
 }
 
 /**
@@ -123,15 +123,15 @@ export function getFontCatalog() {
 }
 
 /**
- * Find the design-system font (a `fontOptions()` entry) whose first family matches a catalog
- * family name, case-insensitively and ignoring wrapping quotes on either side.
+ * Find the favorite (a `fontOptions()` entry) whose family matches a catalog family name,
+ * case-insensitively and ignoring wrapping quotes on either side.
  *
- * @param {Array<{id: string, label: string}>} fonts The design-system fonts (`fontOptions()`).
+ * @param {Array<{id: string, label: string}>} fonts The library's favorites (`fontOptions()`).
  * @param {string}                              name  The catalog family name to match.
  *
  * @since TBD
  *
- * @return {?{id: string, label: string}} The matching font, or `null` when none matches.
+ * @return {?{id: string, label: string}} The matching favorite, or `null` when none matches.
  */
 export function findFontByFamily(fonts, name) {
 	const needle = unquoteFamily(String(name ?? '').trim()).toLowerCase();
@@ -140,56 +140,28 @@ export function findFontByFamily(fonts, name) {
 }
 
 /**
- * Derive a slug stem — a kebab-case id a new token can be minted with — from a catalog family name: lowercase, diacritics
- * stripped (NFD-normalize, then drop the combining marks), any run outside `[a-z0-9]` collapsed to
- * a single hyphen, edge hyphens trimmed. A name that yields nothing (fully non-Latin) falls back to
- * `'font'` rather than an empty slug. Collision suffixing is `nextScaleSlug`'s job, not this
- * helper's — this only derives the stem.
+ * Decide the FONT dropdown's contextual button state for a catalog pick: `'add'` when the pick is
+ * not yet a favorite, `'remove'` when it already is.
  *
- * @param {string} name The catalog family name.
+ * Neither is ever disabled for a real pick. Unlike the token model this replaces, there is no
+ * shipped-and-therefore-undeletable entry: every favorite was put there by a person, so every
+ * favorite can be taken back out. Only an empty dropdown disables the button, since there is
+ * nothing to add.
  *
- * @since TBD
- *
- * @return {string} The derived slug stem, never empty.
- */
-export function fontFamilySlug(name) {
-	const stripped = String(name ?? '')
-		.toLowerCase()
-		.normalize('NFD')
-		.replace(/[\u0300-\u036f]/g, '');
-
-	const slug = stripped.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
-
-	return slug || 'font';
-}
-
-/**
- * Decide the FONT dropdown's contextual button state for a catalog pick: `'add'` (enabled) when
- * the pick matches no design-system font, `'delete'` when it matches a user-created one, or
- * `'add'` (disabled) when it matches a baseline font — a baseline font can never be re-added and
- * must never be offered for deletion (the server independently refuses baseline deletion with 403
- * `rest_design_tokens_locked`; this is defense-in-depth, not the authority).
- *
- * @param {Array<{id: string, label: string, userCreated: boolean}>} fonts The design-system fonts
- *                                                                          (`fontOptions()`).
- * @param {string}                                                    name  The catalog family name
- *                                                                          currently shown in the
- *                                                                          dropdown.
+ * @param {Array<{id: string, label: string}>} fonts The library's favorites (`fontOptions()`).
+ * @param {string}                              name  The catalog family name currently shown in the
+ *                                                    dropdown.
  *
  * @since TBD
  *
- * @return {{type: ('add'|'delete'), disabled: boolean, font: ?Object}} The button state.
+ * @return {{type: ('add'|'remove'), disabled: boolean, font: ?Object}} The button state.
  */
 export function fontActionFor(fonts, name) {
 	const match = findFontByFamily(fonts, name);
 
 	if (!match) {
-		return { type: 'add', disabled: false, font: null };
+		return { type: 'add', disabled: String(name ?? '').trim() === '', font: null };
 	}
 
-	if (isDeletable(match)) {
-		return { type: 'delete', disabled: false, font: match };
-	}
-
-	return { type: 'add', disabled: true, font: match };
+	return { type: 'remove', disabled: false, font: match };
 }


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4207/font-families-become-favorites-not-tokens
:video_camera:  https://www.loom.com/share/2cde91916171494694080f3b7beda6e9

The FONT selector now reads and writes the library's `favoriteFonts` list instead of the `Font Family` UI-schema group. Nothing on this screen mints a `fontFamily` user primitive any more.

- The font tab strip is gone. Favorites pin to the top of the searchable catalog dropdown with a `Favorite` badge — what the design calls for, and how the block editor's picker will surface the same list. A favorite is filtered out of the Google and custom runs below so it appears exactly once, in its pinned position.
- "Add Font" / "Delete" becomes "Add Favorite" / "Remove Favorite". The font-size scale still uses `createUserPrimitive` / `deleteUserPrimitive`; fonts no longer do.
- `fontOptions()` reads `feed.favoriteFonts` and keys each option by its own family name — there is no token id to key on. It quotes a multi-word family in the preview stack so it renders as one family, and invents no generic fallback.
- `fontActionFor()` loses the baseline/user-created split: every favorite was put there by a person, so every favorite can be taken back out.

Font *selection* stays what it already was — view-only, session-scoped state driving the size-token sample preview. Only the list persists.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Typography font selection now prioritizes favorite fonts, while also allowing previews of Google and custom fonts.
  * Added contextual actions to add or remove font families from favorites.
  * Font previews remain stable when favorite selections change.

* **Bug Fixes**
  * Improved handling of multi-word, quoted, blank, and case-insensitive font-family names.
  * Added clearer busy-state and error handling during favorite updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

