### PR TITLE
[DTM] SOFT-4218 fixes [2/5]: keep a border radius a block sets to zero

### DIFF
--- a/src/blocks/column/block.json
+++ b/src/blocks/column/block.json
@@ -108,7 +108,7 @@
 		},
 		"borderRadius": {
 			"type": "array",
-			"default": [0, 0, 0, 0]
+			"default": ["", "", "", ""]
 		},
 		"uniqueID": {
 			"type": "string",

--- a/src/blocks/column/edit.js
+++ b/src/blocks/column/edit.js
@@ -1217,22 +1217,24 @@ function SectionEdit(props) {
 					? `.kadence-column-${uniqueID} > .kadence-inner-column-inner:before { background-attachment:${overlayImg[0].bgImgAttachment}; }`
 					: ''}
 
-				{previewRadiusTop
+				{/* Tested against '' for the same reason the inner element's inline radius is: a corner
+				    set to 0 is a real value that truthiness throws away. */}
+				{'' !== previewRadiusTop
 					? `.kadence-column-${uniqueID} > .kadence-inner-column-inner:before { border-top-left-radius:${
 							previewRadiusTop + (borderRadiusUnit ? borderRadiusUnit : 'px')
 						}; }`
 					: ''}
-				{previewRadiusRight
+				{'' !== previewRadiusRight
 					? `.kadence-column-${uniqueID} > .kadence-inner-column-inner:before { border-top-right-radius:${
 							previewRadiusRight + (borderRadiusUnit ? borderRadiusUnit : 'px')
 						}; }`
 					: ''}
-				{previewRadiusBottom
+				{'' !== previewRadiusBottom
 					? `.kadence-column-${uniqueID} > .kadence-inner-column-inner:before { border-bottom-right-radius:${
 							previewRadiusBottom + (borderRadiusUnit ? borderRadiusUnit : 'px')
 						}; }`
 					: ''}
-				{previewRadiusLeft
+				{'' !== previewRadiusLeft
 					? `.kadence-column-${uniqueID} > .kadence-inner-column-inner:before { border-bottom-left-radius:${
 							previewRadiusLeft + (borderRadiusUnit ? borderRadiusUnit : 'px')
 						}; }`
@@ -3657,18 +3659,27 @@ function SectionEdit(props) {
 					borderRight: previewBorderRightStyle ? previewBorderRightStyle : undefined,
 					borderBottom: previewBorderBottomStyle ? previewBorderBottomStyle : undefined,
 					borderLeft: previewBorderLeftStyle ? previewBorderLeftStyle : undefined,
-					borderTopLeftRadius: previewRadiusTop
-						? previewRadiusTop + (borderRadiusUnit ? borderRadiusUnit : 'px')
-						: undefined,
-					borderTopRightRadius: previewRadiusRight
-						? previewRadiusRight + (borderRadiusUnit ? borderRadiusUnit : 'px')
-						: undefined,
-					borderBottomRightRadius: previewRadiusBottom
-						? previewRadiusBottom + (borderRadiusUnit ? borderRadiusUnit : 'px')
-						: undefined,
-					borderBottomLeftRadius: previewRadiusLeft
-						? previewRadiusLeft + (borderRadiusUnit ? borderRadiusUnit : 'px')
-						: undefined,
+					// Tested against '' rather than truthiness, the way the Advanced Image does it: a corner
+					// set to 0 is a real value, and both `0` and `'0'` are falsy. Skipping the declaration
+					// for them left the block-default rule -- which carries the selected preset's radius --
+					// as the only `border-radius` on the element, so a block squared off at 0 still drew
+					// the preset's corners.
+					borderTopLeftRadius:
+						'' !== previewRadiusTop
+							? previewRadiusTop + (borderRadiusUnit ? borderRadiusUnit : 'px')
+							: undefined,
+					borderTopRightRadius:
+						'' !== previewRadiusRight
+							? previewRadiusRight + (borderRadiusUnit ? borderRadiusUnit : 'px')
+							: undefined,
+					borderBottomRightRadius:
+						'' !== previewRadiusBottom
+							? previewRadiusBottom + (borderRadiusUnit ? borderRadiusUnit : 'px')
+							: undefined,
+					borderBottomLeftRadius:
+						'' !== previewRadiusLeft
+							? previewRadiusLeft + (borderRadiusUnit ? borderRadiusUnit : 'px')
+							: undefined,
 					boxShadow:
 						undefined !== displayShadow &&
 						displayShadow &&

--- a/src/blocks/column/edit.js
+++ b/src/blocks/column/edit.js
@@ -1060,7 +1060,7 @@ function SectionEdit(props) {
 		maxWidth && maxWidth[2] ? maxWidth[2] : ''
 	);
 
-	// Check for falsey to support how units worked before
+	// Check for falsy to support how units worked before
 	const previewMaxWidthUnit = getPreviewSize(
 		previewDevice,
 		maxWidthUnit ? maxWidthUnit : 'px',

--- a/src/blocks/rowlayout/row-background.js
+++ b/src/blocks/rowlayout/row-background.js
@@ -1,3 +1,4 @@
+// cspell:ignore blackonlight outlineblack outlinewhite arrowstyle playsinline
 /**
  * BLOCK Section: Kadence Row / Layout Background
  */

--- a/src/blocks/rowlayout/row-background.js
+++ b/src/blocks/rowlayout/row-background.js
@@ -485,18 +485,22 @@ function RowBackground({ attributes, previewDevice, backgroundClasses, children,
 			borderRight: previewBorderRightStyle ? previewBorderRightStyle : undefined,
 			borderBottom: previewBorderBottomStyle ? previewBorderBottomStyle : undefined,
 			borderLeft: previewBorderLeftStyle ? previewBorderLeftStyle : undefined,
-			borderTopLeftRadius: previewRadiusTop
-				? previewRadiusTop + (borderRadiusUnit ? borderRadiusUnit : 'px')
-				: undefined,
-			borderTopRightRadius: previewRadiusRight
-				? previewRadiusRight + (borderRadiusUnit ? borderRadiusUnit : 'px')
-				: undefined,
-			borderBottomRightRadius: previewRadiusBottom
-				? previewRadiusBottom + (borderRadiusUnit ? borderRadiusUnit : 'px')
-				: undefined,
-			borderBottomLeftRadius: previewRadiusLeft
-				? previewRadiusLeft + (borderRadiusUnit ? borderRadiusUnit : 'px')
-				: undefined,
+			// Tested against '' rather than truthiness, the way the Advanced Image does it: a corner set
+			// to 0 is a real value, and both `0` and `'0'` are falsy. Skipping the declaration for them
+			// left the row's block-default rule -- which carries the selected preset's radius -- as the
+			// only `border-radius` on the element.
+			borderTopLeftRadius:
+				'' !== previewRadiusTop ? previewRadiusTop + (borderRadiusUnit ? borderRadiusUnit : 'px') : undefined,
+			borderTopRightRadius:
+				'' !== previewRadiusRight
+					? previewRadiusRight + (borderRadiusUnit ? borderRadiusUnit : 'px')
+					: undefined,
+			borderBottomRightRadius:
+				'' !== previewRadiusBottom
+					? previewRadiusBottom + (borderRadiusUnit ? borderRadiusUnit : 'px')
+					: undefined,
+			borderBottomLeftRadius:
+				'' !== previewRadiusLeft ? previewRadiusLeft + (borderRadiusUnit ? borderRadiusUnit : 'px') : undefined,
 			minHeight: previewMinHeight ? previewMinHeight + minHeightUnit : undefined,
 			zIndex: zIndex ? zIndex : undefined,
 			boxShadow:


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout

A Section or Row squared off at 0 on every corner still drew the selected preset's radius in the editor.

The inline radius was gated on truthiness, and both `0` and `'0'` are falsy, so a deliberate zero emitted no declaration. That left the low-specificity block-default rule — which resolves the preset's radius variable — as the only `border-radius` on the element.

Both now test against `''`, which is what `getPreviewSize` returns for an unset corner and what the Advanced Image has always done. The row's background carried the same bug, and the Section's `:before` overlay rules carried it a second time.

Worth noting for review: the front end is correct today, but only by enqueue order — the instance selector and the block-default selector have identical specificity. That deserves its own ticket.

First two have no explicit Border Radius set and are inheriting from the Preset properly while the others are getting their explicitly-set Border Radius.
<img width="747" height="297" alt="image" src="https://github.com/user-attachments/assets/1ce40368-7eda-4ee7-99e1-98fbf4519f16" />

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed border-radius styling so explicit zero values are preserved.
  * Ensured zero-radius settings correctly override preset defaults for columns and row backgrounds.
  * Corrected a minor internal comment typo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
