### PR TITLE
[DTM] SOFT-4196 [4/8]: add the grouped color list with a contrast-aware check mark

### DIFF
--- a/src/token-controls/__tests__/ColorGroupList.test.js
+++ b/src/token-controls/__tests__/ColorGroupList.test.js
@@ -1,0 +1,177 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { ColorGroupList } from '../molecules/ColorGroupList';
+
+// Matches `token-popover.test.js`'s stand-in: `@wordpress/components` resolves its own nested
+// `react` copy, a different module instance than the top-level `react-dom/client` this test renders
+// with, which trips React's "Invalid hook call" guard.
+jest.mock('@wordpress/components', () => ({
+	Button: ({ children, isPressed, ...props }) => <button {...props}>{children}</button>,
+}));
+
+jest.mock('@wordpress/icons', () => ({ check: 'check', Icon: ({ icon, ...props }) => <span {...props}>{icon}</span> }));
+
+const GROUPS = [
+	{
+		id: 'accent',
+		label: 'Accent',
+		swatches: [
+			{
+				id: 'primitive.color.brand.primary',
+				label: 'Main 1',
+				value: '#112233',
+				alias: '{primitive.color.brand.primary}',
+			},
+			{
+				id: 'primitive.color.brand.secondary',
+				label: 'Main 2',
+				value: '#445566',
+				alias: '{primitive.color.brand.secondary}',
+			},
+		],
+	},
+	{
+		id: 'contrast',
+		label: 'Contrast',
+		swatches: [
+			{
+				id: 'primitive.color.neutral.100',
+				label: 'Neutral 100',
+				value: '#ffffff',
+				alias: '{primitive.color.neutral.100}',
+			},
+		],
+	},
+];
+
+let container;
+let root;
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+/**
+ * Render `ColorGroupList` with the given props.
+ *
+ * @param {Object} props The component props.
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+function render(props = {}) {
+	act(() =>
+		root.render(
+			createElement(ColorGroupList, {
+				groups: GROUPS,
+				value: '',
+				onPick: jest.fn(),
+				onClose: jest.fn(),
+				...props,
+			})
+		)
+	);
+}
+
+describe('ColorGroupList', () => {
+	/**
+	 * Every group renders its label followed by each of its swatches' labels, in group order.
+	 *
+	 * @return {void}
+	 */
+	it('renders every group with its label and swatch labels', () => {
+		render();
+
+		const groupLabels = Array.from(container.querySelectorAll('.kb-color-control__group-label')).map(
+			(el) => el.textContent
+		);
+		expect(groupLabels).toEqual(['Accent', 'Contrast']);
+
+		const itemLabels = Array.from(container.querySelectorAll('.kb-color-control__item-label')).map(
+			(el) => el.textContent
+		);
+		expect(itemLabels).toEqual(['Main 1', 'Main 2', 'Neutral 100']);
+	});
+
+	/**
+	 * Only the swatch whose alias matches the bound value shows a check mark.
+	 *
+	 * @return {void}
+	 */
+	it('shows a check mark only on the swatch matching the current value', () => {
+		render({ value: '{primitive.color.brand.secondary}' });
+
+		const items = container.querySelectorAll('.kb-color-control__item');
+		expect(within(items[0]).hasCheck()).toBe(false);
+		expect(within(items[1]).hasCheck()).toBe(true);
+		expect(within(items[2]).hasCheck()).toBe(false);
+	});
+
+	/**
+	 * The check mark's color adapts to the swatch it sits on, so it stays legible against dark and
+	 * light colors alike — a fixed mark color would vanish against roughly half of any palette.
+	 *
+	 * @return {void}
+	 */
+	it("colors the check mark for legibility against its own swatch's color", () => {
+		render({ value: '{primitive.color.brand.primary}' });
+
+		const check = container.querySelector('.kb-color-control__item-check');
+		// #112233 is a dark swatch (Main 1's `value` above); the mark should read light against it.
+		expect(check.style.color).toBe('rgb(255, 255, 255)');
+	});
+
+	/**
+	 * Clicking a swatch calls `onPick` with its alias, then `onClose` — applying immediately and
+	 * closing the popover, matching `StyleLibraryTab`'s existing token rows.
+	 *
+	 * @return {void}
+	 */
+	it('calls onPick with the alias then onClose when a swatch is clicked', () => {
+		const onPick = jest.fn();
+		const onClose = jest.fn();
+
+		render({ onPick, onClose });
+
+		const items = container.querySelectorAll('.kb-color-control__item');
+		act(() => items[1].dispatchEvent(new MouseEvent('click', { bubbles: true })));
+
+		expect(onPick).toHaveBeenCalledWith('{primitive.color.brand.secondary}');
+		expect(onClose).toHaveBeenCalled();
+		expect(onPick.mock.invocationCallOrder[0]).toBeLessThan(onClose.mock.invocationCallOrder[0]);
+	});
+});
+
+/**
+ * A small assertion helper scoped to one rendered swatch button, so the check-mark test above reads
+ * as "does this item show the check icon" rather than groping through raw DOM queries.
+ *
+ * @param {Element} el The rendered `.kb-color-control__item` button.
+ *
+ * @since TBD
+ *
+ * @return {{hasCheck: () => boolean}} The scoped helper.
+ */
+function within(el) {
+	return {
+		hasCheck: () => Array.from(el.querySelectorAll('span')).some((span) => span.textContent === 'check'),
+	};
+}

--- a/src/token-controls/__tests__/contrast.test.js
+++ b/src/token-controls/__tests__/contrast.test.js
@@ -1,0 +1,81 @@
+/* eslint-env jest */
+/**
+ * Internal dependencies
+ */
+import { parseColorChannels, readableMarkColor, relativeLuminance } from '../helpers/contrast';
+
+describe('parseColorChannels', () => {
+	it('parses a 6-digit hex color as fully opaque', () => {
+		expect(parseColorChannels('#3182CE')).toEqual({ r: 49, g: 130, b: 206, a: 1 });
+	});
+
+	it('parses a 3-digit hex color by doubling each digit', () => {
+		expect(parseColorChannels('#fff')).toEqual({ r: 255, g: 255, b: 255, a: 1 });
+	});
+
+	it('parses an 8-digit hex color, keeping the alpha channel', () => {
+		expect(parseColorChannels('#1717171f')).toEqual({ r: 23, g: 23, b: 23, a: 0.12156862745098039 });
+	});
+
+	it('parses an rgb() color as fully opaque', () => {
+		expect(parseColorChannels('rgb(23, 23, 23)')).toEqual({ r: 23, g: 23, b: 23, a: 1 });
+	});
+
+	it('parses an rgba() color, keeping the alpha channel', () => {
+		expect(parseColorChannels('rgba(23, 23, 23, 0.12)')).toEqual({ r: 23, g: 23, b: 23, a: 0.12 });
+	});
+
+	it('returns null for a CSS variable reference', () => {
+		expect(parseColorChannels('var(--kb-token--semantic--color--accent--main)')).toBeNull();
+	});
+
+	it('returns null for a non-string value', () => {
+		expect(parseColorChannels(undefined)).toBeNull();
+	});
+});
+
+describe('relativeLuminance', () => {
+	it('is 0 for black', () => {
+		expect(relativeLuminance({ r: 0, g: 0, b: 0 })).toBe(0);
+	});
+
+	it('is 1 for white', () => {
+		expect(relativeLuminance({ r: 255, g: 255, b: 255 })).toBeCloseTo(1);
+	});
+});
+
+describe('readableMarkColor', () => {
+	it('picks the light mark for a dark swatch', () => {
+		expect(readableMarkColor('#1A202C')).toBe('#ffffff');
+	});
+
+	it('picks the dark mark for a light swatch', () => {
+		expect(readableMarkColor('#F7FAFC')).toBe('#1e1e1e');
+	});
+
+	it('falls back to the dark mark when the color cannot be parsed', () => {
+		expect(readableMarkColor('var(--kb-token--semantic--color--accent--main)')).toBe('#1e1e1e');
+	});
+
+	/**
+	 * A fully transparent swatch shows the popover's own white surface, not black — so the mark
+	 * must read as it would against white, not against the swatch's nominal (0,0,0) channels.
+	 *
+	 * @return {void}
+	 */
+	it('picks the dark mark for a fully transparent color, reading it against the white popover surface', () => {
+		expect(readableMarkColor('rgba(0, 0, 0, 0)')).toBe('#1e1e1e');
+	});
+
+	/**
+	 * A semi-transparent dark color lightens toward the white backing as it composites, which can
+	 * flip which mark reads legibly compared to treating the color as fully opaque.
+	 *
+	 * @return {void}
+	 */
+	it('composites a semi-transparent color against the white popover surface before choosing', () => {
+		// #1A202C is opaque-dark enough to pick the light mark (see the test above); at 20% alpha
+		// it composites to a pale gray, which should flip the pick to the dark mark.
+		expect(readableMarkColor('rgba(26, 32, 44, 0.2)')).toBe('#1e1e1e');
+	});
+});

--- a/src/token-controls/helpers/contrast.js
+++ b/src/token-controls/helpers/contrast.js
@@ -1,0 +1,141 @@
+/**
+ * Picking a check mark color that stays legible against whichever swatch it sits on
+ * (`ColorGroupList`'s selected-row mark) — the swatch's own color is a design token's resolved
+ * value, so there is no fixed color that reads on every one of them.
+ */
+
+/**
+ * The mark colors to choose between, matching the design tokens' own light/dark text colors
+ * (`token-controls.scss`'s header comment: gray-900 `#1e1e1e` text, white surfaces).
+ *
+ * @since TBD
+ */
+const LIGHT_MARK = '#ffffff';
+const DARK_MARK = '#1e1e1e';
+
+/**
+ * The popover's own background (`token-controls.scss`'s "260px white sheet") — what an
+ * alpha-bearing swatch color is composited against, since `readableMarkColor()` picks a mark
+ * color for how the swatch actually reads on that surface, not for its channels in isolation.
+ *
+ * @since TBD
+ */
+const SWATCH_BACKING = { r: 255, g: 255, b: 255 };
+
+/**
+ * Parse a CSS color string into its `{ r, g, b, a }` channels (0-255 for color, 0-1 for alpha).
+ * Handles the shapes a resolved design-token value actually takes: `#rgb`, `#rrggbb`,
+ * `#rrggbbaa`, `rgb(...)`, and `rgba(...)`. Returns `null` for anything else (a CSS keyword, a
+ * `var(...)` reference, or an unresolved value) rather than guessing.
+ *
+ * @param {string} value The color string.
+ *
+ * @since TBD
+ *
+ * @return {?{r: number, g: number, b: number, a: number}} The parsed channels, or null.
+ */
+export function parseColorChannels(value) {
+	if (typeof value !== 'string') {
+		return null;
+	}
+
+	const trimmed = value.trim();
+	const hex = trimmed.match(/^#([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i)?.[1];
+
+	if (hex) {
+		const full = hex.length === 3 ? hex.replace(/(.)/g, '$1$1') : hex;
+		const a = full.length === 8 ? parseInt(full.slice(6, 8), 16) / 255 : 1;
+
+		return {
+			r: parseInt(full.slice(0, 2), 16),
+			g: parseInt(full.slice(2, 4), 16),
+			b: parseInt(full.slice(4, 6), 16),
+			a,
+		};
+	}
+
+	const rgb = trimmed.match(/^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)$/i);
+
+	if (rgb) {
+		return {
+			r: Number(rgb[1]),
+			g: Number(rgb[2]),
+			b: Number(rgb[3]),
+			a: rgb[4] === undefined ? 1 : Number(rgb[4]),
+		};
+	}
+
+	return null;
+}
+
+/**
+ * Composite a parsed color's channels over `SWATCH_BACKING`, so an alpha-bearing swatch's
+ * luminance reflects how it actually reads on the popover surface rather than its raw channels —
+ * a fully transparent swatch is indistinguishable from that white surface, not from black.
+ *
+ * @param {{r: number, g: number, b: number, a: number}} channels The parsed channels.
+ *
+ * @since TBD
+ *
+ * @return {{r: number, g: number, b: number}} The composited, fully opaque channels.
+ */
+function compositeOverBacking({ r, g, b, a }) {
+	return {
+		r: a * r + (1 - a) * SWATCH_BACKING.r,
+		g: a * g + (1 - a) * SWATCH_BACKING.g,
+		b: a * b + (1 - a) * SWATCH_BACKING.b,
+	};
+}
+
+/**
+ * The channel-relative luminance a channel contributes under WCAG's contrast formula.
+ *
+ * @param {number} channel An 0-255 color channel.
+ *
+ * @since TBD
+ *
+ * @return {number} The linearized 0-1 contribution.
+ */
+function linearize(channel) {
+	const normalized = channel / 255;
+
+	return normalized <= 0.03928 ? normalized / 12.92 : ((normalized + 0.055) / 1.055) ** 2.4;
+}
+
+/**
+ * WCAG relative luminance (0 = black, 1 = white) for a parsed color.
+ *
+ * @param {{r: number, g: number, b: number}} channels The color's channels.
+ *
+ * @since TBD
+ *
+ * @return {number} The relative luminance.
+ */
+export function relativeLuminance({ r, g, b }) {
+	return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
+}
+
+/**
+ * The check mark color that reads legibly against a swatch's resolved background — white on a
+ * dark swatch, the design tokens' own dark text color on a light one. Defaults to the dark mark
+ * when the swatch's color can't be parsed (a `var(...)` reference or an unresolved value), since
+ * `ColorGroupList`'s rows sit on a light popover background either way.
+ *
+ * @param {*} value The swatch's resolved CSS color.
+ *
+ * @since TBD
+ *
+ * @return {string} `#ffffff` or `#1e1e1e`.
+ */
+export function readableMarkColor(value) {
+	const channels = parseColorChannels(value);
+
+	if (!channels) {
+		return DARK_MARK;
+	}
+
+	// 0.5 splits light from dark roughly at WCAG's own "AA large text" contrast threshold for
+	// these two marks against arbitrary backgrounds — good enough for a decorative check mark,
+	// where the swatch's own color is already the primary signal.
+	return relativeLuminance(compositeOverBacking(channels)) < 0.5 ? LIGHT_MARK : DARK_MARK;
+}

--- a/src/token-controls/molecules/ColorGroupList.js
+++ b/src/token-controls/molecules/ColorGroupList.js
@@ -1,0 +1,74 @@
+/**
+ * `ColorControl`'s Style Library tab body: the active palette's groups, each row's swatch sitting at
+ * the row's right edge (a check mark overlaid on it for the current pick) rather than at the left the
+ * way a plain token row's icon does — the swatch IS the row's own identifying mark here, so it plays
+ * the role a trailing value normally would. Passed to `TokenPopover` via its `renderList` prop, in
+ * place of the flat token list every other control shows.
+ *
+ * The check mark's own color is chosen per swatch (`readableMarkColor`) rather than fixed, since a
+ * palette's colors span the whole lightness range and one hardcoded mark color would vanish against
+ * roughly half of them.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { check, Icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { ColorSwatch } from '../atoms/ColorSwatch';
+import { readableMarkColor } from '../helpers/contrast';
+
+/**
+ * The grouped color list.
+ *
+ * @param {Object}   props
+ * @param {Array}    props.groups  `[{ id, label, swatches: [{ id, label, value, alias }] }]`.
+ * @param {*}        props.value   The current slot value, so the active swatch shows a check mark.
+ * @param {Function} props.onPick  Called with a swatch's `alias` when it is chosen.
+ * @param {Function} props.onClose Closes the popover after a choice.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The rendered grouped list.
+ */
+export function ColorGroupList({ groups, value, onPick, onClose }) {
+	return (
+		<div className="kb-color-control__list">
+			{groups.map((group) => (
+				<div className="kb-color-control__group" key={group.id}>
+					<div className="kb-color-control__group-label">{group.label}</div>
+					{group.swatches.map((entry) => {
+						const isCurrent = entry.alias === value;
+						return (
+							<Button
+								key={entry.id}
+								className="kb-color-control__item"
+								onClick={() => {
+									onPick(entry.alias);
+									onClose();
+								}}
+							>
+								<span className="kb-color-control__item-label">{entry.label}</span>
+								<span className="kb-color-control__item-swatch">
+									<ColorSwatch entry={entry} />
+									{isCurrent && (
+										<Icon
+											className="kb-color-control__item-check"
+											icon={check}
+											size={14}
+											style={{ color: readableMarkColor(entry.value) }}
+										/>
+									)}
+								</span>
+							</Button>
+						);
+					})}
+				</div>
+			))}
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- Adds `ColorGroupList`, the new `ColorControl`'s Style Library tab body: the active palette's groups (Accent/Contrast/Background/Notices), each row's swatch sitting at the row's right edge with a check mark overlaid on the current pick, rather than a plain flat token list.
- The check mark's own color (white or the design tokens' dark text color) is chosen per swatch via a new `readableMarkColor()` contrast helper (WCAG relative luminance), so it stays legible against both dark and light swatches — a fixed mark color would vanish against roughly half of any palette.
- Not yet wired into anything reachable — passed to `TokenPopover` via the `renderList` prop added in the previous slice, but nothing calls `ColorControl` yet (that's a later slice).

## Test plan
- `npx jest src/token-controls` — all green, no regressions.
- New unit tests for `readableMarkColor`/`parseColorChannels`/`relativeLuminance`, and for `ColorGroupList`'s grouping, check-mark placement, and click behavior (`onPick` then `onClose`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added grouped color-palette selection with labeled groups and selectable swatches.
  * Selected colors now display a check mark with contrast-aware coloring for improved visibility.
  * Selecting a swatch applies the color and closes the picker.

* **Tests**
  * Added coverage for color-group rendering, selection behavior, callback order, color parsing, transparency, and readable check-mark contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->