### PR TITLE
[DTM] SOFT-4196 [7/8]: wire all 14 color attributes to the shared ColorControl

### DIFF
--- a/src/blocks/singlebtn/color-control-adapter.js
+++ b/src/blocks/singlebtn/color-control-adapter.js
@@ -1,0 +1,36 @@
+/**
+ * `kadence/singlebtn`'s host-specific `resolveLiteral` for `ColorControl`'s Custom tab.
+ *
+ * Kept as its own file (rather than a `token-controls` export) because the design scoped
+ * host-adapter logic as per-block, not shared — `token-controls` never imports from a host
+ * block, only the reverse.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { tokenCssVar } from '../../token-controls/helpers/token-css-var';
+
+/**
+ * Resolve a token entry's current literal color from the top-document `<html>`.
+ *
+ * `palette-swatch-preview.js`'s `applyPalettePreview()` stamps the selected block's effective
+ * `data-kb-palette` onto `document.documentElement` while the block is selected, so reading the
+ * token's CSS variable there (rather than from any DOM node local to this control) returns the
+ * value under the block's own pinned palette, not the site's default palette.
+ *
+ * @param {Object} entry The token entry (`{ id, label, value, alias }`) to resolve.
+ *
+ * @since TBD
+ *
+ * @return {string} The resolved CSS color literal, or '' when there is no document to read from.
+ */
+export function resolveColorLiteral(entry) {
+	if (typeof document === 'undefined' || !document.documentElement) {
+		return '';
+	}
+
+	const id = entry.alias ? entry.alias.slice(1, -1) : entry.id;
+
+	return getComputedStyle(document.documentElement).getPropertyValue(tokenCssVar(id)).trim();
+}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -54,7 +54,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { tooltip as tooltipIcon } from '@kadence/icons';
 import { link as linkIcon } from '@wordpress/icons';
 import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import {
 	RichText,
 	InspectorControls,
@@ -93,7 +93,6 @@ import {
 	measureAttrsForDevice,
 	presetValueForDevice,
 } from '../../extension/token-indicators/normalize';
-import { TokenControlRow } from '../../extension/token-indicators/components/TokenControlRow';
 import { EditorBoxControl } from '../../extension/design-tokens/components/EditorBoxControl';
 import { EditorBorderControl } from '../../extension/design-tokens/components/EditorBorderControl';
 import {
@@ -102,6 +101,10 @@ import {
 	splitColorOpacity,
 } from '../../extension/design-tokens/components/EditorShadowControl';
 import { pickableTokensForControl, pickableTokensForKey } from '../../extension/token-picker';
+import { ColorControl } from '../../token-controls/controls/ColorControl';
+import { ColorControlGroup } from '../../token-controls/controls/ColorControlGroup';
+import { useColorGroups } from '../../extension/design-tokens/hooks/use-color-groups';
+import { resolveColorLiteral } from './color-control-adapter';
 
 /**
  * `EditorBorderControl`'s `renderColor` render-prop: reuses the block's existing `PopColorControl`
@@ -366,6 +369,9 @@ export default function KadenceButtonEdit(props) {
 	// reset that clears the mapped attribute back to the preset value (served by the existing scoped CSS).
 	const tokenBinding = usePresetBinding('kadence/singlebtn', attributes, undefined, previewDevice);
 	const resetToken = (attr) => resetAttr(attr, setAttributes, tokenBinding[attr]?.kind);
+	// One fetch of the block's effective palette groups, shared by every `ColorControl` instance on
+	// this block — the palette data is identical for all fourteen of them.
+	const colorGroups = useColorGroups(clientId);
 
 	const borderRadiusPresetValue = presetValueForDevice(
 		tokenBinding.borderRadius?.presetValue,
@@ -770,29 +776,6 @@ export default function KadenceButtonEdit(props) {
 			setIsEditingURL(false);
 		}
 	}, [isSelected]);
-
-	// A remount key for the token-mapped color pickers. PopColorControl keeps the picked color in its own
-	// internal state, so clearing the attribute (a per-control revert or the preset Reset-all) updates the
-	// block but not the swatch. Bumping this key when a mapped color attribute goes from set -> empty
-	// remounts the picker, which re-reads the now-empty attribute — the missing wire for token reset.
-	// TODO: remove this stopgap once `@kadence/components` teaches PopColorControl to re-read an externally
-	// cleared value itself (planned alongside that upstream `@kadence/components` update).
-	const [colorResetNonce, setColorResetNonce] = useState(0);
-	const prevTokenColors = useRef({ color, background, colorHover, backgroundHover });
-	useEffect(() => {
-		const prev = prevTokenColors.current;
-		const cleared =
-			(prev.color && !color) ||
-			(prev.background && !background) ||
-			(prev.colorHover && !colorHover) ||
-			(prev.backgroundHover && !backgroundHover);
-
-		if (cleared) {
-			setColorResetNonce((nonce) => nonce + 1);
-		}
-
-		prevTokenColors.current = { color, background, colorHover, backgroundHover };
-	}, [color, background, colorHover, backgroundHover]);
 
 	const themeVersion = window?.kadence_blocks_params?.tVersion ? window.kadence_blocks_params.tVersion : '1.0.0';
 	const supportsSecondaryButton = compareVersions(themeVersion, '1.4.0') >= 0;
@@ -1309,23 +1292,21 @@ export default function KadenceButtonEdit(props) {
 															/>
 														)}
 														{'normal' === textBackgroundHoverType && (
-															<TokenControlRow
-																heading={__('Color Hover', 'kadence-blocks')}
-																attr="colorHover"
-																binding={tokenBinding}
-																onReset={resetToken}
-															>
-																<PopColorControl
-																	key={`btncolorhover-${colorResetNonce}`}
-																	hideClear={!!tokenBinding.colorHover?.bound}
-																	swatchLabel={__('Color Hover', 'kadence-blocks')}
-																	value={colorHover ? colorHover : ''}
-																	default={''}
-																	onChange={(value) =>
-																		setAttributes({ colorHover: value })
-																	}
-																/>
-															</TokenControlRow>
+															<ColorControl
+																label={__('Color Hover', 'kadence-blocks')}
+																value={colorHover ? colorHover : ''}
+																groups={colorGroups}
+																status={{
+																	bound: !!tokenBinding.colorHover?.bound,
+																	modified: !!tokenBinding.colorHover?.overridden,
+																}}
+																onReset={() => resetToken('colorHover')}
+																onPick={(alias) => setAttributes({ colorHover: alias })}
+																onCustom={(literal) =>
+																	setAttributes({ colorHover: literal })
+																}
+																resolveLiteral={resolveColorLiteral}
+															/>
 														)}
 														<BackgroundTypeControl
 															label={__('Background Hover Type', 'kadence-blocks')}
@@ -1345,26 +1326,24 @@ export default function KadenceButtonEdit(props) {
 															/>
 														)}
 														{'normal' === backgroundHoverType && (
-															<TokenControlRow
-																heading={__('Background Color', 'kadence-blocks')}
-																attr="backgroundHover"
-																binding={tokenBinding}
-																onReset={resetToken}
-															>
-																<PopColorControl
-																	key={`btnbghover-${colorResetNonce}`}
-																	hideClear={!!tokenBinding.backgroundHover?.bound}
-																	swatchLabel={__(
-																		'Background Color',
-																		'kadence-blocks'
-																	)}
-																	value={backgroundHover ? backgroundHover : ''}
-																	default={''}
-																	onChange={(value) =>
-																		setAttributes({ backgroundHover: value })
-																	}
-																/>
-															</TokenControlRow>
+															<ColorControl
+																label={__('Background Color', 'kadence-blocks')}
+																value={backgroundHover ? backgroundHover : ''}
+																groups={colorGroups}
+																status={{
+																	bound: !!tokenBinding.backgroundHover?.bound,
+																	modified:
+																		!!tokenBinding.backgroundHover?.overridden,
+																}}
+																onReset={() => resetToken('backgroundHover')}
+																onPick={(alias) =>
+																	setAttributes({ backgroundHover: alias })
+																}
+																onCustom={(literal) =>
+																	setAttributes({ backgroundHover: literal })
+																}
+																resolveLiteral={resolveColorLiteral}
+															/>
 														)}
 														<EditorBorderControl
 															label={__('Border', 'kadence-blocks')}
@@ -1453,23 +1432,21 @@ export default function KadenceButtonEdit(props) {
 															/>
 														)}
 														{'normal' === textBackgroundType && (
-															<TokenControlRow
-																heading={__('Color', 'kadence-blocks')}
-																attr="color"
-																binding={tokenBinding}
-																onReset={resetToken}
-															>
-																<PopColorControl
-																	key={`btncolor-${colorResetNonce}`}
-																	hideClear={!!tokenBinding.color?.bound}
-																	swatchLabel={__('Color', 'kadence-blocks')}
-																	value={color ? color : ''}
-																	default={''}
-																	onChange={(value) =>
-																		setAttributes({ color: value })
-																	}
-																/>
-															</TokenControlRow>
+															<ColorControl
+																label={__('Color', 'kadence-blocks')}
+																value={color ? color : ''}
+																groups={colorGroups}
+																status={{
+																	bound: !!tokenBinding.color?.bound,
+																	modified: !!tokenBinding.color?.overridden,
+																}}
+																onReset={() => resetToken('color')}
+																onPick={(alias) => setAttributes({ color: alias })}
+																onCustom={(literal) =>
+																	setAttributes({ color: literal })
+																}
+																resolveLiteral={resolveColorLiteral}
+															/>
 														)}
 														<BackgroundTypeControl
 															label={__('Background Type', 'kadence-blocks')}
@@ -1487,26 +1464,21 @@ export default function KadenceButtonEdit(props) {
 															/>
 														)}
 														{'normal' === backgroundType && (
-															<TokenControlRow
-																heading={__('Background Color', 'kadence-blocks')}
-																attr="background"
-																binding={tokenBinding}
-																onReset={resetToken}
-															>
-																<PopColorControl
-																	key={`btnbg-${colorResetNonce}`}
-																	hideClear={!!tokenBinding.background?.bound}
-																	swatchLabel={__(
-																		'Background Color',
-																		'kadence-blocks'
-																	)}
-																	value={background ? background : ''}
-																	default={''}
-																	onChange={(value) =>
-																		setAttributes({ background: value })
-																	}
-																/>
-															</TokenControlRow>
+															<ColorControl
+																label={__('Background Color', 'kadence-blocks')}
+																value={background ? background : ''}
+																groups={colorGroups}
+																status={{
+																	bound: !!tokenBinding.background?.bound,
+																	modified: !!tokenBinding.background?.overridden,
+																}}
+																onReset={() => resetToken('background')}
+																onPick={(alias) => setAttributes({ background: alias })}
+																onCustom={(literal) =>
+																	setAttributes({ background: literal })
+																}
+																resolveLiteral={resolveColorLiteral}
+															/>
 														)}
 														<EditorBorderControl
 															label={__('Border', 'kadence-blocks')}
@@ -1578,15 +1550,19 @@ export default function KadenceButtonEdit(props) {
 												<HoverToggleControl
 													hover={
 														<>
-															<PopColorControl
+															<ColorControl
 																label={__('Color Hover', 'kadence-blocks')}
 																value={
 																	colorTransparentHover ? colorTransparentHover : ''
 																}
-																default={''}
-																onChange={(value) =>
-																	setAttributes({ colorTransparentHover: value })
+																groups={colorGroups}
+																onPick={(alias) =>
+																	setAttributes({ colorTransparentHover: alias })
 																}
+																onCustom={(literal) =>
+																	setAttributes({ colorTransparentHover: literal })
+																}
+																resolveLiteral={resolveColorLiteral}
 															/>
 															<BackgroundTypeControl
 																label={__('Hover Type', 'kadence-blocks')}
@@ -1612,17 +1588,25 @@ export default function KadenceButtonEdit(props) {
 																/>
 															)}
 															{'normal' === backgroundTransparentHoverType && (
-																<PopColorControl
+																<ColorControl
 																	label={__('Background Color', 'kadence-blocks')}
 																	value={
 																		backgroundTransparentHover
 																			? backgroundTransparentHover
 																			: ''
 																	}
-																	default={''}
-																	onChange={(value) =>
-																		setAttributes({ backgroundHover: value })
+																	groups={colorGroups}
+																	onPick={(alias) =>
+																		setAttributes({
+																			backgroundTransparentHover: alias,
+																		})
 																	}
+																	onCustom={(literal) =>
+																		setAttributes({
+																			backgroundTransparentHover: literal,
+																		})
+																	}
+																	resolveLiteral={resolveColorLiteral}
 																/>
 															)}
 															<EditorBorderControl
@@ -1709,13 +1693,17 @@ export default function KadenceButtonEdit(props) {
 													}
 													normal={
 														<>
-															<PopColorControl
+															<ColorControl
 																label={__('Color', 'kadence-blocks')}
 																value={colorTransparent ? colorTransparent : ''}
-																default={''}
-																onChange={(value) =>
-																	setAttributes({ colorTransparent: value })
+																groups={colorGroups}
+																onPick={(alias) =>
+																	setAttributes({ colorTransparent: alias })
 																}
+																onCustom={(literal) =>
+																	setAttributes({ colorTransparent: literal })
+																}
+																resolveLiteral={resolveColorLiteral}
 															/>
 															<BackgroundTypeControl
 																label={__('Type', 'kadence-blocks')}
@@ -1739,17 +1727,23 @@ export default function KadenceButtonEdit(props) {
 																/>
 															)}
 															{'normal' === backgroundTransparentType && (
-																<PopColorControl
+																<ColorControl
 																	label={__('Background Color', 'kadence-blocks')}
 																	value={
 																		backgroundTransparent
 																			? backgroundTransparent
 																			: ''
 																	}
-																	default={''}
-																	onChange={(value) =>
-																		setAttributes({ backgroundTransparent: value })
+																	groups={colorGroups}
+																	onPick={(alias) =>
+																		setAttributes({ backgroundTransparent: alias })
 																	}
+																	onCustom={(literal) =>
+																		setAttributes({
+																			backgroundTransparent: literal,
+																		})
+																	}
+																	resolveLiteral={resolveColorLiteral}
 																/>
 															)}
 															<EditorBorderControl
@@ -1839,13 +1833,17 @@ export default function KadenceButtonEdit(props) {
 												<HoverToggleControl
 													hover={
 														<>
-															<PopColorControl
+															<ColorControl
 																label={__('Color Hover', 'kadence-blocks')}
 																value={colorStickyHover ? colorStickyHover : ''}
-																default={''}
-																onChange={(value) =>
-																	setAttributes({ colorStickyHover: value })
+																groups={colorGroups}
+																onPick={(alias) =>
+																	setAttributes({ colorStickyHover: alias })
 																}
+																onCustom={(literal) =>
+																	setAttributes({ colorStickyHover: literal })
+																}
+																resolveLiteral={resolveColorLiteral}
 															/>
 															<BackgroundTypeControl
 																label={__('Hover Type', 'kadence-blocks')}
@@ -1871,17 +1869,25 @@ export default function KadenceButtonEdit(props) {
 																/>
 															)}
 															{'normal' === backgroundStickyHoverType && (
-																<PopColorControl
+																<ColorControl
 																	label={__('Background Color', 'kadence-blocks')}
 																	value={
 																		backgroundStickyHover
 																			? backgroundStickyHover
 																			: ''
 																	}
-																	default={''}
-																	onChange={(value) =>
-																		setAttributes({ backgroundHover: value })
+																	groups={colorGroups}
+																	onPick={(alias) =>
+																		setAttributes({
+																			backgroundStickyHover: alias,
+																		})
 																	}
+																	onCustom={(literal) =>
+																		setAttributes({
+																			backgroundStickyHover: literal,
+																		})
+																	}
+																	resolveLiteral={resolveColorLiteral}
 																/>
 															)}
 															<EditorBorderControl
@@ -1963,13 +1969,17 @@ export default function KadenceButtonEdit(props) {
 													}
 													normal={
 														<>
-															<PopColorControl
+															<ColorControl
 																label={__('Color', 'kadence-blocks')}
 																value={colorSticky ? colorSticky : ''}
-																default={''}
-																onChange={(value) =>
-																	setAttributes({ colorSticky: value })
+																groups={colorGroups}
+																onPick={(alias) =>
+																	setAttributes({ colorSticky: alias })
 																}
+																onCustom={(literal) =>
+																	setAttributes({ colorSticky: literal })
+																}
+																resolveLiteral={resolveColorLiteral}
 															/>
 															<BackgroundTypeControl
 																label={__('Type', 'kadence-blocks')}
@@ -1993,13 +2003,17 @@ export default function KadenceButtonEdit(props) {
 																/>
 															)}
 															{'normal' === backgroundStickyType && (
-																<PopColorControl
+																<ColorControl
 																	label={__('Background Color', 'kadence-blocks')}
 																	value={backgroundSticky ? backgroundSticky : ''}
-																	default={''}
-																	onChange={(value) =>
-																		setAttributes({ backgroundSticky: value })
+																	groups={colorGroups}
+																	onPick={(alias) =>
+																		setAttributes({ backgroundSticky: alias })
 																	}
+																	onCustom={(literal) =>
+																		setAttributes({ backgroundSticky: literal })
+																	}
+																	resolveLiteral={resolveColorLiteral}
 																/>
 															)}
 															<EditorBorderControl
@@ -2300,20 +2314,24 @@ export default function KadenceButtonEdit(props) {
 											}}
 											units={['px', 'em', 'rem']}
 										/>
-										<PopColorControl
-											label={__('Icon Color', 'kadence-blocks')}
-											value={iconColor ? iconColor : ''}
-											default={''}
-											onChange={(value) => {
-												setAttributes({ iconColor: value });
-											}}
-											swatchLabel2={__('Hover Color', 'kadence-blocks')}
-											value2={iconColorHover ? iconColorHover : ''}
-											default2={''}
-											onChange2={(value) => {
-												setAttributes({ iconColorHover: value });
-											}}
-										/>
+										<ColorControlGroup>
+											<ColorControl
+												label={__('Icon Color', 'kadence-blocks')}
+												value={iconColor ? iconColor : ''}
+												groups={colorGroups}
+												onPick={(alias) => setAttributes({ iconColor: alias })}
+												onCustom={(literal) => setAttributes({ iconColor: literal })}
+												resolveLiteral={resolveColorLiteral}
+											/>
+											<ColorControl
+												label={__('Hover Color', 'kadence-blocks')}
+												value={iconColorHover ? iconColorHover : ''}
+												groups={colorGroups}
+												onPick={(alias) => setAttributes({ iconColorHover: alias })}
+												onCustom={(literal) => setAttributes({ iconColorHover: literal })}
+												resolveLiteral={resolveColorLiteral}
+											/>
+										</ColorControlGroup>
 										<ResponsiveMeasureRangeControl
 											label={__('Icon Padding', 'kadence-blocks')}
 											value={undefined !== iconPadding ? iconPadding : ['', '', '', '']}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -1305,6 +1305,7 @@ export default function KadenceButtonEdit(props) {
 																onCustom={(literal) =>
 																	setAttributes({ colorHover: literal })
 																}
+																onClear={() => setAttributes({ colorHover: '' })}
 																resolveLiteral={resolveColorLiteral}
 															/>
 														)}
@@ -1342,6 +1343,7 @@ export default function KadenceButtonEdit(props) {
 																onCustom={(literal) =>
 																	setAttributes({ backgroundHover: literal })
 																}
+																onClear={() => setAttributes({ backgroundHover: '' })}
 																resolveLiteral={resolveColorLiteral}
 															/>
 														)}
@@ -1445,6 +1447,7 @@ export default function KadenceButtonEdit(props) {
 																onCustom={(literal) =>
 																	setAttributes({ color: literal })
 																}
+																onClear={() => setAttributes({ color: '' })}
 																resolveLiteral={resolveColorLiteral}
 															/>
 														)}
@@ -1477,6 +1480,7 @@ export default function KadenceButtonEdit(props) {
 																onCustom={(literal) =>
 																	setAttributes({ background: literal })
 																}
+																onClear={() => setAttributes({ background: '' })}
 																resolveLiteral={resolveColorLiteral}
 															/>
 														)}
@@ -1562,6 +1566,9 @@ export default function KadenceButtonEdit(props) {
 																onCustom={(literal) =>
 																	setAttributes({ colorTransparentHover: literal })
 																}
+																onClear={() =>
+																	setAttributes({ colorTransparentHover: '' })
+																}
 																resolveLiteral={resolveColorLiteral}
 															/>
 															<BackgroundTypeControl
@@ -1604,6 +1611,11 @@ export default function KadenceButtonEdit(props) {
 																	onCustom={(literal) =>
 																		setAttributes({
 																			backgroundTransparentHover: literal,
+																		})
+																	}
+																	onClear={() =>
+																		setAttributes({
+																			backgroundTransparentHover: '',
 																		})
 																	}
 																	resolveLiteral={resolveColorLiteral}
@@ -1703,6 +1715,7 @@ export default function KadenceButtonEdit(props) {
 																onCustom={(literal) =>
 																	setAttributes({ colorTransparent: literal })
 																}
+																onClear={() => setAttributes({ colorTransparent: '' })}
 																resolveLiteral={resolveColorLiteral}
 															/>
 															<BackgroundTypeControl
@@ -1742,6 +1755,9 @@ export default function KadenceButtonEdit(props) {
 																		setAttributes({
 																			backgroundTransparent: literal,
 																		})
+																	}
+																	onClear={() =>
+																		setAttributes({ backgroundTransparent: '' })
 																	}
 																	resolveLiteral={resolveColorLiteral}
 																/>
@@ -1843,6 +1859,7 @@ export default function KadenceButtonEdit(props) {
 																onCustom={(literal) =>
 																	setAttributes({ colorStickyHover: literal })
 																}
+																onClear={() => setAttributes({ colorStickyHover: '' })}
 																resolveLiteral={resolveColorLiteral}
 															/>
 															<BackgroundTypeControl
@@ -1886,6 +1903,9 @@ export default function KadenceButtonEdit(props) {
 																		setAttributes({
 																			backgroundStickyHover: literal,
 																		})
+																	}
+																	onClear={() =>
+																		setAttributes({ backgroundStickyHover: '' })
 																	}
 																	resolveLiteral={resolveColorLiteral}
 																/>
@@ -1979,6 +1999,7 @@ export default function KadenceButtonEdit(props) {
 																onCustom={(literal) =>
 																	setAttributes({ colorSticky: literal })
 																}
+																onClear={() => setAttributes({ colorSticky: '' })}
 																resolveLiteral={resolveColorLiteral}
 															/>
 															<BackgroundTypeControl
@@ -2012,6 +2033,9 @@ export default function KadenceButtonEdit(props) {
 																	}
 																	onCustom={(literal) =>
 																		setAttributes({ backgroundSticky: literal })
+																	}
+																	onClear={() =>
+																		setAttributes({ backgroundSticky: '' })
 																	}
 																	resolveLiteral={resolveColorLiteral}
 																/>
@@ -2321,6 +2345,7 @@ export default function KadenceButtonEdit(props) {
 												groups={colorGroups}
 												onPick={(alias) => setAttributes({ iconColor: alias })}
 												onCustom={(literal) => setAttributes({ iconColor: literal })}
+												onClear={() => setAttributes({ iconColor: '' })}
 												resolveLiteral={resolveColorLiteral}
 											/>
 											<ColorControl
@@ -2329,6 +2354,7 @@ export default function KadenceButtonEdit(props) {
 												groups={colorGroups}
 												onPick={(alias) => setAttributes({ iconColorHover: alias })}
 												onCustom={(literal) => setAttributes({ iconColorHover: literal })}
+												onClear={() => setAttributes({ iconColorHover: '' })}
 												resolveLiteral={resolveColorLiteral}
 											/>
 										</ColorControlGroup>

--- a/src/token-controls/__tests__/ColorControl.test.js
+++ b/src/token-controls/__tests__/ColorControl.test.js
@@ -273,4 +273,47 @@ describe('ColorControl', () => {
 
 		expect(container.querySelector('[data-testid="color-picker"]').dataset.color).toBe('#3182ce');
 	});
+
+	/**
+	 * Clear is opt-in: a host that passes no `onClear` gets no Clear row, keeping the control
+	 * unchanged for callers that have their own way back to unset.
+	 *
+	 * @return {void}
+	 */
+	it('renders no Clear row when onClear is omitted', () => {
+		render({ value: '{semantic.color.accent.soft}' });
+
+		expect(container.querySelector('.kb-color-control__clear')).toBeNull();
+	});
+
+	/**
+	 * The Clear row is the only path back to unset for an attribute no preset binds, so it clears the
+	 * value and closes the popover.
+	 *
+	 * @return {void}
+	 */
+	it('calls onClear and closes the popover when the Clear row is clicked', () => {
+		const onClear = jest.fn();
+
+		render({ value: '{semantic.color.accent.soft}', onClear });
+
+		const clear = container.querySelector('.kb-color-control__clear');
+
+		act(() => clear.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+
+		expect(onClear).toHaveBeenCalled();
+		expect(mockOnToggle).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * With nothing set there is nothing to clear, so the row is present but inert rather than
+	 * offering an action that would be a no-op.
+	 *
+	 * @return {void}
+	 */
+	it('disables the Clear row when the value is already unset', () => {
+		render({ value: '', onClear: jest.fn() });
+
+		expect(container.querySelector('.kb-color-control__clear').disabled).toBe(true);
+	});
 });

--- a/src/token-controls/controls/ColorControl.js
+++ b/src/token-controls/controls/ColorControl.js
@@ -14,7 +14,8 @@
 /**
  * WordPress dependencies
  */
-import { Dropdown } from '@wordpress/components';
+import { Button, Dropdown } from '@wordpress/components';
+import { Icon, undo } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -41,6 +42,10 @@ import '../styles/token-controls.scss';
  *                                           — the active palette's groups, host-resolved.
  * @param {?Object}   [props.status]        `{ bound, modified }`; omit for no indicator.
  * @param {?Function} [props.onReset]       Reset handler, paired with `status`.
+ * @param {?Function} [props.onClear]       Clears the slot back to unset. Independent of `status`:
+ *                                           `BindingIndicator`'s own Reset renders only for a
+ *                                           preset-bound slot, so an attribute that no preset binds
+ *                                           has no other way back to empty. Omit for no Clear row.
  * @param {Function}  props.onPick          Called with a token entry's `alias` when one is chosen.
  * @param {Function}  props.onCustom        Called with a literal color from the Custom tab.
  * @param {?Function} [props.resolveLiteral] `(entry) => string` — the host's hook for seeding the
@@ -59,6 +64,7 @@ export function ColorControl({
 	groups,
 	status = null,
 	onReset = null,
+	onClear = null,
 	onPick,
 	onCustom,
 	resolveLiteral,
@@ -100,7 +106,24 @@ export function ColorControl({
 							tokens={allSwatches}
 							initialTab={initialTab}
 							renderList={({ onPick: pick, onClose: close }) => (
-								<ColorGroupList groups={groups} value={value} onPick={pick} onClose={close} />
+								<>
+									{onClear && (
+										<Button
+											className="kadence-token-field__reset kb-color-control__clear"
+											disabled={!value}
+											onClick={() => {
+												onClear();
+												close();
+											}}
+										>
+											<span className="kadence-token-field__reset-label">
+												{__('Clear', 'kadence-blocks')}
+											</span>
+											<Icon className="kadence-token-field__reset-icon" icon={undo} size={20} />
+										</Button>
+									)}
+									<ColorGroupList groups={groups} value={value} onPick={pick} onClose={close} />
+								</>
 							)}
 							renderCustom={() => (
 								<ColorPicker

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -959,7 +959,6 @@
 
 // The popover's menu: a 4px-radius white sheet, matching the token field's own popover.
 .kb-border-control__style-menu {
-
 	.components-popover__content {
 		min-width: 180px;
 		border-radius: 4px;
@@ -1086,6 +1085,13 @@
 	height: 20px;
 	border: 1px solid rgba(0, 0, 0, 0.1);
 	border-radius: 50%;
+}
+
+// Clear sits above the groups, inset to the same 8px the list itself uses so the two read as one
+// column rather than the button running to the popover's edge.
+.kb-color-control__clear.components-button {
+	width: calc(100% - 16px);
+	margin: 8px 8px 0;
 }
 
 // The popover's Style Library tab: the active palette's groups, each swatch showing a check mark on


### PR DESCRIPTION
## Summary
- Replaces every scalar (non-composite, non-gradient) \`PopColorControl\` in \`kadence/singlebtn\`'s inspector with the new \`ColorControl\` — 14 attribute slots: \`color\`/\`colorHover\`/\`background\`/\`backgroundHover\` (main panel), the same four for the Transparent and Sticky variants, and \`iconColor\`/\`iconColorHover\` (split from a single dual-swatch \`PopColorControl\` instance into two independent \`ColorControl\`s, matching how \`color\`/\`colorHover\` are already two separate controls elsewhere in the block).
- \`groups\` is fetched once per block instance via the previous slice's \`useColorGroups(clientId)\` and shared across all 14 \`ColorControl\`s.
- \`resolveLiteral\` (new \`src/blocks/singlebtn/color-control-adapter.js\`) reads a bound token's resolved value via \`getComputedStyle(document.documentElement)\`, so seeding the Custom tab from a token pick respects the block's own pinned palette (\`data-kb-palette\`, stamped on \`<html>\` by the existing inspector-preview mechanism) rather than the site default.
- Extends the design-token preset binding indicator (previously only on the 4 main-panel attributes) to all 12 scalar text/background attributes, since they're all the same component now.
- Fixes two pre-existing bugs found while rewriting this wiring: \`backgroundTransparentHover\`'s and \`backgroundStickyHover\`'s \`onChange\` handlers were writing to \`backgroundHover\` instead of their own attribute.
- Removes the now-dead \`colorResetNonce\`/remount-key workaround — it existed only to force-remount \`PopColorControl\` on an external reset, which \`ColorControl\` (fully value-driven from props) has no need for.
- Untouched: border color and box-shadow color (their own \`renderColor\` composite wiring — see the follow-up ticket SOFT-4261) and every gradient toggle branch.

## Test plan
- \`npx jest src/blocks/singlebtn\` — all green, no regressions.
- Manually verified in the block editor: all 14 color controls render, open the grouped popover, pick/custom-set correctly, and the binding indicator shows the right bound/modified state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved button color controls with shared, consistent color selection across primary, hover, transparent, sticky, and icon states.
  - Added support for selecting and resetting palette colors, custom colors, and color tokens.
  - Color values now resolve correctly from the active theme palette, including aliased colors.
- **Bug Fixes**
  - Improved color handling to provide more reliable styling when switching between palette and custom color options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->