### PR TITLE
[DTM] SOFT-4167 [2/5]: allow a gap slot only inside a responsive breakpoint override

### DIFF
--- a/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
@@ -1289,6 +1289,12 @@ final class Presets_Controller extends Controller {
 						return $error;
 					}
 
+					$error = $this->guard_dimension_value_shape( $entry, $block, (string) $preset_slug, (string) $property );
+
+					if ( $error instanceof WP_Error ) {
+						return $error;
+					}
+
 					continue;
 				}
 
@@ -1351,6 +1357,66 @@ final class Presets_Controller extends Controller {
 				'property' => $property,
 			]
 		);
+	}
+
+	/**
+	 * Reject a dimension property whose scalar-vs-per-corner shape is ambiguous or inconsistent.
+	 *
+	 * Two write-time invariants the projection layer relies on but nothing else enforces:
+	 *
+	 * - **A per-corner breakpoint override requires a per-corner base.** `Css_Builder` only composes the
+	 *   canonical preset var out of `var()` references to four corner-specific vars when the BASE value is
+	 *   itself a four-slot array; a scalar base emits the canonical var directly, with no corner vars for a
+	 *   later `@media` block to hook into. A per-corner override sitting under a scalar base would redeclare
+	 *   corner vars nothing reads — the media rule would have no visible effect.
+	 * - **No scalar dimension literal may contain a space.** `Preset_Resolver::project()` joins a per-corner
+	 *   slot list with a bare space, and `Css_Builder::slots_of()` tells a slot list apart from a scalar
+	 *   literal purely by counting `explode( ' ', $value )`'s parts. A scalar literal like `"8px 4px 8px
+	 *   4px"` would count as four parts and be misread as a genuine four-corner list, corrupting a value
+	 *   that was only ever meant to be one opaque literal.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed  $entry    The preset token entry.
+	 * @param string $block    The block name, for error context.
+	 * @param string $preset   The preset slug, for error context.
+	 * @param string $property The property name, for error context.
+	 *
+	 * @return WP_Error|null A WP_Error when either invariant is violated, null otherwise.
+	 */
+	private function guard_dimension_value_shape( $entry, string $block, string $preset, string $property ): ?WP_Error {
+		$base          = Extensions::preset_value_of( $entry );
+		$base_is_slots = is_array( $base );
+
+		foreach ( $this->preset_entry_values( $entry ) as $value ) {
+			if ( is_string( $value ) && strpos( $value, ' ' ) !== false ) {
+				return new WP_Error(
+					'rest_design_tokens_invalid',
+					__( 'A dimension value must not contain a space; compound literals (e.g. calc(), clamp()) are not supported.', 'kadence-blocks' ),
+					[
+						'status'   => WP_Http::UNPROCESSABLE_ENTITY,
+						'block'    => $block,
+						'preset'   => $preset,
+						'property' => $property,
+					]
+				);
+			}
+
+			if ( is_array( $value ) && ! $base_is_slots ) {
+				return new WP_Error(
+					'rest_design_tokens_invalid',
+					__( 'A per-corner responsive override requires a per-corner base value for the same property.', 'kadence-blocks' ),
+					[
+						'status'   => WP_Http::UNPROCESSABLE_ENTITY,
+						'block'    => $block,
+						'preset'   => $preset,
+						'property' => $property,
+					]
+				);
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
@@ -1283,6 +1283,12 @@ final class Presets_Controller extends Controller {
 
 			foreach ( $tokens as $property => $entry ) {
 				if ( $bindings->kind( (string) $property ) === Preset_Bindings::get_kind_dimension() ) {
+					$error = $this->guard_base_slot_gap( $entry, $block, (string) $preset_slug, (string) $property );
+
+					if ( $error instanceof WP_Error ) {
+						return $error;
+					}
+
 					continue;
 				}
 
@@ -1309,6 +1315,42 @@ final class Presets_Controller extends Controller {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Reject a base per-corner value that leaves any corner unset.
+	 *
+	 * A base (desktop) value has no cascade above it to inherit from, so every corner must be fully set.
+	 * The same empty-slot sentinel is legal inside a responsive-override breakpoint, where it means "this
+	 * corner is not overridden here, keep inheriting" — this guard only inspects the base, read through
+	 * {@see Extensions::preset_value_of()} so a responsive envelope's overrides are never mistaken for it.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed  $entry    The preset token entry.
+	 * @param string $block    The block name, for error context.
+	 * @param string $preset   The preset slug, for error context.
+	 * @param string $property The property name, for error context.
+	 *
+	 * @return WP_Error|null A WP_Error when the base slot list carries a gap, null otherwise.
+	 */
+	private function guard_base_slot_gap( $entry, string $block, string $preset, string $property ): ?WP_Error {
+		$base = Extensions::preset_value_of( $entry );
+
+		if ( ! is_array( $base ) || ! in_array( '', $base, true ) ) {
+			return null;
+		}
+
+		return new WP_Error(
+			'rest_design_tokens_invalid',
+			__( 'A per-corner base value must set every corner; a gap is only valid inside a responsive override.', 'kadence-blocks' ),
+			[
+				'status'   => WP_Http::UNPROCESSABLE_ENTITY,
+				'block'    => $block,
+				'preset'   => $preset,
+				'property' => $property,
+			]
+		);
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -929,12 +929,15 @@ final class Dtcg_Validator {
 	 *
 	 * @since TBD
 	 *
-	 * @param mixed  $value The decoded value.
-	 * @param string $path  Dot-path to the value.
+	 * @param mixed  $value     The decoded value.
+	 * @param string $path      Dot-path to the value.
+	 * @param bool   $allow_gap Whether an empty-string slot inside a per-corner list is legal here — true
+	 *                          only while validating a responsive-override breakpoint, where the gap means
+	 *                          "not overridden, keep inheriting"; a base value never allows it.
 	 *
 	 * @return Validation_Error|null Null when valid.
 	 */
-	private function validate_extension_value( $value, string $path ): ?Validation_Error {
+	private function validate_extension_value( $value, string $path, bool $allow_gap = false ): ?Validation_Error {
 		if ( Alias::is_alias( $value ) ) {
 			return null;
 		}
@@ -952,7 +955,7 @@ final class Dtcg_Validator {
 		}
 
 		if ( is_array( $value ) && $this->is_list( $value ) ) {
-			return $this->validate_extension_slots( $value, $path );
+			return $this->validate_extension_slots( $value, $path, $allow_gap );
 		}
 
 		if ( is_array( $value ) && array_key_exists( Sentinels::get_value_key(), $value ) ) {
@@ -1015,7 +1018,7 @@ final class Dtcg_Validator {
 				);
 			}
 
-			$error = $this->validate_extension_value( $override, $path . '.' . $breakpoint );
+			$error = $this->validate_extension_value( $override, $path . '.' . $breakpoint, true );
 
 			if ( $error !== null ) {
 				return $error;
@@ -1034,12 +1037,15 @@ final class Dtcg_Validator {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<int, mixed> $slots The slot list.
-	 * @param string            $path  Dot-path to the list.
+	 * @param array<int, mixed> $slots     The slot list.
+	 * @param string            $path      Dot-path to the list.
+	 * @param bool              $allow_gap Whether an empty-string slot is legal here — true only while
+	 *                                     validating a responsive-override breakpoint; see
+	 *                                     {@see self::validate_extension_value()}.
 	 *
 	 * @return Validation_Error|null Null when valid.
 	 */
-	private function validate_extension_slots( array $slots, string $path ): ?Validation_Error {
+	private function validate_extension_slots( array $slots, string $path, bool $allow_gap = false ): ?Validation_Error {
 		$count = count( $slots );
 
 		if ( $count !== self::SLOT_LIST_SIDES ) {
@@ -1051,6 +1057,10 @@ final class Dtcg_Validator {
 		}
 
 		foreach ( $slots as $index => $slot ) {
+			if ( $allow_gap && $slot === '' ) {
+				continue;
+			}
+
 			if ( is_array( $slot ) ) {
 				return new Validation_Error(
 					$path . '.' . $index,

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
@@ -769,6 +769,93 @@ final class PresetsControllerTest extends TestCase {
 	}
 
 	/**
+	 * A per-corner responsive override sitting under a SCALAR base is rejected: the base's canonical var
+	 * is never composed of corner-var references, so a media rule redeclaring only the corner vars would
+	 * have no visible effect — the projection layer relies on this write-time guarantee.
+	 *
+	 * @return void
+	 */
+	public function testADimensionResponsiveOverrideRequiresAPerCornerBase(): void {
+		$entry = $this->responsive_entry(
+			'8px',
+			[ 'mobile' => [ '8px', '4px', '8px', '4px' ] ]
+		);
+
+		$result = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'preset' => 'hero',
+					'tokens' => $this->button_tokens( [ 'button-radius' => $entry ] ),
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+		$this->assertSame( 'button-radius', $result->get_error_data()['property'] );
+		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
+	}
+
+	/**
+	 * A dimension base value containing a space is rejected: `Css_Builder::slots_of()` tells a per-corner
+	 * slot list apart from a scalar literal purely by counting `explode( ' ', $value )`'s parts, so a
+	 * scalar like "8px 4px 8px 4px" would be misread as a genuine four-corner list.
+	 *
+	 * @return void
+	 */
+	public function testADimensionScalarBaseValueWithASpaceIsRejected(): void {
+		$result = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'preset' => 'broken',
+					'tokens' => $this->button_tokens( [ 'button-radius' => '8px 4px 8px 4px' ] ),
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+		$this->assertSame( 'button-radius', $result->get_error_data()['property'] );
+		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
+	}
+
+	/**
+	 * A dimension responsive-override value containing a space is rejected for the same reason a base
+	 * value is — the ambiguity with a genuine per-corner slot list exists at every level.
+	 *
+	 * @return void
+	 */
+	public function testADimensionResponsiveOverrideScalarValueWithASpaceIsRejected(): void {
+		$entry = $this->responsive_entry(
+			[ '{primitive.dimension.radius.md}', '8px', '{primitive.dimension.radius.md}', '8px' ],
+			[ 'mobile' => '8px 4px' ]
+		);
+
+		$result = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'preset' => 'hero',
+					'tokens' => $this->button_tokens( [ 'button-radius' => $entry ] ),
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+		$this->assertSame( 'button-radius', $result->get_error_data()['property'] );
+		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
+	}
+
+	/**
 	 * A well-formed responsive entry is stored intact, base and overrides together.
 	 *
 	 * @return void

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
@@ -706,6 +706,69 @@ final class PresetsControllerTest extends TestCase {
 	}
 
 	/**
+	 * A base per-corner value has no cascade above it to inherit from, so every corner must be fully
+	 * set. An empty slot in the base array is rejected, even though the same slot list shape is legal
+	 * elsewhere.
+	 *
+	 * @return void
+	 */
+	public function testASlotListWithAGapInTheBaseValueIsRejected(): void {
+		$result = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'preset' => 'corners',
+					'tokens' => $this->button_tokens(
+						[ 'button-radius' => [ '{primitive.dimension.radius.md}', '', '8px', '8px' ] ]
+					),
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+		$this->assertSame( 'button-radius', $result->get_error_data()['property'] );
+		// The write was rejected before commit.
+		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
+	}
+
+	/**
+	 * A gap in a per-corner value inside a responsive-override breakpoint means "this corner is not
+	 * overridden here, keep inheriting" — the same shape that is illegal on the base is accepted here.
+	 *
+	 * @return void
+	 */
+	public function testASlotListWithAGapInAResponsiveOverrideIsAccepted(): void {
+		$entry = $this->responsive_entry(
+			[ '{primitive.dimension.radius.md}', '8px', '{primitive.dimension.radius.md}', '8px' ],
+			[ 'mobile' => [ '{primitive.dimension.radius.full}', '', '', '' ] ]
+		);
+
+		$response = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'preset' => 'hero',
+					'tokens' => $this->button_tokens( [ 'button-radius' => $entry ] ),
+				]
+			)
+		);
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+
+		$stored = json_decode( $this->store->get_document( Token_Store::default_slug() ), true );
+		$tokens = $stored['$extensions']['com.kadence.designTokens']['presets'][ self::BUTTON ]['hero']['tokens'];
+
+		$this->assertSame(
+			[ '{primitive.dimension.radius.full}', '', '', '' ],
+			$tokens['button-radius']['$extensions']['com.kadence.designTokens']['responsive']['mobile']
+		);
+	}
+
+	/**
 	 * A well-formed responsive entry is stored intact, base and overrides together.
 	 *
 	 * @return void

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
@@ -1039,6 +1039,13 @@ final class Dtcg_ValidatorTest extends TestCase {
 			),
 		];
 
+		yield 'slot-list base, slot-list override with a gap' => [
+			'entry' => $this->responsive_entry(
+				[ '8px', '4px', '8px', '4px' ],
+				[ 'tablet' => [ '2px', '', '', '' ] ]
+			),
+		];
+
 		yield 'alias base, alias override' => [
 			'entry' => $this->responsive_entry(
 				'{semantic.radius.control}',
@@ -1114,6 +1121,15 @@ final class Dtcg_ValidatorTest extends TestCase {
 			'entry' => $this->responsive_entry( '', [ 'tablet' => '4px' ] ),
 			'code'  => Validation_Error::get_code_value_invalid(),
 			'path'  => $base,
+		];
+
+		yield 'gap in the slot-list base under a valid responsive map' => [
+			'entry' => $this->responsive_entry(
+				[ '8px', '', '8px', '4px' ],
+				[ 'tablet' => [ '4px', '2px', '4px', '2px' ] ]
+			),
+			'code'  => Validation_Error::get_code_value_invalid(),
+			'path'  => $base . '.1',
 		];
 	}
 


### PR DESCRIPTION
Adds a REST write guard (`Presets_Controller::guard_base_slot_gap()`) and a schema-level `$allow_gap` parameter (`Dtcg_Validator`) so an empty-string gap slot is legal only inside a responsive-override breakpoint, never in a base value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for four-corner dimension presets.
  * Base values containing empty slots or spaces are now rejected with a validation error.
  * Responsive overrides may contain empty slots and are preserved correctly.
  * Responsive overrides now require a compatible four-corner base value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->