### PR TITLE
[DTM] SOFT-4083 [41/51]: wrap Border, Border Radius, and Box Shadow controls in kb-token-control-row for spacing

### DIFF
--- a/src/extension/design-tokens/components/EditorBorderControl.js
+++ b/src/extension/design-tokens/components/EditorBorderControl.js
@@ -24,6 +24,10 @@
  * - **the unit lives inside the native value itself** (`source.unit`), not a sibling attribute the
  *   way `BoxControl`'s radius keeps `borderRadiusUnit` — so, unlike `EditorBoxControl`, this
  *   component takes no separate `unit`/`units`/`onUnit` props at all.
+ * - **wraps itself in `TokenControlRow`** (no `heading`, purely for its `.kb-token-control-row`
+ *   spacing) — this component only ever renders inside `singlebtn/edit.js`'s sidebar, so it owns that
+ *   wrapper rather than asking every call site to remember it, matching
+ *   `EditorBoxControl`/`EditorShadowControl`.
  *
  * Color editing itself is untouched — this component neither builds nor redesigns a color field, it
  * only wires the caller's EXISTING one back in via `renderColor` (matching `BorderControl`'s own
@@ -44,6 +48,7 @@ import { BreakpointProvider } from '../../../token-controls';
 import { BorderControl } from '../../../token-controls/controls/BorderControl';
 import { readSlot } from '../../../token-controls/helpers/value-shapes';
 import { isTokenAlias } from '../../../token-controls/helpers/token-summary';
+import { TokenControlRow } from '../../token-indicators/components/TokenControlRow';
 
 const SIDES = ['top', 'right', 'bottom', 'left'];
 
@@ -306,24 +311,26 @@ export function EditorBorderControl({
 	};
 
 	return (
-		<BreakpointProvider value={breakpoint} onChange={changeBreakpoint}>
-			<BorderControl
-				label={label}
-				value={fromNativeBorder(activeNative)}
-				onChange={(next) => activeSetter(toNativeBorder(next, activeUnit))}
-				widthTokens={widthTokens}
-				defaultValue={defaultValue}
-				indicator={indicator}
-				breakpoints={Object.values(BREAKPOINT_FOR_DEVICE)}
-				breakpoint={breakpoint}
-				// The switcher lives in `ControlShell`, driven by this prop directly — it does not read
-				// the `BreakpointProvider` context above, so both must map back to a device the same way.
-				onBreakpointChange={changeBreakpoint}
-				renderColor={renderColor}
-				isLinked={linked}
-				onToggleLink={toggleLink}
-				stacked
-			/>
-		</BreakpointProvider>
+		<TokenControlRow stacked>
+			<BreakpointProvider value={breakpoint} onChange={changeBreakpoint}>
+				<BorderControl
+					label={label}
+					value={fromNativeBorder(activeNative)}
+					onChange={(next) => activeSetter(toNativeBorder(next, activeUnit))}
+					widthTokens={widthTokens}
+					defaultValue={defaultValue}
+					indicator={indicator}
+					breakpoints={Object.values(BREAKPOINT_FOR_DEVICE)}
+					breakpoint={breakpoint}
+					// The switcher lives in `ControlShell`, driven by this prop directly — it does not read
+					// the `BreakpointProvider` context above, so both must map back to a device the same way.
+					onBreakpointChange={changeBreakpoint}
+					renderColor={renderColor}
+					isLinked={linked}
+					onToggleLink={toggleLink}
+					stacked
+				/>
+			</BreakpointProvider>
+		</TokenControlRow>
 	);
 }

--- a/src/extension/design-tokens/components/EditorBoxControl.js
+++ b/src/extension/design-tokens/components/EditorBoxControl.js
@@ -9,6 +9,10 @@
  * - **a slot is always a four-element array**, never collapsed to a scalar, so the link state cannot
  *   be read off the value's shape and is caller-owned UI state instead;
  * - **the unit lives in its own attribute** beside the value.
+ * - **wraps itself in `TokenControlRow`** (no `heading`, purely for its `.kb-token-control-row`
+ *   spacing) — this component only ever renders inside `singlebtn/edit.js`'s sidebar, so it owns that
+ *   wrapper rather than asking every call site to remember it, matching
+ *   `EditorBorderControl`/`EditorShadowControl`.
  *
  * Everything the control needs beyond that — the token pool, the inherited preset default, the
  * binding indicator — the block already computes for its existing control, so this takes them as
@@ -21,6 +25,7 @@
 import { BoxControl, BreakpointProvider } from '../../../token-controls';
 import { TokenIndicator } from '../../token-indicators/components/TokenIndicator';
 import { BREAKPOINT_FOR_DEVICE, deviceForBreakpoint } from './breakpoints';
+import { TokenControlRow } from '../../token-indicators/components/TokenControlRow';
 
 /**
  * Render a box-shaped token control over the editor's per-device attributes.
@@ -80,36 +85,38 @@ export function EditorBoxControl({
 	// The provider is handed the editor's device rather than holding one of its own: the device
 	// preview is global here, so a switcher that tracked its own would disagree with the canvas.
 	return (
-		<BreakpointProvider value={breakpoint} onChange={changeBreakpoint}>
-			<BoxControl
-				label={label}
-				value={value}
-				onChange={onChange}
-				tokens={tokens}
-				defaultValue={defaultValue}
-				inherited={inherited}
-				// The editor's own mark, not this library's: it is the same indicator the block's other
-				// controls show, and two marks meaning the same thing should not look different.
-				indicator={<TokenIndicator state={state} onReset={onReset} />}
-				isLinked={isLinked}
-				onToggleLink={onToggleLink}
-				// Never collapse: the attribute is always a four-element array, so folding a uniform
-				// value down to a scalar would write a shape the block cannot read back.
-				collapse={false}
-				role={role}
-				breakpoints={Object.values(BREAKPOINT_FOR_DEVICE)}
-				breakpoint={breakpoint}
-				// The switcher lives in `ControlShell`, driven by this prop directly — it does not read
-				// the `BreakpointProvider` context above, so both must map back to a device the same way.
-				onBreakpointChange={changeBreakpoint}
-				unit={unit}
-				units={units}
-				onUnit={onUnit}
-				min={min}
-				max={max}
-				step={step}
-				stacked
-			/>
-		</BreakpointProvider>
+		<TokenControlRow stacked>
+			<BreakpointProvider value={breakpoint} onChange={changeBreakpoint}>
+				<BoxControl
+					label={label}
+					value={value}
+					onChange={onChange}
+					tokens={tokens}
+					defaultValue={defaultValue}
+					inherited={inherited}
+					// The editor's own mark, not this library's: it is the same indicator the block's other
+					// controls show, and two marks meaning the same thing should not look different.
+					indicator={<TokenIndicator state={state} onReset={onReset} />}
+					isLinked={isLinked}
+					onToggleLink={onToggleLink}
+					// Never collapse: the attribute is always a four-element array, so folding a uniform
+					// value down to a scalar would write a shape the block cannot read back.
+					collapse={false}
+					role={role}
+					breakpoints={Object.values(BREAKPOINT_FOR_DEVICE)}
+					breakpoint={breakpoint}
+					// The switcher lives in `ControlShell`, driven by this prop directly — it does not read
+					// the `BreakpointProvider` context above, so both must map back to a device the same way.
+					onBreakpointChange={changeBreakpoint}
+					unit={unit}
+					units={units}
+					onUnit={onUnit}
+					min={min}
+					max={max}
+					step={step}
+					stacked
+				/>
+			</BreakpointProvider>
+		</TokenControlRow>
 	);
 }

--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -39,6 +39,11 @@
  * Color is out of scope for redesign here, exactly as in `EditorBorderControl` — this component
  * neither builds nor intercepts a color field, it only wires the caller's EXISTING one back in via
  * `renderColor`.
+ *
+ * This component also wraps itself in `TokenControlRow` (no `heading`, purely for its
+ * `.kb-token-control-row` spacing) — it only ever renders inside `singlebtn/edit.js`'s sidebar, so it
+ * owns that wrapper rather than asking every call site to remember it, matching
+ * `EditorBorderControl`/`EditorBoxControl`.
  */
 
 /**
@@ -51,6 +56,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { BoxShadowControl } from '../../../token-controls/controls/BoxShadowControl';
+import { TokenControlRow } from '../../token-indicators/components/TokenControlRow';
 
 /**
  * The composite's default shape, matching `BoxShadowControl`'s own `DEFAULT_SHADOW` fallback.
@@ -385,37 +391,39 @@ export function EditorShadowControl({
 	disabled = false,
 }) {
 	return (
-		<div className="kb-editor-shadow-control">
-			<div className="kb-editor-shadow-control__header">
-				{label && <span className="kb-editor-shadow-control__label">{label}</span>}
-				<ToggleControl
-					label={
-						label
-							? sprintf(
-									/* translators: %s: the field's own label, e.g. "Shadow". */ __(
-										'Enable %s',
-										'kadence-blocks'
-									),
-									label
-								)
-							: __('Enable shadow', 'kadence-blocks')
-					}
-					hideLabelFromVision
-					checked={!!enable}
-					onChange={onEnableChange}
-					disabled={disabled}
-				/>
+		<TokenControlRow stacked>
+			<div className="kb-editor-shadow-control">
+				<div className="kb-editor-shadow-control__header">
+					{label && <span className="kb-editor-shadow-control__label">{label}</span>}
+					<ToggleControl
+						label={
+							label
+								? sprintf(
+										/* translators: %s: the field's own label, e.g. "Shadow". */ __(
+											'Enable %s',
+											'kadence-blocks'
+										),
+										label
+									)
+								: __('Enable shadow', 'kadence-blocks')
+						}
+						hideLabelFromVision
+						checked={!!enable}
+						onChange={onEnableChange}
+						disabled={disabled}
+					/>
+				</div>
+				{enable && (
+					<BoxShadowControl
+						label={undefined}
+						value={fromNativeShadow(value)}
+						onChange={(next) => onChange(toNativeShadow(next, tokens))}
+						tokens={tokens}
+						renderColor={renderColor}
+						disabled={disabled}
+					/>
+				)}
 			</div>
-			{enable && (
-				<BoxShadowControl
-					label={undefined}
-					value={fromNativeShadow(value)}
-					onChange={(next) => onChange(toNativeShadow(next, tokens))}
-					tokens={tokens}
-					renderColor={renderColor}
-					disabled={disabled}
-				/>
-			)}
-		</div>
+		</TokenControlRow>
 	);
 }

--- a/src/extension/design-tokens/components/__tests__/EditorBoxControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorBoxControl.test.js
@@ -7,16 +7,18 @@ import { EditorBoxControl } from '../EditorBoxControl';
 
 /**
  * Call `EditorBoxControl` as a plain function and return the `BoxControl`/`BreakpointProvider`
- * elements it produced. The component holds no hooks of its own, so the returned element tree can
- * be inspected directly instead of mounting it — matching this file's sibling tests, which inspect
- * returned element types/props rather than rendering.
+ * elements it produced. The component holds no hooks of its own — `TokenControlRow` is referenced in
+ * the returned JSX but never invoked by this plain call, since JSX only builds element descriptors —
+ * so the returned element tree can be inspected directly instead of mounting it, matching this file's
+ * sibling tests, which inspect returned element types/props rather than rendering.
  *
  * @param {Object} overrides Props to override on top of the defaults.
  *
  * @since TBD
  *
- * @return {{provider: Object, boxControl: Object, onDeviceChange: Function}} The provider element,
- *   the `BoxControl` element nested inside it, and the `onDeviceChange` spy passed in.
+ * @return {{provider: Object, boxControl: Object, onDeviceChange: Function}} The `BreakpointProvider`
+ *   element (one level inside the root `TokenControlRow`), the `BoxControl` element nested inside it,
+ *   and the `onDeviceChange` spy passed in.
  */
 function renderEditorBoxControl(overrides = {}) {
 	const onDeviceChange = jest.fn();
@@ -33,7 +35,7 @@ function renderEditorBoxControl(overrides = {}) {
 		...overrides,
 	};
 
-	const provider = EditorBoxControl(props);
+	const provider = EditorBoxControl(props).props.children;
 
 	return { provider, boxControl: provider.props.children, onDeviceChange };
 }

--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -27,16 +27,19 @@ const NATIVE_VALUE = [
 
 /**
  * Call `EditorShadowControl` as a plain function and return the `BoxShadowControl`/`ToggleControl`
- * elements it produced. The component holds no hooks of its own, so the returned element tree can be
- * inspected directly instead of mounting it — matching `EditorBorderControl.test.js`'s own harness.
+ * elements it produced. The component holds no hooks of its own — `TokenControlRow` is referenced in
+ * the returned JSX but never invoked by this plain call, since JSX only builds element descriptors — so
+ * the returned element tree can be inspected directly instead of mounting it, matching
+ * `EditorBorderControl.test.js`'s own harness (before it gained state and needed a real render).
  *
  * @param {Object} overrides Props to override on top of the defaults.
  *
  * @since TBD
  *
  * @return {{root: Object, header: Object, toggle: Object, shadowControl: ?Object, onChange: Function,
- *   onEnableChange: Function}} The root element, the header row, the enable toggle, the
- *   `BoxShadowControl` element (or `null` when `enable` is false), and the setter spies passed in.
+ *   onEnableChange: Function}} The root element (`TokenControlRow`), the header row, the enable
+ *   toggle, the `BoxShadowControl` element (or `null` when `enable` is false), and the setter spies
+ *   passed in.
  */
 function renderEditorShadowControl(overrides = {}) {
 	const onChange = jest.fn();
@@ -53,7 +56,7 @@ function renderEditorShadowControl(overrides = {}) {
 	};
 
 	const root = EditorShadowControl(props);
-	const [header, shadowControl] = root.props.children;
+	const [header, shadowControl] = root.props.children.props.children;
 
 	return {
 		root,

--- a/src/extension/token-indicators/components/TokenControlRow.js
+++ b/src/extension/token-indicators/components/TokenControlRow.js
@@ -7,6 +7,10 @@
  * header row is skipped entirely — the wrapper then only contributes the highlight tint, for a control
  * that already carries its indicator inline (via `TokenLabel`). When "highlight edits" is on and this
  * control overrides its preset, the whole row is tinted a warning color so the edit stands out.
+ *
+ * `attr`/`binding` can be omitted entirely (`highlight` then never fires) for a control with no bound
+ * attribute to track at all — used this way purely for the `.kb-token-control-row` spacing/`stacked`
+ * layout, e.g. by the `Editor*` design-token controls that already carry their own indicator internally.
  */
 
 import { useSelect } from '@wordpress/data';
@@ -20,8 +24,9 @@ import { TokenIndicator } from './TokenIndicator';
  * @param {string}   [props.heading] Heading text shown next to the indicator, above the control; with no
  *                                   heading the header row (and its indicator) is skipped and the wrapper
  *                                   only contributes the highlight tint.
- * @param {string}   props.attr      The attribute the wrapped control writes (the indicator's key).
- * @param {Object}   props.binding   The block's binding map from usePresetBinding.
+ * @param {?string}  [props.attr]    The attribute the wrapped control writes (the indicator's key); omit
+ *                                   alongside `binding` for a control with nothing to highlight.
+ * @param {?Object}  [props.binding] The block's binding map from usePresetBinding; omit alongside `attr`.
  * @param {Function} [props.onReset] Called with `attr` to reset that control's override (headed rows only).
  * @param {boolean}  [props.stacked] Stack the header above a full-width control (for block-level controls
  *                                   like the responsive measurement inputs) instead of the side-by-side row.


### PR DESCRIPTION
🎥  https://www.loom.com/share/ea111c757dc94d058a8c196f9cc72b50

## Summary
- `EditorBorderControl`, `EditorBoxControl` (Border Radius), and `EditorShadowControl` were rendered as bare fields in the Button preset's sidebar, with no spacing between them — `.kb-token-control-row` (the class that already gives the plain color fields their `margin-bottom: 16px`) was never applied to them.
- Wraps each of the 13 call sites (6 states × Border/Box Shadow, plus the single Border Radius field) in a stacked `.kb-token-control-row` div, matching the spacing every other field in the panel already has.

## Test plan
- [ ] Open the Button preset's sidebar and confirm visible spacing between the Border, Border Radius, and Box Shadow fields across every state (Normal, Hover, Transparent, Transparent Hover, Sticky, Sticky Hover).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layout and spacing of border, box, and shadow token controls.
  * Standardized these controls within the shared stacked control-row presentation.
  * Preserved existing breakpoint behavior, token linking, units, sizing, toggles, and conditional shadow controls.

* **Documentation**
  * Clarified control-row options and usage for layout-only controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->