### PR TITLE
[DTM] SOFT-4207 [14/15]: hold the sample on its font until the next loads

### DIFF
--- a/src/style-library/__tests__/use-google-font-loader.test.js
+++ b/src/style-library/__tests__/use-google-font-loader.test.js
@@ -1,0 +1,168 @@
+/* eslint-env jest */
+// cspell:ignore Abril Fatface .
+/**
+ * External dependencies
+ */
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { useGoogleFontLoader } from '../hooks/use-google-font-loader';
+import * as tokenControls from '../../token-controls';
+import * as typography from '../helpers/typography';
+
+// A factory rather than bare automocking: the barrel pulls in every control's JSX and `.scss`
+// chain, and this hook only reaches two pure functions inside it.
+jest.mock('../../token-controls', () => ({
+	googleFontHref: jest.fn((family) => `https://fonts.googleapis.com/css2?family=${family}`),
+	loadFontFamily: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../helpers/typography', () => ({
+	getFontCatalog: jest.fn(() => ({ google: [], custom: [] })),
+}));
+
+let container;
+let root;
+
+beforeEach(() => {
+	jest.clearAllMocks();
+	tokenControls.loadFontFamily.mockImplementation(() => Promise.resolve());
+	typography.getFontCatalog.mockImplementation(() => ({ google: ['Inter', 'Abril Fatface'], custom: ['My Font'] }));
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+/**
+ * Mount the hook behind a probe, so each render's return value can be read directly.
+ *
+ * @since TBD
+ *
+ * @return {{render: Function, latest: Function}} The probe's renderer and its last result.
+ */
+function mountProbe() {
+	let latest = null;
+
+	function Probe({ familyName }) {
+		latest = useGoogleFontLoader(familyName);
+		return null;
+	}
+
+	return {
+		render: async (familyName) => {
+			await act(async () => root.render(<Probe familyName={familyName} />));
+		},
+		latest: () => latest,
+	};
+}
+
+describe('useGoogleFontLoader', () => {
+	// The sample renders from what this returns, not from the selection, so reporting a family before
+	// its file is usable is what would put the fallback face on screen -- the flash the hook exists to
+	// prevent.
+	it('reports no ready family until the font has loaded', async () => {
+		let settle;
+		tokenControls.loadFontFamily.mockImplementation(() => new Promise((resolve) => (settle = resolve)));
+
+		const probe = mountProbe();
+		await probe.render('Inter');
+
+		expect(probe.latest().readyFamily).toBe('');
+		expect(probe.latest().isLoading).toBe(true);
+
+		await act(async () => settle());
+
+		expect(probe.latest().readyFamily).toBe('Inter');
+		expect(probe.latest().isLoading).toBe(false);
+	});
+
+	it('asks Google for a catalog family', async () => {
+		const probe = mountProbe();
+		await probe.render('Abril Fatface');
+
+		expect(tokenControls.googleFontHref).toHaveBeenCalledWith('Abril Fatface');
+		expect(tokenControls.loadFontFamily).toHaveBeenCalledWith('Abril Fatface', {
+			href: 'https://fonts.googleapis.com/css2?family=Abril Fatface',
+		});
+	});
+
+	// A system face and a site custom font are already in the document; asking Google for either
+	// returns a 400 for a font the browser could have painted all along.
+	it.each(['Georgia', 'My Font'])('does not ask Google for %p', async (family) => {
+		const probe = mountProbe();
+		await probe.render(family);
+
+		expect(tokenControls.googleFontHref).not.toHaveBeenCalled();
+		expect(tokenControls.loadFontFamily).toHaveBeenCalledWith(family, { href: null });
+	});
+
+	// Nothing selected is not a font to wait for, so the screen must not read as loading forever.
+	it('reports nothing ready and nothing loading with no selection', async () => {
+		const probe = mountProbe();
+		await probe.render('');
+
+		expect(probe.latest()).toEqual({ readyFamily: '', isLoading: false });
+		expect(tokenControls.loadFontFamily).not.toHaveBeenCalled();
+	});
+
+	it('clears the ready family when the selection is cleared', async () => {
+		const probe = mountProbe();
+		await probe.render('Inter');
+
+		expect(probe.latest().readyFamily).toBe('Inter');
+
+		await probe.render('');
+
+		expect(probe.latest().readyFamily).toBe('');
+	});
+
+	// The whole point of holding the preview: while the next font loads, the sample keeps painting in
+	// the one already on screen rather than dropping to the fallback.
+	it('holds the previous family while the next one loads', async () => {
+		const probe = mountProbe();
+		await probe.render('Inter');
+
+		let settle;
+		tokenControls.loadFontFamily.mockImplementation(() => new Promise((resolve) => (settle = resolve)));
+
+		await probe.render('Abril Fatface');
+
+		expect(probe.latest().readyFamily).toBe('Inter');
+		expect(probe.latest().isLoading).toBe(true);
+
+		await act(async () => settle());
+
+		expect(probe.latest().readyFamily).toBe('Abril Fatface');
+	});
+
+	// A faster switch made while a slower one is still in flight already owns the preview; the late
+	// resolver must not drag it back to the font the user has moved off.
+	it('ignores a pick that settles after a later one', async () => {
+		const settlers = {};
+		tokenControls.loadFontFamily.mockImplementation(
+			(family) => new Promise((resolve) => (settlers[family] = resolve))
+		);
+
+		const probe = mountProbe();
+		await probe.render('Inter');
+		await probe.render('Abril Fatface');
+
+		await act(async () => settlers['Abril Fatface']());
+
+		expect(probe.latest().readyFamily).toBe('Abril Fatface');
+
+		await act(async () => settlers.Inter());
+
+		expect(probe.latest().readyFamily).toBe('Abril Fatface');
+	});
+});

--- a/src/style-library/components/pages/TypographyScreen.js
+++ b/src/style-library/components/pages/TypographyScreen.js
@@ -20,7 +20,7 @@
  */
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button, Notice } from '@wordpress/components';
+import { Button, Notice, Spinner } from '@wordpress/components';
 import { starEmpty, starFilled } from '@wordpress/icons';
 
 /**
@@ -134,6 +134,7 @@ function buildCatalogOptions(fonts) {
  * @param {{type: ('add'|'remove'), disabled: boolean, font: ?Object}} args.fontAction The contextual button's state ({@see fontActionFor}).
  * @param {Function}                                             args.onFontAction    Invokes the add- or remove-favorite flow for the current `fontAction`.
  * @param {boolean}                                              args.fontBusy        Whether a favorite request is in flight.
+ * @param {boolean}                                              args.fontLoading     Whether the selected font is still being fetched.
  * @param {?{message: string}}                                   args.fontError       The current favorite-write error, if any.
  * @param {Function}                                             args.onClearFontError Dismisses `fontError`.
  *
@@ -148,6 +149,7 @@ function typographyToolbarRenderer({
 	fontAction,
 	onFontAction,
 	fontBusy,
+	fontLoading,
 	fontError,
 	onClearFontError,
 }) {
@@ -165,6 +167,7 @@ function typographyToolbarRenderer({
 					<div className="kadence-blocks-style-library__typography-font-selector">
 						<span className="kadence-blocks-style-library__typography-font-label">
 							{__('Font', 'kadence-blocks')}
+							{fontLoading && <Spinner />}
 						</span>
 						<div className="kadence-blocks-style-library__typography-font-picker">
 							<SearchableSelectDropdown
@@ -267,7 +270,9 @@ export function TypographyScreen(props) {
 		}
 	}, [fonts, selectedFamily]);
 
-	useGoogleFontLoader(selectedFamily);
+	// The sample renders from the family that is READY, not the one selected: switching fonts holds
+	// the previous face until the new one can be painted instead of flashing the fallback.
+	const { readyFamily, isLoading: fontLoading } = useGoogleFontLoader(selectedFamily);
 
 	const fontAction = fontActionFor(fonts, selectedFamily);
 
@@ -300,7 +305,7 @@ export function TypographyScreen(props) {
 	const config = useMemo(
 		() => ({
 			...TYPOGRAPHY_CONFIG,
-			renderPreview: samplePreviewRenderer(familyStack(selectedFamily)),
+			renderPreview: samplePreviewRenderer(familyStack(readyFamily)),
 			renderToolbar: typographyToolbarRenderer({
 				catalogOptions,
 				dropdownValue: selectedFamily,
@@ -308,11 +313,12 @@ export function TypographyScreen(props) {
 				fontAction,
 				onFontAction: handleFontAction,
 				fontBusy,
+				fontLoading,
 				fontError,
 				onClearFontError: () => setFontError(null),
 			}),
 		}),
-		[selectedFamily, catalogOptions, fontAction, handleFontAction, fontBusy, fontError]
+		[selectedFamily, readyFamily, catalogOptions, fontAction, handleFontAction, fontBusy, fontLoading, fontError]
 	);
 
 	return <ScaleScreen config={config} {...props} />;

--- a/src/style-library/components/pages/TypographyScreen.scss
+++ b/src/style-library/components/pages/TypographyScreen.scss
@@ -75,6 +75,16 @@
 
 .kadence-blocks-style-library__typography-font-label {
 	@include small-uppercase-label;
+
+	// The spinner sits beside the label while the selected face is being fetched, so the sample
+	// holding its previous font reads as loading rather than as the pick not having registered.
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+
+	.components-spinner {
+		margin: 0;
+	}
 }
 
 // The catalog dropdown and its contextual Add/Remove Favorite button sit side by side, beneath the

--- a/src/style-library/hooks/use-google-font-loader.js
+++ b/src/style-library/hooks/use-google-font-loader.js
@@ -1,66 +1,67 @@
 /**
- * Loads the currently previewed Google font's stylesheet into the page, so the Typography
- * screen's sample text renders in the real face instead of the `system-ui` fallback. Nothing loads
- * font files on the Style Library page otherwise — verified: zero `fonts.googleapis` references
- * under `src/` outside a vendored player — so even the shipped baseline "Inter" preview would
- * silently fall back without this.
+ * Resolves the currently previewed font, so the Typography screen's sample text renders in the real
+ * face instead of the `system-ui` fallback. Nothing else on the Style Library page loads font files.
  *
- * System families (e.g. Georgia, Menlo) are not in the Google catalog and are skipped by
- * construction (the catalog-membership check below). Custom fonts are also skipped: the
- * names-only custom-fonts filter carries no file URLs, so loading them is the custom-font
- * provider's job, not this hook's — a custom preview renders correctly only when the site already
- * loads those files in wp-admin.
+ * Returns the family only once it is actually usable. The sample renders from that, not from the
+ * selection, so switching fonts holds the previous face until the new one can be painted rather than
+ * flashing the fallback in between — the same wait the block editor's picker makes, through the same
+ * shared helper.
+ *
+ * System families (e.g. Georgia, Menlo) are not in the Google catalog and are never fetched: they are
+ * already present, so they resolve as ready immediately. Custom fonts are not fetched either — the
+ * names-only custom-fonts filter carries no file URLs, so loading them is the custom-font provider's
+ * job, and a custom preview renders correctly only when the site already loads those files in
+ * wp-admin.
  */
 
 /**
  * WordPress dependencies
  */
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
+import { googleFontHref, loadFontFamily } from '../../token-controls';
 import { getFontCatalog } from '../helpers/typography';
 
 /**
- * Every family name a `<link>` has already been injected for, across the whole page's lifetime —
- * module-scoped (not component state) so switching the preview font back and forth never injects a
- * duplicate stylesheet, and a link is never removed once added (browser-cached, cheap to keep).
+ * Wait for a family to become usable, and report which one the page may render in.
+ *
+ * @param {string} familyName The selected font's family (`fontOptions()`'s `label`), or an empty
+ *                             string when nothing is selected yet.
  *
  * @since TBD
  *
- * @type {Set<string>}
- */
-const loadedFamilies = new Set();
-
-/**
- * Inject a Google Fonts stylesheet `<link>` for `familyName`, once, when that family is in the
- * Google catalog.
- *
- * @param {string} familyName The currently previewed font's first family (`fontOptions()`'s
- *                             `label`), or an empty string when nothing is selected yet.
- *
- * @since TBD
- *
- * @return {void}
+ * @return {{readyFamily: string, isLoading: boolean}} The family safe to render in, and whether a
+ *         different one is still being fetched.
  */
 export function useGoogleFontLoader(familyName) {
+	const [readyFamily, setReadyFamily] = useState('');
+
 	useEffect(() => {
-		if (!familyName || loadedFamilies.has(familyName)) {
+		if (!familyName) {
+			setReadyFamily('');
+
 			return;
 		}
 
+		let current = true;
 		const { google } = getFontCatalog();
+		const href = google.includes(familyName) ? googleFontHref(familyName) : null;
 
-		if (!google.includes(familyName)) {
-			return;
-		}
+		loadFontFamily(familyName, { href }).then(() => {
+			// A faster switch while this one was in flight already owns the preview; resolving late
+			// must not drag it back to the font the user has since moved off.
+			if (current) {
+				setReadyFamily(familyName);
+			}
+		});
 
-		loadedFamilies.add(familyName);
-
-		const link = document.createElement('link');
-		link.rel = 'stylesheet';
-		link.href = `https://fonts.googleapis.com/css2?family=${encodeURIComponent(familyName)}&display=swap`;
-		document.head.appendChild(link);
+		return () => {
+			current = false;
+		};
 	}, [familyName]);
+
+	return { readyFamily, isLoading: Boolean(familyName) && readyFamily !== familyName };
 }


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4207/font-families-become-favorites-not-tokens
:video_camera:  https://www.loom.com/share/2cde91916171494694080f3b7beda6e9

The Typography screen's sample now renders from the family that is READY, not the one selected, so flipping through fonts holds the previous face until the new one can be painted instead of flashing the fallback between every pick. A spinner beside the FONT label says which state it is in, so the sample keeping its old font reads as loading rather than as the pick not registering.

`useGoogleFontLoader` returns that readiness instead of only injecting a link, and gets the waiting itself from the shared helper — the same one the block editor's picker uses, so the two screens cannot end up disagreeing about when a font is safe to render in.

A late resolution cannot drag the preview backwards: a faster switch made while one was in flight already owns the sample, and the stale one is dropped.

System and custom families are still never fetched. They are already present, so they resolve as ready immediately and the sample switches to them with no wait at all.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading feedback when selecting a typography font.
  * Keeps the last usable font visible while a newly selected font loads.
  * Supports smoother switching between Google, system, and custom fonts.

* **Style**
  * Improved typography labels and loading indicator alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

