### PR TITLE
[DTM] SOFT-4207 [15/15]: keep the theme's global fonts pickable

### DIFF
--- a/src/extension/font-picker/__tests__/index.test.js
+++ b/src/extension/font-picker/__tests__/index.test.js
@@ -68,6 +68,34 @@ describe('fontCatalogOptions', () => {
 		expect(fontCatalogOptions()).toEqual([{ value: 'Inter', label: 'Inter' }]);
 	});
 
+	// The two entries the shared TypographyControls select has always offered on a Kadence-theme
+	// site. They store a `var()` at the theme's typography settings rather than naming a face, so a
+	// block set to one follows the site's Heading/Body font.
+	it('leads with the theme global fonts when the Kadence theme is active', () => {
+		window.kadenceDesignTokensFonts = { favorites: ['Georgia'], custom: [] };
+		window.kadence_blocks_params = { g_font_names: ['Abel'], isKadenceT: true };
+
+		expect(fontCatalogOptions()).toEqual([
+			{
+				value: 'var( --global-heading-font-family, inherit )',
+				label: 'Inherit Heading Font Family',
+				badge: 'Theme',
+			},
+			{ value: 'var( --global-body-font-family, inherit )', label: 'Inherit Body Font Family', badge: 'Theme' },
+			{ value: 'Georgia', label: 'Georgia', badge: 'Favorite' },
+			{ value: 'Abel', label: 'Abel' },
+		]);
+	});
+
+	// On any other theme the custom properties are never emitted, so both rows would resolve to
+	// `inherit` and do nothing.
+	it('omits the theme global fonts on a non-Kadence theme', () => {
+		window.kadenceDesignTokensFonts = { favorites: [], custom: [] };
+		window.kadence_blocks_params = { g_font_names: ['Abel'] };
+
+		expect(fontCatalogOptions()).toEqual([{ value: 'Abel', label: 'Abel' }]);
+	});
+
 	it('matches a favorite against the catalog case-insensitively when deduplicating', () => {
 		window.kadenceDesignTokensFonts = { favorites: ['abril fatface'], custom: [] };
 		window.kadence_blocks_params = { g_font_names: ['Abril Fatface'] };

--- a/src/extension/font-picker/index.js
+++ b/src/extension/font-picker/index.js
@@ -42,6 +42,49 @@ const CUSTOM_BADGE = __('Custom', 'kadence-blocks');
 const FAVORITE_BADGE = __('Favorite', 'kadence-blocks');
 
 /**
+ * The muted badge the Kadence theme's two global font entries carry, so a row whose value is a CSS
+ * variable rather than a family name reads as one.
+ *
+ * @since TBD
+ */
+const THEME_BADGE = __('Theme', 'kadence-blocks');
+
+/**
+ * The Kadence theme's two global font entries, as the shared `TypographyControls` select has always
+ * offered them.
+ *
+ * These are not families. Each writes a `var()` reference at the theme's Customizer typography
+ * settings, so a block set to one tracks whatever the site's Heading or Body font is rather than
+ * naming a face — which is why they can never be favorites (a favorite is a catalog family) and why
+ * they belong in the catalog tab beside the families a block can also be set to.
+ *
+ * Offered only when the Kadence theme is active. On any other theme the custom properties are never
+ * emitted, and an option resolving to `inherit` everywhere would be a row that does nothing.
+ *
+ * @since TBD
+ *
+ * @return {Array<{value: string, label: string, badge: string}>} The theme options, or none.
+ */
+function themeFontOptions() {
+	if (!window.kadence_blocks_params?.isKadenceT) {
+		return [];
+	}
+
+	return [
+		{
+			value: 'var( --global-heading-font-family, inherit )',
+			label: __('Inherit Heading Font Family', 'kadence-blocks'),
+			badge: THEME_BADGE,
+		},
+		{
+			value: 'var( --global-body-font-family, inherit )',
+			label: __('Inherit Body Font Family', 'kadence-blocks'),
+			badge: THEME_BADGE,
+		},
+	];
+}
+
+/**
  * Read the design-tokens font global. Fail-safe on a missing or malformed global, mirroring the
  * token pool's posture — a caller never has to null-check before using either list.
  *
@@ -86,13 +129,18 @@ export function favoriteFonts() {
 }
 
 /**
- * The font-family picker's full option list: favorites first, then every Google family, then every
- * site-registered custom family.
+ * The font-family picker's full option list: the Kadence theme's global font entries first, then
+ * favorites, then every Google family, then every site-registered custom family.
  *
- * Every name appears exactly once, matched case-insensitively across all three sources: a favorite
- * keeps its pinned position rather than repeating mid-list, and a custom font that duplicates a
- * Google one renders once — the same rule the Style Library's Typography dropdown applies, so the
- * two screens list the same names in the same order.
+ * The theme entries lead for the same reason the shared select put them first — they are the two
+ * rows that follow the site's own typography settings, so they are what most blocks want. They are
+ * exempt from the dedupe below: their values are `var()` references, not family names, so they
+ * cannot collide with one.
+ *
+ * Every name appears exactly once, matched case-insensitively across all three name sources: a
+ * favorite keeps its pinned position rather than repeating mid-list, and a custom font that
+ * duplicates a Google one renders once — the same rule the Style Library's Typography dropdown
+ * applies, so the two screens list the same names in the same order.
  *
  * @since TBD
  *
@@ -119,6 +167,7 @@ export function fontCatalogOptions() {
 	const { custom } = fontPool();
 
 	return [
+		...themeFontOptions(),
 		...favorites.map((name) => ({ value: name, label: name, badge: FAVORITE_BADGE })),
 		...googleNames()
 			.filter(unique)

--- a/src/token-controls/__tests__/font-family-selector.test.js
+++ b/src/token-controls/__tests__/font-family-selector.test.js
@@ -148,6 +148,38 @@ describe('FontFamilySelector trigger', () => {
 	});
 });
 
+describe('FontFamilySelector stored-value label', () => {
+	/**
+	 * An option may store something that is not a family name — the Kadence theme's global font
+	 * entries store a `var()` reference at the site's typography settings — and printing that raw
+	 * would show the user CSS instead of the choice they made.
+	 *
+	 * @return {void}
+	 */
+	it('names the stored value by its option label', () => {
+		const trigger = renderSelector({
+			value: 'var( --global-heading-font-family, inherit )',
+			catalogOptions: [
+				{ value: 'var( --global-heading-font-family, inherit )', label: 'Inherit Heading Font Family' },
+			],
+		});
+
+		expect(trigger.querySelector('.kadence-token-field__value').textContent).toBe('Inherit Heading Font Family');
+	});
+
+	/**
+	 * A value no option claims — a family the catalog has since dropped, say — still prints as itself
+	 * rather than disappearing from the field.
+	 *
+	 * @return {void}
+	 */
+	it('falls back to the stored value when no option claims it', () => {
+		const trigger = renderSelector({ value: 'Abril Fatface', catalogOptions: [] });
+
+		expect(trigger.querySelector('.kadence-token-field__value').textContent).toBe('Abril Fatface');
+	});
+});
+
 describe('FontFamilySelector initial tab', () => {
 	/**
 	 * An unset field opens on the curated list — the same nudge `TokenSelector` makes toward picking

--- a/src/token-controls/organisms/FontFamilySelector.js
+++ b/src/token-controls/organisms/FontFamilySelector.js
@@ -34,6 +34,9 @@ import '../styles/token-controls.scss';
  * @param {string}   props.value            The current family, or `''` when unset.
  * @param {Array}    [props.favorites]      The site's favorite families, in display order.
  * @param {Array}    [props.catalogOptions] The full catalog option list (`{ value, label, badge? }`).
+ *                                          Also what the trigger reads to name the stored value, so
+ *                                          an option whose value is not its own label reads as the
+ *                                          label rather than as the raw stored string.
  * @param {string}   [props.inheritedLabel] What an unset family falls back to, for the muted trigger.
  * @param {string}   [props.manageUrl]      Deep link to the screen that manages favorites.
  * @param {Function} props.onPick           Writes a chosen family. May return a promise, in which
@@ -79,6 +82,13 @@ export function FontFamilySelector({
 	const unset = family === '';
 	const isFavorite = favorites.some((entry) => sameFamily(entry, family));
 
+	// What to call a stored value. For a family these are the same string, and this costs nothing. An
+	// option can store something that is not a family name, though — the Kadence theme's global font
+	// entries store a `var()` reference at the site's typography settings — and printing that raw is
+	// a control showing the user CSS instead of the choice they made. A value no option claims (a
+	// family the catalog has since dropped, say) still prints as itself rather than disappearing.
+	const labelFor = (stored) => catalogOptions.find((option) => option.value === stored)?.label ?? stored;
+
 	// A family already in the favorites opens on the short list; anything else opens on the catalog,
 	// which is where it was picked from and the only tab that can show it in context. An unset field
 	// opens on Favorites, the same nudge `TokenSelector` makes toward the curated list over
@@ -92,7 +102,7 @@ export function FontFamilySelector({
 				/* translators: %s: the inherited font family, e.g. "Inter". */ __('Default (%s)', 'kadence-blocks'),
 				fallback
 			)
-		: family;
+		: labelFor(family);
 
 	return (
 		<div className="kadence-token-field kadence-token-field--font-family">
@@ -106,13 +116,13 @@ export function FontFamilySelector({
 						onClick={onToggle}
 						disabled={disabled || pending !== ''}
 						aria-expanded={isOpen}
-						label={pending || triggerName}
+						label={pending ? labelFor(pending) : triggerName}
 						showTooltip
 					>
 						{pending ? (
 							<span className="kadence-token-field__value kadence-token-field__value--pending">
 								<Spinner />
-								{pending}
+								{labelFor(pending)}
 							</span>
 						) : unset ? (
 							<span className="kadence-token-field__value kadence-token-field__label--default">
@@ -120,7 +130,7 @@ export function FontFamilySelector({
 							</span>
 						) : (
 							<span className="kadence-token-field__value" style={{ fontFamily: family }}>
-								{family}
+								{labelFor(family)}
 							</span>
 						)}
 					</Button>


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4207/font-families-become-favorites-not-tokens
:video_camera:  https://www.loom.com/share/2cde91916171494694080f3b7beda6e9

On a Kadence-theme site the shared `TypographyControls` select offers a **Theme Global Fonts** group
— **Inherit Heading Font Family** and **Inherit Body Font Family**. Neither names a face: each stores
a `var()` reference at the theme's Customizer typography settings, so a block set to one follows
whatever the site's Heading or Body font is. The favorites picker replaces that select outright on
the blocks it is wired to, and built its list from favorites plus the font catalog — names only — so
those two entries had nowhere to come from.

A block already set to one kept rendering correctly (its attribute and the CSS it produces are
untouched, and no call site asks Google for a non-Google family), but the value could not be set
again once changed away, and the trigger printed the raw `var( --global-heading-font-family, inherit )`
string where a font name belongs.

`fontCatalogOptions()` now leads with the two entries when the Kadence theme is active, badged
**Theme**, and omits them on any other theme, where the custom properties are never emitted and both
rows would resolve to `inherit`. The trigger names a stored value by its option label rather than by
the value itself — the same string for a family, the readable one for anything that stores CSS — and
a value no option claims still prints as itself.

<img width="539" height="510" alt="image" src="https://github.com/user-attachments/assets/4a103395-6929-4195-a4ed-1dab86a194c6" />

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kadence theme options for inheriting heading and body fonts.
  * Displayed theme-provided font choices before favorites and Google Fonts, with clear theme labels.
* **Improvements**
  * Font selectors now show friendly names for saved font references, including CSS variable values.
  * Unrecognized font values remain visible instead of being replaced or hidden.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->