### PR TITLE
[DTM] SOFT-4218 [6/16]: follow the block's color palette when the editor paints a preset value

### DIFF
--- a/includes/resources/Design_Tokens/Editor/Preset_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Preset_Catalog.php
@@ -132,7 +132,7 @@ final class Preset_Catalog {
 	 *
 	 * @param string $slug The token library slug.
 	 *
-	 * @return array<string, array<string, mixed>> block => { default, presets, properties, values, label }.
+	 * @return array<string, array<string, mixed>> block => { default, presets, properties, values, references, label }.
 	 */
 	private function for_library( string $slug ): array {
 		$out = [];
@@ -159,6 +159,7 @@ final class Preset_Catalog {
 				'presets'    => $bindings->label === null ? [] : $this->preset_options( $block, $slug, $names ),
 				'properties' => $this->properties_for( $bindings ),
 				'values'     => $this->values_for( $block, $slug, $names ),
+				'references' => $this->references_for( $block, $slug, $names ),
 				'responsive' => $this->responsive_for( $block, $slug, $names ),
 				'label'      => $bindings->label,
 			];
@@ -260,6 +261,43 @@ final class Preset_Catalog {
 		}
 
 		return $values;
+	}
+
+	/**
+	 * The per-preset CSS REFERENCES for a block's library: `preset slug => ( property => var() chain )`,
+	 * the same strings the projected CSS uses.
+	 *
+	 * The sibling of `values_for()`, and deliberately not a replacement for it — the two answer different
+	 * questions. A literal is what a control compares against to decide bound-vs-overridden, because a
+	 * `var()` chain cannot be compared to a stored hex. A reference is what the editor PAINTS with when it
+	 * has to resolve a preset value itself rather than let a stylesheet do it.
+	 *
+	 * The difference matters wherever a token's value depends on something the flattening has already
+	 * discarded. A per-block color palette is exactly that: the projector emits a `[data-kb-palette]` layer
+	 * that redefines the token variables, and the editor mirrors the block's selected palette onto the block
+	 * wrapper, so a `var()` reference resolves through whichever palette the block is on. A literal was
+	 * resolved against the default palette before it ever reached the editor and cannot follow the block.
+	 *
+	 * @since TBD
+	 *
+	 * @param string   $block The block name.
+	 * @param string   $slug  The token library slug.
+	 * @param string[] $names The preset slugs to resolve, in catalog order.
+	 *
+	 * @return array<string, array<string, string>> preset slug => ( property => `var()` chain ).
+	 */
+	private function references_for( string $block, string $slug, array $names ): array {
+		$references = [];
+
+		foreach ( $names as $name ) {
+			try {
+				$references[ $name ] = $this->presets->resolve( $block, $name, $slug );
+			} catch ( Unknown_Preset_Exception $e ) {
+				continue; // Preset undefined in this library — skip, fail soft.
+			}
+		}
+
+		return $references;
 	}
 
 	/**

--- a/src/blocks/single-icon/preview-icon.js
+++ b/src/blocks/single-icon/preview-icon.js
@@ -2,8 +2,7 @@ import { getPreviewSize, KadenceColorOutput, getSpacingOptionOutput } from '@kad
 import { useRef } from '@wordpress/element';
 import { IconRender, Tooltip } from '@kadence/components';
 import { tokenPx } from '../../extension/design-tokens/token-px';
-import { tokenLiteral } from '../../extension/design-tokens/token-literals';
-import { presetPropertyValueForDevice } from '../../extension/token-indicators';
+import { presetPropertyReference, presetPropertyValueForDevice } from '../../extension/token-indicators';
 import { boundTokenAliasForControl } from '../../extension/token-picker';
 import { parseCssLength } from '../../token-controls';
 import metadata from './block.json';
@@ -109,11 +108,14 @@ export function PreviewIcon({ attributes, previewDevice }) {
 	// The same story for color, by a different mechanism. The front end renders a cleared color through the
 	// block-default rule's `var(--kb-icon-color, ...)` chain on the `.kb-svg-icon-wrap` span PHP hydrates;
 	// the editor has no such element (it renders `GenIcon`'s own div) and paints the color inline, so the
-	// preset's value is resolved here instead. Without this a preset's color simply never reaches the
-	// canvas — the rule that would carry it matches nothing in the editor's markup.
-	const previewColor =
-		color ||
-		tokenLiteral(presetPropertyValueForDevice(metadata.name, 'color', attributes, undefined, previewDevice));
+	// preset's value is applied here instead. Without this a preset's color never reaches the canvas — the
+	// rule that would carry it matches nothing in the editor's markup.
+	//
+	// The preset's CSS REFERENCE, not its flattened literal: a `var()` chain resolves through the
+	// projector's `[data-kb-palette]` layer, and the editor mirrors the block's selected palette onto its
+	// wrapper, so the icon follows whichever palette the block is on. The literal was flattened against the
+	// default palette upstream and would pin the icon to that palette's color whatever the block is set to.
+	const previewColor = color || presetPropertyReference(metadata.name, 'color', attributes);
 	const previewMarginTop = getPreviewSize(
 		previewDevice,
 		margin && undefined !== margin[0] ? margin[0] : undefined,

--- a/src/extension/preset-picker/index.js
+++ b/src/extension/preset-picker/index.js
@@ -106,6 +106,28 @@ export function blockPresetValues(name, library) {
 }
 
 /**
+ * The per-preset CSS REFERENCES for a block's library: `{ <presetSlug>: { <property>: 'var(...)' } }` —
+ * the same strings the projected CSS uses. Empty object when the block offers none.
+ *
+ * The sibling of `blockPresetValues`, for a different job. A literal is what a control compares against
+ * to decide bound-vs-overridden; a reference is what the editor paints with when it has to apply a preset
+ * value itself instead of letting a stylesheet do it. Only the reference follows a per-block color
+ * palette: the projector's `[data-kb-palette]` layer redefines the token variables and the editor mirrors
+ * the block's palette onto its wrapper, so a `var()` chain resolves through whichever palette the block
+ * is on, while a literal was flattened against the default palette before it ever reached the editor.
+ *
+ * @param {string} name      The block name.
+ * @param {string} [library] The token library slug; defaults to the active library.
+ *
+ * @since TBD
+ *
+ * @return {Object} The per-preset reference map.
+ */
+export function blockPresetReferences(name, library) {
+	return get(blockEntry(name, library), 'references', {}) || {};
+}
+
+/**
  * The per-preset, per-breakpoint resolved values for a block's library:
  * `{ <presetSlug>: { <breakpoint>: { <property>: literalValue } } }`. Empty object when the block
  * offers none, and a preset that declares no breakpoint overrides carries an empty map rather than

--- a/src/extension/token-indicators/__tests__/index.test.js
+++ b/src/extension/token-indicators/__tests__/index.test.js
@@ -13,6 +13,7 @@ jest.mock('../components/TokenControlRow', () => ({ TokenControlRow: () => null 
 import {
 	usePresetBinding,
 	resetAttrPatch,
+	presetPropertyReference,
 	presetPropertyValueForDevice,
 	mappedAttrsFor,
 	deriveStateBinding,
@@ -989,5 +990,88 @@ describe('deriveStateBinding', () => {
 		const state = deriveStateBinding({ shared, kind: 'border', value, previewDevice: 'Desktop' });
 
 		expect(state).toEqual({ bound: true, overridden: false });
+	});
+});
+
+describe('presetPropertyReference', () => {
+	afterEach(() => {
+		delete window.kadenceDesignTokensPresets;
+	});
+
+	/**
+	 * Seed a catalog carrying BOTH the flattened literal and the CSS reference for one property, which is
+	 * the shape the editor localizer prints.
+	 *
+	 * @return {void}
+	 */
+	function seedReferences() {
+		window.kadenceDesignTokensPresets = {
+			active: SET,
+			libraries: {
+				[SET]: {
+					[BLOCK]: {
+						default: 'primary',
+						presets: [{ slug: 'primary', label: 'Primary' }],
+						properties: [{ key: 'button-bg', kind: 'color', token: null, control_attr: 'background' }],
+						values: { primary: { 'button-bg': '#3182CE' } },
+						references: { primary: { 'button-bg': 'var(--kb-token--semantic--color--button-bg)' } },
+						responsive: {},
+					},
+				},
+			},
+		};
+	}
+
+	/**
+	 * The reference is returned, not the literal. Only the `var()` chain resolves through the projector's
+	 * per-block palette layer, so an editor path that paints a preset value itself must use it.
+	 *
+	 * @return {void}
+	 */
+	it("returns the active preset's var() chain rather than its flattened literal", () => {
+		seedReferences();
+
+		expect(presetPropertyReference(BLOCK, 'button-bg', { kbPreset: 'primary' }, SET)).toBe(
+			'var(--kb-token--semantic--color--button-bg)'
+		);
+	});
+
+	/**
+	 * With nothing selected the block follows its `$default`, exactly as the value reader does.
+	 *
+	 * @return {void}
+	 */
+	it('falls back to the block default preset when nothing is selected', () => {
+		seedReferences();
+
+		expect(presetPropertyReference(BLOCK, 'button-bg', {}, SET)).toBe(
+			'var(--kb-token--semantic--color--button-bg)'
+		);
+	});
+
+	/**
+	 * A property the active preset does not set has no reference, so a caller can fall through to its own
+	 * default rather than painting something invented.
+	 *
+	 * @return {void}
+	 */
+	it('returns undefined for a property the preset does not set', () => {
+		seedReferences();
+
+		expect(presetPropertyReference(BLOCK, 'button-text', { kbPreset: 'primary' }, SET)).toBeUndefined();
+	});
+
+	/**
+	 * A catalog with no references section at all degrades to undefined rather than throwing.
+	 *
+	 * @return {void}
+	 */
+	it('returns undefined when the catalog carries no references', () => {
+		window.kadenceDesignTokensPresets = {
+			active: SET,
+			libraries: { [SET]: { [BLOCK]: { default: 'primary', presets: [], properties: [], values: {} } } },
+		};
+
+		expect(presetPropertyReference(BLOCK, 'button-bg', {}, SET)).toBeUndefined();
 	});
 });

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -18,6 +18,7 @@ import {
 	activePresetFor,
 	blockProperties,
 	blockPresetValues,
+	blockPresetReferences,
 	blockPresetResponsive,
 } from '../preset-picker';
 import { isEmptyValue, matchesPreset, presetValueForDevice } from './normalize';
@@ -290,6 +291,36 @@ export function presetPropertyValueForDevice(blockName, propertyKey, attributes,
 		},
 		previewDevice
 	);
+}
+
+/**
+ * The active preset's CSS REFERENCE for one property — the `var()` chain the projected CSS uses, rather
+ * than the flattened literal `presetPropertyValueForDevice` returns.
+ *
+ * For an editor render path that has to apply a preset value itself instead of letting a stylesheet do
+ * it. Painting the reference rather than the literal is what keeps such a path following a per-block
+ * color palette: the projector's `[data-kb-palette]` layer redefines the token variables, and the editor
+ * mirrors the block's selected palette onto its wrapper, so the chain resolves through whichever palette
+ * the block is on. A literal was flattened against the default palette upstream and cannot follow.
+ *
+ * Not device-aware, deliberately: a breakpoint override is carried as a literal in the responsive map,
+ * and there is no per-breakpoint reference to hand back. A caller that needs the value AT a device wants
+ * `presetPropertyValueForDevice`; this answers "what does the preset point this property at".
+ *
+ * @param {string} blockName   The block name.
+ * @param {string} propertyKey The binding's property key.
+ * @param {Object} attributes  The block's current attributes — read for `kbPreset`.
+ * @param {string} [library]   The token library slug; defaults to the active library.
+ *
+ * @since TBD
+ *
+ * @return {*} The `var()` chain, or `undefined` when the active preset does not set the property.
+ */
+export function presetPropertyReference(blockName, propertyKey, attributes, library) {
+	const resolvedLibrary = library || activeLibrary();
+	const activePreset = activePresetFor(blockName, attributes, resolvedLibrary);
+
+	return get(blockPresetReferences(blockName, resolvedLibrary), [activePreset, propertyKey]);
 }
 
 /**

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
@@ -137,6 +137,28 @@ final class Preset_CatalogTest extends TestCase {
 	}
 
 	/**
+	 * Alongside the flattened literals, the catalog carries each preset's CSS REFERENCES — the same
+	 * `var()` chains the projected CSS uses. The editor needs both: a literal to compare a control against,
+	 * and a reference to paint with when it applies a preset value itself, because only the reference
+	 * resolves through the projector's per-block color-palette layer.
+	 *
+	 * @return void
+	 */
+	public function testItSurfacesPerPresetCssReferencesAlongsideLiterals(): void {
+		$button = $this->catalog->all()['libraries'][ Token_Store::default_slug() ][ self::BUTTON ];
+
+		$this->assertArrayHasKey( 'primary', $button['references'] );
+
+		$reference = $button['references']['primary']['button-bg'];
+		$literal   = $button['values']['primary']['button-bg'];
+
+		// The reference is a var() chain; the literal is the flattened value. Both describe the same
+		// property, and the difference between them is the whole point of carrying both.
+		$this->assertStringStartsWith( 'var(--kb-token--', $reference );
+		$this->assertStringNotContainsString( 'var(', $literal );
+	}
+
+	/**
 	 * The surface carries each property's declared composite-control axis, so the editor can tell which
 	 * slot of a shared nested attribute a property owns without matching against property names. The three
 	 * border properties declare one; every other property declares none.


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout
:video_camera: https://www.loom.com/share/c45de6b397424fcf9434d5b8e1fe9582

The editor painted a preset's flattened literal, which was resolved against the default palette upstream and pinned a block to that palette whatever it was set to. It now paints the CSS reference, which resolves through the projector's per-palette layer.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CSS variable reference information to preset catalog entries.
  - Preserved preset references when previewing icon colors and sizes.
  - Added support for retrieving active preset property references, including fallback handling when references are unavailable.

- **Bug Fixes**
  - Improved preset previews by retaining token relationships instead of displaying only flattened values.

- **Tests**
  - Added coverage verifying preset references, fallbacks, unset properties, and catalog compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

