### PR TITLE
[DTM] SOFT-4260 [3/19]: offer the fixed sentinels in the Style Library, fixing the Auto write path

### DIFF
--- a/src/style-library/__tests__/border-field.test.js
+++ b/src/style-library/__tests__/border-field.test.js
@@ -9,6 +9,7 @@ import {
 	toStoredStyleAxis,
 	toStoredWidth,
 	toStoredWidthAxis,
+	widthTokensForField,
 } from '../components/molecules/fields/BorderField';
 
 describe('toControlWidth', () => {
@@ -43,6 +44,15 @@ describe('toStoredWidth', () => {
 	it('writes an unset width as empty', () => {
 		expect(toStoredWidth('')).toBe('');
 		expect(toStoredWidth(null)).toBe('');
+	});
+});
+
+describe('widthTokensForField', () => {
+	it('resolves a None pick to the literal "0", not a bracket string or the garbage sentinel id', () => {
+		const widthTokens = widthTokensForField('');
+		const none = widthTokens.find((token) => token.id === 'ss-none-border-width');
+
+		expect(toStoredWidth(none.alias)).toBe('0');
 	});
 });
 

--- a/src/style-library/__tests__/border-shadow-field-rendering.test.js
+++ b/src/style-library/__tests__/border-shadow-field-rendering.test.js
@@ -80,10 +80,12 @@ describe('BorderField', () => {
 			root.render(createElement(BorderField, { field, values: {}, onValueChange: jest.fn() }));
 		});
 
+		// The role's fixed "None" entry is prepended ahead of the role's own matched tokens.
 		expect(latestBorderControlProps.widthTokens.map((token) => token.id)).toEqual([
+			'ss-none-border-width',
 			'primitive.dimension.border-width.sm',
 		]);
-		expect(latestBorderControlProps.widthTokens[0].alias).toBe('{primitive.dimension.border-width.sm}');
+		expect(latestBorderControlProps.widthTokens[1].alias).toBe('{primitive.dimension.border-width.sm}');
 	});
 
 	it('shows a semantic-bound width as unset rather than listing the semantic', () => {
@@ -99,9 +101,11 @@ describe('BorderField', () => {
 			);
 		});
 
-		// The pool stays the role's primitive scale: a semantic is the block's role-based default, not
-		// something a site owner picked, so it is never offered as a peer of the steps.
+		// The pool stays the role's primitive scale (behind the shared fixed "None" sentinel): a semantic
+		// is the block's role-based default, not something a site owner picked, so it is never offered as
+		// a peer of the steps.
 		expect(latestBorderControlProps.widthTokens.map((token) => token.id)).toEqual([
+			'ss-none-border-width',
 			'primitive.dimension.border-width.sm',
 		]);
 

--- a/src/style-library/__tests__/box-token-field.test.js
+++ b/src/style-library/__tests__/box-token-field.test.js
@@ -12,6 +12,7 @@ import {
 	BoxTokenField,
 	semanticDefaultOf,
 	toControlValue,
+	tokensForField,
 	toStoredValue,
 	withoutSemanticSlots,
 } from '../components/molecules/fields/BoxTokenField';
@@ -70,6 +71,16 @@ describe('toStoredValue', () => {
 	it('writes an unset slot as empty', () => {
 		expect(toStoredValue('', 'px')).toBe('');
 		expect(toStoredValue(null, 'px')).toBe('');
+	});
+
+	/**
+	 * A fixed sentinel's keyword is stored verbatim — it is not a token id to unwrap, nor a number to
+	 * suffix with a unit.
+	 *
+	 * @return {void}
+	 */
+	it('round-trips a fixed sentinel keyword unchanged', () => {
+		expect(toStoredValue('ss-auto', 'px')).toBe('ss-auto');
 	});
 });
 
@@ -265,5 +276,43 @@ describe('the pending unit', () => {
 			latestBoxControlProps.onBreakpointChange('desktop');
 		});
 		expect(latestBoxControlProps.unit).toBe('em');
+	});
+});
+
+describe('tokensForField', () => {
+	/**
+	 * Only a margin field offers the fixed "Auto" sentinel — padding has no auto behavior to express,
+	 * so offering it there would be a pick the block cannot honor.
+	 *
+	 * @return {void}
+	 */
+	it('offers Auto only for a margin field, not padding', () => {
+		const marginTokens = tokensForField(
+			{ path: 'tokens.button-margin', tokenType: 'dimension', role: 'spacing' },
+			''
+		);
+		const paddingTokens = tokensForField(
+			{ path: 'tokens.button-padding', tokenType: 'dimension', role: 'spacing' },
+			''
+		);
+
+		expect(marginTokens.some((token) => token.id === 'ss-auto')).toBe(true);
+		expect(paddingTokens.some((token) => token.id === 'ss-auto')).toBe(false);
+	});
+
+	/**
+	 * The None sentinel's alias is the bare number 0, not a `{...}` id string: it has no registered
+	 * token behind it, so bracket-wrapping it would store a dot-path that resolves to nothing.
+	 *
+	 * @return {void}
+	 */
+	it('resolves a None pick to the bare number 0, not a bracket string', () => {
+		const marginTokens = tokensForField(
+			{ path: 'tokens.button-margin', tokenType: 'dimension', role: 'spacing' },
+			''
+		);
+		const none = marginTokens.find((token) => token.id === 'ss-none-spacing');
+
+		expect(none.alias).toBe(0);
 	});
 });

--- a/src/style-library/__tests__/tokens.test.js
+++ b/src/style-library/__tests__/tokens.test.js
@@ -195,8 +195,10 @@ describe('pickableTokensForType', () => {
 	it('narrows to matching entries when a role is given', () => {
 		const tokens = pickableTokensForType('dimension', 'radius');
 
-		expect(tokens).toHaveLength(1);
-		expect(tokens[0]).toMatchObject({ id: 'primitive.dimension.radius.sm', value: '4px', role: 'radius' });
+		// The role's fixed "None" entry is prepended ahead of the role's own matched tokens.
+		expect(tokens).toHaveLength(2);
+		expect(tokens[0]).toMatchObject({ id: 'ss-none-radius', fixed: true });
+		expect(tokens[1]).toMatchObject({ id: 'primitive.dimension.radius.sm', value: '4px', role: 'radius' });
 	});
 
 	it('keeps the token the field is already bound to, even when it loses the primitive narrowing', () => {
@@ -222,6 +224,18 @@ describe('pickableTokensForType', () => {
 		expect(tokens).toEqual([
 			{ id: 'semantic.color.action-primary', label: 'Action Primary', value: '#3633e1', role: null },
 		]);
+	});
+
+	it('prepends a fixed None entry when a role is given', () => {
+		const tokens = pickableTokensForType('dimension', 'spacing');
+
+		expect(tokens[0]).toMatchObject({ id: 'ss-none-spacing', alias: 0, fixed: true });
+	});
+
+	it('adds no fixed entry when role is omitted', () => {
+		const tokens = pickableTokensForType('dimension');
+
+		expect(tokens.some((token) => token.fixed)).toBe(false);
 	});
 });
 

--- a/src/style-library/components/molecules/fields/BorderField.js
+++ b/src/style-library/components/molecules/fields/BorderField.js
@@ -181,6 +181,32 @@ export function toStoredStyleAxis(next) {
 }
 
 /**
+ * The pickable-token list a border-width field offers: the `border-width` role's narrowed pool
+ * (plus the shared fixed "None" entry, prepended by `pickableTokensForType()` itself). Pulled out
+ * as its own function, mirroring `BoxTokenField`'s `tokensForField`, so it can be unit tested
+ * without rendering the component — `BorderField` uses hooks, so it cannot be called directly as a
+ * plain function the way a hook-free component can.
+ *
+ * A `fixed` entry (the shared "None" sentinel `pickableTokensForType()` already prepended) is
+ * excluded from the re-bracketing below for the same reason `tokensForField` excludes it: its
+ * `alias` is the bare number `0`, and wrapping it in `{${token.id}}` would silently turn it into
+ * the string `"{ss-none-border-width}"`, which `toStoredWidth` then unwraps to the garbage id
+ * `"ss-none-border-width"` instead of the bare `0` the write path expects.
+ *
+ * @param {*} atBreakpoint The resolved width value at the active breakpoint, used to exempt any
+ *                          already-bound token from the primitive narrowing.
+ *
+ * @since TBD
+ *
+ * @return {Array} The pickable-token list.
+ */
+export function widthTokensForField(atBreakpoint) {
+	return pickableTokensForType('dimension', 'border-width', boundTokenIds(atBreakpoint)).map((token) =>
+		token.fixed ? token : { ...token, alias: `{${token.id}}` }
+	);
+}
+
+/**
  * Render a border field from a settings schema entry.
  *
  * @param {Object}   props                    The component props.
@@ -233,11 +259,10 @@ export function BorderField({ field, values, onValueChange }) {
 	// exempts a box control's bound corners: unlinking gives each side its own slot, so pointing one
 	// at a different primitive from its neighbors is ordinary, and exempting only the first would
 	// leave the others rendering their raw dot-path. Width is per-slot (a scalar or a four-slot
-	// list), which is exactly the shape `boundTokenIds` already handles.
-	const widthTokens = pickableTokensForType('dimension', 'border-width', boundTokenIds(shownWidth)).map((token) => ({
-		...token,
-		alias: `{${token.id}}`,
-	}));
+	// list), which is exactly the shape `boundTokenIds` already handles. See `widthTokensForField`'s
+	// own docblock for why its fixed "None" entry is exempt from the re-bracketing every other entry
+	// gets.
+	const widthTokens = widthTokensForField(shownWidth);
 
 	// Which breakpoints the user has opened up into per-side editing. Held here rather than inferred
 	// from the stored shape — see the module docblock — and per breakpoint for the same reason

--- a/src/style-library/components/molecules/fields/BoxTokenField.js
+++ b/src/style-library/components/molecules/fields/BoxTokenField.js
@@ -40,6 +40,7 @@ import { BoxControl } from '../../../../token-controls/controls/BoxControl';
 import { useBreakpoint } from '../../../../token-controls/context/breakpoint';
 import { parseCssLength } from '../../../../token-controls/helpers/parse-css-length';
 import { isSlotList, readSlot } from '../../../../token-controls/helpers/value-shapes';
+import { autoEntry } from '../../../../token-controls';
 import './BoxTokenField.scss';
 
 /**
@@ -195,6 +196,11 @@ export function toStoredValue(next, unit) {
 		return '0';
 	}
 
+	// A sentinel keyword carries its own meaning; appending a unit would corrupt it.
+	if (typeof next === 'string' && Number.isNaN(Number(next)) && !parseCssLength(next)) {
+		return next;
+	}
+
 	return `${next}${unit || ''}`;
 }
 
@@ -262,10 +268,44 @@ function mapSlots(value, convert) {
 }
 
 /**
+ * The pickable-token list a box-token field offers: its role's narrowed, primitive-preferred pool
+ * (plus the shared fixed "None" entry, prepended by `pickableTokensForType()` itself), with Margin's
+ * "Auto" appended when this is a margin field. Pulled out as its own function so it can be unit
+ * tested without rendering the component — `BoxTokenField` uses hooks, so it cannot be called
+ * directly as a plain function the way a hook-free component can.
+ *
+ * Auto is Margin-only; nothing in `field` besides its own path distinguishes a margin field from a
+ * padding field (both declare identical `tokenType`/`role`), so the decision is made here rather
+ * than inside the shared `pickableTokensForType()` narrowing, which both fields call identically.
+ *
+ * A `fixed` entry (the shared "None" sentinel `pickableTokensForType()` already prepended) is
+ * excluded from the re-bracketing below: its `alias` is the bare number `0`, and wrapping it in
+ * `{${token.id}}` would silently turn it into the string `"{ss-none-spacing}"` — a bracket-wrapped
+ * id, not the bare `0` the box-control write path expects for a fixed sentinel.
+ *
+ * @param {Object} field        The field definition (see `BoxTokenField`'s own JSDoc).
+ * @param {*}      atBreakpoint The resolved value at the active breakpoint, used to exempt any
+ *                               already-bound token from the primitive narrowing.
+ *
+ * @since TBD
+ *
+ * @return {Array} The pickable-token list.
+ */
+export function tokensForField(field, atBreakpoint) {
+	const scoped = pickableTokensForType(field.tokenType, field.role, boundTokenIds(atBreakpoint)).map((token) =>
+		token.fixed ? token : { ...token, alias: `{${token.id}}` }
+	);
+
+	return field.path?.endsWith('margin') ? [...scoped, autoEntry()] : scoped;
+}
+
+/**
  * Render a box-shaped token field from a settings schema entry.
  *
  * @param {Object}   props                  The component props.
  * @param {Object}   props.field            The field definition.
+ * @param {string}   props.field.path       The field's dot path; a path ending in `margin` gets an
+ *                                          "Auto" entry in its token list.
  * @param {string}   props.field.tokenType  The DTCG `$type` the pickable pool is filtered to.
  * @param {?string}  [props.field.role]     Narrows the pool further to one token role.
  * @param {?string}  [props.field.label]    The control's label.
@@ -324,12 +364,8 @@ export function BoxTokenField({ field, value, onChange, slots = 'sides' }) {
 	const asLiteral = (slot) =>
 		typeof slot === 'string' ? (everyToken.find((token) => token.id === slot)?.value ?? slot) : slot;
 
-	// A semantic-bound slot is the block's role-based default, not a selection, so it is blanked for
-	// display and its resolved value becomes what this field falls back to. That is the whole of the
-	// "a semantic's name never shows; its value is the Default" rule — see `withoutSemanticSlots`.
-	// It outranks the field's own declared default, which describes the same thing less precisely:
-	// the declared default is a literal written into the screen config, while this is what the
-	// preset actually resolves in the active library.
+	// A semantic's name never shows; its resolved value becomes the field's Default. It outranks
+	// `field.defaultValue`, which is a config literal rather than what the active library resolves.
 	const shown = withoutSemanticSlots(atBreakpoint);
 	const semanticDefault = semanticDefaultOf(atBreakpoint, everyToken, fieldDefault);
 
@@ -378,10 +414,7 @@ export function BoxTokenField({ field, value, onChange, slots = 'sides' }) {
 			// breakpoint's own. A breakpoint that inherits binds nothing itself, so without this the
 			// semantic it falls back to is filtered out of the pool and the field, finding no entry for
 			// it, shows nothing at all instead of the value actually in effect.
-			tokens={pickableTokensForType(field.tokenType, field.role, boundTokenIds(shown)).map((token) => ({
-				...token,
-				alias: `{${token.id}}`,
-			}))}
+			tokens={tokensForField(field, shown)}
 			// The two kinds of default are still shaped differently, which is why `shownDefault` resolves
 			// them separately above instead of passing either straight through: a value inherited from
 			// another breakpoint is stored the way this app stores values, so it is read through `asLiteral`

--- a/src/style-library/helpers/tokens.js
+++ b/src/style-library/helpers/tokens.js
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { PICKABLE_TOKENS_GLOBAL } from '../constants';
+import { noneEntryForRole } from '../../token-controls';
 
 /**
  * Read the localized design-token feed from the window global.
@@ -139,7 +140,15 @@ export function pickableTokensForType(type, role, selected) {
 		return matched;
 	}
 
-	return preferPrimitiveTokens(matched, selected);
+	const preferred = preferPrimitiveTokens(matched, selected);
+
+	// Shadow is deliberately excluded here even though `noneEntryForRole()` itself knows a "None"
+	// value for it: `BoxShadowField` calls this function directly with `role: 'shadow'` and has not
+	// been migrated onto the shared fixed-sentinel token list yet, so prepending "None" to its pool
+	// would change its picker out from under it. That migration is its own, later piece of work.
+	const none = role === 'shadow' ? null : noneEntryForRole(role);
+
+	return none ? [none, ...preferred] : preferred;
 }
 
 /**


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4260/token-control-popover-options-and-the-default-label-show-what-is

Offers the same fixed `None` / `Auto` sentinels in the Style Library's preset fields that the previous slice added to the block editor, so both hosts show one option list.

Also fixes two write-path bugs the sentinels exposed:

- **Auto wrote a corrupted value.** Every pool entry was re-bracketed into `{id}` form on its way to the picker. For a fixed entry that turned `ss-auto` into `"{ss-auto}"`, which the write path then unwrapped to the garbage id `ss-auto` rather than the slug. Fixed entries are now exempt from the re-bracketing, since their `alias` is already the value to store.
- **Border Width's None pick wrote the same corruption**, for the same reason, through `widthTokensForField`.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of “None” and “Auto” options in border, margin, and padding controls.
  * Fixed storage and display of sentinel values so they remain consistent and resolve correctly.
  * Ensured role-specific “None” options appear appropriately without affecting shadow controls.

* **Tests**
  * Expanded coverage for token selection, field rendering, and sentinel value conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->