### PR TITLE
fix(box-control): stop a slot's picker from offering its siblings' own bound tokens

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -187,6 +187,7 @@
         "webp",
         "woocommerce",
         "woodardmc",
+        "worktrees",
         "wpbody",
         "wpcontent",
         "wpdb",

--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -211,6 +211,7 @@ class Kadence_Blocks_CSS {
 	 */
 	protected $spacing_sizes = array(
 		'ss-auto' => 'var(--global-kb-spacing-auto, auto)',
+		'none' => 'var(--global-kb-spacing-none, 0rem)',
 		'xxs' => 'var(--global-kb-spacing-xxs, 0.5rem)',
 		'xs' => 'var(--global-kb-spacing-xs, 1rem)',
 		'sm' => 'var(--global-kb-spacing-sm, 1.5rem)',

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Slot/Spacing_Target.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Slot/Spacing_Target.php
@@ -45,7 +45,7 @@ final class Spacing_Target extends Abstract_Target {
 	 *
 	 * @var string[]
 	 */
-	protected const SLOTS = [ 'ss-auto', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ];
+	protected const SLOTS = [ 'ss-auto', 'none', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ];
 
 	/**
 	 * The primitive dimension tokens that back the spacing slugs; the slug is claimed on the primitive

--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -126,10 +126,6 @@
 				"5xl": {
 					"$type": "dimension",
 					"$value": "10rem"
-				},
-				"none": {
-					"$type": "dimension",
-					"$value": "0"
 				}
 			},
 			"gap": {
@@ -235,10 +231,6 @@
 				}
 			},
 			"radius": {
-				"none": {
-					"$type": "dimension",
-					"$value": "0"
-				},
 				"xs": {
 					"$type": "dimension",
 					"$value": "0.125rem"
@@ -484,11 +476,11 @@
 			},
 			"media-padding": {
 				"$type": "dimension",
-				"$value": "{primitive.dimension.spacing.none}"
+				"$value": "0"
 			},
 			"heading-padding": {
 				"$type": "dimension",
-				"$value": "{primitive.dimension.spacing.none}"
+				"$value": "0"
 			},
 			"button-padding-top": {
 				"$type": "dimension",
@@ -530,19 +522,19 @@
 			},
 			"media": {
 				"$type": "dimension",
-				"$value": "{primitive.dimension.radius.none}"
+				"$value": "0"
 			},
 			"rowlayout": {
 				"$type": "dimension",
-				"$value": "{primitive.dimension.radius.none}"
+				"$value": "0"
 			},
 			"column": {
 				"$type": "dimension",
-				"$value": "{primitive.dimension.radius.none}"
+				"$value": "0"
 			},
 			"heading": {
 				"$type": "dimension",
-				"$value": "{primitive.dimension.radius.none}"
+				"$value": "0"
 			}
 		},
 		"border-width": {

--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -827,19 +827,7 @@
 							"button-radius": "{semantic.radius.control}",
 							"button-border-width": "{semantic.border-width.default}",
 							"button-border-style": "{semantic.border-style.default}",
-							"button-border-color": "{semantic.color.border}",
-							"button-padding": [
-								"{semantic.spacing.button-padding-top}",
-								"{semantic.spacing.button-padding-right}",
-								"{semantic.spacing.button-padding-bottom}",
-								"{semantic.spacing.button-padding-left}"
-							],
-							"button-margin": [
-								"{semantic.spacing.button-margin-top}",
-								"{semantic.spacing.button-margin-right}",
-								"{semantic.spacing.button-margin-bottom}",
-								"{semantic.spacing.button-margin-left}"
-							]
+							"button-border-color": "{semantic.color.border}"
 						}
 					},
 					"secondary": {
@@ -852,19 +840,7 @@
 							"button-radius": "{semantic.radius.control}",
 							"button-border-width": "{semantic.border-width.default}",
 							"button-border-style": "{semantic.border-style.default}",
-							"button-border-color": "{semantic.color.border}",
-							"button-padding": [
-								"{semantic.spacing.button-padding-top}",
-								"{semantic.spacing.button-padding-right}",
-								"{semantic.spacing.button-padding-bottom}",
-								"{semantic.spacing.button-padding-left}"
-							],
-							"button-margin": [
-								"{semantic.spacing.button-margin-top}",
-								"{semantic.spacing.button-margin-right}",
-								"{semantic.spacing.button-margin-bottom}",
-								"{semantic.spacing.button-margin-left}"
-							]
+							"button-border-color": "{semantic.color.border}"
 						}
 					}
 				},

--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -827,7 +827,19 @@
 							"button-radius": "{semantic.radius.control}",
 							"button-border-width": "{semantic.border-width.default}",
 							"button-border-style": "{semantic.border-style.default}",
-							"button-border-color": "{semantic.color.border}"
+							"button-border-color": "{semantic.color.border}",
+							"button-padding": [
+								"{semantic.spacing.button-padding-top}",
+								"{semantic.spacing.button-padding-right}",
+								"{semantic.spacing.button-padding-bottom}",
+								"{semantic.spacing.button-padding-left}"
+							],
+							"button-margin": [
+								"{semantic.spacing.button-margin-top}",
+								"{semantic.spacing.button-margin-right}",
+								"{semantic.spacing.button-margin-bottom}",
+								"{semantic.spacing.button-margin-left}"
+							]
 						}
 					},
 					"secondary": {
@@ -840,7 +852,19 @@
 							"button-radius": "{semantic.radius.control}",
 							"button-border-width": "{semantic.border-width.default}",
 							"button-border-style": "{semantic.border-style.default}",
-							"button-border-color": "{semantic.color.border}"
+							"button-border-color": "{semantic.color.border}",
+							"button-padding": [
+								"{semantic.spacing.button-padding-top}",
+								"{semantic.spacing.button-padding-right}",
+								"{semantic.spacing.button-padding-bottom}",
+								"{semantic.spacing.button-padding-left}"
+							],
+							"button-margin": [
+								"{semantic.spacing.button-margin-top}",
+								"{semantic.spacing.button-margin-right}",
+								"{semantic.spacing.button-margin-bottom}",
+								"{semantic.spacing.button-margin-left}"
+							]
 						}
 					}
 				},

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -362,8 +362,8 @@ return [
 				'group' => __( 'Brand', 'kadence-blocks' ),
 			],
 			[
-				// Block-specific radius defaults, mirroring semantic.radius.media for the image. Each aliases
-				// radius.none (resolves to 0), so a fresh Row Layout / Column stays square — KB's own default —
+				// Block-specific radius defaults, mirroring semantic.radius.media for the image. Each is the
+				// literal "0" in baseline.json, so a fresh Row Layout / Column stays square — KB's own default —
 				// while a site owner can round one block type by overriding its token.
 				'id'    => 'semantic.radius.rowlayout',
 				'type'  => 'dimension',

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -17,7 +17,7 @@
 // omitted: it resolves to "auto", not a length. group_key mirrors the radius/border-width scales' mechanism:
 // it is the stable machine id the Style Library's Spacing screen's "+ Add Spacing" mints custom tokens into,
 // resolved back to the group label at read time by Token_Registry::group_label_for().
-$spacing_slugs = [ 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ];
+$spacing_slugs = [ 'none', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ];
 $gap_slugs     = [ 'none', 'xs', 'sm', 'md', 'lg' ];
 
 $spacing_tokens = array_map(
@@ -25,7 +25,7 @@ $spacing_tokens = array_map(
 		return [
 			'id'          => 'primitive.dimension.spacing.' . $slug,
 			'type'        => 'dimension',
-			'label'       => strtoupper( $slug ),
+			'label'       => 'none' === $slug ? __( 'None', 'kadence-blocks' ) : strtoupper( $slug ),
 			'group'       => __( 'Spacing', 'kadence-blocks' ),
 			'group_key'   => 'spacing',
 			'projections' => [ 'kb_spacing_slot' => $slug ],

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -13,11 +13,16 @@
 // --global-kb-gap-<slug> as the primitive token, so a block already storing that slug follows it and a site
 // owner can retune each step. Usage-specific intent (semantic.spacing.section/.block/.inline) aliases the
 // scale and is where intent-based delivery points — mirroring how semantic.radius.media aliases the radius
-// scale. Defaults match KB's own values, so registering them changes nothing until overridden. ss-auto is
-// omitted: it resolves to "auto", not a length. group_key mirrors the radius/border-width scales' mechanism:
-// it is the stable machine id the Style Library's Spacing screen's "+ Add Spacing" mints custom tokens into,
-// resolved back to the group label at read time by Token_Registry::group_label_for().
-$spacing_slugs = [ 'none', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ];
+// scale. Defaults match KB's own values, so registering them changes nothing until overridden. ss-auto and
+// ss-none are both omitted: neither is a real length a site owner would retune — ss-auto resolves to the
+// CSS keyword "auto", and ss-none is just the literal 0, which every control already writes directly
+// without a token in the way. Both are spliced into the editor's/Style Library's pickable lists as `fixed`
+// sentinels instead (see `token-picker/index.js` and `style-library/helpers/tokens.js`), keeping "None" off
+// the Spacing/Border Radius screens where it would otherwise read as an editable, deletable scale step.
+// group_key mirrors the radius/border-width scales' mechanism: it is the stable machine id the Style
+// Library's Spacing screen's "+ Add Spacing" mints custom tokens into, resolved back to the group label at
+// read time by Token_Registry::group_label_for().
+$spacing_slugs = [ 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ];
 $gap_slugs     = [ 'none', 'xs', 'sm', 'md', 'lg' ];
 
 $spacing_tokens = array_map(
@@ -25,7 +30,7 @@ $spacing_tokens = array_map(
 		return [
 			'id'          => 'primitive.dimension.spacing.' . $slug,
 			'type'        => 'dimension',
-			'label'       => 'none' === $slug ? __( 'None', 'kadence-blocks' ) : strtoupper( $slug ),
+			'label'       => strtoupper( $slug ),
 			'group'       => __( 'Spacing', 'kadence-blocks' ),
 			'group_key'   => 'spacing',
 			'projections' => [ 'kb_spacing_slot' => $slug ],
@@ -55,9 +60,10 @@ $gap_tokens = array_map(
 // drifting into its own bucket (see User_Primitive_Registrar::register_entry()).
 // The step list mirrors the shipped baseline exactly: the screen renders whatever this group holds, and
 // a step declared without a baseline entry would trip Baseline_Guard. Labels are the scale's own, so the
-// Style Library and the editor's token picker name each step identically.
+// Style Library and the editor's token picker name each step identically. "None" carries no entry here,
+// same reasoning as `$spacing_slugs`'s own comment above — it is spliced in as a `fixed` sentinel by the
+// pickable-pool consumers instead, keeping it off the Border Radius screen's editable/deletable list.
 $radius_labels = [
-	'none' => __( 'None', 'kadence-blocks' ),
 	'xs'   => __( 'Extra Small', 'kadence-blocks' ),
 	'sm'   => __( 'Small', 'kadence-blocks' ),
 	'md'   => __( 'Medium', 'kadence-blocks' ),

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -599,23 +599,29 @@ return [
 				// css_prop shape: a css_prop binding only ever reaches Block_Default_Css\Css_Builder, which
 				// resolves exclusively the block's $default preset and can never reflect a *selected*
 				// preset's value. css_var is what lets Preset\Css_Builder (the named-preset projector) emit a
-				// scoped variable a selected preset can actually vary. No control_attr — unlike padding/
-				// margin/radius, the native block attributes for border ([{top:[color,style,size],...},unit])
-				// and shadow ([{color,opacity,hOffset,vOffset,blur,spread,inset}]) are nested per-side/
-				// composite shapes, not a single scalar value, so there is no attribute for a picker/capture
-				// consumer of control_attr (token-picker, preset-picker/capture.js, token-indicators) to
-				// target here.
+				// scoped variable a selected preset can actually vary.
+				//
+				// The three border properties below share ONE control_attr ('borderStyle'), unlike padding/
+				// margin/radius's one-property-per-attribute shape: the native block attribute
+				// ([{top:[color,style,size],...},unit]) is a single nested per-side/per-axis shape that
+				// EditorBorderControl edits as one control with no per-axis reset, so width/style/color all
+				// point at the same attribute rather than three that don't exist. token-indicators reads
+				// each property's own axis out of the shared nested value and combines the three into one
+				// bound/overridden state entry — see token-indicators/index.js's BORDER_AXIS_KIND.
 				'button-border-width' => [
-					'token'   => 'semantic.border-width.default',
-					'css_var' => 'kb-btn-border-width',
+					'token'        => 'semantic.border-width.default',
+					'css_var'      => 'kb-btn-border-width',
+					'control_attr' => 'borderStyle',
 				],
 				'button-border-style' => [
-					'token'   => 'semantic.border-style.default',
-					'css_var' => 'kb-btn-border-style',
+					'token'        => 'semantic.border-style.default',
+					'css_var'      => 'kb-btn-border-style',
+					'control_attr' => 'borderStyle',
 				],
 				'button-border-color' => [
-					'token'   => 'semantic.color.border',
-					'css_var' => 'kb-btn-border-color',
+					'token'        => 'semantic.color.border',
+					'css_var'      => 'kb-btn-border-color',
+					'control_attr' => 'borderStyle',
 				],
 				// No baseline default: an unstyled button carries no shadow, so the preset's $default omits
 				// this property entirely and the projector emits no box-shadow rule until a preset (or the

--- a/jest.config.js
+++ b/jest.config.js
@@ -27,10 +27,18 @@ const baseConfig = require('@wordpress/scripts/config/jest-unit.config.js');
 
 module.exports = {
 	...baseConfig,
-	// `.worktrees/` holds sibling checkouts of this same repo (see `using-git-worktrees`); without
-	// this, jest walks into them too and runs every test a second time against a possibly different
-	// branch's source.
-	testPathIgnorePatterns: [...(baseConfig.testPathIgnorePatterns || []), '/\\.worktrees/'],
+	// `@wordpress/scripts/config/jest-unit.config.js` exports only `{ preset, reporters, transform }`,
+	// so `baseConfig.testPathIgnorePatterns` is always undefined and a spread of it contributes
+	// nothing — `testPathIgnorePatterns` is not one of the keys jest merges across preset and project
+	// (jest-config's normalize.js special-cases `setupFilesAfterEnv`, `modulePathIgnorePatterns`,
+	// `moduleNameMapper`, `transform`, and `globals`; everything else falls through to
+	// `{...preset, ...options}`, so the project value replaces the preset's outright). Written out
+	// literally so the list says what it actually is: the preset's own ignores
+	// (`@wordpress/jest-preset-default`'s `['/node_modules/', '<rootDir>/vendor/']`) plus this repo's
+	// own `.worktrees/` — `.worktrees/` holds sibling checkouts of this same repo (see
+	// `using-git-worktrees`); without it, jest walks into them too and runs every test a second time
+	// against a possibly different branch's source.
+	testPathIgnorePatterns: ['/node_modules/', '<rootDir>/vendor/', '/\\.worktrees/'],
 	moduleNameMapper: {
 		...(baseConfig.moduleNameMapper || {}),
 		'^@wordpress/hooks$': path.join(

--- a/jest.config.js
+++ b/jest.config.js
@@ -27,6 +27,10 @@ const baseConfig = require('@wordpress/scripts/config/jest-unit.config.js');
 
 module.exports = {
 	...baseConfig,
+	// `.worktrees/` holds sibling checkouts of this same repo (see `using-git-worktrees`); without
+	// this, jest walks into them too and runs every test a second time against a possibly different
+	// branch's source.
+	testPathIgnorePatterns: [...(baseConfig.testPathIgnorePatterns || []), '/\\.worktrees/'],
 	moduleNameMapper: {
 		...(baseConfig.moduleNameMapper || {}),
 		'^@wordpress/hooks$': path.join(

--- a/src/blocks/singlebtn/__tests__/deprecated.test.js
+++ b/src/blocks/singlebtn/__tests__/deprecated.test.js
@@ -1,0 +1,127 @@
+/* eslint-env jest */
+
+/**
+ * Internal dependencies
+ */
+import deprecated from '../deprecated';
+
+const [{ isEligible, migrate }] = deprecated;
+
+/**
+ * A representative visible native shadow value, matching what a real shadow composite resolves to.
+ *
+ * @since TBD
+ */
+const VISIBLE_SHADOW = [{ color: '#000000', opacity: 0.5, hOffset: 0, vOffset: 2, blur: 8, spread: 0, inset: false }];
+
+describe('singlebtn deprecated migration: stale toggled-off shadow values', () => {
+	/**
+	 * A block with every toggle already consistent with its value (off and empty, or on with a real
+	 * value) is not eligible — there is nothing stale to clean up.
+	 *
+	 * @return {void}
+	 */
+	it('reports ineligible when every toggle/value pair is already consistent', () => {
+		expect(
+			isEligible({
+				displayShadow: false,
+				shadow: [],
+				displayHoverShadow: true,
+				shadowHover: VISIBLE_SHADOW,
+			})
+		).toBe(false);
+	});
+
+	/**
+	 * A toggle reading off while its paired value still carries a real, non-zero shadow is exactly
+	 * the stale case this migration exists for.
+	 *
+	 * @return {void}
+	 */
+	it('reports eligible when a toggled-off pair still carries a visible shadow', () => {
+		expect(isEligible({ displayShadow: false, shadow: VISIBLE_SHADOW })).toBe(true);
+	});
+
+	/**
+	 * Every one of the six independent toggle/value pairs is checked, not just the normal-state one.
+	 *
+	 * @return {void}
+	 */
+	it.each([
+		['displayShadow', 'shadow'],
+		['displayHoverShadow', 'shadowHover'],
+		['displayShadowTransparent', 'shadowTransparent'],
+		['displayHoverShadowTransparent', 'shadowTransparentHover'],
+		['displayShadowSticky', 'shadowSticky'],
+		['displayHoverShadowSticky', 'shadowStickyHover'],
+	])('reports eligible for the %s / %s pair specifically', (toggleKey, valueKey) => {
+		expect(isEligible({ [toggleKey]: false, [valueKey]: VISIBLE_SHADOW })).toBe(true);
+	});
+
+	/**
+	 * A toggle reading on is never stale, regardless of what its value holds — "on" is a real,
+	 * intentional choice, not leftover data from before a toggle-off.
+	 *
+	 * @return {void}
+	 */
+	it('never reports eligible for a pair whose toggle reads on', () => {
+		expect(isEligible({ displayShadow: true, shadow: VISIBLE_SHADOW })).toBe(false);
+	});
+
+	/**
+	 * A toggled-off pair whose value already has no visible footprint (already clean) is not stale —
+	 * nothing to migrate there either.
+	 *
+	 * @return {void}
+	 */
+	it('does not report eligible for a toggled-off pair whose value is already zero-footprint', () => {
+		expect(
+			isEligible({
+				displayShadow: false,
+				shadow: [{ color: '#000000', opacity: 1, hOffset: 0, vOffset: 0, blur: 0, spread: 0, inset: false }],
+			})
+		).toBe(false);
+	});
+
+	/**
+	 * `migrate` nulls out only the stale pair's value, leaving every other attribute — including the
+	 * toggle itself — untouched.
+	 *
+	 * @return {void}
+	 */
+	it('nulls out only the stale pair, leaving the toggle and every other attribute untouched', () => {
+		const migrated = migrate({
+			displayShadow: false,
+			shadow: VISIBLE_SHADOW,
+			displayHoverShadow: true,
+			shadowHover: VISIBLE_SHADOW,
+			text: 'Click me',
+		});
+
+		expect(migrated).toEqual({
+			displayShadow: false,
+			shadow: [],
+			displayHoverShadow: true,
+			shadowHover: VISIBLE_SHADOW,
+			text: 'Click me',
+		});
+	});
+
+	/**
+	 * Multiple stale pairs in the same block are all cleaned up in one migration pass, not just the
+	 * first one found.
+	 *
+	 * @return {void}
+	 */
+	it('nulls out every stale pair when more than one is affected', () => {
+		const migrated = migrate({
+			displayShadow: false,
+			shadow: VISIBLE_SHADOW,
+			displayShadowSticky: false,
+			shadowSticky: VISIBLE_SHADOW,
+		});
+
+		expect(migrated.shadow).toEqual([]);
+		expect(migrated.shadowSticky).toEqual([]);
+	});
+});

--- a/src/blocks/singlebtn/block.js
+++ b/src/blocks/singlebtn/block.js
@@ -3,6 +3,7 @@
  */
 
 import metadata from './block.json';
+import deprecated from './deprecated';
 
 /**
  * Import Icon stuff
@@ -37,6 +38,7 @@ registerBlockType('kadence/singlebtn', {
 	save() {
 		return null;
 	},
+	deprecated,
 	example: {
 		attributes: {
 			text: __('Click Me!', 'kadence-blocks'),

--- a/src/blocks/singlebtn/deprecated.js
+++ b/src/blocks/singlebtn/deprecated.js
@@ -1,0 +1,120 @@
+/**
+ * Deprecated versions of `kadence/singlebtn`, migrating legacy attribute data forward.
+ *
+ * `save()` always returns `null` here (a fully dynamic, server-rendered block) — every version's
+ * saved markup is identical, so content validation never fails and never recovers a block through
+ * the usual "invalid block" path. `isEligible()` is the mechanism this migration actually runs
+ * through instead: Gutenberg checks it against every parsed block, current version included, purely
+ * to offer an attribute-only migration with no serialization change to validate against.
+ *
+ * The migration itself: before the Box Shadow field's "None" pick replaced a separate enable toggle
+ * (see `EditorShadowControl`'s own docblock), a button could be toggled off while a real, non-zero
+ * shadow composite stayed sitting in the value underneath — invisible at the time (the toggle hid
+ * the whole control while off), and still correctly invisible today (PHP's render gate reads the
+ * toggle attribute, unchanged by this). `EditorShadowControl`'s own read-time fallback already
+ * shows a toggled-off value as "None" regardless of what's stored, so nothing is functionally
+ * broken without this migration — this only physically cleans up that stale leftover data, the
+ * first time one of these six affected blocks is reopened and saved again.
+ */
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+/**
+ * Each display-toggle attribute paired with the shadow-value attribute it gates. Six independent
+ * pairs — normal, hover, transparent variant and its hover, sticky variant and its hover — mirroring
+ * `class-kadence-blocks-singlebtn-block.php`'s own six render-gate checks.
+ *
+ * @since TBD
+ */
+const SHADOW_TOGGLES = [
+	['displayShadow', 'shadow'],
+	['displayHoverShadow', 'shadowHover'],
+	['displayShadowTransparent', 'shadowTransparent'],
+	['displayHoverShadowTransparent', 'shadowTransparentHover'],
+	['displayShadowSticky', 'shadowSticky'],
+	['displayHoverShadowSticky', 'shadowStickyHover'],
+];
+
+/**
+ * Whether a native shadow item has any visible footprint — any of its four length axes non-zero.
+ * Mirrors `EditorShadowControl`'s own `isVisibleNativeShadow`, kept independent rather than imported:
+ * a deprecation is a frozen historical snapshot, and importing a helper the live component could
+ * later change out from under it would let this migration's behavior silently drift.
+ *
+ * @param {?Array} native The native shadow attribute value.
+ *
+ * @since TBD
+ *
+ * @return {boolean} Whether the shadow has a visible footprint.
+ */
+function isVisibleShadowValue(native) {
+	const source = native?.[0];
+
+	if (!source) {
+		return false;
+	}
+
+	return [source.hOffset, source.vOffset, source.blur, source.spread].some((axis) => Number(axis) !== 0);
+}
+
+/**
+ * Whether one toggle/value pair holds stale data worth cleaning up: toggled off, but the value still
+ * carries a real, non-zero shadow.
+ *
+ * @param {Object} attributes The block's attributes.
+ * @param {string} toggleKey  The display-toggle attribute's name.
+ * @param {string} valueKey   The paired shadow-value attribute's name.
+ *
+ * @since TBD
+ *
+ * @return {boolean} Whether this pair is stale.
+ */
+function isStalePair(attributes, toggleKey, valueKey) {
+	return attributes[toggleKey] === false && isVisibleShadowValue(attributes[valueKey]);
+}
+
+export default [
+	{
+		attributes: metadata.attributes,
+		supports: metadata.supports,
+		save() {
+			return null;
+		},
+		/**
+		 * Whether any of the six toggle/value pairs holds stale data.
+		 *
+		 * @param {Object} attributes The block's attributes.
+		 *
+		 * @since TBD
+		 *
+		 * @return {boolean} Whether this deprecation's `migrate()` should run.
+		 */
+		isEligible(attributes) {
+			return SHADOW_TOGGLES.some(([toggleKey, valueKey]) => isStalePair(attributes, toggleKey, valueKey));
+		},
+		/**
+		 * Nulls out every stale pair's shadow value, leaving every other attribute (including the
+		 * toggle itself) untouched.
+		 *
+		 * @param {Object} attributes The block's attributes.
+		 *
+		 * @since TBD
+		 *
+		 * @return {Object} The migrated attributes.
+		 */
+		migrate(attributes) {
+			const next = { ...attributes };
+
+			SHADOW_TOGGLES.forEach(([toggleKey, valueKey]) => {
+				if (isStalePair(attributes, toggleKey, valueKey)) {
+					next[valueKey] = [];
+				}
+			});
+
+			return next;
+		},
+	},
+];

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -910,7 +910,8 @@ export default function KadenceButtonEdit(props) {
 	};
 
 	// The override records a choice made about the PREVIOUS preset's corners, so selecting another preset
-	// drops it — otherwise an explicit "link" would stick and hide a new preset's per-corner radius.
+	// drops it — otherwise an explicit "link" would stick and hide a new preset's per-corner radius (or,
+	// for padding, per-side padding).
 	useEffect(() => {
 		setBorderRadiusModeOverride({});
 		setBorderHoverRadiusModeOverride({});
@@ -918,6 +919,7 @@ export default function KadenceButtonEdit(props) {
 		setBorderTransparentHoverRadiusModeOverride({});
 		setBorderStickyRadiusModeOverride({});
 		setBorderStickyHoverRadiusModeOverride({});
+		setPaddingModeOverride({});
 	}, [attributes.kbPreset]);
 	useEffect(() => {
 		if (!isSelected) {

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -462,9 +462,17 @@ export default function KadenceButtonEdit(props) {
 	// `ss-auto` is already a fully working spacing slot at the PHP/CSS layer (Spacing_Target's SLOTS,
 	// class-kadence-blocks-css.php's $spacing_sizes) — the editor's pickable list is the only gap, so
 	// it is appended here as a fixed entry rather than added to the token registry itself.
+	//
+	// It is deliberately NOT registered as a DTCG token (it resolves to the CSS keyword `auto`, not a
+	// length — see declarations.php's comment on `$spacing_slugs`), so its `alias` is the bare slug the
+	// PHP/CSS layer already reads (`class-kadence-blocks-css.php`'s `$spacing_sizes['ss-auto']`), not the
+	// bracket-wrapped `{dot.path}` form a real token's alias takes. `fixed: true` tells
+	// `token-summary.js`'s `findTokenEntry()` to match this entry on that bare alias — the only sentinel
+	// in the pool allowed to bypass the bracket check, so a hand-typed Custom literal can never be
+	// misread as a token pick.
 	const marginPickableTokens = [
 		...pickableTokensForKey('kadence/singlebtn', 'button-margin'),
-		{ id: 'ss-auto', label: __('Auto', 'kadence-blocks'), value: 'ss-auto', alias: 'ss-auto' },
+		{ id: 'ss-auto', label: __('Auto', 'kadence-blocks'), value: 'auto', alias: 'ss-auto', fixed: true },
 	];
 
 	// The border-radius/padding linked/individual mode is derived from the stored slots (all equal reads

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -509,8 +509,10 @@ export default function KadenceButtonEdit(props) {
 	});
 
 	// Margin's linked/individual mode, mirroring Padding's own hook call above — same shape, run over
-	// `marginForDevice`/`marginPresetValue`/`inheritedMargin`/`marginPickableTokens` instead. Margin
-	// also has no `resetOn`, matching Padding.
+	// `marginForDevice`/`marginPresetValue`/`inheritedMargin`/`marginPickableTokens` instead. Unlike
+	// Padding, Margin does clear its override on a preset change (`resetOn`): an explicit "link" made
+	// under one preset would otherwise stick after switching to a preset with distinct per-side margins,
+	// hiding them behind a stale linked view.
 	const { isLinked: marginIsLinked, toggleLink: toggleMarginLink } = useLinkedMeasureState({
 		forDevice: marginForDevice,
 		inherited: inheritedMargin,
@@ -518,6 +520,7 @@ export default function KadenceButtonEdit(props) {
 		presetValue: marginPresetValue,
 		tokens: marginPickableTokens,
 		setAttributes,
+		resetOn: attributes.kbPreset,
 	});
 
 	// Hover/Transparent/Transparent Hover/Sticky/Sticky Hover each store their own 4 corners, so each
@@ -2334,27 +2337,34 @@ export default function KadenceButtonEdit(props) {
 												max={paddingUnit === 'em' || paddingUnit === 'rem' ? 25 : 999}
 												step={paddingUnit === 'em' || paddingUnit === 'rem' ? 0.1 : 1}
 											/>
-											<EditorBoxControl
-												label={__('Margin', 'kadence-blocks')}
-												value={marginForDevice.value}
-												onChange={(next) => setAttributes({ [marginForDevice.attr]: next })}
-												previewDevice={previewDevice}
-												onDeviceChange={setPreviewDevice}
-												tokens={marginPickableTokens}
-												defaultValue={inheritedMargin.values}
-												inherited={anyCornerInherited(inheritedMargin.inherited)}
-												state={tokenBinding.margin}
-												onReset={() => resetToken('margin')}
-												isLinked={marginIsLinked}
-												onToggleLink={toggleMarginLink}
-												role="sides"
-												unit={marginUnit}
-												units={['px', 'em', 'rem']}
-												onUnit={(value) => setAttributes({ marginUnit: value })}
-												min={marginUnit === 'em' || marginUnit === 'rem' ? -25 : -999}
-												max={marginUnit === 'em' || marginUnit === 'rem' ? 25 : 999}
-												step={marginUnit === 'em' || marginUnit === 'rem' ? 0.1 : 1}
-											/>
+											<div
+												onMouseOver={marginMouseOver.onMouseOver}
+												onMouseOut={marginMouseOver.onMouseOut}
+												onFocus={marginMouseOver.onMouseOver}
+												onBlur={marginMouseOver.onMouseOut}
+											>
+												<EditorBoxControl
+													label={__('Margin', 'kadence-blocks')}
+													value={marginForDevice.value}
+													onChange={(next) => setAttributes({ [marginForDevice.attr]: next })}
+													previewDevice={previewDevice}
+													onDeviceChange={setPreviewDevice}
+													tokens={marginPickableTokens}
+													defaultValue={inheritedMargin.values}
+													inherited={anyCornerInherited(inheritedMargin.inherited)}
+													state={tokenBinding.margin}
+													onReset={() => resetToken('margin')}
+													isLinked={marginIsLinked}
+													onToggleLink={toggleMarginLink}
+													role="sides"
+													unit={marginUnit}
+													units={['px', 'em', 'rem']}
+													onUnit={(value) => setAttributes({ marginUnit: value })}
+													min={marginUnit === 'em' || marginUnit === 'rem' ? -25 : -999}
+													max={marginUnit === 'em' || marginUnit === 'rem' ? 25 : 999}
+													step={marginUnit === 'em' || marginUnit === 'rem' ? 0.1 : 1}
+												/>
+											</div>
 											<TextControl
 												label={__('Add Aria Label', 'kadence-blocks')}
 												value={label ? label : ''}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -21,7 +21,6 @@ import {
 import {
 	PopColorControl,
 	TypographyControls,
-	ResponsiveMeasurementControls,
 	SmallResponsiveControl,
 	ResponsiveRangeControls,
 	IconRender,
@@ -509,10 +508,332 @@ export default function KadenceButtonEdit(props) {
 		// AND this device; a differing corner would derive individual on its own.
 		setBorderRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
 	};
+
+	// Hover/Transparent/Transparent Hover/Sticky/Sticky Hover each store their own 4 corners, so each
+	// gets its own copy of the linked-state machinery above — sharing Normal's `borderRadiusModeOverride`
+	// would couple these states' link/unlink UI together even though the underlying attributes are
+	// independent. All 6 states still read/write the same `tokenBinding.borderRadius` preset binding and
+	// `borderRadiusTokens` pool, since there is only one border-radius preset property.
+	const [borderHoverRadiusModeOverride, setBorderHoverRadiusModeOverride] = useState({});
+	const borderHoverRadiusForDevice = measureAttrsForDevice(
+		attributes,
+		'borderHoverRadius',
+		{ tablet: 'tabletBorderHoverRadius', mobile: 'mobileBorderHoverRadius' },
+		previewDevice
+	);
+	const inheritedBorderHoverRadius = inheritedMeasureSlots(
+		previewDevice,
+		{ desktop: borderHoverRadius, tablet: tabletBorderHoverRadius },
+		borderRadiusPresetValue
+	);
+	const borderHoverRadiusIsLinked =
+		'linked' ===
+		(borderHoverRadiusModeOverride[previewDevice] ??
+			deriveMeasureMode(borderHoverRadiusForDevice.value, borderRadiusPresetValue));
+	const borderHoverInheritedCorners = inheritedBorderHoverRadius.values;
+	const borderHoverInheritedCornersDiffer =
+		Array.isArray(borderHoverInheritedCorners) &&
+		borderHoverInheritedCorners.some((corner) => corner !== borderHoverInheritedCorners[0]);
+	const borderHoverInheritedFirstCorner = Array.isArray(borderHoverInheritedCorners)
+		? aliasForValue(borderHoverInheritedCorners[0])
+		: '';
+	const toggleBorderHoverRadiusLink = () => {
+		if (!borderHoverRadiusIsLinked) {
+			const corners = borderHoverRadiusForDevice.value ?? [];
+			const corner = corners[0] ?? '';
+			const isEmpty = corners.every((value) => '' === value || undefined === value);
+
+			if (isEmpty) {
+				if (!borderHoverInheritedCornersDiffer) {
+					setBorderHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
+
+					return;
+				}
+
+				setAttributes({
+					[borderHoverRadiusForDevice.attr]: [
+						borderHoverInheritedFirstCorner,
+						borderHoverInheritedFirstCorner,
+						borderHoverInheritedFirstCorner,
+						borderHoverInheritedFirstCorner,
+					],
+				});
+				setBorderHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
+
+				return;
+			}
+
+			setAttributes({ [borderHoverRadiusForDevice.attr]: [corner, corner, corner, corner] });
+			setBorderHoverRadiusModeOverride((current) => ({
+				...current,
+				[previewDevice]: '' === corner ? 'linked' : undefined,
+			}));
+
+			return;
+		}
+
+		setBorderHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
+	};
+
+	const [borderTransparentRadiusModeOverride, setBorderTransparentRadiusModeOverride] = useState({});
+	const borderTransparentRadiusForDevice = measureAttrsForDevice(
+		attributes,
+		'borderTransparentRadius',
+		{ tablet: 'tabletBorderTransparentRadius', mobile: 'mobileBorderTransparentRadius' },
+		previewDevice
+	);
+	const inheritedBorderTransparentRadius = inheritedMeasureSlots(
+		previewDevice,
+		{ desktop: borderTransparentRadius, tablet: tabletBorderTransparentRadius },
+		borderRadiusPresetValue
+	);
+	const borderTransparentRadiusIsLinked =
+		'linked' ===
+		(borderTransparentRadiusModeOverride[previewDevice] ??
+			deriveMeasureMode(borderTransparentRadiusForDevice.value, borderRadiusPresetValue));
+	const borderTransparentInheritedCorners = inheritedBorderTransparentRadius.values;
+	const borderTransparentInheritedCornersDiffer =
+		Array.isArray(borderTransparentInheritedCorners) &&
+		borderTransparentInheritedCorners.some((corner) => corner !== borderTransparentInheritedCorners[0]);
+	const borderTransparentInheritedFirstCorner = Array.isArray(borderTransparentInheritedCorners)
+		? aliasForValue(borderTransparentInheritedCorners[0])
+		: '';
+	const toggleBorderTransparentRadiusLink = () => {
+		if (!borderTransparentRadiusIsLinked) {
+			const corners = borderTransparentRadiusForDevice.value ?? [];
+			const corner = corners[0] ?? '';
+			const isEmpty = corners.every((value) => '' === value || undefined === value);
+
+			if (isEmpty) {
+				if (!borderTransparentInheritedCornersDiffer) {
+					setBorderTransparentRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
+
+					return;
+				}
+
+				setAttributes({
+					[borderTransparentRadiusForDevice.attr]: [
+						borderTransparentInheritedFirstCorner,
+						borderTransparentInheritedFirstCorner,
+						borderTransparentInheritedFirstCorner,
+						borderTransparentInheritedFirstCorner,
+					],
+				});
+				setBorderTransparentRadiusModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
+
+				return;
+			}
+
+			setAttributes({ [borderTransparentRadiusForDevice.attr]: [corner, corner, corner, corner] });
+			setBorderTransparentRadiusModeOverride((current) => ({
+				...current,
+				[previewDevice]: '' === corner ? 'linked' : undefined,
+			}));
+
+			return;
+		}
+
+		setBorderTransparentRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
+	};
+
+	const [borderTransparentHoverRadiusModeOverride, setBorderTransparentHoverRadiusModeOverride] = useState({});
+	const borderTransparentHoverRadiusForDevice = measureAttrsForDevice(
+		attributes,
+		'borderTransparentHoverRadius',
+		{ tablet: 'tabletBorderTransparentHoverRadius', mobile: 'mobileBorderTransparentHoverRadius' },
+		previewDevice
+	);
+	const inheritedBorderTransparentHoverRadius = inheritedMeasureSlots(
+		previewDevice,
+		{ desktop: borderTransparentHoverRadius, tablet: tabletBorderTransparentHoverRadius },
+		borderRadiusPresetValue
+	);
+	const borderTransparentHoverRadiusIsLinked =
+		'linked' ===
+		(borderTransparentHoverRadiusModeOverride[previewDevice] ??
+			deriveMeasureMode(borderTransparentHoverRadiusForDevice.value, borderRadiusPresetValue));
+	const borderTransparentHoverInheritedCorners = inheritedBorderTransparentHoverRadius.values;
+	const borderTransparentHoverInheritedCornersDiffer =
+		Array.isArray(borderTransparentHoverInheritedCorners) &&
+		borderTransparentHoverInheritedCorners.some((corner) => corner !== borderTransparentHoverInheritedCorners[0]);
+	const borderTransparentHoverInheritedFirstCorner = Array.isArray(borderTransparentHoverInheritedCorners)
+		? aliasForValue(borderTransparentHoverInheritedCorners[0])
+		: '';
+	const toggleBorderTransparentHoverRadiusLink = () => {
+		if (!borderTransparentHoverRadiusIsLinked) {
+			const corners = borderTransparentHoverRadiusForDevice.value ?? [];
+			const corner = corners[0] ?? '';
+			const isEmpty = corners.every((value) => '' === value || undefined === value);
+
+			if (isEmpty) {
+				if (!borderTransparentHoverInheritedCornersDiffer) {
+					setBorderTransparentHoverRadiusModeOverride((current) => ({
+						...current,
+						[previewDevice]: 'linked',
+					}));
+
+					return;
+				}
+
+				setAttributes({
+					[borderTransparentHoverRadiusForDevice.attr]: [
+						borderTransparentHoverInheritedFirstCorner,
+						borderTransparentHoverInheritedFirstCorner,
+						borderTransparentHoverInheritedFirstCorner,
+						borderTransparentHoverInheritedFirstCorner,
+					],
+				});
+				setBorderTransparentHoverRadiusModeOverride((current) => ({
+					...current,
+					[previewDevice]: undefined,
+				}));
+
+				return;
+			}
+
+			setAttributes({ [borderTransparentHoverRadiusForDevice.attr]: [corner, corner, corner, corner] });
+			setBorderTransparentHoverRadiusModeOverride((current) => ({
+				...current,
+				[previewDevice]: '' === corner ? 'linked' : undefined,
+			}));
+
+			return;
+		}
+
+		setBorderTransparentHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
+	};
+
+	const [borderStickyRadiusModeOverride, setBorderStickyRadiusModeOverride] = useState({});
+	const borderStickyRadiusForDevice = measureAttrsForDevice(
+		attributes,
+		'borderStickyRadius',
+		{ tablet: 'tabletBorderStickyRadius', mobile: 'mobileBorderStickyRadius' },
+		previewDevice
+	);
+	const inheritedBorderStickyRadius = inheritedMeasureSlots(
+		previewDevice,
+		{ desktop: borderStickyRadius, tablet: tabletBorderStickyRadius },
+		borderRadiusPresetValue
+	);
+	const borderStickyRadiusIsLinked =
+		'linked' ===
+		(borderStickyRadiusModeOverride[previewDevice] ??
+			deriveMeasureMode(borderStickyRadiusForDevice.value, borderRadiusPresetValue));
+	const borderStickyInheritedCorners = inheritedBorderStickyRadius.values;
+	const borderStickyInheritedCornersDiffer =
+		Array.isArray(borderStickyInheritedCorners) &&
+		borderStickyInheritedCorners.some((corner) => corner !== borderStickyInheritedCorners[0]);
+	const borderStickyInheritedFirstCorner = Array.isArray(borderStickyInheritedCorners)
+		? aliasForValue(borderStickyInheritedCorners[0])
+		: '';
+	const toggleBorderStickyRadiusLink = () => {
+		if (!borderStickyRadiusIsLinked) {
+			const corners = borderStickyRadiusForDevice.value ?? [];
+			const corner = corners[0] ?? '';
+			const isEmpty = corners.every((value) => '' === value || undefined === value);
+
+			if (isEmpty) {
+				if (!borderStickyInheritedCornersDiffer) {
+					setBorderStickyRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
+
+					return;
+				}
+
+				setAttributes({
+					[borderStickyRadiusForDevice.attr]: [
+						borderStickyInheritedFirstCorner,
+						borderStickyInheritedFirstCorner,
+						borderStickyInheritedFirstCorner,
+						borderStickyInheritedFirstCorner,
+					],
+				});
+				setBorderStickyRadiusModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
+
+				return;
+			}
+
+			setAttributes({ [borderStickyRadiusForDevice.attr]: [corner, corner, corner, corner] });
+			setBorderStickyRadiusModeOverride((current) => ({
+				...current,
+				[previewDevice]: '' === corner ? 'linked' : undefined,
+			}));
+
+			return;
+		}
+
+		setBorderStickyRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
+	};
+
+	const [borderStickyHoverRadiusModeOverride, setBorderStickyHoverRadiusModeOverride] = useState({});
+	const borderStickyHoverRadiusForDevice = measureAttrsForDevice(
+		attributes,
+		'borderStickyHoverRadius',
+		{ tablet: 'tabletBorderStickyHoverRadius', mobile: 'mobileBorderStickyHoverRadius' },
+		previewDevice
+	);
+	const inheritedBorderStickyHoverRadius = inheritedMeasureSlots(
+		previewDevice,
+		{ desktop: borderStickyHoverRadius, tablet: tabletBorderStickyHoverRadius },
+		borderRadiusPresetValue
+	);
+	const borderStickyHoverRadiusIsLinked =
+		'linked' ===
+		(borderStickyHoverRadiusModeOverride[previewDevice] ??
+			deriveMeasureMode(borderStickyHoverRadiusForDevice.value, borderRadiusPresetValue));
+	const borderStickyHoverInheritedCorners = inheritedBorderStickyHoverRadius.values;
+	const borderStickyHoverInheritedCornersDiffer =
+		Array.isArray(borderStickyHoverInheritedCorners) &&
+		borderStickyHoverInheritedCorners.some((corner) => corner !== borderStickyHoverInheritedCorners[0]);
+	const borderStickyHoverInheritedFirstCorner = Array.isArray(borderStickyHoverInheritedCorners)
+		? aliasForValue(borderStickyHoverInheritedCorners[0])
+		: '';
+	const toggleBorderStickyHoverRadiusLink = () => {
+		if (!borderStickyHoverRadiusIsLinked) {
+			const corners = borderStickyHoverRadiusForDevice.value ?? [];
+			const corner = corners[0] ?? '';
+			const isEmpty = corners.every((value) => '' === value || undefined === value);
+
+			if (isEmpty) {
+				if (!borderStickyHoverInheritedCornersDiffer) {
+					setBorderStickyHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
+
+					return;
+				}
+
+				setAttributes({
+					[borderStickyHoverRadiusForDevice.attr]: [
+						borderStickyHoverInheritedFirstCorner,
+						borderStickyHoverInheritedFirstCorner,
+						borderStickyHoverInheritedFirstCorner,
+						borderStickyHoverInheritedFirstCorner,
+					],
+				});
+				setBorderStickyHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
+
+				return;
+			}
+
+			setAttributes({ [borderStickyHoverRadiusForDevice.attr]: [corner, corner, corner, corner] });
+			setBorderStickyHoverRadiusModeOverride((current) => ({
+				...current,
+				[previewDevice]: '' === corner ? 'linked' : undefined,
+			}));
+
+			return;
+		}
+
+		setBorderStickyHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
+	};
+
 	// The override records a choice made about the PREVIOUS preset's corners, so selecting another preset
 	// drops it — otherwise an explicit "link" would stick and hide a new preset's per-corner radius.
 	useEffect(() => {
 		setBorderRadiusModeOverride({});
+		setBorderHoverRadiusModeOverride({});
+		setBorderTransparentRadiusModeOverride({});
+		setBorderTransparentHoverRadiusModeOverride({});
+		setBorderStickyRadiusModeOverride({});
+		setBorderStickyHoverRadiusModeOverride({});
 	}, [attributes.kbPreset]);
 	useEffect(() => {
 		if (!isSelected) {
@@ -1135,20 +1456,25 @@ export default function KadenceButtonEdit(props) {
 															defaultValue={borderWidthPresetValue}
 															renderColor={renderBorderColor}
 														/>
-														<ResponsiveMeasurementControls
+														<EditorBoxControl
 															label={__('Border Radius', 'kadence-blocks')}
-															value={borderHoverRadius}
-															tabletValue={tabletBorderHoverRadius}
-															mobileValue={mobileBorderHoverRadius}
-															onChange={(value) =>
-																setAttributes({ borderHoverRadius: value })
+															value={borderHoverRadiusForDevice.value}
+															onChange={(next) =>
+																setAttributes({
+																	[borderHoverRadiusForDevice.attr]: next,
+																})
 															}
-															onChangeTablet={(value) =>
-																setAttributes({ tabletBorderHoverRadius: value })
-															}
-															onChangeMobile={(value) =>
-																setAttributes({ mobileBorderHoverRadius: value })
-															}
+															previewDevice={previewDevice}
+															onDeviceChange={setPreviewDevice}
+															tokens={borderRadiusTokens}
+															defaultValue={inheritedBorderHoverRadius.values}
+															inherited={anyCornerInherited(
+																inheritedBorderHoverRadius.inherited
+															)}
+															state={tokenBinding.borderRadius}
+															onReset={() => resetToken('borderRadius')}
+															isLinked={borderHoverRadiusIsLinked}
+															onToggleLink={toggleBorderHoverRadiusLink}
 															unit={borderHoverRadiusUnit}
 															units={['px', 'em', 'rem', '%']}
 															onUnit={(value) =>
@@ -1167,8 +1493,6 @@ export default function KadenceButtonEdit(props) {
 																	: 1
 															}
 															min={0}
-															isBorderRadius={true}
-															allowEmpty={true}
 														/>
 														<EditorShadowControl
 															label={__('Box Shadow', 'kadence-blocks')}
@@ -1405,26 +1729,28 @@ export default function KadenceButtonEdit(props) {
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
 															/>
-															<ResponsiveMeasurementControls
+															<EditorBoxControl
 																label={__('Border Radius', 'kadence-blocks')}
-																value={borderTransparentHoverRadius}
-																tabletValue={tabletBorderTransparentHoverRadius}
-																mobileValue={mobileBorderTransparentHoverRadius}
-																onChange={(value) =>
+																value={borderTransparentHoverRadiusForDevice.value}
+																onChange={(next) =>
 																	setAttributes({
-																		borderTransparentHoverRadius: value,
+																		[borderTransparentHoverRadiusForDevice.attr]:
+																			next,
 																	})
 																}
-																onChangeTablet={(value) =>
-																	setAttributes({
-																		tabletBorderTransparentHoverRadius: value,
-																	})
+																previewDevice={previewDevice}
+																onDeviceChange={setPreviewDevice}
+																tokens={borderRadiusTokens}
+																defaultValue={
+																	inheritedBorderTransparentHoverRadius.values
 																}
-																onChangeMobile={(value) =>
-																	setAttributes({
-																		mobileBorderTransparentHoverRadius: value,
-																	})
-																}
+																inherited={anyCornerInherited(
+																	inheritedBorderTransparentHoverRadius.inherited
+																)}
+																state={tokenBinding.borderRadius}
+																onReset={() => resetToken('borderRadius')}
+																isLinked={borderTransparentHoverRadiusIsLinked}
+																onToggleLink={toggleBorderTransparentHoverRadiusLink}
 																unit={borderTransparentHoverRadiusUnit}
 																units={['px', 'em', 'rem', '%']}
 																onUnit={(value) =>
@@ -1445,8 +1771,6 @@ export default function KadenceButtonEdit(props) {
 																		: 1
 																}
 																min={0}
-																isBorderRadius={true}
-																allowEmpty={true}
 															/>
 															<EditorShadowControl
 																label={__('Box Shadow', 'kadence-blocks')}
@@ -1538,24 +1862,25 @@ export default function KadenceButtonEdit(props) {
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
 															/>
-															<ResponsiveMeasurementControls
+															<EditorBoxControl
 																label={__('Border Radius', 'kadence-blocks')}
-																value={borderTransparentRadius}
-																tabletValue={tabletBorderTransparentRadius}
-																mobileValue={mobileBorderTransparentRadius}
-																onChange={(value) =>
-																	setAttributes({ borderTransparentRadius: value })
-																}
-																onChangeTablet={(value) =>
+																value={borderTransparentRadiusForDevice.value}
+																onChange={(next) =>
 																	setAttributes({
-																		tabletBorderTransparentRadius: value,
+																		[borderTransparentRadiusForDevice.attr]: next,
 																	})
 																}
-																onChangeMobile={(value) =>
-																	setAttributes({
-																		mobileBorderTransparentRadius: value,
-																	})
-																}
+																previewDevice={previewDevice}
+																onDeviceChange={setPreviewDevice}
+																tokens={borderRadiusTokens}
+																defaultValue={inheritedBorderTransparentRadius.values}
+																inherited={anyCornerInherited(
+																	inheritedBorderTransparentRadius.inherited
+																)}
+																state={tokenBinding.borderRadius}
+																onReset={() => resetToken('borderRadius')}
+																isLinked={borderTransparentRadiusIsLinked}
+																onToggleLink={toggleBorderTransparentRadiusLink}
 																unit={borderTransparentRadiusUnit}
 																units={['px', 'em', 'rem', '%']}
 																onUnit={(value) =>
@@ -1576,8 +1901,6 @@ export default function KadenceButtonEdit(props) {
 																		: 1
 																}
 																min={0}
-																isBorderRadius={true}
-																allowEmpty={true}
 															/>
 															<EditorShadowControl
 																label={__('Box Shadow', 'kadence-blocks')}
@@ -1681,26 +2004,25 @@ export default function KadenceButtonEdit(props) {
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
 															/>
-															<ResponsiveMeasurementControls
+															<EditorBoxControl
 																label={__('Border Radius', 'kadence-blocks')}
-																value={borderStickyHoverRadius}
-																tabletValue={tabletBorderStickyHoverRadius}
-																mobileValue={mobileBorderStickyHoverRadius}
-																onChange={(value) =>
+																value={borderStickyHoverRadiusForDevice.value}
+																onChange={(next) =>
 																	setAttributes({
-																		borderStickyHoverRadius: value,
+																		[borderStickyHoverRadiusForDevice.attr]: next,
 																	})
 																}
-																onChangeTablet={(value) =>
-																	setAttributes({
-																		tabletBorderStickyHoverRadius: value,
-																	})
-																}
-																onChangeMobile={(value) =>
-																	setAttributes({
-																		mobileBorderStickyHoverRadius: value,
-																	})
-																}
+																previewDevice={previewDevice}
+																onDeviceChange={setPreviewDevice}
+																tokens={borderRadiusTokens}
+																defaultValue={inheritedBorderStickyHoverRadius.values}
+																inherited={anyCornerInherited(
+																	inheritedBorderStickyHoverRadius.inherited
+																)}
+																state={tokenBinding.borderRadius}
+																onReset={() => resetToken('borderRadius')}
+																isLinked={borderStickyHoverRadiusIsLinked}
+																onToggleLink={toggleBorderStickyHoverRadiusLink}
 																unit={borderStickyHoverRadiusUnit}
 																units={['px', 'em', 'rem', '%']}
 																onUnit={(value) =>
@@ -1721,8 +2043,6 @@ export default function KadenceButtonEdit(props) {
 																		: 1
 																}
 																min={0}
-																isBorderRadius={true}
-																allowEmpty={true}
 															/>
 															<EditorShadowControl
 																label={__('Box Shadow', 'kadence-blocks')}
@@ -1808,24 +2128,25 @@ export default function KadenceButtonEdit(props) {
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
 															/>
-															<ResponsiveMeasurementControls
+															<EditorBoxControl
 																label={__('Border Radius', 'kadence-blocks')}
-																value={borderStickyRadius}
-																tabletValue={tabletBorderStickyRadius}
-																mobileValue={mobileBorderStickyRadius}
-																onChange={(value) =>
-																	setAttributes({ borderStickyRadius: value })
-																}
-																onChangeTablet={(value) =>
+																value={borderStickyRadiusForDevice.value}
+																onChange={(next) =>
 																	setAttributes({
-																		tabletBorderStickyRadius: value,
+																		[borderStickyRadiusForDevice.attr]: next,
 																	})
 																}
-																onChangeMobile={(value) =>
-																	setAttributes({
-																		mobileBorderStickyRadius: value,
-																	})
-																}
+																previewDevice={previewDevice}
+																onDeviceChange={setPreviewDevice}
+																tokens={borderRadiusTokens}
+																defaultValue={inheritedBorderStickyRadius.values}
+																inherited={anyCornerInherited(
+																	inheritedBorderStickyRadius.inherited
+																)}
+																state={tokenBinding.borderRadius}
+																onReset={() => resetToken('borderRadius')}
+																isLinked={borderStickyRadiusIsLinked}
+																onToggleLink={toggleBorderStickyRadiusLink}
 																unit={borderStickyRadiusUnit}
 																units={['px', 'em', 'rem', '%']}
 																onUnit={(value) =>
@@ -1846,8 +2167,6 @@ export default function KadenceButtonEdit(props) {
 																		: 1
 																}
 																min={0}
-																isBorderRadius={true}
-																allowEmpty={true}
 															/>
 															<EditorShadowControl
 																label={__('Box Shadow', 'kadence-blocks')}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -445,19 +445,7 @@ export default function KadenceButtonEdit(props) {
 	// state — so every hover/sticky/transparent variant below reuses the same resolved list rather than
 	// re-filtering the pool per state.
 	const borderWidthPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width');
-	const borderWidthTokens = borderWidthPickableTokens;
-	const borderHoverWidthTokens = borderWidthPickableTokens;
-	const borderTransparentWidthTokens = borderWidthPickableTokens;
-	const borderTransparentHoverWidthTokens = borderWidthPickableTokens;
-	const borderStickyWidthTokens = borderWidthPickableTokens;
-	const borderStickyHoverWidthTokens = borderWidthPickableTokens;
 	const shadowPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow');
-	const shadowTokens = shadowPickableTokens;
-	const shadowHoverTokens = shadowPickableTokens;
-	const shadowTransparentTokens = shadowPickableTokens;
-	const shadowTransparentHoverTokens = shadowPickableTokens;
-	const shadowStickyTokens = shadowPickableTokens;
-	const shadowStickyHoverTokens = shadowPickableTokens;
 	const paddingPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-padding');
 
 	// The mode describes what THIS device stores, not what it inherits. A breakpoint that stores nothing
@@ -1538,7 +1526,7 @@ export default function KadenceButtonEdit(props) {
 															}
 															previewDevice={previewDevice}
 															onDeviceChange={setPreviewDevice}
-															widthTokens={borderHoverWidthTokens}
+															widthTokens={borderWidthPickableTokens}
 															defaultValue={borderWidthPresetValue}
 															renderColor={renderBorderColor}
 														/>
@@ -1590,7 +1578,7 @@ export default function KadenceButtonEdit(props) {
 															onEnableChange={(value) =>
 																setAttributes({ displayHoverShadow: value })
 															}
-															tokens={shadowHoverTokens}
+															tokens={shadowPickableTokens}
 															renderColor={renderShadowColor}
 														/>
 													</>
@@ -1684,7 +1672,7 @@ export default function KadenceButtonEdit(props) {
 															}
 															previewDevice={previewDevice}
 															onDeviceChange={setPreviewDevice}
-															widthTokens={borderWidthTokens}
+															widthTokens={borderWidthPickableTokens}
 															defaultValue={borderWidthPresetValue}
 															renderColor={renderBorderColor}
 															state={tokenBinding.borderStyle}
@@ -1724,7 +1712,7 @@ export default function KadenceButtonEdit(props) {
 															onEnableChange={(value) =>
 																setAttributes({ displayShadow: value })
 															}
-															tokens={shadowTokens}
+															tokens={shadowPickableTokens}
 															renderColor={renderShadowColor}
 														/>
 													</>
@@ -1809,7 +1797,7 @@ export default function KadenceButtonEdit(props) {
 																}
 																previewDevice={previewDevice}
 																onDeviceChange={setPreviewDevice}
-																widthTokens={borderTransparentHoverWidthTokens}
+																widthTokens={borderWidthPickableTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
 															/>
@@ -1870,7 +1858,7 @@ export default function KadenceButtonEdit(props) {
 																		displayHoverShadowTransparent: value,
 																	})
 																}
-																tokens={shadowTransparentHoverTokens}
+																tokens={shadowPickableTokens}
 																renderColor={renderShadowColor}
 															/>
 														</>
@@ -1940,7 +1928,7 @@ export default function KadenceButtonEdit(props) {
 																}
 																previewDevice={previewDevice}
 																onDeviceChange={setPreviewDevice}
-																widthTokens={borderTransparentWidthTokens}
+																widthTokens={borderWidthPickableTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
 															/>
@@ -1996,7 +1984,7 @@ export default function KadenceButtonEdit(props) {
 																onEnableChange={(value) =>
 																	setAttributes({ displayShadowTransparent: value })
 																}
-																tokens={shadowTransparentTokens}
+																tokens={shadowPickableTokens}
 																renderColor={renderShadowColor}
 															/>
 														</>
@@ -2080,7 +2068,7 @@ export default function KadenceButtonEdit(props) {
 																}
 																previewDevice={previewDevice}
 																onDeviceChange={setPreviewDevice}
-																widthTokens={borderStickyHoverWidthTokens}
+																widthTokens={borderWidthPickableTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
 															/>
@@ -2136,7 +2124,7 @@ export default function KadenceButtonEdit(props) {
 																onEnableChange={(value) =>
 																	setAttributes({ displayHoverShadowSticky: value })
 																}
-																tokens={shadowStickyHoverTokens}
+																tokens={shadowPickableTokens}
 																renderColor={renderShadowColor}
 															/>
 														</>
@@ -2202,7 +2190,7 @@ export default function KadenceButtonEdit(props) {
 																}
 																previewDevice={previewDevice}
 																onDeviceChange={setPreviewDevice}
-																widthTokens={borderStickyWidthTokens}
+																widthTokens={borderWidthPickableTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
 															/>
@@ -2258,7 +2246,7 @@ export default function KadenceButtonEdit(props) {
 																onEnableChange={(value) =>
 																	setAttributes({ displayShadowSticky: value })
 																}
-																tokens={shadowStickyTokens}
+																tokens={shadowPickableTokens}
 																renderColor={renderShadowColor}
 															/>
 														</>

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -1134,6 +1134,8 @@ export default function KadenceButtonEdit(props) {
 															widthTokens={borderHoverWidthTokens}
 															defaultValue={borderWidthPresetValue}
 															renderColor={renderBorderColor}
+															state={tokenBinding.borderStyle}
+															onReset={() => resetToken('borderStyle')}
 														/>
 														<ResponsiveMeasurementControls
 															label={__('Border Radius', 'kadence-blocks')}
@@ -1279,6 +1281,8 @@ export default function KadenceButtonEdit(props) {
 															widthTokens={borderWidthTokens}
 															defaultValue={borderWidthPresetValue}
 															renderColor={renderBorderColor}
+															state={tokenBinding.borderStyle}
+															onReset={() => resetToken('borderStyle')}
 														/>
 														<EditorBoxControl
 															label={__('Border Radius', 'kadence-blocks')}
@@ -1402,6 +1406,8 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderTransparentHoverWidthTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
+																state={tokenBinding.borderStyle}
+																onReset={() => resetToken('borderStyle')}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1535,6 +1541,8 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderTransparentWidthTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
+																state={tokenBinding.borderStyle}
+																onReset={() => resetToken('borderStyle')}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1678,6 +1686,8 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderStickyHoverWidthTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
+																state={tokenBinding.borderStyle}
+																onReset={() => resetToken('borderStyle')}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1805,6 +1815,8 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderStickyWidthTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
+																state={tokenBinding.borderStyle}
+																onReset={() => resetToken('borderStyle')}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -80,11 +80,11 @@ import {
 } from '@wordpress/components';
 import { addFilter, applyFilters, doAction } from '@wordpress/hooks';
 import BackendStyles from './components/backend-styles';
+import { useLinkedMeasureState } from './hooks/use-linked-measure-state';
 import { PresetButton } from '../../extension/preset-picker/PresetButton';
 import { usePresetBinding, resetAttr, presetPropertyValueForDevice } from '../../extension/token-indicators';
 import {
 	anyCornerInherited,
-	deriveMeasureMode,
 	inheritedMeasureSlots,
 	measureAttrsForDevice,
 	presetValueForDevice,
@@ -421,16 +421,6 @@ export default function KadenceButtonEdit(props) {
 
 	const [activeTab, setActiveTab] = useState('general');
 	const [isEditingURL, setIsEditingURL] = useState(false);
-	// The border-radius linked/individual mode is derived from the stored corners (all equal reads as
-	// linked), so no new attribute is needed and old buttons open in the right mode. This ephemeral
-	// override only records an explicit "unlink" of already-equal corners for the current session — it
-	// resets on remount, matching how the control's mode has always been session-local.
-	// Keyed by device: the responsive control keeps ONE mode but writes three attributes, so a choice
-	// made on Tablet must not flip Desktop's corners (and vice versa).
-	const [borderRadiusModeOverride, setBorderRadiusModeOverride] = useState({});
-	// Padding's linked/individual mode is tracked the same way as Border Radius's, above — its own
-	// override state because the two controls' sides are independent stored values.
-	const [paddingModeOverride, setPaddingModeOverride] = useState({});
 
 	// Everything the new box control needs that the block already knows, gathered in one place rather
 	// than inlined into the JSX.
@@ -448,145 +438,42 @@ export default function KadenceButtonEdit(props) {
 	const shadowPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow');
 	const paddingPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-padding');
 
-	// The mode describes what THIS device stores, not what it inherits. A breakpoint that stores nothing
-	// has nothing that differs, so it reads as linked — deriving from the inherited corners instead would
-	// split an all-empty Tablet into four identical blank fields, showing a difference the user cannot
-	// see. Where the value comes from is surfaced by the field's popover, not by the link toggle.
-	const borderRadiusIsLinked =
-		'linked' ===
-		(borderRadiusModeOverride[previewDevice] ??
-			deriveMeasureMode(borderRadiusForDevice.value, borderRadiusPresetValue));
+	// The border-radius/padding linked/individual mode is derived from the stored slots (all equal reads
+	// as linked), so no new attribute is needed and old buttons open in the right mode. The hook's own
+	// override only records an explicit "unlink" of already-equal slots for the current session — it
+	// resets on remount, matching how the control's mode has always been session-local. It is keyed by
+	// device internally: the responsive control keeps ONE mode but writes three attributes, so a choice
+	// made on Tablet must not flip Desktop's slots (and vice versa). It also resets whenever the active
+	// preset changes (via `resetOn`), since an override records a choice about the PREVIOUS preset's
+	// slots — otherwise an explicit "link" would stick and hide a new preset's per-slot value.
+	const { isLinked: borderRadiusIsLinked, toggleLink: toggleBorderRadiusLink } = useLinkedMeasureState({
+		forDevice: borderRadiusForDevice,
+		inherited: inheritedBorderRadius,
+		previewDevice,
+		presetValue: borderRadiusPresetValue,
+		tokens: borderRadiusTokens,
+		setAttributes,
+		resetOn: attributes.kbPreset,
+	});
 
-	// What the corners inherit, and whether that inheritance is uniform. A per-corner inheritance is the
-	// case where linking is a real change rather than a no-op. Always `inheritedBorderRadius.values`,
-	// never the raw preset value directly: `inheritedMeasureSlots()` already falls through to the
-	// preset's own per-corner slots (`presetSlotAt`) once the device's stored corners run out, so
-	// reading the preset array straight through here would drop any corner this device DOES store —
-	// silently discarding the desktop/tablet cascade for a preset that happens to be per-corner.
-	const inheritedCorners = inheritedBorderRadius.values;
-	const inheritedCornersDiffer =
-		Array.isArray(inheritedCorners) && inheritedCorners.some((corner) => corner !== inheritedCorners[0]);
-	// The preset surface carries resolved literals, not aliases (`blockPresetValues` flattens them so the
-	// overridden-check can be a plain compare), so the literal is matched back to the token that produced
-	// it. Writing the alias keeps the collapsed corner bound to `None` rather than landing as a custom
-	// `0px` that merely happens to look the same.
-	const aliasForValue = (value) => borderRadiusTokens.find((token) => token.value === value)?.alias ?? value ?? '';
-	const inheritedFirstCorner = Array.isArray(inheritedCorners) ? aliasForValue(inheritedCorners[0]) : '';
-
-	const toggleBorderRadiusLink = () => {
-		if (!borderRadiusIsLinked) {
-			const corners = borderRadiusForDevice.value ?? [];
-			const corner = corners[0] ?? '';
-			const isEmpty = corners.every((value) => '' === value || undefined === value);
-
-			if (isEmpty) {
-				// Nothing stored on this device, so ordinarily there is nothing to collapse — the corners
-				// are empty because they inherit, and writing the inherited value would silently pin
-				// Tablet/Mobile to Desktop's current radius. Remember the choice instead.
-				//
-				// Unless what is inherited differs corner to corner: then "link" genuinely changes the
-				// result, and storing nothing would leave the control showing one value while the button
-				// still renders four, with the indicator insisting it matches the preset. Collapsing to
-				// the first corner is the write that makes the three agree.
-				if (!inheritedCornersDiffer) {
-					setBorderRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
-
-					return;
-				}
-
-				setAttributes({
-					[borderRadiusForDevice.attr]: [
-						inheritedFirstCorner,
-						inheritedFirstCorner,
-						inheritedFirstCorner,
-						inheritedFirstCorner,
-					],
-				});
-				setBorderRadiusModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
-
-				return;
-			}
-
-			// Every corner matches the top-left, blank included, and only on the ACTIVE device.
-			setAttributes({ [borderRadiusForDevice.attr]: [corner, corner, corner, corner] });
-			// Equal corners derive linked on their own — except blank ones under a per-corner preset.
-			setBorderRadiusModeOverride((current) => ({
-				...current,
-				[previewDevice]: '' === corner ? 'linked' : undefined,
-			}));
-
-			return;
-		}
-
-		// Unlinking equal corners leaves the values untouched, so remember the choice for this session
-		// AND this device; a differing corner would derive individual on its own.
-		setBorderRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
-	};
-
-	// Padding's linked/individual mode and its toggle, mirroring Border Radius's own block above with
-	// "corner" swapped for "side" — same shape, run over `paddingForDevice`/`paddingPresetValue`/
-	// `inheritedPadding` instead.
-	const paddingIsLinked =
-		'linked' ===
-		(paddingModeOverride[previewDevice] ?? deriveMeasureMode(paddingForDevice.value, paddingPresetValue));
-
-	const inheritedPaddingSides = inheritedPadding.values;
-	const inheritedPaddingSidesDiffer =
-		Array.isArray(inheritedPaddingSides) && inheritedPaddingSides.some((side) => side !== inheritedPaddingSides[0]);
-	const aliasForPaddingValue = (value) =>
-		paddingPickableTokens.find((token) => token.value === value)?.alias ?? value ?? '';
-	const inheritedFirstPaddingSide = Array.isArray(inheritedPaddingSides)
-		? aliasForPaddingValue(inheritedPaddingSides[0])
-		: '';
-
-	const togglePaddingLink = () => {
-		if (!paddingIsLinked) {
-			const sides = paddingForDevice.value ?? [];
-			const side = sides[0] ?? '';
-			const isEmpty = sides.every((value) => '' === value || undefined === value);
-
-			if (isEmpty) {
-				if (!inheritedPaddingSidesDiffer) {
-					setPaddingModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
-
-					return;
-				}
-
-				setAttributes({
-					[paddingForDevice.attr]: [
-						inheritedFirstPaddingSide,
-						inheritedFirstPaddingSide,
-						inheritedFirstPaddingSide,
-						inheritedFirstPaddingSide,
-					],
-				});
-				setPaddingModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
-
-				return;
-			}
-
-			// Every side matches the first, blank included, and only on the ACTIVE device.
-			setAttributes({ [paddingForDevice.attr]: [side, side, side, side] });
-			// Equal sides derive linked on their own — except blank ones under a per-side preset.
-			setPaddingModeOverride((current) => ({
-				...current,
-				[previewDevice]: '' === side ? 'linked' : undefined,
-			}));
-
-			return;
-		}
-
-		// Unlinking equal sides leaves the values untouched, so remember the choice for this session AND
-		// this device; a differing side would derive individual on its own.
-		setPaddingModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
-	};
+	// Padding's linked/individual mode, mirroring Border Radius's own hook call above with "corner"
+	// swapped for "side" — same shape, run over `paddingForDevice`/`paddingPresetValue`/
+	// `inheritedPadding`/`paddingPickableTokens` instead. Padding has no `resetOn`: unlike Border
+	// Radius's 6 states, its override has never been cleared on a preset change.
+	const { isLinked: paddingIsLinked, toggleLink: togglePaddingLink } = useLinkedMeasureState({
+		forDevice: paddingForDevice,
+		inherited: inheritedPadding,
+		previewDevice,
+		presetValue: paddingPresetValue,
+		tokens: paddingPickableTokens,
+		setAttributes,
+	});
 
 	// Hover/Transparent/Transparent Hover/Sticky/Sticky Hover each store their own 4 corners, so each
-	// gets its own copy of the linked-state machinery above — sharing Normal's `borderRadiusModeOverride`
-	// would couple these states' link/unlink UI together even though the underlying attributes are
-	// independent. All 6 states still read/write the same `tokenBinding.borderRadius` preset binding and
-	// `borderRadiusTokens` pool, since there is only one border-radius preset property.
-	const [borderHoverRadiusModeOverride, setBorderHoverRadiusModeOverride] = useState({});
+	// gets its own call to the hook above — sharing Normal's linked state would couple these states'
+	// link/unlink UI together even though the underlying attributes are independent. All 6 states still
+	// read/write the same `tokenBinding.borderRadius` preset binding and `borderRadiusTokens` pool, since
+	// there is only one border-radius preset property.
 	const borderHoverRadiusForDevice = measureAttrsForDevice(
 		attributes,
 		'borderHoverRadius',
@@ -598,56 +485,16 @@ export default function KadenceButtonEdit(props) {
 		{ desktop: borderHoverRadius, tablet: tabletBorderHoverRadius },
 		borderRadiusPresetValue
 	);
-	const borderHoverRadiusIsLinked =
-		'linked' ===
-		(borderHoverRadiusModeOverride[previewDevice] ??
-			deriveMeasureMode(borderHoverRadiusForDevice.value, borderRadiusPresetValue));
-	const borderHoverInheritedCorners = inheritedBorderHoverRadius.values;
-	const borderHoverInheritedCornersDiffer =
-		Array.isArray(borderHoverInheritedCorners) &&
-		borderHoverInheritedCorners.some((corner) => corner !== borderHoverInheritedCorners[0]);
-	const borderHoverInheritedFirstCorner = Array.isArray(borderHoverInheritedCorners)
-		? aliasForValue(borderHoverInheritedCorners[0])
-		: '';
-	const toggleBorderHoverRadiusLink = () => {
-		if (!borderHoverRadiusIsLinked) {
-			const corners = borderHoverRadiusForDevice.value ?? [];
-			const corner = corners[0] ?? '';
-			const isEmpty = corners.every((value) => '' === value || undefined === value);
+	const { isLinked: borderHoverRadiusIsLinked, toggleLink: toggleBorderHoverRadiusLink } = useLinkedMeasureState({
+		forDevice: borderHoverRadiusForDevice,
+		inherited: inheritedBorderHoverRadius,
+		previewDevice,
+		presetValue: borderRadiusPresetValue,
+		tokens: borderRadiusTokens,
+		setAttributes,
+		resetOn: attributes.kbPreset,
+	});
 
-			if (isEmpty) {
-				if (!borderHoverInheritedCornersDiffer) {
-					setBorderHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
-
-					return;
-				}
-
-				setAttributes({
-					[borderHoverRadiusForDevice.attr]: [
-						borderHoverInheritedFirstCorner,
-						borderHoverInheritedFirstCorner,
-						borderHoverInheritedFirstCorner,
-						borderHoverInheritedFirstCorner,
-					],
-				});
-				setBorderHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
-
-				return;
-			}
-
-			setAttributes({ [borderHoverRadiusForDevice.attr]: [corner, corner, corner, corner] });
-			setBorderHoverRadiusModeOverride((current) => ({
-				...current,
-				[previewDevice]: '' === corner ? 'linked' : undefined,
-			}));
-
-			return;
-		}
-
-		setBorderHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
-	};
-
-	const [borderTransparentRadiusModeOverride, setBorderTransparentRadiusModeOverride] = useState({});
 	const borderTransparentRadiusForDevice = measureAttrsForDevice(
 		attributes,
 		'borderTransparentRadius',
@@ -659,56 +506,17 @@ export default function KadenceButtonEdit(props) {
 		{ desktop: borderTransparentRadius, tablet: tabletBorderTransparentRadius },
 		borderRadiusPresetValue
 	);
-	const borderTransparentRadiusIsLinked =
-		'linked' ===
-		(borderTransparentRadiusModeOverride[previewDevice] ??
-			deriveMeasureMode(borderTransparentRadiusForDevice.value, borderRadiusPresetValue));
-	const borderTransparentInheritedCorners = inheritedBorderTransparentRadius.values;
-	const borderTransparentInheritedCornersDiffer =
-		Array.isArray(borderTransparentInheritedCorners) &&
-		borderTransparentInheritedCorners.some((corner) => corner !== borderTransparentInheritedCorners[0]);
-	const borderTransparentInheritedFirstCorner = Array.isArray(borderTransparentInheritedCorners)
-		? aliasForValue(borderTransparentInheritedCorners[0])
-		: '';
-	const toggleBorderTransparentRadiusLink = () => {
-		if (!borderTransparentRadiusIsLinked) {
-			const corners = borderTransparentRadiusForDevice.value ?? [];
-			const corner = corners[0] ?? '';
-			const isEmpty = corners.every((value) => '' === value || undefined === value);
+	const { isLinked: borderTransparentRadiusIsLinked, toggleLink: toggleBorderTransparentRadiusLink } =
+		useLinkedMeasureState({
+			forDevice: borderTransparentRadiusForDevice,
+			inherited: inheritedBorderTransparentRadius,
+			previewDevice,
+			presetValue: borderRadiusPresetValue,
+			tokens: borderRadiusTokens,
+			setAttributes,
+			resetOn: attributes.kbPreset,
+		});
 
-			if (isEmpty) {
-				if (!borderTransparentInheritedCornersDiffer) {
-					setBorderTransparentRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
-
-					return;
-				}
-
-				setAttributes({
-					[borderTransparentRadiusForDevice.attr]: [
-						borderTransparentInheritedFirstCorner,
-						borderTransparentInheritedFirstCorner,
-						borderTransparentInheritedFirstCorner,
-						borderTransparentInheritedFirstCorner,
-					],
-				});
-				setBorderTransparentRadiusModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
-
-				return;
-			}
-
-			setAttributes({ [borderTransparentRadiusForDevice.attr]: [corner, corner, corner, corner] });
-			setBorderTransparentRadiusModeOverride((current) => ({
-				...current,
-				[previewDevice]: '' === corner ? 'linked' : undefined,
-			}));
-
-			return;
-		}
-
-		setBorderTransparentRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
-	};
-
-	const [borderTransparentHoverRadiusModeOverride, setBorderTransparentHoverRadiusModeOverride] = useState({});
 	const borderTransparentHoverRadiusForDevice = measureAttrsForDevice(
 		attributes,
 		'borderTransparentHoverRadius',
@@ -720,62 +528,17 @@ export default function KadenceButtonEdit(props) {
 		{ desktop: borderTransparentHoverRadius, tablet: tabletBorderTransparentHoverRadius },
 		borderRadiusPresetValue
 	);
-	const borderTransparentHoverRadiusIsLinked =
-		'linked' ===
-		(borderTransparentHoverRadiusModeOverride[previewDevice] ??
-			deriveMeasureMode(borderTransparentHoverRadiusForDevice.value, borderRadiusPresetValue));
-	const borderTransparentHoverInheritedCorners = inheritedBorderTransparentHoverRadius.values;
-	const borderTransparentHoverInheritedCornersDiffer =
-		Array.isArray(borderTransparentHoverInheritedCorners) &&
-		borderTransparentHoverInheritedCorners.some((corner) => corner !== borderTransparentHoverInheritedCorners[0]);
-	const borderTransparentHoverInheritedFirstCorner = Array.isArray(borderTransparentHoverInheritedCorners)
-		? aliasForValue(borderTransparentHoverInheritedCorners[0])
-		: '';
-	const toggleBorderTransparentHoverRadiusLink = () => {
-		if (!borderTransparentHoverRadiusIsLinked) {
-			const corners = borderTransparentHoverRadiusForDevice.value ?? [];
-			const corner = corners[0] ?? '';
-			const isEmpty = corners.every((value) => '' === value || undefined === value);
+	const { isLinked: borderTransparentHoverRadiusIsLinked, toggleLink: toggleBorderTransparentHoverRadiusLink } =
+		useLinkedMeasureState({
+			forDevice: borderTransparentHoverRadiusForDevice,
+			inherited: inheritedBorderTransparentHoverRadius,
+			previewDevice,
+			presetValue: borderRadiusPresetValue,
+			tokens: borderRadiusTokens,
+			setAttributes,
+			resetOn: attributes.kbPreset,
+		});
 
-			if (isEmpty) {
-				if (!borderTransparentHoverInheritedCornersDiffer) {
-					setBorderTransparentHoverRadiusModeOverride((current) => ({
-						...current,
-						[previewDevice]: 'linked',
-					}));
-
-					return;
-				}
-
-				setAttributes({
-					[borderTransparentHoverRadiusForDevice.attr]: [
-						borderTransparentHoverInheritedFirstCorner,
-						borderTransparentHoverInheritedFirstCorner,
-						borderTransparentHoverInheritedFirstCorner,
-						borderTransparentHoverInheritedFirstCorner,
-					],
-				});
-				setBorderTransparentHoverRadiusModeOverride((current) => ({
-					...current,
-					[previewDevice]: undefined,
-				}));
-
-				return;
-			}
-
-			setAttributes({ [borderTransparentHoverRadiusForDevice.attr]: [corner, corner, corner, corner] });
-			setBorderTransparentHoverRadiusModeOverride((current) => ({
-				...current,
-				[previewDevice]: '' === corner ? 'linked' : undefined,
-			}));
-
-			return;
-		}
-
-		setBorderTransparentHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
-	};
-
-	const [borderStickyRadiusModeOverride, setBorderStickyRadiusModeOverride] = useState({});
 	const borderStickyRadiusForDevice = measureAttrsForDevice(
 		attributes,
 		'borderStickyRadius',
@@ -787,56 +550,16 @@ export default function KadenceButtonEdit(props) {
 		{ desktop: borderStickyRadius, tablet: tabletBorderStickyRadius },
 		borderRadiusPresetValue
 	);
-	const borderStickyRadiusIsLinked =
-		'linked' ===
-		(borderStickyRadiusModeOverride[previewDevice] ??
-			deriveMeasureMode(borderStickyRadiusForDevice.value, borderRadiusPresetValue));
-	const borderStickyInheritedCorners = inheritedBorderStickyRadius.values;
-	const borderStickyInheritedCornersDiffer =
-		Array.isArray(borderStickyInheritedCorners) &&
-		borderStickyInheritedCorners.some((corner) => corner !== borderStickyInheritedCorners[0]);
-	const borderStickyInheritedFirstCorner = Array.isArray(borderStickyInheritedCorners)
-		? aliasForValue(borderStickyInheritedCorners[0])
-		: '';
-	const toggleBorderStickyRadiusLink = () => {
-		if (!borderStickyRadiusIsLinked) {
-			const corners = borderStickyRadiusForDevice.value ?? [];
-			const corner = corners[0] ?? '';
-			const isEmpty = corners.every((value) => '' === value || undefined === value);
+	const { isLinked: borderStickyRadiusIsLinked, toggleLink: toggleBorderStickyRadiusLink } = useLinkedMeasureState({
+		forDevice: borderStickyRadiusForDevice,
+		inherited: inheritedBorderStickyRadius,
+		previewDevice,
+		presetValue: borderRadiusPresetValue,
+		tokens: borderRadiusTokens,
+		setAttributes,
+		resetOn: attributes.kbPreset,
+	});
 
-			if (isEmpty) {
-				if (!borderStickyInheritedCornersDiffer) {
-					setBorderStickyRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
-
-					return;
-				}
-
-				setAttributes({
-					[borderStickyRadiusForDevice.attr]: [
-						borderStickyInheritedFirstCorner,
-						borderStickyInheritedFirstCorner,
-						borderStickyInheritedFirstCorner,
-						borderStickyInheritedFirstCorner,
-					],
-				});
-				setBorderStickyRadiusModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
-
-				return;
-			}
-
-			setAttributes({ [borderStickyRadiusForDevice.attr]: [corner, corner, corner, corner] });
-			setBorderStickyRadiusModeOverride((current) => ({
-				...current,
-				[previewDevice]: '' === corner ? 'linked' : undefined,
-			}));
-
-			return;
-		}
-
-		setBorderStickyRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
-	};
-
-	const [borderStickyHoverRadiusModeOverride, setBorderStickyHoverRadiusModeOverride] = useState({});
 	const borderStickyHoverRadiusForDevice = measureAttrsForDevice(
 		attributes,
 		'borderStickyHoverRadius',
@@ -848,67 +571,17 @@ export default function KadenceButtonEdit(props) {
 		{ desktop: borderStickyHoverRadius, tablet: tabletBorderStickyHoverRadius },
 		borderRadiusPresetValue
 	);
-	const borderStickyHoverRadiusIsLinked =
-		'linked' ===
-		(borderStickyHoverRadiusModeOverride[previewDevice] ??
-			deriveMeasureMode(borderStickyHoverRadiusForDevice.value, borderRadiusPresetValue));
-	const borderStickyHoverInheritedCorners = inheritedBorderStickyHoverRadius.values;
-	const borderStickyHoverInheritedCornersDiffer =
-		Array.isArray(borderStickyHoverInheritedCorners) &&
-		borderStickyHoverInheritedCorners.some((corner) => corner !== borderStickyHoverInheritedCorners[0]);
-	const borderStickyHoverInheritedFirstCorner = Array.isArray(borderStickyHoverInheritedCorners)
-		? aliasForValue(borderStickyHoverInheritedCorners[0])
-		: '';
-	const toggleBorderStickyHoverRadiusLink = () => {
-		if (!borderStickyHoverRadiusIsLinked) {
-			const corners = borderStickyHoverRadiusForDevice.value ?? [];
-			const corner = corners[0] ?? '';
-			const isEmpty = corners.every((value) => '' === value || undefined === value);
+	const { isLinked: borderStickyHoverRadiusIsLinked, toggleLink: toggleBorderStickyHoverRadiusLink } =
+		useLinkedMeasureState({
+			forDevice: borderStickyHoverRadiusForDevice,
+			inherited: inheritedBorderStickyHoverRadius,
+			previewDevice,
+			presetValue: borderRadiusPresetValue,
+			tokens: borderRadiusTokens,
+			setAttributes,
+			resetOn: attributes.kbPreset,
+		});
 
-			if (isEmpty) {
-				if (!borderStickyHoverInheritedCornersDiffer) {
-					setBorderStickyHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
-
-					return;
-				}
-
-				setAttributes({
-					[borderStickyHoverRadiusForDevice.attr]: [
-						borderStickyHoverInheritedFirstCorner,
-						borderStickyHoverInheritedFirstCorner,
-						borderStickyHoverInheritedFirstCorner,
-						borderStickyHoverInheritedFirstCorner,
-					],
-				});
-				setBorderStickyHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
-
-				return;
-			}
-
-			setAttributes({ [borderStickyHoverRadiusForDevice.attr]: [corner, corner, corner, corner] });
-			setBorderStickyHoverRadiusModeOverride((current) => ({
-				...current,
-				[previewDevice]: '' === corner ? 'linked' : undefined,
-			}));
-
-			return;
-		}
-
-		setBorderStickyHoverRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
-	};
-
-	// The override records a choice made about the PREVIOUS preset's corners, so selecting another preset
-	// drops it — otherwise an explicit "link" would stick and hide a new preset's per-corner radius (or,
-	// for padding, per-side padding).
-	useEffect(() => {
-		setBorderRadiusModeOverride({});
-		setBorderHoverRadiusModeOverride({});
-		setBorderTransparentRadiusModeOverride({});
-		setBorderTransparentHoverRadiusModeOverride({});
-		setBorderStickyRadiusModeOverride({});
-		setBorderStickyHoverRadiusModeOverride({});
-		setPaddingModeOverride({});
-	}, [attributes.kbPreset]);
 	useEffect(() => {
 		if (!isSelected) {
 			setIsEditingURL(false);

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -8,7 +8,6 @@ import {
 	getPreviewSize,
 	showSettings,
 	getSpacingOptionOutput,
-	mouseOverVisualizer,
 	getFontSizeOptionOutput,
 	typographyStyle,
 	getBorderStyle,
@@ -82,7 +81,12 @@ import { addFilter, applyFilters, doAction } from '@wordpress/hooks';
 import BackendStyles from './components/backend-styles';
 import { useLinkedMeasureState } from './hooks/use-linked-measure-state';
 import { PresetButton } from '../../extension/preset-picker/PresetButton';
-import { usePresetBinding, resetAttr, presetPropertyValueForDevice } from '../../extension/token-indicators';
+import {
+	usePresetBinding,
+	resetAttr,
+	presetPropertyValueForDevice,
+	deriveStateBinding,
+} from '../../extension/token-indicators';
 import {
 	anyCornerInherited,
 	inheritedMeasureSlots,
@@ -358,9 +362,6 @@ export default function KadenceButtonEdit(props) {
 		{ tablet: 'tabletPadding', mobile: 'mobilePadding' },
 		previewDevice
 	);
-	const marginMouseOver = mouseOverVisualizer();
-	const paddingMouseOver = mouseOverVisualizer();
-
 	// Design-token indicators: the per-attribute bound/overridden state for the selected preset, plus a
 	// reset that clears the mapped attribute back to the preset value (served by the existing scoped CSS).
 	const tokenBinding = usePresetBinding('kadence/singlebtn', attributes, undefined, previewDevice);
@@ -373,11 +374,12 @@ export default function KadenceButtonEdit(props) {
 	);
 
 	// What an unset Border Width field falls back to: the active preset's own resolved width.
-	// `button-border-width` has no `control_attr` (its native attribute is a nested per-side shape
-	// `usePresetBinding` has nothing to key it by — see `declarations.php`'s comment on that binding),
-	// so `tokenBinding` never carries it; read it directly instead. Shown as `EditorBorderControl`'s
-	// `defaultValue` — without it, a cleared width field renders empty and collapses to zero height
-	// (its `TokenSelector`'s trigger has nothing to show), which reads as broken rather than reset.
+	// `button-border-width` shares `borderStyle`'s `control_attr` with style/color, and
+	// `tokenBinding.borderStyle` combines all three axes into one entry keyed by that shared attribute
+	// — there is no per-axis width-only entry to pull a value out of, so this reads the width axis
+	// directly by its own property key instead. Shown as `EditorBorderControl`'s `defaultValue` —
+	// without it, a cleared width field renders empty and collapses to zero height (its
+	// `TokenSelector`'s trigger has nothing to show), which reads as broken rather than reset.
 	const borderWidthPresetValue = presetPropertyValueForDevice(
 		'kadence/singlebtn',
 		'button-border-width',
@@ -448,13 +450,15 @@ export default function KadenceButtonEdit(props) {
 	const { setPreviewDeviceType: setPreviewDevice } = useDispatch('kadenceblocks/data');
 	const borderRadiusTokens = pickableTokensForControl('kadence/singlebtn', 'borderRadius') || [];
 	const borderRadiusIsRelative = borderRadiusUnit === 'em' || borderRadiusUnit === 'rem';
-	// Border width and shadow bind through their bindings KEY, not a `control_attr` — the native border
-	// and shadow attributes are nested per-side/composite shapes, not a single scalar a `control_attr`
-	// lookup can target, so their PHP bindings declare no `control_attr` at all (see declarations.php's
-	// `kadence/singlebtn` block). One PHP binding exists per property (`button-border-width`,
-	// `button-shadow`) — there is one border-width scale and one shadow scale, not a separate one per
-	// state — so every hover/sticky/transparent variant below reuses the same resolved list rather than
-	// re-filtering the pool per state.
+	// Border width and shadow bind through their bindings KEY, not `pickableTokensForControl`'s
+	// `control_attr` reverse lookup: `button-shadow`'s PHP binding declares no `control_attr` at all
+	// (its native attribute is a composite shape a `control_attr` lookup can't target), and
+	// `button-border-width` shares its `control_attr` ('borderStyle') with style/color, which would make
+	// a control_attr-keyed lookup ambiguous among the three (see declarations.php's `kadence/singlebtn`
+	// block). One PHP binding exists per property (`button-border-width`, `button-shadow`) — there is
+	// one border-width scale and one shadow scale, not a separate one per state — so every
+	// hover/sticky/transparent variant below reuses the same resolved list rather than re-filtering the
+	// pool per state.
 	const borderWidthPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width');
 	const shadowPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow');
 	const paddingPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-padding');
@@ -635,6 +639,131 @@ export default function KadenceButtonEdit(props) {
 			setAttributes,
 			resetOn: attributes.kbPreset,
 		});
+
+	// Each of the 5 non-Normal states' OWN Border Radius/Border indicator and reset — derived from the
+	// shared preset entry above (`tokenBinding.borderRadius`/`tokenBinding.borderStyle`, the same one
+	// Normal's own fields read) plus this state's own resolved value at the active device. Reusing
+	// Normal's `tokenBinding` entries directly here (as every call site once did) would report Normal's
+	// divergence on a field the user never opened, and its `onReset` would silently clear NORMAL's
+	// attributes while leaving this state's own untouched — see `deriveStateBinding`'s own docblock.
+	const borderHoverBorderForDevice = measureAttrsForDevice(
+		attributes,
+		'borderHoverStyle',
+		{ tablet: 'tabletBorderHoverStyle', mobile: 'mobileBorderHoverStyle' },
+		previewDevice
+	);
+	const borderHoverRadiusIsRelative = borderHoverRadiusUnit === 'em' || borderHoverRadiusUnit === 'rem';
+	const borderHoverRadiusBinding = deriveStateBinding({
+		shared: tokenBinding.borderRadius,
+		kind: 'dimension',
+		value: borderHoverRadiusForDevice.value,
+		unit: borderHoverRadiusUnit,
+		devicePresetValue: borderRadiusPresetValue,
+	});
+	const borderHoverBorderBinding = deriveStateBinding({
+		shared: tokenBinding.borderStyle,
+		kind: 'border',
+		value: borderHoverBorderForDevice.value,
+		previewDevice,
+	});
+	const resetBorderHoverRadius = () => resetAttr('borderHoverRadius', setAttributes, 'dimension');
+	const resetBorderHoverBorder = () => resetAttr('borderHoverStyle', setAttributes, 'border');
+
+	const borderTransparentBorderForDevice = measureAttrsForDevice(
+		attributes,
+		'borderTransparentStyle',
+		{ tablet: 'tabletBorderTransparentStyle', mobile: 'mobileBorderTransparentStyle' },
+		previewDevice
+	);
+	const borderTransparentRadiusIsRelative =
+		borderTransparentRadiusUnit === 'em' || borderTransparentRadiusUnit === 'rem';
+	const borderTransparentRadiusBinding = deriveStateBinding({
+		shared: tokenBinding.borderRadius,
+		kind: 'dimension',
+		value: borderTransparentRadiusForDevice.value,
+		unit: borderTransparentRadiusUnit,
+		devicePresetValue: borderRadiusPresetValue,
+	});
+	const borderTransparentBorderBinding = deriveStateBinding({
+		shared: tokenBinding.borderStyle,
+		kind: 'border',
+		value: borderTransparentBorderForDevice.value,
+		previewDevice,
+	});
+	const resetBorderTransparentRadius = () => resetAttr('borderTransparentRadius', setAttributes, 'dimension');
+	const resetBorderTransparentBorder = () => resetAttr('borderTransparentStyle', setAttributes, 'border');
+
+	const borderTransparentHoverBorderForDevice = measureAttrsForDevice(
+		attributes,
+		'borderTransparentHoverStyle',
+		{ tablet: 'tabletBorderTransparentHoverStyle', mobile: 'mobileBorderTransparentHoverStyle' },
+		previewDevice
+	);
+	const borderTransparentHoverRadiusIsRelative =
+		borderTransparentHoverRadiusUnit === 'em' || borderTransparentHoverRadiusUnit === 'rem';
+	const borderTransparentHoverRadiusBinding = deriveStateBinding({
+		shared: tokenBinding.borderRadius,
+		kind: 'dimension',
+		value: borderTransparentHoverRadiusForDevice.value,
+		unit: borderTransparentHoverRadiusUnit,
+		devicePresetValue: borderRadiusPresetValue,
+	});
+	const borderTransparentHoverBorderBinding = deriveStateBinding({
+		shared: tokenBinding.borderStyle,
+		kind: 'border',
+		value: borderTransparentHoverBorderForDevice.value,
+		previewDevice,
+	});
+	const resetBorderTransparentHoverRadius = () =>
+		resetAttr('borderTransparentHoverRadius', setAttributes, 'dimension');
+	const resetBorderTransparentHoverBorder = () => resetAttr('borderTransparentHoverStyle', setAttributes, 'border');
+
+	const borderStickyBorderForDevice = measureAttrsForDevice(
+		attributes,
+		'borderStickyStyle',
+		{ tablet: 'tabletBorderStickyStyle', mobile: 'mobileBorderStickyStyle' },
+		previewDevice
+	);
+	const borderStickyRadiusIsRelative = borderStickyRadiusUnit === 'em' || borderStickyRadiusUnit === 'rem';
+	const borderStickyRadiusBinding = deriveStateBinding({
+		shared: tokenBinding.borderRadius,
+		kind: 'dimension',
+		value: borderStickyRadiusForDevice.value,
+		unit: borderStickyRadiusUnit,
+		devicePresetValue: borderRadiusPresetValue,
+	});
+	const borderStickyBorderBinding = deriveStateBinding({
+		shared: tokenBinding.borderStyle,
+		kind: 'border',
+		value: borderStickyBorderForDevice.value,
+		previewDevice,
+	});
+	const resetBorderStickyRadius = () => resetAttr('borderStickyRadius', setAttributes, 'dimension');
+	const resetBorderStickyBorder = () => resetAttr('borderStickyStyle', setAttributes, 'border');
+
+	const borderStickyHoverBorderForDevice = measureAttrsForDevice(
+		attributes,
+		'borderStickyHoverStyle',
+		{ tablet: 'tabletBorderStickyHoverStyle', mobile: 'mobileBorderStickyHoverStyle' },
+		previewDevice
+	);
+	const borderStickyHoverRadiusIsRelative =
+		borderStickyHoverRadiusUnit === 'em' || borderStickyHoverRadiusUnit === 'rem';
+	const borderStickyHoverRadiusBinding = deriveStateBinding({
+		shared: tokenBinding.borderRadius,
+		kind: 'dimension',
+		value: borderStickyHoverRadiusForDevice.value,
+		unit: borderStickyHoverRadiusUnit,
+		devicePresetValue: borderRadiusPresetValue,
+	});
+	const borderStickyHoverBorderBinding = deriveStateBinding({
+		shared: tokenBinding.borderStyle,
+		kind: 'border',
+		value: borderStickyHoverBorderForDevice.value,
+		previewDevice,
+	});
+	const resetBorderStickyHoverRadius = () => resetAttr('borderStickyHoverRadius', setAttributes, 'dimension');
+	const resetBorderStickyHoverBorder = () => resetAttr('borderStickyHoverStyle', setAttributes, 'border');
 
 	useEffect(() => {
 		if (!isSelected) {
@@ -1256,6 +1385,8 @@ export default function KadenceButtonEdit(props) {
 															widthTokens={borderWidthPickableTokens}
 															defaultValue={borderWidthPresetValue}
 															renderColor={renderBorderColor}
+															state={borderHoverBorderBinding}
+															onReset={resetBorderHoverBorder}
 														/>
 														<EditorBoxControl
 															label={__('Border Radius', 'kadence-blocks')}
@@ -1272,6 +1403,8 @@ export default function KadenceButtonEdit(props) {
 															inherited={anyCornerInherited(
 																inheritedBorderHoverRadius.inherited
 															)}
+															state={borderHoverRadiusBinding}
+															onReset={resetBorderHoverRadius}
 															isLinked={borderHoverRadiusIsLinked}
 															onToggleLink={toggleBorderHoverRadiusLink}
 															unit={borderHoverRadiusUnit}
@@ -1279,18 +1412,8 @@ export default function KadenceButtonEdit(props) {
 															onUnit={(value) =>
 																setAttributes({ borderHoverRadiusUnit: value })
 															}
-															max={
-																borderHoverRadiusUnit === 'em' ||
-																borderHoverRadiusUnit === 'rem'
-																	? 24
-																	: 500
-															}
-															step={
-																borderHoverRadiusUnit === 'em' ||
-																borderHoverRadiusUnit === 'rem'
-																	? 0.1
-																	: 1
-															}
+															max={borderHoverRadiusIsRelative ? 24 : 500}
+															step={borderHoverRadiusIsRelative ? 0.1 : 1}
 															min={0}
 														/>
 														<EditorShadowControl
@@ -1527,6 +1650,8 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderWidthPickableTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
+																state={borderTransparentHoverBorderBinding}
+																onReset={resetBorderTransparentHoverBorder}
 															/>
 															<EditorBoxControl
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1546,6 +1671,8 @@ export default function KadenceButtonEdit(props) {
 																inherited={anyCornerInherited(
 																	inheritedBorderTransparentHoverRadius.inherited
 																)}
+																state={borderTransparentHoverRadiusBinding}
+																onReset={resetBorderTransparentHoverRadius}
 																isLinked={borderTransparentHoverRadiusIsLinked}
 																onToggleLink={toggleBorderTransparentHoverRadiusLink}
 																unit={borderTransparentHoverRadiusUnit}
@@ -1555,18 +1682,8 @@ export default function KadenceButtonEdit(props) {
 																		borderTransparentHoverRadiusUnit: value,
 																	})
 																}
-																max={
-																	borderTransparentHoverRadiusUnit === 'em' ||
-																	borderTransparentHoverRadiusUnit === 'rem'
-																		? 24
-																		: 500
-																}
-																step={
-																	borderTransparentHoverRadiusUnit === 'em' ||
-																	borderTransparentHoverRadiusUnit === 'rem'
-																		? 0.1
-																		: 1
-																}
+																max={borderTransparentHoverRadiusIsRelative ? 24 : 500}
+																step={borderTransparentHoverRadiusIsRelative ? 0.1 : 1}
 																min={0}
 															/>
 															<EditorShadowControl
@@ -1658,6 +1775,8 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderWidthPickableTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
+																state={borderTransparentBorderBinding}
+																onReset={resetBorderTransparentBorder}
 															/>
 															<EditorBoxControl
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1674,6 +1793,8 @@ export default function KadenceButtonEdit(props) {
 																inherited={anyCornerInherited(
 																	inheritedBorderTransparentRadius.inherited
 																)}
+																state={borderTransparentRadiusBinding}
+																onReset={resetBorderTransparentRadius}
 																isLinked={borderTransparentRadiusIsLinked}
 																onToggleLink={toggleBorderTransparentRadiusLink}
 																unit={borderTransparentRadiusUnit}
@@ -1683,18 +1804,8 @@ export default function KadenceButtonEdit(props) {
 																		borderTransparentRadiusUnit: value,
 																	})
 																}
-																max={
-																	borderTransparentRadiusUnit === 'em' ||
-																	borderTransparentRadiusUnit === 'rem'
-																		? 24
-																		: 500
-																}
-																step={
-																	borderTransparentRadiusUnit === 'em' ||
-																	borderTransparentRadiusUnit === 'rem'
-																		? 0.1
-																		: 1
-																}
+																max={borderTransparentRadiusIsRelative ? 24 : 500}
+																step={borderTransparentRadiusIsRelative ? 0.1 : 1}
 																min={0}
 															/>
 															<EditorShadowControl
@@ -1798,6 +1909,8 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderWidthPickableTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
+																state={borderStickyHoverBorderBinding}
+																onReset={resetBorderStickyHoverBorder}
 															/>
 															<EditorBoxControl
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1814,6 +1927,8 @@ export default function KadenceButtonEdit(props) {
 																inherited={anyCornerInherited(
 																	inheritedBorderStickyHoverRadius.inherited
 																)}
+																state={borderStickyHoverRadiusBinding}
+																onReset={resetBorderStickyHoverRadius}
 																isLinked={borderStickyHoverRadiusIsLinked}
 																onToggleLink={toggleBorderStickyHoverRadiusLink}
 																unit={borderStickyHoverRadiusUnit}
@@ -1823,18 +1938,8 @@ export default function KadenceButtonEdit(props) {
 																		borderStickyHoverRadiusUnit: value,
 																	})
 																}
-																max={
-																	borderStickyHoverRadiusUnit === 'em' ||
-																	borderStickyHoverRadiusUnit === 'rem'
-																		? 24
-																		: 500
-																}
-																step={
-																	borderStickyHoverRadiusUnit === 'em' ||
-																	borderStickyHoverRadiusUnit === 'rem'
-																		? 0.1
-																		: 1
-																}
+																max={borderStickyHoverRadiusIsRelative ? 24 : 500}
+																step={borderStickyHoverRadiusIsRelative ? 0.1 : 1}
 																min={0}
 															/>
 															<EditorShadowControl
@@ -1920,6 +2025,8 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderWidthPickableTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
+																state={borderStickyBorderBinding}
+																onReset={resetBorderStickyBorder}
 															/>
 															<EditorBoxControl
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1936,6 +2043,8 @@ export default function KadenceButtonEdit(props) {
 																inherited={anyCornerInherited(
 																	inheritedBorderStickyRadius.inherited
 																)}
+																state={borderStickyRadiusBinding}
+																onReset={resetBorderStickyRadius}
 																isLinked={borderStickyRadiusIsLinked}
 																onToggleLink={toggleBorderStickyRadiusLink}
 																unit={borderStickyRadiusUnit}
@@ -1945,18 +2054,8 @@ export default function KadenceButtonEdit(props) {
 																		borderStickyRadiusUnit: value,
 																	})
 																}
-																max={
-																	borderStickyRadiusUnit === 'em' ||
-																	borderStickyRadiusUnit === 'rem'
-																		? 24
-																		: 500
-																}
-																step={
-																	borderStickyRadiusUnit === 'em' ||
-																	borderStickyRadiusUnit === 'rem'
-																		? 0.1
-																		: 1
-																}
+																max={borderStickyRadiusIsRelative ? 24 : 500}
+																step={borderStickyRadiusIsRelative ? 0.1 : 1}
 																min={0}
 															/>
 															<EditorShadowControl
@@ -2337,34 +2436,27 @@ export default function KadenceButtonEdit(props) {
 												max={paddingUnit === 'em' || paddingUnit === 'rem' ? 25 : 999}
 												step={paddingUnit === 'em' || paddingUnit === 'rem' ? 0.1 : 1}
 											/>
-											<div
-												onMouseOver={marginMouseOver.onMouseOver}
-												onMouseOut={marginMouseOver.onMouseOut}
-												onFocus={marginMouseOver.onMouseOver}
-												onBlur={marginMouseOver.onMouseOut}
-											>
-												<EditorBoxControl
-													label={__('Margin', 'kadence-blocks')}
-													value={marginForDevice.value}
-													onChange={(next) => setAttributes({ [marginForDevice.attr]: next })}
-													previewDevice={previewDevice}
-													onDeviceChange={setPreviewDevice}
-													tokens={marginPickableTokens}
-													defaultValue={inheritedMargin.values}
-													inherited={anyCornerInherited(inheritedMargin.inherited)}
-													state={tokenBinding.margin}
-													onReset={() => resetToken('margin')}
-													isLinked={marginIsLinked}
-													onToggleLink={toggleMarginLink}
-													role="sides"
-													unit={marginUnit}
-													units={['px', 'em', 'rem']}
-													onUnit={(value) => setAttributes({ marginUnit: value })}
-													min={marginUnit === 'em' || marginUnit === 'rem' ? -25 : -999}
-													max={marginUnit === 'em' || marginUnit === 'rem' ? 25 : 999}
-													step={marginUnit === 'em' || marginUnit === 'rem' ? 0.1 : 1}
-												/>
-											</div>
+											<EditorBoxControl
+												label={__('Margin', 'kadence-blocks')}
+												value={marginForDevice.value}
+												onChange={(next) => setAttributes({ [marginForDevice.attr]: next })}
+												previewDevice={previewDevice}
+												onDeviceChange={setPreviewDevice}
+												tokens={marginPickableTokens}
+												defaultValue={inheritedMargin.values}
+												inherited={anyCornerInherited(inheritedMargin.inherited)}
+												state={tokenBinding.margin}
+												onReset={() => resetToken('margin')}
+												isLinked={marginIsLinked}
+												onToggleLink={toggleMarginLink}
+												role="sides"
+												unit={marginUnit}
+												units={['px', 'em', 'rem']}
+												onUnit={(value) => setAttributes({ marginUnit: value })}
+												min={marginUnit === 'em' || marginUnit === 'rem' ? -25 : -999}
+												max={marginUnit === 'em' || marginUnit === 'rem' ? 25 : 999}
+												step={marginUnit === 'em' || marginUnit === 'rem' ? 0.1 : 1}
+											/>
 											<TextControl
 												label={__('Add Aria Label', 'kadence-blocks')}
 												value={label ? label : ''}
@@ -2493,7 +2585,6 @@ export default function KadenceButtonEdit(props) {
 						)}
 						<SpacingVisualizer
 							type="inside"
-							forceShow={paddingMouseOver.isMouseOver}
 							spacing={[
 								getSpacingOptionOutput(previewPaddingTop, previewPaddingUnit),
 								getSpacingOptionOutput(previewPaddingRight, previewPaddingUnit),
@@ -2505,7 +2596,6 @@ export default function KadenceButtonEdit(props) {
 				</Tooltip>
 				<SpacingVisualizer
 					type="inside"
-					forceShow={marginMouseOver.isMouseOver}
 					spacing={[
 						getSpacingOptionOutput(previewMarginTop, previewMarginUnit),
 						getSpacingOptionOutput(previewMarginRight, previewMarginUnit),

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -409,6 +409,27 @@ export default function KadenceButtonEdit(props) {
 		paddingPresetValue
 	);
 
+	// Margin keeps the same one-mode-per-device shape as Padding above.
+	const marginForDevice = measureAttrsForDevice(
+		attributes,
+		'margin',
+		{ tablet: 'tabletMargin', mobile: 'mobileMargin' },
+		previewDevice
+	);
+
+	const marginPresetValue = presetValueForDevice(
+		tokenBinding.margin?.presetValue,
+		tokenBinding.margin?.responsive,
+		previewDevice
+	);
+
+	// What an unset Margin side falls back to on the active device — same cascade as Padding above.
+	const inheritedMargin = inheritedMeasureSlots(
+		previewDevice,
+		{ desktop: margin, tablet: tabletMargin },
+		marginPresetValue
+	);
+
 	useEffect(() => {
 		setAttributes({ inQueryBlock: getInQueryBlock(context, inQueryBlock) });
 
@@ -437,6 +458,14 @@ export default function KadenceButtonEdit(props) {
 	const borderWidthPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width');
 	const shadowPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow');
 	const paddingPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-padding');
+	// Margin's legacy control also offers "Auto" (`allowAuto`), which Padding's never did.
+	// `ss-auto` is already a fully working spacing slot at the PHP/CSS layer (Spacing_Target's SLOTS,
+	// class-kadence-blocks-css.php's $spacing_sizes) — the editor's pickable list is the only gap, so
+	// it is appended here as a fixed entry rather than added to the token registry itself.
+	const marginPickableTokens = [
+		...pickableTokensForKey('kadence/singlebtn', 'button-margin'),
+		{ id: 'ss-auto', label: __('Auto', 'kadence-blocks'), value: 'ss-auto', alias: 'ss-auto' },
+	];
 
 	// The border-radius/padding linked/individual mode is derived from the stored slots (all equal reads
 	// as linked), so no new attribute is needed and old buttons open in the right mode. The hook's own
@@ -469,6 +498,18 @@ export default function KadenceButtonEdit(props) {
 		tokens: paddingPickableTokens,
 		setAttributes,
 		resetOn: attributes.kbPreset,
+	});
+
+	// Margin's linked/individual mode, mirroring Padding's own hook call above — same shape, run over
+	// `marginForDevice`/`marginPresetValue`/`inheritedMargin`/`marginPickableTokens` instead. Margin
+	// also has no `resetOn`, matching Padding.
+	const { isLinked: marginIsLinked, toggleLink: toggleMarginLink } = useLinkedMeasureState({
+		forDevice: marginForDevice,
+		inherited: inheritedMargin,
+		previewDevice,
+		presetValue: marginPresetValue,
+		tokens: marginPickableTokens,
+		setAttributes,
 	});
 
 	// Hover/Transparent/Transparent Hover/Sticky/Sticky Hover each store their own 4 corners, so each
@@ -2285,23 +2326,26 @@ export default function KadenceButtonEdit(props) {
 												max={paddingUnit === 'em' || paddingUnit === 'rem' ? 25 : 999}
 												step={paddingUnit === 'em' || paddingUnit === 'rem' ? 0.1 : 1}
 											/>
-											<ResponsiveMeasureRangeControl
+											<EditorBoxControl
 												label={__('Margin', 'kadence-blocks')}
-												value={margin}
-												onChange={(value) => setAttributes({ margin: value })}
-												tabletValue={tabletMargin}
-												onChangeTablet={(value) => setAttributes({ tabletMargin: value })}
-												mobileValue={mobileMargin}
-												onChangeMobile={(value) => setAttributes({ mobileMargin: value })}
-												min={marginUnit === 'em' || marginUnit === 'rem' ? -25 : -999}
-												max={marginUnit === 'em' || marginUnit === 'rem' ? 25 : 999}
-												step={marginUnit === 'em' || marginUnit === 'rem' ? 0.1 : 1}
+												value={marginForDevice.value}
+												onChange={(next) => setAttributes({ [marginForDevice.attr]: next })}
+												previewDevice={previewDevice}
+												onDeviceChange={setPreviewDevice}
+												tokens={marginPickableTokens}
+												defaultValue={inheritedMargin.values}
+												inherited={anyCornerInherited(inheritedMargin.inherited)}
+												state={tokenBinding.margin}
+												onReset={() => resetToken('margin')}
+												isLinked={marginIsLinked}
+												onToggleLink={toggleMarginLink}
+												role="sides"
 												unit={marginUnit}
 												units={['px', 'em', 'rem']}
 												onUnit={(value) => setAttributes({ marginUnit: value })}
-												onMouseOver={marginMouseOver.onMouseOver}
-												onMouseOut={marginMouseOver.onMouseOut}
-												allowAuto={true}
+												min={marginUnit === 'em' || marginUnit === 'rem' ? -25 : -999}
+												max={marginUnit === 'em' || marginUnit === 'rem' ? 25 : 999}
+												step={marginUnit === 'em' || marginUnit === 'rem' ? 0.1 : 1}
 											/>
 											<TextControl
 												label={__('Add Aria Label', 'kadence-blocks')}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -1134,8 +1134,6 @@ export default function KadenceButtonEdit(props) {
 															widthTokens={borderHoverWidthTokens}
 															defaultValue={borderWidthPresetValue}
 															renderColor={renderBorderColor}
-															state={tokenBinding.borderStyle}
-															onReset={() => resetToken('borderStyle')}
 														/>
 														<ResponsiveMeasurementControls
 															label={__('Border Radius', 'kadence-blocks')}
@@ -1406,8 +1404,6 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderTransparentHoverWidthTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
-																state={tokenBinding.borderStyle}
-																onReset={() => resetToken('borderStyle')}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1541,8 +1537,6 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderTransparentWidthTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
-																state={tokenBinding.borderStyle}
-																onReset={() => resetToken('borderStyle')}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1686,8 +1680,6 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderStickyHoverWidthTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
-																state={tokenBinding.borderStyle}
-																onReset={() => resetToken('borderStyle')}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}
@@ -1815,8 +1807,6 @@ export default function KadenceButtonEdit(props) {
 																widthTokens={borderStickyWidthTokens}
 																defaultValue={borderWidthPresetValue}
 																renderColor={renderBorderColor}
-																state={tokenBinding.borderStyle}
-																onReset={() => resetToken('borderStyle')}
 															/>
 															<ResponsiveMeasurementControls
 																label={__('Border Radius', 'kadence-blocks')}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -1471,8 +1471,6 @@ export default function KadenceButtonEdit(props) {
 															inherited={anyCornerInherited(
 																inheritedBorderHoverRadius.inherited
 															)}
-															state={tokenBinding.borderRadius}
-															onReset={() => resetToken('borderRadius')}
 															isLinked={borderHoverRadiusIsLinked}
 															onToggleLink={toggleBorderHoverRadiusLink}
 															unit={borderHoverRadiusUnit}
@@ -1747,8 +1745,6 @@ export default function KadenceButtonEdit(props) {
 																inherited={anyCornerInherited(
 																	inheritedBorderTransparentHoverRadius.inherited
 																)}
-																state={tokenBinding.borderRadius}
-																onReset={() => resetToken('borderRadius')}
 																isLinked={borderTransparentHoverRadiusIsLinked}
 																onToggleLink={toggleBorderTransparentHoverRadiusLink}
 																unit={borderTransparentHoverRadiusUnit}
@@ -1877,8 +1873,6 @@ export default function KadenceButtonEdit(props) {
 																inherited={anyCornerInherited(
 																	inheritedBorderTransparentRadius.inherited
 																)}
-																state={tokenBinding.borderRadius}
-																onReset={() => resetToken('borderRadius')}
 																isLinked={borderTransparentRadiusIsLinked}
 																onToggleLink={toggleBorderTransparentRadiusLink}
 																unit={borderTransparentRadiusUnit}
@@ -2019,8 +2013,6 @@ export default function KadenceButtonEdit(props) {
 																inherited={anyCornerInherited(
 																	inheritedBorderStickyHoverRadius.inherited
 																)}
-																state={tokenBinding.borderRadius}
-																onReset={() => resetToken('borderRadius')}
 																isLinked={borderStickyHoverRadiusIsLinked}
 																onToggleLink={toggleBorderStickyHoverRadiusLink}
 																unit={borderStickyHoverRadiusUnit}
@@ -2143,8 +2135,6 @@ export default function KadenceButtonEdit(props) {
 																inherited={anyCornerInherited(
 																	inheritedBorderStickyRadius.inherited
 																)}
-																state={tokenBinding.borderRadius}
-																onReset={() => resetToken('borderRadius')}
 																isLinked={borderStickyRadiusIsLinked}
 																onToggleLink={toggleBorderStickyRadiusLink}
 																unit={borderStickyRadiusUnit}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -350,6 +350,14 @@ export default function KadenceButtonEdit(props) {
 		{ tablet: 'tabletBorderRadius', mobile: 'mobileBorderRadius' },
 		previewDevice
 	);
+	// Padding keeps the same one-mode-per-device shape as Border Radius above — one linked/individual
+	// mode, but a different stored attribute per breakpoint.
+	const paddingForDevice = measureAttrsForDevice(
+		attributes,
+		'padding',
+		{ tablet: 'tabletPadding', mobile: 'mobilePadding' },
+		previewDevice
+	);
 	const marginMouseOver = mouseOverVisualizer();
 	const paddingMouseOver = mouseOverVisualizer();
 
@@ -387,6 +395,20 @@ export default function KadenceButtonEdit(props) {
 		borderRadiusPresetValue
 	);
 
+	const paddingPresetValue = presetValueForDevice(
+		tokenBinding.padding?.presetValue,
+		tokenBinding.padding?.responsive,
+		previewDevice
+	);
+
+	// What an unset Padding side falls back to on the active device — same cascade as Border Radius
+	// above, run over sides rather than corners.
+	const inheritedPadding = inheritedMeasureSlots(
+		previewDevice,
+		{ desktop: padding, tablet: tabletPadding },
+		paddingPresetValue
+	);
+
 	useEffect(() => {
 		setAttributes({ inQueryBlock: getInQueryBlock(context, inQueryBlock) });
 
@@ -406,6 +428,9 @@ export default function KadenceButtonEdit(props) {
 	// Keyed by device: the responsive control keeps ONE mode but writes three attributes, so a choice
 	// made on Tablet must not flip Desktop's corners (and vice versa).
 	const [borderRadiusModeOverride, setBorderRadiusModeOverride] = useState({});
+	// Padding's linked/individual mode is tracked the same way as Border Radius's, above — its own
+	// override state because the two controls' sides are independent stored values.
+	const [paddingModeOverride, setPaddingModeOverride] = useState({});
 
 	// Everything the new box control needs that the block already knows, gathered in one place rather
 	// than inlined into the JSX.
@@ -433,6 +458,7 @@ export default function KadenceButtonEdit(props) {
 	const shadowTransparentHoverTokens = shadowPickableTokens;
 	const shadowStickyTokens = shadowPickableTokens;
 	const shadowStickyHoverTokens = shadowPickableTokens;
+	const paddingPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-padding');
 
 	// The mode describes what THIS device stores, not what it inherits. A breakpoint that stores nothing
 	// has nothing that differs, so it reads as linked — deriving from the inherited corners instead would
@@ -507,6 +533,64 @@ export default function KadenceButtonEdit(props) {
 		// Unlinking equal corners leaves the values untouched, so remember the choice for this session
 		// AND this device; a differing corner would derive individual on its own.
 		setBorderRadiusModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
+	};
+
+	// Padding's linked/individual mode and its toggle, mirroring Border Radius's own block above with
+	// "corner" swapped for "side" — same shape, run over `paddingForDevice`/`paddingPresetValue`/
+	// `inheritedPadding` instead.
+	const paddingIsLinked =
+		'linked' ===
+		(paddingModeOverride[previewDevice] ?? deriveMeasureMode(paddingForDevice.value, paddingPresetValue));
+
+	const inheritedPaddingSides = inheritedPadding.values;
+	const inheritedPaddingSidesDiffer =
+		Array.isArray(inheritedPaddingSides) && inheritedPaddingSides.some((side) => side !== inheritedPaddingSides[0]);
+	const aliasForPaddingValue = (value) =>
+		paddingPickableTokens.find((token) => token.value === value)?.alias ?? value ?? '';
+	const inheritedFirstPaddingSide = Array.isArray(inheritedPaddingSides)
+		? aliasForPaddingValue(inheritedPaddingSides[0])
+		: '';
+
+	const togglePaddingLink = () => {
+		if (!paddingIsLinked) {
+			const sides = paddingForDevice.value ?? [];
+			const side = sides[0] ?? '';
+			const isEmpty = sides.every((value) => '' === value || undefined === value);
+
+			if (isEmpty) {
+				if (!inheritedPaddingSidesDiffer) {
+					setPaddingModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
+
+					return;
+				}
+
+				setAttributes({
+					[paddingForDevice.attr]: [
+						inheritedFirstPaddingSide,
+						inheritedFirstPaddingSide,
+						inheritedFirstPaddingSide,
+						inheritedFirstPaddingSide,
+					],
+				});
+				setPaddingModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
+
+				return;
+			}
+
+			// Every side matches the first, blank included, and only on the ACTIVE device.
+			setAttributes({ [paddingForDevice.attr]: [side, side, side, side] });
+			// Equal sides derive linked on their own — except blank ones under a per-side preset.
+			setPaddingModeOverride((current) => ({
+				...current,
+				[previewDevice]: '' === side ? 'linked' : undefined,
+			}));
+
+			return;
+		}
+
+		// Unlinking equal sides leaves the values untouched, so remember the choice for this session AND
+		// this device; a differing side would derive individual on its own.
+		setPaddingModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
 	};
 
 	// Hover/Transparent/Transparent Hover/Sticky/Sticky Hover each store their own 4 corners, so each
@@ -2515,22 +2599,26 @@ export default function KadenceButtonEdit(props) {
 								{showSettings('marginSettings', 'kadence/advancedbtn') && (
 									<>
 										<KadencePanelBody panelName={'kb-single-button-margin-settings'}>
-											<ResponsiveMeasureRangeControl
+											<EditorBoxControl
 												label={__('Padding', 'kadence-blocks')}
-												value={padding}
-												onChange={(value) => setAttributes({ padding: value })}
-												tabletValue={tabletPadding}
-												onChangeTablet={(value) => setAttributes({ tabletPadding: value })}
-												mobileValue={mobilePadding}
-												onChangeMobile={(value) => setAttributes({ mobilePadding: value })}
-												min={paddingUnit === 'em' || paddingUnit === 'rem' ? -25 : -999}
-												max={paddingUnit === 'em' || paddingUnit === 'rem' ? 25 : 999}
-												step={paddingUnit === 'em' || paddingUnit === 'rem' ? 0.1 : 1}
+												value={paddingForDevice.value}
+												onChange={(next) => setAttributes({ [paddingForDevice.attr]: next })}
+												previewDevice={previewDevice}
+												onDeviceChange={setPreviewDevice}
+												tokens={paddingPickableTokens}
+												defaultValue={inheritedPadding.values}
+												inherited={anyCornerInherited(inheritedPadding.inherited)}
+												state={tokenBinding.padding}
+												onReset={() => resetToken('padding')}
+												isLinked={paddingIsLinked}
+												onToggleLink={togglePaddingLink}
+												role="sides"
 												unit={paddingUnit}
 												units={['px', 'em', 'rem']}
 												onUnit={(value) => setAttributes({ paddingUnit: value })}
-												onMouseOver={paddingMouseOver.onMouseOver}
-												onMouseOut={paddingMouseOver.onMouseOut}
+												min={paddingUnit === 'em' || paddingUnit === 'rem' ? -25 : -999}
+												max={paddingUnit === 'em' || paddingUnit === 'rem' ? 25 : 999}
+												step={paddingUnit === 'em' || paddingUnit === 'rem' ? 0.1 : 1}
 											/>
 											<ResponsiveMeasureRangeControl
 												label={__('Margin', 'kadence-blocks')}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -101,7 +101,65 @@ import {
 	combineColorOpacity,
 	splitColorOpacity,
 } from '../../extension/design-tokens/components/EditorShadowControl';
-import { pickableTokensForControl, pickableTokensForKey } from '../../extension/token-picker';
+import { pickableTokensForControl, pickableTokensForKey, resolvedTokenValue } from '../../extension/token-picker';
+
+/**
+ * The button's per-side padding/margin semantic token ids, top/right/bottom/left order — mirrors the
+ * CSS `padding`/`margin` shorthand and `src/blocks/advancedbtn/style.scss`'s default rule. Read only
+ * for their resolved literal (`resolveBoxFallback` below); nothing here binds a preset to them — see
+ * `declarations.php`'s own comment on why they carry no baseline preset binding.
+ *
+ * @since TBD
+ */
+const BUTTON_PADDING_TOKEN_IDS = [
+	'semantic.spacing.button-padding-top',
+	'semantic.spacing.button-padding-right',
+	'semantic.spacing.button-padding-bottom',
+	'semantic.spacing.button-padding-left',
+];
+const BUTTON_MARGIN_TOKEN_IDS = [
+	'semantic.spacing.button-margin-top',
+	'semantic.spacing.button-margin-right',
+	'semantic.spacing.button-margin-bottom',
+	'semantic.spacing.button-margin-left',
+];
+
+/**
+ * The literal each padding token resolves to when the baseline is never overridden — also what
+ * `src/blocks/advancedbtn/style.scss`'s default rule falls back to when the token itself is absent
+ * from the feed. Mirrors the Style Library's own `BUTTON_PADDING_FALLBACK` (`button-preset.js`); kept
+ * as a separate constant rather than shared, since the two apps read a different pool and stay
+ * uncoupled (see `src/style-library/README.md`).
+ *
+ * @since TBD
+ */
+const BUTTON_PADDING_FALLBACK = ['0.4em', '1em', '0.4em', '1em'];
+
+/**
+ * The literal each margin token resolves to when the baseline is never overridden.
+ *
+ * @since TBD
+ */
+const BUTTON_MARGIN_FALLBACK = ['0', '0', '0', '0'];
+
+/**
+ * Resolve a per-side box default (padding/margin) from the resolved design-token pool, one value per
+ * CSS side, falling back to the button's own literal default for any side whose token is missing from
+ * the pool. Neither `button-padding` nor `button-margin` carries a preset binding (see
+ * `BUTTON_PADDING_TOKEN_IDS`'s own docblock), so `tokenBinding.padding.presetValue` is always empty —
+ * this is what an unset field actually falls back to, mirroring the CSS var chain
+ * `advancedbtn/style.scss` itself falls through when no preset targets `--kb-btn-padding`.
+ *
+ * @param {[string, string, string, string]} tokenIds The four semantic token ids, top/right/bottom/left order.
+ * @param {[string, string, string, string]} fallback The literal fallback for each side, same order.
+ *
+ * @since TBD
+ *
+ * @return {[string, string, string, string]} The resolved per-side default.
+ */
+function resolveBoxFallback(tokenIds, fallback) {
+	return tokenIds.map((tokenId, index) => resolvedTokenValue(tokenId) || fallback[index]);
+}
 
 /**
  * `EditorBorderControl`'s `renderColor` render-prop: reuses the block's existing `PopColorControl`
@@ -397,11 +455,12 @@ export default function KadenceButtonEdit(props) {
 		borderRadiusPresetValue
 	);
 
-	const paddingPresetValue = presetValueForDevice(
-		tokenBinding.padding?.presetValue,
-		tokenBinding.padding?.responsive,
-		previewDevice
-	);
+	// Neither preset carries a `button-padding` binding (see `BUTTON_PADDING_TOKEN_IDS`'s own
+	// docblock), so `tokenBinding.padding.presetValue` is always empty — `resolveBoxFallback` is what
+	// an unset field actually falls back to on every device, not just desktop.
+	const paddingPresetValue =
+		presetValueForDevice(tokenBinding.padding?.presetValue, tokenBinding.padding?.responsive, previewDevice) ??
+		resolveBoxFallback(BUTTON_PADDING_TOKEN_IDS, BUTTON_PADDING_FALLBACK);
 
 	// What an unset Padding side falls back to on the active device — same cascade as Border Radius
 	// above, run over sides rather than corners.
@@ -419,11 +478,10 @@ export default function KadenceButtonEdit(props) {
 		previewDevice
 	);
 
-	const marginPresetValue = presetValueForDevice(
-		tokenBinding.margin?.presetValue,
-		tokenBinding.margin?.responsive,
-		previewDevice
-	);
+	// Same reasoning as `paddingPresetValue` above — `button-margin` carries no preset binding either.
+	const marginPresetValue =
+		presetValueForDevice(tokenBinding.margin?.presetValue, tokenBinding.margin?.responsive, previewDevice) ??
+		resolveBoxFallback(BUTTON_MARGIN_TOKEN_IDS, BUTTON_MARGIN_FALLBACK);
 
 	// What an unset Margin side falls back to on the active device — same cascade as Padding above.
 	const inheritedMargin = inheritedMeasureSlots(

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -97,6 +97,7 @@ import { TokenControlRow } from '../../extension/token-indicators/components/Tok
 import { EditorBoxControl } from '../../extension/design-tokens/components/EditorBoxControl';
 import { EditorBorderControl } from '../../extension/design-tokens/components/EditorBorderControl';
 import {
+	BUTTON_SHADOW_NONE_TOKEN_ID,
 	EditorShadowControl,
 	combineColorOpacity,
 	splitColorOpacity,
@@ -141,6 +142,30 @@ const BUTTON_PADDING_FALLBACK = ['0.4em', '1em', '0.4em', '1em'];
  * @since TBD
  */
 const BUTTON_MARGIN_FALLBACK = ['0', '0', '0', '0'];
+
+/**
+ * The "None" entry for the Shadow field: the button's own `semantic.shadow.button` token (already an
+ * invisible, transparent zero-shadow — see the imported `BUTTON_SHADOW_NONE_TOKEN_ID`'s own docblock
+ * in `EditorShadowControl.js`), relabeled
+ * "None" and re-admitted into the pickable list. A real registered token, not a synthetic sentinel
+ * like Margin's `ss-auto`: Shadow's value can be a composite object, and a `fixed` entry's `alias`
+ * only ever matches by `===`, which a freshly-built composite object can never satisfy — reusing a
+ * real, already-resolvable token id sidesteps that entirely.
+ *
+ * @since TBD
+ *
+ * @return {{id: string, alias: string, label: string, value: string, type: string, role: string}} The entry.
+ */
+function shadowNoneEntry() {
+	return {
+		id: BUTTON_SHADOW_NONE_TOKEN_ID,
+		alias: `{${BUTTON_SHADOW_NONE_TOKEN_ID}}`,
+		label: __('None', 'kadence-blocks'),
+		value: resolvedTokenValue(BUTTON_SHADOW_NONE_TOKEN_ID),
+		type: 'shadow',
+		role: 'shadow',
+	};
+}
 
 /**
  * Resolve a per-side box default (padding/margin) from the resolved design-token pool, one value per
@@ -518,7 +543,7 @@ export default function KadenceButtonEdit(props) {
 	// hover/sticky/transparent variant below reuses the same resolved list rather than re-filtering the
 	// pool per state.
 	const borderWidthPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width');
-	const shadowPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow');
+	const shadowPickableTokens = [shadowNoneEntry(), ...pickableTokensForKey('kadence/singlebtn', 'button-shadow')];
 	const paddingPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-padding');
 	// Margin's legacy control also offers "Auto" (`allowAuto`), which Padding's never did.
 	// `ss-auto` is already a fully working spacing slot at the PHP/CSS layer (Spacing_Target's SLOTS,

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -543,7 +543,20 @@ export default function KadenceButtonEdit(props) {
 	// hover/sticky/transparent variant below reuses the same resolved list rather than re-filtering the
 	// pool per state.
 	const borderWidthPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width');
-	const shadowPickableTokens = [shadowNoneEntry(), ...pickableTokensForKey('kadence/singlebtn', 'button-shadow')];
+	// Filtering the real token back out before prepending the relabeled entry (matching the Style
+	// Library's own `BoxShadowField.js`) isn't a no-op today — shadow's primitive scale always has at
+	// least one step, so the "prefer primitives" narrowing already drops `semantic.shadow.button`
+	// before the bound-token pin step runs — but that's an accident of the current scale, not a
+	// structural guarantee. Filtering explicitly keeps this call site correct even if a site's shadow
+	// primitive scale were ever emptied out, which would otherwise let `button-shadow`'s own preset
+	// binding (`semantic.shadow.button`) get pinned back in under its real "Button Shadow" label,
+	// producing the same duplicate row this function exists to prevent.
+	const shadowPickableTokens = [
+		shadowNoneEntry(),
+		...pickableTokensForKey('kadence/singlebtn', 'button-shadow').filter(
+			(token) => token.id !== BUTTON_SHADOW_NONE_TOKEN_ID
+		),
+	];
 	const paddingPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-padding');
 	// Margin's legacy control also offers "Auto" (`allowAuto`), which Padding's never did.
 	// `ss-auto` is already a fully working spacing slot at the PHP/CSS layer (Spacing_Target's SLOTS,

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -458,8 +458,9 @@ export default function KadenceButtonEdit(props) {
 
 	// Padding's linked/individual mode, mirroring Border Radius's own hook call above with "corner"
 	// swapped for "side" — same shape, run over `paddingForDevice`/`paddingPresetValue`/
-	// `inheritedPadding`/`paddingPickableTokens` instead. Padding has no `resetOn`: unlike Border
-	// Radius's 6 states, its override has never been cleared on a preset change.
+	// `inheritedPadding`/`paddingPickableTokens` instead, `resetOn` included: an override records a
+	// choice about the PREVIOUS preset's sides, so it has to clear on a preset change here too, or an
+	// explicit "link" sticks and hides the new preset's own per-side padding.
 	const { isLinked: paddingIsLinked, toggleLink: togglePaddingLink } = useLinkedMeasureState({
 		forDevice: paddingForDevice,
 		inherited: inheritedPadding,
@@ -467,6 +468,7 @@ export default function KadenceButtonEdit(props) {
 		presetValue: paddingPresetValue,
 		tokens: paddingPickableTokens,
 		setAttributes,
+		resetOn: attributes.kbPreset,
 	});
 
 	// Hover/Transparent/Transparent Hover/Sticky/Sticky Hover each store their own 4 corners, so each

--- a/src/blocks/singlebtn/hooks/__tests__/use-linked-measure-state.test.js
+++ b/src/blocks/singlebtn/hooks/__tests__/use-linked-measure-state.test.js
@@ -1,0 +1,267 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement, StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { useLinkedMeasureState } from '../use-linked-measure-state';
+
+const TOKENS = [
+	{ value: '4px', alias: 'sm' },
+	{ value: '6px', alias: 'md' },
+	{ value: '8px', alias: 'lg' },
+];
+
+let container;
+let root;
+
+/**
+ * Render the hook and expose its latest return value, plus a way to re-render with new props on the
+ * SAME mounted instance — needed to exercise state that persists across renders (the mode override).
+ *
+ * @return {{box: {current: Object}, update: Function}} A ref-like box holding the hook's most recent
+ *  return value, and an `update(props)` function that re-renders the same instance with new props.
+ */
+function renderHook(initialProps) {
+	const box = {};
+
+	function Probe(props) {
+		box.current = useLinkedMeasureState(props);
+
+		return null;
+	}
+
+	function render(props) {
+		act(() => {
+			root.render(createElement(StrictMode, null, createElement(Probe, props)));
+		});
+	}
+
+	render(initialProps);
+
+	return { box, update: render };
+}
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	if (root) {
+		act(() => root.unmount());
+	}
+
+	container.remove();
+
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+describe('useLinkedMeasureState', () => {
+	/**
+	 * An unset device value reads as linked — every effective slot falls through to the same scalar
+	 * preset value, so there is nothing to show as different.
+	 *
+	 * @return {void}
+	 */
+	it('reads as linked when the device stores nothing and the preset is a single scalar', () => {
+		const { box } = renderHook({
+			forDevice: { attr: 'radius', value: ['', '', '', ''] },
+			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
+			previewDevice: 'Desktop',
+			presetValue: '4px',
+			tokens: TOKENS,
+			setAttributes: jest.fn(),
+		});
+
+		expect(box.current.isLinked).toBe(true);
+	});
+
+	/**
+	 * A uniform stored value reads as linked, regardless of the preset.
+	 *
+	 * @return {void}
+	 */
+	it('reads as linked when every stored slot matches', () => {
+		const { box } = renderHook({
+			forDevice: { attr: 'radius', value: ['4px', '4px', '4px', '4px'] },
+			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
+			previewDevice: 'Desktop',
+			presetValue: '8px',
+			tokens: TOKENS,
+			setAttributes: jest.fn(),
+		});
+
+		expect(box.current.isLinked).toBe(true);
+	});
+
+	/**
+	 * A stored slot that differs from the rest reads as individual.
+	 *
+	 * @return {void}
+	 */
+	it('reads as individual when a stored slot differs', () => {
+		const { box } = renderHook({
+			forDevice: { attr: 'radius', value: ['4px', '8px', '4px', '4px'] },
+			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
+			previewDevice: 'Desktop',
+			presetValue: '4px',
+			tokens: TOKENS,
+			setAttributes: jest.fn(),
+		});
+
+		expect(box.current.isLinked).toBe(false);
+	});
+
+	/**
+	 * Linking an empty device whose inherited slots are uniform remembers the override without writing
+	 * any attribute — writing would pin the device to another breakpoint's current value.
+	 *
+	 * @return {void}
+	 */
+	it('remembers a link toggle without writing an attribute when the inherited slots are uniform', () => {
+		const setAttributes = jest.fn();
+		const { box } = renderHook({
+			forDevice: { attr: 'tabletRadius', value: ['', '', '', ''] },
+			inherited: { values: ['6px', '6px', '6px', '6px'], inherited: [true, true, true, true] },
+			previewDevice: 'Tablet',
+			presetValue: ['4px', '8px', '4px', '4px'],
+			tokens: TOKENS,
+			setAttributes,
+		});
+
+		expect(box.current.isLinked).toBe(false);
+
+		act(() => box.current.toggleLink());
+
+		expect(setAttributes).not.toHaveBeenCalled();
+		expect(box.current.isLinked).toBe(true);
+	});
+
+	/**
+	 * Linking an empty device whose inherited slots differ collapses them by writing the first
+	 * inherited slot (resolved to its token alias) into every slot, so the control and the preset
+	 * agree.
+	 *
+	 * @return {void}
+	 */
+	it('collapses to the first inherited slot when linking an empty device with differing inherited slots', () => {
+		const setAttributes = jest.fn();
+		const { box } = renderHook({
+			forDevice: { attr: 'tabletRadius', value: ['', '', '', ''] },
+			inherited: { values: ['6px', '8px', '6px', '6px'], inherited: [true, true, true, true] },
+			previewDevice: 'Tablet',
+			presetValue: ['4px', '8px', '4px', '4px'],
+			tokens: TOKENS,
+			setAttributes,
+		});
+
+		expect(box.current.isLinked).toBe(false);
+
+		act(() => box.current.toggleLink());
+
+		expect(setAttributes).toHaveBeenCalledWith({ tabletRadius: ['md', 'md', 'md', 'md'] });
+	});
+
+	/**
+	 * Unlinking a linked device leaves the stored value untouched and remembers 'individual' for that
+	 * device, so a subsequent read reflects the toggle without any attribute write.
+	 *
+	 * @return {void}
+	 */
+	it('unlinking a linked device remembers individual mode without writing an attribute', () => {
+		const setAttributes = jest.fn();
+		const { box } = renderHook({
+			forDevice: { attr: 'radius', value: ['4px', '4px', '4px', '4px'] },
+			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
+			previewDevice: 'Desktop',
+			presetValue: '4px',
+			tokens: TOKENS,
+			setAttributes,
+		});
+
+		expect(box.current.isLinked).toBe(true);
+
+		act(() => box.current.toggleLink());
+
+		expect(setAttributes).not.toHaveBeenCalled();
+		expect(box.current.isLinked).toBe(false);
+	});
+
+	/**
+	 * The mode override is keyed per device, so unlinking Tablet must not affect Desktop's own linked
+	 * state on the same hook instance.
+	 *
+	 * @return {void}
+	 */
+	it('keys the remembered override by device, leaving other devices unaffected', () => {
+		const setAttributes = jest.fn();
+		const { box, update } = renderHook({
+			forDevice: { attr: 'tabletRadius', value: ['4px', '4px', '4px', '4px'] },
+			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
+			previewDevice: 'Tablet',
+			presetValue: '4px',
+			tokens: TOKENS,
+			setAttributes,
+		});
+
+		expect(box.current.isLinked).toBe(true);
+
+		act(() => box.current.toggleLink());
+
+		expect(box.current.isLinked).toBe(false);
+
+		update({
+			forDevice: { attr: 'radius', value: ['4px', '4px', '4px', '4px'] },
+			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
+			previewDevice: 'Desktop',
+			presetValue: '4px',
+			tokens: TOKENS,
+			setAttributes,
+		});
+
+		expect(box.current.isLinked).toBe(true);
+	});
+
+	/**
+	 * A change to `resetOn` (e.g. a new preset selected) clears any remembered override, so the mode
+	 * re-derives from the stored value and preset alone.
+	 *
+	 * @return {void}
+	 */
+	it('clears the remembered override when resetOn changes', () => {
+		const setAttributes = jest.fn();
+		const { box, update } = renderHook({
+			forDevice: { attr: 'radius', value: ['4px', '4px', '4px', '4px'] },
+			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
+			previewDevice: 'Desktop',
+			presetValue: '4px',
+			tokens: TOKENS,
+			setAttributes,
+			resetOn: 'preset-a',
+		});
+
+		act(() => box.current.toggleLink());
+
+		expect(box.current.isLinked).toBe(false);
+
+		update({
+			forDevice: { attr: 'radius', value: ['4px', '4px', '4px', '4px'] },
+			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
+			previewDevice: 'Desktop',
+			presetValue: '4px',
+			tokens: TOKENS,
+			setAttributes,
+			resetOn: 'preset-b',
+		});
+
+		expect(box.current.isLinked).toBe(true);
+	});
+});

--- a/src/blocks/singlebtn/hooks/use-linked-measure-state.js
+++ b/src/blocks/singlebtn/hooks/use-linked-measure-state.js
@@ -1,0 +1,138 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { deriveMeasureMode } from '../../../extension/token-indicators/normalize';
+
+/**
+ * The value a token in `tokens` resolves to, matched back to the alias that produced it.
+ *
+ * The preset surface carries resolved literals, not aliases (`blockPresetValues` flattens them so the
+ * overridden-check can be a plain compare), so the literal is matched back to the token that produced
+ * it. Writing the alias keeps a collapsed slot bound to the token (e.g. `None`) rather than landing as
+ * a custom literal that merely happens to look the same.
+ *
+ * @param {Array}  tokens The pickable tokens for this control, each `{ value, alias }`.
+ * @param {*}      value  The resolved literal to match back to its token.
+ *
+ * @since TBD
+ *
+ * @return {string} The matching token's alias, or the literal itself when no token matches.
+ */
+function aliasForValue(tokens, value) {
+	return tokens.find((token) => token.value === value)?.alias ?? value ?? '';
+}
+
+/**
+ * The linked/individual state — and its toggle — for a responsive 4-slot measure control (Border
+ * Radius's corners, Padding's sides, and any control sharing that shape).
+ *
+ * A responsive measure control keeps ONE linked/individual mode but writes a different attribute per
+ * breakpoint, so the mode must be read from — and "link" must collapse — whichever device is active.
+ * The mode describes what THIS device stores, not what it inherits: a breakpoint that stores nothing
+ * has nothing that differs, so it reads as linked — deriving from the inherited slots instead would
+ * split an all-empty Tablet into four identical blank fields, showing a difference the user cannot see.
+ * Where the value comes from is surfaced by the field's popover, not by the link toggle.
+ *
+ * @param {Object}   config               The hook's configuration.
+ * @param {Object}   config.forDevice     The active device's attribute and value, i.e.
+ *                                        `measureAttrsForDevice()`'s return shape (`{ attr, value }`).
+ * @param {Object}   config.inherited     What each slot inherits at the active device, i.e.
+ *                                        `inheritedMeasureSlots()`'s return shape (`{ values, inherited }`).
+ * @param {string}   config.previewDevice The active preview device ('Desktop' | 'Tablet' | 'Mobile').
+ * @param {*}        config.presetValue   The selected preset's value for the property.
+ * @param {Array}    config.tokens        The pickable tokens for this control, each `{ value, alias }`.
+ * @param {Function} config.setAttributes The block's `setAttributes`.
+ * @param {*}        [config.resetOn]     A value that, when it changes, clears any remembered override
+ *                                        for every device — e.g. the active preset, so a choice made
+ *                                        about one preset's slots doesn't stick onto the next. Omit to
+ *                                        never auto-clear.
+ *
+ * @since TBD
+ *
+ * @return {{isLinked: boolean, toggleLink: Function, inheritedValues: string[], inheritedFirstValue: string}}
+ *  Whether the active device reads as linked, the toggle handler, the slots the active device inherits,
+ *  and the alias/literal the first of those slots resolves to.
+ */
+export function useLinkedMeasureState({
+	forDevice,
+	inherited,
+	previewDevice,
+	presetValue,
+	tokens,
+	setAttributes,
+	resetOn,
+}) {
+	const [modeOverride, setModeOverride] = useState({});
+
+	// The override records a choice made about the PREVIOUS preset's slots, so selecting another preset
+	// drops it — otherwise an explicit "link" would stick and hide a new preset's per-slot measure.
+	useEffect(() => {
+		setModeOverride({});
+	}, [resetOn]);
+
+	const isLinked = 'linked' === (modeOverride[previewDevice] ?? deriveMeasureMode(forDevice.value, presetValue));
+
+	// What the slots inherit, and whether that inheritance is uniform. A per-slot inheritance is the
+	// case where linking is a real change rather than a no-op.
+	const inheritedValues = inherited.values;
+	const inheritedValuesDiffer =
+		Array.isArray(inheritedValues) && inheritedValues.some((value) => value !== inheritedValues[0]);
+	const inheritedFirstValue = Array.isArray(inheritedValues) ? aliasForValue(tokens, inheritedValues[0]) : '';
+
+	const toggleLink = () => {
+		if (!isLinked) {
+			const slots = forDevice.value ?? [];
+			const first = slots[0] ?? '';
+			const isEmpty = slots.every((value) => '' === value || undefined === value);
+
+			if (isEmpty) {
+				// Nothing stored on this device, so ordinarily there is nothing to collapse — the slots
+				// are empty because they inherit, and writing the inherited value would silently pin
+				// Tablet/Mobile to Desktop's current measure.
+				//
+				// Unless what is inherited differs slot to slot: then "link" genuinely changes the
+				// result, and storing nothing would leave the control showing one value while the block
+				// still renders four, with the indicator insisting it matches the preset. Collapsing to
+				// the first slot is the write that makes the three agree.
+				if (!inheritedValuesDiffer) {
+					setModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
+
+					return;
+				}
+
+				setAttributes({
+					[forDevice.attr]: [
+						inheritedFirstValue,
+						inheritedFirstValue,
+						inheritedFirstValue,
+						inheritedFirstValue,
+					],
+				});
+				setModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
+
+				return;
+			}
+
+			// Every slot matches the first, blank included, and only on the ACTIVE device.
+			setAttributes({ [forDevice.attr]: [first, first, first, first] });
+			// Equal slots derive linked on their own — except blank ones under a per-slot preset.
+			setModeOverride((current) => ({
+				...current,
+				[previewDevice]: '' === first ? 'linked' : undefined,
+			}));
+
+			return;
+		}
+
+		// Unlinking equal slots leaves the values untouched, so remember the choice for this session AND
+		// this device; a differing slot would derive individual on its own.
+		setModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
+	};
+
+	return { isLinked, toggleLink, inheritedValues, inheritedFirstValue };
+}

--- a/src/blocks/singlebtn/hooks/use-linked-measure-state.js
+++ b/src/blocks/singlebtn/hooks/use-linked-measure-state.js
@@ -54,9 +54,9 @@ function aliasForValue(tokens, value) {
  *
  * @since TBD
  *
- * @return {{isLinked: boolean, toggleLink: Function, inheritedValues: string[], inheritedFirstValue: string}}
- *  Whether the active device reads as linked, the toggle handler, the slots the active device inherits,
- *  and the alias/literal the first of those slots resolves to.
+ * @return {{isLinked: boolean, toggleLink: Function}} Whether the active device reads as linked, and
+ *  the toggle handler. `inheritedValues`/`inheritedFirstValue` are computed internally (the toggle
+ *  handler needs them) but not returned — no call site has needed them outside the hook so far.
  */
 export function useLinkedMeasureState({
 	forDevice,
@@ -134,5 +134,5 @@ export function useLinkedMeasureState({
 		setModeOverride((current) => ({ ...current, [previewDevice]: 'individual' }));
 	};
 
-	return { isLinked, toggleLink, inheritedValues, inheritedFirstValue };
+	return { isLinked, toggleLink };
 }

--- a/src/extension/design-tokens/components/EditorBorderControl.js
+++ b/src/extension/design-tokens/components/EditorBorderControl.js
@@ -49,6 +49,7 @@ import { BorderControl } from '../../../token-controls/controls/BorderControl';
 import { readSlot } from '../../../token-controls/helpers/value-shapes';
 import { isTokenAlias } from '../../../token-controls/helpers/token-summary';
 import { TokenControlRow } from '../../token-indicators/components/TokenControlRow';
+import { TokenIndicator } from '../../token-indicators/components/TokenIndicator';
 
 const SIDES = ['top', 'right', 'bottom', 'left'];
 
@@ -220,26 +221,27 @@ function toNativeBorder(value, unit = 'px') {
 /**
  * Render the editor-canvas border control.
  *
- * @param {Object}       props                The component props.
- * @param {?Array}       props.value          Desktop border attribute value.
- * @param {?Array}       props.tabletValue    Tablet border attribute value.
- * @param {?Array}       props.mobileValue    Mobile border attribute value.
- * @param {Function}     props.onChange       Desktop attribute setter.
- * @param {Function}     props.onChangeTablet Tablet attribute setter.
- * @param {Function}     props.onChangeMobile Mobile attribute setter.
- * @param {string}       props.previewDevice  The editor's active device (`Desktop`/`Tablet`/`Mobile`).
- * @param {Function}     props.onDeviceChange Called with the next editor device name.
- * @param {string}       props.label          The control's label.
- * @param {Array}        [props.widthTokens]  Pickable border-width tokens.
- * @param {*}            [props.defaultValue] What the width slot falls back to when unset — the
- *                                            active preset's resolved border width, so a cleared
- *                                            width field shows a muted "Default 2px" instead of
- *                                            rendering empty (which collapses the field to zero
- *                                            height, per its own `TokenSelector`'s summary/fallback
- *                                            logic). One scalar for every side: presets set a single
- *                                            border width, never a per-side default.
- * @param {?Function}    [props.renderColor]  The block's existing color field for `value.color`.
- * @param {?JSX.Element} [props.indicator]    The editor's `TokenIndicator`, passed straight through.
+ * @param {Object}    props                The component props.
+ * @param {?Array}    props.value          Desktop border attribute value.
+ * @param {?Array}    props.tabletValue    Tablet border attribute value.
+ * @param {?Array}    props.mobileValue    Mobile border attribute value.
+ * @param {Function}  props.onChange       Desktop attribute setter.
+ * @param {Function}  props.onChangeTablet Tablet attribute setter.
+ * @param {Function}  props.onChangeMobile Mobile attribute setter.
+ * @param {string}    props.previewDevice  The editor's active device (`Desktop`/`Tablet`/`Mobile`).
+ * @param {Function}  props.onDeviceChange Called with the next editor device name.
+ * @param {string}    props.label          The control's label.
+ * @param {Array}     [props.widthTokens]  Pickable border-width tokens.
+ * @param {*}         [props.defaultValue] What the width slot falls back to when unset — the
+ *                                         active preset's resolved border width, so a cleared
+ *                                         width field shows a muted "Default 2px" instead of
+ *                                         rendering empty (which collapses the field to zero
+ *                                         height, per its own `TokenSelector`'s summary/fallback
+ *                                         logic). One scalar for every side: presets set a single
+ *                                         border width, never a per-side default.
+ * @param {?Function} [props.renderColor]  The block's existing color field for `value.color`.
+ * @param {?Object}   [props.state]        The block's own binding state (`{ bound, overridden }`).
+ * @param {?Function} [props.onReset]      Reset handler for the indicator.
  *
  * @since TBD
  *
@@ -258,7 +260,8 @@ export function EditorBorderControl({
 	widthTokens = [],
 	defaultValue,
 	renderColor,
-	indicator = null,
+	state = null,
+	onReset = null,
 }) {
 	const breakpoint = BREAKPOINT_FOR_DEVICE[previewDevice] ?? 'desktop';
 	// Named once and passed to both `BreakpointProvider` and the switcher below, so the two staying
@@ -319,7 +322,9 @@ export function EditorBorderControl({
 					onChange={(next) => activeSetter(toNativeBorder(next, activeUnit))}
 					widthTokens={widthTokens}
 					defaultValue={defaultValue}
-					indicator={indicator}
+					// The editor's own mark, not this library's: it is the same indicator the block's other
+					// controls show, and two marks meaning the same thing should not look different.
+					indicator={<TokenIndicator state={state} onReset={onReset} />}
 					breakpoints={Object.values(BREAKPOINT_FOR_DEVICE)}
 					breakpoint={breakpoint}
 					// The switcher lives in `ControlShell`, driven by this prop directly — it does not read

--- a/src/extension/design-tokens/components/EditorBorderControl.js
+++ b/src/extension/design-tokens/components/EditorBorderControl.js
@@ -24,6 +24,10 @@
  * - **the unit lives inside the native value itself** (`source.unit`), not a sibling attribute the
  *   way `BoxControl`'s radius keeps `borderRadiusUnit` — so, unlike `EditorBoxControl`, this
  *   component takes no separate `unit`/`units`/`onUnit` props at all.
+ * - **wraps itself in `TokenControlRow`** (no `heading`, purely for its `.kb-token-control-row`
+ *   spacing) — this component only ever renders inside `singlebtn/edit.js`'s sidebar, so it owns that
+ *   wrapper rather than asking every call site to remember it, matching
+ *   `EditorBoxControl`/`EditorShadowControl`.
  *
  * Color editing itself is untouched — this component neither builds nor redesigns a color field, it
  * only wires the caller's EXISTING one back in via `renderColor` (matching `BorderControl`'s own
@@ -44,6 +48,7 @@ import { BreakpointProvider } from '../../../token-controls';
 import { BorderControl } from '../../../token-controls/controls/BorderControl';
 import { readSlot } from '../../../token-controls/helpers/value-shapes';
 import { isTokenAlias } from '../../../token-controls/helpers/token-summary';
+import { TokenControlRow } from '../../token-indicators/components/TokenControlRow';
 
 const SIDES = ['top', 'right', 'bottom', 'left'];
 
@@ -306,24 +311,26 @@ export function EditorBorderControl({
 	};
 
 	return (
-		<BreakpointProvider value={breakpoint} onChange={changeBreakpoint}>
-			<BorderControl
-				label={label}
-				value={fromNativeBorder(activeNative)}
-				onChange={(next) => activeSetter(toNativeBorder(next, activeUnit))}
-				widthTokens={widthTokens}
-				defaultValue={defaultValue}
-				indicator={indicator}
-				breakpoints={Object.values(BREAKPOINT_FOR_DEVICE)}
-				breakpoint={breakpoint}
-				// The switcher lives in `ControlShell`, driven by this prop directly — it does not read
-				// the `BreakpointProvider` context above, so both must map back to a device the same way.
-				onBreakpointChange={changeBreakpoint}
-				renderColor={renderColor}
-				isLinked={linked}
-				onToggleLink={toggleLink}
-				stacked
-			/>
-		</BreakpointProvider>
+		<TokenControlRow stacked>
+			<BreakpointProvider value={breakpoint} onChange={changeBreakpoint}>
+				<BorderControl
+					label={label}
+					value={fromNativeBorder(activeNative)}
+					onChange={(next) => activeSetter(toNativeBorder(next, activeUnit))}
+					widthTokens={widthTokens}
+					defaultValue={defaultValue}
+					indicator={indicator}
+					breakpoints={Object.values(BREAKPOINT_FOR_DEVICE)}
+					breakpoint={breakpoint}
+					// The switcher lives in `ControlShell`, driven by this prop directly — it does not read
+					// the `BreakpointProvider` context above, so both must map back to a device the same way.
+					onBreakpointChange={changeBreakpoint}
+					renderColor={renderColor}
+					isLinked={linked}
+					onToggleLink={toggleLink}
+					stacked
+				/>
+			</BreakpointProvider>
+		</TokenControlRow>
 	);
 }

--- a/src/extension/design-tokens/components/EditorBorderControl.js
+++ b/src/extension/design-tokens/components/EditorBorderControl.js
@@ -13,8 +13,14 @@
  * - **once a side has ever been written, it stays a four-element array**, never collapsed back to a
  *   scalar — `fromNativeBorder` only answers the empty scalar (`''`/`'none'`) for a breakpoint that
  *   has never been saved at all; the moment any side is written, `toNativeBorder` always fills in
- *   all four, so every later read comes back as four-element width/style/color arrays and the
- *   control renders unlinked from then on. There is no separate "link" flag to keep in sync.
+ *   all four. So the linked/unlinked view cannot be read off storage the way `BorderControl`'s own
+ *   uncontrolled fallback tries to (it only checks "is this an array", not "do the four elements
+ *   agree") — this component owns that view as UI state instead, seeded from whether the stored
+ *   sides currently agree (`isUniformBorder`) and overridden per breakpoint once the user explicitly
+ *   links or unlinks. This mirrors `singlebtn/edit.js`'s own `borderRadiusModeOverride` for radius,
+ *   just owned locally: border's `defaultValue` is always one scalar for every side (see its own
+ *   docblock below), so there is no per-side preset difference an early "uniform" read could hide
+ *   the way an empty radius corner could.
  * - **the unit lives inside the native value itself** (`source.unit`), not a sibling attribute the
  *   way `BoxControl`'s radius keeps `borderRadiusUnit` — so, unlike `EditorBoxControl`, this
  *   component takes no separate `unit`/`units`/`onUnit` props at all.
@@ -25,6 +31,11 @@
  * still has to fall back to the native value's stored color when `renderColor` writes nothing for a
  * side — see its docblock for why.
  */
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -64,6 +75,35 @@ const BREAKPOINT_FOR_DEVICE = {
  */
 function deviceForBreakpoint(breakpoint) {
 	return Object.keys(BREAKPOINT_FOR_DEVICE).find((name) => BREAKPOINT_FOR_DEVICE[name] === breakpoint) ?? 'Desktop';
+}
+
+/**
+ * Whether a native border value shows the same color, style, and width on every side — the state a
+ * linked view can honestly represent. A breakpoint that has never been written reads as uniform too:
+ * there is nothing stored to differ side to side, and (unlike radius corners) a border preset only
+ * ever sets one width for every side, so there is no per-side preset difference an early "uniform"
+ * read could hide.
+ *
+ * @param {?Array} native `[{top,right,bottom,left,unit}]` or undefined.
+ *
+ * @since TBD
+ *
+ * @return {boolean} Whether every side currently matches.
+ */
+function isUniformBorder(native) {
+	const source = native?.[0];
+
+	if (!source) {
+		return true;
+	}
+
+	const uniform = (values) => values.every((entry) => entry === values[0]);
+
+	return (
+		uniform(SIDES.map((side) => source[side]?.[0] || '')) &&
+		uniform(SIDES.map((side) => source[side]?.[1] || 'none')) &&
+		uniform(SIDES.map((side) => source[side]?.[2]))
+	);
 }
 
 /**
@@ -230,6 +270,36 @@ export function EditorBorderControl({
 	// `ResponsiveBorderControl`'s own `mobileUnit`/`tabletUnit` fallback), and finally 'px'.
 	const activeUnit = activeNative?.[0]?.unit || value?.[0]?.unit || 'px';
 
+	// Per-breakpoint UI override for the linked view — see this file's own docblock for why storage
+	// cannot answer it alone. Keyed by breakpoint so switching devices does not carry one device's
+	// explicit choice onto another; resets on remount, matching `singlebtn/edit.js`'s
+	// `borderRadiusModeOverride` for radius.
+	const [linkOverride, setLinkOverride] = useState({});
+	const linked = linkOverride[breakpoint] ?? isUniformBorder(activeNative);
+
+	const toggleLink = () => {
+		if (linked) {
+			setLinkOverride((current) => ({ ...current, [breakpoint]: false }));
+			return;
+		}
+
+		// Relinking collapses every side to slot 0's value — "the first side wins" is predictable,
+		// matching `BorderControl`'s own uncontrolled relink rule and `BoxControl`'s relink comment.
+		const current = fromNativeBorder(activeNative);
+
+		activeSetter(
+			toNativeBorder(
+				{
+					width: readSlot(current.width, 0),
+					style: readSlot(current.style, 0),
+					color: readSlot(current.color, 0),
+				},
+				activeUnit
+			)
+		);
+		setLinkOverride((next) => ({ ...next, [breakpoint]: true }));
+	};
+
 	return (
 		<BreakpointProvider value={breakpoint} onChange={changeBreakpoint}>
 			<BorderControl
@@ -245,6 +315,8 @@ export function EditorBorderControl({
 				// the `BreakpointProvider` context above, so both must map back to a device the same way.
 				onBreakpointChange={changeBreakpoint}
 				renderColor={renderColor}
+				isLinked={linked}
+				onToggleLink={toggleLink}
 				stacked
 			/>
 		</BreakpointProvider>

--- a/src/extension/design-tokens/components/EditorBorderControl.js
+++ b/src/extension/design-tokens/components/EditorBorderControl.js
@@ -297,7 +297,12 @@ export function EditorBorderControl({
 				activeUnit
 			)
 		);
-		setLinkOverride((next) => ({ ...next, [breakpoint]: true }));
+		// Equal sides derive linked on their own once the collapsed value comes back through `value`
+		// (`isUniformBorder` above), so no override is needed to show the linked view — pinning `true`
+		// unconditionally here was the bug: nothing ever cleared it back, so a later divergence (e.g.
+		// an undo restoring the four original sides) kept rendering as linked regardless of what the
+		// stored value actually was.
+		setLinkOverride((next) => ({ ...next, [breakpoint]: undefined }));
 	};
 
 	return (

--- a/src/extension/design-tokens/components/EditorBoxControl.js
+++ b/src/extension/design-tokens/components/EditorBoxControl.js
@@ -9,6 +9,10 @@
  * - **a slot is always a four-element array**, never collapsed to a scalar, so the link state cannot
  *   be read off the value's shape and is caller-owned UI state instead;
  * - **the unit lives in its own attribute** beside the value.
+ * - **wraps itself in `TokenControlRow`** (no `heading`, purely for its `.kb-token-control-row`
+ *   spacing) — this component only ever renders inside `singlebtn/edit.js`'s sidebar, so it owns that
+ *   wrapper rather than asking every call site to remember it, matching
+ *   `EditorBorderControl`/`EditorShadowControl`.
  *
  * Everything the control needs beyond that — the token pool, the inherited preset default, the
  * binding indicator — the block already computes for its existing control, so this takes them as
@@ -21,6 +25,7 @@
 import { BoxControl, BreakpointProvider } from '../../../token-controls';
 import { TokenIndicator } from '../../token-indicators/components/TokenIndicator';
 import { BREAKPOINT_FOR_DEVICE, deviceForBreakpoint } from './breakpoints';
+import { TokenControlRow } from '../../token-indicators/components/TokenControlRow';
 
 /**
  * Render a box-shaped token control over the editor's per-device attributes.
@@ -80,36 +85,38 @@ export function EditorBoxControl({
 	// The provider is handed the editor's device rather than holding one of its own: the device
 	// preview is global here, so a switcher that tracked its own would disagree with the canvas.
 	return (
-		<BreakpointProvider value={breakpoint} onChange={changeBreakpoint}>
-			<BoxControl
-				label={label}
-				value={value}
-				onChange={onChange}
-				tokens={tokens}
-				defaultValue={defaultValue}
-				inherited={inherited}
-				// The editor's own mark, not this library's: it is the same indicator the block's other
-				// controls show, and two marks meaning the same thing should not look different.
-				indicator={<TokenIndicator state={state} onReset={onReset} />}
-				isLinked={isLinked}
-				onToggleLink={onToggleLink}
-				// Never collapse: the attribute is always a four-element array, so folding a uniform
-				// value down to a scalar would write a shape the block cannot read back.
-				collapse={false}
-				role={role}
-				breakpoints={Object.values(BREAKPOINT_FOR_DEVICE)}
-				breakpoint={breakpoint}
-				// The switcher lives in `ControlShell`, driven by this prop directly — it does not read
-				// the `BreakpointProvider` context above, so both must map back to a device the same way.
-				onBreakpointChange={changeBreakpoint}
-				unit={unit}
-				units={units}
-				onUnit={onUnit}
-				min={min}
-				max={max}
-				step={step}
-				stacked
-			/>
-		</BreakpointProvider>
+		<TokenControlRow stacked>
+			<BreakpointProvider value={breakpoint} onChange={changeBreakpoint}>
+				<BoxControl
+					label={label}
+					value={value}
+					onChange={onChange}
+					tokens={tokens}
+					defaultValue={defaultValue}
+					inherited={inherited}
+					// The editor's own mark, not this library's: it is the same indicator the block's other
+					// controls show, and two marks meaning the same thing should not look different.
+					indicator={<TokenIndicator state={state} onReset={onReset} />}
+					isLinked={isLinked}
+					onToggleLink={onToggleLink}
+					// Never collapse: the attribute is always a four-element array, so folding a uniform
+					// value down to a scalar would write a shape the block cannot read back.
+					collapse={false}
+					role={role}
+					breakpoints={Object.values(BREAKPOINT_FOR_DEVICE)}
+					breakpoint={breakpoint}
+					// The switcher lives in `ControlShell`, driven by this prop directly — it does not read
+					// the `BreakpointProvider` context above, so both must map back to a device the same way.
+					onBreakpointChange={changeBreakpoint}
+					unit={unit}
+					units={units}
+					onUnit={onUnit}
+					min={min}
+					max={max}
+					step={step}
+					stacked
+				/>
+			</BreakpointProvider>
+		</TokenControlRow>
 	);
 }

--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -39,6 +39,11 @@
  * Color is out of scope for redesign here, exactly as in `EditorBorderControl` — this component
  * neither builds nor intercepts a color field, it only wires the caller's EXISTING one back in via
  * `renderColor`.
+ *
+ * This component also wraps itself in `TokenControlRow` (no `heading`, purely for its
+ * `.kb-token-control-row` spacing) — it only ever renders inside `singlebtn/edit.js`'s sidebar, so it
+ * owns that wrapper rather than asking every call site to remember it, matching
+ * `EditorBorderControl`/`EditorBoxControl`.
  */
 
 /**
@@ -51,6 +56,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { BoxShadowControl } from '../../../token-controls/controls/BoxShadowControl';
+import { TokenControlRow } from '../../token-indicators/components/TokenControlRow';
 
 /**
  * The composite's default shape, matching `BoxShadowControl`'s own `DEFAULT_SHADOW` fallback.
@@ -385,37 +391,39 @@ export function EditorShadowControl({
 	disabled = false,
 }) {
 	return (
-		<div className="kb-editor-shadow-control">
-			<div className="kb-editor-shadow-control__header">
-				{label && <span className="kb-editor-shadow-control__label">{label}</span>}
-				<ToggleControl
-					label={
-						label
-							? sprintf(
-									/* translators: %s: the field's own label, e.g. "Shadow". */ __(
-										'Enable %s',
-										'kadence-blocks'
-									),
-									label
-								)
-							: __('Enable shadow', 'kadence-blocks')
-					}
-					hideLabelFromVision
-					checked={!!enable}
-					onChange={onEnableChange}
-					disabled={disabled}
-				/>
+		<TokenControlRow stacked>
+			<div className="kb-editor-shadow-control">
+				<div className="kb-editor-shadow-control__header">
+					{label && <span className="kb-editor-shadow-control__label">{label}</span>}
+					<ToggleControl
+						label={
+							label
+								? sprintf(
+										/* translators: %s: the field's own label, e.g. "Shadow". */ __(
+											'Enable %s',
+											'kadence-blocks'
+										),
+										label
+									)
+								: __('Enable shadow', 'kadence-blocks')
+						}
+						hideLabelFromVision
+						checked={!!enable}
+						onChange={onEnableChange}
+						disabled={disabled}
+					/>
+				</div>
+				{enable && (
+					<BoxShadowControl
+						label={undefined}
+						value={fromNativeShadow(value)}
+						onChange={(next) => onChange(toNativeShadow(next, tokens))}
+						tokens={tokens}
+						renderColor={renderColor}
+						disabled={disabled}
+					/>
+				)}
 			</div>
-			{enable && (
-				<BoxShadowControl
-					label={undefined}
-					value={fromNativeShadow(value)}
-					onChange={(next) => onChange(toNativeShadow(next, tokens))}
-					tokens={tokens}
-					renderColor={renderColor}
-					disabled={disabled}
-				/>
-			)}
-		</div>
+		</TokenControlRow>
 	);
 }

--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -22,10 +22,13 @@
  *   the exact same rules this component uses to read/write the native attribute, keeping both
  *   directions symmetric.
  * - **`enable` lives outside the value entirely** — it is a separate sibling boolean attribute
- *   (`displayShadow`, `displayHoverShadow`, …), not a key inside the shadow array's item. This wrapper
- *   keeps it a plain `ToggleControl` rendered beside `BoxShadowControl`, matching how the native
- *   control also renders its enable toggle as an independent affordance next to the label, hiding the
- *   rest of the control's body while off.
+ *   (`displayShadow`, `displayHoverShadow`, …), not a key inside the shadow array's item. There is no
+ *   toggle for it anymore: `EditorShadowControl` derives it automatically from whether the value has
+ *   any visible footprint (`isVisibleNativeShadow`), on every edit, and reads it back only to decide
+ *   whether a legacy toggle-off value shows as "None" (`fromNativeShadow`) — "no shadow" is a value a
+ *   user picks now (the button's own `semantic.shadow.button` token, relabeled "None" — see
+ *   `singlebtn/edit.js`'s `shadowNoneEntry()`), matching every other token-picked field in this plan,
+ *   not a separate switch next to one.
  *
  * A whole-shadow token pick (the Style Library tab) has no home in the native item's existing keys —
  * unlike border, where an alias replaces a single side's width slot, a shadow alias would replace the
@@ -47,16 +50,20 @@
  */
 
 /**
- * WordPress dependencies
- */
-import { ToggleControl } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import { BoxShadowControl } from '../../../token-controls/controls/BoxShadowControl';
 import { TokenControlRow } from '../../token-indicators/components/TokenControlRow';
+
+/**
+ * The button's own "no shadow" semantic token — already an invisible, transparent zero-shadow (see
+ * `declarations.php`'s own comment on `semantic.shadow.button`). `singlebtn/edit.js` builds its
+ * pickable-tokens "None" entry from this same id (`shadowNoneEntry()`), imported from here rather
+ * than redeclared, so the two never drift apart.
+ *
+ * @since TBD
+ */
+export const BUTTON_SHADOW_NONE_TOKEN_ID = 'semantic.shadow.button';
 
 /**
  * The composite's default shape, matching `BoxShadowControl`'s own `DEFAULT_SHADOW` fallback.
@@ -300,16 +307,47 @@ function resolveShadowAlias(alias, tokens) {
 }
 
 /**
- * Convert the native `[{ color, opacity, hOffset, vOffset, blur, spread, inset }]` attribute value to
- * the composite `BoxShadowControl` edits.
+ * Whether a native shadow item has any visible footprint — any of its four length axes non-zero.
+ * `displayShadow`/`displayHoverShadow`/… no longer gate rendering through a separate control (see
+ * this module's own docblock); this is what `EditorShadowControl` derives that sibling boolean
+ * attribute FROM now, on every edit, so it stays in sync with the value automatically.
  *
  * @param {?Array} native The native shadow attribute value.
  *
  * @since TBD
  *
- * @return {Object} The composite `{ color, offsetX, offsetY, blur, spread, inset }` shape.
+ * @return {boolean} Whether the shadow has a visible footprint.
  */
-export function fromNativeShadow(native) {
+export function isVisibleNativeShadow(native) {
+	const source = native?.[0];
+
+	if (!source) {
+		return false;
+	}
+
+	return [source.hOffset, source.vOffset, source.blur, source.spread].some((axis) => Number(axis) !== 0);
+}
+
+/**
+ * Convert the native `[{ color, opacity, hOffset, vOffset, blur, spread, inset }]` attribute value to
+ * the composite `BoxShadowControl` edits, or the "None" alias while the sibling `enable` boolean
+ * reads false — a legacy toggle-off reads as "None" regardless of whatever is still sitting in the
+ * native item's own fields (leftover from before the field was toggled off, under the old UI this
+ * replaces), matching what the button actually renders: nothing.
+ *
+ * @param {?Array}  native The native shadow attribute value.
+ * @param {boolean} enable The sibling `displayShadow`/… attribute.
+ *
+ * @since TBD
+ *
+ * @return {string|Object} The "None" alias, or the composite `{ color, offsetX, offsetY, blur,
+ * spread, inset }` shape.
+ */
+export function fromNativeShadow(native, enable) {
+	if (!enable) {
+		return `{${BUTTON_SHADOW_NONE_TOKEN_ID}}`;
+	}
+
 	const source = native?.[0];
 
 	if (!source) {
@@ -362,16 +400,23 @@ export function toNativeShadow(value, tokens = []) {
 }
 
 /**
- * Render the editor-canvas box-shadow control: an `enable` toggle (the native attribute's own
- * sibling boolean, kept independent of the shadow value) beside `BoxShadowControl`, shown only while
- * enabled — matching the native `@kadence/components` `BoxShadowControl`'s own layout.
+ * Render the editor-canvas box-shadow control: `BoxShadowControl` alone, no separate enable toggle.
+ * A "None" pick — the button's own `semantic.shadow.button` token, relabeled (see the caller's
+ * `shadowNoneEntry()`) — is how "no shadow" is chosen now, matching every other token-picked
+ * field in this plan; the sibling `displayShadow`/… boolean this replaces is still written, just
+ * derived automatically from the value's own footprint (`isVisibleNativeShadow`) rather than a
+ * manual toggle, so PHP's existing render gate on that attribute needs no change of its own.
  *
  * @param {Object}    props                The component props.
  * @param {string}    props.label          The control's label.
  * @param {?Array}    props.value          The native shadow attribute value.
  * @param {Function}  props.onChange       Called with the next native shadow attribute value.
- * @param {boolean}   props.enable         Whether the shadow is enabled (the sibling boolean attribute).
- * @param {Function}  props.onEnableChange Called with the next enabled state.
+ * @param {boolean}   props.enable         The sibling `displayShadow`/… attribute — read only to
+ *                                         decide whether a legacy toggle-off value shows as "None"
+ *                                         (see `fromNativeShadow`); never toggled by this control.
+ * @param {Function}  props.onEnableChange Called with the value's own next enabled state, every time
+ *                                         `onChange` fires — keeps the sibling attribute in sync
+ *                                         automatically.
  * @param {Array}     [props.tokens]       Pickable `shadow`-type tokens, `[{id, label, value, alias}]`.
  * @param {?Function} [props.renderColor]  The block's existing color field for the composite's `color`.
  * @param {boolean}   [props.disabled]     Whether the control is read-only.
@@ -392,38 +437,19 @@ export function EditorShadowControl({
 }) {
 	return (
 		<TokenControlRow stacked>
-			<div className="kb-editor-shadow-control">
-				<div className="kb-editor-shadow-control__header">
-					{label && <span className="kb-editor-shadow-control__label">{label}</span>}
-					<ToggleControl
-						label={
-							label
-								? sprintf(
-										/* translators: %s: the field's own label, e.g. "Shadow". */ __(
-											'Enable %s',
-											'kadence-blocks'
-										),
-										label
-									)
-								: __('Enable shadow', 'kadence-blocks')
-						}
-						hideLabelFromVision
-						checked={!!enable}
-						onChange={onEnableChange}
-						disabled={disabled}
-					/>
-				</div>
-				{enable && (
-					<BoxShadowControl
-						label={undefined}
-						value={fromNativeShadow(value)}
-						onChange={(next) => onChange(toNativeShadow(next, tokens))}
-						tokens={tokens}
-						renderColor={renderColor}
-						disabled={disabled}
-					/>
-				)}
-			</div>
+			<BoxShadowControl
+				label={label}
+				value={fromNativeShadow(value, enable)}
+				onChange={(next) => {
+					const nextNative = toNativeShadow(next, tokens);
+
+					onChange(nextNative);
+					onEnableChange(isVisibleNativeShadow(nextNative));
+				}}
+				tokens={tokens}
+				renderColor={renderColor}
+				disabled={disabled}
+			/>
 		</TokenControlRow>
 	);
 }

--- a/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
@@ -501,7 +501,9 @@ describe('EditorBorderControl linked view', () => {
 
 	/**
 	 * Toggling link while unlinked collapses every side to the top side's value — matching
-	 * `BorderControl`'s own uncontrolled relink rule — and the control reports linked afterward.
+	 * `BorderControl`'s own uncontrolled relink rule — and once that collapsed value comes back
+	 * through `value` (as it would from a real `setAttributes` round trip), the control derives
+	 * linked from the now-uniform sides on its own, with no override forcing it.
 	 *
 	 * @return {void}
 	 */
@@ -514,7 +516,7 @@ describe('EditorBorderControl linked view', () => {
 			borderControl.props.onToggleLink();
 		});
 
-		expect(onChange).toHaveBeenCalledWith([
+		const collapsed = [
 			{
 				top: ['#111111', 'solid', 2],
 				right: ['#111111', 'solid', 2],
@@ -522,8 +524,29 @@ describe('EditorBorderControl linked view', () => {
 				left: ['#111111', 'solid', 2],
 				unit: 'px',
 			},
-		]);
-		expect(latestBorderControlProps.isLinked).toBe(true);
+		];
+		expect(onChange).toHaveBeenCalledWith(collapsed);
+
+		const { borderControl: rerendered } = renderEditorBorderControl({ value: collapsed });
+		expect(rerendered.props.isLinked).toBe(true);
+	});
+
+	/**
+	 * A relink's optimistic override does not survive a value that arrives back still diverging (e.g.
+	 * an undo restoring the four original sides right after the relink) — the control must fall back
+	 * to deriving from the real value rather than keep insisting the border is linked.
+	 *
+	 * @return {void}
+	 */
+	it('stops reporting linked once a relink is followed by a still-diverging value', () => {
+		const { borderControl } = renderEditorBorderControl({ value: NATIVE_VALUE });
+
+		act(() => {
+			borderControl.props.onToggleLink();
+		});
+
+		const { borderControl: rerendered } = renderEditorBorderControl({ value: NATIVE_VALUE, label: 'Border' });
+		expect(rerendered.props.isLinked).toBe(false);
 	});
 
 	/**

--- a/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
@@ -10,6 +10,7 @@ import { createRoot } from 'react-dom/client';
  * Internal dependencies
  */
 import { EditorBorderControl } from '../EditorBorderControl';
+import { TokenIndicator } from '../../../token-indicators/components/TokenIndicator';
 
 // `BorderControl` now gains its `isLinked`/`onToggleLink` props from state this component owns, so
 // it can no longer be exercised by calling `EditorBorderControl` as a plain function the way this file
@@ -609,5 +610,38 @@ describe('EditorBorderControl linked view', () => {
 			tabletValue: UNIFORM_NATIVE_VALUE,
 		});
 		expect(latestBorderControlProps.isLinked).toBe(true);
+	});
+});
+
+describe('EditorBorderControl token indicator', () => {
+	/**
+	 * `state`/`onReset` are threaded into a `TokenIndicator`, passed to `BorderControl` as its
+	 * `indicator` prop — the same wiring `EditorBoxControl` uses for Border Radius — so the block's
+	 * own binding state reaches the indicator rather than being dropped on the floor.
+	 *
+	 * @return {void}
+	 */
+	it('passes state and onReset through to a TokenIndicator handed to BorderControl as indicator', () => {
+		const onReset = jest.fn();
+		const state = { bound: true, overridden: true };
+
+		const { borderControl } = renderEditorBorderControl({ state, onReset });
+
+		expect(borderControl.props.indicator.type).toBe(TokenIndicator);
+		expect(borderControl.props.indicator.props.state).toBe(state);
+		expect(borderControl.props.indicator.props.onReset).toBe(onReset);
+	});
+
+	/**
+	 * With no `state`/`onReset` passed, the indicator still renders (as `TokenIndicator` renders
+	 * nothing for an unbound control), rather than `EditorBorderControl` omitting it altogether.
+	 *
+	 * @return {void}
+	 */
+	it('still hands BorderControl a TokenIndicator when state and onReset are omitted', () => {
+		const { borderControl } = renderEditorBorderControl();
+
+		expect(borderControl.props.indicator.type).toBe(TokenIndicator);
+		expect(borderControl.props.indicator.props.state).toBeNull();
 	});
 });

--- a/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
@@ -1,9 +1,30 @@
 /* eslint-env jest */
 
 /**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
  * Internal dependencies
  */
 import { EditorBorderControl } from '../EditorBorderControl';
+
+// `BorderControl` now gains its `isLinked`/`onToggleLink` props from state this component owns, so
+// it can no longer be exercised by calling `EditorBorderControl` as a plain function the way this file
+// used to — hooks only work inside a real render. `BorderControl` itself is stood in for here (rather
+// than mocking `@wordpress/components`, the way `border-control.test.js` has to) because these tests
+// only care what props reach it, not how it renders them; capturing props on every render keeps the
+// rest of this file's assertions the same shape they were before.
+let latestBorderControlProps = null;
+
+jest.mock('../../../../token-controls/controls/BorderControl', () => ({
+	BorderControl: (props) => {
+		latestBorderControlProps = props;
+		return null;
+	},
+}));
 
 /**
  * A representative native border value: every side different, so a round-trip that silently
@@ -24,17 +45,53 @@ const NATIVE_VALUE = [
 ];
 
 /**
- * Call `EditorBorderControl` as a plain function and return the `BorderControl`/`BreakpointProvider`
- * elements it produced. The component holds no hooks of its own, so the returned element tree can be
- * inspected directly instead of mounting it — matching `EditorBoxControl.test.js`'s own harness.
+ * A representative native border value with every side identical — the shape `isUniformBorder`
+ * reads as linked.
+ *
+ * @since TBD
+ *
+ * @type {Array}
+ */
+const UNIFORM_NATIVE_VALUE = [
+	{
+		top: ['#111111', 'solid', 2],
+		right: ['#111111', 'solid', 2],
+		bottom: ['#111111', 'solid', 2],
+		left: ['#111111', 'solid', 2],
+		unit: 'px',
+	},
+];
+
+let container;
+let root;
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+	latestBorderControlProps = null;
+});
+
+afterEach(() => {
+	act(() => {
+		root.unmount();
+	});
+	container.remove();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+/**
+ * Render `EditorBorderControl` and return the props its (stood-in) `BorderControl` received, plus
+ * the setter spies passed in.
  *
  * @param {Object} overrides Props to override on top of the defaults.
  *
  * @since TBD
  *
- * @return {{provider: Object, borderControl: Object, onChange: Function, onChangeTablet: Function,
- *   onChangeMobile: Function, onDeviceChange: Function}} The provider element, the `BorderControl`
- *   element nested inside it, and the setter spies passed in.
+ * @return {{borderControl: {props: Object}, onChange: Function, onChangeTablet: Function,
+ *   onChangeMobile: Function, onDeviceChange: Function}} The captured `BorderControl` props (wrapped
+ *   to match this file's previous `element.props` shape) and the setter spies passed in.
  */
 function renderEditorBorderControl(overrides = {}) {
 	const onChange = jest.fn();
@@ -56,11 +113,12 @@ function renderEditorBorderControl(overrides = {}) {
 		...overrides,
 	};
 
-	const provider = EditorBorderControl(props);
+	act(() => {
+		root.render(createElement(EditorBorderControl, props));
+	});
 
 	return {
-		provider,
-		borderControl: provider.props.children,
+		borderControl: { props: latestBorderControlProps },
 		onChange,
 		onChangeTablet,
 		onChangeMobile,
@@ -113,10 +171,12 @@ describe('EditorBorderControl native <-> control value bridging', () => {
 	it('round-trips a representative native value losslessly through a width edit', () => {
 		const { borderControl, onChange } = renderEditorBorderControl();
 
-		borderControl.props.onChange({
-			width: ['9px', '3px', '4px', '5px'],
-			style: ['solid', 'dashed', 'dotted', 'double'],
-			color: ['#111111', '#222222', '#333333', '#444444'],
+		act(() => {
+			borderControl.props.onChange({
+				width: ['9px', '3px', '4px', '5px'],
+				style: ['solid', 'dashed', 'dotted', 'double'],
+				color: ['#111111', '#222222', '#333333', '#444444'],
+			});
 		});
 
 		expect(onChange).toHaveBeenCalledWith([
@@ -141,10 +201,12 @@ describe('EditorBorderControl native <-> control value bridging', () => {
 		const { borderControl, onChange } = renderEditorBorderControl();
 		const alias = '{primitive.dimension.border-width.md}';
 
-		borderControl.props.onChange({
-			width: [alias, '3px', '4px', '5px'],
-			style: ['solid', 'dashed', 'dotted', 'double'],
-			color: ['#111111', '#222222', '#333333', '#444444'],
+		act(() => {
+			borderControl.props.onChange({
+				width: [alias, '3px', '4px', '5px'],
+				style: ['solid', 'dashed', 'dotted', 'double'],
+				color: ['#111111', '#222222', '#333333', '#444444'],
+			});
 		});
 
 		const written = onChange.mock.calls[0][0];
@@ -166,10 +228,12 @@ describe('EditorBorderControl native <-> control value bridging', () => {
 	it('preserves each side existing color when writing a style edit', () => {
 		const { borderControl, onChange } = renderEditorBorderControl();
 
-		borderControl.props.onChange({
-			width: ['2px', '3px', '4px', '5px'],
-			style: ['none', 'dashed', 'dotted', 'double'],
-			color: ['#111111', '#222222', '#333333', '#444444'], // Carried forward by BorderControl's merge.
+		act(() => {
+			borderControl.props.onChange({
+				width: ['2px', '3px', '4px', '5px'],
+				style: ['none', 'dashed', 'dotted', 'double'],
+				color: ['#111111', '#222222', '#333333', '#444444'], // Carried forward by BorderControl's merge.
+			});
 		});
 
 		const written = onChange.mock.calls[0][0][0];
@@ -190,10 +254,12 @@ describe('EditorBorderControl native <-> control value bridging', () => {
 	it('writes an empty string when a side color is cleared, rather than keeping the stale color', () => {
 		const { borderControl, onChange } = renderEditorBorderControl();
 
-		borderControl.props.onChange({
-			width: ['2px', '3px', '4px', '5px'],
-			style: ['solid', 'dashed', 'dotted', 'double'],
-			color: ['', '#222222', '#333333', '#444444'], // Top color cleared.
+		act(() => {
+			borderControl.props.onChange({
+				width: ['2px', '3px', '4px', '5px'],
+				style: ['solid', 'dashed', 'dotted', 'double'],
+				color: ['', '#222222', '#333333', '#444444'], // Top color cleared.
+			});
 		});
 
 		const written = onChange.mock.calls[0][0][0];
@@ -283,10 +349,12 @@ describe('EditorBorderControl native <-> control value bridging', () => {
 	it('writes a genuine per-side color edit through to the native attribute', () => {
 		const { borderControl, onChange } = renderEditorBorderControl();
 
-		borderControl.props.onChange({
-			width: ['2px', '3px', '4px', '5px'],
-			style: ['solid', 'dashed', 'dotted', 'double'],
-			color: ['#ffffff', '#222222', '#333333', '#444444'], // top color changed.
+		act(() => {
+			borderControl.props.onChange({
+				width: ['2px', '3px', '4px', '5px'],
+				style: ['solid', 'dashed', 'dotted', 'double'],
+				color: ['#ffffff', '#222222', '#333333', '#444444'], // top color changed.
+			});
 		});
 
 		const written = onChange.mock.calls[0][0][0];
@@ -297,16 +365,18 @@ describe('EditorBorderControl native <-> control value bridging', () => {
 
 describe('EditorBorderControl breakpoint switching', () => {
 	/**
-	 * The switcher rendered by `ControlShell` drives `BorderControl`'s `onBreakpointChange` prop
-	 * directly, not the `BreakpointProvider` context above it — matching `EditorBoxControl`'s own
-	 * wiring exactly.
+	 * `BorderControl`'s `onBreakpointChange` and the `BreakpointProvider` context above it are wired
+	 * to the same `changeBreakpoint` function, so exercising one exercises the other; invoking it maps
+	 * the control breakpoint key back to the matching editor device name.
 	 *
 	 * @return {void}
 	 */
 	it('invokes onDeviceChange with the matching device when onBreakpointChange fires', () => {
 		const { borderControl, onDeviceChange } = renderEditorBorderControl();
 
-		borderControl.props.onBreakpointChange('tablet');
+		act(() => {
+			borderControl.props.onBreakpointChange('tablet');
+		});
 
 		expect(onDeviceChange).toHaveBeenCalledWith('Tablet');
 	});
@@ -319,28 +389,20 @@ describe('EditorBorderControl breakpoint switching', () => {
 	it('maps every breakpoint key back to its editor device name', () => {
 		const { borderControl, onDeviceChange } = renderEditorBorderControl();
 
-		borderControl.props.onBreakpointChange('mobile');
+		act(() => {
+			borderControl.props.onBreakpointChange('mobile');
+		});
 		expect(onDeviceChange).toHaveBeenLastCalledWith('Mobile');
 
-		borderControl.props.onBreakpointChange('desktop');
+		act(() => {
+			borderControl.props.onBreakpointChange('desktop');
+		});
 		expect(onDeviceChange).toHaveBeenLastCalledWith('Desktop');
 
-		borderControl.props.onBreakpointChange('tablet');
+		act(() => {
+			borderControl.props.onBreakpointChange('tablet');
+		});
 		expect(onDeviceChange).toHaveBeenLastCalledWith('Tablet');
-	});
-
-	/**
-	 * The `BreakpointProvider`'s own `onChange` maps breakpoints back to devices the same way as the
-	 * `onBreakpointChange` prop, using the one shared mapping rather than a second copy of it.
-	 *
-	 * @return {void}
-	 */
-	it('maps the BreakpointProvider onChange consistently with onBreakpointChange', () => {
-		const { provider, onDeviceChange } = renderEditorBorderControl();
-
-		provider.props.onChange('mobile');
-
-		expect(onDeviceChange).toHaveBeenCalledWith('Mobile');
 	});
 
 	/**
@@ -355,10 +417,12 @@ describe('EditorBorderControl breakpoint switching', () => {
 			tabletValue: NATIVE_VALUE,
 		});
 
-		borderControl.props.onChange({
-			width: ['9px', '3px', '4px', '5px'],
-			style: ['solid', 'dashed', 'dotted', 'double'],
-			color: ['#111111', '#222222', '#333333', '#444444'],
+		act(() => {
+			borderControl.props.onChange({
+				width: ['9px', '3px', '4px', '5px'],
+				style: ['solid', 'dashed', 'dotted', 'double'],
+				color: ['#111111', '#222222', '#333333', '#444444'],
+			});
 		});
 
 		expect(onChangeTablet).toHaveBeenCalled();
@@ -373,17 +437,17 @@ describe('EditorBorderControl breakpoint switching', () => {
 	 * @return {void}
 	 */
 	it('falls back to desktop for an unknown preview device', () => {
-		const { provider } = renderEditorBorderControl({ previewDevice: 'Widescreen' });
+		const { borderControl } = renderEditorBorderControl({ previewDevice: 'Widescreen' });
 
-		expect(provider.props.value).toBe('desktop');
+		expect(borderControl.props.breakpoint).toBe('desktop');
 	});
 });
 
 describe('EditorBorderControl unlinked rendering', () => {
 	/**
 	 * The native attribute is always a four-sided object, so `BorderControl`'s value always arrives
-	 * as four-element width/style/color arrays — the control has nothing to collapse and renders
-	 * unlinked by construction, matching `BoxControl`'s own docblock for radius.
+	 * as four-element width/style/color arrays — collapsing them to one row is `isLinked`'s job now,
+	 * not a shape the value itself can ever take on.
 	 *
 	 * @return {void}
 	 */
@@ -394,5 +458,133 @@ describe('EditorBorderControl unlinked rendering', () => {
 		expect(borderControl.props.value.width).toHaveLength(4);
 		expect(Array.isArray(borderControl.props.value.style)).toBe(true);
 		expect(borderControl.props.value.style).toHaveLength(4);
+	});
+});
+
+describe('EditorBorderControl linked view', () => {
+	/**
+	 * A breakpoint that has never stored anything has nothing to differ side to side, so it opens
+	 * linked — matching an unlinked-but-uniform value below, and the unset-value test in the bridging
+	 * suite above.
+	 *
+	 * @return {void}
+	 */
+	it('reads an unset value as linked', () => {
+		const { borderControl } = renderEditorBorderControl({ previewDevice: 'Tablet', tabletValue: undefined });
+
+		expect(borderControl.props.isLinked).toBe(true);
+	});
+
+	/**
+	 * Four sides that already agree on color, style, and width read as linked, even though the native
+	 * shape storing them is the same four-element arrays an actually-diverging value would use —
+	 * `isLinked` is derived from whether the sides agree, not from the shape alone.
+	 *
+	 * @return {void}
+	 */
+	it('reads a uniform four-sided value as linked', () => {
+		const { borderControl } = renderEditorBorderControl({ value: UNIFORM_NATIVE_VALUE });
+
+		expect(borderControl.props.isLinked).toBe(true);
+	});
+
+	/**
+	 * Four sides that disagree on any of color, style, or width read as unlinked.
+	 *
+	 * @return {void}
+	 */
+	it('reads a diverging four-sided value as unlinked', () => {
+		const { borderControl } = renderEditorBorderControl({ value: NATIVE_VALUE });
+
+		expect(borderControl.props.isLinked).toBe(false);
+	});
+
+	/**
+	 * Toggling link while unlinked collapses every side to the top side's value — matching
+	 * `BorderControl`'s own uncontrolled relink rule — and the control reports linked afterward.
+	 *
+	 * @return {void}
+	 */
+	it('collapses every side to the top side value when relinking a diverging border', () => {
+		const { borderControl, onChange } = renderEditorBorderControl({ value: NATIVE_VALUE });
+
+		expect(borderControl.props.isLinked).toBe(false);
+
+		act(() => {
+			borderControl.props.onToggleLink();
+		});
+
+		expect(onChange).toHaveBeenCalledWith([
+			{
+				top: ['#111111', 'solid', 2],
+				right: ['#111111', 'solid', 2],
+				bottom: ['#111111', 'solid', 2],
+				left: ['#111111', 'solid', 2],
+				unit: 'px',
+			},
+		]);
+		expect(latestBorderControlProps.isLinked).toBe(true);
+	});
+
+	/**
+	 * Toggling link while a uniform border is linked switches the view to unlinked without writing
+	 * anything — the four sides already agree, so there is nothing to collapse; only the view changes,
+	 * exactly the behavior Border Radius's own link toggle already has and this control lacked before.
+	 *
+	 * @return {void}
+	 */
+	it('unlinks a uniform border into the per-side grid without writing a change', () => {
+		const { borderControl, onChange } = renderEditorBorderControl({ value: UNIFORM_NATIVE_VALUE });
+
+		expect(borderControl.props.isLinked).toBe(true);
+
+		act(() => {
+			borderControl.props.onToggleLink();
+		});
+
+		expect(onChange).not.toHaveBeenCalled();
+		expect(latestBorderControlProps.isLinked).toBe(false);
+	});
+
+	/**
+	 * The unlinked view, once explicitly chosen, survives an incidental re-render with the same
+	 * uniform value (e.g. a parent re-render that changes an unrelated prop) — an explicit choice is
+	 * not something a value that merely stayed the same should silently revert.
+	 *
+	 * @return {void}
+	 */
+	it('keeps an explicit unlink across a re-render with the same uniform value', () => {
+		const { borderControl } = renderEditorBorderControl({ value: UNIFORM_NATIVE_VALUE });
+
+		act(() => {
+			borderControl.props.onToggleLink();
+		});
+
+		renderEditorBorderControl({ value: UNIFORM_NATIVE_VALUE, label: 'Border' });
+
+		expect(latestBorderControlProps.isLinked).toBe(false);
+	});
+
+	/**
+	 * Each breakpoint's explicit link choice is independent — unlinking Desktop must not leave Tablet
+	 * stuck unlinked too, since the two are edited through entirely separate control instances in
+	 * practice and only share this component's state because a test re-renders the same instance.
+	 *
+	 * @return {void}
+	 */
+	it('tracks the linked override per breakpoint independently', () => {
+		const { borderControl } = renderEditorBorderControl({ value: UNIFORM_NATIVE_VALUE });
+
+		act(() => {
+			borderControl.props.onToggleLink();
+		});
+		expect(latestBorderControlProps.isLinked).toBe(false);
+
+		renderEditorBorderControl({
+			previewDevice: 'Tablet',
+			value: UNIFORM_NATIVE_VALUE,
+			tabletValue: UNIFORM_NATIVE_VALUE,
+		});
+		expect(latestBorderControlProps.isLinked).toBe(true);
 	});
 });

--- a/src/extension/design-tokens/components/__tests__/EditorBoxControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorBoxControl.test.js
@@ -7,16 +7,18 @@ import { EditorBoxControl } from '../EditorBoxControl';
 
 /**
  * Call `EditorBoxControl` as a plain function and return the `BoxControl`/`BreakpointProvider`
- * elements it produced. The component holds no hooks of its own, so the returned element tree can
- * be inspected directly instead of mounting it — matching this file's sibling tests, which inspect
- * returned element types/props rather than rendering.
+ * elements it produced. The component holds no hooks of its own — `TokenControlRow` is referenced in
+ * the returned JSX but never invoked by this plain call, since JSX only builds element descriptors —
+ * so the returned element tree can be inspected directly instead of mounting it, matching this file's
+ * sibling tests, which inspect returned element types/props rather than rendering.
  *
  * @param {Object} overrides Props to override on top of the defaults.
  *
  * @since TBD
  *
- * @return {{provider: Object, boxControl: Object, onDeviceChange: Function}} The provider element,
- *   the `BoxControl` element nested inside it, and the `onDeviceChange` spy passed in.
+ * @return {{provider: Object, boxControl: Object, onDeviceChange: Function}} The `BreakpointProvider`
+ *   element (one level inside the root `TokenControlRow`), the `BoxControl` element nested inside it,
+ *   and the `onDeviceChange` spy passed in.
  */
 function renderEditorBoxControl(overrides = {}) {
 	const onDeviceChange = jest.fn();
@@ -33,7 +35,7 @@ function renderEditorBoxControl(overrides = {}) {
 		...overrides,
 	};
 
-	const provider = EditorBoxControl(props);
+	const provider = EditorBoxControl(props).props.children;
 
 	return { provider, boxControl: provider.props.children, onDeviceChange };
 }

--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -3,7 +3,12 @@
 /**
  * Internal dependencies
  */
-import { EditorShadowControl, combineColorOpacity, splitColorOpacity } from '../EditorShadowControl';
+import {
+	BUTTON_SHADOW_NONE_TOKEN_ID,
+	EditorShadowControl,
+	combineColorOpacity,
+	splitColorOpacity,
+} from '../EditorShadowControl';
 
 /**
  * A representative native shadow value — every field a different, distinguishable number/string, so a
@@ -26,9 +31,9 @@ const NATIVE_VALUE = [
 ];
 
 /**
- * Call `EditorShadowControl` as a plain function and return the `BoxShadowControl`/`ToggleControl`
- * elements it produced. The component holds no hooks of its own — `TokenControlRow` is referenced in
- * the returned JSX but never invoked by this plain call, since JSX only builds element descriptors — so
+ * Call `EditorShadowControl` as a plain function and return the `BoxShadowControl` element it
+ * produced. The component holds no hooks of its own — `TokenControlRow` is referenced in the
+ * returned JSX but never invoked by this plain call, since JSX only builds element descriptors — so
  * the returned element tree can be inspected directly instead of mounting it, matching
  * `EditorBorderControl.test.js`'s own harness (before it gained state and needed a real render).
  *
@@ -36,10 +41,9 @@ const NATIVE_VALUE = [
  *
  * @since TBD
  *
- * @return {{root: Object, header: Object, toggle: Object, shadowControl: ?Object, onChange: Function,
- *   onEnableChange: Function}} The root element (`TokenControlRow`), the header row, the enable
- *   toggle, the `BoxShadowControl` element (or `null` when `enable` is false), and the setter spies
- *   passed in.
+ * @return {{root: Object, shadowControl: Object, onChange: Function, onEnableChange: Function}} The
+ *   root element (`TokenControlRow`), the `BoxShadowControl` element it wraps (always rendered — no
+ *   more enable-gated conditional), and the setter spies passed in.
  */
 function renderEditorShadowControl(overrides = {}) {
 	const onChange = jest.fn();
@@ -56,13 +60,11 @@ function renderEditorShadowControl(overrides = {}) {
 	};
 
 	const root = EditorShadowControl(props);
-	const [header, shadowControl] = root.props.children.props.children;
+	const shadowControl = root.props.children;
 
 	return {
 		root,
-		header,
-		toggle: header.props.children[1],
-		shadowControl: shadowControl || null,
+		shadowControl,
 		onChange,
 		onEnableChange,
 	};
@@ -236,57 +238,118 @@ describe('EditorShadowControl native <-> BoxShadowControl value bridging', () =>
 	});
 });
 
-describe('EditorShadowControl enable toggle', () => {
+describe('EditorShadowControl legacy enable/disable, without a toggle', () => {
 	/**
-	 * The enable toggle reads and writes the sibling boolean attribute independently of the shadow
-	 * value's shape — it stays functional whether the value is a token or a composite literal.
+	 * `BoxShadowControl` always renders now — there is no more `enable`-gated conditional hiding it.
+	 * "No shadow" is a value a user picks (the "None" entry), not a separate switch that hides the
+	 * control entirely.
 	 *
 	 * @return {void}
 	 */
-	it('reflects the enable prop and writes through onEnableChange, independent of the value shape', () => {
-		const { toggle, onEnableChange } = renderEditorShadowControl({ enable: false });
+	it('always renders BoxShadowControl, even while the sibling attribute reads disabled', () => {
+		const { shadowControl } = renderEditorShadowControl({ enable: false });
 
-		expect(toggle.props.checked).toBe(false);
+		expect(shadowControl).not.toBeNull();
+		expect(shadowControl.type.name).toBe('BoxShadowControl');
+	});
 
-		toggle.props.onChange(true);
+	/**
+	 * A legacy toggle-off value (`enable: false`) reads as the "None" alias regardless of whatever is
+	 * still sitting in the native item's own fields — leftover from before the field was toggled off
+	 * under the old UI. This is what makes existing content correctly show "None" without any data
+	 * rewrite: the button's own `semantic.shadow.button` token, not the stale native composite.
+	 *
+	 * @return {void}
+	 */
+	it('reads a legacy toggle-off value as "None", discarding whatever composite is still stored', () => {
+		const { shadowControl } = renderEditorShadowControl({ enable: false, value: NATIVE_VALUE });
+
+		expect(shadowControl.props.value).toBe(`{${BUTTON_SHADOW_NONE_TOKEN_ID}}`);
+	});
+
+	/**
+	 * While enabled, the value reads normally — this legacy fallback only kicks in for a disabled
+	 * field, matching the sibling attribute's own historical meaning.
+	 *
+	 * @return {void}
+	 */
+	it('reads the real composite while the sibling attribute reads enabled', () => {
+		const { shadowControl } = renderEditorShadowControl({ enable: true, value: NATIVE_VALUE });
+
+		expect(shadowControl.props.value).not.toBe(`{${BUTTON_SHADOW_NONE_TOKEN_ID}}`);
+		expect(shadowControl.props.value).toEqual(
+			expect.objectContaining({ offsetX: '2px', offsetY: '3px', blur: '4px', spread: '5px' })
+		);
+	});
+});
+
+describe('EditorShadowControl auto-derives the sibling enable attribute', () => {
+	/**
+	 * Editing to a value with a real visible footprint (any non-zero axis) writes the sibling
+	 * attribute to enabled — the replacement for the old manual toggle, now driven by the value
+	 * itself rather than a separate switch.
+	 *
+	 * @return {void}
+	 */
+	it('writes the sibling attribute enabled when the edited value has a visible footprint', () => {
+		const { shadowControl, onEnableChange } = renderEditorShadowControl();
+
+		shadowControl.props.onChange({
+			color: '#111111',
+			offsetX: '2px',
+			offsetY: '3px',
+			blur: '4px',
+			spread: '5px',
+			inset: false,
+		});
+
 		expect(onEnableChange).toHaveBeenCalledWith(true);
 	});
 
 	/**
-	 * `BoxShadowControl` renders only while enabled, matching the native control's own layout — a
-	 * caller should not be able to edit a shadow value that is currently switched off.
+	 * Editing to a value with no visible footprint (every axis zero — matching the "None" pick's own
+	 * resolved composite) writes the sibling attribute to disabled.
 	 *
 	 * @return {void}
 	 */
-	it('hides BoxShadowControl while disabled', () => {
-		const { shadowControl } = renderEditorShadowControl({ enable: false });
+	it('writes the sibling attribute disabled when the edited value has no visible footprint', () => {
+		const { shadowControl, onEnableChange } = renderEditorShadowControl();
 
-		expect(shadowControl).toBeNull();
+		shadowControl.props.onChange({
+			color: 'transparent',
+			offsetX: '0px',
+			offsetY: '0px',
+			blur: '0px',
+			spread: '0px',
+			inset: false,
+		});
+
+		expect(onEnableChange).toHaveBeenCalledWith(false);
 	});
 
 	/**
-	 * The toggle has no visible text of its own (the field's label sits in a separate, unassociated
-	 * sibling `<span>`), so it needs its own accessible name rather than relying on that span.
+	 * Picking a token whose resolved shadow is zero-sized (e.g. the "None" entry itself) also derives
+	 * disabled — the same path a Custom-tab zero edit takes, since both go through `onChange` with the
+	 * same resolved-then-native value.
 	 *
 	 * @return {void}
 	 */
-	it('gives the toggle an accessible name derived from the field label, hidden visually', () => {
-		const { toggle } = renderEditorShadowControl({ label: 'Box Shadow' });
+	it('writes the sibling attribute disabled when a picked token resolves to a zero-sized shadow', () => {
+		const { shadowControl, onEnableChange } = renderEditorShadowControl({
+			tokens: [
+				{
+					id: BUTTON_SHADOW_NONE_TOKEN_ID,
+					alias: `{${BUTTON_SHADOW_NONE_TOKEN_ID}}`,
+					label: 'None',
+					value: '0px 0px 0px 0px transparent',
+					type: 'shadow',
+				},
+			],
+		});
 
-		expect(toggle.props.label).toBe('Enable Box Shadow');
-		expect(toggle.props.hideLabelFromVision).toBe(true);
-	});
+		shadowControl.props.onChange(`{${BUTTON_SHADOW_NONE_TOKEN_ID}}`);
 
-	/**
-	 * A caller that omits `label` entirely still gets a usable, generic accessible name rather than an
-	 * empty or undefined one.
-	 *
-	 * @return {void}
-	 */
-	it('falls back to a generic accessible name when no label is given', () => {
-		const { toggle } = renderEditorShadowControl({ label: undefined });
-
-		expect(toggle.props.label).toBe('Enable shadow');
+		expect(onEnableChange).toHaveBeenCalledWith(false);
 	});
 });
 

--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -27,16 +27,19 @@ const NATIVE_VALUE = [
 
 /**
  * Call `EditorShadowControl` as a plain function and return the `BoxShadowControl`/`ToggleControl`
- * elements it produced. The component holds no hooks of its own, so the returned element tree can be
- * inspected directly instead of mounting it — matching `EditorBorderControl.test.js`'s own harness.
+ * elements it produced. The component holds no hooks of its own — `TokenControlRow` is referenced in
+ * the returned JSX but never invoked by this plain call, since JSX only builds element descriptors — so
+ * the returned element tree can be inspected directly instead of mounting it, matching
+ * `EditorBorderControl.test.js`'s own harness (before it gained state and needed a real render).
  *
  * @param {Object} overrides Props to override on top of the defaults.
  *
  * @since TBD
  *
  * @return {{root: Object, header: Object, toggle: Object, shadowControl: ?Object, onChange: Function,
- *   onEnableChange: Function}} The root element, the header row, the enable toggle, the
- *   `BoxShadowControl` element (or `null` when `enable` is false), and the setter spies passed in.
+ *   onEnableChange: Function}} The root element (`TokenControlRow`), the header row, the enable
+ *   toggle, the `BoxShadowControl` element (or `null` when `enable` is false), and the setter spies
+ *   passed in.
  */
 function renderEditorShadowControl(overrides = {}) {
 	const onChange = jest.fn();
@@ -53,7 +56,7 @@ function renderEditorShadowControl(overrides = {}) {
 	};
 
 	const root = EditorShadowControl(props);
-	const [header, shadowControl] = root.props.children;
+	const [header, shadowControl] = root.props.children.props.children;
 
 	return {
 		root,

--- a/src/extension/preset-picker/__tests__/capture.test.js
+++ b/src/extension/preset-picker/__tests__/capture.test.js
@@ -294,6 +294,106 @@ describe('capturedTokens', () => {
 	});
 });
 
+describe('capturedTokens border axis properties', () => {
+	/**
+	 * Seed the localized catalog with the three border-axis properties, all sharing the
+	 * `control_attr: 'borderStyle'` binding `declarations.php` declares — the shape whose nested
+	 * per-side native value corrupted the capture loop before this fix.
+	 *
+	 * @return {void}
+	 */
+	function seedBorderCatalog() {
+		window.kadenceDesignTokensPresets = {
+			active: 'default',
+			libraries: {
+				default: {
+					[BLOCK]: {
+						default: 'primary',
+						presets: [{ slug: 'primary', label: 'Primary' }],
+						properties: [
+							{
+								key: 'button-border-width',
+								kind: 'dimension',
+								token: 'semantic.border-width.default',
+								control_attr: 'borderStyle',
+							},
+							{
+								key: 'button-border-style',
+								kind: 'color',
+								token: 'semantic.border-style.default',
+								control_attr: 'borderStyle',
+							},
+							{
+								key: 'button-border-color',
+								kind: 'color',
+								token: 'semantic.color.border',
+								control_attr: 'borderStyle',
+							},
+						],
+						values: {
+							primary: {
+								'button-border-width': '2px',
+								'button-border-style': 'solid',
+								'button-border-color': '#3182ce',
+							},
+						},
+					},
+				},
+			},
+		};
+	}
+
+	beforeEach(() => {
+		seedBorderCatalog();
+	});
+
+	afterEach(() => {
+		delete window.kadenceDesignTokensPresets;
+	});
+
+	/**
+	 * A block with a border set (a populated nested per-side native `borderStyle` attribute) captures
+	 * the three border-axis properties as their unchanged preset values — not the "[object Object]"
+	 * garbage the flat dimension/color read produced before this fix.
+	 *
+	 * @return {void}
+	 */
+	it('captures the three border-axis properties unchanged, not corrupted, when a border is set', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			borderStyle: [
+				{
+					top: ['#ffffff', 'dashed', '4'],
+					right: ['#ffffff', 'dashed', '4'],
+					bottom: ['#ffffff', 'dashed', '4'],
+					left: ['#ffffff', 'dashed', '4'],
+					unit: 'px',
+				},
+			],
+		};
+
+		const tokens = capturedTokens(BLOCK, SET, attributes);
+
+		expect(tokens['button-border-width']).toBe('2px');
+		expect(tokens['button-border-style']).toBe('solid');
+		expect(tokens['button-border-color']).toBe('#3182ce');
+	});
+
+	/**
+	 * A block with no border set at all also captures the three border-axis properties as their
+	 * unchanged preset values, matching the "not edited" fallback every other unmapped property takes.
+	 *
+	 * @return {void}
+	 */
+	it('captures the three border-axis properties unchanged when no border is set', () => {
+		const tokens = capturedTokens(BLOCK, SET, { kbPreset: 'primary' });
+
+		expect(tokens['button-border-width']).toBe('2px');
+		expect(tokens['button-border-style']).toBe('solid');
+		expect(tokens['button-border-color']).toBe('#3182ce');
+	});
+});
+
 describe('capturedCatalogValues', () => {
 	beforeEach(() => {
 		seedCatalog();

--- a/src/extension/preset-picker/capture.js
+++ b/src/extension/preset-picker/capture.js
@@ -9,6 +9,7 @@
 import { get } from 'lodash';
 import { KADENCE_TOKEN_NAMESPACE } from '../../token-controls/helpers/preset-envelope';
 import { activeLibrary, activePresetFor, blockProperties, blockPresetValues } from './index';
+import { BORDER_AXIS_KIND } from '../token-indicators';
 import {
 	normalizeColor,
 	normalizeDimension,
@@ -227,13 +228,28 @@ export function capturedTokens(blockName, library, attributes) {
 	const presetValues = get(blockPresetValues(blockName, resolvedLibrary), currentSlug, {});
 
 	return blockProperties(blockName, resolvedLibrary).reduce((tokens, property) => {
+		const presetValue = get(presetValues, property.key, '');
+
+		// The three border-axis properties (`BORDER_AXIS_KIND`) share ONE `control_attr` pointing at a
+		// nested per-side native shape (`[{ top: [color, style, size], ... }]`) this loop's flat
+		// dimension/color model cannot read — `isEmptyValue`/`attrToLiteral` would stringify the object
+		// and write "[object Object]"-shaped garbage into the captured preset. Reading one axis out of
+		// that shape correctly is real, non-trivial logic (the same axis-aware read
+		// `token-indicators/index.js`'s `usePresetBinding` already does) that this capture flow was never
+		// asked to support — so these three are skipped and pass the preset's existing value through
+		// unchanged, the same "not edited" fallback every other unmapped property already takes.
+		if (BORDER_AXIS_KIND[property.key]) {
+			tokens[property.key] = presetValue;
+
+			return tokens;
+		}
+
 		const attr = property.control_attr;
 		const raw = attr ? get(attributes, attr, '') : '';
 		const unit = property.kind === 'dimension' && attr ? get(attributes, `${attr}Unit`, '') : '';
 		// "Edited" here is simply "the control carries a value" — we snapshot the current visual state, so a
 		// value that happens to equal the preset is captured all the same (no differs-from-preset compare).
 		const edited = attr && !isEmptyValue(property.kind, raw);
-		const presetValue = get(presetValues, property.key, '');
 		const base = edited ? attrToLiteral(property.kind, raw, unit, presetValue) : presetValue;
 
 		tokens[property.key] = withResponsive(base, property, attributes, unit);

--- a/src/extension/token-indicators/__tests__/index.test.js
+++ b/src/extension/token-indicators/__tests__/index.test.js
@@ -10,7 +10,13 @@ jest.mock('../components/TokenIndicator', () => ({ TokenIndicator: () => null })
 jest.mock('../components/TokenLabel', () => ({ TokenLabel: () => null }));
 jest.mock('../components/TokenControlRow', () => ({ TokenControlRow: () => null }));
 
-import { usePresetBinding, resetAttrPatch, presetPropertyValueForDevice, mappedAttrsFor } from '../index';
+import {
+	usePresetBinding,
+	resetAttrPatch,
+	presetPropertyValueForDevice,
+	mappedAttrsFor,
+	deriveStateBinding,
+} from '../index';
 
 const BLOCK = 'kadence/singlebtn';
 const SET = 'default';
@@ -440,6 +446,45 @@ describe('usePresetBinding border width/style/color combining', () => {
 
 		expect(state.borderStyle.overridden).toBe(true);
 	});
+
+	/**
+	 * On Tablet, the compare uses the tablet border attribute against the preset value in effect at
+	 * Tablet, not the (empty) desktop attribute — mirroring the dimension kind's own device-awareness
+	 * (see the `usePresetBinding device-aware overridden` suite above). Before this fix, border kinds
+	 * always read the desktop attribute regardless of `previewDevice`.
+	 *
+	 * @return {void}
+	 */
+	it('reads the tablet border attribute, not the desktop one, when previewDevice is Tablet', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			// Desktop stores a color that would NOT match the preset if read by mistake.
+			borderStyle: [
+				{
+					top: ['#ffffff', 'solid', '2'],
+					right: ['#ffffff', 'solid', '2'],
+					bottom: ['#ffffff', 'solid', '2'],
+					left: ['#ffffff', 'solid', '2'],
+					unit: 'px',
+				},
+			],
+			// Tablet stores exactly the preset's tablet-effective values — color from its tablet
+			// override, width/style falling back to their (device-less) desktop value.
+			tabletBorderStyle: [
+				{
+					top: ['#000000', 'solid', '2'],
+					right: ['#000000', 'solid', '2'],
+					bottom: ['#000000', 'solid', '2'],
+					left: ['#000000', 'solid', '2'],
+					unit: 'px',
+				},
+			],
+		};
+
+		const state = usePresetBinding(BLOCK, attributes, SET, 'Tablet');
+
+		expect(state.borderStyle.overridden).toBe(false);
+	});
 });
 
 describe('mappedAttrsFor border dedupe', () => {
@@ -533,5 +578,162 @@ describe('resetAttrPatch', () => {
 			tabletBorderStyle: [],
 			mobileBorderStyle: [],
 		});
+	});
+});
+
+describe('deriveStateBinding', () => {
+	/**
+	 * When the shared binding is not bound at all (no preset governs the property), the derived state
+	 * is not bound either — there is nothing to compare a per-state value against.
+	 *
+	 * @return {void}
+	 */
+	it('reports not bound when the shared binding is not bound', () => {
+		expect(deriveStateBinding({ shared: undefined, kind: 'dimension', value: ['4', '4', '4', '4'] })).toEqual({
+			bound: false,
+			overridden: false,
+		});
+	});
+
+	/**
+	 * A dimension state (e.g. Sticky's own Border Radius) whose own value matches the shared preset at
+	 * the active device reads as bound and not overridden.
+	 *
+	 * @return {void}
+	 */
+	it('reports a dimension state as bound and not overridden when its own value matches the shared preset', () => {
+		const shared = { bound: true };
+
+		const state = deriveStateBinding({
+			shared,
+			kind: 'dimension',
+			value: ['4', '4', '4', '4'],
+			unit: 'px',
+			devicePresetValue: '4px',
+		});
+
+		expect(state).toEqual({ bound: true, overridden: false });
+	});
+
+	/**
+	 * A dimension state whose own value diverges from the shared preset reads as overridden — even
+	 * though the shared binding itself (Normal's) might still match.
+	 *
+	 * @return {void}
+	 */
+	it('reports a dimension state as overridden when its own value diverges from the shared preset', () => {
+		const shared = { bound: true };
+
+		const state = deriveStateBinding({
+			shared,
+			kind: 'dimension',
+			value: ['8', '8', '8', '8'],
+			unit: 'px',
+			devicePresetValue: '4px',
+		});
+
+		expect(state).toEqual({ bound: true, overridden: true });
+	});
+
+	/**
+	 * A never-written dimension state reads as bound and not overridden, matching the empty => bound
+	 * signal `usePresetBinding` itself uses.
+	 *
+	 * @return {void}
+	 */
+	it('reports a never-written dimension state as bound and not overridden', () => {
+		const shared = { bound: true };
+
+		const state = deriveStateBinding({
+			shared,
+			kind: 'dimension',
+			value: ['', '', '', ''],
+			unit: 'px',
+			devicePresetValue: '4px',
+		});
+
+		expect(state).toEqual({ bound: true, overridden: false });
+	});
+
+	/**
+	 * A border state whose own value matches every axis of the shared border binding's preset values
+	 * reads as bound and not overridden.
+	 *
+	 * @return {void}
+	 */
+	it('reports a border state as bound and not overridden when every axis matches', () => {
+		const shared = {
+			bound: true,
+			presetValue: { width: '2px', style: 'solid', color: '#3182ce' },
+			responsive: { width: {}, style: {}, color: {} },
+		};
+		const value = [
+			{
+				top: ['#3182ce', 'solid', '2'],
+				right: ['#3182ce', 'solid', '2'],
+				bottom: ['#3182ce', 'solid', '2'],
+				left: ['#3182ce', 'solid', '2'],
+				unit: 'px',
+			},
+		];
+
+		const state = deriveStateBinding({ shared, kind: 'border', value, previewDevice: 'Desktop' });
+
+		expect(state).toEqual({ bound: true, overridden: false });
+	});
+
+	/**
+	 * A border state diverging on only one axis (color) still reports the combined entry as
+	 * overridden, matching `usePresetBinding`'s own "any axis diverges" rule.
+	 *
+	 * @return {void}
+	 */
+	it('reports a border state as overridden when only one axis diverges', () => {
+		const shared = {
+			bound: true,
+			presetValue: { width: '2px', style: 'solid', color: '#3182ce' },
+			responsive: { width: {}, style: {}, color: {} },
+		};
+		const value = [
+			{
+				top: ['#ffffff', 'solid', '2'],
+				right: ['#ffffff', 'solid', '2'],
+				bottom: ['#ffffff', 'solid', '2'],
+				left: ['#ffffff', 'solid', '2'],
+				unit: 'px',
+			},
+		];
+
+		const state = deriveStateBinding({ shared, kind: 'border', value, previewDevice: 'Desktop' });
+
+		expect(state).toEqual({ bound: true, overridden: true });
+	});
+
+	/**
+	 * A border state's own device preset value resolves per axis at the active device, mirroring
+	 * `usePresetBinding`'s own device-awareness — a value matching the DESKTOP preset but not the
+	 * TABLET override reads as overridden on Tablet.
+	 *
+	 * @return {void}
+	 */
+	it('resolves each border axis preset value at the active device', () => {
+		const shared = {
+			bound: true,
+			presetValue: { width: '2px', style: 'solid', color: '#3182ce' },
+			responsive: { width: {}, style: {}, color: { tablet: '#ffffff' } },
+		};
+		const value = [
+			{
+				top: ['#3182ce', 'solid', '2'],
+				right: ['#3182ce', 'solid', '2'],
+				bottom: ['#3182ce', 'solid', '2'],
+				left: ['#3182ce', 'solid', '2'],
+				unit: 'px',
+			},
+		];
+
+		const state = deriveStateBinding({ shared, kind: 'border', value, previewDevice: 'Tablet' });
+
+		expect(state).toEqual({ bound: true, overridden: true });
 	});
 });

--- a/src/extension/token-indicators/__tests__/index.test.js
+++ b/src/extension/token-indicators/__tests__/index.test.js
@@ -736,4 +736,32 @@ describe('deriveStateBinding', () => {
 
 		expect(state).toEqual({ bound: true, overridden: true });
 	});
+
+	/**
+	 * A preset that binds only ONE border axis (width) is compared on that axis alone — the style and
+	 * color axes, which the preset never sets, are not checked against an undefined preset value, so a
+	 * value matching the bound width axis reads as bound, not overridden.
+	 *
+	 * @return {void}
+	 */
+	it('compares only the border axes the preset actually binds', () => {
+		const shared = {
+			bound: true,
+			presetValue: { width: '2px' },
+			responsive: { width: {} },
+		};
+		const value = [
+			{
+				top: ['#ffffff', 'dashed', '2'],
+				right: ['#ffffff', 'dashed', '2'],
+				bottom: ['#ffffff', 'dashed', '2'],
+				left: ['#ffffff', 'dashed', '2'],
+				unit: 'px',
+			},
+		];
+
+		const state = deriveStateBinding({ shared, kind: 'border', value, previewDevice: 'Desktop' });
+
+		expect(state).toEqual({ bound: true, overridden: false });
+	});
 });

--- a/src/extension/token-indicators/__tests__/index.test.js
+++ b/src/extension/token-indicators/__tests__/index.test.js
@@ -10,7 +10,7 @@ jest.mock('../components/TokenIndicator', () => ({ TokenIndicator: () => null })
 jest.mock('../components/TokenLabel', () => ({ TokenLabel: () => null }));
 jest.mock('../components/TokenControlRow', () => ({ TokenControlRow: () => null }));
 
-import { usePresetBinding, resetAttrPatch, presetPropertyValueForDevice } from '../index';
+import { usePresetBinding, resetAttrPatch, presetPropertyValueForDevice, mappedAttrsFor } from '../index';
 
 const BLOCK = 'kadence/singlebtn';
 const SET = 'default';
@@ -266,6 +266,182 @@ describe('presetPropertyValueForDevice', () => {
 	});
 });
 
+describe('usePresetBinding border width/style/color combining', () => {
+	/**
+	 * Seed the localized catalog with the three border-axis properties, all sharing the
+	 * `control_attr: 'borderStyle'` binding `declarations.php` now declares.
+	 *
+	 * @return {void}
+	 */
+	function seedBorderCatalog() {
+		window.kadenceDesignTokensPresets = {
+			active: SET,
+			libraries: {
+				[SET]: {
+					[BLOCK]: {
+						default: 'primary',
+						presets: [{ slug: 'primary', label: 'Primary' }],
+						properties: [
+							{
+								key: 'button-border-width',
+								kind: 'dimension',
+								token: 'semantic.border-width.default',
+								control_attr: 'borderStyle',
+							},
+							{
+								key: 'button-border-style',
+								kind: 'color',
+								token: 'semantic.border-style.default',
+								control_attr: 'borderStyle',
+							},
+							{
+								key: 'button-border-color',
+								kind: 'color',
+								token: 'semantic.color.border',
+								control_attr: 'borderStyle',
+							},
+						],
+						values: {
+							primary: {
+								'button-border-width': '2px',
+								'button-border-style': 'solid',
+								'button-border-color': '#3182ce',
+							},
+						},
+						responsive: {},
+					},
+				},
+			},
+		};
+	}
+
+	beforeEach(() => {
+		seedBorderCatalog();
+	});
+
+	afterEach(() => {
+		delete window.kadenceDesignTokensPresets;
+	});
+
+	/**
+	 * A never-written native border value reads as bound and not overridden, combining all three axes
+	 * into the single `borderStyle` state entry.
+	 *
+	 * @return {void}
+	 */
+	it('combines the three axes into one borderStyle entry, reading bound when never written', () => {
+		const state = usePresetBinding(BLOCK, { kbPreset: 'primary' }, SET, 'Desktop');
+
+		expect(Object.keys(state)).toEqual(['borderStyle']);
+		expect(state.borderStyle.kind).toBe('border');
+		expect(state.borderStyle.bound).toBe(true);
+		expect(state.borderStyle.overridden).toBe(false);
+		expect(state.borderStyle.presetValue).toEqual({ width: '2px', style: 'solid', color: '#3182ce' });
+	});
+
+	/**
+	 * A native border value equal to the preset on every axis and every side is bound, not overridden.
+	 *
+	 * @return {void}
+	 */
+	it('reads a native value matching the preset on every axis as not overridden', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			borderStyle: [
+				{
+					top: ['#3182ce', 'solid', '2'],
+					right: ['#3182ce', 'solid', '2'],
+					bottom: ['#3182ce', 'solid', '2'],
+					left: ['#3182ce', 'solid', '2'],
+					unit: 'px',
+				},
+			],
+		};
+
+		const state = usePresetBinding(BLOCK, attributes, SET, 'Desktop');
+
+		expect(state.borderStyle.overridden).toBe(false);
+	});
+
+	/**
+	 * A native border value diverging on only ONE axis (color) still reports the combined entry as
+	 * overridden — "overridden" means any axis diverges, not every axis.
+	 *
+	 * @return {void}
+	 */
+	it('reports overridden when only one axis diverges from its own preset value', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			borderStyle: [
+				{
+					top: ['#ffffff', 'solid', '2'],
+					right: ['#ffffff', 'solid', '2'],
+					bottom: ['#ffffff', 'solid', '2'],
+					left: ['#ffffff', 'solid', '2'],
+					unit: 'px',
+				},
+			],
+		};
+
+		const state = usePresetBinding(BLOCK, attributes, SET, 'Desktop');
+
+		expect(state.borderStyle.overridden).toBe(true);
+	});
+});
+
+describe('mappedAttrsFor border dedupe', () => {
+	/**
+	 * The three border-axis properties, sharing one `control_attr`, collapse to a single mapped
+	 * attribute reporting the combined `'border'` kind — not three entries with three different
+	 * (individually wrong) kinds for `resetAttrPatch` to act on.
+	 *
+	 * @return {void}
+	 */
+	it('collapses the three border-axis properties into one border-kind entry', () => {
+		window.kadenceDesignTokensPresets = {
+			active: SET,
+			libraries: {
+				[SET]: {
+					[BLOCK]: {
+						default: 'primary',
+						presets: [{ slug: 'primary', label: 'Primary' }],
+						properties: [
+							{
+								key: 'button-border-width',
+								kind: 'dimension',
+								token: 'semantic.border-width.default',
+								control_attr: 'borderStyle',
+							},
+							{
+								key: 'button-border-style',
+								kind: 'color',
+								token: 'semantic.border-style.default',
+								control_attr: 'borderStyle',
+							},
+							{
+								key: 'button-border-color',
+								kind: 'color',
+								token: 'semantic.color.border',
+								control_attr: 'borderStyle',
+							},
+							{ key: 'button-radius', kind: 'dimension', token: null, control_attr: 'borderRadius' },
+						],
+						values: {},
+						responsive: {},
+					},
+				},
+			},
+		};
+
+		expect(mappedAttrsFor(BLOCK, SET)).toEqual([
+			{ attr: 'borderStyle', kind: 'border' },
+			{ attr: 'borderRadius', kind: 'dimension' },
+		]);
+
+		delete window.kadenceDesignTokensPresets;
+	});
+});
+
 describe('resetAttrPatch', () => {
 	/**
 	 * A dimension reset clears the primary, unit, and both responsive companion attributes to their
@@ -289,5 +465,20 @@ describe('resetAttrPatch', () => {
 	 */
 	it('clears only the primary attribute for a non-dimension kind', () => {
 		expect(resetAttrPatch('background', 'color')).toEqual({ background: '' });
+	});
+
+	/**
+	 * A border reset clears the primary attribute and both responsive companions to an empty ARRAY
+	 * (`[]`), not `['', '', '', '']` — the shape `EditorBorderControl`'s `fromNativeBorder` reads as
+	 * "never written" via its `!native?.[0]` short-circuit.
+	 *
+	 * @return {void}
+	 */
+	it('clears the primary and responsive companions to an empty array for a border', () => {
+		expect(resetAttrPatch('borderStyle', 'border')).toEqual({
+			borderStyle: [],
+			tabletBorderStyle: [],
+			mobileBorderStyle: [],
+		});
 	});
 });

--- a/src/extension/token-indicators/__tests__/index.test.js
+++ b/src/extension/token-indicators/__tests__/index.test.js
@@ -308,7 +308,9 @@ describe('usePresetBinding border width/style/color combining', () => {
 								'button-border-color': '#3182ce',
 							},
 						},
-						responsive: {},
+						responsive: {
+							primary: { tablet: { 'button-border-color': '#000000' } },
+						},
 					},
 				},
 			},
@@ -384,6 +386,57 @@ describe('usePresetBinding border width/style/color combining', () => {
 		};
 
 		const state = usePresetBinding(BLOCK, attributes, SET, 'Desktop');
+
+		expect(state.borderStyle.overridden).toBe(true);
+	});
+
+	/**
+	 * On Tablet, a border axis reads its OWN device's stored attribute against the preset's tablet
+	 * override — not the desktop attribute against the desktop preset value, which is what the border
+	 * axes did before treating them as responsive like a dimension.
+	 *
+	 * @return {void}
+	 */
+	it('reports not overridden when the tablet border value matches the preset tablet override', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			tabletBorderStyle: [
+				{
+					top: ['#000000', 'solid', '2'],
+					right: ['#000000', 'solid', '2'],
+					bottom: ['#000000', 'solid', '2'],
+					left: ['#000000', 'solid', '2'],
+					unit: 'px',
+				},
+			],
+		};
+
+		const state = usePresetBinding(BLOCK, attributes, SET, 'Tablet');
+
+		expect(state.borderStyle.overridden).toBe(false);
+	});
+
+	/**
+	 * On Tablet, a border axis diverging from the preset's tablet override reads as overridden even
+	 * though it would match the preset's desktop value.
+	 *
+	 * @return {void}
+	 */
+	it('reports overridden when the tablet border value differs from the preset tablet override', () => {
+		const attributes = {
+			kbPreset: 'primary',
+			tabletBorderStyle: [
+				{
+					top: ['#3182ce', 'solid', '2'],
+					right: ['#3182ce', 'solid', '2'],
+					bottom: ['#3182ce', 'solid', '2'],
+					left: ['#3182ce', 'solid', '2'],
+					unit: 'px',
+				},
+			],
+		};
+
+		const state = usePresetBinding(BLOCK, attributes, SET, 'Tablet');
 
 		expect(state.borderStyle.overridden).toBe(true);
 	});

--- a/src/extension/token-indicators/__tests__/normalize.test.js
+++ b/src/extension/token-indicators/__tests__/normalize.test.js
@@ -294,6 +294,88 @@ describe('isEmptyValue', () => {
 	it('treats a populated color as not empty', () => {
 		expect(isEmptyValue('color', 'palette3')).toBe(false);
 	});
+
+	it('treats an undefined native border value as empty for every axis', () => {
+		expect(isEmptyValue('border-width', undefined)).toBe(true);
+		expect(isEmptyValue('border-style', undefined)).toBe(true);
+		expect(isEmptyValue('border-color', undefined)).toBe(true);
+	});
+
+	it('treats an empty-array native border value as empty for every axis', () => {
+		expect(isEmptyValue('border-width', [])).toBe(true);
+		expect(isEmptyValue('border-style', [])).toBe(true);
+		expect(isEmptyValue('border-color', [])).toBe(true);
+	});
+
+	it('treats a written native border value as not empty for every axis, even with all-blank sides', () => {
+		const value = [
+			{
+				top: ['', '', ''],
+				right: ['', '', ''],
+				bottom: ['', '', ''],
+				left: ['', '', ''],
+				unit: 'px',
+			},
+		];
+
+		expect(isEmptyValue('border-width', value)).toBe(false);
+		expect(isEmptyValue('border-style', value)).toBe(false);
+		expect(isEmptyValue('border-color', value)).toBe(false);
+	});
+});
+
+describe('matchesPreset border', () => {
+	const UNIFORM = [
+		{
+			top: ['#3182ce', 'solid', '2'],
+			right: ['#3182ce', 'solid', '2'],
+			bottom: ['#3182ce', 'solid', '2'],
+			left: ['#3182ce', 'solid', '2'],
+			unit: 'px',
+		},
+	];
+
+	const DIVERGENT = [
+		{
+			top: ['#3182ce', 'solid', '2'],
+			right: ['#3182ce', 'solid', '2'],
+			bottom: ['#3182ce', 'solid', '2'],
+			left: ['#ffffff', 'dashed', '4'],
+			unit: 'px',
+		},
+	];
+
+	it('does not match an unset native border value for any axis', () => {
+		expect(matchesPreset('border-width', undefined, '', '2px')).toBe(false);
+		expect(matchesPreset('border-style', undefined, '', 'solid')).toBe(false);
+		expect(matchesPreset('border-color', undefined, '', '#3182ce')).toBe(false);
+	});
+
+	it('matches a native border value equal on every side, per axis', () => {
+		expect(matchesPreset('border-width', UNIFORM, '', '2px')).toBe(true);
+		expect(matchesPreset('border-style', UNIFORM, '', 'solid')).toBe(true);
+		expect(matchesPreset('border-color', UNIFORM, '', '#3182ce')).toBe(true);
+	});
+
+	it('does not match a native border value diverging on one side, per axis', () => {
+		expect(matchesPreset('border-width', DIVERGENT, '', '2px')).toBe(false);
+		expect(matchesPreset('border-style', DIVERGENT, '', 'solid')).toBe(false);
+		expect(matchesPreset('border-color', DIVERGENT, '', '#3182ce')).toBe(false);
+	});
+
+	it('matches a border-width side written as a token alias against the same alias literal', () => {
+		const value = [
+			{
+				top: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
+				right: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
+				bottom: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
+				left: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
+				unit: 'px',
+			},
+		];
+
+		expect(matchesPreset('border-width', value, '', '{primitive.dimension.border-width.md}')).toBe(true);
+	});
 });
 
 describe('normalizeDimension', () => {

--- a/src/extension/token-indicators/__tests__/normalize.test.js
+++ b/src/extension/token-indicators/__tests__/normalize.test.js
@@ -1,0 +1,36 @@
+/* eslint-env jest */
+
+import { isEmptyValue, matchesPreset } from '../normalize';
+
+describe('normalize dispatch falls back to text for an unrecognized kind', () => {
+	/**
+	 * A kind the `KINDS` dispatch table has no entry for degrades to the `text` handler's `isEmpty`
+	 * check instead of throwing — the localized catalog's `kind` values come from PHP's registry and are
+	 * not narrowed to this table's keys at write time.
+	 *
+	 * @return {void}
+	 */
+	it('reads an unrecognized kind as empty when the value is empty text', () => {
+		expect(isEmptyValue('unknown-kind', '')).toBe(true);
+	});
+
+	/**
+	 * An unrecognized kind's non-empty value reads as not empty, matching the `text` handler.
+	 *
+	 * @return {void}
+	 */
+	it('reads an unrecognized kind as not empty when the value is non-empty text', () => {
+		expect(isEmptyValue('unknown-kind', 'value')).toBe(false);
+	});
+
+	/**
+	 * An unrecognized kind's compare falls back to the `text` handler's trimmed string compare instead
+	 * of throwing on a missing dispatch-table entry.
+	 *
+	 * @return {void}
+	 */
+	it('compares an unrecognized kind as text', () => {
+		expect(matchesPreset('unknown-kind', 'value', '', 'value')).toBe(true);
+		expect(matchesPreset('unknown-kind', 'value', '', 'other')).toBe(false);
+	});
+});

--- a/src/extension/token-indicators/__tests__/store.test.js
+++ b/src/extension/token-indicators/__tests__/store.test.js
@@ -1,0 +1,48 @@
+/* eslint-env jest */
+/**
+ * `store.js` registers `kadence/token-indicators` as an unconditional module-load side effect.
+ * Two separate webpack bundles (`early-filters.js` and `blocks-singlebtn.js`) both import it, so
+ * its top-level code runs once per bundle on the same page — `@wordpress/data`'s registry is a
+ * page-wide singleton, so the second bundle's copy must not re-register. These tests exercise the
+ * guard in isolation, mocking `@wordpress/data` so the module's own load-time logic is what's
+ * under test, not the real registry.
+ */
+
+/**
+ * Loads `store.js` fresh, with `@wordpress/data`'s `select`/`register`/`createReduxStore` mocked.
+ *
+ * @param {*} selectReturnValue What the mocked `select( 'kadence/token-indicators' )` returns.
+ *
+ * @since TBD
+ *
+ * @return {Object} `{ register }` — the mocked `register` spy, for assertions.
+ */
+function loadStoreModule(selectReturnValue) {
+	jest.resetModules();
+
+	const register = jest.fn();
+	const select = jest.fn(() => selectReturnValue);
+	const createReduxStore = jest.fn((name, config) => ({ name, config }));
+
+	jest.doMock('@wordpress/data', () => ({ register, select, createReduxStore }));
+
+	require('../store');
+
+	return { register, select };
+}
+
+describe('token-indicators store registration guard', () => {
+	it('registers the store when @wordpress/data reports it as not yet registered', () => {
+		const { register, select } = loadStoreModule(undefined);
+
+		expect(select).toHaveBeenCalledWith('kadence/token-indicators');
+		expect(register).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not re-register when @wordpress/data already reports the store as registered', () => {
+		const { register, select } = loadStoreModule({ isHighlightingEdits: () => false });
+
+		expect(select).toHaveBeenCalledWith('kadence/token-indicators');
+		expect(register).not.toHaveBeenCalled();
+	});
+});

--- a/src/extension/token-indicators/components/TokenControlRow.js
+++ b/src/extension/token-indicators/components/TokenControlRow.js
@@ -7,6 +7,10 @@
  * header row is skipped entirely — the wrapper then only contributes the highlight tint, for a control
  * that already carries its indicator inline (via `TokenLabel`). When "highlight edits" is on and this
  * control overrides its preset, the whole row is tinted a warning color so the edit stands out.
+ *
+ * `attr`/`binding` can be omitted entirely (`highlight` then never fires) for a control with no bound
+ * attribute to track at all — used this way purely for the `.kb-token-control-row` spacing/`stacked`
+ * layout, e.g. by the `Editor*` design-token controls that already carry their own indicator internally.
  */
 
 import { useSelect } from '@wordpress/data';
@@ -20,8 +24,9 @@ import { TokenIndicator } from './TokenIndicator';
  * @param {string}   [props.heading] Heading text shown next to the indicator, above the control; with no
  *                                   heading the header row (and its indicator) is skipped and the wrapper
  *                                   only contributes the highlight tint.
- * @param {string}   props.attr      The attribute the wrapped control writes (the indicator's key).
- * @param {Object}   props.binding   The block's binding map from usePresetBinding.
+ * @param {?string}  [props.attr]    The attribute the wrapped control writes (the indicator's key); omit
+ *                                   alongside `binding` for a control with nothing to highlight.
+ * @param {?Object}  [props.binding] The block's binding map from usePresetBinding; omit alongside `attr`.
  * @param {Function} [props.onReset] Called with `attr` to reset that control's override (headed rows only).
  * @param {boolean}  [props.stacked] Stack the header above a full-width control (for block-level controls
  *                                   like the responsive measurement inputs) instead of the side-by-side row.

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -79,11 +79,15 @@ function unitAttrFor(kind, attr) {
  * `[{ top: [color, style, size], ... }]` shape as a flat scalar/4-side value and never match. This map
  * overrides the kind used for the compare ONLY, by property key, so each axis reads its own slot.
  *
+ * Exported so a caller outside this module that also needs to tell a border-axis property apart from
+ * a plain one (e.g. `capture.js`'s "save as a new preset" flow, which cannot read this nested shape
+ * through its own flat control_attr model) can key off the same map instead of re-deriving it.
+ *
  * @since TBD
  *
  * @type {Object<string, string>}
  */
-const BORDER_AXIS_KIND = {
+export const BORDER_AXIS_KIND = {
 	'button-border-width': 'border-width',
 	'button-border-style': 'border-style',
 	'button-border-color': 'border-color',
@@ -188,16 +192,17 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
 			mobile: get(presetBreakpoints, ['mobile', property.key]),
 		};
 
-		// `overridden` compares like against like: a responsive control (a dimension, or a border axis —
-		// each border axis has its own tabletBorderStyle/mobileBorderStyle-shaped attribute) reads its
-		// OWN device's stored attribute (`tabletBorderRadius` on Tablet), against the preset value in
-		// effect at that same device (its tablet override where the preset declares one, else the base).
-		// Comparing a Tablet-stored value to the desktop preset value — or reporting the desktop
+		// `overridden` compares like against like: a dimension OR border control reads its OWN device's
+		// stored attribute (`tabletBorderRadius`/`tabletBorderStyle` on Tablet), against the preset value
+		// in effect at that same device (its tablet override where the preset declares one, else the
+		// base). Comparing a Tablet-stored value to the desktop preset value — or reporting the desktop
 		// attribute's state while Tablet is open — would show the wrong mark for the device actually
-		// being edited.
-		const isResponsive = kind === 'dimension' || Boolean(axis);
-		const deviceAttr = isResponsive ? deviceAttrFor(attr, previewDevice) : attr;
-		const devicePresetValue = isResponsive
+		// being edited. Border shares this device-awareness with dimension (not just the axis kinds'
+		// nested-shape read) because `resetAttrPatch`'s own `'border'` case already clears the tablet/
+		// mobile companions — the compare and the reset must agree on which attribute is "the" one.
+		const isDeviceAware = kind === 'dimension' || !!axis;
+		const deviceAttr = isDeviceAware ? deviceAttrFor(attr, previewDevice) : attr;
+		const devicePresetValue = isDeviceAware
 			? presetValueForDevice(presetValue, propertyBreakpoints, previewDevice)
 			: presetValue;
 		const value = get(attributes, deviceAttr, '');
@@ -346,4 +351,70 @@ export function resetAttrPatch(attr, kind) {
  */
 export function resetAttr(attr, setAttributes, kind) {
 	setAttributes(resetAttrPatch(attr, kind));
+}
+
+/**
+ * The design-token binding state for a NON-Normal state's own attribute (Hover, Sticky, and so on),
+ * derived from the SHARED `usePresetBinding` entry Normal's own control already carries plus this
+ * state's own current value at the active device.
+ *
+ * There is only one border-radius/border preset property per block, so every state shares Normal's
+ * `tokenBinding.borderRadius`/`tokenBinding.borderStyle` for `bound`, `presetValue`, and `responsive`
+ * — but `overridden` cannot be shared: Normal's entry only ever compares Normal's own attribute, so
+ * reusing it on e.g. Sticky would report Normal's divergence on Sticky's field, and its `onReset`
+ * would clear Normal's attributes instead of Sticky's. This computes `overridden` fresh from the
+ * state's own value, using the exact `isEmptyValue`/`matchesPreset` calls `usePresetBinding`'s own
+ * loop already runs internally — just invoked here directly instead of through that loop's
+ * `control_attr`-driven dispatch, since a per-state attribute is never itself a `control_attr`.
+ *
+ * @param {Object} shared            The shared binding entry from `usePresetBinding` this state's
+ *                                    property maps to (`tokenBinding.borderRadius` or
+ *                                    `tokenBinding.borderStyle`), carrying the combined `presetValue`/
+ *                                    `responsive` this function reuses rather than re-deriving.
+ * @param {string} kind              'dimension' (radius) or 'border' (the combined width/style/color
+ *                                    entry), matching `resetAttrPatch`'s own kind vocabulary.
+ * @param {*}      value             This state's own resolved value at the active device (e.g.
+ *                                    `borderStickyRadiusForDevice.value`, or the border attribute read
+ *                                    at the active device for `kind: 'border'`).
+ * @param {string}   [unit]          This state's own unit at the active device ('dimension' only;
+ *                                    unused for 'border', whose unit lives on the value itself).
+ * @param {*}        [devicePresetValue] For 'dimension': the shared preset value already resolved at
+ *                                    the active device (e.g. `borderRadiusPresetValue`, computed once
+ *                                    and shared across every state). Unused for 'border', which
+ *                                    resolves each axis's own device preset value from `shared`
+ *                                    directly (mirroring `usePresetBinding`'s own per-axis loop).
+ * @param {string}   [previewDevice] The active preview device ('Desktop' | 'Tablet' | 'Mobile') — only
+ *                                    needed for 'border', to resolve each axis's device preset value.
+ *
+ * @since TBD
+ *
+ * @return {{ bound: boolean, overridden: boolean }} This state's own binding state, the shape
+ *                                    `EditorBoxControl`/`EditorBorderControl`'s `state` prop expects.
+ */
+export function deriveStateBinding({ shared, kind, value, unit = '', devicePresetValue, previewDevice }) {
+	if (!shared?.bound) {
+		return { bound: false, overridden: false };
+	}
+
+	if (kind === 'border') {
+		const empty = isEmptyValue('border-width', value);
+		const overridden =
+			!empty &&
+			['width', 'style', 'color'].some((axis) => {
+				const axisPresetValue = presetValueForDevice(
+					shared.presetValue?.[axis],
+					shared.responsive?.[axis],
+					previewDevice
+				);
+
+				return !matchesPreset(`border-${axis}`, value, '', axisPresetValue);
+			});
+
+		return { bound: true, overridden };
+	}
+
+	const empty = isEmptyValue(kind, value);
+	const overridden = !empty && !matchesPreset(kind, value, unit, devicePresetValue);
+
+	return { bound: true, overridden };
 }

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -188,14 +188,18 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
 			mobile: get(presetBreakpoints, ['mobile', property.key]),
 		};
 
-		// `overridden` compares like against like: a dimension control reads its OWN device's stored
-		// attribute (`tabletBorderRadius` on Tablet), against the preset value in effect at that same
-		// device (its tablet override where the preset declares one, else the base). Comparing a
-		// Tablet-stored value to the desktop preset value — or reporting the desktop attribute's state
-		// while Tablet is open — would show the wrong mark for the device actually being edited.
-		const deviceAttr = kind === 'dimension' ? deviceAttrFor(attr, previewDevice) : attr;
-		const devicePresetValue =
-			kind === 'dimension' ? presetValueForDevice(presetValue, propertyBreakpoints, previewDevice) : presetValue;
+		// `overridden` compares like against like: a responsive control (a dimension, or a border axis —
+		// each border axis has its own tabletBorderStyle/mobileBorderStyle-shaped attribute) reads its
+		// OWN device's stored attribute (`tabletBorderRadius` on Tablet), against the preset value in
+		// effect at that same device (its tablet override where the preset declares one, else the base).
+		// Comparing a Tablet-stored value to the desktop preset value — or reporting the desktop
+		// attribute's state while Tablet is open — would show the wrong mark for the device actually
+		// being edited.
+		const isResponsive = kind === 'dimension' || Boolean(axis);
+		const deviceAttr = isResponsive ? deviceAttrFor(attr, previewDevice) : attr;
+		const devicePresetValue = isResponsive
+			? presetValueForDevice(presetValue, propertyBreakpoints, previewDevice)
+			: presetValue;
 		const value = get(attributes, deviceAttr, '');
 		const unit = unitAttrFor(kind, attr) ? get(attributes, unitAttrFor(kind, attr), '') : '';
 

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -67,9 +67,38 @@ function unitAttrFor(kind, attr) {
 }
 
 /**
+ * The `button-border-width`/`button-border-style`/`button-border-color` properties, keyed by their
+ * property key, to the axis kind `normalize.js`'s `isEmptyValue`/`matchesPreset` read for them.
+ *
+ * Declaring these as a single shared `control_attr: 'borderStyle'` (see `declarations.php`) is correct —
+ * `EditorBorderControl` edits all three axes as one control with no per-axis reset — but it means PHP's
+ * generic `Preset_Bindings::kind()` (name/token-group classification with no notion of this nested
+ * per-side shape) cannot tell the three apart: `button-border-width` reads as its generic 'dimension' and
+ * both `button-border-style`/`button-border-color` read as generic 'color'. Passed straight through,
+ * `isEmptyValue`/`matchesPreset`'s existing 'dimension'/'color' branches would try to read the nested
+ * `[{ top: [color, style, size], ... }]` shape as a flat scalar/4-side value and never match. This map
+ * overrides the kind used for the compare ONLY, by property key, so each axis reads its own slot.
+ *
+ * @since TBD
+ *
+ * @type {Object<string, string>}
+ */
+const BORDER_AXIS_KIND = {
+	'button-border-width': 'border-width',
+	'button-border-style': 'border-style',
+	'button-border-color': 'border-color',
+};
+
+/**
  * The mapped control attributes for a block's set, as `[{ attr, kind }]` — the surface reset-all clears.
  * Skips properties with no control attribute. Independent of the selected preset (reset-all clears every
  * mapped override regardless of which preset is active).
+ *
+ * The three border-axis properties share one `control_attr` (see `BORDER_AXIS_KIND`), so they would
+ * otherwise produce three entries for the same attribute, each with a different (and individually wrong)
+ * kind for `resetAttrPatch`. Deduping by attribute and reporting the combined `'border'` kind for any of
+ * them keeps reset-all's one patch-per-attribute clearing every axis at once, matching `resetAttrPatch`'s
+ * own `'border'` case.
  *
  * @param {string} blockName The block name.
  * @param {string} [library] The token library slug; defaults to the active library.
@@ -79,9 +108,23 @@ function unitAttrFor(kind, attr) {
  * @return {Array} The mapped attributes ([{ attr, kind }]).
  */
 export function mappedAttrsFor(blockName, library) {
-	return blockProperties(blockName, library || activeLibrary())
+	const seen = new Set();
+	const attrs = [];
+
+	blockProperties(blockName, library || activeLibrary())
 		.filter((property) => !!property.control_attr)
-		.map((property) => ({ attr: property.control_attr, kind: property.kind }));
+		.forEach((property) => {
+			const attr = property.control_attr;
+
+			if (seen.has(attr)) {
+				return;
+			}
+
+			seen.add(attr);
+			attrs.push({ attr, kind: BORDER_AXIS_KIND[property.key] ? 'border' : property.kind });
+		});
+
+	return attrs;
 }
 
 /**
@@ -102,7 +145,12 @@ export function mappedAttrsFor(blockName, library) {
  *
  * @return {Object} attrName => { property, token, kind, presetValue, responsive, bound, overridden }.
  *                   Keyed by the DESKTOP attribute name even when `overridden` reflects another
- *                   device, so a caller can still look a control up by its one stable key.
+ *                   device, so a caller can still look a control up by its one stable key. The
+ *                   `borderStyle` entry is the one exception: `kind` is `'border'` and `property`/
+ *                   `token`/`presetValue`/`responsive` are each `{ width, style, color }` objects,
+ *                   one slot per axis, combining the three properties that share that attribute (see
+ *                   `BORDER_AXIS_KIND`); `overridden` is true when any axis diverges from its own
+ *                   preset value.
  */
 export function usePresetBinding(blockName, attributes, library, previewDevice) {
 	const resolvedLibrary = library || activeLibrary();
@@ -130,7 +178,10 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
 			return;
 		}
 
-		const kind = property.kind;
+		// The border width/style/color properties all key their compare off `BORDER_AXIS_KIND` rather
+		// than PHP's generic `property.kind` — see that map's own docblock for why.
+		const axis = BORDER_AXIS_KIND[property.key];
+		const kind = axis || property.kind;
 		const presetValue = presetValues[property.key];
 		const propertyBreakpoints = {
 			tablet: get(presetBreakpoints, ['tablet', property.key]),
@@ -151,6 +202,34 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
 		const empty = isEmptyValue(kind, value);
 		const overridden = !empty && !matchesPreset(kind, value, unit, devicePresetValue);
 
+		// Width, style and color share the `borderStyle` attribute (one `EditorBorderControl`, no
+		// per-axis reset), so their three iterations combine into ONE entry rather than overwrite each
+		// other: `property`/`token`/`presetValue`/`responsive` become axis-keyed ('width'/'style'/
+		// 'color') objects, and `overridden` is true when ANY axis diverges from ITS OWN preset value —
+		// a stored border only reads as "matches the preset" once every axis does.
+		if (axis) {
+			const axisKey = axis.replace('border-', '');
+			const combined = state[attr] || {
+				property: {},
+				token: {},
+				kind: 'border',
+				presetValue: {},
+				responsive: {},
+				bound: true,
+				overridden: false,
+			};
+
+			combined.property[axisKey] = property.key;
+			combined.token[axisKey] = property.token;
+			combined.presetValue[axisKey] = presetValue;
+			combined.responsive[axisKey] = propertyBreakpoints;
+			combined.overridden = combined.overridden || overridden;
+
+			state[attr] = combined;
+
+			return;
+		}
+
 		state[attr] = {
 			property: property.key,
 			token: property.token,
@@ -167,14 +246,13 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
 
 /**
  * The active preset's resolved value for one property key, at the given device — for a property with
- * no `control_attr` (a `css_var`-only binding like `button-border-width`, whose native attribute is a
- * nested per-side shape `usePresetBinding` has nothing to key it by; see `declarations.php`'s comment
- * on that binding). `usePresetBinding` skips these properties entirely, so a caller that only needs
- * "what does the active preset resolve this to" — e.g. a dimension control's `defaultValue`, shown
- * muted once the control's own override is cleared — reads it directly here instead.
+ * no `control_attr` at all, whose native attribute `usePresetBinding` has nothing to key it by (a
+ * `css_var`-only binding). `usePresetBinding` skips these properties entirely, so a caller that only
+ * needs "what does the active preset resolve this to" — e.g. a dimension control's `defaultValue`,
+ * shown muted once the control's own override is cleared — reads it directly here instead.
  *
  * @param {string} blockName     The block name (e.g. 'kadence/singlebtn').
- * @param {string} propertyKey   The binding's property key (e.g. 'button-border-width').
+ * @param {string} propertyKey   The binding's property key (e.g. 'button-radius').
  * @param {Object} attributes    The block's current attributes — read for `kbPreset`, so a
  *                                user-selected preset (not just the block's default) resolves.
  * @param {string} [library]     The token library slug; defaults to the active library.
@@ -210,17 +288,33 @@ export function presetPropertyValueForDevice(blockName, propertyKey, attributes,
  * `tabletBorderRadius`, `mobileBorderRadius`) — not a bare `''`, and the unit resets to `'px'`
  * (`borderRadiusUnit`'s declared default), not `''`.
  *
+ * A `border` control (the combined `borderStyle` width/style/color entry) clears its `tablet*`/`mobile*`
+ * companions the same way, but to an empty ARRAY (`[]`), not `['', '', '', '']` — `EditorBorderControl`'s
+ * `fromNativeBorder` reads `[]` (or `undefined`) as "never written" via its `!native?.[0]` short-circuit,
+ * which is what makes the control read as bound again. `block.json`'s own declared default is a
+ * fully-populated-but-blank per-side object (`[{ top: ['', '', ''], ... }]`); that shape is NOT empty by
+ * `fromNativeBorder`'s own test (its `source` is truthy), so resetting to it would leave the control
+ * reading as overridden instead of bound.
+ *
  * Shared by the per-control reset (`resetAttr`) and the picker's reset-all, so their clearing convention
  * cannot drift.
  *
  * @param {string} attr The primary attribute name.
- * @param {string} kind The property kind, so a dimension also clears its companions.
+ * @param {string} kind The property kind, so a dimension/border also clears its companions.
  *
  * @since TBD
  *
  * @return {Object} The attribute patch to pass to `setAttributes`.
  */
 export function resetAttrPatch(attr, kind) {
+	if (kind === 'border') {
+		return {
+			[attr]: [],
+			[deviceAttrFor(attr, 'Tablet')]: [],
+			[deviceAttrFor(attr, 'Mobile')]: [],
+		};
+	}
+
 	if (kind !== 'dimension') {
 		return { [attr]: '' };
 	}

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -398,9 +398,13 @@ export function deriveStateBinding({ shared, kind, value, unit = '', devicePrese
 
 	if (kind === 'border') {
 		const empty = isEmptyValue('border-width', value);
+		// Only an axis the active preset actually binds is compared: `shared.presetValue` is keyed by
+		// exactly the axes `usePresetBinding` combined (see its own docblock), so an axis this preset
+		// never sets has no key here — checking it anyway would compare against `undefined` and read a
+		// matching border as overridden.
 		const overridden =
 			!empty &&
-			['width', 'style', 'color'].some((axis) => {
+			Object.keys(shared.presetValue || {}).some((axis) => {
 				const axisPresetValue = presetValueForDevice(
 					shared.presetValue?.[axis],
 					shared.responsive?.[axis],

--- a/src/extension/token-indicators/kinds/__tests__/border.test.js
+++ b/src/extension/token-indicators/kinds/__tests__/border.test.js
@@ -2,18 +2,37 @@
 import { isEmptyValue, matchesPreset } from '../../normalize';
 
 describe('isEmptyValue border', () => {
+	/**
+	 * A never-written native border value (`undefined`) reads as empty for every axis, matching
+	 * `fromNativeBorder`'s own `!source` short-circuit.
+	 *
+	 * @return {void}
+	 */
 	it('treats an undefined native border value as empty for every axis', () => {
 		expect(isEmptyValue('border-width', undefined)).toBe(true);
 		expect(isEmptyValue('border-style', undefined)).toBe(true);
 		expect(isEmptyValue('border-color', undefined)).toBe(true);
 	});
 
+	/**
+	 * A never-written native border value stored as an empty array reads as empty for every axis, the
+	 * shape `resetAttrPatch`'s own `'border'` case resets to.
+	 *
+	 * @return {void}
+	 */
 	it('treats an empty-array native border value as empty for every axis', () => {
 		expect(isEmptyValue('border-width', [])).toBe(true);
 		expect(isEmptyValue('border-style', [])).toBe(true);
 		expect(isEmptyValue('border-color', [])).toBe(true);
 	});
 
+	/**
+	 * A written native border value reads as not empty for every axis even when every side's slots are
+	 * blank strings — the moment any side is written, `toNativeBorder` always fills in all four, so
+	 * "empty" is a single source-level check, not per-side.
+	 *
+	 * @return {void}
+	 */
 	it('treats a written native border value as not empty for every axis, even with all-blank sides', () => {
 		const value = [
 			{
@@ -52,24 +71,47 @@ describe('matchesPreset border', () => {
 		},
 	];
 
+	/**
+	 * A never-written native border value never matches a preset, for any axis — `isEmptyValue` is the
+	 * signal for "bound", not `matchesPreset`, which only ever runs once `empty` is already false.
+	 *
+	 * @return {void}
+	 */
 	it('does not match an unset native border value for any axis', () => {
 		expect(matchesPreset('border-width', undefined, '', '2px')).toBe(false);
 		expect(matchesPreset('border-style', undefined, '', 'solid')).toBe(false);
 		expect(matchesPreset('border-color', undefined, '', '#3182ce')).toBe(false);
 	});
 
+	/**
+	 * A native border value equal to the preset on every side matches, for every axis.
+	 *
+	 * @return {void}
+	 */
 	it('matches a native border value equal on every side, per axis', () => {
 		expect(matchesPreset('border-width', UNIFORM, '', '2px')).toBe(true);
 		expect(matchesPreset('border-style', UNIFORM, '', 'solid')).toBe(true);
 		expect(matchesPreset('border-color', UNIFORM, '', '#3182ce')).toBe(true);
 	});
 
+	/**
+	 * A native border value diverging on one side does not match, for every axis — the compare is
+	 * side-aware, not just first-side.
+	 *
+	 * @return {void}
+	 */
 	it('does not match a native border value diverging on one side, per axis', () => {
 		expect(matchesPreset('border-width', DIVERGENT, '', '2px')).toBe(false);
 		expect(matchesPreset('border-style', DIVERGENT, '', 'solid')).toBe(false);
 		expect(matchesPreset('border-color', DIVERGENT, '', '#3182ce')).toBe(false);
 	});
 
+	/**
+	 * A border-width side stored as a token alias matches the same alias literal directly, without
+	 * being parsed as a numeric dimension.
+	 *
+	 * @return {void}
+	 */
 	it('matches a border-width side written as a token alias against the same alias literal', () => {
 		const value = [
 			{

--- a/src/extension/token-indicators/kinds/__tests__/border.test.js
+++ b/src/extension/token-indicators/kinds/__tests__/border.test.js
@@ -1,0 +1,86 @@
+/* eslint-env jest */
+import { isEmptyValue, matchesPreset } from '../../normalize';
+
+describe('isEmptyValue border', () => {
+	it('treats an undefined native border value as empty for every axis', () => {
+		expect(isEmptyValue('border-width', undefined)).toBe(true);
+		expect(isEmptyValue('border-style', undefined)).toBe(true);
+		expect(isEmptyValue('border-color', undefined)).toBe(true);
+	});
+
+	it('treats an empty-array native border value as empty for every axis', () => {
+		expect(isEmptyValue('border-width', [])).toBe(true);
+		expect(isEmptyValue('border-style', [])).toBe(true);
+		expect(isEmptyValue('border-color', [])).toBe(true);
+	});
+
+	it('treats a written native border value as not empty for every axis, even with all-blank sides', () => {
+		const value = [
+			{
+				top: ['', '', ''],
+				right: ['', '', ''],
+				bottom: ['', '', ''],
+				left: ['', '', ''],
+				unit: 'px',
+			},
+		];
+
+		expect(isEmptyValue('border-width', value)).toBe(false);
+		expect(isEmptyValue('border-style', value)).toBe(false);
+		expect(isEmptyValue('border-color', value)).toBe(false);
+	});
+});
+
+describe('matchesPreset border', () => {
+	const UNIFORM = [
+		{
+			top: ['#3182ce', 'solid', '2'],
+			right: ['#3182ce', 'solid', '2'],
+			bottom: ['#3182ce', 'solid', '2'],
+			left: ['#3182ce', 'solid', '2'],
+			unit: 'px',
+		},
+	];
+
+	const DIVERGENT = [
+		{
+			top: ['#3182ce', 'solid', '2'],
+			right: ['#3182ce', 'solid', '2'],
+			bottom: ['#3182ce', 'solid', '2'],
+			left: ['#ffffff', 'dashed', '4'],
+			unit: 'px',
+		},
+	];
+
+	it('does not match an unset native border value for any axis', () => {
+		expect(matchesPreset('border-width', undefined, '', '2px')).toBe(false);
+		expect(matchesPreset('border-style', undefined, '', 'solid')).toBe(false);
+		expect(matchesPreset('border-color', undefined, '', '#3182ce')).toBe(false);
+	});
+
+	it('matches a native border value equal on every side, per axis', () => {
+		expect(matchesPreset('border-width', UNIFORM, '', '2px')).toBe(true);
+		expect(matchesPreset('border-style', UNIFORM, '', 'solid')).toBe(true);
+		expect(matchesPreset('border-color', UNIFORM, '', '#3182ce')).toBe(true);
+	});
+
+	it('does not match a native border value diverging on one side, per axis', () => {
+		expect(matchesPreset('border-width', DIVERGENT, '', '2px')).toBe(false);
+		expect(matchesPreset('border-style', DIVERGENT, '', 'solid')).toBe(false);
+		expect(matchesPreset('border-color', DIVERGENT, '', '#3182ce')).toBe(false);
+	});
+
+	it('matches a border-width side written as a token alias against the same alias literal', () => {
+		const value = [
+			{
+				top: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
+				right: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
+				bottom: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
+				left: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
+				unit: 'px',
+			},
+		];
+
+		expect(matchesPreset('border-width', value, '', '{primitive.dimension.border-width.md}')).toBe(true);
+	});
+});

--- a/src/extension/token-indicators/kinds/__tests__/color.test.js
+++ b/src/extension/token-indicators/kinds/__tests__/color.test.js
@@ -1,0 +1,64 @@
+/* eslint-env jest */
+import { normalizeColor } from '../color';
+import { isEmptyValue, matchesPreset } from '../../normalize';
+
+describe('normalizeColor', () => {
+	beforeEach(() => {
+		window.kadence_blocks_params = {
+			global_colors: {
+				'--global-palette1': '#3182CE',
+				'--global-palette3': '#1A202C',
+			},
+		};
+	});
+
+	afterEach(() => {
+		delete window.kadence_blocks_params;
+	});
+
+	it('resolves a paletteN slug to its mapped literal, lower-cased', () => {
+		expect(normalizeColor('palette1')).toBe('#3182ce');
+	});
+
+	it('passes a literal through, lower-cased', () => {
+		expect(normalizeColor('#3182CE')).toBe('#3182ce');
+	});
+
+	it('passes an unresolved slug through as itself (degrade safe)', () => {
+		expect(normalizeColor('palette9')).toBe('palette9');
+	});
+
+	it('returns an empty string for an empty value', () => {
+		expect(normalizeColor('')).toBe('');
+	});
+});
+
+describe('matchesPreset color', () => {
+	beforeEach(() => {
+		window.kadence_blocks_params = {
+			global_colors: { '--global-palette3': '#3182CE' },
+		};
+	});
+
+	afterEach(() => {
+		delete window.kadence_blocks_params;
+	});
+
+	it('matches when a stored palette slug resolves to the preset literal', () => {
+		expect(matchesPreset('color', 'palette3', '', '#3182ce')).toBe(true);
+	});
+
+	it('does not match when the stored literal differs from the preset literal', () => {
+		expect(matchesPreset('color', '#ffffff', '', '#3182ce')).toBe(false);
+	});
+});
+
+describe('isEmptyValue color', () => {
+	it('treats an empty color string as empty', () => {
+		expect(isEmptyValue('color', '')).toBe(true);
+	});
+
+	it('treats a populated color as not empty', () => {
+		expect(isEmptyValue('color', 'palette3')).toBe(false);
+	});
+});

--- a/src/extension/token-indicators/kinds/__tests__/dimension.test.js
+++ b/src/extension/token-indicators/kinds/__tests__/dimension.test.js
@@ -4,63 +4,10 @@ import {
 	deriveMeasureMode,
 	inheritedMeasureSlots,
 	measureAttrsForDevice,
-	isEmptyValue,
-	matchesPreset,
-	normalizeColor,
 	normalizeDimension,
 	presetValueForDevice,
-} from '../normalize';
-
-describe('normalizeColor', () => {
-	beforeEach(() => {
-		window.kadence_blocks_params = {
-			global_colors: {
-				'--global-palette1': '#3182CE',
-				'--global-palette3': '#1A202C',
-			},
-		};
-	});
-
-	afterEach(() => {
-		delete window.kadence_blocks_params;
-	});
-
-	it('resolves a paletteN slug to its mapped literal, lower-cased', () => {
-		expect(normalizeColor('palette1')).toBe('#3182ce');
-	});
-
-	it('passes a literal through, lower-cased', () => {
-		expect(normalizeColor('#3182CE')).toBe('#3182ce');
-	});
-
-	it('passes an unresolved slug through as itself (degrade safe)', () => {
-		expect(normalizeColor('palette9')).toBe('palette9');
-	});
-
-	it('returns an empty string for an empty value', () => {
-		expect(normalizeColor('')).toBe('');
-	});
-});
-
-describe('matchesPreset color', () => {
-	beforeEach(() => {
-		window.kadence_blocks_params = {
-			global_colors: { '--global-palette3': '#3182CE' },
-		};
-	});
-
-	afterEach(() => {
-		delete window.kadence_blocks_params;
-	});
-
-	it('matches when a stored palette slug resolves to the preset literal', () => {
-		expect(matchesPreset('color', 'palette3', '', '#3182ce')).toBe(true);
-	});
-
-	it('does not match when the stored literal differs from the preset literal', () => {
-		expect(matchesPreset('color', '#ffffff', '', '#3182ce')).toBe(false);
-	});
-});
+} from '../dimension';
+import { isEmptyValue, matchesPreset } from '../../normalize';
 
 describe('matchesPreset dimension', () => {
 	it('matches a uniform 4-side array against the preset value + unit', () => {
@@ -268,113 +215,13 @@ describe('matchesPreset dimension against a per-corner preset value', () => {
 	});
 });
 
-describe('matchesPreset text', () => {
-	it('matches trimmed equal strings', () => {
-		expect(matchesPreset('text', ' bold ', '', 'bold')).toBe(true);
-	});
-
-	it('does not match differing strings', () => {
-		expect(matchesPreset('text', 'bold', '', 'normal')).toBe(false);
-	});
-});
-
-describe('isEmptyValue', () => {
-	it('treats an empty color string as empty', () => {
-		expect(isEmptyValue('color', '')).toBe(true);
-	});
-
+describe('isEmptyValue dimension', () => {
 	it('treats an all-empty 4-side dimension array as empty', () => {
 		expect(isEmptyValue('dimension', ['', '', '', ''])).toBe(true);
 	});
 
 	it('treats a populated dimension side as not empty', () => {
 		expect(isEmptyValue('dimension', ['8', '', '', ''])).toBe(false);
-	});
-
-	it('treats a populated color as not empty', () => {
-		expect(isEmptyValue('color', 'palette3')).toBe(false);
-	});
-
-	it('treats an undefined native border value as empty for every axis', () => {
-		expect(isEmptyValue('border-width', undefined)).toBe(true);
-		expect(isEmptyValue('border-style', undefined)).toBe(true);
-		expect(isEmptyValue('border-color', undefined)).toBe(true);
-	});
-
-	it('treats an empty-array native border value as empty for every axis', () => {
-		expect(isEmptyValue('border-width', [])).toBe(true);
-		expect(isEmptyValue('border-style', [])).toBe(true);
-		expect(isEmptyValue('border-color', [])).toBe(true);
-	});
-
-	it('treats a written native border value as not empty for every axis, even with all-blank sides', () => {
-		const value = [
-			{
-				top: ['', '', ''],
-				right: ['', '', ''],
-				bottom: ['', '', ''],
-				left: ['', '', ''],
-				unit: 'px',
-			},
-		];
-
-		expect(isEmptyValue('border-width', value)).toBe(false);
-		expect(isEmptyValue('border-style', value)).toBe(false);
-		expect(isEmptyValue('border-color', value)).toBe(false);
-	});
-});
-
-describe('matchesPreset border', () => {
-	const UNIFORM = [
-		{
-			top: ['#3182ce', 'solid', '2'],
-			right: ['#3182ce', 'solid', '2'],
-			bottom: ['#3182ce', 'solid', '2'],
-			left: ['#3182ce', 'solid', '2'],
-			unit: 'px',
-		},
-	];
-
-	const DIVERGENT = [
-		{
-			top: ['#3182ce', 'solid', '2'],
-			right: ['#3182ce', 'solid', '2'],
-			bottom: ['#3182ce', 'solid', '2'],
-			left: ['#ffffff', 'dashed', '4'],
-			unit: 'px',
-		},
-	];
-
-	it('does not match an unset native border value for any axis', () => {
-		expect(matchesPreset('border-width', undefined, '', '2px')).toBe(false);
-		expect(matchesPreset('border-style', undefined, '', 'solid')).toBe(false);
-		expect(matchesPreset('border-color', undefined, '', '#3182ce')).toBe(false);
-	});
-
-	it('matches a native border value equal on every side, per axis', () => {
-		expect(matchesPreset('border-width', UNIFORM, '', '2px')).toBe(true);
-		expect(matchesPreset('border-style', UNIFORM, '', 'solid')).toBe(true);
-		expect(matchesPreset('border-color', UNIFORM, '', '#3182ce')).toBe(true);
-	});
-
-	it('does not match a native border value diverging on one side, per axis', () => {
-		expect(matchesPreset('border-width', DIVERGENT, '', '2px')).toBe(false);
-		expect(matchesPreset('border-style', DIVERGENT, '', 'solid')).toBe(false);
-		expect(matchesPreset('border-color', DIVERGENT, '', '#3182ce')).toBe(false);
-	});
-
-	it('matches a border-width side written as a token alias against the same alias literal', () => {
-		const value = [
-			{
-				top: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
-				right: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
-				bottom: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
-				left: ['#3182ce', 'solid', '{primitive.dimension.border-width.md}'],
-				unit: 'px',
-			},
-		];
-
-		expect(matchesPreset('border-width', value, '', '{primitive.dimension.border-width.md}')).toBe(true);
 	});
 });
 

--- a/src/extension/token-indicators/kinds/__tests__/text.test.js
+++ b/src/extension/token-indicators/kinds/__tests__/text.test.js
@@ -1,0 +1,12 @@
+/* eslint-env jest */
+import { matchesPreset } from '../../normalize';
+
+describe('matchesPreset text', () => {
+	it('matches trimmed equal strings', () => {
+		expect(matchesPreset('text', ' bold ', '', 'bold')).toBe(true);
+	});
+
+	it('does not match differing strings', () => {
+		expect(matchesPreset('text', 'bold', '', 'normal')).toBe(false);
+	});
+});

--- a/src/extension/token-indicators/kinds/border.js
+++ b/src/extension/token-indicators/kinds/border.js
@@ -1,0 +1,155 @@
+/**
+ * Kind-aware normalization and compare for the `border-width`/`border-style`/`border-color` kinds — read
+ * ONE axis (width, style or color) out of `EditorBorderControl`'s nested per-side native shape
+ * (`[{ top: [color, style, size], right: [...], ... }]`), compared uniformly across all four sides. The
+ * three axes share one native attribute (`borderStyle`), so `usePresetBinding` calls each of these once
+ * per axis and combines the results — see its own docblock.
+ */
+
+import { isTokenAlias } from '../../../token-controls/helpers/token-summary';
+import { normalizeColor } from './color';
+import { normalizeText } from './text';
+import { parseDimensionLiteral } from './dimension';
+
+/**
+ * The order `EditorBorderControl`'s native shape stores per-side tuples in, and the index each axis
+ * occupies within a side's `[color, style, size]` tuple.
+ *
+ * @since TBD
+ *
+ * @type {string[]}
+ */
+export const BORDER_SIDES = ['top', 'right', 'bottom', 'left'];
+
+/**
+ * The index within a side's `[color, style, size]` tuple for each border axis kind.
+ *
+ * @since TBD
+ *
+ * @type {Object<string, number>}
+ */
+export const BORDER_AXIS_INDEX = {
+	'border-color': 0,
+	'border-style': 1,
+	'border-width': 2,
+};
+
+/**
+ * `EditorBorderControl`'s native per-side source object (`native[0]`), or `null` for the never-written
+ * shape (`undefined`, `[]`, or an array with no first element) — matching `fromNativeBorder`'s own
+ * `!source` short-circuit, which is this module's "empty/bound" reading for every border axis.
+ *
+ * @param {*} value The stored `borderStyle`-shaped attribute value.
+ *
+ * @since TBD
+ *
+ * @return {Object|null} The native source object, or null when never written.
+ */
+function borderSource(value) {
+	return (Array.isArray(value) ? value[0] : undefined) || null;
+}
+
+/**
+ * A side's width slot (`source[side][2]`) as a literal comparable to a resolved dimension token value:
+ * a token alias passes through whole, otherwise the numeric size is paired with the border's own
+ * shared unit (`source.unit`) — matching `fromNativeBorder`'s own width mapping so this reads the exact
+ * literal the control itself would show.
+ *
+ * @param {*}      size The side's stored width slot.
+ * @param {string} unit The border's shared unit (`source.unit`, defaulting to 'px').
+ *
+ * @since TBD
+ *
+ * @return {string} The width literal, or '' when the slot is unset.
+ */
+function borderWidthLiteral(size, unit) {
+	if (size === '' || size === undefined || size === null) {
+		return '';
+	}
+
+	return isTokenAlias(size) ? String(size) : `${size}${unit}`;
+}
+
+/**
+ * Whether every side of a stored `borderStyle`-shaped value matches the preset's resolved literal for
+ * ONE axis (width, style or color) — the per-axis compare `matches` delegates to for a
+ * `border-width`/`border-style`/`border-color` kind.
+ *
+ * @param {string} kind        One of 'border-width' | 'border-style' | 'border-color'.
+ * @param {Object} source      The native border source object (`value[0]`), already confirmed non-null.
+ * @param {string} presetValue The preset's resolved literal for this axis.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when every side's axis value equals the preset value.
+ */
+function matchesBorderAxis(kind, source, presetValue) {
+	const index = BORDER_AXIS_INDEX[kind];
+	const unit = source.unit || 'px';
+
+	if (kind === 'border-width') {
+		const preset = parseDimensionLiteral(presetValue);
+
+		return BORDER_SIDES.every((side) => {
+			const literal = borderWidthLiteral((source[side] || [])[index], unit);
+
+			if (literal === '') {
+				return false;
+			}
+
+			if (isTokenAlias(literal)) {
+				return literal === presetValue;
+			}
+
+			const stored = parseDimensionLiteral(literal);
+			const unitMatches = preset.unit === '' || stored.unit === preset.unit;
+
+			return unitMatches && stored.value === preset.value;
+		});
+	}
+
+	if (kind === 'border-color') {
+		return BORDER_SIDES.every(
+			(side) => normalizeColor((source[side] || [])[index]) === normalizeColor(presetValue)
+		);
+	}
+
+	return BORDER_SIDES.every(
+		(side) => normalizeText((source[side] || [])[index] || 'none') === normalizeText(presetValue)
+	);
+}
+
+/**
+ * Whether a stored attribute value is "empty" (untouched) for a border axis kind — the signal a
+ * retarget-bound control uses for `empty => bound`.
+ *
+ * All three axes share one native shape, and the moment any side is written `toNativeBorder` always
+ * fills in all four — so "empty" is a single source-level check, not per-axis.
+ *
+ * @param {*} value The stored primary attribute value.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the value is unset/empty.
+ */
+export function isEmpty(value) {
+	return borderSource(value) === null;
+}
+
+/**
+ * Whether a stored border axis value equals the selected preset's resolved value.
+ *
+ * @param {string} kind        One of 'border-width' | 'border-style' | 'border-color'.
+ * @param {*}      value       The stored primary attribute value.
+ * @param {string} unit        Unused for border kinds (the shared unit lives on the stored value itself).
+ * @param {string} presetValue The preset's resolved literal for this axis.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the stored value matches the preset value.
+ */
+export function matches(kind, value, unit, presetValue) {
+	const source = borderSource(value);
+
+	return source !== null && matchesBorderAxis(kind, source, presetValue);
+}

--- a/src/extension/token-indicators/kinds/color.js
+++ b/src/extension/token-indicators/kinds/color.js
@@ -1,0 +1,52 @@
+/**
+ * Kind-aware normalization for the `color` kind — a Kadence palette slug (`palette3`) is resolved to its
+ * literal via the global palette map, then lower-cased; a literal (`#3182CE`, `rgb(...)`) is lower-cased.
+ */
+
+import { get } from 'lodash';
+
+/**
+ * The editor's global color palette map (`paletteN -> literal color`). Kadence localizes the theme
+ * palette as `window.kadence_blocks_params.global_colors`, keyed by CSS custom-property name
+ * (`--global-palette1`..`--global-palette9`); this reader strips the `--global-` prefix so the map keys
+ * line up with the bare `paletteN` slug a color control writes into a block attribute (confirmed against
+ * `SinglePopColorControl`, the swatch component behind `PopColorControl`). Empty when the params are
+ * absent, so an unresolved slug simply compares as itself — the degrade-safe fallback.
+ *
+ * @since TBD
+ *
+ * @return {Object} slug ('paletteN') => color literal.
+ */
+function paletteMap() {
+	const colors = get(window, ['kadence_blocks_params', 'global_colors'], {}) || {};
+
+	return Object.keys(colors).reduce((map, cssVar) => {
+		const slug = cssVar.replace(/^--global-/, '');
+
+		map[slug] = colors[cssVar];
+
+		return map;
+	}, {});
+}
+
+/**
+ * Resolve a color attribute value to a comparable literal: a `paletteN` slug becomes its mapped color;
+ * anything else passes through. Lower-cased so `#3182CE` and `#3182ce` compare equal. An unresolved slug
+ * (palette map missing the key) passes through as the slug itself, which degrades safe — it never
+ * produces a false match, at worst a false override.
+ *
+ * @param {*} value The stored color value (slug or literal), possibly empty.
+ *
+ * @since TBD
+ *
+ * @return {string} The comparable literal, or '' when empty.
+ */
+export function normalizeColor(value) {
+	if (value === undefined || value === null || value === '') {
+		return '';
+	}
+
+	const literal = paletteMap()[value] || value;
+
+	return String(literal).trim().toLowerCase();
+}

--- a/src/extension/token-indicators/kinds/dimension.js
+++ b/src/extension/token-indicators/kinds/dimension.js
@@ -1,0 +1,334 @@
+/**
+ * Kind-aware normalization and compare for the `dimension` kind — the numeric value paired with its
+ * unit (`{ value, unit }`), tolerant of the 4-side array shape a measurement control writes.
+ */
+
+import { get } from 'lodash';
+
+/**
+ * The populated sides of a stored dimension value, each trimmed to a string. A measurement control writes
+ * a 4-side array (`[top, right, bottom, left]`) where an untouched side is `''`; a scalar value is a
+ * single side. Empty/undefined sides are dropped, so an all-empty value yields `[]` and a per-corner
+ * override yields one entry per touched side — the shape a side-aware compare needs.
+ *
+ * @param {*} value The stored dimension value (number, string, or 4-side array).
+ *
+ * @since TBD
+ *
+ * @return {string[]} The populated sides as trimmed strings; empty array when nothing is set.
+ */
+function dimensionSides(value) {
+	const raw = Array.isArray(value) ? value : [value];
+
+	return raw.filter((side) => side !== '' && side !== undefined && side !== null).map((side) => String(side).trim());
+}
+
+/**
+ * The stored sides of a dimension value with their POSITION preserved: a 4-side array maps one-to-one
+ * and an untouched side stays `''`, while a scalar is a single slot. This is the positional counterpart
+ * to `dimensionSides`, which drops empties and so cannot say WHICH corner a value belongs to — needed
+ * wherever a per-corner value is composed or compared slot by slot.
+ *
+ * @param {*} value The stored dimension value (number, string, or 4-side array).
+ *
+ * @since TBD
+ *
+ * @return {string[]} The slots as trimmed strings, empty slots preserved as ''.
+ */
+export function dimensionSlots(value) {
+	const raw = Array.isArray(value) ? value : [value];
+
+	return raw.map((side) => (side === undefined || side === null ? '' : String(side).trim()));
+}
+
+/**
+ * The value one corner inherits from the selected preset.
+ *
+ * A preset value is either a single literal, which every corner inherits, or a PER-CORNER list, in which
+ * case the corner takes its matching slot.
+ *
+ * @param {*}      presetValue The selected preset's value for the property.
+ * @param {number} index       The corner index.
+ *
+ * @since TBD
+ *
+ * @return {string} The inherited value for that corner, or '' when the preset has none.
+ */
+export function presetSlotAt(presetValue, index) {
+	if (Array.isArray(presetValue)) {
+		return String(presetValue[index] ?? '');
+	}
+
+	return presetValue === undefined || presetValue === null ? '' : String(presetValue);
+}
+
+/**
+ * The selected preset's value for a property AT THE ACTIVE DEVICE: its breakpoint override where the
+ * preset declares one, otherwise the value it inherits through the cascade.
+ *
+ * A preset can carry per-breakpoint values, and the button renders them — so a control sitting on
+ * Tablet that falls back to the preset's desktop value names a size the block is not rendering at
+ * that breakpoint. The fallback order mirrors the projected CSS: Mobile takes the mobile override,
+ * then the tablet one, then the base; Tablet takes the tablet override, then the base.
+ *
+ * @param {*}      presetValue  The preset's base value for the property.
+ * @param {Object} [responsive] The preset's breakpoint values ({ tablet, mobile }), each undefined
+ *                              when the preset declares no override there.
+ * @param {string} [device]     The active preview device ('Desktop' | 'Tablet' | 'Mobile').
+ *
+ * @since TBD
+ *
+ * @return {*} The preset's value in effect at that device.
+ */
+export function presetValueForDevice(presetValue, responsive = {}, device = 'Desktop') {
+	const chain =
+		'Mobile' === device ? [responsive.mobile, responsive.tablet] : 'Tablet' === device ? [responsive.tablet] : [];
+
+	const override = chain.find((value) => value !== undefined && value !== null && value !== '');
+
+	return override === undefined ? presetValue : override;
+}
+
+/**
+ * The attribute a responsive measure control is editing at the given device, and its current value.
+ *
+ * A responsive measure control keeps ONE linked/individual mode but writes three separate attributes
+ * (`borderRadius` / `tabletBorderRadius` / `mobileBorderRadius`). Deriving the mode — or collapsing
+ * corners on "link" — against the desktop attribute while the editor is on Tablet reads and writes the
+ * wrong breakpoint, so both must resolve the device's own attribute first.
+ *
+ * @param {Object} attributes  The block's attributes.
+ * @param {string} baseAttr    The desktop attribute name.
+ * @param {Object} [responsive] Device key ('tablet' | 'mobile') => attribute name.
+ * @param {string} [device]    The active preview device ('Desktop' | 'Tablet' | 'Mobile').
+ *
+ * @since TBD
+ *
+ * @return {{ attr: string, value: * }} The device's attribute name and its stored value.
+ */
+export function measureAttrsForDevice(attributes, baseAttr, responsive = {}, device = 'Desktop') {
+	const attr = get(responsive, String(device).toLowerCase(), '') || baseAttr;
+
+	return { attr, value: get(attributes, attr, '') };
+}
+
+/**
+ * What each corner of a measure control inherits at the given device WHEN THE DEVICE STORES NOTHING —
+ * the device's own value is deliberately left out, because this is the value the corner falls back to.
+ *
+ * A responsive measure control renders through a desktop -> tablet -> mobile cascade that runs PER CORNER:
+ * an empty tablet corner takes the desktop corner, an empty mobile corner takes the tablet corner and
+ * then the desktop one. Only once the whole device chain is empty does the corner reach the selected
+ * preset. Resolving straight to the preset skips those steps, so a Tablet sitting on four different
+ * desktop corners would report the preset's single value — naming a size the button is not rendering at
+ * that breakpoint.
+ *
+ * Nothing here is written back, and this does NOT feed the linked/individual mode: the corners stay empty
+ * so they keep inheriting, and the resolved values only tell the field's popover which size is currently
+ * in effect and where it came from.
+ *
+ * @param {string} device        The active preview device ('Desktop' | 'Tablet' | 'Mobile').
+ * @param {Object} [values]      The stored dimension per device: { desktop, tablet }.
+ * @param {*}      [presetValue] The selected preset's value for the property, the last fallback.
+ *
+ * @since TBD
+ *
+ * @return {{ values: string[], inherited: boolean[] }} The four inherited corners, and per corner whether
+ *                                                      it came from another device rather than the preset.
+ */
+export function inheritedMeasureSlots(device, values = {}, presetValue) {
+	const desktop = dimensionSlots(values.desktop);
+	const tablet = dimensionSlots(values.tablet);
+
+	// Mobile falls through tablet before desktop; tablet only through desktop; desktop inherits the preset.
+	const chain = 'Mobile' === device ? [tablet, desktop] : 'Tablet' === device ? [desktop] : [];
+
+	const slots = [0, 1, 2, 3].map((index) => {
+		const from = chain.find((source) => {
+			const corner = source[index];
+
+			return corner !== undefined && corner !== null && corner !== '';
+		});
+
+		return from
+			? { value: String(from[index]), inherited: true }
+			: { value: presetSlotAt(presetValue, index), inherited: false };
+	});
+
+	return {
+		values: slots.map((slot) => slot.value),
+		inherited: slots.map((slot) => slot.inherited),
+	};
+}
+
+/**
+ * Whether a measure control's single row-level "Inherited" label should show, given each corner's
+ * own inherited flag from `inheritedMeasureSlots()`.
+ *
+ * The control renders one label for all four corners, so "any corner inherited" is the safer read
+ * than "every corner inherited": a mixed row — one corner pulled from another breakpoint, the rest
+ * resolved straight to the preset — is no longer a plain preset default, and reporting "Default"
+ * would understate that. `inherited` is always a four-element array, so a bare truthiness check on
+ * the array itself is always `true`; this reduces it to the actual per-corner flags instead.
+ *
+ * @param {boolean[]} inherited Per-corner inherited flags, i.e. `inheritedMeasureSlots().inherited`.
+ *
+ * @since TBD
+ *
+ * @return {boolean} Whether any corner inherits from another breakpoint rather than the preset.
+ */
+export function anyCornerInherited(inherited) {
+	return Array.isArray(inherited) && inherited.some(Boolean);
+}
+
+/**
+ * The linked/individual mode a measure control should open in, derived from the corners the user would
+ * actually see: each stored corner where one is set, otherwise the value that corner inherits from the
+ * selected preset.
+ *
+ * Deriving from the stored attribute alone is not enough. A block on a preset stores NOTHING — every
+ * corner is empty, which trivially reads as "all equal" — so a preset carrying four different corners
+ * would open the control in linked mode and hide the difference it is displaying.
+ *
+ * @param {*} value       The stored dimension value (4-side array or scalar).
+ * @param {*} presetValue The selected preset's value for the property.
+ *
+ * @since TBD
+ *
+ * @return {string} 'linked' when every effective corner matches, otherwise 'individual'.
+ */
+export function deriveMeasureMode(value, presetValue) {
+	const stored = dimensionSlots(value);
+	const corners = [0, 1, 2, 3].map((index) =>
+		stored[index] !== undefined && stored[index] !== '' ? stored[index] : presetSlotAt(presetValue, index)
+	);
+
+	return corners.every((corner) => corner === corners[0]) ? 'linked' : 'individual';
+}
+
+/**
+ * Normalize a dimension attribute to `{ value, unit }`. A measurement control writes a 4-side array
+ * (`[top, right, bottom, left]`); the representative value is the first populated side. An empty value
+ * yields an empty marker so "no override" is detectable. This is the scalar view used for empty
+ * detection and the single-value path; the bound-vs-overridden compare uses the side-aware `matches`
+ * so a per-corner override is not masked by a matching first side.
+ *
+ * @param {*}      value The stored dimension value (number, string, or 4-side array).
+ * @param {string} unit  The companion unit attribute (e.g. `borderRadiusUnit`).
+ *
+ * @since TBD
+ *
+ * @return {{ value: string, unit: string }} The canonical dimension, `value: ''` when empty.
+ */
+export function normalizeDimension(value, unit) {
+	const sides = dimensionSides(value);
+
+	if (!sides.length) {
+		return { value: '', unit: '' };
+	}
+
+	return { value: sides[0], unit: String(unit || '').trim() };
+}
+
+/**
+ * Split a resolved dimension literal (`"1.5rem"`, `"8px"`, `"0"`) into `{ value, unit }` so it compares
+ * against the control's separate value/unit attributes.
+ *
+ * @param {string} literal The resolved dimension literal.
+ *
+ * @since TBD
+ *
+ * @return {{ value: string, unit: string }} The parsed value and unit.
+ */
+export function parseDimensionLiteral(literal) {
+	const match = String(literal || '')
+		.trim()
+		.match(/^(-?[\d.]+)\s*([a-z%]*)$/i);
+
+	if (!match) {
+		return { value: String(literal || '').trim(), unit: '' };
+	}
+
+	return { value: match[1], unit: match[2] };
+}
+
+/**
+ * Whether a stored dimension matches a PER-CORNER preset value, compared slot by slot.
+ *
+ * Comparing by position means a rotated set of the same corners (e.g. `4,8,4,8` against `8,4,8,4`) reads
+ * as overridden, and a stored value with a different number of populated sides than the preset has slots
+ * cannot match at all.
+ *
+ * @param {string[]} sides       The stored sides, empties already dropped.
+ * @param {string}   storedUnit  The stored companion unit.
+ * @param {Array}    presetSlots The preset's per-corner literals.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when every corner equals its preset slot.
+ */
+function matchesPresetSlots(sides, storedUnit, presetSlots) {
+	const stored = sides;
+	const presets = presetSlots.map(parseDimensionLiteral);
+
+	if (stored.length !== presets.length) {
+		return false;
+	}
+
+	return stored.every((side, index) => {
+		const preset = presets[index];
+		const unitMatches = preset.unit === '' || storedUnit === preset.unit;
+
+		return unitMatches && side === preset.value;
+	});
+}
+
+/**
+ * Whether a stored attribute value is "empty" (untouched) for the `dimension` kind — the signal a
+ * retarget-bound control uses for `empty => bound`.
+ *
+ * @param {*} value The stored primary attribute value.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the value is unset/empty.
+ */
+export function isEmpty(value) {
+	return normalizeDimension(value, '').value === '';
+}
+
+/**
+ * Whether a stored dimension value equals the selected preset's resolved value.
+ *
+ * @param {*}      value       The stored primary attribute value.
+ * @param {string} unit        The companion unit.
+ * @param {string} presetValue The preset's resolved literal for this property.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the stored value matches the preset value.
+ */
+export function matches(value, unit, presetValue) {
+	const sides = dimensionSides(value);
+
+	if (!sides.length) {
+		return false;
+	}
+
+	const storedUnit = String(unit || '').trim();
+
+	// A per-corner preset value is compared corner by corner. `parseDimensionLiteral` reads one length,
+	// so a slot list handed to it whole would never match and the control would read as overridden even
+	// when it exactly matches its preset.
+	if (Array.isArray(presetValue)) {
+		return matchesPresetSlots(sides, storedUnit, presetValue);
+	}
+
+	const preset = parseDimensionLiteral(presetValue);
+	const unitMatches = preset.unit === '' || storedUnit === preset.unit;
+
+	// Side-aware: a stored dimension matches only when EVERY populated side equals the preset value.
+	// A per-corner override (e.g. `['8','8','8','4']` vs `8px`) leaves one side differing and so reads
+	// as overridden, not still-bound.
+	return unitMatches && sides.every((side) => side === preset.value);
+}

--- a/src/extension/token-indicators/kinds/text.js
+++ b/src/extension/token-indicators/kinds/text.js
@@ -1,0 +1,20 @@
+/**
+ * Kind-aware normalization for the `text` kind — a trimmed string compare.
+ */
+
+/**
+ * Normalize a text attribute for compare.
+ *
+ * @param {*} value The stored value.
+ *
+ * @since TBD
+ *
+ * @return {string} The trimmed string, or '' when empty.
+ */
+export function normalizeText(value) {
+	if (value === undefined || value === null) {
+		return '';
+	}
+
+	return String(value).trim();
+}

--- a/src/extension/token-indicators/normalize.js
+++ b/src/extension/token-indicators/normalize.js
@@ -84,6 +84,22 @@ const KINDS = {
 };
 
 /**
+ * The `{ isEmpty, matches }` handler for a kind, falling back to `text` for a kind the localized
+ * catalog carries that this dispatch table has no entry for — the catalog's `kind` values come from
+ * PHP's registry and are not narrowed to this table's keys at write time, so an unrecognized value must
+ * degrade to a safe comparison rather than throw.
+ *
+ * @param {string} kind The property kind.
+ *
+ * @since TBD
+ *
+ * @return {{ isEmpty: Function, matches: Function }} The handler to dispatch through.
+ */
+function handlerFor(kind) {
+	return KINDS[kind] || text;
+}
+
+/**
  * Whether a stored attribute value is "empty" (untouched) for its kind — the signal a retarget-bound
  * control uses for `empty => bound`.
  *
@@ -96,7 +112,7 @@ const KINDS = {
  * @return {boolean} True when the value is unset/empty.
  */
 export function isEmptyValue(kind, value) {
-	return KINDS[kind].isEmpty(value);
+	return handlerFor(kind).isEmpty(value);
 }
 
 /**
@@ -116,5 +132,5 @@ export function matchesPreset(kind, value, unit, presetValue) {
 		return border.matches(kind, value, unit, presetValue);
 	}
 
-	return KINDS[kind].matches(value, unit, presetValue);
+	return handlerFor(kind).matches(value, unit, presetValue);
 }

--- a/src/extension/token-indicators/normalize.js
+++ b/src/extension/token-indicators/normalize.js
@@ -3,14 +3,44 @@
  *
  * A control's stored attribute value and the selected preset's resolved value are compared after being
  * reduced to a canonical form per `kind`:
- *   - `color`      — a Kadence palette slug (`palette3`) is resolved to its literal via the global
- *                    palette map, then lower-cased; a literal (`#3182CE`, `rgb(...)`) is lower-cased.
- *   - `dimension`  — the numeric value is paired with its unit (`{ value, unit }`), tolerant of the
- *                    4-side array shape a measurement control writes.
- *   - `text`       — trimmed string compare.
+ *   - `color`        — a Kadence palette slug (`palette3`) is resolved to its literal via the global
+ *                      palette map, then lower-cased; a literal (`#3182CE`, `rgb(...)`) is lower-cased.
+ *   - `dimension`    — the numeric value is paired with its unit (`{ value, unit }`), tolerant of the
+ *                      4-side array shape a measurement control writes.
+ *   - `text`         — trimmed string compare.
+ *   - `border-width` \
+ *   - `border-style`  | — read ONE axis (width, style or color) out of `EditorBorderControl`'s nested
+ *   - `border-color` / per-side native shape (`[{ top: [color, style, size], right: [...], ... }]`),
+ *                      compared uniformly across all four sides. The three axes share one native
+ *                      attribute (`borderStyle`), so `usePresetBinding` calls each of these once per
+ *                      axis and combines the results — see its own docblock.
  */
 
 import { get } from 'lodash';
+import { isTokenAlias } from '../../token-controls/helpers/token-summary';
+
+/**
+ * The order `EditorBorderControl`'s native shape stores per-side tuples in, and the index each axis
+ * occupies within a side's `[color, style, size]` tuple.
+ *
+ * @since TBD
+ *
+ * @type {string[]}
+ */
+const BORDER_SIDES = ['top', 'right', 'bottom', 'left'];
+
+/**
+ * The index within a side's `[color, style, size]` tuple for each border axis kind.
+ *
+ * @since TBD
+ *
+ * @type {Object<string, number>}
+ */
+const BORDER_AXIS_INDEX = {
+	'border-color': 0,
+	'border-style': 1,
+	'border-width': 2,
+};
 
 /**
  * The editor's global color palette map (`paletteN -> literal color`). Kadence localizes the theme
@@ -301,10 +331,26 @@ export function normalizeText(value) {
 }
 
 /**
+ * `EditorBorderControl`'s native per-side source object (`native[0]`), or `null` for the never-written
+ * shape (`undefined`, `[]`, or an array with no first element) — matching `fromNativeBorder`'s own
+ * `!source` short-circuit, which is this module's "empty/bound" reading for every border axis.
+ *
+ * @param {*} value The stored `borderStyle`-shaped attribute value.
+ *
+ * @since TBD
+ *
+ * @return {Object|null} The native source object, or null when never written.
+ */
+function borderSource(value) {
+	return (Array.isArray(value) ? value[0] : undefined) || null;
+}
+
+/**
  * Whether a stored attribute value is "empty" (untouched) for its kind — the signal a retarget-bound
  * control uses for `empty => bound`.
  *
- * @param {string} kind  The property kind ('color' | 'dimension' | 'text').
+ * @param {string} kind  The property kind ('color' | 'dimension' | 'text' | 'border-width' |
+ *                       'border-style' | 'border-color').
  * @param {*}      value The stored primary attribute value.
  *
  * @since TBD
@@ -314,6 +360,12 @@ export function normalizeText(value) {
 export function isEmptyValue(kind, value) {
 	if (kind === 'dimension') {
 		return normalizeDimension(value, '').value === '';
+	}
+
+	if (kind in BORDER_AXIS_INDEX) {
+		// All three axes share one native shape, and the moment any side is written `toNativeBorder`
+		// always fills in all four — so "empty" is a single source-level check, not per-axis.
+		return borderSource(value) === null;
 	}
 
 	return normalizeColor(value) === '' && normalizeText(value) === '';
@@ -373,6 +425,76 @@ function matchesPresetSlots(sides, storedUnit, presetSlots) {
 }
 
 /**
+ * A side's width slot (`source[side][2]`) as a literal comparable to a resolved dimension token value:
+ * a token alias passes through whole, otherwise the numeric size is paired with the border's own
+ * shared unit (`source.unit`) — matching `fromNativeBorder`'s own width mapping so this reads the exact
+ * literal the control itself would show.
+ *
+ * @param {*}      size The side's stored width slot.
+ * @param {string} unit The border's shared unit (`source.unit`, defaulting to 'px').
+ *
+ * @since TBD
+ *
+ * @return {string} The width literal, or '' when the slot is unset.
+ */
+function borderWidthLiteral(size, unit) {
+	if (size === '' || size === undefined || size === null) {
+		return '';
+	}
+
+	return isTokenAlias(size) ? String(size) : `${size}${unit}`;
+}
+
+/**
+ * Whether every side of a stored `borderStyle`-shaped value matches the preset's resolved literal for
+ * ONE axis (width, style or color) — the per-axis compare `matchesPreset` delegates to for a
+ * `border-width`/`border-style`/`border-color` kind.
+ *
+ * @param {string} kind        One of 'border-width' | 'border-style' | 'border-color'.
+ * @param {Object} source      The native border source object (`value[0]`), already confirmed non-null.
+ * @param {string} presetValue The preset's resolved literal for this axis.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when every side's axis value equals the preset value.
+ */
+function matchesBorderAxis(kind, source, presetValue) {
+	const index = BORDER_AXIS_INDEX[kind];
+	const unit = source.unit || 'px';
+
+	if (kind === 'border-width') {
+		const preset = parseDimensionLiteral(presetValue);
+
+		return BORDER_SIDES.every((side) => {
+			const literal = borderWidthLiteral((source[side] || [])[index], unit);
+
+			if (literal === '') {
+				return false;
+			}
+
+			if (isTokenAlias(literal)) {
+				return literal === presetValue;
+			}
+
+			const stored = parseDimensionLiteral(literal);
+			const unitMatches = preset.unit === '' || stored.unit === preset.unit;
+
+			return unitMatches && stored.value === preset.value;
+		});
+	}
+
+	if (kind === 'border-color') {
+		return BORDER_SIDES.every(
+			(side) => normalizeColor((source[side] || [])[index]) === normalizeColor(presetValue)
+		);
+	}
+
+	return BORDER_SIDES.every(
+		(side) => normalizeText((source[side] || [])[index] || 'none') === normalizeText(presetValue)
+	);
+}
+
+/**
  * Whether a stored value equals the selected preset's resolved value, normalized per kind.
  *
  * @param {string} kind        The property kind.
@@ -385,6 +507,12 @@ function matchesPresetSlots(sides, storedUnit, presetSlots) {
  * @return {boolean} True when the stored value matches the preset value.
  */
 export function matchesPreset(kind, value, unit, presetValue) {
+	if (kind in BORDER_AXIS_INDEX) {
+		const source = borderSource(value);
+
+		return source !== null && matchesBorderAxis(kind, source, presetValue);
+	}
+
 	if (kind === 'dimension') {
 		const sides = dimensionSides(value);
 		const storedUnit = String(unit || '').trim();

--- a/src/extension/token-indicators/normalize.js
+++ b/src/extension/token-indicators/normalize.js
@@ -107,6 +107,11 @@ function handlerFor(kind) {
  *                       'border-style' | 'border-color').
  * @param {*}      value The stored primary attribute value.
  *
+ * An unrecognized `kind` falls back to the `text` kind's handler rather than throwing — PHP's
+ * `Preset_Bindings::kind()` can return a kind this module has no `KINDS` entry for yet (e.g.
+ * `'shadow'`, before its own dispatch entry lands), and a `TypeError` here would crash the editor
+ * render rather than merely mis-marking the indicator.
+ *
  * @since TBD
  *
  * @return {boolean} True when the value is unset/empty.
@@ -122,6 +127,9 @@ export function isEmptyValue(kind, value) {
  * @param {*}      value       The stored primary attribute value.
  * @param {string} unit        The companion unit (dimension only; '' otherwise).
  * @param {string} presetValue The preset's resolved literal for this property.
+ *
+ * An unrecognized `kind` falls back to the `text` kind's handler, matching `isEmptyValue`'s own
+ * fallback — see its docblock for why.
  *
  * @since TBD
  *

--- a/src/extension/token-indicators/normalize.js
+++ b/src/extension/token-indicators/normalize.js
@@ -14,336 +14,74 @@
  *                      compared uniformly across all four sides. The three axes share one native
  *                      attribute (`borderStyle`), so `usePresetBinding` calls each of these once per
  *                      axis and combines the results — see its own docblock.
+ *
+ * The per-kind logic itself lives in the `kinds/` modules (`kinds/dimension.js`, `kinds/color.js`,
+ * `kinds/text.js`, `kinds/border.js`); this module is only the dispatch table plus the two thin wrappers
+ * (`isEmptyValue`, `matchesPreset`) every caller reaches it through.
  */
 
-import { get } from 'lodash';
-import { isTokenAlias } from '../../token-controls/helpers/token-summary';
+import * as dimension from './kinds/dimension';
+import * as border from './kinds/border';
+import { normalizeColor } from './kinds/color';
+import { normalizeText } from './kinds/text';
+
+export { normalizeColor } from './kinds/color';
+export { normalizeText } from './kinds/text';
+export {
+	dimensionSlots,
+	presetSlotAt,
+	presetValueForDevice,
+	measureAttrsForDevice,
+	inheritedMeasureSlots,
+	anyCornerInherited,
+	deriveMeasureMode,
+	normalizeDimension,
+} from './kinds/dimension';
 
 /**
- * The order `EditorBorderControl`'s native shape stores per-side tuples in, and the index each axis
- * occupies within a side's `[color, style, size]` tuple.
+ * The `color` kind's `isEmpty`/`matches` pair for the `KINDS` dispatch table below. Empty is the same
+ * "nothing resolves for either reading" check the `text` kind uses, since a mapped control's kind can be
+ * generic ('color') for a value that is really a bare string — see `isEmptyValue`'s original combined
+ * check.
  *
  * @since TBD
  *
- * @type {string[]}
+ * @type {{ isEmpty: Function, matches: Function }}
  */
-const BORDER_SIDES = ['top', 'right', 'bottom', 'left'];
-
-/**
- * The index within a side's `[color, style, size]` tuple for each border axis kind.
- *
- * @since TBD
- *
- * @type {Object<string, number>}
- */
-const BORDER_AXIS_INDEX = {
-	'border-color': 0,
-	'border-style': 1,
-	'border-width': 2,
+const color = {
+	isEmpty: (value) => normalizeColor(value) === '' && normalizeText(value) === '',
+	matches: (value, unit, presetValue) => normalizeColor(value) === normalizeColor(presetValue),
 };
 
 /**
- * The editor's global color palette map (`paletteN -> literal color`). Kadence localizes the theme
- * palette as `window.kadence_blocks_params.global_colors`, keyed by CSS custom-property name
- * (`--global-palette1`..`--global-palette9`); this reader strips the `--global-` prefix so the map keys
- * line up with the bare `paletteN` slug a color control writes into a block attribute (confirmed against
- * `SinglePopColorControl`, the swatch component behind `PopColorControl`). Empty when the params are
- * absent, so an unresolved slug simply compares as itself — the degrade-safe fallback.
+ * The `text` kind's `isEmpty`/`matches` pair for the `KINDS` dispatch table below.
  *
  * @since TBD
  *
- * @return {Object} slug ('paletteN') => color literal.
+ * @type {{ isEmpty: Function, matches: Function }}
  */
-function paletteMap() {
-	const colors = get(window, ['kadence_blocks_params', 'global_colors'], {}) || {};
-
-	return Object.keys(colors).reduce((map, cssVar) => {
-		const slug = cssVar.replace(/^--global-/, '');
-
-		map[slug] = colors[cssVar];
-
-		return map;
-	}, {});
-}
+const text = {
+	isEmpty: (value) => normalizeColor(value) === '' && normalizeText(value) === '',
+	matches: (value, unit, presetValue) => normalizeText(value) === normalizeText(presetValue),
+};
 
 /**
- * Resolve a color attribute value to a comparable literal: a `paletteN` slug becomes its mapped color;
- * anything else passes through. Lower-cased so `#3182CE` and `#3182ce` compare equal. An unresolved slug
- * (palette map missing the key) passes through as the slug itself, which degrades safe — it never
- * produces a false match, at worst a false override.
- *
- * @param {*} value The stored color value (slug or literal), possibly empty.
+ * The per-kind `{ isEmpty, matches }` handlers `isEmptyValue`/`matchesPreset` dispatch through. The three
+ * border axes share one handler — `EditorBorderControl`'s native shape is axis-agnostic, and `border`'s
+ * own `matches` takes the kind as its first argument to know which axis to read.
  *
  * @since TBD
  *
- * @return {string} The comparable literal, or '' when empty.
+ * @type {Object<string, Object>}
  */
-export function normalizeColor(value) {
-	if (value === undefined || value === null || value === '') {
-		return '';
-	}
-
-	const literal = paletteMap()[value] || value;
-
-	return String(literal).trim().toLowerCase();
-}
-
-/**
- * The populated sides of a stored dimension value, each trimmed to a string. A measurement control writes
- * a 4-side array (`[top, right, bottom, left]`) where an untouched side is `''`; a scalar value is a
- * single side. Empty/undefined sides are dropped, so an all-empty value yields `[]` and a per-corner
- * override yields one entry per touched side — the shape a side-aware compare needs.
- *
- * @param {*} value The stored dimension value (number, string, or 4-side array).
- *
- * @since TBD
- *
- * @return {string[]} The populated sides as trimmed strings; empty array when nothing is set.
- */
-function dimensionSides(value) {
-	const raw = Array.isArray(value) ? value : [value];
-
-	return raw.filter((side) => side !== '' && side !== undefined && side !== null).map((side) => String(side).trim());
-}
-
-/**
- * The stored sides of a dimension value with their POSITION preserved: a 4-side array maps one-to-one
- * and an untouched side stays `''`, while a scalar is a single slot. This is the positional counterpart
- * to `dimensionSides`, which drops empties and so cannot say WHICH corner a value belongs to — needed
- * wherever a per-corner value is composed or compared slot by slot.
- *
- * @param {*} value The stored dimension value (number, string, or 4-side array).
- *
- * @since TBD
- *
- * @return {string[]} The slots as trimmed strings, empty slots preserved as ''.
- */
-export function dimensionSlots(value) {
-	const raw = Array.isArray(value) ? value : [value];
-
-	return raw.map((side) => (side === undefined || side === null ? '' : String(side).trim()));
-}
-
-/**
- * The value one corner inherits from the selected preset.
- *
- * A preset value is either a single literal, which every corner inherits, or a PER-CORNER list, in which
- * case the corner takes its matching slot.
- *
- * @param {*}      presetValue The selected preset's value for the property.
- * @param {number} index       The corner index.
- *
- * @since TBD
- *
- * @return {string} The inherited value for that corner, or '' when the preset has none.
- */
-export function presetSlotAt(presetValue, index) {
-	if (Array.isArray(presetValue)) {
-		return String(presetValue[index] ?? '');
-	}
-
-	return presetValue === undefined || presetValue === null ? '' : String(presetValue);
-}
-
-/**
- * The selected preset's value for a property AT THE ACTIVE DEVICE: its breakpoint override where the
- * preset declares one, otherwise the value it inherits through the cascade.
- *
- * A preset can carry per-breakpoint values, and the button renders them — so a control sitting on
- * Tablet that falls back to the preset's desktop value names a size the block is not rendering at
- * that breakpoint. The fallback order mirrors the projected CSS: Mobile takes the mobile override,
- * then the tablet one, then the base; Tablet takes the tablet override, then the base.
- *
- * @param {*}      presetValue  The preset's base value for the property.
- * @param {Object} [responsive] The preset's breakpoint values ({ tablet, mobile }), each undefined
- *                              when the preset declares no override there.
- * @param {string} [device]     The active preview device ('Desktop' | 'Tablet' | 'Mobile').
- *
- * @since TBD
- *
- * @return {*} The preset's value in effect at that device.
- */
-export function presetValueForDevice(presetValue, responsive = {}, device = 'Desktop') {
-	const chain =
-		'Mobile' === device ? [responsive.mobile, responsive.tablet] : 'Tablet' === device ? [responsive.tablet] : [];
-
-	const override = chain.find((value) => value !== undefined && value !== null && value !== '');
-
-	return override === undefined ? presetValue : override;
-}
-
-/**
- * The attribute a responsive measure control is editing at the given device, and its current value.
- *
- * A responsive measure control keeps ONE linked/individual mode but writes three separate attributes
- * (`borderRadius` / `tabletBorderRadius` / `mobileBorderRadius`). Deriving the mode — or collapsing
- * corners on "link" — against the desktop attribute while the editor is on Tablet reads and writes the
- * wrong breakpoint, so both must resolve the device's own attribute first.
- *
- * @param {Object} attributes  The block's attributes.
- * @param {string} baseAttr    The desktop attribute name.
- * @param {Object} [responsive] Device key ('tablet' | 'mobile') => attribute name.
- * @param {string} [device]    The active preview device ('Desktop' | 'Tablet' | 'Mobile').
- *
- * @since TBD
- *
- * @return {{ attr: string, value: * }} The device's attribute name and its stored value.
- */
-export function measureAttrsForDevice(attributes, baseAttr, responsive = {}, device = 'Desktop') {
-	const attr = get(responsive, String(device).toLowerCase(), '') || baseAttr;
-
-	return { attr, value: get(attributes, attr, '') };
-}
-
-/**
- * What each corner of a measure control inherits at the given device WHEN THE DEVICE STORES NOTHING —
- * the device's own value is deliberately left out, because this is the value the corner falls back to.
- *
- * A responsive measure control renders through a desktop -> tablet -> mobile cascade that runs PER CORNER:
- * an empty tablet corner takes the desktop corner, an empty mobile corner takes the tablet corner and
- * then the desktop one. Only once the whole device chain is empty does the corner reach the selected
- * preset. Resolving straight to the preset skips those steps, so a Tablet sitting on four different
- * desktop corners would report the preset's single value — naming a size the button is not rendering at
- * that breakpoint.
- *
- * Nothing here is written back, and this does NOT feed the linked/individual mode: the corners stay empty
- * so they keep inheriting, and the resolved values only tell the field's popover which size is currently
- * in effect and where it came from.
- *
- * @param {string} device        The active preview device ('Desktop' | 'Tablet' | 'Mobile').
- * @param {Object} [values]      The stored dimension per device: { desktop, tablet }.
- * @param {*}      [presetValue] The selected preset's value for the property, the last fallback.
- *
- * @since TBD
- *
- * @return {{ values: string[], inherited: boolean[] }} The four inherited corners, and per corner whether
- *                                                      it came from another device rather than the preset.
- */
-export function inheritedMeasureSlots(device, values = {}, presetValue) {
-	const desktop = dimensionSlots(values.desktop);
-	const tablet = dimensionSlots(values.tablet);
-
-	// Mobile falls through tablet before desktop; tablet only through desktop; desktop inherits the preset.
-	const chain = 'Mobile' === device ? [tablet, desktop] : 'Tablet' === device ? [desktop] : [];
-
-	const slots = [0, 1, 2, 3].map((index) => {
-		const from = chain.find((source) => {
-			const corner = source[index];
-
-			return corner !== undefined && corner !== null && corner !== '';
-		});
-
-		return from
-			? { value: String(from[index]), inherited: true }
-			: { value: presetSlotAt(presetValue, index), inherited: false };
-	});
-
-	return {
-		values: slots.map((slot) => slot.value),
-		inherited: slots.map((slot) => slot.inherited),
-	};
-}
-
-/**
- * Whether a measure control's single row-level "Inherited" label should show, given each corner's
- * own inherited flag from `inheritedMeasureSlots()`.
- *
- * The control renders one label for all four corners, so "any corner inherited" is the safer read
- * than "every corner inherited": a mixed row — one corner pulled from another breakpoint, the rest
- * resolved straight to the preset — is no longer a plain preset default, and reporting "Default"
- * would understate that. `inherited` is always a four-element array, so a bare truthiness check on
- * the array itself is always `true`; this reduces it to the actual per-corner flags instead.
- *
- * @param {boolean[]} inherited Per-corner inherited flags, i.e. `inheritedMeasureSlots().inherited`.
- *
- * @since TBD
- *
- * @return {boolean} Whether any corner inherits from another breakpoint rather than the preset.
- */
-export function anyCornerInherited(inherited) {
-	return Array.isArray(inherited) && inherited.some(Boolean);
-}
-
-/**
- * The linked/individual mode a measure control should open in, derived from the corners the user would
- * actually see: each stored corner where one is set, otherwise the value that corner inherits from the
- * selected preset.
- *
- * Deriving from the stored attribute alone is not enough. A block on a preset stores NOTHING — every
- * corner is empty, which trivially reads as "all equal" — so a preset carrying four different corners
- * would open the control in linked mode and hide the difference it is displaying.
- *
- * @param {*} value       The stored dimension value (4-side array or scalar).
- * @param {*} presetValue The selected preset's value for the property.
- *
- * @since TBD
- *
- * @return {string} 'linked' when every effective corner matches, otherwise 'individual'.
- */
-export function deriveMeasureMode(value, presetValue) {
-	const stored = dimensionSlots(value);
-	const corners = [0, 1, 2, 3].map((index) =>
-		stored[index] !== undefined && stored[index] !== '' ? stored[index] : presetSlotAt(presetValue, index)
-	);
-
-	return corners.every((corner) => corner === corners[0]) ? 'linked' : 'individual';
-}
-
-/**
- * Normalize a dimension attribute to `{ value, unit }`. A measurement control writes a 4-side array
- * (`[top, right, bottom, left]`); the representative value is the first populated side. An empty value
- * yields an empty marker so "no override" is detectable. This is the scalar view used for empty
- * detection and the single-value path; the bound-vs-overridden compare uses the side-aware `matchesPreset`
- * so a per-corner override is not masked by a matching first side.
- *
- * @param {*}      value The stored dimension value (number, string, or 4-side array).
- * @param {string} unit  The companion unit attribute (e.g. `borderRadiusUnit`).
- *
- * @since TBD
- *
- * @return {{ value: string, unit: string }} The canonical dimension, `value: ''` when empty.
- */
-export function normalizeDimension(value, unit) {
-	const sides = dimensionSides(value);
-
-	if (!sides.length) {
-		return { value: '', unit: '' };
-	}
-
-	return { value: sides[0], unit: String(unit || '').trim() };
-}
-
-/**
- * Normalize a text attribute for compare.
- *
- * @param {*} value The stored value.
- *
- * @since TBD
- *
- * @return {string} The trimmed string, or '' when empty.
- */
-export function normalizeText(value) {
-	if (value === undefined || value === null) {
-		return '';
-	}
-
-	return String(value).trim();
-}
-
-/**
- * `EditorBorderControl`'s native per-side source object (`native[0]`), or `null` for the never-written
- * shape (`undefined`, `[]`, or an array with no first element) — matching `fromNativeBorder`'s own
- * `!source` short-circuit, which is this module's "empty/bound" reading for every border axis.
- *
- * @param {*} value The stored `borderStyle`-shaped attribute value.
- *
- * @since TBD
- *
- * @return {Object|null} The native source object, or null when never written.
- */
-function borderSource(value) {
-	return (Array.isArray(value) ? value[0] : undefined) || null;
-}
+const KINDS = {
+	dimension,
+	color,
+	text,
+	'border-width': border,
+	'border-style': border,
+	'border-color': border,
+};
 
 /**
  * Whether a stored attribute value is "empty" (untouched) for its kind — the signal a retarget-bound
@@ -358,140 +96,7 @@ function borderSource(value) {
  * @return {boolean} True when the value is unset/empty.
  */
 export function isEmptyValue(kind, value) {
-	if (kind === 'dimension') {
-		return normalizeDimension(value, '').value === '';
-	}
-
-	if (kind in BORDER_AXIS_INDEX) {
-		// All three axes share one native shape, and the moment any side is written `toNativeBorder`
-		// always fills in all four — so "empty" is a single source-level check, not per-axis.
-		return borderSource(value) === null;
-	}
-
-	return normalizeColor(value) === '' && normalizeText(value) === '';
-}
-
-/**
- * Split a resolved dimension literal (`"1.5rem"`, `"8px"`, `"0"`) into `{ value, unit }` so it compares
- * against the control's separate value/unit attributes.
- *
- * @param {string} literal The resolved dimension literal.
- *
- * @since TBD
- *
- * @return {{ value: string, unit: string }} The parsed value and unit.
- */
-function parseDimensionLiteral(literal) {
-	const match = String(literal || '')
-		.trim()
-		.match(/^(-?[\d.]+)\s*([a-z%]*)$/i);
-
-	if (!match) {
-		return { value: String(literal || '').trim(), unit: '' };
-	}
-
-	return { value: match[1], unit: match[2] };
-}
-
-/**
- * Whether a stored dimension matches a PER-CORNER preset value, compared slot by slot.
- *
- * Comparing by position means a rotated set of the same corners (e.g. `4,8,4,8` against `8,4,8,4`) reads
- * as overridden, and a stored value with a different number of populated sides than the preset has slots
- * cannot match at all.
- *
- * @param {string[]} sides       The stored sides, empties already dropped.
- * @param {string}   storedUnit  The stored companion unit.
- * @param {Array}    presetSlots The preset's per-corner literals.
- *
- * @since TBD
- *
- * @return {boolean} True when every corner equals its preset slot.
- */
-function matchesPresetSlots(sides, storedUnit, presetSlots) {
-	const stored = sides;
-	const presets = presetSlots.map(parseDimensionLiteral);
-
-	if (stored.length !== presets.length) {
-		return false;
-	}
-
-	return stored.every((side, index) => {
-		const preset = presets[index];
-		const unitMatches = preset.unit === '' || storedUnit === preset.unit;
-
-		return unitMatches && side === preset.value;
-	});
-}
-
-/**
- * A side's width slot (`source[side][2]`) as a literal comparable to a resolved dimension token value:
- * a token alias passes through whole, otherwise the numeric size is paired with the border's own
- * shared unit (`source.unit`) — matching `fromNativeBorder`'s own width mapping so this reads the exact
- * literal the control itself would show.
- *
- * @param {*}      size The side's stored width slot.
- * @param {string} unit The border's shared unit (`source.unit`, defaulting to 'px').
- *
- * @since TBD
- *
- * @return {string} The width literal, or '' when the slot is unset.
- */
-function borderWidthLiteral(size, unit) {
-	if (size === '' || size === undefined || size === null) {
-		return '';
-	}
-
-	return isTokenAlias(size) ? String(size) : `${size}${unit}`;
-}
-
-/**
- * Whether every side of a stored `borderStyle`-shaped value matches the preset's resolved literal for
- * ONE axis (width, style or color) — the per-axis compare `matchesPreset` delegates to for a
- * `border-width`/`border-style`/`border-color` kind.
- *
- * @param {string} kind        One of 'border-width' | 'border-style' | 'border-color'.
- * @param {Object} source      The native border source object (`value[0]`), already confirmed non-null.
- * @param {string} presetValue The preset's resolved literal for this axis.
- *
- * @since TBD
- *
- * @return {boolean} True when every side's axis value equals the preset value.
- */
-function matchesBorderAxis(kind, source, presetValue) {
-	const index = BORDER_AXIS_INDEX[kind];
-	const unit = source.unit || 'px';
-
-	if (kind === 'border-width') {
-		const preset = parseDimensionLiteral(presetValue);
-
-		return BORDER_SIDES.every((side) => {
-			const literal = borderWidthLiteral((source[side] || [])[index], unit);
-
-			if (literal === '') {
-				return false;
-			}
-
-			if (isTokenAlias(literal)) {
-				return literal === presetValue;
-			}
-
-			const stored = parseDimensionLiteral(literal);
-			const unitMatches = preset.unit === '' || stored.unit === preset.unit;
-
-			return unitMatches && stored.value === preset.value;
-		});
-	}
-
-	if (kind === 'border-color') {
-		return BORDER_SIDES.every(
-			(side) => normalizeColor((source[side] || [])[index]) === normalizeColor(presetValue)
-		);
-	}
-
-	return BORDER_SIDES.every(
-		(side) => normalizeText((source[side] || [])[index] || 'none') === normalizeText(presetValue)
-	);
+	return KINDS[kind].isEmpty(value);
 }
 
 /**
@@ -507,39 +112,9 @@ function matchesBorderAxis(kind, source, presetValue) {
  * @return {boolean} True when the stored value matches the preset value.
  */
 export function matchesPreset(kind, value, unit, presetValue) {
-	if (kind in BORDER_AXIS_INDEX) {
-		const source = borderSource(value);
-
-		return source !== null && matchesBorderAxis(kind, source, presetValue);
+	if (kind in border.BORDER_AXIS_INDEX) {
+		return border.matches(kind, value, unit, presetValue);
 	}
 
-	if (kind === 'dimension') {
-		const sides = dimensionSides(value);
-		const storedUnit = String(unit || '').trim();
-
-		if (!sides.length) {
-			return false;
-		}
-
-		// A per-corner preset value is compared corner by corner. `parseDimensionLiteral` reads one length,
-		// so a slot list handed to it whole would never match and the control would read as overridden even
-		// when it exactly matches its preset.
-		if (Array.isArray(presetValue)) {
-			return matchesPresetSlots(sides, storedUnit, presetValue);
-		}
-
-		const preset = parseDimensionLiteral(presetValue);
-		const unitMatches = preset.unit === '' || storedUnit === preset.unit;
-
-		// Side-aware: a stored dimension matches only when EVERY populated side equals the preset value.
-		// A per-corner override (e.g. `['8','8','8','4']` vs `8px`) leaves one side differing and so reads
-		// as overridden, not still-bound.
-		return unitMatches && sides.every((side) => side === preset.value);
-	}
-
-	if (kind === 'color') {
-		return normalizeColor(value) === normalizeColor(presetValue);
-	}
-
-	return normalizeText(value) === normalizeText(presetValue);
+	return KINDS[kind].matches(value, unit, presetValue);
 }

--- a/src/extension/token-indicators/store.js
+++ b/src/extension/token-indicators/store.js
@@ -4,7 +4,7 @@
  * actions (Part D) and read by the token indicators (Part C). Editor-session state only — never persisted.
  */
 
-import { createReduxStore, register } from '@wordpress/data';
+import { createReduxStore, register, select } from '@wordpress/data';
 
 const STORE_NAME = 'kadence/token-indicators';
 
@@ -60,6 +60,14 @@ function reducer(state = DEFAULT_STATE, action) {
 
 const store = createReduxStore(STORE_NAME, { reducer, actions, selectors });
 
-register(store);
+// `early-filters.js` and `blocks-singlebtn.js` are separate webpack entries that both import this
+// module, so its top-level code runs once per bundle — webpack doesn't dedupe modules across
+// entries. `@wordpress/data`'s registry is a page-wide singleton though, so `select()` here (safe
+// to call for an unregistered store; it returns `undefined` rather than warning) checks the same
+// `stores` map `register()` writes to, and prevents the second bundle's copy of this module from
+// re-registering and logging "Store already registered."
+if (!select(STORE_NAME)) {
+	register(store);
+}
 
 export const TOKEN_INDICATORS_STORE = STORE_NAME;

--- a/src/extension/token-picker/__tests__/index.test.js
+++ b/src/extension/token-picker/__tests__/index.test.js
@@ -329,8 +329,9 @@ describe('pickableTokensForControl', () => {
 		const result = pickableTokensForControl('kadence/singlebtn', 'borderRadius');
 
 		// `borderRadius` implies the radius role (spacing drops out); with a primitive radius present the
-		// picker offers only the size scale, so the semantic radius token is dropped too.
-		expect(result.map((token) => token.id)).toEqual(['primitive.dimension.radius.sm']);
+		// picker offers only the size scale, so the semantic radius token is dropped too. The fixed "None"
+		// entry every radius/spacing role carries (see `fixedNoneEntry`) leads the list.
+		expect(result.map((token) => token.id)).toEqual(['ss-none-radius', 'primitive.dimension.radius.sm']);
 		expect(result.every((token) => token.role === 'radius')).toBe(true);
 	});
 
@@ -352,8 +353,8 @@ describe('pickableTokensForControl', () => {
 		const result = pickableTokensForControl('kadence/singlebtn', 'borderRadius');
 
 		// The bound token fixes the radius sub-kind (spacing drops out); the primitive size scale still wins,
-		// so even the bound semantic radius is dropped.
-		expect(result.map((token) => token.id)).toEqual(['primitive.dimension.radius.sm']);
+		// so even the bound semantic radius is dropped. The fixed "None" entry leads, same as the unbound case.
+		expect(result.map((token) => token.id)).toEqual(['ss-none-radius', 'primitive.dimension.radius.sm']);
 		expect(result.every((token) => token.role === 'radius')).toBe(true);
 	});
 
@@ -388,8 +389,9 @@ describe('pickableTokensForControl', () => {
 
 		const result = pickableTokensForControl('kadence/singlebtn', 'borderRadius');
 
-		// A bound primitive is itself a size, so it survives the primitives-only scoping and is pinned first.
-		expect(result.map((token) => token.id)).toEqual(['primitive.dimension.radius.sm']);
+		// A bound primitive is itself a size, so it survives the primitives-only scoping and is pinned
+		// first, ahead of even the fixed "None" entry.
+		expect(result.map((token) => token.id)).toEqual(['primitive.dimension.radius.sm', 'ss-none-radius']);
 	});
 });
 
@@ -434,8 +436,9 @@ describe('pickableTokensForKey', () => {
 		const result = pickableTokensForKey('kadence/singlebtn', 'button-padding');
 
 		// A primitive spacing size exists, so (mirroring the radius narrowing above) the picker offers
-		// only the size scale, dropping even the bound-role semantic spacing token.
-		expect(result.map((token) => token.id)).toEqual(['primitive.dimension.spacing.md']);
+		// only the size scale, dropping even the bound-role semantic spacing token. The fixed "None"
+		// entry leads the list, same as radius.
+		expect(result.map((token) => token.id)).toEqual(['ss-none-spacing', 'primitive.dimension.spacing.md']);
 		expect(result.every((token) => token.role === 'spacing')).toBe(true);
 	});
 

--- a/src/extension/token-picker/__tests__/index.test.js
+++ b/src/extension/token-picker/__tests__/index.test.js
@@ -153,6 +153,7 @@ const PRESETS = {
 					{ key: 'button-radius', kind: 'dimension', token: null, control_attr: 'borderRadius' },
 					{ key: 'button-gap', kind: 'dimension', token: null, control_attr: 'gap' },
 					{ key: 'button-shadow', kind: 'shadow', token: 'semantic.shadow.button', control_attr: null },
+					{ key: 'button-padding', kind: 'dimension', token: null, control_attr: 'padding' },
 				],
 			},
 			'kadence/single-icon': {
@@ -338,7 +339,7 @@ describe('pickableTokensForControl', () => {
 	});
 
 	it('returns an empty array for an unmapped attribute', () => {
-		expect(pickableTokensForControl('kadence/singlebtn', 'padding')).toEqual([]);
+		expect(pickableTokensForControl('kadence/singlebtn', 'margin')).toEqual([]);
 	});
 
 	it('returns an empty array for an unknown block', () => {
@@ -424,6 +425,18 @@ describe('pickableTokensForKey', () => {
 
 	it('returns an empty array for an unmapped key', () => {
 		expect(pickableTokensForKey('kadence/singlebtn', 'button-does-not-exist')).toEqual([]);
+	});
+
+	it('narrows padding to the spacing role, dropping radius/shadow/font-weight tokens', () => {
+		// `button-padding` binds no `token`, and its `control_attr` ('padding') does not literally
+		// contain the word 'spacing' — the fixed padding/margin -> spacing role alias is what narrows it,
+		// not the generic substring match `borderRadius` relies on.
+		const result = pickableTokensForKey('kadence/singlebtn', 'button-padding');
+
+		// A primitive spacing size exists, so (mirroring the radius narrowing above) the picker offers
+		// only the size scale, dropping even the bound-role semantic spacing token.
+		expect(result.map((token) => token.id)).toEqual(['primitive.dimension.spacing.md']);
+		expect(result.every((token) => token.role === 'spacing')).toBe(true);
 	});
 
 	it('returns an empty array for an unknown block', () => {

--- a/src/extension/token-picker/index.js
+++ b/src/extension/token-picker/index.js
@@ -16,6 +16,7 @@
  * That is cosmetic (the alias never goes stale) and live refresh is the picker UI's concern.
  */
 import { get } from 'lodash';
+import { __ } from '@wordpress/i18n';
 import { activeLibrary, blockProperties } from '../preset-picker';
 
 /**
@@ -60,6 +61,23 @@ function valuesFor(library) {
 	const slug = library || activeLibrary();
 
 	return get(values, [slug], null) || get(values, [activeLibrary()], {}) || {};
+}
+
+/**
+ * The resolved literal for a single token id, or `''` when the pool carries no value for it (e.g. the
+ * feed has not loaded yet). For a caller that needs a block's own hardcoded literal to show when even
+ * this comes back empty — e.g. a `defaultValue` a control falls back to when nothing binds it — see
+ * that caller's own fallback constant; this function only ever reads the pool, never invents one.
+ *
+ * @param {string} id        The token id (e.g. 'semantic.spacing.button-padding-top').
+ * @param {string} [library] The token library slug; defaults to the active library.
+ *
+ * @since TBD
+ *
+ * @return {string} The resolved literal, or ''.
+ */
+export function resolvedTokenValue(id, library) {
+	return valuesFor(library)[id] ?? '';
 }
 
 /**
@@ -161,6 +179,49 @@ const ROLE_ALIASES = {
 };
 
 /**
+ * The roles that offer a fixed "None" entry — every role whose scale used to register a `.none`
+ * primitive worth `0` (see `declarations.php`'s own comment on why it no longer does). Sized this
+ * way rather than "every dimension role" because it is a deliberate design choice per role, not a
+ * property every scale has — border-width and icon-size, for instance, have never offered one.
+ *
+ * @since TBD
+ *
+ * @type {string[]}
+ */
+const FIXED_NONE_ROLES = ['spacing', 'radius'];
+
+/**
+ * The fixed "None" entry for one of `FIXED_NONE_ROLES`, matching Margin's own `ss-auto` sentinel in
+ * spirit: a real, working value with no DTCG registration behind it, spliced into the pickable list
+ * at read time instead. Unlike `ss-auto` (the CSS keyword `auto`, meaningless as a length), "None" IS
+ * a length — the plain literal `0` — so no bare, non-bracketed alias convention is needed to reach a
+ * PHP/CSS layer that already special-cases it; `alias` is the JS number `0` itself, exactly what
+ * `toControlValue()`/a hand-typed Custom `0` already produce, so `findTokenEntry()` recognizes either
+ * one as this same fixed entry (see its own docblock on the `fixed` exception).
+ *
+ * Kept off the registry (and therefore off the Spacing/Border Radius screens) on purpose: a "None"
+ * primitive read exactly like the shipped XS/SM/MD/… steps had nothing distinguishing it from a real,
+ * user-owned scale value, so the screen let it be renamed or deleted like any other row.
+ *
+ * @param {string} role The role to build the entry for ('spacing' | 'radius').
+ *
+ * @since TBD
+ *
+ * @return {{id: string, alias: number, label: string, value: string, type: string, role: string, fixed: boolean}} The fixed entry.
+ */
+function fixedNoneEntry(role) {
+	return {
+		id: `ss-none-${role}`,
+		alias: 0,
+		label: __('None', 'kadence-blocks'),
+		value: '0',
+		type: 'dimension',
+		role,
+		fixed: true,
+	};
+}
+
+/**
  * @param {string} controlAttr The attribute the control writes (e.g. 'borderRadius').
  * @param {Array}  tokens      The type-filtered token list whose roles are the candidates.
  *
@@ -200,6 +261,8 @@ function inferRoleFromControl(controlAttr, tokens) {
  * @since TBD
  *
  * @return {Array} The pickable list ([{ id, alias, label, value, type, role }]), empty when unmapped.
+ *                  A 'spacing'/'radius' role list also carries a fixed "None" entry (see
+ *                  `fixedNoneEntry`).
  */
 function pickableTokensForProperty(property, controlAttr, library) {
 	if (!property || !property.kind) {
@@ -221,11 +284,16 @@ function pickableTokensForProperty(property, controlAttr, library) {
 	const primitives = narrowed.filter((token) => token.id.startsWith('primitive.'));
 	const scoped = primitives.length ? primitives : narrowed;
 
+	// "None" is spliced in here, after the primitive-preferring narrow above, rather than into the
+	// registered pool it would otherwise have to survive that narrowing as — see `fixedNoneEntry`'s
+	// own docblock for why it carries no registration at all.
+	const withFixedNone = FIXED_NONE_ROLES.includes(role) ? [fixedNoneEntry(role), ...scoped] : scoped;
+
 	// Pin the exact bound token first when it survived the scoping (order carries through for the rest).
 	// An unresolved or scoped-out bound token drops the pin to a no-op.
 	return [
-		...scoped.filter((token) => token.id === property.token),
-		...scoped.filter((token) => token.id !== property.token),
+		...withFixedNone.filter((token) => token.id === property.token),
+		...withFixedNone.filter((token) => token.id !== property.token),
 	];
 }
 
@@ -249,6 +317,8 @@ function pickableTokensForProperty(property, controlAttr, library) {
  * @since TBD
  *
  * @return {Array} The pickable list ([{ id, alias, label, value, type, role }]), empty when unmapped.
+ *                  A 'spacing'/'radius' role list also carries a fixed "None" entry (see
+ *                  `fixedNoneEntry`).
  */
 export function pickableTokensForControl(blockName, controlAttr, library) {
 	const property = blockProperties(blockName, library).find((entry) => entry.control_attr === controlAttr);
@@ -274,6 +344,8 @@ export function pickableTokensForControl(blockName, controlAttr, library) {
  * @since TBD
  *
  * @return {Array} The pickable list ([{ id, alias, label, value, type, role }]), empty when unmapped.
+ *                  A 'spacing'/'radius' role list also carries a fixed "None" entry (see
+ *                  `fixedNoneEntry`).
  */
 export function pickableTokensForKey(blockName, key, library) {
 	const property = blockProperties(blockName, library).find((entry) => entry.key === key);

--- a/src/extension/token-picker/index.js
+++ b/src/extension/token-picker/index.js
@@ -147,6 +147,20 @@ function roleForId(id) {
  * matches `radius`; `iconSize` matches `icon-size`). Empty unless exactly one role matches, so an
  * ambiguous or unrecognized attribute falls back to the coarse list rather than guessing.
  *
+ * A handful of control attributes name their role by a different word than the role itself uses
+ * (`padding`/`margin` imply the `spacing` role, but neither string contains "spacing") — those get a
+ * fixed alias here rather than a substring guess.
+ *
+ * @since TBD
+ *
+ * @type {Object<string, string>}
+ */
+const ROLE_ALIASES = {
+	padding: 'spacing',
+	margin: 'spacing',
+};
+
+/**
  * @param {string} controlAttr The attribute the control writes (e.g. 'borderRadius').
  * @param {Array}  tokens      The type-filtered token list whose roles are the candidates.
  *
@@ -158,6 +172,10 @@ function inferRoleFromControl(controlAttr, tokens) {
 	const attr = String(controlAttr || '').toLowerCase();
 	if (!attr) {
 		return '';
+	}
+
+	if (ROLE_ALIASES[attr] && tokens.some((token) => token.role === ROLE_ALIASES[attr])) {
+		return ROLE_ALIASES[attr];
 	}
 
 	const roles = [...new Set(tokens.map((token) => token.role).filter(Boolean))];
@@ -218,9 +236,11 @@ function pickableTokensForProperty(property, controlAttr, library) {
  * an unmapped control offers no tokens, which is the "selectable only where it makes sense" guarantee
  * at the per-control call site.
  *
- * Only reaches properties that DO carry a `control_attr` — a property bound to a nested/composite
- * native attribute (border, shadow) is declared with no `control_attr` at all and is invisible to this
- * lookup by design; use `pickableTokensForKey` for those.
+ * Only reaches a property whose `control_attr` this lookup can resolve UNAMBIGUOUSLY by a find-the-
+ * first-match on `controlAttr` — a property bound to a nested/composite native attribute (shadow) is
+ * declared with no `control_attr` at all, and the three border-axis properties share one
+ * (`borderStyle`) among themselves, so none of the four are safely reachable here; use
+ * `pickableTokensForKey` for those instead.
  *
  * @param {string} blockName   The block name (e.g. 'kadence/singlebtn').
  * @param {string} controlAttr The attribute the control writes (e.g. 'borderRadius').
@@ -238,11 +258,14 @@ export function pickableTokensForControl(blockName, controlAttr, library) {
 
 /**
  * The pickable tokens for one bound property, keyed by the property's stable `key` (the PHP bindings
- * array key, e.g. 'button-shadow') rather than its `control_attr`. Exists for properties whose native
- * block attribute is a nested/composite shape (border, shadow) and so is declared with no
- * `control_attr` at all — `pickableTokensForControl` can never find them, since it has no other way to
- * locate a property. Otherwise identical to `pickableTokensForControl`: defers to the same shared
- * narrowing helper once the property is found.
+ * array key, e.g. 'button-shadow') rather than its `control_attr`. Exists for a property whose
+ * `control_attr` cannot resolve a control-based reverse lookup either because it has none at all (a
+ * native attribute that is a nested/composite shape, e.g. border/shadow) or because it shares one
+ * `control_attr` with two other properties (the three border axes all share `borderStyle`, so
+ * `pickableTokensForControl`'s find-the-first-match lookup would be ambiguous among them). Otherwise
+ * identical to `pickableTokensForControl`: defers to the same shared narrowing helper once the
+ * property is found, passing its OWN `control_attr` through (when it has one) as the role-inference
+ * hint — a property with no `control_attr` passes `''`, same as before.
  *
  * @param {string} blockName The block name (e.g. 'kadence/singlebtn').
  * @param {string} key       The property's bindings key (e.g. 'button-shadow').
@@ -255,5 +278,5 @@ export function pickableTokensForControl(blockName, controlAttr, library) {
 export function pickableTokensForKey(blockName, key, library) {
 	const property = blockProperties(blockName, library).find((entry) => entry.key === key);
 
-	return pickableTokensForProperty(property, '', library);
+	return pickableTokensForProperty(property, property?.control_attr || '', library);
 }

--- a/src/style-library/__tests__/border-shadow-field-rendering.test.js
+++ b/src/style-library/__tests__/border-shadow-field-rendering.test.js
@@ -134,6 +134,34 @@ describe('BorderField', () => {
 		expect(latestBorderControlProps.breakpoints).toBeNull();
 	});
 
+	it("passes the field's defaultValue through to BorderControl, so an unset width falls back to it instead of collapsing to nothing", () => {
+		act(() => {
+			root.render(
+				createElement(BorderField, {
+					field: { label: 'Border', path: 'tokens.button-border', defaultValue: '1px' },
+					values: {},
+					onValueChange: jest.fn(),
+				})
+			);
+		});
+
+		expect(latestBorderControlProps.defaultValue).toBe('1px');
+	});
+
+	it('passes no defaultValue when the field declares none, matching every existing caller', () => {
+		act(() => {
+			root.render(
+				createElement(BorderField, {
+					field: { label: 'Border', path: 'tokens.button-border' },
+					values: {},
+					onValueChange: jest.fn(),
+				})
+			);
+		});
+
+		expect(latestBorderControlProps.defaultValue).toBeUndefined();
+	});
+
 	it('writes each axis to its own sibling path, in the stored (not control) shape', () => {
 		const onValueChange = jest.fn();
 

--- a/src/style-library/__tests__/border-shadow-field-rendering.test.js
+++ b/src/style-library/__tests__/border-shadow-field-rendering.test.js
@@ -338,17 +338,22 @@ describe('BoxShadowField', () => {
 		window[PICKABLE_TOKENS_GLOBAL] = originalPool;
 	});
 
-	it("sources tokens via pickableTokensForType('shadow', 'shadow', ...), excluding the Brand-group semantics", () => {
+	it("sources tokens via pickableTokensForType('shadow', 'shadow', ...), excluding the Brand-group semantics except the fixed None entry", () => {
 		act(() => {
 			root.render(createElement(BoxShadowField, { field: { label: 'Shadow' }, value: '', onChange: jest.fn() }));
 		});
 
+		// `shadowNoneEntry()` leads the list — the one deliberate re-admission of a Brand-group semantic
+		// (`semantic.shadow.button`, relabeled "None"); every other Brand-group semantic stays excluded.
 		expect(latestBoxShadowControlProps.tokens.map((token) => token.id)).toEqual([
+			'semantic.shadow.button',
 			'primitive.shadow.xs',
 			'primitive.shadow.sm',
 			'primitive.shadow.md',
 		]);
-		expect(latestBoxShadowControlProps.tokens[0].alias).toBe('{primitive.shadow.xs}');
+		expect(latestBoxShadowControlProps.tokens[0].label).toBe('None');
+		expect(latestBoxShadowControlProps.tokens[0].alias).toBe('{semantic.shadow.button}');
+		expect(latestBoxShadowControlProps.tokens[1].alias).toBe('{primitive.shadow.xs}');
 	});
 
 	it('exempts the bound token from the primitive narrowing when it is a Brand-group semantic', () => {
@@ -382,6 +387,7 @@ describe('BoxShadowField', () => {
 		});
 
 		expect(latestBoxShadowControlProps.tokens.map((token) => token.id)).toEqual([
+			'semantic.shadow.button',
 			'primitive.shadow.xs',
 			'primitive.shadow.sm',
 			'primitive.shadow.md',

--- a/src/style-library/__tests__/tokens.test.js
+++ b/src/style-library/__tests__/tokens.test.js
@@ -194,8 +194,10 @@ describe('pickableTokensForType', () => {
 	it('narrows to matching entries when a role is given', () => {
 		const tokens = pickableTokensForType('dimension', 'radius');
 
-		expect(tokens).toHaveLength(1);
-		expect(tokens[0]).toMatchObject({ id: 'primitive.dimension.radius.sm', value: '4px', role: 'radius' });
+		// The fixed "None" entry every radius/spacing role carries (see `fixedNoneEntry`) leads the list.
+		expect(tokens).toHaveLength(2);
+		expect(tokens[0]).toMatchObject({ id: 'ss-none-radius', value: '0', role: 'radius', fixed: true });
+		expect(tokens[1]).toMatchObject({ id: 'primitive.dimension.radius.sm', value: '4px', role: 'radius' });
 	});
 
 	it('keeps the token the field is already bound to, even when it loses the primitive narrowing', () => {

--- a/src/style-library/components/molecules/fields/BorderField.js
+++ b/src/style-library/components/molecules/fields/BorderField.js
@@ -188,6 +188,8 @@ export function toStoredStyleAxis(next) {
  * @param {string}   props.field.path         The base dot path; the width/style/color axes are
  *                                             stored at `${path}-width` / `-style` / `-color`.
  * @param {?string}  [props.field.label]      The control's label.
+ * @param {?string}  [props.field.defaultValue] What the width field falls back to when unset,
+ *                                             already a resolved literal (e.g. `'1px'`).
  * @param {boolean}  [props.field.readOnly]   Whether the control is non-interactive.
  * @param {boolean}  [props.field.responsive] Whether the field offers a breakpoint switcher.
  * @param {Object}   props.values             The full draft values, read by dot path.
@@ -278,6 +280,7 @@ export function BorderField({ field, values, onValueChange }) {
 			}}
 			label={field.label}
 			widthTokens={widthTokens}
+			defaultValue={field.defaultValue ?? undefined}
 			renderColor={({ value: color, onChange: onColorChange, label: sideLabel }) => (
 				<TokenColorSelectField
 					// `sideLabel` is the row's bare side name ("top", "right", …), or `null` while linked.

--- a/src/style-library/components/molecules/fields/BoxShadowField.js
+++ b/src/style-library/components/molecules/fields/BoxShadowField.js
@@ -34,6 +34,39 @@ import { isTokenAlias } from '../../../../token-controls/helpers/token-summary';
 import { TokenColorSelectField } from './TokenColorSelectField';
 
 /**
+ * The button's own "no shadow" semantic token, already an invisible transparent zero-shadow — see
+ * `declarations.php`'s own comment on `semantic.shadow.button`. Deliberately excluded from the
+ * pickable pool's normal listing as a `Brand`-group semantic (`pickableTokensForType`'s primitive
+ * narrowing); `shadowNoneEntry` below is the one deliberate exception, re-admitting it under a
+ * "None" label instead of its registered "Button Shadow" one.
+ *
+ * @since TBD
+ */
+const BUTTON_SHADOW_NONE_TOKEN_ID = 'semantic.shadow.button';
+
+/**
+ * The "None" entry for the Button preset's Shadow field: `BUTTON_SHADOW_NONE_TOKEN_ID` relabeled
+ * "None". A real registered token, not a synthetic sentinel — see this module's own note on why a
+ * composite-valued control can't use a `fixed` entry the way a scalar dimension field's "None"/Auto
+ * can (`===` never matches a freshly-built composite object).
+ *
+ * @since TBD
+ *
+ * @return {{id: string, alias: string, label: string, value: string, role: string}} The entry.
+ */
+function shadowNoneEntry() {
+	const resolved = pickableTokensForType('shadow').find((token) => token.id === BUTTON_SHADOW_NONE_TOKEN_ID);
+
+	return {
+		id: BUTTON_SHADOW_NONE_TOKEN_ID,
+		alias: `{${BUTTON_SHADOW_NONE_TOKEN_ID}}`,
+		label: __('None', 'kadence-blocks'),
+		value: resolved?.value ?? '',
+		role: 'shadow',
+	};
+}
+
+/**
  * The bound token id, unwrapped from its brace-wrapped alias, or unset when `value` holds a
  * composite shadow object instead. `boundTokenIds` (shared with `BorderField`) expects the bare
  * `primitive.`/`semantic.`-prefixed id a preset's own `tokens` map stores; this field's `value`
@@ -73,10 +106,22 @@ export function BoxShadowField({ field, value, onChange }) {
 	// shadow token's derived role — engages the primitive narrowing, matching the three-entry list the
 	// Shadow screen itself offers. `boundShadowTokenIds` exempts the currently-bound token from that
 	// narrowing so a bound semantic still renders as its own label rather than a raw id.
-	const tokens = pickableTokensForType('shadow', 'shadow', boundShadowTokenIds(value)).map((token) => ({
-		...token,
-		alias: `{${token.id}}`,
-	}));
+	//
+	// `shadowNoneEntry()` leads the list — the one deliberate re-admission of a Brand-group semantic,
+	// under its own "None" label rather than its registered one (see the function's own docblock).
+	const tokens = [
+		shadowNoneEntry(),
+		// `BUTTON_SHADOW_NONE_TOKEN_ID` is dropped here even when it is the bound value the primitive
+		// narrowing would otherwise exempt — `shadowNoneEntry()` above already stands for it, under its
+		// "None" label; keeping the narrowing's own copy too would list the same id twice, once under
+		// each label.
+		...pickableTokensForType('shadow', 'shadow', boundShadowTokenIds(value))
+			.filter((token) => token.id !== BUTTON_SHADOW_NONE_TOKEN_ID)
+			.map((token) => ({
+				...token,
+				alias: `{${token.id}}`,
+			})),
+	];
 
 	return (
 		<BoxShadowControl

--- a/src/style-library/components/molecules/fields/BoxTokenField.js
+++ b/src/style-library/components/molecules/fields/BoxTokenField.js
@@ -285,10 +285,13 @@ export function BoxTokenField({ field, value, onChange, slots = 'sides' }) {
 			// breakpoint's own. A breakpoint that inherits binds nothing itself, so without this the
 			// semantic it falls back to is filtered out of the pool and the field, finding no entry for
 			// it, shows nothing at all instead of the value actually in effect.
-			tokens={pickableTokensForType(field.tokenType, field.role, boundTokenIds(atBreakpoint)).map((token) => ({
-				...token,
-				alias: `{${token.id}}`,
-			}))}
+			//
+			// A `fixed` entry (e.g. "None") keeps its own alias untouched — it already carries the exact
+			// value the control writes (the bare number `0`), not a `{dot.path}` a real registered token's
+			// id would bracket-wrap into.
+			tokens={pickableTokensForType(field.tokenType, field.role, boundTokenIds(atBreakpoint)).map((token) =>
+				token.fixed ? token : { ...token, alias: `{${token.id}}` }
+			)}
 			// The two kinds of default are still shaped differently, which is why `shownDefault` resolves
 			// them separately above instead of passing either straight through: a value inherited from
 			// another breakpoint is stored the way this app stores values, so it is read through `asLiteral`

--- a/src/style-library/components/pages/ShadowScreen.scss
+++ b/src/style-library/components/pages/ShadowScreen.scss
@@ -10,14 +10,14 @@
 	background: transparent;
 }
 
-// The shadowed square itself: fixed 48px inside the 80px slot, centered by the slot's own flex
-// layout, giving 16px of clearance on every side for the cast shadow to read — matching the board's
-// light square sitting proud of the row.
+// The shadowed square itself: 80px, filling the 80px slot (`--kb-sl-size-row-preview`) exactly, so no
+// clearance remains inside the row for the cast shadow to read — it is only visible where it extends
+// past the row into the surrounding page background.
 .kadence-blocks-style-library__shadow-preview {
 	box-sizing: border-box;
 	display: block;
-	width: 3rem;
-	height: 3rem;
+	width: 5rem;
+	height: 5rem;
 	border: var(--kb-sl-border-width-input) solid var(--kb-sl-color-gray-200);
 	border-radius: var(--kb-sl-radius-s);
 	background: var(--kb-sl-color-white);

--- a/src/style-library/helpers/tokens.js
+++ b/src/style-library/helpers/tokens.js
@@ -78,6 +78,40 @@ export function preferPrimitiveTokens(tokens, selected) {
 }
 
 /**
+ * The roles that offer a fixed "None" entry — mirrors the editor's own `FIXED_NONE_ROLES` in
+ * `extension/token-picker/index.js`. Both hosts read the same pool and must offer the same choices.
+ *
+ * @since TBD
+ *
+ * @type {string[]}
+ */
+const FIXED_NONE_ROLES = ['spacing', 'radius'];
+
+/**
+ * The fixed "None" entry for one of `FIXED_NONE_ROLES` — the Style Library's copy of the editor's
+ * `fixedNoneEntry()` (`extension/token-picker/index.js`), same reasoning: "None" carries no DTCG
+ * registration, so it is spliced into the pickable list here instead of surviving the primitive
+ * narrowing as a registered token would. `alias` is the JS number `0`, matching what
+ * `BoxTokenField.js`'s `toControlValue()` already produces for a stored literal `'0'`.
+ *
+ * @param {string} role The role to build the entry for ('spacing' | 'radius').
+ *
+ * @since TBD
+ *
+ * @return {{id: string, alias: number, label: string, value: string, role: string, fixed: boolean}} The fixed entry.
+ */
+function fixedNoneEntry(role) {
+	return {
+		id: `ss-none-${role}`,
+		alias: 0,
+		label: __('None', 'kadence-blocks'),
+		value: '0',
+		role,
+		fixed: true,
+	};
+}
+
+/**
  * The pickable tokens of one DTCG `$type` (e.g. `dimension`, `color`), each with its resolved
  * literal value from the active library. An optional `role` narrows the pool further (e.g. the
  * Radius picker wants only `role: 'radius'` dimensions, not every dimension token) — omitted, this
@@ -116,7 +150,11 @@ export function pickableTokensForType(type, role, selected) {
 		return matched;
 	}
 
-	return preferPrimitiveTokens(matched, selected);
+	const narrowed = preferPrimitiveTokens(matched, selected);
+
+	// Spliced in after the primitive narrowing, not before — its id carries no `primitive.` prefix, so
+	// the narrowing above would otherwise strip it exactly as it strips any other non-primitive entry.
+	return FIXED_NONE_ROLES.includes(role) ? [fixedNoneEntry(role), ...narrowed] : narrowed;
 }
 
 /**

--- a/src/style-library/presets/button-preset.js
+++ b/src/style-library/presets/button-preset.js
@@ -76,6 +76,23 @@ const BUTTON_PADDING_FALLBACK = ['0.4em', '1em', '0.4em', '1em'];
 const BUTTON_MARGIN_FALLBACK = ['0', '0', '0', '0'];
 
 /**
+ * The general-purpose semantic token the Primary/Secondary presets bind `button-border-width` to —
+ * unlike the per-side padding/margin tokens, this one is a real, reusable scale value (see
+ * `declarations.php`), so the field's own resolved default only needs its literal, not an unbind.
+ *
+ * @since TBD
+ */
+const BUTTON_BORDER_WIDTH_TOKEN_ID = 'semantic.border-width.default';
+
+/**
+ * What `semantic.border-width.default` resolves to when the baseline is never overridden — mirrors
+ * that token's own registered default (see `declarations.php`).
+ *
+ * @since TBD
+ */
+const BUTTON_BORDER_WIDTH_FALLBACK = '1px';
+
+/**
  * Resolve a per-side box default (padding/margin) from the resolved design-token feed, one value per
  * CSS side, falling back to the button's own literal default for any side whose token is missing from
  * the feed (e.g. the feed has not loaded yet).
@@ -95,6 +112,22 @@ function resolveBoxDefault(tokenIds, fallback) {
 	const values = getDesignTokensFeed()?.values ?? {};
 
 	return tokenIds.map((tokenId, index) => values[tokenId] || fallback[index]);
+}
+
+/**
+ * Resolve one scalar default from the resolved design-token feed, falling back to the button's own
+ * literal default when the token is missing from the feed. The single-value sibling of
+ * `resolveBoxDefault`, for a property (border width) that has one value rather than four sides.
+ *
+ * @param {string} tokenId The semantic token id.
+ * @param {string} fallback The literal fallback.
+ *
+ * @since TBD
+ *
+ * @return {string} The resolved default.
+ */
+function resolveScalarDefault(tokenId, fallback) {
+	return getDesignTokensFeed()?.values?.[tokenId] || fallback;
 }
 
 /**
@@ -209,10 +242,11 @@ function schemaFor(tab) {
 				// living at this path.
 				path: 'tokens.button-border',
 				label: __('Border', 'kadence-blocks'),
-				// No `defaultValue` here, unlike the radius field above: `BorderField`'s adapter doesn't
-				// read one, because `BorderControl` accepts no `defaultValue`/inherited-value prop the way
-				// `BoxControl` does. Setting one would be a dead key. Add it once `BorderControl` grows that
-				// support, not before.
+				// The width field's own default, resolved from `semantic.border-width.default` the same
+				// way radius resolves its own above — shown muted when the preset sets nothing, so an unset
+				// width reads as the size actually in effect (and Reset lands back on it) rather than
+				// collapsing the row to nothing.
+				defaultValue: resolveScalarDefault(BUTTON_BORDER_WIDTH_TOKEN_ID, BUTTON_BORDER_WIDTH_FALLBACK),
 			},
 			{
 				type: 'box-shadow',

--- a/src/token-controls/__tests__/token-selector.test.js
+++ b/src/token-controls/__tests__/token-selector.test.js
@@ -85,3 +85,25 @@ describe('TokenSelector disabled state', () => {
 		expect(renderSelector().disabled).toBe(false);
 	});
 });
+
+describe('TokenSelector fixed-entry round trip', () => {
+	// Margin's `Auto` choice (`kadence/singlebtn`'s `edit.js`) is a real spacing slot at the PHP/CSS
+	// layer that was never registered as a DTCG token, so it has no bracket-form alias. Its pickable
+	// entry is marked `fixed: true` instead, and this proves the trigger reads that entry back as the
+	// picked token rather than falling through to a `Custom` literal with the unit concatenated on.
+	const AUTO_TOKENS = [{ id: 'ss-auto', label: 'Auto', value: 'auto', alias: 'ss-auto', fixed: true }];
+
+	/**
+	 * Selecting Auto stores the bare `ss-auto` slug; the trigger must show it as the picked `Auto`
+	 * token, never as `Custom` with the unit concatenated onto it.
+	 *
+	 * @return {void}
+	 */
+	it('shows a fixed entry as its label, not as a Custom literal with the unit appended', () => {
+		const trigger = renderSelector({ value: 'ss-auto', tokens: AUTO_TOKENS, unit: 'px' });
+
+		expect(trigger.textContent).toBe('Autoauto');
+		expect(trigger.textContent).not.toContain('ss-auto');
+		expect(trigger.textContent).not.toContain('Custom');
+	});
+});

--- a/src/token-controls/__tests__/token-summary.test.js
+++ b/src/token-controls/__tests__/token-summary.test.js
@@ -14,6 +14,11 @@ const TOKENS = [
 	{ id: 'lg', label: 'Large', value: '0.5rem', alias: '{primitive.dimension.radius-lg}' },
 ];
 
+// A `fixed` entry (e.g. Margin's `Auto`) has no DTCG registration behind it, so its `alias` is a bare
+// slug rather than a bracket-wrapped dot path — the shape `kadence/singlebtn`'s `edit.js` appends for
+// `ss-auto`.
+const TOKENS_WITH_FIXED = [...TOKENS, { id: 'ss-auto', label: 'Auto', value: 'auto', alias: 'ss-auto', fixed: true }];
+
 describe('isTokenAlias', () => {
 	it('accepts a brace-wrapped dot path', () => {
 		expect(isTokenAlias('{primitive.dimension.radius-sm}')).toBe(true);
@@ -44,6 +49,14 @@ describe('findTokenEntry', () => {
 	it('tolerates an absent list', () => {
 		expect(findTokenEntry(undefined, '{x}')).toBeNull();
 	});
+
+	it('matches a fixed entry on its bare alias, since it has no bracket form', () => {
+		expect(findTokenEntry(TOKENS_WITH_FIXED, 'ss-auto').label).toBe('Auto');
+	});
+
+	it('never matches a non-fixed entry on a bare literal, even one equal to its alias text', () => {
+		expect(findTokenEntry(TOKENS, 'primitive.dimension.radius-sm')).toBeNull();
+	});
 });
 
 describe('resolveDefaultValue', () => {
@@ -70,6 +83,10 @@ describe('resolveDefaultValue', () => {
 	it('is empty for an unset default', () => {
 		expect(resolveDefaultValue('', TOKENS, 'px')).toBe('');
 		expect(resolveDefaultValue(null, TOKENS, 'px')).toBe('');
+	});
+
+	it("resolves a fixed entry (Margin's Auto) through the pickable list, same as a bracketed alias", () => {
+		expect(resolveDefaultValue('ss-auto', TOKENS_WITH_FIXED, 'px', true)).toBe('auto');
 	});
 });
 
@@ -108,6 +125,18 @@ describe('fieldSummary', () => {
 
 	it('summarizes an unset slot to nothing, so the caller can show the default instead', () => {
 		expect(fieldSummary('', TOKENS, 'px', 'Custom')).toEqual({ label: '', value: '' });
+	});
+
+	it("names a fixed entry (Margin's Auto) by its label and resolved value, not as a Custom literal", () => {
+		expect(fieldSummary('ss-auto', TOKENS_WITH_FIXED, 'px', 'Custom')).toEqual({
+			label: 'Auto',
+			value: 'auto',
+		});
+	});
+
+	it("never reads a hand-typed literal equal to a fixed entry's alias as that entry", () => {
+		// cspell:disable-next-line
+		expect(fieldSummary('ss-auto', TOKENS, 'px', 'Custom')).toEqual({ label: 'Custom', value: 'ss-autopx' });
 	});
 });
 

--- a/src/token-controls/controls/BoxControl.js
+++ b/src/token-controls/controls/BoxControl.js
@@ -28,6 +28,41 @@ import { TokenSelector } from '../organisms/TokenSelector';
 import { isSlotList, readSlot, toShorthand, toSlotList } from '../helpers/value-shapes';
 
 /**
+ * The token pool one slot's picker should offer: the shared pool, minus any token another slot
+ * currently holds. A caller building `tokens` for the whole control (e.g. the Style Library's
+ * `BoxTokenField`) exempts every currently-bound token from its primitives-only narrowing so no
+ * slot's own binding silently disappears from the pool — but that exemption is computed once for
+ * all four slots together, so the shared list still carries slot B's token when slot A is what's
+ * open. Filtering it back out here, per slot, is what keeps a sibling's specific token from showing
+ * up as a pickable option in a slot it was never bound to. A token equal to THIS slot's own current
+ * value is never dropped, so the field never loses track of its own selection, and the linked
+ * slot (`index === null`) needs no filtering at all — there is only one value to compare against.
+ *
+ * @param {Array}   tokens The shared token pool passed to the whole control.
+ * @param {*}       value  The whole box value (a scalar or a four-slot list).
+ * @param {?number} index  This slot's index, or `null` for the linked slot.
+ * @param {*}       slot   This slot's own current value.
+ *
+ * @since TBD
+ *
+ * @return {Array} The token pool this slot's picker should offer.
+ */
+export function tokensForSlot(tokens, value, index, slot) {
+	if (index === null) {
+		return tokens;
+	}
+
+	const siblingValues = new Set(
+		[0, 1, 2, 3]
+			.filter((slotIndex) => slotIndex !== index)
+			.map((slotIndex) => readSlot(value, slotIndex))
+			.filter((siblingValue) => siblingValue && siblingValue !== slot)
+	);
+
+	return siblingValues.size ? tokens.filter((token) => !siblingValues.has(token.alias)) : tokens;
+}
+
+/**
  * Render a box-shaped token control.
  *
  * @param {Object}    props                      The component props.
@@ -136,7 +171,7 @@ export function BoxControl({
 						defaultValue={index === null ? toShorthand(defaultValue) : readSlot(defaultValue, index)}
 						inherited={inherited}
 						icon={slotIcons?.[index ?? 0]}
-						tokens={tokens}
+						tokens={tokensForSlot(tokens, value, index, slot)}
 						min={min}
 						max={max}
 						step={step}

--- a/src/token-controls/controls/__tests__/BoxControl.test.js
+++ b/src/token-controls/controls/__tests__/BoxControl.test.js
@@ -1,0 +1,83 @@
+/* eslint-env jest */
+
+import { tokensForSlot } from '../BoxControl';
+
+const TOKENS = [
+	{ id: 'primitive.dimension.spacing.none', alias: '{primitive.dimension.spacing.none}' },
+	{ id: 'primitive.dimension.spacing.xxs', alias: '{primitive.dimension.spacing.xxs}' },
+	{ id: 'semantic.spacing.button-padding-top', alias: '{semantic.spacing.button-padding-top}' },
+	{ id: 'semantic.spacing.button-padding-right', alias: '{semantic.spacing.button-padding-right}' },
+	{ id: 'semantic.spacing.button-padding-bottom', alias: '{semantic.spacing.button-padding-bottom}' },
+	{ id: 'semantic.spacing.button-padding-left', alias: '{semantic.spacing.button-padding-left}' },
+];
+
+describe('tokensForSlot', () => {
+	/**
+	 * The linked slot (`index === null`) has only one value to compare against, so it is handed the
+	 * shared pool untouched rather than filtered against itself.
+	 *
+	 * @return {void}
+	 */
+	it('returns the pool unfiltered for the linked slot', () => {
+		const value = '{semantic.spacing.button-padding-top}';
+
+		expect(tokensForSlot(TOKENS, value, null, value)).toBe(TOKENS);
+	});
+
+	/**
+	 * Each corner bound to a different sibling-specific token should not see the other three
+	 * corners' own tokens in its own picker — only the generic scale plus its own current value.
+	 *
+	 * @return {void}
+	 */
+	it('drops sibling slots’ own bound tokens from an unlinked slot’s pool', () => {
+		const value = [
+			'{semantic.spacing.button-padding-top}',
+			'{semantic.spacing.button-padding-right}',
+			'{semantic.spacing.button-padding-bottom}',
+			'{semantic.spacing.button-padding-left}',
+		];
+
+		const forTop = tokensForSlot(TOKENS, value, 0, value[0]);
+
+		expect(forTop.map((token) => token.id)).toEqual([
+			'primitive.dimension.spacing.none',
+			'primitive.dimension.spacing.xxs',
+			'semantic.spacing.button-padding-top',
+		]);
+	});
+
+	/**
+	 * A token equal to the slot's OWN current value is never dropped, even though it also appears in
+	 * the sibling-value comparison set by construction (a slot's own value is excluded from that set
+	 * up front).
+	 *
+	 * @return {void}
+	 */
+	it('keeps a token that matches two corners sharing the same bound value', () => {
+		const value = [
+			'{semantic.spacing.button-padding-top}',
+			'{semantic.spacing.button-padding-top}',
+			'{semantic.spacing.button-padding-bottom}',
+			'{semantic.spacing.button-padding-left}',
+		];
+
+		const forTop = tokensForSlot(TOKENS, value, 0, value[0]);
+		const forRight = tokensForSlot(TOKENS, value, 1, value[1]);
+
+		expect(forTop.some((token) => token.id === 'semantic.spacing.button-padding-top')).toBe(true);
+		expect(forRight.some((token) => token.id === 'semantic.spacing.button-padding-top')).toBe(true);
+	});
+
+	/**
+	 * A scalar (uniform) value reads the same for every slot index, so no sibling comparison ever
+	 * finds a differing value and the pool passes through unfiltered.
+	 *
+	 * @return {void}
+	 */
+	it('returns the pool unfiltered when the whole value is still a uniform scalar', () => {
+		const value = '{semantic.spacing.button-padding-top}';
+
+		expect(tokensForSlot(TOKENS, value, 0, value)).toBe(TOKENS);
+	});
+});

--- a/src/token-controls/helpers/token-summary.js
+++ b/src/token-controls/helpers/token-summary.js
@@ -50,6 +50,15 @@ export function hasValue(value) {
 /**
  * The pickable entry whose `alias` matches a value.
  *
+ * A regular entry only matches while `value` is alias-shaped (`{dot.path}`) — a plain literal that
+ * happens to equal an entry's `alias` string must never resolve to that entry. A `fixed` entry (a
+ * sentinel choice with no DTCG registration behind it, e.g. Margin's `Auto`) is the one exception:
+ * its `alias` IS the bare value written to the attribute, since it has no bracket form to write
+ * instead, so it matches on equality regardless of `isTokenAlias`. This is scoped strictly to
+ * entries explicitly marked `fixed: true` — never a general literal-value fallback — so a hand-typed
+ * Custom literal that happens to equal a real token's resolved value is never misidentified as that
+ * token.
+ *
  * @param {Array}  tokens The pickable-token list.
  * @param {string} value  The alias to match.
  *
@@ -58,7 +67,7 @@ export function hasValue(value) {
  * @return {?Object} The matching entry, or null.
  */
 export function findTokenEntry(tokens, value) {
-	return (tokens || []).find((entry) => entry.alias === value) || null;
+	return (tokens || []).find((entry) => entry.alias === value && (entry.fixed || isTokenAlias(value))) || null;
 }
 
 /**
@@ -78,10 +87,14 @@ export function resolveDefaultValue(defaultValue, tokens, unit, inherited) {
 		return '';
 	}
 
-	if (isTokenAlias(defaultValue)) {
-		const entry = findTokenEntry(tokens, defaultValue);
+	const entry = findTokenEntry(tokens, defaultValue);
 
-		return entry ? entry.value : '';
+	if (entry) {
+		return entry.value;
+	}
+
+	if (isTokenAlias(defaultValue)) {
+		return '';
 	}
 
 	if (inherited && /^-?\d*\.?\d+$/.test(String(defaultValue))) {
@@ -130,13 +143,14 @@ export function defaultSummary(resolvedDefault, tokens, literalLabel = '') {
  * @return {{label: string, value: string}} The trigger label and secondary text, both '' when unset.
  */
 export function fieldSummary(value, tokens, unit, customName) {
-	if (isTokenAlias(value)) {
-		const entry = findTokenEntry(tokens, value);
+	const entry = findTokenEntry(tokens, value);
 
-		return {
-			label: entry ? entry.label : String(value).slice(1, -1),
-			value: entry ? entry.value : '',
-		};
+	if (entry) {
+		return { label: entry.label, value: entry.value };
+	}
+
+	if (isTokenAlias(value)) {
+		return { label: String(value).slice(1, -1), value: '' };
 	}
 
 	if (hasValue(value)) {

--- a/src/token-controls/organisms/TokenSelector.js
+++ b/src/token-controls/organisms/TokenSelector.js
@@ -110,8 +110,11 @@ export function TokenSelector({
 		: resolvedDefault
 			? inheritedName
 			: __('Default', 'kadence-blocks');
-	const aliased = isTokenAlias(value);
-	const entry = aliased ? findTokenEntry(tokens, value) : null;
+	// A `fixed` entry (a sentinel choice with no DTCG registration, e.g. Margin's `Auto`) matches on its
+	// bare `alias` rather than the bracket form `isTokenAlias` checks for, so the entry lookup runs
+	// first and `aliased` widens to cover that match too.
+	const entry = findTokenEntry(tokens, value);
+	const aliased = isTokenAlias(value) || Boolean(entry);
 	const seed = entry ? parseCssLength(entry.value) : null;
 	// An unset slot seeds the Custom tab from whatever it falls back to, so opening the editor starts
 	// from the value on screen instead of an empty box the user has to guess at.

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -4,8 +4,8 @@
  * Styles the token field (the corner icon + input-styled trigger that replaces a control's numeric
  * slot) and its Style Library/Custom popover to the sidebar design, plus the whole-value box-shadow
  * chip/picker. Values mirror the design tokens: gray-900 #1e1e1e text, gray-600 #949494 borders and
- * muted values, gray-300 #dddddd dividers, gray-100 #f0f0f0 selection, theme #3858e9 accents, 13px
- * body type, 2px control radius, 4px popover radius.
+ * muted values, gray-400 #cccccc borders, gray-300 #dddddd dividers, gray-100 #f0f0f0 selection,
+ * theme #3858e9 accents, 13px body type, 2px control radius, 4px popover radius.
  */
 
 // The token field is a corner icon beside the trigger, filling the slot the numeric input held.
@@ -130,16 +130,19 @@
 }
 
 /*
- * `BoxShadowControl`'s preview square: a plain gray-100 box with the active shadow's CSS applied, so
- * a shadow reads at a glance before it is picked. Reuses this file's own established gray-100
- * selection background and 2px control radius rather than new values.
+ * `BoxShadowControl`'s preview square: a white box with the active shadow's CSS applied, so a shadow
+ * reads at a glance before it is picked — white rather than this file's own gray-100 selection
+ * background so a dark shadow shows up clearly against it. The gray-400 border (`#cccccc`, mirroring
+ * the design tokens the way this file's other hardcoded colors do — see its header comment) keeps the
+ * square's own edge visible even when the active shadow is empty.
  */
 .kb-box-shadow-control__preview {
 	flex: 0 0 auto;
-	width: 48px;
-	height: 48px;
+	width: 6rem;
+	height: 6rem;
+	border: 1px solid #cccccc;
 	border-radius: 2px;
-	background: #f0f0f0;
+	background: #fff;
 }
 
 /*

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Css_BuilderTest.php
@@ -354,7 +354,7 @@ final class Css_BuilderTest extends TestCase {
 
 		$css = ( new Css_Builder( $registry ) )->css( $resolved );
 
-		foreach ( [ 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ] as $slug ) {
+		foreach ( [ 'none', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ] as $slug ) {
 			$this->assertStringContainsString( '--global-kb-spacing-' . $slug . ':var(', $css );
 		}
 

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Css_BuilderTest.php
@@ -354,7 +354,7 @@ final class Css_BuilderTest extends TestCase {
 
 		$css = ( new Css_Builder( $registry ) )->css( $resolved );
 
-		foreach ( [ 'none', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ] as $slug ) {
+		foreach ( [ 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ] as $slug ) {
 			$this->assertStringContainsString( '--global-kb-spacing-' . $slug . ':var(', $css );
 		}
 

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Slot_Target_ReaderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Slot_Target_ReaderTest.php
@@ -93,7 +93,6 @@ final class Slot_Target_ReaderTest extends TestCase {
 				'3xl'  => '6.5rem',
 				'4xl'  => '8rem',
 				'5xl'  => '10rem',
-				'none' => '0',
 			],
 			$this->reader->read( Spacing_Target::class )
 		);

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Slot_Target_ReaderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Slot_Target_ReaderTest.php
@@ -83,16 +83,17 @@ final class Slot_Target_ReaderTest extends TestCase {
 	public function testItReadsTheSpacingScaleAsTheShippedLengths(): void {
 		$this->assertEquals(
 			[
-				'xxs' => '0.5rem',
-				'xs'  => '1rem',
-				'sm'  => '1.5rem',
-				'md'  => '2rem',
-				'lg'  => '3rem',
-				'xl'  => '4rem',
-				'xxl' => '5rem',
-				'3xl' => '6.5rem',
-				'4xl' => '8rem',
-				'5xl' => '10rem',
+				'xxs'  => '0.5rem',
+				'xs'   => '1rem',
+				'sm'   => '1.5rem',
+				'md'   => '2rem',
+				'lg'   => '3rem',
+				'xl'   => '4rem',
+				'xxl'  => '5rem',
+				'3xl'  => '6.5rem',
+				'4xl'  => '8rem',
+				'5xl'  => '10rem',
+				'none' => '0',
 			],
 			$this->reader->read( Spacing_Target::class )
 		);

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
@@ -97,9 +97,7 @@ final class Css_BuilderTest extends TestCase {
 				. '--kb-btn-radius:var(--kb-token--preset--kadence-singlebtn--secondary--button-radius);'
 				. '--kb-btn-border-width:var(--kb-token--preset--kadence-singlebtn--secondary--button-border-width);'
 				. '--kb-btn-border-style:var(--kb-token--preset--kadence-singlebtn--secondary--button-border-style);'
-				. '--kb-btn-border-color:var(--kb-token--preset--kadence-singlebtn--secondary--button-border-color);'
-				. '--kb-btn-padding:var(--kb-token--preset--kadence-singlebtn--secondary--button-padding);'
-				. '--kb-btn-margin:var(--kb-token--preset--kadence-singlebtn--secondary--button-margin);}',
+				. '--kb-btn-border-color:var(--kb-token--preset--kadence-singlebtn--secondary--button-border-color);}',
 			$css
 		);
 	}
@@ -122,9 +120,7 @@ final class Css_BuilderTest extends TestCase {
 				. '--kb-btn-radius:var(--kb-token--preset--kadence-singlebtn--primary--button-radius);'
 				. '--kb-btn-border-width:var(--kb-token--preset--kadence-singlebtn--primary--button-border-width);'
 				. '--kb-btn-border-style:var(--kb-token--preset--kadence-singlebtn--primary--button-border-style);'
-				. '--kb-btn-border-color:var(--kb-token--preset--kadence-singlebtn--primary--button-border-color);'
-				. '--kb-btn-padding:var(--kb-token--preset--kadence-singlebtn--primary--button-padding);'
-				. '--kb-btn-margin:var(--kb-token--preset--kadence-singlebtn--primary--button-margin);}',
+				. '--kb-btn-border-color:var(--kb-token--preset--kadence-singlebtn--primary--button-border-color);}',
 			$css
 		);
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
@@ -97,7 +97,9 @@ final class Css_BuilderTest extends TestCase {
 				. '--kb-btn-radius:var(--kb-token--preset--kadence-singlebtn--secondary--button-radius);'
 				. '--kb-btn-border-width:var(--kb-token--preset--kadence-singlebtn--secondary--button-border-width);'
 				. '--kb-btn-border-style:var(--kb-token--preset--kadence-singlebtn--secondary--button-border-style);'
-				. '--kb-btn-border-color:var(--kb-token--preset--kadence-singlebtn--secondary--button-border-color);}',
+				. '--kb-btn-border-color:var(--kb-token--preset--kadence-singlebtn--secondary--button-border-color);'
+				. '--kb-btn-padding:var(--kb-token--preset--kadence-singlebtn--secondary--button-padding);'
+				. '--kb-btn-margin:var(--kb-token--preset--kadence-singlebtn--secondary--button-margin);}',
 			$css
 		);
 	}
@@ -120,7 +122,9 @@ final class Css_BuilderTest extends TestCase {
 				. '--kb-btn-radius:var(--kb-token--preset--kadence-singlebtn--primary--button-radius);'
 				. '--kb-btn-border-width:var(--kb-token--preset--kadence-singlebtn--primary--button-border-width);'
 				. '--kb-btn-border-style:var(--kb-token--preset--kadence-singlebtn--primary--button-border-style);'
-				. '--kb-btn-border-color:var(--kb-token--preset--kadence-singlebtn--primary--button-border-color);}',
+				. '--kb-btn-border-color:var(--kb-token--preset--kadence-singlebtn--primary--button-border-color);'
+				. '--kb-btn-padding:var(--kb-token--preset--kadence-singlebtn--primary--button-padding);'
+				. '--kb-btn-margin:var(--kb-token--preset--kadence-singlebtn--primary--button-margin);}',
 			$css
 		);
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
@@ -128,8 +128,6 @@ final class Preset_ResolverTest extends TestCase {
 				'button-border-color',
 				'button-border-style',
 				'button-border-width',
-				'button-margin',
-				'button-padding',
 				'button-radius',
 				'button-text',
 				'button-text-hover',

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
@@ -128,6 +128,8 @@ final class Preset_ResolverTest extends TestCase {
 				'button-border-color',
 				'button-border-style',
 				'button-border-width',
+				'button-margin',
+				'button-padding',
 				'button-radius',
 				'button-text',
 				'button-text-hover',

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -266,7 +266,6 @@ final class Feed_ControllerTest extends TestCase {
 		$ids = array_column( $data['schema']['groups']['Border Radius'], 'id' );
 		$this->assertSame(
 			[
-				'primitive.dimension.radius.none',
 				'primitive.dimension.radius.xs',
 				'primitive.dimension.radius.sm',
 				'primitive.dimension.radius.md',
@@ -279,7 +278,6 @@ final class Feed_ControllerTest extends TestCase {
 			$ids
 		);
 
-		$this->assertSame( '0', $data['values']['primitive.dimension.radius.none'] );
 		$this->assertSame( '0.125rem', $data['values']['primitive.dimension.radius.xs'] );
 		$this->assertSame( '0.25rem', $data['values']['primitive.dimension.radius.sm'] );
 		$this->assertSame( '0.375rem', $data['values']['primitive.dimension.radius.md'] );


### PR DESCRIPTION
`BoxTokenField`'s (and any future caller's) `boundTokenIds()` exempts every currently-bound token from the primitives-only narrowing so no corner's own binding silently disappears from the shared pool — but that exemption is computed once for all four corners together. The result: editing one corner's picker (e.g. Padding Top) also lists the other corners' own bound tokens (Padding Right/Bottom/Left) as pickable options, even though those are specific to corners the user isn't editing.

Fixes it at the shared `BoxControl` level (used by both the Style Library's `BoxTokenField` and the block editor's `EditorBoxControl`): each slot's picker now filters the shared pool down, dropping any token that's a *sibling* slot's own current value while always keeping a token that matches the slot's own value.

Found while recording review demos for the SOFT-4083 stack — unrelated to that ticket's own scope, so it's a standalone fix rather than another phase in that chain.