### PR TITLE
[DTM] SOFT-4218 fixes [1/5]: resolve a bound semantic through the library, not the picker

### DIFF
--- a/src/style-library/__tests__/box-token-field.test.js
+++ b/src/style-library/__tests__/box-token-field.test.js
@@ -15,6 +15,7 @@ import {
 	toStoredValue,
 	withoutSemanticSlots,
 } from '../components/molecules/fields/BoxTokenField';
+import { PICKABLE_TOKENS_GLOBAL } from '../constants';
 
 // A stub, not the real control: `BoxControl` renders a deep tree of pickers and popovers that have
 // nothing to do with what this suite is after. Standing in for it exposes exactly the props
@@ -151,6 +152,43 @@ describe('semanticDefaultOf', () => {
 
 	it('resolves an unknown semantic to empty rather than to its raw dot-path', () => {
 		expect(semanticDefaultOf('semantic.spacing.gone', pool)).toBe('');
+	});
+
+	/**
+	 * A binding may point at a semantic that was never declared as a pickable token — eleven of the
+	 * shipped bindings do — so a value the picker cannot offer still has to resolve. Searching only the
+	 * pickable list blanked those fields instead of showing the value in effect.
+	 */
+	describe('a semantic the pickable list does not carry', () => {
+		const originalPool = window[PICKABLE_TOKENS_GLOBAL];
+		const originalFeed = window.kadenceDesignTokens;
+
+		beforeEach(() => {
+			window.kadenceDesignTokens = { slug: 'brand' };
+			window[PICKABLE_TOKENS_GLOBAL] = {
+				tokens: [],
+				values: { brand: { 'semantic.spacing.heading-padding': '0' } },
+			};
+		});
+
+		afterEach(() => {
+			window[PICKABLE_TOKENS_GLOBAL] = originalPool;
+			window.kadenceDesignTokens = originalFeed;
+		});
+
+		it('resolves it through the library rather than blanking the field', () => {
+			expect(semanticDefaultOf('semantic.spacing.heading-padding', pool)).toBe('0');
+		});
+
+		it('resolves it in every corner of a slot list', () => {
+			const slots = Array(4).fill('semantic.spacing.heading-padding');
+
+			expect(semanticDefaultOf(slots, pool)).toEqual(['0', '0', '0', '0']);
+		});
+
+		it("falls back to the field's declared default when it resolves nowhere at all", () => {
+			expect(semanticDefaultOf('semantic.spacing.gone', pool, '2px')).toBe('2px');
+		});
 	});
 });
 

--- a/src/style-library/__tests__/tokens.test.js
+++ b/src/style-library/__tests__/tokens.test.js
@@ -4,6 +4,7 @@ import {
 	flattenSchemaTokens,
 	isResponsiveType,
 	pickableTokensForType,
+	resolvedTokenValue,
 	tokenTypeIdSegment,
 } from '../helpers/tokens';
 import { PICKABLE_TOKENS_GLOBAL } from '../constants';
@@ -221,5 +222,50 @@ describe('pickableTokensForType', () => {
 		expect(tokens).toEqual([
 			{ id: 'semantic.color.action-primary', label: 'Action Primary', value: '#3633e1', role: null },
 		]);
+	});
+});
+
+describe('resolvedTokenValue', () => {
+	const originalPool = window[PICKABLE_TOKENS_GLOBAL];
+	const originalFeed = window.kadenceDesignTokens;
+
+	beforeEach(() => {
+		window.kadenceDesignTokens = { slug: 'brand' };
+		window[PICKABLE_TOKENS_GLOBAL] = {
+			// Deliberately narrower than `values`: the declared registry is the subset a picker may
+			// offer, and a binding is free to point at a semantic that was never declared.
+			tokens: [{ id: 'primitive.dimension.radius.sm', label: 'Radius Small', type: 'dimension' }],
+			values: {
+				brand: {
+					'primitive.dimension.radius.sm': '4px',
+					'semantic.spacing.heading-padding': '0',
+				},
+			},
+		};
+	});
+
+	afterEach(() => {
+		window[PICKABLE_TOKENS_GLOBAL] = originalPool;
+		window.kadenceDesignTokens = originalFeed;
+	});
+
+	it('resolves a token the declared registry never offered', () => {
+		expect(resolvedTokenValue('semantic.spacing.heading-padding')).toBe('0');
+	});
+
+	it('resolves a declared token the same way', () => {
+		expect(resolvedTokenValue('primitive.dimension.radius.sm')).toBe('4px');
+	});
+
+	it('yields an empty string for an id the library does not resolve', () => {
+		expect(resolvedTokenValue('semantic.spacing.gone')).toBe('');
+	});
+
+	it('yields an empty string when no feed or pool is on the page', () => {
+		delete window.kadenceDesignTokens;
+		expect(resolvedTokenValue('primitive.dimension.radius.sm')).toBe('');
+
+		delete window[PICKABLE_TOKENS_GLOBAL];
+		expect(resolvedTokenValue('primitive.dimension.radius.sm')).toBe('');
 	});
 });

--- a/src/style-library/components/molecules/fields/BoxTokenField.js
+++ b/src/style-library/components/molecules/fields/BoxTokenField.js
@@ -29,7 +29,7 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { pickableTokensForType } from '../../../helpers/tokens';
+import { pickableTokensForType, resolvedTokenValue } from '../../../helpers/tokens';
 import {
 	PRESET_BREAKPOINTS,
 	readPresetBreakpoint,
@@ -115,6 +115,12 @@ export function withoutSemanticSlots(value) {
  * what keeps that promise: the caller takes this in place of the declared default, not alongside it,
  * so a corner left empty here would show as blank rather than as the value actually in effect.
  *
+ * A semantic is resolved against the RESOLVED library rather than the pickable pool. A binding may
+ * point at a semantic that was never declared as a pickable token — eleven of the shipped bindings
+ * do — and searching the pickable list for one of those found nothing, blanking the field instead of
+ * showing the value in effect. A semantic that resolves nowhere at all falls back to the field's own
+ * declared default, so a gap in the data degrades to the documented default rather than to empty.
+ *
  * @param {*}     value        The stored scalar or slot list.
  * @param {Array} everyToken   The full token pool, before any role narrowing, used to resolve an id.
  * @param {*}     fieldDefault The field's own declared default, for the corners that bind no semantic.
@@ -130,10 +136,11 @@ export function semanticDefaultOf(value, everyToken, fieldDefault = null) {
 		return null;
 	}
 
+	const ownDefault = (index) => readSlot(fieldDefault, index) ?? '';
 	const resolve = (slot, index) =>
 		isSemanticSlot(slot)
-			? (everyToken.find((token) => token.id === slot)?.value ?? '')
-			: (readSlot(fieldDefault, index) ?? '');
+			? everyToken.find((token) => token.id === slot)?.value || resolvedTokenValue(slot) || ownDefault(index)
+			: ownDefault(index);
 
 	return isSlotList(value) ? value.map(resolve) : resolve(value, 0);
 }

--- a/src/style-library/components/molecules/fields/ScalarTokenField.js
+++ b/src/style-library/components/molecules/fields/ScalarTokenField.js
@@ -130,7 +130,9 @@ export function ScalarTokenField({ field, value, onChange }) {
 	const displayValue = (value) => (field.role === 'font-size' ? fontSizeDisplayValue(value) : value);
 
 	const shown = withoutSemanticSlots(atBreakpoint);
-	const semanticDefault = semanticDefaultOf(atBreakpoint, everyToken);
+	// The declared default is handed over so a semantic that resolves nowhere falls back to it rather
+	// than to empty, exactly as the box field does — this field is scalar, so there is one slot to fill.
+	const semanticDefault = semanticDefaultOf(atBreakpoint, everyToken, field.defaultValue ?? null);
 
 	const shownDefault = displayValue(
 		inheritsFromBreakpoint ? asLiteral(inheritedAbove) : (semanticDefault ?? field.defaultValue ?? null)

--- a/src/style-library/helpers/tokens.js
+++ b/src/style-library/helpers/tokens.js
@@ -31,6 +31,29 @@ export function getPickableTokensPool() {
 }
 
 /**
+ * The active library's resolved literal for a token id, whether or not that token is pickable.
+ *
+ * The pool carries two different sets, and the difference matters here. `tokens` is the DECLARED
+ * registry — the subset a picker may offer — while `values` is the RESOLVED library, every id the
+ * document resolves. A binding is free to point at a semantic that was never declared, and eleven of
+ * the shipped bindings do, so a lookup that searches `tokens` finds nothing for them even though the
+ * value is right there in `values`. Resolving a bound token is a `values` question; only offering one
+ * to pick is a `tokens` question.
+ *
+ * @param {string} id The token id.
+ *
+ * @since TBD
+ *
+ * @return {string} The resolved literal, or '' when the library does not resolve that id.
+ */
+export function resolvedTokenValue(id) {
+	const pool = getPickableTokensPool();
+	const feed = getDesignTokensFeed();
+
+	return pool.values?.[feed?.slug]?.[id] ?? '';
+}
+
+/**
  * Narrow a role-scoped token list to its primitive-layer entries, when it has any. A role's
  * primitives are its scale steps (e.g. the radius sizes); its semantic tokens merely alias them, so
  * a picker that already knows the role offers only the steps rather than duplicating them with the


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout

A field whose preset value is semantic-bound rendered blank where it should have shown the value in effect as a muted default.

`semanticDefaultOf()` looked a semantic up in the PICKABLE pool — the declared registry subset a picker may offer. Eleven of the shipped bindings point at a semantic that was never declared, including all eight the Advanced Text screen uses, so the lookup missed and yielded `''`. An empty string is not nullish, so it beat the field's declared default through `??`.

The value was never missing: the pickable catalog already ships the whole resolved library, so a new `resolvedTokenValue()` reads it from there. Resolving a bound token is a library question; only OFFERING one to pick is a registry question.

`ScalarTokenField` was also never passing its declared default down, which is why the heading's Size, Border Width and Radius blanked out too.

Fixes this issue:
<img width="178" height="99" alt="image" src="https://github.com/user-attachments/assets/39105736-f3dd-48f0-8530-f41cd709b9b2" />

After:
<img width="276" height="291" alt="image" src="https://github.com/user-attachments/assets/183ae900-fc1b-404d-910f-59c67fb42660" />

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Semantic token values can now resolve even when they aren’t available in the selectable token list.
  - Unresolved semantic values correctly fall back to the field’s configured default instead of appearing empty.
  - Improved handling of missing or unavailable token values.

- **Tests**
  - Added coverage for scalar and slot-list token resolution, declared defaults, unresolved tokens, and missing token sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
