### PR TITLE
[DTM] SOFT-4083 [50/51]: fix cross-cutting review findings for border/radius/padding/margin token indicators

### DIFF
--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -8,7 +8,6 @@ import {
 	getPreviewSize,
 	showSettings,
 	getSpacingOptionOutput,
-	mouseOverVisualizer,
 	getFontSizeOptionOutput,
 	typographyStyle,
 	getBorderStyle,
@@ -82,7 +81,12 @@ import { addFilter, applyFilters, doAction } from '@wordpress/hooks';
 import BackendStyles from './components/backend-styles';
 import { useLinkedMeasureState } from './hooks/use-linked-measure-state';
 import { PresetButton } from '../../extension/preset-picker/PresetButton';
-import { usePresetBinding, resetAttr, presetPropertyValueForDevice } from '../../extension/token-indicators';
+import {
+	usePresetBinding,
+	resetAttr,
+	presetPropertyValueForDevice,
+	deriveStateBinding,
+} from '../../extension/token-indicators';
 import {
 	anyCornerInherited,
 	inheritedMeasureSlots,
@@ -358,9 +362,6 @@ export default function KadenceButtonEdit(props) {
 		{ tablet: 'tabletPadding', mobile: 'mobilePadding' },
 		previewDevice
 	);
-	const marginMouseOver = mouseOverVisualizer();
-	const paddingMouseOver = mouseOverVisualizer();
-
 	// Design-token indicators: the per-attribute bound/overridden state for the selected preset, plus a
 	// reset that clears the mapped attribute back to the preset value (served by the existing scoped CSS).
 	const tokenBinding = usePresetBinding('kadence/singlebtn', attributes, undefined, previewDevice);
@@ -373,11 +374,12 @@ export default function KadenceButtonEdit(props) {
 	);
 
 	// What an unset Border Width field falls back to: the active preset's own resolved width.
-	// `button-border-width` has no `control_attr` (its native attribute is a nested per-side shape
-	// `usePresetBinding` has nothing to key it by — see `declarations.php`'s comment on that binding),
-	// so `tokenBinding` never carries it; read it directly instead. Shown as `EditorBorderControl`'s
-	// `defaultValue` — without it, a cleared width field renders empty and collapses to zero height
-	// (its `TokenSelector`'s trigger has nothing to show), which reads as broken rather than reset.
+	// `button-border-width` shares `borderStyle`'s `control_attr` with style/color, and
+	// `tokenBinding.borderStyle` combines all three axes into one entry keyed by that shared attribute
+	// — there is no per-axis width-only entry to pull a value out of, so this reads the width axis
+	// directly by its own property key instead. Shown as `EditorBorderControl`'s `defaultValue` —
+	// without it, a cleared width field renders empty and collapses to zero height (its
+	// `TokenSelector`'s trigger has nothing to show), which reads as broken rather than reset.
 	const borderWidthPresetValue = presetPropertyValueForDevice(
 		'kadence/singlebtn',
 		'button-border-width',
@@ -448,13 +450,15 @@ export default function KadenceButtonEdit(props) {
 	const { setPreviewDeviceType: setPreviewDevice } = useDispatch('kadenceblocks/data');
 	const borderRadiusTokens = pickableTokensForControl('kadence/singlebtn', 'borderRadius') || [];
 	const borderRadiusIsRelative = borderRadiusUnit === 'em' || borderRadiusUnit === 'rem';
-	// Border width and shadow bind through their bindings KEY, not a `control_attr` — the native border
-	// and shadow attributes are nested per-side/composite shapes, not a single scalar a `control_attr`
-	// lookup can target, so their PHP bindings declare no `control_attr` at all (see declarations.php's
-	// `kadence/singlebtn` block). One PHP binding exists per property (`button-border-width`,
-	// `button-shadow`) — there is one border-width scale and one shadow scale, not a separate one per
-	// state — so every hover/sticky/transparent variant below reuses the same resolved list rather than
-	// re-filtering the pool per state.
+	// Border width and shadow bind through their bindings KEY, not `pickableTokensForControl`'s
+	// `control_attr` reverse lookup: `button-shadow`'s PHP binding declares no `control_attr` at all
+	// (its native attribute is a composite shape a `control_attr` lookup can't target), and
+	// `button-border-width` shares its `control_attr` ('borderStyle') with style/color, which would make
+	// a control_attr-keyed lookup ambiguous among the three (see declarations.php's `kadence/singlebtn`
+	// block). One PHP binding exists per property (`button-border-width`, `button-shadow`) — there is
+	// one border-width scale and one shadow scale, not a separate one per state — so every
+	// hover/sticky/transparent variant below reuses the same resolved list rather than re-filtering the
+	// pool per state.
 	const borderWidthPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width');
 	const shadowPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow');
 	const paddingPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-padding');
@@ -635,6 +639,131 @@ export default function KadenceButtonEdit(props) {
 			setAttributes,
 			resetOn: attributes.kbPreset,
 		});
+
+	// Each of the 5 non-Normal states' OWN Border Radius/Border indicator and reset — derived from the
+	// shared preset entry above (`tokenBinding.borderRadius`/`tokenBinding.borderStyle`, the same one
+	// Normal's own fields read) plus this state's own resolved value at the active device. Reusing
+	// Normal's `tokenBinding` entries directly here (as every call site once did) would report Normal's
+	// divergence on a field the user never opened, and its `onReset` would silently clear NORMAL's
+	// attributes while leaving this state's own untouched — see `deriveStateBinding`'s own docblock.
+	const borderHoverBorderForDevice = measureAttrsForDevice(
+		attributes,
+		'borderHoverStyle',
+		{ tablet: 'tabletBorderHoverStyle', mobile: 'mobileBorderHoverStyle' },
+		previewDevice
+	);
+	const borderHoverRadiusIsRelative = borderHoverRadiusUnit === 'em' || borderHoverRadiusUnit === 'rem';
+	const borderHoverRadiusBinding = deriveStateBinding({
+		shared: tokenBinding.borderRadius,
+		kind: 'dimension',
+		value: borderHoverRadiusForDevice.value,
+		unit: borderHoverRadiusUnit,
+		devicePresetValue: borderRadiusPresetValue,
+	});
+	const borderHoverBorderBinding = deriveStateBinding({
+		shared: tokenBinding.borderStyle,
+		kind: 'border',
+		value: borderHoverBorderForDevice.value,
+		previewDevice,
+	});
+	const resetBorderHoverRadius = () => resetAttr('borderHoverRadius', setAttributes, 'dimension');
+	const resetBorderHoverBorder = () => resetAttr('borderHoverStyle', setAttributes, 'border');
+
+	const borderTransparentBorderForDevice = measureAttrsForDevice(
+		attributes,
+		'borderTransparentStyle',
+		{ tablet: 'tabletBorderTransparentStyle', mobile: 'mobileBorderTransparentStyle' },
+		previewDevice
+	);
+	const borderTransparentRadiusIsRelative =
+		borderTransparentRadiusUnit === 'em' || borderTransparentRadiusUnit === 'rem';
+	const borderTransparentRadiusBinding = deriveStateBinding({
+		shared: tokenBinding.borderRadius,
+		kind: 'dimension',
+		value: borderTransparentRadiusForDevice.value,
+		unit: borderTransparentRadiusUnit,
+		devicePresetValue: borderRadiusPresetValue,
+	});
+	const borderTransparentBorderBinding = deriveStateBinding({
+		shared: tokenBinding.borderStyle,
+		kind: 'border',
+		value: borderTransparentBorderForDevice.value,
+		previewDevice,
+	});
+	const resetBorderTransparentRadius = () => resetAttr('borderTransparentRadius', setAttributes, 'dimension');
+	const resetBorderTransparentBorder = () => resetAttr('borderTransparentStyle', setAttributes, 'border');
+
+	const borderTransparentHoverBorderForDevice = measureAttrsForDevice(
+		attributes,
+		'borderTransparentHoverStyle',
+		{ tablet: 'tabletBorderTransparentHoverStyle', mobile: 'mobileBorderTransparentHoverStyle' },
+		previewDevice
+	);
+	const borderTransparentHoverRadiusIsRelative =
+		borderTransparentHoverRadiusUnit === 'em' || borderTransparentHoverRadiusUnit === 'rem';
+	const borderTransparentHoverRadiusBinding = deriveStateBinding({
+		shared: tokenBinding.borderRadius,
+		kind: 'dimension',
+		value: borderTransparentHoverRadiusForDevice.value,
+		unit: borderTransparentHoverRadiusUnit,
+		devicePresetValue: borderRadiusPresetValue,
+	});
+	const borderTransparentHoverBorderBinding = deriveStateBinding({
+		shared: tokenBinding.borderStyle,
+		kind: 'border',
+		value: borderTransparentHoverBorderForDevice.value,
+		previewDevice,
+	});
+	const resetBorderTransparentHoverRadius = () =>
+		resetAttr('borderTransparentHoverRadius', setAttributes, 'dimension');
+	const resetBorderTransparentHoverBorder = () => resetAttr('borderTransparentHoverStyle', setAttributes, 'border');
+
+	const borderStickyBorderForDevice = measureAttrsForDevice(
+		attributes,
+		'borderStickyStyle',
+		{ tablet: 'tabletBorderStickyStyle', mobile: 'mobileBorderStickyStyle' },
+		previewDevice
+	);
+	const borderStickyRadiusIsRelative = borderStickyRadiusUnit === 'em' || borderStickyRadiusUnit === 'rem';
+	const borderStickyRadiusBinding = deriveStateBinding({
+		shared: tokenBinding.borderRadius,
+		kind: 'dimension',
+		value: borderStickyRadiusForDevice.value,
+		unit: borderStickyRadiusUnit,
+		devicePresetValue: borderRadiusPresetValue,
+	});
+	const borderStickyBorderBinding = deriveStateBinding({
+		shared: tokenBinding.borderStyle,
+		kind: 'border',
+		value: borderStickyBorderForDevice.value,
+		previewDevice,
+	});
+	const resetBorderStickyRadius = () => resetAttr('borderStickyRadius', setAttributes, 'dimension');
+	const resetBorderStickyBorder = () => resetAttr('borderStickyStyle', setAttributes, 'border');
+
+	const borderStickyHoverBorderForDevice = measureAttrsForDevice(
+		attributes,
+		'borderStickyHoverStyle',
+		{ tablet: 'tabletBorderStickyHoverStyle', mobile: 'mobileBorderStickyHoverStyle' },
+		previewDevice
+	);
+	const borderStickyHoverRadiusIsRelative =
+		borderStickyHoverRadiusUnit === 'em' || borderStickyHoverRadiusUnit === 'rem';
+	const borderStickyHoverRadiusBinding = deriveStateBinding({
+		shared: tokenBinding.borderRadius,
+		kind: 'dimension',
+		value: borderStickyHoverRadiusForDevice.value,
+		unit: borderStickyHoverRadiusUnit,
+		devicePresetValue: borderRadiusPresetValue,
+	});
+	const borderStickyHoverBorderBinding = deriveStateBinding({
+		shared: tokenBinding.borderStyle,
+		kind: 'border',
+		value: borderStickyHoverBorderForDevice.value,
+		previewDevice,
+	});
+	const resetBorderStickyHoverRadius = () => resetAttr('borderStickyHoverRadius', setAttributes, 'dimension');
+	const resetBorderStickyHoverBorder = () => resetAttr('borderStickyHoverStyle', setAttributes, 'border');
 
 	useEffect(() => {
 		if (!isSelected) {
@@ -1256,6 +1385,8 @@ export default function KadenceButtonEdit(props) {
 															widthTokens={borderWidthPickableTokens}
 															defaultValue={borderWidthPresetValue}
 															renderColor={renderBorderColor}
+															state={borderHoverBorderBinding}
+															onReset={resetBorderHoverBorder}
 														/>
 														<EditorBoxControl
 															label={__('Border Radius', 'kadence-blocks')}
@@ -1272,6 +1403,8 @@ export default function KadenceButtonEdit(props) {
 															inherited={anyCornerInherited(
 																inheritedBorderHoverRadius.inherited
 															)}
+															state={borderHoverRadiusBinding}
+															onReset={resetBorderHoverRadius}
 															isLinked={borderHoverRadiusIsLinked}
 															onToggleLink={toggleBorderHoverRadiusLink}
 															unit={borderHoverRadiusUnit}
@@ -1279,18 +1412,8 @@ export default function KadenceButtonEdit(props) {
 															onUnit={(value) =>
 																setAttributes({ borderHoverRadiusUnit: value })
 															}
-															max={
-																borderHoverRadiusUnit === 'em' ||
-																borderHoverRadiusUnit === 'rem'
-																	? 24
-																	: 500
-															}
-															step={
-																borderHoverRadiusUnit === 'em' ||
-																borderHoverRadiusUnit === 'rem'
-																	? 0.1
-																	: 1
-															}
+															max={borderHoverRadiusIsRelative ? 24 : 500}
+															step={borderHoverRadiusIsRelative ? 0.1 : 1}
 															min={0}
 														/>
 														<EditorShadowControl
@@ -1527,6 +1650,8 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderWidthPickableTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
+																state={borderTransparentHoverBorderBinding}
+																onReset={resetBorderTransparentHoverBorder}
 															/>
 															<EditorBoxControl
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1546,6 +1671,8 @@ export default function KadenceButtonEdit(props) {
 																inherited={anyCornerInherited(
 																	inheritedBorderTransparentHoverRadius.inherited
 																)}
+																state={borderTransparentHoverRadiusBinding}
+																onReset={resetBorderTransparentHoverRadius}
 																isLinked={borderTransparentHoverRadiusIsLinked}
 																onToggleLink={toggleBorderTransparentHoverRadiusLink}
 																unit={borderTransparentHoverRadiusUnit}
@@ -1555,18 +1682,8 @@ export default function KadenceButtonEdit(props) {
 																		borderTransparentHoverRadiusUnit: value,
 																	})
 																}
-																max={
-																	borderTransparentHoverRadiusUnit === 'em' ||
-																	borderTransparentHoverRadiusUnit === 'rem'
-																		? 24
-																		: 500
-																}
-																step={
-																	borderTransparentHoverRadiusUnit === 'em' ||
-																	borderTransparentHoverRadiusUnit === 'rem'
-																		? 0.1
-																		: 1
-																}
+																max={borderTransparentHoverRadiusIsRelative ? 24 : 500}
+																step={borderTransparentHoverRadiusIsRelative ? 0.1 : 1}
 																min={0}
 															/>
 															<EditorShadowControl
@@ -1658,6 +1775,8 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderWidthPickableTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
+																state={borderTransparentBorderBinding}
+																onReset={resetBorderTransparentBorder}
 															/>
 															<EditorBoxControl
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1674,6 +1793,8 @@ export default function KadenceButtonEdit(props) {
 																inherited={anyCornerInherited(
 																	inheritedBorderTransparentRadius.inherited
 																)}
+																state={borderTransparentRadiusBinding}
+																onReset={resetBorderTransparentRadius}
 																isLinked={borderTransparentRadiusIsLinked}
 																onToggleLink={toggleBorderTransparentRadiusLink}
 																unit={borderTransparentRadiusUnit}
@@ -1683,18 +1804,8 @@ export default function KadenceButtonEdit(props) {
 																		borderTransparentRadiusUnit: value,
 																	})
 																}
-																max={
-																	borderTransparentRadiusUnit === 'em' ||
-																	borderTransparentRadiusUnit === 'rem'
-																		? 24
-																		: 500
-																}
-																step={
-																	borderTransparentRadiusUnit === 'em' ||
-																	borderTransparentRadiusUnit === 'rem'
-																		? 0.1
-																		: 1
-																}
+																max={borderTransparentRadiusIsRelative ? 24 : 500}
+																step={borderTransparentRadiusIsRelative ? 0.1 : 1}
 																min={0}
 															/>
 															<EditorShadowControl
@@ -1798,6 +1909,8 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderWidthPickableTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
+																state={borderStickyHoverBorderBinding}
+																onReset={resetBorderStickyHoverBorder}
 															/>
 															<EditorBoxControl
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1814,6 +1927,8 @@ export default function KadenceButtonEdit(props) {
 																inherited={anyCornerInherited(
 																	inheritedBorderStickyHoverRadius.inherited
 																)}
+																state={borderStickyHoverRadiusBinding}
+																onReset={resetBorderStickyHoverRadius}
 																isLinked={borderStickyHoverRadiusIsLinked}
 																onToggleLink={toggleBorderStickyHoverRadiusLink}
 																unit={borderStickyHoverRadiusUnit}
@@ -1823,18 +1938,8 @@ export default function KadenceButtonEdit(props) {
 																		borderStickyHoverRadiusUnit: value,
 																	})
 																}
-																max={
-																	borderStickyHoverRadiusUnit === 'em' ||
-																	borderStickyHoverRadiusUnit === 'rem'
-																		? 24
-																		: 500
-																}
-																step={
-																	borderStickyHoverRadiusUnit === 'em' ||
-																	borderStickyHoverRadiusUnit === 'rem'
-																		? 0.1
-																		: 1
-																}
+																max={borderStickyHoverRadiusIsRelative ? 24 : 500}
+																step={borderStickyHoverRadiusIsRelative ? 0.1 : 1}
 																min={0}
 															/>
 															<EditorShadowControl
@@ -1920,6 +2025,8 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderWidthPickableTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
+																state={borderStickyBorderBinding}
+																onReset={resetBorderStickyBorder}
 															/>
 															<EditorBoxControl
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1936,6 +2043,8 @@ export default function KadenceButtonEdit(props) {
 																inherited={anyCornerInherited(
 																	inheritedBorderStickyRadius.inherited
 																)}
+																state={borderStickyRadiusBinding}
+																onReset={resetBorderStickyRadius}
 																isLinked={borderStickyRadiusIsLinked}
 																onToggleLink={toggleBorderStickyRadiusLink}
 																unit={borderStickyRadiusUnit}
@@ -1945,18 +2054,8 @@ export default function KadenceButtonEdit(props) {
 																		borderStickyRadiusUnit: value,
 																	})
 																}
-																max={
-																	borderStickyRadiusUnit === 'em' ||
-																	borderStickyRadiusUnit === 'rem'
-																		? 24
-																		: 500
-																}
-																step={
-																	borderStickyRadiusUnit === 'em' ||
-																	borderStickyRadiusUnit === 'rem'
-																		? 0.1
-																		: 1
-																}
+																max={borderStickyRadiusIsRelative ? 24 : 500}
+																step={borderStickyRadiusIsRelative ? 0.1 : 1}
 																min={0}
 															/>
 															<EditorShadowControl
@@ -2338,34 +2437,27 @@ export default function KadenceButtonEdit(props) {
 												max={paddingUnit === 'em' || paddingUnit === 'rem' ? 25 : 999}
 												step={paddingUnit === 'em' || paddingUnit === 'rem' ? 0.1 : 1}
 											/>
-											<div
-												onMouseOver={marginMouseOver.onMouseOver}
-												onMouseOut={marginMouseOver.onMouseOut}
-												onFocus={marginMouseOver.onMouseOver}
-												onBlur={marginMouseOver.onMouseOut}
-											>
-												<EditorBoxControl
-													label={__('Margin', 'kadence-blocks')}
-													value={marginForDevice.value}
-													onChange={(next) => setAttributes({ [marginForDevice.attr]: next })}
-													previewDevice={previewDevice}
-													onDeviceChange={setPreviewDevice}
-													tokens={marginPickableTokens}
-													defaultValue={inheritedMargin.values}
-													inherited={anyCornerInherited(inheritedMargin.inherited)}
-													state={tokenBinding.margin}
-													onReset={() => resetToken('margin')}
-													isLinked={marginIsLinked}
-													onToggleLink={toggleMarginLink}
-													role="sides"
-													unit={marginUnit}
-													units={['px', 'em', 'rem']}
-													onUnit={(value) => setAttributes({ marginUnit: value })}
-													min={marginUnit === 'em' || marginUnit === 'rem' ? -25 : -999}
-													max={marginUnit === 'em' || marginUnit === 'rem' ? 25 : 999}
-													step={marginUnit === 'em' || marginUnit === 'rem' ? 0.1 : 1}
-												/>
-											</div>
+											<EditorBoxControl
+												label={__('Margin', 'kadence-blocks')}
+												value={marginForDevice.value}
+												onChange={(next) => setAttributes({ [marginForDevice.attr]: next })}
+												previewDevice={previewDevice}
+												onDeviceChange={setPreviewDevice}
+												tokens={marginPickableTokens}
+												defaultValue={inheritedMargin.values}
+												inherited={anyCornerInherited(inheritedMargin.inherited)}
+												state={tokenBinding.margin}
+												onReset={() => resetToken('margin')}
+												isLinked={marginIsLinked}
+												onToggleLink={toggleMarginLink}
+												role="sides"
+												unit={marginUnit}
+												units={['px', 'em', 'rem']}
+												onUnit={(value) => setAttributes({ marginUnit: value })}
+												min={marginUnit === 'em' || marginUnit === 'rem' ? -25 : -999}
+												max={marginUnit === 'em' || marginUnit === 'rem' ? 25 : 999}
+												step={marginUnit === 'em' || marginUnit === 'rem' ? 0.1 : 1}
+											/>
 											<TextControl
 												label={__('Add Aria Label', 'kadence-blocks')}
 												value={label ? label : ''}
@@ -2494,7 +2586,6 @@ export default function KadenceButtonEdit(props) {
 						)}
 						<SpacingVisualizer
 							type="inside"
-							forceShow={paddingMouseOver.isMouseOver}
 							spacing={[
 								getSpacingOptionOutput(previewPaddingTop, previewPaddingUnit),
 								getSpacingOptionOutput(previewPaddingRight, previewPaddingUnit),
@@ -2506,7 +2597,6 @@ export default function KadenceButtonEdit(props) {
 				</Tooltip>
 				<SpacingVisualizer
 					type="inside"
-					forceShow={marginMouseOver.isMouseOver}
 					spacing={[
 						getSpacingOptionOutput(previewMarginTop, previewMarginUnit),
 						getSpacingOptionOutput(previewMarginRight, previewMarginUnit),

--- a/src/blocks/singlebtn/hooks/use-linked-measure-state.js
+++ b/src/blocks/singlebtn/hooks/use-linked-measure-state.js
@@ -54,9 +54,9 @@ function aliasForValue(tokens, value) {
  *
  * @since TBD
  *
- * @return {{isLinked: boolean, toggleLink: Function, inheritedValues: string[], inheritedFirstValue: string}}
- *  Whether the active device reads as linked, the toggle handler, the slots the active device inherits,
- *  and the alias/literal the first of those slots resolves to.
+ * @return {{isLinked: boolean, toggleLink: Function}} Whether the active device reads as linked, and
+ *  the toggle handler. `inheritedValues`/`inheritedFirstValue` are computed internally (the toggle
+ *  handler needs them) but not returned — no call site has needed them outside the hook so far.
  */
 export function useLinkedMeasureState({
 	forDevice,
@@ -134,5 +134,5 @@ export function useLinkedMeasureState({
 		setModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
 	};
 
-	return { isLinked, toggleLink, inheritedValues, inheritedFirstValue };
+	return { isLinked, toggleLink };
 }

--- a/src/extension/preset-picker/__tests__/capture.test.js
+++ b/src/extension/preset-picker/__tests__/capture.test.js
@@ -294,6 +294,106 @@ describe('capturedTokens', () => {
 	});
 });
 
+describe('capturedTokens border axis properties', () => {
+	/**
+	 * Seed the localized catalog with the three border-axis properties, all sharing the
+	 * `control_attr: 'borderStyle'` binding `declarations.php` declares — the shape whose nested
+	 * per-side native value corrupted the capture loop before this fix.
+	 *
+	 * @return {void}
+	 */
+	function seedBorderCatalog() {
+		window.kadenceDesignTokensPresets = {
+			active: 'default',
+			libraries: {
+				default: {
+					[BLOCK]: {
+						default: 'primary',
+						presets: [{ slug: 'primary', label: 'Primary' }],
+						properties: [
+							{
+								key: 'button-border-width',
+								kind: 'dimension',
+								token: 'semantic.border-width.default',
+								control_attr: 'borderStyle',
+							},
+							{
+								key: 'button-border-style',
+								kind: 'color',
+								token: 'semantic.border-style.default',
+								control_attr: 'borderStyle',
+							},
+							{
+								key: 'button-border-color',
+								kind: 'color',
+								token: 'semantic.color.border',
+								control_attr: 'borderStyle',
+							},
+						],
+						values: {
+							primary: {
+								'button-border-width': '2px',
+								'button-border-style': 'solid',
+								'button-border-color': '#3182ce',
+							},
+						},
+					},
+				},
+			},
+		};
+	}
+
+	beforeEach(() => {
+		seedBorderCatalog();
+	});
+
+	afterEach(() => {
+		delete window.kadenceDesignTokensPresets;
+	});
+
+	/**
+	 * A block with a border set (a populated nested per-side native `borderStyle` attribute) captures
+	 * the three border-axis properties as their unchanged preset values — not the "[object Object]"
+	 * garbage the flat dimension/color read produced before this fix.
+	 *
+	 * @return {void}
+	 */
+	it('captures the three border-axis properties unchanged, not corrupted, when a border is set', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			borderStyle: [
+				{
+					top: ['#ffffff', 'dashed', '4'],
+					right: ['#ffffff', 'dashed', '4'],
+					bottom: ['#ffffff', 'dashed', '4'],
+					left: ['#ffffff', 'dashed', '4'],
+					unit: 'px',
+				},
+			],
+		};
+
+		const tokens = capturedTokens(BLOCK, SET, attributes);
+
+		expect(tokens['button-border-width']).toBe('2px');
+		expect(tokens['button-border-style']).toBe('solid');
+		expect(tokens['button-border-color']).toBe('#3182ce');
+	});
+
+	/**
+	 * A block with no border set at all also captures the three border-axis properties as their
+	 * unchanged preset values, matching the "not edited" fallback every other unmapped property takes.
+	 *
+	 * @return {void}
+	 */
+	it('captures the three border-axis properties unchanged when no border is set', () => {
+		const tokens = capturedTokens(BLOCK, SET, { kbPreset: 'primary' });
+
+		expect(tokens['button-border-width']).toBe('2px');
+		expect(tokens['button-border-style']).toBe('solid');
+		expect(tokens['button-border-color']).toBe('#3182ce');
+	});
+});
+
 describe('capturedCatalogValues', () => {
 	beforeEach(() => {
 		seedCatalog();

--- a/src/extension/preset-picker/capture.js
+++ b/src/extension/preset-picker/capture.js
@@ -9,6 +9,7 @@
 import { get } from 'lodash';
 import { KADENCE_TOKEN_NAMESPACE } from '../../token-controls/helpers/preset-envelope';
 import { activeLibrary, activePresetFor, blockProperties, blockPresetValues } from './index';
+import { BORDER_AXIS_KIND } from '../token-indicators';
 import {
 	normalizeColor,
 	normalizeDimension,
@@ -227,13 +228,28 @@ export function capturedTokens(blockName, library, attributes) {
 	const presetValues = get(blockPresetValues(blockName, resolvedLibrary), currentSlug, {});
 
 	return blockProperties(blockName, resolvedLibrary).reduce((tokens, property) => {
+		const presetValue = get(presetValues, property.key, '');
+
+		// The three border-axis properties (`BORDER_AXIS_KIND`) share ONE `control_attr` pointing at a
+		// nested per-side native shape (`[{ top: [color, style, size], ... }]`) this loop's flat
+		// dimension/color model cannot read — `isEmptyValue`/`attrToLiteral` would stringify the object
+		// and write "[object Object]"-shaped garbage into the captured preset. Reading one axis out of
+		// that shape correctly is real, non-trivial logic (the same axis-aware read
+		// `token-indicators/index.js`'s `usePresetBinding` already does) that this capture flow was never
+		// asked to support — so these three are skipped and pass the preset's existing value through
+		// unchanged, the same "not edited" fallback every other unmapped property already takes.
+		if (BORDER_AXIS_KIND[property.key]) {
+			tokens[property.key] = presetValue;
+
+			return tokens;
+		}
+
 		const attr = property.control_attr;
 		const raw = attr ? get(attributes, attr, '') : '';
 		const unit = property.kind === 'dimension' && attr ? get(attributes, `${attr}Unit`, '') : '';
 		// "Edited" here is simply "the control carries a value" — we snapshot the current visual state, so a
 		// value that happens to equal the preset is captured all the same (no differs-from-preset compare).
 		const edited = attr && !isEmptyValue(property.kind, raw);
-		const presetValue = get(presetValues, property.key, '');
 		const base = edited ? attrToLiteral(property.kind, raw, unit, presetValue) : presetValue;
 
 		tokens[property.key] = withResponsive(base, property, attributes, unit);

--- a/src/extension/token-indicators/__tests__/index.test.js
+++ b/src/extension/token-indicators/__tests__/index.test.js
@@ -10,7 +10,13 @@ jest.mock('../components/TokenIndicator', () => ({ TokenIndicator: () => null })
 jest.mock('../components/TokenLabel', () => ({ TokenLabel: () => null }));
 jest.mock('../components/TokenControlRow', () => ({ TokenControlRow: () => null }));
 
-import { usePresetBinding, resetAttrPatch, presetPropertyValueForDevice, mappedAttrsFor } from '../index';
+import {
+	usePresetBinding,
+	resetAttrPatch,
+	presetPropertyValueForDevice,
+	mappedAttrsFor,
+	deriveStateBinding,
+} from '../index';
 
 const BLOCK = 'kadence/singlebtn';
 const SET = 'default';
@@ -440,6 +446,45 @@ describe('usePresetBinding border width/style/color combining', () => {
 
 		expect(state.borderStyle.overridden).toBe(true);
 	});
+
+	/**
+	 * On Tablet, the compare uses the tablet border attribute against the preset value in effect at
+	 * Tablet, not the (empty) desktop attribute — mirroring the dimension kind's own device-awareness
+	 * (see the `usePresetBinding device-aware overridden` suite above). Before this fix, border kinds
+	 * always read the desktop attribute regardless of `previewDevice`.
+	 *
+	 * @return {void}
+	 */
+	it('reads the tablet border attribute, not the desktop one, when previewDevice is Tablet', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			// Desktop stores a color that would NOT match the preset if read by mistake.
+			borderStyle: [
+				{
+					top: ['#ffffff', 'solid', '2'],
+					right: ['#ffffff', 'solid', '2'],
+					bottom: ['#ffffff', 'solid', '2'],
+					left: ['#ffffff', 'solid', '2'],
+					unit: 'px',
+				},
+			],
+			// Tablet stores exactly the preset's tablet-effective values — color from its tablet
+			// override, width/style falling back to their (device-less) desktop value.
+			tabletBorderStyle: [
+				{
+					top: ['#000000', 'solid', '2'],
+					right: ['#000000', 'solid', '2'],
+					bottom: ['#000000', 'solid', '2'],
+					left: ['#000000', 'solid', '2'],
+					unit: 'px',
+				},
+			],
+		};
+
+		const state = usePresetBinding(BLOCK, attributes, SET, 'Tablet');
+
+		expect(state.borderStyle.overridden).toBe(false);
+	});
 });
 
 describe('mappedAttrsFor border dedupe', () => {
@@ -533,5 +578,162 @@ describe('resetAttrPatch', () => {
 			tabletBorderStyle: [],
 			mobileBorderStyle: [],
 		});
+	});
+});
+
+describe('deriveStateBinding', () => {
+	/**
+	 * When the shared binding is not bound at all (no preset governs the property), the derived state
+	 * is not bound either — there is nothing to compare a per-state value against.
+	 *
+	 * @return {void}
+	 */
+	it('reports not bound when the shared binding is not bound', () => {
+		expect(deriveStateBinding({ shared: undefined, kind: 'dimension', value: ['4', '4', '4', '4'] })).toEqual({
+			bound: false,
+			overridden: false,
+		});
+	});
+
+	/**
+	 * A dimension state (e.g. Sticky's own Border Radius) whose own value matches the shared preset at
+	 * the active device reads as bound and not overridden.
+	 *
+	 * @return {void}
+	 */
+	it('reports a dimension state as bound and not overridden when its own value matches the shared preset', () => {
+		const shared = { bound: true };
+
+		const state = deriveStateBinding({
+			shared,
+			kind: 'dimension',
+			value: ['4', '4', '4', '4'],
+			unit: 'px',
+			devicePresetValue: '4px',
+		});
+
+		expect(state).toEqual({ bound: true, overridden: false });
+	});
+
+	/**
+	 * A dimension state whose own value diverges from the shared preset reads as overridden — even
+	 * though the shared binding itself (Normal's) might still match.
+	 *
+	 * @return {void}
+	 */
+	it('reports a dimension state as overridden when its own value diverges from the shared preset', () => {
+		const shared = { bound: true };
+
+		const state = deriveStateBinding({
+			shared,
+			kind: 'dimension',
+			value: ['8', '8', '8', '8'],
+			unit: 'px',
+			devicePresetValue: '4px',
+		});
+
+		expect(state).toEqual({ bound: true, overridden: true });
+	});
+
+	/**
+	 * A never-written dimension state reads as bound and not overridden, matching the empty => bound
+	 * signal `usePresetBinding` itself uses.
+	 *
+	 * @return {void}
+	 */
+	it('reports a never-written dimension state as bound and not overridden', () => {
+		const shared = { bound: true };
+
+		const state = deriveStateBinding({
+			shared,
+			kind: 'dimension',
+			value: ['', '', '', ''],
+			unit: 'px',
+			devicePresetValue: '4px',
+		});
+
+		expect(state).toEqual({ bound: true, overridden: false });
+	});
+
+	/**
+	 * A border state whose own value matches every axis of the shared border binding's preset values
+	 * reads as bound and not overridden.
+	 *
+	 * @return {void}
+	 */
+	it('reports a border state as bound and not overridden when every axis matches', () => {
+		const shared = {
+			bound: true,
+			presetValue: { width: '2px', style: 'solid', color: '#3182ce' },
+			responsive: { width: {}, style: {}, color: {} },
+		};
+		const value = [
+			{
+				top: ['#3182ce', 'solid', '2'],
+				right: ['#3182ce', 'solid', '2'],
+				bottom: ['#3182ce', 'solid', '2'],
+				left: ['#3182ce', 'solid', '2'],
+				unit: 'px',
+			},
+		];
+
+		const state = deriveStateBinding({ shared, kind: 'border', value, previewDevice: 'Desktop' });
+
+		expect(state).toEqual({ bound: true, overridden: false });
+	});
+
+	/**
+	 * A border state diverging on only one axis (color) still reports the combined entry as
+	 * overridden, matching `usePresetBinding`'s own "any axis diverges" rule.
+	 *
+	 * @return {void}
+	 */
+	it('reports a border state as overridden when only one axis diverges', () => {
+		const shared = {
+			bound: true,
+			presetValue: { width: '2px', style: 'solid', color: '#3182ce' },
+			responsive: { width: {}, style: {}, color: {} },
+		};
+		const value = [
+			{
+				top: ['#ffffff', 'solid', '2'],
+				right: ['#ffffff', 'solid', '2'],
+				bottom: ['#ffffff', 'solid', '2'],
+				left: ['#ffffff', 'solid', '2'],
+				unit: 'px',
+			},
+		];
+
+		const state = deriveStateBinding({ shared, kind: 'border', value, previewDevice: 'Desktop' });
+
+		expect(state).toEqual({ bound: true, overridden: true });
+	});
+
+	/**
+	 * A border state's own device preset value resolves per axis at the active device, mirroring
+	 * `usePresetBinding`'s own device-awareness — a value matching the DESKTOP preset but not the
+	 * TABLET override reads as overridden on Tablet.
+	 *
+	 * @return {void}
+	 */
+	it('resolves each border axis preset value at the active device', () => {
+		const shared = {
+			bound: true,
+			presetValue: { width: '2px', style: 'solid', color: '#3182ce' },
+			responsive: { width: {}, style: {}, color: { tablet: '#ffffff' } },
+		};
+		const value = [
+			{
+				top: ['#3182ce', 'solid', '2'],
+				right: ['#3182ce', 'solid', '2'],
+				bottom: ['#3182ce', 'solid', '2'],
+				left: ['#3182ce', 'solid', '2'],
+				unit: 'px',
+			},
+		];
+
+		const state = deriveStateBinding({ shared, kind: 'border', value, previewDevice: 'Tablet' });
+
+		expect(state).toEqual({ bound: true, overridden: true });
 	});
 });

--- a/src/extension/token-indicators/__tests__/index.test.js
+++ b/src/extension/token-indicators/__tests__/index.test.js
@@ -736,4 +736,32 @@ describe('deriveStateBinding', () => {
 
 		expect(state).toEqual({ bound: true, overridden: true });
 	});
+
+	/**
+	 * A preset that binds only ONE border axis (width) is compared on that axis alone — the style and
+	 * color axes, which the preset never sets, are not checked against an undefined preset value, so a
+	 * value matching the bound width axis reads as bound, not overridden.
+	 *
+	 * @return {void}
+	 */
+	it('compares only the border axes the preset actually binds', () => {
+		const shared = {
+			bound: true,
+			presetValue: { width: '2px' },
+			responsive: { width: {} },
+		};
+		const value = [
+			{
+				top: ['#ffffff', 'dashed', '2'],
+				right: ['#ffffff', 'dashed', '2'],
+				bottom: ['#ffffff', 'dashed', '2'],
+				left: ['#ffffff', 'dashed', '2'],
+				unit: 'px',
+			},
+		];
+
+		const state = deriveStateBinding({ shared, kind: 'border', value, previewDevice: 'Desktop' });
+
+		expect(state).toEqual({ bound: true, overridden: false });
+	});
 });

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -79,11 +79,15 @@ function unitAttrFor(kind, attr) {
  * `[{ top: [color, style, size], ... }]` shape as a flat scalar/4-side value and never match. This map
  * overrides the kind used for the compare ONLY, by property key, so each axis reads its own slot.
  *
+ * Exported so a caller outside this module that also needs to tell a border-axis property apart from
+ * a plain one (e.g. `capture.js`'s "save as a new preset" flow, which cannot read this nested shape
+ * through its own flat control_attr model) can key off the same map instead of re-deriving it.
+ *
  * @since TBD
  *
  * @type {Object<string, string>}
  */
-const BORDER_AXIS_KIND = {
+export const BORDER_AXIS_KIND = {
 	'button-border-width': 'border-width',
 	'button-border-style': 'border-style',
 	'button-border-color': 'border-color',
@@ -188,16 +192,17 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
 			mobile: get(presetBreakpoints, ['mobile', property.key]),
 		};
 
-		// `overridden` compares like against like: a responsive control (a dimension, or a border axis —
-		// each border axis has its own tabletBorderStyle/mobileBorderStyle-shaped attribute) reads its
-		// OWN device's stored attribute (`tabletBorderRadius` on Tablet), against the preset value in
-		// effect at that same device (its tablet override where the preset declares one, else the base).
-		// Comparing a Tablet-stored value to the desktop preset value — or reporting the desktop
+		// `overridden` compares like against like: a dimension OR border control reads its OWN device's
+		// stored attribute (`tabletBorderRadius`/`tabletBorderStyle` on Tablet), against the preset value
+		// in effect at that same device (its tablet override where the preset declares one, else the
+		// base). Comparing a Tablet-stored value to the desktop preset value — or reporting the desktop
 		// attribute's state while Tablet is open — would show the wrong mark for the device actually
-		// being edited.
-		const isResponsive = kind === 'dimension' || Boolean(axis);
-		const deviceAttr = isResponsive ? deviceAttrFor(attr, previewDevice) : attr;
-		const devicePresetValue = isResponsive
+		// being edited. Border shares this device-awareness with dimension (not just the axis kinds'
+		// nested-shape read) because `resetAttrPatch`'s own `'border'` case already clears the tablet/
+		// mobile companions — the compare and the reset must agree on which attribute is "the" one.
+		const isDeviceAware = kind === 'dimension' || !!axis;
+		const deviceAttr = isDeviceAware ? deviceAttrFor(attr, previewDevice) : attr;
+		const devicePresetValue = isDeviceAware
 			? presetValueForDevice(presetValue, propertyBreakpoints, previewDevice)
 			: presetValue;
 		const value = get(attributes, deviceAttr, '');
@@ -346,4 +351,70 @@ export function resetAttrPatch(attr, kind) {
  */
 export function resetAttr(attr, setAttributes, kind) {
 	setAttributes(resetAttrPatch(attr, kind));
+}
+
+/**
+ * The design-token binding state for a NON-Normal state's own attribute (Hover, Sticky, and so on),
+ * derived from the SHARED `usePresetBinding` entry Normal's own control already carries plus this
+ * state's own current value at the active device.
+ *
+ * There is only one border-radius/border preset property per block, so every state shares Normal's
+ * `tokenBinding.borderRadius`/`tokenBinding.borderStyle` for `bound`, `presetValue`, and `responsive`
+ * — but `overridden` cannot be shared: Normal's entry only ever compares Normal's own attribute, so
+ * reusing it on e.g. Sticky would report Normal's divergence on Sticky's field, and its `onReset`
+ * would clear Normal's attributes instead of Sticky's. This computes `overridden` fresh from the
+ * state's own value, using the exact `isEmptyValue`/`matchesPreset` calls `usePresetBinding`'s own
+ * loop already runs internally — just invoked here directly instead of through that loop's
+ * `control_attr`-driven dispatch, since a per-state attribute is never itself a `control_attr`.
+ *
+ * @param {Object} shared            The shared binding entry from `usePresetBinding` this state's
+ *                                    property maps to (`tokenBinding.borderRadius` or
+ *                                    `tokenBinding.borderStyle`), carrying the combined `presetValue`/
+ *                                    `responsive` this function reuses rather than re-deriving.
+ * @param {string} kind              'dimension' (radius) or 'border' (the combined width/style/color
+ *                                    entry), matching `resetAttrPatch`'s own kind vocabulary.
+ * @param {*}      value             This state's own resolved value at the active device (e.g.
+ *                                    `borderStickyRadiusForDevice.value`, or the border attribute read
+ *                                    at the active device for `kind: 'border'`).
+ * @param {string}   [unit]          This state's own unit at the active device ('dimension' only;
+ *                                    unused for 'border', whose unit lives on the value itself).
+ * @param {*}        [devicePresetValue] For 'dimension': the shared preset value already resolved at
+ *                                    the active device (e.g. `borderRadiusPresetValue`, computed once
+ *                                    and shared across every state). Unused for 'border', which
+ *                                    resolves each axis's own device preset value from `shared`
+ *                                    directly (mirroring `usePresetBinding`'s own per-axis loop).
+ * @param {string}   [previewDevice] The active preview device ('Desktop' | 'Tablet' | 'Mobile') — only
+ *                                    needed for 'border', to resolve each axis's device preset value.
+ *
+ * @since TBD
+ *
+ * @return {{ bound: boolean, overridden: boolean }} This state's own binding state, the shape
+ *                                    `EditorBoxControl`/`EditorBorderControl`'s `state` prop expects.
+ */
+export function deriveStateBinding({ shared, kind, value, unit = '', devicePresetValue, previewDevice }) {
+	if (!shared?.bound) {
+		return { bound: false, overridden: false };
+	}
+
+	if (kind === 'border') {
+		const empty = isEmptyValue('border-width', value);
+		const overridden =
+			!empty &&
+			['width', 'style', 'color'].some((axis) => {
+				const axisPresetValue = presetValueForDevice(
+					shared.presetValue?.[axis],
+					shared.responsive?.[axis],
+					previewDevice
+				);
+
+				return !matchesPreset(`border-${axis}`, value, '', axisPresetValue);
+			});
+
+		return { bound: true, overridden };
+	}
+
+	const empty = isEmptyValue(kind, value);
+	const overridden = !empty && !matchesPreset(kind, value, unit, devicePresetValue);
+
+	return { bound: true, overridden };
 }

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -398,9 +398,13 @@ export function deriveStateBinding({ shared, kind, value, unit = '', devicePrese
 
 	if (kind === 'border') {
 		const empty = isEmptyValue('border-width', value);
+		// Only an axis the active preset actually binds is compared: `shared.presetValue` is keyed by
+		// exactly the axes `usePresetBinding` combined (see its own docblock), so an axis this preset
+		// never sets has no key here — checking it anyway would compare against `undefined` and read a
+		// matching border as overridden.
 		const overridden =
 			!empty &&
-			['width', 'style', 'color'].some((axis) => {
+			Object.keys(shared.presetValue || {}).some((axis) => {
 				const axisPresetValue = presetValueForDevice(
 					shared.presetValue?.[axis],
 					shared.responsive?.[axis],

--- a/src/extension/token-indicators/kinds/__tests__/border.test.js
+++ b/src/extension/token-indicators/kinds/__tests__/border.test.js
@@ -2,18 +2,37 @@
 import { isEmptyValue, matchesPreset } from '../../normalize';
 
 describe('isEmptyValue border', () => {
+	/**
+	 * A never-written native border value (`undefined`) reads as empty for every axis, matching
+	 * `fromNativeBorder`'s own `!source` short-circuit.
+	 *
+	 * @return {void}
+	 */
 	it('treats an undefined native border value as empty for every axis', () => {
 		expect(isEmptyValue('border-width', undefined)).toBe(true);
 		expect(isEmptyValue('border-style', undefined)).toBe(true);
 		expect(isEmptyValue('border-color', undefined)).toBe(true);
 	});
 
+	/**
+	 * A never-written native border value stored as an empty array reads as empty for every axis, the
+	 * shape `resetAttrPatch`'s own `'border'` case resets to.
+	 *
+	 * @return {void}
+	 */
 	it('treats an empty-array native border value as empty for every axis', () => {
 		expect(isEmptyValue('border-width', [])).toBe(true);
 		expect(isEmptyValue('border-style', [])).toBe(true);
 		expect(isEmptyValue('border-color', [])).toBe(true);
 	});
 
+	/**
+	 * A written native border value reads as not empty for every axis even when every side's slots are
+	 * blank strings — the moment any side is written, `toNativeBorder` always fills in all four, so
+	 * "empty" is a single source-level check, not per-side.
+	 *
+	 * @return {void}
+	 */
 	it('treats a written native border value as not empty for every axis, even with all-blank sides', () => {
 		const value = [
 			{
@@ -52,24 +71,47 @@ describe('matchesPreset border', () => {
 		},
 	];
 
+	/**
+	 * A never-written native border value never matches a preset, for any axis — `isEmptyValue` is the
+	 * signal for "bound", not `matchesPreset`, which only ever runs once `empty` is already false.
+	 *
+	 * @return {void}
+	 */
 	it('does not match an unset native border value for any axis', () => {
 		expect(matchesPreset('border-width', undefined, '', '2px')).toBe(false);
 		expect(matchesPreset('border-style', undefined, '', 'solid')).toBe(false);
 		expect(matchesPreset('border-color', undefined, '', '#3182ce')).toBe(false);
 	});
 
+	/**
+	 * A native border value equal to the preset on every side matches, for every axis.
+	 *
+	 * @return {void}
+	 */
 	it('matches a native border value equal on every side, per axis', () => {
 		expect(matchesPreset('border-width', UNIFORM, '', '2px')).toBe(true);
 		expect(matchesPreset('border-style', UNIFORM, '', 'solid')).toBe(true);
 		expect(matchesPreset('border-color', UNIFORM, '', '#3182ce')).toBe(true);
 	});
 
+	/**
+	 * A native border value diverging on one side does not match, for every axis — the compare is
+	 * side-aware, not just first-side.
+	 *
+	 * @return {void}
+	 */
 	it('does not match a native border value diverging on one side, per axis', () => {
 		expect(matchesPreset('border-width', DIVERGENT, '', '2px')).toBe(false);
 		expect(matchesPreset('border-style', DIVERGENT, '', 'solid')).toBe(false);
 		expect(matchesPreset('border-color', DIVERGENT, '', '#3182ce')).toBe(false);
 	});
 
+	/**
+	 * A border-width side stored as a token alias matches the same alias literal directly, without
+	 * being parsed as a numeric dimension.
+	 *
+	 * @return {void}
+	 */
 	it('matches a border-width side written as a token alias against the same alias literal', () => {
 		const value = [
 			{

--- a/src/extension/token-indicators/normalize.js
+++ b/src/extension/token-indicators/normalize.js
@@ -107,6 +107,11 @@ function handlerFor(kind) {
  *                       'border-style' | 'border-color').
  * @param {*}      value The stored primary attribute value.
  *
+ * An unrecognized `kind` falls back to the `text` kind's handler rather than throwing — PHP's
+ * `Preset_Bindings::kind()` can return a kind this module has no `KINDS` entry for yet (e.g.
+ * `'shadow'`, before its own dispatch entry lands), and a `TypeError` here would crash the editor
+ * render rather than merely mis-marking the indicator.
+ *
  * @since TBD
  *
  * @return {boolean} True when the value is unset/empty.
@@ -122,6 +127,9 @@ export function isEmptyValue(kind, value) {
  * @param {*}      value       The stored primary attribute value.
  * @param {string} unit        The companion unit (dimension only; '' otherwise).
  * @param {string} presetValue The preset's resolved literal for this property.
+ *
+ * An unrecognized `kind` falls back to the `text` kind's handler, matching `isEmptyValue`'s own
+ * fallback — see its docblock for why.
  *
  * @since TBD
  *

--- a/src/extension/token-picker/__tests__/index.test.js
+++ b/src/extension/token-picker/__tests__/index.test.js
@@ -153,6 +153,7 @@ const PRESETS = {
 					{ key: 'button-radius', kind: 'dimension', token: null, control_attr: 'borderRadius' },
 					{ key: 'button-gap', kind: 'dimension', token: null, control_attr: 'gap' },
 					{ key: 'button-shadow', kind: 'shadow', token: 'semantic.shadow.button', control_attr: null },
+					{ key: 'button-padding', kind: 'dimension', token: null, control_attr: 'padding' },
 				],
 			},
 			'kadence/single-icon': {
@@ -338,7 +339,7 @@ describe('pickableTokensForControl', () => {
 	});
 
 	it('returns an empty array for an unmapped attribute', () => {
-		expect(pickableTokensForControl('kadence/singlebtn', 'padding')).toEqual([]);
+		expect(pickableTokensForControl('kadence/singlebtn', 'margin')).toEqual([]);
 	});
 
 	it('returns an empty array for an unknown block', () => {
@@ -424,6 +425,18 @@ describe('pickableTokensForKey', () => {
 
 	it('returns an empty array for an unmapped key', () => {
 		expect(pickableTokensForKey('kadence/singlebtn', 'button-does-not-exist')).toEqual([]);
+	});
+
+	it('narrows padding to the spacing role, dropping radius/shadow/font-weight tokens', () => {
+		// `button-padding` binds no `token`, and its `control_attr` ('padding') does not literally
+		// contain the word 'spacing' — the fixed padding/margin -> spacing role alias is what narrows it,
+		// not the generic substring match `borderRadius` relies on.
+		const result = pickableTokensForKey('kadence/singlebtn', 'button-padding');
+
+		// A primitive spacing size exists, so (mirroring the radius narrowing above) the picker offers
+		// only the size scale, dropping even the bound-role semantic spacing token.
+		expect(result.map((token) => token.id)).toEqual(['primitive.dimension.spacing.md']);
+		expect(result.every((token) => token.role === 'spacing')).toBe(true);
 	});
 
 	it('returns an empty array for an unknown block', () => {

--- a/src/extension/token-picker/index.js
+++ b/src/extension/token-picker/index.js
@@ -147,6 +147,20 @@ function roleForId(id) {
  * matches `radius`; `iconSize` matches `icon-size`). Empty unless exactly one role matches, so an
  * ambiguous or unrecognized attribute falls back to the coarse list rather than guessing.
  *
+ * A handful of control attributes name their role by a different word than the role itself uses
+ * (`padding`/`margin` imply the `spacing` role, but neither string contains "spacing") — those get a
+ * fixed alias here rather than a substring guess.
+ *
+ * @since TBD
+ *
+ * @type {Object<string, string>}
+ */
+const ROLE_ALIASES = {
+	padding: 'spacing',
+	margin: 'spacing',
+};
+
+/**
  * @param {string} controlAttr The attribute the control writes (e.g. 'borderRadius').
  * @param {Array}  tokens      The type-filtered token list whose roles are the candidates.
  *
@@ -158,6 +172,10 @@ function inferRoleFromControl(controlAttr, tokens) {
 	const attr = String(controlAttr || '').toLowerCase();
 	if (!attr) {
 		return '';
+	}
+
+	if (ROLE_ALIASES[attr] && tokens.some((token) => token.role === ROLE_ALIASES[attr])) {
+		return ROLE_ALIASES[attr];
 	}
 
 	const roles = [...new Set(tokens.map((token) => token.role).filter(Boolean))];
@@ -218,9 +236,11 @@ function pickableTokensForProperty(property, controlAttr, library) {
  * an unmapped control offers no tokens, which is the "selectable only where it makes sense" guarantee
  * at the per-control call site.
  *
- * Only reaches properties that DO carry a `control_attr` — a property bound to a nested/composite
- * native attribute (border, shadow) is declared with no `control_attr` at all and is invisible to this
- * lookup by design; use `pickableTokensForKey` for those.
+ * Only reaches a property whose `control_attr` this lookup can resolve UNAMBIGUOUSLY by a find-the-
+ * first-match on `controlAttr` — a property bound to a nested/composite native attribute (shadow) is
+ * declared with no `control_attr` at all, and the three border-axis properties share one
+ * (`borderStyle`) among themselves, so none of the four are safely reachable here; use
+ * `pickableTokensForKey` for those instead.
  *
  * @param {string} blockName   The block name (e.g. 'kadence/singlebtn').
  * @param {string} controlAttr The attribute the control writes (e.g. 'borderRadius').
@@ -238,11 +258,14 @@ export function pickableTokensForControl(blockName, controlAttr, library) {
 
 /**
  * The pickable tokens for one bound property, keyed by the property's stable `key` (the PHP bindings
- * array key, e.g. 'button-shadow') rather than its `control_attr`. Exists for properties whose native
- * block attribute is a nested/composite shape (border, shadow) and so is declared with no
- * `control_attr` at all — `pickableTokensForControl` can never find them, since it has no other way to
- * locate a property. Otherwise identical to `pickableTokensForControl`: defers to the same shared
- * narrowing helper once the property is found.
+ * array key, e.g. 'button-shadow') rather than its `control_attr`. Exists for a property whose
+ * `control_attr` cannot resolve a control-based reverse lookup either because it has none at all (a
+ * native attribute that is a nested/composite shape, e.g. border/shadow) or because it shares one
+ * `control_attr` with two other properties (the three border axes all share `borderStyle`, so
+ * `pickableTokensForControl`'s find-the-first-match lookup would be ambiguous among them). Otherwise
+ * identical to `pickableTokensForControl`: defers to the same shared narrowing helper once the
+ * property is found, passing its OWN `control_attr` through (when it has one) as the role-inference
+ * hint — a property with no `control_attr` passes `''`, same as before.
  *
  * @param {string} blockName The block name (e.g. 'kadence/singlebtn').
  * @param {string} key       The property's bindings key (e.g. 'button-shadow').
@@ -255,5 +278,5 @@ export function pickableTokensForControl(blockName, controlAttr, library) {
 export function pickableTokensForKey(blockName, key, library) {
 	const property = blockProperties(blockName, library).find((entry) => entry.key === key);
 
-	return pickableTokensForProperty(property, '', library);
+	return pickableTokensForProperty(property, property?.control_attr || '', library);
 }


### PR DESCRIPTION
🎥  https://www.loom.com/share/a1a97dccb15e4678a743c0e16d3bb330

Fixes 2 critical findings from the whole-branch review: each non-Normal state now derives its own bound/overridden reading instead of sharing the Normal state's, and preset-picker capture no longer corrupts the 3 border-axis attributes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added state-specific border and radius controls for button hover, transparent, and sticky variants.
  * Improved device-aware preset matching for border and dimension settings.
  * Added more accurate token lookup for spacing and shared control properties.

* **Bug Fixes**
  * Preserved border preset values during capture, including unset nested styles.
  * Prevented unsupported token types from interrupting editor rendering.
  * Improved reset and linked-control behavior across button states.

* **Tests**
  * Expanded coverage for border capture, responsive bindings, token lookup, and unknown token types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->