### PR TITLE
[DTM] SOFT-4196 [8/8]: wire ColorSelectField into the Button preset color panel

### DIFF
--- a/src/style-library/__tests__/ColorSelectField.test.js
+++ b/src/style-library/__tests__/ColorSelectField.test.js
@@ -1,0 +1,240 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import {
+	ColorSelectField,
+	resolveLiteral,
+	toControlValue,
+	toStoredValue,
+} from '../components/molecules/fields/ColorSelectField';
+import { getDesignTokensFeed } from '../helpers/tokens';
+
+const NAMESPACE = 'kb-design-tokens/v1';
+const SLUG = 'default';
+
+const LISTING = {
+	defaultId: 'default',
+	currentId: 'default',
+	userCreated: [],
+	palettes: [
+		{
+			id: 'default',
+			label: 'Default',
+			groups: [
+				{
+					id: 'accent',
+					label: 'Accent',
+					swatches: [{ token: 'semantic.color.accent.main', label: 'Main', $value: '#3182ce' }],
+				},
+			],
+		},
+		{
+			id: 'sunset',
+			label: 'Sunset',
+			groups: [],
+		},
+	],
+};
+
+// A factory, not automock: `helpers/tokens.js` reaches the localized feed, and this test only
+// cares about the namespace/slug the field hands the store selector.
+jest.mock('../helpers/tokens', () => ({
+	getDesignTokensFeed: jest.fn(),
+}));
+
+let capturedProps = null;
+
+// Captures the props `ColorControl` receives rather than rendering the real control (already
+// covered by `ColorControl.test.js`) — this test is only about the adapter's own bridging.
+jest.mock('../../token-controls', () => ({
+	ColorControl: (props) => {
+		capturedProps = props;
+		return null;
+	},
+	isTokenId: (value) =>
+		typeof value === 'string' && (value.startsWith('primitive.') || value.startsWith('semantic.')),
+	mapPaletteToColorControlGroups: (palette) =>
+		palette
+			? palette.groups.map((group) => ({
+					id: group.id,
+					label: group.label,
+					swatches: group.swatches.map((swatch) => ({
+						id: swatch.token,
+						label: swatch.label,
+						value: swatch.$value,
+						alias: `{${swatch.token}}`,
+					})),
+				}))
+			: [],
+}));
+
+const mockGetPaletteListing = jest.fn();
+
+jest.mock('@wordpress/data', () => ({
+	useSelect: (fn) => fn(() => ({ getPaletteListing: mockGetPaletteListing })),
+}));
+
+beforeEach(() => {
+	jest.clearAllMocks();
+	capturedProps = null;
+	mockGetPaletteListing.mockReturnValue(LISTING);
+	getDesignTokensFeed.mockReturnValue({ slug: SLUG, rest: { namespace: NAMESPACE } });
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(() => {
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+/**
+ * Render `ColorSelectField` with the given props.
+ *
+ * @param {Object} props The component props.
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+function render(props = {}) {
+	const container = document.createElement('div');
+	document.body.appendChild(container);
+	const root = createRoot(container);
+
+	act(() =>
+		root.render(
+			createElement(ColorSelectField, {
+				field: { label: 'Text' },
+				value: '',
+				onChange: jest.fn(),
+				...props,
+			})
+		)
+	);
+
+	act(() => root.unmount());
+	container.remove();
+}
+
+describe('toControlValue', () => {
+	it('wraps a bare token id into the bracket alias ColorControl expects', () => {
+		expect(toControlValue('semantic.color.accent.main')).toBe('{semantic.color.accent.main}');
+		expect(toControlValue('primitive.color.brand.primary')).toBe('{primitive.color.brand.primary}');
+	});
+
+	it('passes a raw literal through unchanged', () => {
+		expect(toControlValue('#3182ce')).toBe('#3182ce');
+	});
+
+	it('reads an unset value as unset', () => {
+		expect(toControlValue('')).toBe('');
+		expect(toControlValue(undefined)).toBe('');
+	});
+});
+
+describe('toStoredValue', () => {
+	it('unwraps a bracket alias back to the bare id this field stores', () => {
+		expect(toStoredValue('{semantic.color.accent.main}')).toBe('semantic.color.accent.main');
+	});
+});
+
+describe('resolveLiteral', () => {
+	it("reads an entry's own resolved value with no CSS-variable lookup", () => {
+		expect(resolveLiteral({ value: '#3182ce' })).toBe('#3182ce');
+	});
+});
+
+describe('ColorSelectField', () => {
+	/**
+	 * The field reads the store's palette listing for the feed's namespace/slug and maps the row
+	 * whose id matches `listing.currentId` — the site's active palette — never the row a sibling
+	 * screen happens to be editing.
+	 *
+	 * @return {void}
+	 */
+	it("passes the active palette's groups, not any other row", () => {
+		render();
+
+		expect(capturedProps.groups).toEqual([
+			{
+				id: 'accent',
+				label: 'Accent',
+				swatches: [
+					{
+						id: 'semantic.color.accent.main',
+						label: 'Main',
+						value: '#3182ce',
+						alias: '{semantic.color.accent.main}',
+					},
+				],
+			},
+		]);
+	});
+
+	/**
+	 * A bare stored token id arrives at `ColorControl` as a bracket alias.
+	 *
+	 * @return {void}
+	 */
+	it('bridges a bare stored token id into a bracket alias', () => {
+		render({ value: 'semantic.color.accent.main' });
+
+		expect(capturedProps.value).toBe('{semantic.color.accent.main}');
+	});
+
+	/**
+	 * A stored raw literal arrives at `ColorControl` unchanged.
+	 *
+	 * @return {void}
+	 */
+	it('passes a stored literal through unchanged', () => {
+		render({ value: '#3182ce' });
+
+		expect(capturedProps.value).toBe('#3182ce');
+	});
+
+	/**
+	 * Picking a token writes the bare id back, not the bracket alias `ColorControl` hands it.
+	 *
+	 * @return {void}
+	 */
+	it('writes a picked alias back as a bare token id', () => {
+		const onChange = jest.fn();
+
+		render({ onChange });
+		capturedProps.onPick('{semantic.color.accent.main}');
+
+		expect(onChange).toHaveBeenCalledWith('semantic.color.accent.main');
+	});
+
+	/**
+	 * A Custom-tab pick writes its literal straight through, with no id translation.
+	 *
+	 * @return {void}
+	 */
+	it('writes a custom literal through unchanged', () => {
+		const onChange = jest.fn();
+
+		render({ onChange });
+		capturedProps.onCustom('#ff0000');
+
+		expect(onChange).toHaveBeenCalledWith('#ff0000');
+	});
+
+	/**
+	 * `field.readOnly` disables the control the same way it disables `TokenColorSelectField`.
+	 *
+	 * @return {void}
+	 */
+	it('disables the control when the field is read-only', () => {
+		render({ field: { label: 'Text', readOnly: true } });
+
+		expect(capturedProps.disabled).toBe(true);
+	});
+});

--- a/src/style-library/components/molecules/fields/ColorSelectField.js
+++ b/src/style-library/components/molecules/fields/ColorSelectField.js
@@ -1,0 +1,130 @@
+/**
+ * The Style Library's adapter for `src/token-controls`' `ColorControl` (e.g. the Button preset
+ * screen's Text / Background rows): the same trigger-plus-popover control the block editor's
+ * `singlebtn` inspector uses, bridged to this host's own palette data and stored-value shape.
+ *
+ * `TokenColorSelectField.js` stays in place unchanged — it is still `BorderField`/`BoxShadowField`'s
+ * own color sub-field, out of this control's scope (see the color-control design's border/shadow
+ * exclusion). This is a second, additive field type, not a replacement.
+ *
+ * Value format bridge: a `token-color-select`-style field stores a BARE token id (e.g.
+ * `semantic.color.accent.main`), never a bracket alias — the stored attribute shape does not
+ * change here. `ColorControl` itself only understands a bracket alias (`{semantic.color.accent.main}`)
+ * or a raw literal, so this adapter translates at the write boundary: `isTokenId()` (the same
+ * `primitive.`/`semantic.` prefix check `token-controls` already exports) tells a bare id apart from
+ * a literal on read, and a pick's alias has its brackets stripped back off before it is written.
+ *
+ * Palette source: unlike the block editor, which has to resolve a block's own possibly-pinned
+ * `kbPalette`, the Button preset page has no per-row palette override to consider — it always shows
+ * the SITE's active palette, `listing.currentId` in `usePalettes()`'s own vocabulary. Reading that
+ * requires only the same store selector `usePalettes()` itself calls (`getPaletteListing`, via
+ * `useSelect`) — not the full hook, which also wires `route`/`navigate` and every palette WRITE flow
+ * this read-only field never needs, and which `SettingsForm`'s field contract has no slot to pass in
+ * regardless (a field only ever receives `field`/`value`/`onChange`/`values`/`onValueChange`, matching
+ * `TokenColorSelectField`'s own self-sourcing of the pickable pool via `getDesignTokensFeed()`).
+ *
+ * `resolveLiteral` needs no CSS-variable read the way the block editor's `resolveColorLiteral` does:
+ * `mapPaletteToColorControlGroups()` already carries each swatch's resolved `$value` literal
+ * (sourced from the palette's own effective view, not a JS-recomputed one), so the Custom tab seeds
+ * directly from the entry already in `groups`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { ColorControl, isTokenId, mapPaletteToColorControlGroups } from '../../../../token-controls';
+import { getDesignTokensFeed } from '../../../helpers/tokens';
+// `STORE_NAME` comes from `store/constants` directly, not `store` (the index every hook imports
+// it from) — the index's module body calls `register(createReduxStore(...))`, pulling in
+// `store/resolvers.js` and, through it, `api/client.js`'s `@wordpress/api-fetch` import. That is
+// fine inside a hook, which only ever runs after the app root has already registered the store
+// once, but `field-types.js` (this field's registry entry) is a much wider dependency: several
+// existing field/schema tests import it without ever booting the app, and registering the store a
+// second time from here would import `@wordpress/api-fetch` into every one of them, a package this
+// repo only ships as the `wp.apiFetch` runtime global, not an installed npm dependency.
+import { EMPTY_LISTING, STORE_NAME } from '../../../store/constants';
+
+/**
+ * Resolve a token entry's literal from its own already-shaped `value` — see this file's docblock
+ * for why no CSS-variable read is needed here, unlike the block-editor host's adapter.
+ *
+ * @param {Object} entry The token entry (`{ id, label, value, alias }`) to resolve.
+ *
+ * @since TBD
+ *
+ * @return {string} The entry's resolved literal.
+ */
+export function resolveLiteral(entry) {
+	return entry.value;
+}
+
+/**
+ * Bridge a stored bare token id (or raw literal) into `ColorControl`'s own value contract.
+ *
+ * @param {string} value The stored value: a bare token id, a raw literal, or empty.
+ *
+ * @since TBD
+ *
+ * @return {string} The bracket alias for a token id, the literal unchanged, or ''.
+ */
+export function toControlValue(value) {
+	return isTokenId(value) ? `{${value}}` : value || '';
+}
+
+/**
+ * Bridge `ColorControl`'s picked alias back into the bare id this field stores.
+ *
+ * @param {string} alias The bracket alias `onPick` handed back (e.g. `{semantic.color.accent.main}`).
+ *
+ * @since TBD
+ *
+ * @return {string} The bare token id.
+ */
+export function toStoredValue(alias) {
+	return alias.slice(1, -1);
+}
+
+/**
+ * Render a color-select field.
+ *
+ * @param {Object}  props            The component props.
+ * @param {Object}  field            The field definition.
+ * @param {string}  field.label      The control's static attribute label (e.g. "Text").
+ * @param {boolean} [field.readOnly] Whether the control is non-interactive.
+ * @param {string}  props.value      The stored bare token id, or a raw color literal.
+ * @param {Function} props.onChange  Called with the new bare token id (or literal) on pick.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The field.
+ */
+export function ColorSelectField({ field, value, onChange }) {
+	const feed = getDesignTokensFeed();
+	const namespace = feed?.rest?.namespace;
+	const slug = feed?.slug;
+
+	const listing = useSelect(
+		(select) => (namespace && slug ? select(STORE_NAME).getPaletteListing(namespace, slug) : EMPTY_LISTING),
+		[namespace, slug]
+	);
+
+	const activeRow = listing.palettes.find((row) => row.id === listing.currentId) ?? null;
+	const groups = mapPaletteToColorControlGroups(activeRow);
+
+	return (
+		<ColorControl
+			label={field.label}
+			value={toControlValue(value)}
+			groups={groups}
+			onPick={(alias) => onChange(toStoredValue(alias))}
+			onCustom={(literal) => onChange(literal)}
+			resolveLiteral={resolveLiteral}
+			disabled={field.readOnly}
+		/>
+	);
+}

--- a/src/style-library/constants/demo-settings-schema.js
+++ b/src/style-library/constants/demo-settings-schema.js
@@ -106,6 +106,7 @@ export const DEMO_SETTINGS_SCHEMA = {
 			fields: [
 				{ type: 'color', path: 'background', label: __('Background', 'kadence-blocks') },
 				{ type: 'token-color-select', path: 'tokenColor', label: __('Token Color', 'kadence-blocks') },
+				{ type: 'color-select', path: 'paletteColor', label: __('Palette Color', 'kadence-blocks') },
 				{
 					type: 'color-list',
 					path: 'stateColors',

--- a/src/style-library/constants/field-types.js
+++ b/src/style-library/constants/field-types.js
@@ -13,6 +13,7 @@ import { BoxSidesField } from '../components/molecules/fields/BoxSidesField';
 import { BoxTokenField } from '../components/molecules/fields/BoxTokenField';
 import { ColorField } from '../components/molecules/fields/ColorField';
 import { ColorListField } from '../components/molecules/fields/ColorListField';
+import { ColorSelectField } from '../components/molecules/fields/ColorSelectField';
 import { NumberUnitField } from '../components/molecules/fields/NumberUnitField';
 import { ScalarTokenField } from '../components/molecules/fields/ScalarTokenField';
 import { RangeNumberField } from '../components/molecules/fields/RangeNumberField';
@@ -102,6 +103,7 @@ export const FIELD_TYPES = Object.freeze({
 	'token-select': TokenSelectField,
 	'token-scalar': ScalarTokenField,
 	'token-color-select': TokenColorSelectField,
+	'color-select': ColorSelectField,
 	'font-family': FontFamilyField,
 	'box-sides': BoxSidesField,
 	radius: RadiusField,

--- a/src/style-library/constants/field-types.js
+++ b/src/style-library/constants/field-types.js
@@ -1,7 +1,7 @@
 /**
  * The settings-field type vocabulary: the single source of truth mapping a schema field's `type`
- * string to the component that renders it. Every per-screen settings schema authors against these
- * seventeen strings; `helpers/settings-schema.js`'s `fieldComponentFor` is the only reader.
+ * string to the component that renders it. Every per-screen settings schema authors against the
+ * strings below; `helpers/settings-schema.js`'s `fieldComponentFor` is the only reader.
  */
 
 /**

--- a/src/style-library/presets/button-preset.js
+++ b/src/style-library/presets/button-preset.js
@@ -175,8 +175,8 @@ function schemaFor(tab) {
 		id: 'color',
 		title: __('Color', 'kadence-blocks'),
 		fields: [
-			{ type: 'token-color-select', path: textPath, label: __('Text', 'kadence-blocks') },
-			{ type: 'token-color-select', path: bgPath, label: __('Background', 'kadence-blocks') },
+			{ type: 'color-select', path: textPath, label: __('Text', 'kadence-blocks') },
+			{ type: 'color-select', path: bgPath, label: __('Background', 'kadence-blocks') },
 		],
 	};
 


### PR DESCRIPTION
## Summary
- Adds \`ColorSelectField\` (\`src/style-library/components/molecules/fields/\`), the Style Library adapter for \`ColorControl\`: reads the active palette's groups via \`getPaletteListing\`/\`mapPaletteToColorControlGroups\`, and bridges the stored bare-token-id format (\`semantic.color.accent.main\`) to \`ColorControl\`'s bracket-alias contract (\`{semantic.color.accent.main}\`) at the read/write boundary — the stored format itself doesn't change, so no data migration is needed.
- Wires it into the field-type registry (\`'color-select'\`, alongside the existing \`'token-color-select'\`, which stays untouched for \`BorderField\`/\`BoxShadowField\`'s own color sub-fields) and switches the Button preset page's Text/Background fields (\`button-preset.js\`) to it.
- No binding indicator — the preset page IS the source of truth, nothing to compare a preset color against.
- \`resolveLiteral\` is a plain \`(entry) => entry.value\`, since the Style Library's own token feed already resolves every color to a literal (no CSS-var indirection needed here, unlike the block editor).
- With this slice, the last remaining out-of-the-box color picker this ticket targets is replaced — the new \`ColorControl\` now backs every scalar color attribute in both \`kadence/singlebtn\`'s inspector and the Button preset page.

## Test plan
- \`npx jest src/style-library\` — all green, no regressions.
- New tests for \`ColorSelectField\`'s value-format bridging (bare id ↔ bracket alias) and rendering.
- Manually verified in the Style Library: the Button preset page's Text/Background fields render, open the grouped popover, pick/custom-set correctly, and write back the expected bare-id/literal format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a color selector that uses the active site palette and supports custom color values.
  * Added support for palette color fields in the Style Library settings.
  * Updated button presets to use the new color selector for text and background colors.

* **Tests**
  * Added comprehensive coverage for palette mapping, color values, custom colors, change handling, and read-only behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->