### PR TITLE
[DTM] SOFT-4262: show a busy state on the Add/Remove Favorite font button

### DIFF
--- a/src/style-library/__tests__/typography-screen.test.js
+++ b/src/style-library/__tests__/typography-screen.test.js
@@ -245,6 +245,15 @@ describe('TypographyScreen favorite button', () => {
 		// drop focus to the document the moment a keyboard user activated it.
 		expect(button.getAttribute('aria-disabled')).toBe('true');
 		expect(button.disabled).toBe(false);
+
+		// "Stays focusable" asserted as behavior rather than as markup: jsdom refuses `focus()` on a
+		// button carrying the `disabled` attribute and honors it on an `aria-disabled` one, so this
+		// fails the moment `accessibleWhenDisabled` comes off. Focus RETENTION is the thing a real
+		// keyboard user loses, but it cannot be asserted here — jsdom does not implement the
+		// blur-on-disable that causes it, so such a check would pass either way.
+		button.focus();
+
+		expect(document.activeElement).toBe(button);
 	});
 
 	it('keeps naming the in-flight action after the feed refreshes beneath it', () => {

--- a/src/style-library/__tests__/typography-screen.test.js
+++ b/src/style-library/__tests__/typography-screen.test.js
@@ -1,0 +1,346 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { TypographyScreen } from '../components/pages/TypographyScreen';
+import { useScaleScreen } from '../hooks/use-scale-screen';
+import { useDraftChannel } from '../hooks/use-draft-channel';
+import { useGoogleFontLoader } from '../hooks/use-google-font-loader';
+import { addFavoriteFontFlow, removeFavoriteFontFlow } from '../helpers/font-flows';
+
+// `use-scale-screen.js` pulls in `../api/client`, which imports `@wordpress/api-fetch` (externalized
+// to the `wp.apiFetch` global in production, not an installed npm dependency), so automocking would
+// fail to resolve it. The screen only positions this hook's return value; a stub is enough.
+jest.mock('../hooks/use-scale-screen', () => ({
+	useScaleScreen: jest.fn(),
+}));
+
+// The screen reads its selection guard off this hook. A null channel is the "no provider mounted"
+// path `ScaleScreen` already degrades to.
+jest.mock('../hooks/use-draft-channel', () => ({
+	useDraftChannel: jest.fn(),
+}));
+
+// Loads a real web font off the network. Stubbed so the sample's font never gates a render.
+jest.mock('../hooks/use-google-font-loader', () => ({
+	useGoogleFontLoader: jest.fn(),
+}));
+
+// The subject: these are driven by hand so a write can be held mid-flight, which is the whole point
+// of the states under test. `../api/client` is never reached.
+jest.mock('../helpers/font-flows', () => ({
+	addFavoriteFontFlow: jest.fn(),
+	removeFavoriteFontFlow: jest.fn(),
+}));
+
+// The row list mounts `@dnd-kit` and `ListRow`, neither of which this screen's toolbar touches.
+jest.mock('../components/templates/RowList', () => ({
+	RowList: () => <div className="row-list" />,
+}));
+
+// `jest.config.js` maps the `@wordpress/components` specifier to the copy nested under
+// `@kadence/components/node_modules`, which resolves its own nested `react`/`react-dom` — a
+// different module instance than the top-level `react-dom/client` this test renders with. Mounting
+// the real controls under the top-level renderer trips React's "Invalid hook call" guard. The
+// `Button` stand-in reproduces the one piece of real `Button` behavior under test: `disabled` plus
+// `accessibleWhenDisabled` renders `aria-disabled` INSTEAD of the `disabled` attribute, which is
+// what keeps the button focusable while its write runs.
+jest.mock('@wordpress/components', () => ({
+	Button: ({ children, icon, isBusy, accessibleWhenDisabled, variant, disabled, ...props }) => (
+		<button
+			{...props}
+			disabled={Boolean(disabled) && !accessibleWhenDisabled}
+			aria-disabled={disabled && accessibleWhenDisabled ? 'true' : undefined}
+			data-variant={variant}
+			data-icon={typeof icon === 'string' ? icon : undefined}
+			data-is-busy={isBusy ? 'true' : undefined}
+		>
+			{children}
+		</button>
+	),
+	Notice: ({ children, status, isDismissible, onRemove, ...props }) => (
+		<div className="components-notice" {...props}>
+			{children}
+		</div>
+	),
+	Spinner: () => <span className="components-spinner" />,
+	// Never opened here, so only the toggle is rendered.
+	Dropdown: ({ renderToggle }) => renderToggle({ isOpen: false, onToggle: () => {} }),
+	MenuGroup: ({ children }) => <div>{children}</div>,
+	MenuItem: ({ children, ...props }) => <button {...props}>{children}</button>,
+	TextControl: (props) => <input {...props} />,
+}));
+
+// `@wordpress/primitives` (which `@wordpress/icons`'s `Icon` builds on) nests its own `react` copy,
+// the same cross-copy problem the mock above sidesteps. The glyphs become plain strings so the
+// `Button` stand-in can surface which one the toolbar chose.
+jest.mock('@wordpress/icons', () => ({
+	Icon: (props) => <span className="components-icon" {...props} />,
+	chevronDown: 'chevronDown',
+	plus: 'plus',
+	starEmpty: 'starEmpty',
+	starFilled: 'starFilled',
+}));
+
+const SCALE = {
+	rows: [],
+	selectedId: '',
+	selectToken: () => {},
+	isBusy: false,
+	addError: null,
+	orderError: null,
+	clearAddError: () => {},
+	clearOrderError: () => {},
+	addToken: () => {},
+	saveToken: () => {},
+	deleteToken: () => {},
+	reorderTokens: () => {},
+	tokenById: () => null,
+	initialValuesFor: () => ({}),
+};
+
+let container;
+let root;
+
+/**
+ * Build the `library` prop with a given favorites list.
+ *
+ * @param {Array<string>} favoriteFonts The families the feed reports as favorites.
+ *
+ * @since TBD
+ *
+ * @return {Object} The design-tokens feed hook's return value, as far as this screen reads it.
+ */
+function libraryWith(favoriteFonts) {
+	return {
+		slug: 'default',
+		version: 1,
+		feed: { favoriteFonts },
+		refreshFeed: () => Promise.resolve(),
+		rest: { namespace: 'kb-design-tokens/v1' },
+	};
+}
+
+/**
+ * Render (or re-render) `TypographyScreen` against a given favorites list.
+ *
+ * @param {Array<string>} favoriteFonts The families the feed reports as favorites.
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+function renderScreen(favoriteFonts) {
+	act(() => {
+		root.render(
+			createElement(TypographyScreen, {
+				label: 'Typography',
+				route: { screen: 'typography', item: '' },
+				navigate: () => {},
+				library: libraryWith(favoriteFonts),
+			})
+		);
+	});
+}
+
+/**
+ * The contextual Add/Remove Favorite button currently mounted.
+ *
+ * @since TBD
+ *
+ * @return {HTMLElement} The button node.
+ */
+function favoriteButton() {
+	return container.querySelector('.kadence-blocks-style-library__typography-font-action');
+}
+
+/**
+ * The toolbar's polite live region.
+ *
+ * @since TBD
+ *
+ * @return {HTMLElement} The live-region node.
+ */
+function liveRegion() {
+	return container.querySelector('.kadence-blocks-style-library__typography-toolbar [role="status"]');
+}
+
+/**
+ * Stub a favorite flow so its write can be held mid-flight, mirroring the real flows: `onBusy(true)`
+ * as the call starts, and nothing else until the returned settle function is invoked.
+ *
+ * @param {Function} flow The mocked flow to arm.
+ *
+ * @since TBD
+ *
+ * @return {Function} Returns the captured `{ args, resolve, reject }` for the call in flight.
+ */
+function armFlow(flow) {
+	let inFlight = null;
+
+	flow.mockImplementation((args) => {
+		args.onBusy(true);
+
+		return new Promise((resolve, reject) => {
+			inFlight = { args, resolve, reject };
+		});
+	});
+
+	return () => inFlight;
+}
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+
+	useScaleScreen.mockReturnValue(SCALE);
+	useDraftChannel.mockReturnValue(null);
+	useGoogleFontLoader.mockReturnValue({ readyFamily: 'Inter', isLoading: false });
+	addFavoriteFontFlow.mockReset();
+	removeFavoriteFontFlow.mockReset();
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+describe('TypographyScreen favorite button', () => {
+	it('offers Remove Favorite for the seeded favorite, idle and focusable', () => {
+		renderScreen(['Inter']);
+
+		const button = favoriteButton();
+
+		expect(button.textContent).toBe('Remove Favorite');
+		expect(button.dataset.variant).toBe('tertiary');
+		expect(button.dataset.icon).toBe('starFilled');
+		expect(button.dataset.isBusy).toBeUndefined();
+		expect(button.getAttribute('aria-disabled')).toBeNull();
+		expect(button.disabled).toBe(false);
+	});
+
+	it('shows a busy label and stays focusable while the write is in flight', () => {
+		const pending = armFlow(removeFavoriteFontFlow);
+
+		renderScreen(['Inter']);
+
+		act(() => favoriteButton().click());
+
+		expect(pending().args.name).toBe('Inter');
+
+		const button = favoriteButton();
+
+		expect(button.textContent).toBe('Removing Favorite…');
+		expect(button.dataset.isBusy).toBe('true');
+		// The write disables the button, but through `aria-disabled` — a `disabled` attribute would
+		// drop focus to the document the moment a keyboard user activated it.
+		expect(button.getAttribute('aria-disabled')).toBe('true');
+		expect(button.disabled).toBe(false);
+	});
+
+	it('keeps naming the in-flight action after the feed refreshes beneath it', () => {
+		armFlow(removeFavoriteFontFlow);
+
+		renderScreen(['Inter']);
+
+		act(() => favoriteButton().click());
+
+		// What the real flow does next: refresh the feed, and only then settle `onBusy`. The button
+		// must not read "Adding Favorite…" for that window.
+		renderScreen([]);
+
+		const button = favoriteButton();
+
+		expect(button.textContent).toBe('Removing Favorite…');
+		expect(button.dataset.icon).toBe('starFilled');
+		expect(button.dataset.variant).toBe('tertiary');
+	});
+
+	it('announces the outcome and flips to the opposite action once the write settles', async () => {
+		const pending = armFlow(removeFavoriteFontFlow);
+
+		renderScreen(['Inter']);
+
+		act(() => favoriteButton().click());
+
+		renderScreen([]);
+
+		const settled = pending();
+
+		await act(async () => {
+			settled.args.onBusy(false);
+			settled.resolve('Inter');
+		});
+
+		const button = favoriteButton();
+
+		expect(button.textContent).toBe('Add Favorite');
+		expect(button.dataset.variant).toBe('secondary');
+		expect(button.dataset.icon).toBe('starEmpty');
+		expect(button.dataset.isBusy).toBeUndefined();
+		expect(liveRegion().textContent).toBe('Inter removed from favorites.');
+	});
+
+	it('runs the add path with its own busy label once the family is no longer a favorite', async () => {
+		const pendingRemove = armFlow(removeFavoriteFontFlow);
+
+		renderScreen(['Inter']);
+
+		act(() => favoriteButton().click());
+
+		renderScreen([]);
+
+		await act(async () => {
+			pendingRemove().args.onBusy(false);
+			pendingRemove().resolve('Inter');
+		});
+
+		const pendingAdd = armFlow(addFavoriteFontFlow);
+
+		act(() => favoriteButton().click());
+
+		expect(favoriteButton().textContent).toBe('Adding Favorite…');
+		expect(favoriteButton().dataset.isBusy).toBe('true');
+		expect(favoriteButton().dataset.variant).toBe('secondary');
+
+		renderScreen(['Inter']);
+
+		await act(async () => {
+			pendingAdd().args.onBusy(false);
+			pendingAdd().resolve('Inter');
+		});
+
+		expect(favoriteButton().textContent).toBe('Remove Favorite');
+		expect(liveRegion().textContent).toBe('Inter added to favorites.');
+	});
+
+	it('surfaces the error and announces nothing when the write fails', async () => {
+		const pending = armFlow(removeFavoriteFontFlow);
+
+		renderScreen(['Inter']);
+
+		act(() => favoriteButton().click());
+
+		const settled = pending();
+
+		await act(async () => {
+			settled.args.onError({ message: 'Nope.' });
+			settled.args.onBusy(false);
+			settled.reject(new Error('Nope.'));
+		});
+
+		expect(container.querySelector('.components-notice').textContent).toBe('Nope.');
+		expect(liveRegion().textContent).toBe('');
+		// Back to the label it carried before the click, not stuck on the busy one.
+		expect(favoriteButton().textContent).toBe('Remove Favorite');
+	});
+});

--- a/src/style-library/components/pages/TypographyScreen.js
+++ b/src/style-library/components/pages/TypographyScreen.js
@@ -19,7 +19,7 @@
  * WordPress dependencies
  */
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Button, Notice, Spinner } from '@wordpress/components';
 import { starEmpty, starFilled } from '@wordpress/icons';
 
@@ -62,6 +62,44 @@ const CUSTOM_BADGE = __('Custom', 'kadence-blocks');
  * @since TBD
  */
 const FAVORITE_BADGE = __('Favorite', 'kadence-blocks');
+
+/**
+ * The contextual favorite button's labels, keyed by the action it is offering and by whether that
+ * action's write is in flight. A favorite write is a REST call plus a full feed refresh, so the
+ * button carries the same busy label the app's every other write control does — without one, the
+ * only feedback for the whole round trip is the control going flat, which reads as the click not
+ * having registered.
+ *
+ * @since TBD
+ */
+const FONT_ACTION_LABELS = {
+	add: {
+		idle: __('Add Favorite', 'kadence-blocks'),
+		busy: __('Adding Favorite…', 'kadence-blocks'),
+	},
+	remove: {
+		idle: __('Remove Favorite', 'kadence-blocks'),
+		busy: __('Removing Favorite…', 'kadence-blocks'),
+	},
+};
+
+/**
+ * The sentence announced to screen readers once a favorite write succeeds. The button's own label
+ * and icon flip on success, but a label change on an already-focused control is not something a
+ * screen reader reliably re-reads, so the outcome gets said out loud in its own live region.
+ *
+ * @param {('add'|'remove')} type The action that just settled.
+ * @param {string}           name The family name it was applied to.
+ *
+ * @since TBD
+ *
+ * @return {string} The announcement text.
+ */
+function favoriteAnnouncement(type, name) {
+	return type === 'remove'
+		? sprintf(/* translators: %s: the font family name. */ __('%s removed from favorites.', 'kadence-blocks'), name)
+		: sprintf(/* translators: %s: the font family name. */ __('%s added to favorites.', 'kadence-blocks'), name);
+}
 
 /**
  * Build a `renderPreview` closing over the currently selected font's resolved stack. `row.value` is
@@ -133,7 +171,8 @@ function buildCatalogOptions(fonts) {
  * @param {Function}                                             args.onPickCatalog   Called with a catalog family name when a dropdown option is chosen.
  * @param {{type: ('add'|'remove'), disabled: boolean, font: ?Object}} args.fontAction The contextual button's state ({@see fontActionFor}).
  * @param {Function}                                             args.onFontAction    Invokes the add- or remove-favorite flow for the current `fontAction`.
- * @param {boolean}                                              args.fontBusy        Whether a favorite request is in flight.
+ * @param {?{type: ('add'|'remove'), name: string}}              args.fontPending     The favorite write in flight, or null when none is.
+ * @param {string}                                               args.fontAnnouncement The live-region sentence for the last favorite write that succeeded.
  * @param {boolean}                                              args.fontLoading     Whether the selected font is still being fetched.
  * @param {?{message: string}}                                   args.fontError       The current favorite-write error, if any.
  * @param {Function}                                             args.onClearFontError Dismisses `fontError`.
@@ -148,13 +187,23 @@ function typographyToolbarRenderer({
 	onPickCatalog,
 	fontAction,
 	onFontAction,
-	fontBusy,
+	fontPending,
+	fontAnnouncement,
 	fontLoading,
 	fontError,
 	onClearFontError,
 }) {
 	return function renderToolbar({ addAction, isBusy }) {
+		const fontBusy = fontPending !== null;
 		const controlsBusy = isBusy || fontBusy;
+
+		// While a write is in flight the button describes the action that is in flight, taken from
+		// the descriptor captured at click time. `fontAction` cannot serve here: each flow refreshes
+		// the feed before it settles `onBusy`, so it has already flipped to the opposite action for
+		// the busy state's last frame — reading it would flash "Removing Favorite…" the instant an
+		// add succeeded. Label, icon, and variant all resolve from this one value so the three never
+		// disagree mid-write.
+		const actionType = fontPending ? fontPending.type : fontAction.type;
 
 		return (
 			<div className="kadence-blocks-style-library__typography-toolbar">
@@ -179,19 +228,36 @@ function typographyToolbarRenderer({
 							/>
 							<Button
 								className="kadence-blocks-style-library__typography-font-action"
-								variant={fontAction.type === 'remove' ? 'tertiary' : 'secondary'}
-								icon={fontAction.type === 'remove' ? starFilled : starEmpty}
+								variant={actionType === 'remove' ? 'tertiary' : 'secondary'}
+								icon={actionType === 'remove' ? starFilled : starEmpty}
+								// Only this button's OWN write animates it. A scale write still
+								// disables it (through `controlsBusy`) without making it look like
+								// it is the one saving — the same split `SettingsPanel` draws
+								// between its `isBusy` and `isSaving`/`isDeleting` props.
+								isBusy={fontBusy}
 								disabled={controlsBusy || fontAction.disabled}
+								// Renders `aria-disabled` rather than the `disabled` attribute, so a
+								// keyboard user who just pressed the button keeps focus on it for
+								// the length of the write instead of being dropped to the document.
+								// `Button` installs its own no-op handlers in this mode, so the
+								// click is swallowed without guarding `onClick` here.
+								accessibleWhenDisabled
 								onClick={onFontAction}
 							>
-								{fontAction.type === 'remove'
-									? __('Remove Favorite', 'kadence-blocks')
-									: __('Add Favorite', 'kadence-blocks')}
+								{FONT_ACTION_LABELS[actionType][fontBusy ? 'busy' : 'idle']}
 							</Button>
 						</div>
 					</div>
 					<span className="kadence-blocks-style-library__typography-toolbar-add">{addAction}</span>
 				</div>
+				{/*
+				 * Mounted unconditionally, empty text and all: a live region only announces text
+				 * that changes inside a node the screen reader was already watching, so one that
+				 * appears alongside its own message has nothing to announce.
+				 */}
+				<span className="screen-reader-text" role="status" aria-live="polite">
+					{fontAnnouncement}
+				</span>
 			</div>
 		);
 	};
@@ -259,7 +325,13 @@ export function TypographyScreen(props) {
 	// two is what left every non-favorite pick showing the previous font, since only a favorite had
 	// an id to select by.
 	const [selectedFamily, setSelectedFamily] = useState(() => fonts[0]?.label ?? '');
-	const [fontBusy, setFontBusy] = useState(false);
+
+	// The favorite write in flight, as the action and family captured when the click happened —
+	// not a bare boolean. The toolbar's busy label has to name the action being performed, and by
+	// the time the busy state renders its last frame the feed has already refreshed, so anything
+	// derived from the feed names the opposite one. Null means no write is in flight.
+	const [fontPending, setFontPending] = useState(null);
+	const [fontAnnouncement, setFontAnnouncement] = useState('');
 	const [fontError, setFontError] = useState(null);
 
 	// Seed the preview from the first favorite once the feed arrives, and only then: a family the
@@ -282,20 +354,34 @@ export function TypographyScreen(props) {
 	const handleFontAction = useCallback(() => {
 		setFontError(null);
 
+		// Cleared on every click so repeating an action re-announces it, rather than the live region
+		// sitting on text it already read out.
+		setFontAnnouncement('');
+
+		const { type } = fontAction;
+		const name = fontAction.font?.label ?? selectedFamily;
+
 		const flowArgs = {
-			name: fontAction.font?.label ?? selectedFamily,
+			name,
 			slug: library.slug,
 			feedVersion: library.version,
 			refreshFeed: library.refreshFeed,
-			onBusy: setFontBusy,
+			// Adapts the flows' boolean callback into the descriptor the toolbar reads. The flows
+			// stay unchanged and unaware of it — which action is in flight is a fact this screen
+			// already holds at the moment of the click.
+			onBusy: (busy) => setFontPending(busy ? { type, name } : null),
 			onError: setFontError,
 		};
 
 		// Neither flow touches the preview: the family stays selected whether it was just added to the
 		// favorites or just taken out of them, so the sample does not jump under the user's cursor.
-		const flow = fontAction.type === 'remove' ? removeFavoriteFontFlow : addFavoriteFontFlow;
+		const flow = type === 'remove' ? removeFavoriteFontFlow : addFavoriteFontFlow;
 
-		flow(flowArgs).catch(() => {});
+		// Both flows re-throw on failure, so `then` is the success path alone — a failed write must
+		// never announce that it worked. The visible error `Notice` is the feedback for that case.
+		flow(flowArgs)
+			.then(() => setFontAnnouncement(favoriteAnnouncement(type, name)))
+			.catch(() => {});
 	}, [fontAction, selectedFamily, library]);
 
 	// `useScaleScreen`'s addToken/saveToken/reorderTokens list the whole config in their deps, so an
@@ -312,13 +398,24 @@ export function TypographyScreen(props) {
 				onPickCatalog: setSelectedFamily,
 				fontAction,
 				onFontAction: handleFontAction,
-				fontBusy,
+				fontPending,
+				fontAnnouncement,
 				fontLoading,
 				fontError,
 				onClearFontError: () => setFontError(null),
 			}),
 		}),
-		[selectedFamily, readyFamily, catalogOptions, fontAction, handleFontAction, fontBusy, fontLoading, fontError]
+		[
+			selectedFamily,
+			readyFamily,
+			catalogOptions,
+			fontAction,
+			handleFontAction,
+			fontPending,
+			fontAnnouncement,
+			fontLoading,
+			fontError,
+		]
 	);
 
 	return <ScaleScreen config={config} {...props} />;

--- a/src/style-library/components/pages/TypographyScreen.scss
+++ b/src/style-library/components/pages/TypographyScreen.scss
@@ -94,3 +94,21 @@
 
 	align-items: center;
 }
+
+// The favorite button's busy stripes, restored for its Remove (tertiary) face. `wp-components`
+// flattens the background of a disabled secondary OR tertiary button, then re-asserts the busy
+// gradient over that for `.is-secondary.is-busy` alone — there is no tertiary counterpart, and the
+// generic `.components-button.is-busy` rule loses the specificity contest. So Add Favorite animates
+// while Remove Favorite sits perfectly still, which is the state this control most needs to show.
+// Only the background is clobbered; the animation itself survives, so re-declaring the gradient at a
+// weight the disabled rule cannot beat is the whole fix.
+//
+// The two literals are `wp-components`' own busy-stripe values, copied exactly so this face animates
+// identically to the Add face beside it and to every other busy button in the app (`SettingsPanel`'s
+// Save and Delete, `PresetScreen`'s Add). They are deliberately NOT routed through `--kb-sl-*`
+// primitives: they belong to the platform's button treatment, not to this app's palette, and giving
+// them a token here would both misfile them and let a palette edit silently break the match.
+.kadence-blocks-style-library__typography-font-action.is-tertiary.is-busy[aria-disabled='true'] {
+	background-image: linear-gradient(-45deg, #fafafa 33%, #e0e0e0 33%, #e0e0e0 70%, #fafafa 70%);
+	background-size: 100px 100%;
+}

--- a/src/style-library/components/pages/TypographyScreen.scss
+++ b/src/style-library/components/pages/TypographyScreen.scss
@@ -102,7 +102,7 @@
 // while Remove Favorite sits perfectly still, which is the state this control most needs to show.
 // Only the background is clobbered; the animation itself survives, so re-declaring the gradient at a
 // weight the disabled rule cannot beat is the whole fix.
-//
+
 // The two literals are `wp-components`' own busy-stripe values, copied exactly so this face animates
 // identically to the Add face beside it and to every other busy button in the app (`SettingsPanel`'s
 // Save and Delete, `PresetScreen`'s Add). They are deliberately NOT routed through `--kb-sl-*`


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4262/style-library-ui-no-loading-state-on-the-addremove-favorite-font
:video_camera: https://www.loom.com/share/a5c7d88c3e5641febee58558b014cc7e

The Typography screen's Add/Remove Favorite button fires a REST write plus a full feed refresh, but the only feedback for that round trip was the button going flat.

- Tracks the in-flight write as the action and family captured at click time. The flows refresh the feed before they settle `onBusy`, so anything derived from the feed names the opposite action for the last frame and flashes "Removing Favorite…" the instant an add succeeds. Label, icon, and variant all resolve from the captured value.
- Pairs `isBusy` with a swapped "-ing…" label, matching `SettingsPanel`'s Save and Delete and `PresetScreen`'s Add.
- Disables through `accessibleWhenDisabled`, so a keyboard user keeps focus on the button for the length of the write.
- Announces the outcome in a polite live region on the resolved path only. Both flows re-throw on failure, so a failed write cannot announce success; the existing error `Notice` still covers that case.

One SCSS rule earns its keep: `wp-components` flattens the background of a disabled secondary *or* tertiary button, then re-asserts the busy gradient for `.is-secondary.is-busy` alone. The Remove face is tertiary, so without it that face stays perfectly still while busy.

`helpers/font-flows.js` and `api/client.js` are untouched; the `onBusy` adapter lives at the call site.

New `typography-screen.test.js` covers the busy label, the focusable-while-disabled contract, the announcement, the failure path, and a guard against the label flipping mid-write.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved typography favorite actions with clearer add/remove progress states.
  * Preserved the correct action icon and styling while updates are processing.
  * Kept focus on the favorite control during asynchronous updates.
  * Added accessible announcements for successful font additions and removals.
  * Restored the busy-state animation for disabled favorite buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->