### PR TITLE
[DTM] SOFT-4207 [9/15]: localize the editor font list

### DIFF
--- a/includes/resources/Design_Tokens/Admin/Style_Library/Menu.php
+++ b/includes/resources/Design_Tokens/Admin/Style_Library/Menu.php
@@ -30,6 +30,20 @@ final class Menu {
 	private const MENU_SLUG = 'kadence-blocks-style-library';
 
 	/**
+	 * The query arg naming which screen of the Style Library app to open on.
+	 *
+	 * The app owns its own routing, so this is the PHP counterpart of `SCREEN_QUERY_ARG` in
+	 * src/style-library/helpers/route.js — the two must agree for a deep link built here to land
+	 * anywhere but the default screen. Declared beside the menu slug because a link needs both, and
+	 * a caller that had to know one string and guess the other would be the drift waiting to happen.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const SCREEN_QUERY_ARG = 'kb-screen';
+
+	/**
 	 * The submenu position after Home (0) and Settings (1).
 	 *
 	 * Must stay an integer so Home remains the first submenu item and the default Kadence parent link.
@@ -103,6 +117,25 @@ final class Menu {
 	 */
 	public static function get_menu_slug(): string {
 		return self::MENU_SLUG;
+	}
+
+	/**
+	 * An admin URL that opens the Style Library on one of its screens.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $screen The screen id, e.g. "typography". Empty opens the default screen.
+	 *
+	 * @return string The admin URL.
+	 */
+	public static function get_screen_url( string $screen = '' ): string {
+		$args = [ 'page' => self::MENU_SLUG ];
+
+		if ( $screen !== '' ) {
+			$args[ self::SCREEN_QUERY_ARG ] = $screen;
+		}
+
+		return add_query_arg( $args, admin_url( 'admin.php' ) );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Editor/Favorite_Fonts_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Favorite_Fonts_Catalog.php
@@ -3,6 +3,7 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Editor;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Font_Catalog;
+use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Style_Library\Menu;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Favorite_Font_Index;
@@ -22,9 +23,22 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Document\Favorite_Font_Index;
  * Favorites are read from the active library because that is the library the editor renders by
  * default — the same pointer {@see Pickable_Tokens_Catalog} honors for its sort order.
  *
+ * `manageUrl` deep-links the picker's footer at the screen that edits the list, so a user who wants
+ * to add to that list can get to where it is done rather than being told it exists somewhere. Built here rather than in the shared control, which knows nothing about admin URLs or
+ * about which host mounted it.
+ *
  * @since TBD
  */
 final class Favorite_Fonts_Catalog {
+
+	/**
+	 * The Style Library screen that edits the favorites list.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const MANAGE_SCREEN = 'typography';
 
 	/**
 	 * The sole gateway to the stored token libraries.
@@ -88,12 +102,13 @@ final class Favorite_Fonts_Catalog {
 	 *
 	 * @since TBD
 	 *
-	 * @return array{favorites: list<string>, custom: string[]}
+	 * @return array{favorites: list<string>, custom: string[], manageUrl: string}
 	 */
 	public function all(): array {
 		return [
 			'favorites' => $this->favorites->all( $this->store->get_decoded_document( $this->active->get() ) ),
 			'custom'    => $this->catalog->all()['custom'],
+			'manageUrl' => Menu::get_screen_url( self::MANAGE_SCREEN ),
 		];
 	}
 }

--- a/includes/resources/Design_Tokens/Editor/Favorite_Fonts_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Favorite_Fonts_Catalog.php
@@ -1,0 +1,99 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Editor;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Font_Catalog;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Favorite_Font_Index;
+
+/**
+ * Builds the font list the block editor's font-family picker reads: the ACTIVE library's favorite
+ * families, plus the site-registered custom family names.
+ *
+ * Deliberately NOT the Google names. The editor already carries all ~1,900 of them on every screen
+ * as `kadence_blocks_params.g_font_names` (see class-kadence-blocks-editor-assets.php), so shipping
+ * a second copy here would add ~29KB to every editor load to say the same thing twice. The custom
+ * names ARE shipped, because the editor's own `c_fonts` is an associative shape keyed by a font name
+ * or by a whole font-stack expression — normalizing that is exactly what {@see Font_Catalog} already
+ * does for the Style Library, and duplicating its `family_of()` rule in JS is how the two screens
+ * would start disagreeing about what a font is called.
+ *
+ * Favorites are read from the active library because that is the library the editor renders by
+ * default — the same pointer {@see Pickable_Tokens_Catalog} honors for its sort order.
+ *
+ * @since TBD
+ */
+final class Favorite_Fonts_Catalog {
+
+	/**
+	 * The sole gateway to the stored token libraries.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * The active-library pointer, naming the library whose favorites the editor lists.
+	 *
+	 * @since TBD
+	 *
+	 * @var Active_Token_Library_Store
+	 */
+	private Active_Token_Library_Store $active;
+
+	/**
+	 * Reads the favoriteFonts list out of a stored document.
+	 *
+	 * @since TBD
+	 *
+	 * @var Favorite_Font_Index
+	 */
+	private Favorite_Font_Index $favorites;
+
+	/**
+	 * The site's font catalog, for the normalized custom-family names.
+	 *
+	 * @since TBD
+	 *
+	 * @var Font_Catalog
+	 */
+	private Font_Catalog $catalog;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Store                $store     The token store.
+	 * @param Active_Token_Library_Store $active    The active-library pointer.
+	 * @param Favorite_Font_Index        $favorites Reads the favoriteFonts list.
+	 * @param Font_Catalog               $catalog   The site's font catalog.
+	 */
+	public function __construct(
+		Token_Store $store,
+		Active_Token_Library_Store $active,
+		Favorite_Font_Index $favorites,
+		Font_Catalog $catalog
+	) {
+		$this->store     = $store;
+		$this->active    = $active;
+		$this->favorites = $favorites;
+		$this->catalog   = $catalog;
+	}
+
+	/**
+	 * The editor's font list: the active library's favorites in stored order, and the site's custom
+	 * family names.
+	 *
+	 * @since TBD
+	 *
+	 * @return array{favorites: list<string>, custom: string[]}
+	 */
+	public function all(): array {
+		return [
+			'favorites' => $this->favorites->all( $this->store->get_decoded_document( $this->active->get() ) ),
+			'custom'    => $this->catalog->all()['custom'],
+		];
+	}
+}

--- a/includes/resources/Design_Tokens/Editor/Localizer.php
+++ b/includes/resources/Design_Tokens/Editor/Localizer.php
@@ -78,6 +78,16 @@ final class Localizer {
 	private const PICKABLE_OBJECT = 'kadenceDesignTokensPickable';
 
 	/**
+	 * The JS global the editor's font-family picker reads (the active library's favorite families and
+	 * the site's custom family names).
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const FONTS_OBJECT = 'kadenceDesignTokensFonts';
+
+	/**
 	 * The token registry, for the fail-closed gate.
 	 *
 	 * @since TBD
@@ -123,6 +133,15 @@ final class Localizer {
 	private Palette_Catalog $palette_catalog;
 
 	/**
+	 * The favorite-fonts catalog builder.
+	 *
+	 * @since TBD
+	 *
+	 * @var Favorite_Fonts_Catalog
+	 */
+	private Favorite_Fonts_Catalog $favorite_fonts;
+
+	/**
 	 * @since TBD
 	 *
 	 * @param Token_Registry            $registry           The token registry.
@@ -130,24 +149,27 @@ final class Localizer {
 	 * @param Attribute_Default_Catalog $attribute_defaults The per-block attribute-default catalog builder.
 	 * @param Pickable_Tokens_Catalog   $pickable           The pickable-token pool builder.
 	 * @param Palette_Catalog           $palette_catalog    The color-palette catalog builder.
+	 * @param Favorite_Fonts_Catalog    $favorite_fonts     The favorite-fonts catalog builder.
 	 */
 	public function __construct(
 		Token_Registry $registry,
 		Preset_Catalog $preset_catalog,
 		Attribute_Default_Catalog $attribute_defaults,
 		Pickable_Tokens_Catalog $pickable,
-		Palette_Catalog $palette_catalog
+		Palette_Catalog $palette_catalog,
+		Favorite_Fonts_Catalog $favorite_fonts
 	) {
 		$this->registry           = $registry;
 		$this->preset_catalog     = $preset_catalog;
 		$this->attribute_defaults = $attribute_defaults;
 		$this->pickable           = $pickable;
 		$this->palette_catalog    = $palette_catalog;
+		$this->favorite_fonts     = $favorite_fonts;
 	}
 
 	/**
-	 * Attach the four editor-only catalogs to the editor bundle, when that bundle is on the page and
-	 * the registry is active.
+	 * Attach the editor-only catalogs to the editor bundle, when that bundle is on the page and the
+	 * registry is active.
 	 *
 	 * @since TBD
 	 *
@@ -166,6 +188,7 @@ final class Localizer {
 		$this->attach( self::HANDLE, self::PALETTES_OBJECT, $this->palette_catalog->all() );
 		$this->attach( self::HANDLE, self::ATTRIBUTE_DEFAULTS_OBJECT, $this->attribute_defaults->all() );
 		$this->attach( self::HANDLE, self::REST_OBJECT, $this->rest() );
+		$this->attach( self::HANDLE, self::FONTS_OBJECT, $this->favorite_fonts->all() );
 	}
 
 	/**

--- a/src/extension/font-picker/__tests__/index.test.js
+++ b/src/extension/font-picker/__tests__/index.test.js
@@ -1,0 +1,68 @@
+/* eslint-env jest */
+// cspell:ignore Abril Fatface .
+import { favoriteFonts, fontCatalogOptions } from '../index';
+
+const originalFonts = window.kadenceDesignTokensFonts;
+const originalParams = window.kadence_blocks_params;
+
+afterEach(() => {
+	window.kadenceDesignTokensFonts = originalFonts;
+	window.kadence_blocks_params = originalParams;
+});
+
+describe('favoriteFonts', () => {
+	it('fails safe to an empty list when the global is missing or malformed', () => {
+		delete window.kadenceDesignTokensFonts;
+		expect(favoriteFonts()).toEqual([]);
+
+		window.kadenceDesignTokensFonts = { favorites: 'not-an-array' };
+		expect(favoriteFonts()).toEqual([]);
+	});
+
+	it('reads the stored favorites in order, dropping blank and non-string entries', () => {
+		window.kadenceDesignTokensFonts = { favorites: ['Inter', '', 42, '  Georgia  ', '   ', null] };
+
+		expect(favoriteFonts()).toEqual(['Inter', 'Georgia']);
+	});
+});
+
+describe('fontCatalogOptions', () => {
+	it('fails safe to an empty list when neither global is present', () => {
+		delete window.kadenceDesignTokensFonts;
+		delete window.kadence_blocks_params;
+
+		expect(fontCatalogOptions()).toEqual([]);
+	});
+
+	it('pins favorites first, then google names, then custom names', () => {
+		window.kadenceDesignTokensFonts = { favorites: ['Georgia'], custom: ['My Font'] };
+		window.kadence_blocks_params = { g_font_names: ['Abel', 'Abril Fatface'] };
+
+		expect(fontCatalogOptions()).toEqual([
+			{ value: 'Georgia', label: 'Georgia', badge: 'Favorite' },
+			{ value: 'Abel', label: 'Abel' },
+			{ value: 'Abril Fatface', label: 'Abril Fatface' },
+			{ value: 'My Font', label: 'My Font', badge: 'Custom' },
+		]);
+	});
+
+	// A favorite is almost always also a catalog name; without this it would render twice, once
+	// pinned and once mid-list, and the second row would look like a different font.
+	it('lists a favorite exactly once, keeping its pinned position', () => {
+		window.kadenceDesignTokensFonts = { favorites: ['Abril Fatface', 'My Font'], custom: ['My Font'] };
+		window.kadence_blocks_params = { g_font_names: ['Abel', 'Abril Fatface'] };
+
+		expect(fontCatalogOptions()).toEqual([
+			{ value: 'Abril Fatface', label: 'Abril Fatface', badge: 'Favorite' },
+			{ value: 'My Font', label: 'My Font', badge: 'Favorite' },
+			{ value: 'Abel', label: 'Abel' },
+		]);
+	});
+
+	it('matches a favorite against the catalog case-insensitively when deduplicating', () => {
+		window.kadenceDesignTokensFonts = { favorites: ['abril fatface'], custom: [] };
+		window.kadence_blocks_params = { g_font_names: ['Abril Fatface'] };
+
+		expect(fontCatalogOptions()).toEqual([{ value: 'abril fatface', label: 'abril fatface', badge: 'Favorite' }]);
+	});
+});

--- a/src/extension/font-picker/__tests__/index.test.js
+++ b/src/extension/font-picker/__tests__/index.test.js
@@ -59,6 +59,15 @@ describe('fontCatalogOptions', () => {
 		]);
 	});
 
+	// The server diffs custom against Google by exact string, so a case difference reaches here as
+	// two names for one font.
+	it('lists a custom font that duplicates a Google one only once', () => {
+		window.kadenceDesignTokensFonts = { favorites: [], custom: ['inter'] };
+		window.kadence_blocks_params = { g_font_names: ['Inter'] };
+
+		expect(fontCatalogOptions()).toEqual([{ value: 'Inter', label: 'Inter' }]);
+	});
+
 	it('matches a favorite against the catalog case-insensitively when deduplicating', () => {
 		window.kadenceDesignTokensFonts = { favorites: ['abril fatface'], custom: [] };
 		window.kadence_blocks_params = { g_font_names: ['Abril Fatface'] };

--- a/src/extension/font-picker/__tests__/index.test.js
+++ b/src/extension/font-picker/__tests__/index.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 // cspell:ignore Abril Fatface .
-import { favoriteFonts, fontCatalogOptions } from '../index';
+import { favoriteFonts, favoriteFontsManageUrl, fontCatalogOptions } from '../index';
 
 const originalFonts = window.kadenceDesignTokensFonts;
 const originalParams = window.kadence_blocks_params;
@@ -64,5 +64,23 @@ describe('fontCatalogOptions', () => {
 		window.kadence_blocks_params = { g_font_names: ['Abril Fatface'] };
 
 		expect(fontCatalogOptions()).toEqual([{ value: 'abril fatface', label: 'abril fatface', badge: 'Favorite' }]);
+	});
+});
+
+describe('favoriteFontsManageUrl', () => {
+	it('reads the deep link from the global', () => {
+		window.kadenceDesignTokensFonts = { manageUrl: 'https://example.test/wp-admin/admin.php?page=x' };
+
+		expect(favoriteFontsManageUrl()).toBe('https://example.test/wp-admin/admin.php?page=x');
+	});
+
+	// An empty string is what the control renders as plain text; a missing global must not become the
+	// string "undefined" in an href.
+	it('falls back to an empty string when the global carries none', () => {
+		delete window.kadenceDesignTokensFonts;
+		expect(favoriteFontsManageUrl()).toBe('');
+
+		window.kadenceDesignTokensFonts = { manageUrl: 42 };
+		expect(favoriteFontsManageUrl()).toBe('');
 	});
 });

--- a/src/extension/font-picker/index.js
+++ b/src/extension/font-picker/index.js
@@ -1,0 +1,114 @@
+/**
+ * The block editor's font list accessor: the site's favorite families, and the full catalog option
+ * list the font-family picker's `Custom` tab searches.
+ *
+ * A favorite is not a token. Nothing here resolves an alias, reads the pickable-token pool, or emits
+ * a CSS variable — a picked family is written to the block attribute verbatim, exactly as the shared
+ * `TypographyControls` select has always written it. The only thing favorites buy is position: they
+ * sit at the top of the list so a site is not searching ~1,900 names for the same face every time.
+ *
+ * Two page-load globals feed this, and neither is fetched:
+ *
+ * - `window.kadenceDesignTokensFonts` — `{ favorites, custom }`, printed by the design-tokens
+ *   editor Localizer. `custom` arrives already normalized to family names, because the raw
+ *   `c_fonts` shape keys entries by a name OR by a whole font-stack expression.
+ * - `window.kadence_blocks_params.g_font_names` — the ~1,900 Google names the editor already
+ *   carries on every screen. Read from there rather than shipped a second time.
+ *
+ * Because both are page-load values, a favorite added in another tab is not reflected until reload —
+ * the same staleness the token pool documents, and harmless for the same reason: the value written
+ * is the family name itself, which cannot go stale.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * The muted badge a site-registered custom font carries in the catalog list, matching the Style
+ * Library's Typography screen.
+ *
+ * @since TBD
+ */
+const CUSTOM_BADGE = __('Custom', 'kadence-blocks');
+
+/**
+ * The muted badge a favorite carries where it sits pinned above the catalog.
+ *
+ * @since TBD
+ */
+const FAVORITE_BADGE = __('Favorite', 'kadence-blocks');
+
+/**
+ * Read the design-tokens font global. Fail-safe on a missing or malformed global, mirroring the
+ * token pool's posture — a caller never has to null-check before using either list.
+ *
+ * @since TBD
+ *
+ * @return {{favorites: string[], custom: string[]}} The favorites and custom names, or two empty lists.
+ */
+function fontPool() {
+	const pool = window.kadenceDesignTokensFonts;
+
+	return {
+		favorites: Array.isArray(pool?.favorites) ? pool.favorites : [],
+		custom: Array.isArray(pool?.custom) ? pool.custom : [],
+	};
+}
+
+/**
+ * The Google family names the editor already localizes, fail-safe to an empty list.
+ *
+ * @since TBD
+ *
+ * @return {string[]} The Google family names.
+ */
+function googleNames() {
+	const names = window.kadence_blocks_params?.g_font_names;
+
+	return Array.isArray(names) ? names.filter((name) => typeof name === 'string') : [];
+}
+
+/**
+ * The site's favorite font families, in stored order, with blank entries dropped.
+ *
+ * @since TBD
+ *
+ * @return {string[]} The favorite families.
+ */
+export function favoriteFonts() {
+	return fontPool()
+		.favorites.filter((family) => typeof family === 'string' && family.trim() !== '')
+		.map((family) => family.trim());
+}
+
+/**
+ * The font-family picker's full option list: favorites first, then every Google family, then every
+ * site-registered custom family.
+ *
+ * A favorite is filtered out of the two catalog runs below it so it appears exactly once, in
+ * its pinned position — the same rule the Style Library's Typography dropdown applies, so the two
+ * screens list the same names in the same order.
+ *
+ * @since TBD
+ *
+ * @return {Array<{value: string, label: string, badge?: string}>} The option list.
+ */
+export function fontCatalogOptions() {
+	const favorites = favoriteFonts();
+	const { custom } = fontPool();
+	const pinned = new Set(favorites.map((name) => name.toLowerCase()));
+	const unpinned = (name) => !pinned.has(name.toLowerCase());
+
+	return [
+		...favorites.map((name) => ({ value: name, label: name, badge: FAVORITE_BADGE })),
+		...googleNames()
+			.filter(unpinned)
+			.map((name) => ({ value: name, label: name })),
+		...custom
+			.filter((name) => typeof name === 'string' && name !== '')
+			.filter(unpinned)
+			.map((name) => ({ value: name, label: name, badge: CUSTOM_BADGE })),
+	];
+}

--- a/src/extension/font-picker/index.js
+++ b/src/extension/font-picker/index.js
@@ -9,9 +9,10 @@
  *
  * Two page-load globals feed this, and neither is fetched:
  *
- * - `window.kadenceDesignTokensFonts` — `{ favorites, custom }`, printed by the design-tokens
- *   editor Localizer. `custom` arrives already normalized to family names, because the raw
- *   `c_fonts` shape keys entries by a name OR by a whole font-stack expression.
+ * - `window.kadenceDesignTokensFonts` — `{ favorites, custom, manageUrl }`, printed by the
+ *   design-tokens editor Localizer. `custom` arrives already normalized to family names, because
+ *   the raw `c_fonts` shape keys entries by a name OR by a whole font-stack expression, and
+ *   `manageUrl` deep-links the Style Library screen that edits the favorites.
  * - `window.kadence_blocks_params.g_font_names` — the ~1,900 Google names the editor already
  *   carries on every screen. Read from there rather than shipped a second time.
  *
@@ -46,7 +47,7 @@ const FAVORITE_BADGE = __('Favorite', 'kadence-blocks');
  *
  * @since TBD
  *
- * @return {{favorites: string[], custom: string[]}} The favorites and custom names, or two empty lists.
+ * @return {{favorites: string[], custom: string[], manageUrl: string}} The pool, or empty values.
  */
 function fontPool() {
 	const pool = window.kadenceDesignTokensFonts;
@@ -54,6 +55,7 @@ function fontPool() {
 	return {
 		favorites: Array.isArray(pool?.favorites) ? pool.favorites : [],
 		custom: Array.isArray(pool?.custom) ? pool.custom : [],
+		manageUrl: typeof pool?.manageUrl === 'string' ? pool.manageUrl : '',
 	};
 }
 
@@ -111,4 +113,16 @@ export function fontCatalogOptions() {
 			.filter(unpinned)
 			.map((name) => ({ value: name, label: name, badge: CUSTOM_BADGE })),
 	];
+}
+
+/**
+ * The admin URL of the screen that edits the favorites list, for the picker's footer link. Empty
+ * when the global carries none, which the control renders as plain text rather than a dead link.
+ *
+ * @since TBD
+ *
+ * @return {string} The deep link, or an empty string.
+ */
+export function favoriteFontsManageUrl() {
+	return fontPool().manageUrl;
 }

--- a/src/extension/font-picker/index.js
+++ b/src/extension/font-picker/index.js
@@ -89,28 +89,43 @@ export function favoriteFonts() {
  * The font-family picker's full option list: favorites first, then every Google family, then every
  * site-registered custom family.
  *
- * A favorite is filtered out of the two catalog runs below it so it appears exactly once, in
- * its pinned position — the same rule the Style Library's Typography dropdown applies, so the two
- * screens list the same names in the same order.
+ * Every name appears exactly once, matched case-insensitively across all three sources: a favorite
+ * keeps its pinned position rather than repeating mid-list, and a custom font that duplicates a
+ * Google one renders once — the same rule the Style Library's Typography dropdown applies, so the
+ * two screens list the same names in the same order.
  *
  * @since TBD
  *
  * @return {Array<{value: string, label: string, badge?: string}>} The option list.
  */
 export function fontCatalogOptions() {
-	const favorites = favoriteFonts();
+	// One set across all three sources, not just the favorites. The custom list is diffed against the
+	// Google list server-side by exact string, so a theme registering `inter` alongside Google's
+	// `Inter` reaches here as two names for one font.
+	const seen = new Set();
+	const unique = (name) => {
+		const key = name.toLowerCase();
+
+		if (seen.has(key)) {
+			return false;
+		}
+
+		seen.add(key);
+
+		return true;
+	};
+
+	const favorites = favoriteFonts().filter(unique);
 	const { custom } = fontPool();
-	const pinned = new Set(favorites.map((name) => name.toLowerCase()));
-	const unpinned = (name) => !pinned.has(name.toLowerCase());
 
 	return [
 		...favorites.map((name) => ({ value: name, label: name, badge: FAVORITE_BADGE })),
 		...googleNames()
-			.filter(unpinned)
+			.filter(unique)
 			.map((name) => ({ value: name, label: name })),
 		...custom
-			.filter((name) => typeof name === 'string' && name !== '')
-			.filter(unpinned)
+			.filter((name) => typeof name === 'string' && name.trim() !== '')
+			.filter(unique)
 			.map((name) => ({ value: name, label: name, badge: CUSTOM_BADGE })),
 	];
 }

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Favorite_Fonts_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Favorite_Fonts_CatalogTest.php
@@ -1,0 +1,156 @@
+<?php declare( strict_types=1 );
+
+namespace Tests\wpunit\Resources\Design_Tokens\Editor;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Favorite_Font_Index;
+use KadenceWP\KadenceBlocks\Design_Tokens\Editor\Favorite_Fonts_Catalog;
+use Tests\Support\Classes\TestCase;
+
+/**
+ * Covers the font list the block editor's font-family picker reads: the active library's favorites,
+ * and the site's normalized custom family names.
+ */
+final class Favorite_Fonts_CatalogTest extends TestCase {
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Favorite_Fonts_Catalog
+	 */
+	private Favorite_Fonts_Catalog $catalog;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Active_Token_Library_Store
+	 */
+	private Active_Token_Library_Store $active;
+
+	/**
+	 * @since TBD
+	 *
+	 * @var Favorite_Font_Index
+	 */
+	private Favorite_Font_Index $index;
+
+	/**
+	 * Resolve the catalog and its collaborators from the container.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->catalog = $this->container->get( Favorite_Fonts_Catalog::class );
+		$this->store   = $this->container->get( Token_Store::class );
+		$this->active  = $this->container->get( Active_Token_Library_Store::class );
+		$this->index   = $this->container->get( Favorite_Font_Index::class );
+	}
+
+	/**
+	 * Reset the active-library pointer and drop the custom-fonts filter each test may have added, so
+	 * neither follows the suite into a later case.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		$this->active->set( Token_Store::default_slug() );
+
+		remove_all_filters( 'kadence_blocks_custom_fonts' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * A library with no stored favorites reports an empty list rather than omitting the key, so the
+	 * client never has to probe for it.
+	 *
+	 * @return void
+	 */
+	public function testItReportsAnEmptyFavoritesListForALibraryWithNone(): void {
+		$this->assertSame( [], $this->catalog->all()['favorites'] );
+	}
+
+	/**
+	 * The favorites come back in their stored order — the order every picker renders them in.
+	 *
+	 * @return void
+	 */
+	public function testItReportsTheStoredFavoritesInOrder(): void {
+		$this->save_favorites( Token_Store::default_slug(), [ 'Inter', 'Abril Fatface' ] );
+
+		$this->assertSame( [ 'Inter', 'Abril Fatface' ], $this->catalog->all()['favorites'] );
+	}
+
+	/**
+	 * Favorites are read from the ACTIVE library, not the default one: the editor renders the active
+	 * library, so pointing it elsewhere must change which favorites the picker lists.
+	 *
+	 * @return void
+	 */
+	public function testItReadsFavoritesFromTheActiveLibrary(): void {
+		$this->save_favorites( Token_Store::default_slug(), [ 'Inter' ] );
+		$this->save_favorites( 'brand-b', [ 'Abril Fatface' ] );
+
+		$this->active->set( 'brand-b' );
+
+		$this->assertSame( [ 'Abril Fatface' ], $this->catalog->all()['favorites'] );
+	}
+
+	/**
+	 * The custom names arrive normalized to family names. A theme registering a fallback puts the whole
+	 * stack in the key, and shipping that verbatim would put `"My Font", sans-serif` in the picker as
+	 * one option — this is the reason the catalog ships custom names at all rather than leaving the
+	 * editor's raw `c_fonts` to be normalized in JS.
+	 *
+	 * @return void
+	 */
+	public function testItReportsCustomFamilyNamesNormalizedFromAStackExpression(): void {
+		add_filter(
+			'kadence_blocks_custom_fonts',
+			static function (): array {
+				return [ '"My Font", sans-serif' => [] ];
+			}
+		);
+
+		$this->assertSame( [ 'My Font' ], $this->catalog->all()['custom'] );
+	}
+
+	/**
+	 * The Google names are deliberately absent: the editor already carries all ~1,900 of them as
+	 * `kadence_blocks_params.g_font_names`, so shipping a second copy would add ~29KB per editor load
+	 * to say the same thing twice.
+	 *
+	 * @return void
+	 */
+	public function testItDoesNotShipTheGoogleNames(): void {
+		$this->assertSame( [ 'favorites', 'custom' ], array_keys( $this->catalog->all() ) );
+	}
+
+	/**
+	 * Store a library document carrying only a favorites list.
+	 *
+	 * @param string       $slug     The token library slug.
+	 * @param list<string> $families The favorite families to store.
+	 *
+	 * @return void
+	 */
+	private function save_favorites( string $slug, array $families ): void {
+		$document = [];
+
+		foreach ( $families as $family ) {
+			$document = $this->index->add( $document, $family );
+		}
+
+		$this->store->save_document( (string) wp_json_encode( $document ), $slug );
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Favorite_Fonts_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Favorite_Fonts_CatalogTest.php
@@ -133,7 +133,21 @@ final class Favorite_Fonts_CatalogTest extends TestCase {
 	 * @return void
 	 */
 	public function testItDoesNotShipTheGoogleNames(): void {
-		$this->assertSame( [ 'favorites', 'custom' ], array_keys( $this->catalog->all() ) );
+		$this->assertSame( [ 'favorites', 'custom', 'manageUrl' ], array_keys( $this->catalog->all() ) );
+	}
+
+	/**
+	 * The manage URL deep-links the Typography screen, not the Style Library's default screen: the
+	 * picker's footer exists to get a user to where favorites are edited, and landing them on the
+	 * first screen instead would leave them to find it.
+	 *
+	 * @return void
+	 */
+	public function testItDeepLinksTheTypographyScreen(): void {
+		$url = $this->catalog->all()['manageUrl'];
+
+		$this->assertStringContainsString( 'page=kadence-blocks-style-library', $url );
+		$this->assertStringContainsString( 'kb-screen=typography', $url );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Favorite_Fonts_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Favorite_Fonts_CatalogTest.php
@@ -57,15 +57,31 @@ final class Favorite_Fonts_CatalogTest extends TestCase {
 	}
 
 	/**
-	 * Reset the active-library pointer and drop the custom-fonts filter each test may have added, so
-	 * neither follows the suite into a later case.
+	 * The custom-fonts callback a test registered, so tearDown can remove exactly that one.
+	 *
+	 * @since TBD
+	 *
+	 * @var callable|null
+	 */
+	private $custom_fonts_filter = null;
+
+	/**
+	 * Reset the active-library pointer and drop only the callback this test registered, so neither
+	 * follows the suite into a later case.
+	 *
+	 * Deliberately not remove_all_filters(): the plugin registers its own callback on this hook at
+	 * includes/init.php, and clearing the hook wholesale would strip that for every later test in
+	 * the run rather than only undoing what this one did.
 	 *
 	 * @return void
 	 */
 	protected function tearDown(): void {
 		$this->active->set( Token_Store::default_slug() );
 
-		remove_all_filters( 'kadence_blocks_custom_fonts' );
+		if ( $this->custom_fonts_filter !== null ) {
+			remove_filter( 'kadence_blocks_custom_fonts', $this->custom_fonts_filter );
+			$this->custom_fonts_filter = null;
+		}
 
 		parent::tearDown();
 	}
@@ -115,12 +131,11 @@ final class Favorite_Fonts_CatalogTest extends TestCase {
 	 * @return void
 	 */
 	public function testItReportsCustomFamilyNamesNormalizedFromAStackExpression(): void {
-		add_filter(
-			'kadence_blocks_custom_fonts',
-			static function (): array {
-				return [ '"My Font", sans-serif' => [] ];
-			}
-		);
+		$this->custom_fonts_filter = static function (): array {
+			return [ '"My Font", sans-serif' => [] ];
+		};
+
+		add_filter( 'kadence_blocks_custom_fonts', $this->custom_fonts_filter );
 
 		$this->assertSame( [ 'My Font' ], $this->catalog->all()['custom'] );
 	}


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4207/font-families-become-favorites-not-tokens
:video_camera:  https://www.loom.com/share/2cde91916171494694080f3b7beda6e9

Adds `window.kadenceDesignTokensFonts` — the active library's favorite families plus the site's custom family names — and the JS accessor that reads it.

The Google names are deliberately absent. The editor already carries all ~1,900 on every screen as `kadence_blocks_params.g_font_names`, so shipping a second copy would add ~29KB per editor load to say the same thing twice; the accessor composes its option list from that existing global instead.

The custom names ARE shipped, and normalized. The editor's own `c_fonts` is an associative shape keyed by a font name or by a whole font-stack expression, and `Font_Catalog::family_of()` already reduces that to a family for the Style Library. Duplicating that rule in JS is how the two screens would start disagreeing about what a font is called.

Favorites come from the active library, the same pointer `Pickable_Tokens_Catalog` honors for its sort order. Both globals are page-load values, so a favorite added in another tab needs a reload — harmless here, since the value written is the family name itself, which cannot go stale.

Nothing reads the accessor yet.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added favorite font support to the editor’s font picker.
  * Favorite fonts now appear first, followed by custom and Google fonts, with duplicates removed.
  * Added badges for favorite and custom fonts.
  * Added a direct link to manage favorite fonts and typography settings.
* **Bug Fixes**
  * Improved handling of missing, invalid, or malformed font data with safe fallbacks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

