### PR TITLE
[DTM] SOFT-4218 [11/16]: show a semantic-bound preset value as the field's default, never as a choice

### DIFF
--- a/src/style-library/__tests__/border-shadow-field-rendering.test.js
+++ b/src/style-library/__tests__/border-shadow-field-rendering.test.js
@@ -86,7 +86,7 @@ describe('BorderField', () => {
 		expect(latestBorderControlProps.widthTokens[0].alias).toBe('{primitive.dimension.border-width.sm}');
 	});
 
-	it('exempts the bound width token from the primitive narrowing, so a bound semantic stays pickable', () => {
+	it('shows a semantic-bound width as unset rather than listing the semantic', () => {
 		const field = { label: 'Border', path: 'tokens.button-border' };
 
 		act(() => {
@@ -99,15 +99,15 @@ describe('BorderField', () => {
 			);
 		});
 
-		expect(latestBorderControlProps.widthTokens.map((token) => token.id)).toEqual(
-			expect.arrayContaining(['semantic.border-width.default'])
-		);
+		// The pool stays the role's primitive scale: a semantic is the block's role-based default, not
+		// something a site owner picked, so it is never offered as a peer of the steps.
+		expect(latestBorderControlProps.widthTokens.map((token) => token.id)).toEqual([
+			'primitive.dimension.border-width.sm',
+		]);
 
-		const boundToken = latestBorderControlProps.widthTokens.find(
-			(token) => token.id === 'semantic.border-width.default'
-		);
-
-		expect(boundToken.label).toBe('Border Width');
+		// And the width reads as unset rather than as the raw dot-path it would otherwise render,
+		// having no pool entry to name it.
+		expect(latestBorderControlProps.value.width).toBe('');
 	});
 
 	it('threads breakpoints only when the field is responsive', () => {
@@ -323,7 +323,7 @@ describe('BoxShadowField', () => {
 		expect(latestBoxShadowControlProps.tokens[0].alias).toBe('{primitive.shadow.xs}');
 	});
 
-	it('exempts the bound token from the primitive narrowing when it is a Brand-group semantic', () => {
+	it('shows a semantic-bound shadow as unset rather than listing the semantic', () => {
 		act(() => {
 			root.render(
 				createElement(BoxShadowField, {
@@ -334,12 +334,16 @@ describe('BoxShadowField', () => {
 			);
 		});
 
-		expect(latestBoxShadowControlProps.tokens.map((token) => token.id)).toEqual(
-			expect.arrayContaining(['semantic.shadow.button'])
-		);
-		expect(latestBoxShadowControlProps.tokens).not.toEqual(
-			expect.arrayContaining([expect.objectContaining({ id: 'semantic.shadow.media' })])
-		);
+		// The list stays the Shadow screen's own three steps — no Brand-group semantic among them.
+		expect(latestBoxShadowControlProps.tokens.map((token) => token.id)).toEqual([
+			'primitive.shadow.xs',
+			'primitive.shadow.sm',
+			'primitive.shadow.md',
+		]);
+
+		// Unset, not the composite-shadow reading. Passing the semantic through left the control with no
+		// matching entry and it labelled the trigger `Custom`, which claims a shadow was composed by hand.
+		expect(latestBoxShadowControlProps.value).toBeUndefined();
 	});
 
 	it('does not error and exempts nothing when the value is a composite shadow object, not a token reference', () => {
@@ -360,18 +364,18 @@ describe('BoxShadowField', () => {
 		]);
 	});
 
-	it('passes the value straight through with no envelope/breakpoint handling', () => {
+	it('passes a primitive-bound value straight through with no envelope/breakpoint handling', () => {
 		act(() => {
 			root.render(
 				createElement(BoxShadowField, {
 					field: { label: 'Shadow' },
-					value: '{semantic.shadow.card}',
+					value: '{primitive.shadow.sm}',
 					onChange: jest.fn(),
 				})
 			);
 		});
 
-		expect(latestBoxShadowControlProps.value).toBe('{semantic.shadow.card}');
+		expect(latestBoxShadowControlProps.value).toBe('{primitive.shadow.sm}');
 		expect(latestBoxShadowControlProps.breakpoints).toBeUndefined();
 	});
 

--- a/src/style-library/__tests__/box-token-field.test.js
+++ b/src/style-library/__tests__/box-token-field.test.js
@@ -123,7 +123,24 @@ describe('semanticDefaultOf', () => {
 		expect(semanticDefaultOf('', pool)).toBeNull();
 	});
 
-	it('resolves only the semantic corners of a mixed list, leaving the rest to the field default', () => {
+	it('resolves the semantic corners of a mixed list and reads the rest from the field default', () => {
+		expect(
+			semanticDefaultOf(['semantic.radius.media', 'primitive.dimension.radius.sm', '4px', ''], pool, '2px')
+		).toEqual(['0.5rem', '2px', '2px', '2px']);
+	});
+
+	it("takes each corner's own field default when the declared default is itself a slot list", () => {
+		expect(
+			semanticDefaultOf(['semantic.radius.media', 'primitive.dimension.radius.sm', '4px', ''], pool, [
+				'1px',
+				'2px',
+				'3px',
+				'4px',
+			])
+		).toEqual(['0.5rem', '2px', '3px', '4px']);
+	});
+
+	it('leaves the non-semantic corners empty when the field declares no default', () => {
 		expect(semanticDefaultOf(['semantic.radius.media', 'primitive.dimension.radius.sm', '4px', ''], pool)).toEqual([
 			'0.5rem',
 			'',

--- a/src/style-library/__tests__/box-token-field.test.js
+++ b/src/style-library/__tests__/box-token-field.test.js
@@ -8,7 +8,13 @@ import { createRoot } from 'react-dom/client';
 /**
  * Internal dependencies
  */
-import { BoxTokenField, toControlValue, toStoredValue } from '../components/molecules/fields/BoxTokenField';
+import {
+	BoxTokenField,
+	semanticDefaultOf,
+	toControlValue,
+	toStoredValue,
+	withoutSemanticSlots,
+} from '../components/molecules/fields/BoxTokenField';
 
 // A stub, not the real control: `BoxControl` renders a deep tree of pickers and popovers that have
 // nothing to do with what this suite is after. Standing in for it exposes exactly the props
@@ -77,6 +83,57 @@ describe('the conversion pair', () => {
 		]) {
 			expect(toStoredValue(toControlValue(stored), unit)).toBe(stored);
 		}
+	});
+});
+
+describe('withoutSemanticSlots', () => {
+	it('blanks a semantic-bound scalar, so the field reads as unset rather than as a selection', () => {
+		expect(withoutSemanticSlots('semantic.spacing.media-padding')).toBe('');
+	});
+
+	it('leaves a primitive and a literal alone', () => {
+		expect(withoutSemanticSlots('primitive.dimension.spacing.sm')).toBe('primitive.dimension.spacing.sm');
+		expect(withoutSemanticSlots('1.5rem')).toBe('1.5rem');
+	});
+
+	it('blanks only the semantic corners of a mixed slot list', () => {
+		expect(withoutSemanticSlots(['semantic.radius.media', 'primitive.dimension.radius.sm', '4px', ''])).toEqual([
+			'',
+			'primitive.dimension.radius.sm',
+			'4px',
+			'',
+		]);
+	});
+});
+
+describe('semanticDefaultOf', () => {
+	const pool = [
+		{ id: 'semantic.spacing.media-padding', value: '0' },
+		{ id: 'semantic.radius.media', value: '0.5rem' },
+		{ id: 'primitive.dimension.radius.sm', value: '0.25rem' },
+	];
+
+	it("resolves a semantic scalar to the literal that becomes the field's default", () => {
+		expect(semanticDefaultOf('semantic.spacing.media-padding', pool)).toBe('0');
+	});
+
+	it('returns null when nothing binds a semantic, leaving the field default in charge', () => {
+		expect(semanticDefaultOf('primitive.dimension.radius.sm', pool)).toBeNull();
+		expect(semanticDefaultOf('1.5rem', pool)).toBeNull();
+		expect(semanticDefaultOf('', pool)).toBeNull();
+	});
+
+	it('resolves only the semantic corners of a mixed list, leaving the rest to the field default', () => {
+		expect(semanticDefaultOf(['semantic.radius.media', 'primitive.dimension.radius.sm', '4px', ''], pool)).toEqual([
+			'0.5rem',
+			'',
+			'',
+			'',
+		]);
+	});
+
+	it('resolves an unknown semantic to empty rather than to its raw dot-path', () => {
+		expect(semanticDefaultOf('semantic.spacing.gone', pool)).toBe('');
 	});
 });
 

--- a/src/style-library/components/molecules/fields/BorderField.js
+++ b/src/style-library/components/molecules/fields/BorderField.js
@@ -60,7 +60,7 @@ import {
 	writePresetBreakpoint,
 } from '../../../../token-controls/helpers/preset-envelope';
 import { BorderControl } from '../../../../token-controls/controls/BorderControl';
-import { boundTokenIds } from './BoxTokenField';
+import { boundTokenIds, withoutSemanticSlots } from './BoxTokenField';
 import { useBreakpoint } from '../../../../token-controls/context/breakpoint';
 import { parseCssLength } from '../../../../token-controls/helpers/parse-css-length';
 import { isSlotList, readSlot } from '../../../../token-controls/helpers/value-shapes';
@@ -221,18 +221,23 @@ export function BorderField({ field, values, onValueChange }) {
 		onValueChange(stylePath, responsive ? writePresetBreakpoint(rawStyle, breakpoint, next) : next);
 	const writeColor = (next) => onValueChange(colorPath, next);
 
+	// A semantic-bound width is the block's role-based default rather than a selection — the pool
+	// offers primitives only — so it is blanked and the field reads as unset. Blanking is what keeps
+	// it from rendering the raw dot-path: `boundTokenIds` exempts only primitives from the narrowing,
+	// so a semantic left in place would find no matching entry. Unlike `BoxControl`, `BorderControl`
+	// takes no `defaultValue`, so the semantic's VALUE cannot be shown here the way the box fields
+	// show it; an unset field is the honest reading until that prop exists.
+	const shownWidth = withoutSemanticSlots(widthAtBreakpoint);
+
 	// The bound width token(s) are exempt from the primitive narrowing, the same way `BoxTokenField`
-	// exempts a box control's bound corners: without this, the semantic `border-width` token this
-	// role's primitives coexist with is filtered out of the pool whenever it is the one actually
-	// bound, and the field — finding no matching entry — renders the raw id instead of the token's
-	// label. Width is per-slot (a scalar or a four-slot list), which is exactly the shape
-	// `boundTokenIds` already handles.
-	const widthTokens = pickableTokensForType('dimension', 'border-width', boundTokenIds(widthAtBreakpoint)).map(
-		(token) => ({
-			...token,
-			alias: `{${token.id}}`,
-		})
-	);
+	// exempts a box control's bound corners: unlinking gives each side its own slot, so pointing one
+	// at a different primitive from its neighbors is ordinary, and exempting only the first would
+	// leave the others rendering their raw dot-path. Width is per-slot (a scalar or a four-slot
+	// list), which is exactly the shape `boundTokenIds` already handles.
+	const widthTokens = pickableTokensForType('dimension', 'border-width', boundTokenIds(shownWidth)).map((token) => ({
+		...token,
+		alias: `{${token.id}}`,
+	}));
 
 	// Which breakpoints the user has opened up into per-side editing. Held here rather than inferred
 	// from the stored shape — see the module docblock — and per breakpoint for the same reason
@@ -243,7 +248,7 @@ export function BorderField({ field, values, onValueChange }) {
 	// width/style already use), so a list-shaped color has to force the unlinked view exactly like a
 	// list-shaped width/style does — otherwise the panel would show one linked swatch while the
 	// stored value still carries four different colors.
-	const storedIsList = isSlotList(widthAtBreakpoint) || isSlotList(styleAtBreakpoint) || isSlotList(rawColor);
+	const storedIsList = isSlotList(shownWidth) || isSlotList(styleAtBreakpoint) || isSlotList(rawColor);
 	const linked = storedIsList ? false : !unlinked[breakpoint];
 
 	const toggleLink = () => {
@@ -263,7 +268,7 @@ export function BorderField({ field, values, onValueChange }) {
 	return (
 		<BorderControl
 			value={{
-				width: toControlWidthAxis(widthAtBreakpoint),
+				width: toControlWidthAxis(shownWidth),
 				style: toControlStyleAxis(styleAtBreakpoint),
 				color: rawColor ?? '',
 			}}

--- a/src/style-library/components/molecules/fields/BoxShadowField.js
+++ b/src/style-library/components/molecules/fields/BoxShadowField.js
@@ -53,6 +53,23 @@ function boundShadowTokenIds(value) {
 }
 
 /**
+ * Whether a stored shadow is bound to a SEMANTIC token, which this field shows as unset rather than
+ * as a selection — see the reasoning in `BoxShadowField` below and in `withoutSemanticSlots`.
+ *
+ * Takes the brace-wrapped alias this field's value carries, unlike `withoutSemanticSlots`, which
+ * works on the bare ids a box field's slots hold.
+ *
+ * @param {*} value The stored value: a token alias, or a composite shadow object.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the value is a semantic alias.
+ */
+function isSemanticShadow(value) {
+	return isTokenAlias(value) && value.slice(1, -1).startsWith('semantic.');
+}
+
+/**
  * Render a box-shadow field from a settings schema entry.
  *
  * @param {Object}  props                  The component props.
@@ -67,20 +84,27 @@ function boundShadowTokenIds(value) {
  * @return {JSX.Element} The field.
  */
 export function BoxShadowField({ field, value, onChange }) {
+	// A semantic-bound shadow is the block's role-based default rather than a selection — the pool
+	// offers primitives only — so it is blanked and the field reads as unset. Without this the control
+	// found no pool entry for it and labelled the trigger `Custom`, which reads as "someone composed a
+	// shadow by hand" when nothing of the sort happened. `BoxShadowControl` takes no `defaultValue`,
+	// so the semantic's VALUE cannot be shown the way the box fields show it; unset is the honest
+	// reading until that prop exists.
+	const shown = isSemanticShadow(value) ? undefined : value;
+
 	// A bare `type` filter alone returns every `shadow` token, including the two `Brand`-group
 	// semantics (`semantic.shadow.media`, `semantic.shadow.button`) that back other blocks' own
 	// default CSS and were never meant to be end-user-pickable here. Passing `role: 'shadow'` — every
 	// shadow token's derived role — engages the primitive narrowing, matching the three-entry list the
-	// Shadow screen itself offers. `boundShadowTokenIds` exempts the currently-bound token from that
-	// narrowing so a bound semantic still renders as its own label rather than a raw id.
-	const tokens = pickableTokensForType('shadow', 'shadow', boundShadowTokenIds(value)).map((token) => ({
+	// Shadow screen itself offers.
+	const tokens = pickableTokensForType('shadow', 'shadow', boundShadowTokenIds(shown)).map((token) => ({
 		...token,
 		alias: `{${token.id}}`,
 	}));
 
 	return (
 		<BoxShadowControl
-			value={value}
+			value={shown}
 			onChange={(next) => !field.readOnly && onChange(next)}
 			label={field.label}
 			tokens={tokens}

--- a/src/style-library/components/molecules/fields/BoxTokenField.js
+++ b/src/style-library/components/molecules/fields/BoxTokenField.js
@@ -67,6 +67,73 @@ function unitInPlay(value, fallback) {
 }
 
 /**
+ * Whether a stored slot holds a semantic token id.
+ *
+ * @param {*} slot The stored slot value.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the slot is bound to a semantic.
+ */
+export function isSemanticSlot(slot) {
+	return typeof slot === 'string' && slot.startsWith('semantic.');
+}
+
+/**
+ * Blank out every semantic-bound slot, leaving primitives and literals untouched.
+ *
+ * A semantic is not a value a site owner picked — it cannot be, because the pickers offer only
+ * primitives. It is the role-based default the block already renders, so a slot holding one reads as
+ * UNSET, and {@see semanticDefaultOf} supplies its resolved value as what the field falls back to. The
+ * effect is the one the design asks for: a semantic's name never appears, and its value is what
+ * `Default` means.
+ *
+ * Blanking rather than resolving to the literal is what makes the field read `Default (0)` instead of
+ * a custom `0`: a control given a literal treats it as a value the user typed.
+ *
+ * @param {*} value The stored scalar or slot list.
+ *
+ * @since TBD
+ *
+ * @return {*} The value with semantic slots blanked, in the same shape.
+ */
+export function withoutSemanticSlots(value) {
+	if (isSlotList(value)) {
+		return value.map((slot) => (isSemanticSlot(slot) ? '' : slot));
+	}
+
+	return isSemanticSlot(value) ? '' : value;
+}
+
+/**
+ * The resolved literal a value's semantic slots fall back to, in the value's own shape, or null when
+ * it binds no semantic at all.
+ *
+ * A partially-semantic slot list resolves only its semantic corners and leaves the rest empty, so the
+ * default describes exactly the corners that have one — the others fall back to the field's own
+ * declared default the way they always did.
+ *
+ * @param {*}     value      The stored scalar or slot list.
+ * @param {Array} everyToken The full token pool, before any role narrowing, used to resolve an id.
+ *
+ * @since TBD
+ *
+ * @return {*} The resolved default, in the value's shape, or null when no slot binds a semantic.
+ */
+export function semanticDefaultOf(value, everyToken) {
+	const slots = isSlotList(value) ? value : [value];
+
+	if (!slots.some(isSemanticSlot)) {
+		return null;
+	}
+
+	const resolve = (slot) =>
+		isSemanticSlot(slot) ? (everyToken.find((token) => token.id === slot)?.value ?? '') : '';
+
+	return isSlotList(value) ? value.map(resolve) : resolve(value);
+}
+
+/**
  * Convert one stored slot into what the control expects: an alias, a bare number, or ''.
  *
  * @param {*} stored The stored slot value.
@@ -144,25 +211,28 @@ function boundsForUnit(unit, field) {
 }
 
 /**
- * Every token id a value has bound, so the pool narrowing knows what it must not drop.
+ * Every PRIMITIVE token id a value has bound, so the pool narrowing knows what it must not drop.
  *
  * All of them, not just the first: unlinking gives each corner its own slot, so pointing one at a
- * primitive while the rest still hold a semantic is an ordinary thing to do. Exempting only the first
- * would drop the semantic from the pool, and the corners still holding it would render their raw
- * dot-path instead of the token's name.
+ * different primitive from its neighbors is an ordinary thing to do, and exempting only the first
+ * would drop the others from the pool and leave those corners rendering their raw dot-path.
+ *
+ * Semantics are deliberately NOT exempted, which is what keeps their names out of the pickers. A
+ * semantic is never something a site owner picked — the pool offers primitives only — so a slot
+ * holding one is the block's role-based default rather than a selection. {@see withoutSemanticSlots}
+ * blanks it for display and {@see semanticDefaultOf} surfaces its value as the field's default, so
+ * nothing renders a raw dot-path for want of a pool entry.
  *
  * @param {*} value The stored scalar or slot list.
  *
  * @since TBD
  *
- * @return {Array<string>} The bound token ids, empty when nothing is bound.
+ * @return {Array<string>} The bound primitive token ids, empty when nothing is bound.
  */
 export function boundTokenIds(value) {
 	const slots = isSlotList(value) ? value : [value];
 
-	return slots.filter(
-		(slot) => typeof slot === 'string' && (slot.startsWith('primitive.') || slot.startsWith('semantic.'))
-	);
+	return slots.filter((slot) => typeof slot === 'string' && slot.startsWith('primitive.'));
 }
 
 /**
@@ -242,12 +312,23 @@ export function BoxTokenField({ field, value, onChange, slots = 'sides' }) {
 	const asLiteral = (slot) =>
 		typeof slot === 'string' ? (everyToken.find((token) => token.id === slot)?.value ?? slot) : slot;
 
-	const shownDefault = inheritsFromBreakpoint ? mapSlots(inheritedAbove, asLiteral) : fieldDefault;
+	// A semantic-bound slot is the block's role-based default, not a selection, so it is blanked for
+	// display and its resolved value becomes what this field falls back to. That is the whole of the
+	// "a semantic's name never shows; its value is the Default" rule — see `withoutSemanticSlots`.
+	// It outranks the field's own declared default, which describes the same thing less precisely:
+	// the declared default is a literal written into the screen config, while this is what the
+	// preset actually resolves in the active library.
+	const shown = withoutSemanticSlots(atBreakpoint);
+	const semanticDefault = semanticDefaultOf(atBreakpoint, everyToken);
+
+	const shownDefault = inheritsFromBreakpoint
+		? mapSlots(inheritedAbove, asLiteral)
+		: (semanticDefault ?? fieldDefault);
 
 	// The unit falls back the same way the value does. With nothing stored there is no unit to read, and
 	// defaulting to `units[0]` made the Custom tab open on `px` while the field beside it displayed the
 	// default's own `em` — one value described two different ways.
-	const stored = unitInPlay(atBreakpoint, unitInPlay(shownDefault, units[0]));
+	const stored = unitInPlay(shown, unitInPlay(shownDefault, units[0]));
 
 	// A unit the user picked before typing a number has nowhere to persist — no slot carries it yet
 	// — so it is held here until a value exists to attach it to. Keyed per breakpoint for the same
@@ -263,7 +344,7 @@ export function BoxTokenField({ field, value, onChange, slots = 'sides' }) {
 	// choice per breakpoint is also what keeps the breakpoints independent — tablet can be edited as
 	// four corners while mobile is still a single value.
 	const [unlinked, setUnlinked] = useState({});
-	const storedIsList = isSlotList(atBreakpoint);
+	const storedIsList = isSlotList(shown);
 	const linked = storedIsList ? false : !unlinked[breakpoint];
 
 	const toggleLink = () => {
@@ -278,14 +359,14 @@ export function BoxTokenField({ field, value, onChange, slots = 'sides' }) {
 
 	return (
 		<BoxControl
-			value={mapSlots(atBreakpoint, toControlValue)}
+			value={mapSlots(shown, toControlValue)}
 			onChange={(next) => !field.readOnly && onChange(write(mapSlots(next, (slot) => toStoredValue(slot, unit))))}
 			label={field.label}
 			// The inherited value's token has to be exempt from the narrowing too, not just this
 			// breakpoint's own. A breakpoint that inherits binds nothing itself, so without this the
 			// semantic it falls back to is filtered out of the pool and the field, finding no entry for
 			// it, shows nothing at all instead of the value actually in effect.
-			tokens={pickableTokensForType(field.tokenType, field.role, boundTokenIds(atBreakpoint)).map((token) => ({
+			tokens={pickableTokensForType(field.tokenType, field.role, boundTokenIds(shown)).map((token) => ({
 				...token,
 				alias: `{${token.id}}`,
 			}))}

--- a/src/style-library/components/molecules/fields/BoxTokenField.js
+++ b/src/style-library/components/molecules/fields/BoxTokenField.js
@@ -109,28 +109,33 @@ export function withoutSemanticSlots(value) {
  * The resolved literal a value's semantic slots fall back to, in the value's own shape, or null when
  * it binds no semantic at all.
  *
- * A partially-semantic slot list resolves only its semantic corners and leaves the rest empty, so the
- * default describes exactly the corners that have one — the others fall back to the field's own
- * declared default the way they always did.
+ * A partially-semantic slot list resolves only its semantic corners; the rest read from the field's
+ * own declared default, so the default describes every corner the way it did before any of them
+ * bound a semantic. Resolving the whole list here rather than returning only the semantic corners is
+ * what keeps that promise: the caller takes this in place of the declared default, not alongside it,
+ * so a corner left empty here would show as blank rather than as the value actually in effect.
  *
- * @param {*}     value      The stored scalar or slot list.
- * @param {Array} everyToken The full token pool, before any role narrowing, used to resolve an id.
+ * @param {*}     value        The stored scalar or slot list.
+ * @param {Array} everyToken   The full token pool, before any role narrowing, used to resolve an id.
+ * @param {*}     fieldDefault The field's own declared default, for the corners that bind no semantic.
  *
  * @since TBD
  *
  * @return {*} The resolved default, in the value's shape, or null when no slot binds a semantic.
  */
-export function semanticDefaultOf(value, everyToken) {
+export function semanticDefaultOf(value, everyToken, fieldDefault = null) {
 	const slots = isSlotList(value) ? value : [value];
 
 	if (!slots.some(isSemanticSlot)) {
 		return null;
 	}
 
-	const resolve = (slot) =>
-		isSemanticSlot(slot) ? (everyToken.find((token) => token.id === slot)?.value ?? '') : '';
+	const resolve = (slot, index) =>
+		isSemanticSlot(slot)
+			? (everyToken.find((token) => token.id === slot)?.value ?? '')
+			: (readSlot(fieldDefault, index) ?? '');
 
-	return isSlotList(value) ? value.map(resolve) : resolve(value);
+	return isSlotList(value) ? value.map(resolve) : resolve(value, 0);
 }
 
 /**
@@ -319,7 +324,7 @@ export function BoxTokenField({ field, value, onChange, slots = 'sides' }) {
 	// the declared default is a literal written into the screen config, while this is what the
 	// preset actually resolves in the active library.
 	const shown = withoutSemanticSlots(atBreakpoint);
-	const semanticDefault = semanticDefaultOf(atBreakpoint, everyToken);
+	const semanticDefault = semanticDefaultOf(atBreakpoint, everyToken, fieldDefault);
 
 	const shownDefault = inheritsFromBreakpoint
 		? mapSlots(inheritedAbove, asLiteral)

--- a/src/style-library/components/molecules/fields/ScalarTokenField.js
+++ b/src/style-library/components/molecules/fields/ScalarTokenField.js
@@ -31,7 +31,7 @@ import {
 import { ScalarControl } from '../../../../token-controls/controls/ScalarControl';
 import { useBreakpoint } from '../../../../token-controls/context/breakpoint';
 import { parseCssLength } from '../../../../token-controls/helpers/parse-css-length';
-import { boundTokenIds, toControlValue, toStoredValue } from './BoxTokenField';
+import { boundTokenIds, semanticDefaultOf, toControlValue, toStoredValue, withoutSemanticSlots } from './BoxTokenField';
 
 /**
  * The unit a stored scalar already carries, so a write does not silently retype it.
@@ -119,11 +119,18 @@ export function ScalarTokenField({ field, value, onChange }) {
 	const asLiteral = (stored) =>
 		typeof stored === 'string' ? (everyToken.find((token) => token.id === stored)?.value ?? stored) : stored;
 
-	const shownDefault = inheritsFromBreakpoint ? asLiteral(inheritedAbove) : (field.defaultValue ?? null);
+	// A semantic-bound value is the block's role-based default, not a selection, so it is blanked for
+	// display and its resolved value becomes what this field falls back to — see `withoutSemanticSlots`.
+	const shown = withoutSemanticSlots(atBreakpoint);
+	const semanticDefault = semanticDefaultOf(atBreakpoint, everyToken);
+
+	const shownDefault = inheritsFromBreakpoint
+		? asLiteral(inheritedAbove)
+		: (semanticDefault ?? field.defaultValue ?? null);
 
 	// The unit falls back the same way the value does, so the Custom tab never opens on `px` while the
 	// field beside it displays the default's own `em`.
-	const stored = unitInPlay(atBreakpoint, unitInPlay(shownDefault, units[0]));
+	const stored = unitInPlay(shown, unitInPlay(shownDefault, units[0]));
 
 	// A unit picked before a number has nowhere to persist yet, so it is held here until a value exists to
 	// attach it to — keyed per breakpoint, so a pending unit picked on one does not leak into another.
@@ -133,13 +140,13 @@ export function ScalarTokenField({ field, value, onChange }) {
 
 	return (
 		<ScalarControl
-			value={toControlValue(atBreakpoint)}
+			value={toControlValue(shown)}
 			onChange={(next) => !field.readOnly && onChange(write(toStoredValue(next, unit)))}
 			label={field.label}
-			// The inherited value's token is exempt from the narrowing too, not just this breakpoint's own:
-			// a breakpoint that inherits binds nothing itself, so without this the semantic it falls back to
-			// is filtered out of the pool and the field shows nothing instead of the value in effect.
-			tokens={pickableTokensForType(field.tokenType, field.role, boundTokenIds(atBreakpoint)).map((token) => ({
+			// Only this breakpoint's own PRIMITIVE bindings are exempt from the narrowing. A semantic is
+			// never exempted — it is shown as the default rather than offered as a choice — and an
+			// inherited value is resolved to its literal above rather than added to the pool.
+			tokens={pickableTokensForType(field.tokenType, field.role, boundTokenIds(shown)).map((token) => ({
 				...token,
 				alias: `{${token.id}}`,
 			}))}

--- a/src/style-library/components/pages/ImageScreen.scss
+++ b/src/style-library/components/pages/ImageScreen.scss
@@ -37,13 +37,27 @@
 		padding 300ms ease;
 }
 
-// The stand-in photo: a neutral block filling whatever the padding leaves. Deliberately not a real
-// image — a preset skins whichever image a block holds, so previewing a specific picture would imply
-// the preset selects one.
+// The stand-in photo: a neutral block filling whatever the padding leaves, carrying a generic picture
+// glyph. Deliberately not a real image — a preset skins whichever image a block holds, so previewing a
+// specific picture would imply the preset selects one. The glyph is what makes padding legible: without
+// something that reads as "the image", an inset frame is just a smaller rectangle and the band around
+// it does not obviously belong to the background.
 .kadence-blocks-style-library__image-preset-preview-photo {
-	display: block;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	width: 100%;
 	height: 100%;
 	border-radius: inherit;
 	background: var(--kb-sl-color-gray-700);
+	// Sized in `em` off a font-size floor rather than a fixed px, so the glyph shrinks with the photo
+	// when a large padding squeezes it instead of overflowing the tile.
+	font-size: min(1.5rem, 45%);
+	color: var(--kb-sl-color-gray-200);
+	overflow: hidden;
+
+	svg {
+		width: 1em;
+		height: 1em;
+	}
 }

--- a/src/style-library/presets/image-preset.js
+++ b/src/style-library/presets/image-preset.js
@@ -101,7 +101,14 @@ function renderPreview(row) {
 					padding: row.preview.padding || undefined,
 				}}
 			>
-				<span className="kadence-blocks-style-library__image-preset-preview-photo" />
+				<span className="kadence-blocks-style-library__image-preset-preview-photo">
+					<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+						<path
+							fill="currentColor"
+							d="M4 5h16a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1zm1 12.2 4.6-4.6 3 3L15.4 13l3.6 3.6V7H5v10.2zM8.5 11a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
+						/>
+					</svg>
+				</span>
 			</span>
 		</span>
 	);


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout
:video_camera: https://www.loom.com/share/c45de6b397424fcf9434d5b8e1fe9582

A semantic is not something a site owner can pick, since every field narrows its pool to the role's primitive scale. A slot holding one now reads as unset with the semantic's value as the default, so a semantic's name never appears in a picker.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Style controls now correctly treat semantic token references as inherited or unset values instead of displaying them as custom selections.
  * Token pickers now show only applicable primitive options while preserving literal and primitive values.
  * Border, shadow, spacing, and scalar fields now resolve semantic defaults more consistently, including per-corner settings.

* **UI Improvements**
  * Image preset previews now display a centered, responsive landscape icon when no image is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

