### PR TITLE
[DTM] SOFT-4207 [6/15]: remove the font-family token family

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -301,32 +301,6 @@
 				}
 			}
 		},
-		"font-family": {
-			"sans": {
-				"$type": "fontFamily",
-				"$value": [
-					"Inter",
-					"system-ui",
-					"sans-serif"
-				]
-			},
-			"serif": {
-				"$type": "fontFamily",
-				"$value": [
-					"Georgia",
-					"Cambria",
-					"serif"
-				]
-			},
-			"mono": {
-				"$type": "fontFamily",
-				"$value": [
-					"Menlo",
-					"Consolas",
-					"monospace"
-				]
-			}
-		},
 		"fontSize": {
 			"xs": {
 				"$type": "dimension",
@@ -561,17 +535,6 @@
 			"default": {
 				"$type": "dimension",
 				"$value": "{primitive.dimension.icon-size.md}"
-			}
-		},
-		"font-family": {
-			"control": {
-				"$type": "fontFamily",
-				"$value": "{primitive.font-family.sans}"
-			},
-			"heading": {
-				"$type": "fontFamily",
-				"$value": ["inherit"],
-				"$description": "Inherits the theme's font by default; a site sets a real family here to impose a heading font."
 			}
 		},
 		"font-size": {
@@ -861,7 +824,6 @@
 						"tokens": {
 							"color": "{semantic.color.text}",
 							"background": "{semantic.color.heading-bg}",
-							"typography": "{semantic.font-family.heading}",
 							"fontSize": "{semantic.font-size.heading}",
 							"fontHeight": "{semantic.line-height.heading}",
 							"fontWeight": "{semantic.font-weight.heading}",

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -165,37 +165,6 @@ $font_size_primitive_tokens = array_map(
 	$font_size_slugs
 );
 
-// The three preview fonts are primitives the Style Library's Typography screen lists as FONT
-// options; the font-family semantics (semantic.font-family.control / .heading) keep their own
-// values and already carry whatever projections deliver a family into a block, so these primitives
-// declare none of their own. group_key lets "+ Add Font" mint a user fontFamily primitive into
-// this same group: Token_Type maps the camelCase $type to the kebab id segment "font-family" (the
-// id feeds Css_Var::from_id(), which cannot take a camelCase segment), so the stored $type and the
-// registered id can differ while staying self-consistent.
-//
-// The id segment is kebab-case ("font-family", not "fontFamily") because Token_Definition::from_array()
-// validates every declared id against the kebab charset and throws on a camelCase segment — these
-// tokens (and the baseline.json tree backing them) could never have registered under the old spelling.
-$font_family_slugs = [
-	'sans'  => __( 'Sans', 'kadence-blocks' ),
-	'serif' => __( 'Serif', 'kadence-blocks' ),
-	'mono'  => __( 'Mono', 'kadence-blocks' ),
-];
-
-$font_family_tokens = array_map(
-	static function ( string $slug, string $label ): array {
-		return [
-			'id'        => 'primitive.font-family.' . $slug,
-			'type'      => 'fontFamily',
-			'label'     => $label,
-			'group'     => __( 'Font Family', 'kadence-blocks' ),
-			'group_key' => 'font-family',
-		];
-	},
-	array_keys( $font_family_slugs ),
-	array_values( $font_family_slugs )
-);
-
 /**
  * The brand + neutral primitives ARE the site's global color palette: each claims a Kadence palette slot
  * (palette1..9), so --global-paletteN follows the primitive and the legacy kadence_blocks_colors palette
@@ -511,7 +480,6 @@ return [
 		$spacing_tokens,
 		$gap_tokens,
 		$font_size_primitive_tokens,
-		$font_family_tokens,
 		$radius_tokens,
 		$border_width_tokens,
 		$icon_size_tokens,
@@ -751,11 +719,13 @@ return [
 			// Advanced Text (heading) core design properties + typography set: low-specificity
 			// block-default-CSS rules on the block root (`.wp-block-kadence-advancedheading`), where every
 			// bound attribute is empty by default in block.json — build_css() emits nothing for any of them
-			// until a value is set, so the whole 12-property set fits this mechanism directly with no
-			// per-block adapter and no build_css()/SCSS/editor-JS change. Typography (font-family,
-			// letter-spacing, text-transform) uses the heading's own tokens, kept separate from the
-			// form-control family the Button uses; font-size/line-height/font-weight are the heading's
-			// own re-skin seeds. The rule also overrides a theme's per-tag element styles (h1/h2/p,
+			// until a value is set, so the whole set fits this mechanism directly with no per-block
+			// adapter and no build_css()/SCSS/editor-JS change. Typography (letter-spacing,
+			// text-transform) uses the heading's own tokens, kept separate from the form-control family
+			// the Button uses; font-size/line-height/font-weight are the heading's own re-skin seeds.
+			// Font FAMILY is deliberately absent: a family is a favorite, not a token, so a heading
+			// inherits the theme's font until someone picks one on the block itself.
+			// The rule also overrides a theme's per-tag element styles (h1/h2/p,
 			// specificity 0,0,1), which is what lets the design-system defaults "re-skin" an unset
 			// heading. A per-instance value renders at higher specificity (the `.kt-adv-heading<uid>`
 			// instance selector) and still wins.
@@ -777,10 +747,6 @@ return [
 				'background'    => [
 					'token'    => 'semantic.color.heading-bg',
 					'css_prop' => 'background-color',
-				],
-				'typography'    => [
-					'token'    => 'semantic.font-family.heading',
-					'css_prop' => 'font-family',
 				],
 				'fontSize'      => [
 					'token'    => 'semantic.font-size.heading',

--- a/src/blocks/advancedbtn/editor.scss
+++ b/src/blocks/advancedbtn/editor.scss
@@ -220,7 +220,6 @@
 	cursor: pointer;
 	// Mirror of style.scss: the button follows the semantic.*.control typography tokens so the editor
 	// preview matches the front end. See the note there.
-	font-family: var(--kb-token--semantic--font-family--control, inherit);
 	font-size: var(--kb-token--semantic--font-size--control, 1.125rem);
 	font-weight: var(--kb-token--semantic--font-weight--control);
 	font-style: var(--kb-token--semantic--font-style--control);

--- a/src/blocks/advancedbtn/style.scss
+++ b/src/blocks/advancedbtn/style.scss
@@ -40,7 +40,8 @@
 	// Typography follows the semantic.*.control design tokens, one custom property per property, so a
 	// button follows the design system in the editor and on the front end. Each is a low-specificity
 	// default: a per-button typography value renders at the higher `.kb-btn<uid>` specificity and wins.
-	font-family: var(--kb-token--semantic--font-family--control, inherit);
+	// Font FAMILY is deliberately absent, matching the shipped rule: a family is a favorite, not a
+	// token, so a button inherits whatever the theme gives it until someone picks a font on the block.
 	font-size: var(--kb-token--semantic--font-size--control, 1.125rem);
 	font-weight: var(--kb-token--semantic--font-weight--control);
 	font-style: var(--kb-token--semantic--font-style--control);

--- a/src/style-library/__tests__/typography.test.js
+++ b/src/style-library/__tests__/typography.test.js
@@ -119,8 +119,8 @@ describe('getFontCatalog', () => {
 
 describe('findFontByFamily', () => {
 	const fonts = [
-		{ id: 'primitive.font-family.sans', label: 'Inter' },
-		{ id: 'primitive.font-family.serif', label: 'Georgia' },
+		{ id: 'Inter', label: 'Inter' },
+		{ id: 'Georgia', label: 'Georgia' },
 	];
 
 	it('matches a favorite case-insensitively', () => {

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -166,10 +166,10 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
-	 * The shipped Advanced Text (heading) declarations emit all 13 bound core-design and typography
+	 * The shipped Advanced Text (heading) declarations emit all 12 bound core-design and typography
 	 * properties as one grouped, low-specificity rule on the block root, each pointing its css_prop at the
-	 * matching token var with the resolved default as the fallback — including the font-family fallback
-	 * resolved to the theme's inherited font.
+	 * matching token var with the resolved default as the fallback. Font FAMILY is deliberately not among
+	 * them — a family is a favorite, not a token, so an unset heading inherits the theme's font.
 	 *
 	 * @return void
 	 */
@@ -186,10 +186,6 @@ final class Css_BuilderTest extends TestCase {
 			'background-color:var(' . Css_Var::from_id( 'semantic.color.heading-bg' ) . ',transparent);',
 			$css
 		);
-		$this->assertStringContainsString(
-			'font-family:var(' . Css_Var::from_id( 'semantic.font-family.heading' ) . ',inherit);',
-			$css
-		);
 		$this->assertStringContainsString( 'font-size:var(' . Css_Var::from_id( 'semantic.font-size.heading' ) . ',2rem);', $css );
 		$this->assertStringContainsString( 'line-height:var(' . Css_Var::from_id( 'semantic.line-height.heading' ) . ',1.125);', $css );
 		$this->assertStringContainsString( 'font-weight:var(' . Css_Var::from_id( 'semantic.font-weight.heading' ) . ',400);', $css );
@@ -200,6 +196,7 @@ final class Css_BuilderTest extends TestCase {
 		$this->assertStringContainsString( 'border-width:var(' . Css_Var::from_id( 'semantic.border-width.default' ) . ',1px);', $css );
 		$this->assertStringContainsString( 'border-radius:var(' . Css_Var::from_id( 'semantic.radius.heading' ) . ',0);', $css );
 		$this->assertStringContainsString( 'border-style:var(' . Css_Var::from_id( 'semantic.border-style.default' ) . ',none);}', $css );
+		$this->assertStringNotContainsString( 'font-family:', $css, 'A heading inherits the theme font; no font-family default is emitted.' );
 	}
 
 	/**
@@ -207,7 +204,7 @@ final class Css_BuilderTest extends TestCase {
 	 * heading element the bindings style — the real heading carries the stable `kadence-advancedheading-text`
 	 * class instead. The declared `editor_selector` re-targets the editor build of the rule at that
 	 * descendant, scoped under `.editor-styles-wrapper` so it still outranks the theme's own per-tag element
-	 * styles there, while still carrying every one of the block's 13 bound declarations.
+	 * styles there, while still carrying every one of the block's 12 bound declarations.
 	 *
 	 * @return void
 	 */
@@ -224,10 +221,6 @@ final class Css_BuilderTest extends TestCase {
 			'background-color:var(' . Css_Var::from_id( 'semantic.color.heading-bg' ) . ',transparent);',
 			$css
 		);
-		$this->assertStringContainsString(
-			'font-family:var(' . Css_Var::from_id( 'semantic.font-family.heading' ) . ',inherit);',
-			$css
-		);
 		$this->assertStringContainsString( 'font-size:var(' . Css_Var::from_id( 'semantic.font-size.heading' ) . ',2rem);', $css );
 		$this->assertStringContainsString( 'line-height:var(' . Css_Var::from_id( 'semantic.line-height.heading' ) . ',1.125);', $css );
 		$this->assertStringContainsString( 'font-weight:var(' . Css_Var::from_id( 'semantic.font-weight.heading' ) . ',400);', $css );
@@ -238,6 +231,7 @@ final class Css_BuilderTest extends TestCase {
 		$this->assertStringContainsString( 'border-width:var(' . Css_Var::from_id( 'semantic.border-width.default' ) . ',1px);', $css );
 		$this->assertStringContainsString( 'border-radius:var(' . Css_Var::from_id( 'semantic.radius.heading' ) . ',0);', $css );
 		$this->assertStringContainsString( 'border-style:var(' . Css_Var::from_id( 'semantic.border-style.default' ) . ',none);}', $css );
+		$this->assertStringNotContainsString( 'font-family:', $css, 'A heading inherits the theme font; no font-family default is emitted.' );
 
 		// The front-end rule for the SAME block must stay on the block root, with no editor-only prefix.
 		$this->assertStringNotContainsString( '.editor-styles-wrapper', $this->builder( $registry )->css() );

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Baseline/Json_Baseline_DocumentTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Baseline/Json_Baseline_DocumentTest.php
@@ -48,8 +48,6 @@ final class Json_Baseline_DocumentTest extends TestCase {
 		$this->assertTrue( $baseline->has( 'primitive.color.brand.primary' ) );
 		// Numeric-keyed leaf (json_decode turns "0" into an int key).
 		$this->assertTrue( $baseline->has( 'primitive.color.neutral.0' ) );
-		// fontFamily leaf whose $value is an array.
-		$this->assertTrue( $baseline->has( 'primitive.font-family.sans' ) );
 		// A composite leaf (object $value) is still a single token, not a group.
 		$this->assertTrue( $baseline->has( 'semantic.shadow.card' ) );
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
@@ -181,7 +181,6 @@ final class Preset_ResolverTest extends TestCase {
 			[
 				'color'         => '#1A202C',
 				'background'    => 'transparent',
-				'typography'    => 'inherit',
 				'fontSize'      => '2rem',
 				'fontHeight'    => '1.125',
 				'fontWeight'    => '400',

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -9,6 +9,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\User_Primitive_Registrar;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Feed_Controller;
+use KadenceWP\KadenceBlocks\Utils\Cast;
 use ReflectionClass;
 use ReflectionProperty;
 use Tests\Support\Classes\TestCase;
@@ -721,52 +722,23 @@ final class Feed_ControllerTest extends TestCase {
 	}
 
 	/**
-	 * The renamed, newly declared font-family primitives surface as their own feed group, in
-	 * declaration order, each resolved to the comma-joined stack the Typography screen's FONT
-	 * selector lists — the id rename from `primitive.fontFamily.*` to `primitive.font-family.*`
-	 * reaching all the way through registration and resolution.
+	 * Font family is no longer a token family: the feed carries no `Font Family` group and no
+	 * font-family token at any layer. A family is a favorite, which rides the feed's own
+	 * `favoriteFonts` section instead and resolves through nothing.
 	 *
 	 * @return void
 	 */
-	public function testGetItemReturnsTheFontFamilyGroup(): void {
+	public function testTheFeedCarriesNoFontFamilyTokens(): void {
 		$request = new WP_REST_Request( WP_REST_Server::READABLE );
 		$request->set_param( 'slug', Token_Store::default_slug() );
 
 		$data = $this->controller->get_item( $request )->get_data();
 
-		$this->assertArrayHasKey( 'Font Family', $data['schema']['groups'] );
+		$this->assertArrayNotHasKey( 'Font Family', $data['schema']['groups'] );
 
-		$ids = array_column( $data['schema']['groups']['Font Family'], 'id' );
-		$this->assertSame(
-			[
-				'primitive.font-family.sans',
-				'primitive.font-family.serif',
-				'primitive.font-family.mono',
-			],
-			$ids
-		);
-
-		$this->assertSame( 'Inter, system-ui, sans-serif', $data['values']['primitive.font-family.sans'] );
-		$this->assertSame( 'Georgia, Cambria, serif', $data['values']['primitive.font-family.serif'] );
-		$this->assertSame( 'Menlo, Consolas, monospace', $data['values']['primitive.font-family.mono'] );
-	}
-
-	/**
-	 * `semantic.font-family.control`'s alias followed the primitive rename in the same edit, so it
-	 * still resolves to the renamed primitive's value instead of dangling.
-	 *
-	 * @return void
-	 */
-	public function testSemanticFontFamilyControlResolvesThroughTheRenamedPrimitive(): void {
-		$request = new WP_REST_Request( WP_REST_Server::READABLE );
-		$request->set_param( 'slug', Token_Store::default_slug() );
-
-		$data = $this->controller->get_item( $request )->get_data();
-
-		$this->assertSame(
-			$data['values']['primitive.font-family.sans'],
-			$data['values']['semantic.font-family.control']
-		);
+		foreach ( array_keys( $data['values'] ) as $id ) {
+			$this->assertStringNotContainsString( 'font-family', Cast::to_string( $id ) );
+		}
 	}
 
 	/**
@@ -899,15 +871,18 @@ final class Feed_ControllerTest extends TestCase {
 	}
 
 	/**
-	 * A user-created `fontFamily` primitive minted into the `font-family` group (the $type ->
-	 * id-segment mapping's headline unlock) surfaces inside the declared "Font Family" UI-schema
-	 * group as `userCreated`, and its single-family stack resolves with the spaced name quoted —
-	 * `Css_Renderer::font_family()`'s existing quoting rule, exercised end to end through a minted
-	 * token rather than only a baseline one.
+	 * A `fontFamily` user primitive left in a stored document from before font family stopped being
+	 * a token family still registers and still resolves — `fontFamily` remains a valid DTCG $type,
+	 * so an existing document keeps validating rather than failing on its next write. What it no longer
+	 * does is surface on a screen: with no declared "Font Family" group left to resolve its group key
+	 * against, the registrar's fail-soft files it UNGROUPED — the same path a downgrade or a removed
+	 * group already took — so it keeps its value but has no home screen, and nothing can mint another
+	 * (the create route 404s the group). Its single-family stack still resolves with the spaced name
+	 * quoted, exercising `Css_Renderer::font_family()` end to end through a stored token.
 	 *
 	 * @return void
 	 */
-	public function testUserPrimitiveGroupedIntoFontFamilySurfacesInItsFeedGroupWithQuotedValue(): void {
+	public function testAStoredFontFamilyUserPrimitiveStillResolvesButSurfacesInNoGroup(): void {
 		$slug = Token_Store::default_slug();
 		$id   = 'primitive.font-family.custom.abril-fatface';
 
@@ -946,19 +921,17 @@ final class Feed_ControllerTest extends TestCase {
 		$registry = $this->container->get( Token_Registry::class );
 		$schema   = $registry->to_ui_schema();
 
-		$this->assertArrayHasKey( 'Font Family', $schema['groups'] );
+		$this->assertArrayNotHasKey( 'Font Family', $schema['groups'] );
 
-		$found = null;
-
-		foreach ( $schema['groups']['Font Family'] as $entry ) {
-			if ( $id === $entry['id'] ) {
-				$found = $entry;
-				break;
+		foreach ( $schema['groups'] as $group => $rows ) {
+			if ( '' === $group ) {
+				continue;
 			}
+
+			$this->assertNotContains( $id, array_column( $rows, 'id' ), 'A stored font primitive must not join another screen\'s group.' );
 		}
 
-		$this->assertNotNull( $found, 'The grouped custom font must appear in the declared "Font Family" UI-schema group.' );
-		$this->assertTrue( $found['userCreated'] );
+		$this->assertContains( $id, array_column( $schema['groups'][''] ?? [], 'id' ), 'It lands in the ungrouped bucket no screen renders.' );
 
 		/** @var Token_Resolver $resolver */
 		$resolver = $this->container->get( Token_Resolver::class );

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/User_Primitives_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/User_Primitives_ControllerTest.php
@@ -493,15 +493,15 @@ final class User_Primitives_ControllerTest extends TestCase {
 	}
 
 	/**
-	 * A `fontFamily` create — unblocked by the $type -> id-segment mapping — mirrors the color and
-	 * dimension cases: 201, the leaf lands under the MAPPED kebab id segment
-	 * (primitive.font-family.custom.<slug>, never the camelCase primitive.fontFamily.custom.<slug>),
-	 * and the single-family `$value` (no invented generic fallback — the shipped font arrays carry
-	 * no category data) is stored verbatim.
+	 * A `fontFamily` create into the `font-family` group is refused: font family stopped being a
+	 * token family, so nothing declares that group any more and there is nothing for a minted
+	 * primitive to join. The refusal is the generic unknown-group 400 every undeclared group gets —
+	 * no font-specific branch was added to say so. Adding a family to the favorites list is the
+	 * supported path now (see the favorite-fonts sub-route).
 	 *
 	 * @return void
 	 */
-	public function testItCreatesANewFontFamilyPrimitive(): void {
+	public function testItRefusesAFontFamilyPrimitiveBecauseNoFontGroupIsDeclared(): void {
 		$slug = Token_Store::default_slug();
 
 		$this->store->save_document( '{}' );
@@ -510,17 +510,8 @@ final class User_Primitives_ControllerTest extends TestCase {
 		$request = $this->make_create_request( $slug, 'abel', 'fontFamily', [ 'Abel' ], $version, 'Abel', 'font-family' );
 		$result  = $this->controller->create_item( $request );
 
-		$this->assertInstanceOf( WP_REST_Response::class, $result );
-		$this->assertSame( WP_Http::CREATED, $result->get_status() );
-
-		$doc  = $result->get_data()['document'];
-		$leaf = $doc['primitive']['font-family']['custom']['abel'];
-		$this->assertSame( 'fontFamily', $leaf['$type'] );
-		$this->assertSame( [ 'Abel' ], $leaf['$value'] );
-
-		$ext = $doc[ Extensions::get_extensions_key() ][ Extensions::get_namespace() ][ Extensions::get_section_user_primitives() ];
-		$this->assertArrayHasKey( 'primitive.font-family.custom.abel', $ext );
-		$this->assertSame( 'font-family', $ext['primitive.font-family.custom.abel']['group'] );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_kb_unknown_group', $result->get_error_code() );
 	}
 
 	/**


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4207/font-families-become-favorites-not-tokens
:video_camera:  https://www.loom.com/share/2cde91916171494694080f3b7beda6e9

Font family stops being a design token. The layer was `sans` / `serif` / `mono` — a narrower set than the ~1,900-family catalog a block's own picker already offers, fed from that same theme catalog, so it was never a stable or portable design decision.

- `baseline.json` drops `primitive.font-family.{sans,serif,mono}`, `semantic.font-family.{control,heading}`, and the `advancedheading` preset's `typography` entry.
- `declarations.php` drops the font-family declaration factory and the `advancedheading` `typography` binding. An unset heading now inherits the theme's font, which is the behavior blocks are expected to have.
- The `font-family` declarations on `.kb-button` in the button's `style.scss` and `editor.scss` are deleted, reverting both rules to what ships on master — neither carried a `font-family` before this branch added one.

`fontFamily` stays a valid DTCG `$type`, so the vocabulary stays spec-complete and a `primitive.font-family.custom.*` already stored on a dev site keeps validating. Such a primitive now registers ungrouped through the registrar's existing fail-soft, so it keeps its value but has no home screen; minting a new one is refused with the generic `rest_kb_unknown_group`. Pre-release, so no migration ships.

Note for reviewers pulling this locally: editing `baseline.json` does not bust the decoded-baseline cache, so flush Redis (`lando ssh -s redis -c 'redis-cli flushall'`) or the `Baseline_Guard` throws.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Buttons and headings now inherit the theme’s font family by default.
  * Removed font-family options from baseline design token listings and advanced heading typography settings.
  * Prevented creation of unsupported font-family design tokens.
  * Existing stored font-family values continue to resolve without appearing in grouped token feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

