### PR TITLE
[DTM] SOFT-4207 [4/15]: a REST client for favorite fonts

### DIFF
--- a/src/style-library/__tests__/paths.test.js
+++ b/src/style-library/__tests__/paths.test.js
@@ -14,6 +14,7 @@ import {
 	feedPath,
 	tokenLabelPath,
 	groupOrderPath,
+	favoriteFontPath,
 	blockPresetsPath,
 	blockPresetPath,
 } from '../api/paths';
@@ -128,6 +129,22 @@ describe('tokenLabelPath', () => {
 	it('escapes the slug and the id', () => {
 		expect(tokenLabelPath('my set', 'primitive.dimension.custom.radius 2')).toBe(
 			'/kb-design-tokens/v1/documents/my%20set/labels/primitive.dimension.custom.radius%202'
+		);
+	});
+});
+
+describe('favoriteFontPath', () => {
+	it('builds the favorite path for a family', () => {
+		expect(favoriteFontPath('default', 'Inter')).toBe(
+			'/kb-design-tokens/v1/documents/default/favorite-fonts/Inter'
+		);
+	});
+
+	// Most catalog families are multi-word, so the encoded form is the common case rather than an
+	// edge case — the route matches the percent-encoded segment and decodes it server-side.
+	it('escapes the slug and a multi-word family', () => {
+		expect(favoriteFontPath('my set', 'Abril Fatface')).toBe(
+			'/kb-design-tokens/v1/documents/my%20set/favorite-fonts/Abril%20Fatface'
 		);
 	});
 });

--- a/src/style-library/__tests__/paths.test.js
+++ b/src/style-library/__tests__/paths.test.js
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+// cspell:ignore Abril Fatface .
 import {
 	userPrimitivesPath,
 	userPrimitiveReferencesPath,

--- a/src/style-library/api/client.js
+++ b/src/style-library/api/client.js
@@ -17,6 +17,7 @@ import {
 	tokenPath,
 	tokenLabelPath,
 	groupOrderPath,
+	favoriteFontPath,
 	userPrimitiveReferencesPath,
 	userPrimitivesPath,
 	userPrimitivePath,
@@ -123,6 +124,44 @@ export function setGroupOrder(slug, group, payload) {
 	return apiFetch({
 		path: groupOrderPath(slug, group),
 		method: 'PUT',
+		data: payload,
+	});
+}
+
+/**
+ * Add a font family to the library's favorites.
+ *
+ * @param {string}                  slug    Token library slug.
+ * @param {string}                  family  The font family name.
+ * @param {{ version: string }}     payload Request body.
+ *
+ * @since TBD
+ *
+ * @return {Promise<object>} Updated document item.
+ */
+export function addFavoriteFont(slug, family, payload) {
+	return apiFetch({
+		path: favoriteFontPath(slug, family),
+		method: 'PUT',
+		data: payload,
+	});
+}
+
+/**
+ * Remove a font family from the library's favorites.
+ *
+ * @param {string}              slug    Token library slug.
+ * @param {string}              family  The font family name.
+ * @param {{ version: string }} payload Request body.
+ *
+ * @since TBD
+ *
+ * @return {Promise<object>} Updated document item.
+ */
+export function removeFavoriteFont(slug, family, payload) {
+	return apiFetch({
+		path: favoriteFontPath(slug, family),
+		method: 'DELETE',
 		data: payload,
 	});
 }

--- a/src/style-library/api/paths.js
+++ b/src/style-library/api/paths.js
@@ -108,6 +108,21 @@ export function groupOrderPath(slug, group) {
 }
 
 /**
+ * Build a REST path for a single favorite font family. `family` is a catalog display name, not a
+ * slug — encoded because it usually contains a space.
+ *
+ * @param {string} slug   Token library slug.
+ * @param {string} family The font family name.
+ *
+ * @since TBD
+ *
+ * @return {string} REST path relative to wp-json root.
+ */
+export function favoriteFontPath(slug, family) {
+	return `/kb-design-tokens/v1/documents/${encodeURIComponent(slug)}/favorite-fonts/${encodeURIComponent(family)}`;
+}
+
+/**
  * Build a REST path for the resolved token map.
  *
  * @since TBD


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4207/font-families-become-favorites-not-tokens
:video_camera:  https://www.loom.com/share/2cde91916171494694080f3b7beda6e9

Adds `favoriteFontPath` and the two `apiFetch` wrappers the Typography screen will write favorites through, against the `favorite-fonts/{family}` sub-route.

Additive only — nothing calls them yet, and no existing call site changes. The path builder encodes both segments, which matters more here than on the sibling routes: most catalog families are multi-word, so the percent-encoded form is the common case rather than an edge case.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for marking font families as favorites within style libraries.
  * Added the ability to remove font families from favorites.
  * Added support for libraries and font families with multi-word names.

* **Tests**
  * Added coverage for favorite-font routes across default and multi-word libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

