### PR TITLE
[DTM] SOFT-4218 [2/16]: wire the remaining five alpha blocks for block presets

### DIFF
--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -618,34 +618,73 @@ return [
 					'token'        => 'semantic.color.image-bg',
 					'css_prop'     => 'background-color',
 					'css_selector' => 'img',
+					'css_var'      => 'kb-img-bg',
+					'control_attr' => 'backgroundColor',
 				],
+				// Border color and width are two axes of ONE control: the image migrates its legacy
+				// `borderColor`/`borderWidthDesktop` attributes into the nested `borderStyle` composite
+				// ([{top:[color,style,size],...},unit]) that EditorBorderControl edits, so both point at that
+				// attribute and each names the axis it owns. Same shape as the Button's border trio; the
+				// image binds no border STYLE, so only two of the three axes are present.
 				'border'       => [
-					'token'        => 'semantic.color.border',
-					'css_prop'     => 'border-color',
-					'css_selector' => 'img',
+					'token'            => 'semantic.color.border',
+					'css_prop'         => 'border-color',
+					'css_selector'     => 'img',
+					'css_var'          => 'kb-img-border-color',
+					'control_attr'     => 'borderStyle',
+					'axis'             => 'border-color',
+					'responsive_attrs' => [
+						'tablet' => 'tabletBorderStyle',
+						'mobile' => 'mobileBorderStyle',
+					],
 				],
 				'borderWidth'  => [
-					'token'        => 'semantic.border-width.default',
-					'css_prop'     => 'border-width',
-					'css_selector' => 'img',
+					'token'            => 'semantic.border-width.default',
+					'css_prop'         => 'border-width',
+					'css_selector'     => 'img',
+					'css_var'          => 'kb-img-border-width',
+					'control_attr'     => 'borderStyle',
+					'axis'             => 'border-width',
+					'responsive_attrs' => [
+						'tablet' => 'tabletBorderStyle',
+						'mobile' => 'mobileBorderStyle',
+					],
 				],
 				'borderRadius' => [
-					'token'        => 'semantic.radius.media',
-					'css_prop'     => 'border-radius',
-					'css_selector' => 'img',
+					'token'            => 'semantic.radius.media',
+					'css_prop'         => 'border-radius',
+					'css_selector'     => 'img',
+					'css_var'          => 'kb-img-radius',
+					'control_attr'     => 'borderRadius',
+					'responsive_attrs' => [
+						'tablet' => 'tabletBorderRadius',
+						'mobile' => 'mobileBorderRadius',
+					],
 				],
 				'shadow'       => [
 					'token'        => 'semantic.shadow.media',
 					'css_prop'     => 'box-shadow',
 					'css_selector' => 'img',
+					'css_var'      => 'kb-img-shadow',
+					'control_attr' => 'boxShadow',
 				],
 				// Padding is rendered on the `.kb-img` wrapper, a descendant of the block root. The leading `*`
 				// forces Css_Builder::selector_suffix() to treat `.kb-img` as a descendant (a bare `.kb-img`
 				// would compound onto the root and never match) — see the icon color binding for the rationale.
+				//
+				// The image spells its per-device padding attributes `paddingDesktop`/`paddingTablet`/
+				// `paddingMobile` rather than the bare-plus-prefix convention the Button and the radius binding
+				// above use, which is exactly why responsive_attrs is declared rather than derived.
 				'padding'      => [
-					'token'        => 'semantic.spacing.media-padding',
-					'css_prop'     => 'padding',
-					'css_selector' => '*.kb-img',
+					'token'            => 'semantic.spacing.media-padding',
+					'css_prop'         => 'padding',
+					'css_selector'     => '*.kb-img',
+					'css_var'          => 'kb-img-padding',
+					'control_attr'     => 'paddingDesktop',
+					'responsive_attrs' => [
+						'tablet' => 'paddingTablet',
+						'mobile' => 'paddingMobile',
+					],
 				],
 			],
 		],
@@ -658,17 +697,37 @@ return [
 			// wins. Padding follows the spacing tokens through the slug bridge, not a binding here.
 			'block'    => 'kadence/rowlayout',
 			'bindings' => [
+				// The row names its background attribute `bgColor`, not `background` — the binding key is the
+				// preset property id and need not match the attribute, which is what control_attr is for.
 				'background'   => [
-					'token'    => 'semantic.color.rowlayout-bg',
-					'css_prop' => 'background-color',
+					'token'        => 'semantic.color.rowlayout-bg',
+					'css_prop'     => 'background-color',
+					'css_var'      => 'kb-row-bg',
+					'control_attr' => 'bgColor',
 				],
+				// The row migrates its legacy flat `border`/`borderWidth` attributes into the nested
+				// `borderStyle` composite the current control edits, so the color axis of that composite is
+				// what this property owns — see the image's border bindings for the same shape.
 				'border'       => [
-					'token'    => 'semantic.color.border',
-					'css_prop' => 'border-color',
+					'token'            => 'semantic.color.border',
+					'css_prop'         => 'border-color',
+					'css_var'          => 'kb-row-border-color',
+					'control_attr'     => 'borderStyle',
+					'axis'             => 'border-color',
+					'responsive_attrs' => [
+						'tablet' => 'tabletBorderStyle',
+						'mobile' => 'mobileBorderStyle',
+					],
 				],
 				'borderRadius' => [
-					'token'    => 'semantic.radius.rowlayout',
-					'css_prop' => 'border-radius',
+					'token'            => 'semantic.radius.rowlayout',
+					'css_prop'         => 'border-radius',
+					'css_var'          => 'kb-row-radius',
+					'control_attr'     => 'borderRadius',
+					'responsive_attrs' => [
+						'tablet' => 'tabletBorderRadius',
+						'mobile' => 'mobileBorderRadius',
+					],
 				],
 			],
 		],
@@ -682,16 +741,33 @@ return [
 					'token'        => 'semantic.color.column-bg',
 					'css_prop'     => 'background-color',
 					'css_selector' => '> .kt-inside-inner-col',
+					'css_var'      => 'kb-col-bg',
+					'control_attr' => 'background',
 				],
+				// The column migrates its legacy flat `border`/`borderWidth` into the nested `borderStyle`
+				// composite, exactly as the row does; this property owns that composite's color axis.
 				'border'       => [
-					'token'        => 'semantic.color.border',
-					'css_prop'     => 'border-color',
-					'css_selector' => '> .kt-inside-inner-col',
+					'token'            => 'semantic.color.border',
+					'css_prop'         => 'border-color',
+					'css_selector'     => '> .kt-inside-inner-col',
+					'css_var'          => 'kb-col-border-color',
+					'control_attr'     => 'borderStyle',
+					'axis'             => 'border-color',
+					'responsive_attrs' => [
+						'tablet' => 'tabletBorderStyle',
+						'mobile' => 'mobileBorderStyle',
+					],
 				],
 				'borderRadius' => [
-					'token'        => 'semantic.radius.column',
-					'css_prop'     => 'border-radius',
-					'css_selector' => '> .kt-inside-inner-col',
+					'token'            => 'semantic.radius.column',
+					'css_prop'         => 'border-radius',
+					'css_selector'     => '> .kt-inside-inner-col',
+					'css_var'          => 'kb-col-radius',
+					'control_attr'     => 'borderRadius',
+					'responsive_attrs' => [
+						'tablet' => 'tabletBorderRadius',
+						'mobile' => 'mobileBorderRadius',
+					],
 				],
 			],
 		],
@@ -732,11 +808,14 @@ return [
 					'token'        => 'semantic.color.icon',
 					'css_prop'     => 'color',
 					'css_selector' => '*.kb-svg-icon-wrap',
+					'css_var'      => 'kb-icon-color',
+					'control_attr' => 'color',
 				],
 				'size'  => [
 					'token'            => 'semantic.icon-size.default',
 					'css_prop'         => 'font-size',
 					'css_selector'     => '*.kb-svg-icon-wrap',
+					'css_var'          => 'kb-icon-size',
 					'control_attr'     => 'size',
 					// The block names its per-device size attributes by a prefix convention, which is a naming
 					// rule rather than something safely derivable, so the editor is told them rather than
@@ -774,52 +853,118 @@ return [
 			'editor_selector' => '.wp-block-kadence-advancedheading .kadence-advancedheading-text',
 			'bindings'        => [
 				'color'         => [
-					'token'    => 'semantic.color.text',
-					'css_prop' => 'color',
+					'token'        => 'semantic.color.text',
+					'css_prop'     => 'color',
+					'css_var'      => 'kb-heading-color',
+					'control_attr' => 'color',
 				],
 				'background'    => [
-					'token'    => 'semantic.color.heading-bg',
-					'css_prop' => 'background-color',
+					'token'        => 'semantic.color.heading-bg',
+					'css_prop'     => 'background-color',
+					'css_var'      => 'kb-heading-bg',
+					'control_attr' => 'background',
 				],
+				// No font-family binding: a heading inherits the theme's font, and the block-default CSS
+				// deliberately emits no font-family default for it (see Css_BuilderTest). Font family is
+				// delivered by the font system rather than a token rule, and a preset stores the family the
+				// typography control picked as a literal rather than a token reference.
+				//
+				// fontSize and fontHeight declare NO responsive_attrs, unlike every other responsive property
+				// here: the heading packs all three devices into ONE array attribute (`fontSize[0..2]` is
+				// desktop/tablet/mobile), rather than naming a separate attribute per device. responsive_attrs
+				// maps a breakpoint to an attribute NAME and cannot address an index within one, so a
+				// per-breakpoint preset override has nothing to write through for these two. A preset can still
+				// set their base value. Teaching the editor to address a packed device slot belongs with the
+				// Advanced Text preset screen, where there is a control to verify it against.
 				'fontSize'      => [
-					'token'    => 'semantic.font-size.heading',
-					'css_prop' => 'font-size',
+					'token'        => 'semantic.font-size.heading',
+					'css_prop'     => 'font-size',
+					'css_var'      => 'kb-heading-font-size',
+					'control_attr' => 'fontSize',
 				],
 				'fontHeight'    => [
-					'token'    => 'semantic.line-height.heading',
-					'css_prop' => 'line-height',
+					'token'        => 'semantic.line-height.heading',
+					'css_prop'     => 'line-height',
+					'css_var'      => 'kb-heading-line-height',
+					'control_attr' => 'fontHeight',
 				],
 				'fontWeight'    => [
-					'token'    => 'semantic.font-weight.heading',
-					'css_prop' => 'font-weight',
+					'token'        => 'semantic.font-weight.heading',
+					'css_prop'     => 'font-weight',
+					'css_var'      => 'kb-heading-font-weight',
+					'control_attr' => 'fontWeight',
 				],
 				'letterSpacing' => [
-					'token'    => 'semantic.letter-spacing.heading',
-					'css_prop' => 'letter-spacing',
+					'token'            => 'semantic.letter-spacing.heading',
+					'css_prop'         => 'letter-spacing',
+					'css_var'          => 'kb-heading-letter-spacing',
+					'control_attr'     => 'letterSpacing',
+					'responsive_attrs' => [
+						'tablet' => 'tabletLetterSpacing',
+						'mobile' => 'mobileLetterSpacing',
+					],
 				],
 				'textTransform' => [
-					'token'    => 'semantic.text-transform.heading',
-					'css_prop' => 'text-transform',
+					'token'        => 'semantic.text-transform.heading',
+					'css_prop'     => 'text-transform',
+					'css_var'      => 'kb-heading-text-transform',
+					'control_attr' => 'textTransform',
 				],
 				'padding'       => [
-					'token'    => 'semantic.spacing.heading-padding',
-					'css_prop' => 'padding',
+					'token'            => 'semantic.spacing.heading-padding',
+					'css_prop'         => 'padding',
+					'css_var'          => 'kb-heading-padding',
+					'control_attr'     => 'padding',
+					'responsive_attrs' => [
+						'tablet' => 'tabletPadding',
+						'mobile' => 'mobilePadding',
+					],
 				],
+				// The heading's border trio is the same shape as the Button's — three properties sharing the
+				// nested `borderStyle` composite, each naming its own axis — under the block's own property
+				// keys. Nothing in the editor matches on those keys; it reads the declared axis.
 				'borderColor'   => [
-					'token'    => 'semantic.color.border',
-					'css_prop' => 'border-color',
+					'token'            => 'semantic.color.border',
+					'css_prop'         => 'border-color',
+					'css_var'          => 'kb-heading-border-color',
+					'control_attr'     => 'borderStyle',
+					'axis'             => 'border-color',
+					'responsive_attrs' => [
+						'tablet' => 'tabletBorderStyle',
+						'mobile' => 'mobileBorderStyle',
+					],
 				],
 				'borderWidth'   => [
-					'token'    => 'semantic.border-width.default',
-					'css_prop' => 'border-width',
+					'token'            => 'semantic.border-width.default',
+					'css_prop'         => 'border-width',
+					'css_var'          => 'kb-heading-border-width',
+					'control_attr'     => 'borderStyle',
+					'axis'             => 'border-width',
+					'responsive_attrs' => [
+						'tablet' => 'tabletBorderStyle',
+						'mobile' => 'mobileBorderStyle',
+					],
 				],
 				'borderRadius'  => [
-					'token'    => 'semantic.radius.heading',
-					'css_prop' => 'border-radius',
+					'token'            => 'semantic.radius.heading',
+					'css_prop'         => 'border-radius',
+					'css_var'          => 'kb-heading-radius',
+					'control_attr'     => 'borderRadius',
+					'responsive_attrs' => [
+						'tablet' => 'tabletBorderRadius',
+						'mobile' => 'mobileBorderRadius',
+					],
 				],
 				'borderStyle'   => [
-					'token'    => 'semantic.border-style.default',
-					'css_prop' => 'border-style',
+					'token'            => 'semantic.border-style.default',
+					'css_prop'         => 'border-style',
+					'css_var'          => 'kb-heading-border-style',
+					'control_attr'     => 'borderStyle',
+					'axis'             => 'border-style',
+					'responsive_attrs' => [
+						'tablet' => 'tabletBorderStyle',
+						'mobile' => 'mobileBorderStyle',
+					],
 				],
 			],
 		],

--- a/src/blocks/advancedheading/block.json
+++ b/src/blocks/advancedheading/block.json
@@ -667,6 +667,7 @@
 		"ktdynamic": true,
 		"kbMetadata": true,
 		"kbContentLabel": "content",
+		"kbPreset": true,
 		"kbPalette": true
 	}
 }

--- a/src/blocks/column/block.json
+++ b/src/blocks/column/block.json
@@ -641,6 +641,7 @@
 		"ktdynamic": true,
 		"kbcss": true,
 		"kbMetadata": true,
+		"kbPreset": true,
 		"kbPalette": true
 	},
 	"editorStyle": "kadence-blocks-column",

--- a/src/blocks/image/block.json
+++ b/src/blocks/image/block.json
@@ -404,6 +404,7 @@
 		"ktanimatepreview": true,
 		"ktdynamic": true,
 		"kbMetadata": true,
+		"kbPreset": true,
 		"kbPalette": true
 	}
 }

--- a/src/blocks/rowlayout/block.json
+++ b/src/blocks/rowlayout/block.json
@@ -795,6 +795,7 @@
 		"kbcss": true,
 		"html": false,
 		"kbMetadata": true,
+		"kbPreset": true,
 		"kbPalette": true
 	}
 }

--- a/src/blocks/single-icon/block.json
+++ b/src/blocks/single-icon/block.json
@@ -139,6 +139,7 @@
 		"html": false,
 		"reusable": false,
 		"kbMetadata": true,
+		"kbPreset": true,
 		"kbPalette": true
 	},
 	"usesContext": ["postId", "queryId", "kadence/dynamicSource", "kadence/repeaterRowData", "kadence/repeaterRow"]

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
@@ -3,6 +3,7 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Editor;
 
+use Generator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Editor\Preset_Catalog;
@@ -88,6 +89,51 @@ final class Preset_CatalogTest extends TestCase {
 
 		$this->assertSame( 'color', $kinds['button-bg'] );
 		$this->assertSame( 'dimension', $kinds['button-radius'] );
+	}
+
+	/**
+	 * The five blocks wired for presets but not yet given a Style Library screen expose a full controllable
+	 * surface — every bound property with its control attribute — while offering NO preset options, because
+	 * their bindings declare no picker label. That combination is what keeps the editor's Design Tokens
+	 * panel hidden for them (it renders only when a block has at least one preset option), so declaring the
+	 * wiring ahead of the screen surfaces nothing to a site owner.
+	 *
+	 * @dataProvider wiredWithoutAScreenProvider
+	 *
+	 * @param string $block The block name.
+	 *
+	 * @return void
+	 */
+	public function testAWiredBlockWithNoLabelExposesASurfaceButNoPresetOptions( string $block ): void {
+		$entry = $this->catalog->all()['libraries'][ Token_Store::default_slug() ][ $block ];
+
+		$this->assertSame( [], $entry['presets'], 'A block with no picker label must offer no preset options.' );
+		$this->assertNull( $entry['label'] );
+		$this->assertNotEmpty( $entry['properties'], 'The controllable surface is declared regardless of the label.' );
+
+		foreach ( $entry['properties'] as $property ) {
+			$this->assertNotNull(
+				$property['control_attr'],
+				sprintf( '%s: every bound property must name the control attribute it maps to.', $property['key'] )
+			);
+		}
+	}
+
+	/**
+	 * The blocks whose bindings are wired for presets but whose Style Library screen has not landed yet.
+	 *
+	 * @return Generator
+	 */
+	public function wiredWithoutAScreenProvider(): Generator {
+		yield 'image' => [ 'block' => 'kadence/image' ];
+
+		yield 'rowlayout' => [ 'block' => 'kadence/rowlayout' ];
+
+		yield 'column' => [ 'block' => 'kadence/column' ];
+
+		yield 'single icon' => [ 'block' => 'kadence/single-icon' ];
+
+		yield 'advanced heading' => [ 'block' => 'kadence/advancedheading' ];
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -75,16 +75,16 @@ final class Css_BuilderTest extends TestCase {
 
 		// The <img> surfaces group into one rule, opening with the first bound property (background-color).
 		$this->assertStringContainsString(
-			'.wp-block-kadence-image img{background-color:var(' . Css_Var::from_id( 'semantic.color.image-bg' ) . ',transparent);',
+			'.wp-block-kadence-image img{' . $this->declaration( 'background-color', 'kb-img-bg', 'semantic.color.image-bg', 'transparent' ),
 			$css
 		);
-		$this->assertStringContainsString( 'border-color:var(' . Css_Var::from_id( 'semantic.color.border' ) . ',#E2E8F0);', $css );
-		$this->assertStringContainsString( 'border-width:var(' . Css_Var::from_id( 'semantic.border-width.default' ) . ',1px);', $css );
-		$this->assertStringContainsString( 'border-radius:var(' . Css_Var::from_id( 'semantic.radius.media' ) . ',0);', $css );
+		$this->assertStringContainsString( $this->declaration( 'border-color', 'kb-img-border-color', 'semantic.color.border', '#E2E8F0' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'border-width', 'kb-img-border-width', 'semantic.border-width.default', '1px' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'border-radius', 'kb-img-radius', 'semantic.radius.media', '0' ), $css );
 
 		// Padding is rendered on the `.kb-img` descendant, so it gets its own rule.
 		$this->assertStringContainsString(
-			'.wp-block-kadence-image *.kb-img{padding:var(' . Css_Var::from_id( 'semantic.spacing.media-padding' ) . ',0);}',
+			'.wp-block-kadence-image *.kb-img{' . $this->declaration( 'padding', 'kb-img-padding', 'semantic.spacing.media-padding', '0' ) . '}',
 			$css
 		);
 
@@ -108,7 +108,7 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $registry )->css();
 
 		$this->assertStringContainsString(
-			'.wp-block-kadence-single-icon *.kb-svg-icon-wrap{color:var(' . Css_Var::from_id( 'semantic.color.icon' ),
+			'.wp-block-kadence-single-icon *.kb-svg-icon-wrap{' . $this->declaration( 'color', 'kb-icon-color', 'semantic.color.icon', '#3182CE' ),
 			$css
 		);
 		$this->assertStringNotContainsString( '.wp-block-kadence-icon ', $css );
@@ -129,7 +129,7 @@ final class Css_BuilderTest extends TestCase {
 
 		// Grouped into the same `.kb-svg-icon-wrap` rule as color, with the resolved length as the fallback.
 		$this->assertStringContainsString(
-			'font-size:var(' . Css_Var::from_id( 'semantic.icon-size.default' ) . ',1.5rem);',
+			$this->declaration( 'font-size', 'kb-icon-size', 'semantic.icon-size.default', '1.5rem' ),
 			$css
 		);
 		$this->assertStringContainsString( '.wp-block-kadence-single-icon *.kb-svg-icon-wrap{', $css );
@@ -167,7 +167,7 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $registry )->css();
 
 		$this->assertStringContainsString(
-			'box-shadow:var(' . Css_Var::from_id( 'semantic.shadow.media' ) . ',0px 0px 0px 0px transparent);',
+			$this->declaration( 'box-shadow', 'kb-img-shadow', 'semantic.shadow.media', '0px 0px 0px 0px transparent' ),
 			$css
 		);
 	}
@@ -185,16 +185,16 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $registry )->css();
 
 		$this->assertStringContainsString(
-			'.wp-block-kadence-rowlayout{background-color:var(' . Css_Var::from_id( 'semantic.color.rowlayout-bg' ),
+			'.wp-block-kadence-rowlayout{' . $this->declaration( 'background-color', 'kb-row-bg', 'semantic.color.rowlayout-bg', 'transparent' ),
 			$css
 		);
-		$this->assertStringContainsString( 'border-color:var(' . Css_Var::from_id( 'semantic.color.border' ), $css );
-		$this->assertStringContainsString( 'border-radius:var(' . Css_Var::from_id( 'semantic.radius.rowlayout' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'border-color', 'kb-row-border-color', 'semantic.color.border', '#E2E8F0' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'border-radius', 'kb-row-radius', 'semantic.radius.rowlayout', '0' ), $css );
 		$this->assertStringContainsString(
-			'.wp-block-kadence-column> .kt-inside-inner-col{background-color:var(' . Css_Var::from_id( 'semantic.color.column-bg' ),
+			'.wp-block-kadence-column> .kt-inside-inner-col{' . $this->declaration( 'background-color', 'kb-col-bg', 'semantic.color.column-bg', 'transparent' ),
 			$css
 		);
-		$this->assertStringContainsString( 'border-radius:var(' . Css_Var::from_id( 'semantic.radius.column' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'border-radius', 'kb-col-radius', 'semantic.radius.column', '0' ), $css );
 	}
 
 	/**
@@ -211,23 +211,23 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $registry )->css();
 
 		$this->assertStringContainsString(
-			'.wp-block-kadence-advancedheading{color:var(' . Css_Var::from_id( 'semantic.color.text' ) . ',#1A202C);',
+			'.wp-block-kadence-advancedheading{' . $this->declaration( 'color', 'kb-heading-color', 'semantic.color.text', '#1A202C' ),
 			$css
 		);
 		$this->assertStringContainsString(
-			'background-color:var(' . Css_Var::from_id( 'semantic.color.heading-bg' ) . ',transparent);',
+			$this->declaration( 'background-color', 'kb-heading-bg', 'semantic.color.heading-bg', 'transparent' ),
 			$css
 		);
-		$this->assertStringContainsString( 'font-size:var(' . Css_Var::from_id( 'semantic.font-size.heading' ) . ',2rem);', $css );
-		$this->assertStringContainsString( 'line-height:var(' . Css_Var::from_id( 'semantic.line-height.heading' ) . ',1.125);', $css );
-		$this->assertStringContainsString( 'font-weight:var(' . Css_Var::from_id( 'semantic.font-weight.heading' ) . ',400);', $css );
-		$this->assertStringContainsString( 'letter-spacing:var(' . Css_Var::from_id( 'semantic.letter-spacing.heading' ) . ',0);', $css );
-		$this->assertStringContainsString( 'text-transform:var(' . Css_Var::from_id( 'semantic.text-transform.heading' ) . ',none);', $css );
-		$this->assertStringContainsString( 'padding:var(' . Css_Var::from_id( 'semantic.spacing.heading-padding' ) . ',0);', $css );
-		$this->assertStringContainsString( 'border-color:var(' . Css_Var::from_id( 'semantic.color.border' ) . ',#E2E8F0);', $css );
-		$this->assertStringContainsString( 'border-width:var(' . Css_Var::from_id( 'semantic.border-width.default' ) . ',1px);', $css );
-		$this->assertStringContainsString( 'border-radius:var(' . Css_Var::from_id( 'semantic.radius.heading' ) . ',0);', $css );
-		$this->assertStringContainsString( 'border-style:var(' . Css_Var::from_id( 'semantic.border-style.default' ) . ',none);}', $css );
+		$this->assertStringContainsString( $this->declaration( 'font-size', 'kb-heading-font-size', 'semantic.font-size.heading', '2rem' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'line-height', 'kb-heading-line-height', 'semantic.line-height.heading', '1.125' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'font-weight', 'kb-heading-font-weight', 'semantic.font-weight.heading', '400' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'letter-spacing', 'kb-heading-letter-spacing', 'semantic.letter-spacing.heading', '0' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'text-transform', 'kb-heading-text-transform', 'semantic.text-transform.heading', 'none' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'padding', 'kb-heading-padding', 'semantic.spacing.heading-padding', '0' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'border-color', 'kb-heading-border-color', 'semantic.color.border', '#E2E8F0' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'border-width', 'kb-heading-border-width', 'semantic.border-width.default', '1px' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'border-radius', 'kb-heading-radius', 'semantic.radius.heading', '0' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'border-style', 'kb-heading-border-style', 'semantic.border-style.default', 'none' ) . '}', $css );
 		$this->assertStringNotContainsString( 'font-family:', $css, 'A heading inherits the theme font; no font-family default is emitted.' );
 	}
 
@@ -246,23 +246,23 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $registry )->editor_css();
 
 		$this->assertStringContainsString(
-			'.editor-styles-wrapper .wp-block-kadence-advancedheading .kadence-advancedheading-text{color:var(' . Css_Var::from_id( 'semantic.color.text' ) . ',#1A202C);',
+			'.editor-styles-wrapper .wp-block-kadence-advancedheading .kadence-advancedheading-text{' . $this->declaration( 'color', 'kb-heading-color', 'semantic.color.text', '#1A202C' ),
 			$css
 		);
 		$this->assertStringContainsString(
-			'background-color:var(' . Css_Var::from_id( 'semantic.color.heading-bg' ) . ',transparent);',
+			$this->declaration( 'background-color', 'kb-heading-bg', 'semantic.color.heading-bg', 'transparent' ),
 			$css
 		);
-		$this->assertStringContainsString( 'font-size:var(' . Css_Var::from_id( 'semantic.font-size.heading' ) . ',2rem);', $css );
-		$this->assertStringContainsString( 'line-height:var(' . Css_Var::from_id( 'semantic.line-height.heading' ) . ',1.125);', $css );
-		$this->assertStringContainsString( 'font-weight:var(' . Css_Var::from_id( 'semantic.font-weight.heading' ) . ',400);', $css );
-		$this->assertStringContainsString( 'letter-spacing:var(' . Css_Var::from_id( 'semantic.letter-spacing.heading' ) . ',0);', $css );
-		$this->assertStringContainsString( 'text-transform:var(' . Css_Var::from_id( 'semantic.text-transform.heading' ) . ',none);', $css );
-		$this->assertStringContainsString( 'padding:var(' . Css_Var::from_id( 'semantic.spacing.heading-padding' ) . ',0);', $css );
-		$this->assertStringContainsString( 'border-color:var(' . Css_Var::from_id( 'semantic.color.border' ) . ',#E2E8F0);', $css );
-		$this->assertStringContainsString( 'border-width:var(' . Css_Var::from_id( 'semantic.border-width.default' ) . ',1px);', $css );
-		$this->assertStringContainsString( 'border-radius:var(' . Css_Var::from_id( 'semantic.radius.heading' ) . ',0);', $css );
-		$this->assertStringContainsString( 'border-style:var(' . Css_Var::from_id( 'semantic.border-style.default' ) . ',none);}', $css );
+		$this->assertStringContainsString( $this->declaration( 'font-size', 'kb-heading-font-size', 'semantic.font-size.heading', '2rem' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'line-height', 'kb-heading-line-height', 'semantic.line-height.heading', '1.125' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'font-weight', 'kb-heading-font-weight', 'semantic.font-weight.heading', '400' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'letter-spacing', 'kb-heading-letter-spacing', 'semantic.letter-spacing.heading', '0' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'text-transform', 'kb-heading-text-transform', 'semantic.text-transform.heading', 'none' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'padding', 'kb-heading-padding', 'semantic.spacing.heading-padding', '0' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'border-color', 'kb-heading-border-color', 'semantic.color.border', '#E2E8F0' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'border-width', 'kb-heading-border-width', 'semantic.border-width.default', '1px' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'border-radius', 'kb-heading-radius', 'semantic.radius.heading', '0' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'border-style', 'kb-heading-border-style', 'semantic.border-style.default', 'none' ) . '}', $css );
 		$this->assertStringNotContainsString( 'font-family:', $css, 'A heading inherits the theme font; no font-family default is emitted.' );
 
 		// The front-end rule for the SAME block must stay on the block root, with no editor-only prefix.
@@ -377,6 +377,22 @@ final class Css_BuilderTest extends TestCase {
 		// Asserted whole rather than by substring: the point is that NOTHING wraps the token variable, which a
 		// containment check on the inner value could not tell apart from the wrapped form.
 		$this->assertSame( '.wp-block-kadence-image img{border-radius:var(' . $var . ',0);}', $css );
+	}
+
+	/**
+	 * The declaration a shipped binding emits: the token variable with its resolved literal as the
+	 * fallback, wrapped in the KB-owned custom property the binding declares so a selected preset can vary
+	 * it. Every shipped `css_prop` binding declares a `css_var`, so this is the shape they all take.
+	 *
+	 * @param string $prop     The CSS property.
+	 * @param string $css_var  The binding's KB-owned custom property, without its leading `--`.
+	 * @param string $token_id The referenced token id.
+	 * @param string $literal  The resolved literal that backs the token variable.
+	 *
+	 * @return string The declaration, with its trailing semicolon.
+	 */
+	private function declaration( string $prop, string $css_var, string $token_id, string $literal ): string {
+		return $prop . ':var(--' . $css_var . ',var(' . Css_Var::from_id( $token_id ) . ',' . $literal . '));';
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Projected_Css_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Projected_Css_ControllerTest.php
@@ -97,10 +97,15 @@ final class Projected_Css_ControllerTest extends TestCase {
 			$css,
 			'The editor-scoped, re-targeted Advanced Heading rule should be present.'
 		);
+		// Matched on the DECLARATION, not the selector alone: `.wp-block-kadence-advancedheading{` on its own
+		// legitimately appears in this aggregate, emitted by the selectable-preset projector's class-less
+		// `$default` rule, which sets the block's `--kb-heading-*` custom properties on the wrapper. That rule
+		// is a variable definition and paints nothing; the front-end BLOCK-DEFAULT rule is the one that would
+		// wrongly style the wrapper, and it opens with the first bound property, `color`.
 		$this->assertStringNotContainsString(
-			'.wp-block-kadence-advancedheading{',
+			'.wp-block-kadence-advancedheading{color:',
 			$css,
-			'The bare front-end Advanced Heading rule (on the wrapper div) should not be present.'
+			'The bare front-end Advanced Heading block-default rule (on the wrapper div) should not be present.'
 		);
 	}
 


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout
:video_camera: https://www.loom.com/share/c45de6b397424fcf9434d5b8e1fe9582

Adds `css_var`, `control_attr` and `responsive_attrs` to every binding on Advanced Image, Row Layout, Section, Single Icon and Advanced Text, and declares `kbPreset` support in each `block.json`. The `label` flag is deliberately withheld, so nothing surfaces to a site owner yet and nothing observable changes.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preset support for Image, Row Layout, Column, Icon, and Advanced Heading blocks.
  * Presets now connect design tokens to block controls, responsive settings, CSS variables, and border properties.
  * Token-based styling now supports consistent front-end and editor output.

* **Bug Fixes**
  * Improved generated CSS fallbacks for token-based block styling.
  * Corrected Advanced Heading CSS validation to distinguish declarations from variable definitions.

* **Tests**
  * Expanded coverage for preset availability, controllable properties, and generated CSS across supported blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

