### PR TITLE
[DTM] SOFT-4196 [5/8]: add ColorControl and ColorControlGroup

### DIFF
--- a/src/token-controls/__tests__/ColorControl.test.js
+++ b/src/token-controls/__tests__/ColorControl.test.js
@@ -10,26 +10,44 @@ import { createRoot } from 'react-dom/client';
  */
 import { ColorControl } from '../controls/ColorControl';
 
+// A module-level spy so a test can assert `onToggle` was (or was not) called without the
+// `Dropdown` mock needing to accept one through props — e.g. confirming a `BindingIndicator`
+// Reset click, which sits as `onToggle`'s DOM sibling now rather than nested inside it, never
+// bubbles up and reopens the popover it just closed.
+const mockOnToggle = jest.fn();
+
 // Matches `token-popover.test.js`'s stand-in: `@wordpress/components` resolves its own nested
 // `react` copy, a different module instance than the top-level `react-dom/client` this test renders
 // with, which trips React's "Invalid hook call" guard. `Dropdown` renders both its toggle and its
 // content at once (rather than gating on `isOpen`) so a test can reach the popover's rows without
 // simulating a real open click.
 jest.mock('@wordpress/components', () => ({
-	Button: ({ children, isPressed, ...props }) => <button {...props}>{children}</button>,
+	// `showTooltip` (like `isPressed`) is a `Button`-only prop — spreading it onto a DOM `<button>`
+	// trips React's "unrecognized DOM attribute" warning, which `@wordpress/jest-console` treats as
+	// a test failure.
+	Button: ({ children, isPressed, showTooltip, ...props }) => <button {...props}>{children}</button>,
 	Dropdown: ({ renderToggle, renderContent }) => (
 		<>
-			{renderToggle({ isOpen: false, onToggle: () => {} })}
+			{renderToggle({ isOpen: false, onToggle: mockOnToggle })}
 			{renderContent({ onClose: () => {} })}
 		</>
 	),
 	Icon: ({ icon, ...props }) => <span {...props}>{icon}</span>,
 	RangeControl: ({ label }) => <div>{label}</div>,
 	SelectControl: ({ label }) => <div>{label}</div>,
-	TabPanel: ({ children, tabs, initialTabName }) => {
-		const initialTab = tabs.find((tab) => tab.name === initialTabName) || tabs[0];
-		return <div data-testid="tab-panel">{children(initialTab)}</div>;
-	},
+	// Renders every tab's content unconditionally, not just `initialTabName`'s — `ColorControl`
+	// computes its own initial tab internally (never `'custom'` while a value is bound to an entry,
+	// since a bound value is always alias-shaped), so a test asserting on the Custom tab's output
+	// needs it mounted regardless of which tab a real `TabPanel` would show as active.
+	TabPanel: ({ children, tabs }) => (
+		<div data-testid="tab-panel">
+			{tabs.map((tab) => (
+				<div key={tab.name} data-tab={tab.name}>
+					{children(tab)}
+				</div>
+			))}
+		</div>
+	),
 	Tooltip: ({ children }) => children,
 	__experimentalNumberControl: ({ label }) => <div>{label}</div>,
 }));
@@ -47,9 +65,13 @@ jest.mock('@wordpress/i18n', () => ({
 	sprintf: (format, ...args) => format.replace(/%s/g, () => args.shift()),
 }));
 
-// `ColorPicker` pulls in `react-color`, which the token-popover-style tests never need to exercise —
-// `ColorControl`'s own behavior under test never opens the Custom tab.
-jest.mock('../molecules/ColorPicker', () => ({ ColorPicker: () => null }));
+// `ColorPicker` pulls in `react-color`, which these tests never need to exercise — this stand-in
+// exposes the `color` prop it was called with (`data-testid="color-picker"`'s own `data-color`
+// attribute) so a test can assert what `ColorControl` resolves for the Custom tab without
+// rendering the real saturation/hue UI.
+jest.mock('../molecules/ColorPicker', () => ({
+	ColorPicker: ({ color }) => <div data-testid="color-picker" data-color={color ?? ''} />,
+}));
 
 jest.mock('../styles/token-controls.scss', () => ({}), { virtual: true });
 
@@ -82,6 +104,7 @@ beforeEach(() => {
 	container = document.createElement('div');
 	document.body.appendChild(container);
 	root = createRoot(container);
+	mockOnToggle.mockClear();
 });
 
 afterEach(() => {
@@ -200,5 +223,54 @@ describe('ColorControl', () => {
 		act(() => items[1].dispatchEvent(new MouseEvent('click', { bubbles: true })));
 
 		expect(onPick).toHaveBeenCalledWith('{semantic.color.accent.soft}');
+	});
+
+	/**
+	 * `BindingIndicator`'s Reset button is a DOM sibling of the dropdown's toggle button, not
+	 * nested inside it — a Reset click must never bubble up and reopen the popover it just closed.
+	 *
+	 * @return {void}
+	 */
+	it('does not toggle the popover when the binding indicator is reset', () => {
+		const onReset = jest.fn();
+
+		render({
+			value: '{semantic.color.accent.soft}',
+			status: { bound: true, modified: true },
+			onReset,
+		});
+
+		const reset = container.querySelector('.kb-token-control__indicator-reset');
+		expect(reset).not.toBeNull();
+		expect(container.querySelector('.kb-color-control__trigger-button').contains(reset)).toBe(false);
+
+		act(() => reset.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+
+		expect(onReset).toHaveBeenCalled();
+		expect(mockOnToggle).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * When the value is bound to a group entry and the host supplies no `resolveLiteral`, the
+	 * Custom tab must never receive the raw bracket alias as a literal CSS color — `ColorPicker`
+	 * requires a parseable value, and an alias string like `{semantic.color.accent.soft}` isn't one.
+	 *
+	 * @return {void}
+	 */
+	it('does not pass a raw token alias to the Custom tab when resolveLiteral is omitted', () => {
+		render({ value: '{semantic.color.accent.soft}', resolveLiteral: undefined });
+
+		expect(container.querySelector('[data-testid="color-picker"]').dataset.color).toBe('');
+	});
+
+	/**
+	 * The Custom tab still seeds from the host's resolved literal when one is available.
+	 *
+	 * @return {void}
+	 */
+	it('passes the resolved literal to the Custom tab when resolveLiteral is provided', () => {
+		render({ value: '{semantic.color.accent.soft}', resolveLiteral: () => '#3182ce' });
+
+		expect(container.querySelector('[data-testid="color-picker"]').dataset.color).toBe('#3182ce');
 	});
 });

--- a/src/token-controls/__tests__/ColorControl.test.js
+++ b/src/token-controls/__tests__/ColorControl.test.js
@@ -1,0 +1,204 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { ColorControl } from '../controls/ColorControl';
+
+// Matches `token-popover.test.js`'s stand-in: `@wordpress/components` resolves its own nested
+// `react` copy, a different module instance than the top-level `react-dom/client` this test renders
+// with, which trips React's "Invalid hook call" guard. `Dropdown` renders both its toggle and its
+// content at once (rather than gating on `isOpen`) so a test can reach the popover's rows without
+// simulating a real open click.
+jest.mock('@wordpress/components', () => ({
+	Button: ({ children, isPressed, ...props }) => <button {...props}>{children}</button>,
+	Dropdown: ({ renderToggle, renderContent }) => (
+		<>
+			{renderToggle({ isOpen: false, onToggle: () => {} })}
+			{renderContent({ onClose: () => {} })}
+		</>
+	),
+	Icon: ({ icon, ...props }) => <span {...props}>{icon}</span>,
+	RangeControl: ({ label }) => <div>{label}</div>,
+	SelectControl: ({ label }) => <div>{label}</div>,
+	TabPanel: ({ children, tabs, initialTabName }) => {
+		const initialTab = tabs.find((tab) => tab.name === initialTabName) || tabs[0];
+		return <div data-testid="tab-panel">{children(initialTab)}</div>;
+	},
+	Tooltip: ({ children }) => children,
+	__experimentalNumberControl: ({ label }) => <div>{label}</div>,
+}));
+
+jest.mock('@wordpress/icons', () => ({
+	check: 'check',
+	globe: 'globe',
+	settings: 'settings',
+	undo: 'undo',
+	Icon: ({ icon, ...props }) => <span {...props}>{icon}</span>,
+}));
+
+jest.mock('@wordpress/i18n', () => ({
+	__: (text) => text,
+	sprintf: (format, ...args) => format.replace(/%s/g, () => args.shift()),
+}));
+
+// `ColorPicker` pulls in `react-color`, which the token-popover-style tests never need to exercise —
+// `ColorControl`'s own behavior under test never opens the Custom tab.
+jest.mock('../molecules/ColorPicker', () => ({ ColorPicker: () => null }));
+
+jest.mock('../styles/token-controls.scss', () => ({}), { virtual: true });
+
+const GROUPS = [
+	{
+		id: 'accent',
+		label: 'Accent',
+		swatches: [
+			{
+				id: 'semantic.color.accent.strong',
+				label: 'Strongest',
+				value: '',
+				alias: '{semantic.color.accent.strong}',
+			},
+			{
+				id: 'semantic.color.accent.soft',
+				label: 'Soft',
+				value: '',
+				alias: '{semantic.color.accent.soft}',
+			},
+		],
+	},
+];
+
+let container;
+let root;
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+/**
+ * Render `ColorControl` with the given props.
+ *
+ * @param {Object} props The component props.
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+function render(props = {}) {
+	act(() =>
+		root.render(
+			createElement(ColorControl, {
+				label: 'Text',
+				value: '',
+				groups: GROUPS,
+				onPick: jest.fn(),
+				onCustom: jest.fn(),
+				resolveLiteral: () => '',
+				...props,
+			})
+		)
+	);
+}
+
+describe('ColorControl', () => {
+	/**
+	 * The static attribute label always renders on the trigger, regardless of the current value.
+	 *
+	 * @return {void}
+	 */
+	it('renders the static label', () => {
+		render();
+
+		expect(container.querySelector('.kb-color-control__label').textContent).toBe('Text');
+	});
+
+	/**
+	 * When the bound value matches a group entry, the trigger shows that entry's own label
+	 * right-aligned beside the static label.
+	 *
+	 * @return {void}
+	 */
+	it("shows the selected token's label when value matches a group entry", () => {
+		render({ value: '{semantic.color.accent.soft}' });
+
+		expect(container.querySelector('.kb-color-control__value').textContent).toBe('Soft');
+	});
+
+	/**
+	 * An unbound trigger shows no selected-value text.
+	 *
+	 * @return {void}
+	 */
+	it('shows no selected-value text when nothing is bound', () => {
+		render();
+
+		expect(container.querySelector('.kb-color-control__value')).toBeNull();
+	});
+
+	/**
+	 * A bound alias that resolves to no entry in this control's own groups (e.g. a button preset's
+	 * default text/background color, outside the Accent/Contrast/Background palette) shows the muted
+	 * "Default" fallback rather than the raw, overflowing alias text.
+	 *
+	 * @return {void}
+	 */
+	it('shows the muted "Default" fallback when the value is bound but not one of the pickable groups', () => {
+		render({ value: '{semantic.color.button-primary-text}' });
+
+		expect(container.querySelector('.kb-color-control__value').textContent).toBe('Default');
+	});
+
+	/**
+	 * The same out-of-group case never leaks the raw bracket-alias string into the swatch's inline
+	 * `background`, which is not a valid CSS color.
+	 *
+	 * @return {void}
+	 */
+	it('renders a transparent swatch, not the raw alias, for an out-of-group value', () => {
+		render({ value: '{semantic.color.button-primary-text}' });
+
+		expect(container.querySelector('.kb-color-swatch').style.background).toBe('transparent');
+	});
+
+	/**
+	 * The trigger always renders a swatch mark, bound or not.
+	 *
+	 * @return {void}
+	 */
+	it('renders the swatch', () => {
+		render({ value: '{semantic.color.accent.soft}' });
+
+		expect(container.querySelector('.kb-color-control__trigger .kb-color-swatch')).not.toBeNull();
+	});
+
+	/**
+	 * Clicking a `ColorGroupList` row calls `onPick` with that entry's alias.
+	 *
+	 * @return {void}
+	 */
+	it('calls onPick with the alias when a group list row is clicked', () => {
+		const onPick = jest.fn();
+
+		render({ onPick });
+
+		const items = container.querySelectorAll('.kb-color-control__item');
+		act(() => items[1].dispatchEvent(new MouseEvent('click', { bubbles: true })));
+
+		expect(onPick).toHaveBeenCalledWith('{semantic.color.accent.soft}');
+	});
+});

--- a/src/token-controls/controls/ColorControl.js
+++ b/src/token-controls/controls/ColorControl.js
@@ -1,0 +1,118 @@
+/**
+ * The color token control: a swatch, the control's own static attribute label, and the currently
+ * selected token's own label right-aligned — all inside one clickable trigger, no separate header
+ * above it.
+ *
+ * No `ControlShell` — its header-above-body split does not fit a control whose label lives inside
+ * the trigger row itself, the way `BorderControl`'s width `TokenSelector` does. Composes `Dropdown`
+ * and `TokenPopover` directly, passing `ColorGroupList` through `TokenPopover`'s `renderList` prop
+ * for a grouped Style Library tab (Accent/Contrast/Background/Notices) instead of the flat token
+ * list every other control shows, and the relocated `ColorPicker` through `renderCustom` for the
+ * Custom tab.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Dropdown } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { BindingIndicator } from '../atoms/BindingIndicator';
+import { ColorSwatch } from '../atoms/ColorSwatch';
+import { ColorGroupList } from '../molecules/ColorGroupList';
+import { ColorPicker } from '../molecules/ColorPicker';
+import { TokenPopover } from '../molecules/TokenPopover';
+import { findTokenEntry, isTokenAlias } from '../helpers/token-summary';
+import '../styles/token-controls.scss';
+
+/**
+ * Render a color token control.
+ *
+ * @param {Object}    props                 The component props.
+ * @param {string}    props.label           The control's own static attribute label (e.g. "Text"),
+ *                                           never changing with the current selection.
+ * @param {*}         props.value           The current slot value: a bracket alias
+ *                                           (`{token.id}`, a token pick) or a raw literal
+ *                                           (hex/rgba, a Custom-tab pick).
+ * @param {Array}     props.groups          `[{ id, label, swatches: [{ id, label, value, alias }] }]`
+ *                                           — the active palette's groups, host-resolved.
+ * @param {?Object}   [props.status]        `{ bound, modified }`; omit for no indicator.
+ * @param {?Function} [props.onReset]       Reset handler, paired with `status`.
+ * @param {Function}  props.onPick          Called with a token entry's `alias` when one is chosen.
+ * @param {Function}  props.onCustom        Called with a literal color from the Custom tab.
+ * @param {?Function} [props.resolveLiteral] `(entry) => string` — the host's hook for seeding the
+ *                                           Custom tab from a currently-bound token entry, letting
+ *                                           the block-editor adapter read the token's resolved
+ *                                           value under the block's own pinned palette scope.
+ * @param {boolean}   [props.disabled]      Whether the control is read-only.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The rendered control.
+ */
+export function ColorControl({
+	label,
+	value,
+	groups,
+	status = null,
+	onReset = null,
+	onPick,
+	onCustom,
+	resolveLiteral,
+	disabled = false,
+}) {
+	const allSwatches = groups.flatMap((group) => group.swatches);
+	const entry = findTokenEntry(allSwatches, value);
+	// A bound alias that resolves to no entry in this control's own groups (e.g. a button preset's
+	// text/background default, a token from outside the Accent/Contrast/Background palette) is still
+	// a real, working color — just not one this control can name. Reading it back as raw dot-path
+	// text would overflow the trigger and read as broken; "Default" matches every other token
+	// control's muted fallback for "set, but not to one of my own pickable options."
+	const selectedLabel = entry ? entry.label : isTokenAlias(value) ? __('Default', 'kadence-blocks') : null;
+	const initialTab = isTokenAlias(value) || !value ? 'style-library' : 'custom';
+
+	return (
+		<div className="kb-color-control">
+			<Dropdown
+				className="kb-color-control__dropdown"
+				contentClassName="kb-color-control__popover"
+				popoverProps={{ placement: 'left-start' }}
+				renderToggle={({ isOpen, onToggle }) => (
+					<button
+						type="button"
+						className="kb-color-control__trigger"
+						aria-expanded={isOpen}
+						disabled={disabled}
+						onClick={onToggle}
+					>
+						<ColorSwatch entry={entry} value={!entry && !isTokenAlias(value) ? value : null} />
+						<span className="kb-color-control__label">{label}</span>
+						{selectedLabel && <span className="kb-color-control__value">{selectedLabel}</span>}
+						<BindingIndicator status={status} onReset={onReset} showReset disabled={disabled} />
+					</button>
+				)}
+				renderContent={({ onClose }) => (
+					<TokenPopover
+						value={value}
+						tokens={allSwatches}
+						initialTab={initialTab}
+						renderList={({ onPick: pick, onClose: close }) => (
+							<ColorGroupList groups={groups} value={value} onPick={pick} onClose={close} />
+						)}
+						renderCustom={() => (
+							<ColorPicker
+								color={entry && resolveLiteral ? resolveLiteral(entry) : value}
+								onChange={onCustom}
+							/>
+						)}
+						onPick={onPick}
+						onClose={onClose}
+					/>
+				)}
+			/>
+		</div>
+	);
+}

--- a/src/token-controls/controls/ColorControl.js
+++ b/src/token-controls/controls/ColorControl.js
@@ -76,43 +76,48 @@ export function ColorControl({
 
 	return (
 		<div className="kb-color-control">
-			<Dropdown
-				className="kb-color-control__dropdown"
-				contentClassName="kb-color-control__popover"
-				popoverProps={{ placement: 'left-start' }}
-				renderToggle={({ isOpen, onToggle }) => (
-					<button
-						type="button"
-						className="kb-color-control__trigger"
-						aria-expanded={isOpen}
-						disabled={disabled}
-						onClick={onToggle}
-					>
-						<ColorSwatch entry={entry} value={!entry && !isTokenAlias(value) ? value : null} />
-						<span className="kb-color-control__label">{label}</span>
-						{selectedLabel && <span className="kb-color-control__value">{selectedLabel}</span>}
-						<BindingIndicator status={status} onReset={onReset} showReset disabled={disabled} />
-					</button>
-				)}
-				renderContent={({ onClose }) => (
-					<TokenPopover
-						value={value}
-						tokens={allSwatches}
-						initialTab={initialTab}
-						renderList={({ onPick: pick, onClose: close }) => (
-							<ColorGroupList groups={groups} value={value} onPick={pick} onClose={close} />
-						)}
-						renderCustom={() => (
-							<ColorPicker
-								color={entry && resolveLiteral ? resolveLiteral(entry) : value}
-								onChange={onCustom}
-							/>
-						)}
-						onPick={onPick}
-						onClose={onClose}
-					/>
-				)}
-			/>
+			<div className="kb-color-control__trigger">
+				<Dropdown
+					className="kb-color-control__dropdown"
+					contentClassName="kb-color-control__popover"
+					popoverProps={{ placement: 'left-start' }}
+					renderToggle={({ isOpen, onToggle }) => (
+						<button
+							type="button"
+							className="kb-color-control__trigger-button"
+							aria-expanded={isOpen}
+							disabled={disabled}
+							onClick={onToggle}
+						>
+							<ColorSwatch entry={entry} value={!entry && !isTokenAlias(value) ? value : null} />
+							<span className="kb-color-control__label">{label}</span>
+							{selectedLabel && <span className="kb-color-control__value">{selectedLabel}</span>}
+						</button>
+					)}
+					renderContent={({ onClose }) => (
+						<TokenPopover
+							value={value}
+							tokens={allSwatches}
+							initialTab={initialTab}
+							renderList={({ onPick: pick, onClose: close }) => (
+								<ColorGroupList groups={groups} value={value} onPick={pick} onClose={close} />
+							)}
+							renderCustom={() => (
+								<ColorPicker
+									color={entry && resolveLiteral ? resolveLiteral(entry) : entry ? '' : value}
+									onChange={onCustom}
+								/>
+							)}
+							onPick={onPick}
+							onClose={onClose}
+						/>
+					)}
+				/>
+				{/* A sibling of the toggle button, never nested inside it — `BindingIndicator` renders its
+				    own `<button>` for Reset once modified, and nesting two buttons would let a Reset
+				    click bubble to the toggle's `onClick` and reopen the popover it just closed. */}
+				<BindingIndicator status={status} onReset={onReset} showReset disabled={disabled} />
+			</div>
 		</div>
 	);
 }

--- a/src/token-controls/controls/ColorControlGroup.js
+++ b/src/token-controls/controls/ColorControlGroup.js
@@ -1,0 +1,28 @@
+/**
+ * A no-gap stacking wrapper for two or more `ColorControl`s, so a group of related color rows (e.g.
+ * Text / Background) reads as one bordered box instead of a stack of separately bordered ones.
+ *
+ * CSS-only, mirroring `.kb-border-control__box`'s pattern in `styles/token-controls.scss`: the
+ * border/radius reset lives on this wrapper's stylesheet rule, keyed off `:first-child`/
+ * `:last-child`/`:not(:first-child)`, rather than on `ColorControl` itself, so `ColorControl` stays
+ * unaware of whether it is grouped.
+ */
+
+/**
+ * Internal dependencies
+ */
+import '../styles/token-controls.scss';
+
+/**
+ * Render a no-gap group of `ColorControl`s.
+ *
+ * @param {Object} props          The component props.
+ * @param {*}      props.children The `ColorControl`s to stack.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The rendered group.
+ */
+export function ColorControlGroup({ children }) {
+	return <div className="kb-color-control-group">{children}</div>;
+}

--- a/src/token-controls/index.js
+++ b/src/token-controls/index.js
@@ -23,6 +23,8 @@ export { FontFamilySelector } from './organisms/FontFamilySelector';
 export { ControlShell } from './templates/ControlShell';
 export { SlotGrid } from './templates/SlotGrid';
 export { BoxControl } from './controls/BoxControl';
+export { ColorControl } from './controls/ColorControl';
+export { ColorControlGroup } from './controls/ColorControlGroup';
 export { ScalarControl } from './controls/ScalarControl';
 export { ColorPicker } from './molecules/ColorPicker';
 

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -984,10 +984,11 @@
 	width: 100%;
 }
 
-// `Dropdown`'s own wrapping element has no intrinsic width; without this the trigger's `width: 100%`
-// below has nothing to fill and the control reads narrower than every other field beside it.
+// `Dropdown`'s own wrapping element has no intrinsic width; without this it has nothing to fill
+// within `.kb-color-control__trigger`'s row and the toggle button reads narrower than its share.
 .kb-color-control__dropdown {
-	width: 100%;
+	flex: 1 1 auto;
+	min-width: 0;
 }
 
 // Matches `.kadence-token-field__popover`'s own sheet size — without it the popover falls back to
@@ -1001,6 +1002,12 @@
  * `ColorControl`'s own trigger row: a swatch, the control's static attribute label, the currently
  * selected token's label right-aligned, and the `BindingIndicator` mark — no `.kb-token-control`
  * header above it, since the label lives inside this row instead.
+ *
+ * The bordered box and the clickable toggle are two elements, not one: `BindingIndicator` renders
+ * its own `<button>` for Reset once modified, and nesting that inside the toggle `<button>` would
+ * let a Reset click bubble up and reopen the popover it just closed. This div carries the row's
+ * border/background/hover/disabled chrome; `.kb-color-control__trigger-button` below is the actual
+ * (borderless) toggle sitting inside it, with `BindingIndicator` as its sibling.
  */
 .kb-color-control__trigger {
 	display: flex;
@@ -1015,15 +1022,37 @@
 	color: #1e1e1e;
 	font-size: 13px;
 	line-height: 1.4;
-	cursor: pointer;
 
 	&:hover {
 		border-color: #1e1e1e;
 	}
 
+	&:has(.kb-color-control__trigger-button[aria-expanded="true"]) {
+		border-color: #3858e9;
+		box-shadow: 0 0 0 1px #3858e9;
+	}
+
+	&:has(.kb-color-control__trigger-button:disabled) {
+		opacity: 0.5;
+	}
+}
+
+// The dropdown's actual toggle: unstyled but for layout, so only `.kb-color-control__trigger`'s
+// border/background reads as the control's own box.
+.kb-color-control__trigger-button {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	padding: 0;
+	border: 0;
+	background: none;
+	color: inherit;
+	font: inherit;
+	cursor: pointer;
+
 	&:disabled {
 		cursor: default;
-		opacity: 0.5;
 	}
 }
 

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -978,3 +978,160 @@
 .kb-border-control__style-menu-label {
 	flex: 1 1 auto;
 }
+
+// Fills its container the way every other field does (`.kadence-token-field`'s own `width: 100%`).
+.kb-color-control {
+	width: 100%;
+}
+
+// `Dropdown`'s own wrapping element has no intrinsic width; without this the trigger's `width: 100%`
+// below has nothing to fill and the control reads narrower than every other field beside it.
+.kb-color-control__dropdown {
+	width: 100%;
+}
+
+// Matches `.kadence-token-field__popover`'s own sheet size — without it the popover falls back to
+// `@wordpress/components`' default width, narrower than every other control's popover.
+.kb-color-control__popover .components-popover__content {
+	min-width: 260px;
+	border-radius: 4px;
+}
+
+/*
+ * `ColorControl`'s own trigger row: a swatch, the control's static attribute label, the currently
+ * selected token's label right-aligned, and the `BindingIndicator` mark — no `.kb-token-control`
+ * header above it, since the label lives inside this row instead.
+ */
+.kb-color-control__trigger {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	height: 32px;
+	padding: 0 8px;
+	border: 1px solid #949494;
+	border-radius: 2px;
+	background: #fff;
+	color: #1e1e1e;
+	font-size: 13px;
+	line-height: 1.4;
+	cursor: pointer;
+
+	&:hover {
+		border-color: #1e1e1e;
+	}
+
+	&:disabled {
+		cursor: default;
+		opacity: 0.5;
+	}
+}
+
+// Bold, matching `.kb-token-control__label`'s own weight for every other control's field label —
+// this control just carries its label inside the trigger row instead of in a header above it.
+.kb-color-control__label {
+	flex: 0 0 auto;
+	font-weight: 500;
+}
+
+// Pushes the selected-token label and the binding indicator to the trigger's right edge.
+.kb-color-control__value {
+	flex: 1 1 auto;
+	overflow: hidden;
+	color: #949494;
+	text-align: right;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+// The round swatch `ColorControl`'s trigger and `ColorGroupList`'s rows both render.
+.kb-color-swatch {
+	display: inline-flex;
+	flex: 0 0 auto;
+	width: 20px;
+	height: 20px;
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	border-radius: 50%;
+}
+
+// The popover's Style Library tab: the active palette's groups, each swatch showing a check mark on
+// the current pick.
+.kb-color-control__list {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	padding: 8px;
+}
+
+.kb-color-control__group-label {
+	padding: 4px 8px;
+	color: #949494;
+	font-size: 11px;
+	text-transform: uppercase;
+}
+
+.kb-color-control__item.components-button {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	height: 32px;
+	padding: 0 8px;
+	border: 0;
+	border-radius: 2px;
+	background: transparent;
+	color: #1e1e1e;
+	font-size: 13px;
+	font-weight: normal;
+	text-align: left;
+
+	&:hover {
+		background: #f0f0f0;
+	}
+}
+
+// Not bold — matches `.kadence-token-field__item-label`'s own weight, every other control's popover
+// rows.
+.kb-color-control__item-label {
+	flex: 1 1 auto;
+	overflow: hidden;
+	font-weight: normal;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+// The row's swatch sits at its right edge, playing the role a trailing value normally would; the
+// check mark on the current pick overlays it rather than following as a separate glyph.
+.kb-color-control__item-swatch {
+	position: relative;
+	display: inline-flex;
+	flex: 0 0 auto;
+}
+
+.kb-color-control__item-check {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+/*
+ * No-gap stacking for two or more `ColorControl`s: the shared edge between adjacent rows collapses
+ * to one line, and only the group's outer corners round — the same pattern
+ * `.kb-border-control__box` uses for its own composite row, applied here across siblings instead of
+ * within one row.
+ */
+.kb-color-control-group {
+	.kb-color-control:not(:first-child) .kb-color-control__trigger {
+		border-top: 0;
+	}
+
+	.kb-color-control:first-child .kb-color-control__trigger {
+		border-radius: 2px 2px 0 0;
+	}
+
+	.kb-color-control:last-child .kb-color-control__trigger {
+		border-radius: 0 0 2px 2px;
+	}
+}

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -1013,6 +1013,11 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
+	// The padding and border are part of the 100% width, not added to it. Unlike the token field's
+	// own trigger, this is a plain `<div>` rather than a `.components-button`, so it inherits no
+	// border-box from `@wordpress/components` — and the Style Library, where this also renders, has
+	// no global reset of its own.
+	box-sizing: border-box;
 	width: 100%;
 	height: 32px;
 	padding: 0 8px;


### PR DESCRIPTION
## Summary
- Adds the public `ColorControl` component: a swatch, the control's own static attribute label, and the currently selected token's label right-aligned — all inside one clickable trigger row, no separate header above it (unlike every other token control, whose label lives above the control; this one's lives inside the row).
- Composes `Dropdown` + `TokenPopover` directly, passing the previous slices' `ColorGroupList` through `renderList` for the grouped Style Library tab, and the relocated `ColorPicker` through `renderCustom` for the Custom tab.
- Adds `ColorControlGroup`, a thin CSS-only wrapper for stacking multiple `ColorControl`s with no gap between them, matching `.kb-border-control__box`'s established pattern.
- Adds every `.kb-color-control*` style rule to `token-controls.scss`: full-width field and popover, the trigger's bold static label, the popover list's non-bold row labels, and the swatch/check-mark layout.
- Still not wired into anything reachable — the next two slices build the data source and wire it into `kadence/singlebtn` and the Style Library.

## Test plan
- `npx jest src/token-controls` — all green, no regressions.
- New unit tests: static label always renders, selected-token label shows when bound to a group entry, muted "Default" fallback for a value outside the control's own groups, swatch renders, clicking a `ColorGroupList` row calls `onPick` with the entry's alias.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added color controls with token selection, custom color picking, swatches, binding indicators, reset support, and disabled states.
  - Added grouped color-control layouts for organizing related controls.
  - Added support for displaying token palettes and unresolved or default values.

- **Style**
  - Added styling for color-control popovers, selectable palette rows, swatches, and grouped layouts.

- **Tests**
  - Added coverage for rendering, token states, swatches, and color-selection interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->