### PR TITLE
[DTM] SOFT-4218 [4/16]: add the Single Icon block preset screen

### DIFF
--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -802,8 +802,13 @@ return [
 			// cleared size. The per-block Adapter and the editor attribute-default catalog are unaffected: they
 			// seed the registration default so a never-customized icon carries a concrete size, and this rule
 			// answers only for an explicitly cleared one.
-			'block'    => 'kadence/single-icon',
-			'bindings' => [
+			'block'         => 'kadence/single-icon',
+			'label'         => __( 'Style', 'kadence-blocks' ), // the editor picker control's label.
+			'style_library' => [
+				// The Style Library BLOCK PRESETS nav label — names the block, not the picker control.
+				'label' => __( 'Icon', 'kadence-blocks' ),
+			],
+			'bindings'      => [
 				'color' => [
 					'token'        => 'semantic.color.icon',
 					'css_prop'     => 'color',

--- a/src/blocks/single-icon/edit.js
+++ b/src/blocks/single-icon/edit.js
@@ -23,6 +23,7 @@ import { EditorScalarControl } from '../../extension/design-tokens/components/Ed
 import { tokenLiteral } from '../../extension/design-tokens/token-literals';
 import { activeLibrary } from '../../extension/preset-picker';
 import { measureAttrsForDevice } from '../../extension/token-indicators/normalize';
+import { presetPropertyValueForDevice } from '../../extension/token-indicators';
 import { boundTokenAliasForControl, pickableTokensForControl } from '../../extension/token-picker';
 import { PreviewIcon } from './preview-icon';
 import { AdvancedSettings } from './advanced-settings';
@@ -108,10 +109,14 @@ function KadenceSingleIcon(props) {
 	// fallback rather than leaving the block with no size control at all.
 	const iconSizeTokens = pickableTokensForControl(name, 'size') || [];
 	// What the active device falls back to when it stores nothing: the breakpoints ABOVE it, in cascade
-	// order, and then the icon-size token the binding names. The device's own value is deliberately left
-	// out — this is what the field reports when it is unset, so including it would just echo the value
-	// already on screen. Tablet and Mobile inherit; Desktop has nothing above it and lands on the token,
-	// which is the value the front end's block-default rule resolves for a cleared size.
+	// order, then the SELECTED PRESET's size, then the icon-size token the binding names. The device's own
+	// value is deliberately left out — this is what the field reports when it is unset, so including it
+	// would just echo the value already on screen. Tablet and Mobile inherit; Desktop has nothing above it.
+	//
+	// The preset sits ahead of the token because that is the order the rendered CSS resolves in: the
+	// preset's scoped rule sets `--kb-icon-size`, which the block-default rule reads before falling through
+	// to the token. Reporting the token here would tell a site owner their unset field inherits one size
+	// while the block renders another.
 	const inheritedSizeChain = {
 		Tablet: [size],
 		Mobile: [tabletSize, size],
@@ -119,7 +124,11 @@ function KadenceSingleIcon(props) {
 	const inheritedSize = (inheritedSizeChain[previewDevice] || []).find(
 		(value) => value !== undefined && value !== null && value !== ''
 	);
-	const iconSizeDefault = inheritedSize ?? tokenLiteral(boundTokenAliasForControl(name, 'size'), activeLibrary());
+	const presetSize = presetPropertyValueForDevice(name, 'size', attributes, undefined, previewDevice);
+	const iconSizeDefault =
+		inheritedSize ??
+		(presetSize ? tokenLiteral(presetSize, activeLibrary()) : undefined) ??
+		tokenLiteral(boundTokenAliasForControl(name, 'size'), activeLibrary());
 
 	useEffect(() => {
 		setAttributes({ inQueryBlock: getInQueryBlock(context, inQueryBlock) });

--- a/src/blocks/single-icon/preview-icon.js
+++ b/src/blocks/single-icon/preview-icon.js
@@ -2,6 +2,8 @@ import { getPreviewSize, KadenceColorOutput, getSpacingOptionOutput } from '@kad
 import { useRef } from '@wordpress/element';
 import { IconRender, Tooltip } from '@kadence/components';
 import { tokenPx } from '../../extension/design-tokens/token-px';
+import { tokenLiteral } from '../../extension/design-tokens/token-literals';
+import { presetPropertyValueForDevice } from '../../extension/token-indicators';
 import { boundTokenAliasForControl } from '../../extension/token-picker';
 import { parseCssLength } from '../../token-controls';
 import metadata from './block.json';
@@ -88,14 +90,30 @@ export function PreviewIcon({ attributes, previewDevice }) {
 	// icon-size token's fallback rule. Both of those become a number here instead, on the same 16px root
 	// assumption PHP uses, so the two render paths agree.
 	//
-	// A cleared size therefore falls back to the very token the block-default CSS names for it, read from
-	// the binding rather than restated. Anything still unresolved after that is left `undefined` so
-	// `GenIcon` applies its own default, which is the one shape that renders rather than breaking.
+	// A cleared size falls back to the SELECTED PRESET's size, then to the token the block-default CSS
+	// names for it, read from the binding rather than restated. The preset comes first because that is what
+	// the front end renders: the preset's scoped rule sets `--kb-icon-size` on the block root, and the
+	// block-default rule reads it ahead of the token. Falling straight to the token here would show every
+	// preset at the same size in the editor while the front end showed each preset's own.
+	//
+	// Anything still unresolved is left `undefined` so `GenIcon` applies its own default, which is the one
+	// shape that renders rather than breaking.
+	const presetSize = presetPropertyValueForDevice(metadata.name, 'size', attributes, undefined, previewDevice);
 	const previewSizePx =
 		tokenPx(previewSize) ??
 		iconSizeNumber(previewSize) ??
+		tokenPx(presetSize) ??
+		iconSizeNumber(presetSize) ??
 		tokenPx(boundTokenAliasForControl(metadata.name, 'size')) ??
 		undefined;
+	// The same story for color, by a different mechanism. The front end renders a cleared color through the
+	// block-default rule's `var(--kb-icon-color, ...)` chain on the `.kb-svg-icon-wrap` span PHP hydrates;
+	// the editor has no such element (it renders `GenIcon`'s own div) and paints the color inline, so the
+	// preset's value is resolved here instead. Without this a preset's color simply never reaches the
+	// canvas — the rule that would carry it matches nothing in the editor's markup.
+	const previewColor =
+		color ||
+		tokenLiteral(presetPropertyValueForDevice(metadata.name, 'color', attributes, undefined, previewDevice));
 	const previewMarginTop = getPreviewSize(
 		previewDevice,
 		margin && undefined !== margin[0] ? margin[0] : undefined,
@@ -164,7 +182,7 @@ export function PreviewIcon({ attributes, previewDevice }) {
 							strokeWidth={'fe' === icon.substring(0, 2) ? width : undefined}
 							title={title ? title : ''}
 							style={{
-								color: color ? KadenceColorOutput(color) : undefined,
+								color: previewColor ? KadenceColorOutput(previewColor) : undefined,
 								backgroundColor:
 									background && style !== 'default' ? KadenceColorOutput(background) : undefined,
 								paddingTop:

--- a/src/extension/preset-picker/PresetButton.js
+++ b/src/extension/preset-picker/PresetButton.js
@@ -18,6 +18,7 @@
 import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { getBlockType } from '@wordpress/blocks';
 import { Icon, check } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { get } from 'lodash';
@@ -98,9 +99,11 @@ export function PresetButton({ blockName, attributes, setAttributes, library }) 
 	 *
 	 * @return {Object} The reset patch.
 	 */
+	const declaredAttributes = getBlockType(blockName)?.attributes;
+
 	const resetPatch = () =>
 		mappedAttrsFor(blockName, resolvedLibrary).reduce(
-			(acc, { attr, kind }) => Object.assign(acc, resetAttrPatch(attr, kind)),
+			(acc, { attr, kind }) => Object.assign(acc, resetAttrPatch(attr, kind, declaredAttributes)),
 			{}
 		);
 

--- a/src/extension/token-indicators/__tests__/index.test.js
+++ b/src/extension/token-indicators/__tests__/index.test.js
@@ -726,6 +726,72 @@ describe('resetAttrPatch', () => {
 	});
 
 	/**
+	 * A dimension whose block stores it as a SCALAR clears to '', not to a 4-side array. Writing the
+	 * array shape into `kadence/single-icon`'s `size` — a single number written into the SVG's geometry
+	 * attributes — leaves the control reading an array back as a custom value.
+	 *
+	 * @return {void}
+	 */
+	it('clears a scalar dimension to an empty string, not a 4-side array', () => {
+		const declared = {
+			size: { type: ['number', 'string'], default: 50 },
+			tabletSize: { type: ['number', 'string'], default: '' },
+			mobileSize: { type: ['number', 'string'], default: '' },
+		};
+
+		expect(resetAttrPatch('size', 'dimension', declared)).toEqual({
+			size: '',
+			tabletSize: '',
+			mobileSize: '',
+		});
+	});
+
+	/**
+	 * The unit companion is written only when the block declares one — `size` has no `sizeUnit`, and
+	 * inventing it would store an attribute the block never reads.
+	 *
+	 * @return {void}
+	 */
+	it('does not invent a unit attribute the block does not declare', () => {
+		const declared = { size: { default: 50 } };
+
+		expect(resetAttrPatch('size', 'dimension', declared)).not.toHaveProperty('sizeUnit');
+	});
+
+	/**
+	 * A 4-side dimension still clears to the array shape and its unit when the schema says so, so the
+	 * shape is read from the block rather than guessed either way.
+	 *
+	 * @return {void}
+	 */
+	it('still clears a declared 4-side dimension to the array shape', () => {
+		const declared = {
+			borderRadius: { type: 'array', default: ['', '', '', ''] },
+			borderRadiusUnit: { type: 'string', default: 'px' },
+			tabletBorderRadius: { type: 'array', default: ['', '', '', ''] },
+			mobileBorderRadius: { type: 'array', default: ['', '', '', ''] },
+		};
+
+		expect(resetAttrPatch('borderRadius', 'dimension', declared)).toEqual({
+			borderRadius: ['', '', '', ''],
+			borderRadiusUnit: 'px',
+			tabletBorderRadius: ['', '', '', ''],
+			mobileBorderRadius: ['', '', '', ''],
+		});
+	});
+
+	/**
+	 * A block that declares no responsive companions gets none written.
+	 *
+	 * @return {void}
+	 */
+	it('omits responsive companions the block does not declare', () => {
+		const declared = { iconSize: { type: 'string', default: '' } };
+
+		expect(resetAttrPatch('iconSize', 'dimension', declared)).toEqual({ iconSize: '' });
+	});
+
+	/**
 	 * A border reset clears the primary attribute and both responsive companions to an empty ARRAY
 	 * (`[]`), not `['', '', '', '']` — the shape `EditorBorderControl`'s `fromNativeBorder` reads as
 	 * "never written" via its `!native?.[0]` short-circuit.

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -296,11 +296,16 @@ export function presetPropertyValueForDevice(blockName, propertyKey, attributes,
  * The `setAttributes` patch that clears a mapped control's attribute(s) back to their block.json default
  * shape, so the block falls back to the existing preset-scoped CSS (the `.wp-block-*.kb-preset--<preset>`
  * retarget) or the preset default — no new render path. A `color`/`text` control clears its single
- * attribute to `''`. A `dimension` control (e.g. `borderRadius`) also clears its unit companion and its
- * `tablet*`/`mobile*` companions by convention; the primary and companion array attributes reset to the
- * block's declared default shape — a 4-side `['', '', '', '']` array, per `block.json` (e.g. `borderRadius`,
- * `tabletBorderRadius`, `mobileBorderRadius`) — not a bare `''`, and the unit resets to `'px'`
- * (`borderRadiusUnit`'s declared default), not `''`.
+ * attribute to `''`. A `dimension` control also clears its `tablet*`/`mobile*` companions by convention,
+ * and its unit companion where the block has one.
+ *
+ * What a dimension clears TO depends on the shape the block declares for it, which is why the block's
+ * attribute schema is passed in. A measure control's attribute is a 4-side array and resets to
+ * `['', '', '', '']` with its unit back to `'px'` (`borderRadiusUnit`'s own declared default), not to a
+ * bare `''`. A scalar dimension — `kadence/single-icon`'s `size`, one number written into the SVG's
+ * geometry attributes — resets to `''`; giving it the array shape stores an array in a scalar attribute,
+ * which the control reads back as a custom value. With no schema passed, the 4-side shape stands, which is
+ * what every caller that omits it wants.
  *
  * A `border` control (the combined `borderStyle` width/style/color entry) clears its `tablet*`/`mobile*`
  * companions the same way, but to an empty ARRAY (`[]`), not `['', '', '', '']` — `EditorBorderControl`'s
@@ -313,14 +318,17 @@ export function presetPropertyValueForDevice(blockName, propertyKey, attributes,
  * Shared by the per-control reset (`resetAttr`) and the picker's reset-all, so their clearing convention
  * cannot drift.
  *
- * @param {string} attr The primary attribute name.
- * @param {string} kind The property kind, so a dimension/border also clears its companions.
+ * @param {string}  attr       The primary attribute name.
+ * @param {string}  kind       The property kind, so a dimension/border also clears its companions.
+ * @param {?Object} [declared] The block's declared attributes (`getBlockType(name).attributes`), read for
+ *                             the shape a dimension clears to and which companions exist. Omit when the
+ *                             caller has no block to read it from.
  *
  * @since TBD
  *
  * @return {Object} The attribute patch to pass to `setAttributes`.
  */
-export function resetAttrPatch(attr, kind) {
+export function resetAttrPatch(attr, kind, declared) {
 	if (kind === 'border') {
 		return {
 			[attr]: [],
@@ -333,14 +341,56 @@ export function resetAttrPatch(attr, kind) {
 		return { [attr]: '' };
 	}
 
-	const emptySides = ['', '', '', ''];
+	// A dimension is not always a measure control's 4-side array. `kadence/single-icon`'s `size` is a
+	// single number written into the SVG's geometry attributes, and clearing it to `['', '', '', '']`
+	// stores an array in a scalar attribute — which the control then reads back as a custom value.
+	// The block's own schema already says which shape it is, so it is passed in rather than assumed;
+	// with no schema (a caller that has none) the historical 4-side shape stands.
+	const isSides = !declared || Array.isArray(declared[attr]?.default);
 
-	return {
-		[attr]: emptySides,
-		[`${attr}Unit`]: 'px',
-		[deviceAttrFor(attr, 'Tablet')]: emptySides,
-		[deviceAttrFor(attr, 'Mobile')]: emptySides,
-	};
+	if (!isSides) {
+		return withDeviceCompanions({ [attr]: '' }, attr, declared, '');
+	}
+
+	const emptySides = ['', '', '', ''];
+	const patch = withDeviceCompanions({ [attr]: emptySides }, attr, declared, emptySides);
+
+	// Only when the block declares the companion: `borderRadius` has `borderRadiusUnit`, `size` has no
+	// `sizeUnit`, and writing one would leave an attribute the block never reads.
+	if (!declared || declared[`${attr}Unit`]) {
+		patch[`${attr}Unit`] = 'px';
+	}
+
+	return patch;
+}
+
+/**
+ * Add a dimension's per-device companion attributes to a reset patch, cleared to the same shape as the
+ * primary.
+ *
+ * The companions are named by the `tablet`/`mobile` prefix convention. A block that declares them under
+ * that convention gets them cleared; one that does not is left alone rather than gaining attributes it
+ * never declared.
+ *
+ * @param {Object}  patch    The patch so far.
+ * @param {string}  attr     The primary attribute name.
+ * @param {?Object} declared The block's declared attributes, or undefined when unknown.
+ * @param {*}       empty    The cleared value to write.
+ *
+ * @since TBD
+ *
+ * @return {Object} The patch, with any companions added.
+ */
+function withDeviceCompanions(patch, attr, declared, empty) {
+	['Tablet', 'Mobile'].forEach((device) => {
+		const companion = deviceAttrFor(attr, device);
+
+		if (!declared || declared[companion]) {
+			patch[companion] = empty;
+		}
+	});
+
+	return patch;
 }
 
 /**
@@ -354,8 +404,8 @@ export function resetAttrPatch(attr, kind) {
  *
  * @return {void}
  */
-export function resetAttr(attr, setAttributes, kind) {
-	setAttributes(resetAttrPatch(attr, kind));
+export function resetAttr(attr, setAttributes, kind, declared) {
+	setAttributes(resetAttrPatch(attr, kind, declared));
 }
 
 /**

--- a/src/style-library/__tests__/single-icon-preset.test.js
+++ b/src/style-library/__tests__/single-icon-preset.test.js
@@ -1,0 +1,131 @@
+/* eslint-env jest */
+/**
+ * The Single Icon preset config — the one per-block file a preset screen needs. Everything else the
+ * screen uses (`PresetScreen`, `PresetSidebar`, `usePresetScreen`, `helpers/presets`) is generic and
+ * covered by its own suites, so this asserts only what this config contributes: the bound surface it
+ * reads, the preview it resolves, its schema, and that it registers on the public screens filter.
+ */
+import { applyFilters } from '@wordpress/hooks';
+import { SINGLE_ICON_PRESET, SINGLE_ICON_BLOCK } from '../presets/single-icon-preset';
+import { PRESET_SCREENS_FILTER } from '../constants/screens';
+
+// The screen module is imported only to trigger its module-scope `addFilter`. Its two children pull in
+// the REST client (and so `@wordpress/api-fetch`, absent from this environment), which the registration
+// contract does not depend on — the generic panel and sidebar have their own suites.
+jest.mock('../components/pages/PresetScreen', () => ({ PresetScreen: () => null }));
+jest.mock('../components/pages/SingleIconSettings', () => ({ SingleIconSettings: () => null }));
+
+describe('SINGLE_ICON_PRESET', () => {
+	afterEach(() => {
+		delete window.kadenceDesignTokens;
+	});
+
+	/**
+	 * The config names the child Single Icon block, which owns the color/size attributes — not the
+	 * legacy `kadence/icon` container.
+	 *
+	 * @return {void}
+	 */
+	it('targets the single-icon child block', () => {
+		expect(SINGLE_ICON_PRESET.block).toBe('kadence/single-icon');
+		expect(SINGLE_ICON_BLOCK).toBe('kadence/single-icon');
+	});
+
+	/**
+	 * `properties` is a live getter over the feed, not a snapshot, so the screen can never offer a
+	 * property the server's write guard would reject.
+	 *
+	 * @return {void}
+	 */
+	it('reads its bound surface live from the feed', () => {
+		window.kadenceDesignTokens = {
+			presets: { 'kadence/single-icon': { properties: ['color', 'size'] } },
+		};
+
+		expect(SINGLE_ICON_PRESET.properties).toEqual(['color', 'size']);
+	});
+
+	/**
+	 * The preview resolves both bound properties through the feed's value map, aliases included.
+	 *
+	 * @return {void}
+	 */
+	it('resolves the preview color and size from stored aliases', () => {
+		const values = {
+			'semantic.color.icon': '#3182CE',
+			'semantic.icon-size.default': '1.5rem',
+		};
+		const tokens = {
+			color: '{semantic.color.icon}',
+			size: '{semantic.icon-size.default}',
+		};
+
+		expect(SINGLE_ICON_PRESET.preview(tokens, values)).toEqual({
+			color: '#3182CE',
+			size: '1.5rem',
+		});
+	});
+
+	/**
+	 * A dangling alias previews as empty rather than as the raw alias text, so `renderPreview` can fall
+	 * back to the icon's own built-in look.
+	 *
+	 * @return {void}
+	 */
+	it('previews a dangling alias as empty', () => {
+		expect(SINGLE_ICON_PRESET.preview({ color: '{semantic.color.gone}', size: '' }, {})).toEqual({
+			color: '',
+			size: '',
+		});
+	});
+
+	/**
+	 * The icon binds no hover property, so it declares no tabs and `PresetSidebar` renders the field
+	 * area bare.
+	 *
+	 * @return {void}
+	 */
+	it('declares no state tabs', () => {
+		expect(SINGLE_ICON_PRESET.tabs).toBeUndefined();
+	});
+
+	/**
+	 * The schema edits exactly the bound surface: a token-color field for the color and a token picker
+	 * narrowed to the icon-size scale for the size, both writing token ids rather than literals.
+	 *
+	 * @return {void}
+	 */
+	it('builds one panel covering both bound properties', () => {
+		const { panels } = SINGLE_ICON_PRESET.schemaFor();
+
+		expect(panels).toHaveLength(1);
+
+		const paths = panels[0].fields.map((field) => field.path);
+		const types = panels[0].fields.map((field) => field.type);
+
+		expect(paths).toEqual(['tokens.color', 'tokens.size']);
+		expect(types).toEqual(['token-color-select', 'token-select']);
+
+		const size = panels[0].fields[1];
+
+		expect(size.tokenType).toBe('dimension');
+		expect(size.role).toBe('icon-size');
+	});
+});
+
+describe('SingleIconScreen registration', () => {
+	/**
+	 * The app never imports the screen component directly — importing the module is what registers it
+	 * on the public filter, exactly as a third-party screen would register itself.
+	 *
+	 * @return {void}
+	 */
+	it('registers itself on the preset-screens filter with a settings panel', () => {
+		require('../components/pages/SingleIconScreen');
+
+		const screens = applyFilters(PRESET_SCREENS_FILTER, {});
+
+		expect(screens[SINGLE_ICON_BLOCK]).toBeDefined();
+		expect(screens[SINGLE_ICON_BLOCK].SettingsPanel).toBeDefined();
+	});
+});

--- a/src/style-library/__tests__/single-icon-preset.test.js
+++ b/src/style-library/__tests__/single-icon-preset.test.js
@@ -8,6 +8,7 @@
 import { applyFilters } from '@wordpress/hooks';
 import { SINGLE_ICON_PRESET, SINGLE_ICON_BLOCK } from '../presets/single-icon-preset';
 import { PRESET_SCREENS_FILTER } from '../constants/screens';
+import { FIELD_TYPES, RESPONSIVE_CAPABLE_FIELD_TYPES } from '../constants/field-types';
 
 // The screen module is imported only to trigger its module-scope `addFilter`. Its two children pull in
 // the REST client (and so `@wordpress/api-fetch`, absent from this environment), which the registration
@@ -104,12 +105,29 @@ describe('SINGLE_ICON_PRESET', () => {
 		const types = panels[0].fields.map((field) => field.type);
 
 		expect(paths).toEqual(['tokens.color', 'tokens.size']);
-		expect(types).toEqual(['token-color-select', 'token-select']);
+		expect(types).toEqual(['token-color-select', 'token-scalar']);
+
+		// Every type the schema names must be one the registry can render.
+		types.forEach((type) => expect(FIELD_TYPES).toHaveProperty(type));
 
 		const size = panels[0].fields[1];
 
 		expect(size.tokenType).toBe('dimension');
 		expect(size.role).toBe('icon-size');
+	});
+
+	/**
+	 * The block's own size control is per-device (`size`/`tabletSize`/`mobileSize`, all three declared on
+	 * the binding), so the preset field has to be too — otherwise a preset could not reproduce a look a
+	 * site owner had already built with that control.
+	 *
+	 * @return {void}
+	 */
+	it('makes the size field responsive, and of a type that can be', () => {
+		const size = SINGLE_ICON_PRESET.schemaFor().panels[0].fields[1];
+
+		expect(size.responsive).toBe(true);
+		expect(RESPONSIVE_CAPABLE_FIELD_TYPES).toContain(size.type);
 	});
 });
 

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -30,6 +30,7 @@ import { SpacingScreen } from '../components/pages/SpacingScreen';
 import { IconSizesScreen } from '../components/pages/IconSizesScreen';
 import { ShadowScreen } from '../components/pages/ShadowScreen';
 import '../components/pages/ButtonScreen';
+import '../components/pages/SingleIconScreen';
 import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
 import { useLibraries } from '../hooks/use-libraries';

--- a/src/style-library/components/molecules/fields/ScalarTokenField.js
+++ b/src/style-library/components/molecules/fields/ScalarTokenField.js
@@ -1,0 +1,170 @@
+/**
+ * A responsive, token-aware field for a SCALAR design value — one length, not a four-slot box.
+ *
+ * The scalar sibling of `BoxTokenField`, and deliberately built the same way: the same responsive
+ * envelope, the same breakpoint inheritance, the same picker narrowing, the same stored/control value
+ * conversion (reused from that module rather than restated). What it drops is everything that only makes
+ * sense for four slots — the link toggle, the per-slot mapping, the slot-list unit sniffing.
+ *
+ * It exists because `token-select` cannot answer here: that field is a bare picker with nowhere to put a
+ * breakpoint switcher, so a property whose block control IS responsive — `kadence/single-icon`'s size,
+ * which stores `size`/`tabletSize`/`mobileSize` — could only ever be given one value for every device
+ * through it. A preset that cannot say what the block's own control can say is a preset that cannot
+ * reproduce the look a site owner built.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { pickableTokensForType } from '../../../helpers/tokens';
+import {
+	PRESET_BREAKPOINTS,
+	readPresetBreakpoint,
+	resolvePresetBreakpoint,
+	writePresetBreakpoint,
+} from '../../../../token-controls/helpers/preset-envelope';
+import { ScalarControl } from '../../../../token-controls/controls/ScalarControl';
+import { useBreakpoint } from '../../../../token-controls/context/breakpoint';
+import { parseCssLength } from '../../../../token-controls/helpers/parse-css-length';
+import { boundTokenIds, toControlValue, toStoredValue } from './BoxTokenField';
+
+/**
+ * The unit a stored scalar already carries, so a write does not silently retype it.
+ *
+ * @param {*}      value    The stored value.
+ * @param {string} fallback The unit to assume when nothing carries one yet.
+ *
+ * @since TBD
+ *
+ * @return {string} The unit in play.
+ */
+function unitInPlay(value, fallback) {
+	return parseCssLength(value)?.unit || fallback;
+}
+
+/**
+ * The Custom tab's numeric bounds for the unit in play, so a `rem` field is not offered a 0-200 range
+ * meant for pixels. Mirrors `BoxTokenField`'s own rule.
+ *
+ * @param {string} unit  The unit in play.
+ * @param {Object} field The field definition, which may override any bound.
+ *
+ * @since TBD
+ *
+ * @return {{min: number, max: number, step: number}} The bounds.
+ */
+function boundsForUnit(unit, field) {
+	const relative = unit === 'em' || unit === 'rem';
+
+	return {
+		min: field.min ?? 0,
+		max: field.max ?? (relative ? 24 : 200),
+		step: field.step ?? (relative ? 0.1 : 1),
+	};
+}
+
+/**
+ * Render a scalar token field.
+ *
+ * @param {Object}   props                      The component props.
+ * @param {Object}   props.field                The field definition.
+ * @param {string}   props.field.tokenType      The DTCG `$type` the pickable pool is filtered to.
+ * @param {?string}  [props.field.role]         Narrows the pool further to one token role.
+ * @param {?string}  [props.field.label]        The control's label.
+ * @param {boolean}  [props.field.readOnly]     Whether the control is non-interactive.
+ * @param {boolean}  [props.field.responsive]   Whether the field offers a breakpoint switcher.
+ * @param {*}        [props.field.defaultValue] What the block renders when the preset sets nothing,
+ *                                              shown muted so an unset field is not blank.
+ * @param {?Array}   [props.field.units]        Units the Custom tab offers.
+ * @param {?number}  [props.field.min]          Lowest allowed number on the Custom tab.
+ * @param {?number}  [props.field.max]          Highest allowed number; the slider needs one.
+ * @param {?number}  [props.field.step]         Custom tab increment.
+ * @param {*}        props.value                The stored value: an alias, a literal, or empty.
+ * @param {Function} props.onChange             Called with the next stored value.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The field.
+ */
+export function ScalarTokenField({ field, value, onChange }) {
+	const units = field.units ?? ['px', 'em', 'rem', '%'];
+	const responsive = field.responsive === true;
+
+	// Shared, not local: switching to Tablet here switches every other responsive control in the panel
+	// with it, matching the block editor.
+	const [breakpoint, setBreakpoint] = useBreakpoint(PRESET_BREAKPOINTS[0]);
+
+	const atBreakpoint = responsive ? readPresetBreakpoint(value, breakpoint) : value;
+	const write = (next) => (responsive ? writePresetBreakpoint(value, breakpoint, next) : next);
+
+	// An unset breakpoint shows what is actually in effect rather than reading as empty, and it inherits
+	// from the next breakpoint up, not straight from desktop: mobile shows the tablet value whenever
+	// tablet is set, because the projected tablet media query also covers mobile widths. Desktop has
+	// nothing above it — a preset's base value is the root of that chain, and falls back only to the
+	// field's declared default (what the block renders when the preset sets nothing).
+	const onDesktop = !responsive || breakpoint === PRESET_BREAKPOINTS[0];
+	const inheritedAbove = onDesktop
+		? null
+		: resolvePresetBreakpoint(value, PRESET_BREAKPOINTS[PRESET_BREAKPOINTS.indexOf(breakpoint) - 1]);
+	const inheritsFromBreakpoint = inheritedAbove !== null && inheritedAbove !== '';
+
+	// An inherited value is shown, not offered: resolving it to its literal lets the picker stay exactly
+	// the role's scale while a value outside that scale still reads as the size in effect.
+	const everyToken = pickableTokensForType(field.tokenType);
+	const asLiteral = (stored) =>
+		typeof stored === 'string' ? (everyToken.find((token) => token.id === stored)?.value ?? stored) : stored;
+
+	const shownDefault = inheritsFromBreakpoint ? asLiteral(inheritedAbove) : (field.defaultValue ?? null);
+
+	// The unit falls back the same way the value does, so the Custom tab never opens on `px` while the
+	// field beside it displays the default's own `em`.
+	const stored = unitInPlay(atBreakpoint, unitInPlay(shownDefault, units[0]));
+
+	// A unit picked before a number has nowhere to persist yet, so it is held here until a value exists to
+	// attach it to — keyed per breakpoint, so a pending unit picked on one does not leak into another.
+	const [pendingUnit, setPendingUnit] = useState({});
+	const unit = pendingUnit[breakpoint] ?? stored;
+	const bounds = boundsForUnit(unit, field);
+
+	return (
+		<ScalarControl
+			value={toControlValue(atBreakpoint)}
+			onChange={(next) => !field.readOnly && onChange(write(toStoredValue(next, unit)))}
+			label={field.label}
+			// The inherited value's token is exempt from the narrowing too, not just this breakpoint's own:
+			// a breakpoint that inherits binds nothing itself, so without this the semantic it falls back to
+			// is filtered out of the pool and the field shows nothing instead of the value in effect.
+			tokens={pickableTokensForType(field.tokenType, field.role, boundTokenIds(atBreakpoint)).map((token) => ({
+				...token,
+				alias: `{${token.id}}`,
+			}))}
+			defaultValue={shownDefault ?? undefined}
+			inherited={inheritsFromBreakpoint}
+			unit={unit}
+			units={units}
+			onUnit={(next) => {
+				setPendingUnit((current) => ({ ...current, [breakpoint]: next }));
+
+				// Retype a value that already exists; a field with nothing stored has nothing to retype and
+				// waits for the pending unit above.
+				const parsed = parseCssLength(atBreakpoint);
+
+				if (parsed && parsed.unit) {
+					onChange(write(`${parsed.size}${next}`));
+				}
+			}}
+			breakpoints={responsive ? PRESET_BREAKPOINTS : null}
+			breakpoint={breakpoint}
+			onBreakpointChange={setBreakpoint}
+			disabled={field.readOnly}
+			min={bounds.min}
+			max={bounds.max}
+			step={bounds.step}
+		/>
+	);
+}

--- a/src/style-library/components/pages/SingleIconScreen.js
+++ b/src/style-library/components/pages/SingleIconScreen.js
@@ -1,0 +1,46 @@
+/**
+ * The Single Icon preset screen: `PresetScreen` does the work and `presets/single-icon-preset.js`
+ * describes the block, so this file only binds the two together and registers the screen. Its
+ * settings panel is `SingleIconSettings`, assigned below as `SingleIconScreen.SettingsPanel`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { PresetScreen } from './PresetScreen';
+import { SingleIconSettings } from './SingleIconSettings';
+import { SINGLE_ICON_PRESET, SINGLE_ICON_BLOCK } from '../../presets/single-icon-preset';
+import { PRESET_SCREENS_FILTER } from '../../constants/screens';
+import './SingleIconScreen.scss';
+
+/**
+ * Render the Single Icon preset screen.
+ *
+ * @param {Object} props The screen props (`label`, `route`, `navigate`, `library`).
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The screen body.
+ */
+export function SingleIconScreen(props) {
+	return <PresetScreen {...props} preset={SINGLE_ICON_PRESET} />;
+}
+
+SingleIconScreen.SettingsPanel = SingleIconSettings;
+
+/**
+ * Register the Single Icon screen for `kadence/single-icon` on the public preset-screens filter,
+ * exactly as a third party would — the app never imports this component directly, so this
+ * module-scope call is the only registration path.
+ *
+ * @since TBD
+ */
+addFilter(PRESET_SCREENS_FILTER, 'kadence-blocks/style-library-single-icon-screen', (screens) => ({
+	...screens,
+	[SINGLE_ICON_BLOCK]: SingleIconScreen,
+}));

--- a/src/style-library/components/pages/SingleIconScreen.scss
+++ b/src/style-library/components/pages/SingleIconScreen.scss
@@ -1,0 +1,35 @@
+// The glyph is drawn at its true size (an icon-size scale is only legible at true size), so it can
+// exceed `ListRow`'s framed 80px preview slot. Relax the slot rather than scale the glyph down —
+// the same override the Button, Spacing, Icon Sizes and Shadow screens make.
+.kadence-blocks-style-library__single-icon-screen .kadence-blocks-style-library__list-row-preview {
+	width: auto;
+	height: auto;
+	border: 0;
+	background: transparent;
+	overflow: visible;
+}
+
+// Preset names are full words ("Muted Small"), not the short numeric labels the shared 4rem column
+// was sized for.
+.kadence-blocks-style-library__single-icon-screen .kadence-blocks-style-library__list-row-label {
+	width: 15rem;
+}
+
+// The live glyph. `font-size` carries the resolved size token and the SVG sizes itself in `em`, so
+// one style drives the whole preview; `color` feeds the path's `currentColor` fill. A minimum keeps
+// the smallest step from collapsing to an unreadable speck in the row.
+.kadence-blocks-style-library__single-icon-preset-preview {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 1rem;
+	min-height: 1rem;
+	transition: color 300ms ease, font-size 300ms ease;
+
+	svg {
+		width: 1em;
+		height: 1em;
+		min-width: 1rem;
+		min-height: 1rem;
+	}
+}

--- a/src/style-library/components/pages/SingleIconSettings.js
+++ b/src/style-library/components/pages/SingleIconSettings.js
@@ -1,0 +1,29 @@
+/**
+ * The Single Icon preset's settings sidebar: `PresetSidebar` does the work, this binds the block's
+ * config to it.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { PresetSidebar } from './PresetSidebar';
+import { usePresetScreen } from '../../hooks/use-preset-screen';
+import { SINGLE_ICON_PRESET } from '../../presets/single-icon-preset';
+
+/**
+ * Render the Single Icon preset's settings sidebar.
+ *
+ * @param {Object}   props          The component props.
+ * @param {Object}   props.route    The current route (`{ screen, item }`).
+ * @param {Function} props.navigate The route navigator.
+ * @param {Object}   props.library  The design-tokens feed hook's return value.
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The sidebar, or null while there is no open preset to edit.
+ */
+export function SingleIconSettings({ route, navigate, library }) {
+	const screen = usePresetScreen(library, SINGLE_ICON_PRESET);
+
+	return <PresetSidebar route={route} navigate={navigate} screen={screen} preset={SINGLE_ICON_PRESET} />;
+}

--- a/src/style-library/constants/demo-settings-schema.js
+++ b/src/style-library/constants/demo-settings-schema.js
@@ -158,6 +158,15 @@ export const DEMO_SETTINGS_SCHEMA = {
 					label: __('Spacing', 'kadence-blocks'),
 					tokenType: 'dimension',
 				},
+				{
+					// The responsive counterpart to `token-select` above: one token-backed length, with a
+					// breakpoint switcher. Left non-responsive here so the responsive-field count below stays
+					// the two the schema is asserted on — the type's own capability is covered by its field.
+					type: 'token-scalar',
+					path: 'iconSize',
+					label: __('Icon Size', 'kadence-blocks'),
+					tokenType: 'dimension',
+				},
 				{ type: 'toggle', path: 'enabled', label: __('Enabled', 'kadence-blocks') },
 			],
 		},

--- a/src/style-library/constants/field-types.js
+++ b/src/style-library/constants/field-types.js
@@ -14,6 +14,7 @@ import { BoxTokenField } from '../components/molecules/fields/BoxTokenField';
 import { ColorField } from '../components/molecules/fields/ColorField';
 import { ColorListField } from '../components/molecules/fields/ColorListField';
 import { NumberUnitField } from '../components/molecules/fields/NumberUnitField';
+import { ScalarTokenField } from '../components/molecules/fields/ScalarTokenField';
 import { RangeNumberField } from '../components/molecules/fields/RangeNumberField';
 import { SelectField } from '../components/molecules/fields/SelectField';
 import { ShadowField } from '../components/molecules/fields/ShadowField';
@@ -98,6 +99,7 @@ export const FIELD_TYPES = Object.freeze({
 	color: ColorField,
 	'color-list': ColorListField,
 	'token-select': TokenSelectField,
+	'token-scalar': ScalarTokenField,
 	'token-color-select': TokenColorSelectField,
 	'box-sides': BoxSidesField,
 	radius: RadiusField,
@@ -118,6 +120,11 @@ export const FIELD_TYPES = Object.freeze({
  * their UI could read back; the rest are excluded because their DTCG types are never
  * responsive-capable.
  *
+ * `token-scalar` is the responsive answer for a single token-backed length, where `token-select` is the
+ * non-responsive one: it wraps `ScalarControl`, which carries the breakpoint switcher, so a property
+ * whose block control is itself per-device (an icon's size, stored as `size`/`tabletSize`/`mobileSize`)
+ * can be given one value per breakpoint from a preset too.
+ *
  * `border` qualifies for the same reason `radius`/`spacing` do: its width is a `dimension` value,
  * held in the same per-slot shape. `box-shadow` is excluded — the Button panel's shadow field has no
  * breakpoint switcher (see `BoxShadowField.js`'s docblock).
@@ -128,6 +135,7 @@ export const RESPONSIVE_CAPABLE_FIELD_TYPES = Object.freeze([
 	'number-unit',
 	'radius',
 	'spacing',
+	'token-scalar',
 	'range-number',
 	'stepper',
 	'unit',

--- a/src/style-library/presets/single-icon-preset.js
+++ b/src/style-library/presets/single-icon-preset.js
@@ -97,12 +97,11 @@ function renderPreview(row) {
  * The settings schema. The icon declares no tabs: it binds no hover property, so there is no second
  * state to switch to and `PresetSidebar` renders the field area bare.
  *
- * Size uses `token-select` rather than a numeric field so a preset stores a token id and keeps
- * following the Icon Sizes scale, the same way the block's own size control does. That also means it
- * carries no breakpoint switcher — `token-select` is deliberately outside
- * `RESPONSIVE_CAPABLE_FIELD_TYPES` — so an icon preset sets one size for every device. The binding
- * declares `responsive_attrs` regardless, so a per-breakpoint override remains expressible once a
- * responsive token picker exists.
+ * Size uses `token-scalar` so a preset stores a token id and keeps following the Icon Sizes scale, the
+ * same way the block's own size control does — and, like that control, can say something different per
+ * breakpoint. The block stores its size in `size`/`tabletSize`/`mobileSize` and the binding declares all
+ * three, so a preset that could only set one value for every device would be unable to reproduce a look
+ * a site owner had already built with the block's own control.
  *
  * @since TBD
  *
@@ -117,11 +116,15 @@ function schemaFor() {
 				fields: [
 					{ type: 'token-color-select', path: 'tokens.color', label: __('Color', 'kadence-blocks') },
 					{
-						type: 'token-select',
+						type: 'token-scalar',
 						tokenType: 'dimension',
 						role: 'icon-size',
+						responsive: true,
 						path: 'tokens.size',
 						label: __('Size', 'kadence-blocks'),
+						// What an un-preset icon renders at, shown muted so an unset field reports the size the
+						// block really has rather than reading as empty.
+						defaultValue: ICON_SIZE_FALLBACK,
 					},
 				],
 			},

--- a/src/style-library/presets/single-icon-preset.js
+++ b/src/style-library/presets/single-icon-preset.js
@@ -1,0 +1,153 @@
+/**
+ * Everything specific to the `kadence/single-icon` preset screen, in one place: the block name, the
+ * bound property surface, the row preview, and the settings schema.
+ *
+ * The generic preset machinery — `helpers/presets.js`, `usePresetScreen`, `PresetSidebar` — reads
+ * this config and knows nothing else about icons. See `src/style-library/README.md`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getPresetProperties, resolveTokenValue } from '../helpers/presets';
+
+/**
+ * The block name this screen edits — the single JS spelling, shared by the screen registration and
+ * the config below so the two can never drift.
+ *
+ * @since TBD
+ */
+export const SINGLE_ICON_BLOCK = 'kadence/single-icon';
+
+/**
+ * The icon's built-in color, used when the preset's color does not resolve — `semantic.color.icon`'s
+ * own shipped value, which is what an un-preset icon renders at.
+ *
+ * @since TBD
+ */
+const ICON_COLOR_FALLBACK = '#3182CE';
+
+/**
+ * The icon's built-in size, matching `semantic.icon-size.default`.
+ *
+ * @since TBD
+ */
+const ICON_SIZE_FALLBACK = '1.5rem';
+
+/**
+ * Build a row's preview from its stored tokens.
+ *
+ * An icon's whole bound surface is its color and its size, so both are previewed — unlike the
+ * Button, whose preview shows three of eleven properties. Size is previewed as a real length rather
+ * than a scaled-down swatch, because an icon-size scale is only legible at true size.
+ *
+ * @param {Record<string, *>}      tokens       The preset's stored token map.
+ * @param {Record<string, string>} values       The feed's resolved value map.
+ * @param {string}                 [breakpoint] The breakpoint to resolve responsive values at.
+ *
+ * @since TBD
+ *
+ * @return {{color: string, size: string}} The preview.
+ */
+function preview(tokens, values, breakpoint) {
+	return {
+		color: resolveTokenValue(values, tokens.color, breakpoint),
+		size: resolveTokenValue(values, tokens.size, breakpoint),
+	};
+}
+
+/**
+ * The row's live preview: a generic glyph drawn at the row's resolved color and size.
+ *
+ * A neutral shape rather than a real Kadence icon on purpose — a preset skins whichever icon a block
+ * happens to use, so previewing one specific glyph would imply the preset selects it. `currentColor`
+ * lets the single `color` style drive the fill.
+ *
+ * @param {{id: string, label: string, preview: {color: string, size: string}}} row The row descriptor.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The preview element.
+ */
+function renderPreview(row) {
+	return (
+		<span
+			className="kadence-blocks-style-library__single-icon-preset-preview"
+			style={{
+				color: row.preview.color || ICON_COLOR_FALLBACK,
+				fontSize: row.preview.size || ICON_SIZE_FALLBACK,
+			}}
+		>
+			<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+				<path
+					fill="currentColor"
+					d="M12 2 9.2 8.6 2 9.2l5.5 4.8L5.8 21 12 17.3 18.2 21l-1.7-7 5.5-4.8-7.2-.6z"
+				/>
+			</svg>
+		</span>
+	);
+}
+
+/**
+ * The settings schema. The icon declares no tabs: it binds no hover property, so there is no second
+ * state to switch to and `PresetSidebar` renders the field area bare.
+ *
+ * Size uses `token-select` rather than a numeric field so a preset stores a token id and keeps
+ * following the Icon Sizes scale, the same way the block's own size control does. That also means it
+ * carries no breakpoint switcher — `token-select` is deliberately outside
+ * `RESPONSIVE_CAPABLE_FIELD_TYPES` — so an icon preset sets one size for every device. The binding
+ * declares `responsive_attrs` regardless, so a per-breakpoint override remains expressible once a
+ * responsive token picker exists.
+ *
+ * @since TBD
+ *
+ * @return {{panels: Array<Object>}} The settings-form schema.
+ */
+function schemaFor() {
+	return {
+		panels: [
+			{
+				id: 'icon',
+				title: __('Icon', 'kadence-blocks'),
+				fields: [
+					{ type: 'token-color-select', path: 'tokens.color', label: __('Color', 'kadence-blocks') },
+					{
+						type: 'token-select',
+						tokenType: 'dimension',
+						role: 'icon-size',
+						path: 'tokens.size',
+						label: __('Size', 'kadence-blocks'),
+					},
+				],
+			},
+		],
+	};
+}
+
+/**
+ * The Single Icon preset screen's whole configuration, passed to the generic preset machinery.
+ *
+ * `properties` is a getter rather than a snapshot, for the same reason the Button's is: the config is
+ * frozen at module evaluation, before the localized feed is guaranteed to exist, so a snapshot taken
+ * here could throw or go stale.
+ *
+ * @since TBD
+ */
+export const SINGLE_ICON_PRESET = Object.freeze({
+	block: SINGLE_ICON_BLOCK,
+	get properties() {
+		return getPresetProperties(SINGLE_ICON_BLOCK);
+	},
+	slugBase: 'icon',
+	addLabel: __('Add Icon Style', 'kadence-blocks'),
+	newLabel: __('New Icon Style', 'kadence-blocks'),
+	className: 'kadence-blocks-style-library__single-icon-screen',
+	preview,
+	renderPreview,
+	schemaFor,
+});

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/PresetNavTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/PresetNavTest.php
@@ -28,9 +28,9 @@ final class PresetNavTest extends TestCase {
 	}
 
 	/**
-	 * The shipped registry surfaces exactly one nav entry today — the singlebtn block — carrying
-	 * its declared Style Library section label ("Button"), never the picker control's own label
-	 * ("Style").
+	 * Every shipped nav entry carries its declared Style Library section label ("Button", "Icon"),
+	 * never the picker control's own label — both blocks declare that as "Style". Order is
+	 * registration order, which is declaration order in `declarations.php`.
 	 *
 	 * @return void
 	 */
@@ -42,6 +42,10 @@ final class PresetNavTest extends TestCase {
 				[
 					'block' => 'kadence/singlebtn',
 					'label' => 'Button',
+				],
+				[
+					'block' => 'kadence/single-icon',
+					'label' => 'Icon',
 				],
 			],
 			$entries
@@ -239,8 +243,6 @@ final class PresetNavTest extends TestCase {
 		yield 'rowlayout' => [ 'block' => 'kadence/rowlayout' ];
 
 		yield 'column' => [ 'block' => 'kadence/column' ];
-
-		yield 'single icon' => [ 'block' => 'kadence/single-icon' ];
 
 		yield 'advanced heading' => [ 'block' => 'kadence/advancedheading' ];
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
@@ -22,6 +22,8 @@ final class Preset_CatalogTest extends TestCase {
 
 	private const ICON = 'kadence/single-icon';
 
+	private const IMAGE = 'kadence/image';
+
 	/**
 	 * @var Preset_Catalog
 	 */
@@ -131,8 +133,6 @@ final class Preset_CatalogTest extends TestCase {
 
 		yield 'column' => [ 'block' => 'kadence/column' ];
 
-		yield 'single icon' => [ 'block' => 'kadence/single-icon' ];
-
 		yield 'advanced heading' => [ 'block' => 'kadence/advancedheading' ];
 	}
 
@@ -240,14 +240,14 @@ final class Preset_CatalogTest extends TestCase {
 	public function testABlockWithoutAPickerLabelCarriesPropertiesButNoPresetOptions(): void {
 		$library = $this->catalog->all()['libraries'][ Token_Store::default_slug() ];
 
-		$this->assertArrayHasKey( self::ICON, $library );
-		$this->assertNull( $library[ self::ICON ]['label'] );
-		$this->assertSame( [], $library[ self::ICON ]['presets'] );
+		$this->assertArrayHasKey( self::IMAGE, $library );
+		$this->assertNull( $library[ self::IMAGE ]['label'] );
+		$this->assertSame( [], $library[ self::IMAGE ]['presets'] );
 
 		// The surface the token picker keys off is present regardless, as is the default the controls compare
 		// against.
-		$this->assertNotEmpty( $library[ self::ICON ]['properties'] );
-		$this->assertSame( 'default', $library[ self::ICON ]['default'] );
+		$this->assertNotEmpty( $library[ self::IMAGE ]['properties'] );
+		$this->assertSame( 'default', $library[ self::IMAGE ]['default'] );
 
 		// The picker-driven Button is unaffected: it declares a label, so it still carries its options.
 		$this->assertNotEmpty( $library[ self::BUTTON ]['presets'] );

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
@@ -404,6 +404,63 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
+	 * An icon preset whose size varies by breakpoint projects the same way a button's radius does: a
+	 * scoped rule pointing `--kb-icon-size` at the canonical preset var, and a media block redeclaring
+	 * that var per breakpoint. Proves a SCALAR dimension on a block other than the Button reaches the
+	 * responsive layer, which is what lets an icon preset say what the block's own per-device size
+	 * control says.
+	 *
+	 * @return void
+	 */
+	public function testAnIconPresetsSizeVariesByBreakpoint(): void {
+		$this->store->save_document(
+			(string) wp_json_encode(
+				[
+					'$extensions' => [
+						'com.kadence.designTokens' => [
+							'presets' => [
+								'kadence/single-icon' => [
+									'compact' => [
+										'label'  => 'Compact',
+										'tokens' => [
+											'size' => [
+												'$value'      => '2rem',
+												'$extensions' => [
+													'com.kadence.designTokens' => [
+														'responsive' => [ 'mobile' => '1rem' ],
+													],
+												],
+											],
+										],
+									],
+								],
+							],
+						],
+					],
+				]
+			),
+			Token_Store::default_slug()
+		);
+
+		$css = $this->builder( $this->registry )->css( 'default', $this->breakpoints() );
+
+		// The base value, and the scoped rule that points the block's own variable at it.
+		$this->assertStringContainsString( '--kb-token--preset--kadence-single-icon--compact--size:2rem;', $css );
+		$this->assertStringContainsString(
+			'.wp-block-kadence-single-icon.kb-preset--compact{--kb-icon-size:var(--kb-token--preset--kadence-single-icon--compact--size);}',
+			$css
+		);
+
+		// The mobile override redeclares the canonical var INSIDE the breakpoint's media block — asserted
+		// with the enclosing braces so a bare declaration sitting outside one could not satisfy it.
+		$this->assertStringContainsString(
+			'){:root,:root:where(.kb-tokens){--kb-token--preset--kadence-single-icon--compact--size:1rem;}}',
+			$css
+		);
+		$this->assertStringContainsString( '@media', $css );
+	}
+
+	/**
 	 * Persist a "hero" button preset whose radius varies by breakpoint into the active library.
 	 *
 	 * @param array<string, mixed> $responsive Breakpoint => override value.


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout
:video_camera: https://www.loom.com/share/c45de6b397424fcf9434d5b8e1fe9582

The first per-block preset screen: config, screen, settings panel, styles and the `label` flip that opens the Style Library nav entry and the editor picker. Also makes a selected preset actually reach the icon's size and color, and lets a preset set a size per breakpoint.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Single Icon presets to the Style Library.
  - Configure icon color and size with responsive, device-specific values.
  - Preview icon changes live, including inherited and token-based settings.
  - Added clearer Style Library navigation and editor picker labels.

- **Bug Fixes**
  - Improved reset behavior for responsive dimensions and units.
  - Preserved device-specific settings when changing icon size units.
  - Improved fallback handling for preset-based icon colors and sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

