### PR TITLE
[DTM] SOFT-4218 [14/16]: let a preset set the Advanced Text font family

### DIFF
--- a/includes/blocks/class-kadence-blocks-advanced-heading-block.php
+++ b/includes/blocks/class-kadence-blocks-advanced-heading-block.php
@@ -1000,8 +1000,61 @@ class Kadence_Blocks_Advancedheading_Block extends Kadence_Blocks_Abstract_Block
 		$family = Cast::to_string( $values['typography'] );
 
 		if ( $family !== '' && 'inherit' !== $family ) {
-			$css->maybe_add_google_font( $family, ! empty( $attributes['fontVariant'] ) ? $attributes['fontVariant'] : null );
+			$variant = $this->preset_font_variant( $attributes, $values );
+
+			$css->maybe_add_google_font( $family, $variant !== '' ? $variant : null );
 		}
+	}
+
+	/**
+	 * The Google variant to request alongside a preset's family, so the weight the page asks for is a
+	 * face the browser actually has.
+	 *
+	 * A preset carries its family and its weight as two independent properties: the family arrives here,
+	 * while the weight reaches the page as a `font-weight` declaration through its own binding. Asking
+	 * for the family without its weight loads the upright default and leaves the browser to synthesize
+	 * everything else — a heading set to 700 renders as a faked bold rather than the real face, which is
+	 * the outcome narrowing the weight picker to a family's shipped weights exists to prevent.
+	 *
+	 * Precedence follows what actually renders. An explicit `fontVariant` on the block is a direct
+	 * statement about the face and wins outright; a `fontWeight` the block sets itself comes next, since
+	 * that is the weight the CSS above emits for it; the preset's own weight applies only when the block
+	 * states neither.
+	 *
+	 * `presetFontVariant()` in `src/blocks/advancedheading/preset-font-variant.js` holds the JS twin of
+	 * this mapping, so the editor's loader and this enqueue ask Google for the same face. Keep the two in
+	 * step. A weight neither recognizes yields `''`, which asks for no variant and so leaves the family
+	 * loading exactly as it did before this bridge existed.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $attributes The block attributes.
+	 * @param array<string, mixed> $values     The active preset's resolved values.
+	 *
+	 * @return string The Google variant, or '' when nothing names a face to ask for.
+	 */
+	private function preset_font_variant( array $attributes, array $values ): string {
+		if ( ! empty( $attributes['fontVariant'] ) ) {
+			return Cast::to_string( $attributes['fontVariant'] );
+		}
+
+		$weight = ! empty( $attributes['fontWeight'] )
+			? Cast::to_string( $attributes['fontWeight'] )
+			: Cast::to_string( $values['fontWeight'] ?? '' );
+
+		$weight = strtolower( trim( $weight ) );
+
+		// `regular` rather than `400`: it is the v1 spelling the rest of this plugin already uses for the
+		// upright default (see `render_font_weight()`), and the editor's `parseVariant` reads it as 400.
+		if ( 'normal' === $weight || 'regular' === $weight || '400' === $weight ) {
+			return 'regular';
+		}
+
+		if ( 'bold' === $weight ) {
+			return '700';
+		}
+
+		return preg_match( '/^[1-9]00$/', $weight ) === 1 ? $weight : '';
 	}
 }
 

--- a/includes/blocks/class-kadence-blocks-advanced-heading-block.php
+++ b/includes/blocks/class-kadence-blocks-advanced-heading-block.php
@@ -5,6 +5,11 @@
  * @package Kadence Blocks
  */
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Preset_Resolver;
+use KadenceWP\KadenceBlocks\Utils\Cast;
+
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -59,10 +64,10 @@ class Kadence_Blocks_Advancedheading_Block extends Kadence_Blocks_Abstract_Block
 	/**
 	 * Builds CSS for block.
 	 *
-	 * @param array $attributes the blocks attributes.
-	 * @param Kadence_Blocks_CSS $css the css class for blocks.
-	 * @param string $unique_id the blocks attr ID.
-	 * @param string $unique_style_id the blocks alternate ID for queries.
+	 * @param array              $attributes      the blocks attributes.
+	 * @param Kadence_Blocks_CSS $css             the css class for blocks.
+	 * @param string             $unique_id       the blocks attr ID.
+	 * @param string             $unique_style_id the blocks alternate ID for queries.
 	 */
 	public function build_css( $attributes, $css, $unique_id, $unique_style_id ) {
 
@@ -130,6 +135,8 @@ class Kadence_Blocks_Advancedheading_Block extends Kadence_Blocks_Abstract_Block
 			$google = $google && ( isset( $attributes['loadGoogleFont'] ) && $attributes['loadGoogleFont'] || ! isset( $attributes['loadGoogleFont'] ) ) ? true : false;
 			$variant = ! empty( $attributes['fontVariant'] ) ? $attributes['fontVariant'] : null;
 			$css->add_property( 'font-family', $css->render_font_family( $attributes['typography'], $google, $variant ) );
+		} else {
+			$this->render_preset_typography( $css, $attributes );
 		}
 		if ( ! empty( $attributes['textTransform'] ) ) {
 			$css->add_property( 'text-transform', $attributes['textTransform'] );
@@ -925,6 +932,76 @@ class Kadence_Blocks_Advancedheading_Block extends Kadence_Blocks_Abstract_Block
 			return $default;
 		}
 		return $fallback;
+	}
+	/**
+	 * Point font-family at its preset variable, but only when the active preset actually resolves one.
+	 *
+	 * Called only where the block's own `typography` attribute is empty, so a family a site owner picked
+	 * per-instance always wins — this supplies the family a preset carries for a heading that has none of
+	 * its own.
+	 *
+	 * The gate matters for the same reason it does on the Single Button's spacing bridge:
+	 * `font-family: var(--kb-heading-font-family)` is not inert when the variable is undefined, it is
+	 * invalid at computed-value time, which resets the property to its initial value rather than letting
+	 * the heading inherit the theme's font. Emitting only when the preset resolves a family is what keeps
+	 * a heading whose preset sets none looking exactly as it does today.
+	 *
+	 * The variable, not the literal: the preset projector sets `--kb-heading-font-family` per preset
+	 * scope, so one rule follows whichever preset the heading is on. The binding deliberately declares no
+	 * `css_prop`, which is what keeps font-family out of the block-default rule that every heading gets
+	 * (see the declaration for why that would break theme inheritance).
+	 *
+	 * @since TBD
+	 *
+	 * @param Kadence_Blocks_CSS   $css        The css object.
+	 * @param array<string, mixed> $attributes The block attributes.
+	 *
+	 * @return void
+	 */
+	private function render_preset_typography( Kadence_Blocks_CSS $css, array $attributes ): void {
+		try {
+			$registry = kadence_blocks()->get( Token_Registry::class );
+			$library  = kadence_blocks()->get( Active_Token_Library_Store::class );
+			$resolver = kadence_blocks()->get( Preset_Resolver::class );
+
+			// The container is typed `mixed`, and this runs on every heading render, so the services are
+			// checked rather than assumed — a misconfigured container degrades to today's font.
+			if (
+				! $registry instanceof Token_Registry
+				|| ! $library instanceof Active_Token_Library_Store
+				|| ! $resolver instanceof Preset_Resolver
+				|| ! $registry->is_active()
+			) {
+				return;
+			}
+
+			$slug     = $library->get();
+			$selected = Cast::to_string( $attributes['kbPreset'] ?? '' );
+			$preset   = $selected !== '' && $resolver->has_preset( 'kadence/advancedheading', $selected, $slug )
+				? $selected
+				: $resolver->default_preset( 'kadence/advancedheading', $slug );
+			$values   = $resolver->resolve( 'kadence/advancedheading', $preset, $slug );
+		} catch ( Throwable $e ) {
+			// This runs in the render path, so a broken token graph must not take the page down with it —
+			// the heading simply keeps the font it has today.
+			return;
+		}
+
+		if ( ! isset( $values['typography'] ) ) {
+			return;
+		}
+
+		$css->add_property( 'font-family', 'var(--kb-heading-font-family)' );
+
+		// Enqueue the family as well as name it. The block's own loading is driven by the `typography`
+		// attribute, which is empty in exactly the case this bridge fires, so without this a heading that
+		// takes its family from a preset would render in a fallback face while the CSS asked for the real
+		// one. The preset stores the family as a literal, which is the shape this expects.
+		$family = Cast::to_string( $values['typography'] );
+
+		if ( $family !== '' && 'inherit' !== $family ) {
+			$css->maybe_add_google_font( $family, ! empty( $attributes['fontVariant'] ) ? $attributes['fontVariant'] : null );
+		}
 	}
 }
 

--- a/includes/resources/Design_Tokens/Admin/Feed/Font_Catalog.php
+++ b/includes/resources/Design_Tokens/Admin/Feed/Font_Catalog.php
@@ -8,9 +8,12 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Admin\Feed;
  *
  * The Google names come from includes/gfonts-names-array.php, the same generated, flat name
  * list the block editor already localizes (class-kadence-blocks-editor-assets.php's g_font_names).
- * The larger includes/gfonts-array.php (variants/subsets/weights/italics per family) is not read
- * here: it carries no category field, so it cannot contribute anything a generic-fallback stack
- * would need, and shipping its 338KB to this catalog would be pure waste.
+ *
+ * Per-family WEIGHTS come from the larger includes/gfonts-array.php, but only the weights: that file
+ * also carries variants, subsets and italics per family, and shipping all 338KB of it would be waste
+ * when the one thing a consumer needs from it is which weights a family actually has. A weight
+ * control that offers 100-900 for every family promises faces most families do not ship, and the
+ * browser answers with a synthesized approximation rather than the design system's own type.
  *
  * Custom names come from the kadence_blocks_custom_fonts filter, the same one the block editor
  * localizes as c_fonts — its shape is an associative array keyed by font name (a string key may
@@ -31,6 +34,15 @@ final class Font_Catalog {
 	private const NAMES_FILE = 'includes/gfonts-names-array.php';
 
 	/**
+	 * The generated Google font detail file, read for its per-family weight lists alone.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const DETAILS_FILE = 'includes/gfonts-array.php';
+
+	/**
 	 * The filter the block editor already reads for site-registered custom fonts.
 	 *
 	 * @since TBD
@@ -40,20 +52,94 @@ final class Font_Catalog {
 	private const CUSTOM_FONTS_FILTER = 'kadence_blocks_custom_fonts';
 
 	/**
-	 * The catalog: every Google family name, and every custom family name not already among them.
+	 * The catalog: every Google family name, every custom family name not already among them, and the
+	 * weights each Google family ships.
+	 *
+	 * A custom family contributes no weights — the custom-fonts filter carries none — so it is absent
+	 * from the map rather than present with an empty list, which lets a consumer tell "this family
+	 * ships only regular" apart from "nothing is known about this family".
 	 *
 	 * @since TBD
 	 *
-	 * @return array{google: string[], custom: string[]}
+	 * @return array{google: string[], custom: string[], weights: array<string, string[]>}
 	 */
 	public function all(): array {
 		$google = $this->google_names();
 		$custom = array_values( array_diff( $this->custom_names(), $google ) );
 
 		return [
-			'google' => $google,
-			'custom' => $custom,
+			'google'  => $google,
+			'custom'  => $custom,
+			'weights' => $this->google_weights(),
 		];
+	}
+
+	/**
+	 * The weights each Google family ships, keyed by family name.
+	 *
+	 * Normalized to numeric strings: the generated file spells the default weight `regular`, which is
+	 * `400` everywhere a CSS `font-weight` is written, and leaving both spellings in would make a
+	 * consumer match two things for one weight. Sorted numerically so a picker lists them in weight
+	 * order rather than the file's own.
+	 *
+	 * Fail-soft to an empty map when the generated file is absent, the same posture google_names()
+	 * takes for its own file.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, string[]>
+	 */
+	private function google_weights(): array {
+		$path = KADENCE_BLOCKS_PATH . self::DETAILS_FILE;
+
+		if ( ! file_exists( $path ) ) {
+			return [];
+		}
+
+		$fonts = include $path;
+
+		if ( ! is_array( $fonts ) ) {
+			return [];
+		}
+
+		$weights = [];
+
+		foreach ( $fonts as $family => $details ) {
+			if ( ! is_string( $family ) || ! is_array( $details ) || ! isset( $details['w'] ) || ! is_array( $details['w'] ) ) {
+				continue;
+			}
+
+			$family_weights = [];
+
+			foreach ( $details['w'] as $weight ) {
+				if ( ! is_string( $weight ) && ! is_int( $weight ) ) {
+					continue;
+				}
+
+				$weight = 'regular' === $weight ? '400' : (string) $weight;
+
+				// An italic-only entry ("700italic") names a weight already listed in its own right, so
+				// it would duplicate rather than add one.
+				if ( ! preg_match( '/^\d+$/', $weight ) ) {
+					continue;
+				}
+
+				$family_weights[] = $weight;
+			}
+
+			if ( $family_weights === [] ) {
+				continue;
+			}
+
+			// Deduplicated by VALUE, not by key: PHP converts a numeric-string array key to an integer, so
+			// keying on the weight would hand back `400` where every consumer compares against `'400'`.
+			$family_weights = array_values( array_unique( $family_weights ) );
+			sort( $family_weights, SORT_NUMERIC );
+
+			$weights[ $family ] = $family_weights;
+		}
+
+		return $weights;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -927,10 +927,19 @@ return [
 					'css_var'      => 'kb-heading-bg',
 					'control_attr' => 'background',
 				],
-				// No font-family binding: a heading inherits the theme's font, and the block-default CSS
-				// deliberately emits no font-family default for it (see Css_BuilderTest). Font family is
-				// delivered by the font system rather than a token rule, and a preset stores the family the
-				// typography control picked as a literal rather than a token reference.
+				// Font family carries NO css_prop, and that omission is the whole design rather than an
+				// oversight. A css_prop would put font-family into the block-default rule, which emits for
+				// every heading on the site: `font-family: inherit` on the block root overrides the theme's
+				// own h1/h2 element styles, so a heading would stop inheriting the theme font (see
+				// Css_BuilderTest, which asserts no font-family default is emitted). Declaring only the
+				// css_var keeps the block-default rule out of it while still giving Preset\Css_Builder a
+				// variable to set for a SELECTED preset, which the block's own render path reads through
+				// render_preset_typography(). A preset stores the family the typography control picked as a
+				// literal, not a token reference — the font catalog is not a token scale.
+				'typography'    => [
+					'css_var'      => 'kb-heading-font-family',
+					'control_attr' => 'typography',
+				],
 				//
 				// fontHeight and letterSpacing are bound but NOT offered on the Style Library screen: neither
 				// has a primitive scale to pick from (their semantic groups hold one entry per usage, which is

--- a/src/blocks/advancedheading/__tests__/preset-font-variant.test.js
+++ b/src/blocks/advancedheading/__tests__/preset-font-variant.test.js
@@ -1,0 +1,70 @@
+/* eslint-env jest */
+/**
+ * `presetFontVariant` turns the weight a preset stores into the variant a Google Fonts request takes,
+ * so the family a preset names is loaded at the weight the page then asks for rather than at 400 with
+ * a synthesized bold over it. Its PHP twin is `preset_font_variant()` on the Advanced Heading block;
+ * the cases here are the ones both sides must agree on.
+ */
+import { presetFontVariant } from '../preset-font-variant';
+
+describe('presetFontVariant', () => {
+	/**
+	 * A numeric weight is already Google's own variant spelling and passes through, which is the case
+	 * that matters: a preset set to 700 has to request the real bold face.
+	 *
+	 * @return {void}
+	 */
+	it('passes a numeric weight through as the variant', () => {
+		expect(presetFontVariant('700')).toBe('700');
+		expect(presetFontVariant('100')).toBe('100');
+		expect(presetFontVariant('900')).toBe('900');
+	});
+
+	/**
+	 * The upright default is asked for as `regular`, the v1 spelling the rest of the plugin uses, which
+	 * the editor's `parseVariant` also reads as 400. All three ways of writing it converge.
+	 *
+	 * @return {void}
+	 */
+	it('normalizes every spelling of the upright default to regular', () => {
+		expect(presetFontVariant('400')).toBe('regular');
+		expect(presetFontVariant('normal')).toBe('regular');
+		expect(presetFontVariant('regular')).toBe('regular');
+	});
+
+	/**
+	 * `bold` is a legal DTCG font weight, so a token that spells 700 that way still resolves to a face
+	 * rather than falling through to no variant at all.
+	 *
+	 * @return {void}
+	 */
+	it('resolves the bold keyword to its numeric face', () => {
+		expect(presetFontVariant('bold')).toBe('700');
+	});
+
+	/**
+	 * Casing and stray whitespace come from authored token values, not from a controlled vocabulary, so
+	 * they are normalized rather than treated as unrecognized.
+	 *
+	 * @return {void}
+	 */
+	it('ignores casing and surrounding whitespace', () => {
+		expect(presetFontVariant('  Bold  ')).toBe('700');
+		expect(presetFontVariant(' REGULAR ')).toBe('regular');
+	});
+
+	/**
+	 * An empty or unrecognized weight asks for no variant, which leaves the family loading exactly as it
+	 * did before this bridge existed rather than requesting a face that does not exist.
+	 *
+	 * @return {void}
+	 */
+	it('asks for no variant when the weight names no face', () => {
+		expect(presetFontVariant('')).toBe('');
+		expect(presetFontVariant(undefined)).toBe('');
+		expect(presetFontVariant(null)).toBe('');
+		expect(presetFontVariant('lighter')).toBe('');
+		expect(presetFontVariant('450')).toBe('');
+		expect(presetFontVariant('70')).toBe('');
+	});
+});

--- a/src/blocks/advancedheading/edit.js
+++ b/src/blocks/advancedheading/edit.js
@@ -79,6 +79,7 @@ import Typed from 'typed.js';
  */
 import './editor.scss';
 import { presetPropertyValueForDevice } from '../../extension/token-indicators';
+import { presetFontVariant } from './preset-font-variant';
 import metadata from './block.json';
 /**
  * Internal block libraries
@@ -523,6 +524,12 @@ function KadenceAdvancedHeading(props) {
 	// The front end does the same through `render_preset_typography()`, which points font-family at the
 	// preset variable only when the block's own `typography` is empty — the two agree by construction.
 	const presetTypography = presetPropertyValueForDevice(metadata.name, 'typography', attributes);
+	// The weight to ASK GOOGLE FOR alongside that family. The preset's weight already reaches the page
+	// as a `font-weight` declaration through its own binding, but the face it names has to be requested
+	// too — a family loaded at 400 with `font-weight: 700` over it renders as a synthesized bold. An
+	// explicit variant on the block still wins, then a weight the block sets itself, then the preset's.
+	const presetFontWeight = presetPropertyValueForDevice(metadata.name, 'fontWeight', attributes);
+	const presetVariant = fontVariant || presetFontVariant(fontWeight || presetFontWeight);
 	const effectiveTypography = typography || presetTypography || '';
 	const renderTypography =
 		effectiveTypography && !effectiveTypography.includes(',')
@@ -2748,7 +2755,7 @@ function KadenceAdvancedHeading(props) {
 			 */}
 			{!typography && presetTypography && (
 				<KadenceWebfontLoader
-					typography={[{ family: presetTypography, variant: fontVariant ? fontVariant : '' }]}
+					typography={[{ family: presetTypography, variant: presetVariant }]}
 					clientId={clientId}
 					id={'adv-heading-preset'}
 				/>

--- a/src/blocks/advancedheading/edit.js
+++ b/src/blocks/advancedheading/edit.js
@@ -78,6 +78,7 @@ import Typed from 'typed.js';
  * Import Css
  */
 import './editor.scss';
+import { presetPropertyValueForDevice } from '../../extension/token-indicators';
 import metadata from './block.json';
 /**
  * Internal block libraries
@@ -516,7 +517,17 @@ function KadenceAdvancedHeading(props) {
 		richTextFormats = richTextFormatsBase;
 	}
 
-	const renderTypography = typography && !typography.includes(',') ? "'" + typography + "'" : typography;
+	// The family a heading with none of its own falls back to: whatever the SELECTED preset carries.
+	// A preset stores the family as a literal (the font catalog is not a token scale), so this is the
+	// name itself rather than a token reference, and it is quoted for CSS exactly like the block's own.
+	// The front end does the same through `render_preset_typography()`, which points font-family at the
+	// preset variable only when the block's own `typography` is empty — the two agree by construction.
+	const presetTypography = presetPropertyValueForDevice(metadata.name, 'typography', attributes);
+	const effectiveTypography = typography || presetTypography || '';
+	const renderTypography =
+		effectiveTypography && !effectiveTypography.includes(',')
+			? "'" + effectiveTypography + "'"
+			: effectiveTypography;
 	const markBGString = markBG ? KadenceColorOutput(markBG, markBGOpacity) : '';
 	const markBorderString = markBorder ? KadenceColorOutput(markBorder, markBorderOpacity) : '';
 	const textColorClass = getColorClassName('color', colorClass);
@@ -1176,7 +1187,7 @@ function KadenceAdvancedHeading(props) {
 							? previewLetterSpacing + (letterSpacingType ? letterSpacingType : 'px')
 							: undefined,
 						textTransform: textTransform ? textTransform : undefined,
-						fontFamily: typography ? renderTypography : '',
+						fontFamily: effectiveTypography ? renderTypography : '',
 						textShadow: enableTextShadow
 							? `${previewHOffset}px ${previewVOffset}px ${previewBlur}px ${
 									isRGBA(previewColorTextShadow)
@@ -2730,6 +2741,18 @@ function KadenceAdvancedHeading(props) {
 				</div>
 			)}
 			{!kadenceAnimation && (link ? headingLinkContent : headingContent)}
+			{/*
+			 * The preset's family is loaded on the same terms as the block's own. Without this a heading
+			 * that takes its family from a preset renders in a fallback face: the loader is driven by the
+			 * `typography` attribute, which is empty in exactly the case the preset supplies one.
+			 */}
+			{!typography && presetTypography && (
+				<KadenceWebfontLoader
+					typography={[{ family: presetTypography, variant: fontVariant ? fontVariant : '' }]}
+					clientId={clientId}
+					id={'adv-heading-preset'}
+				/>
+			)}
 			{googleFont && typography && (
 				<KadenceWebfontLoader
 					typography={[{ family: typography, variant: fontVariant ? fontVariant : '' }]}

--- a/src/blocks/advancedheading/preset-font-variant.js
+++ b/src/blocks/advancedheading/preset-font-variant.js
@@ -1,0 +1,42 @@
+/**
+ * Express a preset's stored font weight as the variant a Google Fonts request takes.
+ *
+ * A preset carries its family and its weight as two independent properties: the family reaches the
+ * font loader, while the weight reaches the page as a `font-weight` declaration through its own
+ * binding. Loading the family without asking for the weight is what makes the browser synthesize a
+ * bold rather than paint the real face -- the exact outcome narrowing the weight picker to a family's
+ * shipped weights exists to prevent. This turns the stored weight into the variant that closes that
+ * gap.
+ *
+ * `render_preset_typography()` in `includes/blocks/class-kadence-blocks-advanced-heading-block.php`
+ * holds the PHP twin of this mapping, so the editor and the front end ask Google for the same face.
+ * Keep the two in step.
+ *
+ * The vocabulary is Google's own variant spelling, which both endpoints in play understand: the v1
+ * `family=Inter:700` form the front end builds, and the css2 form `KadenceWebfontLoader` builds
+ * through `parseVariant`. A weight this does not recognize yields `''`, which asks for no variant at
+ * all and so leaves the family loading exactly as it does without this bridge.
+ *
+ * @param {*} weight The preset's stored font weight.
+ *
+ * @since TBD
+ *
+ * @return {string} The Google variant, or '' when the weight names no face to ask for.
+ */
+export function presetFontVariant(weight) {
+	const value = String(weight ?? '')
+		.trim()
+		.toLowerCase();
+
+	// `regular` rather than `400`: it is the v1 spelling the rest of this plugin already uses for the
+	// upright default (see `render_font_weight`), and `parseVariant` reads it as 400 all the same.
+	if (value === 'normal' || value === 'regular' || value === '400') {
+		return 'regular';
+	}
+
+	if (value === 'bold') {
+		return '700';
+	}
+
+	return /^[1-9]00$/.test(value) ? value : '';
+}

--- a/src/style-library/__tests__/advancedheading-preset.test.js
+++ b/src/style-library/__tests__/advancedheading-preset.test.js
@@ -299,6 +299,24 @@ describe('HEADING_PRESET font family and weight', () => {
 	});
 
 	/**
+	 * The favorites come from the LIVE feed the caller passes, not from the page-load global. Adding a
+	 * favorite on the Typography screen refreshes the feed and leaves the global untouched, so reading
+	 * the global would leave the new face unselectable here until a reload.
+	 *
+	 * @return {void}
+	 */
+	it('builds its favorites from the feed it is given, not the page-load global', () => {
+		// The global carries the pre-refresh list; the live feed carries the face just added.
+		stubFonts(['Inter'], {});
+
+		const family = HEADING_PRESET.schemaFor(undefined, {}, { favoriteFonts: ['Inter', 'Abril Fatface'] })
+			.panels.flatMap((panel) => panel.fields)
+			.find((field) => field.path === 'tokens.typography');
+
+		expect(family.favorites).toEqual(['Inter', 'Abril Fatface']);
+	});
+
+	/**
 	 * Weight narrows to the weights the chosen family actually ships. Abril Fatface ships only 400, and a
 	 * flat 100-900 list would offer eight faces it does not have -- the browser answers a missing one
 	 * with a synthesized approximation rather than the real face.

--- a/src/style-library/__tests__/advancedheading-preset.test.js
+++ b/src/style-library/__tests__/advancedheading-preset.test.js
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+// cspell:ignore Abril Fatface -- a Google font family named as a concrete example.
 /**
  * The Advanced Text preset config — the one per-block file a preset screen needs. Everything else the
  * screen uses (`PresetScreen`, `PresetSidebar`, `usePresetScreen`, `helpers/presets`) is generic and
@@ -169,11 +170,9 @@ describe('HEADING_PRESET', () => {
 	});
 
 	/**
-	 * Ten of the block's twelve bound properties are offered. `fontHeight` and `letterSpacing` are bound
-	 * but withheld: neither has a token scale, and unlike the keyword properties they are open numeric
-	 * ranges, so the only control that would fit is a bare number. Font family is absent for a different
-	 * reason -- it is not a bound property at all, the family being stored as a literal from the
-	 * typography control's own catalog.
+	 * Eleven of the block's thirteen bound properties are offered. `fontHeight` and `letterSpacing` are
+	 * bound but withheld: neither has a token scale, and unlike the keyword properties they are open
+	 * numeric ranges, so the only control that would fit is a bare number.
 	 *
 	 * @return {void}
 	 */
@@ -181,6 +180,7 @@ describe('HEADING_PRESET', () => {
 		expect(fields().map((field) => field.path)).toEqual([
 			'tokens.color',
 			'tokens.background',
+			'tokens.typography',
 			'tokens.fontSize',
 			'tokens.fontWeight',
 			'tokens.textTransform',
@@ -216,6 +216,11 @@ describe('HEADING_PRESET', () => {
 			expect(byPath[path].type).toBe('select');
 			expect(byPath[path].options.length).toBeGreaterThan(1);
 		});
+
+		// Font family is a select too, but over the library's favorites rather than a keyword set, so its
+		// length depends on what the site has kept. With none kept it still offers the theme font.
+		expect(byPath['tokens.typography'].type).toBe('select');
+		expect(byPath['tokens.typography'].options.map((option) => option.value)).toEqual(['']);
 
 		expect(byPath['tokens.fontSize'].type).toBe('token-scalar');
 		expect(byPath['tokens.borderWidth'].type).toBe('token-scalar');
@@ -254,6 +259,104 @@ describe('HEADING_PRESET', () => {
 			'tokens.padding',
 		]);
 		responsive.forEach((field) => expect(RESPONSIVE_CAPABLE_FIELD_TYPES).toContain(field.type));
+	});
+});
+
+describe('HEADING_PRESET font family and weight', () => {
+	afterEach(() => {
+		delete window.kadenceDesignTokens;
+		delete window.kadenceDesignTokensFontCatalog;
+	});
+
+	/**
+	 * Stub the library's favorites and the font catalog the weights come from.
+	 *
+	 * @param {string[]}                 favorites The library's favorite families.
+	 * @param {Record<string, string[]>} weights   The catalog's per-family weights.
+	 *
+	 * @since TBD
+	 *
+	 * @return {void}
+	 */
+	function stubFonts(favorites, weights) {
+		window.kadenceDesignTokens = { favoriteFonts: favorites };
+		window.kadenceDesignTokensFontCatalog = { google: Object.keys(weights), custom: [], weights };
+	}
+
+	/**
+	 * The family select lists the library's favorites, storing each as a literal family name rather than
+	 * a token id -- the font catalog is a list of real faces, not a token scale.
+	 *
+	 * @return {void}
+	 */
+	it('offers the library favorites as literal family names', () => {
+		stubFonts(['Inter', 'Abril Fatface'], {});
+
+		const family = fields().find((field) => field.path === 'tokens.typography');
+
+		expect(family.options.map((option) => option.value)).toEqual(['', 'Inter', 'Abril Fatface']);
+	});
+
+	/**
+	 * Weight narrows to the weights the chosen family actually ships. Abril Fatface ships only 400, and a
+	 * flat 100-900 list would offer eight faces it does not have -- the browser answers a missing one
+	 * with a synthesized approximation rather than the real face.
+	 *
+	 * @return {void}
+	 */
+	it('narrows the weight list to the weights the chosen family ships', () => {
+		stubFonts(['Abril Fatface'], { 'Abril Fatface': ['400'] });
+
+		const weight = HEADING_PRESET.schemaFor(undefined, { tokens: { typography: 'Abril Fatface' } })
+			.panels.flatMap((panel) => panel.fields)
+			.find((field) => field.path === 'tokens.fontWeight');
+
+		expect(weight.options.map((option) => option.value)).toEqual(['', '400']);
+	});
+
+	/**
+	 * A family the catalog does know is narrowed to exactly its own weights, in weight order.
+	 *
+	 * @return {void}
+	 */
+	it('offers every weight a rich family ships', () => {
+		stubFonts(['Inter'], { Inter: ['100', '400', '700', '900'] });
+
+		const weight = HEADING_PRESET.schemaFor(undefined, { tokens: { typography: 'Inter' } })
+			.panels.flatMap((panel) => panel.fields)
+			.find((field) => field.path === 'tokens.fontWeight');
+
+		expect(weight.options.map((option) => option.value)).toEqual(['', '100', '400', '700', '900']);
+	});
+
+	/**
+	 * With no family chosen the heading inherits the theme's font, which could be anything, and a custom
+	 * font carries no weight data at all. Both offer the full set rather than guessing at a narrower one.
+	 *
+	 * @return {void}
+	 */
+	it('offers every weight when the family is unknown or unset', () => {
+		stubFonts(['Inter'], { Inter: ['400'] });
+
+		const weightsFor = (typography) =>
+			HEADING_PRESET.schemaFor(undefined, { tokens: { typography } })
+				.panels.flatMap((panel) => panel.fields)
+				.find((field) => field.path === 'tokens.fontWeight')
+				.options.map((option) => option.value);
+
+		expect(weightsFor('')).toEqual(['', '100', '200', '300', '400', '500', '600', '700', '800', '900']);
+		expect(weightsFor('Some Custom Face')).toEqual([
+			'',
+			'100',
+			'200',
+			'300',
+			'400',
+			'500',
+			'600',
+			'700',
+			'800',
+			'900',
+		]);
 	});
 });
 

--- a/src/style-library/__tests__/advancedheading-preset.test.js
+++ b/src/style-library/__tests__/advancedheading-preset.test.js
@@ -217,10 +217,10 @@ describe('HEADING_PRESET', () => {
 			expect(byPath[path].options.length).toBeGreaterThan(1);
 		});
 
-		// Font family is a select too, but over the library's favorites rather than a keyword set, so its
-		// length depends on what the site has kept. With none kept it still offers the theme font.
-		expect(byPath['tokens.typography'].type).toBe('select');
-		expect(byPath['tokens.typography'].options.map((option) => option.value)).toEqual(['']);
+		// Font family is not a keyword set at all: it uses the same tabbed picker the block editor
+		// mounts, which builds its own list from the library's favorites and the font catalog.
+		expect(byPath['tokens.typography'].type).toBe('font-family');
+		expect(byPath['tokens.typography'].options).toBeUndefined();
 
 		expect(byPath['tokens.fontSize'].type).toBe('token-scalar');
 		expect(byPath['tokens.borderWidth'].type).toBe('token-scalar');
@@ -284,17 +284,18 @@ describe('HEADING_PRESET font family and weight', () => {
 	}
 
 	/**
-	 * The family select lists the library's favorites, storing each as a literal family name rather than
-	 * a token id -- the font catalog is a list of real faces, not a token scale.
+	 * The family field is the tabbed picker, and it names what an unset family falls back to rather than
+	 * reading as empty -- a heading with no family of its own still renders in the theme's face.
 	 *
 	 * @return {void}
 	 */
-	it('offers the library favorites as literal family names', () => {
+	it('uses the tabbed font picker and names the fallback face', () => {
 		stubFonts(['Inter', 'Abril Fatface'], {});
 
 		const family = fields().find((field) => field.path === 'tokens.typography');
 
-		expect(family.options.map((option) => option.value)).toEqual(['', 'Inter', 'Abril Fatface']);
+		expect(family.type).toBe('font-family');
+		expect(family.inherited).toBe('Theme Font');
 	});
 
 	/**

--- a/src/style-library/__tests__/font-family-field.test.js
+++ b/src/style-library/__tests__/font-family-field.test.js
@@ -70,21 +70,25 @@ describe('FontFamilyField', () => {
 	/**
 	 * Render the field with a given stored value.
 	 *
-	 * @param {string}   value    The stored family.
-	 * @param {Function} onChange The write callback.
-	 * @param {Object}   [field]  Extra field-definition keys.
+	 * @param {string}   value           The stored family.
+	 * @param {Function} onChange        The write callback.
+	 * @param {Object}   [field]         Extra field-definition keys.
+	 * @param {Object}   [values]        The surrounding draft, for the sibling-weight rule.
+	 * @param {Function} [onValueChange] The raw path-taking writer.
 	 *
 	 * @since TBD
 	 *
 	 * @return {void}
 	 */
-	function renderField(value, onChange, field = {}) {
+	function renderField(value, onChange, field = {}, values = {}, onValueChange = jest.fn()) {
 		act(() => {
 			root.render(
 				createElement(FontFamilyField, {
 					field: { label: 'Font Family', ...field },
 					value,
 					onChange,
+					values,
+					onValueChange,
 				})
 			);
 		});
@@ -194,5 +198,82 @@ describe('FontFamilyField', () => {
 		expect(loadFontFamily).not.toHaveBeenCalled();
 		expect(onChange).not.toHaveBeenCalled();
 		expect(latestSelectorProps.disabled).toBe(true);
+	});
+
+	/**
+	 * Narrowing the Weight list does not touch what is already stored, so a weight the new family has
+	 * no face for is cleared back to Default rather than left to be synthesized by the browser.
+	 *
+	 * @return {void}
+	 */
+	it('clears a stored weight the newly picked family does not ship', async () => {
+		window.kadenceDesignTokensFontCatalog.weights = { Abel: ['400'], Inter: ['300', '400'] };
+
+		const onValueChange = jest.fn();
+
+		renderField(
+			'Inter',
+			jest.fn(),
+			{ weightPath: 'tokens.fontWeight' },
+			{ tokens: { fontWeight: '300' } },
+			onValueChange
+		);
+
+		await act(async () => {
+			await latestSelectorProps.onPick('Abel');
+		});
+
+		expect(onValueChange).toHaveBeenCalledWith('tokens.fontWeight', '');
+	});
+
+	/**
+	 * A weight the new family does ship is the user's own choice and survives the switch untouched.
+	 *
+	 * @return {void}
+	 */
+	it('keeps a stored weight the newly picked family does ship', async () => {
+		window.kadenceDesignTokensFontCatalog.weights = { Abel: ['400'], Inter: ['300', '400'] };
+
+		const onValueChange = jest.fn();
+
+		renderField(
+			'Inter',
+			jest.fn(),
+			{ weightPath: 'tokens.fontWeight' },
+			{ tokens: { fontWeight: '400' } },
+			onValueChange
+		);
+
+		await act(async () => {
+			await latestSelectorProps.onPick('Abel');
+		});
+
+		expect(onValueChange).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * A family the catalog knows nothing about narrows nothing, so a custom face leaves every stored
+	 * weight standing rather than clearing one it has no data to judge.
+	 *
+	 * @return {void}
+	 */
+	it('leaves the weight alone for a family the catalog carries no weights for', async () => {
+		window.kadenceDesignTokensFontCatalog.weights = { Abel: ['400'] };
+
+		const onValueChange = jest.fn();
+
+		renderField(
+			'Abel',
+			jest.fn(),
+			{ weightPath: 'tokens.fontWeight' },
+			{ tokens: { fontWeight: '300' } },
+			onValueChange
+		);
+
+		await act(async () => {
+			await latestSelectorProps.onPick('My Font');
+		});
+
+		expect(onValueChange).not.toHaveBeenCalled();
 	});
 });

--- a/src/style-library/__tests__/font-family-field.test.js
+++ b/src/style-library/__tests__/font-family-field.test.js
@@ -1,0 +1,198 @@
+/* eslint-env jest */
+// cspell:ignore Fatface -- a Google font family named as a concrete example.
+/**
+ * `FontFamilyField` is the Style Library's adapter for the shared `FontFamilySelector` — the same
+ * tabbed picker the block editor mounts. The selector itself has its own suite, so this covers only
+ * what the adapter contributes: the option list it builds from this page's globals, and the rule that
+ * a pick waits for its web font before writing.
+ */
+
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+// Stubs, not the real components: the selector renders a popover tree that has nothing to do with what
+// this suite asserts, and the loader would reach for the network.
+let latestSelectorProps;
+
+jest.mock('../../token-controls', () => ({
+	FontFamilySelector: (props) => {
+		latestSelectorProps = props;
+
+		return null;
+	},
+	googleFontHref: (family) => `https://fonts.example/${family}`,
+	loadFontFamily: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../hooks/use-google-font-loader', () => ({
+	useGoogleFontLoader: jest.fn(() => ({ readyFamily: '', isLoading: false })),
+}));
+
+/**
+ * Internal dependencies
+ */
+// eslint-disable-next-line import/first -- must follow the jest.mock calls above.
+import { FontFamilyField } from '../components/molecules/fields/FontFamilyField';
+// eslint-disable-next-line import/first -- must follow the jest.mock calls above.
+import { loadFontFamily } from '../../token-controls';
+
+describe('FontFamilyField', () => {
+	let container;
+	let root;
+
+	beforeEach(() => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+
+		window.kadenceDesignTokens = { favoriteFonts: ['Inter'] };
+		window.kadenceDesignTokensFontCatalog = {
+			google: ['Abel', 'Inter'],
+			custom: ['My Font'],
+			weights: {},
+		};
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		latestSelectorProps = undefined;
+		loadFontFamily.mockClear();
+		delete window.kadenceDesignTokens;
+		delete window.kadenceDesignTokensFontCatalog;
+	});
+
+	/**
+	 * Render the field with a given stored value.
+	 *
+	 * @param {string}   value    The stored family.
+	 * @param {Function} onChange The write callback.
+	 * @param {Object}   [field]  Extra field-definition keys.
+	 *
+	 * @since TBD
+	 *
+	 * @return {void}
+	 */
+	function renderField(value, onChange, field = {}) {
+		act(() => {
+			root.render(
+				createElement(FontFamilyField, {
+					field: { label: 'Font Family', ...field },
+					value,
+					onChange,
+				})
+			);
+		});
+	}
+
+	/**
+	 * The favorites are pinned above the full catalog, so the faces a site has kept sit at the top of a
+	 * list otherwise nearly two thousand names long.
+	 *
+	 * @return {void}
+	 */
+	it('pins the library favorites above the full catalog', () => {
+		renderField('', jest.fn());
+
+		expect(latestSelectorProps.favorites).toEqual(['Inter']);
+		expect(latestSelectorProps.catalogOptions.map((option) => option.value)).toEqual(['Inter', 'Abel', 'My Font']);
+	});
+
+	/**
+	 * A pick waits for its web font before writing, matching the editor's listener: the preview switches
+	 * straight from the old face to the new one instead of flashing a fallback in between.
+	 *
+	 * @return {void}
+	 */
+	it('waits for the web font before writing the pick', async () => {
+		const onChange = jest.fn();
+		let release;
+
+		loadFontFamily.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					release = resolve;
+				})
+		);
+
+		renderField('', onChange);
+
+		let picked;
+
+		await act(async () => {
+			picked = latestSelectorProps.onPick('Abel');
+		});
+
+		// Still in flight: nothing has been written yet.
+		expect(loadFontFamily).toHaveBeenCalledWith('Abel', { href: 'https://fonts.example/Abel' });
+		expect(onChange).not.toHaveBeenCalled();
+
+		await act(async () => {
+			release();
+			await picked;
+		});
+
+		expect(onChange).toHaveBeenCalledWith('Abel');
+	});
+
+	/**
+	 * A family the catalog does not serve needs no stylesheet — a system face and a site-registered
+	 * custom font are already in the document, and asking Google for either returns a 400 for a font the
+	 * browser could have painted all along.
+	 *
+	 * @return {void}
+	 */
+	it('fetches no stylesheet for a family Google does not serve', async () => {
+		const onChange = jest.fn();
+
+		renderField('', onChange);
+
+		await act(async () => {
+			await latestSelectorProps.onPick('My Font');
+		});
+
+		expect(loadFontFamily).toHaveBeenCalledWith('My Font', { href: null });
+		expect(onChange).toHaveBeenCalledWith('My Font');
+	});
+
+	/**
+	 * Clearing writes immediately: there is no face to fetch when falling back to the theme's font.
+	 *
+	 * @return {void}
+	 */
+	it('clears without waiting on a font', () => {
+		const onChange = jest.fn();
+
+		renderField('Abel', onChange);
+
+		act(() => latestSelectorProps.onClear());
+
+		expect(onChange).toHaveBeenCalledWith('');
+		expect(loadFontFamily).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * A read-only field neither fetches nor writes. Guarding only the write would still hit the network
+	 * for a pick the field was never going to keep.
+	 *
+	 * @return {void}
+	 */
+	it('neither fetches nor writes when read-only', async () => {
+		const onChange = jest.fn();
+
+		renderField('', onChange, { readOnly: true });
+
+		await act(async () => {
+			await latestSelectorProps.onPick('Abel');
+		});
+
+		expect(loadFontFamily).not.toHaveBeenCalled();
+		expect(onChange).not.toHaveBeenCalled();
+		expect(latestSelectorProps.disabled).toBe(true);
+	});
+});

--- a/src/style-library/__tests__/typography.test.js
+++ b/src/style-library/__tests__/typography.test.js
@@ -9,6 +9,7 @@ import {
 	fontCatalogOptions,
 	fontWeightsFor,
 	getFontCatalog,
+	shipsFontWeight,
 } from '../helpers/typography';
 
 describe('fontOptions', () => {
@@ -212,6 +213,42 @@ describe('fontWeightsFor', () => {
 		expect(fontWeightsFor('Some Custom Face')).toBeNull();
 		expect(fontWeightsFor('')).toBeNull();
 		expect(fontWeightsFor(undefined)).toBeNull();
+	});
+});
+
+describe('shipsFontWeight', () => {
+	const originalCatalog = window.kadenceDesignTokensFontCatalog;
+
+	beforeEach(() => {
+		window.kadenceDesignTokensFontCatalog = { weights: { 'Abril Fatface': ['400'], Inter: ['300', '400'] } };
+	});
+
+	afterEach(() => {
+		window.kadenceDesignTokensFontCatalog = originalCatalog;
+	});
+
+	it('answers for the weights a known family does and does not ship', () => {
+		expect(shipsFontWeight('Inter', '300')).toBe(true);
+		expect(shipsFontWeight('Abril Fatface', '300')).toBe(false);
+		expect(shipsFontWeight('Abril Fatface', '400')).toBe(true);
+	});
+
+	it("compares a numeric weight against the catalog's strings", () => {
+		expect(shipsFontWeight('Inter', 300)).toBe(true);
+		expect(shipsFontWeight('Abril Fatface', 300)).toBe(false);
+	});
+
+	/**
+	 * A family the catalog cannot narrow keeps every weight, and the empty value is the Default option
+	 * rather than a weight, so neither is ever cleared.
+	 *
+	 * @return {void}
+	 */
+	it('keeps every weight for an unknown family, and always keeps the empty one', () => {
+		expect(shipsFontWeight('Some Custom Face', '300')).toBe(true);
+		expect(shipsFontWeight('', '300')).toBe(true);
+		expect(shipsFontWeight('Abril Fatface', '')).toBe(true);
+		expect(shipsFontWeight('Abril Fatface', undefined)).toBe(true);
 	});
 });
 

--- a/src/style-library/__tests__/typography.test.js
+++ b/src/style-library/__tests__/typography.test.js
@@ -6,6 +6,7 @@ import {
 	fontActionFor,
 	fontOptions,
 	fontSizeDisplayValue,
+	fontCatalogOptions,
 	fontWeightsFor,
 	getFontCatalog,
 } from '../helpers/typography';
@@ -123,6 +124,57 @@ describe('getFontCatalog', () => {
 			custom: ['My Font'],
 			weights: { 'Abril Fatface': ['400'] },
 		});
+	});
+});
+
+describe('fontCatalogOptions', () => {
+	const originalCatalog = window.kadenceDesignTokensFontCatalog;
+
+	afterEach(() => {
+		window.kadenceDesignTokensFontCatalog = originalCatalog;
+	});
+
+	/**
+	 * Favorites lead and carry a badge, so the faces a site has kept sit at the top of a list otherwise
+	 * nearly two thousand names long; Google follows, then site-registered custom families.
+	 *
+	 * @return {void}
+	 */
+	it('lists favorites first, then google, then custom', () => {
+		window.kadenceDesignTokensFontCatalog = { google: ['Abel', 'Inter'], custom: ['My Font'], weights: {} };
+
+		expect(fontCatalogOptions({ favoriteFonts: ['Inter'] })).toEqual([
+			{ value: 'Inter', label: 'Inter', badge: 'Favorite' },
+			{ value: 'Abel', label: 'Abel' },
+			{ value: 'My Font', label: 'My Font', badge: 'Custom' },
+		]);
+	});
+
+	/**
+	 * A favorite keeps its pinned position rather than repeating mid-list, and a custom font duplicating
+	 * a Google one renders once. The custom list is diffed against the Google one server-side by exact
+	 * string, so a theme registering `inter` alongside Google's `Inter` reaches here as two names for
+	 * one font.
+	 *
+	 * @return {void}
+	 */
+	it('lists every name once, matched case-insensitively across all three sources', () => {
+		window.kadenceDesignTokensFontCatalog = { google: ['Inter'], custom: ['inter'], weights: {} };
+
+		expect(fontCatalogOptions({ favoriteFonts: ['Inter'] })).toEqual([
+			{ value: 'Inter', label: 'Inter', badge: 'Favorite' },
+		]);
+	});
+
+	/**
+	 * With no catalog global and no favorites there is nothing to offer, rather than a list of blanks.
+	 *
+	 * @return {void}
+	 */
+	it('fails safe to an empty list', () => {
+		delete window.kadenceDesignTokensFontCatalog;
+
+		expect(fontCatalogOptions(undefined)).toEqual([]);
 	});
 });
 

--- a/src/style-library/__tests__/typography.test.js
+++ b/src/style-library/__tests__/typography.test.js
@@ -6,6 +6,7 @@ import {
 	fontActionFor,
 	fontOptions,
 	fontSizeDisplayValue,
+	fontWeightsFor,
 	getFontCatalog,
 } from '../helpers/typography';
 
@@ -98,22 +99,67 @@ describe('getFontCatalog', () => {
 		window.kadenceDesignTokensFontCatalog = originalCatalog;
 	});
 
-	it('fails safe to two empty lists when the global is missing', () => {
+	it('fails safe to two empty lists and an empty weight map when the global is missing', () => {
 		delete window.kadenceDesignTokensFontCatalog;
 
-		expect(getFontCatalog()).toEqual({ google: [], custom: [] });
+		expect(getFontCatalog()).toEqual({ google: [], custom: [], weights: {} });
 	});
 
-	it('fails safe to two empty lists when the global is malformed', () => {
-		window.kadenceDesignTokensFontCatalog = { google: 'not-an-array' };
+	it('fails safe to two empty lists and an empty weight map when the global is malformed', () => {
+		window.kadenceDesignTokensFontCatalog = { google: 'not-an-array', weights: 'not-an-object' };
 
-		expect(getFontCatalog()).toEqual({ google: [], custom: [] });
+		expect(getFontCatalog()).toEqual({ google: [], custom: [], weights: {} });
 	});
 
-	it('reads the google and custom lists verbatim when present', () => {
-		window.kadenceDesignTokensFontCatalog = { google: ['Abel', 'Abril Fatface'], custom: ['My Font'] };
+	it('reads the google and custom lists and the weight map verbatim when present', () => {
+		window.kadenceDesignTokensFontCatalog = {
+			google: ['Abel', 'Abril Fatface'],
+			custom: ['My Font'],
+			weights: { 'Abril Fatface': ['400'] },
+		};
 
-		expect(getFontCatalog()).toEqual({ google: ['Abel', 'Abril Fatface'], custom: ['My Font'] });
+		expect(getFontCatalog()).toEqual({
+			google: ['Abel', 'Abril Fatface'],
+			custom: ['My Font'],
+			weights: { 'Abril Fatface': ['400'] },
+		});
+	});
+});
+
+describe('fontWeightsFor', () => {
+	const originalCatalog = window.kadenceDesignTokensFontCatalog;
+
+	afterEach(() => {
+		window.kadenceDesignTokensFontCatalog = originalCatalog;
+	});
+
+	it('returns the weights a known family ships', () => {
+		window.kadenceDesignTokensFontCatalog = { weights: { 'Abril Fatface': ['400'], Inter: ['100', '900'] } };
+
+		expect(fontWeightsFor('Abril Fatface')).toEqual(['400']);
+		expect(fontWeightsFor('Inter')).toEqual(['100', '900']);
+	});
+
+	it('matches a family case-insensitively and through wrapping quotes', () => {
+		window.kadenceDesignTokensFontCatalog = { weights: { 'Abril Fatface': ['400'] } };
+
+		expect(fontWeightsFor('abril fatface')).toEqual(['400']);
+		expect(fontWeightsFor('"Abril Fatface"')).toEqual(['400']);
+	});
+
+	/**
+	 * `null` rather than `[]`, because the two mean different things to a caller: a custom font carries
+	 * no weight data at all, while a family the catalog knows always lists at least one weight. Only
+	 * the first should widen a control back to the full set.
+	 *
+	 * @return {void}
+	 */
+	it('returns null for a family the catalog does not know, and for none', () => {
+		window.kadenceDesignTokensFontCatalog = { weights: { Inter: ['400'] } };
+
+		expect(fontWeightsFor('Some Custom Face')).toBeNull();
+		expect(fontWeightsFor('')).toBeNull();
+		expect(fontWeightsFor(undefined)).toBeNull();
 	});
 });
 

--- a/src/style-library/components/molecules/fields/FontFamilyField.js
+++ b/src/style-library/components/molecules/fields/FontFamilyField.js
@@ -1,0 +1,72 @@
+// cspell:ignore Fatface -- a Google font family named as a concrete example.
+/**
+ * The Style Library's adapter for `src/token-controls`' `FontFamilySelector` — the same tabbed picker
+ * the block editor mounts through the shared typography control's seam, so a family is chosen the same
+ * way in both places.
+ *
+ * The value is a plain family string, not a token reference: the font catalog is a list of real faces
+ * rather than a token scale, so there is nothing to alias to. That is why this field speaks none of the
+ * alias/id codec `BoxTokenField` and friends do.
+ *
+ * The editor's own listener builds its option list from editor globals (`kadence_blocks_params`'s
+ * Google names, `kadenceDesignTokensFonts`). Those do not exist on this page, so the list is built
+ * here from the Style Library's own feed and catalog instead — the same names in the same order,
+ * reached through different globals.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { FontFamilySelector } from '../../../../token-controls';
+import { fontCatalogOptions, fontOptions } from '../../../helpers/typography';
+import { getDesignTokensFeed } from '../../../helpers/tokens';
+import { useGoogleFontLoader } from '../../../hooks/use-google-font-loader';
+import { FieldLabel } from './FieldLabel';
+
+/**
+ * Render a font-family field from a settings schema entry.
+ *
+ * A pick waits for its web font before writing, matching the editor's listener: the preview switches
+ * straight from the old face to the new one rather than flashing a fallback in between. The wait is
+ * the loader hook's, so a font that never arrives still writes.
+ *
+ * @param {Object}   props                   The component props.
+ * @param {Object}   props.field             The field definition.
+ * @param {?string}  [props.field.label]     The control's label.
+ * @param {?string}  [props.field.inherited] What an unset family falls back to, named on the muted trigger.
+ * @param {boolean}  [props.field.readOnly]  Whether the control is non-interactive.
+ * @param {string}   props.value             The stored family, or `''` when unset.
+ * @param {Function} props.onChange          Called with the chosen family; never called when read-only.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The field.
+ */
+export function FontFamilyField({ field, value, onChange }) {
+	// Loads whatever is currently stored, so the row preview and the trigger render in the real face
+	// rather than a fallback. A family already present in the document (a system or custom face) is a
+	// no-op for the hook.
+	useGoogleFontLoader(value);
+
+	const feed = getDesignTokensFeed();
+
+	return (
+		<div className="kadence-blocks-style-library__field kadence-blocks-style-library__field--font-family">
+			{field.label && <FieldLabel>{field.label}</FieldLabel>}
+			<FontFamilySelector
+				value={value ?? ''}
+				favorites={fontOptions(feed).map((font) => font.label)}
+				catalogOptions={fontCatalogOptions(feed)}
+				inheritedLabel={field.inherited ?? __('Theme Font', 'kadence-blocks')}
+				onPick={(family) => !field.readOnly && onChange(family)}
+				onClear={() => !field.readOnly && onChange('')}
+				disabled={field.readOnly}
+			/>
+		</div>
+	);
+}

--- a/src/style-library/components/molecules/fields/FontFamilyField.js
+++ b/src/style-library/components/molecules/fields/FontFamilyField.js
@@ -22,18 +22,40 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { FontFamilySelector } from '../../../../token-controls';
-import { fontCatalogOptions, fontOptions } from '../../../helpers/typography';
+import { FontFamilySelector, googleFontHref, loadFontFamily } from '../../../../token-controls';
+import { fontCatalogOptions, fontOptions, getFontCatalog } from '../../../helpers/typography';
 import { getDesignTokensFeed } from '../../../helpers/tokens';
 import { useGoogleFontLoader } from '../../../hooks/use-google-font-loader';
 import { FieldLabel } from './FieldLabel';
 
 /**
+ * Fetch a family's web font, resolving once it is usable.
+ *
+ * Google membership is decided by the catalog exactly as `useGoogleFontLoader` decides it, so the two
+ * paths agree on which families need a stylesheet: a system face and a site-registered custom font are
+ * already in the document, and asking Google for either returns a 400 for a font the browser could
+ * have painted all along.
+ *
+ * @param {string} family The family to load.
+ *
+ * @since TBD
+ *
+ * @return {Promise} Resolves when the font is usable, or immediately when there is nothing to fetch.
+ */
+function loadPickedFamily(family) {
+	const { google } = getFontCatalog();
+
+	return loadFontFamily(family, { href: google.includes(family) ? googleFontHref(family) : null });
+}
+
+/**
  * Render a font-family field from a settings schema entry.
  *
- * A pick waits for its web font before writing, matching the editor's listener: the preview switches
- * straight from the old face to the new one rather than flashing a fallback in between. The wait is
- * the loader hook's, so a font that never arrives still writes.
+ * A pick WAITS for its web font before writing, matching the editor's listener: the preview switches
+ * straight from the old face to the new one instead of flashing a fallback in between, and the field
+ * shows the pending family with a spinner meanwhile — `FontFamilySelector` reads a promise-returning
+ * `onPick` for exactly this. `loadFontFamily` bounds its own wait, so a font that never arrives still
+ * writes rather than leaving the field stuck.
  *
  * @param {Object}   props                   The component props.
  * @param {Object}   props.field             The field definition.
@@ -63,7 +85,15 @@ export function FontFamilyField({ field, value, onChange }) {
 				favorites={fontOptions(feed).map((font) => font.label)}
 				catalogOptions={fontCatalogOptions(feed)}
 				inheritedLabel={field.inherited ?? __('Theme Font', 'kadence-blocks')}
-				onPick={(family) => !field.readOnly && onChange(family)}
+				onPick={async (family) => {
+					if (field.readOnly) {
+						return;
+					}
+
+					await loadPickedFamily(family);
+
+					onChange(family);
+				}}
 				onClear={() => !field.readOnly && onChange('')}
 				disabled={field.readOnly}
 			/>

--- a/src/style-library/components/molecules/fields/FontFamilyField.js
+++ b/src/style-library/components/molecules/fields/FontFamilyField.js
@@ -58,8 +58,13 @@ function loadPickedFamily(family) {
  * writes rather than leaving the field stuck.
  *
  * @param {Object}   props                   The component props.
- * @param {Object}   props.field             The field definition.
- * @param {?string}  [props.field.label]     The control's label.
+ * @param {Object}   props.field                The field definition.
+ * @param {?string}  [props.field.label]        The control's label.
+ * @param {?Array}   [props.field.favorites]    The library's favorite families. Supplied by a schema
+ *                                              with the live feed in hand, so a favorite added on
+ *                                              another screen is selectable without a reload; falls
+ *                                              back to the page-load global when absent.
+ * @param {?Array}   [props.field.catalogOptions] The full option list, on the same terms.
  * @param {?string}  [props.field.inherited] What an unset family falls back to, named on the muted trigger.
  * @param {boolean}  [props.field.readOnly]  Whether the control is non-interactive.
  * @param {string}   props.value             The stored family, or `''` when unset.
@@ -82,8 +87,8 @@ export function FontFamilyField({ field, value, onChange }) {
 			{field.label && <FieldLabel>{field.label}</FieldLabel>}
 			<FontFamilySelector
 				value={value ?? ''}
-				favorites={fontOptions(feed).map((font) => font.label)}
-				catalogOptions={fontCatalogOptions(feed)}
+				favorites={field.favorites ?? fontOptions(feed).map((font) => font.label)}
+				catalogOptions={field.catalogOptions ?? fontCatalogOptions(feed)}
 				inheritedLabel={field.inherited ?? __('Theme Font', 'kadence-blocks')}
 				onPick={async (family) => {
 					if (field.readOnly) {

--- a/src/style-library/components/molecules/fields/FontFamilyField.js
+++ b/src/style-library/components/molecules/fields/FontFamilyField.js
@@ -23,7 +23,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { FontFamilySelector, googleFontHref, loadFontFamily } from '../../../../token-controls';
-import { fontCatalogOptions, fontOptions, getFontCatalog } from '../../../helpers/typography';
+import { fontCatalogOptions, fontOptions, getFontCatalog, shipsFontWeight } from '../../../helpers/typography';
+import { getValueAtPath } from '../../../helpers/settings-schema';
 import { getDesignTokensFeed } from '../../../helpers/tokens';
 import { useGoogleFontLoader } from '../../../hooks/use-google-font-loader';
 import { FieldLabel } from './FieldLabel';
@@ -57,6 +58,13 @@ function loadPickedFamily(family) {
  * `onPick` for exactly this. `loadFontFamily` bounds its own wait, so a font that never arrives still
  * writes rather than leaving the field stuck.
  *
+ * A pick also clears a sibling weight the new family has no face for. Narrowing the Weight field's
+ * option list is only half the job — the list is rebuilt from the family, but the stored value is
+ * not, so a weight picked under the old family would survive the switch and render as a
+ * browser-synthesized approximation, which is the exact outcome the narrowing exists to prevent.
+ * Reaching a sibling stored key means reading `values` and writing through `onValueChange`, the two
+ * props `SettingsForm` hands every field for this case — see `BorderField` for the same posture.
+ *
  * @param {Object}   props                   The component props.
  * @param {Object}   props.field                The field definition.
  * @param {?string}  [props.field.label]        The control's label.
@@ -66,15 +74,19 @@ function loadPickedFamily(family) {
  *                                              back to the page-load global when absent.
  * @param {?Array}   [props.field.catalogOptions] The full option list, on the same terms.
  * @param {?string}  [props.field.inherited] What an unset family falls back to, named on the muted trigger.
+ * @param {?string}  [props.field.weightPath] The sibling weight's dot path, when the schema pairs one
+ *                                            with this family. Omitted by a screen with no weight field.
  * @param {boolean}  [props.field.readOnly]  Whether the control is non-interactive.
  * @param {string}   props.value             The stored family, or `''` when unset.
  * @param {Function} props.onChange          Called with the chosen family; never called when read-only.
+ * @param {Object}   [props.values]          The full draft, for reading the sibling weight.
+ * @param {Function} [props.onValueChange]   The raw path-taking writer, for clearing that weight.
  *
  * @since TBD
  *
  * @return {JSX.Element} The field.
  */
-export function FontFamilyField({ field, value, onChange }) {
+export function FontFamilyField({ field, value, onChange, values = {}, onValueChange = () => {} }) {
 	// Loads whatever is currently stored, so the row preview and the trigger render in the real face
 	// rather than a fallback. A family already present in the document (a system or custom face) is a
 	// no-op for the hook.
@@ -98,6 +110,13 @@ export function FontFamilyField({ field, value, onChange }) {
 					await loadPickedFamily(family);
 
 					onChange(family);
+
+					// Back to Default rather than to the nearest shipped weight: no other weight is
+					// a better guess than the family's own, and silently retyping the text to a
+					// weight the user never chose is the more surprising of the two answers.
+					if (field.weightPath && !shipsFontWeight(family, getValueAtPath(values, field.weightPath))) {
+						onValueChange(field.weightPath, '');
+					}
 				}}
 				onClear={() => !field.readOnly && onChange('')}
 				disabled={field.readOnly}

--- a/src/style-library/components/molecules/fields/ScalarTokenField.js
+++ b/src/style-library/components/molecules/fields/ScalarTokenField.js
@@ -22,6 +22,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { pickableTokensForType } from '../../../helpers/tokens';
+import { fontSizeDisplayValue } from '../../../helpers/typography';
 import {
 	PRESET_BREAKPOINTS,
 	readPresetBreakpoint,
@@ -121,12 +122,19 @@ export function ScalarTokenField({ field, value, onChange }) {
 
 	// A semantic-bound value is the block's role-based default, not a selection, so it is blanked for
 	// display and its resolved value becomes what this field falls back to — see `withoutSemanticSlots`.
+	// The font-size scale is fluid: every step resolves to a whole `clamp(min, preferred, max)` string,
+	// which overran its row and made the trigger unreadable. `fontSizeDisplayValue` reads the authored
+	// scalar back out — every shipped step authors its `$value` as the clamp's own max — so a step reads
+	// as the size it is rather than as the expression that computes it. Every other role resolves to a
+	// plain length already and passes through untouched.
+	const displayValue = (value) => (field.role === 'font-size' ? fontSizeDisplayValue(value) : value);
+
 	const shown = withoutSemanticSlots(atBreakpoint);
 	const semanticDefault = semanticDefaultOf(atBreakpoint, everyToken);
 
-	const shownDefault = inheritsFromBreakpoint
-		? asLiteral(inheritedAbove)
-		: (semanticDefault ?? field.defaultValue ?? null);
+	const shownDefault = displayValue(
+		inheritsFromBreakpoint ? asLiteral(inheritedAbove) : (semanticDefault ?? field.defaultValue ?? null)
+	);
 
 	// The unit falls back the same way the value does, so the Custom tab never opens on `px` while the
 	// field beside it displays the default's own `em`.
@@ -148,13 +156,10 @@ export function ScalarTokenField({ field, value, onChange }) {
 			// inherited value is resolved to its literal above rather than added to the pool.
 			tokens={pickableTokensForType(field.tokenType, field.role, boundTokenIds(shown)).map((token) => ({
 				...token,
+				value: displayValue(token.value),
 				alias: `{${token.id}}`,
 			}))}
 			defaultValue={shownDefault ?? undefined}
-			// A field whose tokens resolve to something too long to read in a row opts out of showing
-			// values beside their labels. A fluid font size resolves to a whole `clamp()` expression,
-			// which overran the row and pushed the label out of view.
-			showValue={field.showValue !== false}
 			inherited={inheritsFromBreakpoint}
 			unit={unit}
 			units={units}

--- a/src/style-library/components/pages/PresetSidebar.js
+++ b/src/style-library/components/pages/PresetSidebar.js
@@ -46,7 +46,11 @@ import { notifySuccess } from '../../helpers/notify';
  * @param {?Array}   [props.tabs]        `[{ name, title }]` state tabs, or null/empty for a block
  *                                       whose presets have no states — `schemaFor` is then called
  *                                       with null and should ignore its argument.
- * @param {Function} props.schemaFor     Maps the active tab name to that tab's settings schema.
+ * @param {Function} props.schemaFor     Maps the active tab name, and the current draft, to that tab's
+ *                                       settings schema. The draft is what lets one field's options
+ *                                       depend on another's value — Advanced Text narrows its weight
+ *                                       list to the weights the chosen font family actually ships. A
+ *                                       config that needs no such thing ignores the second argument.
  *
  * @since TBD
  *
@@ -171,7 +175,11 @@ function PresetSidebarBody({ navigate, route, screen, initialValues, presetLabel
 					{screen.deleteError.message}
 				</Notice>
 			)}
-			<SettingsForm schema={schemaFor(activeTab)} values={panel.draft} onChange={panel.setFieldValue} />
+			<SettingsForm
+				schema={schemaFor(activeTab, panel.draft)}
+				values={panel.draft}
+				onChange={panel.setFieldValue}
+			/>
 		</SettingsPanel>
 	);
 }

--- a/src/style-library/components/pages/PresetSidebar.js
+++ b/src/style-library/components/pages/PresetSidebar.js
@@ -47,10 +47,13 @@ import { notifySuccess } from '../../helpers/notify';
  *                                       whose presets have no states — `schemaFor` is then called
  *                                       with null and should ignore its argument.
  * @param {Function} props.schemaFor     Maps the active tab name, and the current draft, to that tab's
- *                                       settings schema. The draft is what lets one field's options
- *                                       depend on another's value — Advanced Text narrows its weight
- *                                       list to the weights the chosen font family actually ships. A
- *                                       config that needs no such thing ignores the second argument.
+ *                                       settings schema, given the LIVE feed. The draft is what lets one
+ *                                       field's options depend on another's value — Advanced Text
+ *                                       narrows its weight list to the weights the chosen font family
+ *                                       actually ships — and the feed is what keeps a list that comes
+ *                                       from the library current, a font favorite added on another
+ *                                       screen refreshing the feed rather than the page-load global. A
+ *                                       config that needs neither ignores both arguments.
  *
  * @since TBD
  *
@@ -176,7 +179,7 @@ function PresetSidebarBody({ navigate, route, screen, initialValues, presetLabel
 				</Notice>
 			)}
 			<SettingsForm
-				schema={schemaFor(activeTab, panel.draft)}
+				schema={schemaFor(activeTab, panel.draft, screen.feed)}
 				values={panel.draft}
 				onChange={panel.setFieldValue}
 			/>

--- a/src/style-library/constants/demo-settings-schema.js
+++ b/src/style-library/constants/demo-settings-schema.js
@@ -167,6 +167,13 @@ export const DEMO_SETTINGS_SCHEMA = {
 					label: __('Icon Size', 'kadence-blocks'),
 					tokenType: 'dimension',
 				},
+				{
+					// The tabbed font picker, the one field whose value is a plain family string rather than
+					// anything token-shaped — the font catalog is a list of real faces, not a scale.
+					type: 'font-family',
+					path: 'fontFamily',
+					label: __('Font Family', 'kadence-blocks'),
+				},
 				{ type: 'toggle', path: 'enabled', label: __('Enabled', 'kadence-blocks') },
 			],
 		},

--- a/src/style-library/constants/field-types.js
+++ b/src/style-library/constants/field-types.js
@@ -22,6 +22,7 @@ import { StepperField } from '../components/molecules/fields/StepperField';
 import { TextField } from '../components/molecules/fields/TextField';
 import { ToggleField } from '../components/molecules/fields/ToggleField';
 import { TokenColorSelectField } from '../components/molecules/fields/TokenColorSelectField';
+import { FontFamilyField } from '../components/molecules/fields/FontFamilyField';
 import { TokenSelectField } from '../components/molecules/fields/TokenSelectField';
 import { UnitField } from '../components/molecules/fields/UnitField';
 
@@ -101,6 +102,7 @@ export const FIELD_TYPES = Object.freeze({
 	'token-select': TokenSelectField,
 	'token-scalar': ScalarTokenField,
 	'token-color-select': TokenColorSelectField,
+	'font-family': FontFamilyField,
 	'box-sides': BoxSidesField,
 	radius: RadiusField,
 	spacing: SpacingField,

--- a/src/style-library/helpers/typography.js
+++ b/src/style-library/helpers/typography.js
@@ -247,6 +247,31 @@ export function fontWeightsFor(family) {
 }
 
 /**
+ * Whether a family still offers a weight, which is what decides if an already-stored weight survives
+ * a change of family.
+ *
+ * A family the catalog does not know narrows nothing -- the theme's own font and a site-registered
+ * custom face both keep the full 100-900 range -- so every weight stands. So does the empty value,
+ * which is the Default option rather than a weight.
+ *
+ * @param {string} family The family to check against.
+ * @param {*}      weight The stored weight.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when `family` can still render `weight`.
+ */
+export function shipsFontWeight(family, weight) {
+	const weights = fontWeightsFor(family);
+
+	if (weights === null || weight === '' || weight === null || weight === undefined) {
+		return true;
+	}
+
+	return weights.some((shipped) => String(shipped) === String(weight));
+}
+
+/**
  * Find the favorite (a `fontOptions()` entry) whose family matches a catalog family name,
  * case-insensitively and ignoring wrapping quotes on either side.
  *

--- a/src/style-library/helpers/typography.js
+++ b/src/style-library/helpers/typography.js
@@ -1,3 +1,4 @@
+// cspell:ignore Abril Fatface -- a Google font family named as a concrete example.
 /**
  * The Typography screen's pure helpers: mapping the library's favorite families into the FONT
  * selector's options, reading a fluid font-size step's authored scalar out of its resolved
@@ -150,7 +151,8 @@ export function fontSizeDisplayValue(value) {
  *
  * @since TBD
  *
- * @return {{google: string[], custom: string[]}} The catalog, or two empty lists when unavailable.
+ * @return {{google: string[], custom: string[], weights: Record<string, string[]>}} The catalog, or
+ *         two empty lists and an empty weight map when unavailable.
  */
 export function getFontCatalog() {
 	const catalog = window.kadenceDesignTokensFontCatalog;
@@ -158,7 +160,39 @@ export function getFontCatalog() {
 	return {
 		google: Array.isArray(catalog?.google) ? catalog.google : [],
 		custom: Array.isArray(catalog?.custom) ? catalog.custom : [],
+		weights: catalog?.weights && typeof catalog.weights === 'object' ? catalog.weights : {},
 	};
+}
+
+/**
+ * The weights a family actually ships, or `null` when the catalog knows nothing about it.
+ *
+ * `null` and `[]` mean different things and the caller needs both: a custom font contributes no weight
+ * data at all (the custom-fonts filter carries none), while a Google family the catalog does know is
+ * always listed with at least one weight. A control offering 100-900 for every family promises faces
+ * most families do not ship -- Abril Fatface ships only 400 -- and the browser answers with a
+ * synthesized approximation rather than the design system's own type.
+ *
+ * Matched case-insensitively and ignoring wrapping quotes, the way `findFontByFamily` matches, so a
+ * stored `"Abril Fatface"` finds the catalog's `Abril Fatface`.
+ *
+ * @param {string} family The family name.
+ *
+ * @since TBD
+ *
+ * @return {?string[]} The family's weights, or null when the catalog does not know it.
+ */
+export function fontWeightsFor(family) {
+	const name = unquoteFamily(String(family ?? '').trim()).toLowerCase();
+
+	if (name === '') {
+		return null;
+	}
+
+	const { weights } = getFontCatalog();
+	const match = Object.keys(weights).find((key) => unquoteFamily(key.trim()).toLowerCase() === name);
+
+	return match ? weights[match] : null;
 }
 
 /**

--- a/src/style-library/helpers/typography.js
+++ b/src/style-library/helpers/typography.js
@@ -13,6 +13,11 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Strip a pair of wrapping quotes (single or double) from a font-family name, the same trimming a
  * browser applies when it renders a quoted family in a `font-family` list.
  *
@@ -162,6 +167,52 @@ export function getFontCatalog() {
 		custom: Array.isArray(catalog?.custom) ? catalog.custom : [],
 		weights: catalog?.weights && typeof catalog.weights === 'object' ? catalog.weights : {},
 	};
+}
+
+/**
+ * The font-family picker's full option list: the library's favorites first, then every Google family,
+ * then every site-registered custom family.
+ *
+ * Favorites lead and carry a badge, so the faces a site has kept sit at the top of a list otherwise
+ * nearly two thousand names long. Every name appears exactly once, matched case-insensitively across
+ * all three sources — the custom list is diffed against the Google one server-side by exact string, so
+ * a theme registering `inter` alongside Google's `Inter` reaches here as two names for one font.
+ *
+ * This mirrors the editor's own `fontCatalogOptions()`, which builds the same list from editor globals
+ * that do not exist on this page. The theme's "inherit heading/body font" rows are deliberately absent:
+ * they resolve through custom properties the block editor's canvas carries, and a preset storing one
+ * would name a variable rather than a face.
+ *
+ * @param {{ favoriteFonts?: string[] }} feed The design-tokens feed.
+ *
+ * @since TBD
+ *
+ * @return {Array<{value: string, label: string, badge?: string}>} The option list.
+ */
+export function fontCatalogOptions(feed) {
+	const seen = new Set();
+	const unique = (name) => {
+		const key = unquoteFamily(String(name ?? '').trim()).toLowerCase();
+
+		if (key === '' || seen.has(key)) {
+			return false;
+		}
+
+		seen.add(key);
+
+		return true;
+	};
+
+	const { google, custom } = getFontCatalog();
+
+	return [
+		...fontOptions(feed)
+			.map((font) => font.label)
+			.filter(unique)
+			.map((name) => ({ value: name, label: name, badge: __('Favorite', 'kadence-blocks') })),
+		...google.filter(unique).map((name) => ({ value: name, label: name })),
+		...custom.filter(unique).map((name) => ({ value: name, label: name, badge: __('Custom', 'kadence-blocks') })),
+	];
 }
 
 /**

--- a/src/style-library/hooks/use-preset-screen.js
+++ b/src/style-library/hooks/use-preset-screen.js
@@ -40,7 +40,7 @@ import { STORE_NAME } from '../store';
  *
  * @since TBD
  *
- * @return {{payload: ?object, isLoading: boolean, loadError: ?Error, rows: Array<Object>, initialValuesFor: Function, isBusy: boolean, addError: ?Object, saveError: ?Object, deleteError: ?Object, orderError: ?Object, clearAddError: Function, clearSaveError: Function, clearDeleteError: Function, clearOrderError: Function, addPreset: Function, savePreset: Function, deletePreset: Function, reorderPresets: Function, isDeletable: Function}}
+ * @return {{feed: ?object, payload: ?object, isLoading: boolean, loadError: ?Error, rows: Array<Object>, initialValuesFor: Function, isBusy: boolean, addError: ?Object, saveError: ?Object, deleteError: ?Object, orderError: ?Object, clearAddError: Function, clearSaveError: Function, clearDeleteError: Function, clearOrderError: Function, addPreset: Function, savePreset: Function, deletePreset: Function, reorderPresets: Function, isDeletable: Function}}
  */
 export function usePresetScreen(library, preset) {
 	// `properties` is deliberately not destructured here: on the preset configs it is a getter that
@@ -265,6 +265,10 @@ export function usePresetScreen(library, preset) {
 	);
 
 	return {
+		// The LIVE feed, not the page-load global: adding a font favorite refreshes this and leaves the
+		// global untouched, so a field building options from the global would not see the new face until
+		// the page reloaded.
+		feed: library?.feed ?? null,
 		payload: presets.payload,
 		isLoading: presets.isLoading,
 		loadError: presets.loadError,

--- a/src/style-library/presets/advancedheading-preset.js
+++ b/src/style-library/presets/advancedheading-preset.js
@@ -280,10 +280,6 @@ function schemaFor(tab, values) {
 						path: 'tokens.fontSize',
 						label: __('Size', 'kadence-blocks'),
 						defaultValue: HEADING_FONT_SIZE_FALLBACK,
-						// The font-size scale is fluid: every step resolves to a whole `clamp()`
-						// expression, which overran its row and pushed the step's own name out of view.
-						// The names (SM, MD, LG…) are what a site owner picks by, so the value goes.
-						showValue: false,
 					},
 					{
 						type: 'select',

--- a/src/style-library/presets/advancedheading-preset.js
+++ b/src/style-library/presets/advancedheading-preset.js
@@ -277,6 +277,9 @@ function schemaFor(tab, values, feed) {
 						// What a heading with no family of its own renders in. Named on the muted trigger so
 						// an unset field reports the face actually in use rather than reading as empty.
 						inherited: __('Theme Font', 'kadence-blocks'),
+						// Pairs the Weight field below with this one, so a family switch clears a weight
+						// the new family has no face for instead of leaving it to be synthesized.
+						weightPath: 'tokens.fontWeight',
 					},
 					{
 						type: 'token-scalar',

--- a/src/style-library/presets/advancedheading-preset.js
+++ b/src/style-library/presets/advancedheading-preset.js
@@ -16,8 +16,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getPresetProperties, resolveTokenValue } from '../helpers/presets';
-import { fontOptions, fontWeightsFor } from '../helpers/typography';
-import { getDesignTokensFeed } from '../helpers/tokens';
+import { fontWeightsFor } from '../helpers/typography';
 
 /**
  * The block name this screen edits. The block is called Advanced Text in the UI but
@@ -110,26 +109,6 @@ const FONT_WEIGHT_LABELS = {
  * @since TBD
  */
 const ALL_FONT_WEIGHTS = Object.keys(FONT_WEIGHT_LABELS);
-
-/**
- * The font families a preset may pick from: the library's favorites, plus an entry for leaving the
- * family alone.
- *
- * Favorites rather than a token pool, because a font family is not a token: the catalog is a list of
- * real faces a site has kept, and a preset stores the family it picked as a LITERAL. The empty option
- * is what a heading does with no family of its own — inherit the theme's — which is the block's own
- * behavior rather than an invented default.
- *
- * @since TBD
- *
- * @return {Array<{value: string, label: string}>} The family options.
- */
-function fontFamilyOptions() {
-	return [
-		{ value: '', label: __('Theme Font', 'kadence-blocks') },
-		...fontOptions(getDesignTokensFeed()).map((font) => ({ value: font.label, label: font.label })),
-	];
-}
 
 /**
  * The weights a family actually ships, as select options.
@@ -238,11 +217,11 @@ function renderPreview(row) {
  * Eleven of the block's thirteen bound properties are offered, grouped by what a site owner is doing
  * rather than by how each value is stored.
  *
- * Font family is a select over the library's FAVORITES, storing the family as a literal: the font
- * catalog is a list of real faces, not a token scale, so there is nothing to alias to. Weight then
- * narrows to the weights that family actually ships, which is why this takes the draft — the two
- * fields are linked, and offering a weight a family does not have would render a synthesized face
- * rather than the one the design system promised.
+ * Font family uses the same tabbed picker the block editor mounts — favorites pinned above the full
+ * catalog — and stores the family as a literal: the font catalog is a list of real faces, not a token
+ * scale, so there is nothing to alias to. Weight then narrows to the weights that family actually
+ * ships, which is why this takes the draft — the two fields are linked, and offering a weight a family
+ * does not have would render a synthesized face rather than the one the design system promised.
  *
  * The split between a token picker and a keyword select is not arbitrary: a property is offered as a
  * picker when the design system actually has a scale for it, and as a select when it does not.
@@ -286,10 +265,12 @@ function schemaFor(tab, values) {
 				title: __('Typography', 'kadence-blocks'),
 				fields: [
 					{
-						type: 'select',
+						type: 'font-family',
 						path: 'tokens.typography',
 						label: __('Font Family', 'kadence-blocks'),
-						options: fontFamilyOptions(),
+						// What a heading with no family of its own renders in. Named on the muted trigger so
+						// an unset field reports the face actually in use rather than reading as empty.
+						inherited: __('Theme Font', 'kadence-blocks'),
 					},
 					{
 						type: 'token-scalar',

--- a/src/style-library/presets/advancedheading-preset.js
+++ b/src/style-library/presets/advancedheading-preset.js
@@ -16,7 +16,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getPresetProperties, resolveTokenValue } from '../helpers/presets';
-import { fontWeightsFor } from '../helpers/typography';
+import { fontCatalogOptions, fontOptions, fontWeightsFor } from '../helpers/typography';
 
 /**
  * The block name this screen edits. The block is called Advanced Text in the UI but
@@ -238,12 +238,13 @@ function renderPreview(row) {
  *
  * @param {string} tab    The active tab name; the heading declares no tabs, so this is unused.
  * @param {Object} values The current draft, read for the chosen font family.
+ * @param {Object} feed   The live design-tokens feed, read for the library's font favorites.
  *
  * @since TBD
  *
  * @return {{panels: Array<Object>}} The settings-form schema.
  */
-function schemaFor(tab, values) {
+function schemaFor(tab, values, feed) {
 	const family = values?.tokens?.typography ?? '';
 
 	return {
@@ -268,6 +269,11 @@ function schemaFor(tab, values) {
 						type: 'font-family',
 						path: 'tokens.typography',
 						label: __('Font Family', 'kadence-blocks'),
+						// Built from the LIVE feed rather than left to the field's own page-load global: a
+						// favorite added on the Typography screen refreshes the feed, so passing it through
+						// is what makes the new face selectable here without a reload.
+						favorites: fontOptions(feed).map((font) => font.label),
+						catalogOptions: fontCatalogOptions(feed),
 						// What a heading with no family of its own renders in. Named on the muted trigger so
 						// an unset field reports the face actually in use rather than reading as empty.
 						inherited: __('Theme Font', 'kadence-blocks'),

--- a/src/style-library/presets/advancedheading-preset.js
+++ b/src/style-library/presets/advancedheading-preset.js
@@ -1,3 +1,4 @@
+// cspell:ignore Abril Fatface -- a Google font family named as a concrete example.
 /**
  * Everything specific to the `kadence/advancedheading` (Advanced Text) preset screen, in one place:
  * the block name, the bound property surface, the row preview, and the settings schema.
@@ -15,6 +16,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getPresetProperties, resolveTokenValue } from '../helpers/presets';
+import { fontOptions, fontWeightsFor } from '../helpers/typography';
+import { getDesignTokensFeed } from '../helpers/tokens';
 
 /**
  * The block name this screen edits. The block is called Advanced Text in the UI but
@@ -85,31 +88,82 @@ const TEXT_TRANSFORM_OPTIONS = [
 ];
 
 /**
- * The weights the preset offers. A closed set, for the same reason as {@see BORDER_STYLE_OPTIONS} —
- * `semantic.font-weight` holds one entry per usage, not a scale.
+ * The human name for each CSS weight, so a list narrowed to one family still reads as words.
  *
  * @since TBD
  */
-const FONT_WEIGHT_OPTIONS = [
-	{ value: '', label: __('Default', 'kadence-blocks') },
-	{ value: '100', label: __('100 Thin', 'kadence-blocks') },
-	{ value: '200', label: __('200 Extra Light', 'kadence-blocks') },
-	{ value: '300', label: __('300 Light', 'kadence-blocks') },
-	{ value: '400', label: __('400 Regular', 'kadence-blocks') },
-	{ value: '500', label: __('500 Medium', 'kadence-blocks') },
-	{ value: '600', label: __('600 Semi Bold', 'kadence-blocks') },
-	{ value: '700', label: __('700 Bold', 'kadence-blocks') },
-	{ value: '800', label: __('800 Extra Bold', 'kadence-blocks') },
-	{ value: '900', label: __('900 Black', 'kadence-blocks') },
-];
+const FONT_WEIGHT_LABELS = {
+	100: __('100 Thin', 'kadence-blocks'),
+	200: __('200 Extra Light', 'kadence-blocks'),
+	300: __('300 Light', 'kadence-blocks'),
+	400: __('400 Regular', 'kadence-blocks'),
+	500: __('500 Medium', 'kadence-blocks'),
+	600: __('600 Semi Bold', 'kadence-blocks'),
+	700: __('700 Bold', 'kadence-blocks'),
+	800: __('800 Extra Bold', 'kadence-blocks'),
+	900: __('900 Black', 'kadence-blocks'),
+};
+
+/**
+ * Every CSS weight, offered when nothing narrower is known.
+ *
+ * @since TBD
+ */
+const ALL_FONT_WEIGHTS = Object.keys(FONT_WEIGHT_LABELS);
+
+/**
+ * The font families a preset may pick from: the library's favorites, plus an entry for leaving the
+ * family alone.
+ *
+ * Favorites rather than a token pool, because a font family is not a token: the catalog is a list of
+ * real faces a site has kept, and a preset stores the family it picked as a LITERAL. The empty option
+ * is what a heading does with no family of its own — inherit the theme's — which is the block's own
+ * behavior rather than an invented default.
+ *
+ * @since TBD
+ *
+ * @return {Array<{value: string, label: string}>} The family options.
+ */
+function fontFamilyOptions() {
+	return [
+		{ value: '', label: __('Theme Font', 'kadence-blocks') },
+		...fontOptions(getDesignTokensFeed()).map((font) => ({ value: font.label, label: font.label })),
+	];
+}
+
+/**
+ * The weights a family actually ships, as select options.
+ *
+ * A family the catalog knows is narrowed to its own weights, which is the point of the exercise: a
+ * flat 100-900 list offers faces most families do not have — Abril Fatface ships only 400 — and the
+ * browser answers a missing one with a synthesized approximation rather than the real face. With no
+ * family chosen the heading inherits the theme's font, which could be anything, and a custom font
+ * carries no weight data at all; both cases offer the full set rather than guessing.
+ *
+ * @param {string} family The family the preset has chosen, or '' for the theme's font.
+ *
+ * @since TBD
+ *
+ * @return {Array<{value: string, label: string}>} The weight options.
+ */
+function fontWeightOptions(family) {
+	const weights = family ? fontWeightsFor(family) : null;
+
+	return [
+		{ value: '', label: __('Default', 'kadence-blocks') },
+		...(weights ?? ALL_FONT_WEIGHTS).map((weight) => ({
+			value: String(weight),
+			label: FONT_WEIGHT_LABELS[weight] ?? String(weight),
+		})),
+	];
+}
 
 /**
  * Build a row's preview from its stored tokens.
  *
  * Everything the screen edits that a chip of text can honestly show. `borderWidth` and `borderStyle`
  * are previewed alongside `borderColor` because all three are needed for a border to render at all —
- * a color on its own is invisible, which is the trap the Row Layout and Section screens hit. Font
- * family is absent because it is not a bound property; see `schemaFor()`.
+ * a color on its own is invisible, which is the trap the Row Layout and Section screens hit.
  *
  * @param {Record<string, *>}      tokens       The preset's stored token map.
  * @param {Record<string, string>} values       The feed's resolved value map.
@@ -125,6 +179,7 @@ function preview(tokens, values, breakpoint) {
 	return {
 		color: resolve('color'),
 		background: resolve('background'),
+		typography: resolve('typography'),
 		fontSize: resolve('fontSize'),
 		fontWeight: resolve('fontWeight'),
 		textTransform: resolve('textTransform'),
@@ -141,7 +196,7 @@ function preview(tokens, values, breakpoint) {
  * its own frame.
  *
  * Real text rather than a swatch, because every property this screen edits except the box ones is a
- * type property, and a color chip cannot show a weight or a transform. The size is deliberately
+ * type property, and a color chip cannot show a family, a weight or a transform. The size is deliberately
  * NOT applied at true size — the scale reaches 4rem and a row cannot grow that far without dwarfing its
  * neighbors — so the chip states the family, weight, transform, color and frame faithfully and leaves
  * size to the sidebar. The Advanced Image tile can afford to grow because its padding is the only
@@ -161,6 +216,7 @@ function renderPreview(row) {
 				color: row.preview.color || undefined,
 				background: row.preview.background || undefined,
 				fontWeight: row.preview.fontWeight || undefined,
+				fontFamily: row.preview.typography || undefined,
 				textTransform: row.preview.textTransform || undefined,
 				borderColor: row.preview.borderColor || undefined,
 				borderWidth: row.preview.borderWidth || undefined,
@@ -179,13 +235,14 @@ function renderPreview(row) {
  * The settings schema. The heading declares no tabs: it binds no hover property, so there is no second
  * state to switch to and `PresetSidebar` renders the field area bare.
  *
- * Ten of the block's twelve bound properties are offered, grouped by what a site owner is doing rather
- * than by how each value is stored.
+ * Eleven of the block's thirteen bound properties are offered, grouped by what a site owner is doing
+ * rather than by how each value is stored.
  *
- * Font family is not among them, and is not a bound property at all: a heading inherits the theme's
- * font, the block-default CSS emits no font-family default for it, and the family a site owner picks
- * comes from the typography control's own font catalog and is stored as a literal. See the block's
- * `preset_bindings` declaration.
+ * Font family is a select over the library's FAVORITES, storing the family as a literal: the font
+ * catalog is a list of real faces, not a token scale, so there is nothing to alias to. Weight then
+ * narrows to the weights that family actually ships, which is why this takes the draft — the two
+ * fields are linked, and offering a weight a family does not have would render a synthesized face
+ * rather than the one the design system promised.
  *
  * The split between a token picker and a keyword select is not arbitrary: a property is offered as a
  * picker when the design system actually has a scale for it, and as a select when it does not.
@@ -200,11 +257,16 @@ function renderPreview(row) {
  * would fit is a bare number — which invites exactly the unsystematic values a design token library
  * exists to prevent. They want a line-height and letter-spacing scale first; SOFT-4235 covers that.
  *
+ * @param {string} tab    The active tab name; the heading declares no tabs, so this is unused.
+ * @param {Object} values The current draft, read for the chosen font family.
+ *
  * @since TBD
  *
  * @return {{panels: Array<Object>}} The settings-form schema.
  */
-function schemaFor() {
+function schemaFor(tab, values) {
+	const family = values?.tokens?.typography ?? '';
+
 	return {
 		panels: [
 			{
@@ -224,6 +286,12 @@ function schemaFor() {
 				title: __('Typography', 'kadence-blocks'),
 				fields: [
 					{
+						type: 'select',
+						path: 'tokens.typography',
+						label: __('Font Family', 'kadence-blocks'),
+						options: fontFamilyOptions(),
+					},
+					{
 						type: 'token-scalar',
 						tokenType: 'dimension',
 						role: 'font-size',
@@ -240,7 +308,7 @@ function schemaFor() {
 						type: 'select',
 						path: 'tokens.fontWeight',
 						label: __('Weight', 'kadence-blocks'),
-						options: FONT_WEIGHT_OPTIONS,
+						options: fontWeightOptions(family),
 					},
 					{
 						type: 'select',

--- a/src/token-controls/controls/ScalarControl.js
+++ b/src/token-controls/controls/ScalarControl.js
@@ -80,7 +80,6 @@ export function ScalarControl({
 	min,
 	max,
 	step,
-	showValue = true,
 }) {
 	return (
 		<ControlShell
@@ -107,7 +106,6 @@ export function ScalarControl({
 				min={min}
 				max={max}
 				step={step}
-				showValue={showValue}
 				disabled={disabled}
 				// The field speaks three intents; a scalar stores one value, so they collapse here rather
 				// than in every host. `onCustom` writes a bare number — the unit is the control's, exactly

--- a/src/token-controls/organisms/TokenSelector.js
+++ b/src/token-controls/organisms/TokenSelector.js
@@ -58,11 +58,6 @@ import '../styles/token-controls.scss';
  * @param {Function} props.onClear    Clears the slot's override (the `Reset` choice).
  * @param {Function} props.onCustom   Writes a literal number to the slot (used when leaving a token).
  * @param {Function} [props.renderCustom] Overrides the Custom tab body; passed through to `TokenPopover`.
- * @param {boolean}  [props.showValue] Whether each token row states its resolved value beside its
- *                                      label. Defaults to `true`; a field whose values are too long to
- *                                      read in a row (a fluid font size resolves to a whole `clamp()`
- *                                      expression) opts out, exactly as `BoxShadowControl` does for a
- *                                      shadow's shorthand.
  * @param {boolean}  [props.disabled] Disable the trigger, which is the only control outside the
  *                                      popover — with it inert the popover cannot open, so nothing
  *                                      below it is reachable either. Callers that only guard their
@@ -89,7 +84,6 @@ export function TokenSelector({
 	onClear,
 	onCustom,
 	renderCustom,
-	showValue = true,
 	disabled = false,
 }) {
 	const summary = fieldSummary(value, tokens, unit, __('Custom', 'kadence-blocks'));
@@ -177,7 +171,6 @@ export function TokenSelector({
 						resolvedDefault={resolvedDefault}
 						inherited={inherited}
 						initialTab={initialTab}
-						showValue={showValue}
 						custom={{ number, unit, units, onUnit, min, max, step, onNumber: writeNumber }}
 						renderCustom={renderCustom}
 						onPick={onPick}

--- a/tests/wpunit/Blocks/AdvancedHeadingTest.php
+++ b/tests/wpunit/Blocks/AdvancedHeadingTest.php
@@ -1,8 +1,12 @@
 <?php
+// cspell:ignore fontvariants -- the array key `maybe_add_google_font()` stores variants under.
 
 namespace Tests\wpunit\Blocks;
 
 use Kadence_Blocks_Advancedheading_Block;
+use Kadence_Blocks_CSS;
+use Kadence_Blocks_Google_Fonts;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use Tests\Support\Classes\KadenceBlocksUnit;
 
 class AdvancedHeadingTest extends KadenceBlocksUnit {
@@ -87,5 +91,124 @@ class AdvancedHeadingTest extends KadenceBlocksUnit {
 		$html = $this->block->build_html( $attributes, $unique_id, $saved_content, $block_instance );
 
 		$this->assertStringContainsString( 'href="' . $static_url . '"', $html, 'Static link should be preserved.' );
+	}
+
+	/**
+	 * A heading taking its family from a preset requests that preset's weight alongside it, so the
+	 * browser loads the real face rather than synthesizing one over the upright default.
+	 *
+	 * @return void
+	 */
+	public function testAPresetFamilyIsRequestedAtThePresetsOwnWeight(): void {
+		$fonts = $this->buildCssForSeededPreset( '700', [] );
+
+		$this->assertArrayHasKey( 'Inter', $fonts, 'The preset family should be enqueued.' );
+		$this->assertSame( [ '700' ], $fonts['Inter']['fontvariants'], 'The preset weight should be requested.' );
+	}
+
+	/**
+	 * A weight of 400 is asked for as `regular`, the variant spelling the rest of the plugin uses for
+	 * the upright default.
+	 *
+	 * @return void
+	 */
+	public function testAPresetWeightOfFourHundredIsRequestedAsRegular(): void {
+		$fonts = $this->buildCssForSeededPreset( '400', [] );
+
+		$this->assertSame( [ 'regular' ], $fonts['Inter']['fontvariants'] );
+	}
+
+	/**
+	 * A variant the block states itself is a direct statement about the face and outranks the preset's
+	 * weight, matching the precedence the rendered `font-weight` already follows.
+	 *
+	 * @return void
+	 */
+	public function testAnInstanceFontVariantOutranksThePresetWeight(): void {
+		$fonts = $this->buildCssForSeededPreset( '700', [ 'fontVariant' => '300italic' ] );
+
+		$this->assertSame( [ '300italic' ], $fonts['Inter']['fontvariants'] );
+	}
+
+	/**
+	 * A weight the block sets itself is what the CSS emits, so it is also what gets requested — the
+	 * preset's weight applies only where the block states none.
+	 *
+	 * @return void
+	 */
+	public function testAnInstanceFontWeightOutranksThePresetWeight(): void {
+		$fonts = $this->buildCssForSeededPreset( '700', [ 'fontWeight' => '300' ] );
+
+		$this->assertSame( [ '300' ], $fonts['Inter']['fontvariants'] );
+	}
+
+	/**
+	 * A preset that names no weight asks for no variant, leaving the family to load exactly as it did
+	 * before the weight was bridged rather than requesting a face nothing named.
+	 *
+	 * @return void
+	 */
+	public function testAPresetWithNoWeightRequestsNoVariant(): void {
+		$fonts = $this->buildCssForSeededPreset( null, [] );
+
+		$this->assertArrayHasKey( 'Inter', $fonts, 'The family should still be enqueued.' );
+		$this->assertSame( [], $fonts['Inter']['fontvariants'], 'No variant should be requested.' );
+	}
+
+	/**
+	 * Seed a preset carrying a family (and optionally a weight), build the block's CSS for a heading
+	 * with no family of its own, and return the Google fonts the build collected.
+	 *
+	 * @param string|null          $weight The preset's font weight, or null to set none.
+	 * @param array<string, mixed> $extra  Extra block attributes, for the precedence cases.
+	 *
+	 * @return array<string, array<string, mixed>> The collected Google fonts, keyed by family.
+	 */
+	private function buildCssForSeededPreset( ?string $weight, array $extra ): array {
+		$tokens = [ 'typography' => 'Inter' ];
+
+		if ( null !== $weight ) {
+			$tokens['fontWeight'] = $weight;
+		}
+
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'presets' => [
+						'kadence/advancedheading' => [
+							'preset-font-test' => [
+								'label'  => 'Font Test',
+								'tokens' => $tokens,
+							],
+						],
+					],
+				],
+			],
+		];
+
+		/** @var Token_Store $store */
+		$store = kadence_blocks()->get( Token_Store::class );
+		$store->save_document( (string) wp_json_encode( $document ), Token_Store::default_slug() );
+
+		$css = new Kadence_Blocks_CSS();
+		$css->clear();
+		Kadence_Blocks_Google_Fonts::$gfonts = [];
+
+		// `typography` is deliberately absent: the preset bridge fires only where the block names no
+		// family of its own, which is the whole case under test.
+		$attributes = array_merge(
+			[
+				'uniqueID' => '789_1234',
+				'kbPreset' => 'preset-font-test',
+			],
+			$extra
+		);
+
+		$this->block->build_css( $attributes, $css, '789_1234', '789_1234' );
+
+		// Read the collector rather than the builder: `build_css` ends in `css_output()`, which hands the
+		// fonts it gathered to `Kadence_Blocks_Google_Fonts` and then clears its own list, so by the time
+		// this returns the builder holds nothing. The collector is also what actually prints the tag.
+		return Kadence_Blocks_Google_Fonts::$gfonts;
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Font_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Font_CatalogTest.php
@@ -49,6 +49,54 @@ final class Font_CatalogTest extends TestCase {
 	}
 
 	/**
+	 * The weight map is read from the generated detail file, keyed by family. "Abril Fatface" ships only
+	 * a regular face and pins both halves of the point: the file is genuinely being read, and a family's
+	 * real weight list can be a single entry -- which is exactly why a flat 100-900 control would promise
+	 * eight faces it does not have.
+	 *
+	 * @return void
+	 */
+	public function testAllReturnsThePerFamilyWeightsFromTheGeneratedFile(): void {
+		$result = $this->catalog->all();
+
+		$this->assertArrayHasKey( 'weights', $result );
+		$this->assertNotEmpty( $result['weights'] );
+		$this->assertSame( [ '400' ], $result['weights']['Abril Fatface'] ?? null );
+	}
+
+	/**
+	 * The generated file spells the default weight "regular", which is 400 everywhere a CSS font-weight
+	 * is written. Both spellings surviving would make a consumer match two things for one weight.
+	 *
+	 * @return void
+	 */
+	public function testWeightsNormalizeRegularToItsNumericSpelling(): void {
+		$weights = $this->catalog->all()['weights'];
+
+		foreach ( $weights as $family => $family_weights ) {
+			$this->assertNotContains( 'regular', $family_weights, sprintf( '%s carries an unnormalized weight.', $family ) );
+		}
+	}
+
+	/**
+	 * A family shipping several weights lists them in weight order, so a picker reads low-to-high rather
+	 * than in the generated file's own order.
+	 *
+	 * @return void
+	 */
+	public function testWeightsAreSortedNumerically(): void {
+		$weights = $this->catalog->all()['weights']['Inter'] ?? [];
+
+		$this->assertNotEmpty( $weights, 'Inter should be present in the generated file.' );
+
+		$sorted = $weights;
+		sort( $sorted, SORT_NUMERIC );
+
+		$this->assertSame( $sorted, $weights );
+		$this->assertGreaterThan( 1, count( $weights ), 'Inter ships several weights.' );
+	}
+
+	/**
 	 * A custom-fonts filter returning the shape kadence_blocks_convert_custom_fonts() (init.php)
 	 * produces — string-keyed by the font-stack expression, each value an array with its own
 	 * "name" — normalizes to that string key as the catalog name.


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout
:video_camera: https://www.loom.com/share/c45de6b397424fcf9434d5b8e1fe9582

Adds the font-family binding, the render bridge that points font-family at it on both surfaces, and font loading for a preset-supplied family. Weight now narrows to the weights the chosen family ships, from a weights-only catalog addition rather than the full 338KB font detail file.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Advanced Heading presets now support font-family selection with Google font loading.
  * Font-weight options update automatically based on the selected font family.
  * Added font catalog options with favorites, custom fonts, and available weights.
  * Typography previews now reflect preset font families in the editor and style library.
* **Improvements**
  * Font-size values display more clearly in controls.
  * Unsupported font weights are cleared when switching families.
* **Tests**
  * Added coverage for font catalogs, font loading, weight filtering, and preset typography behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

