### PR TITLE
[DTM] SOFT-4218 [16/16]: draw the Advanced Text preview at the size the preset sets

### DIFF
--- a/src/style-library/__tests__/advancedheading-preset.test.js
+++ b/src/style-library/__tests__/advancedheading-preset.test.js
@@ -119,14 +119,14 @@ describe('HEADING_PRESET', () => {
 			preview: {
 				color: '#1A202C',
 				background: '#F7FAFC',
-				fontSize: '4rem',
+				fontSize: '6rem',
 				fontWeight: '700',
 				textTransform: 'uppercase',
 				borderColor: '#E2E8F0',
-				borderWidth: '1px',
 				borderStyle: 'solid',
 				borderRadius: '0.5rem',
 				padding: '3rem',
+				borderWidth: '1px',
 			},
 		});
 
@@ -137,13 +137,47 @@ describe('HEADING_PRESET', () => {
 			fontWeight: '700',
 			textTransform: 'uppercase',
 			borderColor: '#E2E8F0',
-			borderWidth: '1px',
 			borderStyle: 'solid',
 			borderRadius: '0.5rem',
-			// Applied at true size: a heading's padding is bounded by the scale the field offers.
-			padding: '3rem',
 		});
 		expect(chip.props.style.fontSize).toBeUndefined();
+
+		// Padding and border width are re-expressed against the preset's own font size, so the chip keeps
+		// the preset's proportions at whatever size the row can afford. 3rem against a 6rem size is 0.5em.
+		expect(chip.props.style.padding).toBe('0.5em');
+		expect(chip.props.style.borderWidth).toBe('0.0104em');
+	});
+
+	/**
+	 * With no font size to measure against, padding and border width pass through at true size rather
+	 * than being dropped or guessed at.
+	 *
+	 * @return {void}
+	 */
+	it('leaves padding at true size when the preset sets no font size', () => {
+		const chip = HEADING_PRESET.renderPreview({
+			id: 'plain',
+			label: 'Plain',
+			preview: { padding: '3rem', borderWidth: '1px', fontSize: '' },
+		});
+
+		expect(chip.props.style.padding).toBe('3rem');
+		expect(chip.props.style.borderWidth).toBe('1px');
+	});
+
+	/**
+	 * A per-corner padding shorthand scales each side on its own, since each is its own length.
+	 *
+	 * @return {void}
+	 */
+	it('scales every side of a padding shorthand against the font size', () => {
+		const chip = HEADING_PRESET.renderPreview({
+			id: 'corners',
+			label: 'Corners',
+			preview: { padding: '1rem 2rem 1rem 2rem', fontSize: '2rem' },
+		});
+
+		expect(chip.props.style.padding).toBe('0.5em 1em 0.5em 1em');
 	});
 
 	/**

--- a/src/style-library/__tests__/advancedheading-preset.test.js
+++ b/src/style-library/__tests__/advancedheading-preset.test.js
@@ -164,12 +164,13 @@ describe('HEADING_PRESET', () => {
 	});
 
 	/**
-	 * With no font size to measure against, padding and border width pass through at true size rather
-	 * than being dropped or guessed at.
+	 * With no font size of its own the chip writes no inline size, leaving the stylesheet's body-size
+	 * fallback in charge rather than guessing one. Padding and border width still pass through at true
+	 * size.
 	 *
 	 * @return {void}
 	 */
-	it('leaves the chip unsized when the preset sets no font size', () => {
+	it('writes no inline font size when the preset sets none', () => {
 		const chip = HEADING_PRESET.renderPreview({
 			id: 'plain',
 			label: 'Plain',

--- a/src/style-library/__tests__/advancedheading-preset.test.js
+++ b/src/style-library/__tests__/advancedheading-preset.test.js
@@ -126,6 +126,7 @@ describe('HEADING_PRESET', () => {
 				borderWidth: '1px',
 				borderStyle: 'solid',
 				borderRadius: '0.5rem',
+				padding: '3rem',
 			},
 		});
 
@@ -139,6 +140,8 @@ describe('HEADING_PRESET', () => {
 			borderWidth: '1px',
 			borderStyle: 'solid',
 			borderRadius: '0.5rem',
+			// Applied at true size: a heading's padding is bounded by the scale the field offers.
+			padding: '3rem',
 		});
 		expect(chip.props.style.fontSize).toBeUndefined();
 	});

--- a/src/style-library/__tests__/advancedheading-preset.test.js
+++ b/src/style-library/__tests__/advancedheading-preset.test.js
@@ -147,12 +147,6 @@ describe('HEADING_PRESET', () => {
 	});
 
 	/**
-	 * With no font size to measure against, padding and border width pass through at true size rather
-	 * than being dropped or guessed at.
-	 *
-	 * @return {void}
-	 */
-	/**
 	 * A fluid font-size step resolves to a whole `clamp()`, which sizes against the VIEWPORT -- drawing it
 	 * would size the chip by how wide the browser happens to be. The step's authored scalar is drawn
 	 * instead, the same value the SIZE field states.
@@ -169,6 +163,12 @@ describe('HEADING_PRESET', () => {
 		expect(chip.props.style.fontSize).toBe('6rem');
 	});
 
+	/**
+	 * With no font size to measure against, padding and border width pass through at true size rather
+	 * than being dropped or guessed at.
+	 *
+	 * @return {void}
+	 */
 	it('leaves the chip unsized when the preset sets no font size', () => {
 		const chip = HEADING_PRESET.renderPreview({
 			id: 'plain',

--- a/src/style-library/__tests__/advancedheading-preset.test.js
+++ b/src/style-library/__tests__/advancedheading-preset.test.js
@@ -107,12 +107,13 @@ describe('HEADING_PRESET', () => {
 	});
 
 	/**
-	 * The chip states the preset's type and frame. Font SIZE is deliberately not applied: the scale
-	 * reaches 4rem and a row set at true size would dwarf its neighbors, so the sidebar names it instead.
+	 * The chip states the preset's type and frame at the size the preset actually sets, and the row grows
+	 * to fit. Anything else misrepresents it: at body size, 3rem of padding read as a circle where the
+	 * page rendered a pill.
 	 *
 	 * @return {void}
 	 */
-	it('renders a chip carrying the type and frame but not the font size', () => {
+	it('renders a chip carrying the type and frame at the size the preset sets', () => {
 		const chip = HEADING_PRESET.renderPreview({
 			id: 'title',
 			label: 'Title',
@@ -140,12 +141,9 @@ describe('HEADING_PRESET', () => {
 			borderStyle: 'solid',
 			borderRadius: '0.5rem',
 		});
-		expect(chip.props.style.fontSize).toBeUndefined();
-
-		// Padding and border width are re-expressed against the preset's own font size, so the chip keeps
-		// the preset's proportions at whatever size the row can afford. 3rem against a 6rem size is 0.5em.
-		expect(chip.props.style.padding).toBe('0.5em');
-		expect(chip.props.style.borderWidth).toBe('0.0104em');
+		expect(chip.props.style.fontSize).toBe('6rem');
+		expect(chip.props.style.padding).toBe('3rem');
+		expect(chip.props.style.borderWidth).toBe('1px');
 	});
 
 	/**
@@ -154,7 +152,24 @@ describe('HEADING_PRESET', () => {
 	 *
 	 * @return {void}
 	 */
-	it('leaves padding at true size when the preset sets no font size', () => {
+	/**
+	 * A fluid font-size step resolves to a whole `clamp()`, which sizes against the VIEWPORT -- drawing it
+	 * would size the chip by how wide the browser happens to be. The step's authored scalar is drawn
+	 * instead, the same value the SIZE field states.
+	 *
+	 * @return {void}
+	 */
+	it('draws a fluid step at its authored scalar rather than its clamp', () => {
+		const chip = HEADING_PRESET.renderPreview({
+			id: 'fluid',
+			label: 'Fluid',
+			preview: { fontSize: 'clamp(2.75rem, 0.489rem + 7.065vw, 6rem)' },
+		});
+
+		expect(chip.props.style.fontSize).toBe('6rem');
+	});
+
+	it('leaves the chip unsized when the preset sets no font size', () => {
 		const chip = HEADING_PRESET.renderPreview({
 			id: 'plain',
 			label: 'Plain',
@@ -163,21 +178,7 @@ describe('HEADING_PRESET', () => {
 
 		expect(chip.props.style.padding).toBe('3rem');
 		expect(chip.props.style.borderWidth).toBe('1px');
-	});
-
-	/**
-	 * A per-corner padding shorthand scales each side on its own, since each is its own length.
-	 *
-	 * @return {void}
-	 */
-	it('scales every side of a padding shorthand against the font size', () => {
-		const chip = HEADING_PRESET.renderPreview({
-			id: 'corners',
-			label: 'Corners',
-			preview: { padding: '1rem 2rem 1rem 2rem', fontSize: '2rem' },
-		});
-
-		expect(chip.props.style.padding).toBe('0.5em 1em 0.5em 1em');
+		expect(chip.props.style.fontSize).toBeUndefined();
 	});
 
 	/**

--- a/src/style-library/components/pages/HeadingScreen.scss
+++ b/src/style-library/components/pages/HeadingScreen.scss
@@ -19,9 +19,10 @@
 // width draws no frame — matching the block, where all three are needed before a border renders, and
 // keeping an unstyled preset from sprouting an edge the page would not have.
 //
-// The font size is deliberately not the preset's: the scale reaches 4rem and a row set at true size
-// would dwarf its neighbors. The chip states family, weight, transform, color and frame faithfully and
-// leaves size to the sidebar, which names the actual value while a preset is being edited.
+// `font-size`, `padding` and `border-width` are all set inline from the preset at the size it actually
+// sets, and the row grows to fit. The values here are the floor for a preset that sets none.
+// `line-height` is unitless so it follows whatever size the chip lands on, rather than pinning a
+// body-text leading onto 6rem type.
 .kadence-blocks-style-library__heading-preset-preview {
 	display: inline-flex;
 	align-items: center;
@@ -29,15 +30,18 @@
 	// A floor, not a fixed inset: the preset's own padding is applied inline and overrides this, while a
 	// preset that sets none still reads as a chip rather than as bare text.
 	padding: var(--kb-sl-space-10) var(--kb-sl-space-20);
+	// A long word at 6rem would otherwise force the row wider than the panel.
+	max-width: 100%;
+	overflow-wrap: anywhere;
 	border-width: 0;
 	border-style: none;
 	font-size: var(--kb-sl-font-size-body);
-	line-height: var(--kb-sl-line-height-s);
-	white-space: nowrap;
+	line-height: 1.2;
 	transition:
 		background-color 300ms ease,
 		border-color 300ms ease,
 		border-radius 300ms ease,
 		padding 300ms ease,
+		font-size 300ms ease,
 		color 300ms ease;
 }

--- a/src/style-library/components/pages/HeadingScreen.scss
+++ b/src/style-library/components/pages/HeadingScreen.scss
@@ -26,6 +26,8 @@
 	display: inline-flex;
 	align-items: center;
 	box-sizing: border-box;
+	// A floor, not a fixed inset: the preset's own padding is applied inline and overrides this, while a
+	// preset that sets none still reads as a chip rather than as bare text.
 	padding: var(--kb-sl-space-10) var(--kb-sl-space-20);
 	border-width: 0;
 	border-style: none;
@@ -36,5 +38,6 @@
 		background-color 300ms ease,
 		border-color 300ms ease,
 		border-radius 300ms ease,
+		padding 300ms ease,
 		color 300ms ease;
 }

--- a/src/style-library/presets/advancedheading-preset.js
+++ b/src/style-library/presets/advancedheading-preset.js
@@ -17,7 +17,6 @@ import { __ } from '@wordpress/i18n';
  */
 import { getPresetProperties, resolveTokenValue } from '../helpers/presets';
 import { fontCatalogOptions, fontOptions, fontSizeDisplayValue, fontWeightsFor } from '../helpers/typography';
-import { pxFromLength } from '../../token-controls/helpers/px-from-length';
 
 /**
  * The block name this screen edits. The block is called Advanced Text in the UI but
@@ -139,44 +138,6 @@ function fontWeightOptions(family) {
 }
 
 /**
- * Re-express a length as a multiple of the preset's own font size, so the chip keeps the preset's
- * PROPORTIONS at whatever size the row can afford.
- *
- * The chip deliberately does not render at the preset's font size -- the scale reaches 6rem and a row
- * set there would dwarf its neighbors -- but padding and border width were being applied at true size
- * regardless. The mismatch is not subtle: 3rem of padding around 6rem text is a pill, and the same 3rem
- * around the chip's own body text is a circle, so the preview contradicted the page it was previewing.
- *
- * Returned in `em`, which resolves against the chip's own font size, so the relationship holds no matter
- * what that size is. A value that cannot be measured against a font size -- either side unparsable, or a
- * preset that sets no size -- passes through at true size, which is the honest fallback and what every
- * other screen does.
- *
- * @param {string} length   The resolved length.
- * @param {number} fontSize The preset's font size in pixels, or null when it has none.
- *
- * @since TBD
- *
- * @return {string} The length in `em`, or unchanged.
- */
-function scaledToFontSize(length, fontSize) {
-	if (!length || !fontSize) {
-		return length;
-	}
-
-	// A shorthand carries one value per side, each scaled on its own.
-	return String(length)
-		.trim()
-		.split(/\s+/)
-		.map((side) => {
-			const px = pxFromLength(side);
-
-			return px === null ? side : `${Number((px / fontSize).toFixed(4))}em`;
-		})
-		.join(' ');
-}
-
-/**
  * Build a row's preview from its stored tokens.
  *
  * Everything the screen edits that a chip of text can honestly show. `borderWidth` and `borderStyle`
@@ -216,11 +177,16 @@ function preview(tokens, values, breakpoint) {
  * Real text rather than a swatch, because every property this screen edits except the box ones is a
  * type property, and a color chip cannot show a family, a weight or a transform.
  *
- * Font SIZE is deliberately not applied -- the scale reaches 6rem and a row set there would dwarf its
- * neighbors -- so padding and border width are re-expressed as multiples of it instead (see
- * `scaledToFontSize`). Applying those two at true size while the text stayed small was worse than not
- * showing them: 3rem of padding reads as a pill around 6rem text and as a circle around the chip's own,
- * so the preview contradicted the page. The size is deliberately
+ * Everything is drawn at the size the preset actually sets -- font size, padding and border width alike
+ * -- and the row grows to fit, the way the Advanced Image tile grows to fit its padding. Anything else
+ * misrepresents the preset: holding the text at body size made 3rem of padding read as a circle where
+ * the page rendered a pill, and re-expressing the padding proportionally fixed the shape but shrank it
+ * to about seven pixels, which reads as no padding at all. A preview is only worth having if it is the
+ * thing it previews.
+ *
+ * The one substitution is the font size itself: a fluid step resolves to a `clamp()`, which sizes
+ * against the VIEWPORT, so the chip would be sized by how wide the browser happens to be. The step's
+ * authored scalar is drawn instead -- the same value the SIZE field states. The size is deliberately
  * NOT applied at true size — the scale reaches 4rem and a row cannot grow that far without dwarfing its
  * neighbors — so the chip states the family, weight, transform, color and frame faithfully and leaves
  * size to the sidebar. The Advanced Image tile can afford to grow because its padding is the only
@@ -233,28 +199,30 @@ function preview(tokens, values, breakpoint) {
  * @return {JSX.Element} The preview element.
  */
 function renderPreview(row) {
-	// Every shipped font-size step is fluid, so the resolved value is a `clamp()`; its authored scalar is
-	// what the proportions are relative to.
-	const fontSize = pxFromLength(fontSizeDisplayValue(row.preview.fontSize));
+	// Every shipped font-size step is fluid, so the resolved value is a whole `clamp()`. Its authored
+	// scalar is what to draw: a clamp resolves against the VIEWPORT, so rendering it here would size the
+	// chip by how wide the browser happens to be rather than by what the preset says.
+	const fontSize = fontSizeDisplayValue(row.preview.fontSize);
 
 	return (
 		<span
 			className="kadence-blocks-style-library__heading-preset-preview"
 			style={{
+				fontSize: fontSize || undefined,
 				color: row.preview.color || undefined,
 				background: row.preview.background || undefined,
 				fontWeight: row.preview.fontWeight || undefined,
 				fontFamily: row.preview.typography || undefined,
 				textTransform: row.preview.textTransform || undefined,
 				borderColor: row.preview.borderColor || undefined,
-				borderWidth: scaledToFontSize(row.preview.borderWidth, fontSize) || undefined,
+				borderWidth: row.preview.borderWidth || undefined,
 				// A border renders only when all three are set, so the style is what decides whether the
 				// frame appears at all. Left absent, the stylesheet's own `none` leaves the chip without a frame.
 				borderStyle: row.preview.borderStyle || undefined,
 				borderRadius: row.preview.borderRadius || undefined,
 				// The preset's own padding, not the stylesheet's. Without this the chip showed a fixed
 				// inset and a padding preset read as doing nothing at all.
-				padding: scaledToFontSize(row.preview.padding, fontSize) || undefined,
+				padding: row.preview.padding || undefined,
 			}}
 		>
 			{__('Heading', 'kadence-blocks')}

--- a/src/style-library/presets/advancedheading-preset.js
+++ b/src/style-library/presets/advancedheading-preset.js
@@ -175,7 +175,9 @@ function preview(tokens, values, breakpoint) {
  * its own frame.
  *
  * Real text rather than a swatch, because every property this screen edits except the box ones is a
- * type property, and a color chip cannot show a family, a weight or a transform. The size is deliberately
+ * type property, and a color chip cannot show a family, a weight or a transform. Padding is applied at
+ * true size: a heading's padding is bounded by the scale the field offers, unlike the image tile's,
+ * which had to be capped. The size is deliberately
  * NOT applied at true size — the scale reaches 4rem and a row cannot grow that far without dwarfing its
  * neighbors — so the chip states the family, weight, transform, color and frame faithfully and leaves
  * size to the sidebar. The Advanced Image tile can afford to grow because its padding is the only
@@ -203,6 +205,9 @@ function renderPreview(row) {
 				// frame appears at all. Left absent, the stylesheet's own `none` leaves the chip without a frame.
 				borderStyle: row.preview.borderStyle || undefined,
 				borderRadius: row.preview.borderRadius || undefined,
+				// The preset's own padding, not the stylesheet's. Without this the chip showed a fixed
+				// inset and a padding preset read as doing nothing at all.
+				padding: row.preview.padding || undefined,
 			}}
 		>
 			{__('Heading', 'kadence-blocks')}

--- a/src/style-library/presets/advancedheading-preset.js
+++ b/src/style-library/presets/advancedheading-preset.js
@@ -186,11 +186,8 @@ function preview(tokens, values, breakpoint) {
  *
  * The one substitution is the font size itself: a fluid step resolves to a `clamp()`, which sizes
  * against the VIEWPORT, so the chip would be sized by how wide the browser happens to be. The step's
- * authored scalar is drawn instead -- the same value the SIZE field states. The size is deliberately
- * NOT applied at true size — the scale reaches 4rem and a row cannot grow that far without dwarfing its
- * neighbors — so the chip states the family, weight, transform, color and frame faithfully and leaves
- * size to the sidebar. The Advanced Image tile can afford to grow because its padding is the only
- * property that drives its geometry; a heading's font size drives everything at once.
+ * authored scalar is drawn instead -- the same value the SIZE field states, and a fixed length the row
+ * can actually be measured against.
  *
  * @param {{id: string, label: string, preview: Record<string, string>}} row The row descriptor.
  *

--- a/src/style-library/presets/advancedheading-preset.js
+++ b/src/style-library/presets/advancedheading-preset.js
@@ -16,7 +16,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getPresetProperties, resolveTokenValue } from '../helpers/presets';
-import { fontCatalogOptions, fontOptions, fontWeightsFor } from '../helpers/typography';
+import { fontCatalogOptions, fontOptions, fontSizeDisplayValue, fontWeightsFor } from '../helpers/typography';
+import { pxFromLength } from '../../token-controls/helpers/px-from-length';
 
 /**
  * The block name this screen edits. The block is called Advanced Text in the UI but
@@ -138,6 +139,44 @@ function fontWeightOptions(family) {
 }
 
 /**
+ * Re-express a length as a multiple of the preset's own font size, so the chip keeps the preset's
+ * PROPORTIONS at whatever size the row can afford.
+ *
+ * The chip deliberately does not render at the preset's font size -- the scale reaches 6rem and a row
+ * set there would dwarf its neighbors -- but padding and border width were being applied at true size
+ * regardless. The mismatch is not subtle: 3rem of padding around 6rem text is a pill, and the same 3rem
+ * around the chip's own body text is a circle, so the preview contradicted the page it was previewing.
+ *
+ * Returned in `em`, which resolves against the chip's own font size, so the relationship holds no matter
+ * what that size is. A value that cannot be measured against a font size -- either side unparsable, or a
+ * preset that sets no size -- passes through at true size, which is the honest fallback and what every
+ * other screen does.
+ *
+ * @param {string} length   The resolved length.
+ * @param {number} fontSize The preset's font size in pixels, or null when it has none.
+ *
+ * @since TBD
+ *
+ * @return {string} The length in `em`, or unchanged.
+ */
+function scaledToFontSize(length, fontSize) {
+	if (!length || !fontSize) {
+		return length;
+	}
+
+	// A shorthand carries one value per side, each scaled on its own.
+	return String(length)
+		.trim()
+		.split(/\s+/)
+		.map((side) => {
+			const px = pxFromLength(side);
+
+			return px === null ? side : `${Number((px / fontSize).toFixed(4))}em`;
+		})
+		.join(' ');
+}
+
+/**
  * Build a row's preview from its stored tokens.
  *
  * Everything the screen edits that a chip of text can honestly show. `borderWidth` and `borderStyle`
@@ -175,9 +214,13 @@ function preview(tokens, values, breakpoint) {
  * its own frame.
  *
  * Real text rather than a swatch, because every property this screen edits except the box ones is a
- * type property, and a color chip cannot show a family, a weight or a transform. Padding is applied at
- * true size: a heading's padding is bounded by the scale the field offers, unlike the image tile's,
- * which had to be capped. The size is deliberately
+ * type property, and a color chip cannot show a family, a weight or a transform.
+ *
+ * Font SIZE is deliberately not applied -- the scale reaches 6rem and a row set there would dwarf its
+ * neighbors -- so padding and border width are re-expressed as multiples of it instead (see
+ * `scaledToFontSize`). Applying those two at true size while the text stayed small was worse than not
+ * showing them: 3rem of padding reads as a pill around 6rem text and as a circle around the chip's own,
+ * so the preview contradicted the page. The size is deliberately
  * NOT applied at true size — the scale reaches 4rem and a row cannot grow that far without dwarfing its
  * neighbors — so the chip states the family, weight, transform, color and frame faithfully and leaves
  * size to the sidebar. The Advanced Image tile can afford to grow because its padding is the only
@@ -190,6 +233,10 @@ function preview(tokens, values, breakpoint) {
  * @return {JSX.Element} The preview element.
  */
 function renderPreview(row) {
+	// Every shipped font-size step is fluid, so the resolved value is a `clamp()`; its authored scalar is
+	// what the proportions are relative to.
+	const fontSize = pxFromLength(fontSizeDisplayValue(row.preview.fontSize));
+
 	return (
 		<span
 			className="kadence-blocks-style-library__heading-preset-preview"
@@ -200,14 +247,14 @@ function renderPreview(row) {
 				fontFamily: row.preview.typography || undefined,
 				textTransform: row.preview.textTransform || undefined,
 				borderColor: row.preview.borderColor || undefined,
-				borderWidth: row.preview.borderWidth || undefined,
+				borderWidth: scaledToFontSize(row.preview.borderWidth, fontSize) || undefined,
 				// A border renders only when all three are set, so the style is what decides whether the
 				// frame appears at all. Left absent, the stylesheet's own `none` leaves the chip without a frame.
 				borderStyle: row.preview.borderStyle || undefined,
 				borderRadius: row.preview.borderRadius || undefined,
 				// The preset's own padding, not the stylesheet's. Without this the chip showed a fixed
 				// inset and a padding preset read as doing nothing at all.
-				padding: row.preview.padding || undefined,
+				padding: scaledToFontSize(row.preview.padding, fontSize) || undefined,
 			}}
 		>
 			{__('Heading', 'kadence-blocks')}


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout
:video_camera: https://www.loom.com/share/c45de6b397424fcf9434d5b8e1fe9582

The chip renders the preset's font size, padding and border width at true size and the row grows to fit. A fluid step's authored scalar is drawn rather than its `clamp()`, which would size the chip by the browser width.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Advanced Heading preset previews now accurately reflect configured font size, padding, and border width.
  * Fluid font-size settings display their authored value correctly.
  * Long heading labels wrap properly instead of being truncated.
  * Preview transitions now smoothly include font-size and padding changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

