### PR TITLE
[DTM] SOFT-4207 [3/15]: surface favoriteFonts in the admin feed

### DIFF
--- a/includes/resources/Design_Tokens/Admin/Feed/Builder.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Builder.php
@@ -80,28 +80,33 @@ final class Builder {
 	 *                                                                          tokens that carry one (for editor hydration).
 	 * @param array<string, string>                                 $labels     id => display-label override for this library.
 	 * @param array<int, string>                                    $order      The flat ordered token id list for this library.
+	 * @param array<int, string>                                    $favorite_fonts The ordered favorite font families for this library.
 	 *
 	 * @return array<string, mixed> The localized payload.
 	 */
-	public function build( array $values, bool $resolved, array $presets, array $rest, string $version, string $slug, string $title = '', array $responsive = [], array $labels = [], array $order = [] ): array {
+	public function build( array $values, bool $resolved, array $presets, array $rest, string $version, string $slug, string $title = '', array $responsive = [], array $labels = [], array $order = [], array $favorite_fonts = [] ): array {
 		$active = $this->registry->is_active();
 
 		return [
-			'active'     => $active,
-			'resolved'   => $active && $resolved,
-			'version'    => $version,
-			'slug'       => $slug,
+			'active'        => $active,
+			'resolved'      => $active && $resolved,
+			'version'       => $version,
+			'slug'          => $slug,
 			// Carried alongside the slug so the library selector can name the active library on first
 			// paint, before its REST list has loaded and any row is available to look the title up in.
-			'title'      => $title,
-			'schema'     => $active
+			'title'         => $title,
+			'schema'        => $active
 				? $this->apply_group_order( $this->apply_label_overrides( $this->registry->to_ui_schema(), $labels ), $order )
 				: [ 'groups' => [] ],
-			'values'     => $active ? $values : [],
-			'presets'    => $active ? $presets : [],
-			'presetNav'  => $active ? $this->preset_nav->all() : [],
-			'responsive' => $active ? $responsive : [],
-			'rest'       => $rest,
+			'values'        => $active ? $values : [],
+			'presets'       => $active ? $presets : [],
+			'presetNav'     => $active ? $this->preset_nav->all() : [],
+			'responsive'    => $active ? $responsive : [],
+			// Alongside the schema rather than inside it: a favorite is not a token, so it has no
+			// row in any UI-schema group. The Typography screen's font picker reads this list
+			// directly and pins those families above the catalog.
+			'favoriteFonts' => $active ? $favorite_fonts : [],
+			'rest'          => $rest,
 		];
 	}
 

--- a/includes/resources/Design_Tokens/Admin/Feed/Feed_Assembler.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Feed_Assembler.php
@@ -3,6 +3,7 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Favorite_Font_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Order_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Alias_Cycle_Exception;
@@ -26,10 +27,10 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
  * than a fatal, so the caller still gets structure. The fail-closed case (registry deactivated) is
  * handled inside the builder.
  *
- * The per-token label-override and per-group sort-order reads also live here rather than in either
- * emitter: they are applied inside Builder::build(), so both {@see Localizer} and
- * {@see \KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Feed_Controller} get the overridden labels
- * and stored order automatically instead of one of them silently missing them.
+ * The per-token label-override, per-group sort-order and favorite-font reads also live here rather
+ * than in either emitter: they are applied inside Builder::build(), so both {@see Localizer} and
+ * {@see \KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Feed_Controller} get the overridden labels,
+ * stored order and favorites automatically instead of one of them silently missing them.
  *
  * @since TBD
  */
@@ -99,15 +100,25 @@ final class Feed_Assembler {
 	private Token_Order_Index $order_index;
 
 	/**
+	 * Reads the favoriteFonts ordered family list out of the stored document.
+	 *
 	 * @since TBD
 	 *
-	 * @param Token_Resolver    $resolver        The token resolver.
-	 * @param Token_Store       $store           The token store.
-	 * @param Presets           $preset_feed     The presets section builder.
-	 * @param Builder           $builder         The pure payload assembler.
-	 * @param Responsive_Feed   $responsive_feed The responsive / clamp shape extractor.
-	 * @param Token_Label_Index $label_index     Reads the tokenLabels override map.
-	 * @param Token_Order_Index $order_index     Reads the tokenOrder flat ordered id list.
+	 * @var Favorite_Font_Index
+	 */
+	private Favorite_Font_Index $favorite_font_index;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Resolver      $resolver            The token resolver.
+	 * @param Token_Store         $store               The token store.
+	 * @param Presets             $preset_feed         The presets section builder.
+	 * @param Builder             $builder             The pure payload assembler.
+	 * @param Responsive_Feed     $responsive_feed     The responsive / clamp shape extractor.
+	 * @param Token_Label_Index   $label_index         Reads the tokenLabels override map.
+	 * @param Token_Order_Index   $order_index         Reads the tokenOrder flat ordered id list.
+	 * @param Favorite_Font_Index $favorite_font_index Reads the favoriteFonts ordered family list.
 	 */
 	public function __construct(
 		Token_Resolver $resolver,
@@ -116,15 +127,17 @@ final class Feed_Assembler {
 		Builder $builder,
 		Responsive_Feed $responsive_feed,
 		Token_Label_Index $label_index,
-		Token_Order_Index $order_index
+		Token_Order_Index $order_index,
+		Favorite_Font_Index $favorite_font_index
 	) {
-		$this->resolver        = $resolver;
-		$this->store           = $store;
-		$this->preset_feed     = $preset_feed;
-		$this->builder         = $builder;
-		$this->responsive_feed = $responsive_feed;
-		$this->label_index     = $label_index;
-		$this->order_index     = $order_index;
+		$this->resolver            = $resolver;
+		$this->store               = $store;
+		$this->preset_feed         = $preset_feed;
+		$this->builder             = $builder;
+		$this->responsive_feed     = $responsive_feed;
+		$this->label_index         = $label_index;
+		$this->order_index         = $order_index;
+		$this->favorite_font_index = $favorite_font_index;
 	}
 
 	/**
@@ -164,7 +177,8 @@ final class Feed_Assembler {
 			$this->title( $slug ),
 			$responsive,
 			$this->label_index->all( $document ),
-			$this->order_index->all( $document )
+			$this->order_index->all( $document ),
+			$this->favorite_font_index->all( $document )
 		);
 	}
 

--- a/tests/snapshot/Resources/Design_Tokens/Admin/Feed/__snapshots__/Builder_SnapshotTest__testFullPayloadMatchesSnapshot__1.txt
+++ b/tests/snapshot/Resources/Design_Tokens/Admin/Feed/__snapshots__/Builder_SnapshotTest__testFullPayloadMatchesSnapshot__1.txt
@@ -74,6 +74,7 @@
     },
     "presetNav": [],
     "responsive": [],
+    "favoriteFonts": [],
     "rest": {
         "root": "https:\/\/example.test\/wp-json\/",
         "namespace": "kb-design-tokens\/v1",

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/BuilderTest.php
@@ -130,6 +130,55 @@ final class BuilderTest extends TestCase {
 	}
 
 	/**
+	 * Favorite fonts surface as their own top-level feed section, in the order they were given —
+	 * never folded into the schema, since a favorite is not a token and has no UI-schema row.
+	 *
+	 * @return void
+	 */
+	public function testFavoriteFontsSurfaceAsTheirOwnSectionInOrder(): void {
+		$feed = $this->builder()->build(
+			[],
+			true,
+			[],
+			$this->rest(),
+			'v7',
+			'default',
+			'',
+			[],
+			[],
+			[],
+			[ 'Inter', 'Abril Fatface' ]
+		);
+
+		$this->assertSame( [ 'Inter', 'Abril Fatface' ], $feed['favoriteFonts'] );
+	}
+
+	/**
+	 * A build with no favorites still carries the section, as an empty list, so the client never
+	 * has to probe for its presence.
+	 *
+	 * @return void
+	 */
+	public function testFavoriteFontsDefaultToAnEmptyList(): void {
+		$feed = $this->builder()->build( [], true, [], $this->rest(), 'v7', 'default' );
+
+		$this->assertSame( [], $feed['favoriteFonts'] );
+	}
+
+	/**
+	 * A deactivated registry clears the favorites alongside every other content section.
+	 *
+	 * @return void
+	 */
+	public function testDeactivatedRegistryClearsFavoriteFonts(): void {
+		$this->registry->deactivate();
+
+		$feed = $this->builder()->build( [], true, [], $this->rest(), 'v7', 'default', '', [], [], [], [ 'Inter' ] );
+
+		$this->assertSame( [], $feed['favoriteFonts'] );
+	}
+
+	/**
 	 * The slug passes through the feed unchanged regardless of whether the registry is active.
 	 *
 	 * @return void

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Feed_AssemblerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Feed_AssemblerTest.php
@@ -7,6 +7,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Feed_Assembler;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Presets;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Responsive_Feed;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Favorite_Font_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Order_Index;
@@ -182,7 +183,8 @@ final class Feed_AssemblerTest extends TestCase {
 			$this->container->get( Builder::class ),
 			$this->container->get( Responsive_Feed::class ),
 			$this->container->get( Token_Label_Index::class ),
-			$this->container->get( Token_Order_Index::class )
+			$this->container->get( Token_Order_Index::class ),
+			$this->container->get( Favorite_Font_Index::class )
 		);
 
 		$feed = $assembler->for_slug( Token_Store::default_slug() );

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
@@ -11,6 +11,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Presets;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Style_Library\Asset_Loader;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Favorite_Font_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Label_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Token_Order_Index;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
@@ -236,7 +237,8 @@ final class LocalizerTest extends TestCase {
 			$this->container->get( Builder::class ),
 			$this->container->get( Responsive_Feed::class ),
 			$this->container->get( Token_Label_Index::class ),
-			$this->container->get( Token_Order_Index::class )
+			$this->container->get( Token_Order_Index::class ),
+			$this->container->get( Favorite_Font_Index::class )
 		);
 
 		$localizer = new Localizer(

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerFavoriteFontsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerFavoriteFontsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Rest\V1;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Feed_Assembler;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Font_Catalog;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Favorite_Font_Index;
@@ -92,11 +93,11 @@ final class DocumentsControllerFavoriteFontsTest extends TestCase {
 	}
 
 	/**
-	 * A PUT stores the family in the document.
+	 * A PUT stores the family, and the feed carries it under favoriteFonts.
 	 *
 	 * @return void
 	 */
-	public function testPutStoresTheFamily(): void {
+	public function testPutStoresTheFamilyAndTheFeedReflectsIt(): void {
 		$slug = Token_Store::default_slug();
 
 		$response = $this->controller->set_favorite_font(
@@ -106,6 +107,7 @@ final class DocumentsControllerFavoriteFontsTest extends TestCase {
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
 		$this->assertSame( WP_Http::CREATED, $response->get_status() );
 		$this->assertSame( [ $this->families[0] ], $this->stored_favorites( $slug ) );
+		$this->assertSame( [ $this->families[0] ], $this->feed_favorites( $slug ) );
 	}
 
 	/**
@@ -369,6 +371,17 @@ final class DocumentsControllerFavoriteFontsTest extends TestCase {
 	 */
 	private function stored_favorites( string $slug ): array {
 		return $this->index->all( $this->store->get_decoded_document( $slug ) );
+	}
+
+	/**
+	 * The favorites the assembled feed carries for a library.
+	 *
+	 * @param string $slug The token library slug.
+	 *
+	 * @return list<string>
+	 */
+	private function feed_favorites( string $slug ): array {
+		return $this->container->get( Feed_Assembler::class )->for_slug( $slug )['favoriteFonts'];
 	}
 
 	/**


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4207/font-families-become-favorites-not-tokens
:video_camera:  https://www.loom.com/share/2cde91916171494694080f3b7beda6e9

The feed carries the library's favorites as its own top-level section, beside `schema` rather than inside it: a favorite is not a token, so it has no UI-schema group and no row to sit in. A build with no favorites still carries the key as an empty list, so a client never has to probe for it.

The read lives in `Feed_Assembler` alongside the label-override and sort-order reads, for the same reason those do: both emitters of the payload — the page-load Localizer and the REST feed endpoint — go through `for_slug()`, so neither can silently miss the section.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated `favoriteFonts` section to the feed.
  * Favorite fonts now appear in the order selected and are reflected after being saved.
  * The section defaults to empty when no fonts are selected.

* **Bug Fixes**
  * Favorite fonts are cleared from the feed when the related registry is inactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

