### PR TITLE
[DTM] SOFT-4218 fixes [5/5]: let an image preset store a composite shadow

### DIFF
--- a/includes/resources/Design_Tokens/Resolver/Preset_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Preset_Resolver.php
@@ -7,6 +7,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Css_Var;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Exception\Unknown_Preset_Exception;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
 use KadenceWP\KadenceBlocks\Utils\Cast;
 
 /**
@@ -68,16 +69,26 @@ final class Preset_Resolver {
 	private Preset_Order_Index $order_index;
 
 	/**
+	 * @var Css_Renderer Renders a composite value into the one CSS string its property takes, so a stored
+	 *                    composite and an aliased one reach output in the same form.
+	 *
+	 * @since TBD
+	 */
+	private Css_Renderer $renderer;
+
+	/**
 	 * @since TBD
 	 *
 	 * @param Effective_Presets  $presets     The per-library effective preset definitions.
 	 * @param Token_Resolver     $resolver    The token resolver.
 	 * @param Preset_Order_Index $order_index Applies the stored per-block display order to names().
+	 * @param Css_Renderer       $renderer    Renders a composite value into its CSS string.
 	 */
-	public function __construct( Effective_Presets $presets, Token_Resolver $resolver, Preset_Order_Index $order_index ) {
+	public function __construct( Effective_Presets $presets, Token_Resolver $resolver, Preset_Order_Index $order_index, Css_Renderer $renderer ) {
 		$this->presets     = $presets;
 		$this->resolver    = $resolver;
 		$this->order_index = $order_index;
+		$this->renderer    = $renderer;
 	}
 
 	/**
@@ -440,11 +451,59 @@ final class Preset_Resolver {
 			return (string) $value;
 		}
 
+		if ( Token_Type::is_composite_shape( Token_Type::get_type_shadow(), $value ) ) {
+			return $this->flatten_composite( $value, $resolved );
+		}
+
 		if ( is_array( $value ) ) {
 			return $this->flatten_slots( $value, $resolved, $keep_gaps );
 		}
 
 		return null;
+	}
+
+	/**
+	 * Flatten a composite value into the single CSS string its property takes, or null when any required
+	 * sub-field fails to flatten.
+	 *
+	 * Rendered here rather than left as a map because the aliased form of the same property already
+	 * arrives rendered — an alias resolves through Resolved_Tokens, which ran the composite through this
+	 * same renderer. A stored composite that stayed a map would make one property answer in two different
+	 * shapes depending on how it happened to be written.
+	 *
+	 * `inset` is carried across rather than flattened: it is a boolean, and flatten() answers null for a
+	 * boolean, which would drop the whole property. A shadow that saved cleanly and then rendered nothing
+	 * is the worst way for this to fail, so the flag skips the step that cannot handle it.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $value    The composite's sub-field map.
+	 * @param Resolved_Tokens      $resolved The resolved token maps.
+	 *
+	 * @return string|null The rendered CSS string, or null when the composite cannot be rendered.
+	 */
+	private function flatten_composite( array $value, Resolved_Tokens $resolved ): ?string {
+		$fields = [];
+
+		foreach ( $value as $field => $sub ) {
+			if ( $field === 'inset' ) {
+				$fields[ $field ] = $sub;
+
+				continue;
+			}
+
+			$flat = $this->flatten( $sub, $resolved );
+
+			if ( ! is_string( $flat ) || $flat === '' ) {
+				return null;
+			}
+
+			$fields[ $field ] = $flat;
+		}
+
+		$rendered = $this->renderer->render( Token_Type::get_type_shadow(), $fields );
+
+		return $rendered === '' ? null : $rendered;
 	}
 
 	/**
@@ -520,6 +579,18 @@ final class Preset_Resolver {
 	private function project( $value ): string {
 		if ( is_string( $value ) && Alias::is_alias( $value ) ) {
 			return 'var(' . Css_Var::from_id( Alias::path_of( $value ) ) . ')';
+		}
+
+		// Before the slot-list branch: that one joins VALUES in insertion order, which for a composite
+		// would emit its color first and produce a valid-looking, wrong shorthand.
+		if ( Token_Type::is_composite_shape( Token_Type::get_type_shadow(), $value ) ) {
+			$fields = [];
+
+			foreach ( $value as $field => $sub ) {
+				$fields[ $field ] = $field === 'inset' ? $sub : $this->project( $sub );
+			}
+
+			return $this->renderer->render( Token_Type::get_type_shadow(), $fields );
 		}
 
 		if ( is_array( $value ) ) {

--- a/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
@@ -17,6 +17,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Contracts\Controller;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Dtcg_Validator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Token_Type;
 use KadenceWP\KadenceBlocks\Utils\Cast;
 use KadenceWP\KadenceBlocks\StellarWP\DB\Database\Exceptions\DatabaseQueryException;
 use WP_Error;
@@ -1342,6 +1343,16 @@ final class Presets_Controller extends Controller {
 					continue;
 				}
 
+				if ( $bindings->kind( (string) $property ) === Preset_Bindings::get_kind_shadow() ) {
+					$error = $this->guard_shadow_value_shape( $entry, $block, (string) $preset_slug, (string) $property );
+
+					if ( $error instanceof WP_Error ) {
+						return $error;
+					}
+
+					continue;
+				}
+
 				// Check the base and every breakpoint override. Each is unwrapped first, so what remains is
 				// a scalar, an alias or a slot list — an array here is therefore a slot list, never the
 				// responsive envelope (which is legal on any kind).
@@ -1458,6 +1469,49 @@ final class Presets_Controller extends Controller {
 					]
 				);
 			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Reject a shadow value that is an array without being a composite shadow.
+	 *
+	 * A shadow is one of the two kinds whose value may legitimately be an object: the Style Library's
+	 * Custom tab composes `color`, the four offsets and an optional `inset` and stores that map, so the
+	 * parts stay separately editable instead of collapsing into a shorthand nothing can take apart again.
+	 * What a shadow may NOT be is a per-corner list — corners are a dimension idea, and a four-slot array
+	 * on a shadow reaches projection as something no renderer can compose.
+	 *
+	 * The generic branch this replaces rejected every array alike, so the composite the Custom tab had
+	 * just produced came back as "a per-corner value is only valid for a dimension property" — an error
+	 * about corners, for a value that never mentioned one.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed  $entry    The preset token entry.
+	 * @param string $block    The block name, for error context.
+	 * @param string $preset   The preset slug, for error context.
+	 * @param string $property The property name, for error context.
+	 *
+	 * @return WP_Error|null A WP_Error when an array value is not a composite shadow, null otherwise.
+	 */
+	private function guard_shadow_value_shape( $entry, string $block, string $preset, string $property ): ?WP_Error {
+		foreach ( $this->preset_entry_values( $entry ) as $value ) {
+			if ( ! is_array( $value ) || Token_Type::is_composite_shape( Token_Type::get_type_shadow(), $value ) ) {
+				continue;
+			}
+
+			return new WP_Error(
+				'rest_design_tokens_invalid',
+				__( 'A shadow value must be an alias, a literal, or a composite carrying color, offsetX, offsetY, blur and spread.', 'kadence-blocks' ),
+				[
+					'status'   => WP_Http::UNPROCESSABLE_ENTITY,
+					'block'    => $block,
+					'preset'   => $preset,
+					'property' => $property,
+				]
+			);
 		}
 
 		return null;

--- a/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
+++ b/includes/resources/Design_Tokens/Schema/Validation/Dtcg_Validator.php
@@ -922,10 +922,15 @@ final class Dtcg_Validator {
 	}
 
 	/**
-	 * A foundation-preset / block-preset token value must be an alias, a non-empty literal scalar, or a
-	 * per-corner slot list. The target token's $type is not resolved here, so the literal is checked only
-	 * for shape, not per-type grammar; whether a slot list is meaningful for the bound property's kind is
-	 * a registry-aware question answered by the REST write guard, not by the schema.
+	 * A foundation-preset / block-preset token value must be an alias, a non-empty literal scalar, a
+	 * per-corner slot list, a responsive envelope, or a composite shadow object. The target token's $type
+	 * is not resolved here, so the literal is checked only for shape, not per-type grammar; whether a slot
+	 * list is meaningful for the bound property's kind is a registry-aware question answered by the REST
+	 * write guard, not by the schema.
+	 *
+	 * The composite needs no $type resolution either: shadow is v1's only composite, so the shape alone
+	 * identifies it. The envelope is claimed first because a composite validator tolerates `$`-prefixed
+	 * keys, and an envelope carrying `$value` would otherwise be mistaken for one.
 	 *
 	 * @since TBD
 	 *
@@ -962,10 +967,17 @@ final class Dtcg_Validator {
 			return $this->validate_extension_envelope( $value, $path );
 		}
 
+		if ( Token_Type::is_composite_shape( Token_Type::get_type_shadow(), $value ) ) {
+			// The shadow validator already covers every sub-field: an alias or a literal of the right kind
+			// for each, a strict literal boolean for `inset`, and a named error for an unknown sub-field.
+			// It answers with a list; this contract is one error, so the first is the one to report.
+			return $this->validators[ Token_Type::get_type_shadow() ]->validate( $value, $path )[0] ?? null;
+		}
+
 		return new Validation_Error(
 			$path,
 			Validation_Error::get_code_value_invalid(),
-			'A foundation-preset/block-preset token value must be an alias, a non-empty literal, a slot list, or a responsive entry.'
+			'A foundation-preset/block-preset token value must be an alias, a non-empty literal, a slot list, a responsive entry, or a composite shadow.'
 		);
 	}
 

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Token_Type.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Token_Type.php
@@ -270,6 +270,48 @@ final class Token_Type {
 	}
 
 	/**
+	 * Whether a value is shaped like the given composite $type's object form.
+	 *
+	 * A shape test, not a validity test: it answers "which KIND of value is this" so a caller can route
+	 * to the right validator, and the validator then says whether it is well formed. The two array
+	 * shapes a preset property may carry have to be told apart before either can be checked — a
+	 * per-corner value is a four-element LIST, a composite is a MAP of named sub-fields, and a list can
+	 * never carry a `color` key.
+	 *
+	 * Required fields decide it, and unknown extra keys do not disqualify. A map carrying all five
+	 * shadow fields plus a misspelled sixth is a composite with a typo, and saying so is more use than
+	 * refusing to recognize it at all; the composite validator names the offending sub-field. A map
+	 * missing a required field is not claimed here, so it keeps the generic "not a valid value" answer
+	 * rather than being reported as a broken shadow.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $type  The composite $type to test against.
+	 * @param mixed  $value The value to test.
+	 *
+	 * @phpstan-assert-if-true array<string, mixed> $value
+	 *
+	 * @return bool
+	 */
+	public static function is_composite_shape( string $type, $value ): bool {
+		if ( ! is_array( $value ) || $value === [] || ! isset( self::COMPOSITE_FIELDS[ $type ] ) ) {
+			return false;
+		}
+
+		if ( array_keys( $value ) === range( 0, count( $value ) - 1 ) ) {
+			return false;
+		}
+
+		foreach ( array_keys( self::COMPOSITE_FIELDS[ $type ] ) as $field ) {
+			if ( ! array_key_exists( $field, $value ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
 	 * The sub-field => $type map for a composite $type, or an empty array for a non-composite type.
 	 *
 	 * @since TBD

--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -369,6 +369,27 @@ describe('presetSaveTokens', () => {
 		expect(presetSaveTokens({ 'button-radius': ['', '', '', ''] })).toEqual({});
 	});
 
+	/**
+	 * The shadow control keeps `inset: false` on a cleared value, and `false` draws no inset shadow. It
+	 * must not be what makes an otherwise-empty composite look worth saving — the server rejects an
+	 * empty composite the same way it rejects an empty literal.
+	 */
+	it('omits a composite shadow cleared down to inset:false', () => {
+		expect(
+			presetSaveTokens({
+				shadow: { color: '', offsetX: '', offsetY: '', blur: '', spread: '', inset: false },
+			})
+		).toEqual({});
+	});
+
+	it('keeps a composite shadow that still carries a sub-field', () => {
+		const result = presetSaveTokens({
+			shadow: { color: '#17171f', offsetX: '0px', offsetY: '2px', blur: '8px', spread: '0px' },
+		});
+
+		expect(result).toHaveProperty('shadow');
+	});
+
 	it('keeps a per-corner property when any slot carries a value', () => {
 		// Asserts only that the property survives the unset guard: how the slots themselves are
 		// wrapped is the aliasing helper's business, and it changes in a later slice.

--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -926,3 +926,52 @@ describe('resolveTokenValue at a breakpoint', () => {
 		expect(resolveTokenValue(values, perCorner, 'tablet')).toBe('0.5rem 0 0.5rem 0');
 	});
 });
+
+describe('resolveTokenValue with a composite shadow', () => {
+	const values = { 'primitive.color.brand.primary': '#3633e1' };
+
+	/**
+	 * The Custom tab stores a composite, and the row preview needs one string. Each sub-field resolves
+	 * on its own so an aliased color still follows a token edit.
+	 */
+	it('composes the sub-fields into one shadow string', () => {
+		const shadow = {
+			color: '{primitive.color.brand.primary}',
+			offsetX: '0px',
+			offsetY: '2px',
+			blur: '8px',
+			spread: '0px',
+		};
+
+		expect(resolveTokenValue(values, shadow)).toBe('0px 2px 8px 0px #3633e1');
+	});
+
+	it('carries inset through as a prefix rather than resolving it', () => {
+		const shadow = {
+			color: '#000000',
+			offsetX: '0px',
+			offsetY: '2px',
+			blur: '8px',
+			spread: '0px',
+			inset: true,
+		};
+
+		expect(resolveTokenValue(values, shadow)).toBe('inset 0px 2px 8px 0px #000000');
+	});
+
+	/**
+	 * All or nothing, for the same reason a slot list is: a shorthand with a hole renders something the
+	 * preset never said.
+	 */
+	it('yields an empty string when a sub-field does not resolve', () => {
+		const shadow = {
+			color: '{primitive.color.gone}',
+			offsetX: '0px',
+			offsetY: '2px',
+			blur: '8px',
+			spread: '0px',
+		};
+
+		expect(resolveTokenValue(values, shadow)).toBe('');
+	});
+});

--- a/src/style-library/helpers/presets.js
+++ b/src/style-library/helpers/presets.js
@@ -359,10 +359,19 @@ function isUnsetPresetValue(value) {
 		return value.every((slot) => slot === '' || slot === null || slot === undefined);
 	}
 
-	// A composite whose every sub-field is empty carries nothing to write either, and sending it would
-	// be rejected the same way an empty literal is.
-	if (typeof value === 'object' && value !== null) {
-		return Object.values(value).every((sub) => sub === '' || sub === null || sub === undefined);
+	// A composite whose every REQUIRED sub-field is empty carries nothing to write, and sending it would
+	// be rejected the same way an empty literal is. `inset` is judged on its own: it is optional, and
+	// only `true` says anything — a cleared shadow keeps `inset: false`, which draws no inset shadow and
+	// must not be what makes the composite look worth saving.
+	//
+	// Gated on the shape rather than on "is an object", because a responsive envelope is an object too
+	// and carries none of these fields — testing it here would read every envelope as empty and drop it.
+	if (isCompositeShadow(value)) {
+		const emptyFields = SHADOW_FIELDS.every(
+			(field) => value[field] === '' || value[field] === null || value[field] === undefined
+		);
+
+		return emptyFields && value.inset !== true;
 	}
 
 	return false;

--- a/src/style-library/helpers/presets.js
+++ b/src/style-library/helpers/presets.js
@@ -25,6 +25,7 @@ import {
 	writePresetBreakpoint,
 } from '../../token-controls/helpers/preset-envelope';
 import { nextScaleSlug } from './scale';
+import { shadowCss } from './shadow';
 import { getDesignTokensFeed } from './tokens';
 
 /**
@@ -34,6 +35,16 @@ import { getDesignTokensFeed } from './tokens';
  * @since TBD
  */
 const SLOT_LIST_SIDES = 4;
+
+/**
+ * The sub-fields every composite shadow carries, mirroring `Token_Type::COMPOSITE_FIELDS`. `inset` is
+ * optional and deliberately absent: a shadow that predates it is still a shadow.
+ *
+ * @since TBD
+ *
+ * @type {string[]}
+ */
+const SHADOW_FIELDS = ['color', 'offsetX', 'offsetY', 'blur', 'spread'];
 
 /**
  * The block name the Button preset screen edits — the single JS spelling, so the preset-screens
@@ -141,6 +152,29 @@ function isSlotList(value) {
 }
 
 /**
+ * Whether a stored token entry is a composite shadow — the map the Custom tab composes, rather than an
+ * alias or a rendered literal.
+ *
+ * Required fields decide it, matching `Token_Type::is_composite_shape()` on the server so both sides
+ * agree on which values are composites. An array is excluded outright: a per-corner list is the other
+ * array-shaped entry, and the two must never be confused.
+ *
+ * @param {*} value The stored token entry.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when `value` is a composite shadow.
+ */
+function isCompositeShadow(value) {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		!Array.isArray(value) &&
+		SHADOW_FIELDS.every((field) => field in value)
+	);
+}
+
+/**
  * Whether a stored preset token entry is one of the shapes the single-value token picker cannot
  * represent — a responsive envelope or a per-corner slot list. Both carry more than the picker's
  * one alias-or-literal slot, so editing them through it would silently flatten the value on save;
@@ -195,6 +229,20 @@ export function resolveTokenValue(values, value, breakpoint = PRESET_BREAKPOINTS
 		// than in `isSlotList`, which also decides whether the single-value picker may edit the
 		// entry — narrowing that would make a malformed slot list look editable.
 		return slots.some((slot) => slot === '') ? '' : slots.join(' ');
+	}
+
+	if (isCompositeShadow(value)) {
+		// Each sub-field resolves on its own, so an aliased color still follows a token edit, then the
+		// parts are composed into the one string a `box-shadow` takes. All or nothing for the same reason
+		// a slot list is: a shorthand with a hole in it renders something the preset never said.
+		const fields = Object.fromEntries(
+			Object.entries(value).map(([field, sub]) => [
+				field,
+				field === 'inset' ? sub : resolveTokenValue(values, sub, breakpoint),
+			])
+		);
+
+		return Object.entries(fields).some(([field, sub]) => field !== 'inset' && sub === '') ? '' : shadowCss(fields);
 	}
 
 	if (typeof value !== 'string') {
@@ -309,6 +357,12 @@ function isUnsetPresetValue(value) {
 
 	if (Array.isArray(value)) {
 		return value.every((slot) => slot === '' || slot === null || slot === undefined);
+	}
+
+	// A composite whose every sub-field is empty carries nothing to write either, and sending it would
+	// be rejected the same way an empty literal is.
+	if (typeof value === 'object' && value !== null) {
+		return Object.values(value).every((sub) => sub === '' || sub === null || sub === undefined);
 	}
 
 	return false;

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -219,7 +219,12 @@ function ShadowCustomTab({ shadow, onChange, renderColor, disabled = false }) {
  */
 export function BoxShadowControl({ value, onChange, label, tokens = [], renderColor, disabled = false }) {
 	const aliased = isTokenAlias(value);
-	const shadow = { ...DEFAULT_SHADOW, ...(aliased || !value ? {} : value) };
+	// Only a real object is spread. A shadow can also arrive as a rendered STRING — the editor's capture
+	// flow writes one — and spreading a string splays it into indexed character keys, which the Custom
+	// tab would then write back as a shadow whose sub-fields are `0`, `p`, `x`. Degrading to the default
+	// shape reads as unset, which is wrong but harmless where the alternative cannot be saved at all.
+	const custom = typeof value === 'object' && value !== null && !Array.isArray(value) ? value : {};
+	const shadow = { ...DEFAULT_SHADOW, ...(aliased ? {} : custom) };
 	// The trigger shows a label only, never a value — for either shape. Aliased still reads
 	// `fieldSummary()`'s bound-token label (dropping the `value` half it also returns, which does not
 	// fit this control's icon-plus-label trigger); a genuine composite reads bare "Custom"; unset

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Preset/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Preset/ProjectorTest.php
@@ -11,6 +11,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Preset\Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Presets;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Css_Renderer;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Preset_Resolver;
 use Tests\Support\Classes\Fake_Baseline_Document;
 use Tests\Support\Classes\TestCase;
@@ -57,7 +58,7 @@ final class ProjectorTest extends TestCase {
 			$this->container->get( Mutator::class )
 		);
 
-		$this->resolver = new Preset_Resolver( $presets, $this->container->get( Token_Resolver::class ), new Preset_Order_Index() );
+		$this->resolver = new Preset_Resolver( $presets, $this->container->get( Token_Resolver::class ), new Preset_Order_Index(), $this->container->get( Css_Renderer::class ) );
 	}
 
 	public function testItMapsThePresetValuesOntoTheBoundBlockAttributes(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
@@ -633,6 +633,122 @@ final class Preset_ResolverTest extends TestCase {
 	}
 
 	/**
+	 * A composite shadow flattens to the one string its property takes. The aliased form of the same
+	 * property already arrives rendered, so a stored composite has to match rather than answering in a
+	 * second shape.
+	 *
+	 * @return void
+	 */
+	public function testItRendersAStoredCompositeShadowToItsCssString(): void {
+		$this->seedPreset(
+			Token_Store::default_slug(),
+			'shadowed',
+			'Shadowed',
+			[
+				'button-shadow' => [
+					'color'   => '#17171f',
+					'offsetX' => '0px',
+					'offsetY' => '2px',
+					'blur'    => '8px',
+					'spread'  => '0px',
+				],
+			]
+		);
+
+		$values = $this->resolver->resolve_literal( self::BUTTON, 'shadowed' );
+
+		$this->assertSame( '0px 2px 8px 0px #17171f', $values['button-shadow'] );
+	}
+
+	/**
+	 * `inset` is a boolean, and the value flattener answers null for a boolean. Carried around that step
+	 * rather than through it, since dropping it would take the whole property with it and leave a preset
+	 * that saved cleanly rendering nothing at all.
+	 *
+	 * @return void
+	 */
+	public function testAnInsetCompositeShadowKeepsItsPrefixRatherThanBeingDropped(): void {
+		$this->seedPreset(
+			Token_Store::default_slug(),
+			'inset-shadow',
+			'Inset',
+			[
+				'button-shadow' => [
+					'color'   => '#17171f',
+					'offsetX' => '0px',
+					'offsetY' => '2px',
+					'blur'    => '8px',
+					'spread'  => '0px',
+					'inset'   => true,
+				],
+			]
+		);
+
+		$values = $this->resolver->resolve_literal( self::BUTTON, 'inset-shadow' );
+
+		$this->assertArrayHasKey( 'button-shadow', $values, 'An inset shadow must not drop the property.' );
+		$this->assertSame( 'inset 0px 2px 8px 0px #17171f', $values['button-shadow'] );
+	}
+
+	/**
+	 * An aliased sub-field projects to its token variable inside the shorthand, so a color edit still
+	 * reaches the shadow live rather than being baked in at write time.
+	 *
+	 * @return void
+	 */
+	public function testItProjectsAnAliasedShadowSubFieldAsAVariable(): void {
+		$this->seedPreset(
+			Token_Store::default_slug(),
+			'aliased-shadow',
+			'Aliased',
+			[
+				'button-shadow' => [
+					'color'   => '{semantic.color.button-primary-bg}',
+					'offsetX' => '0px',
+					'offsetY' => '2px',
+					'blur'    => '8px',
+					'spread'  => '0px',
+				],
+			]
+		);
+
+		$values = $this->resolver->resolve( self::BUTTON, 'aliased-shadow' );
+
+		$this->assertSame(
+			'0px 2px 8px 0px var(--kb-token--semantic--color--button-primary-bg)',
+			$values['button-shadow']
+		);
+	}
+
+	/**
+	 * A sub-field that resolves to nothing drops the whole property, the same fail-closed choice a
+	 * per-corner value makes: half a shadow is not a usable shadow.
+	 *
+	 * @return void
+	 */
+	public function testACompositeShadowWithAnUnresolvableSubFieldDropsTheProperty(): void {
+		$this->seedPreset(
+			Token_Store::default_slug(),
+			'broken-shadow',
+			'Broken',
+			[
+				'button-shadow' => [
+					'color'   => '{semantic.color.does-not-exist}',
+					'offsetX' => '0px',
+					'offsetY' => '2px',
+					'blur'    => '8px',
+					'spread'  => '0px',
+				],
+			]
+		);
+
+		$this->assertArrayNotHasKey(
+			'button-shadow',
+			$this->resolver->resolve_literal( self::BUTTON, 'broken-shadow' )
+		);
+	}
+
+	/**
 	 * Persist a single button preset into a token library's overrides document.
 	 *
 	 * @param string               $slug   The token library slug to write into.

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
@@ -26,6 +26,8 @@ final class PresetsControllerTest extends TestCase {
 
 	private const HEADING = 'kadence/advancedheading';
 
+	private const IMAGE = 'kadence/image';
+
 	/**
 	 * @var Token_Store
 	 */
@@ -1084,6 +1086,118 @@ final class PresetsControllerTest extends TestCase {
 
 		$this->assertTrue( Alias::is_alias( $tokens['button-bg'] ) );
 		$this->assertSame( 'rgba(1,2,3,0.42)', $tokens['button-text'] );
+	}
+
+	/**
+	 * The Style Library's Custom shadow tab composes a map of sub-fields rather than a shorthand string,
+	 * so the parts stay separately editable. That map has to survive the write intact.
+	 *
+	 * @return void
+	 */
+	public function testACompositeShadowOnAShadowPropertyIsAccepted(): void {
+		$shadow = [
+			'color'   => '#17171f',
+			'offsetX' => '0px',
+			'offsetY' => '2px',
+			'blur'    => '8px',
+			'spread'  => '0px',
+		];
+
+		$response = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::IMAGE,
+				[
+					'preset' => 'accent',
+					'tokens' => [ 'shadow' => $shadow ],
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( $shadow, $response->get_data()['presets']['accent']['tokens']['shadow'] );
+	}
+
+	/**
+	 * `inset` is optional and boolean, and a shadow carrying it must round-trip as readily as one
+	 * without — it is the sub-field most easily dropped by a value pipeline built for strings.
+	 *
+	 * @return void
+	 */
+	public function testACompositeShadowWithInsetIsAccepted(): void {
+		$shadow = [
+			'color'   => '#17171f',
+			'offsetX' => '0px',
+			'offsetY' => '2px',
+			'blur'    => '8px',
+			'spread'  => '0px',
+			'inset'   => true,
+		];
+
+		$response = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::IMAGE,
+				[
+					'preset' => 'accent',
+					'tokens' => [ 'shadow' => $shadow ],
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertTrue( $response->get_data()['presets']['accent']['tokens']['shadow']['inset'] );
+	}
+
+	/**
+	 * Corners are a dimension idea. A four-slot list on a shadow reaches projection as something no
+	 * renderer can compose, so it stays rejected even though an object now passes.
+	 *
+	 * @return void
+	 */
+	public function testASlotListOnAShadowPropertyIsRejected(): void {
+		$response = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::IMAGE,
+				[
+					'preset' => 'accent',
+					'tokens' => [ 'shadow' => [ '1px', '1px', '1px', '1px' ] ],
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_design_tokens_invalid', $response->get_error_code() );
+		$this->assertSame( 'shadow', $response->get_error_data()['property'] );
+	}
+
+	/**
+	 * A map missing a required sub-field is not a composite, so it is refused rather than stored as a
+	 * shadow the renderer would later fail to compose.
+	 *
+	 * @return void
+	 */
+	public function testACompositeShadowMissingASubFieldIsRejected(): void {
+		$response = $this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::IMAGE,
+				[
+					'preset' => 'accent',
+					'tokens' => [
+						'shadow' => [
+							'color'   => '#17171f',
+							'offsetX' => '0px',
+							'offsetY' => '2px',
+							'blur'    => '8px',
+						],
+					],
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
 	}
 
 	/**


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4218/block-presets-for-the-remaining-alpha-blocks-advanced-image-row-layout

Saving a custom shadow on an Advanced Image preset failed with "A per-corner value is only valid for a dimension property" — an error about corners, for a value that never mentioned one.

The Custom tab composes a MAP of sub-fields rather than a shorthand string, so the parts stay separately editable; a joined string could not round-trip, since the control spreads its value and a string splays into indexed characters.

A shadow may now be that map. `Token_Type::is_composite_shape()` tells it apart from a per-corner list, and both the schema validator and the REST guard route through it. A four-slot list on a shadow stays rejected.

Storing it is only half of it: the resolver renders a stored composite through the same `Css_Renderer` an aliased one already goes through. Two traps closed there — `inset` is carried around the value flattener, which answers null for a boolean and would drop the whole property, and the composite branch precedes the slot-list branch, which joins values in insertion order and would emit the color first.

The editor capture flow still writes a shadow as a string; teaching it to emit a composite is its own change.

<img width="1567" height="615" alt="image" src="https://github.com/user-attachments/assets/028f4bc6-be61-4001-9170-499c94bd8f87" />

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for composite shadow design tokens, including color, offset, blur, spread, and optional inset values.
  * Composite shadows now render correctly as CSS and preserve variable references for aliased values.
  * Responsive and extended preset values now accept valid composite shadow formats.

* **Bug Fixes**
  * Improved handling of rendered shadow values in controls.
  * Invalid or incomplete shadow definitions are rejected with clear validation errors.
  * Unresolvable shadow components now fail safely instead of producing invalid output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
