### PR TITLE
[DTM] SOFT-4218 [13/16]: add the Advanced Text block preset screen

### DIFF
--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -906,6 +906,13 @@ return [
 			// INLINE styles on that same element (and font-weight inline on its child), so they keep winning
 			// regardless of this rule's specificity.
 			'block'           => 'kadence/advancedheading',
+			'label'           => __( 'Style', 'kadence-blocks' ), // a picker-driven set; this is the editor control's label.
+			'style_library'   => [
+				// The Style Library BLOCK PRESETS nav label — distinct from "label" above, which names the
+				// inspector's picker control, not the block. "Advanced Text" is the block's UI name;
+				// "advancedheading" is only its code name.
+				'label' => __( 'Advanced Text', 'kadence-blocks' ),
+			],
 			'editor_selector' => '.wp-block-kadence-advancedheading .kadence-advancedheading-text',
 			'bindings'        => [
 				'color'         => [
@@ -924,6 +931,13 @@ return [
 				// deliberately emits no font-family default for it (see Css_BuilderTest). Font family is
 				// delivered by the font system rather than a token rule, and a preset stores the family the
 				// typography control picked as a literal rather than a token reference.
+				//
+				// fontHeight and letterSpacing are bound but NOT offered on the Style Library screen: neither
+				// has a primitive scale to pick from (their semantic groups hold one entry per usage, which is
+				// a delivery point rather than a set of choices), and unlike the keyword properties below they
+				// are open numeric ranges, so the only control that would fit is a bare number.
+				//
+				// @todo SOFT-4235: give line-height and letter-spacing a primitive scale.
 				//
 				// fontSize and fontHeight declare NO responsive_attrs, unlike every other responsive property
 				// here: the heading packs all three devices into ONE array attribute (`fontSize[0..2]` is

--- a/src/style-library/__tests__/advancedheading-preset.test.js
+++ b/src/style-library/__tests__/advancedheading-preset.test.js
@@ -66,7 +66,6 @@ describe('HEADING_PRESET', () => {
 		const values = {
 			'semantic.color.text': '#1A202C',
 			'semantic.color.heading-bg': 'transparent',
-			'semantic.font-family.heading': 'inherit',
 			'semantic.font-size.heading': '2rem',
 			'semantic.color.border': '#E2E8F0',
 			'semantic.border-width.default': '1px',
@@ -76,7 +75,6 @@ describe('HEADING_PRESET', () => {
 		const tokens = {
 			color: '{semantic.color.text}',
 			background: '{semantic.color.heading-bg}',
-			typography: '{semantic.font-family.heading}',
 			fontSize: '{semantic.font-size.heading}',
 			borderColor: '{semantic.color.border}',
 			borderWidth: '{semantic.border-width.default}',
@@ -87,7 +85,6 @@ describe('HEADING_PRESET', () => {
 		expect(HEADING_PRESET.preview(tokens, values)).toMatchObject({
 			color: '#1A202C',
 			background: 'transparent',
-			typography: 'inherit',
 			fontSize: '2rem',
 			borderColor: '#E2E8F0',
 			borderWidth: '1px',
@@ -121,7 +118,6 @@ describe('HEADING_PRESET', () => {
 			preview: {
 				color: '#1A202C',
 				background: '#F7FAFC',
-				typography: 'Georgia',
 				fontSize: '4rem',
 				fontWeight: '700',
 				textTransform: 'uppercase',
@@ -136,7 +132,6 @@ describe('HEADING_PRESET', () => {
 		expect(chip.props.style).toMatchObject({
 			color: '#1A202C',
 			background: '#F7FAFC',
-			fontFamily: 'Georgia',
 			fontWeight: '700',
 			textTransform: 'uppercase',
 			borderColor: '#E2E8F0',
@@ -174,9 +169,11 @@ describe('HEADING_PRESET', () => {
 	});
 
 	/**
-	 * Eleven of the block's thirteen bound properties are offered. `fontHeight` and `letterSpacing` are
-	 * bound but withheld: neither has a token scale, and unlike the keyword properties they are open
-	 * numeric ranges, so the only control that would fit is a bare number.
+	 * Ten of the block's twelve bound properties are offered. `fontHeight` and `letterSpacing` are bound
+	 * but withheld: neither has a token scale, and unlike the keyword properties they are open numeric
+	 * ranges, so the only control that would fit is a bare number. Font family is absent for a different
+	 * reason -- it is not a bound property at all, the family being stored as a literal from the
+	 * typography control's own catalog.
 	 *
 	 * @return {void}
 	 */
@@ -184,7 +181,6 @@ describe('HEADING_PRESET', () => {
 		expect(fields().map((field) => field.path)).toEqual([
 			'tokens.color',
 			'tokens.background',
-			'tokens.typography',
 			'tokens.fontSize',
 			'tokens.fontWeight',
 			'tokens.textTransform',
@@ -221,7 +217,6 @@ describe('HEADING_PRESET', () => {
 			expect(byPath[path].options.length).toBeGreaterThan(1);
 		});
 
-		expect(byPath['tokens.typography'].type).toBe('token-select');
 		expect(byPath['tokens.fontSize'].type).toBe('token-scalar');
 		expect(byPath['tokens.borderWidth'].type).toBe('token-scalar');
 	});

--- a/src/style-library/__tests__/advancedheading-preset.test.js
+++ b/src/style-library/__tests__/advancedheading-preset.test.js
@@ -1,0 +1,280 @@
+/* eslint-env jest */
+/**
+ * The Advanced Text preset config — the one per-block file a preset screen needs. Everything else the
+ * screen uses (`PresetScreen`, `PresetSidebar`, `usePresetScreen`, `helpers/presets`) is generic and
+ * covered by its own suites, so this asserts only what this config contributes: the bound surface it
+ * reads, the preview it resolves, its schema, and that it registers on the public screens filter.
+ */
+import { applyFilters } from '@wordpress/hooks';
+import { HEADING_PRESET, HEADING_BLOCK } from '../presets/advancedheading-preset';
+import { PRESET_SCREENS_FILTER } from '../constants/screens';
+import { FIELD_TYPES, RESPONSIVE_CAPABLE_FIELD_TYPES } from '../constants/field-types';
+
+// The screen module is imported only to trigger its module-scope `addFilter`. Its two children pull in
+// the REST client (and so `@wordpress/api-fetch`, absent from this environment), which the registration
+// contract does not depend on — the generic panel and sidebar have their own suites.
+jest.mock('../components/pages/PresetScreen', () => ({ PresetScreen: () => null }));
+jest.mock('../components/pages/HeadingSettings', () => ({ HeadingSettings: () => null }));
+
+/**
+ * Every field the schema declares, flattened across its panels.
+ *
+ * @since TBD
+ *
+ * @return {Array<Object>} The fields.
+ */
+function fields() {
+	return HEADING_PRESET.schemaFor().panels.flatMap((panel) => panel.fields);
+}
+
+describe('HEADING_PRESET', () => {
+	afterEach(() => {
+		delete window.kadenceDesignTokens;
+	});
+
+	/**
+	 * The config names the block by its code name. Advanced Text is the UI name and appears only in
+	 * labels, so the two must not be confused when wiring the screen to the feed.
+	 *
+	 * @return {void}
+	 */
+	it('targets the advancedheading block by its code name', () => {
+		expect(HEADING_PRESET.block).toBe('kadence/advancedheading');
+		expect(HEADING_BLOCK).toBe('kadence/advancedheading');
+	});
+
+	/**
+	 * `properties` is a live getter over the feed, not a snapshot, so the screen can never offer a
+	 * property the server's write guard would reject.
+	 *
+	 * @return {void}
+	 */
+	it('reads its bound surface live from the feed', () => {
+		window.kadenceDesignTokens = {
+			presets: { 'kadence/advancedheading': { properties: ['color', 'fontSize'] } },
+		};
+
+		expect(HEADING_PRESET.properties).toEqual(['color', 'fontSize']);
+	});
+
+	/**
+	 * The preview resolves every property the chip can show through the feed's value map.
+	 *
+	 * @return {void}
+	 */
+	it('resolves the previewed properties from stored aliases', () => {
+		const values = {
+			'semantic.color.text': '#1A202C',
+			'semantic.color.heading-bg': 'transparent',
+			'semantic.font-family.heading': 'inherit',
+			'semantic.font-size.heading': '2rem',
+			'semantic.color.border': '#E2E8F0',
+			'semantic.border-width.default': '1px',
+			'semantic.border-style.default': 'none',
+			'semantic.radius.heading': '0',
+		};
+		const tokens = {
+			color: '{semantic.color.text}',
+			background: '{semantic.color.heading-bg}',
+			typography: '{semantic.font-family.heading}',
+			fontSize: '{semantic.font-size.heading}',
+			borderColor: '{semantic.color.border}',
+			borderWidth: '{semantic.border-width.default}',
+			borderStyle: '{semantic.border-style.default}',
+			borderRadius: '{semantic.radius.heading}',
+		};
+
+		expect(HEADING_PRESET.preview(tokens, values)).toMatchObject({
+			color: '#1A202C',
+			background: 'transparent',
+			typography: 'inherit',
+			fontSize: '2rem',
+			borderColor: '#E2E8F0',
+			borderWidth: '1px',
+			borderStyle: 'none',
+			borderRadius: '0',
+		});
+	});
+
+	/**
+	 * A keyword property is stored as a literal, having no token to alias, and previews as itself.
+	 *
+	 * @return {void}
+	 */
+	it('previews a keyword property stored as a literal', () => {
+		expect(HEADING_PRESET.preview({ fontWeight: '700', textTransform: 'uppercase' }, {})).toMatchObject({
+			fontWeight: '700',
+			textTransform: 'uppercase',
+		});
+	});
+
+	/**
+	 * The chip states the preset's type and frame. Font SIZE is deliberately not applied: the scale
+	 * reaches 4rem and a row set at true size would dwarf its neighbors, so the sidebar names it instead.
+	 *
+	 * @return {void}
+	 */
+	it('renders a chip carrying the type and frame but not the font size', () => {
+		const chip = HEADING_PRESET.renderPreview({
+			id: 'title',
+			label: 'Title',
+			preview: {
+				color: '#1A202C',
+				background: '#F7FAFC',
+				typography: 'Georgia',
+				fontSize: '4rem',
+				fontWeight: '700',
+				textTransform: 'uppercase',
+				borderColor: '#E2E8F0',
+				borderWidth: '1px',
+				borderStyle: 'solid',
+				borderRadius: '0.5rem',
+			},
+		});
+
+		expect(chip.props.className).toBe('kadence-blocks-style-library__heading-preset-preview');
+		expect(chip.props.style).toMatchObject({
+			color: '#1A202C',
+			background: '#F7FAFC',
+			fontFamily: 'Georgia',
+			fontWeight: '700',
+			textTransform: 'uppercase',
+			borderColor: '#E2E8F0',
+			borderWidth: '1px',
+			borderStyle: 'solid',
+			borderRadius: '0.5rem',
+		});
+		expect(chip.props.style.fontSize).toBeUndefined();
+	});
+
+	/**
+	 * A border needs all three of style, width and color before it renders, so an unresolved style leaves
+	 * the chip without a frame rather than inventing an edge the page would not have.
+	 *
+	 * @return {void}
+	 */
+	it('leaves the chip without a frame when the preset resolves no border style', () => {
+		const chip = HEADING_PRESET.renderPreview({
+			id: 'bare',
+			label: 'Bare',
+			preview: { borderColor: '#E2E8F0', borderWidth: '1px', borderStyle: '' },
+		});
+
+		expect(chip.props.style.borderStyle).toBeUndefined();
+	});
+
+	/**
+	 * The heading binds no hover property, so it declares no tabs and `PresetSidebar` renders the field
+	 * area bare.
+	 *
+	 * @return {void}
+	 */
+	it('declares no state tabs', () => {
+		expect(HEADING_PRESET.tabs).toBeUndefined();
+	});
+
+	/**
+	 * Eleven of the block's thirteen bound properties are offered. `fontHeight` and `letterSpacing` are
+	 * bound but withheld: neither has a token scale, and unlike the keyword properties they are open
+	 * numeric ranges, so the only control that would fit is a bare number.
+	 *
+	 * @return {void}
+	 */
+	it('offers every bound property that has a control to offer it through', () => {
+		expect(fields().map((field) => field.path)).toEqual([
+			'tokens.color',
+			'tokens.background',
+			'tokens.typography',
+			'tokens.fontSize',
+			'tokens.fontWeight',
+			'tokens.textTransform',
+			'tokens.borderStyle',
+			'tokens.borderWidth',
+			'tokens.borderColor',
+			'tokens.borderRadius',
+			'tokens.padding',
+		]);
+	});
+
+	/**
+	 * Every type the schema names must be one the field registry knows how to render.
+	 *
+	 * @return {void}
+	 */
+	it('names only field types the registry can render', () => {
+		fields().forEach((field) => expect(FIELD_TYPES).toHaveProperty(field.type));
+	});
+
+	/**
+	 * A property is a token picker when the design system has a scale for it and a keyword select when it
+	 * does not. `border-style`, `text-transform` and `font-weight` have no primitive layer — their
+	 * semantic groups hold one entry per usage, not a set of choices — so a picker would show an empty
+	 * list.
+	 *
+	 * @return {void}
+	 */
+	it('offers a keyword select exactly where there is no token scale to pick from', () => {
+		const byPath = Object.fromEntries(fields().map((field) => [field.path, field]));
+
+		['tokens.fontWeight', 'tokens.textTransform', 'tokens.borderStyle'].forEach((path) => {
+			expect(byPath[path].type).toBe('select');
+			expect(byPath[path].options.length).toBeGreaterThan(1);
+		});
+
+		expect(byPath['tokens.typography'].type).toBe('token-select');
+		expect(byPath['tokens.fontSize'].type).toBe('token-scalar');
+		expect(byPath['tokens.borderWidth'].type).toBe('token-scalar');
+	});
+
+	/**
+	 * Border style is the field that decides whether a border appears at all. Offering color and width
+	 * without it is the dead control the Row Layout and Section screens had to drop, so its presence is
+	 * asserted on its own rather than left implied by the field list.
+	 *
+	 * @return {void}
+	 */
+	it('offers a border style, without which a preset border could never be seen', () => {
+		const style = fields().find((field) => field.path === 'tokens.borderStyle');
+
+		expect(style).toBeDefined();
+		expect(style.options.map((option) => option.value)).toEqual(
+			expect.arrayContaining(['solid', 'dashed', 'dotted', 'double'])
+		);
+	});
+
+	/**
+	 * Only the properties whose block controls are per-device are responsive, and each is of a type that
+	 * may be. `fontSize` is included even though its binding declares no `responsive_attrs`: that gap is
+	 * about the editor addressing a packed device slot, while a preset's own per-breakpoint override is
+	 * carried by the responsive envelope and projected as a media query.
+	 *
+	 * @return {void}
+	 */
+	it('marks the per-device fields responsive and no others', () => {
+		const responsive = fields().filter((field) => field.responsive);
+
+		expect(responsive.map((field) => field.path)).toEqual([
+			'tokens.fontSize',
+			'tokens.borderRadius',
+			'tokens.padding',
+		]);
+		responsive.forEach((field) => expect(RESPONSIVE_CAPABLE_FIELD_TYPES).toContain(field.type));
+	});
+});
+
+describe('HeadingScreen registration', () => {
+	/**
+	 * The app never imports the screen component directly — importing the module is what registers it
+	 * on the public filter, exactly as a third-party screen would register itself.
+	 *
+	 * @return {void}
+	 */
+	it('registers itself on the preset-screens filter with a settings panel', () => {
+		require('../components/pages/HeadingScreen');
+
+		const screens = applyFilters(PRESET_SCREENS_FILTER, {});
+
+		expect(screens[HEADING_BLOCK]).toBeDefined();
+		expect(screens[HEADING_BLOCK].SettingsPanel).toBeDefined();
+	});
+});

--- a/src/style-library/__tests__/token-select-field.test.js
+++ b/src/style-library/__tests__/token-select-field.test.js
@@ -40,23 +40,42 @@ afterEach(() => {
 
 describe('TokenSelectField token pool', () => {
 	/**
-	 * The field's current value is handed to the pool as `selected`, which exempts it from the
-	 * primitive narrowing. Without it a bound semantic token is filtered out of its own picker, so
-	 * the field renders with its current value absent from the list.
+	 * A bound PRIMITIVE is handed to the pool as `selected`, which exempts it from the narrowing so it
+	 * survives even when it sits outside the role's own scale.
 	 *
 	 * @return {void}
 	 */
-	it('passes the bound value through as the selected token', () => {
+	it('passes a bound primitive through as the selected token', () => {
 		act(() =>
 			root.render(
 				createElement(TokenSelectField, {
 					field: { tokenType: 'dimension', role: 'radius', label: 'Radius' },
-					value: 'semantic.dimension.radius-control',
+					value: 'primitive.dimension.radius.sm',
 					onChange: jest.fn(),
 				})
 			)
 		);
 
-		expect(pickableTokensForType).toHaveBeenCalledWith('dimension', 'radius', 'semantic.dimension.radius-control');
+		expect(pickableTokensForType).toHaveBeenCalledWith('dimension', 'radius', 'primitive.dimension.radius.sm');
+	});
+
+	/**
+	 * A bound SEMANTIC is not a selection — the pool offers primitives only — so it is neither exempted
+	 * into the list nor shown as the field's value. Its name never reaches the picker.
+	 *
+	 * @return {void}
+	 */
+	it('treats a bound semantic as unset rather than exempting it into the list', () => {
+		act(() =>
+			root.render(
+				createElement(TokenSelectField, {
+					field: { tokenType: 'dimension', role: 'radius', label: 'Radius' },
+					value: 'semantic.radius.control',
+					onChange: jest.fn(),
+				})
+			)
+		);
+
+		expect(pickableTokensForType).toHaveBeenCalledWith('dimension', 'radius', '');
 	});
 });

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -34,6 +34,7 @@ import '../components/pages/SingleIconScreen';
 import '../components/pages/RowLayoutScreen';
 import '../components/pages/ColumnScreen';
 import '../components/pages/ImageScreen';
+import '../components/pages/HeadingScreen';
 import { useDesignTokensFeed } from '../hooks/use-design-tokens-feed';
 import { useStyleLibraryRoute } from '../hooks/use-style-library-route';
 import { useLibraries } from '../hooks/use-libraries';

--- a/src/style-library/components/molecules/fields/ScalarTokenField.js
+++ b/src/style-library/components/molecules/fields/ScalarTokenField.js
@@ -151,6 +151,10 @@ export function ScalarTokenField({ field, value, onChange }) {
 				alias: `{${token.id}}`,
 			}))}
 			defaultValue={shownDefault ?? undefined}
+			// A field whose tokens resolve to something too long to read in a row opts out of showing
+			// values beside their labels. A fluid font size resolves to a whole `clamp()` expression,
+			// which overran the row and pushed the label out of view.
+			showValue={field.showValue !== false}
 			inherited={inheritsFromBreakpoint}
 			unit={unit}
 			units={units}

--- a/src/style-library/components/molecules/fields/TokenSelectField.js
+++ b/src/style-library/components/molecules/fields/TokenSelectField.js
@@ -15,6 +15,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { pickableTokensForType } from '../../../helpers/tokens';
+import { isSemanticSlot } from './BoxTokenField';
 import { SelectDropdown } from '../SelectDropdown';
 import { FieldLabel } from './FieldLabel';
 import './TokenSelectField.scss';
@@ -37,9 +38,15 @@ import './TokenSelectField.scss';
  * @return {JSX.Element} The field.
  */
 export function TokenSelectField({ field, value, onChange }) {
-	// `value` is passed as `selected` so the token this field is already bound to survives the
-	// primitive narrowing — without it a bound semantic token is filtered out of its own picker.
-	const tokens = pickableTokensForType(field.tokenType, field.role, value);
+	// A semantic-bound value is the block's role-based default rather than a selection — the pool
+	// offers primitives only — so it reads as unset and its name never reaches the list. Unlike the box
+	// fields, this control has no Default row to show the value behind it; an empty selection is the
+	// closest honest reading. See `withoutSemanticSlots`.
+	const shown = isSemanticSlot(value) ? '' : value;
+
+	// The bound PRIMITIVE is passed as `selected` so it survives the narrowing even if it sits outside
+	// the role's own scale.
+	const tokens = pickableTokensForType(field.tokenType, field.role, shown);
 	const options = tokens.map((token) => ({
 		value: token.id,
 		label: (
@@ -59,10 +66,10 @@ export function TokenSelectField({ field, value, onChange }) {
 		>
 			{field.label && <FieldLabel>{field.label}</FieldLabel>}
 			<SelectDropdown
-				value={value}
+				value={shown}
 				options={options}
 				leadingIcon={field.leadingIcon}
-				valueLabel={value ? __('Custom', 'kadence-blocks') : ''}
+				valueLabel={shown ? __('Custom', 'kadence-blocks') : ''}
 				onChange={(next) => !field.readOnly && onChange(next)}
 			/>
 		</div>

--- a/src/style-library/components/pages/HeadingScreen.js
+++ b/src/style-library/components/pages/HeadingScreen.js
@@ -1,0 +1,46 @@
+/**
+ * The Advanced Text preset screen: `PresetScreen` does the work and `presets/advancedheading-preset.js`
+ * describes the block, so this file only binds the two together and registers the screen. Its settings
+ * panel is `HeadingSettings`, assigned below as `HeadingScreen.SettingsPanel`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { PresetScreen } from './PresetScreen';
+import { HeadingSettings } from './HeadingSettings';
+import { HEADING_PRESET, HEADING_BLOCK } from '../../presets/advancedheading-preset';
+import { PRESET_SCREENS_FILTER } from '../../constants/screens';
+import './HeadingScreen.scss';
+
+/**
+ * Render the Advanced Text preset screen.
+ *
+ * @param {Object} props The screen props (`label`, `route`, `navigate`, `library`).
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The screen body.
+ */
+export function HeadingScreen(props) {
+	return <PresetScreen {...props} preset={HEADING_PRESET} />;
+}
+
+HeadingScreen.SettingsPanel = HeadingSettings;
+
+/**
+ * Register the Advanced Text screen for `kadence/advancedheading` on the public preset-screens filter,
+ * exactly as a third party would — the app never imports this component directly, so this module-scope
+ * call is the only registration path.
+ *
+ * @since TBD
+ */
+addFilter(PRESET_SCREENS_FILTER, 'kadence-blocks/style-library-heading-screen', (screens) => ({
+	...screens,
+	[HEADING_BLOCK]: HeadingScreen,
+}));

--- a/src/style-library/components/pages/HeadingScreen.scss
+++ b/src/style-library/components/pages/HeadingScreen.scss
@@ -1,0 +1,40 @@
+// The chip is content-sized (a line of type, not a swatch), so this screen relaxes `ListRow`'s default
+// framed 80px preview slot — the Button, Row Layout, Section, Spacing, Icon Sizes and Shadow
+// slot-override precedent.
+.kadence-blocks-style-library__heading-screen .kadence-blocks-style-library__list-row-preview {
+	width: auto;
+	height: auto;
+	border: 0;
+	background: transparent;
+	overflow: visible;
+}
+
+// Preset names are full words ("Section Title"), not the short numeric labels the shared 4rem column
+// was sized for.
+.kadence-blocks-style-library__heading-screen .kadence-blocks-style-library__list-row-label {
+	width: 15rem;
+}
+
+// The live heading chip. `border-style` is left at `none` so a preset that sets only a border color or
+// width draws no frame — matching the block, where all three are needed before a border renders, and
+// keeping an unstyled preset from sprouting an edge the page would not have.
+//
+// The font size is deliberately not the preset's: the scale reaches 4rem and a row set at true size
+// would dwarf its neighbors. The chip states family, weight, transform, color and frame faithfully and
+// leaves size to the sidebar, which names the actual value while a preset is being edited.
+.kadence-blocks-style-library__heading-preset-preview {
+	display: inline-flex;
+	align-items: center;
+	box-sizing: border-box;
+	padding: var(--kb-sl-space-10) var(--kb-sl-space-20);
+	border-width: 0;
+	border-style: none;
+	font-size: var(--kb-sl-font-size-body);
+	line-height: var(--kb-sl-line-height-s);
+	white-space: nowrap;
+	transition:
+		background-color 300ms ease,
+		border-color 300ms ease,
+		border-radius 300ms ease,
+		color 300ms ease;
+}

--- a/src/style-library/components/pages/HeadingSettings.js
+++ b/src/style-library/components/pages/HeadingSettings.js
@@ -1,0 +1,29 @@
+/**
+ * The Advanced Text preset's settings sidebar: `PresetSidebar` does the work, this binds the block's
+ * config to it.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { PresetSidebar } from './PresetSidebar';
+import { usePresetScreen } from '../../hooks/use-preset-screen';
+import { HEADING_PRESET } from '../../presets/advancedheading-preset';
+
+/**
+ * Render the Advanced Text preset's settings sidebar.
+ *
+ * @param {Object}   props          The component props.
+ * @param {Object}   props.route    The current route (`{ screen, item }`).
+ * @param {Function} props.navigate The route navigator.
+ * @param {Object}   props.library  The design-tokens feed hook's return value.
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The sidebar, or null while there is no open preset to edit.
+ */
+export function HeadingSettings({ route, navigate, library }) {
+	const screen = usePresetScreen(library, HEADING_PRESET);
+
+	return <PresetSidebar route={route} navigate={navigate} screen={screen} preset={HEADING_PRESET} />;
+}

--- a/src/style-library/presets/advancedheading-preset.js
+++ b/src/style-library/presets/advancedheading-preset.js
@@ -108,7 +108,8 @@ const FONT_WEIGHT_OPTIONS = [
  *
  * Everything the screen edits that a chip of text can honestly show. `borderWidth` and `borderStyle`
  * are previewed alongside `borderColor` because all three are needed for a border to render at all —
- * a color on its own is invisible, which is the trap the Row Layout and Section screens hit.
+ * a color on its own is invisible, which is the trap the Row Layout and Section screens hit. Font
+ * family is absent because it is not a bound property; see `schemaFor()`.
  *
  * @param {Record<string, *>}      tokens       The preset's stored token map.
  * @param {Record<string, string>} values       The feed's resolved value map.
@@ -124,7 +125,6 @@ function preview(tokens, values, breakpoint) {
 	return {
 		color: resolve('color'),
 		background: resolve('background'),
-		typography: resolve('typography'),
 		fontSize: resolve('fontSize'),
 		fontWeight: resolve('fontWeight'),
 		textTransform: resolve('textTransform'),
@@ -141,7 +141,7 @@ function preview(tokens, values, breakpoint) {
  * its own frame.
  *
  * Real text rather than a swatch, because every property this screen edits except the box ones is a
- * type property, and a color chip cannot show a weight, a family or a transform. The size is deliberately
+ * type property, and a color chip cannot show a weight or a transform. The size is deliberately
  * NOT applied at true size — the scale reaches 4rem and a row cannot grow that far without dwarfing its
  * neighbors — so the chip states the family, weight, transform, color and frame faithfully and leaves
  * size to the sidebar. The Advanced Image tile can afford to grow because its padding is the only
@@ -160,7 +160,6 @@ function renderPreview(row) {
 			style={{
 				color: row.preview.color || undefined,
 				background: row.preview.background || undefined,
-				fontFamily: row.preview.typography || undefined,
 				fontWeight: row.preview.fontWeight || undefined,
 				textTransform: row.preview.textTransform || undefined,
 				borderColor: row.preview.borderColor || undefined,
@@ -180,8 +179,13 @@ function renderPreview(row) {
  * The settings schema. The heading declares no tabs: it binds no hover property, so there is no second
  * state to switch to and `PresetSidebar` renders the field area bare.
  *
- * Eleven of the block's thirteen bound properties are offered, grouped by what a site owner is doing
- * rather than by how each value is stored.
+ * Ten of the block's twelve bound properties are offered, grouped by what a site owner is doing rather
+ * than by how each value is stored.
+ *
+ * Font family is not among them, and is not a bound property at all: a heading inherits the theme's
+ * font, the block-default CSS emits no font-family default for it, and the family a site owner picks
+ * comes from the typography control's own font catalog and is stored as a literal. See the block's
+ * `preset_bindings` declaration.
  *
  * The split between a token picker and a keyword select is not arbitrary: a property is offered as a
  * picker when the design system actually has a scale for it, and as a select when it does not.
@@ -219,13 +223,6 @@ function schemaFor() {
 				id: 'typography',
 				title: __('Typography', 'kadence-blocks'),
 				fields: [
-					{
-						type: 'token-select',
-						tokenType: 'fontFamily',
-						role: 'font-family',
-						path: 'tokens.typography',
-						label: __('Font Family', 'kadence-blocks'),
-					},
 					{
 						type: 'token-scalar',
 						tokenType: 'dimension',

--- a/src/style-library/presets/advancedheading-preset.js
+++ b/src/style-library/presets/advancedheading-preset.js
@@ -1,0 +1,326 @@
+/**
+ * Everything specific to the `kadence/advancedheading` (Advanced Text) preset screen, in one place:
+ * the block name, the bound property surface, the row preview, and the settings schema.
+ *
+ * The generic preset machinery — `helpers/presets.js`, `usePresetScreen`, `PresetSidebar` — reads
+ * this config and knows nothing else about headings. See `src/style-library/README.md`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getPresetProperties, resolveTokenValue } from '../helpers/presets';
+
+/**
+ * The block name this screen edits. The block is called Advanced Text in the UI but
+ * `kadence/advancedheading` in code, and this is the single JS spelling of the code name.
+ *
+ * @since TBD
+ */
+export const HEADING_BLOCK = 'kadence/advancedheading';
+
+/**
+ * The heading's built-in font size, matching `semantic.font-size.heading`.
+ *
+ * @since TBD
+ */
+const HEADING_FONT_SIZE_FALLBACK = '2rem';
+
+/**
+ * The heading's built-in corner radius, matching `semantic.radius.heading` (square corners).
+ *
+ * @since TBD
+ */
+const HEADING_RADIUS_FALLBACK = ['0', '0', '0', '0'];
+
+/**
+ * The heading's built-in padding, matching `semantic.spacing.heading-padding` (none).
+ *
+ * @since TBD
+ */
+const HEADING_PADDING_FALLBACK = ['0', '0', '0', '0'];
+
+/**
+ * The heading's built-in border width, matching `semantic.border-width.default`.
+ *
+ * @since TBD
+ */
+const HEADING_BORDER_WIDTH_FALLBACK = '1px';
+
+/**
+ * The CSS keywords `border-style` accepts, as the preset offers them.
+ *
+ * A closed keyword set rather than a token pool: `border-style` has no primitive scale to pick from —
+ * `semantic.border-style` holds a single `default` entry, which is a delivery point rather than a set
+ * of choices — so a select over the keywords is the honest control. See `schemaFor()`.
+ *
+ * @since TBD
+ */
+const BORDER_STYLE_OPTIONS = [
+	{ value: '', label: __('Default', 'kadence-blocks') },
+	{ value: 'none', label: __('None', 'kadence-blocks') },
+	{ value: 'solid', label: __('Solid', 'kadence-blocks') },
+	{ value: 'dashed', label: __('Dashed', 'kadence-blocks') },
+	{ value: 'dotted', label: __('Dotted', 'kadence-blocks') },
+	{ value: 'double', label: __('Double', 'kadence-blocks') },
+];
+
+/**
+ * The CSS keywords `text-transform` accepts, as the preset offers them. A closed keyword set, for the
+ * same reason as {@see BORDER_STYLE_OPTIONS}.
+ *
+ * @since TBD
+ */
+const TEXT_TRANSFORM_OPTIONS = [
+	{ value: '', label: __('Default', 'kadence-blocks') },
+	{ value: 'none', label: __('None', 'kadence-blocks') },
+	{ value: 'capitalize', label: __('Capitalize', 'kadence-blocks') },
+	{ value: 'uppercase', label: __('Uppercase', 'kadence-blocks') },
+	{ value: 'lowercase', label: __('Lowercase', 'kadence-blocks') },
+];
+
+/**
+ * The weights the preset offers. A closed set, for the same reason as {@see BORDER_STYLE_OPTIONS} —
+ * `semantic.font-weight` holds one entry per usage, not a scale.
+ *
+ * @since TBD
+ */
+const FONT_WEIGHT_OPTIONS = [
+	{ value: '', label: __('Default', 'kadence-blocks') },
+	{ value: '100', label: __('100 Thin', 'kadence-blocks') },
+	{ value: '200', label: __('200 Extra Light', 'kadence-blocks') },
+	{ value: '300', label: __('300 Light', 'kadence-blocks') },
+	{ value: '400', label: __('400 Regular', 'kadence-blocks') },
+	{ value: '500', label: __('500 Medium', 'kadence-blocks') },
+	{ value: '600', label: __('600 Semi Bold', 'kadence-blocks') },
+	{ value: '700', label: __('700 Bold', 'kadence-blocks') },
+	{ value: '800', label: __('800 Extra Bold', 'kadence-blocks') },
+	{ value: '900', label: __('900 Black', 'kadence-blocks') },
+];
+
+/**
+ * Build a row's preview from its stored tokens.
+ *
+ * Everything the screen edits that a chip of text can honestly show. `borderWidth` and `borderStyle`
+ * are previewed alongside `borderColor` because all three are needed for a border to render at all —
+ * a color on its own is invisible, which is the trap the Row Layout and Section screens hit.
+ *
+ * @param {Record<string, *>}      tokens       The preset's stored token map.
+ * @param {Record<string, string>} values       The feed's resolved value map.
+ * @param {string}                 [breakpoint] The breakpoint to resolve responsive values at.
+ *
+ * @since TBD
+ *
+ * @return {Record<string, string>} The preview.
+ */
+function preview(tokens, values, breakpoint) {
+	const resolve = (property) => resolveTokenValue(values, tokens[property], breakpoint);
+
+	return {
+		color: resolve('color'),
+		background: resolve('background'),
+		typography: resolve('typography'),
+		fontSize: resolve('fontSize'),
+		fontWeight: resolve('fontWeight'),
+		textTransform: resolve('textTransform'),
+		padding: resolve('padding'),
+		borderColor: resolve('borderColor'),
+		borderWidth: resolve('borderWidth'),
+		borderStyle: resolve('borderStyle'),
+		borderRadius: resolve('borderRadius'),
+	};
+}
+
+/**
+ * The row's live preview: the word "Heading" set in the preset's own type, on its own background, in
+ * its own frame.
+ *
+ * Real text rather than a swatch, because every property this screen edits except the box ones is a
+ * type property, and a color chip cannot show a weight, a family or a transform. The size is deliberately
+ * NOT applied at true size — the scale reaches 4rem and a row cannot grow that far without dwarfing its
+ * neighbors — so the chip states the family, weight, transform, color and frame faithfully and leaves
+ * size to the sidebar. The Advanced Image tile can afford to grow because its padding is the only
+ * property that drives its geometry; a heading's font size drives everything at once.
+ *
+ * @param {{id: string, label: string, preview: Record<string, string>}} row The row descriptor.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The preview element.
+ */
+function renderPreview(row) {
+	return (
+		<span
+			className="kadence-blocks-style-library__heading-preset-preview"
+			style={{
+				color: row.preview.color || undefined,
+				background: row.preview.background || undefined,
+				fontFamily: row.preview.typography || undefined,
+				fontWeight: row.preview.fontWeight || undefined,
+				textTransform: row.preview.textTransform || undefined,
+				borderColor: row.preview.borderColor || undefined,
+				borderWidth: row.preview.borderWidth || undefined,
+				// A border renders only when all three are set, so the style is what decides whether the
+				// frame appears at all. Left absent, the stylesheet's own `none` leaves the chip without a frame.
+				borderStyle: row.preview.borderStyle || undefined,
+				borderRadius: row.preview.borderRadius || undefined,
+			}}
+		>
+			{__('Heading', 'kadence-blocks')}
+		</span>
+	);
+}
+
+/**
+ * The settings schema. The heading declares no tabs: it binds no hover property, so there is no second
+ * state to switch to and `PresetSidebar` renders the field area bare.
+ *
+ * Eleven of the block's thirteen bound properties are offered, grouped by what a site owner is doing
+ * rather than by how each value is stored.
+ *
+ * The split between a token picker and a keyword select is not arbitrary: a property is offered as a
+ * picker when the design system actually has a scale for it, and as a select when it does not.
+ * `border-style`, `text-transform` and `font-weight` have no primitive layer at all — their semantic
+ * groups hold one entry per usage (`control`, `heading`), which is a delivery point rather than a set
+ * of choices — so a picker would show an empty list. `border-style` in particular has to be offered:
+ * without it a preset can set a border's color and width and never make it visible, which is exactly
+ * the dead control the Row Layout and Section screens had to drop.
+ *
+ * `fontHeight` and `letterSpacing` are bound but NOT offered. They have no scale either, and unlike the
+ * three above they are open numeric ranges rather than closed keyword sets, so the only control that
+ * would fit is a bare number — which invites exactly the unsystematic values a design token library
+ * exists to prevent. They want a line-height and letter-spacing scale first; SOFT-4235 covers that.
+ *
+ * @since TBD
+ *
+ * @return {{panels: Array<Object>}} The settings-form schema.
+ */
+function schemaFor() {
+	return {
+		panels: [
+			{
+				id: 'color',
+				title: __('Color', 'kadence-blocks'),
+				fields: [
+					{ type: 'token-color-select', path: 'tokens.color', label: __('Text', 'kadence-blocks') },
+					{
+						type: 'token-color-select',
+						path: 'tokens.background',
+						label: __('Background', 'kadence-blocks'),
+					},
+				],
+			},
+			{
+				id: 'typography',
+				title: __('Typography', 'kadence-blocks'),
+				fields: [
+					{
+						type: 'token-select',
+						tokenType: 'fontFamily',
+						role: 'font-family',
+						path: 'tokens.typography',
+						label: __('Font Family', 'kadence-blocks'),
+					},
+					{
+						type: 'token-scalar',
+						tokenType: 'dimension',
+						role: 'font-size',
+						responsive: true,
+						path: 'tokens.fontSize',
+						label: __('Size', 'kadence-blocks'),
+						defaultValue: HEADING_FONT_SIZE_FALLBACK,
+					},
+					{
+						type: 'select',
+						path: 'tokens.fontWeight',
+						label: __('Weight', 'kadence-blocks'),
+						options: FONT_WEIGHT_OPTIONS,
+					},
+					{
+						type: 'select',
+						path: 'tokens.textTransform',
+						label: __('Transform', 'kadence-blocks'),
+						options: TEXT_TRANSFORM_OPTIONS,
+					},
+				],
+			},
+			{
+				id: 'border',
+				title: __('Border', 'kadence-blocks'),
+				fields: [
+					{
+						type: 'select',
+						path: 'tokens.borderStyle',
+						label: __('Style', 'kadence-blocks'),
+						options: BORDER_STYLE_OPTIONS,
+					},
+					{
+						type: 'token-scalar',
+						tokenType: 'dimension',
+						role: 'border-width',
+						path: 'tokens.borderWidth',
+						label: __('Width', 'kadence-blocks'),
+						defaultValue: HEADING_BORDER_WIDTH_FALLBACK,
+					},
+					{
+						type: 'token-color-select',
+						path: 'tokens.borderColor',
+						label: __('Color', 'kadence-blocks'),
+					},
+					{
+						type: 'radius',
+						tokenType: 'dimension',
+						role: 'radius',
+						responsive: true,
+						path: 'tokens.borderRadius',
+						label: __('Radius', 'kadence-blocks'),
+						defaultValue: HEADING_RADIUS_FALLBACK,
+					},
+				],
+			},
+			{
+				id: 'spacing',
+				title: __('Spacing', 'kadence-blocks'),
+				fields: [
+					{
+						type: 'spacing',
+						tokenType: 'dimension',
+						role: 'spacing',
+						responsive: true,
+						path: 'tokens.padding',
+						label: __('Padding', 'kadence-blocks'),
+						defaultValue: HEADING_PADDING_FALLBACK,
+					},
+				],
+			},
+		],
+	};
+}
+
+/**
+ * The Advanced Text preset screen's whole configuration, passed to the generic preset machinery.
+ *
+ * `properties` is a getter rather than a snapshot, for the same reason the Button's is: the config is
+ * frozen at module evaluation, before the localized feed is guaranteed to exist, so a snapshot taken
+ * here could throw or go stale.
+ *
+ * @since TBD
+ */
+export const HEADING_PRESET = Object.freeze({
+	block: HEADING_BLOCK,
+	get properties() {
+		return getPresetProperties(HEADING_BLOCK);
+	},
+	slugBase: 'heading',
+	addLabel: __('Add Text Style', 'kadence-blocks'),
+	newLabel: __('New Text Style', 'kadence-blocks'),
+	className: 'kadence-blocks-style-library__heading-screen',
+	preview,
+	renderPreview,
+	schemaFor,
+});

--- a/src/style-library/presets/advancedheading-preset.js
+++ b/src/style-library/presets/advancedheading-preset.js
@@ -234,6 +234,10 @@ function schemaFor() {
 						path: 'tokens.fontSize',
 						label: __('Size', 'kadence-blocks'),
 						defaultValue: HEADING_FONT_SIZE_FALLBACK,
+						// The font-size scale is fluid: every step resolves to a whole `clamp()`
+						// expression, which overran its row and pushed the step's own name out of view.
+						// The names (SM, MD, LG…) are what a site owner picks by, so the value goes.
+						showValue: false,
 					},
 					{
 						type: 'select',

--- a/src/token-controls/controls/ScalarControl.js
+++ b/src/token-controls/controls/ScalarControl.js
@@ -80,6 +80,7 @@ export function ScalarControl({
 	min,
 	max,
 	step,
+	showValue = true,
 }) {
 	return (
 		<ControlShell
@@ -106,6 +107,7 @@ export function ScalarControl({
 				min={min}
 				max={max}
 				step={step}
+				showValue={showValue}
 				disabled={disabled}
 				// The field speaks three intents; a scalar stores one value, so they collapse here rather
 				// than in every host. `onCustom` writes a bare number — the unit is the control's, exactly

--- a/src/token-controls/organisms/TokenSelector.js
+++ b/src/token-controls/organisms/TokenSelector.js
@@ -58,6 +58,11 @@ import '../styles/token-controls.scss';
  * @param {Function} props.onClear    Clears the slot's override (the `Reset` choice).
  * @param {Function} props.onCustom   Writes a literal number to the slot (used when leaving a token).
  * @param {Function} [props.renderCustom] Overrides the Custom tab body; passed through to `TokenPopover`.
+ * @param {boolean}  [props.showValue] Whether each token row states its resolved value beside its
+ *                                      label. Defaults to `true`; a field whose values are too long to
+ *                                      read in a row (a fluid font size resolves to a whole `clamp()`
+ *                                      expression) opts out, exactly as `BoxShadowControl` does for a
+ *                                      shadow's shorthand.
  * @param {boolean}  [props.disabled] Disable the trigger, which is the only control outside the
  *                                      popover — with it inert the popover cannot open, so nothing
  *                                      below it is reachable either. Callers that only guard their
@@ -84,6 +89,7 @@ export function TokenSelector({
 	onClear,
 	onCustom,
 	renderCustom,
+	showValue = true,
 	disabled = false,
 }) {
 	const summary = fieldSummary(value, tokens, unit, __('Custom', 'kadence-blocks'));
@@ -171,6 +177,7 @@ export function TokenSelector({
 						resolvedDefault={resolvedDefault}
 						inherited={inherited}
 						initialTab={initialTab}
+						showValue={showValue}
 						custom={{ number, unit, units, onUnit, min, max, step, onNumber: writeNumber }}
 						renderCustom={renderCustom}
 						onPick={onPick}

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/PresetNavTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/PresetNavTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Admin\Feed;
 
-use Generator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed\Preset_Nav;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
@@ -28,11 +27,11 @@ final class PresetNavTest extends TestCase {
 	}
 
 	/**
-	 * Every shipped nav entry carries its declared Style Library section label ("Button", "Advanced
-	 * Image", "Row Layout", "Section", "Icon"), never the picker control's own label — every one of those
-	 * blocks declares that as "Style". The Section's entry is the case that proves the point: the block is
-	 * `kadence/column` in code and the nav must still read "Section", which is what it is called in the
-	 * UI. Order is registration order, which is declaration order in `declarations.php`.
+	 * Every shipped nav entry carries its declared Style Library section label, never the picker
+	 * control's own label — every one of these blocks declares that as "Style". The Section and Advanced
+	 * Text entries are the cases that prove the point: they are `kadence/column` and
+	 * `kadence/advancedheading` in code, and the nav must read the names the UI calls them. Order is
+	 * registration order, which is declaration order in `declarations.php`.
 	 *
 	 * @return void
 	 */
@@ -61,26 +60,38 @@ final class PresetNavTest extends TestCase {
 					'block' => 'kadence/single-icon',
 					'label' => 'Icon',
 				],
+				[
+					'block' => 'kadence/advancedheading',
+					'label' => 'Advanced Text',
+				],
 			],
 			$entries
 		);
 	}
 
 	/**
-	 * A default-look-only binding set — one with no declared label — is excluded from the nav,
-	 * across every shipped block that registers bindings with no picker.
+	 * A default-look-only binding set — one with no declared label — is excluded from the nav.
 	 *
-	 * @dataProvider defaultLookOnlyBlockProvider
-	 *
-	 * @param string $block The default-look-only block name.
+	 * Exercised against a registry built here rather than a shipped block: every shipped block now
+	 * declares a label, so there is no longer one to point at, but the exclusion is still the contract a
+	 * third-party block relies on to wire tokens without surfacing a preset UI.
 	 *
 	 * @return void
 	 */
-	public function testAllExcludesBindingSetsWithNoLabel( string $block ): void {
-		$entries = ( new Preset_Nav( $this->registry ) )->all();
-		$blocks  = array_column( $entries, 'block' );
+	public function testAllExcludesABindingSetWithNoLabel(): void {
+		$registry = new Token_Registry();
+		$registry->register_preset_bindings( [ 'block' => 'my-vendor/default-look-only' ] );
+		$registry->register_preset_bindings(
+			[
+				'block'         => 'my-vendor/picker-driven',
+				'label'         => 'Style',
+				'style_library' => [ 'label' => 'Picker Driven' ],
+			]
+		);
 
-		$this->assertNotContains( $block, $blocks );
+		$entries = ( new Preset_Nav( $registry ) )->all();
+
+		$this->assertSame( [ 'my-vendor/picker-driven' ], array_column( $entries, 'block' ) );
 	}
 
 	/**
@@ -245,13 +256,4 @@ final class PresetNavTest extends TestCase {
 		$this->assertSame( ( new Preset_Nav( $this->registry ) )->all(), $feed['presetNav'] );
 	}
 
-	/**
-	 * The shipped blocks whose preset bindings declare no label — default-look-only sets with no
-	 * user-facing preset concept.
-	 *
-	 * @return Generator
-	 */
-	public function defaultLookOnlyBlockProvider(): Generator {
-		yield 'advanced heading' => [ 'block' => 'kadence/advancedheading' ];
-	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
@@ -93,42 +93,7 @@ final class Preset_CatalogTest extends TestCase {
 		$this->assertSame( 'dimension', $kinds['button-radius'] );
 	}
 
-	/**
-	 * The blocks wired for presets but not yet given a Style Library screen expose a full controllable
-	 * surface — every bound property with its control attribute — while offering NO preset options, because
-	 * their bindings declare no picker label. That combination is what keeps the editor's Design Tokens
-	 * panel hidden for them (it renders only when a block has at least one preset option), so declaring the
-	 * wiring ahead of the screen surfaces nothing to a site owner.
-	 *
-	 * @dataProvider wiredWithoutAScreenProvider
-	 *
-	 * @param string $block The block name.
-	 *
-	 * @return void
-	 */
-	public function testAWiredBlockWithNoLabelExposesASurfaceButNoPresetOptions( string $block ): void {
-		$entry = $this->catalog->all()['libraries'][ Token_Store::default_slug() ][ $block ];
 
-		$this->assertSame( [], $entry['presets'], 'A block with no picker label must offer no preset options.' );
-		$this->assertNull( $entry['label'] );
-		$this->assertNotEmpty( $entry['properties'], 'The controllable surface is declared regardless of the label.' );
-
-		foreach ( $entry['properties'] as $property ) {
-			$this->assertNotNull(
-				$property['control_attr'],
-				sprintf( '%s: every bound property must name the control attribute it maps to.', $property['key'] )
-			);
-		}
-	}
-
-	/**
-	 * The blocks whose bindings are wired for presets but whose Style Library screen has not landed yet.
-	 *
-	 * @return Generator
-	 */
-	public function wiredWithoutAScreenProvider(): Generator {
-		yield 'advanced heading' => [ 'block' => 'kadence/advancedheading' ];
-	}
 
 	/**
 	 * Alongside the flattened literals, the catalog carries each preset's CSS REFERENCES — the same
@@ -254,19 +219,58 @@ final class Preset_CatalogTest extends TestCase {
 	 * @return void
 	 */
 	public function testABlockWithoutAPickerLabelCarriesPropertiesButNoPresetOptions(): void {
-		$library = $this->catalog->all()['libraries'][ Token_Store::default_slug() ];
+		// Two blocks registered here rather than shipped ones: every shipped block now declares a label,
+		// and the separation this asserts is the contract a third-party block wiring tokens without a
+		// preset UI depends on. Both are given a preset in the document, so neither is skipped for having
+		// none and the only difference between them is the label.
+		$bindings = [
+			'background' => [
+				'token'        => 'semantic.color.text',
+				'css_prop'     => 'background-color',
+				'control_attr' => 'background',
+			],
+		];
 
-		$this->assertArrayHasKey( self::HEADING, $library );
-		$this->assertNull( $library[ self::HEADING ]['label'] );
-		$this->assertSame( [], $library[ self::HEADING ]['presets'] );
+		$registry = new Token_Registry();
+		$registry->register_preset_bindings(
+			[
+				'block'    => 'my-vendor/default-look-only',
+				'bindings' => $bindings,
+			]
+		);
+		$registry->register_preset_bindings(
+			[
+				'block'    => 'my-vendor/picker-driven',
+				'label'    => 'Style',
+				'bindings' => $bindings,
+			]
+		);
 
-		// The surface the token picker keys off is present regardless, as is the default the controls compare
-		// against.
-		$this->assertNotEmpty( $library[ self::HEADING ]['properties'] );
-		$this->assertSame( 'default', $library[ self::HEADING ]['default'] );
+		$this->store->save_document(
+			'{"$extensions":{"com.kadence.designTokens":{"presets":{'
+			. '"my-vendor/default-look-only":{"$default":"only","only":{"label":"Only","tokens":{"background":"#ff0000"}}},'
+			. '"my-vendor/picker-driven":{"$default":"only","only":{"label":"Only","tokens":{"background":"#ff0000"}}}'
+			. '}}}}'
+		);
 
-		// The picker-driven Button is unaffected: it declares a label, so it still carries its options.
-		$this->assertNotEmpty( $library[ self::BUTTON ]['presets'] );
+		$library = ( new Preset_Catalog(
+			$registry,
+			$this->container->get( Preset_Resolver::class ),
+			$this->store,
+			$this->container->get( Active_Token_Library_Store::class ),
+			$this->container->get( Effective_Presets::class )
+		) )->all()['libraries'][ Token_Store::default_slug() ];
+
+		$unlabeled = $library['my-vendor/default-look-only'];
+
+		$this->assertNull( $unlabeled['label'] );
+		$this->assertSame( [], $unlabeled['presets'], 'A block with no picker label must offer no preset options.' );
+
+		// The surface the token picker keys off is present regardless of the label.
+		$this->assertNotEmpty( $unlabeled['properties'] );
+
+		// The labeled sibling, identical but for the label, does carry its options.
+		$this->assertNotEmpty( $library['my-vendor/picker-driven']['presets'] );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
@@ -3,7 +3,6 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Editor;
 
-use Generator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Editor\Preset_Catalog;


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout
:video_camera: https://www.loom.com/share/c45de6b397424fcf9434d5b8e1fe9582

Ten of the block's twelve bound properties. A property is a token picker where the design system has a scale for it and a keyword select where it does not; offering border style is what makes a preset border visible at all.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Advanced Text preset for Advanced Text blocks.
  * Added a dedicated Advanced Text settings screen with live previews for typography, colors, borders, spacing, and responsive options.
  * Added preset navigation and controls for border styles, text transforms, font weights, and design tokens.

* **Improvements**
  * Improved token selection behavior for semantic values.
  * Added the option to hide resolved token values in controls for a cleaner editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

