### PR TITLE
[DTM] SOFT-4083 [43/51]: extract normalize.js's per-kind logic into kinds/ modules

### DIFF
--- a/src/extension/token-indicators/__tests__/normalize.test.js
+++ b/src/extension/token-indicators/__tests__/normalize.test.js
@@ -1,0 +1,36 @@
+/* eslint-env jest */
+
+import { isEmptyValue, matchesPreset } from '../normalize';
+
+describe('normalize dispatch falls back to text for an unrecognized kind', () => {
+	/**
+	 * A kind the `KINDS` dispatch table has no entry for degrades to the `text` handler's `isEmpty`
+	 * check instead of throwing — the localized catalog's `kind` values come from PHP's registry and are
+	 * not narrowed to this table's keys at write time.
+	 *
+	 * @return {void}
+	 */
+	it('reads an unrecognized kind as empty when the value is empty text', () => {
+		expect(isEmptyValue('unknown-kind', '')).toBe(true);
+	});
+
+	/**
+	 * An unrecognized kind's non-empty value reads as not empty, matching the `text` handler.
+	 *
+	 * @return {void}
+	 */
+	it('reads an unrecognized kind as not empty when the value is non-empty text', () => {
+		expect(isEmptyValue('unknown-kind', 'value')).toBe(false);
+	});
+
+	/**
+	 * An unrecognized kind's compare falls back to the `text` handler's trimmed string compare instead
+	 * of throwing on a missing dispatch-table entry.
+	 *
+	 * @return {void}
+	 */
+	it('compares an unrecognized kind as text', () => {
+		expect(matchesPreset('unknown-kind', 'value', '', 'value')).toBe(true);
+		expect(matchesPreset('unknown-kind', 'value', '', 'other')).toBe(false);
+	});
+});

--- a/src/extension/token-indicators/kinds/__tests__/border.test.js
+++ b/src/extension/token-indicators/kinds/__tests__/border.test.js
@@ -1,0 +1,86 @@
+/* eslint-env jest */
+import { isEmptyValue, matchesPreset } from '../../normalize';
+
+describe('isEmptyValue border', () => {
+	it('treats an undefined native border value as empty for every axis', () => {
+		expect(isEmptyValue('border-width', undefined)).toBe(true);
+		expect(isEmptyValue('border-style', undefined)).toBe(true);
+		expect(isEmptyValue('border-color', undefined)).toBe(true);
+	});
+
+	it('treats an empty-array native border value as empty for every axis', () => {
+		expect(isEmptyValue('border-width', [])).toBe(true);
+		expect(isEmptyValue('border-style', [])).toBe(true);
+		expect(isEmptyValue('border-color', [])).toBe(true);
+	});
+
+	it('treats a written native border value as not empty for every axis, even with all-blank sides', () => {
+		const value = [
+			{
+				top: ['', '', ''],
+				right: ['', '', ''],
+				bottom: ['', '', ''],
+				left: ['', '', ''],
+				unit: 'px',
+			},
+		];
+
+		expect(isEmptyValue('border-width', value)).toBe(false);
+		expect(isEmptyValue('border-style', value)).toBe(false);
+		expect(isEmptyValue('border-color', value)).toBe(false);
+	});
+});
+
+describe('matchesPreset border', () => {
+	const UNIFORM = [
+		{
+			top: ['#3182ce', 'solid', '2'],
+			right: ['#3182ce', 'solid', '2'],
+			bottom: ['#3182ce', 'solid', '2'],
+			left: ['#3182ce', 'solid', '2'],
+			unit: 'px',
+		},
+	];
+
+	const DIVERGENT = [
+		{
+			top: ['#3182ce', 'solid', '2'],
+			right: ['#3182ce', 'solid', '2'],
+			bottom: ['#3182ce', 'solid', '2'],
+			left: ['#ffffff', 'dashed', '4'],
+			unit: 'px',
+		},
+	];
+
+	it('does not match an unset native border value for any axis', () => {
+		expect(matchesPreset('border-width', undefined, '', '2px')).toBe(false);
+		expect(matchesPreset('border-style', undefined, '', 'solid')).toBe(false);
+		expect(matchesPreset('border-color', undefined, '', '#3182ce')).toBe(false);
+	});
+
+	it('matches a native border value equal on every side, per axis', () => {
+		expect(matchesPreset('border-width', UNIFORM, '', '2px')).toBe(true);
+		expect(matchesPreset('border-style', UNIFORM, '', 'solid')).toBe(true);
+		expect(matchesPreset('border-color', UNIFORM, '', '#3182ce')).toBe(true);
+	});
+
+	it('does not match a native border value diverging on one side, per axis', () => {
+		expect(matchesPreset('border-width', DIVERGENT, '', '2px')).toBe(false);
+		expect(matchesPreset('border-style', DIVERGENT, '', 'solid')).toBe(false);
+		expect(matchesPreset('border-color', DIVERGENT, '', '#3182ce')).toBe(false);
+	});
+
+	it('matches a border-width side written as a token alias against the same alias literal', () => {
+		const value = [
+			{
+				top: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
+				right: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
+				bottom: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
+				left: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
+				unit: 'px',
+			},
+		];
+
+		expect(matchesPreset('border-width', value, '', '{primitive.dimension.border-width.md}')).toBe(true);
+	});
+});

--- a/src/extension/token-indicators/kinds/__tests__/color.test.js
+++ b/src/extension/token-indicators/kinds/__tests__/color.test.js
@@ -1,0 +1,64 @@
+/* eslint-env jest */
+import { normalizeColor } from '../color';
+import { isEmptyValue, matchesPreset } from '../../normalize';
+
+describe('normalizeColor', () => {
+	beforeEach(() => {
+		window.kadence_blocks_params = {
+			global_colors: {
+				'--global-palette1': '#3182CE',
+				'--global-palette3': '#1A202C',
+			},
+		};
+	});
+
+	afterEach(() => {
+		delete window.kadence_blocks_params;
+	});
+
+	it('resolves a paletteN slug to its mapped literal, lower-cased', () => {
+		expect(normalizeColor('palette1')).toBe('#3182ce');
+	});
+
+	it('passes a literal through, lower-cased', () => {
+		expect(normalizeColor('#3182CE')).toBe('#3182ce');
+	});
+
+	it('passes an unresolved slug through as itself (degrade safe)', () => {
+		expect(normalizeColor('palette9')).toBe('palette9');
+	});
+
+	it('returns an empty string for an empty value', () => {
+		expect(normalizeColor('')).toBe('');
+	});
+});
+
+describe('matchesPreset color', () => {
+	beforeEach(() => {
+		window.kadence_blocks_params = {
+			global_colors: { '--global-palette3': '#3182CE' },
+		};
+	});
+
+	afterEach(() => {
+		delete window.kadence_blocks_params;
+	});
+
+	it('matches when a stored palette slug resolves to the preset literal', () => {
+		expect(matchesPreset('color', 'palette3', '', '#3182ce')).toBe(true);
+	});
+
+	it('does not match when the stored literal differs from the preset literal', () => {
+		expect(matchesPreset('color', '#ffffff', '', '#3182ce')).toBe(false);
+	});
+});
+
+describe('isEmptyValue color', () => {
+	it('treats an empty color string as empty', () => {
+		expect(isEmptyValue('color', '')).toBe(true);
+	});
+
+	it('treats a populated color as not empty', () => {
+		expect(isEmptyValue('color', 'palette3')).toBe(false);
+	});
+});

--- a/src/extension/token-indicators/kinds/__tests__/dimension.test.js
+++ b/src/extension/token-indicators/kinds/__tests__/dimension.test.js
@@ -4,63 +4,10 @@ import {
 	deriveMeasureMode,
 	inheritedMeasureSlots,
 	measureAttrsForDevice,
-	isEmptyValue,
-	matchesPreset,
-	normalizeColor,
 	normalizeDimension,
 	presetValueForDevice,
-} from '../normalize';
-
-describe('normalizeColor', () => {
-	beforeEach(() => {
-		window.kadence_blocks_params = {
-			global_colors: {
-				'--global-palette1': '#3182CE',
-				'--global-palette3': '#1A202C',
-			},
-		};
-	});
-
-	afterEach(() => {
-		delete window.kadence_blocks_params;
-	});
-
-	it('resolves a paletteN slug to its mapped literal, lower-cased', () => {
-		expect(normalizeColor('palette1')).toBe('#3182ce');
-	});
-
-	it('passes a literal through, lower-cased', () => {
-		expect(normalizeColor('#3182CE')).toBe('#3182ce');
-	});
-
-	it('passes an unresolved slug through as itself (degrade safe)', () => {
-		expect(normalizeColor('palette9')).toBe('palette9');
-	});
-
-	it('returns an empty string for an empty value', () => {
-		expect(normalizeColor('')).toBe('');
-	});
-});
-
-describe('matchesPreset color', () => {
-	beforeEach(() => {
-		window.kadence_blocks_params = {
-			global_colors: { '--global-palette3': '#3182CE' },
-		};
-	});
-
-	afterEach(() => {
-		delete window.kadence_blocks_params;
-	});
-
-	it('matches when a stored palette slug resolves to the preset literal', () => {
-		expect(matchesPreset('color', 'palette3', '', '#3182ce')).toBe(true);
-	});
-
-	it('does not match when the stored literal differs from the preset literal', () => {
-		expect(matchesPreset('color', '#ffffff', '', '#3182ce')).toBe(false);
-	});
-});
+} from '../dimension';
+import { isEmptyValue, matchesPreset } from '../../normalize';
 
 describe('matchesPreset dimension', () => {
 	it('matches a uniform 4-side array against the preset value + unit', () => {
@@ -268,113 +215,13 @@ describe('matchesPreset dimension against a per-corner preset value', () => {
 	});
 });
 
-describe('matchesPreset text', () => {
-	it('matches trimmed equal strings', () => {
-		expect(matchesPreset('text', ' bold ', '', 'bold')).toBe(true);
-	});
-
-	it('does not match differing strings', () => {
-		expect(matchesPreset('text', 'bold', '', 'normal')).toBe(false);
-	});
-});
-
-describe('isEmptyValue', () => {
-	it('treats an empty color string as empty', () => {
-		expect(isEmptyValue('color', '')).toBe(true);
-	});
-
+describe('isEmptyValue dimension', () => {
 	it('treats an all-empty 4-side dimension array as empty', () => {
 		expect(isEmptyValue('dimension', ['', '', '', ''])).toBe(true);
 	});
 
 	it('treats a populated dimension side as not empty', () => {
 		expect(isEmptyValue('dimension', ['8', '', '', ''])).toBe(false);
-	});
-
-	it('treats a populated color as not empty', () => {
-		expect(isEmptyValue('color', 'palette3')).toBe(false);
-	});
-
-	it('treats an undefined native border value as empty for every axis', () => {
-		expect(isEmptyValue('border-width', undefined)).toBe(true);
-		expect(isEmptyValue('border-style', undefined)).toBe(true);
-		expect(isEmptyValue('border-color', undefined)).toBe(true);
-	});
-
-	it('treats an empty-array native border value as empty for every axis', () => {
-		expect(isEmptyValue('border-width', [])).toBe(true);
-		expect(isEmptyValue('border-style', [])).toBe(true);
-		expect(isEmptyValue('border-color', [])).toBe(true);
-	});
-
-	it('treats a written native border value as not empty for every axis, even with all-blank sides', () => {
-		const value = [
-			{
-				top: ['', '', ''],
-				right: ['', '', ''],
-				bottom: ['', '', ''],
-				left: ['', '', ''],
-				unit: 'px',
-			},
-		];
-
-		expect(isEmptyValue('border-width', value)).toBe(false);
-		expect(isEmptyValue('border-style', value)).toBe(false);
-		expect(isEmptyValue('border-color', value)).toBe(false);
-	});
-});
-
-describe('matchesPreset border', () => {
-	const UNIFORM = [
-		{
-			top: ['#3182ce', 'solid', '2'],
-			right: ['#3182ce', 'solid', '2'],
-			bottom: ['#3182ce', 'solid', '2'],
-			left: ['#3182ce', 'solid', '2'],
-			unit: 'px',
-		},
-	];
-
-	const DIVERGENT = [
-		{
-			top: ['#3182ce', 'solid', '2'],
-			right: ['#3182ce', 'solid', '2'],
-			bottom: ['#3182ce', 'solid', '2'],
-			left: ['#ffffff', 'dashed', '4'],
-			unit: 'px',
-		},
-	];
-
-	it('does not match an unset native border value for any axis', () => {
-		expect(matchesPreset('border-width', undefined, '', '2px')).toBe(false);
-		expect(matchesPreset('border-style', undefined, '', 'solid')).toBe(false);
-		expect(matchesPreset('border-color', undefined, '', '#3182ce')).toBe(false);
-	});
-
-	it('matches a native border value equal on every side, per axis', () => {
-		expect(matchesPreset('border-width', UNIFORM, '', '2px')).toBe(true);
-		expect(matchesPreset('border-style', UNIFORM, '', 'solid')).toBe(true);
-		expect(matchesPreset('border-color', UNIFORM, '', '#3182ce')).toBe(true);
-	});
-
-	it('does not match a native border value diverging on one side, per axis', () => {
-		expect(matchesPreset('border-width', DIVERGENT, '', '2px')).toBe(false);
-		expect(matchesPreset('border-style', DIVERGENT, '', 'solid')).toBe(false);
-		expect(matchesPreset('border-color', DIVERGENT, '', '#3182ce')).toBe(false);
-	});
-
-	it('matches a border-width side written as a token alias against the same alias literal', () => {
-		const value = [
-			{
-				top: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
-				right: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
-				bottom: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
-				left: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
-				unit: 'px',
-			},
-		];
-
-		expect(matchesPreset('border-width', value, '', '{primitive.dimension.border-width.md}')).toBe(true);
 	});
 });
 

--- a/src/extension/token-indicators/kinds/__tests__/text.test.js
+++ b/src/extension/token-indicators/kinds/__tests__/text.test.js
@@ -1,0 +1,12 @@
+/* eslint-env jest */
+import { matchesPreset } from '../../normalize';
+
+describe('matchesPreset text', () => {
+	it('matches trimmed equal strings', () => {
+		expect(matchesPreset('text', ' bold ', '', 'bold')).toBe(true);
+	});
+
+	it('does not match differing strings', () => {
+		expect(matchesPreset('text', 'bold', '', 'normal')).toBe(false);
+	});
+});

--- a/src/extension/token-indicators/kinds/border.js
+++ b/src/extension/token-indicators/kinds/border.js
@@ -1,0 +1,155 @@
+/**
+ * Kind-aware normalization and compare for the `border-width`/`border-style`/`border-color` kinds — read
+ * ONE axis (width, style or color) out of `EditorBorderControl`'s nested per-side native shape
+ * (`[{ top: [color, style, size], right: [...], ... }]`), compared uniformly across all four sides. The
+ * three axes share one native attribute (`borderStyle`), so `usePresetBinding` calls each of these once
+ * per axis and combines the results — see its own docblock.
+ */
+
+import { isTokenAlias } from '../../../token-controls/helpers/token-summary';
+import { normalizeColor } from './color';
+import { normalizeText } from './text';
+import { parseDimensionLiteral } from './dimension';
+
+/**
+ * The order `EditorBorderControl`'s native shape stores per-side tuples in, and the index each axis
+ * occupies within a side's `[color, style, size]` tuple.
+ *
+ * @since TBD
+ *
+ * @type {string[]}
+ */
+export const BORDER_SIDES = ['top', 'right', 'bottom', 'left'];
+
+/**
+ * The index within a side's `[color, style, size]` tuple for each border axis kind.
+ *
+ * @since TBD
+ *
+ * @type {Object<string, number>}
+ */
+export const BORDER_AXIS_INDEX = {
+	'border-color': 0,
+	'border-style': 1,
+	'border-width': 2,
+};
+
+/**
+ * `EditorBorderControl`'s native per-side source object (`native[0]`), or `null` for the never-written
+ * shape (`undefined`, `[]`, or an array with no first element) — matching `fromNativeBorder`'s own
+ * `!source` short-circuit, which is this module's "empty/bound" reading for every border axis.
+ *
+ * @param {*} value The stored `borderStyle`-shaped attribute value.
+ *
+ * @since TBD
+ *
+ * @return {Object|null} The native source object, or null when never written.
+ */
+function borderSource(value) {
+	return (Array.isArray(value) ? value[0] : undefined) || null;
+}
+
+/**
+ * A side's width slot (`source[side][2]`) as a literal comparable to a resolved dimension token value:
+ * a token alias passes through whole, otherwise the numeric size is paired with the border's own
+ * shared unit (`source.unit`) — matching `fromNativeBorder`'s own width mapping so this reads the exact
+ * literal the control itself would show.
+ *
+ * @param {*}      size The side's stored width slot.
+ * @param {string} unit The border's shared unit (`source.unit`, defaulting to 'px').
+ *
+ * @since TBD
+ *
+ * @return {string} The width literal, or '' when the slot is unset.
+ */
+function borderWidthLiteral(size, unit) {
+	if (size === '' || size === undefined || size === null) {
+		return '';
+	}
+
+	return isTokenAlias(size) ? String(size) : `${size}${unit}`;
+}
+
+/**
+ * Whether every side of a stored `borderStyle`-shaped value matches the preset's resolved literal for
+ * ONE axis (width, style or color) — the per-axis compare `matches` delegates to for a
+ * `border-width`/`border-style`/`border-color` kind.
+ *
+ * @param {string} kind        One of 'border-width' | 'border-style' | 'border-color'.
+ * @param {Object} source      The native border source object (`value[0]`), already confirmed non-null.
+ * @param {string} presetValue The preset's resolved literal for this axis.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when every side's axis value equals the preset value.
+ */
+function matchesBorderAxis(kind, source, presetValue) {
+	const index = BORDER_AXIS_INDEX[kind];
+	const unit = source.unit || 'px';
+
+	if (kind === 'border-width') {
+		const preset = parseDimensionLiteral(presetValue);
+
+		return BORDER_SIDES.every((side) => {
+			const literal = borderWidthLiteral((source[side] || [])[index], unit);
+
+			if (literal === '') {
+				return false;
+			}
+
+			if (isTokenAlias(literal)) {
+				return literal === presetValue;
+			}
+
+			const stored = parseDimensionLiteral(literal);
+			const unitMatches = preset.unit === '' || stored.unit === preset.unit;
+
+			return unitMatches && stored.value === preset.value;
+		});
+	}
+
+	if (kind === 'border-color') {
+		return BORDER_SIDES.every(
+			(side) => normalizeColor((source[side] || [])[index]) === normalizeColor(presetValue)
+		);
+	}
+
+	return BORDER_SIDES.every(
+		(side) => normalizeText((source[side] || [])[index] || 'none') === normalizeText(presetValue)
+	);
+}
+
+/**
+ * Whether a stored attribute value is "empty" (untouched) for a border axis kind — the signal a
+ * retarget-bound control uses for `empty => bound`.
+ *
+ * All three axes share one native shape, and the moment any side is written `toNativeBorder` always
+ * fills in all four — so "empty" is a single source-level check, not per-axis.
+ *
+ * @param {*} value The stored primary attribute value.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the value is unset/empty.
+ */
+export function isEmpty(value) {
+	return borderSource(value) === null;
+}
+
+/**
+ * Whether a stored border axis value equals the selected preset's resolved value.
+ *
+ * @param {string} kind        One of 'border-width' | 'border-style' | 'border-color'.
+ * @param {*}      value       The stored primary attribute value.
+ * @param {string} unit        Unused for border kinds (the shared unit lives on the stored value itself).
+ * @param {string} presetValue The preset's resolved literal for this axis.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the stored value matches the preset value.
+ */
+export function matches(kind, value, unit, presetValue) {
+	const source = borderSource(value);
+
+	return source !== null && matchesBorderAxis(kind, source, presetValue);
+}

--- a/src/extension/token-indicators/kinds/color.js
+++ b/src/extension/token-indicators/kinds/color.js
@@ -1,0 +1,52 @@
+/**
+ * Kind-aware normalization for the `color` kind — a Kadence palette slug (`palette3`) is resolved to its
+ * literal via the global palette map, then lower-cased; a literal (`#3182CE`, `rgb(...)`) is lower-cased.
+ */
+
+import { get } from 'lodash';
+
+/**
+ * The editor's global color palette map (`paletteN -> literal color`). Kadence localizes the theme
+ * palette as `window.kadence_blocks_params.global_colors`, keyed by CSS custom-property name
+ * (`--global-palette1`..`--global-palette9`); this reader strips the `--global-` prefix so the map keys
+ * line up with the bare `paletteN` slug a color control writes into a block attribute (confirmed against
+ * `SinglePopColorControl`, the swatch component behind `PopColorControl`). Empty when the params are
+ * absent, so an unresolved slug simply compares as itself — the degrade-safe fallback.
+ *
+ * @since TBD
+ *
+ * @return {Object} slug ('paletteN') => color literal.
+ */
+function paletteMap() {
+	const colors = get(window, ['kadence_blocks_params', 'global_colors'], {}) || {};
+
+	return Object.keys(colors).reduce((map, cssVar) => {
+		const slug = cssVar.replace(/^--global-/, '');
+
+		map[slug] = colors[cssVar];
+
+		return map;
+	}, {});
+}
+
+/**
+ * Resolve a color attribute value to a comparable literal: a `paletteN` slug becomes its mapped color;
+ * anything else passes through. Lower-cased so `#3182CE` and `#3182ce` compare equal. An unresolved slug
+ * (palette map missing the key) passes through as the slug itself, which degrades safe — it never
+ * produces a false match, at worst a false override.
+ *
+ * @param {*} value The stored color value (slug or literal), possibly empty.
+ *
+ * @since TBD
+ *
+ * @return {string} The comparable literal, or '' when empty.
+ */
+export function normalizeColor(value) {
+	if (value === undefined || value === null || value === '') {
+		return '';
+	}
+
+	const literal = paletteMap()[value] || value;
+
+	return String(literal).trim().toLowerCase();
+}

--- a/src/extension/token-indicators/kinds/dimension.js
+++ b/src/extension/token-indicators/kinds/dimension.js
@@ -1,0 +1,334 @@
+/**
+ * Kind-aware normalization and compare for the `dimension` kind — the numeric value paired with its
+ * unit (`{ value, unit }`), tolerant of the 4-side array shape a measurement control writes.
+ */
+
+import { get } from 'lodash';
+
+/**
+ * The populated sides of a stored dimension value, each trimmed to a string. A measurement control writes
+ * a 4-side array (`[top, right, bottom, left]`) where an untouched side is `''`; a scalar value is a
+ * single side. Empty/undefined sides are dropped, so an all-empty value yields `[]` and a per-corner
+ * override yields one entry per touched side — the shape a side-aware compare needs.
+ *
+ * @param {*} value The stored dimension value (number, string, or 4-side array).
+ *
+ * @since TBD
+ *
+ * @return {string[]} The populated sides as trimmed strings; empty array when nothing is set.
+ */
+function dimensionSides(value) {
+	const raw = Array.isArray(value) ? value : [value];
+
+	return raw.filter((side) => side !== '' && side !== undefined && side !== null).map((side) => String(side).trim());
+}
+
+/**
+ * The stored sides of a dimension value with their POSITION preserved: a 4-side array maps one-to-one
+ * and an untouched side stays `''`, while a scalar is a single slot. This is the positional counterpart
+ * to `dimensionSides`, which drops empties and so cannot say WHICH corner a value belongs to — needed
+ * wherever a per-corner value is composed or compared slot by slot.
+ *
+ * @param {*} value The stored dimension value (number, string, or 4-side array).
+ *
+ * @since TBD
+ *
+ * @return {string[]} The slots as trimmed strings, empty slots preserved as ''.
+ */
+export function dimensionSlots(value) {
+	const raw = Array.isArray(value) ? value : [value];
+
+	return raw.map((side) => (side === undefined || side === null ? '' : String(side).trim()));
+}
+
+/**
+ * The value one corner inherits from the selected preset.
+ *
+ * A preset value is either a single literal, which every corner inherits, or a PER-CORNER list, in which
+ * case the corner takes its matching slot.
+ *
+ * @param {*}      presetValue The selected preset's value for the property.
+ * @param {number} index       The corner index.
+ *
+ * @since TBD
+ *
+ * @return {string} The inherited value for that corner, or '' when the preset has none.
+ */
+export function presetSlotAt(presetValue, index) {
+	if (Array.isArray(presetValue)) {
+		return String(presetValue[index] ?? '');
+	}
+
+	return presetValue === undefined || presetValue === null ? '' : String(presetValue);
+}
+
+/**
+ * The selected preset's value for a property AT THE ACTIVE DEVICE: its breakpoint override where the
+ * preset declares one, otherwise the value it inherits through the cascade.
+ *
+ * A preset can carry per-breakpoint values, and the button renders them — so a control sitting on
+ * Tablet that falls back to the preset's desktop value names a size the block is not rendering at
+ * that breakpoint. The fallback order mirrors the projected CSS: Mobile takes the mobile override,
+ * then the tablet one, then the base; Tablet takes the tablet override, then the base.
+ *
+ * @param {*}      presetValue  The preset's base value for the property.
+ * @param {Object} [responsive] The preset's breakpoint values ({ tablet, mobile }), each undefined
+ *                              when the preset declares no override there.
+ * @param {string} [device]     The active preview device ('Desktop' | 'Tablet' | 'Mobile').
+ *
+ * @since TBD
+ *
+ * @return {*} The preset's value in effect at that device.
+ */
+export function presetValueForDevice(presetValue, responsive = {}, device = 'Desktop') {
+	const chain =
+		'Mobile' === device ? [responsive.mobile, responsive.tablet] : 'Tablet' === device ? [responsive.tablet] : [];
+
+	const override = chain.find((value) => value !== undefined && value !== null && value !== '');
+
+	return override === undefined ? presetValue : override;
+}
+
+/**
+ * The attribute a responsive measure control is editing at the given device, and its current value.
+ *
+ * A responsive measure control keeps ONE linked/individual mode but writes three separate attributes
+ * (`borderRadius` / `tabletBorderRadius` / `mobileBorderRadius`). Deriving the mode — or collapsing
+ * corners on "link" — against the desktop attribute while the editor is on Tablet reads and writes the
+ * wrong breakpoint, so both must resolve the device's own attribute first.
+ *
+ * @param {Object} attributes  The block's attributes.
+ * @param {string} baseAttr    The desktop attribute name.
+ * @param {Object} [responsive] Device key ('tablet' | 'mobile') => attribute name.
+ * @param {string} [device]    The active preview device ('Desktop' | 'Tablet' | 'Mobile').
+ *
+ * @since TBD
+ *
+ * @return {{ attr: string, value: * }} The device's attribute name and its stored value.
+ */
+export function measureAttrsForDevice(attributes, baseAttr, responsive = {}, device = 'Desktop') {
+	const attr = get(responsive, String(device).toLowerCase(), '') || baseAttr;
+
+	return { attr, value: get(attributes, attr, '') };
+}
+
+/**
+ * What each corner of a measure control inherits at the given device WHEN THE DEVICE STORES NOTHING —
+ * the device's own value is deliberately left out, because this is the value the corner falls back to.
+ *
+ * A responsive measure control renders through a desktop -> tablet -> mobile cascade that runs PER CORNER:
+ * an empty tablet corner takes the desktop corner, an empty mobile corner takes the tablet corner and
+ * then the desktop one. Only once the whole device chain is empty does the corner reach the selected
+ * preset. Resolving straight to the preset skips those steps, so a Tablet sitting on four different
+ * desktop corners would report the preset's single value — naming a size the button is not rendering at
+ * that breakpoint.
+ *
+ * Nothing here is written back, and this does NOT feed the linked/individual mode: the corners stay empty
+ * so they keep inheriting, and the resolved values only tell the field's popover which size is currently
+ * in effect and where it came from.
+ *
+ * @param {string} device        The active preview device ('Desktop' | 'Tablet' | 'Mobile').
+ * @param {Object} [values]      The stored dimension per device: { desktop, tablet }.
+ * @param {*}      [presetValue] The selected preset's value for the property, the last fallback.
+ *
+ * @since TBD
+ *
+ * @return {{ values: string[], inherited: boolean[] }} The four inherited corners, and per corner whether
+ *                                                      it came from another device rather than the preset.
+ */
+export function inheritedMeasureSlots(device, values = {}, presetValue) {
+	const desktop = dimensionSlots(values.desktop);
+	const tablet = dimensionSlots(values.tablet);
+
+	// Mobile falls through tablet before desktop; tablet only through desktop; desktop inherits the preset.
+	const chain = 'Mobile' === device ? [tablet, desktop] : 'Tablet' === device ? [desktop] : [];
+
+	const slots = [0, 1, 2, 3].map((index) => {
+		const from = chain.find((source) => {
+			const corner = source[index];
+
+			return corner !== undefined && corner !== null && corner !== '';
+		});
+
+		return from
+			? { value: String(from[index]), inherited: true }
+			: { value: presetSlotAt(presetValue, index), inherited: false };
+	});
+
+	return {
+		values: slots.map((slot) => slot.value),
+		inherited: slots.map((slot) => slot.inherited),
+	};
+}
+
+/**
+ * Whether a measure control's single row-level "Inherited" label should show, given each corner's
+ * own inherited flag from `inheritedMeasureSlots()`.
+ *
+ * The control renders one label for all four corners, so "any corner inherited" is the safer read
+ * than "every corner inherited": a mixed row — one corner pulled from another breakpoint, the rest
+ * resolved straight to the preset — is no longer a plain preset default, and reporting "Default"
+ * would understate that. `inherited` is always a four-element array, so a bare truthiness check on
+ * the array itself is always `true`; this reduces it to the actual per-corner flags instead.
+ *
+ * @param {boolean[]} inherited Per-corner inherited flags, i.e. `inheritedMeasureSlots().inherited`.
+ *
+ * @since TBD
+ *
+ * @return {boolean} Whether any corner inherits from another breakpoint rather than the preset.
+ */
+export function anyCornerInherited(inherited) {
+	return Array.isArray(inherited) && inherited.some(Boolean);
+}
+
+/**
+ * The linked/individual mode a measure control should open in, derived from the corners the user would
+ * actually see: each stored corner where one is set, otherwise the value that corner inherits from the
+ * selected preset.
+ *
+ * Deriving from the stored attribute alone is not enough. A block on a preset stores NOTHING — every
+ * corner is empty, which trivially reads as "all equal" — so a preset carrying four different corners
+ * would open the control in linked mode and hide the difference it is displaying.
+ *
+ * @param {*} value       The stored dimension value (4-side array or scalar).
+ * @param {*} presetValue The selected preset's value for the property.
+ *
+ * @since TBD
+ *
+ * @return {string} 'linked' when every effective corner matches, otherwise 'individual'.
+ */
+export function deriveMeasureMode(value, presetValue) {
+	const stored = dimensionSlots(value);
+	const corners = [0, 1, 2, 3].map((index) =>
+		stored[index] !== undefined && stored[index] !== '' ? stored[index] : presetSlotAt(presetValue, index)
+	);
+
+	return corners.every((corner) => corner === corners[0]) ? 'linked' : 'individual';
+}
+
+/**
+ * Normalize a dimension attribute to `{ value, unit }`. A measurement control writes a 4-side array
+ * (`[top, right, bottom, left]`); the representative value is the first populated side. An empty value
+ * yields an empty marker so "no override" is detectable. This is the scalar view used for empty
+ * detection and the single-value path; the bound-vs-overridden compare uses the side-aware `matches`
+ * so a per-corner override is not masked by a matching first side.
+ *
+ * @param {*}      value The stored dimension value (number, string, or 4-side array).
+ * @param {string} unit  The companion unit attribute (e.g. `borderRadiusUnit`).
+ *
+ * @since TBD
+ *
+ * @return {{ value: string, unit: string }} The canonical dimension, `value: ''` when empty.
+ */
+export function normalizeDimension(value, unit) {
+	const sides = dimensionSides(value);
+
+	if (!sides.length) {
+		return { value: '', unit: '' };
+	}
+
+	return { value: sides[0], unit: String(unit || '').trim() };
+}
+
+/**
+ * Split a resolved dimension literal (`"1.5rem"`, `"8px"`, `"0"`) into `{ value, unit }` so it compares
+ * against the control's separate value/unit attributes.
+ *
+ * @param {string} literal The resolved dimension literal.
+ *
+ * @since TBD
+ *
+ * @return {{ value: string, unit: string }} The parsed value and unit.
+ */
+export function parseDimensionLiteral(literal) {
+	const match = String(literal || '')
+		.trim()
+		.match(/^(-?[\d.]+)\s*([a-z%]*)$/i);
+
+	if (!match) {
+		return { value: String(literal || '').trim(), unit: '' };
+	}
+
+	return { value: match[1], unit: match[2] };
+}
+
+/**
+ * Whether a stored dimension matches a PER-CORNER preset value, compared slot by slot.
+ *
+ * Comparing by position means a rotated set of the same corners (e.g. `4,8,4,8` against `8,4,8,4`) reads
+ * as overridden, and a stored value with a different number of populated sides than the preset has slots
+ * cannot match at all.
+ *
+ * @param {string[]} sides       The stored sides, empties already dropped.
+ * @param {string}   storedUnit  The stored companion unit.
+ * @param {Array}    presetSlots The preset's per-corner literals.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when every corner equals its preset slot.
+ */
+function matchesPresetSlots(sides, storedUnit, presetSlots) {
+	const stored = sides;
+	const presets = presetSlots.map(parseDimensionLiteral);
+
+	if (stored.length !== presets.length) {
+		return false;
+	}
+
+	return stored.every((side, index) => {
+		const preset = presets[index];
+		const unitMatches = preset.unit === '' || storedUnit === preset.unit;
+
+		return unitMatches && side === preset.value;
+	});
+}
+
+/**
+ * Whether a stored attribute value is "empty" (untouched) for the `dimension` kind — the signal a
+ * retarget-bound control uses for `empty => bound`.
+ *
+ * @param {*} value The stored primary attribute value.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the value is unset/empty.
+ */
+export function isEmpty(value) {
+	return normalizeDimension(value, '').value === '';
+}
+
+/**
+ * Whether a stored dimension value equals the selected preset's resolved value.
+ *
+ * @param {*}      value       The stored primary attribute value.
+ * @param {string} unit        The companion unit.
+ * @param {string} presetValue The preset's resolved literal for this property.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the stored value matches the preset value.
+ */
+export function matches(value, unit, presetValue) {
+	const sides = dimensionSides(value);
+
+	if (!sides.length) {
+		return false;
+	}
+
+	const storedUnit = String(unit || '').trim();
+
+	// A per-corner preset value is compared corner by corner. `parseDimensionLiteral` reads one length,
+	// so a slot list handed to it whole would never match and the control would read as overridden even
+	// when it exactly matches its preset.
+	if (Array.isArray(presetValue)) {
+		return matchesPresetSlots(sides, storedUnit, presetValue);
+	}
+
+	const preset = parseDimensionLiteral(presetValue);
+	const unitMatches = preset.unit === '' || storedUnit === preset.unit;
+
+	// Side-aware: a stored dimension matches only when EVERY populated side equals the preset value.
+	// A per-corner override (e.g. `['8','8','8','4']` vs `8px`) leaves one side differing and so reads
+	// as overridden, not still-bound.
+	return unitMatches && sides.every((side) => side === preset.value);
+}

--- a/src/extension/token-indicators/kinds/text.js
+++ b/src/extension/token-indicators/kinds/text.js
@@ -1,0 +1,20 @@
+/**
+ * Kind-aware normalization for the `text` kind — a trimmed string compare.
+ */
+
+/**
+ * Normalize a text attribute for compare.
+ *
+ * @param {*} value The stored value.
+ *
+ * @since TBD
+ *
+ * @return {string} The trimmed string, or '' when empty.
+ */
+export function normalizeText(value) {
+	if (value === undefined || value === null) {
+		return '';
+	}
+
+	return String(value).trim();
+}

--- a/src/extension/token-indicators/normalize.js
+++ b/src/extension/token-indicators/normalize.js
@@ -84,6 +84,22 @@ const KINDS = {
 };
 
 /**
+ * The `{ isEmpty, matches }` handler for a kind, falling back to `text` for a kind the localized
+ * catalog carries that this dispatch table has no entry for — the catalog's `kind` values come from
+ * PHP's registry and are not narrowed to this table's keys at write time, so an unrecognized value must
+ * degrade to a safe comparison rather than throw.
+ *
+ * @param {string} kind The property kind.
+ *
+ * @since TBD
+ *
+ * @return {{ isEmpty: Function, matches: Function }} The handler to dispatch through.
+ */
+function handlerFor(kind) {
+	return KINDS[kind] || text;
+}
+
+/**
  * Whether a stored attribute value is "empty" (untouched) for its kind — the signal a retarget-bound
  * control uses for `empty => bound`.
  *
@@ -96,7 +112,7 @@ const KINDS = {
  * @return {boolean} True when the value is unset/empty.
  */
 export function isEmptyValue(kind, value) {
-	return KINDS[kind].isEmpty(value);
+	return handlerFor(kind).isEmpty(value);
 }
 
 /**
@@ -116,5 +132,5 @@ export function matchesPreset(kind, value, unit, presetValue) {
 		return border.matches(kind, value, unit, presetValue);
 	}
 
-	return KINDS[kind].matches(value, unit, presetValue);
+	return handlerFor(kind).matches(value, unit, presetValue);
 }

--- a/src/extension/token-indicators/normalize.js
+++ b/src/extension/token-indicators/normalize.js
@@ -14,336 +14,74 @@
  *                      compared uniformly across all four sides. The three axes share one native
  *                      attribute (`borderStyle`), so `usePresetBinding` calls each of these once per
  *                      axis and combines the results — see its own docblock.
+ *
+ * The per-kind logic itself lives in the `kinds/` modules (`kinds/dimension.js`, `kinds/color.js`,
+ * `kinds/text.js`, `kinds/border.js`); this module is only the dispatch table plus the two thin wrappers
+ * (`isEmptyValue`, `matchesPreset`) every caller reaches it through.
  */
 
-import { get } from 'lodash';
-import { isTokenAlias } from '../../token-controls/helpers/token-summary';
+import * as dimension from './kinds/dimension';
+import * as border from './kinds/border';
+import { normalizeColor } from './kinds/color';
+import { normalizeText } from './kinds/text';
+
+export { normalizeColor } from './kinds/color';
+export { normalizeText } from './kinds/text';
+export {
+	dimensionSlots,
+	presetSlotAt,
+	presetValueForDevice,
+	measureAttrsForDevice,
+	inheritedMeasureSlots,
+	anyCornerInherited,
+	deriveMeasureMode,
+	normalizeDimension,
+} from './kinds/dimension';
 
 /**
- * The order `EditorBorderControl`'s native shape stores per-side tuples in, and the index each axis
- * occupies within a side's `[color, style, size]` tuple.
+ * The `color` kind's `isEmpty`/`matches` pair for the `KINDS` dispatch table below. Empty is the same
+ * "nothing resolves for either reading" check the `text` kind uses, since a mapped control's kind can be
+ * generic ('color') for a value that is really a bare string — see `isEmptyValue`'s original combined
+ * check.
  *
  * @since TBD
  *
- * @type {string[]}
+ * @type {{ isEmpty: Function, matches: Function }}
  */
-const BORDER_SIDES = ['top', 'right', 'bottom', 'left'];
-
-/**
- * The index within a side's `[color, style, size]` tuple for each border axis kind.
- *
- * @since TBD
- *
- * @type {Object<string, number>}
- */
-const BORDER_AXIS_INDEX = {
-	'border-color': 0,
-	'border-style': 1,
-	'border-width': 2,
+const color = {
+	isEmpty: (value) => normalizeColor(value) === '' && normalizeText(value) === '',
+	matches: (value, unit, presetValue) => normalizeColor(value) === normalizeColor(presetValue),
 };
 
 /**
- * The editor's global color palette map (`paletteN -> literal color`). Kadence localizes the theme
- * palette as `window.kadence_blocks_params.global_colors`, keyed by CSS custom-property name
- * (`--global-palette1`..`--global-palette9`); this reader strips the `--global-` prefix so the map keys
- * line up with the bare `paletteN` slug a color control writes into a block attribute (confirmed against
- * `SinglePopColorControl`, the swatch component behind `PopColorControl`). Empty when the params are
- * absent, so an unresolved slug simply compares as itself — the degrade-safe fallback.
+ * The `text` kind's `isEmpty`/`matches` pair for the `KINDS` dispatch table below.
  *
  * @since TBD
  *
- * @return {Object} slug ('paletteN') => color literal.
+ * @type {{ isEmpty: Function, matches: Function }}
  */
-function paletteMap() {
-	const colors = get(window, ['kadence_blocks_params', 'global_colors'], {}) || {};
-
-	return Object.keys(colors).reduce((map, cssVar) => {
-		const slug = cssVar.replace(/^--global-/, '');
-
-		map[slug] = colors[cssVar];
-
-		return map;
-	}, {});
-}
+const text = {
+	isEmpty: (value) => normalizeColor(value) === '' && normalizeText(value) === '',
+	matches: (value, unit, presetValue) => normalizeText(value) === normalizeText(presetValue),
+};
 
 /**
- * Resolve a color attribute value to a comparable literal: a `paletteN` slug becomes its mapped color;
- * anything else passes through. Lower-cased so `#3182CE` and `#3182ce` compare equal. An unresolved slug
- * (palette map missing the key) passes through as the slug itself, which degrades safe — it never
- * produces a false match, at worst a false override.
- *
- * @param {*} value The stored color value (slug or literal), possibly empty.
+ * The per-kind `{ isEmpty, matches }` handlers `isEmptyValue`/`matchesPreset` dispatch through. The three
+ * border axes share one handler — `EditorBorderControl`'s native shape is axis-agnostic, and `border`'s
+ * own `matches` takes the kind as its first argument to know which axis to read.
  *
  * @since TBD
  *
- * @return {string} The comparable literal, or '' when empty.
+ * @type {Object<string, Object>}
  */
-export function normalizeColor(value) {
-	if (value === undefined || value === null || value === '') {
-		return '';
-	}
-
-	const literal = paletteMap()[value] || value;
-
-	return String(literal).trim().toLowerCase();
-}
-
-/**
- * The populated sides of a stored dimension value, each trimmed to a string. A measurement control writes
- * a 4-side array (`[top, right, bottom, left]`) where an untouched side is `''`; a scalar value is a
- * single side. Empty/undefined sides are dropped, so an all-empty value yields `[]` and a per-corner
- * override yields one entry per touched side — the shape a side-aware compare needs.
- *
- * @param {*} value The stored dimension value (number, string, or 4-side array).
- *
- * @since TBD
- *
- * @return {string[]} The populated sides as trimmed strings; empty array when nothing is set.
- */
-function dimensionSides(value) {
-	const raw = Array.isArray(value) ? value : [value];
-
-	return raw.filter((side) => side !== '' && side !== undefined && side !== null).map((side) => String(side).trim());
-}
-
-/**
- * The stored sides of a dimension value with their POSITION preserved: a 4-side array maps one-to-one
- * and an untouched side stays `''`, while a scalar is a single slot. This is the positional counterpart
- * to `dimensionSides`, which drops empties and so cannot say WHICH corner a value belongs to — needed
- * wherever a per-corner value is composed or compared slot by slot.
- *
- * @param {*} value The stored dimension value (number, string, or 4-side array).
- *
- * @since TBD
- *
- * @return {string[]} The slots as trimmed strings, empty slots preserved as ''.
- */
-export function dimensionSlots(value) {
-	const raw = Array.isArray(value) ? value : [value];
-
-	return raw.map((side) => (side === undefined || side === null ? '' : String(side).trim()));
-}
-
-/**
- * The value one corner inherits from the selected preset.
- *
- * A preset value is either a single literal, which every corner inherits, or a PER-CORNER list, in which
- * case the corner takes its matching slot.
- *
- * @param {*}      presetValue The selected preset's value for the property.
- * @param {number} index       The corner index.
- *
- * @since TBD
- *
- * @return {string} The inherited value for that corner, or '' when the preset has none.
- */
-export function presetSlotAt(presetValue, index) {
-	if (Array.isArray(presetValue)) {
-		return String(presetValue[index] ?? '');
-	}
-
-	return presetValue === undefined || presetValue === null ? '' : String(presetValue);
-}
-
-/**
- * The selected preset's value for a property AT THE ACTIVE DEVICE: its breakpoint override where the
- * preset declares one, otherwise the value it inherits through the cascade.
- *
- * A preset can carry per-breakpoint values, and the button renders them — so a control sitting on
- * Tablet that falls back to the preset's desktop value names a size the block is not rendering at
- * that breakpoint. The fallback order mirrors the projected CSS: Mobile takes the mobile override,
- * then the tablet one, then the base; Tablet takes the tablet override, then the base.
- *
- * @param {*}      presetValue  The preset's base value for the property.
- * @param {Object} [responsive] The preset's breakpoint values ({ tablet, mobile }), each undefined
- *                              when the preset declares no override there.
- * @param {string} [device]     The active preview device ('Desktop' | 'Tablet' | 'Mobile').
- *
- * @since TBD
- *
- * @return {*} The preset's value in effect at that device.
- */
-export function presetValueForDevice(presetValue, responsive = {}, device = 'Desktop') {
-	const chain =
-		'Mobile' === device ? [responsive.mobile, responsive.tablet] : 'Tablet' === device ? [responsive.tablet] : [];
-
-	const override = chain.find((value) => value !== undefined && value !== null && value !== '');
-
-	return override === undefined ? presetValue : override;
-}
-
-/**
- * The attribute a responsive measure control is editing at the given device, and its current value.
- *
- * A responsive measure control keeps ONE linked/individual mode but writes three separate attributes
- * (`borderRadius` / `tabletBorderRadius` / `mobileBorderRadius`). Deriving the mode — or collapsing
- * corners on "link" — against the desktop attribute while the editor is on Tablet reads and writes the
- * wrong breakpoint, so both must resolve the device's own attribute first.
- *
- * @param {Object} attributes  The block's attributes.
- * @param {string} baseAttr    The desktop attribute name.
- * @param {Object} [responsive] Device key ('tablet' | 'mobile') => attribute name.
- * @param {string} [device]    The active preview device ('Desktop' | 'Tablet' | 'Mobile').
- *
- * @since TBD
- *
- * @return {{ attr: string, value: * }} The device's attribute name and its stored value.
- */
-export function measureAttrsForDevice(attributes, baseAttr, responsive = {}, device = 'Desktop') {
-	const attr = get(responsive, String(device).toLowerCase(), '') || baseAttr;
-
-	return { attr, value: get(attributes, attr, '') };
-}
-
-/**
- * What each corner of a measure control inherits at the given device WHEN THE DEVICE STORES NOTHING —
- * the device's own value is deliberately left out, because this is the value the corner falls back to.
- *
- * A responsive measure control renders through a desktop -> tablet -> mobile cascade that runs PER CORNER:
- * an empty tablet corner takes the desktop corner, an empty mobile corner takes the tablet corner and
- * then the desktop one. Only once the whole device chain is empty does the corner reach the selected
- * preset. Resolving straight to the preset skips those steps, so a Tablet sitting on four different
- * desktop corners would report the preset's single value — naming a size the button is not rendering at
- * that breakpoint.
- *
- * Nothing here is written back, and this does NOT feed the linked/individual mode: the corners stay empty
- * so they keep inheriting, and the resolved values only tell the field's popover which size is currently
- * in effect and where it came from.
- *
- * @param {string} device        The active preview device ('Desktop' | 'Tablet' | 'Mobile').
- * @param {Object} [values]      The stored dimension per device: { desktop, tablet }.
- * @param {*}      [presetValue] The selected preset's value for the property, the last fallback.
- *
- * @since TBD
- *
- * @return {{ values: string[], inherited: boolean[] }} The four inherited corners, and per corner whether
- *                                                      it came from another device rather than the preset.
- */
-export function inheritedMeasureSlots(device, values = {}, presetValue) {
-	const desktop = dimensionSlots(values.desktop);
-	const tablet = dimensionSlots(values.tablet);
-
-	// Mobile falls through tablet before desktop; tablet only through desktop; desktop inherits the preset.
-	const chain = 'Mobile' === device ? [tablet, desktop] : 'Tablet' === device ? [desktop] : [];
-
-	const slots = [0, 1, 2, 3].map((index) => {
-		const from = chain.find((source) => {
-			const corner = source[index];
-
-			return corner !== undefined && corner !== null && corner !== '';
-		});
-
-		return from
-			? { value: String(from[index]), inherited: true }
-			: { value: presetSlotAt(presetValue, index), inherited: false };
-	});
-
-	return {
-		values: slots.map((slot) => slot.value),
-		inherited: slots.map((slot) => slot.inherited),
-	};
-}
-
-/**
- * Whether a measure control's single row-level "Inherited" label should show, given each corner's
- * own inherited flag from `inheritedMeasureSlots()`.
- *
- * The control renders one label for all four corners, so "any corner inherited" is the safer read
- * than "every corner inherited": a mixed row — one corner pulled from another breakpoint, the rest
- * resolved straight to the preset — is no longer a plain preset default, and reporting "Default"
- * would understate that. `inherited` is always a four-element array, so a bare truthiness check on
- * the array itself is always `true`; this reduces it to the actual per-corner flags instead.
- *
- * @param {boolean[]} inherited Per-corner inherited flags, i.e. `inheritedMeasureSlots().inherited`.
- *
- * @since TBD
- *
- * @return {boolean} Whether any corner inherits from another breakpoint rather than the preset.
- */
-export function anyCornerInherited(inherited) {
-	return Array.isArray(inherited) && inherited.some(Boolean);
-}
-
-/**
- * The linked/individual mode a measure control should open in, derived from the corners the user would
- * actually see: each stored corner where one is set, otherwise the value that corner inherits from the
- * selected preset.
- *
- * Deriving from the stored attribute alone is not enough. A block on a preset stores NOTHING — every
- * corner is empty, which trivially reads as "all equal" — so a preset carrying four different corners
- * would open the control in linked mode and hide the difference it is displaying.
- *
- * @param {*} value       The stored dimension value (4-side array or scalar).
- * @param {*} presetValue The selected preset's value for the property.
- *
- * @since TBD
- *
- * @return {string} 'linked' when every effective corner matches, otherwise 'individual'.
- */
-export function deriveMeasureMode(value, presetValue) {
-	const stored = dimensionSlots(value);
-	const corners = [0, 1, 2, 3].map((index) =>
-		stored[index] !== undefined && stored[index] !== '' ? stored[index] : presetSlotAt(presetValue, index)
-	);
-
-	return corners.every((corner) => corner === corners[0]) ? 'linked' : 'individual';
-}
-
-/**
- * Normalize a dimension attribute to `{ value, unit }`. A measurement control writes a 4-side array
- * (`[top, right, bottom, left]`); the representative value is the first populated side. An empty value
- * yields an empty marker so "no override" is detectable. This is the scalar view used for empty
- * detection and the single-value path; the bound-vs-overridden compare uses the side-aware `matchesPreset`
- * so a per-corner override is not masked by a matching first side.
- *
- * @param {*}      value The stored dimension value (number, string, or 4-side array).
- * @param {string} unit  The companion unit attribute (e.g. `borderRadiusUnit`).
- *
- * @since TBD
- *
- * @return {{ value: string, unit: string }} The canonical dimension, `value: ''` when empty.
- */
-export function normalizeDimension(value, unit) {
-	const sides = dimensionSides(value);
-
-	if (!sides.length) {
-		return { value: '', unit: '' };
-	}
-
-	return { value: sides[0], unit: String(unit || '').trim() };
-}
-
-/**
- * Normalize a text attribute for compare.
- *
- * @param {*} value The stored value.
- *
- * @since TBD
- *
- * @return {string} The trimmed string, or '' when empty.
- */
-export function normalizeText(value) {
-	if (value === undefined || value === null) {
-		return '';
-	}
-
-	return String(value).trim();
-}
-
-/**
- * `EditorBorderControl`'s native per-side source object (`native[0]`), or `null` for the never-written
- * shape (`undefined`, `[]`, or an array with no first element) — matching `fromNativeBorder`'s own
- * `!source` short-circuit, which is this module's "empty/bound" reading for every border axis.
- *
- * @param {*} value The stored `borderStyle`-shaped attribute value.
- *
- * @since TBD
- *
- * @return {Object|null} The native source object, or null when never written.
- */
-function borderSource(value) {
-	return (Array.isArray(value) ? value[0] : undefined) || null;
-}
+const KINDS = {
+	dimension,
+	color,
+	text,
+	'border-width': border,
+	'border-style': border,
+	'border-color': border,
+};
 
 /**
  * Whether a stored attribute value is "empty" (untouched) for its kind — the signal a retarget-bound
@@ -358,140 +96,7 @@ function borderSource(value) {
  * @return {boolean} True when the value is unset/empty.
  */
 export function isEmptyValue(kind, value) {
-	if (kind === 'dimension') {
-		return normalizeDimension(value, '').value === '';
-	}
-
-	if (kind in BORDER_AXIS_INDEX) {
-		// All three axes share one native shape, and the moment any side is written `toNativeBorder`
-		// always fills in all four — so "empty" is a single source-level check, not per-axis.
-		return borderSource(value) === null;
-	}
-
-	return normalizeColor(value) === '' && normalizeText(value) === '';
-}
-
-/**
- * Split a resolved dimension literal (`"1.5rem"`, `"8px"`, `"0"`) into `{ value, unit }` so it compares
- * against the control's separate value/unit attributes.
- *
- * @param {string} literal The resolved dimension literal.
- *
- * @since TBD
- *
- * @return {{ value: string, unit: string }} The parsed value and unit.
- */
-function parseDimensionLiteral(literal) {
-	const match = String(literal || '')
-		.trim()
-		.match(/^(-?[\d.]+)\s*([a-z%]*)$/i);
-
-	if (!match) {
-		return { value: String(literal || '').trim(), unit: '' };
-	}
-
-	return { value: match[1], unit: match[2] };
-}
-
-/**
- * Whether a stored dimension matches a PER-CORNER preset value, compared slot by slot.
- *
- * Comparing by position means a rotated set of the same corners (e.g. `4,8,4,8` against `8,4,8,4`) reads
- * as overridden, and a stored value with a different number of populated sides than the preset has slots
- * cannot match at all.
- *
- * @param {string[]} sides       The stored sides, empties already dropped.
- * @param {string}   storedUnit  The stored companion unit.
- * @param {Array}    presetSlots The preset's per-corner literals.
- *
- * @since TBD
- *
- * @return {boolean} True when every corner equals its preset slot.
- */
-function matchesPresetSlots(sides, storedUnit, presetSlots) {
-	const stored = sides;
-	const presets = presetSlots.map(parseDimensionLiteral);
-
-	if (stored.length !== presets.length) {
-		return false;
-	}
-
-	return stored.every((side, index) => {
-		const preset = presets[index];
-		const unitMatches = preset.unit === '' || storedUnit === preset.unit;
-
-		return unitMatches && side === preset.value;
-	});
-}
-
-/**
- * A side's width slot (`source[side][2]`) as a literal comparable to a resolved dimension token value:
- * a token alias passes through whole, otherwise the numeric size is paired with the border's own
- * shared unit (`source.unit`) — matching `fromNativeBorder`'s own width mapping so this reads the exact
- * literal the control itself would show.
- *
- * @param {*}      size The side's stored width slot.
- * @param {string} unit The border's shared unit (`source.unit`, defaulting to 'px').
- *
- * @since TBD
- *
- * @return {string} The width literal, or '' when the slot is unset.
- */
-function borderWidthLiteral(size, unit) {
-	if (size === '' || size === undefined || size === null) {
-		return '';
-	}
-
-	return isTokenAlias(size) ? String(size) : `${size}${unit}`;
-}
-
-/**
- * Whether every side of a stored `borderStyle`-shaped value matches the preset's resolved literal for
- * ONE axis (width, style or color) — the per-axis compare `matchesPreset` delegates to for a
- * `border-width`/`border-style`/`border-color` kind.
- *
- * @param {string} kind        One of 'border-width' | 'border-style' | 'border-color'.
- * @param {Object} source      The native border source object (`value[0]`), already confirmed non-null.
- * @param {string} presetValue The preset's resolved literal for this axis.
- *
- * @since TBD
- *
- * @return {boolean} True when every side's axis value equals the preset value.
- */
-function matchesBorderAxis(kind, source, presetValue) {
-	const index = BORDER_AXIS_INDEX[kind];
-	const unit = source.unit || 'px';
-
-	if (kind === 'border-width') {
-		const preset = parseDimensionLiteral(presetValue);
-
-		return BORDER_SIDES.every((side) => {
-			const literal = borderWidthLiteral((source[side] || [])[index], unit);
-
-			if (literal === '') {
-				return false;
-			}
-
-			if (isTokenAlias(literal)) {
-				return literal === presetValue;
-			}
-
-			const stored = parseDimensionLiteral(literal);
-			const unitMatches = preset.unit === '' || stored.unit === preset.unit;
-
-			return unitMatches && stored.value === preset.value;
-		});
-	}
-
-	if (kind === 'border-color') {
-		return BORDER_SIDES.every(
-			(side) => normalizeColor((source[side] || [])[index]) === normalizeColor(presetValue)
-		);
-	}
-
-	return BORDER_SIDES.every(
-		(side) => normalizeText((source[side] || [])[index] || 'none') === normalizeText(presetValue)
-	);
+	return KINDS[kind].isEmpty(value);
 }
 
 /**
@@ -507,39 +112,9 @@ function matchesBorderAxis(kind, source, presetValue) {
  * @return {boolean} True when the stored value matches the preset value.
  */
 export function matchesPreset(kind, value, unit, presetValue) {
-	if (kind in BORDER_AXIS_INDEX) {
-		const source = borderSource(value);
-
-		return source !== null && matchesBorderAxis(kind, source, presetValue);
+	if (kind in border.BORDER_AXIS_INDEX) {
+		return border.matches(kind, value, unit, presetValue);
 	}
 
-	if (kind === 'dimension') {
-		const sides = dimensionSides(value);
-		const storedUnit = String(unit || '').trim();
-
-		if (!sides.length) {
-			return false;
-		}
-
-		// A per-corner preset value is compared corner by corner. `parseDimensionLiteral` reads one length,
-		// so a slot list handed to it whole would never match and the control would read as overridden even
-		// when it exactly matches its preset.
-		if (Array.isArray(presetValue)) {
-			return matchesPresetSlots(sides, storedUnit, presetValue);
-		}
-
-		const preset = parseDimensionLiteral(presetValue);
-		const unitMatches = preset.unit === '' || storedUnit === preset.unit;
-
-		// Side-aware: a stored dimension matches only when EVERY populated side equals the preset value.
-		// A per-corner override (e.g. `['8','8','8','4']` vs `8px`) leaves one side differing and so reads
-		// as overridden, not still-bound.
-		return unitMatches && sides.every((side) => side === preset.value);
-	}
-
-	if (kind === 'color') {
-		return normalizeColor(value) === normalizeColor(presetValue);
-	}
-
-	return normalizeText(value) === normalizeText(presetValue);
+	return KINDS[kind].matches(value, unit, presetValue);
 }


### PR DESCRIPTION
Splits `token-indicators/normalize.js`'s per-kind comparison logic out into dedicated `kinds/` modules (dimension, color, border, text), leaving `normalize.js` as a thin dispatch wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and matching of border widths, styles, and colors, including per-side values and empty states.
  * Improved color normalization for palette references and literal color values.
  * Improved responsive dimension handling, preset inheritance, units, and per-corner values.
  * Standardized text value normalization by trimming whitespace and handling empty values.

* **Tests**
  * Added comprehensive coverage for border, color, dimension, and text normalization and preset matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->