### PR TITLE
[DTM] SOFT-4212: compare metadata saves against the client's version

### DIFF
--- a/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Documents_Controller.php
@@ -1078,7 +1078,8 @@ final class Documents_Controller extends Controller {
 			return $this->unknown_token( $id );
 		}
 
-		$error = $this->guard_client_version( $slug, Cast::to_string( $request->get_param( self::VERSION_PARAM ) ) );
+		$client_version = Cast::to_string( $request->get_param( self::VERSION_PARAM ) );
+		$error          = $this->guard_client_version( $slug, $client_version );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
@@ -1087,7 +1088,7 @@ final class Documents_Controller extends Controller {
 		$stored = $this->store->get_decoded_document( $slug );
 
 		if ( $label === '' ) {
-			return $this->persist_label_clear( $stored, $slug, $id );
+			return $this->persist_label_clear( $stored, $slug, $id, $client_version );
 		}
 
 		if ( $this->user_primitive_index->has( $stored, $id ) ) {
@@ -1097,7 +1098,7 @@ final class Documents_Controller extends Controller {
 			$candidate = $this->label_index->set( $stored, $id, $label );
 		}
 
-		return $this->persist_metadata_candidate( $candidate, $slug );
+		return $this->persist_metadata_candidate( $candidate, $slug, $client_version );
 	}
 
 	/**
@@ -1123,13 +1124,14 @@ final class Documents_Controller extends Controller {
 			return $this->unknown_token( $id );
 		}
 
-		$error = $this->guard_client_version( $slug, Cast::to_string( $request->get_param( self::VERSION_PARAM ) ) );
+		$client_version = Cast::to_string( $request->get_param( self::VERSION_PARAM ) );
+		$error          = $this->guard_client_version( $slug, $client_version );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
 		}
 
-		return $this->persist_label_clear( $this->store->get_decoded_document( $slug ), $slug, $id );
+		return $this->persist_label_clear( $this->store->get_decoded_document( $slug ), $slug, $id, $client_version );
 	}
 
 	/**
@@ -1162,7 +1164,8 @@ final class Documents_Controller extends Controller {
 			return $this->unknown_group( $group );
 		}
 
-		$error = $this->guard_client_version( $slug, Cast::to_string( $request->get_param( self::VERSION_PARAM ) ) );
+		$client_version = Cast::to_string( $request->get_param( self::VERSION_PARAM ) );
+		$error          = $this->guard_client_version( $slug, $client_version );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
@@ -1177,7 +1180,7 @@ final class Documents_Controller extends Controller {
 			? $this->order_index->remove_group( $stored, $group_ids )
 			: $this->order_index->set_group( $stored, $group_ids, $ids );
 
-		return $this->persist_metadata_candidate( $candidate, $slug );
+		return $this->persist_metadata_candidate( $candidate, $slug, $client_version );
 	}
 
 	/**
@@ -1205,7 +1208,8 @@ final class Documents_Controller extends Controller {
 			return $this->unknown_group( $group );
 		}
 
-		$error = $this->guard_client_version( $slug, Cast::to_string( $request->get_param( self::VERSION_PARAM ) ) );
+		$client_version = Cast::to_string( $request->get_param( self::VERSION_PARAM ) );
+		$error          = $this->guard_client_version( $slug, $client_version );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
@@ -1219,7 +1223,7 @@ final class Documents_Controller extends Controller {
 			return new WP_REST_Response( $this->prepare_item( $slug ), WP_Http::OK );
 		}
 
-		return $this->persist_metadata_candidate( $candidate, $slug );
+		return $this->persist_metadata_candidate( $candidate, $slug, $client_version );
 	}
 
 	/**
@@ -1568,15 +1572,24 @@ final class Documents_Controller extends Controller {
 	 * either). The section is still validated whenever the full document is (bulk POST/PATCH/PUT),
 	 * via its validator branch.
 	 *
+	 * The conditional save compares against the version the CLIENT was accepted on, never a freshly
+	 * read one. Re-reading here would reopen the window the version guard exists to close: another
+	 * write landing between the guard and this call would move the stored version, the compare would
+	 * match that new value, and this write would overwrite the other one and report success. Passing
+	 * the guarded version through means such a write loses the compare and returns 409 instead.
+	 * Required rather than defaulted, so a caller that has not been updated fails loudly rather than
+	 * silently keeping the old behavior.
+	 *
 	 * @since TBD
 	 *
-	 * @param array<string, mixed> $candidate The candidate document with the metadata edit applied.
-	 * @param string               $slug      The token library slug.
+	 * @param array<string, mixed> $candidate      The candidate document with the metadata edit applied.
+	 * @param string               $slug           The token library slug.
+	 * @param string               $client_version The version {@see guard_client_version()} accepted.
 	 *
 	 * @return WP_REST_Response|WP_Error
 	 */
-	private function persist_metadata_candidate( array $candidate, string $slug ) {
-		$expected_version = $this->store->get_version( $slug );
+	private function persist_metadata_candidate( array $candidate, string $slug, string $client_version ) {
+		$expected_version = $client_version;
 		$status           = $expected_version !== '' ? WP_Http::OK : WP_Http::CREATED;
 
 		if ( $candidate === [] ) {
@@ -1609,13 +1622,14 @@ final class Documents_Controller extends Controller {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, mixed> $stored The stored document to clear the override from.
-	 * @param string               $slug   The token library slug.
-	 * @param string               $id     The token id.
+	 * @param array<string, mixed> $stored         The stored document to clear the override from.
+	 * @param string               $slug           The token library slug.
+	 * @param string               $id             The token id.
+	 * @param string               $client_version The version {@see guard_client_version()} accepted.
 	 *
 	 * @return WP_REST_Response|WP_Error
 	 */
-	private function persist_label_clear( array $stored, string $slug, string $id ) {
+	private function persist_label_clear( array $stored, string $slug, string $id, string $client_version ) {
 		if ( $this->user_primitive_index->has( $stored, $id ) ) {
 			$candidate = $this->user_primitive_index->add( $stored, $id, '' );
 		} else {
@@ -1626,7 +1640,7 @@ final class Documents_Controller extends Controller {
 			return new WP_REST_Response( $this->prepare_item( $slug ), WP_Http::OK );
 		}
 
-		return $this->persist_metadata_candidate( $candidate, $slug );
+		return $this->persist_metadata_candidate( $candidate, $slug, $client_version );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerLabelsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerLabelsTest.php
@@ -10,6 +10,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\User_Primitive_Registrar;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Documents_Controller;
+use ReflectionMethod;
 use Tests\Support\Classes\TestCase;
 use WP_Error;
 use WP_Http;
@@ -475,5 +476,75 @@ final class DocumentsControllerLabelsTest extends TestCase {
 		}
 
 		return $request;
+	}
+
+	/**
+	 * A write that lands after the version guard has passed must lose the conditional save, not win
+	 * it. The guard and the save are two separate reads of the store, so anything committed between
+	 * them moves the stored version; comparing against a freshly read value would match that new
+	 * version and overwrite the other write while reporting success. Comparing against the version
+	 * the client was accepted on refuses instead.
+	 *
+	 * Driven through the shared helper directly because there is no hook between the guard and the
+	 * save to commit an interleaved write from — passing a version the store has since moved past is
+	 * exactly the state that interleaving produces.
+	 *
+	 * @return void
+	 */
+	public function testAWriteLandingAfterTheGuardLosesTheConditionalSave(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}', $slug );
+		$superseded_version = $this->store->get_version( $slug );
+
+		// Whatever the interleaved write was, it moved the stored version on.
+		$this->store->save_document( (string) wp_json_encode( [ 'primitive' => [] ] ), $slug );
+
+		$this->assertNotSame( $superseded_version, $this->store->get_version( $slug ) );
+
+		$candidate = $this->label_index->set( [], self::BASELINE_ID, 'Renamed' );
+		$result    = $this->persist_metadata( $candidate, $slug, $superseded_version );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_conflict', $result->get_error_code() );
+		$this->assertSame( WP_Http::CONFLICT, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * The same path succeeds on the version the client actually holds, so the assertion above cannot
+	 * pass by refusing every write.
+	 *
+	 * @return void
+	 */
+	public function testTheSamePathSucceedsOnTheHeldVersion(): void {
+		$slug = Token_Store::default_slug();
+
+		$this->store->save_document( '{}', $slug );
+
+		$candidate = $this->label_index->set( [], self::BASELINE_ID, 'Renamed' );
+		$result    = $this->persist_metadata( $candidate, $slug, $this->store->get_version( $slug ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame(
+			'Renamed',
+			$this->label_index->label_for( $this->store->get_decoded_document( $slug ), self::BASELINE_ID )
+		);
+	}
+
+	/**
+	 * Invoke the shared metadata-persist helper, which is private because every route reaches it
+	 * through a handler that has already run the guard.
+	 *
+	 * @param array<string, mixed> $candidate      The candidate document.
+	 * @param string               $slug           The token library slug.
+	 * @param string               $client_version The version to compare against.
+	 *
+	 * @return mixed The helper's response or error.
+	 */
+	private function persist_metadata( array $candidate, string $slug, string $client_version ) {
+		$method = new ReflectionMethod( Documents_Controller::class, 'persist_metadata_candidate' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $this->controller, $candidate, $slug, $client_version );
 	}
 }


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4212/metadata-writes-can-lose-an-update-conditional-save-compares-against-a

The metadata write handlers (`token label PUT/DELETE`, `token order PUT`, `preset order PUT`) run
the version guard, then call a persist helper that read the stored version a second time to hand to
the conditional save. Any write committed between those two reads moves the stored version, and the
second read picks the new value up -- so the compare-and-swap matches, the write lands on top of the
other one, and the response reports success. The lost update is invisible from both sides.

`persist_metadata_candidate()` and `persist_label_clear()` now take the version the guard accepted
as an explicit `string $client_version` parameter and compare against that. A write that lands after
the guard loses the swap and returns 409, the same as a client that arrived stale.

`validate_and_save()` keeps its own read: its callers declare no `version` parameter and are
last-write-wins by design, so there is no client version to compare against.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

