### PR TITLE
[DTM] SOFT-4218 fixes [3/5]: alias a captured literal to the semantic its binding declares

### DIFF
--- a/includes/resources/Design_Tokens/Resolver/Preset_Value_Normalizer.php
+++ b/includes/resources/Design_Tokens/Resolver/Preset_Value_Normalizer.php
@@ -2,6 +2,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Resolver;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Preset_Bindings;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Layers;
@@ -18,11 +19,23 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Sentinels;
  * so a later edit to the semantic (or the primitive it points at) still cascades into the preset. A value
  * that is already an alias is left untouched, and a value with no matching semantic stays a literal.
  *
- * The match is deterministic: candidates are the semantic-layer entries of the library's resolved token map, in
- * document order; when several share a value the one whose id best matches the property's role wins (e.g.
- * `button-bg` prefers a semantic id containing "button" and "bg"), tie-broken by document order. Matching is
- * done PHP-side on write because the Resolver is the only authority that can guarantee the chosen alias
- * resolves, and it keeps the whole semantic value map off the editor page.
+ * The match is deterministic, and its precedence is: the semantic the property's own BINDING declares, then
+ * the candidate whose id best matches the property's role, then document order.
+ *
+ * The binding comes first because it is a statement of intent rather than a guess. Candidates are the
+ * semantic-layer entries of the library's resolved token map that share the captured value, so several
+ * unrelated semantics collide the moment they resolve alike — four of the shipped ones resolve to `0`. Role
+ * scoring alone cannot separate those: it counts how much of the property's name appears in a candidate id,
+ * and a preset property is named in camelCase (`borderRadius`) while ids are kebab-case, so before this every
+ * candidate scored zero and document order decided. A heading's corner radius of `0` was stored as
+ * `{semantic.spacing.media-padding}` — it rendered correctly, because the wrong token resolved to the same
+ * literal, and would have drifted the moment that token was edited.
+ *
+ * A binding that declares no token still falls through to scoring: eight shipped bindings name only a slot or
+ * a CSS variable, and requiring a declared token would freeze every one of their captures as a literal.
+ *
+ * Matching is done PHP-side on write because the Resolver is the only authority that can guarantee the chosen
+ * alias resolves, and it keeps the whole semantic value map off the editor page.
  *
  * @since TBD
  */
@@ -50,18 +63,26 @@ final class Preset_Value_Normalizer {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, mixed> $tokens The preset's property => alias-or-literal token map.
-	 * @param string               $slug   The token library the values are matched against.
+	 * @param array<string, mixed> $tokens   The preset's property => alias-or-literal token map.
+	 * @param string               $slug     The token library the values are matched against.
+	 * @param Preset_Bindings|null $bindings The block's bindings, so a property can prefer the semantic it
+	 *                                       declares. Null when the caller has no block in hand, which
+	 *                                       falls back to role scoring alone.
 	 *
 	 * @return array<string, mixed> The token map with literals aliased where a semantic matches.
 	 */
-	public function normalize( array $tokens, string $slug ): array {
+	public function normalize( array $tokens, string $slug, ?Preset_Bindings $bindings = null ): array {
 		$index = $this->semantic_index( $slug );
 
 		$out = [];
 
 		foreach ( $tokens as $property => $value ) {
-			$out[ $property ] = $this->alias_for( (string) $property, $value, $index );
+			$out[ $property ] = $this->alias_for(
+				(string) $property,
+				$value,
+				$index,
+				$this->preferred_semantic( $bindings, (string) $property )
+			);
 		}
 
 		return $out;
@@ -77,23 +98,24 @@ final class Preset_Value_Normalizer {
 	 *
 	 * @since TBD
 	 *
-	 * @param string                  $property The property the value is set on, used to break ties.
-	 * @param mixed                   $value    The captured value (alias string, literal, or slot list).
-	 * @param array<string, string[]> $index    The normalized-value => semantic-ids map.
+	 * @param string                  $property  The property the value is set on, used to break ties.
+	 * @param mixed                   $value     The captured value (alias string, literal, or slot list).
+	 * @param array<string, string[]> $index     The normalized-value => semantic-ids map.
+	 * @param string|null             $preferred The semantic this property's binding declares, if any.
 	 *
 	 * @return mixed The alias string when matched, otherwise the original value.
 	 */
-	private function alias_for( string $property, $value, array $index ) {
+	private function alias_for( string $property, $value, array $index, ?string $preferred = null ) {
 		// A property that varies by breakpoint keeps its envelope; its base and each override are matched
 		// on their own, so a captured per-breakpoint literal re-joins the cascade like any other value.
 		if ( is_array( $value ) && array_key_exists( Sentinels::get_value_key(), $value ) ) {
 			$entry = $value;
 
-			$entry[ Sentinels::get_value_key() ] = $this->alias_for( $property, Extensions::preset_value_of( $value ), $index );
+			$entry[ Sentinels::get_value_key() ] = $this->alias_for( $property, Extensions::preset_value_of( $value ), $index, $preferred );
 
 			foreach ( Extensions::preset_responsive_of( $value ) as $breakpoint => $override ) {
 				$entry[ Extensions::get_extensions_key() ][ Extensions::get_namespace() ][ Responsive::get_responsive_key() ][ $breakpoint ] =
-					$this->alias_for( $property, $override, $index );
+					$this->alias_for( $property, $override, $index, $preferred );
 			}
 
 			return $entry;
@@ -103,7 +125,7 @@ final class Preset_Value_Normalizer {
 			$slots = [];
 
 			foreach ( $value as $key => $slot ) {
-				$slots[ $key ] = $this->alias_for( $property, $slot, $index );
+				$slots[ $key ] = $this->alias_for( $property, $slot, $index, $preferred );
 			}
 
 			return $slots;
@@ -119,7 +141,37 @@ final class Preset_Value_Normalizer {
 			return $value;
 		}
 
+		// Membership in the candidate list IS the proof that the declared semantic resolves to this exact
+		// value, so no second resolve is needed. A declaration that has drifted out of the list falls
+		// through to scoring rather than minting an alias that would not round-trip.
+		if ( $preferred !== null && in_array( $preferred, $candidates, true ) ) {
+			return Alias::wrap( $preferred );
+		}
+
 		return Alias::wrap( $this->pick( $property, $candidates ) );
+	}
+
+	/**
+	 * The semantic a property's binding declares, when it declares one.
+	 *
+	 * Only a semantic-layer token qualifies. A binding may point straight at a primitive, and aliasing a
+	 * captured value to a primitive would skip the semantic layer the cascade is built on.
+	 *
+	 * @since TBD
+	 *
+	 * @param Preset_Bindings|null $bindings The block's bindings, or null when the caller has none.
+	 * @param string               $property The property to read the declared token for.
+	 *
+	 * @return string|null The declared semantic id, or null when there is none to prefer.
+	 */
+	private function preferred_semantic( ?Preset_Bindings $bindings, string $property ): ?string {
+		$token = $bindings === null ? null : ( $bindings->binding( $property )->token ?? null );
+
+		if ( ! is_string( $token ) || strpos( $token, Layers::get_semantic() . '.' ) !== 0 ) {
+			return null;
+		}
+
+		return $token;
 	}
 
 	/**
@@ -152,13 +204,13 @@ final class Preset_Value_Normalizer {
 	 *
 	 * @since TBD
 	 *
-	 * @param string   $property   The property the value is set on, e.g. "button-bg".
+	 * @param string   $property   The property the value is set on, e.g. "button-bg" or "borderRadius".
 	 * @param string[] $candidates The semantic ids sharing the value, in document order.
 	 *
 	 * @return string
 	 */
 	private function pick( string $property, array $candidates ): string {
-		$parts = array_filter( explode( '-', $property ) );
+		$parts = $this->role_parts( $property );
 		$best  = $candidates[0];
 		$score = $this->score( $best, $parts );
 
@@ -175,20 +227,41 @@ final class Preset_Value_Normalizer {
 	}
 
 	/**
-	 * How many of the property's role parts appear in a semantic id.
+	 * Split a property name into the role words a semantic id can be scored against.
+	 *
+	 * Two naming conventions meet here. A binding property is named either kebab-case (`button-bg`) or
+	 * camelCase (`borderRadius`), while every token id is kebab-case. Splitting on hyphens alone left a
+	 * camelCase property as a single run of characters that appears in no id, so every candidate scored
+	 * zero and the tie-break fell through to document order.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $property The property name.
+	 *
+	 * @return string[] The lowercased role words.
+	 */
+	private function role_parts( string $property ): array {
+		$hyphenated = preg_replace( '/(?<=[a-z0-9])(?=[A-Z])/', '-', $property ) ?? $property;
+
+		return array_values( array_filter( explode( '-', strtolower( $hyphenated ) ) ) );
+	}
+
+	/**
+	 * How many of the property's role words appear in a semantic id.
 	 *
 	 * @since TBD
 	 *
 	 * @param string   $id    The semantic id.
-	 * @param string[] $parts The property's hyphen-separated role parts.
+	 * @param string[] $parts The property's role words, lowercased.
 	 *
 	 * @return int
 	 */
 	private function score( string $id, array $parts ): int {
-		$score = 0;
+		$score    = 0;
+		$haystack = strtolower( $id );
 
 		foreach ( $parts as $part ) {
-			if ( $part !== '' && strpos( $id, $part ) !== false ) {
+			if ( $part !== '' && strpos( $haystack, $part ) !== false ) {
 				++$score;
 			}
 		}

--- a/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
@@ -553,7 +553,7 @@ final class Presets_Controller extends Controller {
 			return $error;
 		}
 
-		$block_node = $this->normalize_block_node( $block_node, $slug );
+		$block_node = $this->normalize_block_node( $block_node, $block, $slug );
 		$stored     = $this->stored_document( $slug );
 
 		// The token map replaces wholesale rather than merging property by property: the client
@@ -637,7 +637,7 @@ final class Presets_Controller extends Controller {
 			return $error;
 		}
 
-		$block_node = $this->normalize_block_node( $block_node, $slug );
+		$block_node = $this->normalize_block_node( $block_node, $block, $slug );
 
 		// Replace, not merge: drop the stored block node first so a preset the body omits does not survive.
 		$stored    = $this->unset_block( $this->stored_document( $slug ), $block );
@@ -1554,15 +1554,21 @@ final class Presets_Controller extends Controller {
 	 * library, so a value captured off a block instance re-joins the theming cascade rather than freezing
 	 * as a literal.
 	 *
+	 * The block's bindings are handed over so a property can prefer the semantic it already declares over
+	 * any other that happens to resolve to the same literal. Several unrelated semantics collide whenever
+	 * they resolve alike, and without the declaration the tie-break has only the property's name to go on.
+	 *
 	 * @since TBD
 	 *
 	 * @param array<string, mixed> $block_node The block's preset node from the request.
+	 * @param string               $block      The block name, for reading its declared bindings.
 	 * @param string               $slug       The token library the values are matched against.
 	 *
 	 * @return array<string, mixed> The preset node with literals aliased where a semantic matches.
 	 */
-	private function normalize_block_node( array $block_node, string $slug ): array {
+	private function normalize_block_node( array $block_node, string $block, string $slug ): array {
 		$tokens_key = Extensions::get_tokens_key();
+		$bindings   = $this->registry->for_block( $block );
 
 		foreach ( $block_node as $preset_slug => $preset ) {
 			// $default and any other "$"-prefixed metadata key carries no token map to normalize.
@@ -1574,7 +1580,7 @@ final class Presets_Controller extends Controller {
 				continue;
 			}
 
-			$preset[ $tokens_key ]      = $this->normalizer->normalize( $preset[ $tokens_key ], $slug );
+			$preset[ $tokens_key ]      = $this->normalizer->normalize( $preset[ $tokens_key ], $slug, $bindings );
 			$block_node[ $preset_slug ] = $preset;
 		}
 

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_Value_NormalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_Value_NormalizerTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\wpunit\Resources\Design_Tokens\Resolver;
 
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Preset_Value_Normalizer;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
@@ -27,6 +29,11 @@ final class Preset_Value_NormalizerTest extends TestCase {
 	private Token_Resolver $resolver;
 
 	/**
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
 	 * @return void
 	 */
 	protected function setUp(): void {
@@ -34,6 +41,7 @@ final class Preset_Value_NormalizerTest extends TestCase {
 
 		$this->normalizer = $this->container->get( Preset_Value_Normalizer::class );
 		$this->resolver   = $this->container->get( Token_Resolver::class );
+		$this->registry   = $this->container->get( Token_Registry::class );
 	}
 
 	/**
@@ -173,6 +181,128 @@ final class Preset_Value_NormalizerTest extends TestCase {
 			'hover',
 			Alias::path_of( $result['button-text-hover'] ),
 			'The hover property should prefer a hover-role semantic.'
+		);
+	}
+
+	/**
+	 * A property whose binding declares a semantic aliases to that one, even when several unrelated
+	 * semantics resolve to the same literal and would otherwise win on document order.
+	 *
+	 * @dataProvider declaredSemanticProvider
+	 *
+	 * @param string $block    The block whose bindings declare the property.
+	 * @param string $property The preset property being written.
+	 * @param string $value    The captured literal.
+	 * @param string $expected The semantic id the binding declares.
+	 *
+	 * @return void
+	 */
+	public function testItPrefersTheSemanticTheBindingDeclares( string $block, string $property, string $value, string $expected ): void {
+		$result = $this->normalizer->normalize( [ $property => $value ], self::SET, $this->registry->for_block( $block ) );
+
+		$this->assertSame( $expected, Alias::path_of( $result[ $property ] ) );
+		$this->assertSame(
+			$value,
+			$this->resolver->resolve( self::SET )->value( $expected ),
+			'The declared semantic must resolve back to the captured value.'
+		);
+	}
+
+	/**
+	 * The bindings that collide with an unrelated semantic on a shared literal.
+	 *
+	 * @return Generator
+	 */
+	public function declaredSemanticProvider(): Generator {
+		yield 'heading radius' => [
+			'block'    => 'kadence/advancedheading',
+			'property' => 'borderRadius',
+			'value'    => '0',
+			'expected' => 'semantic.radius.heading',
+		];
+
+		yield 'heading padding' => [
+			'block'    => 'kadence/advancedheading',
+			'property' => 'padding',
+			'value'    => '0',
+			'expected' => 'semantic.spacing.heading-padding',
+		];
+
+		yield 'heading letter spacing' => [
+			'block'    => 'kadence/advancedheading',
+			'property' => 'letterSpacing',
+			'value'    => '0',
+			'expected' => 'semantic.letter-spacing.heading',
+		];
+
+		yield 'heading text transform' => [
+			'block'    => 'kadence/advancedheading',
+			'property' => 'textTransform',
+			'value'    => 'none',
+			'expected' => 'semantic.text-transform.heading',
+		];
+
+		yield 'column background' => [
+			'block'    => 'kadence/column',
+			'property' => 'background',
+			'value'    => 'transparent',
+			'expected' => 'semantic.color.column-bg',
+		];
+
+		yield 'image radius' => [
+			'block'    => 'kadence/image',
+			'property' => 'borderRadius',
+			'value'    => '0',
+			'expected' => 'semantic.radius.media',
+		];
+	}
+
+	/**
+	 * A per-corner value takes the declared semantic in every slot, so an unlinked radius is aliased the
+	 * same way a linked one is rather than falling back to document order corner by corner.
+	 *
+	 * @return void
+	 */
+	public function testItPrefersTheDeclaredSemanticForEachSlotOfAPerCornerValue(): void {
+		$bindings = $this->registry->for_block( 'kadence/advancedheading' );
+		$result   = $this->normalizer->normalize( [ 'borderRadius' => [ '0', '0', '0', '0' ] ], self::SET, $bindings );
+
+		foreach ( $result['borderRadius'] as $slot ) {
+			$this->assertSame( 'semantic.radius.heading', Alias::path_of( $slot ) );
+		}
+	}
+
+	/**
+	 * A property whose binding declares no token still aliases by role scoring, so the seven Button
+	 * bindings that name only a slot or a CSS variable keep the behavior they have always had.
+	 *
+	 * @return void
+	 */
+	public function testItFallsBackToRoleScoringForAPropertyWithNoDeclaredToken(): void {
+		$bindings = $this->registry->for_block( 'kadence/singlebtn' );
+		$result   = $this->normalizer->normalize( [ 'button-bg' => '#3633e1' ], self::SET, $bindings );
+
+		$this->assertTrue( Alias::is_alias( $result['button-bg'] ) );
+		$this->assertSame(
+			'#3633e1',
+			$this->resolver->resolve( self::SET )->value( Alias::path_of( $result['button-bg'] ) )
+		);
+	}
+
+	/**
+	 * Role scoring splits a camelCase property into words, so a property named the way a preset names one
+	 * can score against a kebab-case token id at all. Called with no bindings, which is the only way to
+	 * exercise scoring for a property whose binding would otherwise short-circuit it.
+	 *
+	 * @return void
+	 */
+	public function testItSplitsACamelCasePropertyIntoRoleParts(): void {
+		$result = $this->normalizer->normalize( [ 'fontSize' => '2rem' ], self::SET );
+
+		$this->assertStringContainsString(
+			'font-size',
+			Alias::path_of( $result['fontSize'] ),
+			'A camelCase property should score against the matching kebab-case role.'
 		);
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
@@ -24,6 +24,8 @@ final class PresetsControllerTest extends TestCase {
 
 	private const BUTTON = 'kadence/singlebtn';
 
+	private const HEADING = 'kadence/advancedheading';
+
 	/**
 	 * @var Token_Store
 	 */
@@ -1082,6 +1084,64 @@ final class PresetsControllerTest extends TestCase {
 
 		$this->assertTrue( Alias::is_alias( $tokens['button-bg'] ) );
 		$this->assertSame( 'rgba(1,2,3,0.42)', $tokens['button-text'] );
+	}
+
+	/**
+	 * A captured literal aliases to the semantic the property's own binding declares, not merely to some
+	 * semantic that happens to resolve to the same literal. Four shipped semantics resolve to "0", so a
+	 * heading radius written as 0 would otherwise be stored as an unrelated spacing token.
+	 *
+	 * @return void
+	 */
+	public function testCreateAliasesToTheSemanticTheBindingDeclares(): void {
+		$response = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::HEADING,
+				[
+					'preset' => 'accent',
+					'tokens' => [ 'borderRadius' => '0' ],
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+
+		$this->assertSame(
+			'semantic.radius.heading',
+			Alias::path_of( $response->get_data()['presets']['accent']['tokens']['borderRadius'] )
+		);
+	}
+
+	/**
+	 * The write response carries the same normalized token map a later read returns. The Style Library
+	 * seeds its draft from this payload after a save, so a divergence here would leave the panel
+	 * permanently dirty.
+	 *
+	 * @return void
+	 */
+	public function testCreateResponseCarriesTheNormalizedTokens(): void {
+		$written = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::HEADING,
+				[
+					'preset' => 'accent',
+					'tokens' => [ 'borderRadius' => '0' ],
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $written );
+
+		$read = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, self::HEADING ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $read );
+		$this->assertSame(
+			$written->get_data()['presets']['accent']['tokens'],
+			$read->get_data()['presets']['accent']['tokens'],
+			'A write response must match what a later read returns.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout

Writing a preset rewrote each captured literal into a semantic alias, and picked the wrong semantic for 11 of the 27 token-declaring bindings.

Candidates are every semantic resolving to the captured value, so unrelated tokens collide whenever they resolve alike — four shipped semantics resolve to `0`. The tie-break scored how much of the property's name appeared in a candidate id, but a preset property is named in camelCase while ids are kebab-case, so every candidate scored zero and document order decided. A heading's corner radius of `0` was stored as `{semantic.spacing.media-padding}`.

It rendered correctly, because the wrong token resolved to the same literal, and would have drifted the moment that token was edited.

The property's own binding now wins when it declares a semantic. Scoring stays as the fallback and now splits camelCase, because eight bindings declare no token at all.

Presets already stored with a wrong alias are not rewritten; that needs a repair pass of its own.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preset values now select the semantic token declared for each block and property.
  * Responsive and per-corner values preserve the appropriate semantic aliases.
  * Improved matching for camelCase property names.

* **Bug Fixes**
  * Preset creation and replacement now return consistent, correctly normalized token values.
  * Values without a declared semantic token continue to use role-based matching as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
