### PR TITLE
[DTM] SOFT-4218 [10/16]: add the Advanced Image block preset screen

### DIFF
--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -612,8 +612,25 @@ return [
 			// below). Each token is seeded to KB's existing default (transparent background, invisible border
 			// until a style is set, no shadow, square corners), so a fresh image is unchanged; any value the
 			// user sets renders at higher specificity (the `.kb-image<uid>` instance selector) and still wins.
-			'block'    => 'kadence/image',
-			'bindings' => [
+			//
+			// The `border` and `borderWidth` bindings below stay declared -- they feed the block-default rules
+			// that seed an image's border color and width from the tokens -- but the Style Library screen
+			// deliberately offers neither as a preset field. The image binds no border STYLE, so a preset
+			// cannot turn a border on: with the block's style unset render_border_styles() emits nothing and
+			// `border-style` stays `none`. Once a site owner sets one, the block emits a `border-<side>`
+			// shorthand that overrides the color, and the single shape that would leave the width to a preset
+			// (style and color set, width blank) renders no border in the EDITOR at all, because
+			// getBorderStyle() returns an empty string without a width.
+			//
+			// @todo SOFT-4234: give the image a preset-able border trio.
+			'block'         => 'kadence/image',
+			'label'         => __( 'Style', 'kadence-blocks' ), // a picker-driven set; this is the editor control's label.
+			'style_library' => [
+				// The Style Library BLOCK PRESETS nav label — distinct from "label" above, which names the
+				// inspector's picker control, not the block.
+				'label' => __( 'Advanced Image', 'kadence-blocks' ),
+			],
+			'bindings'      => [
 				'background'   => [
 					'token'        => 'semantic.color.image-bg',
 					'css_prop'     => 'background-color',

--- a/src/style-library/__tests__/image-preset.test.js
+++ b/src/style-library/__tests__/image-preset.test.js
@@ -1,0 +1,243 @@
+/* eslint-env jest */
+/**
+ * The Advanced Image preset config — the one per-block file a preset screen needs. Everything else the
+ * screen uses (`PresetScreen`, `PresetSidebar`, `usePresetScreen`, `helpers/presets`) is generic and
+ * covered by its own suites, so this asserts only what this config contributes: the bound surface it
+ * reads, the preview it resolves, its schema, and that it registers on the public screens filter.
+ */
+import { applyFilters } from '@wordpress/hooks';
+import { IMAGE_PRESET, IMAGE_BLOCK } from '../presets/image-preset';
+import { PRESET_SCREENS_FILTER } from '../constants/screens';
+import { FIELD_TYPES, RESPONSIVE_CAPABLE_FIELD_TYPES } from '../constants/field-types';
+
+// The screen module is imported only to trigger its module-scope `addFilter`. Its two children pull in
+// the REST client (and so `@wordpress/api-fetch`, absent from this environment), which the registration
+// contract does not depend on — the generic panel and sidebar have their own suites.
+jest.mock('../components/pages/PresetScreen', () => ({ PresetScreen: () => null }));
+jest.mock('../components/pages/ImageSettings', () => ({ ImageSettings: () => null }));
+
+describe('IMAGE_PRESET', () => {
+	afterEach(() => {
+		delete window.kadenceDesignTokens;
+	});
+
+	/**
+	 * The config names the Advanced Image block.
+	 *
+	 * @return {void}
+	 */
+	it('targets the image block', () => {
+		expect(IMAGE_PRESET.block).toBe('kadence/image');
+		expect(IMAGE_BLOCK).toBe('kadence/image');
+	});
+
+	/**
+	 * `properties` is a live getter over the feed, not a snapshot, so the screen can never offer a
+	 * property the server's write guard would reject.
+	 *
+	 * @return {void}
+	 */
+	it('reads its bound surface live from the feed', () => {
+		window.kadenceDesignTokens = {
+			presets: {
+				'kadence/image': {
+					properties: ['background', 'border', 'borderWidth', 'borderRadius', 'shadow', 'padding'],
+				},
+			},
+		};
+
+		expect(IMAGE_PRESET.properties).toEqual([
+			'background',
+			'border',
+			'borderWidth',
+			'borderRadius',
+			'shadow',
+			'padding',
+		]);
+	});
+
+	/**
+	 * The preview resolves the four previewed properties through the feed's value map, aliases included.
+	 *
+	 * @return {void}
+	 */
+	it('resolves the preview background, radius, shadow and padding from stored aliases', () => {
+		const values = {
+			'semantic.color.image-bg': 'transparent',
+			'semantic.radius.media': '0',
+			'semantic.shadow.media': '0px 0px 0px 0px transparent',
+			'semantic.spacing.media-padding': '0',
+		};
+		const tokens = {
+			background: '{semantic.color.image-bg}',
+			borderRadius: '{semantic.radius.media}',
+			shadow: '{semantic.shadow.media}',
+			padding: '{semantic.spacing.media-padding}',
+		};
+
+		expect(IMAGE_PRESET.preview(tokens, values)).toEqual({
+			background: 'transparent',
+			borderRadius: '0',
+			shadow: '0px 0px 0px 0px transparent',
+			padding: '0',
+		});
+	});
+
+	/**
+	 * A per-corner padding slot list resolves to the CSS shorthand, so the preview insets the photo by
+	 * the same four values the front end applies.
+	 *
+	 * @return {void}
+	 */
+	it('resolves a per-corner padding slot list into a shorthand', () => {
+		const values = { 'primitive.dimension.spacing.xs': '1rem', 'primitive.dimension.spacing.sm': '1.5rem' };
+		const tokens = {
+			padding: [
+				'{primitive.dimension.spacing.xs}',
+				'{primitive.dimension.spacing.sm}',
+				'{primitive.dimension.spacing.xs}',
+				'{primitive.dimension.spacing.sm}',
+			],
+		};
+
+		expect(IMAGE_PRESET.preview(tokens, values).padding).toBe('1rem 1.5rem 1rem 1.5rem');
+	});
+
+	/**
+	 * A dangling alias previews as empty rather than as the raw alias text, so `renderPreview` can fall
+	 * back to the image's own built-in look.
+	 *
+	 * @return {void}
+	 */
+	it('previews a dangling alias as empty', () => {
+		expect(
+			IMAGE_PRESET.preview({ background: '{semantic.color.gone}', borderRadius: '', shadow: '', padding: '' }, {})
+		).toEqual({
+			background: '',
+			borderRadius: '',
+			shadow: '',
+			padding: '',
+		});
+	});
+
+	/**
+	 * Three nested elements, each carrying the properties it alone can render: the outer casts the shadow
+	 * (which must not be clipped) and holds the radius, the fill holds the background and the padding, and
+	 * the photo is the stand-in the padding insets.
+	 *
+	 * @return {void}
+	 */
+	it('splits the preview across a frame, a padded fill and a photo', () => {
+		const frame = IMAGE_PRESET.renderPreview({
+			id: 'framed',
+			label: 'Framed',
+			preview: {
+				background: '#F7FAFC',
+				borderRadius: '0.5rem',
+				shadow: '0px 2px 6px 0px #0000001a',
+				padding: '0.5rem',
+			},
+		});
+		const fill = frame.props.children;
+		const photo = fill.props.children;
+
+		expect(frame.props.className).toBe('kadence-blocks-style-library__image-preset-preview');
+		expect(frame.props.style.boxShadow).toBe('0px 2px 6px 0px #0000001a');
+		expect(frame.props.style.borderRadius).toBe('0.5rem');
+		// The frame must not paint the background itself, or it would cover its own checker.
+		expect(frame.props.style.background).toBeUndefined();
+
+		expect(fill.props.className).toBe('kadence-blocks-style-library__image-preset-preview-fill');
+		expect(fill.props.style.background).toBe('#F7FAFC');
+		expect(fill.props.style.padding).toBe('0.5rem');
+
+		expect(photo.props.className).toBe('kadence-blocks-style-library__image-preset-preview-photo');
+	});
+
+	/**
+	 * An unresolved value is left absent rather than invented, so the stylesheet's own square-cornered
+	 * checkered tile shows through with no inset.
+	 *
+	 * @return {void}
+	 */
+	it('leaves unresolved values absent rather than inventing them', () => {
+		const frame = IMAGE_PRESET.renderPreview({
+			id: 'bare',
+			label: 'Bare',
+			preview: { background: '', borderRadius: '', shadow: '', padding: '' },
+		});
+
+		expect(frame.props.style.borderRadius).toBeUndefined();
+		expect(frame.props.style.boxShadow).toBeUndefined();
+		expect(frame.props.children.props.style.background).toBeUndefined();
+		expect(frame.props.children.props.style.padding).toBeUndefined();
+	});
+
+	/**
+	 * The image binds no hover property, so it declares no tabs and `PresetSidebar` renders the field area
+	 * bare.
+	 *
+	 * @return {void}
+	 */
+	it('declares no state tabs', () => {
+		expect(IMAGE_PRESET.tabs).toBeUndefined();
+	});
+
+	/**
+	 * The schema offers the four properties a preset can actually deliver. `border` and `borderWidth` are
+	 * bound — they feed the block-default rules that seed an image's border from the tokens — but are
+	 * deliberately absent here, because the image binds no border STYLE and so a preset can never turn a
+	 * border on. See the config's `schemaFor()` docblock and SOFT-4234.
+	 *
+	 * @return {void}
+	 */
+	it('builds panels covering the deliverable properties and nothing more', () => {
+		const { panels } = IMAGE_PRESET.schemaFor();
+
+		const paths = panels.flatMap((panel) => panel.fields.map((field) => field.path));
+		const types = panels.flatMap((panel) => panel.fields.map((field) => field.type));
+
+		expect(paths).toEqual(['tokens.background', 'tokens.borderRadius', 'tokens.shadow', 'tokens.padding']);
+		expect(types).toEqual(['token-color-select', 'radius', 'box-shadow', 'spacing']);
+
+		// Every type the schema names must be one the registry can render.
+		types.forEach((type) => expect(FIELD_TYPES).toHaveProperty(type));
+	});
+
+	/**
+	 * Radius and padding mirror per-device block controls, so both preset fields are responsive and of
+	 * types that may be. Shadow is not: `BoxShadowField` carries no breakpoint switcher, so marking it
+	 * responsive would write an override its own UI could never read back.
+	 *
+	 * @return {void}
+	 */
+	it('makes only the per-device fields responsive', () => {
+		const fields = IMAGE_PRESET.schemaFor().panels.flatMap((panel) => panel.fields);
+		const byPath = Object.fromEntries(fields.map((field) => [field.path, field]));
+
+		expect(byPath['tokens.borderRadius'].responsive).toBe(true);
+		expect(byPath['tokens.padding'].responsive).toBe(true);
+		expect(RESPONSIVE_CAPABLE_FIELD_TYPES).toContain(byPath['tokens.borderRadius'].type);
+		expect(RESPONSIVE_CAPABLE_FIELD_TYPES).toContain(byPath['tokens.padding'].type);
+
+		expect(byPath['tokens.shadow'].responsive).toBeUndefined();
+		expect(byPath['tokens.background'].responsive).toBeUndefined();
+	});
+});
+
+describe('ImageScreen registration', () => {
+	/**
+	 * The app never imports the screen component directly — importing the module is what registers it
+	 * on the public filter, exactly as a third-party screen would register itself.
+	 *
+	 * @return {void}
+	 */
+	it('registers itself on the preset-screens filter with a settings panel', () => {
+		require('../components/pages/ImageScreen');
+
+		const screens = applyFilters(PRESET_SCREENS_FILTER, {});
+
+		expect(screens[IMAGE_BLOCK]).toBeDefined();
+		expect(screens[IMAGE_BLOCK].SettingsPanel).toBeDefined();
+	});
+});

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -33,6 +33,7 @@ import '../components/pages/ButtonScreen';
 import '../components/pages/SingleIconScreen';
 import '../components/pages/RowLayoutScreen';
 import '../components/pages/ColumnScreen';
+import '../components/pages/ImageScreen';
 import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
 import { useLibraries } from '../hooks/use-libraries';

--- a/src/style-library/components/pages/ImageScreen.js
+++ b/src/style-library/components/pages/ImageScreen.js
@@ -1,0 +1,46 @@
+/**
+ * The Advanced Image preset screen: `PresetScreen` does the work and `presets/image-preset.js`
+ * describes the block, so this file only binds the two together and registers the screen. Its
+ * settings panel is `ImageSettings`, assigned below as `ImageScreen.SettingsPanel`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { PresetScreen } from './PresetScreen';
+import { ImageSettings } from './ImageSettings';
+import { IMAGE_PRESET, IMAGE_BLOCK } from '../../presets/image-preset';
+import { PRESET_SCREENS_FILTER } from '../../constants/screens';
+import './ImageScreen.scss';
+
+/**
+ * Render the Advanced Image preset screen.
+ *
+ * @param {Object} props The screen props (`label`, `route`, `navigate`, `library`).
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The screen body.
+ */
+export function ImageScreen(props) {
+	return <PresetScreen {...props} preset={IMAGE_PRESET} />;
+}
+
+ImageScreen.SettingsPanel = ImageSettings;
+
+/**
+ * Register the Advanced Image screen for `kadence/image` on the public preset-screens filter, exactly
+ * as a third party would — the app never imports this component directly, so this module-scope call is
+ * the only registration path.
+ *
+ * @since TBD
+ */
+addFilter(PRESET_SCREENS_FILTER, 'kadence-blocks/style-library-image-screen', (screens) => ({
+	...screens,
+	[IMAGE_BLOCK]: ImageScreen,
+}));

--- a/src/style-library/components/pages/ImageScreen.scss
+++ b/src/style-library/components/pages/ImageScreen.scss
@@ -1,0 +1,49 @@
+@use "../../styles/mixins" as *;
+
+// The tile carries a shadow, which is cast OUTSIDE the element casting it, so this screen relaxes
+// `ListRow`'s default framed preview slot rather than letting `overflow: hidden` clip it — the same
+// override the Shadow screen makes for the same reason.
+.kadence-blocks-style-library__image-screen .kadence-blocks-style-library__list-row-preview {
+	width: auto;
+	height: auto;
+	border: 0;
+	background: transparent;
+	overflow: visible;
+}
+
+// Preset names are full words ("Framed Soft"), not the short numeric labels the shared 4rem column
+// was sized for.
+.kadence-blocks-style-library__image-screen .kadence-blocks-style-library__list-row-label {
+	width: 15rem;
+}
+
+// Landscape, the aspect a photo most often takes. The shared surface mixin supplies the frame and the
+// transparency checker; the shadow is applied inline from the preset, so it must not be clipped —
+// hence no `overflow` here either.
+.kadence-blocks-style-library__image-preset-preview {
+	@include preset-surface-preview(5rem, 3.75rem);
+}
+
+// Carries the background AND the preset's padding, so the padding renders as real space between the
+// frame and the photo below rather than as a number. `box-sizing: border-box` keeps a large padding
+// shrinking the photo instead of growing the tile past its row.
+.kadence-blocks-style-library__image-preset-preview-fill {
+	@include preset-surface-fill;
+
+	box-sizing: border-box;
+	transition:
+		background-color 300ms ease,
+		border-radius 300ms ease,
+		padding 300ms ease;
+}
+
+// The stand-in photo: a neutral block filling whatever the padding leaves. Deliberately not a real
+// image — a preset skins whichever image a block holds, so previewing a specific picture would imply
+// the preset selects one.
+.kadence-blocks-style-library__image-preset-preview-photo {
+	display: block;
+	width: 100%;
+	height: 100%;
+	border-radius: inherit;
+	background: var(--kb-sl-color-gray-700);
+}

--- a/src/style-library/components/pages/ImageSettings.js
+++ b/src/style-library/components/pages/ImageSettings.js
@@ -1,0 +1,29 @@
+/**
+ * The Advanced Image preset's settings sidebar: `PresetSidebar` does the work, this binds the block's
+ * config to it.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { PresetSidebar } from './PresetSidebar';
+import { usePresetScreen } from '../../hooks/use-preset-screen';
+import { IMAGE_PRESET } from '../../presets/image-preset';
+
+/**
+ * Render the Advanced Image preset's settings sidebar.
+ *
+ * @param {Object}   props          The component props.
+ * @param {Object}   props.route    The current route (`{ screen, item }`).
+ * @param {Function} props.navigate The route navigator.
+ * @param {Object}   props.library  The design-tokens feed hook's return value.
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The sidebar, or null while there is no open preset to edit.
+ */
+export function ImageSettings({ route, navigate, library }) {
+	const screen = usePresetScreen(library, IMAGE_PRESET);
+
+	return <PresetSidebar route={route} navigate={navigate} screen={screen} preset={IMAGE_PRESET} />;
+}

--- a/src/style-library/presets/image-preset.js
+++ b/src/style-library/presets/image-preset.js
@@ -1,0 +1,215 @@
+/**
+ * Everything specific to the `kadence/image` (Advanced Image) preset screen, in one place: the block
+ * name, the bound property surface, the row preview, and the settings schema.
+ *
+ * The generic preset machinery — `helpers/presets.js`, `usePresetScreen`, `PresetSidebar` — reads
+ * this config and knows nothing else about images. See `src/style-library/README.md`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getPresetProperties, resolveTokenValue } from '../helpers/presets';
+
+/**
+ * The block name this screen edits — the single JS spelling, shared by the screen registration and
+ * the config below so the two can never drift.
+ *
+ * @since TBD
+ */
+export const IMAGE_BLOCK = 'kadence/image';
+
+/**
+ * The image's built-in corner radius, matching `semantic.radius.media` (square corners).
+ *
+ * @since TBD
+ */
+const IMAGE_RADIUS_FALLBACK = ['0', '0', '0', '0'];
+
+/**
+ * The image's built-in padding, matching `semantic.spacing.media-padding` (none).
+ *
+ * @since TBD
+ */
+const IMAGE_PADDING_FALLBACK = ['0', '0', '0', '0'];
+
+/**
+ * Build a row's preview from its stored tokens.
+ *
+ * Four of the image's six bound properties, which is its whole editable surface here — border color
+ * and border width are bound but deliberately not offered, see `schemaFor()`. Padding is previewed as
+ * real inset rather than a number, because that is the only way a spacing value reads at a glance
+ * next to a radius and a shadow.
+ *
+ * @param {Record<string, *>}      tokens       The preset's stored token map.
+ * @param {Record<string, string>} values       The feed's resolved value map.
+ * @param {string}                 [breakpoint] The breakpoint to resolve responsive values at.
+ *
+ * @since TBD
+ *
+ * @return {{background: string, borderRadius: string, shadow: string, padding: string}} The preview.
+ */
+function preview(tokens, values, breakpoint) {
+	return {
+		background: resolveTokenValue(values, tokens.background, breakpoint),
+		borderRadius: resolveTokenValue(values, tokens.borderRadius, breakpoint),
+		shadow: resolveTokenValue(values, tokens.shadow, breakpoint),
+		padding: resolveTokenValue(values, tokens.padding, breakpoint),
+	};
+}
+
+/**
+ * The image's live preview: a landscape tile standing in for a photo, drawn at the preset's resolved
+ * radius and shadow, with its background showing through the padding as an inset frame around a
+ * neutral photo block.
+ *
+ * Three nested elements, each earning its place. The outer carries the radius and the shadow, which
+ * has to be cast from outside anything that clips. The middle carries the background AND the padding,
+ * so padding renders as what it actually is — space between the frame and the image — rather than as a
+ * number in a corner. The inner is the stand-in photo: a neutral block, not a real image, because a
+ * preset skins whatever image a block happens to hold and previewing a specific picture would imply it
+ * selects one.
+ *
+ * The transparency checker sits on the outer element for the same reason it does on the Row Layout and
+ * Section previews: the image's shipped background is transparent, and against the list's white
+ * surface a transparent background and a white one are indistinguishable.
+ *
+ * @param {{id: string, label: string, preview: {background: string, borderRadius: string, shadow: string, padding: string}}} row The row descriptor.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The preview element.
+ */
+function renderPreview(row) {
+	const radius = row.preview.borderRadius || undefined;
+
+	return (
+		<span
+			className="kadence-blocks-style-library__image-preset-preview"
+			style={{ borderRadius: radius, boxShadow: row.preview.shadow || undefined }}
+		>
+			<span
+				className="kadence-blocks-style-library__image-preset-preview-fill"
+				style={{
+					background: row.preview.background || undefined,
+					borderRadius: radius,
+					padding: row.preview.padding || undefined,
+				}}
+			>
+				<span className="kadence-blocks-style-library__image-preset-preview-photo" />
+			</span>
+		</span>
+	);
+}
+
+/**
+ * The settings schema. The image declares no tabs: it binds no hover property, so there is no second
+ * state to switch to and `PresetSidebar` renders the field area bare.
+ *
+ * Radius and padding are responsive because the block declares per-device attributes for both and its
+ * own controls are per-device, so a preset that could name only one value for every breakpoint could
+ * not reproduce a look a site owner had already built by hand. Background is a single non-responsive
+ * picker (no per-device attribute), and shadow is non-responsive because `BoxShadowField` carries no
+ * breakpoint switcher.
+ *
+ * The image binds `border` (color) and `borderWidth` as well, and neither is offered here. Both are
+ * unreachable in practice, and the reason is worth stating because it is not obvious from the
+ * declaration: the image binds no border STYLE, so a preset cannot turn a border on at all — with the
+ * block's style unset, `render_border_styles()` emits nothing and `border-style` stays `none`. Once a
+ * site owner does set a style, the block emits a `border-<side>` shorthand that overrides the color
+ * (with a width set, as `2px solid`, resetting the color to `currentColor`), and the one shape that
+ * leaves the width to a preset — style and color set, width blank — renders nothing in the editor at
+ * all, because `getBorderStyle()` returns an empty string without a width. Offering either field would
+ * save a value a site owner could not see. SOFT-4234 covers making them work.
+ *
+ * @since TBD
+ *
+ * @return {{panels: Array<Object>}} The settings-form schema.
+ */
+function schemaFor() {
+	return {
+		panels: [
+			{
+				id: 'color',
+				title: __('Color', 'kadence-blocks'),
+				fields: [
+					{
+						type: 'token-color-select',
+						path: 'tokens.background',
+						label: __('Background', 'kadence-blocks'),
+					},
+				],
+			},
+			{
+				id: 'border-and-shadow',
+				title: __('Border and Shadow', 'kadence-blocks'),
+				fields: [
+					{
+						type: 'radius',
+						tokenType: 'dimension',
+						role: 'radius',
+						responsive: true,
+						path: 'tokens.borderRadius',
+						label: __('Radius', 'kadence-blocks'),
+						// Square corners, which is what an un-preset image renders and what
+						// `semantic.radius.media` holds. Shown muted so an unset field reports the radius the
+						// image really has rather than reading as empty.
+						defaultValue: IMAGE_RADIUS_FALLBACK,
+					},
+					{
+						type: 'box-shadow',
+						path: 'tokens.shadow',
+						label: __('Shadow', 'kadence-blocks'),
+						// No `defaultValue`, matching the Button's shadow field: `BoxShadowControl` accepts no
+						// such prop, so the key would go unread.
+					},
+				],
+			},
+			{
+				id: 'spacing',
+				title: __('Spacing', 'kadence-blocks'),
+				fields: [
+					{
+						type: 'spacing',
+						tokenType: 'dimension',
+						role: 'spacing',
+						responsive: true,
+						path: 'tokens.padding',
+						label: __('Padding', 'kadence-blocks'),
+						// An image carries no padding of its own, which is a real answer rather than an absent
+						// one — `semantic.spacing.media-padding` resolves to 0.
+						defaultValue: IMAGE_PADDING_FALLBACK,
+					},
+				],
+			},
+		],
+	};
+}
+
+/**
+ * The Advanced Image preset screen's whole configuration, passed to the generic preset machinery.
+ *
+ * `properties` is a getter rather than a snapshot, for the same reason the Button's is: the config is
+ * frozen at module evaluation, before the localized feed is guaranteed to exist, so a snapshot taken
+ * here could throw or go stale.
+ *
+ * @since TBD
+ */
+export const IMAGE_PRESET = Object.freeze({
+	block: IMAGE_BLOCK,
+	get properties() {
+		return getPresetProperties(IMAGE_BLOCK);
+	},
+	slugBase: 'image',
+	addLabel: __('Add Image Style', 'kadence-blocks'),
+	newLabel: __('New Image Style', 'kadence-blocks'),
+	className: 'kadence-blocks-style-library__image-screen',
+	preview,
+	renderPreview,
+	schemaFor,
+});

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/PresetNavTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/PresetNavTest.php
@@ -28,11 +28,11 @@ final class PresetNavTest extends TestCase {
 	}
 
 	/**
-	 * Every shipped nav entry carries its declared Style Library section label ("Button", "Row Layout",
-	 * "Section", "Icon"), never the picker control's own label — every one of those blocks declares that
-	 * as "Style". The Section's entry is the case that proves the point: the block is `kadence/column` in
-	 * code and the nav must still read "Section", which is what it is called in the UI. Order is
-	 * registration order, which is declaration order in `declarations.php`.
+	 * Every shipped nav entry carries its declared Style Library section label ("Button", "Advanced
+	 * Image", "Row Layout", "Section", "Icon"), never the picker control's own label — every one of those
+	 * blocks declares that as "Style". The Section's entry is the case that proves the point: the block is
+	 * `kadence/column` in code and the nav must still read "Section", which is what it is called in the
+	 * UI. Order is registration order, which is declaration order in `declarations.php`.
 	 *
 	 * @return void
 	 */
@@ -44,6 +44,10 @@ final class PresetNavTest extends TestCase {
 				[
 					'block' => 'kadence/singlebtn',
 					'label' => 'Button',
+				],
+				[
+					'block' => 'kadence/image',
+					'label' => 'Advanced Image',
 				],
 				[
 					'block' => 'kadence/rowlayout',
@@ -248,8 +252,6 @@ final class PresetNavTest extends TestCase {
 	 * @return Generator
 	 */
 	public function defaultLookOnlyBlockProvider(): Generator {
-		yield 'image' => [ 'block' => 'kadence/image' ];
-
 		yield 'advanced heading' => [ 'block' => 'kadence/advancedheading' ];
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
@@ -22,7 +22,7 @@ final class Preset_CatalogTest extends TestCase {
 
 	private const ICON = 'kadence/single-icon';
 
-	private const IMAGE = 'kadence/image';
+	private const HEADING = 'kadence/advancedheading';
 
 	/**
 	 * @var Preset_Catalog
@@ -127,8 +127,6 @@ final class Preset_CatalogTest extends TestCase {
 	 * @return Generator
 	 */
 	public function wiredWithoutAScreenProvider(): Generator {
-		yield 'image' => [ 'block' => 'kadence/image' ];
-
 		yield 'advanced heading' => [ 'block' => 'kadence/advancedheading' ];
 	}
 
@@ -258,14 +256,14 @@ final class Preset_CatalogTest extends TestCase {
 	public function testABlockWithoutAPickerLabelCarriesPropertiesButNoPresetOptions(): void {
 		$library = $this->catalog->all()['libraries'][ Token_Store::default_slug() ];
 
-		$this->assertArrayHasKey( self::IMAGE, $library );
-		$this->assertNull( $library[ self::IMAGE ]['label'] );
-		$this->assertSame( [], $library[ self::IMAGE ]['presets'] );
+		$this->assertArrayHasKey( self::HEADING, $library );
+		$this->assertNull( $library[ self::HEADING ]['label'] );
+		$this->assertSame( [], $library[ self::HEADING ]['presets'] );
 
 		// The surface the token picker keys off is present regardless, as is the default the controls compare
 		// against.
-		$this->assertNotEmpty( $library[ self::IMAGE ]['properties'] );
-		$this->assertSame( 'default', $library[ self::IMAGE ]['default'] );
+		$this->assertNotEmpty( $library[ self::HEADING ]['properties'] );
+		$this->assertSame( 'default', $library[ self::HEADING ]['default'] );
 
 		// The picker-driven Button is unaffected: it declares a label, so it still carries its options.
 		$this->assertNotEmpty( $library[ self::BUTTON ]['presets'] );


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout
:video_camera: https://www.loom.com/share/c45de6b397424fcf9434d5b8e1fe9582

Background, corner radius, shadow and padding. Border color and width stay bound but are not offered: the image binds no border style, so a preset cannot turn a border on at all.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Advanced Image preset to the Style Library.
  * Added image customization options for background, responsive corner radius, shadow, and responsive padding.
  * Added live image previews with support for nested styles, aliases, and shorthand values.
  * Registered Advanced Image in Style Library navigation.

* **Bug Fixes**
  * Improved handling of unresolved or unavailable style values in previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

