### PR TITLE
[DTM] SOFT-4260 [4/19]: retire the radius.none/spacing.none tokens in favor of the sentinel

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -126,10 +126,6 @@
 				"5xl": {
 					"$type": "dimension",
 					"$value": "10rem"
-				},
-				"none": {
-					"$type": "dimension",
-					"$value": "0"
 				}
 			},
 			"gap": {
@@ -235,10 +231,6 @@
 				}
 			},
 			"radius": {
-				"none": {
-					"$type": "dimension",
-					"$value": "0"
-				},
 				"xs": {
 					"$type": "dimension",
 					"$value": "0.125rem"
@@ -458,11 +450,11 @@
 			},
 			"media-padding": {
 				"$type": "dimension",
-				"$value": "{primitive.dimension.spacing.none}"
+				"$value": "0"
 			},
 			"heading-padding": {
 				"$type": "dimension",
-				"$value": "{primitive.dimension.spacing.none}"
+				"$value": "0"
 			},
 			"button-padding-top": {
 				"$type": "dimension",
@@ -504,19 +496,19 @@
 			},
 			"media": {
 				"$type": "dimension",
-				"$value": "{primitive.dimension.radius.none}"
+				"$value": "0"
 			},
 			"rowlayout": {
 				"$type": "dimension",
-				"$value": "{primitive.dimension.radius.none}"
+				"$value": "0"
 			},
 			"column": {
 				"$type": "dimension",
-				"$value": "{primitive.dimension.radius.none}"
+				"$value": "0"
 			},
 			"heading": {
 				"$type": "dimension",
-				"$value": "{primitive.dimension.radius.none}"
+				"$value": "0"
 			}
 		},
 		"border-width": {

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -17,7 +17,7 @@
 // omitted: it resolves to "auto", not a length. group_key mirrors the radius/border-width scales' mechanism:
 // it is the stable machine id the Style Library's Spacing screen's "+ Add Spacing" mints custom tokens into,
 // resolved back to the group label at read time by Token_Registry::group_label_for().
-$spacing_slugs = [ 'none', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ];
+$spacing_slugs = [ 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ];
 $gap_slugs     = [ 'none', 'xs', 'sm', 'md', 'lg' ];
 
 $spacing_tokens = array_map(
@@ -25,7 +25,7 @@ $spacing_tokens = array_map(
 		return [
 			'id'          => 'primitive.dimension.spacing.' . $slug,
 			'type'        => 'dimension',
-			'label'       => 'none' === $slug ? __( 'None', 'kadence-blocks' ) : strtoupper( $slug ),
+			'label'       => strtoupper( $slug ),
 			'group'       => __( 'Spacing', 'kadence-blocks' ),
 			'group_key'   => 'spacing',
 			'projections' => [ 'kb_spacing_slot' => $slug ],
@@ -57,7 +57,6 @@ $gap_tokens = array_map(
 // a step declared without a baseline entry would trip Baseline_Guard. Labels are the scale's own, so the
 // Style Library and the editor's token picker name each step identically.
 $radius_labels = [
-	'none' => __( 'None', 'kadence-blocks' ),
 	'xs'   => __( 'Extra Small', 'kadence-blocks' ),
 	'sm'   => __( 'Small', 'kadence-blocks' ),
 	'md'   => __( 'Medium', 'kadence-blocks' ),
@@ -325,8 +324,8 @@ return [
 				'group' => __( 'Brand', 'kadence-blocks' ),
 			],
 			[
-				// Block-specific radius defaults, mirroring semantic.radius.media for the image. Each aliases
-				// radius.none (resolves to 0), so a fresh Row Layout / Column stays square — KB's own default —
+				// Block-specific radius defaults, mirroring semantic.radius.media for the image. Each holds a literal
+				// 0 in baseline.json (resolves to 0), so a fresh Row Layout / Column stays square — KB's own default —
 				// while a site owner can round one block type by overriding its token.
 				'id'    => 'semantic.radius.rowlayout',
 				'type'  => 'dimension',

--- a/src/extension/design-tokens/__tests__/token-px.test.js
+++ b/src/extension/design-tokens/__tests__/token-px.test.js
@@ -22,8 +22,8 @@ import { tokenPx } from '../token-px';
 import conformance from './fixtures/length-to-px-conformance.json';
 
 /**
- * The pickable pool the editor localizer prints, trimmed to the icon-size family plus one token whose
- * value is a bare `0` — the unitless case both languages decline.
+ * The pickable pool the editor localizer prints, trimmed to the icon-size family plus one entry keyed
+ * on an unregistered id whose value is a bare `0` — the unitless case both languages decline.
  */
 const POOL = {
 	tokens: [],
@@ -107,8 +107,9 @@ describe('tokenPx alias resolution', () => {
 	});
 
 	/**
-	 * A token whose resolved value is a unitless `0` is declined, matching the PHP trait. Pinning the
-	 * gap rather than papering over it on one side is what keeps the two conversions identical.
+	 * A pool entry whose resolved value is a unitless `0` is declined, matching the PHP trait. Pinning
+	 * the gap rather than papering over it on one side is what keeps the two conversions identical. The
+	 * alias itself is an unregistered id — `tokenPx()` never validates registration, only shape.
 	 */
 	it('declines an alias resolving to a unitless value', () => {
 		expect(tokenPx('{primitive.dimension.radius.none}')).toBeNull();

--- a/src/extension/preset-picker/__tests__/capture.test.js
+++ b/src/extension/preset-picker/__tests__/capture.test.js
@@ -430,9 +430,9 @@ describe('capturedCatalogValues', () => {
 	});
 
 	it('keeps an alias the library does not define, rather than emptying it', () => {
-		const captured = capturedCatalogValues({ 'button-radius': '{primitive.dimension.radius.none}' }, SET);
+		const captured = capturedCatalogValues({ 'button-radius': '{primitive.dimension.radius.unknown}' }, SET);
 
-		expect(captured.values['button-radius']).toBe('{primitive.dimension.radius.none}');
+		expect(captured.values['button-radius']).toBe('{primitive.dimension.radius.unknown}');
 	});
 
 	it('resolves a per-corner list slot by slot', () => {

--- a/src/style-library/__tests__/preset-flows.test.js
+++ b/src/style-library/__tests__/preset-flows.test.js
@@ -305,7 +305,7 @@ describe('savePresetFlow', () => {
 	// contract against data this screen cannot itself author yet.
 	describe('non-scalar button-radius (per-corner / responsive shapes)', () => {
 		const nonScalarRadius = {
-			$value: ['{radius.lg}', '{radius.none}', '{radius.lg}', '{radius.none}'],
+			$value: ['{radius.lg}', '{radius.xs}', '{radius.lg}', '{radius.xs}'],
 			$extensions: {
 				'com.kadence.designTokens': {
 					responsive: { tablet: ['{radius.sm}', '0', '{radius.sm}', '0'] },

--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -82,8 +82,8 @@ describe('resolveTokenValue', () => {
 	});
 
 	it('resolves a per-corner slot list to a space-joined CSS value', () => {
-		const dimensionValues = { 'radius.lg': '1rem', 'radius.none': '0' };
-		const slots = ['{radius.lg}', '{radius.none}', '{radius.lg}', '{radius.none}'];
+		const dimensionValues = { 'radius.lg': '1rem', 'radius.xs': '0' };
+		const slots = ['{radius.lg}', '{radius.xs}', '{radius.lg}', '{radius.xs}'];
 
 		expect(resolveTokenValue(dimensionValues, slots)).toBe('1rem 0 1rem 0');
 	});
@@ -112,8 +112,8 @@ describe('resolveTokenValue', () => {
 	});
 
 	it('keeps a zero-valued slot, which resolves to a real value rather than nothing', () => {
-		const dimensionValues = { 'radius.none': '0' };
-		const slots = ['{radius.none}', '{radius.none}', '{radius.none}', '{radius.none}'];
+		const dimensionValues = { 'radius.xs': '0' };
+		const slots = ['{radius.xs}', '{radius.xs}', '{radius.xs}', '{radius.xs}'];
 
 		expect(resolveTokenValue(dimensionValues, slots)).toBe('0 0 0 0');
 	});
@@ -913,7 +913,7 @@ describe('seed/save round trip', () => {
 
 describe('resolveTokenValue at a breakpoint', () => {
 	const NS = 'com.kadence.designTokens';
-	const values = { 'radius.sm': '0.1875rem', 'radius.lg': '0.5rem', 'radius.none': '0' };
+	const values = { 'radius.sm': '0.1875rem', 'radius.lg': '0.5rem', 'radius.xs': '0' };
 
 	const envelope = {
 		$value: '{radius.sm}',
@@ -941,7 +941,7 @@ describe('resolveTokenValue at a breakpoint', () => {
 	it('resolves a slot list held at a breakpoint into the shorthand', () => {
 		const perCorner = {
 			$value: '{radius.sm}',
-			$extensions: { [NS]: { responsive: { tablet: ['{radius.lg}', '{radius.none}', '{radius.lg}', '0'] } } },
+			$extensions: { [NS]: { responsive: { tablet: ['{radius.lg}', '{radius.xs}', '{radius.lg}', '0'] } } },
 		};
 
 		expect(resolveTokenValue(values, perCorner, 'tablet')).toBe('0.5rem 0 0.5rem 0');

--- a/src/style-library/__tests__/scale.test.js
+++ b/src/style-library/__tests__/scale.test.js
@@ -26,18 +26,18 @@ describe('scaleRows', () => {
 		const schema = {
 			groups: {
 				'Border Radius': [
-					{ id: 'primitive.dimension.radius.none', label: 'None', userCreated: false },
+					{ id: 'primitive.dimension.radius.xs', label: 'XS', userCreated: false },
 					{ id: 'primitive.dimension.custom.radius-2', label: 'Custom', userCreated: true },
 				],
 			},
 		};
 		const values = {
-			'primitive.dimension.radius.none': '0',
+			'primitive.dimension.radius.xs': '0.125rem',
 			'primitive.dimension.custom.radius-2': '0.75rem',
 		};
 
 		expect(scaleRows(schema, values, 'Border Radius')).toEqual([
-			{ id: 'primitive.dimension.radius.none', label: 'None', value: '0', userCreated: false },
+			{ id: 'primitive.dimension.radius.xs', label: 'XS', value: '0.125rem', userCreated: false },
 			{ id: 'primitive.dimension.custom.radius-2', label: 'Custom', value: '0.75rem', userCreated: true },
 		]);
 	});

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -48,7 +48,8 @@ final class Css_BuilderTest extends TestCase {
 	public function testItEmitsALowSpecificityRulePointingTheCssPropAtTheTokenVar(): void {
 		$var = Css_Var::from_id( 'semantic.radius.media' );
 
-		// Image's $default binds borderRadius to semantic.radius.media (resolves to 0 via radius.none).
+		// Image's $default binds borderRadius to semantic.radius.media, which holds a literal 0 in the
+		// baseline (it aliases no other token), so the projected fallback is that 0.
 		$css = $this->builder( $this->image_registry() )->css();
 
 		// One rule on a single .wp-block-* class plus the " img" descendant, the resolved length as the

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Css_BuilderTest.php
@@ -354,7 +354,7 @@ final class Css_BuilderTest extends TestCase {
 
 		$css = ( new Css_Builder( $registry ) )->css( $resolved );
 
-		foreach ( [ 'none', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ] as $slug ) {
+		foreach ( [ 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ] as $slug ) {
 			$this->assertStringContainsString( '--global-kb-spacing-' . $slug . ':var(', $css );
 		}
 

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Slot_Target_ReaderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Slot_Target_ReaderTest.php
@@ -93,7 +93,6 @@ final class Slot_Target_ReaderTest extends TestCase {
 				'3xl'  => '6.5rem',
 				'4xl'  => '8rem',
 				'5xl'  => '10rem',
-				'none' => '0',
 			],
 			$this->reader->read( Spacing_Target::class )
 		);

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -267,7 +267,6 @@ final class Feed_ControllerTest extends TestCase {
 		$ids = array_column( $data['schema']['groups']['Border Radius'], 'id' );
 		$this->assertSame(
 			[
-				'primitive.dimension.radius.none',
 				'primitive.dimension.radius.xs',
 				'primitive.dimension.radius.sm',
 				'primitive.dimension.radius.md',
@@ -280,7 +279,6 @@ final class Feed_ControllerTest extends TestCase {
 			$ids
 		);
 
-		$this->assertSame( '0', $data['values']['primitive.dimension.radius.none'] );
 		$this->assertSame( '0.125rem', $data['values']['primitive.dimension.radius.xs'] );
 		$this->assertSame( '0.25rem', $data['values']['primitive.dimension.radius.sm'] );
 		$this->assertSame( '0.375rem', $data['values']['primitive.dimension.radius.md'] );

--- a/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Schema/Validation/Dtcg_ValidatorTest.php
@@ -249,13 +249,13 @@ final class Dtcg_ValidatorTest extends TestCase {
 	public function nonArrayExtensionSectionProvider(): Generator {
 		$sections = [ 'colorPalettes', 'tokenLabels', 'tokenOrder', 'favoriteFonts' ];
 		$values   = [
-			'string'  => 'Inter',
+			'string'       => 'Inter',
 			'empty string' => '',
-			'int'     => 42,
-			'float'   => 1.5,
-			'true'    => true,
-			'false'   => false,
-			'null'    => null,
+			'int'          => 42,
+			'float'        => 1.5,
+			'true'         => true,
+			'false'        => false,
+			'null'         => null,
 		];
 
 		foreach ( $sections as $section ) {
@@ -1062,7 +1062,7 @@ final class Dtcg_ValidatorTest extends TestCase {
 		yield 'alias base, alias override' => [
 			'entry' => $this->responsive_entry(
 				'{semantic.radius.control}',
-				[ 'mobile' => '{primitive.dimension.radius.none}' ]
+				[ 'mobile' => '{primitive.dimension.radius.xs}' ]
 			),
 		];
 


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4260/token-control-popover-options-and-the-default-label-show-what-is

Un-registers `primitive.dimension.radius.none` and `primitive.dimension.spacing.none` now that the fixed sentinel covers them.

They were the wrong shape for what they expressed. A registered token can be renamed, repointed, or deleted from its Style Library screen — which is exactly what a "None" that must always resolve to `0` cannot allow. They also showed up as editable rows on the Radius and Spacing screens, inviting a site owner to retune a value nothing should ever move.

Test fixtures that named the two ids are repointed to real scale steps, so nothing asserts against tokens that no longer exist.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the `none` spacing and radius design tokens from the available scales.
  * Updated baseline media, heading, row, and column styles to use a literal zero value where applicable.
  * Refined token labels and documentation to reflect the supported design-token scales.

* **Tests**
  * Updated validation and preset scenarios to use supported radius tokens.
  * Adjusted expectations for spacing and radius outputs after removing the `none` entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->