### PR TITLE
[DTM] SOFT-4083 [44/51]: show the token indicator and reset button on the Border field

### DIFF
--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -1134,6 +1134,8 @@ export default function KadenceButtonEdit(props) {
 															widthTokens={borderHoverWidthTokens}
 															defaultValue={borderWidthPresetValue}
 															renderColor={renderBorderColor}
+															state={tokenBinding.borderStyle}
+															onReset={() => resetToken('borderStyle')}
 														/>
 														<ResponsiveMeasurementControls
 															label={__('Border Radius', 'kadence-blocks')}
@@ -1279,6 +1281,8 @@ export default function KadenceButtonEdit(props) {
 															widthTokens={borderWidthTokens}
 															defaultValue={borderWidthPresetValue}
 															renderColor={renderBorderColor}
+															state={tokenBinding.borderStyle}
+															onReset={() => resetToken('borderStyle')}
 														/>
 														<EditorBoxControl
 															label={__('Border Radius', 'kadence-blocks')}
@@ -1402,6 +1406,8 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderTransparentHoverWidthTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
+																state={tokenBinding.borderStyle}
+																onReset={() => resetToken('borderStyle')}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1535,6 +1541,8 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderTransparentWidthTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
+																state={tokenBinding.borderStyle}
+																onReset={() => resetToken('borderStyle')}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1678,6 +1686,8 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderStickyHoverWidthTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
+																state={tokenBinding.borderStyle}
+																onReset={() => resetToken('borderStyle')}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1805,6 +1815,8 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderStickyWidthTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
+																state={tokenBinding.borderStyle}
+																onReset={() => resetToken('borderStyle')}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -1134,8 +1134,6 @@ export default function KadenceButtonEdit(props) {
 															widthTokens={borderHoverWidthTokens}
 															defaultValue={borderWidthPresetValue}
 															renderColor={renderBorderColor}
-															state={tokenBinding.borderStyle}
-															onReset={() => resetToken('borderStyle')}
 														/>
 														<ResponsiveMeasurementControls
 															label={__('Border Radius', 'kadence-blocks')}
@@ -1406,8 +1404,6 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderTransparentHoverWidthTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
-																state={tokenBinding.borderStyle}
-																onReset={() => resetToken('borderStyle')}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1541,8 +1537,6 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderTransparentWidthTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
-																state={tokenBinding.borderStyle}
-																onReset={() => resetToken('borderStyle')}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1686,8 +1680,6 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderStickyHoverWidthTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
-																state={tokenBinding.borderStyle}
-																onReset={() => resetToken('borderStyle')}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1815,8 +1807,6 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderStickyWidthTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
-																state={tokenBinding.borderStyle}
-																onReset={() => resetToken('borderStyle')}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}

--- a/src/extension/design-tokens/components/EditorBorderControl.js
+++ b/src/extension/design-tokens/components/EditorBorderControl.js
@@ -49,6 +49,7 @@ import { BorderControl } from '../../../token-controls/controls/BorderControl';
 import { readSlot } from '../../../token-controls/helpers/value-shapes';
 import { isTokenAlias } from '../../../token-controls/helpers/token-summary';
 import { TokenControlRow } from '../../token-indicators/components/TokenControlRow';
+import { TokenIndicator } from '../../token-indicators/components/TokenIndicator';
 
 const SIDES = ['top', 'right', 'bottom', 'left'];
 
@@ -220,26 +221,27 @@ function toNativeBorder(value, unit = 'px') {
 /**
  * Render the editor-canvas border control.
  *
- * @param {Object}       props                The component props.
- * @param {?Array}       props.value          Desktop border attribute value.
- * @param {?Array}       props.tabletValue    Tablet border attribute value.
- * @param {?Array}       props.mobileValue    Mobile border attribute value.
- * @param {Function}     props.onChange       Desktop attribute setter.
- * @param {Function}     props.onChangeTablet Tablet attribute setter.
- * @param {Function}     props.onChangeMobile Mobile attribute setter.
- * @param {string}       props.previewDevice  The editor's active device (`Desktop`/`Tablet`/`Mobile`).
- * @param {Function}     props.onDeviceChange Called with the next editor device name.
- * @param {string}       props.label          The control's label.
- * @param {Array}        [props.widthTokens]  Pickable border-width tokens.
- * @param {*}            [props.defaultValue] What the width slot falls back to when unset — the
- *                                            active preset's resolved border width, so a cleared
- *                                            width field shows a muted "Default 2px" instead of
- *                                            rendering empty (which collapses the field to zero
- *                                            height, per its own `TokenSelector`'s summary/fallback
- *                                            logic). One scalar for every side: presets set a single
- *                                            border width, never a per-side default.
- * @param {?Function}    [props.renderColor]  The block's existing color field for `value.color`.
- * @param {?JSX.Element} [props.indicator]    The editor's `TokenIndicator`, passed straight through.
+ * @param {Object}    props                The component props.
+ * @param {?Array}    props.value          Desktop border attribute value.
+ * @param {?Array}    props.tabletValue    Tablet border attribute value.
+ * @param {?Array}    props.mobileValue    Mobile border attribute value.
+ * @param {Function}  props.onChange       Desktop attribute setter.
+ * @param {Function}  props.onChangeTablet Tablet attribute setter.
+ * @param {Function}  props.onChangeMobile Mobile attribute setter.
+ * @param {string}    props.previewDevice  The editor's active device (`Desktop`/`Tablet`/`Mobile`).
+ * @param {Function}  props.onDeviceChange Called with the next editor device name.
+ * @param {string}    props.label          The control's label.
+ * @param {Array}     [props.widthTokens]  Pickable border-width tokens.
+ * @param {*}         [props.defaultValue] What the width slot falls back to when unset — the
+ *                                         active preset's resolved border width, so a cleared
+ *                                         width field shows a muted "Default 2px" instead of
+ *                                         rendering empty (which collapses the field to zero
+ *                                         height, per its own `TokenSelector`'s summary/fallback
+ *                                         logic). One scalar for every side: presets set a single
+ *                                         border width, never a per-side default.
+ * @param {?Function} [props.renderColor]  The block's existing color field for `value.color`.
+ * @param {?Object}   [props.state]        The block's own binding state (`{ bound, overridden }`).
+ * @param {?Function} [props.onReset]      Reset handler for the indicator.
  *
  * @since TBD
  *
@@ -258,7 +260,8 @@ export function EditorBorderControl({
 	widthTokens = [],
 	defaultValue,
 	renderColor,
-	indicator = null,
+	state = null,
+	onReset = null,
 }) {
 	const breakpoint = BREAKPOINT_FOR_DEVICE[previewDevice] ?? 'desktop';
 	// Named once and passed to both `BreakpointProvider` and the switcher below, so the two staying
@@ -319,7 +322,9 @@ export function EditorBorderControl({
 					onChange={(next) => activeSetter(toNativeBorder(next, activeUnit))}
 					widthTokens={widthTokens}
 					defaultValue={defaultValue}
-					indicator={indicator}
+					// The editor's own mark, not this library's: it is the same indicator the block's other
+					// controls show, and two marks meaning the same thing should not look different.
+					indicator={<TokenIndicator state={state} onReset={onReset} />}
 					breakpoints={Object.values(BREAKPOINT_FOR_DEVICE)}
 					breakpoint={breakpoint}
 					// The switcher lives in `ControlShell`, driven by this prop directly — it does not read

--- a/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
@@ -10,6 +10,7 @@ import { createRoot } from 'react-dom/client';
  * Internal dependencies
  */
 import { EditorBorderControl } from '../EditorBorderControl';
+import { TokenIndicator } from '../../../token-indicators/components/TokenIndicator';
 
 // `BorderControl` now gains its `isLinked`/`onToggleLink` props from state this component owns, so
 // it can no longer be exercised by calling `EditorBorderControl` as a plain function the way this file
@@ -609,5 +610,38 @@ describe('EditorBorderControl linked view', () => {
 			tabletValue: UNIFORM_NATIVE_VALUE,
 		});
 		expect(latestBorderControlProps.isLinked).toBe(true);
+	});
+});
+
+describe('EditorBorderControl token indicator', () => {
+	/**
+	 * `state`/`onReset` are threaded into a `TokenIndicator`, passed to `BorderControl` as its
+	 * `indicator` prop — the same wiring `EditorBoxControl` uses for Border Radius — so the block's
+	 * own binding state reaches the indicator rather than being dropped on the floor.
+	 *
+	 * @return {void}
+	 */
+	it('passes state and onReset through to a TokenIndicator handed to BorderControl as indicator', () => {
+		const onReset = jest.fn();
+		const state = { bound: true, overridden: true };
+
+		const { borderControl } = renderEditorBorderControl({ state, onReset });
+
+		expect(borderControl.props.indicator.type).toBe(TokenIndicator);
+		expect(borderControl.props.indicator.props.state).toBe(state);
+		expect(borderControl.props.indicator.props.onReset).toBe(onReset);
+	});
+
+	/**
+	 * With no `state`/`onReset` passed, the indicator still renders (as `TokenIndicator` renders
+	 * nothing for an unbound control), rather than `EditorBorderControl` omitting it altogether.
+	 *
+	 * @return {void}
+	 */
+	it('still hands BorderControl a TokenIndicator when state and onReset are omitted', () => {
+		const { borderControl } = renderEditorBorderControl();
+
+		expect(borderControl.props.indicator.type).toBe(TokenIndicator);
+		expect(borderControl.props.indicator.props.state).toBeNull();
 	});
 });


### PR DESCRIPTION
🎥  https://www.loom.com/share/7198d5dc45f84a81b6d9323baa51b3d2

Wires the Border field on `kadence/singlebtn`'s Normal state to the token indicator and reset button, using the `control_attr` binding added in [42/51].

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added token-aware indicators and reset handling for button border styles across normal, hover, transparent, and sticky states.
  * Border controls now consistently reflect token bindings and support resetting linked styles.

* **Bug Fixes**
  * Improved reliability of token indicators when border token information is unavailable.
  * Ensured indicators remain visible when token state or reset options are not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->