### PR TITLE
[DTM] SOFT-4218 fixes [4/5]: seed a saved preset panel from what the server stored

### DIFF
--- a/src/style-library/__tests__/preset-flows.test.js
+++ b/src/style-library/__tests__/preset-flows.test.js
@@ -145,6 +145,57 @@ describe('savePresetFlow', () => {
 		expect(refreshFeed).not.toHaveBeenCalled();
 	});
 
+	/**
+	 * The write already answers with what it stored, normalized. Carrying that back is what lets the
+	 * panel seed from the truth rather than guess at the server's rewrites, so it must survive the
+	 * feed refresh and the busy flag rather than being swallowed by either.
+	 */
+	it('resolves with the write response, after the feed refresh', async () => {
+		const response = { presets: { primary: { tokens: { 'button-bg': '{semantic.color.action-primary}' } } } };
+		const order = [];
+
+		client.saveBlockPreset.mockImplementation(() => {
+			order.push('write');
+
+			return Promise.resolve(response);
+		});
+
+		const refreshFeed = jest.fn().mockImplementation(() => {
+			order.push('refresh');
+
+			return Promise.resolve({});
+		});
+
+		const onBusy = jest.fn().mockImplementation((busy) => order.push(`busy:${busy}`));
+
+		const result = await savePresetFlow({
+			...baseArgs,
+			draft: { label: 'Accent', tokens: { 'button-bg': '#3633e1' } },
+			initialValues: { label: 'Primary', tokens: { 'button-bg': 'semantic.color.action-primary' } },
+			refreshFeed,
+			onBusy,
+			onError: jest.fn(),
+		});
+
+		expect(result).toBe(response);
+		expect(order).toEqual(['busy:true', 'write', 'refresh', 'busy:false']);
+	});
+
+	it('resolves with null when the unchanged draft skipped the write', async () => {
+		const draft = { label: 'Primary', tokens: { 'button-bg': 'semantic.color.action-primary' } };
+
+		const result = await savePresetFlow({
+			...baseArgs,
+			draft,
+			initialValues: { ...draft },
+			refreshFeed: jest.fn(),
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(result).toBeNull();
+	});
+
 	it('posts the label and all five wrapped tokens when the draft is dirty, and refreshes the feed', async () => {
 		client.saveBlockPreset.mockResolvedValue({});
 		const refreshFeed = jest.fn().mockResolvedValue({});

--- a/src/style-library/__tests__/preset-sidebar.test.js
+++ b/src/style-library/__tests__/preset-sidebar.test.js
@@ -144,6 +144,59 @@ describe('PresetSidebar write flows notify success', () => {
 	});
 
 	/**
+	 * A save is not a round trip: the server rewrites a captured literal into the semantic alias that
+	 * carries it, so what comes back is equivalent without being equal. Seeding the draft from that
+	 * response is the only thing that lets the panel go clean — before it, Save stayed enabled and
+	 * navigating away raised the unsaved-changes guard over a preset with nothing left to save.
+	 *
+	 * @return {void}
+	 */
+	it('goes clean after a save whose response normalized what was sent', async () => {
+		const stored = { label: 'Renamed', tokens: { fontWeight: 'semantic.font-weight.heading' } };
+		// The feed refresh is awaited inside the save flow, so by the time `savePreset` resolves, the
+		// values the panel compares against are already the stored ones. Modelled here so the draft and
+		// `initialValues` meet on the SERVER's shape rather than on what was typed.
+		let persisted = { label: 'Primary' };
+		const savePreset = jest.fn().mockImplementation(() => {
+			persisted = stored;
+
+			return Promise.resolve(stored);
+		});
+
+		const screen = {
+			payload: { presets: { primary: { label: 'Primary' } } },
+			isLoading: false,
+			loadError: null,
+			initialValuesFor: () => persisted,
+			savePreset,
+			deletePreset: jest.fn(),
+			isDeletable: () => true,
+			isBusy: false,
+			saveError: null,
+			deleteError: null,
+			clearSaveError: jest.fn(),
+			clearDeleteError: jest.fn(),
+		};
+
+		renderPresetSidebar(screen, 'primary');
+
+		makeDirty();
+
+		expect(findButton('Save').disabled).toBe(false);
+
+		await act(async () => {
+			findButton('Save').click();
+		});
+
+		// Re-rendered rather than remounted, which is what the store update does in the app: the panel
+		// keeps its draft and receives the refreshed values as a prop.
+		renderPresetSidebar(screen, 'primary');
+
+		// The draft now holds what the server stored, so the panel has nothing left to save.
+		expect(findButton('Save').disabled).toBe(true);
+	});
+
+	/**
 	 * A failed save must not fire the success Snackbar — the existing `saveError` handling still
 	 * owns error feedback for this flow.
 	 *

--- a/src/style-library/__tests__/use-settings-panel.test.js
+++ b/src/style-library/__tests__/use-settings-panel.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { computeIsDirty, resolveDraftSeed } from '../hooks/use-settings-panel';
+import { computeIsDirty, resolveDraftSeed, resolveSavedSeed } from '../hooks/use-settings-panel';
 
 describe('resolveDraftSeed', () => {
 	it('does not seed while the caller has no values yet (initialValues null)', () => {
@@ -98,5 +98,36 @@ describe('computeIsDirty', () => {
 	it('treats a missing initialValues as an empty object, matching an empty draft', () => {
 		expect(computeIsDirty({}, null)).toBe(false);
 		expect(computeIsDirty({ label: 'Main 1' }, null)).toBe(true);
+	});
+});
+
+describe('resolveSavedSeed', () => {
+	/**
+	 * The whole point: a write is not a round trip, so the panel has to be told what was actually
+	 * stored before its dirty check can ever come out clean.
+	 */
+	it('takes what the server stored when the draft has not moved since the write', () => {
+		const submitted = { label: 'Title', tokens: { fontWeight: '400' } };
+		const saved = { label: 'Title', tokens: { fontWeight: 'semantic.font-weight.heading' } };
+
+		expect(resolveSavedSeed({ ...submitted }, submitted, saved)).toBe(saved);
+	});
+
+	/**
+	 * An edit made while the write was in flight is the user's, and keeping it means the panel stays
+	 * honestly dirty. Returned by reference so React bails out of the re-render.
+	 */
+	it('keeps the current draft, by reference, when it moved during the write', () => {
+		const submitted = { label: 'Title', tokens: { fontWeight: '400' } };
+		const current = { label: 'Title', tokens: { fontWeight: '700' } };
+		const saved = { label: 'Title', tokens: { fontWeight: 'semantic.font-weight.heading' } };
+
+		expect(resolveSavedSeed(current, submitted, saved)).toBe(current);
+	});
+
+	it('keeps the current draft when there was nothing to save', () => {
+		const current = { label: 'Title', tokens: {} };
+
+		expect(resolveSavedSeed(current, current, null)).toBe(current);
 	});
 });

--- a/src/style-library/components/molecules/fields/SelectField.js
+++ b/src/style-library/components/molecules/fields/SelectField.js
@@ -15,10 +15,19 @@ import { FieldLabel } from './FieldLabel';
 /**
  * Render a select field.
  *
- * @param {Object}   props          The component props.
- * @param {Object}   props.field    The field definition ({ label, options, readOnly }).
- * @param {string}   props.value    The current value.
- * @param {Function} props.onChange Called with the new value on edit; never called when read-only.
+ * A select speaks LITERALS — its options are keywords like `700` or `uppercase` — while storage may
+ * hand back a token id for the same property, because a written literal is stored as the semantic alias
+ * that carries it. A select handed `semantic.font-weight.heading` matches no option and renders blank,
+ * so a stored id is displayed as the literal it resolves to. Only the display is translated: an edit
+ * still writes the keyword, and storage is free to alias it again on the next save.
+ *
+ * @param {Object}   props           The component props.
+ * @param {Object}   props.field     The field definition ({ label, options, readOnly, values }).
+ * @param {?Object}  [props.field.values] The library's resolved id => literal map, when the schema has
+ *                                        one to give. Absent for a select whose values are never token
+ *                                        ids, which then behaves exactly as before.
+ * @param {string}   props.value     The current value: a literal, or a token id storage aliased it to.
+ * @param {Function} props.onChange  Called with the new value on edit; never called when read-only.
  *
  * @since TBD
  *
@@ -30,7 +39,7 @@ export function SelectField({ field, value, onChange }) {
 			<FieldLabel>{field.label}</FieldLabel>
 			<SelectControl
 				__next40pxDefaultSize
-				value={value}
+				value={field.values?.[value] ?? value}
 				options={field.options || []}
 				disabled={field.readOnly}
 				onChange={(next) => !field.readOnly && onChange(next)}

--- a/src/style-library/components/pages/PresetSidebar.js
+++ b/src/style-library/components/pages/PresetSidebar.js
@@ -108,9 +108,20 @@ function PresetSidebarBody({ navigate, route, screen, initialValues, presetLabel
 	// over the current `panel.draft`, so storing them in state would either loop the publish effect
 	// above or hand the guard modal a stale draft. `save` is the raw promise, rejection intact — the
 	// modal's own Save button is the one place that needs to see a failure.
+	// Seeds the draft from what the write actually stored. A save is not a round trip — the server
+	// rewrites a captured literal into the semantic alias carrying it — so without this the draft never
+	// equals the values it is compared against and the panel stays dirty forever, guarding a navigation
+	// that has nothing left to lose. Reassigned every render for the same reason the actions below are:
+	// memoizing would capture a stale draft, and `submitted` has to be the draft the write was given.
+	const runSave = () => {
+		const submitted = panel.draft;
+
+		return screen.savePreset(id, submitted, initialValues).then((saved) => panel.reseedDraft(submitted, saved));
+	};
+
 	if (channel) {
 		channel.actionsRef.current = {
-			save: () => screen.savePreset(id, panel.draft, initialValues),
+			save: runSave,
 			discard: panel.resetDraft,
 		};
 	}
@@ -125,8 +136,7 @@ function PresetSidebarBody({ navigate, route, screen, initialValues, presetLabel
 		}
 
 		setPendingAction('save');
-		screen
-			.savePreset(id, panel.draft, initialValues)
+		runSave()
 			.then(() => notifySuccess(__('Preset saved.', 'kadence-blocks')))
 			.catch(() => {})
 			.finally(() => setPendingAction(null));

--- a/src/style-library/helpers/preset-flows.js
+++ b/src/style-library/helpers/preset-flows.js
@@ -115,15 +115,13 @@ export function createPresetFlow({
  * @param {Function} args.refreshFeed Replaces the feed with a fresh REST read for a slug.
  * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
  * @param {Function} args.onError     Called with `{ message }` on failure.
- * @param {Function} args.onVersion   Called with the version the write returned, before the feed
- *                                      refresh, so a caller serializing drops can hand the next
- *                                      one a current version without waiting for a re-read.
  *
  * @since TBD
  *
- * @return {Promise<void>} Resolves once an unchanged draft is skipped, or the write and feed
- *                          refresh complete; rejects on failure, after `onError`/`onBusy` have
- *                          already run.
+ * @return {Promise<?Object>} Resolves with the preset payload the write returned — the same shape a
+ *                             read returns, carrying the server's normalized tokens — or null when an
+ *                             unchanged draft was skipped. Rejects on failure, after `onError`/`onBusy`
+ *                             have already run.
  */
 export function savePresetFlow({
 	namespace,
@@ -138,25 +136,33 @@ export function savePresetFlow({
 	onError,
 }) {
 	if (isEqual(draft, initialValues)) {
-		return Promise.resolve();
+		return Promise.resolve(null);
 	}
 
 	onBusy(true);
 
-	return saveBlockPreset(
-		namespace,
-		block,
-		{ preset, label: draft.label, tokens: presetSaveTokens(draft.tokens, initialValues?.tokens, storedTokens) },
-		slug
-	)
-		.then(() => refreshFeed(slug))
-		.then(() => onBusy(false))
-		.catch((err) => {
-			onError({ message: errorMessage(err) });
-			onBusy(false);
+	return (
+		saveBlockPreset(
+			namespace,
+			block,
+			{ preset, label: draft.label, tokens: presetSaveTokens(draft.tokens, initialValues?.tokens, storedTokens) },
+			slug
+		)
+			// The write already answers with what it stored, normalized. Carrying it past the refresh is what
+			// lets the panel seed from the truth instead of guessing at the server's rewrites.
+			.then((response) => refreshFeed(slug).then(() => response))
+			.then((response) => {
+				onBusy(false);
 
-			throw err;
-		});
+				return response;
+			})
+			.catch((err) => {
+				onError({ message: errorMessage(err) });
+				onBusy(false);
+
+				throw err;
+			})
+	);
 }
 
 /**

--- a/src/style-library/hooks/use-preset-screen.js
+++ b/src/style-library/hooks/use-preset-screen.js
@@ -40,6 +40,9 @@ import { STORE_NAME } from '../store';
  *
  * @since TBD
  *
+ * `savePreset` resolves with the saved preset in the panel's own seed shape — what the server actually
+ * stored, not what was sent — or null when an unchanged draft was skipped.
+ *
  * @return {{feed: ?object, payload: ?object, isLoading: boolean, loadError: ?Error, rows: Array<Object>, initialValuesFor: Function, isBusy: boolean, addError: ?Object, saveError: ?Object, deleteError: ?Object, orderError: ?Object, clearAddError: Function, clearSaveError: Function, clearDeleteError: Function, clearOrderError: Function, addPreset: Function, savePreset: Function, deletePreset: Function, reorderPresets: Function, isDeletable: Function}}
  */
 export function usePresetScreen(library, preset) {
@@ -183,9 +186,12 @@ export function usePresetScreen(library, preset) {
 				refreshFeed,
 				onBusy: setIsBusy,
 				onError: setSaveError,
-			});
+				// Shaped into the panel's seed here rather than in the sidebar, which knows nothing about
+				// any one block. Read inside the callback because `preset.properties` is a live getter
+				// that throws when the feed has not arrived.
+			}).then((response) => (response ? presetInitialValues(response, id, preset.properties) : null));
 		},
-		[namespace, block, presets.payload, slug, refreshFeed]
+		[namespace, block, preset, presets.payload, slug, refreshFeed]
 	);
 
 	const deletePreset = useCallback(

--- a/src/style-library/hooks/use-settings-panel.js
+++ b/src/style-library/hooks/use-settings-panel.js
@@ -32,6 +32,10 @@ import { isEqual, setValueAtPath } from '../helpers/settings-schema';
  * ends in `refreshFeed`, which changes that identity while the user may be mid-edit on a sibling
  * instance of this hook.
  *
+ * That rule governs seeding driven by `initialValues` ARRIVING. It is not the only way the draft can be
+ * replaced: `reseedDraft` seeds from a settled write, on a caller that knows one just happened, and
+ * leaves the tracking value alone precisely so this guarantee still holds for a sibling panel.
+ *
  * Pure so the seeding rule is testable without rendering a component — `useSettingsPanel` is a thin
  * `useEffect` wrapper around this.
  *
@@ -74,6 +78,35 @@ export function computeIsDirty(draft, initialValues) {
 }
 
 /**
+ * The draft to hold after a write settles: what the server actually stored, unless the user has edited
+ * since the request went out.
+ *
+ * A write is not a round trip. The server rewrites a captured literal into the semantic alias that
+ * carries it, so what comes back is equivalent to what was sent without being equal to it — and the
+ * panel's dirty flag is a deep equality test. Seeding from the response is what lets a saved panel go
+ * clean; nothing else can, because the two values never converge on their own.
+ *
+ * A draft that moved while the request was in flight is kept untouched, and kept BY REFERENCE so React
+ * bails out of the re-render. Merging the two would produce a draft matching neither the save nor the
+ * user, and "the user typed during the save, so the panel is still dirty" is already the honest answer.
+ *
+ * @param {Object}  current   The draft as it stands now.
+ * @param {Object}  submitted The draft the write was given.
+ * @param {?Object} saved     What the server stored, or null when there was nothing to write.
+ *
+ * @since TBD
+ *
+ * @return {Object} The draft to hold.
+ */
+export function resolveSavedSeed(current, submitted, saved) {
+	if (!saved || !isEqual(current, submitted)) {
+		return current;
+	}
+
+	return saved;
+}
+
+/**
  * Read and drive the settings-panel state.
  *
  * @param {Object}   options               The options.
@@ -85,8 +118,9 @@ export function computeIsDirty(draft, initialValues) {
  *
  * @since TBD
  *
- * @return {{itemId: string, isOpen: boolean, close: Function, draft: Object, setFieldValue: Function, isDirty: boolean, resetDraft: Function}}
- *         The panel state and controls.
+ * @return {{itemId: string, isOpen: boolean, close: Function, draft: Object, setFieldValue: Function, isDirty: boolean, resetDraft: Function, reseedDraft: Function}}
+ *         The panel state and controls. `reseedDraft(submitted, saved)` re-seeds from a settled write —
+ *         see `resolveSavedSeed`.
  */
 export function useSettingsPanel({ route, navigate, initialValues }) {
 	const itemId = route.item;
@@ -110,7 +144,12 @@ export function useSettingsPanel({ route, navigate, initialValues }) {
 	const close = () => navigate({ item: '' });
 	const setFieldValue = (path, value) => setDraft((current) => setValueAtPath(current, path, value));
 	const resetDraft = () => setDraft(initialValues || {});
+	// Functional, so the equality check reads the live draft rather than the one this render closed
+	// over — the whole point is to detect an edit made while the write was in flight. Deliberately does
+	// not touch `seededForRef`: the one-shot seeding rule protects a SIBLING panel from a feed refresh,
+	// and this reseed is a different thing, driven by a caller that knows a write just settled.
+	const reseedDraft = (submitted, saved) => setDraft((current) => resolveSavedSeed(current, submitted, saved));
 	const isDirty = computeIsDirty(draft, initialValues);
 
-	return { itemId, isOpen: Boolean(itemId), close, draft, setFieldValue, isDirty, resetDraft };
+	return { itemId, isOpen: Boolean(itemId), close, draft, setFieldValue, isDirty, resetDraft, reseedDraft };
 }

--- a/src/style-library/presets/advancedheading-preset.js
+++ b/src/style-library/presets/advancedheading-preset.js
@@ -312,12 +312,18 @@ function schemaFor(tab, values, feed) {
 						path: 'tokens.fontWeight',
 						label: __('Weight', 'kadence-blocks'),
 						options: fontWeightOptions(family),
+						// The library's resolved map, so a value storage aliased to a token id still
+						// displays as the keyword it resolves to rather than blanking the select.
+						values: feed?.values,
 					},
 					{
 						type: 'select',
 						path: 'tokens.textTransform',
 						label: __('Transform', 'kadence-blocks'),
 						options: TEXT_TRANSFORM_OPTIONS,
+						// The library's resolved map, so a value storage aliased to a token id still
+						// displays as the keyword it resolves to rather than blanking the select.
+						values: feed?.values,
 					},
 				],
 			},
@@ -330,6 +336,9 @@ function schemaFor(tab, values, feed) {
 						path: 'tokens.borderStyle',
 						label: __('Style', 'kadence-blocks'),
 						options: BORDER_STYLE_OPTIONS,
+						// The library's resolved map, so a value storage aliased to a token id still
+						// displays as the keyword it resolves to rather than blanking the select.
+						values: feed?.values,
 					},
 					{
 						type: 'token-scalar',


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout

Saving a preset and then navigating away raised the unsaved-changes dialog over a preset with nothing left to save, and Save stayed enabled.

A write is not a round trip: the server rewrites a captured literal into the semantic alias that carries it, so what comes back is equivalent to what was sent without being EQUAL to it — and the dirty flag is a deep equality test. Nothing reseeded the draft afterwards, so the two never converged.

The response was already on the wire and thrown away. It now travels back through the save flow and seeds the draft. A draft the user moved while the request was in flight keeps its edit and stays honestly dirty.

The one-shot seeding rule is untouched — it protects a sibling panel, and this reseed is caller-driven.

A select also had to learn to display a value aliased to a token id as the keyword it resolves to, or the reseed alone would leave the panel silently clean while showing an empty Weight.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preset saves now reflect server-normalized values and automatically clear the unsaved-changes state.
  * User edits made during an in-progress save are preserved.
  * Select fields display readable values when aliases are available.

* **Bug Fixes**
  * Prevented unnecessary saves when preset drafts are unchanged.
  * Improved saved-state reconciliation after refreshing preset data.

* **Tests**
  * Added coverage for save responses, draft preservation, busy-state handling, and normalized preset values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
