### PR TITLE
[DTM] SOFT-4218 [15/16]: clear a stale palette class on preset and color change

### DIFF
--- a/src/blocks/advancedheading/edit.js
+++ b/src/blocks/advancedheading/edit.js
@@ -1573,7 +1573,7 @@ function KadenceAdvancedHeading(props) {
 							label={__('Color', 'kadence-blocks')}
 							value={color ? color : ''}
 							default={''}
-							onChange={(value) => setAttributes({ color: value })}
+							onChange={(value) => setAttributes({ color: value, colorClass: '' })}
 							onClassChange={(value) => setAttributes({ colorClass: value })}
 						/>
 					)}
@@ -1736,14 +1736,18 @@ function KadenceAdvancedHeading(props) {
 													label={__('Color', 'kadence-blocks')}
 													value={color ? color : ''}
 													default={''}
-													onChange={(value) => setAttributes({ color: value })}
+													onChange={(value) =>
+														setAttributes({ color: value, colorClass: '' })
+													}
 													onClassChange={(value) => setAttributes({ colorClass: value })}
 												/>
 												<PopColorControl
 													label={__('Background Color', 'kadence-blocks')}
 													value={background ? background : ''}
 													default={''}
-													onChange={(value) => setAttributes({ background: value })}
+													onChange={(value) =>
+														setAttributes({ background: value, backgroundColorClass: '' })
+													}
 													onClassChange={(value) =>
 														setAttributes({ backgroundColorClass: value })
 													}

--- a/src/extension/token-indicators/__tests__/index.test.js
+++ b/src/extension/token-indicators/__tests__/index.test.js
@@ -718,12 +718,57 @@ describe('resetAttrPatch', () => {
 	});
 
 	/**
-	 * A non-dimension kind clears only its single attribute.
+	 * A non-dimension kind clears only its single attribute when the block declares no companion.
 	 *
 	 * @return {void}
 	 */
 	it('clears only the primary attribute for a non-dimension kind', () => {
 		expect(resetAttrPatch('background', 'color')).toEqual({ background: '' });
+	});
+
+	/**
+	 * A color also clears its palette-CLASS companion, in whichever spelling the block declares.
+	 *
+	 * WordPress emits its palette utility classes with `!important` -- over a hundred of them -- so a
+	 * stale `has-<slug>-color` beats every rule a preset can produce, at any specificity. Clearing the
+	 * color attribute alone leaves the class on the element still winning, and the preset reads as
+	 * broken rather than overridden.
+	 *
+	 * @return {void}
+	 */
+	it('clears a color attribute palette-class companion', () => {
+		// `color` -> `colorClass`, the Advanced Text spelling.
+		expect(resetAttrPatch('color', 'color', { color: {}, colorClass: {} })).toEqual({
+			color: '',
+			colorClass: '',
+		});
+
+		// `background` -> `backgroundColorClass`, the same block's other spelling.
+		expect(resetAttrPatch('background', 'color', { background: {}, backgroundColorClass: {} })).toEqual({
+			background: '',
+			backgroundColorClass: '',
+		});
+
+		// `bgColor` -> `bgColorClass`, the Row Layout spelling.
+		expect(resetAttrPatch('bgColor', 'color', { bgColor: {}, bgColorClass: {} })).toEqual({
+			bgColor: '',
+			bgColorClass: '',
+		});
+	});
+
+	/**
+	 * A block declaring no such companion gains no attribute it never declared, and a non-color kind is
+	 * never given one at all.
+	 *
+	 * @return {void}
+	 */
+	it('writes no palette-class companion the block does not declare', () => {
+		expect(resetAttrPatch('color', 'color', { color: {} })).toEqual({ color: '' });
+
+		// Not a color: a `textTransform` has no palette class even if something similarly named exists.
+		expect(resetAttrPatch('textTransform', 'text', { textTransform: {}, textTransformClass: {} })).toEqual({
+			textTransform: '',
+		});
 	});
 
 	/**

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -369,7 +369,7 @@ export function resetAttrPatch(attr, kind, declared) {
 	}
 
 	if (kind !== 'dimension') {
-		return { [attr]: '' };
+		return withPaletteClassCompanions({ [attr]: '' }, attr, kind, declared);
 	}
 
 	// A dimension is not always a measure control's 4-side array. `kadence/single-icon`'s `size` is a
@@ -391,6 +391,43 @@ export function resetAttrPatch(attr, kind, declared) {
 	if (!declared || declared[`${attr}Unit`]) {
 		patch[`${attr}Unit`] = 'px';
 	}
+
+	return patch;
+}
+
+/**
+ * Add a color attribute's palette-CLASS companion to a reset patch.
+ *
+ * A block that stores a WordPress palette color keeps the slug in a companion attribute
+ * (`color`/`colorClass`, `background`/`backgroundColorClass`, `bgColor`/`bgColorClass`), which renders
+ * as a `has-<slug>-color` class. WordPress emits those utility classes with `!important` — over a
+ * hundred of them — so a stale one beats every rule a preset can produce, at any specificity. Clearing
+ * the color attribute alone therefore does nothing visible: the class is still on the element and still
+ * wins, and the preset looks broken rather than overridden.
+ *
+ * Both spellings are checked against the block's own schema and only a declared one is written, so a
+ * block using neither is left alone rather than gaining an attribute it never declared.
+ *
+ * @param {Object}  patch      The patch so far.
+ * @param {string}  attr       The primary attribute name.
+ * @param {string}  kind       The property kind; only a color carries a palette class.
+ * @param {?Object} [declared] The block's declared attributes, read for which companion exists.
+ *
+ * @since TBD
+ *
+ * @return {Object} The patch, with any declared palette-class companion cleared.
+ */
+function withPaletteClassCompanions(patch, attr, kind, declared) {
+	if (kind !== 'color' || !declared) {
+		return patch;
+	}
+
+	// `color` -> `colorClass`; `background` -> `backgroundColorClass`; `bgColor` -> `bgColorClass`.
+	[`${attr}Class`, `${attr}ColorClass`].forEach((companion) => {
+		if (declared[companion]) {
+			patch[companion] = '';
+		}
+	});
 
 	return patch;
 }


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout
:video_camera: https://www.loom.com/share/c45de6b397424fcf9434d5b8e1fe9582

WordPress emits its palette utility classes with `!important`, so a stale `has-<slug>-color` beats every rule a preset can produce at any specificity. Clearing the color attribute alone left the class winning and the preset reading as broken.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom text and background colors now correctly override palette colors without stale styling persisting.
  * Resetting color settings now also removes their associated palette classes when declared.
  * Other reset types continue to clear only their intended attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

