### PR TITLE
[DTM] SOFT-4207 [10/15]: wire the font-family picker onto the control seam

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@floating-ui/react": "^0.27.12",
         "@hcaptcha/react-hcaptcha": "^1.8.1",
-        "@kadence/components": "github:stellarwp/kadence-components#feature/design-tokens-module",
+        "@kadence/components": "github:stellarwp/kadence-components#SOFT-4207/font-family-control-seam",
         "@kadence/helpers": "github:stellarwp/kadence-helpers#feature/design-tokens-module",
         "@kadence/icons": "github:stellarwp/kadence-icons#1.1.4",
         "@lottiefiles/dotlottie-react": "^0.15.2",
@@ -683,7 +683,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@kadence/components": ["@kadence/components@github:stellarwp/kadence-components#c0f79a0", { "dependencies": { "@floating-ui/react": "^0.26.16", "@wordpress/icons": "^9.49.0", "classnames": "^2.2.6", "colord": "^2.9.3", "react-color": "^2.18.0", "react-select": "^5.10.2" }, "peerDependencies": { "@kadence/helpers": "*", "@kadence/icons": "*", "react": ">=17 <19", "react-dom": ">=17 <19" }, "optionalPeers": ["@kadence/helpers", "@kadence/icons"] }, "stellarwp-kadence-components-c0f79a0"],
+    "@kadence/components": ["@kadence/components@github:stellarwp/kadence-components#77d87fe", { "dependencies": { "@floating-ui/react": "^0.26.16", "@wordpress/icons": "^9.49.0", "classnames": "^2.2.6", "colord": "^2.9.3", "react-color": "^2.18.0", "react-select": "^5.10.2" }, "peerDependencies": { "@kadence/helpers": "*", "@kadence/icons": "*", "react": ">=17 <19", "react-dom": ">=17 <19" }, "optionalPeers": ["@kadence/helpers", "@kadence/icons"] }, "stellarwp-kadence-components-77d87fe"],
 
     "@kadence/helpers": ["@kadence/helpers@github:stellarwp/kadence-helpers#e192350", { "dependencies": { "@kadence/icons": "git+https://github.com/stellarwp/kadence-icons.git#1.1.0" }, "peerDependencies": { "@wordpress/hooks": ">=4 <5", "react": ">=17 <19", "react-dom": ">=17 <19" } }, "stellarwp-kadence-helpers-e192350"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@floating-ui/react": "^0.27.12",
         "@hcaptcha/react-hcaptcha": "^1.8.1",
-        "@kadence/components": "github:stellarwp/kadence-components#SOFT-4207/webfont-loader-typography-prop",
+        "@kadence/components": "github:stellarwp/kadence-components#feature/design-tokens-module",
         "@kadence/helpers": "github:stellarwp/kadence-helpers#feature/design-tokens-module",
         "@kadence/icons": "github:stellarwp/kadence-icons#1.1.4",
         "@lottiefiles/dotlottie-react": "^0.15.2",
@@ -683,7 +683,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@kadence/components": ["@kadence/components@github:stellarwp/kadence-components#27fe731", { "dependencies": { "@floating-ui/react": "^0.26.16", "@wordpress/icons": "^9.49.0", "classnames": "^2.2.6", "colord": "^2.9.3", "react-color": "^2.18.0", "react-select": "^5.10.2" }, "peerDependencies": { "@kadence/helpers": "*", "@kadence/icons": "*", "react": ">=17 <19", "react-dom": ">=17 <19" }, "optionalPeers": ["@kadence/helpers", "@kadence/icons"] }, "stellarwp-kadence-components-27fe731"],
+    "@kadence/components": ["@kadence/components@github:stellarwp/kadence-components#8c85466", { "dependencies": { "@floating-ui/react": "^0.26.16", "@wordpress/icons": "^9.49.0", "classnames": "^2.2.6", "colord": "^2.9.3", "react-color": "^2.18.0", "react-select": "^5.10.2" }, "peerDependencies": { "@kadence/helpers": "*", "@kadence/icons": "*", "react": ">=17 <19", "react-dom": ">=17 <19" }, "optionalPeers": ["@kadence/helpers", "@kadence/icons"] }, "stellarwp-kadence-components-8c85466"],
 
     "@kadence/helpers": ["@kadence/helpers@github:stellarwp/kadence-helpers#e192350", { "dependencies": { "@kadence/icons": "git+https://github.com/stellarwp/kadence-icons.git#1.1.0" }, "peerDependencies": { "@wordpress/hooks": ">=4 <5", "react": ">=17 <19", "react-dom": ">=17 <19" } }, "stellarwp-kadence-helpers-e192350"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -683,7 +683,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@kadence/components": ["@kadence/components@github:stellarwp/kadence-components#710f3ee", { "dependencies": { "@floating-ui/react": "^0.26.16", "@wordpress/icons": "^9.49.0", "classnames": "^2.2.6", "colord": "^2.9.3", "react-color": "^2.18.0", "react-select": "^5.10.2" }, "peerDependencies": { "@kadence/helpers": "*", "@kadence/icons": "*", "react": ">=17 <19", "react-dom": ">=17 <19" }, "optionalPeers": ["@kadence/helpers", "@kadence/icons"] }, "stellarwp-kadence-components-710f3ee"],
+    "@kadence/components": ["@kadence/components@github:stellarwp/kadence-components#27fe731", { "dependencies": { "@floating-ui/react": "^0.26.16", "@wordpress/icons": "^9.49.0", "classnames": "^2.2.6", "colord": "^2.9.3", "react-color": "^2.18.0", "react-select": "^5.10.2" }, "peerDependencies": { "@kadence/helpers": "*", "@kadence/icons": "*", "react": ">=17 <19", "react-dom": ">=17 <19" }, "optionalPeers": ["@kadence/helpers", "@kadence/icons"] }, "stellarwp-kadence-components-27fe731"],
 
     "@kadence/helpers": ["@kadence/helpers@github:stellarwp/kadence-helpers#e192350", { "dependencies": { "@kadence/icons": "git+https://github.com/stellarwp/kadence-icons.git#1.1.0" }, "peerDependencies": { "@wordpress/hooks": ">=4 <5", "react": ">=17 <19", "react-dom": ">=17 <19" } }, "stellarwp-kadence-helpers-e192350"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@floating-ui/react": "^0.27.12",
         "@hcaptcha/react-hcaptcha": "^1.8.1",
-        "@kadence/components": "github:stellarwp/kadence-components#SOFT-4207/font-family-control-seam",
+        "@kadence/components": "github:stellarwp/kadence-components#SOFT-4207/webfont-loader-typography-prop",
         "@kadence/helpers": "github:stellarwp/kadence-helpers#feature/design-tokens-module",
         "@kadence/icons": "github:stellarwp/kadence-icons#1.1.4",
         "@lottiefiles/dotlottie-react": "^0.15.2",
@@ -683,7 +683,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@kadence/components": ["@kadence/components@github:stellarwp/kadence-components#77d87fe", { "dependencies": { "@floating-ui/react": "^0.26.16", "@wordpress/icons": "^9.49.0", "classnames": "^2.2.6", "colord": "^2.9.3", "react-color": "^2.18.0", "react-select": "^5.10.2" }, "peerDependencies": { "@kadence/helpers": "*", "@kadence/icons": "*", "react": ">=17 <19", "react-dom": ">=17 <19" }, "optionalPeers": ["@kadence/helpers", "@kadence/icons"] }, "stellarwp-kadence-components-77d87fe"],
+    "@kadence/components": ["@kadence/components@github:stellarwp/kadence-components#710f3ee", { "dependencies": { "@floating-ui/react": "^0.26.16", "@wordpress/icons": "^9.49.0", "classnames": "^2.2.6", "colord": "^2.9.3", "react-color": "^2.18.0", "react-select": "^5.10.2" }, "peerDependencies": { "@kadence/helpers": "*", "@kadence/icons": "*", "react": ">=17 <19", "react-dom": ">=17 <19" }, "optionalPeers": ["@kadence/helpers", "@kadence/icons"] }, "stellarwp-kadence-components-710f3ee"],
 
     "@kadence/helpers": ["@kadence/helpers@github:stellarwp/kadence-helpers#e192350", { "dependencies": { "@kadence/icons": "git+https://github.com/stellarwp/kadence-icons.git#1.1.0" }, "peerDependencies": { "@wordpress/hooks": ">=4 <5", "react": ">=17 <19", "react-dom": ">=17 <19" } }, "stellarwp-kadence-helpers-e192350"],
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@dnd-kit/sortable": "^10.0.0",
 		"@floating-ui/react": "^0.27.12",
 		"@hcaptcha/react-hcaptcha": "^1.8.1",
-		"@kadence/components": "github:stellarwp/kadence-components#SOFT-4207/webfont-loader-typography-prop",
+		"@kadence/components": "github:stellarwp/kadence-components#feature/design-tokens-module",
 		"@kadence/helpers": "github:stellarwp/kadence-helpers#feature/design-tokens-module",
 		"@kadence/icons": "github:stellarwp/kadence-icons#1.1.4",
 		"@lottiefiles/dotlottie-react": "^0.15.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@dnd-kit/sortable": "^10.0.0",
 		"@floating-ui/react": "^0.27.12",
 		"@hcaptcha/react-hcaptcha": "^1.8.1",
-		"@kadence/components": "github:stellarwp/kadence-components#SOFT-4207/font-family-control-seam",
+		"@kadence/components": "github:stellarwp/kadence-components#SOFT-4207/webfont-loader-typography-prop",
 		"@kadence/helpers": "github:stellarwp/kadence-helpers#feature/design-tokens-module",
 		"@kadence/icons": "github:stellarwp/kadence-icons#1.1.4",
 		"@lottiefiles/dotlottie-react": "^0.15.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@dnd-kit/sortable": "^10.0.0",
 		"@floating-ui/react": "^0.27.12",
 		"@hcaptcha/react-hcaptcha": "^1.8.1",
-		"@kadence/components": "github:stellarwp/kadence-components#feature/design-tokens-module",
+		"@kadence/components": "github:stellarwp/kadence-components#SOFT-4207/font-family-control-seam",
 		"@kadence/helpers": "github:stellarwp/kadence-helpers#feature/design-tokens-module",
 		"@kadence/icons": "github:stellarwp/kadence-icons#1.1.4",
 		"@lottiefiles/dotlottie-react": "^0.15.2",

--- a/src/extension/design-tokens/__tests__/register-component-filters.test.js
+++ b/src/extension/design-tokens/__tests__/register-component-filters.test.js
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+// cspell:ignore Abril Fatface .
 
 // `@wordpress/components` is not resolvable in the jest env; the token UI only references it at render
 // time, and these tests inspect the returned element types/props (never render), so light stubs are
@@ -31,7 +32,12 @@ import { pickableTokensForControl } from '../../token-picker';
 import { registerComponentTokenFilters } from '../register-component-filters';
 // Through the barrel, the same path the production file uses: importing the implementation files
 // directly would let this pass while a missing or renamed barrel export broke the real import.
-import { TokenChip, TokenPickerButton, TokenSelector as TokenFieldControl } from '../../../token-controls';
+import {
+	FontFamilySelector,
+	TokenChip,
+	TokenPickerButton,
+	TokenSelector as TokenFieldControl,
+} from '../../../token-controls';
 
 const EDITOR_HOOK = 'kadence.components.control.editor';
 const ACTIONS_HOOK = 'kadence.components.control.actions';
@@ -327,5 +333,101 @@ describe('box-shadow whole-shadow seam', () => {
 		expect(actions[0].type).toBe(TokenChip);
 		actions[0].props.onUnlink();
 		expect(onChange).toHaveBeenCalledWith('');
+	});
+});
+
+describe('font-family seam', () => {
+	const FONTS = { favorites: ['Georgia'], custom: [] };
+
+	beforeEach(() => {
+		window.kadenceDesignTokensFonts = FONTS;
+		window.kadence_blocks_params = { g_font_names: ['Abel'] };
+	});
+
+	afterEach(() => {
+		delete window.kadenceDesignTokensFonts;
+		delete window.kadence_blocks_params;
+	});
+
+	/**
+	 * A block that opted in gets the favorites-aware picker in place of the shared control's font
+	 * select, carrying the current family and the site's favorites.
+	 *
+	 * @return {void}
+	 */
+	it('replaces the font select with the font-family field, carrying the favorites', () => {
+		const editor = applyFilters(EDITOR_HOOK, 'DEFAULT', {
+			control: 'fontFamily',
+			index: null,
+			value: 'Inter',
+			onChange: jest.fn(),
+			context: { blockName: 'kadence/singlebtn' },
+		});
+
+		expect(editor.type).toBe(FontFamilySelector);
+		expect(editor.props.value).toBe('Inter');
+		expect(editor.props.favorites).toEqual(['Georgia']);
+	});
+
+	/**
+	 * Both of the picker's tabs write a plain family string — never an alias, since a favorite is not
+	 * a token — and Reset clears back to the theme's font.
+	 *
+	 * @return {void}
+	 */
+	it('writes a plain family string on pick, and empty on clear', () => {
+		const onChange = jest.fn();
+		const editor = applyFilters(EDITOR_HOOK, 'DEFAULT', {
+			control: 'fontFamily',
+			index: null,
+			value: '',
+			onChange,
+			context: { blockName: 'kadence/singlebtn' },
+		});
+
+		editor.props.onPick('Abril Fatface');
+		expect(onChange).toHaveBeenCalledWith('Abril Fatface');
+
+		editor.props.onClear();
+		expect(onChange).toHaveBeenCalledWith('');
+	});
+
+	/**
+	 * A block that passes no context keeps the react-select it has always had — that is how a block
+	 * which has not opted in is left untouched.
+	 *
+	 * @return {void}
+	 */
+	it('falls back to the control default when the block passes no context', () => {
+		const editor = applyFilters(EDITOR_HOOK, 'DEFAULT', {
+			control: 'fontFamily',
+			index: null,
+			value: 'Inter',
+			onChange: jest.fn(),
+		});
+
+		expect(editor).toBe('DEFAULT');
+	});
+
+	/**
+	 * The font-family case never consults the pickable-token pool: a family is not a token, so the
+	 * picker must render even with an empty pool.
+	 *
+	 * @return {void}
+	 */
+	it('renders without consulting the pickable-token pool', () => {
+		pickableTokensForControl.mockReturnValue([]);
+		pickableTokensForControl.mockClear();
+
+		const editor = applyFilters(EDITOR_HOOK, 'DEFAULT', {
+			control: 'fontFamily',
+			index: null,
+			value: 'Inter',
+			onChange: jest.fn(),
+			context: { blockName: 'kadence/singlebtn' },
+		});
+
+		expect(editor.type).toBe(FontFamilySelector);
+		expect(pickableTokensForControl).not.toHaveBeenCalled();
 	});
 });

--- a/src/extension/design-tokens/__tests__/register-component-filters.test.js
+++ b/src/extension/design-tokens/__tests__/register-component-filters.test.js
@@ -337,7 +337,7 @@ describe('box-shadow whole-shadow seam', () => {
 });
 
 describe('font-family seam', () => {
-	const FONTS = { favorites: ['Georgia'], custom: [] };
+	const FONTS = { favorites: ['Georgia'], custom: [], manageUrl: 'https://example.test/manage' };
 
 	beforeEach(() => {
 		window.kadenceDesignTokensFonts = FONTS;
@@ -367,6 +367,7 @@ describe('font-family seam', () => {
 		expect(editor.type).toBe(FontFamilySelector);
 		expect(editor.props.value).toBe('Inter');
 		expect(editor.props.favorites).toEqual(['Georgia']);
+		expect(editor.props.manageUrl).toBe('https://example.test/manage');
 	});
 
 	/**

--- a/src/extension/design-tokens/register-component-filters.js
+++ b/src/extension/design-tokens/register-component-filters.js
@@ -14,6 +14,12 @@
  * in. The pickable-token list is resolved per control from `pickableTokensForControl`; per-slot picks
  * write through the adapter's `writeLeaf`, so a linked slot writes every side and an individual slot
  * writes only its own — per-corner tokens fall out for free.
+ *
+ * The `fontFamily` seam is the one case that is NOT about tokens. Font family stopped being a token
+ * family, so its picker offers the site's FAVORITES over the full font catalog and writes a plain
+ * family string either way — no alias, no pickable pool, no adapter. It rides this same seam because
+ * the shared typography control gates font weight / style / subset behind the same `onFontFamily`
+ * prop as the family select, so a block cannot substitute a picker by dropping the prop.
  */
 
 /**
@@ -21,7 +27,8 @@
  */
 import { addFilter, removeFilter } from '@wordpress/hooks';
 import { pickableTokensForControl } from '../token-picker';
-import { TokenChip, TokenPickerButton, TokenSelector, isTokenAlias } from '../../token-controls';
+import { favoriteFonts, fontCatalogOptions } from '../font-picker';
+import { FontFamilySelector, TokenChip, TokenPickerButton, TokenSelector, isTokenAlias } from '../../token-controls';
 
 const NAMESPACE = 'kadence-blocks/component-token';
 const EDITOR_HOOK = 'kadence.components.control.editor';
@@ -135,6 +142,10 @@ function defaultValueForSlot(defaultValue, index) {
  * @return {*} The token field when the control is token-mapped, otherwise `defaultEditor`.
  */
 function editorFilter(defaultEditor, ctx) {
+	if (ctx.control === 'fontFamily') {
+		return fontFamilyEditor(defaultEditor, ctx);
+	}
+
 	const adapter = ADAPTERS[ctx.control];
 	if (!adapter || !adapter.leaf) {
 		return defaultEditor;
@@ -164,6 +175,40 @@ function editorFilter(defaultEditor, ctx) {
 			onPick={(alias) => write(adapter.writeLeaf(ctx.value, ctx.index, alias))}
 			onClear={() => write(adapter.writeLeaf(ctx.value, ctx.index, ''))}
 			onCustom={(next) => write(adapter.writeLeaf(ctx.value, ctx.index, next))}
+		/>
+	);
+}
+
+/**
+ * Editor seam, font-family case: replace the shared typography control's font select with the
+ * favorites-aware picker. No adapter and no token pool — the value is a plain family string, and
+ * both of the picker's tabs write one.
+ *
+ * Falls back to the control's own select when the block passes no `context`, which is how a block
+ * that has not opted in keeps the react-select it has always had.
+ *
+ * @param {*}      defaultEditor The control's own select node.
+ * @param {Object} ctx           Neutral seam context: { control, index, value, onChange, context }.
+ *
+ * @since TBD
+ *
+ * @return {*} The font-family field when the block opted in, otherwise `defaultEditor`.
+ */
+function fontFamilyEditor(defaultEditor, ctx) {
+	const write = writerFor(ctx);
+
+	if (!ctx.context?.blockName || !write) {
+		return defaultEditor;
+	}
+
+	return (
+		<FontFamilySelector
+			value={ctx.value}
+			favorites={favoriteFonts()}
+			catalogOptions={fontCatalogOptions()}
+			inheritedLabel={ctx.context?.inheritedDefault}
+			onPick={(family) => write(family)}
+			onClear={() => write('')}
 		/>
 	);
 }

--- a/src/extension/design-tokens/register-component-filters.js
+++ b/src/extension/design-tokens/register-component-filters.js
@@ -27,7 +27,7 @@
  */
 import { addFilter, removeFilter } from '@wordpress/hooks';
 import { pickableTokensForControl } from '../token-picker';
-import { favoriteFonts, fontCatalogOptions } from '../font-picker';
+import { favoriteFonts, favoriteFontsManageUrl, fontCatalogOptions } from '../font-picker';
 import { FontFamilySelector, TokenChip, TokenPickerButton, TokenSelector, isTokenAlias } from '../../token-controls';
 
 const NAMESPACE = 'kadence-blocks/component-token';
@@ -206,6 +206,7 @@ function fontFamilyEditor(defaultEditor, ctx) {
 			value={ctx.value}
 			favorites={favoriteFonts()}
 			catalogOptions={fontCatalogOptions()}
+			manageUrl={favoriteFontsManageUrl()}
 			inheritedLabel={ctx.context?.inheritedDefault}
 			onPick={(family) => write(family)}
 			onClear={() => write('')}


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4207/font-families-become-favorites-not-tokens
:video_camera:  https://www.loom.com/share/2cde91916171494694080f3b7beda6e9

Adds the `fontFamily` case to the design-token listener on `kadence.components.control.editor`, swapping the shared typography control's react-select for the Favorites/Custom picker.

It falls through to the control's own select whenever a block passes no `context`, so a block that has not opted in is untouched. It needs no `ADAPTERS` entry and never consults the pickable-token pool: the value is a plain family string and `index` is always null, because a favorite is not a token.

**Pin bump:** `package.json` and `bun.lock` point `@kadence/components` at https://github.com/stellarwp/kadence-components/pull/21, which adds the `controlEditor` seam this listens on. The lock moves that one package and nothing else. Once #21 merges, the pin goes back to `feature/design-tokens-module` and the lock is re-resolved — CI runs `bun install --frozen-lockfile`, so without that follow-up the seam would never fire.

The listener is inert without the seam — nothing in the old package ever calls `controlEditor` with `control: 'fontFamily'` — so the two belong together.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated font-family selector with favorites, catalog options, management links, and support for clearing selections.
  * Font-family settings now preserve plain font-family values and inherited labels.
* **Bug Fixes**
  * Improved fallback behavior when font-family controls are unavailable or not enabled.
* **Tests**
  * Added coverage for font-family selection, clearing, favorites, management links, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

