### PR TITLE
[DTM] SOFT-4167 [5/5]: walk each corner's own breakpoint cascade in the sidebar indicator

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
@@ -63,16 +63,18 @@ final class Css_Builder {
 	private const PRESET_SEGMENT = 'preset--';
 
 	/**
-	 * The four corner-var name suffixes a per-corner dimension property's base declaration splits
-	 * into, in the same positional order every layer of the per-corner model agrees on — CSS
-	 * shorthand order (top, right, bottom, left), matching the resolver's slot list and the editor's
-	 * SLOT_LABELS.sides. Index N here is corner index N everywhere else in the pipeline.
+	 * The four positional slot labels a per-slot dimension property's base declaration splits into,
+	 * in CSS shorthand order (top, right, bottom, left). They are positional labels, not a claim
+	 * about geometry: for a side-shaped property (padding, margin, border width) the label matches
+	 * the CSS side it names, while for a corner-shaped property such as `button-radius` index
+	 * 0/`'top'` is really the top-left corner. Index N here is slot index N everywhere else in the
+	 * pipeline — the resolver's slot list and the editor's `dimensionSlots()`.
 	 *
 	 * @since TBD
 	 *
 	 * @var string[]
 	 */
-	private const CORNERS = [ 'top', 'right', 'bottom', 'left' ];
+	private const SLOTS = [ 'top', 'right', 'bottom', 'left' ];
 
 	/**
 	 * Kadence theme global custom-property slots a preset may retarget beyond the numbered palette
@@ -309,8 +311,8 @@ final class Css_Builder {
 					$properties[ $property ] = [
 						'target'    => $target,
 						'value'     => $value,
-						// Only a "dimension" kind binding ever carries a per-corner slot list (the write-time
-						// guard rejects one on any other kind); gating the corner split on this, rather than
+						// Only a "dimension" kind binding ever carries a per-slot list (the write-time
+						// guard rejects one on any other kind); gating the slot split on this, rather than
 						// on the value's own shape, avoids a false-positive split of an unrelated value that
 						// happens to contain spaces (e.g. a shadow literal).
 						'dimension' => $bindings->kind( $property ) === Preset_Bindings::get_kind_dimension(),
@@ -362,8 +364,8 @@ final class Css_Builder {
 	 * The raw `--kb-token--preset--*:<value>;` declaration list for the collected presets, shared by the
 	 * `:root` canonical block and the palette switch layer's re-emission.
 	 *
-	 * A per-corner dimension property (border radius, padding, margin, border width) emits four extra
-	 * corner-specific vars alongside its usual canonical var — see {@see self::property_declarations()}.
+	 * A per-slot dimension property (border radius, padding, margin, border width) emits four extra
+	 * slot-specific vars alongside its usual canonical var — see {@see self::property_declarations()}.
 	 * Every other property emits exactly the single declaration it always has.
 	 *
 	 * @since TBD
@@ -393,13 +395,13 @@ final class Css_Builder {
 	 * four-slot shorthand) emits the single canonical declaration it always has:
 	 * `--kb-token--preset--<block>--<preset>--<property>:<value>;`.
 	 *
-	 * A per-corner dimension value instead emits four corner-specific vars — one per {@see self::CORNERS}
+	 * A per-slot dimension value instead emits four slot-specific vars — one per {@see self::SLOTS}
 	 * suffix — plus the canonical var, now composed purely from `var()` references to those four:
 	 * `--...--<property>:var(--...--top) var(--...--right) var(--...--bottom) var(--...--left);`. The
-	 * corner vars are new plumbing underneath an unchanged public contract: the composed var's name and
+	 * slot vars are new plumbing underneath an unchanged public contract: the composed var's name and
 	 * resolved value are exactly what they always were, so every bridge (`--global-*`, `--kb-btn-radius`)
 	 * that already points at it keeps working unchanged, and {@see self::responsive_blocks()} can redeclare
-	 * a single touched corner without ever redeclaring the composed var itself.
+	 * a single touched slot without ever redeclaring the composed var itself.
 	 *
 	 * @since TBD
 	 *
@@ -411,93 +413,79 @@ final class Css_Builder {
 	 * @return string
 	 */
 	private function property_declarations( string $block, string $preset, string $property, array $info ): string {
-		$corners = $this->corners_of( $info['value'], $info['dimension'] );
+		$slots = $this->slots_of( $info['value'], $info['dimension'] );
 
-		if ( $corners === null ) {
+		if ( $slots === null ) {
 			return $this->preset_var( $block, $preset, $property ) . ':' . $this->sanitize_value( $info['value'] ) . ';';
 		}
 
 		$declarations = '';
 		$refs         = [];
 
-		foreach ( self::CORNERS as $index => $corner ) {
-			$corner_var    = $this->corner_var( $block, $preset, $property, $corner );
-			$declarations .= $corner_var . ':' . $this->sanitize_value( $corners[ $index ] ) . ';';
-			$refs[]        = 'var(' . $corner_var . ')';
+		foreach ( self::SLOTS as $index => $slot_suffix ) {
+			$slot_var      = $this->slot_var( $block, $preset, $property, $slot_suffix );
+			$declarations .= $slot_var . ':' . $this->sanitize_value( $slots[ $index ] ) . ';';
+			$refs[]        = 'var(' . $slot_var . ')';
 		}
 
 		return $declarations . $this->preset_var( $block, $preset, $property ) . ':' . implode( ' ', $refs ) . ';';
 	}
 
 	/**
-	 * Split a property's projected value into its four corner values, or null when it isn't a per-corner
+	 * Split a property's projected value into its four slot values, or null when it isn't a per-slot
 	 * dimension value.
 	 *
-	 * Gated on the property being a "dimension" kind binding (the only kind a per-corner slot list is
-	 * meaningful for — see {@see Preset_Bindings::kind()}) AND the value actually splitting into exactly
-	 * {@see self::CORNERS}'s four parts. {@see \KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Preset_Resolver::project()}
-	 * is the only place that ever joins a value with a bare space (`implode(' ', $projected)`, one call per
-	 * per-corner slot list, always exactly four slots per the write-time validator), so `explode(' ', $value)`
-	 * reconstructs the original four segments losslessly FOR EVERY VALUE SHAPE THAT IS ITSELF SPACE-FREE — an
-	 * alias reference (`var(--x)`) or a plain length/keyword literal, which is everything the write-time
-	 * validator (`Dtcg_Validator`) currently accepts into a per-corner slot. It is NOT a general guarantee: a
-	 * compound-literal value with an internal space (e.g. a `calc(1px + 1px)` or `clamp(...)` literal) is not
-	 * rejected by `Dtcg_Validator` today, so it is writable into a per-corner slot through the REST endpoint
-	 * even though no shipped preset or editor control produces one. Such a value's own space(s) would corrupt
-	 * the part count this method keys off, so `count($parts) === count(self::CORNERS)` no longer identifies
-	 * "four real corners" reliably. The failure this degrades to is contained, not silent corruption: for a
-	 * BASE value it just falls through to null (this property renders as the single old-style declaration,
-	 * matching pre-this-task behavior — no regression). For a RESPONSIVE override it also falls through to
-	 * null, which makes {@see self::responsive_declarations()} redeclare the WHOLE composed var inside
-	 * `@media` instead of the one touched corner — the exact "gap gets frozen/dropped" failure this task
-	 * exists to prevent, just for a value shape outside what write-time validation lets through as of this
-	 * writing. Fixing this properly means rejecting (or otherwise disambiguating) a compound-literal
-	 * per-corner slot in `Dtcg_Validator`/`Preset_Resolver`, both outside this class's scope.
+	 * The split is lossless because {@see \KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Preset_Resolver::project()}
+	 * is the only place that joins a slot list with a bare space (`implode(' ', $projected)`), and
+	 * `Dtcg_Validator` rejects any slot literal containing a space, so every segment `explode(' ', $value)`
+	 * produces is exactly one slot — including the responsive-only `''` gap sentinel, which round-trips as
+	 * an empty segment. The split is additionally gated on the property being a "dimension" kind binding
+	 * (the only kind a slot list is meaningful for — see {@see Preset_Bindings::kind()}).
 	 *
-	 * A gap slot (the responsive-only `''` sentinel) round-trips the same way as any other space-free
-	 * segment: an empty segment between two single spaces.
+	 * @todo A slot list handed over as an array, rather than pre-joined into a string by the resolver,
+	 *       would remove the need to split it back apart here at all.
 	 *
 	 * @since TBD
 	 *
 	 * @param string $value     The property's projected value.
 	 * @param bool   $dimension Whether the property is a "dimension" kind binding.
 	 *
-	 * @return string[]|null The four corner values (index 0-3 = top, right, bottom, left; a gap is `''`),
-	 *                       or null when the value is not a four-part per-corner shorthand.
+	 * @return string[]|null The four slot values (index 0-3 = top, right, bottom, left; a gap is `''`),
+	 *                       or null when the value is not a four-part per-slot shorthand.
 	 */
-	private function corners_of( string $value, bool $dimension ): ?array {
+	private function slots_of( string $value, bool $dimension ): ?array {
 		if ( ! $dimension ) {
 			return null;
 		}
 
 		$parts = explode( ' ', $value );
 
-		return count( $parts ) === count( self::CORNERS ) ? $parts : null;
+		return count( $parts ) === count( self::SLOTS ) ? $parts : null;
 	}
 
 	/**
-	 * The per-corner var name for a (block, preset, property, corner): the canonical preset var with a
-	 * "--<corner>" suffix, e.g. --kb-token--preset--kadence-singlebtn--hero--button-radius--top.
+	 * The per-slot var name for a (block, preset, property, slot): the canonical preset var with a
+	 * "--<slot>" suffix, e.g. --kb-token--preset--kadence-singlebtn--hero--button-radius--top.
 	 *
 	 * @since TBD
 	 *
-	 * @param string $block    The block name.
-	 * @param string $preset   The preset slug.
-	 * @param string $property The block property.
-	 * @param string $corner   The corner suffix (one of {@see self::CORNERS}).
+	 * @param string $block       The block name.
+	 * @param string $preset      The preset slug.
+	 * @param string $property    The block property.
+	 * @param string $slot_suffix The slot suffix (one of {@see self::SLOTS}).
 	 *
 	 * @return string
 	 */
-	private function corner_var( string $block, string $preset, string $property, string $corner ): string {
-		return $this->preset_var( $block, $preset, $property ) . '--' . $corner;
+	private function slot_var( string $block, string $preset, string $property, string $slot_suffix ): string {
+		return $this->preset_var( $block, $preset, $property ) . '--' . $slot_suffix;
 	}
 
 	/**
 	 * The `@media`-block declaration(s) for one breakpoint's override of one property.
 	 *
 	 * A scalar override (a non-dimension property, or a dimension property overridden with one uniform
-	 * value) redeclares the canonical var itself, exactly like the pre-per-corner behavior. A per-corner
-	 * override instead redeclares only the touched corner vars — a `''` gap slot is skipped so that corner
+	 * value) redeclares the canonical var itself, exactly like the pre-per-slot behavior. A per-slot
+	 * override instead redeclares only the touched slot vars — a `''` gap slot is skipped so that slot
 	 * keeps inheriting live — and never redeclares the composed var (see {@see self::responsive_blocks()}).
 	 *
 	 * @since TBD
@@ -511,20 +499,20 @@ final class Css_Builder {
 	 * @return string
 	 */
 	private function responsive_declarations( string $block, string $preset, string $property, string $value, bool $dimension ): string {
-		$corners = $this->corners_of( $value, $dimension );
+		$slots = $this->slots_of( $value, $dimension );
 
-		if ( $corners === null ) {
+		if ( $slots === null ) {
 			return $this->preset_var( $block, $preset, $property ) . ':' . $this->sanitize_value( $value ) . ';';
 		}
 
 		$declarations = '';
 
-		foreach ( self::CORNERS as $index => $corner ) {
-			if ( $corners[ $index ] === '' ) {
+		foreach ( self::SLOTS as $index => $slot_suffix ) {
+			if ( $slots[ $index ] === '' ) {
 				continue; // A gap: not overridden at this breakpoint, keep inheriting live.
 			}
 
-			$declarations .= $this->corner_var( $block, $preset, $property, $corner ) . ':' . $this->sanitize_value( $corners[ $index ] ) . ';';
+			$declarations .= $this->slot_var( $block, $preset, $property, $slot_suffix ) . ':' . $this->sanitize_value( $slots[ $index ] ) . ';';
 		}
 
 		return $declarations;
@@ -695,12 +683,12 @@ final class Css_Builder {
 	 * {@see \KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var\Css_Builder} responsive layer: same
 	 * media wrapper, same :root scope, same "redeclare the same custom property" approach.
 	 *
-	 * For a per-corner dimension property, ONLY the touched corner vars are redeclared — never the
-	 * composed var. A gap slot (the responsive-only `''` sentinel Task 3's resolver keeps in place) is
-	 * skipped entirely, so that corner keeps inheriting live from whatever the composed var's `var()` chain
+	 * For a per-slot dimension property, ONLY the touched slot vars are redeclared — never the
+	 * composed var. A gap slot (the responsive-only `''` sentinel {@see Preset_Resolver} keeps in place) is
+	 * skipped entirely, so that slot keeps inheriting live from whatever the composed var's `var()` chain
 	 * currently resolves to outside this media query, rather than freezing it. The composed var itself picks
-	 * up a touched corner's new value automatically: browsers re-evaluate a `var()` reference live, so
-	 * redeclaring one corner var here changes what the (untouched, never-redeclared) composed var resolves
+	 * up a touched slot's new value automatically: browsers re-evaluate a `var()` reference live, so
+	 * redeclaring one slot var here changes what the (untouched, never-redeclared) composed var resolves
 	 * to for elements matching this breakpoint.
 	 *
 	 * @since TBD
@@ -734,13 +722,20 @@ final class Css_Builder {
 							continue;
 						}
 
-						$by_breakpoint[ $breakpoint ][] = $this->responsive_declarations(
+						$declaration = $this->responsive_declarations(
 							$block,
 							(string) $preset,
 							(string) $property,
 							$value,
 							$properties[ $property ]['dimension']
 						);
+
+						// An all-gap per-slot override declares nothing; keeping it out avoids an empty @media block.
+						if ( $declaration === '' ) {
+							continue;
+						}
+
+						$by_breakpoint[ $breakpoint ][] = $declaration;
 					}
 				}
 			}

--- a/includes/resources/Design_Tokens/Resolver/Preset_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Preset_Resolver.php
@@ -487,7 +487,9 @@ final class Preset_Resolver {
 			}
 
 			// Nested lists are rejected at validation; guard anyway so a hand-edited document fails closed.
-			$value = is_array( $slot ) ? null : $this->flatten( $slot, $resolved, $keep_gaps );
+			// $slot is therefore always a scalar here, so flatten() never reaches its array branch — the only
+			// branch $keep_gaps affects — and is left at its default.
+			$value = is_array( $slot ) ? null : $this->flatten( $slot, $resolved );
 
 			if ( ! is_string( $value ) ) {
 				return null;

--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -1033,7 +1033,9 @@ final class Dtcg_Validator {
 	 * each an alias or a non-empty literal scalar. "Every corner" is already expressed by a bare scalar, so
 	 * a shorter list would be a second spelling of the same thing. A slot is validated by the
 	 * same alias-or-literal rule as a scalar value, so "alias anywhere" stays one rule applied once; a
-	 * nested list is rejected because that rule accepts no array.
+	 * nested list is rejected because that rule accepts no array. A slot literal must additionally be
+	 * free of spaces — the projection round-trips a slot list through a space-separated shorthand, so a
+	 * compound literal such as `calc(1px + 1px)` would break the split and is rejected here at write time.
 	 *
 	 * @since TBD
 	 *
@@ -1066,6 +1068,16 @@ final class Dtcg_Validator {
 					$path . '.' . $index,
 					Validation_Error::get_code_value_invalid(),
 					'A preset token slot must be an alias or a non-empty literal, not a nested list.'
+				);
+			}
+
+			// The projection joins a slot list into a space-separated shorthand and splits it back apart by
+			// space, so a slot carrying its own space would silently shift every slot after it.
+			if ( is_string( $slot ) && strpos( $slot, ' ' ) !== false ) {
+				return new Validation_Error(
+					$path . '.' . $index,
+					Validation_Error::get_code_value_invalid(),
+					'A preset token slot must not contain a space; a compound literal (e.g. calc(), clamp()) is not supported in a slot.'
 				);
 			}
 

--- a/src/extension/token-indicators/__tests__/index.test.js
+++ b/src/extension/token-indicators/__tests__/index.test.js
@@ -146,6 +146,77 @@ describe('usePresetBinding device-aware overridden', () => {
 	});
 });
 
+describe('usePresetBinding per-corner breakpoint gaps', () => {
+	// The preset's tablet override touches only the top corner (index 0); the other three corners
+	// carry a `''` gap, meaning "keep inheriting the base value live" — see
+	// `resolve_responsive_literal()`'s docblock. The indicator must read each corner's own state
+	// rather than treating the whole property as one overridden/matching unit.
+	beforeEach(() => {
+		window.kadenceDesignTokensPresets = {
+			active: SET,
+			libraries: {
+				[SET]: {
+					[BLOCK]: {
+						default: 'primary',
+						presets: [{ slug: 'primary', label: 'Primary' }],
+						properties: [
+							{ key: 'button-radius', kind: 'dimension', token: null, control_attr: 'borderRadius' },
+						],
+						values: {
+							primary: { 'button-radius': '4px' },
+						},
+						responsive: {
+							primary: { tablet: { 'button-radius': ['8px', '', '', ''] } },
+						},
+					},
+				},
+			},
+		};
+	});
+
+	afterEach(() => {
+		delete window.kadenceDesignTokensPresets;
+	});
+
+	/**
+	 * A stored tablet value matching the overridden top corner AND the base value the other three
+	 * corners keep inheriting reads as bound, not overridden — a gap corner is compared against the
+	 * base, not against the (nonexistent) tablet override.
+	 *
+	 * @return {void}
+	 */
+	it('reports not overridden when every corner matches its own per-corner cascade value', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			tabletBorderRadius: ['8', '4', '4', '4'],
+			borderRadiusUnit: 'px',
+		};
+
+		const state = usePresetBinding(BLOCK, attributes, SET, 'Tablet');
+
+		expect(state.borderRadius.overridden).toBe(false);
+	});
+
+	/**
+	 * A stored value on a GAP corner (right, index 1) that diverges from the base value it should be
+	 * inheriting is caught as overridden, even though the touched corner (top) still matches its own
+	 * tablet override.
+	 *
+	 * @return {void}
+	 */
+	it('reports overridden when a gap corner diverges from the base value it inherits', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			tabletBorderRadius: ['8', '5', '4', '4'],
+			borderRadiusUnit: 'px',
+		};
+
+		const state = usePresetBinding(BLOCK, attributes, SET, 'Tablet');
+
+		expect(state.borderRadius.overridden).toBe(true);
+	});
+});
+
 describe('presetPropertyValueForDevice', () => {
 	/**
 	 * Seed a property with no `control_attr` — `usePresetBinding` cannot key it by an attribute name,

--- a/src/extension/token-indicators/kinds/__tests__/dimension.test.js
+++ b/src/extension/token-indicators/kinds/__tests__/dimension.test.js
@@ -263,3 +263,52 @@ describe('presetValueForDevice', () => {
 		expect(presetValueForDevice('0.5rem', undefined, 'Mobile')).toBe('0.5rem');
 	});
 });
+
+describe('presetValueForDevice per-corner cascade', () => {
+	// Corner order is top, right, bottom, left (index 0-3), matching CSS shorthand order — confirmed
+	// against `dimensionSlots()`/`presetSlotAt()`'s own convention and re-confirmed by Tasks 1 and 4.
+	const CORNERS = ['top', 'right', 'bottom', 'left'];
+
+	CORNERS.forEach((corner, index) => {
+		it(`walks the ${corner} corner's own cascade independently on Tablet, leaving the other three on the base value`, () => {
+			const tabletOverride = ['', '', '', ''];
+
+			tabletOverride[index] = '8px';
+
+			const result = presetValueForDevice('4px', { tablet: tabletOverride }, 'Tablet');
+			const expected = ['4px', '4px', '4px', '4px'];
+
+			expected[index] = '8px';
+
+			expect(result).toEqual(expected);
+		});
+	});
+
+	it('falls each corner without a mobile override through tablet before reaching the base', () => {
+		// Corner 0 (top): overridden at Tablet only, no Mobile override -> inherits the Tablet value.
+		// Corner 1 (right): overridden at Mobile directly.
+		// Corners 2-3 (bottom/left): a gap at both breakpoints -> fall all the way to the base.
+		const result = presetValueForDevice(
+			'4px',
+			{ tablet: ['8px', '', '', ''], mobile: ['', '2px', '', ''] },
+			'Mobile'
+		);
+
+		expect(result).toEqual(['8px', '2px', '4px', '4px']);
+	});
+
+	it('takes a fully scalar tablet override at every corner when the breakpoint sets no gaps', () => {
+		const corners = ['9999px', '1rem', '1rem', '1rem'];
+
+		expect(presetValueForDevice('0.5rem', { tablet: corners }, 'Tablet')).toEqual(corners);
+	});
+
+	it('broadcasts a scalar base value to every corner a gapped override leaves untouched', () => {
+		expect(presetValueForDevice('4px', { tablet: ['', '8px', '', ''] }, 'Tablet')).toEqual([
+			'4px',
+			'8px',
+			'4px',
+			'4px',
+		]);
+	});
+});

--- a/src/extension/token-indicators/kinds/__tests__/dimension.test.js
+++ b/src/extension/token-indicators/kinds/__tests__/dimension.test.js
@@ -213,6 +213,26 @@ describe('matchesPreset dimension against a per-corner preset value', () => {
 	it('does not match a scalar stored value against a mixed per-corner preset value', () => {
 		expect(matchesPreset('dimension', '8', 'px', ['8px', '4px', '8px', '4px'])).toBe(false);
 	});
+
+	it('matches when the one touched corner equals its preset slot and the rest are gaps', () => {
+		expect(matchesPreset('dimension', ['8', '', '', ''], 'px', ['8px', '4px', '8px', '4px'])).toBe(true);
+	});
+
+	it('does not match when the one touched corner differs from its preset slot', () => {
+		expect(matchesPreset('dimension', ['2', '', '', ''], 'px', ['8px', '4px', '8px', '4px'])).toBe(false);
+	});
+
+	it('matches when two touched corners equal their preset slots and the other two are gaps', () => {
+		expect(matchesPreset('dimension', ['8', '', '', '4'], 'px', ['8px', '4px', '8px', '4px'])).toBe(true);
+	});
+
+	it('compares a touched corner against the preset slot at ITS OWN index, not the first slot', () => {
+		expect(matchesPreset('dimension', ['', '8', '', ''], 'px', ['8px', '4px', '8px', '4px'])).toBe(false);
+	});
+
+	it('does not match an all-gap per-corner value', () => {
+		expect(matchesPreset('dimension', ['', '', '', ''], 'px', ['8px', '4px', '8px', '4px'])).toBe(false);
+	});
 });
 
 describe('isEmptyValue dimension', () => {

--- a/src/extension/token-indicators/kinds/__tests__/dimension.test.js
+++ b/src/extension/token-indicators/kinds/__tests__/dimension.test.js
@@ -266,7 +266,8 @@ describe('presetValueForDevice', () => {
 
 describe('presetValueForDevice per-corner cascade', () => {
 	// Corner order is top, right, bottom, left (index 0-3), matching CSS shorthand order — confirmed
-	// against `dimensionSlots()`/`presetSlotAt()`'s own convention and re-confirmed by Tasks 1 and 4.
+	// against `dimensionSlots()`/`presetSlotAt()`'s own convention and re-confirmed against the
+	// resolver's flattened slot order and the CSS projection's corner-var naming.
 	const CORNERS = ['top', 'right', 'bottom', 'left'];
 
 	CORNERS.forEach((corner, index) => {

--- a/src/extension/token-indicators/kinds/dimension.js
+++ b/src/extension/token-indicators/kinds/dimension.js
@@ -307,33 +307,38 @@ export function parseDimensionLiteral(literal) {
 }
 
 /**
- * Whether a stored dimension matches a PER-CORNER preset value, compared slot by slot.
+ * Whether a stored dimension matches a PER-CORNER preset value, compared corner by corner at the SAME
+ * index into `presetSlots`.
  *
- * Comparing by position means a rotated set of the same corners (e.g. `4,8,4,8` against `8,4,8,4`) reads
- * as overridden, and a stored value with a different number of populated sides than the preset has slots
- * cannot match at all.
+ * The stored slots keep their position (a gap is `''`, not dropped), so the two lists line up index for
+ * index and must be the same length. A gap slot counts as matching: an unset corner inherits the preset's
+ * own value for that corner, so there is nothing there to disagree with. Because the compare is
+ * positional, a rotated set of the same values (e.g. `4,8,4,8` against `8,4,8,4`) reads as overridden.
  *
- * @param {string[]} sides       The stored sides, empties already dropped.
+ * @param {string[]} slots       The stored slots with position preserved, a gap kept as ''.
  * @param {string}   storedUnit  The stored companion unit.
  * @param {Array}    presetSlots The preset's per-corner literals.
  *
  * @since TBD
  *
- * @return {boolean} True when every corner equals its preset slot.
+ * @return {boolean} True when every populated corner equals its preset slot.
  */
-function matchesPresetSlots(sides, storedUnit, presetSlots) {
-	const stored = sides;
+function matchesPresetSlots(slots, storedUnit, presetSlots) {
 	const presets = presetSlots.map(parseDimensionLiteral);
 
-	if (stored.length !== presets.length) {
+	if (slots.length !== presets.length) {
 		return false;
 	}
 
-	return stored.every((side, index) => {
+	return slots.every((slot, index) => {
+		if (slot === '') {
+			return true;
+		}
+
 		const preset = presets[index];
 		const unitMatches = preset.unit === '' || storedUnit === preset.unit;
 
-		return unitMatches && side === preset.value;
+		return unitMatches && slot === preset.value;
 	});
 }
 
@@ -354,6 +359,12 @@ export function isEmpty(value) {
 /**
  * Whether a stored dimension value equals the selected preset's resolved value.
  *
+ * A PER-CORNER preset is compared positionally against the stored slots, with a gap slot always counted
+ * as matching because that corner inherits the preset's own value for that corner. So a partial override
+ * — e.g. only the top corner set at Tablet — still reads as bound when the corner(s) the user did touch
+ * agree with the preset. A scalar preset keeps the side-aware compare below: every POPULATED side must
+ * equal the one preset value.
+ *
  * @param {*}      value       The stored primary attribute value.
  * @param {string} unit        The companion unit.
  * @param {string} presetValue The preset's resolved literal for this property.
@@ -363,6 +374,19 @@ export function isEmpty(value) {
  * @return {boolean} True when the stored value matches the preset value.
  */
 export function matches(value, unit, presetValue) {
+	// `parseDimensionLiteral` reads one length, so a slot list handed to it whole would never match and
+	// the control would read as overridden even when it exactly matches its preset.
+	if (Array.isArray(presetValue)) {
+		const slots = dimensionSlots(value);
+
+		// A fully untouched value has nothing to agree with the preset about; keep it reading as unmatched.
+		if (!slots.some((slot) => slot !== '')) {
+			return false;
+		}
+
+		return matchesPresetSlots(slots, String(unit || '').trim(), presetValue);
+	}
+
 	const sides = dimensionSides(value);
 
 	if (!sides.length) {
@@ -370,14 +394,6 @@ export function matches(value, unit, presetValue) {
 	}
 
 	const storedUnit = String(unit || '').trim();
-
-	// A per-corner preset value is compared corner by corner. `parseDimensionLiteral` reads one length,
-	// so a slot list handed to it whole would never match and the control would read as overridden even
-	// when it exactly matches its preset.
-	if (Array.isArray(presetValue)) {
-		return matchesPresetSlots(sides, storedUnit, presetValue);
-	}
-
 	const preset = parseDimensionLiteral(presetValue);
 	const unitMatches = preset.unit === '' || storedUnit === preset.unit;
 

--- a/src/extension/token-indicators/kinds/dimension.js
+++ b/src/extension/token-indicators/kinds/dimension.js
@@ -63,6 +63,42 @@ export function presetSlotAt(presetValue, index) {
 }
 
 /**
+ * The corner a device's own breakpoint chain resolves to at ONE corner index, walking closest
+ * breakpoint first — the per-corner counterpart to the whole-property fallback `presetValueForDevice`
+ * runs for a non-corner value.
+ *
+ * A chain entry can itself be a per-corner list (with `''` gaps left by `resolve_responsive_literal()`
+ * for a corner that breakpoint didn't touch) or a scalar (a breakpoint override captured as one
+ * uniform value broadcasts to every corner). A gap at one breakpoint is skipped, not treated as
+ * "found" — that is exactly what lets the NEXT breakpoint up (and ultimately the base) answer for
+ * that corner instead.
+ *
+ * @param {Array} chain       The device's breakpoint values, closest first (e.g. Mobile's
+ *                            `[responsive.mobile, responsive.tablet]`).
+ * @param {*}     presetValue The preset's base value for the property, the last fallback.
+ * @param {number} index      The corner index.
+ *
+ * @since TBD
+ *
+ * @return {string} The corner's resolved value at this device.
+ */
+function cornerValueForDevice(chain, presetValue, index) {
+	for (const value of chain) {
+		if (value === undefined || value === null) {
+			continue;
+		}
+
+		const slot = Array.isArray(value) ? value[index] : value;
+
+		if (slot !== undefined && slot !== null && slot !== '') {
+			return String(slot);
+		}
+	}
+
+	return presetSlotAt(presetValue, index);
+}
+
+/**
  * The selected preset's value for a property AT THE ACTIVE DEVICE: its breakpoint override where the
  * preset declares one, otherwise the value it inherits through the cascade.
  *
@@ -71,6 +107,15 @@ export function presetSlotAt(presetValue, index) {
  * that breakpoint. The fallback order mirrors the projected CSS: Mobile takes the mobile override,
  * then the tablet one, then the base; Tablet takes the tablet override, then the base.
  *
+ * A per-corner (dimension) property's breakpoint override can be SPARSE — `resolve_responsive_literal()`
+ * keeps a `''` gap at any corner a breakpoint didn't touch, meaning "not overridden here, keep
+ * inheriting live" (see that method's own docblock). Each corner has to walk this cascade
+ * independently rather than the property being resolved as one all-or-nothing unit, or a gap corner
+ * would incorrectly inherit the WHOLE touched breakpoint's override instead of falling through to the
+ * next breakpoint/base for just that corner. Whether this property is corner-shaped at all is read
+ * from the data, not from a passed-in kind: a per-corner list shows up in the base value or in either
+ * breakpoint's override, a plain scalar property never does.
+ *
  * @param {*}      presetValue  The preset's base value for the property.
  * @param {Object} [responsive] The preset's breakpoint values ({ tablet, mobile }), each undefined
  *                              when the preset declares no override there.
@@ -78,15 +123,24 @@ export function presetSlotAt(presetValue, index) {
  *
  * @since TBD
  *
- * @return {*} The preset's value in effect at that device.
+ * @return {*} The preset's value in effect at that device — a per-corner array when the property is
+ *             corner-shaped, otherwise a scalar.
  */
 export function presetValueForDevice(presetValue, responsive = {}, device = 'Desktop') {
-	const chain =
-		'Mobile' === device ? [responsive.mobile, responsive.tablet] : 'Tablet' === device ? [responsive.tablet] : [];
+	if ('Tablet' !== device && 'Mobile' !== device) {
+		return presetValue;
+	}
 
-	const override = chain.find((value) => value !== undefined && value !== null && value !== '');
+	const chain = 'Mobile' === device ? [responsive.mobile, responsive.tablet] : [responsive.tablet];
+	const isCornerShaped = Array.isArray(presetValue) || chain.some((value) => Array.isArray(value));
 
-	return override === undefined ? presetValue : override;
+	if (!isCornerShaped) {
+		const override = chain.find((value) => value !== undefined && value !== null && value !== '');
+
+		return override === undefined ? presetValue : override;
+	}
+
+	return [0, 1, 2, 3].map((index) => cornerValueForDevice(chain, presetValue, index));
 }
 
 /**

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
@@ -374,6 +374,24 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
+	 * A responsive override whose every slot is a gap declares nothing, so its breakpoint contributes no
+	 * `@media` block at all rather than an empty one.
+	 *
+	 * @return void
+	 */
+	public function testAnAllGapResponsiveOverrideEmitsNoMediaBlock(): void {
+		$this->seedPerCornerPreset(
+			[
+				'tablet' => [ '', '', '', '' ],
+			]
+		);
+
+		$css = $this->builder( $this->registry )->css( 'default', $this->breakpoints() );
+
+		$this->assertStringNotContainsString( '@media all and (max-width: 1024px)', $css );
+	}
+
+	/**
 	 * The breakpoint => media-query map a projector passes at emit time.
 	 *
 	 * @return array<string, string>

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
@@ -916,7 +916,8 @@ final class Dtcg_ValidatorTest extends TestCase {
 
 	/**
 	 * A preset token slot list is rejected when its length is not 1 or 4, when a slot nests another list,
-	 * when a slot is empty, or when a slot carries braces without being a whole-string alias.
+	 * when a slot is empty, when a slot carries a space (a compound literal), or when a slot carries braces
+	 * without being a whole-string alias.
 	 *
 	 * @dataProvider invalidSlotListProvider
 	 *
@@ -989,6 +990,18 @@ final class Dtcg_ValidatorTest extends TestCase {
 			'value' => [ '8px', '{primitive.dimension.radius.sm}px', '8px', '4px' ],
 			'code'  => Validation_Error::get_code_alias_malformed(),
 			'path'  => $base . '.1',
+		];
+
+		yield 'compound literal slot carrying a space' => [
+			'value' => [ '8px', 'calc(1px + 1px)', '8px', '4px' ],
+			'code'  => Validation_Error::get_code_value_invalid(),
+			'path'  => $base . '.1',
+		];
+
+		yield 'clamp literal slot carrying a space' => [
+			'value' => [ 'clamp(1px, 2vw, 3px)', '4px', '8px', '4px' ],
+			'code'  => Validation_Error::get_code_value_invalid(),
+			'path'  => $base . '.0',
 		];
 	}
 


### PR DESCRIPTION
The sidebar's bound/overridden indicator now walks each corner's breakpoint cascade independently for a per-corner dimension property, instead of resolving the whole property as one unit — so a partially-overridden corner set reads correctly against the preset instead of a gap corner inheriting the wrong breakpoint's value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added independent responsive handling for each dimension corner, allowing corners to inherit or override values separately across breakpoints.
  - Improved preset matching for sparse and scalar dimension values.

- **Bug Fixes**
  - Prevented empty responsive styles from being generated when overrides contain only inherited gap values.
  - Improved validation for unsupported compound values in preset slot lists.

- **Tests**
  - Added coverage for responsive corner inheritance, preset matching, validation, and empty breakpoint output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->