### PR TITLE
[DTM] SOFT-4218 [7/16]: add the Row Layout block preset screen

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -747,8 +747,7 @@
 						"tokens": {
 							"background": "{semantic.color.rowlayout-bg}",
 							"border": "{semantic.color.border}",
-							"borderRadius": "{semantic.radius.rowlayout}",
-							"padding": "{semantic.spacing.section}"
+							"borderRadius": "{semantic.radius.rowlayout}"
 						}
 					}
 				},
@@ -759,8 +758,7 @@
 						"tokens": {
 							"background": "{semantic.color.column-bg}",
 							"border": "{semantic.color.border}",
-							"borderRadius": "{semantic.radius.column}",
-							"padding": "{semantic.spacing.block}"
+							"borderRadius": "{semantic.radius.column}"
 						}
 					}
 				},

--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -746,7 +746,6 @@
 						"label": "Default",
 						"tokens": {
 							"background": "{semantic.color.rowlayout-bg}",
-							"border": "{semantic.color.border}",
 							"borderRadius": "{semantic.radius.rowlayout}"
 						}
 					}

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -694,7 +694,20 @@ return [
 			// primitive — so an uncustomized row stays transparent (KB's own default) unless a site owner brands
 			// that token. Border color follows the brand border token (invisible until a border is added). A
 			// value the user sets is a per-instance rule of equal specificity but later source order, so it still
-			// wins. Padding follows the spacing tokens through the slug bridge, not a binding here.
+			// wins.
+			//
+			// Padding is not a preset property here. It could be one, but not in the css_prop shape the three
+			// bindings below use: the row's `padding` attribute ships a non-empty default of Kadence spacing
+			// slugs ([ 'sm', '', 'sm', '' ]), so every row emits its own per-instance padding rule and a
+			// low-specificity block-default rule would lose to it on every row ever published. Presetting it
+			// needs the button's css_var bridge shape instead (see render_preset_spacing() on the Single
+			// Button block class), plus a gate the button does not need: the row's default padding IS an
+			// attribute value, so an untouched row and a row deliberately set to "sm" are indistinguishable
+			// server-side, and the bridge would have to compare against the shipped default to know whether a
+			// preset may supply padding at all. Until that exists the row's padding follows the spacing
+			// tokens through the slug bridge, which a token-backed padding control also rides — that control
+			// stores its token in the attribute (render_measure_output already resolves a variable value
+			// there) and needs no binding here.
 			'block'    => 'kadence/rowlayout',
 			'bindings' => [
 				// The row names its background attribute `bgColor`, not `background` — the binding key is the
@@ -735,6 +748,13 @@ return [
 			// Column (Section): same as Row Layout, but KB renders the background and border on the inner
 			// `.kt-inside-inner-col` child, so the rules target that descendant. column-bg is the
 			// column's own transparent-by-default override seam, distinct from the row's.
+			//
+			// Unlike the row, the column CAN take a padding binding in the css_prop shape below: its `padding`
+			// attribute defaults to empty, so a low-specificity block-default rule reaches an untouched column
+			// and any value the user sets still wins. It needs its own zero-seeded semantic to do that safely
+			// (the way semantic.spacing.media-padding seeds the image's at 0) — a column renders no padding
+			// today, so seeding it from a non-zero spacing step would indent every column on the site at
+			// upgrade. That belongs with the Section preset screen.
 			'block'    => 'kadence/column',
 			'bindings' => [
 				'background'   => [

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -708,8 +708,14 @@ return [
 			// tokens through the slug bridge, which a token-backed padding control also rides — that control
 			// stores its token in the attribute (render_measure_output already resolves a variable value
 			// there) and needs no binding here.
-			'block'    => 'kadence/rowlayout',
-			'bindings' => [
+			'block'         => 'kadence/rowlayout',
+			'label'         => __( 'Style', 'kadence-blocks' ), // a picker-driven set; this is the editor control's label.
+			'style_library' => [
+				// The Style Library BLOCK PRESETS nav label — distinct from "label" above, which names the
+				// inspector's picker control, not the block.
+				'label' => __( 'Row Layout', 'kadence-blocks' ),
+			],
+			'bindings'      => [
 				// The row names its background attribute `bgColor`, not `background` — the binding key is the
 				// preset property id and need not match the attribute, which is what control_attr is for.
 				'background'   => [

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -726,20 +726,18 @@ return [
 					'css_var'      => 'kb-row-bg',
 					'control_attr' => 'bgColor',
 				],
-				// The row migrates its legacy flat `border`/`borderWidth` attributes into the nested
-				// `borderStyle` composite the current control edits, so the color axis of that composite is
-				// what this property owns — see the image's border bindings for the same shape.
-				'border'       => [
-					'token'            => 'semantic.color.border',
-					'css_prop'         => 'border-color',
-					'css_var'          => 'kb-row-border-color',
-					'control_attr'     => 'borderStyle',
-					'axis'             => 'border-color',
-					'responsive_attrs' => [
-						'tablet' => 'tabletBorderStyle',
-						'mobile' => 'mobileBorderStyle',
-					],
-				],
+				// Border color is NOT a preset property here, and a color-only binding could never become one.
+				// The row calls Kadence_Blocks_CSS::render_border_styles() WITHOUT $single_styles, which takes
+				// the shorthand path: with a border width set it emits `border-top: <width> <style> <color>`,
+				// defaulting an unset color to `transparent` (see that method's $value_defaults). That shorthand
+				// beats a block-default `border-color` rule on both surfaces — inline in the editor, later
+				// source order at equal specificity on the front end — so a preset's color has no path to the
+				// page; with NO width set no border renders at all and a color is invisible by definition. The
+				// Button and the Image pass $single_styles = true, which is exactly why their color bindings do
+				// work. Presetting a row border needs the Button's full width/style/color trio plus a render
+				// bridge that SUPPRESSES the shorthand rather than preceding it.
+				//
+				// @todo SOFT-4234: give the row a preset-able border trio.
 				'borderRadius' => [
 					'token'            => 'semantic.radius.rowlayout',
 					'css_prop'         => 'border-radius',

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -708,6 +708,8 @@ return [
 			// tokens through the slug bridge, which a token-backed padding control also rides — that control
 			// stores its token in the attribute (render_measure_output already resolves a variable value
 			// there) and needs no binding here.
+			//
+			// @todo SOFT-4233: give the row's padding the css_var bridge so a preset can set it.
 			'block'         => 'kadence/rowlayout',
 			'label'         => __( 'Style', 'kadence-blocks' ), // a picker-driven set; this is the editor control's label.
 			'style_library' => [

--- a/src/style-library/__tests__/rowlayout-preset.test.js
+++ b/src/style-library/__tests__/rowlayout-preset.test.js
@@ -1,0 +1,211 @@
+/* eslint-env jest */
+/**
+ * The Row Layout preset config — the one per-block file a preset screen needs. Everything else the
+ * screen uses (`PresetScreen`, `PresetSidebar`, `usePresetScreen`, `helpers/presets`) is generic and
+ * covered by its own suites, so this asserts only what this config contributes: the bound surface it
+ * reads, the preview it resolves, its schema, and that it registers on the public screens filter.
+ */
+import { applyFilters } from '@wordpress/hooks';
+import { ROWLAYOUT_PRESET, ROWLAYOUT_BLOCK } from '../presets/rowlayout-preset';
+import { PRESET_SCREENS_FILTER } from '../constants/screens';
+import { FIELD_TYPES, RESPONSIVE_CAPABLE_FIELD_TYPES } from '../constants/field-types';
+
+// The screen module is imported only to trigger its module-scope `addFilter`. Its two children pull in
+// the REST client (and so `@wordpress/api-fetch`, absent from this environment), which the registration
+// contract does not depend on — the generic panel and sidebar have their own suites.
+jest.mock('../components/pages/PresetScreen', () => ({ PresetScreen: () => null }));
+jest.mock('../components/pages/RowLayoutSettings', () => ({ RowLayoutSettings: () => null }));
+
+describe('ROWLAYOUT_PRESET', () => {
+	afterEach(() => {
+		delete window.kadenceDesignTokens;
+	});
+
+	/**
+	 * The config names the Row Layout block itself, which owns the background/border/radius attributes.
+	 *
+	 * @return {void}
+	 */
+	it('targets the rowlayout block', () => {
+		expect(ROWLAYOUT_PRESET.block).toBe('kadence/rowlayout');
+		expect(ROWLAYOUT_BLOCK).toBe('kadence/rowlayout');
+	});
+
+	/**
+	 * `properties` is a live getter over the feed, not a snapshot, so the screen can never offer a
+	 * property the server's write guard would reject.
+	 *
+	 * @return {void}
+	 */
+	it('reads its bound surface live from the feed', () => {
+		window.kadenceDesignTokens = {
+			presets: { 'kadence/rowlayout': { properties: ['background', 'border', 'borderRadius'] } },
+		};
+
+		expect(ROWLAYOUT_PRESET.properties).toEqual(['background', 'border', 'borderRadius']);
+	});
+
+	/**
+	 * The preview resolves all three bound properties through the feed's value map, aliases included.
+	 *
+	 * @return {void}
+	 */
+	it('resolves the preview background, border and radius from stored aliases', () => {
+		const values = {
+			'semantic.color.rowlayout-bg': 'transparent',
+			'semantic.color.border': '#E2E8F0',
+			'semantic.radius.rowlayout': '0',
+		};
+		const tokens = {
+			background: '{semantic.color.rowlayout-bg}',
+			border: '{semantic.color.border}',
+			borderRadius: '{semantic.radius.rowlayout}',
+		};
+
+		expect(ROWLAYOUT_PRESET.preview(tokens, values)).toEqual({
+			background: 'transparent',
+			border: '#E2E8F0',
+			borderRadius: '0',
+		});
+	});
+
+	/**
+	 * A dangling alias previews as empty rather than as the raw alias text, so `renderPreview` can fall
+	 * back to the row's own built-in look.
+	 *
+	 * @return {void}
+	 */
+	it('previews a dangling alias as empty', () => {
+		expect(
+			ROWLAYOUT_PRESET.preview({ background: '{semantic.color.gone}', border: '', borderRadius: '' }, {})
+		).toEqual({
+			background: '',
+			border: '',
+			borderRadius: '',
+		});
+	});
+
+	/**
+	 * The slab is two nested elements so the preset's background can sit above the transparency checker
+	 * — a single element cannot layer them in that order. The frame carries the border color and radius,
+	 * the fill carries the background.
+	 *
+	 * @return {void}
+	 */
+	it('renders the background on a fill nested inside the framed slab', () => {
+		const frame = ROWLAYOUT_PRESET.renderPreview({
+			id: 'muted',
+			label: 'Muted',
+			preview: { background: '#F7FAFC', border: '#E2E8F0', borderRadius: '0.5rem' },
+		});
+		const fill = frame.props.children;
+
+		expect(frame.props.className).toBe('kadence-blocks-style-library__rowlayout-preset-preview');
+		expect(frame.props.style.borderColor).toBe('#E2E8F0');
+		expect(frame.props.style.borderRadius).toBe('0.5rem');
+		// The frame must not paint the background itself, or it would cover its own checker.
+		expect(frame.props.style.background).toBeUndefined();
+
+		expect(fill.props.className).toBe('kadence-blocks-style-library__rowlayout-preset-preview-fill');
+		expect(fill.props.style.background).toBe('#F7FAFC');
+	});
+
+	/**
+	 * An unresolved border still draws a visible edge — the row's own shipped border color — so a preset
+	 * whose background matches the page does not read as a blank gap in the list.
+	 *
+	 * @return {void}
+	 */
+	it('falls back to the row border color when the preset resolves none', () => {
+		const frame = ROWLAYOUT_PRESET.renderPreview({
+			id: 'bare',
+			label: 'Bare',
+			preview: { background: '', border: '', borderRadius: '' },
+		});
+
+		expect(frame.props.style.borderColor).toBe('#E2E8F0');
+		// An unresolved radius/background is left absent rather than invented, so the stylesheet's own
+		// square-cornered, checkered slab shows through.
+		expect(frame.props.style.borderRadius).toBeUndefined();
+		expect(frame.props.children.props.style.background).toBeUndefined();
+	});
+
+	/**
+	 * The row binds no hover property, so it declares no tabs and `PresetSidebar` renders the field area
+	 * bare.
+	 *
+	 * @return {void}
+	 */
+	it('declares no state tabs', () => {
+		expect(ROWLAYOUT_PRESET.tabs).toBeUndefined();
+	});
+
+	/**
+	 * The schema edits exactly the bound surface: two token-color fields and a radius picker narrowed to
+	 * the radius scale, all writing token ids rather than literals.
+	 *
+	 * @return {void}
+	 */
+	it('builds panels covering every bound property', () => {
+		const { panels } = ROWLAYOUT_PRESET.schemaFor();
+
+		const paths = panels.flatMap((panel) => panel.fields.map((field) => field.path));
+		const types = panels.flatMap((panel) => panel.fields.map((field) => field.type));
+
+		expect(paths).toEqual(['tokens.background', 'tokens.border', 'tokens.borderRadius']);
+		expect(types).toEqual(['token-color-select', 'token-color-select', 'radius']);
+
+		// Every type the schema names must be one the registry can render.
+		types.forEach((type) => expect(FIELD_TYPES).toHaveProperty(type));
+
+		const radius = panels[1].fields[0];
+
+		expect(radius.tokenType).toBe('dimension');
+		expect(radius.role).toBe('radius');
+	});
+
+	/**
+	 * The block's own radius control is per-device (`tabletBorderRadius`/`mobileBorderRadius`, both
+	 * declared on the binding), so the preset field has to be too — otherwise a preset could not
+	 * reproduce a look a site owner had already built with that control.
+	 *
+	 * @return {void}
+	 */
+	it('makes the radius field responsive, and of a type that can be', () => {
+		const radius = ROWLAYOUT_PRESET.schemaFor().panels[1].fields[0];
+
+		expect(radius.responsive).toBe(true);
+		expect(RESPONSIVE_CAPABLE_FIELD_TYPES).toContain(radius.type);
+	});
+
+	/**
+	 * Background and border are single non-responsive pickers: the row's background attribute has no
+	 * per-device counterpart, and `token-color-select` carries no breakpoint switcher to drive one, so
+	 * marking either responsive would write an override its own UI could never read back.
+	 *
+	 * @return {void}
+	 */
+	it('leaves the color fields non-responsive', () => {
+		ROWLAYOUT_PRESET.schemaFor().panels[0].fields.forEach((field) => {
+			expect(field.responsive).toBeUndefined();
+			expect(RESPONSIVE_CAPABLE_FIELD_TYPES).not.toContain(field.type);
+		});
+	});
+});
+
+describe('RowLayoutScreen registration', () => {
+	/**
+	 * The app never imports the screen component directly — importing the module is what registers it
+	 * on the public filter, exactly as a third-party screen would register itself.
+	 *
+	 * @return {void}
+	 */
+	it('registers itself on the preset-screens filter with a settings panel', () => {
+		require('../components/pages/RowLayoutScreen');
+
+		const screens = applyFilters(PRESET_SCREENS_FILTER, {});
+
+		expect(screens[ROWLAYOUT_BLOCK]).toBeDefined();
+		expect(screens[ROWLAYOUT_BLOCK].SettingsPanel).toBeDefined();
+	});
+});

--- a/src/style-library/__tests__/rowlayout-preset.test.js
+++ b/src/style-library/__tests__/rowlayout-preset.test.js
@@ -22,7 +22,7 @@ describe('ROWLAYOUT_PRESET', () => {
 	});
 
 	/**
-	 * The config names the Row Layout block itself, which owns the background/border/radius attributes.
+	 * The config names the Row Layout block itself, which owns the background and radius attributes.
 	 *
 	 * @return {void}
 	 */
@@ -39,32 +39,29 @@ describe('ROWLAYOUT_PRESET', () => {
 	 */
 	it('reads its bound surface live from the feed', () => {
 		window.kadenceDesignTokens = {
-			presets: { 'kadence/rowlayout': { properties: ['background', 'border', 'borderRadius'] } },
+			presets: { 'kadence/rowlayout': { properties: ['background', 'borderRadius'] } },
 		};
 
-		expect(ROWLAYOUT_PRESET.properties).toEqual(['background', 'border', 'borderRadius']);
+		expect(ROWLAYOUT_PRESET.properties).toEqual(['background', 'borderRadius']);
 	});
 
 	/**
-	 * The preview resolves all three bound properties through the feed's value map, aliases included.
+	 * The preview resolves both bound properties through the feed's value map, aliases included.
 	 *
 	 * @return {void}
 	 */
-	it('resolves the preview background, border and radius from stored aliases', () => {
+	it('resolves the preview background and radius from stored aliases', () => {
 		const values = {
 			'semantic.color.rowlayout-bg': 'transparent',
-			'semantic.color.border': '#E2E8F0',
 			'semantic.radius.rowlayout': '0',
 		};
 		const tokens = {
 			background: '{semantic.color.rowlayout-bg}',
-			border: '{semantic.color.border}',
 			borderRadius: '{semantic.radius.rowlayout}',
 		};
 
 		expect(ROWLAYOUT_PRESET.preview(tokens, values)).toEqual({
 			background: 'transparent',
-			border: '#E2E8F0',
 			borderRadius: '0',
 		});
 	});
@@ -76,19 +73,16 @@ describe('ROWLAYOUT_PRESET', () => {
 	 * @return {void}
 	 */
 	it('previews a dangling alias as empty', () => {
-		expect(
-			ROWLAYOUT_PRESET.preview({ background: '{semantic.color.gone}', border: '', borderRadius: '' }, {})
-		).toEqual({
+		expect(ROWLAYOUT_PRESET.preview({ background: '{semantic.color.gone}', borderRadius: '' }, {})).toEqual({
 			background: '',
-			border: '',
 			borderRadius: '',
 		});
 	});
 
 	/**
 	 * The slab is two nested elements so the preset's background can sit above the transparency checker
-	 * — a single element cannot layer them in that order. The frame carries the border color and radius,
-	 * the fill carries the background.
+	 * — a single element cannot layer them in that order. The frame carries the radius, the fill carries
+	 * the background.
 	 *
 	 * @return {void}
 	 */
@@ -96,13 +90,14 @@ describe('ROWLAYOUT_PRESET', () => {
 		const frame = ROWLAYOUT_PRESET.renderPreview({
 			id: 'muted',
 			label: 'Muted',
-			preview: { background: '#F7FAFC', border: '#E2E8F0', borderRadius: '0.5rem' },
+			preview: { background: '#F7FAFC', borderRadius: '0.5rem' },
 		});
 		const fill = frame.props.children;
 
 		expect(frame.props.className).toBe('kadence-blocks-style-library__rowlayout-preset-preview');
-		expect(frame.props.style.borderColor).toBe('#E2E8F0');
 		expect(frame.props.style.borderRadius).toBe('0.5rem');
+		// The frame's edge is the stylesheet's neutral hairline; a preset holds no border color.
+		expect(frame.props.style.borderColor).toBeUndefined();
 		// The frame must not paint the background itself, or it would cover its own checker.
 		expect(frame.props.style.background).toBeUndefined();
 
@@ -111,21 +106,18 @@ describe('ROWLAYOUT_PRESET', () => {
 	});
 
 	/**
-	 * An unresolved border still draws a visible edge — the row's own shipped border color — so a preset
-	 * whose background matches the page does not read as a blank gap in the list.
+	 * An unresolved value is left absent rather than invented, so the stylesheet's own square-cornered,
+	 * checkered slab shows through and the row still reads as a discrete shape in the list.
 	 *
 	 * @return {void}
 	 */
-	it('falls back to the row border color when the preset resolves none', () => {
+	it('leaves unresolved values absent rather than inventing them', () => {
 		const frame = ROWLAYOUT_PRESET.renderPreview({
 			id: 'bare',
 			label: 'Bare',
-			preview: { background: '', border: '', borderRadius: '' },
+			preview: { background: '', borderRadius: '' },
 		});
 
-		expect(frame.props.style.borderColor).toBe('#E2E8F0');
-		// An unresolved radius/background is left absent rather than invented, so the stylesheet's own
-		// square-cornered, checkered slab shows through.
 		expect(frame.props.style.borderRadius).toBeUndefined();
 		expect(frame.props.children.props.style.background).toBeUndefined();
 	});
@@ -141,19 +133,22 @@ describe('ROWLAYOUT_PRESET', () => {
 	});
 
 	/**
-	 * The schema edits exactly the bound surface: two token-color fields and a radius picker narrowed to
-	 * the radius scale, all writing token ids rather than literals.
+	 * The schema edits exactly the bound surface and nothing beyond it: a token-color field for the
+	 * background and a radius picker narrowed to the radius scale, both writing token ids rather than
+	 * literals. No border-color field — the row's border output takes `render_border_styles()`'s
+	 * shorthand path, which no block-default `border-color` rule can reach, so the field would save a
+	 * value that changes nothing on the page.
 	 *
 	 * @return {void}
 	 */
-	it('builds panels covering every bound property', () => {
+	it('builds panels covering every bound property and nothing more', () => {
 		const { panels } = ROWLAYOUT_PRESET.schemaFor();
 
 		const paths = panels.flatMap((panel) => panel.fields.map((field) => field.path));
 		const types = panels.flatMap((panel) => panel.fields.map((field) => field.type));
 
-		expect(paths).toEqual(['tokens.background', 'tokens.border', 'tokens.borderRadius']);
-		expect(types).toEqual(['token-color-select', 'token-color-select', 'radius']);
+		expect(paths).toEqual(['tokens.background', 'tokens.borderRadius']);
+		expect(types).toEqual(['token-color-select', 'radius']);
 
 		// Every type the schema names must be one the registry can render.
 		types.forEach((type) => expect(FIELD_TYPES).toHaveProperty(type));
@@ -179,13 +174,13 @@ describe('ROWLAYOUT_PRESET', () => {
 	});
 
 	/**
-	 * Background and border are single non-responsive pickers: the row's background attribute has no
-	 * per-device counterpart, and `token-color-select` carries no breakpoint switcher to drive one, so
-	 * marking either responsive would write an override its own UI could never read back.
+	 * Background is a single non-responsive picker: the row's background attribute has no per-device
+	 * counterpart, and `token-color-select` carries no breakpoint switcher to drive one, so marking it
+	 * responsive would write an override its own UI could never read back.
 	 *
 	 * @return {void}
 	 */
-	it('leaves the color fields non-responsive', () => {
+	it('leaves the color field non-responsive', () => {
 		ROWLAYOUT_PRESET.schemaFor().panels[0].fields.forEach((field) => {
 			expect(field.responsive).toBeUndefined();
 			expect(RESPONSIVE_CAPABLE_FIELD_TYPES).not.toContain(field.type);

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -31,6 +31,7 @@ import { IconSizesScreen } from '../components/pages/IconSizesScreen';
 import { ShadowScreen } from '../components/pages/ShadowScreen';
 import '../components/pages/ButtonScreen';
 import '../components/pages/SingleIconScreen';
+import '../components/pages/RowLayoutScreen';
 import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
 import { useLibraries } from '../hooks/use-libraries';

--- a/src/style-library/components/pages/RowLayoutScreen.js
+++ b/src/style-library/components/pages/RowLayoutScreen.js
@@ -1,0 +1,46 @@
+/**
+ * The Row Layout preset screen: `PresetScreen` does the work and `presets/rowlayout-preset.js`
+ * describes the block, so this file only binds the two together and registers the screen. Its
+ * settings panel is `RowLayoutSettings`, assigned below as `RowLayoutScreen.SettingsPanel`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { PresetScreen } from './PresetScreen';
+import { RowLayoutSettings } from './RowLayoutSettings';
+import { ROWLAYOUT_PRESET, ROWLAYOUT_BLOCK } from '../../presets/rowlayout-preset';
+import { PRESET_SCREENS_FILTER } from '../../constants/screens';
+import './RowLayoutScreen.scss';
+
+/**
+ * Render the Row Layout preset screen.
+ *
+ * @param {Object} props The screen props (`label`, `route`, `navigate`, `library`).
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The screen body.
+ */
+export function RowLayoutScreen(props) {
+	return <PresetScreen {...props} preset={ROWLAYOUT_PRESET} />;
+}
+
+RowLayoutScreen.SettingsPanel = RowLayoutSettings;
+
+/**
+ * Register the Row Layout screen for `kadence/rowlayout` on the public preset-screens filter,
+ * exactly as a third party would — the app never imports this component directly, so this
+ * module-scope call is the only registration path.
+ *
+ * @since TBD
+ */
+addFilter(PRESET_SCREENS_FILTER, 'kadence-blocks/style-library-rowlayout-screen', (screens) => ({
+	...screens,
+	[ROWLAYOUT_BLOCK]: RowLayoutScreen,
+}));

--- a/src/style-library/components/pages/RowLayoutScreen.scss
+++ b/src/style-library/components/pages/RowLayoutScreen.scss
@@ -1,0 +1,54 @@
+// The slab is its own shape (wide and short, standing in for a section band) rather than the shared
+// framed square, so this screen relaxes `ListRow`'s default 80px preview slot — the Button, Spacing,
+// Icon Sizes and Shadow slot-override precedent.
+.kadence-blocks-style-library__rowlayout-screen .kadence-blocks-style-library__list-row-preview {
+	width: auto;
+	height: auto;
+	border: 0;
+	background: transparent;
+	overflow: visible;
+}
+
+// Preset names are full words ("Muted Band"), not the short numeric labels the shared 4rem column
+// was sized for.
+.kadence-blocks-style-library__rowlayout-screen .kadence-blocks-style-library__list-row-label {
+	width: 15rem;
+}
+
+// The live slab's frame and checker. Proportions matter here rather than being decorative: a Row
+// Layout is always full-width and short relative to its width, and a corner radius reads very
+// differently at those proportions than on a square swatch, so the preview keeps a band's aspect.
+//
+// The checker is this element's own background because the row's shipped background really is
+// transparent, and against the list's white surface a transparent background and a white one are
+// indistinguishable — every unstyled preset would look like it had set white. The preset's own
+// background is painted by the nested fill below, which is a separate element for the one reason
+// that a single element cannot layer them in this order: a background image always paints above its
+// own background color.
+.kadence-blocks-style-library__rowlayout-preset-preview {
+	position: relative;
+	display: block;
+	box-sizing: border-box;
+	width: 7.5rem;
+	height: 2.75rem;
+	border: var(--kb-sl-border-width-input) solid var(--kb-sl-color-gray-200);
+	background-color: #fff;
+	background-image: repeating-conic-gradient(var(--kb-sl-color-gray-200) 0% 25%, transparent 0% 50%);
+	background-size: 0.75rem 0.75rem;
+	transition:
+		border-color 300ms ease,
+		border-radius 300ms ease;
+}
+
+// The preset's resolved background, laid over the checker. Inset by the frame's own border rather
+// than by a guessed value, and inheriting the radius so a rounded preset does not show square
+// corners of fill poking past its frame.
+.kadence-blocks-style-library__rowlayout-preset-preview-fill {
+	position: absolute;
+	inset: 0;
+	display: block;
+	border-radius: inherit;
+	transition:
+		background-color 300ms ease,
+		border-radius 300ms ease;
+}

--- a/src/style-library/components/pages/RowLayoutSettings.js
+++ b/src/style-library/components/pages/RowLayoutSettings.js
@@ -1,0 +1,29 @@
+/**
+ * The Row Layout preset's settings sidebar: `PresetSidebar` does the work, this binds the block's
+ * config to it.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { PresetSidebar } from './PresetSidebar';
+import { usePresetScreen } from '../../hooks/use-preset-screen';
+import { ROWLAYOUT_PRESET } from '../../presets/rowlayout-preset';
+
+/**
+ * Render the Row Layout preset's settings sidebar.
+ *
+ * @param {Object}   props          The component props.
+ * @param {Object}   props.route    The current route (`{ screen, item }`).
+ * @param {Function} props.navigate The route navigator.
+ * @param {Object}   props.library  The design-tokens feed hook's return value.
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The sidebar, or null while there is no open preset to edit.
+ */
+export function RowLayoutSettings({ route, navigate, library }) {
+	const screen = usePresetScreen(library, ROWLAYOUT_PRESET);
+
+	return <PresetSidebar route={route} navigate={navigate} screen={screen} preset={ROWLAYOUT_PRESET} />;
+}

--- a/src/style-library/helpers/presets.js
+++ b/src/style-library/helpers/presets.js
@@ -75,7 +75,6 @@ export function getPresetProperties(block) {
 }
 
 /**
-/**
  * Convert a stored alias to its bare dot-path id. A value that is not brace-wrapped (a literal) is
  * returned verbatim.
  *

--- a/src/style-library/presets/rowlayout-preset.js
+++ b/src/style-library/presets/rowlayout-preset.js
@@ -25,14 +25,6 @@ import { getPresetProperties, resolveTokenValue } from '../helpers/presets';
 export const ROWLAYOUT_BLOCK = 'kadence/rowlayout';
 
 /**
- * The row's built-in border color, used to draw the preview's edge when the preset's border does not
- * resolve — `semantic.color.border`'s own shipped value.
- *
- * @since TBD
- */
-const ROW_BORDER_FALLBACK = '#E2E8F0';
-
-/**
  * The row's built-in corner radius, matching `semantic.radius.rowlayout` (square corners).
  *
  * @since TBD
@@ -42,11 +34,10 @@ const ROW_RADIUS_FALLBACK = ['0', '0', '0', '0'];
 /**
  * Build a row's preview from its stored tokens.
  *
- * The row's whole bound surface is a background, a border color and a radius, so all three are
- * previewed. Border is a COLOR only: the binding owns the `borderStyle` composite's color axis and
- * nothing else, because the row's border width and style stay with the block's own control. The
- * preview therefore draws a fixed hairline in the preset's color rather than implying the preset
- * sets a thickness.
+ * The row's whole bound surface is a background and a radius, so both are previewed. Border color is
+ * deliberately not part of that surface — see the row's `preset_bindings` declaration for why a
+ * color-only border binding can never reach the page — so the preview's edge is a neutral frame from
+ * the stylesheet rather than anything the preset holds.
  *
  * @param {Record<string, *>}      tokens       The preset's stored token map.
  * @param {Record<string, string>} values       The feed's resolved value map.
@@ -54,19 +45,18 @@ const ROW_RADIUS_FALLBACK = ['0', '0', '0', '0'];
  *
  * @since TBD
  *
- * @return {{background: string, border: string, borderRadius: string}} The preview.
+ * @return {{background: string, borderRadius: string}} The preview.
  */
 function preview(tokens, values, breakpoint) {
 	return {
 		background: resolveTokenValue(values, tokens.background, breakpoint),
-		border: resolveTokenValue(values, tokens.border, breakpoint),
 		borderRadius: resolveTokenValue(values, tokens.borderRadius, breakpoint),
 	};
 }
 
 /**
  * The row's live preview: a wide, short slab standing in for a section band, drawn at the row's
- * resolved background, border color and radius.
+ * resolved background and radius.
  *
  * A slab rather than a square because a Row Layout is always full-width and short relative to its
  * width, and a corner radius reads very differently at those proportions than on a square swatch.
@@ -77,7 +67,7 @@ function preview(tokens, values, breakpoint) {
  * color), and against the list's white surface a transparent background and a white one would
  * otherwise be indistinguishable.
  *
- * @param {{id: string, label: string, preview: {background: string, border: string, borderRadius: string}}} row The row descriptor.
+ * @param {{id: string, label: string, preview: {background: string, borderRadius: string}}} row The row descriptor.
  *
  * @since TBD
  *
@@ -87,13 +77,7 @@ function renderPreview(row) {
 	const radius = row.preview.borderRadius || undefined;
 
 	return (
-		<span
-			className="kadence-blocks-style-library__rowlayout-preset-preview"
-			style={{
-				borderColor: row.preview.border || ROW_BORDER_FALLBACK,
-				borderRadius: radius,
-			}}
-		>
+		<span className="kadence-blocks-style-library__rowlayout-preset-preview" style={{ borderRadius: radius }}>
 			<span
 				className="kadence-blocks-style-library__rowlayout-preset-preview-fill"
 				style={{ background: row.preview.background || undefined }}
@@ -109,9 +93,13 @@ function renderPreview(row) {
  * Radius uses the responsive `radius` field because the block declares `tabletBorderRadius`/
  * `mobileBorderRadius` and its own control is per-device — a preset that could only say one radius
  * for every breakpoint could not reproduce a look a site owner had already built by hand. Background
- * and border are single non-responsive pickers: the row's background attribute has no per-device
- * counterpart, and the border binding owns one axis of a composite whose width and style are not
- * the preset's to set.
+ * is a single non-responsive picker: the row's background attribute has no per-device counterpart,
+ * and `token-color-select` carries no breakpoint switcher to drive one.
+ *
+ * There is no border-color field, and its absence is deliberate rather than an omission: the row's
+ * border output takes `render_border_styles()`'s shorthand path, which no block-default `border-color`
+ * rule can reach. Offering the field would save a value that changes nothing on the page. See the
+ * row's `preset_bindings` declaration.
  *
  * @since TBD
  *
@@ -128,11 +116,6 @@ function schemaFor() {
 						type: 'token-color-select',
 						path: 'tokens.background',
 						label: __('Background', 'kadence-blocks'),
-					},
-					{
-						type: 'token-color-select',
-						path: 'tokens.border',
-						label: __('Border Color', 'kadence-blocks'),
 					},
 				],
 			},

--- a/src/style-library/presets/rowlayout-preset.js
+++ b/src/style-library/presets/rowlayout-preset.js
@@ -1,0 +1,182 @@
+/**
+ * Everything specific to the `kadence/rowlayout` preset screen, in one place: the block name, the
+ * bound property surface, the row preview, and the settings schema.
+ *
+ * The generic preset machinery — `helpers/presets.js`, `usePresetScreen`, `PresetSidebar` — reads
+ * this config and knows nothing else about rows. See `src/style-library/README.md`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getPresetProperties, resolveTokenValue } from '../helpers/presets';
+
+/**
+ * The block name this screen edits — the single JS spelling, shared by the screen registration and
+ * the config below so the two can never drift.
+ *
+ * @since TBD
+ */
+export const ROWLAYOUT_BLOCK = 'kadence/rowlayout';
+
+/**
+ * The row's built-in border color, used to draw the preview's edge when the preset's border does not
+ * resolve — `semantic.color.border`'s own shipped value.
+ *
+ * @since TBD
+ */
+const ROW_BORDER_FALLBACK = '#E2E8F0';
+
+/**
+ * The row's built-in corner radius, matching `semantic.radius.rowlayout` (square corners).
+ *
+ * @since TBD
+ */
+const ROW_RADIUS_FALLBACK = ['0', '0', '0', '0'];
+
+/**
+ * Build a row's preview from its stored tokens.
+ *
+ * The row's whole bound surface is a background, a border color and a radius, so all three are
+ * previewed. Border is a COLOR only: the binding owns the `borderStyle` composite's color axis and
+ * nothing else, because the row's border width and style stay with the block's own control. The
+ * preview therefore draws a fixed hairline in the preset's color rather than implying the preset
+ * sets a thickness.
+ *
+ * @param {Record<string, *>}      tokens       The preset's stored token map.
+ * @param {Record<string, string>} values       The feed's resolved value map.
+ * @param {string}                 [breakpoint] The breakpoint to resolve responsive values at.
+ *
+ * @since TBD
+ *
+ * @return {{background: string, border: string, borderRadius: string}} The preview.
+ */
+function preview(tokens, values, breakpoint) {
+	return {
+		background: resolveTokenValue(values, tokens.background, breakpoint),
+		border: resolveTokenValue(values, tokens.border, breakpoint),
+		borderRadius: resolveTokenValue(values, tokens.borderRadius, breakpoint),
+	};
+}
+
+/**
+ * The row's live preview: a wide, short slab standing in for a section band, drawn at the row's
+ * resolved background, border color and radius.
+ *
+ * A slab rather than a square because a Row Layout is always full-width and short relative to its
+ * width, and a corner radius reads very differently at those proportions than on a square swatch.
+ * The background is deliberately allowed to resolve to `transparent` — that is the row's real
+ * shipped default — which is why the slab is two nested elements rather than one: the outer carries
+ * the frame and a checker, the inner carries the preset's background on top of it. Painting both onto
+ * one element cannot work in either order (a background image always sits above its own background
+ * color), and against the list's white surface a transparent background and a white one would
+ * otherwise be indistinguishable.
+ *
+ * @param {{id: string, label: string, preview: {background: string, border: string, borderRadius: string}}} row The row descriptor.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The preview element.
+ */
+function renderPreview(row) {
+	const radius = row.preview.borderRadius || undefined;
+
+	return (
+		<span
+			className="kadence-blocks-style-library__rowlayout-preset-preview"
+			style={{
+				borderColor: row.preview.border || ROW_BORDER_FALLBACK,
+				borderRadius: radius,
+			}}
+		>
+			<span
+				className="kadence-blocks-style-library__rowlayout-preset-preview-fill"
+				style={{ background: row.preview.background || undefined }}
+			/>
+		</span>
+	);
+}
+
+/**
+ * The settings schema. The row declares no tabs: it binds no hover property, so there is no second
+ * state to switch to and `PresetSidebar` renders the field area bare.
+ *
+ * Radius uses the responsive `radius` field because the block declares `tabletBorderRadius`/
+ * `mobileBorderRadius` and its own control is per-device — a preset that could only say one radius
+ * for every breakpoint could not reproduce a look a site owner had already built by hand. Background
+ * and border are single non-responsive pickers: the row's background attribute has no per-device
+ * counterpart, and the border binding owns one axis of a composite whose width and style are not
+ * the preset's to set.
+ *
+ * @since TBD
+ *
+ * @return {{panels: Array<Object>}} The settings-form schema.
+ */
+function schemaFor() {
+	return {
+		panels: [
+			{
+				id: 'color',
+				title: __('Color', 'kadence-blocks'),
+				fields: [
+					{
+						type: 'token-color-select',
+						path: 'tokens.background',
+						label: __('Background', 'kadence-blocks'),
+					},
+					{
+						type: 'token-color-select',
+						path: 'tokens.border',
+						label: __('Border Color', 'kadence-blocks'),
+					},
+				],
+			},
+			{
+				id: 'border',
+				title: __('Border', 'kadence-blocks'),
+				fields: [
+					{
+						type: 'radius',
+						tokenType: 'dimension',
+						role: 'radius',
+						responsive: true,
+						path: 'tokens.borderRadius',
+						label: __('Radius', 'kadence-blocks'),
+						// Square corners, which is what an un-preset row renders and what
+						// `semantic.radius.rowlayout` holds. Shown muted so an unset field reports the radius
+						// the row really has rather than reading as empty.
+						defaultValue: ROW_RADIUS_FALLBACK,
+					},
+				],
+			},
+		],
+	};
+}
+
+/**
+ * The Row Layout preset screen's whole configuration, passed to the generic preset machinery.
+ *
+ * `properties` is a getter rather than a snapshot, for the same reason the Button's is: the config is
+ * frozen at module evaluation, before the localized feed is guaranteed to exist, so a snapshot taken
+ * here could throw or go stale.
+ *
+ * @since TBD
+ */
+export const ROWLAYOUT_PRESET = Object.freeze({
+	block: ROWLAYOUT_BLOCK,
+	get properties() {
+		return getPresetProperties(ROWLAYOUT_BLOCK);
+	},
+	slugBase: 'row',
+	addLabel: __('Add Row Style', 'kadence-blocks'),
+	newLabel: __('New Row Style', 'kadence-blocks'),
+	className: 'kadence-blocks-style-library__rowlayout-screen',
+	preview,
+	renderPreview,
+	schemaFor,
+});

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/PresetNavTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/PresetNavTest.php
@@ -28,9 +28,9 @@ final class PresetNavTest extends TestCase {
 	}
 
 	/**
-	 * Every shipped nav entry carries its declared Style Library section label ("Button", "Icon"),
-	 * never the picker control's own label — both blocks declare that as "Style". Order is
-	 * registration order, which is declaration order in `declarations.php`.
+	 * Every shipped nav entry carries its declared Style Library section label ("Button", "Row Layout",
+	 * "Icon"), never the picker control's own label — every one of those blocks declares that as
+	 * "Style". Order is registration order, which is declaration order in `declarations.php`.
 	 *
 	 * @return void
 	 */
@@ -42,6 +42,10 @@ final class PresetNavTest extends TestCase {
 				[
 					'block' => 'kadence/singlebtn',
 					'label' => 'Button',
+				],
+				[
+					'block' => 'kadence/rowlayout',
+					'label' => 'Row Layout',
 				],
 				[
 					'block' => 'kadence/single-icon',
@@ -239,8 +243,6 @@ final class PresetNavTest extends TestCase {
 	 */
 	public function defaultLookOnlyBlockProvider(): Generator {
 		yield 'image' => [ 'block' => 'kadence/image' ];
-
-		yield 'rowlayout' => [ 'block' => 'kadence/rowlayout' ];
 
 		yield 'column' => [ 'block' => 'kadence/column' ];
 

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
@@ -129,8 +129,6 @@ final class Preset_CatalogTest extends TestCase {
 	public function wiredWithoutAScreenProvider(): Generator {
 		yield 'image' => [ 'block' => 'kadence/image' ];
 
-		yield 'rowlayout' => [ 'block' => 'kadence/rowlayout' ];
-
 		yield 'column' => [ 'block' => 'kadence/column' ];
 
 		yield 'advanced heading' => [ 'block' => 'kadence/advancedheading' ];

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -179,7 +179,7 @@ final class Css_BuilderTest extends TestCase {
 		// Row Layout / Column follow the tokens through a low-specificity block-default rule: the row on the
 		// block root, the column on its inner `.kt-inside-inner-col` child. Background follows each block's own
 		// background token (which aliases the transparent primitive, so an uncustomized block stays transparent
-		// — KB's own default); border color follows the brand border token.
+		// — KB's own default).
 		$registry = $this->container->get( Token_Registry::class );
 
 		$css = $this->builder( $registry )->css();
@@ -188,7 +188,6 @@ final class Css_BuilderTest extends TestCase {
 			'.wp-block-kadence-rowlayout{' . $this->declaration( 'background-color', 'kb-row-bg', 'semantic.color.rowlayout-bg', 'transparent' ),
 			$css
 		);
-		$this->assertStringContainsString( $this->declaration( 'border-color', 'kb-row-border-color', 'semantic.color.border', '#E2E8F0' ), $css );
 		$this->assertStringContainsString( $this->declaration( 'border-radius', 'kb-row-radius', 'semantic.radius.rowlayout', '0' ), $css );
 		$this->assertStringContainsString(
 			'.wp-block-kadence-column> .kt-inside-inner-col{' . $this->declaration( 'background-color', 'kb-col-bg', 'semantic.color.column-bg', 'transparent' ),

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
@@ -165,6 +165,40 @@ final class Preset_ResolverTest extends TestCase {
 	}
 
 	/**
+	 * Every block that declares preset bindings values only properties it binds.
+	 *
+	 * A baseline preset may name a property the block does not bind, which is silently inert in the
+	 * projectors (they iterate bindings) but is NOT inert at the REST write boundary: guard_surface()
+	 * checks the EFFECTIVE preset — the stored override merged over the baseline — so the stray property
+	 * comes back with every save and rejects it as unbound. The block's shipped preset would be
+	 * permanently uneditable, and only against a running site. This asserts the surfaces agree for every
+	 * wired block rather than the Button alone.
+	 *
+	 * @return void
+	 */
+	public function testEveryShippedPresetBindingSurfaceIsConsistent(): void {
+		/** @var Token_Registry $registry */
+		$registry = $this->container->get( Token_Registry::class );
+		$blocks   = $registry->preset_binding_blocks();
+
+		$this->assertNotEmpty( $blocks, 'Preset bindings should be registered at boot.' );
+
+		foreach ( $blocks as $block ) {
+			$bindings = $registry->for_block( $block );
+
+			$this->assertNotNull( $bindings, sprintf( '%s should have registered bindings.', $block ) );
+
+			$report = $bindings->consistency( $this->resolver->value_properties( $block ) );
+
+			$this->assertSame(
+				[],
+				$report['unbound'],
+				sprintf( '%s: baseline presets value properties the block does not bind.', $block )
+			);
+		}
+	}
+
+	/**
 	 * The Advanced Text (heading) preset bindings are registered at boot and their $default resolves the full
 	 * 13-property core-design and typography surface to the shipped baseline's literal values.
 	 *


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout
:video_camera: https://www.loom.com/share/c45de6b397424fcf9434d5b8e1fe9582

Background and corner radius. Also drops an unbound `padding` property from the Row Layout and Section baseline presets, which was silently rejecting every save of those presets, and adds a test asserting every block's preset surface matches its bindings.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated Row Layout preset screen in the Style Library.
  - Added Row Layout previews with background and responsive border-radius styling.
  - Added Row Layout to the preset navigation for easier discovery and customization.

- **Bug Fixes**
  - Improved Row Layout and Column preset styling by removing bindings that did not render reliably.
  - Preserved supported background, border-radius, and spacing behavior while avoiding ineffective border output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

