### PR TITLE
[DTM] SOFT-4218 [8/16]: let a binding name the element the EDITOR renders it on

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
@@ -148,10 +148,13 @@ final class Css_Builder {
 
 	/**
 	 * Build the EDITOR-scoped version of the block-default CSS for a token library. Identical to {@see self::css()}
-	 * for every block that declares no `editor_selector` (e.g. Image, Single Icon, Row Layout, Column) — the
-	 * front-end `.wp-block-*` selector is reused verbatim. For a block that declares one (currently Advanced
-	 * Heading), the rule targets `.editor-styles-wrapper <editor_selector>` instead, so the default lands on
-	 * the element the editor actually renders the bindings against rather than the `useBlockProps()` wrapper.
+	 * for every block whose editor markup matches its saved markup (e.g. Image, Single Icon, Row Layout) — the
+	 * front-end selector is reused verbatim. Two independent declarations move it where they differ. A block
+	 * declaring a set-level `editor_selector` (currently Advanced Heading) has its rule target
+	 * `.editor-styles-wrapper <editor_selector>` instead, so the default lands on the element the editor
+	 * actually renders the bindings against rather than the `useBlockProps()` wrapper. A binding declaring
+	 * `editor_css_selector` (currently the Section's, whose editor renders `.kadence-inner-column-inner` where
+	 * `save.js` renders `.kt-inside-inner-col`) swaps the DESCENDANT suffix for that property alone.
 	 *
 	 * @since TBD
 	 *
@@ -182,8 +185,8 @@ final class Css_Builder {
 	/**
 	 * Cached version of editor_css(): same memo/object-cache mechanics as {@see self::css_for_version()}, but
 	 * keyed under a distinct `editor:` context so the editor-scoped string (which differs from the front-end
-	 * one for any block declaring an `editor_selector`) never collides with, or gets served in place of, the
-	 * front-end cache entry.
+	 * one for any block declaring an `editor_selector`, or any binding declaring an `editor_css_selector`)
+	 * never collides with, or gets served in place of, the front-end cache entry.
 	 *
 	 * @since TBD
 	 *
@@ -197,8 +200,9 @@ final class Css_Builder {
 	}
 
 	/**
-	 * Shared build for both {@see self::css()} and {@see self::editor_css()}; only the selector base differs
-	 * per block, per the presence of an `editor_selector` declaration.
+	 * Shared build for both {@see self::css()} and {@see self::editor_css()}; only the selector differs, per
+	 * block from a set-level `editor_selector` declaration and per property from a binding's
+	 * `editor_css_selector`.
 	 *
 	 * @since TBD
 	 *
@@ -278,8 +282,10 @@ final class Css_Builder {
 					continue;
 				}
 
-				$var      = $this->registry->css_var_for( $token );
-				$suffix   = $this->selector_suffix( $binding->css_selector() );
+				$var    = $this->registry->css_var_for( $token );
+				$suffix = $this->selector_suffix(
+					$editor ? $binding->editor_css_selector() : $binding->css_selector()
+				);
 
 				$by_suffix[ $suffix ][] = $prop . ':' . $this->declaration_value( $binding, $var, $literal );
 			}

--- a/includes/resources/Design_Tokens/Registry/Binding.php
+++ b/includes/resources/Design_Tokens/Registry/Binding.php
@@ -100,6 +100,26 @@ final class Binding {
 	private const CSS_SELECTOR = 'css_selector';
 
 	/**
+	 * Inline target: the selector suffix to use instead of `css_selector` when the block-default-CSS
+	 * projector is building for the editor canvas, for a block whose editor markup renders the bound
+	 * property on a DIFFERENT descendant than its saved markup does (the Section renders
+	 * `.kadence-inner-column-inner` while `save.js` renders `.kt-inside-inner-col`). Without it the
+	 * front-end suffix is reused in the editor, where it matches nothing, and the property silently keeps
+	 * its editor look while the front end follows the token.
+	 *
+	 * This is the per-property counterpart to {@see Preset_Bindings::$editor_selector}, which swaps the
+	 * block ROOT rather than the descendant suffix. The two compose, and neither substitutes for the
+	 * other: a block whose editor root differs declares that one, a block whose editor descendant differs
+	 * declares this one. Optional; `css_selector` is reused in the editor when omitted, which is the
+	 * right answer for every block whose two render paths agree.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const EDITOR_CSS_SELECTOR = 'editor_css_selector';
+
+	/**
 	 * Editor-only target: the block attribute the editor control for this property writes, so the
 	 * indicator layer can tell whether a control is bound to the active preset or has been overridden.
 	 * Deliberately NOT a projection target — it is excluded from STRING_TARGETS / inline_targets(), so it
@@ -147,7 +167,7 @@ final class Binding {
 	 *
 	 * @var string[]
 	 */
-	private const STRING_TARGETS = [ self::KADENCE_SLOT, self::BLOCK_ATTR, self::CSS_PROP, self::CSS_SELECTOR, self::CSS_VAR ];
+	private const STRING_TARGETS = [ self::KADENCE_SLOT, self::BLOCK_ATTR, self::CSS_PROP, self::CSS_SELECTOR, self::EDITOR_CSS_SELECTOR, self::CSS_VAR ];
 
 	/**
 	 * The block property this binding drives, e.g. "button-bg". Carried for error messages and so a
@@ -384,6 +404,22 @@ final class Binding {
 		$selector = $this->projections[ self::CSS_SELECTOR ] ?? null;
 
 		return is_string( $selector ) ? $selector : null;
+	}
+
+	/**
+	 * The selector suffix for this binding's `css_prop` rule in the EDITOR canvas: the declared
+	 * `editor_css_selector` when the block's editor markup renders the property on a different descendant
+	 * than its saved markup, and otherwise {@see self::css_selector()}, which is the right answer whenever
+	 * the two render paths agree. Inline only.
+	 *
+	 * @since TBD
+	 *
+	 * @return string|null
+	 */
+	public function editor_css_selector(): ?string {
+		$selector = $this->projections[ self::EDITOR_CSS_SELECTOR ] ?? null;
+
+		return is_string( $selector ) ? $selector : $this->css_selector();
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -761,36 +761,46 @@ return [
 			// (the way semantic.spacing.media-padding seeds the image's at 0) — a column renders no padding
 			// today, so seeding it from a non-zero spacing step would indent every column on the site at
 			// upgrade. That belongs with the Section preset screen.
+			// Every binding below declares an `editor_css_selector` as well, because the column is the one
+			// wired block whose two render paths disagree about the element: `save.js` renders
+			// `.kt-inside-inner-col` and the editor renders `.kadence-inner-column-inner`. The front-end class
+			// does not exist in the canvas at all, so without the override each rule would match nothing there
+			// and a column's default look (and any selected preset) would reach the front end while the editor
+			// showed the block's own unstyled markup. The editor paints its own value inline on that element,
+			// which beats any stylesheet rule, so a column the user has styled by hand is unaffected either way.
 			'block'    => 'kadence/column',
 			'bindings' => [
 				'background'   => [
-					'token'        => 'semantic.color.column-bg',
-					'css_prop'     => 'background-color',
-					'css_selector' => '> .kt-inside-inner-col',
-					'css_var'      => 'kb-col-bg',
-					'control_attr' => 'background',
+					'token'               => 'semantic.color.column-bg',
+					'css_prop'            => 'background-color',
+					'css_selector'        => '> .kt-inside-inner-col',
+					'editor_css_selector' => '> .kadence-inner-column-inner',
+					'css_var'             => 'kb-col-bg',
+					'control_attr'        => 'background',
 				],
 				// The column migrates its legacy flat `border`/`borderWidth` into the nested `borderStyle`
 				// composite, exactly as the row does; this property owns that composite's color axis.
 				'border'       => [
-					'token'            => 'semantic.color.border',
-					'css_prop'         => 'border-color',
-					'css_selector'     => '> .kt-inside-inner-col',
-					'css_var'          => 'kb-col-border-color',
-					'control_attr'     => 'borderStyle',
-					'axis'             => 'border-color',
-					'responsive_attrs' => [
+					'token'               => 'semantic.color.border',
+					'css_prop'            => 'border-color',
+					'css_selector'        => '> .kt-inside-inner-col',
+					'editor_css_selector' => '> .kadence-inner-column-inner',
+					'css_var'             => 'kb-col-border-color',
+					'control_attr'        => 'borderStyle',
+					'axis'                => 'border-color',
+					'responsive_attrs'    => [
 						'tablet' => 'tabletBorderStyle',
 						'mobile' => 'mobileBorderStyle',
 					],
 				],
 				'borderRadius' => [
-					'token'            => 'semantic.radius.column',
-					'css_prop'         => 'border-radius',
-					'css_selector'     => '> .kt-inside-inner-col',
-					'css_var'          => 'kb-col-radius',
-					'control_attr'     => 'borderRadius',
-					'responsive_attrs' => [
+					'token'               => 'semantic.radius.column',
+					'css_prop'            => 'border-radius',
+					'css_selector'        => '> .kt-inside-inner-col',
+					'editor_css_selector' => '> .kadence-inner-column-inner',
+					'css_var'             => 'kb-col-radius',
+					'control_attr'        => 'borderRadius',
+					'responsive_attrs'    => [
 						'tablet' => 'tabletBorderRadius',
 						'mobile' => 'mobileBorderRadius',
 					],

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -269,6 +269,51 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
+	 * The Section renders its background, border and radius on `.kt-inside-inner-col` when saved but on
+	 * `.kadence-inner-column-inner` in the editor canvas, so its bindings declare an `editor_css_selector`
+	 * and the two builds target different descendants of the same block root. Without the override the
+	 * editor build would carry the saved-markup class, which does not exist in the canvas, and a column's
+	 * default look would reach the front end while the editor showed the block's own unstyled markup.
+	 *
+	 * @return void
+	 */
+	public function testTheEditorBuildRetargetsTheColumnRuleAtTheEditorsOwnInnerElement(): void {
+		$registry = $this->container->get( Token_Registry::class );
+
+		$editor = $this->builder( $registry )->editor_css();
+		$front  = $this->builder( $registry )->css();
+
+		$this->assertStringContainsString(
+			'.wp-block-kadence-column> .kadence-inner-column-inner{' . $this->declaration( 'background-color', 'kb-col-bg', 'semantic.color.column-bg', 'transparent' ),
+			$editor
+		);
+		$this->assertStringContainsString( $this->declaration( 'border-radius', 'kb-col-radius', 'semantic.radius.column', '0' ), $editor );
+
+		// Each build carries only its own surface's class — neither leaks the other's.
+		$this->assertStringNotContainsString( '.wp-block-kadence-column> .kt-inside-inner-col', $editor );
+		$this->assertStringNotContainsString( '.wp-block-kadence-column> .kadence-inner-column-inner', $front );
+	}
+
+	/**
+	 * A binding declaring no `editor_css_selector` reuses its front-end `css_selector` in the editor, which
+	 * is the right answer for every block whose two render paths agree — the Row Layout sits on the block
+	 * root in both, and the Image's `img` descendant exists in both.
+	 *
+	 * @return void
+	 */
+	public function testABindingWithNoEditorCssSelectorReusesItsFrontEndSelector(): void {
+		$registry = $this->container->get( Token_Registry::class );
+
+		$editor = $this->builder( $registry )->editor_css();
+
+		$this->assertStringContainsString(
+			'.wp-block-kadence-rowlayout{' . $this->declaration( 'background-color', 'kb-row-bg', 'semantic.color.rowlayout-bg', 'transparent' ),
+			$editor
+		);
+		$this->assertStringContainsString( '.wp-block-kadence-image img{', $editor );
+	}
+
+	/**
 	 * A block whose Preset_Bindings declares no `editor_selector` (e.g. Image) must emit an editor build
 	 * byte-for-byte identical to its front-end build — no `.editor-styles-wrapper` prefix and no
 	 * re-targeting — so blocks without the wrapper-div problem see zero regression from this mechanism. Uses

--- a/tests/wpunit/Resources/Design_Tokens/Registry/BindingTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/BindingTest.php
@@ -95,6 +95,56 @@ final class BindingTest extends TestCase {
 
 		$this->assertNull( $binding->css_prop() );
 		$this->assertNull( $binding->css_selector() );
+		$this->assertNull( $binding->editor_css_selector() );
+	}
+
+	/**
+	 * A declared editor_css_selector replaces css_selector for the editor build alone, for a block whose
+	 * editor markup renders the bound property on a different descendant than its saved markup does.
+	 *
+	 * @return void
+	 */
+	public function testEditorCssSelectorOverridesTheFrontEndSelector(): void {
+		$binding = Binding::from_array(
+			'background',
+			[
+				'token'               => 'semantic.color.column-bg',
+				'css_prop'            => 'background-color',
+				'css_selector'        => '> .kt-inside-inner-col',
+				'editor_css_selector' => '> .kadence-inner-column-inner',
+			]
+		);
+
+		$this->assertSame( '> .kt-inside-inner-col', $binding->css_selector() );
+		$this->assertSame( '> .kadence-inner-column-inner', $binding->editor_css_selector() );
+	}
+
+	/**
+	 * With no editor_css_selector declared, the editor reuses the front-end selector — the right answer
+	 * for every block whose two render paths agree, and what keeps the override opt-in.
+	 *
+	 * @return void
+	 */
+	public function testEditorCssSelectorFallsBackToTheFrontEndSelector(): void {
+		$binding = Binding::from_array(
+			'borderRadius',
+			[
+				'token'        => 'semantic.radius.media',
+				'css_prop'     => 'border-radius',
+				'css_selector' => ' img',
+			]
+		);
+
+		$this->assertSame( ' img', $binding->editor_css_selector() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItThrowsWhenEditorCssSelectorIsNotAString(): void {
+		$this->expectException( InvalidArgumentException::class );
+
+		Binding::from_array( 'background', [ 'editor_css_selector' => [] ] );
 	}
 
 	/**


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout
:video_camera: https://www.loom.com/share/c45de6b397424fcf9434d5b8e1fe9582

The Section renders `.kt-inside-inner-col` when saved and `.kadence-inner-column-inner` in the editor, so its bindings matched nothing in the canvas. A binding may now declare an `editor_css_selector` for the editor build alone.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved design token styling in the block editor by targeting the correct editor-specific elements.
  * Preserved existing front-end styling while preventing editor selectors from affecting front-end output.
  * Added fallback behavior for bindings without a dedicated editor selector.

* **Tests**
  * Added coverage for editor selector overrides, fallback behavior, and invalid selector values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

