### PR TITLE
[DTM] SOFT-4260 [1/19]: add a shared None/Auto fixed-sentinel helper

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -136,6 +136,7 @@
         "recaptcha",
         "recognised",
         "renameable",
+        "repointed",
         "Reselecting",
         "resends",
         "resizer",

--- a/src/token-controls/__tests__/fixed-tokens.test.js
+++ b/src/token-controls/__tests__/fixed-tokens.test.js
@@ -1,0 +1,64 @@
+/* eslint-env jest */
+import { autoEntry, noneEntryForRole } from '../helpers/fixed-tokens';
+
+describe('noneEntryForRole', () => {
+	it('builds a numeric-zero None entry for radius', () => {
+		expect(noneEntryForRole('radius')).toEqual({
+			id: 'ss-none-radius',
+			label: 'None',
+			value: '0',
+			alias: 0,
+			fixed: true,
+			type: 'dimension',
+			role: 'radius',
+		});
+	});
+
+	it('builds a numeric-zero None entry for spacing', () => {
+		expect(noneEntryForRole('spacing')).toMatchObject({
+			id: 'ss-none-spacing',
+			alias: 0,
+			type: 'dimension',
+			role: 'spacing',
+		});
+	});
+
+	it('builds a numeric-zero None entry for border-width', () => {
+		expect(noneEntryForRole('border-width')).toMatchObject({
+			id: 'ss-none-border-width',
+			alias: 0,
+			type: 'dimension',
+			role: 'border-width',
+		});
+	});
+
+	it('builds a shorthand-string None entry for shadow', () => {
+		expect(noneEntryForRole('shadow')).toEqual({
+			id: 'ss-none-shadow',
+			label: 'None',
+			value: '0px 0px 0px 0px transparent',
+			alias: '0px 0px 0px 0px transparent',
+			fixed: true,
+			type: 'shadow',
+			role: 'shadow',
+		});
+	});
+
+	it('returns null for a role with no None', () => {
+		expect(noneEntryForRole('color')).toBeNull();
+	});
+});
+
+describe('autoEntry', () => {
+	it('builds the Auto sentinel', () => {
+		expect(autoEntry()).toEqual({
+			id: 'ss-auto',
+			label: 'Auto',
+			value: 'auto',
+			alias: 'ss-auto',
+			fixed: true,
+			type: 'dimension',
+			role: 'spacing',
+		});
+	});
+});

--- a/src/token-controls/helpers/fixed-tokens.js
+++ b/src/token-controls/helpers/fixed-tokens.js
@@ -1,0 +1,77 @@
+/**
+ * The two kinds of pickable option every `token-controls` box/border/shadow control needs beyond
+ * its role's own registered scale: a "None" choice on every dimension/shadow property, and an
+ * "Auto" choice on Margin only. Neither is a registered DTCG token — a registered token can be
+ * renamed, deleted, or repointed to a different value from its Style Library screen, which is
+ * exactly what a sentinel meant to always resolve to the same literal must not allow. `fixed: true`
+ * is what lets `token-summary.js`'s `findTokenEntry()` match one of these by plain equality
+ * instead of requiring the bracket-wrapped alias form a real token id takes.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * A role's "None" sentinel value. Radius/spacing/border-width collapse to the bare number `0` —
+ * the box-control write paths (`toStoredValue`, `toStoredWidth`, and the editor's raw attribute
+ * write) already special-case a literal `0` as a clean, unitless value, so no further conversion
+ * is needed anywhere else. Shadow can't collapse to a number; its resolved value is the same
+ * `box-shadow` shorthand shape a real shadow token's `value` already carries.
+ *
+ * @since TBD
+ */
+const NONE_VALUE_BY_ROLE = {
+	radius: 0,
+	spacing: 0,
+	'border-width': 0,
+	shadow: '0px 0px 0px 0px transparent',
+};
+
+/**
+ * Build the fixed "None" entry for a role.
+ *
+ * @param {string} role The token role ('radius' | 'spacing' | 'border-width' | 'shadow').
+ *
+ * @since TBD
+ *
+ * @return {?Object} The fixed entry, or null when the role has no "None".
+ */
+export function noneEntryForRole(role) {
+	if (!Object.prototype.hasOwnProperty.call(NONE_VALUE_BY_ROLE, role)) {
+		return null;
+	}
+
+	const alias = NONE_VALUE_BY_ROLE[role];
+
+	return {
+		id: `ss-none-${role}`,
+		label: __('None', 'kadence-blocks'),
+		value: String(alias),
+		alias,
+		fixed: true,
+		type: role === 'shadow' ? 'shadow' : 'dimension',
+		role,
+	};
+}
+
+/**
+ * Margin's "Auto" sentinel: the CSS keyword `auto`, not a length, so — like "None" above — it is
+ * deliberately never a registered token (see `declarations.php`'s comment on `$spacing_slugs`).
+ *
+ * @since TBD
+ *
+ * @return {Object} The fixed entry.
+ */
+export function autoEntry() {
+	return {
+		id: 'ss-auto',
+		label: __('Auto', 'kadence-blocks'),
+		value: 'auto',
+		alias: 'ss-auto',
+		fixed: true,
+		type: 'dimension',
+		role: 'spacing',
+	};
+}

--- a/src/token-controls/index.js
+++ b/src/token-controls/index.js
@@ -50,6 +50,7 @@ export {
 	isTokenAlias,
 	resolveDefaultValue,
 } from './helpers/token-summary';
+export { autoEntry, noneEntryForRole } from './helpers/fixed-tokens';
 export {
 	SLOT_COUNT,
 	SLOT_LABELS,


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4260/token-control-popover-options-and-the-default-label-show-what-is

Adds a shared helper that builds the fixed `None` / `Auto` sentinel entries a token picker offers alongside a role's real tokens. These are not registered design tokens — there is no `primitive.dimension.radius.none` behind them — so they carry a `fixed` marker and their own literal `alias`, which is what lets a caller tell a sentinel pick apart from a token pick and store the literal instead of a dangling dot-path.

Nothing consumes it yet; the two hosts are wired in the next two slices.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fixed “None” options for radius, spacing, border width, and shadow token controls.
  * Added a fixed “Auto” option for spacing controls.
  * Unsupported token roles no longer display an invalid “None” option.

* **Tests**
  * Added coverage validating the new fixed token options and their supported roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->