### PR TITLE
[DTM] SOFT-4083 [49/51]: migrate Margin to EditorBoxControl with Auto and spacing-scale None tokens

### DIFF
--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -211,6 +211,7 @@ class Kadence_Blocks_CSS {
 	 */
 	protected $spacing_sizes = array(
 		'ss-auto' => 'var(--global-kb-spacing-auto, auto)',
+		'none' => 'var(--global-kb-spacing-none, 0rem)',
 		'xxs' => 'var(--global-kb-spacing-xxs, 0.5rem)',
 		'xs' => 'var(--global-kb-spacing-xs, 1rem)',
 		'sm' => 'var(--global-kb-spacing-sm, 1.5rem)',

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Slot/Spacing_Target.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Slot/Spacing_Target.php
@@ -45,7 +45,7 @@ final class Spacing_Target extends Abstract_Target {
 	 *
 	 * @var string[]
 	 */
-	protected const SLOTS = [ 'ss-auto', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ];
+	protected const SLOTS = [ 'ss-auto', 'none', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ];
 
 	/**
 	 * The primitive dimension tokens that back the spacing slugs; the slug is claimed on the primitive

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -17,7 +17,7 @@
 // omitted: it resolves to "auto", not a length. group_key mirrors the radius/border-width scales' mechanism:
 // it is the stable machine id the Style Library's Spacing screen's "+ Add Spacing" mints custom tokens into,
 // resolved back to the group label at read time by Token_Registry::group_label_for().
-$spacing_slugs = [ 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ];
+$spacing_slugs = [ 'none', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ];
 $gap_slugs     = [ 'none', 'xs', 'sm', 'md', 'lg' ];
 
 $spacing_tokens = array_map(
@@ -25,7 +25,7 @@ $spacing_tokens = array_map(
 		return [
 			'id'          => 'primitive.dimension.spacing.' . $slug,
 			'type'        => 'dimension',
-			'label'       => strtoupper( $slug ),
+			'label'       => 'none' === $slug ? __( 'None', 'kadence-blocks' ) : strtoupper( $slug ),
 			'group'       => __( 'Spacing', 'kadence-blocks' ),
 			'group_key'   => 'spacing',
 			'projections' => [ 'kb_spacing_slot' => $slug ],

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -462,9 +462,17 @@ export default function KadenceButtonEdit(props) {
 	// `ss-auto` is already a fully working spacing slot at the PHP/CSS layer (Spacing_Target's SLOTS,
 	// class-kadence-blocks-css.php's $spacing_sizes) — the editor's pickable list is the only gap, so
 	// it is appended here as a fixed entry rather than added to the token registry itself.
+	//
+	// It is deliberately NOT registered as a DTCG token (it resolves to the CSS keyword `auto`, not a
+	// length — see declarations.php's comment on `$spacing_slugs`), so its `alias` is the bare slug the
+	// PHP/CSS layer already reads (`class-kadence-blocks-css.php`'s `$spacing_sizes['ss-auto']`), not the
+	// bracket-wrapped `{dot.path}` form a real token's alias takes. `fixed: true` tells
+	// `token-summary.js`'s `findTokenEntry()` to match this entry on that bare alias — the only sentinel
+	// in the pool allowed to bypass the bracket check, so a hand-typed Custom literal can never be
+	// misread as a token pick.
 	const marginPickableTokens = [
 		...pickableTokensForKey('kadence/singlebtn', 'button-margin'),
-		{ id: 'ss-auto', label: __('Auto', 'kadence-blocks'), value: 'ss-auto', alias: 'ss-auto' },
+		{ id: 'ss-auto', label: __('Auto', 'kadence-blocks'), value: 'auto', alias: 'ss-auto', fixed: true },
 	];
 
 	// The border-radius/padding linked/individual mode is derived from the stored slots (all equal reads

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -409,6 +409,27 @@ export default function KadenceButtonEdit(props) {
 		paddingPresetValue
 	);
 
+	// Margin keeps the same one-mode-per-device shape as Padding above.
+	const marginForDevice = measureAttrsForDevice(
+		attributes,
+		'margin',
+		{ tablet: 'tabletMargin', mobile: 'mobileMargin' },
+		previewDevice
+	);
+
+	const marginPresetValue = presetValueForDevice(
+		tokenBinding.margin?.presetValue,
+		tokenBinding.margin?.responsive,
+		previewDevice
+	);
+
+	// What an unset Margin side falls back to on the active device — same cascade as Padding above.
+	const inheritedMargin = inheritedMeasureSlots(
+		previewDevice,
+		{ desktop: margin, tablet: tabletMargin },
+		marginPresetValue
+	);
+
 	useEffect(() => {
 		setAttributes({ inQueryBlock: getInQueryBlock(context, inQueryBlock) });
 
@@ -437,6 +458,14 @@ export default function KadenceButtonEdit(props) {
 	const borderWidthPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width');
 	const shadowPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow');
 	const paddingPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-padding');
+	// Margin's legacy control also offers "Auto" (`allowAuto`), which Padding's never did.
+	// `ss-auto` is already a fully working spacing slot at the PHP/CSS layer (Spacing_Target's SLOTS,
+	// class-kadence-blocks-css.php's $spacing_sizes) — the editor's pickable list is the only gap, so
+	// it is appended here as a fixed entry rather than added to the token registry itself.
+	const marginPickableTokens = [
+		...pickableTokensForKey('kadence/singlebtn', 'button-margin'),
+		{ id: 'ss-auto', label: __('Auto', 'kadence-blocks'), value: 'ss-auto', alias: 'ss-auto' },
+	];
 
 	// The border-radius/padding linked/individual mode is derived from the stored slots (all equal reads
 	// as linked), so no new attribute is needed and old buttons open in the right mode. The hook's own
@@ -469,6 +498,18 @@ export default function KadenceButtonEdit(props) {
 		tokens: paddingPickableTokens,
 		setAttributes,
 		resetOn: attributes.kbPreset,
+	});
+
+	// Margin's linked/individual mode, mirroring Padding's own hook call above — same shape, run over
+	// `marginForDevice`/`marginPresetValue`/`inheritedMargin`/`marginPickableTokens` instead. Margin
+	// also has no `resetOn`, matching Padding.
+	const { isLinked: marginIsLinked, toggleLink: toggleMarginLink } = useLinkedMeasureState({
+		forDevice: marginForDevice,
+		inherited: inheritedMargin,
+		previewDevice,
+		presetValue: marginPresetValue,
+		tokens: marginPickableTokens,
+		setAttributes,
 	});
 
 	// Hover/Transparent/Transparent Hover/Sticky/Sticky Hover each store their own 4 corners, so each
@@ -2286,23 +2327,26 @@ export default function KadenceButtonEdit(props) {
 												max={paddingUnit === 'em' || paddingUnit === 'rem' ? 25 : 999}
 												step={paddingUnit === 'em' || paddingUnit === 'rem' ? 0.1 : 1}
 											/>
-											<ResponsiveMeasureRangeControl
+											<EditorBoxControl
 												label={__('Margin', 'kadence-blocks')}
-												value={margin}
-												onChange={(value) => setAttributes({ margin: value })}
-												tabletValue={tabletMargin}
-												onChangeTablet={(value) => setAttributes({ tabletMargin: value })}
-												mobileValue={mobileMargin}
-												onChangeMobile={(value) => setAttributes({ mobileMargin: value })}
-												min={marginUnit === 'em' || marginUnit === 'rem' ? -25 : -999}
-												max={marginUnit === 'em' || marginUnit === 'rem' ? 25 : 999}
-												step={marginUnit === 'em' || marginUnit === 'rem' ? 0.1 : 1}
+												value={marginForDevice.value}
+												onChange={(next) => setAttributes({ [marginForDevice.attr]: next })}
+												previewDevice={previewDevice}
+												onDeviceChange={setPreviewDevice}
+												tokens={marginPickableTokens}
+												defaultValue={inheritedMargin.values}
+												inherited={anyCornerInherited(inheritedMargin.inherited)}
+												state={tokenBinding.margin}
+												onReset={() => resetToken('margin')}
+												isLinked={marginIsLinked}
+												onToggleLink={toggleMarginLink}
+												role="sides"
 												unit={marginUnit}
 												units={['px', 'em', 'rem']}
 												onUnit={(value) => setAttributes({ marginUnit: value })}
-												onMouseOver={marginMouseOver.onMouseOver}
-												onMouseOut={marginMouseOver.onMouseOut}
-												allowAuto={true}
+												min={marginUnit === 'em' || marginUnit === 'rem' ? -25 : -999}
+												max={marginUnit === 'em' || marginUnit === 'rem' ? 25 : 999}
+												step={marginUnit === 'em' || marginUnit === 'rem' ? 0.1 : 1}
 											/>
 											<TextControl
 												label={__('Add Aria Label', 'kadence-blocks')}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -509,8 +509,10 @@ export default function KadenceButtonEdit(props) {
 	});
 
 	// Margin's linked/individual mode, mirroring Padding's own hook call above — same shape, run over
-	// `marginForDevice`/`marginPresetValue`/`inheritedMargin`/`marginPickableTokens` instead. Margin
-	// also has no `resetOn`, matching Padding.
+	// `marginForDevice`/`marginPresetValue`/`inheritedMargin`/`marginPickableTokens` instead. Unlike
+	// Padding, Margin does clear its override on a preset change (`resetOn`): an explicit "link" made
+	// under one preset would otherwise stick after switching to a preset with distinct per-side margins,
+	// hiding them behind a stale linked view.
 	const { isLinked: marginIsLinked, toggleLink: toggleMarginLink } = useLinkedMeasureState({
 		forDevice: marginForDevice,
 		inherited: inheritedMargin,
@@ -518,6 +520,7 @@ export default function KadenceButtonEdit(props) {
 		presetValue: marginPresetValue,
 		tokens: marginPickableTokens,
 		setAttributes,
+		resetOn: attributes.kbPreset,
 	});
 
 	// Hover/Transparent/Transparent Hover/Sticky/Sticky Hover each store their own 4 corners, so each
@@ -2335,27 +2338,34 @@ export default function KadenceButtonEdit(props) {
 												max={paddingUnit === 'em' || paddingUnit === 'rem' ? 25 : 999}
 												step={paddingUnit === 'em' || paddingUnit === 'rem' ? 0.1 : 1}
 											/>
-											<EditorBoxControl
-												label={__('Margin', 'kadence-blocks')}
-												value={marginForDevice.value}
-												onChange={(next) => setAttributes({ [marginForDevice.attr]: next })}
-												previewDevice={previewDevice}
-												onDeviceChange={setPreviewDevice}
-												tokens={marginPickableTokens}
-												defaultValue={inheritedMargin.values}
-												inherited={anyCornerInherited(inheritedMargin.inherited)}
-												state={tokenBinding.margin}
-												onReset={() => resetToken('margin')}
-												isLinked={marginIsLinked}
-												onToggleLink={toggleMarginLink}
-												role="sides"
-												unit={marginUnit}
-												units={['px', 'em', 'rem']}
-												onUnit={(value) => setAttributes({ marginUnit: value })}
-												min={marginUnit === 'em' || marginUnit === 'rem' ? -25 : -999}
-												max={marginUnit === 'em' || marginUnit === 'rem' ? 25 : 999}
-												step={marginUnit === 'em' || marginUnit === 'rem' ? 0.1 : 1}
-											/>
+											<div
+												onMouseOver={marginMouseOver.onMouseOver}
+												onMouseOut={marginMouseOver.onMouseOut}
+												onFocus={marginMouseOver.onMouseOver}
+												onBlur={marginMouseOver.onMouseOut}
+											>
+												<EditorBoxControl
+													label={__('Margin', 'kadence-blocks')}
+													value={marginForDevice.value}
+													onChange={(next) => setAttributes({ [marginForDevice.attr]: next })}
+													previewDevice={previewDevice}
+													onDeviceChange={setPreviewDevice}
+													tokens={marginPickableTokens}
+													defaultValue={inheritedMargin.values}
+													inherited={anyCornerInherited(inheritedMargin.inherited)}
+													state={tokenBinding.margin}
+													onReset={() => resetToken('margin')}
+													isLinked={marginIsLinked}
+													onToggleLink={toggleMarginLink}
+													role="sides"
+													unit={marginUnit}
+													units={['px', 'em', 'rem']}
+													onUnit={(value) => setAttributes({ marginUnit: value })}
+													min={marginUnit === 'em' || marginUnit === 'rem' ? -25 : -999}
+													max={marginUnit === 'em' || marginUnit === 'rem' ? 25 : 999}
+													step={marginUnit === 'em' || marginUnit === 'rem' ? 0.1 : 1}
+												/>
+											</div>
 											<TextControl
 												label={__('Add Aria Label', 'kadence-blocks')}
 												value={label ? label : ''}

--- a/src/token-controls/__tests__/token-selector.test.js
+++ b/src/token-controls/__tests__/token-selector.test.js
@@ -85,3 +85,25 @@ describe('TokenSelector disabled state', () => {
 		expect(renderSelector().disabled).toBe(false);
 	});
 });
+
+describe('TokenSelector fixed-entry round trip', () => {
+	// Margin's `Auto` choice (`kadence/singlebtn`'s `edit.js`) is a real spacing slot at the PHP/CSS
+	// layer that was never registered as a DTCG token, so it has no bracket-form alias. Its pickable
+	// entry is marked `fixed: true` instead, and this proves the trigger reads that entry back as the
+	// picked token rather than falling through to a `Custom` literal with the unit concatenated on.
+	const AUTO_TOKENS = [{ id: 'ss-auto', label: 'Auto', value: 'auto', alias: 'ss-auto', fixed: true }];
+
+	/**
+	 * Selecting Auto stores the bare `ss-auto` slug; the trigger must show it as the picked `Auto`
+	 * token, never as `Custom` with the unit concatenated onto it.
+	 *
+	 * @return {void}
+	 */
+	it('shows a fixed entry as its label, not as a Custom literal with the unit appended', () => {
+		const trigger = renderSelector({ value: 'ss-auto', tokens: AUTO_TOKENS, unit: 'px' });
+
+		expect(trigger.textContent).toBe('Autoauto');
+		expect(trigger.textContent).not.toContain('ss-auto');
+		expect(trigger.textContent).not.toContain('Custom');
+	});
+});

--- a/src/token-controls/__tests__/token-summary.test.js
+++ b/src/token-controls/__tests__/token-summary.test.js
@@ -14,6 +14,11 @@ const TOKENS = [
 	{ id: 'lg', label: 'Large', value: '0.5rem', alias: '{primitive.dimension.radius-lg}' },
 ];
 
+// A `fixed` entry (e.g. Margin's `Auto`) has no DTCG registration behind it, so its `alias` is a bare
+// slug rather than a bracket-wrapped dot path — the shape `kadence/singlebtn`'s `edit.js` appends for
+// `ss-auto`.
+const TOKENS_WITH_FIXED = [...TOKENS, { id: 'ss-auto', label: 'Auto', value: 'auto', alias: 'ss-auto', fixed: true }];
+
 describe('isTokenAlias', () => {
 	it('accepts a brace-wrapped dot path', () => {
 		expect(isTokenAlias('{primitive.dimension.radius-sm}')).toBe(true);
@@ -44,6 +49,14 @@ describe('findTokenEntry', () => {
 	it('tolerates an absent list', () => {
 		expect(findTokenEntry(undefined, '{x}')).toBeNull();
 	});
+
+	it('matches a fixed entry on its bare alias, since it has no bracket form', () => {
+		expect(findTokenEntry(TOKENS_WITH_FIXED, 'ss-auto').label).toBe('Auto');
+	});
+
+	it('never matches a non-fixed entry on a bare literal, even one equal to its alias text', () => {
+		expect(findTokenEntry(TOKENS, 'primitive.dimension.radius-sm')).toBeNull();
+	});
 });
 
 describe('resolveDefaultValue', () => {
@@ -70,6 +83,10 @@ describe('resolveDefaultValue', () => {
 	it('is empty for an unset default', () => {
 		expect(resolveDefaultValue('', TOKENS, 'px')).toBe('');
 		expect(resolveDefaultValue(null, TOKENS, 'px')).toBe('');
+	});
+
+	it("resolves a fixed entry (Margin's Auto) through the pickable list, same as a bracketed alias", () => {
+		expect(resolveDefaultValue('ss-auto', TOKENS_WITH_FIXED, 'px', true)).toBe('auto');
 	});
 });
 
@@ -108,6 +125,18 @@ describe('fieldSummary', () => {
 
 	it('summarizes an unset slot to nothing, so the caller can show the default instead', () => {
 		expect(fieldSummary('', TOKENS, 'px', 'Custom')).toEqual({ label: '', value: '' });
+	});
+
+	it("names a fixed entry (Margin's Auto) by its label and resolved value, not as a Custom literal", () => {
+		expect(fieldSummary('ss-auto', TOKENS_WITH_FIXED, 'px', 'Custom')).toEqual({
+			label: 'Auto',
+			value: 'auto',
+		});
+	});
+
+	it("never reads a hand-typed literal equal to a fixed entry's alias as that entry", () => {
+		// cspell:disable-next-line
+		expect(fieldSummary('ss-auto', TOKENS, 'px', 'Custom')).toEqual({ label: 'Custom', value: 'ss-autopx' });
 	});
 });
 

--- a/src/token-controls/helpers/token-summary.js
+++ b/src/token-controls/helpers/token-summary.js
@@ -50,6 +50,15 @@ export function hasValue(value) {
 /**
  * The pickable entry whose `alias` matches a value.
  *
+ * A regular entry only matches while `value` is alias-shaped (`{dot.path}`) — a plain literal that
+ * happens to equal an entry's `alias` string must never resolve to that entry. A `fixed` entry (a
+ * sentinel choice with no DTCG registration behind it, e.g. Margin's `Auto`) is the one exception:
+ * its `alias` IS the bare value written to the attribute, since it has no bracket form to write
+ * instead, so it matches on equality regardless of `isTokenAlias`. This is scoped strictly to
+ * entries explicitly marked `fixed: true` — never a general literal-value fallback — so a hand-typed
+ * Custom literal that happens to equal a real token's resolved value is never misidentified as that
+ * token.
+ *
  * @param {Array}  tokens The pickable-token list.
  * @param {string} value  The alias to match.
  *
@@ -58,7 +67,7 @@ export function hasValue(value) {
  * @return {?Object} The matching entry, or null.
  */
 export function findTokenEntry(tokens, value) {
-	return (tokens || []).find((entry) => entry.alias === value) || null;
+	return (tokens || []).find((entry) => entry.alias === value && (entry.fixed || isTokenAlias(value))) || null;
 }
 
 /**
@@ -78,10 +87,14 @@ export function resolveDefaultValue(defaultValue, tokens, unit, inherited) {
 		return '';
 	}
 
-	if (isTokenAlias(defaultValue)) {
-		const entry = findTokenEntry(tokens, defaultValue);
+	const entry = findTokenEntry(tokens, defaultValue);
 
-		return entry ? entry.value : '';
+	if (entry) {
+		return entry.value;
+	}
+
+	if (isTokenAlias(defaultValue)) {
+		return '';
 	}
 
 	if (inherited && /^-?\d*\.?\d+$/.test(String(defaultValue))) {
@@ -130,13 +143,14 @@ export function defaultSummary(resolvedDefault, tokens, literalLabel = '') {
  * @return {{label: string, value: string}} The trigger label and secondary text, both '' when unset.
  */
 export function fieldSummary(value, tokens, unit, customName) {
-	if (isTokenAlias(value)) {
-		const entry = findTokenEntry(tokens, value);
+	const entry = findTokenEntry(tokens, value);
 
-		return {
-			label: entry ? entry.label : String(value).slice(1, -1),
-			value: entry ? entry.value : '',
-		};
+	if (entry) {
+		return { label: entry.label, value: entry.value };
+	}
+
+	if (isTokenAlias(value)) {
+		return { label: String(value).slice(1, -1), value: '' };
 	}
 
 	if (hasValue(value)) {

--- a/src/token-controls/organisms/TokenSelector.js
+++ b/src/token-controls/organisms/TokenSelector.js
@@ -110,8 +110,11 @@ export function TokenSelector({
 		: resolvedDefault
 			? inheritedName
 			: __('Default', 'kadence-blocks');
-	const aliased = isTokenAlias(value);
-	const entry = aliased ? findTokenEntry(tokens, value) : null;
+	// A `fixed` entry (a sentinel choice with no DTCG registration, e.g. Margin's `Auto`) matches on its
+	// bare `alias` rather than the bracket form `isTokenAlias` checks for, so the entry lookup runs
+	// first and `aliased` widens to cover that match too.
+	const entry = findTokenEntry(tokens, value);
+	const aliased = isTokenAlias(value) || Boolean(entry);
 	const seed = entry ? parseCssLength(entry.value) : null;
 	// An unset slot seeds the Custom tab from whatever it falls back to, so opening the editor starts
 	// from the value on screen instead of an empty box the user has to guess at.

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Css_BuilderTest.php
@@ -354,7 +354,7 @@ final class Css_BuilderTest extends TestCase {
 
 		$css = ( new Css_Builder( $registry ) )->css( $resolved );
 
-		foreach ( [ 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ] as $slug ) {
+		foreach ( [ 'none', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ] as $slug ) {
 			$this->assertStringContainsString( '--global-kb-spacing-' . $slug . ':var(', $css );
 		}
 

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Slot_Target_ReaderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Slot_Target_ReaderTest.php
@@ -83,16 +83,17 @@ final class Slot_Target_ReaderTest extends TestCase {
 	public function testItReadsTheSpacingScaleAsTheShippedLengths(): void {
 		$this->assertEquals(
 			[
-				'xxs' => '0.5rem',
-				'xs'  => '1rem',
-				'sm'  => '1.5rem',
-				'md'  => '2rem',
-				'lg'  => '3rem',
-				'xl'  => '4rem',
-				'xxl' => '5rem',
-				'3xl' => '6.5rem',
-				'4xl' => '8rem',
-				'5xl' => '10rem',
+				'xxs'  => '0.5rem',
+				'xs'   => '1rem',
+				'sm'   => '1.5rem',
+				'md'   => '2rem',
+				'lg'   => '3rem',
+				'xl'   => '4rem',
+				'xxl'  => '5rem',
+				'3xl'  => '6.5rem',
+				'4xl'  => '8rem',
+				'5xl'  => '10rem',
+				'none' => '0',
 			],
 			$this->reader->read( Spacing_Target::class )
 		);


### PR DESCRIPTION
🎥  https://www.loom.com/share/989fe52acd1f4650b196c4a0cc75d77e

Migrates the Margin field to `EditorBoxControl` with the token indicator, adding `Auto` and spacing-scale `None` token support, and fixes Margin's `Auto` token pick to round-trip without leaking the raw slug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “None” spacing option with a zero-value preset.
  * Improved margin controls with linked, responsive, token-aware settings.
  * Added a fixed “Auto” margin option.

* **Bug Fixes**
  * Improved handling and display of fixed token values, preventing them from appearing as “Custom.”
  * Preserved unmatched custom values and resolved token aliases more accurately.

* **Tests**
  * Added coverage for spacing presets, fixed values, aliases, and token summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->