### PR TITLE
[DTM] SOFT-4083 [48/51]: extract the 7 linked-state blocks into a useLinkedMeasureState hook

### DIFF
--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -80,11 +80,11 @@ import {
 } from '@wordpress/components';
 import { addFilter, applyFilters, doAction } from '@wordpress/hooks';
 import BackendStyles from './components/backend-styles';
+import { useLinkedMeasureState } from './hooks/use-linked-measure-state';
 import { PresetButton } from '../../extension/preset-picker/PresetButton';
 import { usePresetBinding, resetAttr, presetPropertyValueForDevice } from '../../extension/token-indicators';
 import {
 	anyCornerInherited,
-	deriveMeasureMode,
 	inheritedMeasureSlots,
 	measureAttrsForDevice,
 	presetValueForDevice,
@@ -421,16 +421,6 @@ export default function KadenceButtonEdit(props) {
 
 	const [activeTab, setActiveTab] = useState('general');
 	const [isEditingURL, setIsEditingURL] = useState(false);
-	// The border-radius linked/individual mode is derived from the stored corners (all equal reads as
-	// linked), so no new attribute is needed and old buttons open in the right mode. This ephemeral
-	// override only records an explicit "unlink" of already-equal corners for the current session — it
-	// resets on remount, matching how the control's mode has always been session-local.
-	// Keyed by device: the responsive control keeps ONE mode but writes three attributes, so a choice
-	// made on Tablet must not flip Desktop's corners (and vice versa).
-	const [borderRadiusModeOverride, setBorderRadiusModeOverride] = useState({});
-	// Padding's linked/individual mode is tracked the same way as Border Radius's, above — its own
-	// override state because the two controls' sides are independent stored values.
-	const [paddingModeOverride, setPaddingModeOverride] = useState({});
 
 	// Everything the new box control needs that the block already knows, gathered in one place rather
 	// than inlined into the JSX.
@@ -448,145 +438,42 @@ export default function KadenceButtonEdit(props) {
 	const shadowPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow');
 	const paddingPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-padding');
 
-	// The mode describes what THIS device stores, not what it inherits. A breakpoint that stores nothing
-	// has nothing that differs, so it reads as linked — deriving from the inherited corners instead would
-	// split an all-empty Tablet into four identical blank fields, showing a difference the user cannot
-	// see. Where the value comes from is surfaced by the field's popover, not by the link toggle.
-	const borderRadiusIsLinked =
-		'linked' ===
-		(borderRadiusModeOverride[previewDevice] ??
-			deriveMeasureMode(borderRadiusForDevice.value, borderRadiusPresetValue));
+	// The border-radius/padding linked/individual mode is derived from the stored slots (all equal reads
+	// as linked), so no new attribute is needed and old buttons open in the right mode. The hook's own
+	// override only records an explicit "unlink" of already-equal slots for the current session — it
+	// resets on remount, matching how the control's mode has always been session-local. It is keyed by
+	// device internally: the responsive control keeps ONE mode but writes three attributes, so a choice
+	// made on Tablet must not flip Desktop's slots (and vice versa). It also resets whenever the active
+	// preset changes (via `resetOn`), since an override records a choice about the PREVIOUS preset's
+	// slots — otherwise an explicit "link" would stick and hide a new preset's per-slot value.
+	const { isLinked: borderRadiusIsLinked, toggleLink: toggleBorderRadiusLink } = useLinkedMeasureState({
+		forDevice: borderRadiusForDevice,
+		inherited: inheritedBorderRadius,
+		previewDevice,
+		presetValue: borderRadiusPresetValue,
+		tokens: borderRadiusTokens,
+		setAttributes,
+		resetOn: attributes.kbPreset,
+	});
 
-	// What the corners inherit, and whether that inheritance is uniform. A per-corner inheritance is the
-	// case where linking is a real change rather than a no-op. Always `inheritedBorderRadius.values`,
-	// never the raw preset value directly: `inheritedMeasureSlots()` already falls through to the
-	// preset's own per-corner slots (`presetSlotAt`) once the device's stored corners run out, so
-	// reading the preset array straight through here would drop any corner this device DOES store —
-	// silently discarding the desktop/tablet cascade for a preset that happens to be per-corner.
-	const inheritedCorners = inheritedBorderRadius.values;
-	const inheritedCornersDiffer =
-		Array.isArray(inheritedCorners) && inheritedCorners.some((corner) => corner !== inheritedCorners[0]);
-	// The preset surface carries resolved literals, not aliases (`blockPresetValues` flattens them so the
-	// overridden-check can be a plain compare), so the literal is matched back to the token that produced
-	// it. Writing the alias keeps the collapsed corner bound to `None` rather than landing as a custom
-	// `0px` that merely happens to look the same.
-	const aliasForValue = (value) => borderRadiusTokens.find((token) => token.value === value)?.alias ?? value ?? '';
-	const inheritedFirstCorner = Array.isArray(inheritedCorners) ? aliasForValue(inheritedCorners[0]) : '';
-
-	const toggleBorderRadiusLink = () => {
-		if (!borderRadiusIsLinked) {
-			const corners = borderRadiusForDevice.value ?? [];
-			const corner = corners[0] ?? '';
-			const isEmpty = corners.every((value) => '' === value || undefined === value);
-
-			if (isEmpty) {
-				// Nothing stored on this device, so ordinarily there is nothing to collapse — the corners
-				// are empty because they inherit, and writing the inherited value would silently pin
-				// Tablet/Mobile to Desktop's current radius. Remember the choice instead.
-				//
-				// Unless what is inherited differs corner to corner: then "link" genuinely changes the
-				// result, and storing nothing would leave the control showing one value while the button
-				// still renders four, with the indicator insisting it matches the preset. Collapsing to
-				// the first corner is the write that makes the three agree.
-				if (!inheritedCornersDiffer) {
-					setBorderRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
-
-					return;
-				}
-
-				setAttributes({
-					[borderRadiusForDevice.attr]: [
-						inheritedFirstCorner,
-						inheritedFirstCorner,
-						inheritedFirstCorner,
-						inheritedFirstCorner,
-					],
-				});
-				setBorderRadiusModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
-
-				return;
-			}
-
-			// Every corner matches the top-left, blank included, and only on the ACTIVE device.
-			setAttributes({ [borderRadiusForDevice.attr]: [corner, corner, corner, corner] });
-			// Equal corners derive linked on their own — except blank ones under a per-corner preset.
-			setBorderRadiusModeOverride((current) => ({
-				...current,
-				[previewDevice]: '' === corner ? 'linked' : undefined,
-			}));
-
-			return;
-		}
-
-		// Unlinking equal corners leaves the values untouched, so remember the choice for this session
-		// AND this device; a differing corner would derive individual on its own.
-		setBorderRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
-	};
-
-	// Padding's linked/individual mode and its toggle, mirroring Border Radius's own block above with
-	// "corner" swapped for "side" — same shape, run over `paddingForDevice`/`paddingPresetValue`/
-	// `inheritedPadding` instead.
-	const paddingIsLinked =
-		'linked' ===
-		(paddingModeOverride[previewDevice] ?? deriveMeasureMode(paddingForDevice.value, paddingPresetValue));
-
-	const inheritedPaddingSides = inheritedPadding.values;
-	const inheritedPaddingSidesDiffer =
-		Array.isArray(inheritedPaddingSides) && inheritedPaddingSides.some((side) => side !== inheritedPaddingSides[0]);
-	const aliasForPaddingValue = (value) =>
-		paddingPickableTokens.find((token) => token.value === value)?.alias ?? value ?? '';
-	const inheritedFirstPaddingSide = Array.isArray(inheritedPaddingSides)
-		? aliasForPaddingValue(inheritedPaddingSides[0])
-		: '';
-
-	const togglePaddingLink = () => {
-		if (!paddingIsLinked) {
-			const sides = paddingForDevice.value ?? [];
-			const side = sides[0] ?? '';
-			const isEmpty = sides.every((value) => '' === value || undefined === value);
-
-			if (isEmpty) {
-				if (!inheritedPaddingSidesDiffer) {
-					setPaddingModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
-
-					return;
-				}
-
-				setAttributes({
-					[paddingForDevice.attr]: [
-						inheritedFirstPaddingSide,
-						inheritedFirstPaddingSide,
-						inheritedFirstPaddingSide,
-						inheritedFirstPaddingSide,
-					],
-				});
-				setPaddingModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
-
-				return;
-			}
-
-			// Every side matches the first, blank included, and only on the ACTIVE device.
-			setAttributes({ [paddingForDevice.attr]: [side, side, side, side] });
-			// Equal sides derive linked on their own — except blank ones under a per-side preset.
-			setPaddingModeOverride((current) => ({
-				...current,
-				[previewDevice]: '' === side ? 'linked' : undefined,
-			}));
-
-			return;
-		}
-
-		// Unlinking equal sides leaves the values untouched, so remember the choice for this session AND
-		// this device; a differing side would derive individual on its own.
-		setPaddingModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
-	};
+	// Padding's linked/individual mode, mirroring Border Radius's own hook call above with "corner"
+	// swapped for "side" — same shape, run over `paddingForDevice`/`paddingPresetValue`/
+	// `inheritedPadding`/`paddingPickableTokens` instead. Padding has no `resetOn`: unlike Border
+	// Radius's 6 states, its override has never been cleared on a preset change.
+	const { isLinked: paddingIsLinked, toggleLink: togglePaddingLink } = useLinkedMeasureState({
+		forDevice: paddingForDevice,
+		inherited: inheritedPadding,
+		previewDevice,
+		presetValue: paddingPresetValue,
+		tokens: paddingPickableTokens,
+		setAttributes,
+	});
 
 	// Hover/Transparent/Transparent Hover/Sticky/Sticky Hover each store their own 4 corners, so each
-	// gets its own copy of the linked-state machinery above — sharing Normal's `borderRadiusModeOverride`
-	// would couple these states' link/unlink UI together even though the underlying attributes are
-	// independent. All 6 states still read/write the same `tokenBinding.borderRadius` preset binding and
-	// `borderRadiusTokens` pool, since there is only one border-radius preset property.
-	const [borderHoverRadiusModeOverride, setBorderHoverRadiusModeOverride] = useState({});
+	// gets its own call to the hook above — sharing Normal's linked state would couple these states'
+	// link/unlink UI together even though the underlying attributes are independent. All 6 states still
+	// read/write the same `tokenBinding.borderRadius` preset binding and `borderRadiusTokens` pool, since
+	// there is only one border-radius preset property.
 	const borderHoverRadiusForDevice = measureAttrsForDevice(
 		attributes,
 		'borderHoverRadius',
@@ -598,56 +485,16 @@ export default function KadenceButtonEdit(props) {
 		{ desktop: borderHoverRadius, tablet: tabletBorderHoverRadius },
 		borderRadiusPresetValue
 	);
-	const borderHoverRadiusIsLinked =
-		'linked' ===
-		(borderHoverRadiusModeOverride[previewDevice] ??
-			deriveMeasureMode(borderHoverRadiusForDevice.value, borderRadiusPresetValue));
-	const borderHoverInheritedCorners = inheritedBorderHoverRadius.values;
-	const borderHoverInheritedCornersDiffer =
-		Array.isArray(borderHoverInheritedCorners) &&
-		borderHoverInheritedCorners.some((corner) => corner !== borderHoverInheritedCorners[0]);
-	const borderHoverInheritedFirstCorner = Array.isArray(borderHoverInheritedCorners)
-		? aliasForValue(borderHoverInheritedCorners[0])
-		: '';
-	const toggleBorderHoverRadiusLink = () => {
-		if (!borderHoverRadiusIsLinked) {
-			const corners = borderHoverRadiusForDevice.value ?? [];
-			const corner = corners[0] ?? '';
-			const isEmpty = corners.every((value) => '' === value || undefined === value);
+	const { isLinked: borderHoverRadiusIsLinked, toggleLink: toggleBorderHoverRadiusLink } = useLinkedMeasureState({
+		forDevice: borderHoverRadiusForDevice,
+		inherited: inheritedBorderHoverRadius,
+		previewDevice,
+		presetValue: borderRadiusPresetValue,
+		tokens: borderRadiusTokens,
+		setAttributes,
+		resetOn: attributes.kbPreset,
+	});
 
-			if (isEmpty) {
-				if (!borderHoverInheritedCornersDiffer) {
-					setBorderHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
-
-					return;
-				}
-
-				setAttributes({
-					[borderHoverRadiusForDevice.attr]: [
-						borderHoverInheritedFirstCorner,
-						borderHoverInheritedFirstCorner,
-						borderHoverInheritedFirstCorner,
-						borderHoverInheritedFirstCorner,
-					],
-				});
-				setBorderHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
-
-				return;
-			}
-
-			setAttributes({ [borderHoverRadiusForDevice.attr]: [corner, corner, corner, corner] });
-			setBorderHoverRadiusModeOverride((current) => ({
-				...current,
-				[previewDevice]: '' === corner ? 'linked' : undefined,
-			}));
-
-			return;
-		}
-
-		setBorderHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
-	};
-
-	const [borderTransparentRadiusModeOverride, setBorderTransparentRadiusModeOverride] = useState({});
 	const borderTransparentRadiusForDevice = measureAttrsForDevice(
 		attributes,
 		'borderTransparentRadius',
@@ -659,56 +506,17 @@ export default function KadenceButtonEdit(props) {
 		{ desktop: borderTransparentRadius, tablet: tabletBorderTransparentRadius },
 		borderRadiusPresetValue
 	);
-	const borderTransparentRadiusIsLinked =
-		'linked' ===
-		(borderTransparentRadiusModeOverride[previewDevice] ??
-			deriveMeasureMode(borderTransparentRadiusForDevice.value, borderRadiusPresetValue));
-	const borderTransparentInheritedCorners = inheritedBorderTransparentRadius.values;
-	const borderTransparentInheritedCornersDiffer =
-		Array.isArray(borderTransparentInheritedCorners) &&
-		borderTransparentInheritedCorners.some((corner) => corner !== borderTransparentInheritedCorners[0]);
-	const borderTransparentInheritedFirstCorner = Array.isArray(borderTransparentInheritedCorners)
-		? aliasForValue(borderTransparentInheritedCorners[0])
-		: '';
-	const toggleBorderTransparentRadiusLink = () => {
-		if (!borderTransparentRadiusIsLinked) {
-			const corners = borderTransparentRadiusForDevice.value ?? [];
-			const corner = corners[0] ?? '';
-			const isEmpty = corners.every((value) => '' === value || undefined === value);
+	const { isLinked: borderTransparentRadiusIsLinked, toggleLink: toggleBorderTransparentRadiusLink } =
+		useLinkedMeasureState({
+			forDevice: borderTransparentRadiusForDevice,
+			inherited: inheritedBorderTransparentRadius,
+			previewDevice,
+			presetValue: borderRadiusPresetValue,
+			tokens: borderRadiusTokens,
+			setAttributes,
+			resetOn: attributes.kbPreset,
+		});
 
-			if (isEmpty) {
-				if (!borderTransparentInheritedCornersDiffer) {
-					setBorderTransparentRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
-
-					return;
-				}
-
-				setAttributes({
-					[borderTransparentRadiusForDevice.attr]: [
-						borderTransparentInheritedFirstCorner,
-						borderTransparentInheritedFirstCorner,
-						borderTransparentInheritedFirstCorner,
-						borderTransparentInheritedFirstCorner,
-					],
-				});
-				setBorderTransparentRadiusModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
-
-				return;
-			}
-
-			setAttributes({ [borderTransparentRadiusForDevice.attr]: [corner, corner, corner, corner] });
-			setBorderTransparentRadiusModeOverride((current) => ({
-				...current,
-				[previewDevice]: '' === corner ? 'linked' : undefined,
-			}));
-
-			return;
-		}
-
-		setBorderTransparentRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
-	};
-
-	const [borderTransparentHoverRadiusModeOverride, setBorderTransparentHoverRadiusModeOverride] = useState({});
 	const borderTransparentHoverRadiusForDevice = measureAttrsForDevice(
 		attributes,
 		'borderTransparentHoverRadius',
@@ -720,62 +528,17 @@ export default function KadenceButtonEdit(props) {
 		{ desktop: borderTransparentHoverRadius, tablet: tabletBorderTransparentHoverRadius },
 		borderRadiusPresetValue
 	);
-	const borderTransparentHoverRadiusIsLinked =
-		'linked' ===
-		(borderTransparentHoverRadiusModeOverride[previewDevice] ??
-			deriveMeasureMode(borderTransparentHoverRadiusForDevice.value, borderRadiusPresetValue));
-	const borderTransparentHoverInheritedCorners = inheritedBorderTransparentHoverRadius.values;
-	const borderTransparentHoverInheritedCornersDiffer =
-		Array.isArray(borderTransparentHoverInheritedCorners) &&
-		borderTransparentHoverInheritedCorners.some((corner) => corner !== borderTransparentHoverInheritedCorners[0]);
-	const borderTransparentHoverInheritedFirstCorner = Array.isArray(borderTransparentHoverInheritedCorners)
-		? aliasForValue(borderTransparentHoverInheritedCorners[0])
-		: '';
-	const toggleBorderTransparentHoverRadiusLink = () => {
-		if (!borderTransparentHoverRadiusIsLinked) {
-			const corners = borderTransparentHoverRadiusForDevice.value ?? [];
-			const corner = corners[0] ?? '';
-			const isEmpty = corners.every((value) => '' === value || undefined === value);
+	const { isLinked: borderTransparentHoverRadiusIsLinked, toggleLink: toggleBorderTransparentHoverRadiusLink } =
+		useLinkedMeasureState({
+			forDevice: borderTransparentHoverRadiusForDevice,
+			inherited: inheritedBorderTransparentHoverRadius,
+			previewDevice,
+			presetValue: borderRadiusPresetValue,
+			tokens: borderRadiusTokens,
+			setAttributes,
+			resetOn: attributes.kbPreset,
+		});
 
-			if (isEmpty) {
-				if (!borderTransparentHoverInheritedCornersDiffer) {
-					setBorderTransparentHoverRadiusModeOverride((current) => ({
-						...current,
-						[previewDevice]: 'linked',
-					}));
-
-					return;
-				}
-
-				setAttributes({
-					[borderTransparentHoverRadiusForDevice.attr]: [
-						borderTransparentHoverInheritedFirstCorner,
-						borderTransparentHoverInheritedFirstCorner,
-						borderTransparentHoverInheritedFirstCorner,
-						borderTransparentHoverInheritedFirstCorner,
-					],
-				});
-				setBorderTransparentHoverRadiusModeOverride((current) => ({
-					...current,
-					[previewDevice]: undefined,
-				}));
-
-				return;
-			}
-
-			setAttributes({ [borderTransparentHoverRadiusForDevice.attr]: [corner, corner, corner, corner] });
-			setBorderTransparentHoverRadiusModeOverride((current) => ({
-				...current,
-				[previewDevice]: '' === corner ? 'linked' : undefined,
-			}));
-
-			return;
-		}
-
-		setBorderTransparentHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
-	};
-
-	const [borderStickyRadiusModeOverride, setBorderStickyRadiusModeOverride] = useState({});
 	const borderStickyRadiusForDevice = measureAttrsForDevice(
 		attributes,
 		'borderStickyRadius',
@@ -787,56 +550,16 @@ export default function KadenceButtonEdit(props) {
 		{ desktop: borderStickyRadius, tablet: tabletBorderStickyRadius },
 		borderRadiusPresetValue
 	);
-	const borderStickyRadiusIsLinked =
-		'linked' ===
-		(borderStickyRadiusModeOverride[previewDevice] ??
-			deriveMeasureMode(borderStickyRadiusForDevice.value, borderRadiusPresetValue));
-	const borderStickyInheritedCorners = inheritedBorderStickyRadius.values;
-	const borderStickyInheritedCornersDiffer =
-		Array.isArray(borderStickyInheritedCorners) &&
-		borderStickyInheritedCorners.some((corner) => corner !== borderStickyInheritedCorners[0]);
-	const borderStickyInheritedFirstCorner = Array.isArray(borderStickyInheritedCorners)
-		? aliasForValue(borderStickyInheritedCorners[0])
-		: '';
-	const toggleBorderStickyRadiusLink = () => {
-		if (!borderStickyRadiusIsLinked) {
-			const corners = borderStickyRadiusForDevice.value ?? [];
-			const corner = corners[0] ?? '';
-			const isEmpty = corners.every((value) => '' === value || undefined === value);
+	const { isLinked: borderStickyRadiusIsLinked, toggleLink: toggleBorderStickyRadiusLink } = useLinkedMeasureState({
+		forDevice: borderStickyRadiusForDevice,
+		inherited: inheritedBorderStickyRadius,
+		previewDevice,
+		presetValue: borderRadiusPresetValue,
+		tokens: borderRadiusTokens,
+		setAttributes,
+		resetOn: attributes.kbPreset,
+	});
 
-			if (isEmpty) {
-				if (!borderStickyInheritedCornersDiffer) {
-					setBorderStickyRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
-
-					return;
-				}
-
-				setAttributes({
-					[borderStickyRadiusForDevice.attr]: [
-						borderStickyInheritedFirstCorner,
-						borderStickyInheritedFirstCorner,
-						borderStickyInheritedFirstCorner,
-						borderStickyInheritedFirstCorner,
-					],
-				});
-				setBorderStickyRadiusModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
-
-				return;
-			}
-
-			setAttributes({ [borderStickyRadiusForDevice.attr]: [corner, corner, corner, corner] });
-			setBorderStickyRadiusModeOverride((current) => ({
-				...current,
-				[previewDevice]: '' === corner ? 'linked' : undefined,
-			}));
-
-			return;
-		}
-
-		setBorderStickyRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
-	};
-
-	const [borderStickyHoverRadiusModeOverride, setBorderStickyHoverRadiusModeOverride] = useState({});
 	const borderStickyHoverRadiusForDevice = measureAttrsForDevice(
 		attributes,
 		'borderStickyHoverRadius',
@@ -848,67 +571,17 @@ export default function KadenceButtonEdit(props) {
 		{ desktop: borderStickyHoverRadius, tablet: tabletBorderStickyHoverRadius },
 		borderRadiusPresetValue
 	);
-	const borderStickyHoverRadiusIsLinked =
-		'linked' ===
-		(borderStickyHoverRadiusModeOverride[previewDevice] ??
-			deriveMeasureMode(borderStickyHoverRadiusForDevice.value, borderRadiusPresetValue));
-	const borderStickyHoverInheritedCorners = inheritedBorderStickyHoverRadius.values;
-	const borderStickyHoverInheritedCornersDiffer =
-		Array.isArray(borderStickyHoverInheritedCorners) &&
-		borderStickyHoverInheritedCorners.some((corner) => corner !== borderStickyHoverInheritedCorners[0]);
-	const borderStickyHoverInheritedFirstCorner = Array.isArray(borderStickyHoverInheritedCorners)
-		? aliasForValue(borderStickyHoverInheritedCorners[0])
-		: '';
-	const toggleBorderStickyHoverRadiusLink = () => {
-		if (!borderStickyHoverRadiusIsLinked) {
-			const corners = borderStickyHoverRadiusForDevice.value ?? [];
-			const corner = corners[0] ?? '';
-			const isEmpty = corners.every((value) => '' === value || undefined === value);
+	const { isLinked: borderStickyHoverRadiusIsLinked, toggleLink: toggleBorderStickyHoverRadiusLink } =
+		useLinkedMeasureState({
+			forDevice: borderStickyHoverRadiusForDevice,
+			inherited: inheritedBorderStickyHoverRadius,
+			previewDevice,
+			presetValue: borderRadiusPresetValue,
+			tokens: borderRadiusTokens,
+			setAttributes,
+			resetOn: attributes.kbPreset,
+		});
 
-			if (isEmpty) {
-				if (!borderStickyHoverInheritedCornersDiffer) {
-					setBorderStickyHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
-
-					return;
-				}
-
-				setAttributes({
-					[borderStickyHoverRadiusForDevice.attr]: [
-						borderStickyHoverInheritedFirstCorner,
-						borderStickyHoverInheritedFirstCorner,
-						borderStickyHoverInheritedFirstCorner,
-						borderStickyHoverInheritedFirstCorner,
-					],
-				});
-				setBorderStickyHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
-
-				return;
-			}
-
-			setAttributes({ [borderStickyHoverRadiusForDevice.attr]: [corner, corner, corner, corner] });
-			setBorderStickyHoverRadiusModeOverride((current) => ({
-				...current,
-				[previewDevice]: '' === corner ? 'linked' : undefined,
-			}));
-
-			return;
-		}
-
-		setBorderStickyHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
-	};
-
-	// The override records a choice made about the PREVIOUS preset's corners, so selecting another preset
-	// drops it — otherwise an explicit "link" would stick and hide a new preset's per-corner radius (or,
-	// for padding, per-side padding).
-	useEffect(() => {
-		setBorderRadiusModeOverride({});
-		setBorderHoverRadiusModeOverride({});
-		setBorderTransparentRadiusModeOverride({});
-		setBorderTransparentHoverRadiusModeOverride({});
-		setBorderStickyRadiusModeOverride({});
-		setBorderStickyHoverRadiusModeOverride({});
-		setPaddingModeOverride({});
-	}, [attributes.kbPreset]);
 	useEffect(() => {
 		if (!isSelected) {
 			setIsEditingURL(false);

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -458,8 +458,9 @@ export default function KadenceButtonEdit(props) {
 
 	// Padding's linked/individual mode, mirroring Border Radius's own hook call above with "corner"
 	// swapped for "side" — same shape, run over `paddingForDevice`/`paddingPresetValue`/
-	// `inheritedPadding`/`paddingPickableTokens` instead. Padding has no `resetOn`: unlike Border
-	// Radius's 6 states, its override has never been cleared on a preset change.
+	// `inheritedPadding`/`paddingPickableTokens` instead, `resetOn` included: an override records a
+	// choice about the PREVIOUS preset's sides, so it has to clear on a preset change here too, or an
+	// explicit "link" sticks and hides the new preset's own per-side padding.
 	const { isLinked: paddingIsLinked, toggleLink: togglePaddingLink } = useLinkedMeasureState({
 		forDevice: paddingForDevice,
 		inherited: inheritedPadding,
@@ -467,6 +468,7 @@ export default function KadenceButtonEdit(props) {
 		presetValue: paddingPresetValue,
 		tokens: paddingPickableTokens,
 		setAttributes,
+		resetOn: attributes.kbPreset,
 	});
 
 	// Hover/Transparent/Transparent Hover/Sticky/Sticky Hover each store their own 4 corners, so each

--- a/src/blocks/singlebtn/hooks/__tests__/use-linked-measure-state.test.js
+++ b/src/blocks/singlebtn/hooks/__tests__/use-linked-measure-state.test.js
@@ -1,0 +1,267 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement, StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { useLinkedMeasureState } from '../use-linked-measure-state';
+
+const TOKENS = [
+	{ value: '4px', alias: 'sm' },
+	{ value: '6px', alias: 'md' },
+	{ value: '8px', alias: 'lg' },
+];
+
+let container;
+let root;
+
+/**
+ * Render the hook and expose its latest return value, plus a way to re-render with new props on the
+ * SAME mounted instance — needed to exercise state that persists across renders (the mode override).
+ *
+ * @return {{box: {current: Object}, update: Function}} A ref-like box holding the hook's most recent
+ *  return value, and an `update(props)` function that re-renders the same instance with new props.
+ */
+function renderHook(initialProps) {
+	const box = {};
+
+	function Probe(props) {
+		box.current = useLinkedMeasureState(props);
+
+		return null;
+	}
+
+	function render(props) {
+		act(() => {
+			root.render(createElement(StrictMode, null, createElement(Probe, props)));
+		});
+	}
+
+	render(initialProps);
+
+	return { box, update: render };
+}
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	if (root) {
+		act(() => root.unmount());
+	}
+
+	container.remove();
+
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+describe('useLinkedMeasureState', () => {
+	/**
+	 * An unset device value reads as linked — every effective slot falls through to the same scalar
+	 * preset value, so there is nothing to show as different.
+	 *
+	 * @return {void}
+	 */
+	it('reads as linked when the device stores nothing and the preset is a single scalar', () => {
+		const { box } = renderHook({
+			forDevice: { attr: 'radius', value: ['', '', '', ''] },
+			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
+			previewDevice: 'Desktop',
+			presetValue: '4px',
+			tokens: TOKENS,
+			setAttributes: jest.fn(),
+		});
+
+		expect(box.current.isLinked).toBe(true);
+	});
+
+	/**
+	 * A uniform stored value reads as linked, regardless of the preset.
+	 *
+	 * @return {void}
+	 */
+	it('reads as linked when every stored slot matches', () => {
+		const { box } = renderHook({
+			forDevice: { attr: 'radius', value: ['4px', '4px', '4px', '4px'] },
+			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
+			previewDevice: 'Desktop',
+			presetValue: '8px',
+			tokens: TOKENS,
+			setAttributes: jest.fn(),
+		});
+
+		expect(box.current.isLinked).toBe(true);
+	});
+
+	/**
+	 * A stored slot that differs from the rest reads as individual.
+	 *
+	 * @return {void}
+	 */
+	it('reads as individual when a stored slot differs', () => {
+		const { box } = renderHook({
+			forDevice: { attr: 'radius', value: ['4px', '8px', '4px', '4px'] },
+			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
+			previewDevice: 'Desktop',
+			presetValue: '4px',
+			tokens: TOKENS,
+			setAttributes: jest.fn(),
+		});
+
+		expect(box.current.isLinked).toBe(false);
+	});
+
+	/**
+	 * Linking an empty device whose inherited slots are uniform remembers the override without writing
+	 * any attribute — writing would pin the device to another breakpoint's current value.
+	 *
+	 * @return {void}
+	 */
+	it('remembers a link toggle without writing an attribute when the inherited slots are uniform', () => {
+		const setAttributes = jest.fn();
+		const { box } = renderHook({
+			forDevice: { attr: 'tabletRadius', value: ['', '', '', ''] },
+			inherited: { values: ['6px', '6px', '6px', '6px'], inherited: [true, true, true, true] },
+			previewDevice: 'Tablet',
+			presetValue: ['4px', '8px', '4px', '4px'],
+			tokens: TOKENS,
+			setAttributes,
+		});
+
+		expect(box.current.isLinked).toBe(false);
+
+		act(() => box.current.toggleLink());
+
+		expect(setAttributes).not.toHaveBeenCalled();
+		expect(box.current.isLinked).toBe(true);
+	});
+
+	/**
+	 * Linking an empty device whose inherited slots differ collapses them by writing the first
+	 * inherited slot (resolved to its token alias) into every slot, so the control and the preset
+	 * agree.
+	 *
+	 * @return {void}
+	 */
+	it('collapses to the first inherited slot when linking an empty device with differing inherited slots', () => {
+		const setAttributes = jest.fn();
+		const { box } = renderHook({
+			forDevice: { attr: 'tabletRadius', value: ['', '', '', ''] },
+			inherited: { values: ['6px', '8px', '6px', '6px'], inherited: [true, true, true, true] },
+			previewDevice: 'Tablet',
+			presetValue: ['4px', '8px', '4px', '4px'],
+			tokens: TOKENS,
+			setAttributes,
+		});
+
+		expect(box.current.isLinked).toBe(false);
+
+		act(() => box.current.toggleLink());
+
+		expect(setAttributes).toHaveBeenCalledWith({ tabletRadius: ['md', 'md', 'md', 'md'] });
+	});
+
+	/**
+	 * Unlinking a linked device leaves the stored value untouched and remembers 'individual' for that
+	 * device, so a subsequent read reflects the toggle without any attribute write.
+	 *
+	 * @return {void}
+	 */
+	it('unlinking a linked device remembers individual mode without writing an attribute', () => {
+		const setAttributes = jest.fn();
+		const { box } = renderHook({
+			forDevice: { attr: 'radius', value: ['4px', '4px', '4px', '4px'] },
+			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
+			previewDevice: 'Desktop',
+			presetValue: '4px',
+			tokens: TOKENS,
+			setAttributes,
+		});
+
+		expect(box.current.isLinked).toBe(true);
+
+		act(() => box.current.toggleLink());
+
+		expect(setAttributes).not.toHaveBeenCalled();
+		expect(box.current.isLinked).toBe(false);
+	});
+
+	/**
+	 * The mode override is keyed per device, so unlinking Tablet must not affect Desktop's own linked
+	 * state on the same hook instance.
+	 *
+	 * @return {void}
+	 */
+	it('keys the remembered override by device, leaving other devices unaffected', () => {
+		const setAttributes = jest.fn();
+		const { box, update } = renderHook({
+			forDevice: { attr: 'tabletRadius', value: ['4px', '4px', '4px', '4px'] },
+			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
+			previewDevice: 'Tablet',
+			presetValue: '4px',
+			tokens: TOKENS,
+			setAttributes,
+		});
+
+		expect(box.current.isLinked).toBe(true);
+
+		act(() => box.current.toggleLink());
+
+		expect(box.current.isLinked).toBe(false);
+
+		update({
+			forDevice: { attr: 'radius', value: ['4px', '4px', '4px', '4px'] },
+			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
+			previewDevice: 'Desktop',
+			presetValue: '4px',
+			tokens: TOKENS,
+			setAttributes,
+		});
+
+		expect(box.current.isLinked).toBe(true);
+	});
+
+	/**
+	 * A change to `resetOn` (e.g. a new preset selected) clears any remembered override, so the mode
+	 * re-derives from the stored value and preset alone.
+	 *
+	 * @return {void}
+	 */
+	it('clears the remembered override when resetOn changes', () => {
+		const setAttributes = jest.fn();
+		const { box, update } = renderHook({
+			forDevice: { attr: 'radius', value: ['4px', '4px', '4px', '4px'] },
+			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
+			previewDevice: 'Desktop',
+			presetValue: '4px',
+			tokens: TOKENS,
+			setAttributes,
+			resetOn: 'preset-a',
+		});
+
+		act(() => box.current.toggleLink());
+
+		expect(box.current.isLinked).toBe(false);
+
+		update({
+			forDevice: { attr: 'radius', value: ['4px', '4px', '4px', '4px'] },
+			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
+			previewDevice: 'Desktop',
+			presetValue: '4px',
+			tokens: TOKENS,
+			setAttributes,
+			resetOn: 'preset-b',
+		});
+
+		expect(box.current.isLinked).toBe(true);
+	});
+});

--- a/src/blocks/singlebtn/hooks/use-linked-measure-state.js
+++ b/src/blocks/singlebtn/hooks/use-linked-measure-state.js
@@ -1,0 +1,138 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { deriveMeasureMode } from '../../../extension/token-indicators/normalize';
+
+/**
+ * The value a token in `tokens` resolves to, matched back to the alias that produced it.
+ *
+ * The preset surface carries resolved literals, not aliases (`blockPresetValues` flattens them so the
+ * overridden-check can be a plain compare), so the literal is matched back to the token that produced
+ * it. Writing the alias keeps a collapsed slot bound to the token (e.g. `None`) rather than landing as
+ * a custom literal that merely happens to look the same.
+ *
+ * @param {Array}  tokens The pickable tokens for this control, each `{ value, alias }`.
+ * @param {*}      value  The resolved literal to match back to its token.
+ *
+ * @since TBD
+ *
+ * @return {string} The matching token's alias, or the literal itself when no token matches.
+ */
+function aliasForValue(tokens, value) {
+	return tokens.find((token) => token.value === value)?.alias ?? value ?? '';
+}
+
+/**
+ * The linked/individual state — and its toggle — for a responsive 4-slot measure control (Border
+ * Radius's corners, Padding's sides, and any control sharing that shape).
+ *
+ * A responsive measure control keeps ONE linked/individual mode but writes a different attribute per
+ * breakpoint, so the mode must be read from — and "link" must collapse — whichever device is active.
+ * The mode describes what THIS device stores, not what it inherits: a breakpoint that stores nothing
+ * has nothing that differs, so it reads as linked — deriving from the inherited slots instead would
+ * split an all-empty Tablet into four identical blank fields, showing a difference the user cannot see.
+ * Where the value comes from is surfaced by the field's popover, not by the link toggle.
+ *
+ * @param {Object}   config               The hook's configuration.
+ * @param {Object}   config.forDevice     The active device's attribute and value, i.e.
+ *                                        `measureAttrsForDevice()`'s return shape (`{ attr, value }`).
+ * @param {Object}   config.inherited     What each slot inherits at the active device, i.e.
+ *                                        `inheritedMeasureSlots()`'s return shape (`{ values, inherited }`).
+ * @param {string}   config.previewDevice The active preview device ('Desktop' | 'Tablet' | 'Mobile').
+ * @param {*}        config.presetValue   The selected preset's value for the property.
+ * @param {Array}    config.tokens        The pickable tokens for this control, each `{ value, alias }`.
+ * @param {Function} config.setAttributes The block's `setAttributes`.
+ * @param {*}        [config.resetOn]     A value that, when it changes, clears any remembered override
+ *                                        for every device — e.g. the active preset, so a choice made
+ *                                        about one preset's slots doesn't stick onto the next. Omit to
+ *                                        never auto-clear.
+ *
+ * @since TBD
+ *
+ * @return {{isLinked: boolean, toggleLink: Function, inheritedValues: string[], inheritedFirstValue: string}}
+ *  Whether the active device reads as linked, the toggle handler, the slots the active device inherits,
+ *  and the alias/literal the first of those slots resolves to.
+ */
+export function useLinkedMeasureState({
+	forDevice,
+	inherited,
+	previewDevice,
+	presetValue,
+	tokens,
+	setAttributes,
+	resetOn,
+}) {
+	const [modeOverride, setModeOverride] = useState({});
+
+	// The override records a choice made about the PREVIOUS preset's slots, so selecting another preset
+	// drops it — otherwise an explicit "link" would stick and hide a new preset's per-slot measure.
+	useEffect(() => {
+		setModeOverride({});
+	}, [resetOn]);
+
+	const isLinked = 'linked' === (modeOverride[previewDevice] ?? deriveMeasureMode(forDevice.value, presetValue));
+
+	// What the slots inherit, and whether that inheritance is uniform. A per-slot inheritance is the
+	// case where linking is a real change rather than a no-op.
+	const inheritedValues = inherited.values;
+	const inheritedValuesDiffer =
+		Array.isArray(inheritedValues) && inheritedValues.some((value) => value !== inheritedValues[0]);
+	const inheritedFirstValue = Array.isArray(inheritedValues) ? aliasForValue(tokens, inheritedValues[0]) : '';
+
+	const toggleLink = () => {
+		if (!isLinked) {
+			const slots = forDevice.value ?? [];
+			const first = slots[0] ?? '';
+			const isEmpty = slots.every((value) => '' === value || undefined === value);
+
+			if (isEmpty) {
+				// Nothing stored on this device, so ordinarily there is nothing to collapse — the slots
+				// are empty because they inherit, and writing the inherited value would silently pin
+				// Tablet/Mobile to Desktop's current measure.
+				//
+				// Unless what is inherited differs slot to slot: then "link" genuinely changes the
+				// result, and storing nothing would leave the control showing one value while the block
+				// still renders four, with the indicator insisting it matches the preset. Collapsing to
+				// the first slot is the write that makes the three agree.
+				if (!inheritedValuesDiffer) {
+					setModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
+
+					return;
+				}
+
+				setAttributes({
+					[forDevice.attr]: [
+						inheritedFirstValue,
+						inheritedFirstValue,
+						inheritedFirstValue,
+						inheritedFirstValue,
+					],
+				});
+				setModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
+
+				return;
+			}
+
+			// Every slot matches the first, blank included, and only on the ACTIVE device.
+			setAttributes({ [forDevice.attr]: [first, first, first, first] });
+			// Equal slots derive linked on their own — except blank ones under a per-slot preset.
+			setModeOverride((current) => ({
+				...current,
+				[previewDevice]: '' === first ? 'linked' : undefined,
+			}));
+
+			return;
+		}
+
+		// Unlinking equal slots leaves the values untouched, so remember the choice for this session AND
+		// this device; a differing slot would derive individual on its own.
+		setModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
+	};
+
+	return { isLinked, toggleLink, inheritedValues, inheritedFirstValue };
+}


### PR DESCRIPTION
Extracts the 7 duplicated linked-state blocks across Border Radius, Padding, and Margin into one shared `useLinkedMeasureState` hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent linked and individual controls for button border radius and padding.
  * Preserved responsive device-specific settings when switching between linked and individual modes.
  * Improved handling of inherited values, token aliases, and differing responsive values.

* **Bug Fixes**
  * Reset temporary overrides when presets or related settings change.
  * Prevented unintended changes to stored values when toggling linked mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->