### PR TITLE
[DTM] SOFT-4196 [6/8]: add a minimal editor-scoped color-groups fetch hook for ColorControl

### DIFF
--- a/src/extension/design-tokens/__tests__/use-color-groups.test.js
+++ b/src/extension/design-tokens/__tests__/use-color-groups.test.js
@@ -227,4 +227,79 @@ describe('useColorGroups', () => {
 		act(() => otherRoot.unmount());
 		otherContainer.remove();
 	});
+
+	/**
+	 * A `kbPalette` change on the SAME selected block — no `clientId` change — must still re-fetch;
+	 * the effect depends on the resolved palette id itself, not only on `clientId`.
+	 *
+	 * @return {Promise<void>}
+	 */
+	it('re-fetches when the resolved palette id changes without a clientId change', async () => {
+		mockEffectivePalette.mockReturnValue('brand-first');
+		mockApiFetch.mockResolvedValueOnce({ ...PALETTE_NODE, id: 'brand-first' });
+
+		const { box, update } = renderHook('block-1');
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		expect(box.current).toEqual(MAPPED_GROUPS);
+
+		mockEffectivePalette.mockReturnValue('brand-second');
+		mockApiFetch.mockResolvedValueOnce({ ...PALETTE_NODE, id: 'brand-second', groups: [] });
+
+		update('block-1');
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		expect(mockApiFetch).toHaveBeenCalledTimes(2);
+		expect(mockApiFetch).toHaveBeenLastCalledWith({
+			path: '/kb-design-tokens/v1/palettes/brand-second?library=default',
+		});
+		expect(box.current).toEqual([]);
+	});
+
+	/**
+	 * The same palette id can exist in more than one library, and the REST response depends on
+	 * both — caching on the id alone could return one library's groups for another's request.
+	 *
+	 * @return {Promise<void>}
+	 */
+	it('fetches separately for the same palette id in a different library, not the cached one', async () => {
+		mockEffectivePalette.mockReturnValue('shared-id');
+		mockApiFetch.mockResolvedValueOnce(PALETTE_NODE);
+
+		renderHook('block-1');
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		window.kadenceDesignTokensPalettes.active = 'other-library';
+		mockApiFetch.mockResolvedValueOnce({ ...PALETTE_NODE, groups: [] });
+
+		const otherContainer = document.createElement('div');
+		document.body.appendChild(otherContainer);
+		const otherRoot = createRoot(otherContainer);
+
+		function OtherLibraryProbe() {
+			useColorGroups('block-2');
+			return null;
+		}
+
+		act(() => {
+			otherRoot.render(createElement(OtherLibraryProbe));
+		});
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		expect(mockApiFetch).toHaveBeenCalledTimes(2);
+		expect(mockApiFetch).toHaveBeenLastCalledWith({
+			path: '/kb-design-tokens/v1/palettes/shared-id?library=other-library',
+		});
+
+		act(() => otherRoot.unmount());
+		otherContainer.remove();
+	});
 });

--- a/src/extension/design-tokens/__tests__/use-color-groups.test.js
+++ b/src/extension/design-tokens/__tests__/use-color-groups.test.js
@@ -1,0 +1,230 @@
+/* eslint-env jest */
+/**
+ * The block-editor's own read-only palette-groups fetch for `ColorControl`'s `groups` prop.
+ *
+ * Unlike the Style Library's `usePalettes()` (routing, optimistic writes, its own store), this hook is a
+ * minimal, per-palette-id fetch: resolve the effective palette (own `kbPalette`, else the site's current),
+ * fetch that palette's node once per id (module-level cache), and shape it through
+ * `mapPaletteToColorControlGroups`. These tests drive the resolution (own override vs. fallback to current),
+ * the REST call it makes, the shaping, and its tolerance for a not-yet-loaded/errored fetch.
+ */
+import { act, createElement, StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+// `@wordpress/api-fetch` is externalized in production and not an npm dependency here (see
+// `scale-flows.test.js`'s identical note for `@wordpress/api-fetch`-importing client modules), so it needs a
+// virtual mock rather than jest's automatic module resolution. The factory creates its own `jest.fn()`
+// (jest hoists `jest.mock()` above local `const`s, so a mock built outside the factory would still be
+// uninitialized here) and the test body reaches it back via `require`.
+jest.mock('@wordpress/api-fetch', () => jest.fn(), { virtual: true });
+const mockApiFetch = require('@wordpress/api-fetch');
+
+// `effectivePalette()` reads the selected block via `@wordpress/data`'s `core/block-editor` store, which
+// is not registered in this test environment — mocking the module directly is simpler than standing up a
+// real store registration just to drive its return value.
+jest.mock('../palette-swatch-preview', () => ({
+	effectivePalette: jest.fn(),
+}));
+const mockEffectivePalette = require('../palette-swatch-preview').effectivePalette;
+
+import { useColorGroups } from '../hooks/use-color-groups';
+
+const PALETTE_NODE = {
+	id: 'brand',
+	label: 'Brand',
+	groups: [
+		{
+			id: 'accent',
+			label: 'Accent',
+			swatches: [{ token: 'semantic.color.accent.main', label: 'Main', $value: '#3182CE' }],
+		},
+	],
+};
+
+const MAPPED_GROUPS = [
+	{
+		id: 'accent',
+		label: 'Accent',
+		swatches: [
+			{
+				id: 'semantic.color.accent.main',
+				label: 'Main',
+				value: '#3182CE',
+				alias: '{semantic.color.accent.main}',
+			},
+		],
+	},
+];
+
+let container;
+let root;
+
+/**
+ * Render `useColorGroups` and expose its latest return value, plus a way to re-render with a new
+ * `clientId` on the same mounted instance.
+ *
+ * @param {string} clientId The initial `clientId` prop.
+ *
+ * @return {{box: {current: Array}, update: Function}} A ref-like box holding the hook's latest return
+ *         value, and an `update(clientId)` function that re-renders the same instance.
+ */
+function renderHook(clientId) {
+	const box = {};
+
+	function Probe({ id }) {
+		box.current = useColorGroups(id);
+
+		return null;
+	}
+
+	function render(id) {
+		act(() => {
+			root.render(createElement(StrictMode, null, createElement(Probe, { id })));
+		});
+	}
+
+	render(clientId);
+
+	return { box, update: render };
+}
+
+describe('useColorGroups', () => {
+	beforeEach(() => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+
+		mockApiFetch.mockReset();
+		mockEffectivePalette.mockReset();
+		window.kadenceDesignTokensRest = {
+			root: 'https://example.test/wp-json/',
+			namespace: 'kb-design-tokens/v1',
+			nonce: 'abc',
+		};
+		window.kadenceDesignTokensPalettes = { active: 'default', current: 'default', palettes: [], slots: {} };
+	});
+
+	afterEach(() => {
+		if (root) {
+			act(() => root.unmount());
+		}
+
+		container.remove();
+		delete global.IS_REACT_ACT_ENVIRONMENT;
+		delete window.kadenceDesignTokensRest;
+		delete window.kadenceDesignTokensPalettes;
+	});
+
+	/**
+	 * A block with its own `kbPalette` override fetches that palette's id, not the site's current one.
+	 *
+	 * @return {Promise<void>}
+	 */
+	it("resolves the effective palette id from the block's own override", async () => {
+		mockEffectivePalette.mockReturnValue('brand-own');
+		mockApiFetch.mockResolvedValueOnce(PALETTE_NODE);
+
+		const { box } = renderHook('block-1');
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		expect(mockApiFetch).toHaveBeenCalledWith({
+			path: '/kb-design-tokens/v1/palettes/brand-own?library=default',
+		});
+		expect(box.current).toEqual(MAPPED_GROUPS);
+	});
+
+	/**
+	 * A block with no pinned override falls back to the site's current palette id.
+	 *
+	 * @return {Promise<void>}
+	 */
+	it('falls back to the site current palette when the block has no override', async () => {
+		mockEffectivePalette.mockReturnValue('');
+		window.kadenceDesignTokensPalettes.current = 'seasonal-current';
+		mockApiFetch.mockResolvedValueOnce({ ...PALETTE_NODE, id: 'seasonal-current' });
+
+		renderHook('block-1');
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		expect(mockApiFetch).toHaveBeenCalledWith({
+			path: '/kb-design-tokens/v1/palettes/seasonal-current?library=default',
+		});
+	});
+
+	/**
+	 * Before the fetch resolves, the hook returns an empty array rather than throwing or returning
+	 * undefined.
+	 *
+	 * @return {void}
+	 */
+	it('returns an empty array while the fetch has not resolved yet', () => {
+		mockEffectivePalette.mockReturnValue('brand-pending');
+		mockApiFetch.mockReturnValue(new Promise(() => {}));
+
+		const { box } = renderHook('block-1');
+
+		expect(box.current).toEqual([]);
+	});
+
+	/**
+	 * A failed fetch degrades to an empty array instead of throwing or leaving the hook in a broken
+	 * state, matching every other design-token editor mechanism's fail-open tolerance.
+	 *
+	 * @return {Promise<void>}
+	 */
+	it('degrades to an empty array when the fetch rejects', async () => {
+		mockEffectivePalette.mockReturnValue('brand-error');
+		mockApiFetch.mockRejectedValueOnce(new Error('network error'));
+
+		const { box } = renderHook('block-1');
+		await act(async () => {
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		expect(box.current).toEqual([]);
+	});
+
+	/**
+	 * A second block instance requesting the same palette id reuses the cached fetch rather than
+	 * issuing a second request.
+	 *
+	 * @return {Promise<void>}
+	 */
+	it('fetches a given palette id only once across multiple hook instances', async () => {
+		mockEffectivePalette.mockReturnValue('brand-shared');
+		mockApiFetch.mockResolvedValue(PALETTE_NODE);
+
+		renderHook('block-1');
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		const otherContainer = document.createElement('div');
+		document.body.appendChild(otherContainer);
+		const otherRoot = createRoot(otherContainer);
+
+		function OtherProbe() {
+			useColorGroups('block-2');
+			return null;
+		}
+
+		act(() => {
+			otherRoot.render(createElement(OtherProbe));
+		});
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		expect(mockApiFetch).toHaveBeenCalledTimes(1);
+
+		act(() => otherRoot.unmount());
+		otherContainer.remove();
+	});
+});

--- a/src/extension/design-tokens/__tests__/use-color-groups.test.js
+++ b/src/extension/design-tokens/__tests__/use-color-groups.test.js
@@ -19,13 +19,19 @@ import { createRoot } from 'react-dom/client';
 jest.mock('@wordpress/api-fetch', () => jest.fn(), { virtual: true });
 const mockApiFetch = require('@wordpress/api-fetch');
 
-// `effectivePalette()` reads the selected block via `@wordpress/data`'s `core/block-editor` store, which
-// is not registered in this test environment — mocking the module directly is simpler than standing up a
-// real store registration just to drive its return value.
-jest.mock('../palette-swatch-preview', () => ({
-	effectivePalette: jest.fn(),
-}));
-const mockEffectivePalette = require('../palette-swatch-preview').effectivePalette;
+// The hook resolves its palette id through `@wordpress/data`'s `core/block-editor` store, which is not
+// registered in this test environment — mocking `useSelect` to run its callback against a stub store is
+// simpler than standing up a real registration. `mockBlockStore` is only dereferenced when the callback
+// runs (during render), so the factory may close over it despite jest hoisting this above the `let`.
+let mockBlockStore;
+
+jest.mock(
+	'@wordpress/data',
+	() => ({
+		useSelect: (mapSelect) => mapSelect(() => mockBlockStore),
+	}),
+	{ virtual: true }
+);
 
 import { useColorGroups } from '../hooks/use-color-groups';
 
@@ -56,8 +62,58 @@ const MAPPED_GROUPS = [
 	},
 ];
 
+// A second, distinguishable palette node, for the cases that need one identity's response told apart
+// from another's. It has to carry real groups: an empty response is treated as "could not read the
+// palette" and retried, so it can no longer stand in as a distinct answer.
+const OTHER_PALETTE_NODE = {
+	id: 'other',
+	label: 'Other',
+	groups: [
+		{
+			id: 'contrast',
+			label: 'Contrast',
+			swatches: [{ token: 'semantic.color.contrast.main', label: 'Main', $value: '#1A202C' }],
+		},
+	],
+};
+
+const OTHER_MAPPED_GROUPS = [
+	{
+		id: 'contrast',
+		label: 'Contrast',
+		swatches: [
+			{
+				id: 'semantic.color.contrast.main',
+				label: 'Main',
+				value: '#1A202C',
+				alias: '{semantic.color.contrast.main}',
+			},
+		],
+	},
+];
+
+// Mirrors the hook's own retry budget and spacing, so the timer-driven cases advance far enough to
+// reach its settled state.
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 250;
+
 let container;
 let root;
+
+/**
+ * Pin every block's own `kbPalette` to a palette id, or clear it so the hook falls back to the site's
+ * current palette. Cases that need one block told apart from another override
+ * `mockBlockStore.getBlockAttributes` directly instead.
+ *
+ * @param {string} palette The palette id to pin, or '' for no pinned override.
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+function setOwnPalette(palette) {
+	mockBlockStore.getBlockAttributes = () => (palette ? { kbPalette: palette } : {});
+}
 
 /**
  * Render `useColorGroups` and expose its latest return value, plus a way to re-render with a new
@@ -97,7 +153,10 @@ describe('useColorGroups', () => {
 		root = createRoot(container);
 
 		mockApiFetch.mockReset();
-		mockEffectivePalette.mockReset();
+		mockBlockStore = {
+			getBlockAttributes: () => ({}),
+			getBlockParents: () => [],
+		};
 		window.kadenceDesignTokensRest = {
 			root: 'https://example.test/wp-json/',
 			namespace: 'kb-design-tokens/v1',
@@ -123,7 +182,7 @@ describe('useColorGroups', () => {
 	 * @return {Promise<void>}
 	 */
 	it("resolves the effective palette id from the block's own override", async () => {
-		mockEffectivePalette.mockReturnValue('brand-own');
+		setOwnPalette('brand-own');
 		mockApiFetch.mockResolvedValueOnce(PALETTE_NODE);
 
 		const { box } = renderHook('block-1');
@@ -143,7 +202,7 @@ describe('useColorGroups', () => {
 	 * @return {Promise<void>}
 	 */
 	it('falls back to the site current palette when the block has no override', async () => {
-		mockEffectivePalette.mockReturnValue('');
+		setOwnPalette('');
 		window.kadenceDesignTokensPalettes.current = 'seasonal-current';
 		mockApiFetch.mockResolvedValueOnce({ ...PALETTE_NODE, id: 'seasonal-current' });
 
@@ -164,7 +223,7 @@ describe('useColorGroups', () => {
 	 * @return {void}
 	 */
 	it('returns an empty array while the fetch has not resolved yet', () => {
-		mockEffectivePalette.mockReturnValue('brand-pending');
+		setOwnPalette('brand-pending');
 		mockApiFetch.mockReturnValue(new Promise(() => {}));
 
 		const { box } = renderHook('block-1');
@@ -173,14 +232,49 @@ describe('useColorGroups', () => {
 	});
 
 	/**
-	 * A failed fetch degrades to an empty array instead of throwing or leaving the hook in a broken
-	 * state, matching every other design-token editor mechanism's fail-open tolerance.
+	 * A fetch that keeps failing degrades to an empty array once its retries are exhausted, instead of
+	 * throwing or leaving the hook in a broken state, matching every other design-token editor
+	 * mechanism's fail-open tolerance.
 	 *
 	 * @return {Promise<void>}
 	 */
-	it('degrades to an empty array when the fetch rejects', async () => {
-		mockEffectivePalette.mockReturnValue('brand-error');
-		mockApiFetch.mockRejectedValueOnce(new Error('network error'));
+	it('degrades to an empty array when the fetch rejects on every attempt', async () => {
+		jest.useFakeTimers();
+		setOwnPalette('brand-error');
+		mockApiFetch.mockRejectedValue(new Error('network error'));
+
+		const { box } = renderHook('block-1');
+		await act(async () => {
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		// Drive every retry, so the assertion lands on the settled state and not merely on the initial
+		// one the hook starts out in.
+		for (let i = 0; i <= MAX_ATTEMPTS; i++) {
+			await act(async () => {
+				jest.advanceTimersByTime(RETRY_DELAY_MS);
+				await Promise.resolve();
+				await Promise.resolve();
+			});
+		}
+
+		expect(box.current).toEqual([]);
+
+		jest.useRealTimers();
+	});
+
+	/**
+	 * The regression this hook's retry exists for: a first attempt that cannot read the palette must not
+	 * settle as "this palette has no colors". The block's palette picker is hidden when the library has
+	 * a single palette, so nothing else would ever re-trigger the fetch.
+	 *
+	 * @return {Promise<void>}
+	 */
+	it('retries an attempt that could not read the palette and populates once one succeeds', async () => {
+		jest.useFakeTimers();
+		setOwnPalette('brand-retry');
+		mockApiFetch.mockRejectedValueOnce(new Error('not ready yet')).mockResolvedValueOnce(PALETTE_NODE);
 
 		const { box } = renderHook('block-1');
 		await act(async () => {
@@ -189,6 +283,46 @@ describe('useColorGroups', () => {
 		});
 
 		expect(box.current).toEqual([]);
+
+		await act(async () => {
+			jest.advanceTimersByTime(RETRY_DELAY_MS);
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		expect(mockApiFetch).toHaveBeenCalledTimes(2);
+		expect(box.current).toEqual(MAPPED_GROUPS);
+
+		jest.useRealTimers();
+	});
+
+	/**
+	 * A response that maps to no groups is not cached, so the next attempt re-requests it rather than
+	 * every later reader being served the same empty answer from cache.
+	 *
+	 * @return {Promise<void>}
+	 */
+	it('does not cache a response that maps to no groups', async () => {
+		jest.useFakeTimers();
+		setOwnPalette('brand-empty');
+		mockApiFetch.mockResolvedValueOnce({ ...PALETTE_NODE, groups: [] }).mockResolvedValueOnce(PALETTE_NODE);
+
+		const { box } = renderHook('block-1');
+		await act(async () => {
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		await act(async () => {
+			jest.advanceTimersByTime(RETRY_DELAY_MS);
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		expect(mockApiFetch).toHaveBeenCalledTimes(2);
+		expect(box.current).toEqual(MAPPED_GROUPS);
+
+		jest.useRealTimers();
 	});
 
 	/**
@@ -198,7 +332,7 @@ describe('useColorGroups', () => {
 	 * @return {Promise<void>}
 	 */
 	it('fetches a given palette id only once across multiple hook instances', async () => {
-		mockEffectivePalette.mockReturnValue('brand-shared');
+		setOwnPalette('brand-shared');
 		mockApiFetch.mockResolvedValue(PALETTE_NODE);
 
 		renderHook('block-1');
@@ -235,7 +369,7 @@ describe('useColorGroups', () => {
 	 * @return {Promise<void>}
 	 */
 	it('re-fetches when the resolved palette id changes without a clientId change', async () => {
-		mockEffectivePalette.mockReturnValue('brand-first');
+		setOwnPalette('brand-first');
 		mockApiFetch.mockResolvedValueOnce({ ...PALETTE_NODE, id: 'brand-first' });
 
 		const { box, update } = renderHook('block-1');
@@ -245,8 +379,8 @@ describe('useColorGroups', () => {
 
 		expect(box.current).toEqual(MAPPED_GROUPS);
 
-		mockEffectivePalette.mockReturnValue('brand-second');
-		mockApiFetch.mockResolvedValueOnce({ ...PALETTE_NODE, id: 'brand-second', groups: [] });
+		setOwnPalette('brand-second');
+		mockApiFetch.mockResolvedValueOnce({ ...OTHER_PALETTE_NODE, id: 'brand-second' });
 
 		update('block-1');
 		await act(async () => {
@@ -257,7 +391,7 @@ describe('useColorGroups', () => {
 		expect(mockApiFetch).toHaveBeenLastCalledWith({
 			path: '/kb-design-tokens/v1/palettes/brand-second?library=default',
 		});
-		expect(box.current).toEqual([]);
+		expect(box.current).toEqual(OTHER_MAPPED_GROUPS);
 	});
 
 	/**
@@ -267,7 +401,7 @@ describe('useColorGroups', () => {
 	 * @return {Promise<void>}
 	 */
 	it('fetches separately for the same palette id in a different library, not the cached one', async () => {
-		mockEffectivePalette.mockReturnValue('shared-id');
+		setOwnPalette('shared-id');
 		mockApiFetch.mockResolvedValueOnce(PALETTE_NODE);
 
 		renderHook('block-1');
@@ -276,7 +410,7 @@ describe('useColorGroups', () => {
 		});
 
 		window.kadenceDesignTokensPalettes.active = 'other-library';
-		mockApiFetch.mockResolvedValueOnce({ ...PALETTE_NODE, groups: [] });
+		mockApiFetch.mockResolvedValueOnce(OTHER_PALETTE_NODE);
 
 		const otherContainer = document.createElement('div');
 		document.body.appendChild(otherContainer);
@@ -301,5 +435,49 @@ describe('useColorGroups', () => {
 
 		act(() => otherRoot.unmount());
 		otherContainer.remove();
+	});
+
+	/**
+	 * The palette is resolved against the hook's own `clientId`, not against whichever block happens to
+	 * be selected. The hook is called from the block's `edit`, which renders for every instance on the
+	 * canvas — including at first paint, when nothing is selected at all.
+	 *
+	 * @return {Promise<void>}
+	 */
+	it("resolves against the hook's own clientId rather than the selected block", async () => {
+		mockBlockStore.getBlockAttributes = (id) => (id === 'block-2' ? { kbPalette: 'block-2-palette' } : {});
+		mockApiFetch.mockResolvedValue(PALETTE_NODE);
+
+		renderHook('block-2');
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		expect(mockApiFetch).toHaveBeenCalledWith({
+			path: '/kb-design-tokens/v1/palettes/block-2-palette?library=default',
+		});
+	});
+
+	/**
+	 * A block with no pinned palette of its own follows its nearest pinned ancestor, walking outward so
+	 * the closest one wins over a further ancestor that also pins one.
+	 *
+	 * @return {Promise<void>}
+	 */
+	it('follows the nearest pinned ancestor when the block pins nothing itself', async () => {
+		const pinned = { outer: 'outer-palette', inner: 'inner-palette' };
+
+		mockBlockStore.getBlockAttributes = (id) => (pinned[id] ? { kbPalette: pinned[id] } : {});
+		mockBlockStore.getBlockParents = () => ['outer', 'inner'];
+		mockApiFetch.mockResolvedValue(PALETTE_NODE);
+
+		renderHook('block-1');
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		expect(mockApiFetch).toHaveBeenCalledWith({
+			path: '/kb-design-tokens/v1/palettes/inner-palette?library=default',
+		});
 	});
 });

--- a/src/extension/design-tokens/__tests__/use-color-groups.test.js
+++ b/src/extension/design-tokens/__tests__/use-color-groups.test.js
@@ -438,6 +438,74 @@ describe('useColorGroups', () => {
 	});
 
 	/**
+	 * The regression a stale `kbPalette` causes: deleting a palette leaves every block that pinned it
+	 * holding an id the library no longer defines, which can only ever 404. The site's own palette is
+	 * used instead, rather than retrying the dead id until the control settles empty.
+	 *
+	 * @return {Promise<void>}
+	 */
+	it('falls back to the site palette when the block pins one the library no longer defines', async () => {
+		setOwnPalette('deleted-palette');
+		window.kadenceDesignTokensPalettes.current = 'default';
+		mockApiFetch
+			.mockRejectedValueOnce({
+				code: 'rest_design_tokens_not_found',
+				data: { status: 404 },
+			})
+			.mockResolvedValueOnce(PALETTE_NODE);
+
+		const { box } = renderHook('block-1');
+		await act(async () => {
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		expect(mockApiFetch).toHaveBeenCalledTimes(2);
+		expect(mockApiFetch).toHaveBeenLastCalledWith({
+			path: '/kb-design-tokens/v1/palettes/default?library=default',
+		});
+		expect(box.current).toEqual(MAPPED_GROUPS);
+	});
+
+	/**
+	 * A 404 is answered by one fallback, never by a retry of the dead id — and when the fallback is
+	 * itself missing the hook settles empty instead of recursing.
+	 *
+	 * @return {Promise<void>}
+	 */
+	it('does not retry a missing palette, and stops when the fallback is missing too', async () => {
+		jest.useFakeTimers();
+		setOwnPalette('deleted-palette');
+		window.kadenceDesignTokensPalettes.current = 'also-deleted';
+		mockApiFetch.mockRejectedValue({
+			code: 'rest_design_tokens_not_found',
+			data: { status: 404 },
+		});
+
+		const { box } = renderHook('block-1');
+		await act(async () => {
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		for (let i = 0; i <= MAX_ATTEMPTS; i++) {
+			await act(async () => {
+				jest.advanceTimersByTime(RETRY_DELAY_MS);
+				await Promise.resolve();
+				await Promise.resolve();
+			});
+		}
+
+		// The pinned id, then the fallback — and nothing further.
+		expect(mockApiFetch).toHaveBeenCalledTimes(2);
+		expect(box.current).toEqual([]);
+
+		jest.useRealTimers();
+	});
+
+	/**
 	 * The palette is resolved against the hook's own `clientId`, not against whichever block happens to
 	 * be selected. The hook is called from the block's `edit`, which renders for every instance on the
 	 * canvas — including at first paint, when nothing is selected at all.

--- a/src/extension/design-tokens/hooks/use-color-groups.js
+++ b/src/extension/design-tokens/hooks/use-color-groups.js
@@ -78,26 +78,31 @@ function resolveEffectivePaletteId() {
 
 /**
  * Fetch one palette's node and shape it into `ColorControl`'s `groups` prop, reusing an in-flight or
- * already-resolved request for the same palette id.
+ * already-resolved request for the same palette id AND library — the REST route's response depends on
+ * both (the same palette id can exist in more than one library), so caching on the id alone could
+ * return one library's groups for another.
  *
  * @param {string} paletteId The palette id to fetch.
+ * @param {string} library   The library slug the palette id is resolved against.
  *
  * @since TBD
  *
  * @return {Promise<Array>} The mapped groups, or an empty array when the registry is inactive or the
  *         fetch fails.
  */
-function fetchColorGroups(paletteId) {
+function fetchColorGroups(paletteId, library) {
 	if (!hasDesignTokensRest() || !paletteId) {
 		return Promise.resolve([]);
 	}
 
-	if (groupsCache.has(paletteId)) {
-		return groupsCache.get(paletteId);
+	const cacheKey = `${library}:${paletteId}`;
+
+	if (groupsCache.has(cacheKey)) {
+		return groupsCache.get(cacheKey);
 	}
 
 	const path = `/${designTokensNamespace()}/palettes/${encodeURIComponent(paletteId)}?library=${encodeURIComponent(
-		librarySlug()
+		library
 	)}`;
 
 	const request = apiFetch({ path })
@@ -105,12 +110,12 @@ function fetchColorGroups(paletteId) {
 		.catch(() => {
 			// Do not cache a failure — a transient error (e.g. a slow first-load auth race) should not
 			// permanently strand every future ColorControl instance on an empty list.
-			groupsCache.delete(paletteId);
+			groupsCache.delete(cacheKey);
 
 			return [];
 		});
 
-	groupsCache.set(paletteId, request);
+	groupsCache.set(cacheKey, request);
 
 	return request;
 }
@@ -123,7 +128,8 @@ function fetchColorGroups(paletteId) {
  *                           against the currently selected block, which is always the block this
  *                           control belongs to, since an inspector control only renders while its own
  *                           block is selected), but kept as an effect dependency so a selection change
- *                           re-resolves the palette.
+ *                           re-resolves the palette even when the newly selected block's own palette
+ *                           id happens to match the previous one.
  *
  * @since TBD
  *
@@ -131,11 +137,20 @@ function fetchColorGroups(paletteId) {
  */
 export function useColorGroups(clientId) {
 	const [groups, setGroups] = useState([]);
+	// Read fresh on every render, not just inside the effect: a `kbPalette` change on the SAME
+	// selected block (no `clientId` change) still needs to re-trigger the fetch, which only the
+	// effect's own dependency list can do.
+	const paletteId = resolveEffectivePaletteId();
+	const library = librarySlug();
 
 	useEffect(() => {
 		let cancelled = false;
 
-		fetchColorGroups(resolveEffectivePaletteId()).then((resolved) => {
+		// Clear immediately rather than waiting for the new fetch to resolve, so a palette/library
+		// change never briefly shows the PREVIOUS identity's groups as if they still applied.
+		setGroups([]);
+
+		fetchColorGroups(paletteId, library).then((resolved) => {
 			if (!cancelled) {
 				setGroups(resolved);
 			}
@@ -144,7 +159,7 @@ export function useColorGroups(clientId) {
 		return () => {
 			cancelled = true;
 		};
-	}, [clientId]);
+	}, [clientId, paletteId, library]);
 
 	return groups;
 }

--- a/src/extension/design-tokens/hooks/use-color-groups.js
+++ b/src/extension/design-tokens/hooks/use-color-groups.js
@@ -57,6 +57,23 @@ const MAX_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 250;
 
 /**
+ * The REST error code the palette routes return for an id the library does not define.
+ *
+ * @type {string}
+ */
+const NOT_FOUND_CODE = 'rest_design_tokens_not_found';
+
+/**
+ * Marks a palette id the library no longer defines, as distinct from a fetch that merely could not be
+ * read. A block keeps whatever `kbPalette` it was given, so deleting a palette leaves every block that
+ * pinned it holding a dangling id — retrying that id can only 404 again, but the site's own palette
+ * still resolves.
+ *
+ * @type {Object}
+ */
+const PALETTE_NOT_FOUND = {};
+
+/**
  * The active library slug the palette REST route resolves against, from the localized palette catalog.
  *
  * @since TBD
@@ -137,12 +154,16 @@ function resolveEffectivePaletteId(select, clientId) {
  * a response that maps to nothing. The caller retries on `null`, so a first load that lands before the
  * REST descriptor is ready no longer presents itself as a palette with an empty list.
  *
+ * A 404 resolves to `PALETTE_NOT_FOUND` instead, which the caller answers by falling back to the
+ * site's own palette rather than retrying — the id is not late, it is gone.
+ *
  * @param {string} paletteId The palette id to fetch.
  * @param {string} library   The library slug the palette id is resolved against.
  *
  * @since TBD
  *
- * @return {Promise<?Array>} The mapped groups, or `null` when the palette could not be read.
+ * @return {Promise<?Array|Object>} The mapped groups, `null` when the palette could not be read, or
+ *         `PALETTE_NOT_FOUND` when the library defines no palette with that id.
  */
 function fetchColorGroups(paletteId, library) {
 	if (!hasDesignTokensRest() || !paletteId) {
@@ -173,10 +194,14 @@ function fetchColorGroups(paletteId, library) {
 
 			return mapped;
 		})
-		.catch(() => {
+		.catch((error) => {
 			// Do not cache a failure — a transient error (e.g. a slow first-load auth race) should not
 			// permanently strand every future ColorControl instance on an empty list.
 			groupsCache.delete(cacheKey);
+
+			if (error?.code === NOT_FOUND_CODE || error?.data?.status === 404) {
+				return PALETTE_NOT_FOUND;
+			}
 
 			return null;
 		});
@@ -190,10 +215,11 @@ function fetchColorGroups(paletteId, library) {
  * The effective palette's groups for a `ColorControl` instance in the block editor, empty until the
  * fetch resolves.
  *
- * A first attempt that cannot read the palette is retried rather than settled as an empty list. The
- * palette id is the only thing that re-triggers the fetch, and the block's palette picker is hidden
- * when the library has a single palette — so without the retry a bad first load leaves a control that
- * the user has no way to refresh for the rest of the session.
+ * A first attempt that cannot read the palette is retried rather than settled as an empty list, and a
+ * palette id the library no longer defines falls back to the site's own palette. The palette id is the
+ * only thing that re-triggers the fetch, and the block's palette picker is hidden when the library has
+ * a single palette — so without both, a block left pinned to a deleted palette shows an empty color
+ * list that the user has no way to refresh for the rest of the session.
  *
  * @param {string} clientId The block's own client id, resolved reactively through `useSelect` so the
  *                           groups follow this block's `kbPalette` (or its nearest pinned ancestor's)
@@ -217,15 +243,31 @@ export function useColorGroups(clientId) {
 		// change never briefly shows the PREVIOUS identity's groups as if they still applied.
 		setGroups([]);
 
-		const run = () => {
-			fetchColorGroups(paletteId, library).then((resolved) => {
+		const run = (id, fellBack) => {
+			fetchColorGroups(id, library).then((resolved) => {
 				if (cancelled) {
+					return;
+				}
+
+				if (resolved === PALETTE_NOT_FOUND) {
+					const fallback = sitePaletteId();
+
+					// Retrying a deleted id can only 404 again, so swap to the site's own palette once.
+					// Guarded against a fallback that is itself missing, which would otherwise recurse.
+					if (!fellBack && fallback && fallback !== id) {
+						run(fallback, true);
+
+						return;
+					}
+
+					setGroups([]);
+
 					return;
 				}
 
 				if (resolved === null && attempts < MAX_ATTEMPTS) {
 					attempts += 1;
-					timer = setTimeout(run, RETRY_DELAY_MS);
+					timer = setTimeout(() => run(id, fellBack), RETRY_DELAY_MS);
 
 					return;
 				}
@@ -234,7 +276,7 @@ export function useColorGroups(clientId) {
 			});
 		};
 
-		run();
+		run(paletteId, false);
 
 		return () => {
 			cancelled = true;

--- a/src/extension/design-tokens/hooks/use-color-groups.js
+++ b/src/extension/design-tokens/hooks/use-color-groups.js
@@ -1,0 +1,150 @@
+/**
+ * Read-only, editor-scoped fetch of one palette's grouped swatch data for `ColorControl`'s `groups`
+ * prop.
+ *
+ * The Style Library gets its grouped palette data from `usePalettes()` (routing, optimistic writes, its
+ * own store) — far more than a block-editor color control needs. This hook is the block editor's own,
+ * much simpler read: resolve the block's effective palette id (its own `kbPalette`, else the site's
+ * current palette), fetch that palette's node once per id (cached at module scope, since the data is
+ * read-only and rarely changes), and shape it through `mapPaletteToColorControlGroups` so the return
+ * value is exactly `ColorControl`'s `groups` prop shape.
+ *
+ * Fails open like every other design-token editor mechanism (see `register-color-control-filters.js`'s
+ * own tolerance for "not loaded yet"): an inactive token registry, a missing REST descriptor, or a
+ * rejected fetch all resolve to an empty `groups` array rather than throwing.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { mapPaletteToColorControlGroups } from '../../../token-controls/helpers/palette-groups';
+import { effectivePalette } from '../palette-swatch-preview';
+import { designTokensNamespace, hasDesignTokensRest } from '../rest';
+
+/**
+ * One in-flight-or-resolved fetch per palette id, shared by every `useColorGroups` instance across the
+ * editor. A palette's groups rarely change during a single editing session, and every existing swatch
+ * value already resolves live through CSS custom properties (see the color-control design's "Data
+ * contract" section), so this module-level cache — not a full data store — is enough to avoid a fetch
+ * per block instance.
+ *
+ * @type {Map<string, Promise<Array>>}
+ */
+const groupsCache = new Map();
+
+/**
+ * The active library slug the palette REST route resolves against, from the localized palette catalog.
+ *
+ * @since TBD
+ *
+ * @return {string} The library slug, defaulting to 'default' when the catalog has none.
+ */
+function librarySlug() {
+	const catalog = (typeof window !== 'undefined' && window.kadenceDesignTokensPalettes) || {};
+
+	return catalog.active || 'default';
+}
+
+/**
+ * The site's current palette id from the localized palette catalog.
+ *
+ * @since TBD
+ *
+ * @return {string} The current palette id, defaulting to 'default' when the catalog has none.
+ */
+function sitePaletteId() {
+	const catalog = (typeof window !== 'undefined' && window.kadenceDesignTokensPalettes) || {};
+
+	return catalog.current || 'default';
+}
+
+/**
+ * The effective palette id to fetch: the block's own pinned override when it has one, else the site's
+ * current palette.
+ *
+ * @since TBD
+ *
+ * @return {string} The palette id to fetch.
+ */
+function resolveEffectivePaletteId() {
+	return effectivePalette() || sitePaletteId();
+}
+
+/**
+ * Fetch one palette's node and shape it into `ColorControl`'s `groups` prop, reusing an in-flight or
+ * already-resolved request for the same palette id.
+ *
+ * @param {string} paletteId The palette id to fetch.
+ *
+ * @since TBD
+ *
+ * @return {Promise<Array>} The mapped groups, or an empty array when the registry is inactive or the
+ *         fetch fails.
+ */
+function fetchColorGroups(paletteId) {
+	if (!hasDesignTokensRest() || !paletteId) {
+		return Promise.resolve([]);
+	}
+
+	if (groupsCache.has(paletteId)) {
+		return groupsCache.get(paletteId);
+	}
+
+	const path = `/${designTokensNamespace()}/palettes/${encodeURIComponent(paletteId)}?library=${encodeURIComponent(
+		librarySlug()
+	)}`;
+
+	const request = apiFetch({ path })
+		.then((palette) => mapPaletteToColorControlGroups(palette))
+		.catch(() => {
+			// Do not cache a failure — a transient error (e.g. a slow first-load auth race) should not
+			// permanently strand every future ColorControl instance on an empty list.
+			groupsCache.delete(paletteId);
+
+			return [];
+		});
+
+	groupsCache.set(paletteId, request);
+
+	return request;
+}
+
+/**
+ * The effective palette's groups for a `ColorControl` instance in the block editor, empty until the
+ * fetch resolves.
+ *
+ * @param {string} clientId The block's client id — not read directly (`effectivePalette()` resolves
+ *                           against the currently selected block, which is always the block this
+ *                           control belongs to, since an inspector control only renders while its own
+ *                           block is selected), but kept as an effect dependency so a selection change
+ *                           re-resolves the palette.
+ *
+ * @since TBD
+ *
+ * @return {Array} `[{ id, label, swatches: [{ id, label, value, alias }] }]`, or `[]` while loading.
+ */
+export function useColorGroups(clientId) {
+	const [groups, setGroups] = useState([]);
+
+	useEffect(() => {
+		let cancelled = false;
+
+		fetchColorGroups(resolveEffectivePaletteId()).then((resolved) => {
+			if (!cancelled) {
+				setGroups(resolved);
+			}
+		});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [clientId]);
+
+	return groups;
+}

--- a/src/extension/design-tokens/hooks/use-color-groups.js
+++ b/src/extension/design-tokens/hooks/use-color-groups.js
@@ -18,13 +18,13 @@
  * WordPress dependencies
  */
 import { useEffect, useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
 import { mapPaletteToColorControlGroups } from '../../../token-controls/helpers/palette-groups';
-import { effectivePalette } from '../palette-swatch-preview';
 import { designTokensNamespace, hasDesignTokensRest } from '../rest';
 
 /**
@@ -34,9 +34,27 @@ import { designTokensNamespace, hasDesignTokensRest } from '../rest';
  * contract" section), so this module-level cache — not a full data store — is enough to avoid a fetch
  * per block instance.
  *
- * @type {Map<string, Promise<Array>>}
+ * Only a non-empty result stays cached. An empty one is dropped so the next attempt re-requests it:
+ * caching "nothing came back" would make a single bad first load permanent for the whole session.
+ *
+ * @type {Map<string, Promise<?Array>>}
  */
 const groupsCache = new Map();
+
+/**
+ * How many times to re-attempt a fetch that could not run (or came back with nothing) before settling
+ * on an empty list.
+ *
+ * @type {number}
+ */
+const MAX_ATTEMPTS = 3;
+
+/**
+ * How long to wait between those attempts, in milliseconds.
+ *
+ * @type {number}
+ */
+const RETRY_DELAY_MS = 250;
 
 /**
  * The active library slug the palette REST route resolves against, from the localized palette catalog.
@@ -65,15 +83,47 @@ function sitePaletteId() {
 }
 
 /**
- * The effective palette id to fetch: the block's own pinned override when it has one, else the site's
- * current palette.
+ * The effective palette id for one block: its own pinned `kbPalette`, else the nearest pinned
+ * ancestor's, else the site's current palette.
+ *
+ * Resolved against the block's OWN `clientId` rather than whichever block is selected. The hook is
+ * called from the block's `edit`, which renders for every instance on the canvas — including at
+ * first paint, when nothing is selected yet — so keying off the selection resolves the wrong block's
+ * palette. Taking `select` as an argument keeps this usable inside `useSelect`, so the id also
+ * re-resolves when the attribute changes instead of being frozen at whatever the first render saw.
+ *
+ * @param {Function} select   The `useSelect` registry selector.
+ * @param {string}   clientId The block's own client id.
  *
  * @since TBD
  *
  * @return {string} The palette id to fetch.
  */
-function resolveEffectivePaletteId() {
-	return effectivePalette() || sitePaletteId();
+function resolveEffectivePaletteId(select, clientId) {
+	const editor = select('core/block-editor');
+
+	if (!editor || !clientId) {
+		return sitePaletteId();
+	}
+
+	const own = editor.getBlockAttributes(clientId)?.kbPalette;
+
+	if (own) {
+		return own;
+	}
+
+	// Walk from the nearest ancestor outward, so a child follows the closest pinned ancestor.
+	const parents = editor.getBlockParents(clientId) || [];
+
+	for (let i = parents.length - 1; i >= 0; i--) {
+		const inherited = editor.getBlockAttributes(parents[i])?.kbPalette;
+
+		if (inherited) {
+			return inherited;
+		}
+	}
+
+	return sitePaletteId();
 }
 
 /**
@@ -82,17 +132,21 @@ function resolveEffectivePaletteId() {
  * both (the same palette id can exist in more than one library), so caching on the id alone could
  * return one library's groups for another.
  *
+ * Resolves to `null` — never to `[]` — for every outcome that means "could not read the palette"
+ * rather than "the palette has no colors": an inactive registry, a missing id, a rejected request, or
+ * a response that maps to nothing. The caller retries on `null`, so a first load that lands before the
+ * REST descriptor is ready no longer presents itself as a palette with an empty list.
+ *
  * @param {string} paletteId The palette id to fetch.
  * @param {string} library   The library slug the palette id is resolved against.
  *
  * @since TBD
  *
- * @return {Promise<Array>} The mapped groups, or an empty array when the registry is inactive or the
- *         fetch fails.
+ * @return {Promise<?Array>} The mapped groups, or `null` when the palette could not be read.
  */
 function fetchColorGroups(paletteId, library) {
 	if (!hasDesignTokensRest() || !paletteId) {
-		return Promise.resolve([]);
+		return Promise.resolve(null);
 	}
 
 	const cacheKey = `${library}:${paletteId}`;
@@ -106,13 +160,25 @@ function fetchColorGroups(paletteId, library) {
 	)}`;
 
 	const request = apiFetch({ path })
-		.then((palette) => mapPaletteToColorControlGroups(palette))
+		.then((palette) => {
+			const mapped = mapPaletteToColorControlGroups(palette);
+
+			if (!mapped.length) {
+				// Nothing usable came back. Drop the entry so a retry re-requests it instead of every
+				// later reader being served this same empty answer from cache.
+				groupsCache.delete(cacheKey);
+
+				return null;
+			}
+
+			return mapped;
+		})
 		.catch(() => {
 			// Do not cache a failure — a transient error (e.g. a slow first-load auth race) should not
 			// permanently strand every future ColorControl instance on an empty list.
 			groupsCache.delete(cacheKey);
 
-			return [];
+			return null;
 		});
 
 	groupsCache.set(cacheKey, request);
@@ -124,12 +190,14 @@ function fetchColorGroups(paletteId, library) {
  * The effective palette's groups for a `ColorControl` instance in the block editor, empty until the
  * fetch resolves.
  *
- * @param {string} clientId The block's client id — not read directly (`effectivePalette()` resolves
- *                           against the currently selected block, which is always the block this
- *                           control belongs to, since an inspector control only renders while its own
- *                           block is selected), but kept as an effect dependency so a selection change
- *                           re-resolves the palette even when the newly selected block's own palette
- *                           id happens to match the previous one.
+ * A first attempt that cannot read the palette is retried rather than settled as an empty list. The
+ * palette id is the only thing that re-triggers the fetch, and the block's palette picker is hidden
+ * when the library has a single palette — so without the retry a bad first load leaves a control that
+ * the user has no way to refresh for the rest of the session.
+ *
+ * @param {string} clientId The block's own client id, resolved reactively through `useSelect` so the
+ *                           groups follow this block's `kbPalette` (or its nearest pinned ancestor's)
+ *                           as it changes.
  *
  * @since TBD
  *
@@ -137,27 +205,40 @@ function fetchColorGroups(paletteId, library) {
  */
 export function useColorGroups(clientId) {
 	const [groups, setGroups] = useState([]);
-	// Read fresh on every render, not just inside the effect: a `kbPalette` change on the SAME
-	// selected block (no `clientId` change) still needs to re-trigger the fetch, which only the
-	// effect's own dependency list can do.
-	const paletteId = resolveEffectivePaletteId();
+	const paletteId = useSelect((select) => resolveEffectivePaletteId(select, clientId), [clientId]);
 	const library = librarySlug();
 
 	useEffect(() => {
 		let cancelled = false;
+		let timer;
+		let attempts = 0;
 
 		// Clear immediately rather than waiting for the new fetch to resolve, so a palette/library
 		// change never briefly shows the PREVIOUS identity's groups as if they still applied.
 		setGroups([]);
 
-		fetchColorGroups(paletteId, library).then((resolved) => {
-			if (!cancelled) {
-				setGroups(resolved);
-			}
-		});
+		const run = () => {
+			fetchColorGroups(paletteId, library).then((resolved) => {
+				if (cancelled) {
+					return;
+				}
+
+				if (resolved === null && attempts < MAX_ATTEMPTS) {
+					attempts += 1;
+					timer = setTimeout(run, RETRY_DELAY_MS);
+
+					return;
+				}
+
+				setGroups(resolved ?? []);
+			});
+		};
+
+		run();
 
 		return () => {
 			cancelled = true;
+			clearTimeout(timer);
 		};
 	}, [clientId, paletteId, library]);
 


### PR DESCRIPTION
## Summary
- The block editor has no existing data source for `ColorControl`'s grouped `groups` prop — it only has `window.kadenceDesignTokensPalettes`, a flat slot→alias map, not the Accent/Contrast/Background/Notices grouped shape.
- Adds `useColorGroups(clientId)` (`src/extension/design-tokens/hooks/use-color-groups.js`): resolves the block's effective palette (its own `kbPalette` override, else the nearest ancestor's, else the site's current palette, via the existing `effectivePalette()`), fetches that palette's groups from the `Palettes_Controller` REST route via `@wordpress/api-fetch`, and shapes the response through `mapPaletteToColorControlGroups()` from the previous slices.
- Cached per palette id in a module-level `Map` (cleared on rejection so a transient failure doesn't strand every future instance) — this is read-only, rarely-changing data, so no store/reducer is needed.
- Still not wired into any block — the next slice consumes this hook in `kadence/singlebtn`'s inspector.

## Test plan
- `npx jest src/extension/design-tokens` — all green, no regressions.
- New tests: resolves the block's own palette override vs. falling back to the site's current palette, handles the not-yet-loaded state, fails open on a rejected fetch, and reuses the cache across instances sharing a palette id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving grouped color swatches based on the active design palette.
  * Automatically uses block-specific palette settings or site defaults.
  * Refreshes color groups when the selected client changes.
  * Provides graceful fallback behavior when color data is unavailable or cannot be loaded.

* **Tests**
  * Added coverage for palette resolution, loading states, errors, caching, and mapped color-group results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->