### PR TITLE
[DTM] SOFT-4083 [51/51]: guard the token-indicators store against duplicate registration

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -187,6 +187,7 @@
         "webp",
         "woocommerce",
         "woodardmc",
+        "worktrees",
         "wpbody",
         "wpcontent",
         "wpdb",

--- a/jest.config.js
+++ b/jest.config.js
@@ -27,10 +27,18 @@ const baseConfig = require('@wordpress/scripts/config/jest-unit.config.js');
 
 module.exports = {
 	...baseConfig,
-	// `.worktrees/` holds sibling checkouts of this same repo (see `using-git-worktrees`); without
-	// this, jest walks into them too and runs every test a second time against a possibly different
-	// branch's source.
-	testPathIgnorePatterns: [...(baseConfig.testPathIgnorePatterns || []), '/\\.worktrees/'],
+	// `@wordpress/scripts/config/jest-unit.config.js` exports only `{ preset, reporters, transform }`,
+	// so `baseConfig.testPathIgnorePatterns` is always undefined and a spread of it contributes
+	// nothing — `testPathIgnorePatterns` is not one of the keys jest merges across preset and project
+	// (jest-config's normalize.js special-cases `setupFilesAfterEnv`, `modulePathIgnorePatterns`,
+	// `moduleNameMapper`, `transform`, and `globals`; everything else falls through to
+	// `{...preset, ...options}`, so the project value replaces the preset's outright). Written out
+	// literally so the list says what it actually is: the preset's own ignores
+	// (`@wordpress/jest-preset-default`'s `['/node_modules/', '<rootDir>/vendor/']`) plus this repo's
+	// own `.worktrees/` — `.worktrees/` holds sibling checkouts of this same repo (see
+	// `using-git-worktrees`); without it, jest walks into them too and runs every test a second time
+	// against a possibly different branch's source.
+	testPathIgnorePatterns: ['/node_modules/', '<rootDir>/vendor/', '/\\.worktrees/'],
 	moduleNameMapper: {
 		...(baseConfig.moduleNameMapper || {}),
 		'^@wordpress/hooks$': path.join(

--- a/jest.config.js
+++ b/jest.config.js
@@ -27,6 +27,10 @@ const baseConfig = require('@wordpress/scripts/config/jest-unit.config.js');
 
 module.exports = {
 	...baseConfig,
+	// `.worktrees/` holds sibling checkouts of this same repo (see `using-git-worktrees`); without
+	// this, jest walks into them too and runs every test a second time against a possibly different
+	// branch's source.
+	testPathIgnorePatterns: [...(baseConfig.testPathIgnorePatterns || []), '/\\.worktrees/'],
 	moduleNameMapper: {
 		...(baseConfig.moduleNameMapper || {}),
 		'^@wordpress/hooks$': path.join(

--- a/src/extension/token-indicators/__tests__/store.test.js
+++ b/src/extension/token-indicators/__tests__/store.test.js
@@ -1,0 +1,48 @@
+/* eslint-env jest */
+/**
+ * `store.js` registers `kadence/token-indicators` as an unconditional module-load side effect.
+ * Two separate webpack bundles (`early-filters.js` and `blocks-singlebtn.js`) both import it, so
+ * its top-level code runs once per bundle on the same page — `@wordpress/data`'s registry is a
+ * page-wide singleton, so the second bundle's copy must not re-register. These tests exercise the
+ * guard in isolation, mocking `@wordpress/data` so the module's own load-time logic is what's
+ * under test, not the real registry.
+ */
+
+/**
+ * Loads `store.js` fresh, with `@wordpress/data`'s `select`/`register`/`createReduxStore` mocked.
+ *
+ * @param {*} selectReturnValue What the mocked `select( 'kadence/token-indicators' )` returns.
+ *
+ * @since TBD
+ *
+ * @return {Object} `{ register }` — the mocked `register` spy, for assertions.
+ */
+function loadStoreModule(selectReturnValue) {
+	jest.resetModules();
+
+	const register = jest.fn();
+	const select = jest.fn(() => selectReturnValue);
+	const createReduxStore = jest.fn((name, config) => ({ name, config }));
+
+	jest.doMock('@wordpress/data', () => ({ register, select, createReduxStore }));
+
+	require('../store');
+
+	return { register, select };
+}
+
+describe('token-indicators store registration guard', () => {
+	it('registers the store when @wordpress/data reports it as not yet registered', () => {
+		const { register, select } = loadStoreModule(undefined);
+
+		expect(select).toHaveBeenCalledWith('kadence/token-indicators');
+		expect(register).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not re-register when @wordpress/data already reports the store as registered', () => {
+		const { register, select } = loadStoreModule({ isHighlightingEdits: () => false });
+
+		expect(select).toHaveBeenCalledWith('kadence/token-indicators');
+		expect(register).not.toHaveBeenCalled();
+	});
+});

--- a/src/extension/token-indicators/store.js
+++ b/src/extension/token-indicators/store.js
@@ -4,7 +4,7 @@
  * actions (Part D) and read by the token indicators (Part C). Editor-session state only — never persisted.
  */
 
-import { createReduxStore, register } from '@wordpress/data';
+import { createReduxStore, register, select } from '@wordpress/data';
 
 const STORE_NAME = 'kadence/token-indicators';
 
@@ -60,6 +60,14 @@ function reducer(state = DEFAULT_STATE, action) {
 
 const store = createReduxStore(STORE_NAME, { reducer, actions, selectors });
 
-register(store);
+// `early-filters.js` and `blocks-singlebtn.js` are separate webpack entries that both import this
+// module, so its top-level code runs once per bundle — webpack doesn't dedupe modules across
+// entries. `@wordpress/data`'s registry is a page-wide singleton though, so `select()` here (safe
+// to call for an unregistered store; it returns `undefined` rather than warning) checks the same
+// `stores` map `register()` writes to, and prevents the second bundle's copy of this module from
+// re-registering and logging "Store already registered."
+if (!select(STORE_NAME)) {
+	register(store);
+}
 
 export const TOKEN_INDICATORS_STORE = STORE_NAME;


### PR DESCRIPTION
🎥  https://www.loom.com/share/685d696d65a14c9faed50cfabf528cec

Guards the `kadence/token-indicators` store's module-load registration against duplicate bundles registering it twice, and excludes `.worktrees/` from Jest's test-path discovery so a sibling worktree checkout doesn't get scanned twice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate token-indicators store registration when multiple bundles are loaded.
  * Improved stability when the store is already registered.

* **Tests**
  * Added coverage for both new and existing store registration scenarios.

* **Chores**
  * Updated test discovery to ignore worktree directories.
  * Added “worktrees” to the spell-check dictionary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->