### PR TITLE
[DTM] SOFT-4218 [3/16]: compare a raw-number dimension against its preset in pixels

### DIFF
--- a/src/extension/design-tokens/token-px.js
+++ b/src/extension/design-tokens/token-px.js
@@ -7,34 +7,19 @@
  * `height` presentation attributes by `GenIcon`, and an SVG geometry attribute takes a number, not a
  * `var()`. Those call sites need the token's value as a number before they render.
  *
- * This is the JS mirror of the PHP `Converts_Number_To_Px` trait, deliberately kept exact — including
- * where it declines. Both accept only `px`, `rem`, and `em`; both assume a 16px root font size, the
- * same assumption an unstyled `rem` makes in a browser (nothing in this module tracks a site's actual
- * root font size); and both decline a UNITLESS value, `%`, and any function or keyword. A token whose
- * value is a bare `0` therefore converts in neither language. Matching the PHP behavior exactly,
- * gaps included, is the point: the two are pinned to one shared conformance fixture, so a change to
- * either has to be a deliberate change to both.
+ * This module is the alias-resolving half: it looks a `{dot.alias}` up in the active token library and
+ * hands the resulting literal to `pxFromLength`, which owns the conversion itself and is the JS mirror
+ * of the PHP `Converts_Number_To_Px` trait (see that helper for the shared units, the assumed 16px root,
+ * and what both languages decline). The conversion lives there rather than here because the indicator
+ * layer's dimension compare needs it without any library lookup.
  */
 
 /**
  * Internal dependencies
  */
-import { parseCssLength } from '../../token-controls/helpers/parse-css-length';
+import { pxFromLength } from '../../token-controls/helpers/px-from-length';
 import { activeLibrary } from '../preset-picker';
 import { tokenLiteral } from './token-literals';
-
-/**
- * Pixel-convertible units and their multiplier against the assumed 16px root.
- *
- * @since TBD
- *
- * @type {Object<string, number>}
- */
-const PX_PER_UNIT = {
-	px: 1,
-	rem: 16,
-	em: 16,
-};
 
 /**
  * The pixel number a value resolves to.
@@ -55,11 +40,5 @@ const PX_PER_UNIT = {
 export function tokenPx(value, library) {
 	// `tokenLiteral()` takes an explicit library, so the active-library default is resolved here rather
 	// than left to a caller that has no reason to know which library is selected.
-	const parsed = parseCssLength(tokenLiteral(value, library || activeLibrary()));
-
-	if (!parsed || !Object.prototype.hasOwnProperty.call(PX_PER_UNIT, parsed.unit)) {
-		return null;
-	}
-
-	return parsed.size * PX_PER_UNIT[parsed.unit];
+	return pxFromLength(tokenLiteral(value, library || activeLibrary()));
 }

--- a/src/extension/token-indicators/kinds/__tests__/dimension.test.js
+++ b/src/extension/token-indicators/kinds/__tests__/dimension.test.js
@@ -31,6 +31,59 @@ describe('matchesPreset dimension', () => {
 	});
 });
 
+describe('matchesPreset dimension for a control that stores a raw number', () => {
+	/**
+	 * `kadence/single-icon`'s `size` is written straight into the SVG's geometry attributes, so it
+	 * stores a raw number with no companion unit attribute, and its default is seeded from the token by
+	 * PHP's rem-to-px conversion. A never-touched icon therefore holds 24 while its preset resolves to
+	 * `1.5rem`; compared as strings those disagree and the control would report as overridden.
+	 *
+	 * @return {void}
+	 */
+	it('matches a seeded pixel number against a rem preset value', () => {
+		expect(matchesPreset('dimension', 24, '', '1.5rem')).toBe(true);
+	});
+
+	/**
+	 * The same conversion applies to a value the user typed, not just the seeded default.
+	 *
+	 * @return {void}
+	 */
+	it('matches a unitless number against an equivalent px preset value', () => {
+		expect(matchesPreset('dimension', '36', '', '36px')).toBe(true);
+	});
+
+	/**
+	 * The pixel path must not turn a genuine override into a match.
+	 *
+	 * @return {void}
+	 */
+	it('does not match a unitless number that differs from the converted preset value', () => {
+		expect(matchesPreset('dimension', 32, '', '1.5rem')).toBe(false);
+	});
+
+	/**
+	 * A control that DOES carry a unit attribute keeps the strict same-unit compare — a rem value
+	 * against a px preset stays overridden rather than being silently converted into agreement.
+	 *
+	 * @return {void}
+	 */
+	it('leaves a unit-bearing control on the strict same-unit compare', () => {
+		expect(matchesPreset('dimension', '1.5', 'rem', '24px')).toBe(false);
+	});
+
+	/**
+	 * A preset literal the shared conversion declines — a percentage, a keyword, a calc() — has no
+	 * pixel equivalent, so there is nothing to agree with and the control reads as overridden.
+	 *
+	 * @return {void}
+	 */
+	it('does not match when the preset literal has no pixel equivalent', () => {
+		expect(matchesPreset('dimension', 24, '', '50%')).toBe(false);
+		expect(matchesPreset('dimension', 24, '', 'auto')).toBe(false);
+	});
+});
+
 describe('deriveMeasureMode', () => {
 	it('reads all-empty corners on a scalar preset as linked', () => {
 		expect(deriveMeasureMode(['', '', '', ''], '0.5rem')).toBe('linked');

--- a/src/extension/token-indicators/kinds/dimension.js
+++ b/src/extension/token-indicators/kinds/dimension.js
@@ -6,6 +6,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import { pxFromLength } from '../../../token-controls/helpers/px-from-length';
+
+/**
  * The populated sides of a stored dimension value, each trimmed to a string. A measurement control writes
  * a 4-side array (`[top, right, bottom, left]`) where an untouched side is `''`; a scalar value is a
  * single side. Empty/undefined sides are dropped, so an all-empty value yields `[]` and a per-corner
@@ -324,22 +329,55 @@ export function parseDimensionLiteral(literal) {
  * @return {boolean} True when every populated corner equals its preset slot.
  */
 function matchesPresetSlots(slots, storedUnit, presetSlots) {
-	const presets = presetSlots.map(parseDimensionLiteral);
-
-	if (slots.length !== presets.length) {
+	if (slots.length !== presetSlots.length) {
 		return false;
 	}
 
-	return slots.every((slot, index) => {
-		if (slot === '') {
-			return true;
-		}
+	return slots.every((slot, index) => slot === '' || lengthMatches(slot, storedUnit, presetSlots[index]));
+}
 
-		const preset = presets[index];
-		const unitMatches = preset.unit === '' || storedUnit === preset.unit;
+/**
+ * Whether one stored length equals one resolved preset literal.
+ *
+ * Two comparisons, in order:
+ *
+ * 1. **Same-unit string compare**, the ordinary case: a control stores its number in one attribute and
+ *    its unit in a companion (`borderRadius` + `borderRadiusUnit`), so `8` + `px` equals `8px`. A
+ *    preset literal carrying no unit of its own (a bare `0`) matches any stored unit.
+ * 2. **Pixel compare**, for a control that stores a RAW NUMBER with no companion unit attribute at all
+ *    — `kadence/single-icon`'s `size`, written straight into the SVG's geometry attributes. Its
+ *    attribute default is seeded from the token by PHP's `Converts_Number_To_Px`, so a never-touched
+ *    icon holds `24` while its preset resolves to `1.5rem`. Compared as strings those disagree and an
+ *    untouched control reports as overridden. Converting through `pxFromLength` — the JS mirror of that
+ *    same PHP trait, pinned to it by a shared conformance fixture — makes the two agree exactly when
+ *    the seeding says they should.
+ *
+ * The pixel path is reached only when the stored value has NO unit and the preset literal HAS one, so a
+ * control that does carry a unit attribute is unaffected: an `em` value against a `px` preset still
+ * reads as overridden rather than being silently converted into agreement.
+ *
+ * @param {string} side          The stored length, without its unit.
+ * @param {string} storedUnit    The stored companion unit, '' when the control has none.
+ * @param {*}      presetLiteral The preset's resolved literal for this slot.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the two describe the same length.
+ */
+function lengthMatches(side, storedUnit, presetLiteral) {
+	const preset = parseDimensionLiteral(presetLiteral);
 
-		return unitMatches && slot === preset.value;
-	});
+	if (preset.unit === '' || storedUnit === preset.unit) {
+		return side === preset.value;
+	}
+
+	if (storedUnit !== '') {
+		return false;
+	}
+
+	const presetPx = pxFromLength(presetLiteral);
+
+	return presetPx !== null && side !== '' && Number(side) === presetPx;
 }
 
 /**
@@ -394,11 +432,9 @@ export function matches(value, unit, presetValue) {
 	}
 
 	const storedUnit = String(unit || '').trim();
-	const preset = parseDimensionLiteral(presetValue);
-	const unitMatches = preset.unit === '' || storedUnit === preset.unit;
 
 	// Side-aware: a stored dimension matches only when EVERY populated side equals the preset value.
 	// A per-corner override (e.g. `['8','8','8','4']` vs `8px`) leaves one side differing and so reads
 	// as overridden, not still-bound.
-	return unitMatches && sides.every((side) => side === preset.value);
+	return sides.every((side) => lengthMatches(side, storedUnit, presetValue));
 }

--- a/src/token-controls/helpers/px-from-length.js
+++ b/src/token-controls/helpers/px-from-length.js
@@ -1,0 +1,53 @@
+/**
+ * Convert a CSS length literal to a raw pixel number.
+ *
+ * The JS mirror of the PHP `Converts_Number_To_Px` trait, deliberately kept exact — including where it
+ * declines. Both accept only `px`, `rem`, and `em`; both assume a 16px root font size, the same
+ * assumption an unstyled `rem` makes in a browser (nothing in this module tracks a site's actual root
+ * font size); and both decline a UNITLESS value, `%`, and any function or keyword. A value that is a
+ * bare `0` therefore converts in neither language. Matching the PHP behavior exactly, gaps included, is
+ * the point: the two are pinned to one shared conformance fixture, so a change to either has to be a
+ * deliberate change to both.
+ *
+ * Lives here, beside `parse-css-length`, rather than in either consumer: the editor's `token-px.js`
+ * wraps it with alias resolution against the active token library, and the indicator layer's dimension
+ * compare needs the bare conversion with no library lookup at all. A shared, dependency-free home keeps
+ * one conversion table without either consumer importing the other's dependencies.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { parseCssLength } from './parse-css-length';
+
+/**
+ * Pixel-convertible units and their multiplier against the assumed 16px root.
+ *
+ * @since TBD
+ *
+ * @type {Object<string, number>}
+ */
+const PX_PER_UNIT = {
+	px: 1,
+	rem: 16,
+	em: 16,
+};
+
+/**
+ * The pixel number a CSS length literal resolves to.
+ *
+ * @param {*} literal A CSS length literal (`"1.5rem"`, `"24px"`).
+ *
+ * @since TBD
+ *
+ * @return {?number} The pixel value, or `null` when the literal cannot be safely converted.
+ */
+export function pxFromLength(literal) {
+	const parsed = parseCssLength(literal);
+
+	if (!parsed || !Object.prototype.hasOwnProperty.call(PX_PER_UNIT, parsed.unit)) {
+		return null;
+	}
+
+	return parsed.size * PX_PER_UNIT[parsed.unit];
+}


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout
:video_camera: https://www.loom.com/share/c45de6b397424fcf9434d5b8e1fe9582

A dimension is not always a measure control's four-side array. Single Icon's `size` is one number written into the SVG's geometry attributes, so comparing it against a preset needs a unit conversion rather than a shape match.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent conversion of `px`, `rem`, and `em` CSS lengths using a 16px root assumption.
  - Dimension controls now recognize equivalent pixel values when comparing unitless settings with token-based lengths.
  - Added support for consistent comparisons across scalar and per-corner dimension values.

- **Bug Fixes**
  - Improved handling of dimension presets with differing units.
  - Unsupported values such as percentages, keywords, and invalid literals are safely excluded from matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

