### PR TITLE
[DTM] SOFT-4218 [9/16]: add the Section block preset screen

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -756,7 +756,6 @@
 						"label": "Default",
 						"tokens": {
 							"background": "{semantic.color.column-bg}",
-							"border": "{semantic.color.border}",
 							"borderRadius": "{semantic.radius.column}"
 						}
 					}

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -785,21 +785,12 @@ return [
 					'css_var'             => 'kb-col-bg',
 					'control_attr'        => 'background',
 				],
-				// The column migrates its legacy flat `border`/`borderWidth` into the nested `borderStyle`
-				// composite, exactly as the row does; this property owns that composite's color axis.
-				'border'       => [
-					'token'               => 'semantic.color.border',
-					'css_prop'            => 'border-color',
-					'css_selector'        => '> .kt-inside-inner-col',
-					'editor_css_selector' => '> .kadence-inner-column-inner',
-					'css_var'             => 'kb-col-border-color',
-					'control_attr'        => 'borderStyle',
-					'axis'                => 'border-color',
-					'responsive_attrs'    => [
-						'tablet' => 'tabletBorderStyle',
-						'mobile' => 'mobileBorderStyle',
-					],
-				],
+				// Border color is NOT a preset property, for exactly the reason it is not one on the row: the
+				// column calls Kadence_Blocks_CSS::render_border_styles() without $single_styles, so its border
+				// output is a shorthand that defaults an unset color to `transparent` and beats a block-default
+				// `border-color` rule on both surfaces. See the row's declaration above for the full account.
+				//
+				// @todo SOFT-4234: give the column a preset-able border trio.
 				'borderRadius' => [
 					'token'               => 'semantic.radius.column',
 					'css_prop'            => 'border-radius',

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -768,8 +768,15 @@ return [
 			// and a column's default look (and any selected preset) would reach the front end while the editor
 			// showed the block's own unstyled markup. The editor paints its own value inline on that element,
 			// which beats any stylesheet rule, so a column the user has styled by hand is unaffected either way.
-			'block'    => 'kadence/column',
-			'bindings' => [
+			'block'         => 'kadence/column',
+			'label'         => __( 'Style', 'kadence-blocks' ), // a picker-driven set; this is the editor control's label.
+			'style_library' => [
+				// The Style Library BLOCK PRESETS nav label — distinct from "label" above, which names the
+				// inspector's picker control, not the block. "Section" is what the block is called in the UI;
+				// "column" is only its code name.
+				'label' => __( 'Section', 'kadence-blocks' ),
+			],
+			'bindings'      => [
 				'background'   => [
 					'token'               => 'semantic.color.column-bg',
 					'css_prop'            => 'background-color',

--- a/src/style-library/__tests__/column-preset.test.js
+++ b/src/style-library/__tests__/column-preset.test.js
@@ -41,32 +41,29 @@ describe('COLUMN_PRESET', () => {
 	 */
 	it('reads its bound surface live from the feed', () => {
 		window.kadenceDesignTokens = {
-			presets: { 'kadence/column': { properties: ['background', 'border', 'borderRadius'] } },
+			presets: { 'kadence/column': { properties: ['background', 'borderRadius'] } },
 		};
 
-		expect(COLUMN_PRESET.properties).toEqual(['background', 'border', 'borderRadius']);
+		expect(COLUMN_PRESET.properties).toEqual(['background', 'borderRadius']);
 	});
 
 	/**
-	 * The preview resolves all three bound properties through the feed's value map, aliases included.
+	 * The preview resolves both bound properties through the feed's value map, aliases included.
 	 *
 	 * @return {void}
 	 */
-	it('resolves the preview background, border and radius from stored aliases', () => {
+	it('resolves the preview background and radius from stored aliases', () => {
 		const values = {
 			'semantic.color.column-bg': 'transparent',
-			'semantic.color.border': '#E2E8F0',
 			'semantic.radius.column': '0',
 		};
 		const tokens = {
 			background: '{semantic.color.column-bg}',
-			border: '{semantic.color.border}',
 			borderRadius: '{semantic.radius.column}',
 		};
 
 		expect(COLUMN_PRESET.preview(tokens, values)).toEqual({
 			background: 'transparent',
-			border: '#E2E8F0',
 			borderRadius: '0',
 		});
 	});
@@ -78,19 +75,16 @@ describe('COLUMN_PRESET', () => {
 	 * @return {void}
 	 */
 	it('previews a dangling alias as empty', () => {
-		expect(
-			COLUMN_PRESET.preview({ background: '{semantic.color.gone}', border: '', borderRadius: '' }, {})
-		).toEqual({
+		expect(COLUMN_PRESET.preview({ background: '{semantic.color.gone}', borderRadius: '' }, {})).toEqual({
 			background: '',
-			border: '',
 			borderRadius: '',
 		});
 	});
 
 	/**
 	 * The slab is two nested elements so the preset's background can sit above the transparency checker
-	 * — a single element cannot layer them in that order. The frame carries the border color and radius,
-	 * the fill carries the background.
+	 * — a single element cannot layer them in that order. The frame carries the radius, the fill carries
+	 * the background.
 	 *
 	 * @return {void}
 	 */
@@ -98,13 +92,14 @@ describe('COLUMN_PRESET', () => {
 		const frame = COLUMN_PRESET.renderPreview({
 			id: 'card',
 			label: 'Card',
-			preview: { background: '#F7FAFC', border: '#E2E8F0', borderRadius: '0.5rem' },
+			preview: { background: '#F7FAFC', borderRadius: '0.5rem' },
 		});
 		const fill = frame.props.children;
 
 		expect(frame.props.className).toBe('kadence-blocks-style-library__column-preset-preview');
-		expect(frame.props.style.borderColor).toBe('#E2E8F0');
 		expect(frame.props.style.borderRadius).toBe('0.5rem');
+		// The frame's edge is the stylesheet's neutral hairline; a preset holds no border color.
+		expect(frame.props.style.borderColor).toBeUndefined();
 		// The frame must not paint the background itself, or it would cover its own checker.
 		expect(frame.props.style.background).toBeUndefined();
 
@@ -113,21 +108,18 @@ describe('COLUMN_PRESET', () => {
 	});
 
 	/**
-	 * An unresolved border still draws a visible edge — the section's own shipped border color — so a
-	 * preset whose background matches the page does not read as a blank gap in the list.
+	 * An unresolved value is left absent rather than invented, so the stylesheet's own square-cornered,
+	 * checkered slab shows through and the row still reads as a discrete shape in the list.
 	 *
 	 * @return {void}
 	 */
-	it('falls back to the section border color when the preset resolves none', () => {
+	it('leaves unresolved values absent rather than inventing them', () => {
 		const frame = COLUMN_PRESET.renderPreview({
 			id: 'bare',
 			label: 'Bare',
-			preview: { background: '', border: '', borderRadius: '' },
+			preview: { background: '', borderRadius: '' },
 		});
 
-		expect(frame.props.style.borderColor).toBe('#E2E8F0');
-		// An unresolved radius/background is left absent rather than invented, so the stylesheet's own
-		// square-cornered, checkered slab shows through.
 		expect(frame.props.style.borderRadius).toBeUndefined();
 		expect(frame.props.children.props.style.background).toBeUndefined();
 	});
@@ -143,19 +135,22 @@ describe('COLUMN_PRESET', () => {
 	});
 
 	/**
-	 * The schema edits exactly the bound surface: two token-color fields and a radius picker narrowed to
-	 * the radius scale, all writing token ids rather than literals.
+	 * The schema edits exactly the bound surface and nothing beyond it: a token-color field for the
+	 * background and a radius picker narrowed to the radius scale, both writing token ids rather than
+	 * literals. No border-color field — the section's border output takes `render_border_styles()`'s
+	 * shorthand path, which no block-default `border-color` rule can reach, so the field would save a
+	 * value that changes nothing on the page.
 	 *
 	 * @return {void}
 	 */
-	it('builds panels covering every bound property', () => {
+	it('builds panels covering every bound property and nothing more', () => {
 		const { panels } = COLUMN_PRESET.schemaFor();
 
 		const paths = panels.flatMap((panel) => panel.fields.map((field) => field.path));
 		const types = panels.flatMap((panel) => panel.fields.map((field) => field.type));
 
-		expect(paths).toEqual(['tokens.background', 'tokens.border', 'tokens.borderRadius']);
-		expect(types).toEqual(['token-color-select', 'token-color-select', 'radius']);
+		expect(paths).toEqual(['tokens.background', 'tokens.borderRadius']);
+		expect(types).toEqual(['token-color-select', 'radius']);
 
 		// Every type the schema names must be one the registry can render.
 		types.forEach((type) => expect(FIELD_TYPES).toHaveProperty(type));
@@ -181,13 +176,13 @@ describe('COLUMN_PRESET', () => {
 	});
 
 	/**
-	 * Background and border are single non-responsive pickers: the section's background attribute has no
-	 * per-device counterpart, and `token-color-select` carries no breakpoint switcher to drive one, so
-	 * marking either responsive would write an override its own UI could never read back.
+	 * Background is a single non-responsive picker: the section's background attribute has no per-device
+	 * counterpart, and `token-color-select` carries no breakpoint switcher to drive one, so marking it
+	 * responsive would write an override its own UI could never read back.
 	 *
 	 * @return {void}
 	 */
-	it('leaves the color fields non-responsive', () => {
+	it('leaves the color field non-responsive', () => {
 		COLUMN_PRESET.schemaFor().panels[0].fields.forEach((field) => {
 			expect(field.responsive).toBeUndefined();
 			expect(RESPONSIVE_CAPABLE_FIELD_TYPES).not.toContain(field.type);

--- a/src/style-library/__tests__/column-preset.test.js
+++ b/src/style-library/__tests__/column-preset.test.js
@@ -1,0 +1,213 @@
+/* eslint-env jest */
+/**
+ * The Section (`kadence/column`) preset config — the one per-block file a preset screen needs.
+ * Everything else the screen uses (`PresetScreen`, `PresetSidebar`, `usePresetScreen`,
+ * `helpers/presets`) is generic and covered by its own suites, so this asserts only what this config
+ * contributes: the bound surface it reads, the preview it resolves, its schema, and that it registers
+ * on the public screens filter.
+ */
+import { applyFilters } from '@wordpress/hooks';
+import { COLUMN_PRESET, COLUMN_BLOCK } from '../presets/column-preset';
+import { PRESET_SCREENS_FILTER } from '../constants/screens';
+import { FIELD_TYPES, RESPONSIVE_CAPABLE_FIELD_TYPES } from '../constants/field-types';
+
+// The screen module is imported only to trigger its module-scope `addFilter`. Its two children pull in
+// the REST client (and so `@wordpress/api-fetch`, absent from this environment), which the registration
+// contract does not depend on — the generic panel and sidebar have their own suites.
+jest.mock('../components/pages/PresetScreen', () => ({ PresetScreen: () => null }));
+jest.mock('../components/pages/ColumnSettings', () => ({ ColumnSettings: () => null }));
+
+describe('COLUMN_PRESET', () => {
+	afterEach(() => {
+		delete window.kadenceDesignTokens;
+	});
+
+	/**
+	 * The config names the block by its code name. Section is the UI name and appears only in labels,
+	 * so the two must not be confused when wiring the screen to the feed.
+	 *
+	 * @return {void}
+	 */
+	it('targets the column block by its code name', () => {
+		expect(COLUMN_PRESET.block).toBe('kadence/column');
+		expect(COLUMN_BLOCK).toBe('kadence/column');
+	});
+
+	/**
+	 * `properties` is a live getter over the feed, not a snapshot, so the screen can never offer a
+	 * property the server's write guard would reject.
+	 *
+	 * @return {void}
+	 */
+	it('reads its bound surface live from the feed', () => {
+		window.kadenceDesignTokens = {
+			presets: { 'kadence/column': { properties: ['background', 'border', 'borderRadius'] } },
+		};
+
+		expect(COLUMN_PRESET.properties).toEqual(['background', 'border', 'borderRadius']);
+	});
+
+	/**
+	 * The preview resolves all three bound properties through the feed's value map, aliases included.
+	 *
+	 * @return {void}
+	 */
+	it('resolves the preview background, border and radius from stored aliases', () => {
+		const values = {
+			'semantic.color.column-bg': 'transparent',
+			'semantic.color.border': '#E2E8F0',
+			'semantic.radius.column': '0',
+		};
+		const tokens = {
+			background: '{semantic.color.column-bg}',
+			border: '{semantic.color.border}',
+			borderRadius: '{semantic.radius.column}',
+		};
+
+		expect(COLUMN_PRESET.preview(tokens, values)).toEqual({
+			background: 'transparent',
+			border: '#E2E8F0',
+			borderRadius: '0',
+		});
+	});
+
+	/**
+	 * A dangling alias previews as empty rather than as the raw alias text, so `renderPreview` can fall
+	 * back to the section's own built-in look.
+	 *
+	 * @return {void}
+	 */
+	it('previews a dangling alias as empty', () => {
+		expect(
+			COLUMN_PRESET.preview({ background: '{semantic.color.gone}', border: '', borderRadius: '' }, {})
+		).toEqual({
+			background: '',
+			border: '',
+			borderRadius: '',
+		});
+	});
+
+	/**
+	 * The slab is two nested elements so the preset's background can sit above the transparency checker
+	 * — a single element cannot layer them in that order. The frame carries the border color and radius,
+	 * the fill carries the background.
+	 *
+	 * @return {void}
+	 */
+	it('renders the background on a fill nested inside the framed slab', () => {
+		const frame = COLUMN_PRESET.renderPreview({
+			id: 'card',
+			label: 'Card',
+			preview: { background: '#F7FAFC', border: '#E2E8F0', borderRadius: '0.5rem' },
+		});
+		const fill = frame.props.children;
+
+		expect(frame.props.className).toBe('kadence-blocks-style-library__column-preset-preview');
+		expect(frame.props.style.borderColor).toBe('#E2E8F0');
+		expect(frame.props.style.borderRadius).toBe('0.5rem');
+		// The frame must not paint the background itself, or it would cover its own checker.
+		expect(frame.props.style.background).toBeUndefined();
+
+		expect(fill.props.className).toBe('kadence-blocks-style-library__column-preset-preview-fill');
+		expect(fill.props.style.background).toBe('#F7FAFC');
+	});
+
+	/**
+	 * An unresolved border still draws a visible edge — the section's own shipped border color — so a
+	 * preset whose background matches the page does not read as a blank gap in the list.
+	 *
+	 * @return {void}
+	 */
+	it('falls back to the section border color when the preset resolves none', () => {
+		const frame = COLUMN_PRESET.renderPreview({
+			id: 'bare',
+			label: 'Bare',
+			preview: { background: '', border: '', borderRadius: '' },
+		});
+
+		expect(frame.props.style.borderColor).toBe('#E2E8F0');
+		// An unresolved radius/background is left absent rather than invented, so the stylesheet's own
+		// square-cornered, checkered slab shows through.
+		expect(frame.props.style.borderRadius).toBeUndefined();
+		expect(frame.props.children.props.style.background).toBeUndefined();
+	});
+
+	/**
+	 * The section binds no hover property, so it declares no tabs and `PresetSidebar` renders the field
+	 * area bare.
+	 *
+	 * @return {void}
+	 */
+	it('declares no state tabs', () => {
+		expect(COLUMN_PRESET.tabs).toBeUndefined();
+	});
+
+	/**
+	 * The schema edits exactly the bound surface: two token-color fields and a radius picker narrowed to
+	 * the radius scale, all writing token ids rather than literals.
+	 *
+	 * @return {void}
+	 */
+	it('builds panels covering every bound property', () => {
+		const { panels } = COLUMN_PRESET.schemaFor();
+
+		const paths = panels.flatMap((panel) => panel.fields.map((field) => field.path));
+		const types = panels.flatMap((panel) => panel.fields.map((field) => field.type));
+
+		expect(paths).toEqual(['tokens.background', 'tokens.border', 'tokens.borderRadius']);
+		expect(types).toEqual(['token-color-select', 'token-color-select', 'radius']);
+
+		// Every type the schema names must be one the registry can render.
+		types.forEach((type) => expect(FIELD_TYPES).toHaveProperty(type));
+
+		const radius = panels[1].fields[0];
+
+		expect(radius.tokenType).toBe('dimension');
+		expect(radius.role).toBe('radius');
+	});
+
+	/**
+	 * The block's own radius control is per-device (`tabletBorderRadius`/`mobileBorderRadius`, both
+	 * declared on the binding), so the preset field has to be too — otherwise a preset could not
+	 * reproduce a look a site owner had already built with that control.
+	 *
+	 * @return {void}
+	 */
+	it('makes the radius field responsive, and of a type that can be', () => {
+		const radius = COLUMN_PRESET.schemaFor().panels[1].fields[0];
+
+		expect(radius.responsive).toBe(true);
+		expect(RESPONSIVE_CAPABLE_FIELD_TYPES).toContain(radius.type);
+	});
+
+	/**
+	 * Background and border are single non-responsive pickers: the section's background attribute has no
+	 * per-device counterpart, and `token-color-select` carries no breakpoint switcher to drive one, so
+	 * marking either responsive would write an override its own UI could never read back.
+	 *
+	 * @return {void}
+	 */
+	it('leaves the color fields non-responsive', () => {
+		COLUMN_PRESET.schemaFor().panels[0].fields.forEach((field) => {
+			expect(field.responsive).toBeUndefined();
+			expect(RESPONSIVE_CAPABLE_FIELD_TYPES).not.toContain(field.type);
+		});
+	});
+});
+
+describe('ColumnScreen registration', () => {
+	/**
+	 * The app never imports the screen component directly — importing the module is what registers it
+	 * on the public filter, exactly as a third-party screen would register itself.
+	 *
+	 * @return {void}
+	 */
+	it('registers itself on the preset-screens filter with a settings panel', () => {
+		require('../components/pages/ColumnScreen');
+
+		const screens = applyFilters(PRESET_SCREENS_FILTER, {});
+
+		expect(screens[COLUMN_BLOCK]).toBeDefined();
+		expect(screens[COLUMN_BLOCK].SettingsPanel).toBeDefined();
+	});
+});

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -32,6 +32,7 @@ import { ShadowScreen } from '../components/pages/ShadowScreen';
 import '../components/pages/ButtonScreen';
 import '../components/pages/SingleIconScreen';
 import '../components/pages/RowLayoutScreen';
+import '../components/pages/ColumnScreen';
 import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
 import { useLibraries } from '../hooks/use-libraries';

--- a/src/style-library/components/pages/ColumnScreen.js
+++ b/src/style-library/components/pages/ColumnScreen.js
@@ -1,0 +1,46 @@
+/**
+ * The Section preset screen: `PresetScreen` does the work and `presets/column-preset.js` describes
+ * the block, so this file only binds the two together and registers the screen. Its settings panel is
+ * `ColumnSettings`, assigned below as `ColumnScreen.SettingsPanel`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { PresetScreen } from './PresetScreen';
+import { ColumnSettings } from './ColumnSettings';
+import { COLUMN_PRESET, COLUMN_BLOCK } from '../../presets/column-preset';
+import { PRESET_SCREENS_FILTER } from '../../constants/screens';
+import './ColumnScreen.scss';
+
+/**
+ * Render the Section preset screen.
+ *
+ * @param {Object} props The screen props (`label`, `route`, `navigate`, `library`).
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The screen body.
+ */
+export function ColumnScreen(props) {
+	return <PresetScreen {...props} preset={COLUMN_PRESET} />;
+}
+
+ColumnScreen.SettingsPanel = ColumnSettings;
+
+/**
+ * Register the Section screen for `kadence/column` on the public preset-screens filter, exactly as a
+ * third party would — the app never imports this component directly, so this module-scope call is the
+ * only registration path.
+ *
+ * @since TBD
+ */
+addFilter(PRESET_SCREENS_FILTER, 'kadence-blocks/style-library-column-screen', (screens) => ({
+	...screens,
+	[COLUMN_BLOCK]: ColumnScreen,
+}));

--- a/src/style-library/components/pages/ColumnScreen.scss
+++ b/src/style-library/components/pages/ColumnScreen.scss
@@ -1,0 +1,28 @@
+@use "../../styles/mixins" as *;
+
+// The slab is its own shape (tall and narrow, standing in for a column of content) rather than the
+// shared framed square, so this screen relaxes `ListRow`'s default 80px preview slot — the Button,
+// Spacing, Icon Sizes and Shadow slot-override precedent.
+.kadence-blocks-style-library__column-screen .kadence-blocks-style-library__list-row-preview {
+	width: auto;
+	height: auto;
+	border: 0;
+	background: transparent;
+	overflow: visible;
+}
+
+// Preset names are full words ("Muted Card"), not the short numeric labels the shared 4rem column
+// was sized for.
+.kadence-blocks-style-library__column-screen .kadence-blocks-style-library__list-row-label {
+	width: 15rem;
+}
+
+// Portrait where the Row Layout's band is landscape, because that is the shape each block actually
+// takes on a page, and a corner radius reads differently at each aspect.
+.kadence-blocks-style-library__column-preset-preview {
+	@include preset-surface-preview(3.5rem, 4.5rem);
+}
+
+.kadence-blocks-style-library__column-preset-preview-fill {
+	@include preset-surface-fill;
+}

--- a/src/style-library/components/pages/ColumnSettings.js
+++ b/src/style-library/components/pages/ColumnSettings.js
@@ -1,0 +1,29 @@
+/**
+ * The Section preset's settings sidebar: `PresetSidebar` does the work, this binds the block's config
+ * to it.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { PresetSidebar } from './PresetSidebar';
+import { usePresetScreen } from '../../hooks/use-preset-screen';
+import { COLUMN_PRESET } from '../../presets/column-preset';
+
+/**
+ * Render the Section preset's settings sidebar.
+ *
+ * @param {Object}   props          The component props.
+ * @param {Object}   props.route    The current route (`{ screen, item }`).
+ * @param {Function} props.navigate The route navigator.
+ * @param {Object}   props.library  The design-tokens feed hook's return value.
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The sidebar, or null while there is no open preset to edit.
+ */
+export function ColumnSettings({ route, navigate, library }) {
+	const screen = usePresetScreen(library, COLUMN_PRESET);
+
+	return <PresetSidebar route={route} navigate={navigate} screen={screen} preset={COLUMN_PRESET} />;
+}

--- a/src/style-library/components/pages/RowLayoutScreen.scss
+++ b/src/style-library/components/pages/RowLayoutScreen.scss
@@ -1,3 +1,5 @@
+@use "../../styles/mixins" as *;
+
 // The slab is its own shape (wide and short, standing in for a section band) rather than the shared
 // framed square, so this screen relaxes `ListRow`'s default 80px preview slot — the Button, Spacing,
 // Icon Sizes and Shadow slot-override precedent.
@@ -15,40 +17,12 @@
 	width: 15rem;
 }
 
-// The live slab's frame and checker. Proportions matter here rather than being decorative: a Row
-// Layout is always full-width and short relative to its width, and a corner radius reads very
-// differently at those proportions than on a square swatch, so the preview keeps a band's aspect.
-//
-// The checker is this element's own background because the row's shipped background really is
-// transparent, and against the list's white surface a transparent background and a white one are
-// indistinguishable — every unstyled preset would look like it had set white. The preset's own
-// background is painted by the nested fill below, which is a separate element for the one reason
-// that a single element cannot layer them in this order: a background image always paints above its
-// own background color.
+// A Row Layout is always full-width and short relative to its width, and a corner radius reads very
+// differently at those proportions than on a square swatch, so the band keeps that aspect.
 .kadence-blocks-style-library__rowlayout-preset-preview {
-	position: relative;
-	display: block;
-	box-sizing: border-box;
-	width: 7.5rem;
-	height: 2.75rem;
-	border: var(--kb-sl-border-width-input) solid var(--kb-sl-color-gray-200);
-	background-color: #fff;
-	background-image: repeating-conic-gradient(var(--kb-sl-color-gray-200) 0% 25%, transparent 0% 50%);
-	background-size: 0.75rem 0.75rem;
-	transition:
-		border-color 300ms ease,
-		border-radius 300ms ease;
+	@include preset-surface-preview(7.5rem, 2.75rem);
 }
 
-// The preset's resolved background, laid over the checker. Inset by the frame's own border rather
-// than by a guessed value, and inheriting the radius so a rounded preset does not show square
-// corners of fill poking past its frame.
 .kadence-blocks-style-library__rowlayout-preset-preview-fill {
-	position: absolute;
-	inset: 0;
-	display: block;
-	border-radius: inherit;
-	transition:
-		background-color 300ms ease,
-		border-radius 300ms ease;
+	@include preset-surface-fill;
 }

--- a/src/style-library/presets/column-preset.js
+++ b/src/style-library/presets/column-preset.js
@@ -1,0 +1,178 @@
+/**
+ * Everything specific to the `kadence/column` (Section) preset screen, in one place: the block name,
+ * the bound property surface, the row preview, and the settings schema.
+ *
+ * The generic preset machinery — `helpers/presets.js`, `usePresetScreen`, `PresetSidebar` — reads
+ * this config and knows nothing else about sections. See `src/style-library/README.md`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getPresetProperties, resolveTokenValue } from '../helpers/presets';
+
+/**
+ * The block name this screen edits. The block is called Section in the UI but `kadence/column` in
+ * code, and this is the single JS spelling of the code name, shared by the screen registration and
+ * the config below so the two can never drift.
+ *
+ * @since TBD
+ */
+export const COLUMN_BLOCK = 'kadence/column';
+
+/**
+ * The section's built-in border color, used to draw the preview's edge when the preset's border does
+ * not resolve — `semantic.color.border`'s own shipped value.
+ *
+ * @since TBD
+ */
+const COLUMN_BORDER_FALLBACK = '#E2E8F0';
+
+/**
+ * The section's built-in corner radius, matching `semantic.radius.column` (square corners).
+ *
+ * @since TBD
+ */
+const COLUMN_RADIUS_FALLBACK = ['0', '0', '0', '0'];
+
+/**
+ * Build a row's preview from its stored tokens.
+ *
+ * The section's whole bound surface is a background, a border color and a radius, so all three are
+ * previewed. Border is a COLOR only: the binding owns the `borderStyle` composite's color axis and
+ * nothing else, because the section's border width and style stay with the block's own control.
+ *
+ * @param {Record<string, *>}      tokens       The preset's stored token map.
+ * @param {Record<string, string>} values       The feed's resolved value map.
+ * @param {string}                 [breakpoint] The breakpoint to resolve responsive values at.
+ *
+ * @since TBD
+ *
+ * @return {{background: string, border: string, borderRadius: string}} The preview.
+ */
+function preview(tokens, values, breakpoint) {
+	return {
+		background: resolveTokenValue(values, tokens.background, breakpoint),
+		border: resolveTokenValue(values, tokens.border, breakpoint),
+		borderRadius: resolveTokenValue(values, tokens.borderRadius, breakpoint),
+	};
+}
+
+/**
+ * The section's live preview: a tall, narrow slab drawn at the section's resolved background, border
+ * color and radius.
+ *
+ * Portrait where the Row Layout's band is landscape, because that is the shape each block actually
+ * takes on a page — a section is a column of content — and a corner radius reads differently at each
+ * aspect. The two nested elements are the shared `preset-surface` shape: the frame carries the border
+ * and a transparency checker, the fill carries the preset's background above it, which a single
+ * element cannot layer in that order since a background image always paints above its own background
+ * color. The section ships a transparent background, so without the checker every unstyled preset
+ * would look like it had set white.
+ *
+ * @param {{id: string, label: string, preview: {background: string, border: string, borderRadius: string}}} row The row descriptor.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The preview element.
+ */
+function renderPreview(row) {
+	return (
+		<span
+			className="kadence-blocks-style-library__column-preset-preview"
+			style={{
+				borderColor: row.preview.border || COLUMN_BORDER_FALLBACK,
+				borderRadius: row.preview.borderRadius || undefined,
+			}}
+		>
+			<span
+				className="kadence-blocks-style-library__column-preset-preview-fill"
+				style={{ background: row.preview.background || undefined }}
+			/>
+		</span>
+	);
+}
+
+/**
+ * The settings schema. The section declares no tabs: it binds no hover property, so there is no
+ * second state to switch to and `PresetSidebar` renders the field area bare.
+ *
+ * Radius uses the responsive `radius` field because the block declares `tabletBorderRadius`/
+ * `mobileBorderRadius` and its own control is per-device — a preset that could only say one radius
+ * for every breakpoint could not reproduce a look a site owner had already built by hand. Background
+ * and border are single non-responsive pickers: the section's background attribute has no per-device
+ * counterpart, and the border binding owns one axis of a composite whose width and style are not the
+ * preset's to set.
+ *
+ * @since TBD
+ *
+ * @return {{panels: Array<Object>}} The settings-form schema.
+ */
+function schemaFor() {
+	return {
+		panels: [
+			{
+				id: 'color',
+				title: __('Color', 'kadence-blocks'),
+				fields: [
+					{
+						type: 'token-color-select',
+						path: 'tokens.background',
+						label: __('Background', 'kadence-blocks'),
+					},
+					{
+						type: 'token-color-select',
+						path: 'tokens.border',
+						label: __('Border Color', 'kadence-blocks'),
+					},
+				],
+			},
+			{
+				id: 'border',
+				title: __('Border', 'kadence-blocks'),
+				fields: [
+					{
+						type: 'radius',
+						tokenType: 'dimension',
+						role: 'radius',
+						responsive: true,
+						path: 'tokens.borderRadius',
+						label: __('Radius', 'kadence-blocks'),
+						// Square corners, which is what an un-preset section renders and what
+						// `semantic.radius.column` holds. Shown muted so an unset field reports the radius the
+						// section really has rather than reading as empty.
+						defaultValue: COLUMN_RADIUS_FALLBACK,
+					},
+				],
+			},
+		],
+	};
+}
+
+/**
+ * The Section preset screen's whole configuration, passed to the generic preset machinery.
+ *
+ * `properties` is a getter rather than a snapshot, for the same reason the Button's is: the config is
+ * frozen at module evaluation, before the localized feed is guaranteed to exist, so a snapshot taken
+ * here could throw or go stale.
+ *
+ * @since TBD
+ */
+export const COLUMN_PRESET = Object.freeze({
+	block: COLUMN_BLOCK,
+	get properties() {
+		return getPresetProperties(COLUMN_BLOCK);
+	},
+	slugBase: 'section',
+	addLabel: __('Add Section Style', 'kadence-blocks'),
+	newLabel: __('New Section Style', 'kadence-blocks'),
+	className: 'kadence-blocks-style-library__column-screen',
+	preview,
+	renderPreview,
+	schemaFor,
+});

--- a/src/style-library/presets/column-preset.js
+++ b/src/style-library/presets/column-preset.js
@@ -26,14 +26,6 @@ import { getPresetProperties, resolveTokenValue } from '../helpers/presets';
 export const COLUMN_BLOCK = 'kadence/column';
 
 /**
- * The section's built-in border color, used to draw the preview's edge when the preset's border does
- * not resolve — `semantic.color.border`'s own shipped value.
- *
- * @since TBD
- */
-const COLUMN_BORDER_FALLBACK = '#E2E8F0';
-
-/**
  * The section's built-in corner radius, matching `semantic.radius.column` (square corners).
  *
  * @since TBD
@@ -43,9 +35,10 @@ const COLUMN_RADIUS_FALLBACK = ['0', '0', '0', '0'];
 /**
  * Build a row's preview from its stored tokens.
  *
- * The section's whole bound surface is a background, a border color and a radius, so all three are
- * previewed. Border is a COLOR only: the binding owns the `borderStyle` composite's color axis and
- * nothing else, because the section's border width and style stay with the block's own control.
+ * The section's whole bound surface is a background and a radius, so both are previewed. Border color
+ * is deliberately not part of that surface — see the section's `preset_bindings` declaration for why a
+ * color-only border binding can never reach the page — so the preview's edge is a neutral frame from
+ * the stylesheet rather than anything the preset holds.
  *
  * @param {Record<string, *>}      tokens       The preset's stored token map.
  * @param {Record<string, string>} values       The feed's resolved value map.
@@ -53,19 +46,18 @@ const COLUMN_RADIUS_FALLBACK = ['0', '0', '0', '0'];
  *
  * @since TBD
  *
- * @return {{background: string, border: string, borderRadius: string}} The preview.
+ * @return {{background: string, borderRadius: string}} The preview.
  */
 function preview(tokens, values, breakpoint) {
 	return {
 		background: resolveTokenValue(values, tokens.background, breakpoint),
-		border: resolveTokenValue(values, tokens.border, breakpoint),
 		borderRadius: resolveTokenValue(values, tokens.borderRadius, breakpoint),
 	};
 }
 
 /**
- * The section's live preview: a tall, narrow slab drawn at the section's resolved background, border
- * color and radius.
+ * The section's live preview: a tall, narrow slab drawn at the section's resolved background and
+ * radius.
  *
  * Portrait where the Row Layout's band is landscape, because that is the shape each block actually
  * takes on a page — a section is a column of content — and a corner radius reads differently at each
@@ -75,7 +67,7 @@ function preview(tokens, values, breakpoint) {
  * color. The section ships a transparent background, so without the checker every unstyled preset
  * would look like it had set white.
  *
- * @param {{id: string, label: string, preview: {background: string, border: string, borderRadius: string}}} row The row descriptor.
+ * @param {{id: string, label: string, preview: {background: string, borderRadius: string}}} row The row descriptor.
  *
  * @since TBD
  *
@@ -85,10 +77,7 @@ function renderPreview(row) {
 	return (
 		<span
 			className="kadence-blocks-style-library__column-preset-preview"
-			style={{
-				borderColor: row.preview.border || COLUMN_BORDER_FALLBACK,
-				borderRadius: row.preview.borderRadius || undefined,
-			}}
+			style={{ borderRadius: row.preview.borderRadius || undefined }}
 		>
 			<span
 				className="kadence-blocks-style-library__column-preset-preview-fill"
@@ -104,10 +93,14 @@ function renderPreview(row) {
  *
  * Radius uses the responsive `radius` field because the block declares `tabletBorderRadius`/
  * `mobileBorderRadius` and its own control is per-device — a preset that could only say one radius
- * for every breakpoint could not reproduce a look a site owner had already built by hand. Background
- * and border are single non-responsive pickers: the section's background attribute has no per-device
- * counterpart, and the border binding owns one axis of a composite whose width and style are not the
- * preset's to set.
+ * for every breakpoint could not reproduce a look a site owner had already built by hand. Background is
+ * a single non-responsive picker: the section's background attribute has no per-device counterpart, and
+ * `token-color-select` carries no breakpoint switcher to drive one.
+ *
+ * There is no border-color field, and its absence is deliberate rather than an omission: the section's
+ * border output takes `render_border_styles()`'s shorthand path, which no block-default `border-color`
+ * rule can reach. Offering the field would save a value that changes nothing on the page. See the
+ * section's `preset_bindings` declaration.
  *
  * @since TBD
  *
@@ -124,11 +117,6 @@ function schemaFor() {
 						type: 'token-color-select',
 						path: 'tokens.background',
 						label: __('Background', 'kadence-blocks'),
-					},
-					{
-						type: 'token-color-select',
-						path: 'tokens.border',
-						label: __('Border Color', 'kadence-blocks'),
 					},
 				],
 			},

--- a/src/style-library/styles/_mixins.scss
+++ b/src/style-library/styles/_mixins.scss
@@ -63,3 +63,41 @@
 	text-transform: uppercase;
 	color: var(--kb-sl-color-text-primary);
 }
+
+// The frame half of a block-preset row preview that stands in for a colored surface (the Row Layout
+// band, the Section slab). Draws the border the preset's color is applied to, and a checker BEHIND
+// where the preset's background will be painted -- both blocks ship a transparent background, and
+// against the list's white surface a transparent background and a white one are indistinguishable, so
+// without the checker every unstyled preset would look like it had set white.
+//
+// The background belongs to the companion `preset-surface-fill` element, not here: a single element
+// cannot layer them in this order, because a background image always paints above its own background
+// color. Geometry is the caller's, since the proportions are the point -- a Row Layout is wide and
+// short, a Section is tall and narrow, and a corner radius reads very differently at each.
+@mixin preset-surface-preview($width, $height) {
+	position: relative;
+	display: block;
+	box-sizing: border-box;
+	width: $width;
+	height: $height;
+	border: var(--kb-sl-border-width-input) solid var(--kb-sl-color-gray-200);
+	background-color: #fff;
+	background-image: repeating-conic-gradient(var(--kb-sl-color-gray-200) 0% 25%, transparent 0% 50%);
+	background-size: 0.75rem 0.75rem;
+	transition:
+		border-color 300ms ease,
+		border-radius 300ms ease;
+}
+
+// The fill half: the preset's resolved background, laid over the checker `preset-surface-preview`
+// draws. Inherits the radius so a rounded preset does not show square corners of fill poking past its
+// frame.
+@mixin preset-surface-fill {
+	position: absolute;
+	inset: 0;
+	display: block;
+	border-radius: inherit;
+	transition:
+		background-color 300ms ease,
+		border-radius 300ms ease;
+}

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/PresetNavTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/PresetNavTest.php
@@ -29,8 +29,10 @@ final class PresetNavTest extends TestCase {
 
 	/**
 	 * Every shipped nav entry carries its declared Style Library section label ("Button", "Row Layout",
-	 * "Icon"), never the picker control's own label — every one of those blocks declares that as
-	 * "Style". Order is registration order, which is declaration order in `declarations.php`.
+	 * "Section", "Icon"), never the picker control's own label — every one of those blocks declares that
+	 * as "Style". The Section's entry is the case that proves the point: the block is `kadence/column` in
+	 * code and the nav must still read "Section", which is what it is called in the UI. Order is
+	 * registration order, which is declaration order in `declarations.php`.
 	 *
 	 * @return void
 	 */
@@ -46,6 +48,10 @@ final class PresetNavTest extends TestCase {
 				[
 					'block' => 'kadence/rowlayout',
 					'label' => 'Row Layout',
+				],
+				[
+					'block' => 'kadence/column',
+					'label' => 'Section',
 				],
 				[
 					'block' => 'kadence/single-icon',
@@ -243,8 +249,6 @@ final class PresetNavTest extends TestCase {
 	 */
 	public function defaultLookOnlyBlockProvider(): Generator {
 		yield 'image' => [ 'block' => 'kadence/image' ];
-
-		yield 'column' => [ 'block' => 'kadence/column' ];
 
 		yield 'advanced heading' => [ 'block' => 'kadence/advancedheading' ];
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
@@ -94,7 +94,7 @@ final class Preset_CatalogTest extends TestCase {
 	}
 
 	/**
-	 * The five blocks wired for presets but not yet given a Style Library screen expose a full controllable
+	 * The blocks wired for presets but not yet given a Style Library screen expose a full controllable
 	 * surface — every bound property with its control attribute — while offering NO preset options, because
 	 * their bindings declare no picker label. That combination is what keeps the editor's Design Tokens
 	 * panel hidden for them (it renders only when a block has at least one preset option), so declaring the
@@ -128,8 +128,6 @@ final class Preset_CatalogTest extends TestCase {
 	 */
 	public function wiredWithoutAScreenProvider(): Generator {
 		yield 'image' => [ 'block' => 'kadence/image' ];
-
-		yield 'column' => [ 'block' => 'kadence/column' ];
 
 		yield 'advanced heading' => [ 'block' => 'kadence/advancedheading' ];
 	}


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout
:video_camera: https://www.loom.com/share/c45de6b397424fcf9434d5b8e1fe9582

Background and corner radius, sharing the Row Layout preview shape. The nav label reads "Section", the name the UI uses, rather than the block's code name.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Style Library screen for configuring column styles.
  - Added Section presets with controls for background color and border radius.
  - Added portrait-style previews and improved visual styling for column and row layout presets.
  - Added Section labeling and clearer Style picker terminology.

- **Bug Fixes**
  - Removed unsupported column border-color preset mapping to prevent incorrect border styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

