### PR TITLE
[DTM] SOFT-4196 [3/8]: extend TokenPopover with an additive renderList prop for the new color control

### DIFF
--- a/src/token-controls/__tests__/token-popover.test.js
+++ b/src/token-controls/__tests__/token-popover.test.js
@@ -131,6 +131,61 @@ describe('TokenPopover renderCustom prop', () => {
 	});
 });
 
+describe('TokenPopover renderList prop', () => {
+	/**
+	 * When `renderList` is absent — every consumer besides `ColorControl` today — the default
+	 * `StyleLibraryTab` renders exactly as before. This is the regression check that the additive
+	 * prop leaves existing consumers unchanged.
+	 *
+	 * @return {void}
+	 */
+	it('renders the default StyleLibraryTab when renderList is absent', () => {
+		const tokens = [{ id: 'md', label: 'Medium', value: '8px', alias: '{primitive.radius.md}' }];
+
+		render({ initialTab: 'style-library', tokens, renderList: undefined });
+
+		expect(container.querySelector('.kadence-token-field__list')).not.toBeNull();
+		expect(container.querySelector('.kadence-token-field__item-label').textContent).toBe('Medium');
+	});
+
+	/**
+	 * When `renderList` is provided, it is called with `{ value, tokens, onPick, onClose }` and its
+	 * output renders instead of the default `StyleLibraryTab` — `ColorControl`'s grouped
+	 * `ColorGroupList` is the intended consumer.
+	 *
+	 * @return {void}
+	 */
+	it('renders renderList output instead of StyleLibraryTab when provided, called with value/tokens/onPick/onClose', () => {
+		const onPick = jest.fn();
+		const onClose = jest.fn();
+		const tokens = [{ id: 'md', label: 'Medium', value: '8px', alias: '{primitive.radius.md}' }];
+		const renderList = jest.fn(({ onPick: pick, onClose: close }) =>
+			createElement(
+				'button',
+				{ 'data-testid': 'grouped-list', onClick: () => (pick('{primitive.radius.md}'), close()) },
+				'grouped'
+			)
+		);
+
+		render({ initialTab: 'style-library', value: '{primitive.radius.md}', tokens, onPick, onClose, renderList });
+
+		expect(renderList).toHaveBeenCalledWith({
+			value: '{primitive.radius.md}',
+			tokens,
+			onPick: expect.any(Function),
+			onClose: expect.any(Function),
+		});
+		expect(container.querySelector('.kadence-token-field__list')).toBeNull();
+
+		const button = container.querySelector('[data-testid="grouped-list"]');
+		expect(button).not.toBeNull();
+
+		act(() => button.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+		expect(onPick).toHaveBeenCalledWith('{primitive.radius.md}');
+		expect(onClose).toHaveBeenCalled();
+	});
+});
+
 describe('TokenPopover showValue prop', () => {
 	/**
 	 * When `showValue` is omitted — every consumer besides `BoxShadowControl` today — each token row

--- a/src/token-controls/molecules/TokenPopover.js
+++ b/src/token-controls/molecules/TokenPopover.js
@@ -201,6 +201,12 @@ export function CustomTab({ number, unit, units, onUnit, min, max, step, onNumbe
  * @param {Object}   props.custom           Props forwarded to the `Custom` tab.
  * @param {Function} [props.renderCustom]   Overrides the Custom tab body; called with `props.custom`.
  *                                          Omit to render the default numeric `CustomTab`.
+ * @param {?Function} [props.renderList]    Overrides the Style Library tab body entirely; called
+ *                                          with `{ value, tokens, onPick, onClose }`. Omit to render
+ *                                          the default `StyleLibraryTab` — `ColorControl` is the
+ *                                          only consumer that passes this, for its grouped
+ *                                          `ColorGroupList` in place of the flat token list every
+ *                                          other control shows.
  * @param {Function} props.onPick           Writes a picked token's alias.
  * @param {Function} props.onClear          Clears the slot's override.
  * @param {Function} props.onClose          Closes the popover after a choice.
@@ -228,6 +234,7 @@ export function TokenPopover({
 	initialTab,
 	custom,
 	renderCustom,
+	renderList,
 	onPick,
 	onClear,
 	onClose,
@@ -261,17 +268,21 @@ export function TokenPopover({
 		>
 			{(tab) =>
 				tab.name === 'style-library' ? (
-					<StyleLibraryTab
-						value={value}
-						tokens={tokens}
-						defaultValue={resolvedDefault}
-						inherited={inherited}
-						onPick={onPick}
-						onClear={onClear}
-						onClose={onClose}
-						showValue={showValue}
-						renderPreview={renderPreview}
-					/>
+					renderList ? (
+						renderList({ value, tokens, onPick, onClose })
+					) : (
+						<StyleLibraryTab
+							value={value}
+							tokens={tokens}
+							defaultValue={resolvedDefault}
+							inherited={inherited}
+							onPick={onPick}
+							onClear={onClear}
+							onClose={onClose}
+							showValue={showValue}
+							renderPreview={renderPreview}
+						/>
+					)
 				) : renderCustom ? (
 					renderCustom(custom)
 				) : (


### PR DESCRIPTION
## Summary
- Adds an optional `renderList` prop to `TokenPopover`, called in place of the default flat `StyleLibraryTab` when supplied.
- Purely additive: every existing caller (Border/Radius/Spacing/BoxShadow controls) passes no `renderList`, so their rendered output is byte-identical — the same pattern the existing `renderCustom`/`renderPreview` props already established.
- Lets the new `ColorControl` (a later slice) swap in a grouped, checkmarked list instead of the flat token list every other control shows.

## Test plan
- `npx jest src/token-controls` — all green, no regressions.
- New test confirms `renderList` is called with `{ value, tokens, onPick, onClose }` when supplied, and that omitting it still renders the default `StyleLibraryTab` unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for customizing the Style Library list within the token popover.
  - Custom list renderers receive the current value, available tokens, and callbacks for selecting an item or closing the popover.
  - The default Style Library view remains available when no custom renderer is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->