### PR TITLE
[DTM] SOFT-4207 [2/15]: favorite-fonts REST routes

### DIFF
--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -2,9 +2,11 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Font_Catalog;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Responsive_Feed;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Document_Path;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Favorite_Font_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Reserved_Namespace;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
@@ -219,6 +221,41 @@ final class Documents_Controller extends Controller {
 	private const ORDER_PARAM = 'order';
 
 	/**
+	 * The sub-route, relative to a single library, that collects the favorite-font endpoints.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const FAVORITE_FONTS_ROUTE = 'favorite-fonts';
+
+	/**
+	 * The request parameter that carries a single font family name, on the favorite-fonts sub-route.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const FAMILY_PARAM = 'family';
+
+	/**
+	 * The family path segment for the favorite-fonts sub-route.
+	 *
+	 * Like GROUP_ROUTE, and unlike the token dot-path routes, this segment carries a display name
+	 * rather than a slug — a font family is whatever the catalog registered it as ("Abril Fatface",
+	 * "Press Start 2P"), so it cannot be restricted to `\w`/`-`. The REST server matches route
+	 * regexes against the raw, still percent-encoded request path, so a multi-word family arrives
+	 * here as e.g. `Abril%20Fatface`. The pattern only needs to exclude the path separator, since
+	 * the family is a single URL path segment; the percent-encoding is undone by the
+	 * `sanitize_callback` on the family arg (see `get_favorite_font_params()`).
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const FAMILY_ROUTE = '(?P<' . self::FAMILY_PARAM . '>[^/]+)';
+
+	/**
 	 * The dot-path path segment for the single-token routes. The character class matches the alias
 	 * grammar (a dot-path) minus the braces, so a token is addressable as a sub-resource of its library.
 	 *
@@ -338,6 +375,24 @@ final class Documents_Controller extends Controller {
 	private Token_Order_Index $order_index;
 
 	/**
+	 * Reads and writes the favoriteFonts ordered family list.
+	 *
+	 * @since TBD
+	 *
+	 * @var Favorite_Font_Index
+	 */
+	private Favorite_Font_Index $favorite_font_index;
+
+	/**
+	 * The site's font catalog, used only to 404 a favorite write against a family the site cannot render.
+	 *
+	 * @since TBD
+	 *
+	 * @var Font_Catalog
+	 */
+	private Font_Catalog $font_catalog;
+
+	/**
 	 * Memoized item schema for this request. Null until first built.
 	 *
 	 * @since TBD
@@ -370,6 +425,8 @@ final class Documents_Controller extends Controller {
 	 * @param Token_Registry                    $registry              The token registry, for the labels sub-route's unregistered-id 404.
 	 * @param Token_Label_Index                 $label_index           Reads and writes the tokenLabels override map.
 	 * @param Token_Order_Index                 $order_index           Reads and writes the tokenOrder flat ordered id list.
+	 * @param Favorite_Font_Index               $favorite_font_index   Reads and writes the favoriteFonts ordered family list.
+	 * @param Font_Catalog                      $font_catalog          The site's font catalog, for the favorite-fonts sub-route's unknown-family 404.
 	 */
 	public function __construct(
 		Token_Store $store,
@@ -383,7 +440,9 @@ final class Documents_Controller extends Controller {
 		Responsive_Feed $responsive_feed,
 		Token_Registry $registry,
 		Token_Label_Index $label_index,
-		Token_Order_Index $order_index
+		Token_Order_Index $order_index,
+		Favorite_Font_Index $favorite_font_index,
+		Font_Catalog $font_catalog
 	) {
 		$this->store                    = $store;
 		$this->resolver                 = $resolver;
@@ -397,6 +456,8 @@ final class Documents_Controller extends Controller {
 		$this->registry                 = $registry;
 		$this->label_index              = $label_index;
 		$this->order_index              = $order_index;
+		$this->favorite_font_index      = $favorite_font_index;
+		$this->font_catalog             = $font_catalog;
 		$this->rest_base                = 'documents';
 	}
 
@@ -594,6 +655,31 @@ final class Documents_Controller extends Controller {
 					'callback'            => [ $this, 'delete_order' ],
 					'permission_callback' => [ $this, 'update_item_permissions_check' ],
 					'args'                => $this->get_order_delete_params(),
+				],
+				'schema' => [ $this, 'get_item_schema' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/' . self::SLUG_ROUTE . '/' . self::FAVORITE_FONTS_ROUTE . '/' . self::FAMILY_ROUTE,
+			[
+				[
+					// PUT only, mirroring the labels and order sub-routes: adding a favorite is idempotent
+					// set-membership, so there is no partial-update verb to distinguish from PUT.
+					'methods'             => 'PUT',
+					'callback'            => [ $this, 'set_favorite_font' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_favorite_font_params(),
+				],
+				[
+					// DELETE uses the same capability as PUT — dropping a favorite is an update to
+					// the document, not a resource removal, so the two verbs of one operation cannot
+					// diverge on permission.
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => [ $this, 'delete_favorite_font' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_favorite_font_params(),
 				],
 				'schema' => [ $this, 'get_item_schema' ],
 			]
@@ -1227,6 +1313,105 @@ final class Documents_Controller extends Controller {
 	}
 
 	/**
+	 * Favorite a font family (PUT /documents/{slug}/favorite-fonts/{family}).
+	 *
+	 * The family must be one the site can actually render — a Google family or a name registered
+	 * through the custom-fonts filter — so a typo cannot accumulate as a favorite that every picker
+	 * lists and no browser resolves. Idempotent: adding a family already in the list returns the
+	 * current item without a write, and keeps its existing position rather than moving it to the
+	 * end, so a replayed write cannot shuffle a picker's display order.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function set_favorite_font( $request ) {
+		$slug   = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+		$family = Cast::to_string( $request->get_param( self::FAMILY_PARAM ) );
+
+		if ( ! $this->is_known_library( $slug ) ) {
+			return $this->not_found( $slug );
+		}
+
+		if ( ! $this->is_catalog_family( $family ) ) {
+			return $this->unknown_font_family( $family );
+		}
+
+		$error = $this->guard_client_version( $slug, Cast::to_string( $request->get_param( self::VERSION_PARAM ) ) );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$stored    = $this->store->get_decoded_document( $slug );
+		$candidate = $this->favorite_font_index->add( $stored, $family );
+
+		if ( $candidate === $stored ) {
+			return new WP_REST_Response( $this->prepare_item( $slug ), WP_Http::OK );
+		}
+
+		return $this->persist_metadata_candidate( $candidate, $slug );
+	}
+
+	/**
+	 * Un-favorite a font family (DELETE /documents/{slug}/favorite-fonts/{family}).
+	 *
+	 * Deliberately does NOT check the family against the catalog, unlike the PUT half. A theme
+	 * switch or a deactivated plugin can stop registering a family the site chose earlier, and
+	 * that stale favorite is exactly the one a user most needs to clear — gating removal on the
+	 * catalog would strand it in the document with no way to remove it from the UI. Idempotent:
+	 * removing a family that is not in the list returns the current item without a write.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_favorite_font( $request ) {
+		$slug   = Cast::to_string( $request->get_param( self::SLUG_PARAM ) );
+		$family = Cast::to_string( $request->get_param( self::FAMILY_PARAM ) );
+
+		if ( ! $this->is_known_library( $slug ) ) {
+			return $this->not_found( $slug );
+		}
+
+		$error = $this->guard_client_version( $slug, Cast::to_string( $request->get_param( self::VERSION_PARAM ) ) );
+
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$stored    = $this->store->get_decoded_document( $slug );
+		$candidate = $this->favorite_font_index->remove( $stored, $family );
+
+		if ( $candidate === $stored ) {
+			return new WP_REST_Response( $this->prepare_item( $slug ), WP_Http::OK );
+		}
+
+		return $this->persist_metadata_candidate( $candidate, $slug );
+	}
+
+	/**
+	 * Undo the percent-encoding a font family reaches the favorite-fonts route with.
+	 *
+	 * Public because it is a `sanitize_callback`. Mirrors {@see self::decode_group()}: the REST
+	 * server matches routes against the raw request path, so a multi-word family arrives as e.g.
+	 * `Abril%20Fatface`.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $value The raw, still percent-encoded family segment.
+	 *
+	 * @return string The decoded family name.
+	 */
+	public function decode_font_family( $value ): string {
+		return rawurldecode( Cast::to_string( $value ) );
+	}
+
+	/**
 	 * Validate that the token dot-path begins with a real token layer and names a token below it.
 	 *
 	 * Used as the path argument's validate_callback so a path into "$extensions" (any non-layer root), a
@@ -1562,8 +1747,8 @@ final class Documents_Controller extends Controller {
 	}
 
 	/**
-	 * Persist a candidate whose only change is inside an id-keyed authoring-metadata $extensions
-	 * section (token labels or token order). Deliberately skips the full DTCG validator and the
+	 * Persist a candidate whose only change is inside an authoring-metadata $extensions section
+	 * (token labels, token order, or favorite fonts). Deliberately skips the full DTCG validator and the
 	 * resolver dry-run: the index helpers' edits are mechanically confined to a section the
 	 * effective-document builder strips, so they cannot introduce grammar or alias problems — and
 	 * running the full pipeline would make a rename or reorder impossible in any library whose
@@ -1707,6 +1892,26 @@ final class Documents_Controller extends Controller {
 			[
 				'status' => WP_Http::NOT_FOUND,
 				'group'  => $group,
+			]
+		);
+	}
+
+	/**
+	 * The error returned when a favorite-fonts family is not in the site's font catalog.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $family The unknown family name.
+	 *
+	 * @return WP_Error
+	 */
+	private function unknown_font_family( string $family ): WP_Error {
+		return new WP_Error(
+			'rest_design_tokens_unknown_font_family',
+			__( 'Sorry, that font family is not available on this site.', 'kadence-blocks' ),
+			[
+				'status' => WP_Http::NOT_FOUND,
+				'family' => $family,
 			]
 		);
 	}
@@ -2067,6 +2272,72 @@ final class Documents_Controller extends Controller {
 				],
 			]
 		);
+	}
+
+	/**
+	 * The arguments accepted by both favorite-fonts verbs: the slug, the font family and the
+	 * version-conditional guard. One builder for both, unlike the labels and order routes, because
+	 * a favorite carries no payload beyond the family already named in the path — PUT and DELETE
+	 * take exactly the same arguments.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_favorite_font_params(): array {
+		return array_merge(
+			$this->get_slug_params(),
+			[
+				self::FAMILY_PARAM  => [
+					'description'       => __( 'The font family name to add as a favorite, e.g. Abril Fatface.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => true,
+					// Matches self::FAMILY_ROUTE: a catalog display name, not a slug — only the path
+					// separator is excluded. See the FAMILY_ROUTE docblock for why.
+					'pattern'           => '^[^/]+$',
+					// The value on the wire is still percent-encoded (e.g. "Abril%20Fatface"); decode
+					// it once here so both handlers see the real family. See decode_font_family().
+					'sanitize_callback' => [ $this, 'decode_font_family' ],
+				],
+				self::VERSION_PARAM => [
+					'description'       => __( 'The version the client last read; empty for a first write. A mismatch is rejected with HTTP 409.', 'kadence-blocks' ),
+					'type'              => 'string',
+					'required'          => true,
+					'sanitize_callback' => 'sanitize_text_field',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Whether a family name is one the site can render: a Google family, or a name registered
+	 * through the custom-fonts filter. Compared case-insensitively, since the catalog's casing is
+	 * whatever the generator or the registering theme chose and a client should not have to match
+	 * it byte for byte.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $family The submitted family name.
+	 *
+	 * @return bool
+	 */
+	private function is_catalog_family( string $family ): bool {
+		$family = trim( $family );
+
+		if ( $family === '' ) {
+			return false;
+		}
+
+		$catalog = $this->font_catalog->all();
+		$names   = array_merge( $catalog['google'], $catalog['custom'] );
+
+		foreach ( $names as $name ) {
+			if ( strcasecmp( $name, $family ) === 0 ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -1339,7 +1339,8 @@ final class Documents_Controller extends Controller {
 			return $this->unknown_font_family( $family );
 		}
 
-		$error = $this->guard_client_version( $slug, Cast::to_string( $request->get_param( self::VERSION_PARAM ) ) );
+		$client_version = Cast::to_string( $request->get_param( self::VERSION_PARAM ) );
+		$error          = $this->guard_client_version( $slug, $client_version );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
@@ -1352,7 +1353,7 @@ final class Documents_Controller extends Controller {
 			return new WP_REST_Response( $this->prepare_item( $slug ), WP_Http::OK );
 		}
 
-		return $this->persist_metadata_candidate( $candidate, $slug );
+		return $this->persist_metadata_candidate( $candidate, $slug, $client_version );
 	}
 
 	/**
@@ -1378,7 +1379,8 @@ final class Documents_Controller extends Controller {
 			return $this->not_found( $slug );
 		}
 
-		$error = $this->guard_client_version( $slug, Cast::to_string( $request->get_param( self::VERSION_PARAM ) ) );
+		$client_version = Cast::to_string( $request->get_param( self::VERSION_PARAM ) );
+		$error          = $this->guard_client_version( $slug, $client_version );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
@@ -1391,7 +1393,7 @@ final class Documents_Controller extends Controller {
 			return new WP_REST_Response( $this->prepare_item( $slug ), WP_Http::OK );
 		}
 
-		return $this->persist_metadata_candidate( $candidate, $slug );
+		return $this->persist_metadata_candidate( $candidate, $slug, $client_version );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerFavoriteFontsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerFavoriteFontsTest.php
@@ -1,0 +1,392 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Rest\V1;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Font_Catalog;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Favorite_Font_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Documents_Controller;
+use Tests\Support\Classes\TestCase;
+use WP_Error;
+use WP_Http;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Covers the favorite-fonts sub-route: PUT/DELETE /documents/{slug}/favorite-fonts/{family}, its
+ * catalog membership gate, its narrowed write path, and the version-conditional guard.
+ *
+ * @since TBD
+ */
+final class DocumentsControllerFavoriteFontsTest extends TestCase {
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Documents_Controller
+	 */
+	private Documents_Controller $controller;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Favorite_Font_Index
+	 */
+	private Favorite_Font_Index $index;
+
+	/**
+	 * Two real catalog family names, discovered fresh per test so the fixture stays correct
+	 * regardless of what the generated Google names file happens to ship.
+	 *
+	 * @since TBD
+	 *
+	 * @var list<string>
+	 */
+	private array $families;
+
+	/**
+	 * Build the controller and its collaborators fresh before each test, and discover two real
+	 * catalog families to favorite.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->store      = $this->container->get( Token_Store::class );
+		$this->controller = $this->container->get( Documents_Controller::class );
+		$this->index      = $this->container->get( Favorite_Font_Index::class );
+
+		$catalog = $this->container->get( Font_Catalog::class )->all();
+		$names   = array_merge( $catalog['google'], $catalog['custom'] );
+
+		$this->assertGreaterThanOrEqual( 2, count( $names ), 'The font catalog must carry at least two families.' );
+
+		$this->families = [ $names[0], $names[1] ];
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Reset the current user and the global REST server after each test.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		wp_set_current_user( 0 );
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * A PUT stores the family in the document.
+	 *
+	 * @return void
+	 */
+	public function testPutStoresTheFamily(): void {
+		$slug = Token_Store::default_slug();
+
+		$response = $this->controller->set_favorite_font(
+			$this->favorite_request( 'PUT', $slug, $this->families[0], $this->store->get_version( $slug ) )
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::CREATED, $response->get_status() );
+		$this->assertSame( [ $this->families[0] ], $this->stored_favorites( $slug ) );
+	}
+
+	/**
+	 * Favorites keep their insertion order, which is the order every picker renders them in.
+	 *
+	 * @return void
+	 */
+	public function testFavoritesKeepTheirInsertionOrder(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->favorite( $slug, $this->families[0] );
+		$this->favorite( $slug, $this->families[1] );
+
+		$this->assertSame( $this->families, $this->stored_favorites( $slug ) );
+	}
+
+	/**
+	 * Re-adding a family already in the list is idempotent: no write happens, so the store
+	 * version is unchanged and the family keeps its existing position rather than moving to the end.
+	 *
+	 * @return void
+	 */
+	public function testRepeatedPutIsIdempotentAndPreservesPosition(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->favorite( $slug, $this->families[0] );
+		$this->favorite( $slug, $this->families[1] );
+
+		$version_before = $this->store->get_version( $slug );
+
+		$response = $this->controller->set_favorite_font(
+			$this->favorite_request( 'PUT', $slug, $this->families[0], $version_before )
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertSame( $version_before, $this->store->get_version( $slug ) );
+		$this->assertSame( $this->families, $this->stored_favorites( $slug ) );
+	}
+
+	/**
+	 * A catalog family matches case-insensitively, so a client need not reproduce the catalog's
+	 * own casing byte for byte.
+	 *
+	 * @return void
+	 */
+	public function testCatalogMatchIsCaseInsensitive(): void {
+		$slug = Token_Store::default_slug();
+
+		$response = $this->controller->set_favorite_font(
+			$this->favorite_request( 'PUT', $slug, strtoupper( $this->families[0] ), $this->store->get_version( $slug ) )
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( [ strtoupper( $this->families[0] ) ], $this->stored_favorites( $slug ) );
+	}
+
+	/**
+	 * A DELETE removes the family, leaving its siblings intact, and a second DELETE is idempotent.
+	 *
+	 * @return void
+	 */
+	public function testDeleteRemovesTheFamilyAndASecondDeleteIsIdempotent(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->favorite( $slug, $this->families[0] );
+		$this->favorite( $slug, $this->families[1] );
+
+		$response = $this->controller->delete_favorite_font(
+			$this->favorite_request( 'DELETE', $slug, $this->families[0], $this->store->get_version( $slug ) )
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertSame( [ $this->families[1] ], $this->stored_favorites( $slug ) );
+
+		$version_after_first_delete = $this->store->get_version( $slug );
+
+		$second = $this->controller->delete_favorite_font(
+			$this->favorite_request( 'DELETE', $slug, $this->families[0], $version_after_first_delete )
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $second );
+		$this->assertSame( WP_Http::OK, $second->get_status() );
+		$this->assertSame( $version_after_first_delete, $this->store->get_version( $slug ) );
+	}
+
+	/**
+	 * A favorite whose family the catalog no longer carries can still be removed. That is the
+	 * whole reason DELETE does not gate on the catalog: a theme switch strands the favorite, and
+	 * gating removal would leave no way to clear it from the UI.
+	 *
+	 * @return void
+	 */
+	public function testDeleteRemovesAFamilyTheCatalogNoLongerCarries(): void {
+		$slug     = Token_Store::default_slug();
+		$stranded = 'A Font No Catalog Carries';
+
+		$document = (string) wp_json_encode( $this->index->add( [], $stranded ) );
+		$this->store->save_document( $document );
+
+		$response = $this->controller->delete_favorite_font(
+			$this->favorite_request( 'DELETE', $slug, $stranded, $this->store->get_version( $slug ) )
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertSame( [], $this->stored_favorites( $slug ) );
+	}
+
+	/**
+	 * A family the site's catalog does not carry is refused on PUT, so a typo cannot accumulate as
+	 * a favorite every picker lists and no browser resolves.
+	 *
+	 * @return void
+	 */
+	public function testUnknownFamilyReturns404OnPut(): void {
+		$slug = Token_Store::default_slug();
+
+		$response = $this->controller->set_favorite_font(
+			$this->favorite_request( 'PUT', $slug, 'Not A Real Font Family', $this->store->get_version( $slug ) )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_design_tokens_unknown_font_family', $response->get_error_code() );
+		$this->assertSame( WP_Http::NOT_FOUND, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * An unknown library slug is a 404, on both PUT and DELETE.
+	 *
+	 * @return void
+	 */
+	public function testUnknownSlugReturns404(): void {
+		$put = $this->controller->set_favorite_font(
+			$this->favorite_request( 'PUT', 'does-not-exist', $this->families[0], '' )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $put );
+		$this->assertSame( 'rest_design_tokens_not_found', $put->get_error_code() );
+
+		$delete = $this->controller->delete_favorite_font(
+			$this->favorite_request( 'DELETE', 'does-not-exist', $this->families[0], '' )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $delete );
+		$this->assertSame( 'rest_design_tokens_not_found', $delete->get_error_code() );
+	}
+
+	/**
+	 * A stale client version is rejected with 409, and the document is left unchanged.
+	 *
+	 * @return void
+	 */
+	public function testStaleVersionReturns409AndDocumentIsUnchanged(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->favorite( $slug, $this->families[0] );
+
+		$stored_before = $this->store->get_document( $slug );
+
+		$response = $this->controller->set_favorite_font(
+			$this->favorite_request( 'PUT', $slug, $this->families[1], 'stale-version' )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_design_tokens_conflict', $response->get_error_code() );
+		$this->assertSame( WP_Http::CONFLICT, $response->get_error_data()['status'] );
+		$this->assertSame( $stored_before, $this->store->get_document( $slug ) );
+	}
+
+	/**
+	 * A family name containing a space is reachable through the actual WP REST dispatch layer,
+	 * with the family segment built the way a real client must build it: percent-encoded via
+	 * `rawurlencode()`. Every other test in this suite calls the controller method directly, which
+	 * never exercises `register_routes()`'s regex, the `family` arg's `pattern`/`sanitize_callback`,
+	 * or WP's own URL routing — this is the one test that dispatches a real request on a path built
+	 * the way a browser `fetch()` would build it, so both a route character class that excludes
+	 * spaces and a handler that fails to decode the percent-escapes would fail here rather than
+	 * shipping unnoticed. Most Google families are multi-word, so this is the common case.
+	 *
+	 * @return void
+	 */
+	public function testMultiWordFamilyIsReachableThroughRealRestDispatch(): void {
+		$slug   = Token_Store::default_slug();
+		$family = null;
+
+		foreach ( $this->container->get( Font_Catalog::class )->all()['google'] as $candidate ) {
+			if ( str_contains( $candidate, ' ' ) ) {
+				$family = $candidate;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $family, 'The Google catalog must carry at least one multi-word family.' );
+
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$request = new WP_REST_Request( 'PUT', '/kb-design-tokens/v1/documents/' . $slug . '/favorite-fonts/' . rawurlencode( $family ) );
+		$request->set_param( 'version', $this->store->get_version( $slug ) );
+
+		global $wp_rest_server;
+		$response = $wp_rest_server->dispatch( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::CREATED, $response->get_status(), 'The family route must match a percent-encoded multi-word family rather than 404 at the routing layer.' );
+		$this->assertSame( [ $family ], $this->stored_favorites( $slug ) );
+	}
+
+	/**
+	 * The narrowed write path lets a favorite succeed even in a library whose stored document
+	 * currently fails full DTCG validation, and leaves the invalid remainder untouched.
+	 *
+	 * @return void
+	 */
+	public function testNarrowedPathAllowsAFavoriteInALibraryThatFailsFullValidation(): void {
+		$slug    = Token_Store::default_slug();
+		$invalid = '{"primitive":{"color":{"x":{"$type":"color","$value":"not-a-color"}}}}';
+
+		$this->store->save_document( $invalid );
+
+		$response = $this->controller->set_favorite_font(
+			$this->favorite_request( 'PUT', $slug, $this->families[0], $this->store->get_version( $slug ) )
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+
+		$stored = json_decode( $this->store->get_document( $slug ), true );
+
+		$this->assertSame( [ $this->families[0] ], $this->index->all( $stored ) );
+		$this->assertSame( 'not-a-color', $stored['primitive']['color']['x']['$value'], 'The pre-existing invalid remainder must be left untouched.' );
+	}
+
+	// -------------------------------------------------------------------------
+	// helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Favorite a family through the controller, asserting the write succeeded.
+	 *
+	 * @param string $slug   The token library slug.
+	 * @param string $family The family to favorite.
+	 *
+	 * @return void
+	 */
+	private function favorite( string $slug, string $family ): void {
+		$response = $this->controller->set_favorite_font(
+			$this->favorite_request( 'PUT', $slug, $family, $this->store->get_version( $slug ) )
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+	}
+
+	/**
+	 * The favorites currently stored in a library's document.
+	 *
+	 * @param string $slug The token library slug.
+	 *
+	 * @return list<string>
+	 */
+	private function stored_favorites( string $slug ): array {
+		return $this->index->all( $this->store->get_decoded_document( $slug ) );
+	}
+
+	/**
+	 * Build a favorite-fonts request with the params both handlers read.
+	 *
+	 * @param string $method  The HTTP method.
+	 * @param string $slug    The token library slug.
+	 * @param string $family  The font family name.
+	 * @param string $version The client's last-read version.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function favorite_request( string $method, string $slug, string $family, string $version ): WP_REST_Request {
+		$request = new WP_REST_Request( $method );
+		$request->set_param( 'slug', $slug );
+		$request->set_param( 'family', $family );
+		$request->set_param( 'version', $version );
+
+		return $request;
+	}
+}


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4207/font-families-become-favorites-not-tokens
:video_camera:  https://www.loom.com/share/2cde91916171494694080f3b7beda6e9

`PUT`/`DELETE /documents/{slug}/favorite-fonts/{family}`, mirroring the `labels/{id}` and `order/{group}` sub-routes: the same narrowed write path that skips the full validator and resolver dry-run, and the same version-conditional guard.

The two verbs deliberately disagree about the font catalog. `PUT` gates on it, so a typo cannot accumulate as a favorite every picker lists and no browser resolves. `DELETE` does not, because a theme switch or a deactivated plugin can stop registering a family the site favorited earlier — and that stale favorite is exactly the one a user most needs to clear. Gating removal on the catalog would strand it in the document with no way to remove it from the UI.

Both verbs are idempotent. The family segment matches `[^/]+` and is percent-decoded, since most catalog families are multi-word.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added REST API support for adding and removing favorite fonts.
  - Favorite fonts retain their insertion order, and repeated requests avoid duplicates or unintended changes.
  - Font family names with spaces and URL encoding are supported.
  - Adding a font validates that it exists in the site catalog, while removing outdated favorites remains supported.

- **Bug Fixes**
  - Added safeguards for stale document versions and invalid font or slug requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

