### PR TITLE
[DTM] SOFT-4207 [7/15]: lift the catalog filter into the shared library

### DIFF
--- a/src/style-library/__tests__/catalog-filter.test.js
+++ b/src/style-library/__tests__/catalog-filter.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 // cspell:ignore Abril Fatface .
-import { CATALOG_RENDER_CAP, filterCatalogOptions } from '../helpers/catalog-filter';
+import { CATALOG_RENDER_CAP, filterCatalogOptions } from '../../token-controls/helpers/catalog-filter';
 
 describe('filterCatalogOptions', () => {
 	const options = [

--- a/src/style-library/components/molecules/SearchableSelectDropdown.js
+++ b/src/style-library/components/molecules/SearchableSelectDropdown.js
@@ -31,7 +31,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { filterCatalogOptions } from '../../helpers/catalog-filter';
+import { filterCatalogOptions } from '../../../token-controls';
 import './SearchableSelectDropdown.scss';
 
 /**

--- a/src/token-controls/helpers/catalog-filter.js
+++ b/src/token-controls/helpers/catalog-filter.js
@@ -1,8 +1,10 @@
 /**
- * The font catalog dropdown's matching + render-cap logic, pulled out of
- * `SearchableSelectDropdown.js` as its own pure module (no React/JSX/REST) so it is directly
- * jest-covered without importing the component's JSX/`.scss` chain — this app's tests are
- * pure-helpers-only for exactly that reason.
+ * A large flat catalog's matching + render-cap logic — a pure module (no React/JSX/REST) so it is
+ * directly jest-covered without importing any component's JSX/`.scss` chain.
+ *
+ * Shared rather than app-local: the Style Library's font dropdown and the block editor's font-family
+ * picker search the same ~1,900-name catalog, and a cap or a match rule that drifted between them
+ * would make the same query return different lists on the two screens.
  */
 
 /**

--- a/src/token-controls/index.js
+++ b/src/token-controls/index.js
@@ -24,6 +24,7 @@ export { BoxControl } from './controls/BoxControl';
 
 export { BreakpointProvider, useBreakpoint } from './context/breakpoint';
 
+export { CATALOG_RENDER_CAP, filterCatalogOptions } from './helpers/catalog-filter';
 export { parseCssLength } from './helpers/parse-css-length';
 export {
 	KADENCE_TOKEN_NAMESPACE,


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4207/font-families-become-favorites-not-tokens
:video_camera:  https://www.loom.com/share/2cde91916171494694080f3b7beda6e9

`filterCatalogOptions` and its render cap move from the Style Library's helpers into the shared token-control library, and are exported from its barrel.

Both hosts search the same ~1,900-name font catalog: the Style Library's Typography dropdown today, and the block editor's font-family picker next. A cap or a match rule that drifted between two copies would make the same query return different lists on the two screens, which is the kind of difference nobody reports as a bug because each screen looks reasonable on its own.

Pure move. The module is already React-free and REST-free, so nothing about it changes beyond its path and its docblock; the only other edits are the import in `SearchableSelectDropdown` and the one in its test.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized catalog filtering across font-selection interfaces.
  * Improved consistency for font options in the Style Library and block editor.
  * Shared catalog filtering utilities are now available across token controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

