### PR TITLE
[DTM] SOFT-4196 [1/8]: add the color-token id and palette-group resolution helpers

### DIFF
--- a/src/style-library/helpers/palettes.js
+++ b/src/style-library/helpers/palettes.js
@@ -32,76 +32,20 @@ const CUSTOM_COLOR_PREFIX = 'primitive.color.custom.';
 const FALLBACK_SWATCH_VALUE = '#000000';
 
 /**
- * Reshape the flat embedded-array wire response into the shape every consumer already expects. The
- * wire shape is a flat array of rows (WP core's `_embed` only resolves top-level collection items,
- * never something nested inside a wrapper key — see the REST controller's own docblock for why)
- * with `is_default`/`is_current`/`user_created` flags per row instead of collection-level pointers;
- * this reshapes those flags back into the pointer-based shape this app's own code was already built
- * around.
+ * `reshapePaletteRows()` and `mapPaletteToSwatchGroups()` moved to
+ * `src/token-controls/helpers/palette-groups.js`, so the new shared `ColorControl` can read the
+ * same palette-group shaping this screen already relies on. Re-exported here so every existing
+ * caller in this app keeps importing from this file unchanged.
  *
- * Used internally by `store/selectors.js`'s `getPaletteListing` only — reshaping the raw wire-format
- * rows, exactly as the reducer stores them, into the shape the frontend consumes. Nothing else
- * should call this directly, and specifically not code that writes into the store:
- * `helpers/palette-flows.js` dispatches every write's response RAW, via `onReceive`, with no
- * reshaping before dispatch — reshaping a write's response before it reaches the store would
- * double-reshape it on the next read, since `getPaletteListing` is the one canonical place
- * reshaping happens. Deliberately kept out of `store/selectors.js` itself, even though it is only
- * ever called from there: that module is imported wholesale (`import * as selectors`) as the
- * store's registered selector map, so a plain helper living there would also become a callable
- * `select(STORE_NAME).reshapePaletteRows()` — which `@wordpress/data` would invoke with `state` as
- * the first argument instead of `rows`, throwing the moment anything called it that way.
- *
- * @param {Array<Object>} rows The flat embedded-array rows.
- *
- * @since TBD
- *
- * @return {{defaultId: string, currentId: string, palettes: Array<Object>, userCreated: Array<string>}}
+ * `reshapePaletteRows()` is used internally by `store/selectors.js`'s `getPaletteListing` only —
+ * reshaping the raw wire-format rows, exactly as the reducer stores them, into the shape the
+ * frontend consumes. Nothing else in this app should call it directly, and specifically not code
+ * that writes into the store: `helpers/palette-flows.js` dispatches every write's response RAW, via
+ * `onReceive`, with no reshaping before dispatch — reshaping a write's response before it reaches
+ * the store would double-reshape it on the next read, since `getPaletteListing` is the one
+ * canonical place reshaping happens.
  */
-export function reshapePaletteRows(rows) {
-	return {
-		defaultId: rows.find((row) => row.is_default)?.id ?? '',
-		currentId: rows.find((row) => row.is_current)?.id ?? '',
-		palettes: rows.map((row) => ({
-			id: row.id,
-			label: row.label,
-			groups: row._embedded?.self?.[0]?.groups ?? [],
-		})),
-		userCreated: rows.filter((row) => row.user_created).map((row) => row.id),
-	};
-}
-
-/**
- * Map a palette effective view to the data half of `SwatchGrid`'s `groups` prop. Pure data only —
- * no JSX: the screen supplies each card's `preview` node and drag flags itself, because a React
- * element in a helper would make this untestable under the pure-function policy.
- *
- * @param {Object} palette The palette effective view.
- *
- * @since TBD
- *
- * @return {Array<Object>} `[{ id, label, pendingDelete, items: [{ id, name, subLine, value,
- *         overridden, pendingDelete }] }]` — `id` is the swatch token dot-path (stable, unique per
- *         palette, and what `?kb-item=` carries), `subLine` the raw `$value`.
- */
-export function mapPaletteToSwatchGroups(palette) {
-	if (!palette || !Array.isArray(palette.groups)) {
-		return [];
-	}
-
-	return palette.groups.map((group) => ({
-		id: group.id,
-		label: group.label,
-		pendingDelete: Boolean(group.pendingDelete),
-		items: (Array.isArray(group.swatches) ? group.swatches : []).map((swatch) => ({
-			id: swatch.token,
-			name: swatch.label,
-			subLine: swatch.$value,
-			value: swatch.$value,
-			overridden: Boolean(swatch.overridden),
-			pendingDelete: Boolean(swatch.pendingDelete),
-		})),
-	}));
-}
+export { reshapePaletteRows, mapPaletteToSwatchGroups } from '../../token-controls/helpers/palette-groups';
 
 /**
  * The swatch entry for a token in an effective view, or null.

--- a/src/token-controls/__tests__/ColorSwatch.test.js
+++ b/src/token-controls/__tests__/ColorSwatch.test.js
@@ -1,0 +1,43 @@
+/* eslint-env jest */
+/**
+ * Internal dependencies
+ */
+import { colorSwatchStyle } from '../atoms/ColorSwatch';
+
+describe('colorSwatchStyle', () => {
+	it("uses the entry's own literal value when it has one", () => {
+		const entry = {
+			id: 'custom-1',
+			label: 'Custom 1',
+			value: '#3182CE',
+			alias: '{primitive.color.custom.custom-1}',
+		};
+
+		expect(colorSwatchStyle(entry)).toEqual({ background: '#3182CE' });
+	});
+
+	it('falls back to the token CSS variable, keyed on alias, when the entry has no literal value', () => {
+		const entry = { id: 'brand-primary', label: 'Brand primary', alias: '{primitive.color.brand.primary}' };
+
+		expect(colorSwatchStyle(entry)).toEqual({
+			background: 'var(--kb-token--primitive--color--brand--primary)',
+		});
+	});
+
+	it('falls back to the token CSS variable, keyed on id, when the entry has neither value nor alias', () => {
+		const entry = { id: 'primitive.color.brand.primary', label: 'Brand primary' };
+
+		expect(colorSwatchStyle(entry)).toEqual({
+			background: 'var(--kb-token--primitive--color--brand--primary)',
+		});
+	});
+
+	it('uses the raw literal value prop when there is no entry — a Custom-tab pick', () => {
+		expect(colorSwatchStyle(null, '#ff00aa')).toEqual({ background: '#ff00aa' });
+	});
+
+	it('falls back to transparent when there is neither an entry nor a value', () => {
+		expect(colorSwatchStyle(null, null)).toEqual({ background: 'transparent' });
+		expect(colorSwatchStyle(undefined, undefined)).toEqual({ background: 'transparent' });
+	});
+});

--- a/src/token-controls/__tests__/palette-groups.test.js
+++ b/src/token-controls/__tests__/palette-groups.test.js
@@ -1,0 +1,165 @@
+/* eslint-env jest */
+/**
+ * Internal dependencies
+ */
+import {
+	mapPaletteToColorControlGroups,
+	mapPaletteToSwatchGroups,
+	reshapePaletteRows,
+} from '../helpers/palette-groups';
+
+const effectivePalette = () => ({
+	id: 'default',
+	label: 'Default',
+	groups: [
+		{
+			id: 'accent',
+			label: 'Accent',
+			swatches: [
+				{ token: 'primitive.color.brand.primary', label: 'Main 1', $value: '#112233', overridden: false },
+				{ token: 'primitive.color.brand.secondary', label: 'Main 2', $value: '#445566', overridden: true },
+			],
+		},
+		{
+			id: 'contrast',
+			label: 'Contrast',
+			swatches: [
+				{ token: 'primitive.color.neutral.100', label: 'Neutral 100', $value: '#ffffff', overridden: false },
+			],
+		},
+	],
+});
+
+describe('reshapePaletteRows', () => {
+	it('reshapes flat is_default/is_current/user_created flags into defaultId/currentId/userCreated pointers', () => {
+		const rows = [
+			{
+				id: 'default',
+				label: 'Default',
+				is_default: true,
+				is_current: false,
+				user_created: false,
+				_embedded: { self: [{ groups: [{ id: 'accent', label: 'Accent', swatches: [] }] }] },
+			},
+			{
+				id: 'brand-b',
+				label: 'Brand B',
+				is_default: false,
+				is_current: true,
+				user_created: true,
+				_embedded: { self: [{ groups: [] }] },
+			},
+		];
+
+		expect(reshapePaletteRows(rows)).toEqual({
+			defaultId: 'default',
+			currentId: 'brand-b',
+			palettes: [
+				{ id: 'default', label: 'Default', groups: [{ id: 'accent', label: 'Accent', swatches: [] }] },
+				{ id: 'brand-b', label: 'Brand B', groups: [] },
+			],
+			userCreated: ['brand-b'],
+		});
+	});
+});
+
+describe('mapPaletteToSwatchGroups', () => {
+	it('maps a palette effective view onto SwatchGrid items', () => {
+		expect(mapPaletteToSwatchGroups(effectivePalette())).toEqual([
+			{
+				id: 'accent',
+				label: 'Accent',
+				pendingDelete: false,
+				items: [
+					{
+						id: 'primitive.color.brand.primary',
+						name: 'Main 1',
+						subLine: '#112233',
+						value: '#112233',
+						overridden: false,
+						pendingDelete: false,
+					},
+					{
+						id: 'primitive.color.brand.secondary',
+						name: 'Main 2',
+						subLine: '#445566',
+						value: '#445566',
+						overridden: true,
+						pendingDelete: false,
+					},
+				],
+			},
+			{
+				id: 'contrast',
+				label: 'Contrast',
+				pendingDelete: false,
+				items: [
+					{
+						id: 'primitive.color.neutral.100',
+						name: 'Neutral 100',
+						subLine: '#ffffff',
+						value: '#ffffff',
+						overridden: false,
+						pendingDelete: false,
+					},
+				],
+			},
+		]);
+	});
+
+	it('returns an empty array for a null or group-less palette', () => {
+		expect(mapPaletteToSwatchGroups(null)).toEqual([]);
+		expect(mapPaletteToSwatchGroups({})).toEqual([]);
+	});
+});
+
+describe('mapPaletteToColorControlGroups', () => {
+	/**
+	 * ColorControl's `groups` prop needs `{ id, label, value, alias }` per swatch — `id` for the React
+	 * key and the current-pick check mark's identity, `alias` as the bracket-wrapped string ColorControl compares
+	 * against its bound `value` and writes back on pick, and `label`/`value` as the display name and
+	 * resolved literal. The raw palette shape carries the token dot-path as `token` and the literal as
+	 * `$value`, with no bracket form — this bridges that gap rather than reusing
+	 * `mapPaletteToSwatchGroups`, whose `items` shape (`name`/`subLine`, no `alias`) exists for the
+	 * Color Palette Screen's `SwatchGrid` and is a different, incompatible consumer.
+	 */
+	it('maps a palette effective view onto ColorControl swatches, deriving a bracket alias from each token', () => {
+		expect(mapPaletteToColorControlGroups(effectivePalette())).toEqual([
+			{
+				id: 'accent',
+				label: 'Accent',
+				swatches: [
+					{
+						id: 'primitive.color.brand.primary',
+						label: 'Main 1',
+						value: '#112233',
+						alias: '{primitive.color.brand.primary}',
+					},
+					{
+						id: 'primitive.color.brand.secondary',
+						label: 'Main 2',
+						value: '#445566',
+						alias: '{primitive.color.brand.secondary}',
+					},
+				],
+			},
+			{
+				id: 'contrast',
+				label: 'Contrast',
+				swatches: [
+					{
+						id: 'primitive.color.neutral.100',
+						label: 'Neutral 100',
+						value: '#ffffff',
+						alias: '{primitive.color.neutral.100}',
+					},
+				],
+			},
+		]);
+	});
+
+	it('returns an empty array for a null or group-less palette', () => {
+		expect(mapPaletteToColorControlGroups(null)).toEqual([]);
+		expect(mapPaletteToColorControlGroups({})).toEqual([]);
+	});
+});

--- a/src/token-controls/__tests__/token-css-var.test.js
+++ b/src/token-controls/__tests__/token-css-var.test.js
@@ -1,0 +1,30 @@
+/* eslint-env jest */
+/**
+ * Internal dependencies
+ */
+import { tokenCssVar } from '../helpers/token-css-var';
+
+describe('tokenCssVar', () => {
+	it('prefixes a single-segment id with --kb-token--', () => {
+		expect(tokenCssVar('a')).toBe('--kb-token--a');
+	});
+
+	it('replaces every dot with a double dash', () => {
+		expect(tokenCssVar('semantic.radius.media')).toBe('--kb-token--semantic--radius--media');
+	});
+
+	it('leaves a dash inside a segment untouched', () => {
+		expect(tokenCssVar('semantic.color.button-primary-bg')).toBe('--kb-token--semantic--color--button-primary-bg');
+	});
+
+	it('matches the shared alias-conformance fixture for a dot-path id', () => {
+		// The fixture pairs the bracketed alias with its full `var(--kb-token--…)` reference; tokenCssVar
+		// produces only the bare custom-property name, so the alias's braces are stripped and the
+		// `var(...)` wrapper is trimmed off both ends before comparing.
+		const alias = '{primitive.color.brand.primary}';
+		const expectedVar = 'var(--kb-token--primitive--color--brand--primary)';
+		const id = alias.slice(1, -1);
+
+		expect(tokenCssVar(id)).toBe(expectedVar.slice(4, -1));
+	});
+});

--- a/src/token-controls/atoms/ColorSwatch.js
+++ b/src/token-controls/atoms/ColorSwatch.js
@@ -1,0 +1,61 @@
+/**
+ * The round color mark `ColorControl`'s trigger and `ColorGroupList`'s rows both render.
+ *
+ * Resolution happens entirely at the CSS layer, never as a JS-computed hex — see the color-control
+ * design's "Data contract" section. A swatch backed by a design token renders
+ * `var(--kb-token--<id>)`, letting CSS custom-property inheritance under the block's own
+ * `data-kb-palette` scope pick the right literal for free; only a Custom-tab literal (no token
+ * entry at all) is written to `background` directly.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { tokenCssVar } from '../helpers/token-css-var';
+
+/**
+ * The swatch's inline style, split out from the component so it can be unit-tested without a
+ * renderer — this repo has no `@testing-library/react`/`react-test-renderer` dependency, so a
+ * component's actual logic has to live in a plain function the test calls directly (the same split
+ * `BoxTokenField.js`'s `toStoredValue`/`toControlValue` use).
+ *
+ * @param {?Object} entry        The swatch's token entry (`{ id, label, value, alias }`), or null.
+ * @param {?string} [value]      A raw literal (hex/rgba), used only when `entry` is null — a
+ *                                Custom-tab pick with no backing token entry.
+ *
+ * @since TBD
+ *
+ * @return {{background: string}} The swatch's inline style.
+ */
+export function colorSwatchStyle(entry, value) {
+	if (entry) {
+		if (entry.value) {
+			return { background: entry.value };
+		}
+
+		const id = entry.alias ? entry.alias.slice(1, -1) : entry.id;
+
+		return { background: `var(${tokenCssVar(id)})` };
+	}
+
+	if (value) {
+		return { background: value };
+	}
+
+	return { background: 'transparent' };
+}
+
+/**
+ * The round color swatch.
+ *
+ * @param {Object}  props
+ * @param {?Object} props.entry The swatch's token entry (`{ id, label, value, alias }`), or null.
+ * @param {?string} [props.value] A raw literal, used only when `entry` is null.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The rendered swatch.
+ */
+export function ColorSwatch({ entry, value }) {
+	return <span className="kb-color-swatch" style={colorSwatchStyle(entry, value)} />;
+}

--- a/src/token-controls/helpers/palette-groups.js
+++ b/src/token-controls/helpers/palette-groups.js
@@ -1,0 +1,98 @@
+/**
+ * Pure shaping functions for a palette's `groups[]`, shared by both hosts.
+ *
+ * Relocated from `src/style-library/helpers/palettes.js`, which kept these two functions private to
+ * the Color Palette Screen. `ColorControl`'s Style Library tab needs the same active-palette group
+ * data, so this is the one place both the Style Library and the block editor host adapters read from
+ * — see `src/token-controls/README.md`'s "no host imports" rule this satisfies for the editor side.
+ */
+
+/**
+ * Reshape the flat embedded-array wire response into the shape every consumer already expects. The
+ * wire shape is a flat array of rows (WP core's `_embed` only resolves top-level collection items,
+ * never something nested inside a wrapper key) with `is_default`/`is_current`/`user_created` flags
+ * per row instead of collection-level pointers; this reshapes those flags back into the
+ * pointer-based shape both hosts are built around.
+ *
+ * @param {Array<Object>} rows The flat embedded-array rows.
+ *
+ * @since TBD
+ *
+ * @return {{defaultId: string, currentId: string, palettes: Array<Object>, userCreated: Array<string>}}
+ */
+export function reshapePaletteRows(rows) {
+	return {
+		defaultId: rows.find((row) => row.is_default)?.id ?? '',
+		currentId: rows.find((row) => row.is_current)?.id ?? '',
+		palettes: rows.map((row) => ({
+			id: row.id,
+			label: row.label,
+			groups: row._embedded?.self?.[0]?.groups ?? [],
+		})),
+		userCreated: rows.filter((row) => row.user_created).map((row) => row.id),
+	};
+}
+
+/**
+ * Map a palette effective view to the data half of `SwatchGrid`'s `groups` prop. Pure data only —
+ * no JSX: the Color Palette Screen supplies each card's `preview` node and drag flags itself.
+ *
+ * @param {Object} palette The palette effective view.
+ *
+ * @since TBD
+ *
+ * @return {Array<Object>} `[{ id, label, pendingDelete, items: [{ id, name, subLine, value,
+ *         overridden, pendingDelete }] }]` — `id` is the swatch token dot-path (stable, unique per
+ *         palette, and what `?kb-item=` carries), `subLine` the raw `$value`.
+ */
+export function mapPaletteToSwatchGroups(palette) {
+	if (!palette || !Array.isArray(palette.groups)) {
+		return [];
+	}
+
+	return palette.groups.map((group) => ({
+		id: group.id,
+		label: group.label,
+		pendingDelete: Boolean(group.pendingDelete),
+		items: (Array.isArray(group.swatches) ? group.swatches : []).map((swatch) => ({
+			id: swatch.token,
+			name: swatch.label,
+			subLine: swatch.$value,
+			value: swatch.$value,
+			overridden: Boolean(swatch.overridden),
+			pendingDelete: Boolean(swatch.pendingDelete),
+		})),
+	}));
+}
+
+/**
+ * Map a palette effective view to `ColorControl`'s `groups` prop.
+ *
+ * A different shape than `mapPaletteToSwatchGroups()`, which exists for the Color Palette Screen's
+ * `SwatchGrid` (`items`, `name`/`subLine`, no alias) — `ColorControl` compares its bound `value`
+ * against each swatch's `alias` and writes that alias back on pick (see the "Value storage
+ * contract" in the color-control design), so each swatch needs the bracket-wrapped alias form a
+ * `SwatchGrid` item never carries.
+ *
+ * @param {Object} palette The palette effective view.
+ *
+ * @since TBD
+ *
+ * @return {Array<Object>} `[{ id, label, swatches: [{ id, label, value, alias }] }]`.
+ */
+export function mapPaletteToColorControlGroups(palette) {
+	if (!palette || !Array.isArray(palette.groups)) {
+		return [];
+	}
+
+	return palette.groups.map((group) => ({
+		id: group.id,
+		label: group.label,
+		swatches: (Array.isArray(group.swatches) ? group.swatches : []).map((swatch) => ({
+			id: swatch.token,
+			label: swatch.label,
+			value: swatch.$value,
+			alias: `{${swatch.token}}`,
+		})),
+	}));
+}

--- a/src/token-controls/helpers/token-css-var.js
+++ b/src/token-controls/helpers/token-css-var.js
@@ -1,0 +1,28 @@
+/**
+ * The pure token-id-to-CSS-variable transform, private to this library.
+ *
+ * A clean-room copy of the same rule `src/extension/design-tokens/alias.js`'s `resolveTokenAlias()`
+ * and PHP's `Css_Var::from_id()` both apply — prefix `--kb-token--`, replace every `.` with `--`,
+ * leave `-` untouched — kept here rather than imported so `token-controls` never reaches into the
+ * host plugin's `src/extension/*` tree (see this library's README, "no host imports").
+ */
+
+/**
+ * The CSS custom-property namespace for Kadence design tokens.
+ *
+ * @since TBD
+ */
+const TOKEN_VAR_PREFIX = '--kb-token--';
+
+/**
+ * The CSS custom-property name a design-token id resolves to.
+ *
+ * @param {string} id The token's dot-path id, e.g. `semantic.radius.media`.
+ *
+ * @since TBD
+ *
+ * @return {string} `--kb-token--<id>`, with every `.` replaced by `--`.
+ */
+export function tokenCssVar(id) {
+	return TOKEN_VAR_PREFIX + id.replace(/\./g, '--');
+}

--- a/src/token-controls/index.js
+++ b/src/token-controls/index.js
@@ -56,3 +56,5 @@ export {
 	toSlotList,
 	writeSlot,
 } from './helpers/value-shapes';
+export { tokenCssVar } from './helpers/token-css-var';
+export { mapPaletteToColorControlGroups } from './helpers/palette-groups';


### PR DESCRIPTION
## Summary
- First slice of a new shared `ColorControl` (a swatch + label + value token control, matching the border/radius/shadow pattern already in `src/token-controls/`), which will eventually replace the color pickers in `kadence/singlebtn` and the Style Library's Button preset page.
- Adds `tokenCssVar(id)` — a pure `--kb-token--` transform (kept self-contained in `token-controls`, per its "no host imports" rule, rather than importing from `src/extension/*`).
- Adds `mapPaletteToColorControlGroups()` in a new `src/token-controls/helpers/palette-groups.js`, relocated (with `reshapePaletteRows`/`mapPaletteToSwatchGroups`) out of the Style Library so both hosts can read the same active-palette grouping.
- Adds the `ColorSwatch` atom (round swatch, resolves via `var(--kb-token--<id>)` or a literal, never a JS-computed color).

## Test plan
- `npx jest src/token-controls src/style-library` — all green, no regressions.
- New unit tests for `tokenCssVar`, `mapPaletteToColorControlGroups`, and `ColorSwatch`'s pure style function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable color swatches that support token-based colors, direct values, and transparent fallbacks.
  * Added palette grouping and mapping for swatch grids and color controls.
  * Added consistent conversion of token identifiers to CSS custom properties.

* **Bug Fixes**
  * Preserved compatibility for existing palette helper imports.

* **Tests**
  * Added coverage for color swatches, palette grouping, and token CSS variable conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->