### PR TITLE
[DTM] SOFT-4211: reject a non-array $extensions metadata section

### DIFF
--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -611,7 +611,7 @@ final class Dtcg_Validator {
 		// each swatch `$value` with the same alias-or-literal grammar here.
 		$palettes_section = Extensions::get_section_color_palettes();
 
-		if ( isset( $namespace[ $palettes_section ] ) && is_array( $namespace[ $palettes_section ] ) ) {
+		if ( array_key_exists( $palettes_section, $namespace ) ) {
 			$errors = array_merge(
 				$errors,
 				$this->validate_color_palettes( $namespace[ $palettes_section ], $base . '.' . $palettes_section )
@@ -623,7 +623,7 @@ final class Dtcg_Validator {
 		// never covers it. Without this branch it would pass through with no validation at all.
 		$labels_section = Extensions::get_section_token_labels();
 
-		if ( isset( $namespace[ $labels_section ] ) && is_array( $namespace[ $labels_section ] ) ) {
+		if ( array_key_exists( $labels_section, $namespace ) ) {
 			$errors = array_merge(
 				$errors,
 				$this->validate_token_labels( $namespace[ $labels_section ], $base . '.' . $labels_section )
@@ -635,7 +635,7 @@ final class Dtcg_Validator {
 		// it) never covers it. Without this branch it would pass through with no validation at all.
 		$order_section = Extensions::get_section_token_order();
 
-		if ( isset( $namespace[ $order_section ] ) && is_array( $namespace[ $order_section ] ) ) {
+		if ( array_key_exists( $order_section, $namespace ) ) {
 			$errors = array_merge(
 				$errors,
 				$this->validate_token_order( $namespace[ $order_section ], $base . '.' . $order_section )
@@ -647,7 +647,7 @@ final class Dtcg_Validator {
 		// it) never covers it. Without this branch it would pass through with no validation at all.
 		$favorites_section = Extensions::get_section_favorite_fonts();
 
-		if ( isset( $namespace[ $favorites_section ] ) && is_array( $namespace[ $favorites_section ] ) ) {
+		if ( array_key_exists( $favorites_section, $namespace ) ) {
 			$errors = array_merge(
 				$errors,
 				$this->validate_favorite_fonts( $namespace[ $favorites_section ], $base . '.' . $favorites_section )
@@ -664,14 +664,28 @@ final class Dtcg_Validator {
 	 * leaf, no duplicate `token` within a palette, `$default` / `$current` naming a real palette) is enforced
 	 * by the palette controller's write guards, not here — this branch is the value-grammar gate only.
 	 *
+	 * Takes the section unshaped, because a section that is not an array at all is exactly what this has
+	 * to report. The caller only checks that the key is present; anything else here would let a scalar
+	 * stored under it skip validation and pass as a valid document.
+	 *
 	 * @since TBD
 	 *
-	 * @param array<int|string, mixed> $palettes The decoded colorPalettes section.
-	 * @param string                   $prefix   Dot-path to the section, for error messages.
+	 * @param mixed  $palettes The decoded colorPalettes section, before its shape is known.
+	 * @param string $prefix   Dot-path to the section, for error messages.
 	 *
 	 * @return Validation_Error[]
 	 */
-	private function validate_color_palettes( array $palettes, string $prefix ): array {
+	private function validate_color_palettes( $palettes, string $prefix ): array {
+		if ( ! is_array( $palettes ) ) {
+			return [
+				new Validation_Error(
+					$prefix,
+					Validation_Error::get_code_value_invalid(),
+					'colorPalettes must be a map of palette ids to palette definitions.'
+				),
+			];
+		}
+
 		$groups_key   = Extensions::get_groups_key();
 		$swatches_key = Extensions::get_swatches_key();
 		$value_key    = Sentinels::get_value_key();
@@ -720,14 +734,26 @@ final class Dtcg_Validator {
 	 * write guard, not here — a label for a since-unregistered token is stale data, not a
 	 * grammar error, and read-side consumers already ignore it.
 	 *
+	 * Takes the section unshaped, for the reason {@see validate_color_palettes()} gives.
+	 *
 	 * @since TBD
 	 *
-	 * @param array<int|string, mixed> $labels The decoded tokenLabels section.
-	 * @param string                   $prefix Dot-path to the section, for error messages.
+	 * @param mixed  $labels The decoded tokenLabels section, before its shape is known.
+	 * @param string $prefix Dot-path to the section, for error messages.
 	 *
 	 * @return Validation_Error[]
 	 */
-	private function validate_token_labels( array $labels, string $prefix ): array {
+	private function validate_token_labels( $labels, string $prefix ): array {
+		if ( ! is_array( $labels ) ) {
+			return [
+				new Validation_Error(
+					$prefix,
+					Validation_Error::get_code_value_invalid(),
+					'tokenLabels must be a map of token ids to non-empty string labels.'
+				),
+			];
+		}
+
 		$errors = [];
 
 		foreach ( $labels as $id => $label ) {
@@ -751,14 +777,26 @@ final class Dtcg_Validator {
 	 * the feed merge's concern (which ignores on read) — a stale id is data drift, not a grammar
 	 * error, so it does not fail full-document validation.
 	 *
+	 * Takes the section unshaped, for the reason {@see validate_color_palettes()} gives.
+	 *
 	 * @since TBD
 	 *
-	 * @param array<int|string, mixed> $order  The decoded tokenOrder section.
-	 * @param string                   $prefix Dot-path to the section, for error messages.
+	 * @param mixed  $order  The decoded tokenOrder section, before its shape is known.
+	 * @param string $prefix Dot-path to the section, for error messages.
 	 *
 	 * @return Validation_Error[]
 	 */
-	private function validate_token_order( array $order, string $prefix ): array {
+	private function validate_token_order( $order, string $prefix ): array {
+		if ( ! is_array( $order ) ) {
+			return [
+				new Validation_Error(
+					$prefix,
+					Validation_Error::get_code_value_invalid(),
+					'tokenOrder must be a sequential list of non-empty string token ids.'
+				),
+			];
+		}
+
 		// The `$order === []` check is required, not redundant: `range( 0, -1 )` returns
 		// `[ 0, -1 ]` in PHP, not `[]`, so without this short-circuit an empty order list would be
 		// misclassified as malformed rather than as a valid empty list.
@@ -795,14 +833,26 @@ final class Dtcg_Validator {
 	 * concern — a family that a theme or plugin has since stopped registering is data drift, not a
 	 * grammar error, and read-side consumers already ignore what they cannot render.
 	 *
+	 * Takes the section unshaped, for the reason {@see validate_color_palettes()} gives.
+	 *
 	 * @since TBD
 	 *
-	 * @param array<int|string, mixed> $favorites The decoded favoriteFonts section.
-	 * @param string                   $prefix    Dot-path to the section, for error messages.
+	 * @param mixed  $favorites The decoded favoriteFonts section, before its shape is known.
+	 * @param string $prefix    Dot-path to the section, for error messages.
 	 *
 	 * @return Validation_Error[]
 	 */
-	private function validate_favorite_fonts( array $favorites, string $prefix ): array {
+	private function validate_favorite_fonts( $favorites, string $prefix ): array {
+		if ( ! is_array( $favorites ) ) {
+			return [
+				new Validation_Error(
+					$prefix,
+					Validation_Error::get_code_value_invalid(),
+					'favoriteFonts must be a sequential list of non-empty font family names.'
+				),
+			];
+		}
+
 		// The `$favorites === []` check is required, not redundant: `range( 0, -1 )` returns
 		// `[ 0, -1 ]` in PHP, not `[]`, so without this short-circuit an empty favorites list would
 		// be misclassified as malformed rather than as a valid empty list.

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
@@ -212,6 +212,134 @@ final class Dtcg_ValidatorTest extends TestCase {
 	}
 
 	/**
+	 * Every one of the four metadata sections contracts for an array, so a scalar or a null stored
+	 * under any of their keys is a malformed document and has to be reported as one. Each section
+	 * used to be reached through a guard that required an array before it would run its validator,
+	 * which meant exactly the values that are wrong were the values that skipped the check.
+	 *
+	 * @dataProvider nonArrayExtensionSectionProvider
+	 *
+	 * @param string $section The `$extensions.com.kadence.designTokens` section key.
+	 * @param mixed  $value   The malformed value stored under it.
+	 *
+	 * @return void
+	 */
+	public function testANonArrayExtensionSectionIsRejected( string $section, $value ): void {
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					$section => $value,
+				],
+			],
+		];
+
+		$errors = $this->validator->validate( $document, Dtcg_Validator::get_context_overrides() )->errors();
+
+		$this->assertCount( 1, $errors, $this->describe( $errors ) );
+		$this->assertSame( Validation_Error::get_code_value_invalid(), $errors[0]->code );
+		$this->assertSame( '$extensions.com.kadence.designTokens.' . $section, $errors[0]->path );
+	}
+
+	/**
+	 * Each of the four sections against each way a stored value can fail to be an array. Written as a
+	 * cross-product so tightening one section can never quietly leave a sibling behind.
+	 *
+	 * @return Generator
+	 */
+	public function nonArrayExtensionSectionProvider(): Generator {
+		$sections = [ 'colorPalettes', 'tokenLabels', 'tokenOrder', 'favoriteFonts' ];
+		$values   = [
+			'string'  => 'Inter',
+			'empty string' => '',
+			'int'     => 42,
+			'float'   => 1.5,
+			'true'    => true,
+			'false'   => false,
+			'null'    => null,
+		];
+
+		foreach ( $sections as $section ) {
+			foreach ( $values as $label => $value ) {
+				yield $section . ' as a ' . $label => [
+					'section' => $section,
+					'value'   => $value,
+				];
+			}
+		}
+	}
+
+	/**
+	 * The array control for the case above: each section's own well-formed shape still validates, so
+	 * the rejection cannot be passing by refusing every value stored under these keys.
+	 *
+	 * @dataProvider wellFormedExtensionSectionProvider
+	 *
+	 * @param string               $section The `$extensions.com.kadence.designTokens` section key.
+	 * @param array<int|string, mixed> $value The section's well-formed value.
+	 *
+	 * @return void
+	 */
+	public function testAWellFormedExtensionSectionStillValidates( string $section, array $value ): void {
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					$section => $value,
+				],
+			],
+		];
+
+		$result = $this->validator->validate( $document, Dtcg_Validator::get_context_overrides() );
+
+		$this->assertTrue( $result->is_valid(), $this->describe( $result->errors() ) );
+	}
+
+	/**
+	 * One well-formed value per section, plus the empty array each of them accepts.
+	 *
+	 * @return Generator
+	 */
+	public function wellFormedExtensionSectionProvider(): Generator {
+		yield 'colorPalettes' => [
+			'section' => 'colorPalettes',
+			'value'   => [
+				'default' => [
+					'groups' => [
+						[ 'swatches' => [ [ '$value' => '#3182CE' ] ] ],
+					],
+				],
+			],
+		];
+		yield 'tokenLabels' => [
+			'section' => 'tokenLabels',
+			'value'   => [ 'semantic.color.button-bg' => 'Button Background' ],
+		];
+		yield 'tokenOrder' => [
+			'section' => 'tokenOrder',
+			'value'   => [ 'semantic.color.button-bg', 'semantic.color.button-text' ],
+		];
+		yield 'favoriteFonts' => [
+			'section' => 'favoriteFonts',
+			'value'   => [ 'Inter', 'Abril Fatface' ],
+		];
+		yield 'colorPalettes empty' => [
+			'section' => 'colorPalettes',
+			'value'   => [],
+		];
+		yield 'tokenLabels empty' => [
+			'section' => 'tokenLabels',
+			'value'   => [],
+		];
+		yield 'tokenOrder empty' => [
+			'section' => 'tokenOrder',
+			'value'   => [],
+		];
+		yield 'favoriteFonts empty' => [
+			'section' => 'favoriteFonts',
+			'value'   => [],
+		];
+	}
+
+	/**
 	 * A document without a tokenOrder section produces no new errors, and a non-Kadence extension
 	 * namespace alongside it is passed through untouched.
 	 *


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4211/dtcg-validator-reject-non-array-dollarextensions-metadata-sections

All four `$extensions.com.kadence.designTokens` metadata sections — `colorPalettes`, `tokenLabels`,
`tokenOrder`, `favoriteFonts` — were reached through a guard that required the stored value to
already be an array before it would run the section's validator. Every one of them contracts for an
array, so that guard let exactly the values that are wrong skip the check: a string, a number, a
bool or a null stored under any of those keys was reported as a valid document and accepted on
write.

Nothing broke downstream — the document indexes fail soft and degrade a malformed section to an
empty result — but a bad write was accepted silently instead of coming back as a `Validation_Error`
a caller could surface.

The guard now only asks whether the key is present, and each section validator takes its value
unshaped and reports the section itself as invalid when it is not an array. All four together:
tightening one would leave three siblings behind with nothing to explain the difference.

The fail-soft behavior in the document indexes is unchanged — this is about the validator reporting
a malformed section, not about how readers cope with one.

Based on the tip of the SOFT-4207 stack, because `favoriteFonts` is one of the four sections and
only exists there. Not part of that stack.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved design-token validation for extension sections.
  * Invalid scalar and null values now produce clear validation errors instead of being skipped or rejected prematurely.
  * Valid and empty arrays continue to be accepted.

* **Tests**
  * Added comprehensive coverage for invalid and valid extension-section values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->