### PR TITLE
[DTM] SOFT-4207 [12/15]: wait for a web font before rendering in it

### DIFF
--- a/src/token-controls/__tests__/font-loading.test.js
+++ b/src/token-controls/__tests__/font-loading.test.js
@@ -1,0 +1,183 @@
+/* eslint-env jest */
+// cspell:ignore Abril Fatface .
+/**
+ * Tests for the font-readiness helper: the ordering that makes waiting meaningful, and the bounds
+ * that stop a caller waiting forever on a font that will never arrive.
+ */
+import { FONT_LOAD_TIMEOUT, ensureStylesheet, googleFontHref, loadFontFamily } from '../helpers/font-loading';
+
+/**
+ * Let every pending promise callback settle. The helper races and re-wraps its promises, so a fixed
+ * number of `await Promise.resolve()` ticks is a guess that breaks the moment a layer is added.
+ *
+ * @return {Promise<void>} Resolves once the queue has drained.
+ */
+function flush() {
+	return new Promise((resolve) => setImmediate(resolve));
+}
+
+/**
+ * Build a stand-in document whose `<link>` loads resolve when the test says so, and whose font set
+ * records what was asked for.
+ *
+ * @param {Object}  [options]
+ * @param {boolean} [options.fonts] Whether the document exposes a font set at all.
+ *
+ * @return {Object} The fake document plus the handles the tests drive it with.
+ */
+function fakeDoc({ fonts = true } = {}) {
+	const links = [];
+	const requested = [];
+	let resolveFace;
+
+	const doc = {
+		head: { appendChild: (link) => links.push(link) },
+		createElement: () => ({ rel: '', href: '', onload: null, onerror: null }),
+	};
+
+	if (fonts) {
+		doc.fonts = {
+			load: (spec) => {
+				requested.push(spec);
+				return new Promise((resolve) => {
+					resolveFace = resolve;
+				});
+			},
+		};
+	}
+
+	return {
+		doc,
+		links,
+		requested,
+		loadStylesheet: () => links[links.length - 1].onload(),
+		failStylesheet: () => links[links.length - 1].onerror(),
+		resolveFace: () => resolveFace(),
+	};
+}
+
+describe('googleFontHref', () => {
+	it('asks for the family at its default weight, with swap', () => {
+		expect(googleFontHref('Abril Fatface')).toBe(
+			'https://fonts.googleapis.com/css2?family=Abril%20Fatface&display=swap'
+		);
+	});
+});
+
+describe('ensureStylesheet', () => {
+	it('injects the stylesheet once per document and shares the wait', async () => {
+		const { doc, links, loadStylesheet } = fakeDoc();
+
+		const first = ensureStylesheet('https://example.test/a.css', doc);
+		const second = ensureStylesheet('https://example.test/a.css', doc);
+
+		expect(links).toHaveLength(1);
+		expect(first).toBe(second);
+
+		loadStylesheet();
+		await expect(first).resolves.toBeUndefined();
+	});
+
+	it('injects separately into a second document, since each has its own font set', async () => {
+		const a = fakeDoc();
+		const b = fakeDoc();
+
+		ensureStylesheet('https://example.test/b.css', a.doc);
+		ensureStylesheet('https://example.test/b.css', b.doc);
+
+		expect(a.links).toHaveLength(1);
+		expect(b.links).toHaveLength(1);
+	});
+
+	// A stylesheet that 404s must not strand the caller; the font simply will not be there.
+	it('resolves when the stylesheet fails rather than rejecting', async () => {
+		const { doc, failStylesheet } = fakeDoc();
+
+		const ready = ensureStylesheet('https://example.test/missing.css', doc);
+		failStylesheet();
+
+		await expect(ready).resolves.toBeUndefined();
+	});
+
+	it('resolves for a document with no head to inject into', async () => {
+		await expect(ensureStylesheet('https://example.test/c.css', {})).resolves.toBeUndefined();
+	});
+});
+
+describe('loadFontFamily', () => {
+	it('resolves immediately when no family is named', async () => {
+		const { doc, links } = fakeDoc();
+
+		await expect(loadFontFamily('', { doc })).resolves.toBeUndefined();
+		expect(links).toHaveLength(0);
+	});
+
+	// The ordering that makes the whole thing work: asking the font set before the stylesheet is
+	// parsed resolves against no faces and reports success while the font is still missing.
+	it('waits for the stylesheet before asking the font set', async () => {
+		const { doc, requested, loadStylesheet, resolveFace } = fakeDoc();
+
+		const ready = loadFontFamily('Inter', { doc, href: 'https://example.test/inter.css' });
+
+		await flush();
+		expect(requested).toEqual([]);
+
+		loadStylesheet();
+		await flush();
+
+		expect(requested).toEqual(['1em "Inter"']);
+
+		resolveFace();
+		await expect(ready).resolves.toBeUndefined();
+	});
+
+	it('skips injection for a family the document already has', async () => {
+		const { doc, links, requested, resolveFace } = fakeDoc();
+
+		const ready = loadFontFamily('Georgia', { doc });
+		await flush();
+
+		expect(links).toHaveLength(0);
+		expect(requested).toEqual(['1em "Georgia"']);
+
+		resolveFace();
+		await ready;
+	});
+
+	it('quotes the family so a multi-word name is one font-family', async () => {
+		const { doc, requested, resolveFace } = fakeDoc();
+
+		const ready = loadFontFamily('Abril Fatface', { doc });
+		await flush();
+
+		expect(requested).toEqual(['1em "Abril Fatface"']);
+
+		resolveFace();
+		await ready;
+	});
+
+	it('resolves for a document with no font set at all', async () => {
+		const { doc } = fakeDoc({ fonts: false });
+
+		await expect(loadFontFamily('Inter', { doc })).resolves.toBeUndefined();
+	});
+
+	// The caller is holding the user's pick until this settles, so it always has to settle.
+	it('gives up after the timeout when the face never arrives', async () => {
+		jest.useFakeTimers();
+
+		const { doc } = fakeDoc();
+		const ready = loadFontFamily('Inter', { doc, timeout: 50 });
+
+		await Promise.resolve();
+		jest.advanceTimersByTime(50);
+
+		await expect(ready).resolves.toBeUndefined();
+
+		jest.useRealTimers();
+	});
+
+	it('exposes a default timeout so callers need not pick one', () => {
+		expect(FONT_LOAD_TIMEOUT).toBeGreaterThan(0);
+	});
+});

--- a/src/token-controls/__tests__/font-loading.test.js
+++ b/src/token-controls/__tests__/font-loading.test.js
@@ -65,17 +65,20 @@ describe('googleFontHref', () => {
 });
 
 describe('ensureStylesheet', () => {
-	it('injects the stylesheet once per document and shares the wait', async () => {
+	// One injection, both waits satisfied by it. The promises are deliberately NOT the same object:
+	// each caller bounds the shared injection on its own clock.
+	it('injects the stylesheet once per document and satisfies every waiter', async () => {
 		const { doc, links, loadStylesheet } = fakeDoc();
 
 		const first = ensureStylesheet('https://example.test/a.css', doc);
 		const second = ensureStylesheet('https://example.test/a.css', doc);
 
 		expect(links).toHaveLength(1);
-		expect(first).toBe(second);
 
 		loadStylesheet();
+
 		await expect(first).resolves.toBeUndefined();
+		await expect(second).resolves.toBeUndefined();
 	});
 
 	it('injects separately into a second document, since each has its own font set', async () => {
@@ -97,6 +100,29 @@ describe('ensureStylesheet', () => {
 		failStylesheet();
 
 		await expect(ready).resolves.toBeUndefined();
+	});
+
+	// The regression that made the whole module pointless on a slow connection: one caller giving up
+	// must not tell every later caller the stylesheet has parsed.
+	it('makes a later caller keep waiting after an earlier one timed out', async () => {
+		const { doc, loadStylesheet } = fakeDoc();
+		const href = 'https://example.test/slow.css';
+
+		await ensureStylesheet(href, doc, 10);
+
+		let settled = false;
+		const second = ensureStylesheet(href, doc, 1000);
+		second.then(() => {
+			settled = true;
+		});
+
+		await flush();
+		expect(settled).toBe(false);
+
+		loadStylesheet();
+		await second;
+
+		expect(settled).toBe(true);
 	});
 
 	it('resolves for a document with no head to inject into', async () => {

--- a/src/token-controls/helpers/font-loading.js
+++ b/src/token-controls/helpers/font-loading.js
@@ -80,8 +80,9 @@ function bounded(promise, timeout) {
 /**
  * Inject a stylesheet into a document once, and resolve when it has been parsed.
  *
- * Repeat calls for the same href in the same document share the first call's promise, so two
- * controls asking for the same family neither inject twice nor wait independently.
+ * Repeat calls for the same URL in the same document share the first call's injection, so two
+ * controls asking for the same family never inject twice. Each still bounds the wait itself, so one
+ * caller giving up says nothing about whether the stylesheet has parsed.
  *
  * @param {string}   href      The stylesheet URL.
  * @param {Document} doc       The document to inject into.
@@ -102,25 +103,27 @@ export function ensureStylesheet(href, doc = document, timeout = FONT_LOAD_TIMEO
 
 	const sheets = injected.get(doc);
 
+	// What is cached is the link's own completion, never a bounded wait on it. Caching the bounded
+	// one would let a single caller's timeout stand in for the stylesheet having parsed: every later
+	// caller would get an already-resolved promise and go straight to `fonts.load()` against faces
+	// that still do not exist — the flash this module exists to prevent, on exactly the slow
+	// connection where it is most likely. Each caller bounds the shared promise for itself.
 	if (sheets.has(href)) {
-		return sheets.get(href);
+		return bounded(sheets.get(href), timeout);
 	}
 
-	const ready = bounded(
-		new Promise((resolve) => {
-			const link = doc.createElement('link');
-			link.rel = 'stylesheet';
-			link.href = href;
-			link.onload = resolve;
-			link.onerror = resolve;
-			doc.head.appendChild(link);
-		}),
-		timeout
-	);
+	const loaded = new Promise((resolve) => {
+		const link = doc.createElement('link');
+		link.rel = 'stylesheet';
+		link.href = href;
+		link.onload = resolve;
+		link.onerror = resolve;
+		doc.head.appendChild(link);
+	});
 
-	sheets.set(href, ready);
+	sheets.set(href, loaded);
 
-	return ready;
+	return bounded(loaded, timeout);
 }
 
 /**

--- a/src/token-controls/helpers/font-loading.js
+++ b/src/token-controls/helpers/font-loading.js
@@ -1,0 +1,159 @@
+/**
+ * Waiting for a web font to be usable before anything renders in it.
+ *
+ * Picking a font used to flash: the browser painted the fallback face immediately and swapped when
+ * the file arrived (`display=swap`), so every first pick of a family showed the wrong font for a
+ * moment. Loading the file earlier would only move the cost around — the fix is to keep showing what
+ * is already on screen until the new face is actually usable, then switch once.
+ *
+ * Two waits, in order, and the order is the part worth knowing:
+ *
+ * 1. **The stylesheet.** `fonts.load()` resolves against the faces the document currently knows. A
+ *    freshly injected `<link>` has not been parsed yet, so asking immediately resolves with no faces
+ *    and reports success while the font is still missing. The link's own `load` event is what says
+ *    the `@font-face` rules exist.
+ * 2. **The face.** Only then does `fonts.load()` fetch the file and resolve when it can be painted.
+ *
+ * Every wait is bounded. A font that never arrives — offline, a blocked request, a family Google
+ * does not serve — must not leave a caller waiting on a promise that never settles, because the
+ * caller is holding the user's pick until it resolves.
+ *
+ * Host-agnostic by taking the target document: the block editor canvas is an iframe with its own
+ * document and its own font set, and a stylesheet appended to the outer one styles nothing the user
+ * can see. Callers pass the document they render into; nothing here knows which host is asking.
+ */
+
+/**
+ * Injected stylesheet URLs, per document. A `WeakMap` rather than a module-level `Set` because the
+ * editor canvas is replaced on device switches — the entry for a discarded document goes with it,
+ * instead of claiming a stylesheet is present in a document that no longer exists.
+ *
+ * @since TBD
+ *
+ * @type {WeakMap<Document, Map<string, Promise<void>>>}
+ */
+const injected = new WeakMap();
+
+/**
+ * How long to wait on any single step before giving up and letting the caller proceed.
+ *
+ * @since TBD
+ *
+ * @type {number}
+ */
+export const FONT_LOAD_TIMEOUT = 3000;
+
+/**
+ * The Google Fonts stylesheet URL for a family, at its default weight.
+ *
+ * No axis is requested: both callers preview a family rather than a specific cut, and asking for a
+ * weight the family does not publish returns a 400 for the whole request.
+ *
+ * @param {string} family The family name.
+ *
+ * @since TBD
+ *
+ * @return {string} The stylesheet URL.
+ */
+export function googleFontHref(family) {
+	return `https://fonts.googleapis.com/css2?family=${encodeURIComponent(family)}&display=swap`;
+}
+
+/**
+ * Resolve when `promise` settles, or after `timeout` ms, whichever comes first. Never rejects: a
+ * font that fails to load is a font the caller renders without, not an error it has to handle.
+ *
+ * @param {Promise} promise The promise to bound.
+ * @param {number}  timeout Milliseconds to wait.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Settles either way.
+ */
+function bounded(promise, timeout) {
+	return Promise.race([
+		Promise.resolve(promise).catch(() => undefined),
+		new Promise((resolve) => setTimeout(resolve, timeout)),
+	]).then(() => undefined);
+}
+
+/**
+ * Inject a stylesheet into a document once, and resolve when it has been parsed.
+ *
+ * Repeat calls for the same href in the same document share the first call's promise, so two
+ * controls asking for the same family neither inject twice nor wait independently.
+ *
+ * @param {string}   href      The stylesheet URL.
+ * @param {Document} doc       The document to inject into.
+ * @param {number}   [timeout] Milliseconds to wait for the load event.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves once the stylesheet is parsed, or on timeout.
+ */
+export function ensureStylesheet(href, doc = document, timeout = FONT_LOAD_TIMEOUT) {
+	if (!doc?.head) {
+		return Promise.resolve();
+	}
+
+	if (!injected.has(doc)) {
+		injected.set(doc, new Map());
+	}
+
+	const sheets = injected.get(doc);
+
+	if (sheets.has(href)) {
+		return sheets.get(href);
+	}
+
+	const ready = bounded(
+		new Promise((resolve) => {
+			const link = doc.createElement('link');
+			link.rel = 'stylesheet';
+			link.href = href;
+			link.onload = resolve;
+			link.onerror = resolve;
+			doc.head.appendChild(link);
+		}),
+		timeout
+	);
+
+	sheets.set(href, ready);
+
+	return ready;
+}
+
+/**
+ * Resolve when a family is usable in a document: its stylesheet parsed and its face fetched.
+ *
+ * Resolves immediately for an empty family, and for a document with no font set (older browsers, and
+ * the jsdom the tests run in) — in both cases there is nothing to wait for, and blocking a pick on a
+ * capability the browser lacks would be worse than the flash this exists to prevent.
+ *
+ * @param {string}    family            The family name.
+ * @param {Object}    [options]
+ * @param {Document}  [options.doc]     The document that will render the font.
+ * @param {?string}   [options.href]    A stylesheet to inject first; omit for a family the document
+ *                                      already has (a system face, or one the site loads itself).
+ * @param {number}    [options.timeout] Milliseconds to wait for each step.
+ *
+ * @since TBD
+ *
+ * @return {Promise<void>} Resolves when the font is usable, or when waiting has gone on long enough.
+ */
+export async function loadFontFamily(family, { doc = document, href = null, timeout = FONT_LOAD_TIMEOUT } = {}) {
+	if (!family) {
+		return;
+	}
+
+	if (href) {
+		await ensureStylesheet(href, doc, timeout);
+	}
+
+	if (!doc?.fonts?.load) {
+		return;
+	}
+
+	// Quoted, so a multi-word family parses as one font-family rather than a list.
+	await bounded(doc.fonts.load(`1em "${family}"`), timeout);
+}

--- a/src/token-controls/index.js
+++ b/src/token-controls/index.js
@@ -28,6 +28,7 @@ export { BreakpointProvider, useBreakpoint } from './context/breakpoint';
 
 export { CATALOG_RENDER_CAP, filterCatalogOptions } from './helpers/catalog-filter';
 export { sameFamily } from './helpers/font-family';
+export { FONT_LOAD_TIMEOUT, ensureStylesheet, googleFontHref, loadFontFamily } from './helpers/font-loading';
 export { parseCssLength } from './helpers/parse-css-length';
 export {
 	KADENCE_TOKEN_NAMESPACE,


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4207/font-families-become-favorites-not-tokens
:video_camera:  https://www.loom.com/share/2cde91916171494694080f3b7beda6e9

Picking a font flashes: the browser paints the fallback face immediately and swaps when the file lands (`display=swap`), so a first pick of any family shows the wrong font for a moment. Loading earlier only moves the cost around. Keeping the current font on screen until the new face is usable, then switching once, is what removes it — at **no extra requests**, since it is the same single file.

Two waits, and the order is the whole point. `fonts.load()` resolves against the faces a document currently knows, so asking right after injecting a `<link>` resolves against none and reports success while the font is still missing. The link's own load event is what says the `@font-face` rules exist; only then is there anything to fetch.

Every wait is bounded. A caller holds the user's pick until this settles, so it always settles — offline, a blocked request, or a family Google does not serve ends in the font not being there, never in a promise that never resolves.

Takes the target document rather than assuming one: the editor canvas is an iframe with its own font set, and a stylesheet in the outer document styles nothing the user can see. Nothing here knows which host is asking.

Nothing consumes it yet.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added font-loading support that waits for stylesheets and font faces to be ready before rendering.
  * Added Google Fonts URL generation and shared stylesheet loading.
  * Added support for document-specific contexts, including iframes.
  * Added bounded handling for failed or delayed font loads without blocking rendering.

* **Tests**
  * Added comprehensive coverage for font loading, deduplication, timeouts, failures, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

