### PR TITLE
[DTM] SOFT-4083 [46/51]: migrate Padding to EditorBoxControl with token indicator and real preset defaults

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -790,7 +790,19 @@
 							"button-radius": "{semantic.radius.control}",
 							"button-border-width": "{semantic.border-width.default}",
 							"button-border-style": "{semantic.border-style.default}",
-							"button-border-color": "{semantic.color.border}"
+							"button-border-color": "{semantic.color.border}",
+							"button-padding": [
+								"{semantic.spacing.button-padding-top}",
+								"{semantic.spacing.button-padding-right}",
+								"{semantic.spacing.button-padding-bottom}",
+								"{semantic.spacing.button-padding-left}"
+							],
+							"button-margin": [
+								"{semantic.spacing.button-margin-top}",
+								"{semantic.spacing.button-margin-right}",
+								"{semantic.spacing.button-margin-bottom}",
+								"{semantic.spacing.button-margin-left}"
+							]
 						}
 					},
 					"secondary": {
@@ -803,7 +815,19 @@
 							"button-radius": "{semantic.radius.control}",
 							"button-border-width": "{semantic.border-width.default}",
 							"button-border-style": "{semantic.border-style.default}",
-							"button-border-color": "{semantic.color.border}"
+							"button-border-color": "{semantic.color.border}",
+							"button-padding": [
+								"{semantic.spacing.button-padding-top}",
+								"{semantic.spacing.button-padding-right}",
+								"{semantic.spacing.button-padding-bottom}",
+								"{semantic.spacing.button-padding-left}"
+							],
+							"button-margin": [
+								"{semantic.spacing.button-margin-top}",
+								"{semantic.spacing.button-margin-right}",
+								"{semantic.spacing.button-margin-bottom}",
+								"{semantic.spacing.button-margin-left}"
+							]
 						}
 					}
 				},

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -910,7 +910,8 @@ export default function KadenceButtonEdit(props) {
 	};
 
 	// The override records a choice made about the PREVIOUS preset's corners, so selecting another preset
-	// drops it — otherwise an explicit "link" would stick and hide a new preset's per-corner radius.
+	// drops it — otherwise an explicit "link" would stick and hide a new preset's per-corner radius (or,
+	// for padding, per-side padding).
 	useEffect(() => {
 		setBorderRadiusModeOverride({});
 		setBorderHoverRadiusModeOverride({});
@@ -918,6 +919,7 @@ export default function KadenceButtonEdit(props) {
 		setBorderTransparentHoverRadiusModeOverride({});
 		setBorderStickyRadiusModeOverride({});
 		setBorderStickyHoverRadiusModeOverride({});
+		setPaddingModeOverride({});
 	}, [attributes.kbPreset]);
 	useEffect(() => {
 		if (!isSelected) {

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -350,6 +350,14 @@ export default function KadenceButtonEdit(props) {
 		{ tablet: 'tabletBorderRadius', mobile: 'mobileBorderRadius' },
 		previewDevice
 	);
+	// Padding keeps the same one-mode-per-device shape as Border Radius above — one linked/individual
+	// mode, but a different stored attribute per breakpoint.
+	const paddingForDevice = measureAttrsForDevice(
+		attributes,
+		'padding',
+		{ tablet: 'tabletPadding', mobile: 'mobilePadding' },
+		previewDevice
+	);
 	const marginMouseOver = mouseOverVisualizer();
 	const paddingMouseOver = mouseOverVisualizer();
 
@@ -387,6 +395,20 @@ export default function KadenceButtonEdit(props) {
 		borderRadiusPresetValue
 	);
 
+	const paddingPresetValue = presetValueForDevice(
+		tokenBinding.padding?.presetValue,
+		tokenBinding.padding?.responsive,
+		previewDevice
+	);
+
+	// What an unset Padding side falls back to on the active device — same cascade as Border Radius
+	// above, run over sides rather than corners.
+	const inheritedPadding = inheritedMeasureSlots(
+		previewDevice,
+		{ desktop: padding, tablet: tabletPadding },
+		paddingPresetValue
+	);
+
 	useEffect(() => {
 		setAttributes({ inQueryBlock: getInQueryBlock(context, inQueryBlock) });
 
@@ -406,6 +428,9 @@ export default function KadenceButtonEdit(props) {
 	// Keyed by device: the responsive control keeps ONE mode but writes three attributes, so a choice
 	// made on Tablet must not flip Desktop's corners (and vice versa).
 	const [borderRadiusModeOverride, setBorderRadiusModeOverride] = useState({});
+	// Padding's linked/individual mode is tracked the same way as Border Radius's, above — its own
+	// override state because the two controls' sides are independent stored values.
+	const [paddingModeOverride, setPaddingModeOverride] = useState({});
 
 	// Everything the new box control needs that the block already knows, gathered in one place rather
 	// than inlined into the JSX.
@@ -433,6 +458,7 @@ export default function KadenceButtonEdit(props) {
 	const shadowTransparentHoverTokens = shadowPickableTokens;
 	const shadowStickyTokens = shadowPickableTokens;
 	const shadowStickyHoverTokens = shadowPickableTokens;
+	const paddingPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-padding');
 
 	// The mode describes what THIS device stores, not what it inherits. A breakpoint that stores nothing
 	// has nothing that differs, so it reads as linked — deriving from the inherited corners instead would
@@ -507,6 +533,64 @@ export default function KadenceButtonEdit(props) {
 		// Unlinking equal corners leaves the values untouched, so remember the choice for this session
 		// AND this device; a differing corner would derive individual on its own.
 		setBorderRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
+	};
+
+	// Padding's linked/individual mode and its toggle, mirroring Border Radius's own block above with
+	// "corner" swapped for "side" — same shape, run over `paddingForDevice`/`paddingPresetValue`/
+	// `inheritedPadding` instead.
+	const paddingIsLinked =
+		'linked' ===
+		(paddingModeOverride[previewDevice] ?? deriveMeasureMode(paddingForDevice.value, paddingPresetValue));
+
+	const inheritedPaddingSides = inheritedPadding.values;
+	const inheritedPaddingSidesDiffer =
+		Array.isArray(inheritedPaddingSides) && inheritedPaddingSides.some((side) => side !== inheritedPaddingSides[0]);
+	const aliasForPaddingValue = (value) =>
+		paddingPickableTokens.find((token) => token.value === value)?.alias ?? value ?? '';
+	const inheritedFirstPaddingSide = Array.isArray(inheritedPaddingSides)
+		? aliasForPaddingValue(inheritedPaddingSides[0])
+		: '';
+
+	const togglePaddingLink = () => {
+		if (!paddingIsLinked) {
+			const sides = paddingForDevice.value ?? [];
+			const side = sides[0] ?? '';
+			const isEmpty = sides.every((value) => '' === value || undefined === value);
+
+			if (isEmpty) {
+				if (!inheritedPaddingSidesDiffer) {
+					setPaddingModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
+
+					return;
+				}
+
+				setAttributes({
+					[paddingForDevice.attr]: [
+						inheritedFirstPaddingSide,
+						inheritedFirstPaddingSide,
+						inheritedFirstPaddingSide,
+						inheritedFirstPaddingSide,
+					],
+				});
+				setPaddingModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
+
+				return;
+			}
+
+			// Every side matches the first, blank included, and only on the ACTIVE device.
+			setAttributes({ [paddingForDevice.attr]: [side, side, side, side] });
+			// Equal sides derive linked on their own — except blank ones under a per-side preset.
+			setPaddingModeOverride((current) => ({
+				...current,
+				[previewDevice]: '' === side ? 'linked' : undefined,
+			}));
+
+			return;
+		}
+
+		// Unlinking equal sides leaves the values untouched, so remember the choice for this session AND
+		// this device; a differing side would derive individual on its own.
+		setPaddingModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
 	};
 
 	// Hover/Transparent/Transparent Hover/Sticky/Sticky Hover each store their own 4 corners, so each
@@ -2516,22 +2600,26 @@ export default function KadenceButtonEdit(props) {
 								{showSettings('marginSettings', 'kadence/advancedbtn') && (
 									<>
 										<KadencePanelBody panelName={'kb-single-button-margin-settings'}>
-											<ResponsiveMeasureRangeControl
+											<EditorBoxControl
 												label={__('Padding', 'kadence-blocks')}
-												value={padding}
-												onChange={(value) => setAttributes({ padding: value })}
-												tabletValue={tabletPadding}
-												onChangeTablet={(value) => setAttributes({ tabletPadding: value })}
-												mobileValue={mobilePadding}
-												onChangeMobile={(value) => setAttributes({ mobilePadding: value })}
-												min={paddingUnit === 'em' || paddingUnit === 'rem' ? -25 : -999}
-												max={paddingUnit === 'em' || paddingUnit === 'rem' ? 25 : 999}
-												step={paddingUnit === 'em' || paddingUnit === 'rem' ? 0.1 : 1}
+												value={paddingForDevice.value}
+												onChange={(next) => setAttributes({ [paddingForDevice.attr]: next })}
+												previewDevice={previewDevice}
+												onDeviceChange={setPreviewDevice}
+												tokens={paddingPickableTokens}
+												defaultValue={inheritedPadding.values}
+												inherited={anyCornerInherited(inheritedPadding.inherited)}
+												state={tokenBinding.padding}
+												onReset={() => resetToken('padding')}
+												isLinked={paddingIsLinked}
+												onToggleLink={togglePaddingLink}
+												role="sides"
 												unit={paddingUnit}
 												units={['px', 'em', 'rem']}
 												onUnit={(value) => setAttributes({ paddingUnit: value })}
-												onMouseOver={paddingMouseOver.onMouseOver}
-												onMouseOut={paddingMouseOver.onMouseOut}
+												min={paddingUnit === 'em' || paddingUnit === 'rem' ? -25 : -999}
+												max={paddingUnit === 'em' || paddingUnit === 'rem' ? 25 : 999}
+												step={paddingUnit === 'em' || paddingUnit === 'rem' ? 0.1 : 1}
 											/>
 											<ResponsiveMeasureRangeControl
 												label={__('Margin', 'kadence-blocks')}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
@@ -97,7 +97,9 @@ final class Css_BuilderTest extends TestCase {
 				. '--kb-btn-radius:var(--kb-token--preset--kadence-singlebtn--secondary--button-radius);'
 				. '--kb-btn-border-width:var(--kb-token--preset--kadence-singlebtn--secondary--button-border-width);'
 				. '--kb-btn-border-style:var(--kb-token--preset--kadence-singlebtn--secondary--button-border-style);'
-				. '--kb-btn-border-color:var(--kb-token--preset--kadence-singlebtn--secondary--button-border-color);}',
+				. '--kb-btn-border-color:var(--kb-token--preset--kadence-singlebtn--secondary--button-border-color);'
+				. '--kb-btn-padding:var(--kb-token--preset--kadence-singlebtn--secondary--button-padding);'
+				. '--kb-btn-margin:var(--kb-token--preset--kadence-singlebtn--secondary--button-margin);}',
 			$css
 		);
 	}
@@ -120,7 +122,9 @@ final class Css_BuilderTest extends TestCase {
 				. '--kb-btn-radius:var(--kb-token--preset--kadence-singlebtn--primary--button-radius);'
 				. '--kb-btn-border-width:var(--kb-token--preset--kadence-singlebtn--primary--button-border-width);'
 				. '--kb-btn-border-style:var(--kb-token--preset--kadence-singlebtn--primary--button-border-style);'
-				. '--kb-btn-border-color:var(--kb-token--preset--kadence-singlebtn--primary--button-border-color);}',
+				. '--kb-btn-border-color:var(--kb-token--preset--kadence-singlebtn--primary--button-border-color);'
+				. '--kb-btn-padding:var(--kb-token--preset--kadence-singlebtn--primary--button-padding);'
+				. '--kb-btn-margin:var(--kb-token--preset--kadence-singlebtn--primary--button-margin);}',
 			$css
 		);
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
@@ -128,6 +128,8 @@ final class Preset_ResolverTest extends TestCase {
 				'button-border-color',
 				'button-border-style',
 				'button-border-width',
+				'button-margin',
+				'button-padding',
 				'button-radius',
 				'button-text',
 				'button-text-hover',


### PR DESCRIPTION
🎥  https://www.loom.com/share/a6317d0389974404bb07e33e637cb8a8

Migrates the Padding field to `EditorBoxControl` with the token indicator, and gives `button-padding`/`button-margin` real per-corner preset defaults (`primary`/`secondary`) so the control no longer loads with an empty, height-shrinking value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Button presets now support dedicated padding and margin settings for primary and secondary styles.
  * Padding can be customized independently on each side and adjusted per device.
  * Responsive padding controls support linked or individual side values, inherited settings, preset defaults, and design-token values.
  * Padding values can be reset to their preset or inherited settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->