### PR TITLE
[DTM] SOFT-4207 [11/15]: adopt the font-family picker in every wired block

### DIFF
--- a/src/blocks/advancedheading/edit.js
+++ b/src/blocks/advancedheading/edit.js
@@ -1461,6 +1461,7 @@ function KadenceAdvancedHeading(props) {
 							onLetterSpacing={(value) => setAttributes({ letterSpacing: value })}
 							fontFamily={typography}
 							onFontFamily={(value) => setAttributes({ typography: value })}
+							context={{ blockName: 'kadence/advancedheading' }}
 							onFontChange={(select) => {
 								setAttributes({
 									typography: select.value,
@@ -1884,6 +1885,7 @@ function KadenceAdvancedHeading(props) {
 										onLetterSpacingType={(value) => setAttributes({ letterSpacingType: value })}
 										fontFamily={typography}
 										onFontFamily={(value) => setAttributes({ typography: value })}
+										context={{ blockName: 'kadence/advancedheading' }}
 										onFontChange={(select) => {
 											setAttributes({
 												typography: select.value,
@@ -2391,6 +2393,7 @@ function KadenceAdvancedHeading(props) {
 										onLetterSpacingType={(value) => setAttributes({ markLetterSpacingType: value })}
 										fontFamily={markTypography}
 										onFontFamily={(value) => setAttributes({ markTypography: value })}
+										context={{ blockName: 'kadence/advancedheading' }}
 										onFontChange={(select) => {
 											setAttributes({
 												markTypography: select.value,

--- a/src/blocks/image/image.js
+++ b/src/blocks/image/image.js
@@ -1500,6 +1500,7 @@ export default function Image({
 										onTextTransform={(value) => saveCaptionFont({ textTransform: value })}
 										fontFamily={captionStyles[0].family}
 										onFontFamily={(value) => saveCaptionFont({ family: value })}
+										context={{ blockName: 'kadence/image' }}
 										onFontChange={(select) => {
 											saveCaptionFont({
 												family: select.value,
@@ -2029,7 +2030,7 @@ export default function Image({
 		// explicit pixel value for the max-width. In absence of being able to
 		// set the content-width, this max-width is currently dictated by the
 		// vanilla editor style. The following variable adds a buffer to this
-		// vanilla style, so 3rd party themes have some wiggleroom. This does,
+		// vanilla style, so 3rd party themes have some wiggle room. This does,
 		// in most cases, allow you to scale the image beyond the width of the
 		// main column, though not infinitely.
 		// @todo It would be good to revisit this once a content-width variable

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -2164,6 +2164,7 @@ export default function KadenceButtonEdit(props) {
 											onTextTransform={(value) => saveTypography({ textTransform: value })}
 											fontFamily={typography[0].family}
 											onFontFamily={(value) => saveTypography({ family: value })}
+											context={{ blockName: 'kadence/singlebtn' }}
 											onFontChange={(select) => {
 												saveTypography({
 													family: select.value,


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4207/font-families-become-favorites-not-tokens
:video_camera:  https://www.loom.com/share/2cde91916171494694080f3b7beda6e9

One line per call site: passing `context` opts the block's typography control into the `fontFamily` seam, which swaps its react-select for the favorites-aware picker. A block that passes no context keeps the select it has always had.

Every declared block with a font-family control — 5 sites across 3 blocks:

- `kadence/singlebtn` — the button's Typography Settings panel.
- `kadence/image` — the caption font.
- `kadence/advancedheading` — the sidebar panel, the highlight (`markTypography`) panel, and the inline toolbar. All three are listed because the sidebar and the toolbar write the **same** `typography` attribute through two different controls; wiring one and not the other would give the same value two different pickers.

Also fixes a spelling typo in an unrelated `kadence/image` comment: cSpell runs against whole changed files, so touching that file surfaces a pre-existing `wiggleroom` that would otherwise fail this PR's check.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved typography settings for Advanced Heading, Image, and Single Button blocks.
  * Ensured typography controls apply consistently within each block’s editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

