### PR TITLE
[DTM] SOFT-4260 [2/19]: offer the fixed None/Auto sentinels in the block editor

### DIFF
--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -468,22 +468,7 @@ export default function KadenceButtonEdit(props) {
 	const borderWidthPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width');
 	const shadowPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow');
 	const paddingPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-padding');
-	// Margin's legacy control also offers "Auto" (`allowAuto`), which Padding's never did.
-	// `ss-auto` is already a fully working spacing slot at the PHP/CSS layer (Spacing_Target's SLOTS,
-	// class-kadence-blocks-css.php's $spacing_sizes) — the editor's pickable list is the only gap, so
-	// it is appended here as a fixed entry rather than added to the token registry itself.
-	//
-	// It is deliberately NOT registered as a DTCG token (it resolves to the CSS keyword `auto`, not a
-	// length — see declarations.php's comment on `$spacing_slugs`), so its `alias` is the bare slug the
-	// PHP/CSS layer already reads (`class-kadence-blocks-css.php`'s `$spacing_sizes['ss-auto']`), not the
-	// bracket-wrapped `{dot.path}` form a real token's alias takes. `fixed: true` tells
-	// `token-summary.js`'s `findTokenEntry()` to match this entry on that bare alias — the only sentinel
-	// in the pool allowed to bypass the bracket check, so a hand-typed Custom literal can never be
-	// misread as a token pick.
-	const marginPickableTokens = [
-		...pickableTokensForKey('kadence/singlebtn', 'button-margin'),
-		{ id: 'ss-auto', label: __('Auto', 'kadence-blocks'), value: 'auto', alias: 'ss-auto', fixed: true },
-	];
+	const marginPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-margin');
 
 	// The border-radius/padding linked/individual mode is derived from the stored slots (all equal reads
 	// as linked), so no new attribute is needed and old buttons open in the right mode. The hook's own

--- a/src/extension/token-picker/__tests__/index.test.js
+++ b/src/extension/token-picker/__tests__/index.test.js
@@ -117,6 +117,22 @@ const POOL = {
 			layer: 'semantic',
 			role: 'shadow',
 		},
+		{
+			id: 'primitive.dimension.border-width.sm',
+			alias: '{primitive.dimension.border-width.sm}',
+			label: 'Border Width SM',
+			type: 'dimension',
+			layer: 'primitive',
+			role: 'border-width',
+		},
+		{
+			id: 'semantic.border-width.default',
+			alias: '{semantic.border-width.default}',
+			label: 'Default Border Width',
+			type: 'dimension',
+			layer: 'semantic',
+			role: 'border-width',
+		},
 	],
 	values: {
 		default: {
@@ -132,6 +148,8 @@ const POOL = {
 			'primitive.font-weight.bold': '700',
 			'primitive.shadow.sm': '0 1px 2px rgba(0,0,0,0.1)',
 			'semantic.shadow.button': '0 2px 4px rgba(0,0,0,0.2)',
+			'primitive.dimension.border-width.sm': '1px',
+			'semantic.border-width.default': '2px',
 		},
 		brand: { 'semantic.color.button-primary-bg': '#000000' },
 	},
@@ -154,6 +172,13 @@ const PRESETS = {
 					{ key: 'button-gap', kind: 'dimension', token: null, control_attr: 'gap' },
 					{ key: 'button-shadow', kind: 'shadow', token: 'semantic.shadow.button', control_attr: null },
 					{ key: 'button-padding', kind: 'dimension', token: null, control_attr: 'padding' },
+					{ key: 'button-margin', kind: 'dimension', token: null, control_attr: 'margin' },
+					{
+						key: 'button-border-width',
+						kind: 'dimension',
+						token: 'semantic.border-width.default',
+						control_attr: 'borderStyle',
+					},
 				],
 			},
 			'kadence/single-icon': {
@@ -249,19 +274,23 @@ describe('pickableTokensFor', () => {
 			'semantic.radius.button',
 			'semantic.spacing.block',
 			'semantic.icon-size.default',
+			'semantic.border-width.default',
 			'primitive.dimension.radius.sm',
 			'primitive.dimension.spacing.md',
 			'primitive.dimension.icon-size.md',
 			'primitive.dimension.custom.brand-icon',
+			'primitive.dimension.border-width.sm',
 		]);
 		expect(result.map((token) => token.value)).toEqual([
 			'0.5rem',
 			'1.5rem',
 			'1.5rem',
+			'2px',
 			'4px',
 			'16px',
 			'1.5rem',
 			'2rem',
+			'1px',
 		]);
 	});
 
@@ -329,8 +358,9 @@ describe('pickableTokensForControl', () => {
 		const result = pickableTokensForControl('kadence/singlebtn', 'borderRadius');
 
 		// `borderRadius` implies the radius role (spacing drops out); with a primitive radius present the
-		// picker offers only the size scale, so the semantic radius token is dropped too.
-		expect(result.map((token) => token.id)).toEqual(['primitive.dimension.radius.sm']);
+		// picker offers only the size scale, so the semantic radius token is dropped too. A fixed "None"
+		// entry is prepended for every radius-role control, ahead of the size scale.
+		expect(result.map((token) => token.id)).toEqual(['ss-none-radius', 'primitive.dimension.radius.sm']);
 		expect(result.every((token) => token.role === 'radius')).toBe(true);
 	});
 
@@ -339,7 +369,7 @@ describe('pickableTokensForControl', () => {
 	});
 
 	it('returns an empty array for an unmapped attribute', () => {
-		expect(pickableTokensForControl('kadence/singlebtn', 'margin')).toEqual([]);
+		expect(pickableTokensForControl('kadence/singlebtn', 'backgroundColor')).toEqual([]);
 	});
 
 	it('returns an empty array for an unknown block', () => {
@@ -352,8 +382,9 @@ describe('pickableTokensForControl', () => {
 		const result = pickableTokensForControl('kadence/singlebtn', 'borderRadius');
 
 		// The bound token fixes the radius sub-kind (spacing drops out); the primitive size scale still wins,
-		// so even the bound semantic radius is dropped.
-		expect(result.map((token) => token.id)).toEqual(['primitive.dimension.radius.sm']);
+		// so even the bound semantic radius is dropped. The bound token itself did not survive the scoping,
+		// so the pin is a no-op and the fixed "None" entry leads.
+		expect(result.map((token) => token.id)).toEqual(['ss-none-radius', 'primitive.dimension.radius.sm']);
 		expect(result.every((token) => token.role === 'radius')).toBe(true);
 	});
 
@@ -388,8 +419,17 @@ describe('pickableTokensForControl', () => {
 
 		const result = pickableTokensForControl('kadence/singlebtn', 'borderRadius');
 
-		// A bound primitive is itself a size, so it survives the primitives-only scoping and is pinned first.
-		expect(result.map((token) => token.id)).toEqual(['primitive.dimension.radius.sm']);
+		// A bound primitive is itself a size, so it survives the primitives-only scoping and is pinned
+		// first — ahead of even the fixed "None" entry, since the pin always wins.
+		expect(result.map((token) => token.id)).toEqual(['primitive.dimension.radius.sm', 'ss-none-radius']);
+	});
+
+	it('prepends a fixed None entry for a radius-role control', () => {
+		// The existing setup above stubs `window.kadenceDesignTokensPickable` with a radius-role token pool
+		// and `blockProperties()` (via `PRESETS`) returning a `borderRadius` control_attr property.
+		const tokens = pickableTokensForControl('kadence/singlebtn', 'borderRadius');
+
+		expect(tokens[0]).toMatchObject({ id: 'ss-none-radius', alias: 0, fixed: true });
 	});
 });
 
@@ -408,8 +448,9 @@ describe('pickableTokensForKey', () => {
 		const result = pickableTokensForKey('kadence/singlebtn', 'button-shadow');
 
 		// The bound token fixes the shadow role; with a primitive shadow present the picker offers only
-		// the size scale (mirroring the radius narrowing above), so even the bound semantic drops out.
-		expect(result.map((token) => token.id)).toEqual(['primitive.shadow.sm']);
+		// the size scale (mirroring the radius narrowing above), so even the bound semantic drops out. The
+		// bound token did not survive the scoping, so the fixed "None" entry leads.
+		expect(result.map((token) => token.id)).toEqual(['ss-none-shadow', 'primitive.shadow.sm']);
 		expect(result.every((token) => token.role === 'shadow')).toBe(true);
 	});
 
@@ -434,13 +475,34 @@ describe('pickableTokensForKey', () => {
 		const result = pickableTokensForKey('kadence/singlebtn', 'button-padding');
 
 		// A primitive spacing size exists, so (mirroring the radius narrowing above) the picker offers
-		// only the size scale, dropping even the bound-role semantic spacing token.
-		expect(result.map((token) => token.id)).toEqual(['primitive.dimension.spacing.md']);
+		// only the size scale, dropping even the bound-role semantic spacing token. Padding's fixed
+		// "None" entry leads (Padding never offers "Auto"; only Margin does).
+		expect(result.map((token) => token.id)).toEqual(['ss-none-spacing', 'primitive.dimension.spacing.md']);
 		expect(result.every((token) => token.role === 'spacing')).toBe(true);
 	});
 
 	it('returns an empty array for an unknown block', () => {
 		expect(pickableTokensForKey('kadence/does-not-exist', 'button-shadow')).toEqual([]);
+	});
+
+	it('prepends a fixed None entry, and no Auto, for the padding property', () => {
+		const tokens = pickableTokensForKey('kadence/singlebtn', 'button-padding');
+
+		expect(tokens[0]).toMatchObject({ id: 'ss-none-spacing', alias: 0, fixed: true });
+		expect(tokens.some((token) => token.id === 'ss-auto')).toBe(false);
+	});
+
+	it('prepends None and appends Auto for the margin property, matching the Style Library order', () => {
+		const tokens = pickableTokensForKey('kadence/singlebtn', 'button-margin');
+
+		expect(tokens[0]).toMatchObject({ id: 'ss-none-spacing', alias: 0, fixed: true });
+		expect(tokens[tokens.length - 1]).toMatchObject({ id: 'ss-auto', alias: 'ss-auto', fixed: true });
+	});
+
+	it('prepends a fixed None entry for the border-width property', () => {
+		const tokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width');
+
+		expect(tokens[0]).toMatchObject({ id: 'ss-none-border-width', alias: 0, fixed: true });
 	});
 });
 

--- a/src/extension/token-picker/index.js
+++ b/src/extension/token-picker/index.js
@@ -17,6 +17,7 @@
  */
 import { get } from 'lodash';
 import { activeLibrary, blockProperties } from '../preset-picker';
+import { autoEntry, noneEntryForRole } from '../../token-controls';
 
 /**
  * Token $types compatible with each control kind. Keys are the preset catalog's coarse control
@@ -221,12 +222,24 @@ function pickableTokensForProperty(property, controlAttr, library) {
 	const primitives = narrowed.filter((token) => token.id.startsWith('primitive.'));
 	const scoped = primitives.length ? primitives : narrowed;
 
+	// "None" is a fixed sentinel for every role that has one — never a registered token, so it can
+	// never be renamed or deleted from a Style Library screen. "Auto" is Margin-only, and `role`
+	// alone can't identify Margin: Padding and Margin both narrow to `role === 'spacing'`, so this
+	// reads `controlAttr` (the property's own bound attribute, 'margin' vs 'padding') instead. Auto is
+	// appended after the scale rather than prepended alongside None — None, scale, Auto — to match
+	// the Style Library's `BoxTokenField.tokensForField()`, which orders its own margin field the
+	// same way.
+	const none = noneEntryForRole(role);
+	const withFixed = none ? [none, ...scoped] : scoped;
+
 	// Pin the exact bound token first when it survived the scoping (order carries through for the rest).
 	// An unresolved or scoped-out bound token drops the pin to a no-op.
-	return [
-		...scoped.filter((token) => token.id === property.token),
-		...scoped.filter((token) => token.id !== property.token),
+	const pinned = [
+		...withFixed.filter((token) => token.id === property.token),
+		...withFixed.filter((token) => token.id !== property.token),
 	];
+
+	return controlAttr === 'margin' ? [...pinned, autoEntry()] : pinned;
 }
 
 /**


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4260/token-control-popover-options-and-the-default-label-show-what-is

Prepends the shared fixed sentinels to the block editor's pickable pool, so every dimension/shadow control offers `None` and Margin also offers `Auto`. The block was building Margin's `Auto` row inline; that now comes from the shared helper, which is what keeps the editor's option list identical to the Style Library's.

Option order matches the Style Library too: the sentinels lead, then the role's own scale.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spacing, border-width, radius, and shadow token selection.
  * Corrected the placement and availability of “None” and “Auto” options.
  * Preserved relevant bound tokens while presenting semantic options first.
  * Added support for border-width presets and improved handling of radius tokens.
* **Tests**
  * Expanded coverage to verify token ordering, filtering, presets, and special entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->