### PR TITLE
[DTM] SOFT-4083 [42/51]: give button-border-width/style/color a control_attr for the border indicator

### DIFF
--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -567,23 +567,29 @@ return [
 				// css_prop shape: a css_prop binding only ever reaches Block_Default_Css\Css_Builder, which
 				// resolves exclusively the block's $default preset and can never reflect a *selected*
 				// preset's value. css_var is what lets Preset\Css_Builder (the named-preset projector) emit a
-				// scoped variable a selected preset can actually vary. No control_attr — unlike padding/
-				// margin/radius, the native block attributes for border ([{top:[color,style,size],...},unit])
-				// and shadow ([{color,opacity,hOffset,vOffset,blur,spread,inset}]) are nested per-side/
-				// composite shapes, not a single scalar value, so there is no attribute for a picker/capture
-				// consumer of control_attr (token-picker, preset-picker/capture.js, token-indicators) to
-				// target here.
+				// scoped variable a selected preset can actually vary.
+				//
+				// The three border properties below share ONE control_attr ('borderStyle'), unlike padding/
+				// margin/radius's one-property-per-attribute shape: the native block attribute
+				// ([{top:[color,style,size],...},unit]) is a single nested per-side/per-axis shape that
+				// EditorBorderControl edits as one control with no per-axis reset, so width/style/color all
+				// point at the same attribute rather than three that don't exist. token-indicators reads
+				// each property's own axis out of the shared nested value and combines the three into one
+				// bound/overridden state entry — see token-indicators/index.js's BORDER_AXIS_KIND.
 				'button-border-width' => [
-					'token'   => 'semantic.border-width.default',
-					'css_var' => 'kb-btn-border-width',
+					'token'        => 'semantic.border-width.default',
+					'css_var'      => 'kb-btn-border-width',
+					'control_attr' => 'borderStyle',
 				],
 				'button-border-style' => [
-					'token'   => 'semantic.border-style.default',
-					'css_var' => 'kb-btn-border-style',
+					'token'        => 'semantic.border-style.default',
+					'css_var'      => 'kb-btn-border-style',
+					'control_attr' => 'borderStyle',
 				],
 				'button-border-color' => [
-					'token'   => 'semantic.color.border',
-					'css_var' => 'kb-btn-border-color',
+					'token'        => 'semantic.color.border',
+					'css_var'      => 'kb-btn-border-color',
+					'control_attr' => 'borderStyle',
 				],
 				// No baseline default: an unstyled button carries no shadow, so the preset's $default omits
 				// this property entirely and the projector emits no box-shadow rule until a preset (or the

--- a/src/extension/token-indicators/__tests__/index.test.js
+++ b/src/extension/token-indicators/__tests__/index.test.js
@@ -10,7 +10,7 @@ jest.mock('../components/TokenIndicator', () => ({ TokenIndicator: () => null })
 jest.mock('../components/TokenLabel', () => ({ TokenLabel: () => null }));
 jest.mock('../components/TokenControlRow', () => ({ TokenControlRow: () => null }));
 
-import { usePresetBinding, resetAttrPatch, presetPropertyValueForDevice } from '../index';
+import { usePresetBinding, resetAttrPatch, presetPropertyValueForDevice, mappedAttrsFor } from '../index';
 
 const BLOCK = 'kadence/singlebtn';
 const SET = 'default';
@@ -266,6 +266,182 @@ describe('presetPropertyValueForDevice', () => {
 	});
 });
 
+describe('usePresetBinding border width/style/color combining', () => {
+	/**
+	 * Seed the localized catalog with the three border-axis properties, all sharing the
+	 * `control_attr: 'borderStyle'` binding `declarations.php` now declares.
+	 *
+	 * @return {void}
+	 */
+	function seedBorderCatalog() {
+		window.kadenceDesignTokensPresets = {
+			active: SET,
+			libraries: {
+				[SET]: {
+					[BLOCK]: {
+						default: 'primary',
+						presets: [{ slug: 'primary', label: 'Primary' }],
+						properties: [
+							{
+								key: 'button-border-width',
+								kind: 'dimension',
+								token: 'semantic.border-width.default',
+								control_attr: 'borderStyle',
+							},
+							{
+								key: 'button-border-style',
+								kind: 'color',
+								token: 'semantic.border-style.default',
+								control_attr: 'borderStyle',
+							},
+							{
+								key: 'button-border-color',
+								kind: 'color',
+								token: 'semantic.color.border',
+								control_attr: 'borderStyle',
+							},
+						],
+						values: {
+							primary: {
+								'button-border-width': '2px',
+								'button-border-style': 'solid',
+								'button-border-color': '#3182ce',
+							},
+						},
+						responsive: {},
+					},
+				},
+			},
+		};
+	}
+
+	beforeEach(() => {
+		seedBorderCatalog();
+	});
+
+	afterEach(() => {
+		delete window.kadenceDesignTokensPresets;
+	});
+
+	/**
+	 * A never-written native border value reads as bound and not overridden, combining all three axes
+	 * into the single `borderStyle` state entry.
+	 *
+	 * @return {void}
+	 */
+	it('combines the three axes into one borderStyle entry, reading bound when never written', () => {
+		const state = usePresetBinding(BLOCK, { kbPreset: 'primary' }, SET, 'Desktop');
+
+		expect(Object.keys(state)).toEqual(['borderStyle']);
+		expect(state.borderStyle.kind).toBe('border');
+		expect(state.borderStyle.bound).toBe(true);
+		expect(state.borderStyle.overridden).toBe(false);
+		expect(state.borderStyle.presetValue).toEqual({ width: '2px', style: 'solid', color: '#3182ce' });
+	});
+
+	/**
+	 * A native border value equal to the preset on every axis and every side is bound, not overridden.
+	 *
+	 * @return {void}
+	 */
+	it('reads a native value matching the preset on every axis as not overridden', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			borderStyle: [
+				{
+					top: ['#3182ce', 'solid', '2'],
+					right: ['#3182ce', 'solid', '2'],
+					bottom: ['#3182ce', 'solid', '2'],
+					left: ['#3182ce', 'solid', '2'],
+					unit: 'px',
+				},
+			],
+		};
+
+		const state = usePresetBinding(BLOCK, attributes, SET, 'Desktop');
+
+		expect(state.borderStyle.overridden).toBe(false);
+	});
+
+	/**
+	 * A native border value diverging on only ONE axis (color) still reports the combined entry as
+	 * overridden — "overridden" means any axis diverges, not every axis.
+	 *
+	 * @return {void}
+	 */
+	it('reports overridden when only one axis diverges from its own preset value', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			borderStyle: [
+				{
+					top: ['#ffffff', 'solid', '2'],
+					right: ['#ffffff', 'solid', '2'],
+					bottom: ['#ffffff', 'solid', '2'],
+					left: ['#ffffff', 'solid', '2'],
+					unit: 'px',
+				},
+			],
+		};
+
+		const state = usePresetBinding(BLOCK, attributes, SET, 'Desktop');
+
+		expect(state.borderStyle.overridden).toBe(true);
+	});
+});
+
+describe('mappedAttrsFor border dedupe', () => {
+	/**
+	 * The three border-axis properties, sharing one `control_attr`, collapse to a single mapped
+	 * attribute reporting the combined `'border'` kind — not three entries with three different
+	 * (individually wrong) kinds for `resetAttrPatch` to act on.
+	 *
+	 * @return {void}
+	 */
+	it('collapses the three border-axis properties into one border-kind entry', () => {
+		window.kadenceDesignTokensPresets = {
+			active: SET,
+			libraries: {
+				[SET]: {
+					[BLOCK]: {
+						default: 'primary',
+						presets: [{ slug: 'primary', label: 'Primary' }],
+						properties: [
+							{
+								key: 'button-border-width',
+								kind: 'dimension',
+								token: 'semantic.border-width.default',
+								control_attr: 'borderStyle',
+							},
+							{
+								key: 'button-border-style',
+								kind: 'color',
+								token: 'semantic.border-style.default',
+								control_attr: 'borderStyle',
+							},
+							{
+								key: 'button-border-color',
+								kind: 'color',
+								token: 'semantic.color.border',
+								control_attr: 'borderStyle',
+							},
+							{ key: 'button-radius', kind: 'dimension', token: null, control_attr: 'borderRadius' },
+						],
+						values: {},
+						responsive: {},
+					},
+				},
+			},
+		};
+
+		expect(mappedAttrsFor(BLOCK, SET)).toEqual([
+			{ attr: 'borderStyle', kind: 'border' },
+			{ attr: 'borderRadius', kind: 'dimension' },
+		]);
+
+		delete window.kadenceDesignTokensPresets;
+	});
+});
+
 describe('resetAttrPatch', () => {
 	/**
 	 * A dimension reset clears the primary, unit, and both responsive companion attributes to their
@@ -289,5 +465,20 @@ describe('resetAttrPatch', () => {
 	 */
 	it('clears only the primary attribute for a non-dimension kind', () => {
 		expect(resetAttrPatch('background', 'color')).toEqual({ background: '' });
+	});
+
+	/**
+	 * A border reset clears the primary attribute and both responsive companions to an empty ARRAY
+	 * (`[]`), not `['', '', '', '']` — the shape `EditorBorderControl`'s `fromNativeBorder` reads as
+	 * "never written" via its `!native?.[0]` short-circuit.
+	 *
+	 * @return {void}
+	 */
+	it('clears the primary and responsive companions to an empty array for a border', () => {
+		expect(resetAttrPatch('borderStyle', 'border')).toEqual({
+			borderStyle: [],
+			tabletBorderStyle: [],
+			mobileBorderStyle: [],
+		});
 	});
 });

--- a/src/extension/token-indicators/__tests__/index.test.js
+++ b/src/extension/token-indicators/__tests__/index.test.js
@@ -308,7 +308,9 @@ describe('usePresetBinding border width/style/color combining', () => {
 								'button-border-color': '#3182ce',
 							},
 						},
-						responsive: {},
+						responsive: {
+							primary: { tablet: { 'button-border-color': '#000000' } },
+						},
 					},
 				},
 			},
@@ -384,6 +386,57 @@ describe('usePresetBinding border width/style/color combining', () => {
 		};
 
 		const state = usePresetBinding(BLOCK, attributes, SET, 'Desktop');
+
+		expect(state.borderStyle.overridden).toBe(true);
+	});
+
+	/**
+	 * On Tablet, a border axis reads its OWN device's stored attribute against the preset's tablet
+	 * override — not the desktop attribute against the desktop preset value, which is what the border
+	 * axes did before treating them as responsive like a dimension.
+	 *
+	 * @return {void}
+	 */
+	it('reports not overridden when the tablet border value matches the preset tablet override', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			tabletBorderStyle: [
+				{
+					top: ['#000000', 'solid', '2'],
+					right: ['#000000', 'solid', '2'],
+					bottom: ['#000000', 'solid', '2'],
+					left: ['#000000', 'solid', '2'],
+					unit: 'px',
+				},
+			],
+		};
+
+		const state = usePresetBinding(BLOCK, attributes, SET, 'Tablet');
+
+		expect(state.borderStyle.overridden).toBe(false);
+	});
+
+	/**
+	 * On Tablet, a border axis diverging from the preset's tablet override reads as overridden even
+	 * though it would match the preset's desktop value.
+	 *
+	 * @return {void}
+	 */
+	it('reports overridden when the tablet border value differs from the preset tablet override', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			tabletBorderStyle: [
+				{
+					top: ['#3182ce', 'solid', '2'],
+					right: ['#3182ce', 'solid', '2'],
+					bottom: ['#3182ce', 'solid', '2'],
+					left: ['#3182ce', 'solid', '2'],
+					unit: 'px',
+				},
+			],
+		};
+
+		const state = usePresetBinding(BLOCK, attributes, SET, 'Tablet');
 
 		expect(state.borderStyle.overridden).toBe(true);
 	});

--- a/src/extension/token-indicators/__tests__/normalize.test.js
+++ b/src/extension/token-indicators/__tests__/normalize.test.js
@@ -294,6 +294,88 @@ describe('isEmptyValue', () => {
 	it('treats a populated color as not empty', () => {
 		expect(isEmptyValue('color', 'palette3')).toBe(false);
 	});
+
+	it('treats an undefined native border value as empty for every axis', () => {
+		expect(isEmptyValue('border-width', undefined)).toBe(true);
+		expect(isEmptyValue('border-style', undefined)).toBe(true);
+		expect(isEmptyValue('border-color', undefined)).toBe(true);
+	});
+
+	it('treats an empty-array native border value as empty for every axis', () => {
+		expect(isEmptyValue('border-width', [])).toBe(true);
+		expect(isEmptyValue('border-style', [])).toBe(true);
+		expect(isEmptyValue('border-color', [])).toBe(true);
+	});
+
+	it('treats a written native border value as not empty for every axis, even with all-blank sides', () => {
+		const value = [
+			{
+				top: ['', '', ''],
+				right: ['', '', ''],
+				bottom: ['', '', ''],
+				left: ['', '', ''],
+				unit: 'px',
+			},
+		];
+
+		expect(isEmptyValue('border-width', value)).toBe(false);
+		expect(isEmptyValue('border-style', value)).toBe(false);
+		expect(isEmptyValue('border-color', value)).toBe(false);
+	});
+});
+
+describe('matchesPreset border', () => {
+	const UNIFORM = [
+		{
+			top: ['#3182ce', 'solid', '2'],
+			right: ['#3182ce', 'solid', '2'],
+			bottom: ['#3182ce', 'solid', '2'],
+			left: ['#3182ce', 'solid', '2'],
+			unit: 'px',
+		},
+	];
+
+	const DIVERGENT = [
+		{
+			top: ['#3182ce', 'solid', '2'],
+			right: ['#3182ce', 'solid', '2'],
+			bottom: ['#3182ce', 'solid', '2'],
+			left: ['#ffffff', 'dashed', '4'],
+			unit: 'px',
+		},
+	];
+
+	it('does not match an unset native border value for any axis', () => {
+		expect(matchesPreset('border-width', undefined, '', '2px')).toBe(false);
+		expect(matchesPreset('border-style', undefined, '', 'solid')).toBe(false);
+		expect(matchesPreset('border-color', undefined, '', '#3182ce')).toBe(false);
+	});
+
+	it('matches a native border value equal on every side, per axis', () => {
+		expect(matchesPreset('border-width', UNIFORM, '', '2px')).toBe(true);
+		expect(matchesPreset('border-style', UNIFORM, '', 'solid')).toBe(true);
+		expect(matchesPreset('border-color', UNIFORM, '', '#3182ce')).toBe(true);
+	});
+
+	it('does not match a native border value diverging on one side, per axis', () => {
+		expect(matchesPreset('border-width', DIVERGENT, '', '2px')).toBe(false);
+		expect(matchesPreset('border-style', DIVERGENT, '', 'solid')).toBe(false);
+		expect(matchesPreset('border-color', DIVERGENT, '', '#3182ce')).toBe(false);
+	});
+
+	it('matches a border-width side written as a token alias against the same alias literal', () => {
+		const value = [
+			{
+				top: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
+				right: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
+				bottom: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
+				left: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
+				unit: 'px',
+			},
+		];
+
+		expect(matchesPreset('border-width', value, '', '{primitive.dimension.border-width.md}')).toBe(true);
+	});
 });
 
 describe('normalizeDimension', () => {

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -188,14 +188,18 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
 			mobile: get(presetBreakpoints, ['mobile', property.key]),
 		};
 
-		// `overridden` compares like against like: a dimension control reads its OWN device's stored
-		// attribute (`tabletBorderRadius` on Tablet), against the preset value in effect at that same
-		// device (its tablet override where the preset declares one, else the base). Comparing a
-		// Tablet-stored value to the desktop preset value — or reporting the desktop attribute's state
-		// while Tablet is open — would show the wrong mark for the device actually being edited.
-		const deviceAttr = kind === 'dimension' ? deviceAttrFor(attr, previewDevice) : attr;
-		const devicePresetValue =
-			kind === 'dimension' ? presetValueForDevice(presetValue, propertyBreakpoints, previewDevice) : presetValue;
+		// `overridden` compares like against like: a responsive control (a dimension, or a border axis —
+		// each border axis has its own tabletBorderStyle/mobileBorderStyle-shaped attribute) reads its
+		// OWN device's stored attribute (`tabletBorderRadius` on Tablet), against the preset value in
+		// effect at that same device (its tablet override where the preset declares one, else the base).
+		// Comparing a Tablet-stored value to the desktop preset value — or reporting the desktop
+		// attribute's state while Tablet is open — would show the wrong mark for the device actually
+		// being edited.
+		const isResponsive = kind === 'dimension' || Boolean(axis);
+		const deviceAttr = isResponsive ? deviceAttrFor(attr, previewDevice) : attr;
+		const devicePresetValue = isResponsive
+			? presetValueForDevice(presetValue, propertyBreakpoints, previewDevice)
+			: presetValue;
 		const value = get(attributes, deviceAttr, '');
 		const unit = unitAttrFor(kind, attr) ? get(attributes, unitAttrFor(kind, attr), '') : '';
 

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -67,9 +67,38 @@ function unitAttrFor(kind, attr) {
 }
 
 /**
+ * The `button-border-width`/`button-border-style`/`button-border-color` properties, keyed by their
+ * property key, to the axis kind `normalize.js`'s `isEmptyValue`/`matchesPreset` read for them.
+ *
+ * Declaring these as a single shared `control_attr: 'borderStyle'` (see `declarations.php`) is correct —
+ * `EditorBorderControl` edits all three axes as one control with no per-axis reset — but it means PHP's
+ * generic `Preset_Bindings::kind()` (name/token-group classification with no notion of this nested
+ * per-side shape) cannot tell the three apart: `button-border-width` reads as its generic 'dimension' and
+ * both `button-border-style`/`button-border-color` read as generic 'color'. Passed straight through,
+ * `isEmptyValue`/`matchesPreset`'s existing 'dimension'/'color' branches would try to read the nested
+ * `[{ top: [color, style, size], ... }]` shape as a flat scalar/4-side value and never match. This map
+ * overrides the kind used for the compare ONLY, by property key, so each axis reads its own slot.
+ *
+ * @since TBD
+ *
+ * @type {Object<string, string>}
+ */
+const BORDER_AXIS_KIND = {
+	'button-border-width': 'border-width',
+	'button-border-style': 'border-style',
+	'button-border-color': 'border-color',
+};
+
+/**
  * The mapped control attributes for a block's set, as `[{ attr, kind }]` — the surface reset-all clears.
  * Skips properties with no control attribute. Independent of the selected preset (reset-all clears every
  * mapped override regardless of which preset is active).
+ *
+ * The three border-axis properties share one `control_attr` (see `BORDER_AXIS_KIND`), so they would
+ * otherwise produce three entries for the same attribute, each with a different (and individually wrong)
+ * kind for `resetAttrPatch`. Deduping by attribute and reporting the combined `'border'` kind for any of
+ * them keeps reset-all's one patch-per-attribute clearing every axis at once, matching `resetAttrPatch`'s
+ * own `'border'` case.
  *
  * @param {string} blockName The block name.
  * @param {string} [library] The token library slug; defaults to the active library.
@@ -79,9 +108,23 @@ function unitAttrFor(kind, attr) {
  * @return {Array} The mapped attributes ([{ attr, kind }]).
  */
 export function mappedAttrsFor(blockName, library) {
-	return blockProperties(blockName, library || activeLibrary())
+	const seen = new Set();
+	const attrs = [];
+
+	blockProperties(blockName, library || activeLibrary())
 		.filter((property) => !!property.control_attr)
-		.map((property) => ({ attr: property.control_attr, kind: property.kind }));
+		.forEach((property) => {
+			const attr = property.control_attr;
+
+			if (seen.has(attr)) {
+				return;
+			}
+
+			seen.add(attr);
+			attrs.push({ attr, kind: BORDER_AXIS_KIND[property.key] ? 'border' : property.kind });
+		});
+
+	return attrs;
 }
 
 /**
@@ -102,7 +145,12 @@ export function mappedAttrsFor(blockName, library) {
  *
  * @return {Object} attrName => { property, token, kind, presetValue, responsive, bound, overridden }.
  *                   Keyed by the DESKTOP attribute name even when `overridden` reflects another
- *                   device, so a caller can still look a control up by its one stable key.
+ *                   device, so a caller can still look a control up by its one stable key. The
+ *                   `borderStyle` entry is the one exception: `kind` is `'border'` and `property`/
+ *                   `token`/`presetValue`/`responsive` are each `{ width, style, color }` objects,
+ *                   one slot per axis, combining the three properties that share that attribute (see
+ *                   `BORDER_AXIS_KIND`); `overridden` is true when any axis diverges from its own
+ *                   preset value.
  */
 export function usePresetBinding(blockName, attributes, library, previewDevice) {
 	const resolvedLibrary = library || activeLibrary();
@@ -130,7 +178,10 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
 			return;
 		}
 
-		const kind = property.kind;
+		// The border width/style/color properties all key their compare off `BORDER_AXIS_KIND` rather
+		// than PHP's generic `property.kind` — see that map's own docblock for why.
+		const axis = BORDER_AXIS_KIND[property.key];
+		const kind = axis || property.kind;
 		const presetValue = presetValues[property.key];
 		const propertyBreakpoints = {
 			tablet: get(presetBreakpoints, ['tablet', property.key]),
@@ -151,6 +202,34 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
 		const empty = isEmptyValue(kind, value);
 		const overridden = !empty && !matchesPreset(kind, value, unit, devicePresetValue);
 
+		// Width, style and color share the `borderStyle` attribute (one `EditorBorderControl`, no
+		// per-axis reset), so their three iterations combine into ONE entry rather than overwrite each
+		// other: `property`/`token`/`presetValue`/`responsive` become axis-keyed ('width'/'style'/
+		// 'color') objects, and `overridden` is true when ANY axis diverges from ITS OWN preset value —
+		// a stored border only reads as "matches the preset" once every axis does.
+		if (axis) {
+			const axisKey = axis.replace('border-', '');
+			const combined = state[attr] || {
+				property: {},
+				token: {},
+				kind: 'border',
+				presetValue: {},
+				responsive: {},
+				bound: true,
+				overridden: false,
+			};
+
+			combined.property[axisKey] = property.key;
+			combined.token[axisKey] = property.token;
+			combined.presetValue[axisKey] = presetValue;
+			combined.responsive[axisKey] = propertyBreakpoints;
+			combined.overridden = combined.overridden || overridden;
+
+			state[attr] = combined;
+
+			return;
+		}
+
 		state[attr] = {
 			property: property.key,
 			token: property.token,
@@ -167,14 +246,13 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
 
 /**
  * The active preset's resolved value for one property key, at the given device — for a property with
- * no `control_attr` (a `css_var`-only binding like `button-border-width`, whose native attribute is a
- * nested per-side shape `usePresetBinding` has nothing to key it by; see `declarations.php`'s comment
- * on that binding). `usePresetBinding` skips these properties entirely, so a caller that only needs
- * "what does the active preset resolve this to" — e.g. a dimension control's `defaultValue`, shown
- * muted once the control's own override is cleared — reads it directly here instead.
+ * no `control_attr` at all, whose native attribute `usePresetBinding` has nothing to key it by (a
+ * `css_var`-only binding). `usePresetBinding` skips these properties entirely, so a caller that only
+ * needs "what does the active preset resolve this to" — e.g. a dimension control's `defaultValue`,
+ * shown muted once the control's own override is cleared — reads it directly here instead.
  *
  * @param {string} blockName     The block name (e.g. 'kadence/singlebtn').
- * @param {string} propertyKey   The binding's property key (e.g. 'button-border-width').
+ * @param {string} propertyKey   The binding's property key (e.g. 'button-radius').
  * @param {Object} attributes    The block's current attributes — read for `kbPreset`, so a
  *                                user-selected preset (not just the block's default) resolves.
  * @param {string} [library]     The token library slug; defaults to the active library.
@@ -210,17 +288,33 @@ export function presetPropertyValueForDevice(blockName, propertyKey, attributes,
  * `tabletBorderRadius`, `mobileBorderRadius`) — not a bare `''`, and the unit resets to `'px'`
  * (`borderRadiusUnit`'s declared default), not `''`.
  *
+ * A `border` control (the combined `borderStyle` width/style/color entry) clears its `tablet*`/`mobile*`
+ * companions the same way, but to an empty ARRAY (`[]`), not `['', '', '', '']` — `EditorBorderControl`'s
+ * `fromNativeBorder` reads `[]` (or `undefined`) as "never written" via its `!native?.[0]` short-circuit,
+ * which is what makes the control read as bound again. `block.json`'s own declared default is a
+ * fully-populated-but-blank per-side object (`[{ top: ['', '', ''], ... }]`); that shape is NOT empty by
+ * `fromNativeBorder`'s own test (its `source` is truthy), so resetting to it would leave the control
+ * reading as overridden instead of bound.
+ *
  * Shared by the per-control reset (`resetAttr`) and the picker's reset-all, so their clearing convention
  * cannot drift.
  *
  * @param {string} attr The primary attribute name.
- * @param {string} kind The property kind, so a dimension also clears its companions.
+ * @param {string} kind The property kind, so a dimension/border also clears its companions.
  *
  * @since TBD
  *
  * @return {Object} The attribute patch to pass to `setAttributes`.
  */
 export function resetAttrPatch(attr, kind) {
+	if (kind === 'border') {
+		return {
+			[attr]: [],
+			[deviceAttrFor(attr, 'Tablet')]: [],
+			[deviceAttrFor(attr, 'Mobile')]: [],
+		};
+	}
+
 	if (kind !== 'dimension') {
 		return { [attr]: '' };
 	}

--- a/src/extension/token-indicators/normalize.js
+++ b/src/extension/token-indicators/normalize.js
@@ -3,14 +3,44 @@
  *
  * A control's stored attribute value and the selected preset's resolved value are compared after being
  * reduced to a canonical form per `kind`:
- *   - `color`      — a Kadence palette slug (`palette3`) is resolved to its literal via the global
- *                    palette map, then lower-cased; a literal (`#3182CE`, `rgb(...)`) is lower-cased.
- *   - `dimension`  — the numeric value is paired with its unit (`{ value, unit }`), tolerant of the
- *                    4-side array shape a measurement control writes.
- *   - `text`       — trimmed string compare.
+ *   - `color`        — a Kadence palette slug (`palette3`) is resolved to its literal via the global
+ *                      palette map, then lower-cased; a literal (`#3182CE`, `rgb(...)`) is lower-cased.
+ *   - `dimension`    — the numeric value is paired with its unit (`{ value, unit }`), tolerant of the
+ *                      4-side array shape a measurement control writes.
+ *   - `text`         — trimmed string compare.
+ *   - `border-width` \
+ *   - `border-style`  | — read ONE axis (width, style or color) out of `EditorBorderControl`'s nested
+ *   - `border-color` / per-side native shape (`[{ top: [color, style, size], right: [...], ... }]`),
+ *                      compared uniformly across all four sides. The three axes share one native
+ *                      attribute (`borderStyle`), so `usePresetBinding` calls each of these once per
+ *                      axis and combines the results — see its own docblock.
  */
 
 import { get } from 'lodash';
+import { isTokenAlias } from '../../token-controls/helpers/token-summary';
+
+/**
+ * The order `EditorBorderControl`'s native shape stores per-side tuples in, and the index each axis
+ * occupies within a side's `[color, style, size]` tuple.
+ *
+ * @since TBD
+ *
+ * @type {string[]}
+ */
+const BORDER_SIDES = ['top', 'right', 'bottom', 'left'];
+
+/**
+ * The index within a side's `[color, style, size]` tuple for each border axis kind.
+ *
+ * @since TBD
+ *
+ * @type {Object<string, number>}
+ */
+const BORDER_AXIS_INDEX = {
+	'border-color': 0,
+	'border-style': 1,
+	'border-width': 2,
+};
 
 /**
  * The editor's global color palette map (`paletteN -> literal color`). Kadence localizes the theme
@@ -301,10 +331,26 @@ export function normalizeText(value) {
 }
 
 /**
+ * `EditorBorderControl`'s native per-side source object (`native[0]`), or `null` for the never-written
+ * shape (`undefined`, `[]`, or an array with no first element) — matching `fromNativeBorder`'s own
+ * `!source` short-circuit, which is this module's "empty/bound" reading for every border axis.
+ *
+ * @param {*} value The stored `borderStyle`-shaped attribute value.
+ *
+ * @since TBD
+ *
+ * @return {Object|null} The native source object, or null when never written.
+ */
+function borderSource(value) {
+	return (Array.isArray(value) ? value[0] : undefined) || null;
+}
+
+/**
  * Whether a stored attribute value is "empty" (untouched) for its kind — the signal a retarget-bound
  * control uses for `empty => bound`.
  *
- * @param {string} kind  The property kind ('color' | 'dimension' | 'text').
+ * @param {string} kind  The property kind ('color' | 'dimension' | 'text' | 'border-width' |
+ *                       'border-style' | 'border-color').
  * @param {*}      value The stored primary attribute value.
  *
  * @since TBD
@@ -314,6 +360,12 @@ export function normalizeText(value) {
 export function isEmptyValue(kind, value) {
 	if (kind === 'dimension') {
 		return normalizeDimension(value, '').value === '';
+	}
+
+	if (kind in BORDER_AXIS_INDEX) {
+		// All three axes share one native shape, and the moment any side is written `toNativeBorder`
+		// always fills in all four — so "empty" is a single source-level check, not per-axis.
+		return borderSource(value) === null;
 	}
 
 	return normalizeColor(value) === '' && normalizeText(value) === '';
@@ -373,6 +425,76 @@ function matchesPresetSlots(sides, storedUnit, presetSlots) {
 }
 
 /**
+ * A side's width slot (`source[side][2]`) as a literal comparable to a resolved dimension token value:
+ * a token alias passes through whole, otherwise the numeric size is paired with the border's own
+ * shared unit (`source.unit`) — matching `fromNativeBorder`'s own width mapping so this reads the exact
+ * literal the control itself would show.
+ *
+ * @param {*}      size The side's stored width slot.
+ * @param {string} unit The border's shared unit (`source.unit`, defaulting to 'px').
+ *
+ * @since TBD
+ *
+ * @return {string} The width literal, or '' when the slot is unset.
+ */
+function borderWidthLiteral(size, unit) {
+	if (size === '' || size === undefined || size === null) {
+		return '';
+	}
+
+	return isTokenAlias(size) ? String(size) : `${size}${unit}`;
+}
+
+/**
+ * Whether every side of a stored `borderStyle`-shaped value matches the preset's resolved literal for
+ * ONE axis (width, style or color) — the per-axis compare `matchesPreset` delegates to for a
+ * `border-width`/`border-style`/`border-color` kind.
+ *
+ * @param {string} kind        One of 'border-width' | 'border-style' | 'border-color'.
+ * @param {Object} source      The native border source object (`value[0]`), already confirmed non-null.
+ * @param {string} presetValue The preset's resolved literal for this axis.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when every side's axis value equals the preset value.
+ */
+function matchesBorderAxis(kind, source, presetValue) {
+	const index = BORDER_AXIS_INDEX[kind];
+	const unit = source.unit || 'px';
+
+	if (kind === 'border-width') {
+		const preset = parseDimensionLiteral(presetValue);
+
+		return BORDER_SIDES.every((side) => {
+			const literal = borderWidthLiteral((source[side] || [])[index], unit);
+
+			if (literal === '') {
+				return false;
+			}
+
+			if (isTokenAlias(literal)) {
+				return literal === presetValue;
+			}
+
+			const stored = parseDimensionLiteral(literal);
+			const unitMatches = preset.unit === '' || stored.unit === preset.unit;
+
+			return unitMatches && stored.value === preset.value;
+		});
+	}
+
+	if (kind === 'border-color') {
+		return BORDER_SIDES.every(
+			(side) => normalizeColor((source[side] || [])[index]) === normalizeColor(presetValue)
+		);
+	}
+
+	return BORDER_SIDES.every(
+		(side) => normalizeText((source[side] || [])[index] || 'none') === normalizeText(presetValue)
+	);
+}
+
+/**
  * Whether a stored value equals the selected preset's resolved value, normalized per kind.
  *
  * @param {string} kind        The property kind.
@@ -385,6 +507,12 @@ function matchesPresetSlots(sides, storedUnit, presetSlots) {
  * @return {boolean} True when the stored value matches the preset value.
  */
 export function matchesPreset(kind, value, unit, presetValue) {
+	if (kind in BORDER_AXIS_INDEX) {
+		const source = borderSource(value);
+
+		return source !== null && matchesBorderAxis(kind, source, presetValue);
+	}
+
 	if (kind === 'dimension') {
 		const sides = dimensionSides(value);
 		const storedUnit = String(unit || '').trim();


### PR DESCRIPTION
Gives `button-border-width`, `button-border-style`, and `button-border-color` a `control_attr` so `usePresetBinding` can track whether the sidebar's Border field is bound to the active preset or overridden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved border token indicators for width, style, and color settings.
  - Border values now combine into a single, consistent border state across all sides.
  - Improved detection of custom overrides, preset matches, token aliases, and empty border values.
  - Reset actions now correctly clear border settings, including responsive variations.
  - Border widths and colors are more accurately resolved when using design tokens, palettes, and CSS variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->