### PR TITLE
[SMTNC-2046] Fix cSpell failures on the navigation block files

### DIFF
--- a/src/assets/js/kb-navigation-block.js
+++ b/src/assets/js/kb-navigation-block.js
@@ -2,6 +2,8 @@
  * File kb-navigation-block.js.
  *
  * Handles accessibility and mobile toggles for navigation.
+ *
+ * cSpell:ignore contenteditable keymap navs
  */
 (function () {
 	const focusableElementsString =
@@ -229,7 +231,7 @@
 		}
 	};
 	/**
-	 * Determine what orientation the nav is at the currrent screen size.
+	 * Determine what orientation the nav is at the current screen size.
 	 */
 	const trackOrientation = function (navs) {
 		// No point if no submenus.
@@ -263,7 +265,7 @@
 		}
 	};
 	/**
-	 * Setup the Fullwith Menu.
+	 * Setup the Full-width Menu.
 	 */
 	const runSubMenuFullSize = function () {
 		var contentSubmenus = null;
@@ -312,7 +314,7 @@
 		}
 	};
 	/**
-	 * Initiate the script to handle fullwith mega menus.
+	 * Initiate the script to handle full-width mega menus.
 	 */
 	const initFullSubMenuSize = function () {
 		var megaMenus = document.querySelectorAll(

--- a/src/blocks/navigation/style.scss
+++ b/src/blocks/navigation/style.scss
@@ -1,6 +1,8 @@
 /**
  * Frontend only CSS.
  * Styles for both the navigation and nav link block
+ *
+ * cSpell:ignore fullheight modbile navs radiusp uncollapse
  */
 
 @use "../../assets/css/variables" as vars;
@@ -268,7 +270,7 @@ $link-color-property: var(
 			@include parent-toggles-menus-styles();
 		}
 	}
-	//Mobiel parent toggle sub menus
+	//Mobile parent toggle sub menus
 	.navigation-mobile-parent-toggles-menus-true {
 		@media (max-width: vars.$phone-minus-query) {
 			@include parent-toggles-menus-styles();
@@ -910,7 +912,7 @@ $link-color-property: var(
 		position: var(--kb-nav-link-position);
 		border-bottom: var(--kb-nav-menu-item-border-bottom);
 
-		//active nav links (extra specificty to hack correct ordering against direct styling)
+		//active nav links (extra specificity to hack correct ordering against direct styling)
 		&.current-menu-item > .kb-link-wrap.kb-link-wrap.kb-link-wrap {
 			--kb-nav-link-color-active-lv: var(--kb-nav-link-color-active);
 			--kb-nav-link-background-active-lv: var(--kb-nav-link-background-active);
@@ -1056,7 +1058,7 @@ $link-color-property: var(
 		margin-right: var(--kb-nav-link-margin-right);
 		margin-bottom: var(--kb-nav-link-margin-bottom);
 		margin-left: var(--kb-nav-link-margin-left);
-		//color copied here for specifity reasons
+		//color copied here for specificity reasons
 		color: $link-color-property;
 		gap: var(--kb-nav-link-gap);
 		text-align: var(--kb-nav-link-align, left);
@@ -1070,7 +1072,7 @@ $link-color-property: var(
 		}
 		&:hover,
 		&:focus {
-			//color copied here for specifity reasons in non-iframe editors
+			//color copied here for specificity reasons in non-iframe editors
 			color: $link-color-property;
 			--kb-nav-link-highlight-color-hover-lv: var(--kb-nav-link-highlight-color-hover);
 			--kb-nav-link-highlight-background-hover-lv: var(--kb-nav-link-highlight-background-hover);


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-2046](https://linear.app/nexcess/issue/SMTNC-2046)

### 🗒️ Description

**Tweak** (code quality - no runtime change)

Fixed the failing cSpell check on `release/M26.nidoking` introduced here #968 .

**Change in `src/assets/js/kb-navigation-block.js`:**
- **Comment typos:** `currrent` → `current`, `Fullwith` → `Full-width`, `fullwith` → `full-width`
- **Header directive added:** `cSpell:ignore contenteditable keymap navs`

**Change in `src/blocks/navigation/style.scss`:**
- **Comment typos:** `Mobiel` → `Mobile`, `specificty` → `specificity`, `specifity` → `specificity` (×2)
- **Header directive added:** `cSpell:ignore fullheight modbile navs radiusp uncollapse`

`fullwith` appears only in two JSDoc blocks and nowhere as an identifier, so correcting it is text-only. Ignores are scoped to these two files rather than added to `.cspell.json`, to avoid blessing these words repo-wide.

### ⚠️ Blockers

None.

### 🧪 Testing Instructions for QA

Provided in the task description.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)
