### PR TITLE
[DTM] SOFT-4218 [5/16]: allow editing a block's shipped default preset

### DIFF
--- a/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
@@ -533,6 +533,7 @@ final class Presets_Controller extends Controller {
 		}
 
 		$block_node = [ $preset => $this->preset_definition( $request ) ];
+		$slug       = $this->slug( $request );
 
 		$error = $this->guard_preset_shape( $block_node, $block );
 
@@ -540,7 +541,7 @@ final class Presets_Controller extends Controller {
 			return $error;
 		}
 
-		$error = $this->guard_reserved_slugs( $block_node, $block );
+		$error = $this->guard_reserved_slugs( $block_node, $block, $slug );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
@@ -552,7 +553,6 @@ final class Presets_Controller extends Controller {
 			return $error;
 		}
 
-		$slug       = $this->slug( $request );
 		$block_node = $this->normalize_block_node( $block_node, $slug );
 		$stored     = $this->stored_document( $slug );
 
@@ -617,13 +617,15 @@ final class Presets_Controller extends Controller {
 			$block_node[ Extensions::get_default_key() ] = $default;
 		}
 
+		$slug = $this->slug( $request );
+
 		$error = $this->guard_preset_shape( $block_node, $block );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
 		}
 
-		$error = $this->guard_reserved_slugs( $block_node, $block );
+		$error = $this->guard_reserved_slugs( $block_node, $block, $slug );
 
 		if ( $error instanceof WP_Error ) {
 			return $error;
@@ -635,7 +637,6 @@ final class Presets_Controller extends Controller {
 			return $error;
 		}
 
-		$slug       = $this->slug( $request );
 		$block_node = $this->normalize_block_node( $block_node, $slug );
 
 		// Replace, not merge: drop the stored block node first so a preset the body omits does not survive.
@@ -1191,19 +1192,29 @@ final class Presets_Controller extends Controller {
 	}
 
 	/**
-	 * Reject a preset whose slug is reserved. "default" is the literal used by the block's `/default`
-	 * sub-route and by `delete_preset`, and "order" is the literal used by the block's `/order` sub-route, so
-	 * a preset named either could never be deleted or set through its dedicated route; refuse to create one.
+	 * Reject the CREATION of a preset whose slug is reserved. "default" is the literal used by the block's
+	 * `/default` sub-route and "order" by its `/order` sub-route, so a preset named either can never be
+	 * addressed through the per-preset item route — it would be undeletable.
+	 *
+	 * Scoped to creation, because "default" is not a hypothetical: every block but the Button ships its
+	 * baseline look as a preset slugged exactly that, and a site owner editing it is the ordinary case. A
+	 * slug already present in the block's effective presets is therefore writable — the collision it would
+	 * cause is one the shipped data already made, and the only route it forecloses is DELETE, which that
+	 * preset should refuse anyway: it is the block's built-in look, and the editor offers deletion only for
+	 * user-created presets. Minting a NEW preset under a reserved slug is still refused, so nobody can
+	 * strand one that cannot be removed.
 	 *
 	 * @since TBD
 	 *
 	 * @param array<string, mixed> $block_node The block's preset node being written.
 	 * @param string               $block      The block name, for error context.
+	 * @param string               $library    The token library the write targets.
 	 *
-	 * @return WP_Error|null A WP_Error when a reserved slug is used, null otherwise.
+	 * @return WP_Error|null A WP_Error when a reserved slug is newly created, null otherwise.
 	 */
-	private function guard_reserved_slugs( array $block_node, string $block ): ?WP_Error {
+	private function guard_reserved_slugs( array $block_node, string $block, string $library ): ?WP_Error {
 		$reserved = [ self::DEFAULT_ROUTE, self::ORDER_ROUTE ];
+		$existing = $this->existing_preset_slugs( $block, $library );
 
 		foreach ( array_keys( $block_node ) as $slug ) {
 			// $default and any other "$"-prefixed metadata key is not a named preset.
@@ -1211,20 +1222,53 @@ final class Presets_Controller extends Controller {
 				continue;
 			}
 
-			if ( in_array( (string) $slug, $reserved, true ) ) {
-				return new WP_Error(
-					'rest_design_tokens_reserved_slug',
-					__( 'That preset slug is reserved.', 'kadence-blocks' ),
-					[
-						'status' => WP_Http::UNPROCESSABLE_ENTITY,
-						'block'  => $block,
-						'preset' => (string) $slug,
-					]
-				);
+			if ( ! in_array( (string) $slug, $reserved, true ) ) {
+				continue;
 			}
+
+			if ( in_array( (string) $slug, $existing, true ) ) {
+				continue;
+			}
+
+			return new WP_Error(
+				'rest_design_tokens_reserved_slug',
+				__( 'That preset slug is reserved.', 'kadence-blocks' ),
+				[
+					'status' => WP_Http::UNPROCESSABLE_ENTITY,
+					'block'  => $block,
+					'preset' => (string) $slug,
+				]
+			);
 		}
 
 		return null;
+	}
+
+	/**
+	 * The named preset slugs a block already has in a library, baseline and stored overrides merged.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block   The block name.
+	 * @param string $library The token library slug.
+	 *
+	 * @return string[] The existing preset slugs.
+	 */
+	private function existing_preset_slugs( string $block, string $library ): array {
+		$node = $this->presets->block( $block, $library );
+
+		if ( ! is_array( $node ) ) {
+			return [];
+		}
+
+		return array_values(
+			array_filter(
+				array_map( 'strval', array_keys( $node ) ),
+				static function ( string $slug ): bool {
+					return strpos( $slug, '$' ) !== 0;
+				}
+			)
+		);
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
@@ -185,6 +185,80 @@ final class PresetsControllerTest extends TestCase {
 	}
 
 	/**
+	 * A block's shipped "default" preset is editable, even though "default" is the literal the block's
+	 * `/default` sub-route uses. Every block but the Button ships its baseline look under exactly that slug,
+	 * so a site owner editing it is the ordinary case — refusing it would leave the one preset those blocks
+	 * have permanently read-only.
+	 *
+	 * @return void
+	 */
+	public function testTheShippedDefaultPresetIsEditable(): void {
+		$response = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				'kadence/single-icon',
+				[
+					'preset' => 'default',
+					'label'  => 'Default',
+					'tokens' => [ 'color' => '#ff0000' ],
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'default', $data['presets'] );
+		$this->assertSame( '#ff0000', $data['presets']['default']['tokens']['color'] );
+	}
+
+	/**
+	 * Minting a NEW preset under a reserved slug is still refused: the per-preset item route could never
+	 * address it, so it would be undeletable. The Button ships no "default", so this is a creation.
+	 *
+	 * @return void
+	 */
+	public function testCreatingANewPresetUnderAReservedSlugIsRefused(): void {
+		$response = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'preset' => 'default',
+					'label'  => 'Default',
+					'tokens' => $this->button_tokens(),
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_design_tokens_reserved_slug', $response->get_error_code() );
+	}
+
+	/**
+	 * "order" is reserved for every block: nothing ships a preset under it, so any write is a creation.
+	 *
+	 * @return void
+	 */
+	public function testCreatingAPresetNamedOrderIsRefused(): void {
+		$response = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'preset' => 'order',
+					'label'  => 'Order',
+					'tokens' => $this->button_tokens(),
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_design_tokens_reserved_slug', $response->get_error_code() );
+	}
+
+	/**
 	 * A create deep-merges a single preset into the block's presets, leaving the baseline siblings and the default in
 	 * place.
 	 *


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout
:video_camera: https://www.loom.com/share/c45de6b397424fcf9434d5b8e1fe9582

Every block's shipped `default` preset was read-only, so a site owner could not edit the one preset each block actually ships. The reserved-slug guard now skips a slug that already exists.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Existing shipped presets using reserved names (`default` and `order`) can now be edited.
  - New presets cannot be created with reserved names and receive a clear validation error.
  - Preset validation now correctly accounts for the target library before applying naming restrictions.

- **Tests**
  - Added coverage for editing shipped presets and rejecting newly created reserved-name presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

