### PR TITLE
[DTM] SOFT-4218 [12/16]: fix the Advanced Image shadow field and preview

### DIFF
--- a/src/style-library/__tests__/border-shadow-field-rendering.test.js
+++ b/src/style-library/__tests__/border-shadow-field-rendering.test.js
@@ -328,7 +328,9 @@ describe('BoxShadowField', () => {
 			root.render(
 				createElement(BoxShadowField, {
 					field: { label: 'Shadow' },
-					value: '{semantic.shadow.button}',
+					// A BARE id, which is what a draft holds: `presetInitialValues` runs every seeded
+					// value through `aliasToIdDeep`. The braced form is accepted too, but never arrives.
+					value: 'semantic.shadow.button',
 					onChange: jest.fn(),
 				})
 			);
@@ -364,19 +366,54 @@ describe('BoxShadowField', () => {
 		]);
 	});
 
-	it('passes a primitive-bound value straight through with no envelope/breakpoint handling', () => {
+	it('wraps a primitive-bound bare id into the alias the control matches its list against', () => {
 		act(() => {
 			root.render(
 				createElement(BoxShadowField, {
 					field: { label: 'Shadow' },
-					value: '{primitive.shadow.sm}',
+					value: 'primitive.shadow.sm',
 					onChange: jest.fn(),
 				})
 			);
 		});
 
+		// Without the wrap the control finds no entry for the bare id and labels the trigger `Custom`,
+		// which claims a shadow was composed by hand.
 		expect(latestBoxShadowControlProps.value).toBe('{primitive.shadow.sm}');
 		expect(latestBoxShadowControlProps.breakpoints).toBeUndefined();
+	});
+
+	it('writes a pick back as a bare id, so the panel can tell a saved preset is no longer dirty', () => {
+		const onChange = jest.fn();
+
+		act(() => {
+			root.render(createElement(BoxShadowField, { field: { label: 'Shadow' }, value: '', onChange }));
+		});
+
+		act(() => {
+			latestBoxShadowControlProps.onChange('{primitive.shadow.md}');
+		});
+
+		// Bare, matching every other field and the shape `presetInitialValues` seeds. Storing the braced
+		// form would leave the draft permanently unequal to its seeded value and Save enabled forever.
+		expect(onChange).toHaveBeenCalledWith('primitive.shadow.md');
+	});
+
+	it('passes a composite shadow object through untouched', () => {
+		const onChange = jest.fn();
+		const composite = { color: '#000', hOffset: 0, vOffset: 4, blur: 8, spread: 0 };
+
+		act(() => {
+			root.render(createElement(BoxShadowField, { field: { label: 'Shadow' }, value: composite, onChange }));
+		});
+
+		expect(latestBoxShadowControlProps.value).toBe(composite);
+
+		act(() => {
+			latestBoxShadowControlProps.onChange(composite);
+		});
+
+		expect(onChange).toHaveBeenCalledWith(composite);
 	});
 
 	it('never calls onChange when the field is read-only', () => {

--- a/src/style-library/__tests__/image-preset.test.js
+++ b/src/style-library/__tests__/image-preset.test.js
@@ -149,9 +149,44 @@ describe('IMAGE_PRESET', () => {
 
 		expect(fill.props.className).toBe('kadence-blocks-style-library__image-preset-preview-fill');
 		expect(fill.props.style.background).toBe('#F7FAFC');
-		expect(fill.props.style.padding).toBe('0.5rem');
+		expect(fill.props.style.padding).toBe('min(0.5rem, 22%)');
 
 		expect(photo.props.className).toBe('kadence-blocks-style-library__image-preset-preview-photo');
+	});
+
+	/**
+	 * Preview padding is capped per side. The tile is a few rem across and the spacing scale runs to
+	 * 10rem, so a real value applied at true size swallows the photo: `MD` alone (2rem a side) leaves
+	 * the tile's content box with negative height and the row shows only a colored rectangle.
+	 *
+	 * @return {void}
+	 */
+	it('caps each side of the preview padding so the photo never collapses', () => {
+		const frame = IMAGE_PRESET.renderPreview({
+			id: 'roomy',
+			label: 'Roomy',
+			preview: { background: '', borderRadius: '', shadow: '', padding: '2rem' },
+		});
+
+		expect(frame.props.children.props.style.padding).toBe('min(2rem, 22%)');
+	});
+
+	/**
+	 * A per-corner preset resolves to a shorthand, and CSS `min()` takes one length rather than a
+	 * shorthand, so each side is wrapped on its own.
+	 *
+	 * @return {void}
+	 */
+	it('caps every side of a per-corner padding shorthand independently', () => {
+		const frame = IMAGE_PRESET.renderPreview({
+			id: 'corners',
+			label: 'Corners',
+			preview: { background: '', borderRadius: '', shadow: '', padding: '1rem 2rem 1rem 2rem' },
+		});
+
+		expect(frame.props.children.props.style.padding).toBe(
+			'min(1rem, 22%) min(2rem, 22%) min(1rem, 22%) min(2rem, 22%)'
+		);
 	});
 
 	/**

--- a/src/style-library/__tests__/image-preset.test.js
+++ b/src/style-library/__tests__/image-preset.test.js
@@ -149,26 +149,27 @@ describe('IMAGE_PRESET', () => {
 
 		expect(fill.props.className).toBe('kadence-blocks-style-library__image-preset-preview-fill');
 		expect(fill.props.style.background).toBe('#F7FAFC');
-		expect(fill.props.style.padding).toBe('min(0.5rem, 22%)');
+		expect(fill.props.style.padding).toBe('min(0.5rem, 4rem)');
 
 		expect(photo.props.className).toBe('kadence-blocks-style-library__image-preset-preview-photo');
 	});
 
 	/**
-	 * Preview padding is capped per side. The tile is a few rem across and the spacing scale runs to
-	 * 10rem, so a real value applied at true size swallows the photo: `MD` alone (2rem a side) leaves
-	 * the tile's content box with negative height and the row shows only a colored rectangle.
+	 * The tile grows to fit its padding, so a step is shown at true size; the cap only bounds the very
+	 * top of the scale, which runs to 10rem and would otherwise produce a row taller than the screen.
 	 *
 	 * @return {void}
 	 */
-	it('caps each side of the preview padding so the photo never collapses', () => {
+	it('caps each side of the preview padding, bounding one extreme preset', () => {
 		const frame = IMAGE_PRESET.renderPreview({
 			id: 'roomy',
 			label: 'Roomy',
 			preview: { background: '', borderRadius: '', shadow: '', padding: '2rem' },
 		});
 
-		expect(frame.props.children.props.style.padding).toBe('min(2rem, 22%)');
+		// A length, not a percentage: the tile's width is derived from the padding, so a percentage
+		// would resolve against a size the padding itself determines.
+		expect(frame.props.children.props.style.padding).toBe('min(2rem, 4rem)');
 	});
 
 	/**
@@ -185,7 +186,7 @@ describe('IMAGE_PRESET', () => {
 		});
 
 		expect(frame.props.children.props.style.padding).toBe(
-			'min(1rem, 22%) min(2rem, 22%) min(1rem, 22%) min(2rem, 22%)'
+			'min(1rem, 4rem) min(2rem, 4rem) min(1rem, 4rem) min(2rem, 4rem)'
 		);
 	});
 

--- a/src/style-library/__tests__/image-preset.test.js
+++ b/src/style-library/__tests__/image-preset.test.js
@@ -173,6 +173,39 @@ describe('IMAGE_PRESET', () => {
 	});
 
 	/**
+	 * A unitless zero is never wrapped. `min()` requires one type throughout, so `min(0, 4rem)` mixes a
+	 * number with a length, is invalid, and is dropped by the browser -- leaving the property at its
+	 * previous value, which made picking the `None` step appear to do nothing at all.
+	 *
+	 * @return {void}
+	 */
+	it('leaves a unitless zero uncapped, which min() could not legally take', () => {
+		const frame = IMAGE_PRESET.renderPreview({
+			id: 'none',
+			label: 'None',
+			preview: { background: '', borderRadius: '', shadow: '', padding: '0' },
+		});
+
+		expect(frame.props.children.props.style.padding).toBe('0');
+	});
+
+	/**
+	 * The same rule per side: a shorthand mixing zero with real lengths caps only the lengths, because
+	 * one invalid component would take the whole declaration down with it.
+	 *
+	 * @return {void}
+	 */
+	it('caps only the sides carrying a unit in a mixed shorthand', () => {
+		const frame = IMAGE_PRESET.renderPreview({
+			id: 'mixed',
+			label: 'Mixed',
+			preview: { background: '', borderRadius: '', shadow: '', padding: '0 2rem 0 2rem' },
+		});
+
+		expect(frame.props.children.props.style.padding).toBe('0 min(2rem, 4rem) 0 min(2rem, 4rem)');
+	});
+
+	/**
 	 * A per-corner preset resolves to a shorthand, and CSS `min()` takes one length rather than a
 	 * shorthand, so each side is wrapped on its own.
 	 *

--- a/src/style-library/components/molecules/fields/BoxShadowField.js
+++ b/src/style-library/components/molecules/fields/BoxShadowField.js
@@ -34,39 +34,84 @@ import { isTokenAlias } from '../../../../token-controls/helpers/token-summary';
 import { TokenColorSelectField } from './TokenColorSelectField';
 
 /**
- * The bound token id, unwrapped from its brace-wrapped alias, or unset when `value` holds a
- * composite shadow object instead. `boundTokenIds` (shared with `BorderField`) expects the bare
- * `primitive.`/`semantic.`-prefixed id a preset's own `tokens` map stores; this field's `value`
- * carries the brace-wrapped alias `BoxShadowControl` matches against instead (see this file's own
- * docblock — no envelope, no per-slot conversion), so the brace has to come off first. A composite
- * object is not an alias at all and passes through unwrapped, matching `boundTokenIds`'
- * non-string, non-list values with an empty exemption set.
+ * The bare token id a stored shadow holds, or the value unchanged when it holds a composite shadow
+ * object instead.
  *
- * @param {*} value The stored value: a token alias, or a composite shadow object.
+ * A draft carries BARE ids — `presetInitialValues()` runs every seeded value through
+ * `aliasToIdDeep()` — while `BoxShadowControl` matches against the brace-wrapped form. Both shapes
+ * are accepted here so the helper describes the same token either way.
+ *
+ * @param {*} value The stored value: a bare token id, an alias, or a composite shadow object.
  *
  * @since TBD
  *
- * @return {Array<string>} The bound token ids, empty when nothing is bound.
+ * @return {*} The bare id, or the value unchanged.
  */
-function boundShadowTokenIds(value) {
-	return boundTokenIds(isTokenAlias(value) ? value.slice(1, -1) : value);
+function bareShadowId(value) {
+	return isTokenAlias(value) ? value.slice(1, -1) : value;
 }
 
 /**
- * Whether a stored shadow is bound to a SEMANTIC token, which this field shows as unset rather than
- * as a selection — see the reasoning in `BoxShadowField` below and in `withoutSemanticSlots`.
+ * The bound token id `pickableTokensForType` must not narrow away, or none when the value holds a
+ * composite shadow object. `boundTokenIds` (shared with `BorderField`) expects the bare id a
+ * preset's `tokens` map stores, and returns only PRIMITIVES — a semantic is shown as the default
+ * rather than offered, so it is never exempted.
  *
- * Takes the brace-wrapped alias this field's value carries, unlike `withoutSemanticSlots`, which
- * works on the bare ids a box field's slots hold.
- *
- * @param {*} value The stored value: a token alias, or a composite shadow object.
+ * @param {*} value The stored value: a bare token id, an alias, or a composite shadow object.
  *
  * @since TBD
  *
- * @return {boolean} True when the value is a semantic alias.
+ * @return {Array<string>} The bound primitive token ids, empty when nothing is bound.
  */
-function isSemanticShadow(value) {
-	return isTokenAlias(value) && value.slice(1, -1).startsWith('semantic.');
+function boundShadowTokenIds(value) {
+	return boundTokenIds(bareShadowId(value));
+}
+
+/**
+ * Convert a stored shadow into what `BoxShadowControl` expects.
+ *
+ * Three cases, and the first is the one this field exists to get right. A SEMANTIC-bound shadow is
+ * the block's role-based default rather than a selection — the pool offers primitives only — so it
+ * reads as unset. A primitive-bound one is wrapped into the alias the control matches its list
+ * against, the same conversion `toControlValue` performs for a box field's slots; without it the
+ * control finds no entry for the bare id and labels the trigger `Custom`, which claims someone
+ * composed a shadow by hand when nothing of the sort happened. Anything else — a composite object,
+ * or nothing at all — passes through.
+ *
+ * @param {*} value The stored value: a bare token id, an alias, or a composite shadow object.
+ *
+ * @since TBD
+ *
+ * @return {*} The control-shaped value.
+ */
+export function toControlShadow(value) {
+	const id = bareShadowId(value);
+
+	if (typeof id !== 'string' || id === '') {
+		return value;
+	}
+
+	if (id.startsWith('semantic.')) {
+		return undefined;
+	}
+
+	return id.startsWith('primitive.') ? `{${id}}` : value;
+}
+
+/**
+ * Convert what the control writes back into what a preset draft stores: a bare id, matching every
+ * other field. A draft holding the brace-wrapped form would never compare equal to the bare id
+ * `presetInitialValues` seeds, so the panel's dirty bit could never clear and Save would stay
+ * enabled after a successful write — the mismatch `aliasToIdDeep`'s docblock describes.
+ *
+ * @param {*} next The control-shaped value: an alias, or a composite shadow object.
+ *
+ * @since TBD
+ *
+ * @return {*} The value a preset draft stores.
+ */
+export function toStoredShadow(next) {
+	return isTokenAlias(next) ? next.slice(1, -1) : next;
 }
 
 /**
@@ -84,13 +129,9 @@ function isSemanticShadow(value) {
  * @return {JSX.Element} The field.
  */
 export function BoxShadowField({ field, value, onChange }) {
-	// A semantic-bound shadow is the block's role-based default rather than a selection — the pool
-	// offers primitives only — so it is blanked and the field reads as unset. Without this the control
-	// found no pool entry for it and labelled the trigger `Custom`, which reads as "someone composed a
-	// shadow by hand" when nothing of the sort happened. `BoxShadowControl` takes no `defaultValue`,
-	// so the semantic's VALUE cannot be shown the way the box fields show it; unset is the honest
-	// reading until that prop exists.
-	const shown = isSemanticShadow(value) ? undefined : value;
+	// `BoxShadowControl` takes no `defaultValue`, so a semantic's VALUE cannot be shown here the way
+	// the box fields show it; unset is the honest reading until that prop exists.
+	const shown = toControlShadow(value);
 
 	// A bare `type` filter alone returns every `shadow` token, including the two `Brand`-group
 	// semantics (`semantic.shadow.media`, `semantic.shadow.button`) that back other blocks' own
@@ -105,7 +146,7 @@ export function BoxShadowField({ field, value, onChange }) {
 	return (
 		<BoxShadowControl
 			value={shown}
-			onChange={(next) => !field.readOnly && onChange(next)}
+			onChange={(next) => !field.readOnly && onChange(toStoredShadow(next))}
 			label={field.label}
 			tokens={tokens}
 			renderColor={({ value: color, onChange: onColorChange }) => (

--- a/src/style-library/components/pages/ImageScreen.scss
+++ b/src/style-library/components/pages/ImageScreen.scss
@@ -17,20 +17,26 @@
 	width: 15rem;
 }
 
-// Landscape, the aspect a photo most often takes. The shared surface mixin supplies the frame and the
-// transparency checker; the shadow is applied inline from the preset, so it must not be clipped —
-// hence no `overflow` here either.
+// Unlike the Row Layout band and the Section slab, this tile has no fixed size: it GROWS to fit the
+// preset's padding, so a bigger step reads as a bigger inset instead of eating the photo. The frame
+// mixin supplies the border and the transparency checker and leaves the geometry to the fill inside.
+// The shadow is applied inline from the preset and is drawn outside whatever casts it, so nothing
+// here may clip.
 .kadence-blocks-style-library__image-preset-preview {
-	@include preset-surface-preview(5rem, 3.75rem);
+	@include preset-surface-frame;
+
+	display: inline-block;
+	vertical-align: middle;
 }
 
-// Carries the background AND the preset's padding, so the padding renders as real space between the
-// frame and the photo below rather than as a number. `box-sizing: border-box` keeps a large padding
-// shrinking the photo instead of growing the tile past its row.
+// Carries the background AND the preset's padding. `content-box` is what makes the tile grow: the box
+// is the photo's fixed size PLUS the padding, so the padding is real space between the frame and the
+// photo at every step rather than an inset that eventually has nowhere left to go. Static, not
+// absolutely positioned — an out-of-flow fill could not size its parent.
 .kadence-blocks-style-library__image-preset-preview-fill {
-	@include preset-surface-fill;
-
-	box-sizing: border-box;
+	display: block;
+	box-sizing: content-box;
+	border-radius: inherit;
 	transition:
 		background-color 300ms ease,
 		border-radius 300ms ease,
@@ -46,16 +52,18 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 100%;
-	height: 100%;
+	// Fixed, and the reason the tile can grow: with the photo a known size and the fill sized
+	// `content-box`, the frame's dimensions are simply this plus the padding.
+	width: 3rem;
+	height: 2.25rem;
 	border-radius: inherit;
 	background: var(--kb-sl-color-gray-700);
 	color: var(--kb-sl-color-gray-200);
 	overflow: hidden;
 
 	svg {
-		// Sized against the photo box rather than a font-size, so the glyph fills a useful share of the
-		// tile and shrinks with it when a large padding squeezes the photo, instead of overflowing.
+		// Sized against the photo box rather than a font-size — a percentage font-size would resolve
+		// against the inherited size, not the box, and collapse the glyph to a dot.
 		width: 62%;
 		height: 62%;
 	}

--- a/src/style-library/components/pages/ImageScreen.scss
+++ b/src/style-library/components/pages/ImageScreen.scss
@@ -50,14 +50,13 @@
 	height: 100%;
 	border-radius: inherit;
 	background: var(--kb-sl-color-gray-700);
-	// Sized in `em` off a font-size floor rather than a fixed px, so the glyph shrinks with the photo
-	// when a large padding squeezes it instead of overflowing the tile.
-	font-size: min(1.5rem, 45%);
 	color: var(--kb-sl-color-gray-200);
 	overflow: hidden;
 
 	svg {
-		width: 1em;
-		height: 1em;
+		// Sized against the photo box rather than a font-size, so the glyph fills a useful share of the
+		// tile and shrinks with it when a large padding squeezes the photo, instead of overflowing.
+		width: 62%;
+		height: 62%;
 	}
 }

--- a/src/style-library/presets/image-preset.js
+++ b/src/style-library/presets/image-preset.js
@@ -59,8 +59,12 @@ const PADDING_PREVIEW_CAP = '4rem';
  * size.
  *
  * Each side is wrapped separately because a per-corner preset stores four, and CSS `min()` takes a
- * single length rather than a shorthand. A component carrying a function call is left alone: nothing
- * the feed resolves looks like that, and wrapping one blindly would produce invalid CSS.
+ * single length rather than a shorthand. Only a component that is a NUMBER WITH A UNIT is wrapped,
+ * and that restriction is load-bearing rather than defensive: `min()` requires its arguments to be of
+ * one type, so `min(0, 4rem)` — mixing a number with a length — is invalid and the browser drops the
+ * whole declaration. The `None` step resolves to a unitless `0` (kept unitless on purpose, so a stored
+ * zero still equals the token), which made picking it silently leave the previous padding on screen,
+ * the property having never been assigned. Nothing without a unit needs capping anyway.
  *
  * @param {string} padding The resolved padding: one length, or a space-separated shorthand.
  *
@@ -76,7 +80,7 @@ function cappedPadding(padding) {
 	return String(padding)
 		.trim()
 		.split(/\s+/)
-		.map((side) => (side.includes('(') ? side : `min(${side}, ${PADDING_PREVIEW_CAP})`))
+		.map((side) => (/^-?\d*\.?\d+[a-z%]+$/i.test(side) ? `min(${side}, ${PADDING_PREVIEW_CAP})` : side))
 		.join(' ');
 }
 

--- a/src/style-library/presets/image-preset.js
+++ b/src/style-library/presets/image-preset.js
@@ -39,6 +39,48 @@ const IMAGE_RADIUS_FALLBACK = ['0', '0', '0', '0'];
 const IMAGE_PADDING_FALLBACK = ['0', '0', '0', '0'];
 
 /**
+ * The share of the tile's width any one side's preview padding may take.
+ *
+ * @since TBD
+ */
+const PADDING_PREVIEW_CAP = '22%';
+
+/**
+ * Cap each side of a resolved padding value so the preview stays legible at every step of the scale.
+ *
+ * The tile is a few rem across and the spacing scale runs to 10rem, so a real value applied at true
+ * size swallows the photo whole: `MD` alone (2rem a side) leaves the tile's content box with negative
+ * height, collapsing the photo to nothing and leaving a row that shows only a colored rectangle. The
+ * cap keeps every step visibly different from `None` while making sure something always reads as the
+ * image inside the frame.
+ *
+ * The preview is indicative rather than to scale — the sidebar names the actual value while a preset is
+ * being edited — and a capped inset communicates "there is padding here, and the background shows
+ * through it" far better than a blank tile does.
+ *
+ * Each side is wrapped separately because a per-corner preset stores four, and CSS `min()` takes a
+ * single length rather than a shorthand. A component carrying a function call is left alone: nothing
+ * the feed resolves looks like that, and wrapping one blindly would produce invalid CSS.
+ *
+ * @param {string} padding The resolved padding: one length, or a space-separated shorthand.
+ *
+ * @since TBD
+ *
+ * @return {?string} The capped padding, or undefined when there is nothing to apply.
+ */
+function cappedPadding(padding) {
+	if (!padding) {
+		return undefined;
+	}
+
+	return String(padding)
+		.trim()
+		.split(/\s+/)
+		.map((side) => (side.includes('(') ? side : `min(${side}, ${PADDING_PREVIEW_CAP})`))
+		.join(' ');
+}
+
+/**
  * Build a row's preview from its stored tokens.
  *
  * Four of the image's six bound properties, which is its whole editable surface here — border color
@@ -69,11 +111,13 @@ function preview(tokens, values, breakpoint) {
  * neutral photo block.
  *
  * Three nested elements, each earning its place. The outer carries the radius and the shadow, which
- * has to be cast from outside anything that clips. The middle carries the background AND the padding,
- * so padding renders as what it actually is — space between the frame and the image — rather than as a
- * number in a corner. The inner is the stand-in photo: a neutral block, not a real image, because a
- * preset skins whatever image a block happens to hold and previewing a specific picture would imply it
- * selects one.
+ * has to be cast from outside anything that clips. The middle carries the background AND the padding
+ * (capped — see `cappedPadding`), so padding renders as what it actually is: space between the frame
+ * and the image. The inner is the stand-in photo, a neutral block carrying a generic picture glyph
+ * rather than a real image, because a preset skins whatever image a block happens to hold and
+ * previewing a specific picture would imply it selects one. The glyph is what makes the padding
+ * legible — without something that reads as "the image", an inset frame is just a smaller rectangle,
+ * and it is not obvious that the band around it is the preset's background showing through.
  *
  * The transparency checker sits on the outer element for the same reason it does on the Row Layout and
  * Section previews: the image's shipped background is transparent, and against the list's white
@@ -98,7 +142,7 @@ function renderPreview(row) {
 				style={{
 					background: row.preview.background || undefined,
 					borderRadius: radius,
-					padding: row.preview.padding || undefined,
+					padding: cappedPadding(row.preview.padding),
 				}}
 			>
 				<span className="kadence-blocks-style-library__image-preset-preview-photo">

--- a/src/style-library/presets/image-preset.js
+++ b/src/style-library/presets/image-preset.js
@@ -39,24 +39,24 @@ const IMAGE_RADIUS_FALLBACK = ['0', '0', '0', '0'];
 const IMAGE_PADDING_FALLBACK = ['0', '0', '0', '0'];
 
 /**
- * The share of the tile's width any one side's preview padding may take.
+ * The most preview padding any one side may show.
+ *
+ * A LENGTH, not a percentage: the tile sizes itself from the photo plus the padding, so a percentage
+ * would resolve against a width the padding itself determines.
  *
  * @since TBD
  */
-const PADDING_PREVIEW_CAP = '22%';
+const PADDING_PREVIEW_CAP = '4rem';
 
 /**
- * Cap each side of a resolved padding value so the preview stays legible at every step of the scale.
+ * Cap each side of a resolved padding value, so one extreme preset cannot make a list row enormous.
  *
- * The tile is a few rem across and the spacing scale runs to 10rem, so a real value applied at true
- * size swallows the photo whole: `MD` alone (2rem a side) leaves the tile's content box with negative
- * height, collapsing the photo to nothing and leaving a row that shows only a colored rectangle. The
- * cap keeps every step visibly different from `None` while making sure something always reads as the
- * image inside the frame.
- *
- * The preview is indicative rather than to scale — the sidebar names the actual value while a preset is
- * being edited — and a capped inset communicates "there is padding here, and the background shows
- * through it" far better than a blank tile does.
+ * The tile GROWS to fit its padding rather than insetting into a fixed frame (see `ImageScreen.scss`),
+ * which is what keeps each step of the scale visibly different and always leaves a photo to see. That
+ * alone is unbounded, though, and the spacing scale runs to 10rem — a preset using the top step would
+ * produce a tile over 20rem on a side and a row taller than the screen. The cap bounds that end while
+ * leaving every step up to `XL` exact, so the values a preset realistically uses are shown true to
+ * size.
  *
  * Each side is wrapped separately because a per-corner preset stores four, and CSS `min()` takes a
  * single length rather than a shorthand. A component carrying a function call is left alone: nothing
@@ -112,8 +112,8 @@ function preview(tokens, values, breakpoint) {
  *
  * Three nested elements, each earning its place. The outer carries the radius and the shadow, which
  * has to be cast from outside anything that clips. The middle carries the background AND the padding
- * (capped — see `cappedPadding`), so padding renders as what it actually is: space between the frame
- * and the image. The inner is the stand-in photo, a neutral block carrying a generic picture glyph
+ * (capped only at the very top of the scale — see `cappedPadding`), so padding renders as what it
+ * actually is: space between the frame and the image, at true size, with the tile growing to fit it. The inner is the stand-in photo, a neutral block carrying a generic picture glyph
  * rather than a real image, because a preset skins whatever image a block happens to hold and
  * previewing a specific picture would imply it selects one. The glyph is what makes the padding
  * legible — without something that reads as "the image", an inset frame is just a smaller rectangle,

--- a/src/style-library/styles/_mixins.scss
+++ b/src/style-library/styles/_mixins.scss
@@ -74,12 +74,9 @@
 // cannot layer them in this order, because a background image always paints above its own background
 // color. Geometry is the caller's, since the proportions are the point -- a Row Layout is wide and
 // short, a Section is tall and narrow, and a corner radius reads very differently at each.
-@mixin preset-surface-preview($width, $height) {
+@mixin preset-surface-frame {
 	position: relative;
-	display: block;
 	box-sizing: border-box;
-	width: $width;
-	height: $height;
 	border: var(--kb-sl-border-width-input) solid var(--kb-sl-color-gray-200);
 	background-color: #fff;
 	background-image: repeating-conic-gradient(var(--kb-sl-color-gray-200) 0% 25%, transparent 0% 50%);
@@ -87,6 +84,17 @@
 	transition:
 		border-color 300ms ease,
 		border-radius 300ms ease;
+}
+
+// The fixed-geometry form, for a preview whose size says something about the block (a Row Layout band
+// is wide and short, a Section slab tall and narrow). A preview that has to GROW with one of its own
+// values instead -- the image's padding -- takes `preset-surface-frame` and sizes itself.
+@mixin preset-surface-preview($width, $height) {
+	@include preset-surface-frame;
+
+	display: block;
+	width: $width;
+	height: $height;
 }
 
 // The fill half: the preset's resolved background, laid over the checker `preset-surface-preview`


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout
:video_camera: https://www.loom.com/share/c45de6b397424fcf9434d5b8e1fe9582

Converts a shadow field's value at the control boundary in both directions, and lets the image preview grow to fit its padding rather than insetting into a fixed tile.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved box shadow token handling for more consistent display and saving of semantic, primitive, and composite values.
  * Prevented image preset previews from expanding excessively when large padding values are applied.
  * Improved image preview sizing and padding behavior for more accurate visual rendering.

* **Style**
  * Updated preview frames and placeholder images to use intrinsic sizing and consistent dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

