### PR TITLE
[DTM] SOFT-4167 [3/5]: keep gaps through the responsive resolver, fail closed on the base path

### DIFF
--- a/includes/resources/Design_Tokens/Resolver/Preset_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Preset_Resolver.php
@@ -200,7 +200,9 @@ final class Preset_Resolver {
 			foreach ( Extensions::preset_responsive_of( $value ) as $breakpoint => $override ) {
 				// Gate on the literal first, exactly as resolve() does, so an override that resolves to
 				// nothing never emits a var() pointing at a token the base projection did not define.
-				if ( $this->flatten( $override, $resolved ) === null ) {
+				// keep_gaps: true — a per-corner override may legally leave a corner as a `''` gap
+				// (see flatten_slots()); that must not fail the whole property here either.
+				if ( $this->flatten( $override, $resolved, true ) === null ) {
 					continue;
 				}
 
@@ -215,6 +217,12 @@ final class Preset_Resolver {
 	 * Resolve a preset's PER-BREAKPOINT overrides to flattened LITERALS, for the editor surfaces that
 	 * cannot consume a var() chain. The literal counterpart of resolve_responsive(), covering exactly the
 	 * same overrides.
+	 *
+	 * A per-corner override may leave some corners as a `''` gap — "not overridden at this breakpoint,
+	 * keep inheriting live from the cascade." Unlike every other value this resolver flattens, a gap is
+	 * kept in the returned slot list rather than resolved or dropped, so a caller can tell "overridden
+	 * here" apart from "not overridden here" per corner. This is the one place this resolver's output is
+	 * deliberately sparse; every other property/value it returns is fully resolved.
 	 *
 	 * @since TBD
 	 *
@@ -232,7 +240,10 @@ final class Preset_Resolver {
 
 		foreach ( $this->preset_tokens( $block, $preset, $slug ) as $property => $value ) {
 			foreach ( Extensions::preset_responsive_of( $value ) as $breakpoint => $override ) {
-				$flat = $this->flatten( $override, $resolved );
+				// keep_gaps: true — the returned slot list must keep a `''` gap in place rather than
+				// resolve or drop it, so the editor's per-corner breakpoint cascade can tell "overridden
+				// at this breakpoint" apart from "not overridden" per corner.
+				$flat = $this->flatten( $override, $resolved, true );
 
 				if ( $flat === null ) {
 					continue;
@@ -411,12 +422,16 @@ final class Preset_Resolver {
 	 *
 	 * @since TBD
 	 *
-	 * @param mixed           $value    The raw binding value (alias string, literal, or slot list).
-	 * @param Resolved_Tokens $resolved The resolved token maps.
+	 * @param mixed           $value     The raw binding value (alias string, literal, or slot list).
+	 * @param Resolved_Tokens $resolved  The resolved token maps.
+	 * @param bool            $keep_gaps Whether a per-corner `''` gap slot should be kept in the
+	 *                                   output instead of failing the whole value closed. Only the
+	 *                                   responsive path (resolve_responsive()/resolve_responsive_literal())
+	 *                                   passes true — see flatten_slots().
 	 *
 	 * @return string|string[]|null
 	 */
-	private function flatten( $value, Resolved_Tokens $resolved ) {
+	private function flatten( $value, Resolved_Tokens $resolved, bool $keep_gaps = false ) {
 		if ( is_string( $value ) ) {
 			return Alias::is_alias( $value ) ? $resolved->value( Alias::path_of( $value ) ) : $value;
 		}
@@ -426,7 +441,7 @@ final class Preset_Resolver {
 		}
 
 		if ( is_array( $value ) ) {
-			return $this->flatten_slots( $value, $resolved );
+			return $this->flatten_slots( $value, $resolved, $keep_gaps );
 		}
 
 		return null;
@@ -439,19 +454,40 @@ final class Preset_Resolver {
 	 * border-radius missing one corner is not a usable value, so failing the property is the same
 	 * fail-closed choice a scalar binding makes when its alias resolves to nothing.
 	 *
+	 * A `''` slot is the "gap" sentinel — "this corner isn't set here, keep inheriting live from the
+	 * cascade." It is legal ONLY inside a responsive-override slot list (enforced at write time by
+	 * Presets_Controller/Dtcg_Validator); a base value's slot list must never contain one. This method
+	 * does not trust that the write-time validation actually ran, so $keep_gaps gates the behavior
+	 * itself: resolve_responsive()/resolve_responsive_literal() pass true and get the gap back in
+	 * place (their whole point — the editor's per-corner breakpoint cascade needs to see which corners
+	 * are, and are not, overridden at a breakpoint); resolve()/resolve_literal() (the base path, via flatten()'s default
+	 * false) fail the property closed exactly like any other unresolvable slot, so a gap that somehow
+	 * reaches the base path here is caught rather than silently emitted as an empty literal.
+	 *
 	 * @since TBD
 	 *
-	 * @param array<int|string, mixed> $slots    The raw slot list.
-	 * @param Resolved_Tokens          $resolved The resolved token maps.
+	 * @param array<int|string, mixed> $slots     The raw slot list.
+	 * @param Resolved_Tokens          $resolved  The resolved token maps.
+	 * @param bool                     $keep_gaps Whether a `''` gap slot is kept as-is (responsive path)
+	 *                                             instead of failing the whole slot list closed (base path).
 	 *
 	 * @return string[]|null
 	 */
-	private function flatten_slots( array $slots, Resolved_Tokens $resolved ): ?array {
+	private function flatten_slots( array $slots, Resolved_Tokens $resolved, bool $keep_gaps = false ): ?array {
 		$flat = [];
 
 		foreach ( $slots as $slot ) {
+			if ( $slot === '' ) {
+				if ( ! $keep_gaps ) {
+					return null;
+				}
+
+				$flat[] = '';
+				continue;
+			}
+
 			// Nested lists are rejected at validation; guard anyway so a hand-edited document fails closed.
-			$value = is_array( $slot ) ? null : $this->flatten( $slot, $resolved );
+			$value = is_array( $slot ) ? null : $this->flatten( $slot, $resolved, $keep_gaps );
 
 			if ( ! is_string( $value ) ) {
 				return null;

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
@@ -480,6 +480,105 @@ final class Preset_ResolverTest extends TestCase {
 	}
 
 	/**
+	 * A responsive override's per-corner slot list may leave some corners as a `''` gap — this
+	 * breakpoint does not override that corner, so it keeps inheriting live from the cascade. The
+	 * responsive-literal form (which feeds the editor's localized catalog) must keep the gap in the
+	 * array rather than resolving or dropping it, so the editor can tell "overridden here" apart
+	 * from "not overridden here" per corner.
+	 *
+	 * @return void
+	 */
+	public function testResolveResponsiveLiteralPreservesGapsInASparseOverride(): void {
+		$this->seedPreset(
+			Token_Store::default_slug(),
+			'hero',
+			'Hero',
+			[
+				'button-radius' => $this->responsiveEntry(
+					'8px',
+					[ 'tablet' => [ '{semantic.radius.control}', '', '', '' ] ]
+				),
+			]
+		);
+
+		$this->assertSame(
+			[ 'tablet' => [ 'button-radius' => [ '0.1875rem', '', '', '' ] ] ],
+			$this->resolver->resolve_responsive_literal( self::BUTTON, 'hero' )
+		);
+	}
+
+	/**
+	 * The var()-preserving responsive form also keeps a sparse override's property instead of
+	 * dropping it — a gap is not an unresolvable slot, so it does not trigger the fail-closed path a
+	 * genuinely unresolvable alias does.
+	 *
+	 * @return void
+	 */
+	public function testResolveResponsivePreservesGapsInASparseOverride(): void {
+		$this->seedPreset(
+			Token_Store::default_slug(),
+			'hero',
+			'Hero',
+			[
+				'button-radius' => $this->responsiveEntry(
+					'8px',
+					[ 'tablet' => [ '{semantic.radius.control}', '', '8px', '' ] ]
+				),
+			]
+		);
+
+		$responsive = $this->resolver->resolve_responsive( self::BUTTON, 'hero' );
+
+		$this->assertArrayHasKey( 'tablet', $responsive );
+		$this->assertArrayHasKey( 'button-radius', $responsive['tablet'] );
+	}
+
+	/**
+	 * The base path (resolve()/resolve_literal(), and resolve_default() which delegates to it) is
+	 * untouched by the responsive path's keep-the-gap mode: a fully-set per-corner base value still
+	 * resolves exactly as before, projected and literal alike.
+	 *
+	 * @return void
+	 */
+	public function testBasePathStillResolvesAFullySetSlotListUnchanged(): void {
+		$this->seedPreset(
+			Token_Store::default_slug(),
+			'corners',
+			'Corners',
+			[ 'button-radius' => [ '{semantic.radius.control}', '8px', '{semantic.radius.control}', '8px' ] ]
+		);
+
+		$this->assertSame(
+			[ '0.1875rem', '8px', '0.1875rem', '8px' ],
+			$this->resolver->resolve_literal( self::BUTTON, 'corners' )['button-radius']
+		);
+		$this->assertSame(
+			'var(--kb-token--semantic--radius--control) 8px var(--kb-token--semantic--radius--control) 8px',
+			$this->resolver->resolve( self::BUTTON, 'corners' )['button-radius']
+		);
+	}
+
+	/**
+	 * A base value's per-corner slot list is rejected with a `''` gap at write time (Presets_Controller
+	 * and Dtcg_Validator), but the resolver does not trust that validation ran — a gap reaching the
+	 * base path here still fails the whole property closed, exactly like an unresolvable alias, rather
+	 * than silently passing the empty string through as a literal.
+	 *
+	 * @return void
+	 */
+	public function testBasePathFailsClosedOnAGapAsADefenseInDepthSafetyNet(): void {
+		$this->seedPreset(
+			Token_Store::default_slug(),
+			'corners',
+			'Corners',
+			[ 'button-radius' => [ '{semantic.radius.control}', '', '8px', '8px' ] ]
+		);
+
+		$this->assertArrayNotHasKey( 'button-radius', $this->resolver->resolve_literal( self::BUTTON, 'corners' ) );
+		$this->assertArrayNotHasKey( 'button-radius', $this->resolver->resolve( self::BUTTON, 'corners' ) );
+	}
+
+	/**
 	 * A preset token entry carrying per-breakpoint overrides, in the same envelope a responsive token leaf
 	 * uses.
 	 *


### PR DESCRIPTION
Adds a `$keep_gaps` parameter to `Preset_Resolver::flatten()`/`flatten_slots()`: the responsive path now preserves a gap slot instead of resolving it away, while the base path gains a real defense-in-depth rejection of a gap it was previously accepting silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Responsive design presets now preserve per-corner inheritance when only some breakpoint values are provided.
  * Sparse responsive overrides retain their intended gaps instead of losing or rejecting them.
  * Base presets continue to fail safely when incomplete gap values are encountered.

* **Tests**
  * Added coverage for sparse responsive overrides, inherited values, complete base presets, and safe handling of incomplete base values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->