### PR TITLE
[DTM] SOFT-4207 [13/15]: hold a font pick until the face is ready

### DIFF
--- a/src/extension/design-tokens/__tests__/register-component-filters.test.js
+++ b/src/extension/design-tokens/__tests__/register-component-filters.test.js
@@ -376,7 +376,7 @@ describe('font-family seam', () => {
 	 *
 	 * @return {void}
 	 */
-	it('writes a plain family string on pick, and empty on clear', () => {
+	it('writes a plain family string on pick, and empty on clear', async () => {
 		const onChange = jest.fn();
 		const editor = applyFilters(EDITOR_HOOK, 'DEFAULT', {
 			control: 'fontFamily',
@@ -386,11 +386,36 @@ describe('font-family seam', () => {
 			context: { blockName: 'kadence/singlebtn' },
 		});
 
-		editor.props.onPick('Abril Fatface');
+		await editor.props.onPick('Abril Fatface');
 		expect(onChange).toHaveBeenCalledWith('Abril Fatface');
 
 		editor.props.onClear();
 		expect(onChange).toHaveBeenCalledWith('');
+	});
+
+	/**
+	 * The write waits on the font, which is the whole point: writing first would put the new family
+	 * on the canvas before the face existed, which is the flash this removes.
+	 *
+	 * @return {void}
+	 */
+	it('does not write until the font is ready', async () => {
+		const onChange = jest.fn();
+		const editor = applyFilters(EDITOR_HOOK, 'DEFAULT', {
+			control: 'fontFamily',
+			index: null,
+			value: '',
+			onChange,
+			context: { blockName: 'kadence/singlebtn' },
+		});
+
+		const pick = editor.props.onPick('Abril Fatface');
+
+		expect(onChange).not.toHaveBeenCalled();
+
+		await pick;
+
+		expect(onChange).toHaveBeenCalledWith('Abril Fatface');
 	});
 
 	/**

--- a/src/extension/design-tokens/register-component-filters.js
+++ b/src/extension/design-tokens/register-component-filters.js
@@ -27,8 +27,16 @@
  */
 import { addFilter, removeFilter } from '@wordpress/hooks';
 import { pickableTokensForControl } from '../token-picker';
-import { favoriteFonts, favoriteFontsManageUrl, fontCatalogOptions } from '../font-picker';
-import { FontFamilySelector, TokenChip, TokenPickerButton, TokenSelector, isTokenAlias } from '../../token-controls';
+import { favoriteFonts, favoriteFontsManageUrl, fontCatalogOptions, isGoogleFamily } from '../font-picker';
+import {
+	FontFamilySelector,
+	TokenChip,
+	TokenPickerButton,
+	TokenSelector,
+	googleFontHref,
+	isTokenAlias,
+	loadFontFamily,
+} from '../../token-controls';
 
 const NAMESPACE = 'kadence-blocks/component-token';
 const EDITOR_HOOK = 'kadence.components.control.editor';
@@ -187,6 +195,10 @@ function editorFilter(defaultEditor, ctx) {
  * Falls back to the control's own select when the block passes no `context`, which is how a block
  * that has not opted in keeps the react-select it has always had.
  *
+ * A pick waits for its web font before writing, so the canvas switches straight from the old face to
+ * the new one instead of flashing a fallback in between. The field shows the pending family with a
+ * spinner while that happens; the wait is bounded, so a font that never arrives still writes.
+ *
  * @param {*}      defaultEditor The control's own select node.
  * @param {Object} ctx           Neutral seam context: { control, index, value, onChange, context }.
  *
@@ -208,10 +220,29 @@ function fontFamilyEditor(defaultEditor, ctx) {
 			catalogOptions={fontCatalogOptions()}
 			manageUrl={favoriteFontsManageUrl()}
 			inheritedLabel={ctx.context?.inheritedDefault}
-			onPick={(family) => write(family)}
+			onPick={async (family) => {
+				await loadFontFamily(family, {
+					doc: canvasDocument(),
+					href: isGoogleFamily(family) ? googleFontHref(family) : null,
+				});
+
+				write(family);
+			}}
 			onClear={() => write('')}
 		/>
 	);
+}
+
+/**
+ * The document the block canvas renders into: its own once the editor is iframed, the page's
+ * otherwise. A font loaded into the wrong one is a font the user never sees.
+ *
+ * @since TBD
+ *
+ * @return {Document} The canvas document.
+ */
+function canvasDocument() {
+	return window.frames?.['editor-canvas']?.document || document;
 }
 
 /**

--- a/src/extension/font-picker/__tests__/index.test.js
+++ b/src/extension/font-picker/__tests__/index.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 // cspell:ignore Abril Fatface .
-import { favoriteFonts, favoriteFontsManageUrl, fontCatalogOptions } from '../index';
+import { favoriteFonts, favoriteFontsManageUrl, fontCatalogOptions, isGoogleFamily } from '../index';
 
 const originalFonts = window.kadenceDesignTokensFonts;
 const originalParams = window.kadence_blocks_params;
@@ -91,5 +91,30 @@ describe('favoriteFontsManageUrl', () => {
 
 		window.kadenceDesignTokensFonts = { manageUrl: 42 };
 		expect(favoriteFontsManageUrl()).toBe('');
+	});
+});
+
+describe('isGoogleFamily', () => {
+	beforeEach(() => {
+		window.kadence_blocks_params = { g_font_names: ['Abril Fatface', 'Inter'] };
+	});
+
+	it('recognizes a catalog family, case-insensitively', () => {
+		expect(isGoogleFamily('Abril Fatface')).toBe(true);
+		expect(isGoogleFamily('abril fatface')).toBe(true);
+	});
+
+	// A system face and a site custom font are already in the document; asking Google for either
+	// returns a 400 for a font the browser could have painted anyway.
+	it('rejects a family Google does not serve', () => {
+		expect(isGoogleFamily('Georgia')).toBe(false);
+		expect(isGoogleFamily('')).toBe(false);
+		expect(isGoogleFamily(undefined)).toBe(false);
+	});
+
+	it('rejects everything when the editor global is missing', () => {
+		delete window.kadence_blocks_params;
+
+		expect(isGoogleFamily('Inter')).toBe(false);
 	});
 });

--- a/src/extension/font-picker/index.js
+++ b/src/extension/font-picker/index.js
@@ -141,3 +141,21 @@ export function fontCatalogOptions() {
 export function favoriteFontsManageUrl() {
 	return fontPool().manageUrl;
 }
+
+/**
+ * Whether a family is one Google serves, and so one a stylesheet has to be fetched for.
+ *
+ * A system face and a site-registered custom font are both already present in the document — asking
+ * Google for either returns a 400 for a font the browser could have painted all along.
+ *
+ * @param {string} family The family name.
+ *
+ * @since TBD
+ *
+ * @return {boolean} Whether to fetch it from Google.
+ */
+export function isGoogleFamily(family) {
+	const name = String(family ?? '').trim();
+
+	return name !== '' && googleNames().some((candidate) => candidate.toLowerCase() === name.toLowerCase());
+}

--- a/src/token-controls/__tests__/font-family-selector.test.js
+++ b/src/token-controls/__tests__/font-family-selector.test.js
@@ -26,6 +26,7 @@ jest.mock('@wordpress/components', () => ({
 			{renderContent({ onClose: () => {} })}
 		</>
 	),
+	Spinner: () => <span className="components-spinner" />,
 	Tooltip: ({ children }) => children,
 }));
 
@@ -206,6 +207,73 @@ describe('FontFamilySelector initial tab', () => {
 		renderSelector({ value: 'Abril Fatface', favorites: ['Inter'] });
 
 		expect(popoverProps.initialTab).toBe('custom');
+	});
+});
+
+describe('FontFamilySelector pending pick', () => {
+	/**
+	 * A host that fetches the web font before writing leaves the old family on screen meanwhile, so
+	 * the field names the family it is fetching instead of looking like the click did nothing.
+	 *
+	 * @return {void}
+	 */
+	it('names the family it is waiting on', async () => {
+		let settle;
+		const onPick = jest.fn(() => new Promise((resolve) => (settle = resolve)));
+
+		renderSelector({ value: 'Inter', onPick });
+
+		await act(async () => {
+			popoverProps.onPick('Abril Fatface');
+		});
+
+		const trigger = container.querySelector('.kadence-token-field__trigger');
+
+		expect(trigger.querySelector('.kadence-token-field__value--pending').textContent).toContain('Abril Fatface');
+
+		await act(async () => settle());
+	});
+
+	/**
+	 * Picking again while a pick is in flight would let the slower of the two settle last and write
+	 * the family the user moved off. The trigger is the only way back into the popover, so holding it
+	 * shut for the length of the wait is what keeps the picks ordered.
+	 *
+	 * @return {void}
+	 */
+	it('holds the trigger shut until the pick settles', async () => {
+		let settle;
+		const onPick = jest.fn(() => new Promise((resolve) => (settle = resolve)));
+
+		renderSelector({ value: 'Inter', onPick });
+
+		await act(async () => {
+			popoverProps.onPick('Abril Fatface');
+		});
+
+		expect(container.querySelector('.kadence-token-field__trigger').disabled).toBe(true);
+
+		await act(async () => settle());
+
+		expect(container.querySelector('.kadence-token-field__trigger').disabled).toBe(false);
+	});
+
+	/**
+	 * A pick whose host rejects still has to give the field back, or one failed fetch would leave the
+	 * control unusable for the rest of the session.
+	 *
+	 * @return {void}
+	 */
+	it('re-opens the trigger when the pick rejects', async () => {
+		const onPick = jest.fn(() => Promise.reject(new Error('offline')));
+
+		renderSelector({ value: 'Inter', onPick });
+
+		await act(async () => {
+			await popoverProps.onPick('Abril Fatface').catch(() => {});
+		});
+
+		expect(container.querySelector('.kadence-token-field__trigger').disabled).toBe(false);
 	});
 });
 

--- a/src/token-controls/organisms/FontFamilySelector.js
+++ b/src/token-controls/organisms/FontFamilySelector.js
@@ -60,7 +60,9 @@ export function FontFamilySelector({
 }) {
 	// The family a pick is still waiting on. A host that fetches the web font before writing keeps
 	// the current font on screen meanwhile, so without this the field would look like the click did
-	// nothing for as long as the download takes.
+	// nothing for as long as the download takes. It also holds the trigger shut until the pick
+	// settles: picking a second family while the first is in flight would let the slower of the two
+	// write last and leave the field on the family the user moved off.
 	const [pending, setPending] = useState('');
 
 	const handlePick = async (picked) => {
@@ -102,7 +104,7 @@ export function FontFamilySelector({
 					<Button
 						className="kadence-token-field__trigger"
 						onClick={onToggle}
-						disabled={disabled}
+						disabled={disabled || pending !== ''}
 						aria-expanded={isOpen}
 						label={pending || triggerName}
 						showTooltip

--- a/src/token-controls/organisms/FontFamilySelector.js
+++ b/src/token-controls/organisms/FontFamilySelector.js
@@ -11,7 +11,8 @@
 /**
  * WordPress dependencies
  */
-import { Button, Dropdown } from '@wordpress/components';
+import { Button, Dropdown, Spinner } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -35,7 +36,8 @@ import '../styles/token-controls.scss';
  * @param {Array}    [props.catalogOptions] The full catalog option list (`{ value, label, badge? }`).
  * @param {string}   [props.inheritedLabel] What an unset family falls back to, for the muted trigger.
  * @param {string}   [props.manageUrl]      Deep link to the screen that manages favorites.
- * @param {Function} props.onPick           Writes a chosen family.
+ * @param {Function} props.onPick           Writes a chosen family. May return a promise, in which
+ *                                          case the field reads as loading until it settles.
  * @param {Function} props.onClear          Clears the family back to the theme's.
  * @param {boolean}  [props.disabled]       Disable the trigger. It is the only control outside the
  *                                          popover, so with it inert nothing below is reachable —
@@ -56,6 +58,21 @@ export function FontFamilySelector({
 	onClear,
 	disabled = false,
 }) {
+	// The family a pick is still waiting on. A host that fetches the web font before writing keeps
+	// the current font on screen meanwhile, so without this the field would look like the click did
+	// nothing for as long as the download takes.
+	const [pending, setPending] = useState('');
+
+	const handlePick = async (picked) => {
+		setPending(picked);
+
+		try {
+			await onPick(picked);
+		} finally {
+			setPending('');
+		}
+	};
+
 	const family = typeof value === 'string' ? value : '';
 	const unset = family === '';
 	const isFavorite = favorites.some((entry) => sameFamily(entry, family));
@@ -87,10 +104,15 @@ export function FontFamilySelector({
 						onClick={onToggle}
 						disabled={disabled}
 						aria-expanded={isOpen}
-						label={triggerName}
+						label={pending || triggerName}
 						showTooltip
 					>
-						{unset ? (
+						{pending ? (
+							<span className="kadence-token-field__value kadence-token-field__value--pending">
+								<Spinner />
+								{pending}
+							</span>
+						) : unset ? (
 							<span className="kadence-token-field__value kadence-token-field__label--default">
 								{fallback}
 							</span>
@@ -108,7 +130,7 @@ export function FontFamilySelector({
 						catalogOptions={catalogOptions}
 						initialTab={initialTab}
 						manageUrl={manageUrl}
-						onPick={onPick}
+						onPick={handlePick}
 						onClear={onClear}
 						onClose={onClose}
 					/>

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -222,6 +222,19 @@
 	font-size: 13px;
 }
 
+// A pick that is still fetching its web font: the family it will become, beside a spinner, so the
+// wait reads as loading rather than as the click having missed.
+.kadence-token-field__value--pending {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	color: #949494;
+
+	.components-spinner {
+		margin: 0;
+	}
+}
+
 .kadence-token-field__search {
 	flex: 0 0 auto;
 	margin-bottom: 4px;


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4207/font-families-become-favorites-not-tokens
:video_camera:  https://www.loom.com/share/2cde91916171494694080f3b7beda6e9

A pick now fetches its web font before writing the family, so the canvas switches straight from the old face to the new one instead of flashing a fallback in between. The field shows the pending family beside a spinner while that happens, so the wait reads as loading rather than as the click having missed.

**Only the picked font is fetched.** Nothing preloads the favorites or previews a catalog row, so the request count is unchanged — one file per family ever chosen, cached after that, which is why a second pick of the same font is already instant.

The stylesheet goes into the canvas document, which is its own once the editor is iframed; a font loaded into the outer document is one the user never sees. `isGoogleFamily` gates the fetch, because a system face and a site-registered custom font are already in the document and asking Google for either returns a 400 for a font the browser could have painted anyway.

The wait is bounded by the helper, so an offline or blocked request still writes the family — a pick is never lost to a font that will not arrive.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading selected web fonts before applying them.
  * Font selections now display a pending state with the chosen family and a spinner.
  * Added fallback behavior so font selections are applied if loading takes too long.

* **Bug Fixes**
  * Improved recognition of Google font families, including case-insensitive matching.
  * Pending font selections now clear correctly after successful or failed loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

