### PR TITLE
[DTM] SOFT-4167 [4/5]: redeclare only the touched corner inside a breakpoint's CSS

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
@@ -437,10 +437,25 @@ final class Css_Builder {
 	 * meaningful for — see {@see Preset_Bindings::kind()}) AND the value actually splitting into exactly
 	 * {@see self::CORNERS}'s four parts. {@see \KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Preset_Resolver::project()}
 	 * is the only place that ever joins a value with a bare space (`implode(' ', $projected)`, one call per
-	 * per-corner slot list, always exactly four slots per the write-time validator) — every literal or
-	 * `var()` segment it joins is itself space-free, so `explode(' ', $value)` losslessly reconstructs the
-	 * original four segments whenever this really was a per-corner value. A gap slot (the responsive-only
-	 * `''` sentinel) round-trips the same way: an empty segment between two single spaces.
+	 * per-corner slot list, always exactly four slots per the write-time validator), so `explode(' ', $value)`
+	 * reconstructs the original four segments losslessly FOR EVERY VALUE SHAPE THAT IS ITSELF SPACE-FREE — an
+	 * alias reference (`var(--x)`) or a plain length/keyword literal, which is everything the write-time
+	 * validator (`Dtcg_Validator`) currently accepts into a per-corner slot. It is NOT a general guarantee: a
+	 * compound-literal value with an internal space (e.g. a `calc(1px + 1px)` or `clamp(...)` literal) is not
+	 * rejected by `Dtcg_Validator` today, so it is writable into a per-corner slot through the REST endpoint
+	 * even though no shipped preset or editor control produces one. Such a value's own space(s) would corrupt
+	 * the part count this method keys off, so `count($parts) === count(self::CORNERS)` no longer identifies
+	 * "four real corners" reliably. The failure this degrades to is contained, not silent corruption: for a
+	 * BASE value it just falls through to null (this property renders as the single old-style declaration,
+	 * matching pre-this-task behavior — no regression). For a RESPONSIVE override it also falls through to
+	 * null, which makes {@see self::responsive_declarations()} redeclare the WHOLE composed var inside
+	 * `@media` instead of the one touched corner — the exact "gap gets frozen/dropped" failure this task
+	 * exists to prevent, just for a value shape outside what write-time validation lets through as of this
+	 * writing. Fixing this properly means rejecting (or otherwise disambiguating) a compound-literal
+	 * per-corner slot in `Dtcg_Validator`/`Preset_Resolver`, both outside this class's scope.
+	 *
+	 * A gap slot (the responsive-only `''` sentinel) round-trips the same way as any other space-free
+	 * segment: an empty segment between two single spaces.
 	 *
 	 * @since TBD
 	 *

--- a/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
@@ -9,6 +9,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Value;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Scope;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Binding;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Preset_Bindings;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Preset_Resolver;
 use RuntimeException;
@@ -60,6 +61,18 @@ final class Css_Builder {
 	 * @var string
 	 */
 	private const PRESET_SEGMENT = 'preset--';
+
+	/**
+	 * The four corner-var name suffixes a per-corner dimension property's base declaration splits
+	 * into, in the same positional order every layer of the per-corner model agrees on — CSS
+	 * shorthand order (top, right, bottom, left), matching the resolver's slot list and the editor's
+	 * SLOT_LABELS.sides. Index N here is corner index N everywhere else in the pipeline.
+	 *
+	 * @since TBD
+	 *
+	 * @var string[]
+	 */
+	private const CORNERS = [ 'top', 'right', 'bottom', 'left' ];
 
 	/**
 	 * Kadence theme global custom-property slots a preset may retarget beyond the numbered palette
@@ -125,7 +138,7 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @var array<string, array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string}>>}>>
+	 * @var array<string, array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string, dimension:bool}>>}>>
 	 */
 	private array $collected = [];
 
@@ -243,7 +256,7 @@ final class Css_Builder {
 	 *
 	 * @param string $slug The library slug to resolve against.
 	 *
-	 * @return array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string}>>}>
+	 * @return array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string, dimension:bool}>>}>
 	 */
 	private function collect( string $slug ): array {
 		$key = $slug . '_' . $this->store->get_version( $slug );
@@ -294,8 +307,13 @@ final class Css_Builder {
 					}
 
 					$properties[ $property ] = [
-						'target' => $target,
-						'value'  => $value,
+						'target'    => $target,
+						'value'     => $value,
+						// Only a "dimension" kind binding ever carries a per-corner slot list (the write-time
+						// guard rejects one on any other kind); gating the corner split on this, rather than
+						// on the value's own shape, avoids a false-positive split of an unrelated value that
+						// happens to contain spaces (e.g. a shadow literal).
+						'dimension' => $bindings->kind( $property ) === Preset_Bindings::get_kind_dimension(),
 					];
 				}
 
@@ -330,7 +348,7 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string}>>}> $collected The active library's collected presets.
+	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string, dimension:bool}>>}> $collected The active library's collected presets.
 	 *
 	 * @return string
 	 */
@@ -344,9 +362,13 @@ final class Css_Builder {
 	 * The raw `--kb-token--preset--*:<value>;` declaration list for the collected presets, shared by the
 	 * `:root` canonical block and the palette switch layer's re-emission.
 	 *
+	 * A per-corner dimension property (border radius, padding, margin, border width) emits four extra
+	 * corner-specific vars alongside its usual canonical var — see {@see self::property_declarations()}.
+	 * Every other property emits exactly the single declaration it always has.
+	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string}>>}> $collected The active library's collected presets.
+	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string, dimension:bool}>>}> $collected The active library's collected presets.
 	 *
 	 * @return string
 	 */
@@ -356,9 +378,138 @@ final class Css_Builder {
 		foreach ( $collected as $block => $data ) {
 			foreach ( $data['presets'] as $preset => $properties ) {
 				foreach ( $properties as $property => $info ) {
-					$declarations .= $this->preset_var( $block, $preset, $property ) . ':' . $this->sanitize_value( $info['value'] ) . ';';
+					$declarations .= $this->property_declarations( $block, (string) $preset, (string) $property, $info );
 				}
 			}
+		}
+
+		return $declarations;
+	}
+
+	/**
+	 * The base declaration(s) for one preset property.
+	 *
+	 * A scalar value (any non-dimension property, or a dimension property whose value was not a
+	 * four-slot shorthand) emits the single canonical declaration it always has:
+	 * `--kb-token--preset--<block>--<preset>--<property>:<value>;`.
+	 *
+	 * A per-corner dimension value instead emits four corner-specific vars — one per {@see self::CORNERS}
+	 * suffix — plus the canonical var, now composed purely from `var()` references to those four:
+	 * `--...--<property>:var(--...--top) var(--...--right) var(--...--bottom) var(--...--left);`. The
+	 * corner vars are new plumbing underneath an unchanged public contract: the composed var's name and
+	 * resolved value are exactly what they always were, so every bridge (`--global-*`, `--kb-btn-radius`)
+	 * that already points at it keeps working unchanged, and {@see self::responsive_blocks()} can redeclare
+	 * a single touched corner without ever redeclaring the composed var itself.
+	 *
+	 * @since TBD
+	 *
+	 * @param string                                  $block    The block name.
+	 * @param string                                  $preset   The preset slug.
+	 * @param string                                  $property The block property.
+	 * @param array{target:string, value:string, dimension:bool} $info The property's collected target/value/kind.
+	 *
+	 * @return string
+	 */
+	private function property_declarations( string $block, string $preset, string $property, array $info ): string {
+		$corners = $this->corners_of( $info['value'], $info['dimension'] );
+
+		if ( $corners === null ) {
+			return $this->preset_var( $block, $preset, $property ) . ':' . $this->sanitize_value( $info['value'] ) . ';';
+		}
+
+		$declarations = '';
+		$refs         = [];
+
+		foreach ( self::CORNERS as $index => $corner ) {
+			$corner_var    = $this->corner_var( $block, $preset, $property, $corner );
+			$declarations .= $corner_var . ':' . $this->sanitize_value( $corners[ $index ] ) . ';';
+			$refs[]        = 'var(' . $corner_var . ')';
+		}
+
+		return $declarations . $this->preset_var( $block, $preset, $property ) . ':' . implode( ' ', $refs ) . ';';
+	}
+
+	/**
+	 * Split a property's projected value into its four corner values, or null when it isn't a per-corner
+	 * dimension value.
+	 *
+	 * Gated on the property being a "dimension" kind binding (the only kind a per-corner slot list is
+	 * meaningful for — see {@see Preset_Bindings::kind()}) AND the value actually splitting into exactly
+	 * {@see self::CORNERS}'s four parts. {@see \KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Preset_Resolver::project()}
+	 * is the only place that ever joins a value with a bare space (`implode(' ', $projected)`, one call per
+	 * per-corner slot list, always exactly four slots per the write-time validator) — every literal or
+	 * `var()` segment it joins is itself space-free, so `explode(' ', $value)` losslessly reconstructs the
+	 * original four segments whenever this really was a per-corner value. A gap slot (the responsive-only
+	 * `''` sentinel) round-trips the same way: an empty segment between two single spaces.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $value     The property's projected value.
+	 * @param bool   $dimension Whether the property is a "dimension" kind binding.
+	 *
+	 * @return string[]|null The four corner values (index 0-3 = top, right, bottom, left; a gap is `''`),
+	 *                       or null when the value is not a four-part per-corner shorthand.
+	 */
+	private function corners_of( string $value, bool $dimension ): ?array {
+		if ( ! $dimension ) {
+			return null;
+		}
+
+		$parts = explode( ' ', $value );
+
+		return count( $parts ) === count( self::CORNERS ) ? $parts : null;
+	}
+
+	/**
+	 * The per-corner var name for a (block, preset, property, corner): the canonical preset var with a
+	 * "--<corner>" suffix, e.g. --kb-token--preset--kadence-singlebtn--hero--button-radius--top.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block    The block name.
+	 * @param string $preset   The preset slug.
+	 * @param string $property The block property.
+	 * @param string $corner   The corner suffix (one of {@see self::CORNERS}).
+	 *
+	 * @return string
+	 */
+	private function corner_var( string $block, string $preset, string $property, string $corner ): string {
+		return $this->preset_var( $block, $preset, $property ) . '--' . $corner;
+	}
+
+	/**
+	 * The `@media`-block declaration(s) for one breakpoint's override of one property.
+	 *
+	 * A scalar override (a non-dimension property, or a dimension property overridden with one uniform
+	 * value) redeclares the canonical var itself, exactly like the pre-per-corner behavior. A per-corner
+	 * override instead redeclares only the touched corner vars — a `''` gap slot is skipped so that corner
+	 * keeps inheriting live — and never redeclares the composed var (see {@see self::responsive_blocks()}).
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block     The block name.
+	 * @param string $preset    The preset slug.
+	 * @param string $property  The block property.
+	 * @param string $value     The breakpoint's projected override value for the property.
+	 * @param bool   $dimension Whether the property is a "dimension" kind binding.
+	 *
+	 * @return string
+	 */
+	private function responsive_declarations( string $block, string $preset, string $property, string $value, bool $dimension ): string {
+		$corners = $this->corners_of( $value, $dimension );
+
+		if ( $corners === null ) {
+			return $this->preset_var( $block, $preset, $property ) . ':' . $this->sanitize_value( $value ) . ';';
+		}
+
+		$declarations = '';
+
+		foreach ( self::CORNERS as $index => $corner ) {
+			if ( $corners[ $index ] === '' ) {
+				continue; // A gap: not overridden at this breakpoint, keep inheriting live.
+			}
+
+			$declarations .= $this->corner_var( $block, $preset, $property, $corner ) . ':' . $this->sanitize_value( $corners[ $index ] ) . ';';
 		}
 
 		return $declarations;
@@ -371,7 +522,7 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string}>>}> $collected The active library's collected presets.
+	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string, dimension:bool}>>}> $collected The active library's collected presets.
 	 *
 	 * @return string
 	 */
@@ -399,7 +550,7 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string}>>}> $collected The active library's collected presets.
+	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string, dimension:bool}>>}> $collected The active library's collected presets.
 	 *
 	 * @return string
 	 */
@@ -430,7 +581,7 @@ final class Css_Builder {
 	 *
 	 * @param string                                            $block      The block name.
 	 * @param string                                            $preset     The preset slug.
-	 * @param array<string, array{target:string, value:string}> $properties The preset's collected properties.
+	 * @param array<string, array{target:string, value:string, dimension:bool}> $properties The preset's collected properties.
 	 *
 	 * @return string
 	 */
@@ -522,16 +673,25 @@ final class Css_Builder {
 	/**
 	 * Redeclare each preset var that varies by breakpoint inside that breakpoint's `@media` block.
 	 *
-	 * Only the canonical var is redeclared — the scoped `--global-*` / `--kb-*` bridges are untouched,
-	 * because they already point at the preset var, so overriding it inside the media query is enough for
-	 * every consumer (including each corner of a per-corner shorthand) to follow. Mirrors the token
-	 * projection's {@see \KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Css_Builder} responsive
-	 * layer: same media wrapper, same :root scope, same "redeclare the same custom property" approach.
+	 * For a scalar property (any non-dimension property, or a dimension property overridden uniformly),
+	 * the canonical var itself is redeclared, exactly as before — the scoped `--global-*` / `--kb-*`
+	 * bridges are untouched, because they already point at the preset var, so overriding it inside the
+	 * media query is enough for every consumer to follow. Mirrors the token projection's
+	 * {@see \KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Css_Builder} responsive layer: same
+	 * media wrapper, same :root scope, same "redeclare the same custom property" approach.
+	 *
+	 * For a per-corner dimension property, ONLY the touched corner vars are redeclared — never the
+	 * composed var. A gap slot (the responsive-only `''` sentinel Task 3's resolver keeps in place) is
+	 * skipped entirely, so that corner keeps inheriting live from whatever the composed var's `var()` chain
+	 * currently resolves to outside this media query, rather than freezing it. The composed var itself picks
+	 * up a touched corner's new value automatically: browsers re-evaluate a `var()` reference live, so
+	 * redeclaring one corner var here changes what the (untouched, never-redeclared) composed var resolves
+	 * to for elements matching this breakpoint.
 	 *
 	 * @since TBD
 	 *
 	 * @param string                $active_slug The active library's slug.
-	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string}>>}> $collected The collected preset structure, for the block/preset list.
+	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string, dimension:bool}>>}> $collected The collected preset structure, for the block/preset list.
 	 * @param array<string, string> $breakpoints Breakpoint => media-query string.
 	 *
 	 * @return string
@@ -544,23 +704,28 @@ final class Css_Builder {
 		$by_breakpoint = [];
 
 		foreach ( $collected as $block => $data ) {
-			foreach ( array_keys( $data['presets'] ) as $preset ) {
+			foreach ( $data['presets'] as $preset => $properties ) {
 				try {
 					$responsive = $this->presets->resolve_responsive( $block, (string) $preset, $active_slug );
 				} catch ( RuntimeException $e ) {
 					continue; // A preset that stopped resolving contributes no overrides, like the flat layer.
 				}
 
-				foreach ( $responsive as $breakpoint => $properties ) {
-					foreach ( $properties as $property => $value ) {
+				foreach ( $responsive as $breakpoint => $overrides ) {
+					foreach ( $overrides as $property => $value ) {
 						// Only a property the flat layer emitted has a var to override; skip anything else so a
 						// media block can never introduce a var the base projection never defined.
-						if ( ! isset( $data['presets'][ $preset ][ $property ] ) ) {
+						if ( ! isset( $properties[ $property ] ) ) {
 							continue;
 						}
 
-						$by_breakpoint[ $breakpoint ][] = $this->preset_var( $block, (string) $preset, (string) $property )
-							. ':' . $this->sanitize_value( $value ) . ';';
+						$by_breakpoint[ $breakpoint ][] = $this->responsive_declarations(
+							$block,
+							(string) $preset,
+							(string) $property,
+							$value,
+							$properties[ $property ]['dimension']
+						);
 					}
 				}
 			}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
@@ -253,6 +253,127 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
+	 * A per-corner dimension property's base declaration emits four corner-specific vars (top, right,
+	 * bottom, left) plus the canonical var, now composed purely from var() references to those four —
+	 * the technique the whole projection change hinges on.
+	 *
+	 * @return void
+	 */
+	public function testItEmitsFourCornerVarsPlusAComposedVarForAPerCornerDimensionProperty(): void {
+		$this->seedPerCornerPreset();
+
+		$css = $this->builder( $this->registry )->css( 'default' );
+
+		$this->assertStringContainsString( '--kb-token--preset--kadence-singlebtn--corners--button-radius--top:var(--kb-token--semantic--radius--control);', $css );
+		$this->assertStringContainsString( '--kb-token--preset--kadence-singlebtn--corners--button-radius--right:4px;', $css );
+		$this->assertStringContainsString( '--kb-token--preset--kadence-singlebtn--corners--button-radius--bottom:var(--kb-token--semantic--radius--media);', $css );
+		$this->assertStringContainsString( '--kb-token--preset--kadence-singlebtn--corners--button-radius--left:2px;', $css );
+		$this->assertStringContainsString(
+			'--kb-token--preset--kadence-singlebtn--corners--button-radius:'
+				. 'var(--kb-token--preset--kadence-singlebtn--corners--button-radius--top) '
+				. 'var(--kb-token--preset--kadence-singlebtn--corners--button-radius--right) '
+				. 'var(--kb-token--preset--kadence-singlebtn--corners--button-radius--bottom) '
+				. 'var(--kb-token--preset--kadence-singlebtn--corners--button-radius--left);',
+			$css
+		);
+	}
+
+	/**
+	 * The bridge (--kb-btn-radius) keeps pointing at the composed var by its unchanged name — the public
+	 * contract every block's own CSS/SCSS already consumes is untouched by the corner-var plumbing
+	 * underneath it.
+	 *
+	 * @return void
+	 */
+	public function testTheBridgeStillPointsAtTheComposedVarForAPerCornerProperty(): void {
+		$this->seedPerCornerPreset();
+
+		$css = $this->builder( $this->registry )->css( 'default' );
+
+		$this->assertStringContainsString(
+			'--kb-btn-radius:var(--kb-token--preset--kadence-singlebtn--corners--button-radius);',
+			$css
+		);
+	}
+
+	/**
+	 * A sparse responsive override (only the top corner touched, the other three left as `''` gaps by the
+	 * resolver) redeclares ONLY the touched corner var inside its @media block — never the untouched
+	 * corners, and never the composed var, so the untouched corners keep inheriting live.
+	 *
+	 * @return void
+	 */
+	public function testResponsiveBlocksRedeclareOnlyTheTouchedCornerForASparseOverride(): void {
+		$this->seedPerCornerPreset(
+			[
+				'tablet' => [ '{semantic.radius.media}', '', '', '' ],
+			]
+		);
+
+		$css = $this->builder( $this->registry )->css( 'default', $this->breakpoints() );
+
+		$this->assertStringContainsString(
+			'@media all and (max-width: 1024px){:root,:root:where(.kb-tokens){'
+				. '--kb-token--preset--kadence-singlebtn--corners--button-radius--top:var(--kb-token--semantic--radius--media);'
+				. '}}',
+			$css
+		);
+
+		// Extract the tablet media block and confirm the other three corners, and the composed var, are
+		// never redeclared inside it.
+		$tablet_block = $this->extractMediaBlock( $css, '(max-width: 1024px)' );
+
+		$this->assertStringNotContainsString( '--button-radius--right:', $tablet_block );
+		$this->assertStringNotContainsString( '--button-radius--bottom:', $tablet_block );
+		$this->assertStringNotContainsString( '--button-radius--left:', $tablet_block );
+		$this->assertStringNotContainsString( '--kb-token--preset--kadence-singlebtn--corners--button-radius:', $tablet_block );
+	}
+
+	/**
+	 * Regression guard: a property that is NOT a per-corner dimension (button-bg, a color-kind property)
+	 * emits exactly the single declaration it always has — no corner vars, no composed-var restructuring —
+	 * proving the corner-var technique is scoped strictly to per-corner dimension properties.
+	 *
+	 * @return void
+	 */
+	public function testNonPerCornerPropertiesAreUnaffectedByTheCornerVarChange(): void {
+		$css = $this->builder( $this->registry )->css( 'default' );
+
+		$this->assertStringContainsString( '--kb-token--preset--kadence-singlebtn--primary--button-bg:var(--kb-token--semantic--color--button-primary-bg);', $css );
+		$this->assertStringNotContainsString( '--kb-token--preset--kadence-singlebtn--primary--button-bg--top', $css );
+		$this->assertStringNotContainsString( '--kb-token--preset--kadence-singlebtn--primary--button-bg--right', $css );
+	}
+
+	/**
+	 * Regression guard: a fully-set per-corner property with no gaps at any breakpoint resolves to the
+	 * SAME four values it always did — the composed var's value is built purely from var() references to
+	 * the four corner vars, and those corner vars, read back together in order, reproduce exactly the
+	 * original joined shorthand the pre-corner-var projection would have emitted as a single declaration.
+	 *
+	 * @return void
+	 */
+	public function testAFullySetPerCornerResponsiveOverrideResolvesToTheSameFourValues(): void {
+		$this->seedPerCornerPreset(
+			[
+				'tablet' => [ '2px', '4px', '6px', '8px' ],
+			]
+		);
+
+		$css = $this->builder( $this->registry )->css( 'default', $this->breakpoints() );
+
+		$tablet_block = $this->extractMediaBlock( $css, '(max-width: 1024px)' );
+
+		// All four corners are redeclared (a fully-set override touches every corner)...
+		$this->assertStringContainsString( '--button-radius--top:2px;', $tablet_block );
+		$this->assertStringContainsString( '--button-radius--right:4px;', $tablet_block );
+		$this->assertStringContainsString( '--button-radius--bottom:6px;', $tablet_block );
+		$this->assertStringContainsString( '--button-radius--left:8px;', $tablet_block );
+		// ...but the composed var is never redeclared: it keeps resolving through the same var() chain the
+		// base declaration already set up, which now points at these freshly-redeclared corner values.
+		$this->assertStringNotContainsString( '--kb-token--preset--kadence-singlebtn--corners--button-radius:', $tablet_block );
+	}
+
+	/**
 	 * The breakpoint => media-query map a projector passes at emit time.
 	 *
 	 * @return array<string, string>
@@ -331,5 +452,71 @@ final class Css_BuilderTest extends TestCase {
 		];
 
 		$store->save_document( (string) wp_json_encode( $document ), 'dark' );
+	}
+
+	/**
+	 * Persist a "corners" button preset whose radius is a per-corner slot list, optionally with a
+	 * responsive override at one or more breakpoints (also slot lists, possibly with `''` gap corners).
+	 *
+	 * @param array<string, array<int, string>> $responsive Breakpoint => four-slot override.
+	 *
+	 * @return void
+	 */
+	private function seedPerCornerPreset( array $responsive = [] ): void {
+		$tokens = [
+			'$value' => [ '{semantic.radius.control}', '4px', '{semantic.radius.media}', '2px' ],
+		];
+
+		if ( $responsive !== [] ) {
+			$tokens['$extensions'] = [
+				'com.kadence.designTokens' => [
+					'responsive' => $responsive,
+				],
+			];
+		}
+
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'presets' => [
+						'kadence/singlebtn' => [
+							'corners' => [
+								'label'  => 'Corners',
+								'tokens' => [
+									'button-radius' => $tokens,
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$this->store->save_document( (string) wp_json_encode( $document ), Token_Store::default_slug() );
+	}
+
+	/**
+	 * Extract the `@media all and <query>{...}` block for one query from a built CSS string, or an empty
+	 * string when no such block is present — a small parsing helper so a test can assert what is, and is
+	 * not, redeclared inside ONE specific breakpoint's block without the assertion being confused by a
+	 * sibling breakpoint's block.
+	 *
+	 * @param string $css   The full generated CSS.
+	 * @param string $query The media-query string the block was opened with (e.g. "(max-width: 1024px)").
+	 *
+	 * @return string
+	 */
+	private function extractMediaBlock( string $css, string $query ): string {
+		$needle = '@media all and ' . $query . '{';
+		$start  = strpos( $css, $needle );
+
+		if ( $start === false ) {
+			return '';
+		}
+
+		$start += strlen( $needle );
+		$end    = strpos( $css, '}}', $start );
+
+		return $end === false ? '' : substr( $css, $start, $end - $start );
 	}
 }


### PR DESCRIPTION
`Css_Builder` now splits a per-corner dimension's base declaration into 4 per-slot vars composed into the existing canonical var, so a breakpoint override can redeclare just the touched slot instead of the whole shorthand — an untouched corner keeps inheriting live from outside the `@media` block instead of getting frozen or dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for per-corner dimension values in preset-based styling.
  - Generates individual corner variables alongside a combined value for four-part dimensions.
  - Responsive styles now update only the corners that change while preserving existing values.
  - Gap sentinel values are excluded from responsive output.

- **Bug Fixes**
  - Preserved existing behavior for scalar and non-corner properties.

- **Tests**
  - Added coverage for complete and partial responsive corner overrides and combined variable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->