### PR TITLE
[DTM] SOFT-4260 [5/19]: show the button's own literal default for an unset Padding/Margin slot

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -70,6 +70,7 @@
         "fluentcrm",
         "fluidcarousel",
         "formalises",
+        "Fullwidth",
         "gfont",
         "gfonts",
         "ghernkadence",

--- a/src/blocks/advancedbtn/utils.js
+++ b/src/blocks/advancedbtn/utils.js
@@ -439,7 +439,6 @@ export function migrateToInnerblocks(attributes) {
 			}
 			// 12. Box Shadow to new format.
 			if (undefined !== newAttrs?.boxShadow?.[0] && true === newAttrs.boxShadow[0]) {
-				newAttrs.displayShadow = true;
 				newAttrs.shadow = [
 					{
 						color: undefined !== newAttrs?.boxShadow?.[1] ? newAttrs.boxShadow[1] : '#000000',
@@ -454,7 +453,6 @@ export function migrateToInnerblocks(attributes) {
 			}
 			// Hover
 			if (undefined !== newAttrs?.boxShadowHover?.[0] && true === newAttrs.boxShadowHover[0]) {
-				newAttrs.displayHoverShadow = true;
 				newAttrs.shadowHover = [
 					{
 						color: undefined !== newAttrs?.boxShadowHover?.[1] ? newAttrs.boxShadowHover[1] : '#000000',

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -92,6 +92,7 @@ import {
 	inheritedMeasureSlots,
 	measureAttrsForDevice,
 	presetValueForDevice,
+	presetValueOr,
 } from '../../extension/token-indicators/normalize';
 import { EditorBoxControl } from '../../extension/design-tokens/components/EditorBoxControl';
 import { EditorBorderControl } from '../../extension/design-tokens/components/EditorBorderControl';
@@ -407,9 +408,10 @@ export default function KadenceButtonEdit(props) {
 	// `button-padding` carries no baseline preset value, so `presetValueForDevice` above always resolves
 	// to nothing for it — OR in the button's own literal default so an unset Padding side shows what the
 	// button actually renders instead of reading as blank.
-	const paddingPresetValue =
-		presetValueForDevice(tokenBinding.padding?.presetValue, tokenBinding.padding?.responsive, previewDevice) ||
-		BUTTON_PADDING_FALLBACK;
+	const paddingPresetValue = presetValueOr(
+		presetValueForDevice(tokenBinding.padding?.presetValue, tokenBinding.padding?.responsive, previewDevice),
+		BUTTON_PADDING_FALLBACK
+	);
 
 	// What an unset Padding side falls back to on the active device — same cascade as Border Radius
 	// above, run over sides rather than corners.
@@ -428,9 +430,10 @@ export default function KadenceButtonEdit(props) {
 	);
 
 	// Same reasoning as `paddingPresetValue` above, for `button-margin`.
-	const marginPresetValue =
-		presetValueForDevice(tokenBinding.margin?.presetValue, tokenBinding.margin?.responsive, previewDevice) ||
-		BUTTON_MARGIN_FALLBACK;
+	const marginPresetValue = presetValueOr(
+		presetValueForDevice(tokenBinding.margin?.presetValue, tokenBinding.margin?.responsive, previewDevice),
+		BUTTON_MARGIN_FALLBACK
+	);
 
 	// What an unset Margin side falls back to on the active device — same cascade as Padding above.
 	const inheritedMargin = inheritedMeasureSlots(

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -103,6 +103,7 @@ import {
 import { pickableTokensForControl, pickableTokensForKey } from '../../extension/token-picker';
 import { ColorControl } from '../../token-controls/controls/ColorControl';
 import { ColorControlGroup } from '../../token-controls/controls/ColorControlGroup';
+import { BUTTON_MARGIN_FALLBACK, BUTTON_PADDING_FALLBACK } from '../../token-controls/helpers/button-box-defaults';
 import { useColorGroups } from '../../extension/design-tokens/hooks/use-color-groups';
 import { resolveColorLiteral } from './color-control-adapter';
 
@@ -403,11 +404,12 @@ export default function KadenceButtonEdit(props) {
 		borderRadiusPresetValue
 	);
 
-	const paddingPresetValue = presetValueForDevice(
-		tokenBinding.padding?.presetValue,
-		tokenBinding.padding?.responsive,
-		previewDevice
-	);
+	// `button-padding` carries no baseline preset value, so `presetValueForDevice` above always resolves
+	// to nothing for it — OR in the button's own literal default so an unset Padding side shows what the
+	// button actually renders instead of reading as blank.
+	const paddingPresetValue =
+		presetValueForDevice(tokenBinding.padding?.presetValue, tokenBinding.padding?.responsive, previewDevice) ||
+		BUTTON_PADDING_FALLBACK;
 
 	// What an unset Padding side falls back to on the active device — same cascade as Border Radius
 	// above, run over sides rather than corners.
@@ -425,11 +427,10 @@ export default function KadenceButtonEdit(props) {
 		previewDevice
 	);
 
-	const marginPresetValue = presetValueForDevice(
-		tokenBinding.margin?.presetValue,
-		tokenBinding.margin?.responsive,
-		previewDevice
-	);
+	// Same reasoning as `paddingPresetValue` above, for `button-margin`.
+	const marginPresetValue =
+		presetValueForDevice(tokenBinding.margin?.presetValue, tokenBinding.margin?.responsive, previewDevice) ||
+		BUTTON_MARGIN_FALLBACK;
 
 	// What an unset Margin side falls back to on the active device — same cascade as Padding above.
 	const inheritedMargin = inheritedMeasureSlots(

--- a/src/extension/token-indicators/kinds/__tests__/dimension.test.js
+++ b/src/extension/token-indicators/kinds/__tests__/dimension.test.js
@@ -2,6 +2,7 @@
 import {
 	anyCornerInherited,
 	deriveMeasureMode,
+	presetValueOr,
 	inheritedMeasureSlots,
 	measureAttrsForDevice,
 	normalizeDimension,
@@ -384,5 +385,23 @@ describe('presetValueForDevice per-corner cascade', () => {
 			'4px',
 			'4px',
 		]);
+	});
+});
+
+describe('presetValueOr', () => {
+	it('keeps a numeric zero, which is what the fixed None pick resolves to', () => {
+		expect(presetValueOr(0, ['0.4em', '1em', '0.4em', '1em'])).toBe(0);
+		expect(presetValueOr('0', ['0.4em'])).toBe('0');
+		expect(presetValueOr(['0', '0', '0', '0'], ['0.4em'])).toEqual(['0', '0', '0', '0']);
+	});
+
+	it('falls back only when the preset sets nothing at all', () => {
+		expect(presetValueOr(undefined, 'fallback')).toBe('fallback');
+		expect(presetValueOr(null, 'fallback')).toBe('fallback');
+		expect(presetValueOr('', 'fallback')).toBe('fallback');
+	});
+
+	it('keeps a real value untouched', () => {
+		expect(presetValueOr('1em', 'fallback')).toBe('1em');
 	});
 });

--- a/src/extension/token-indicators/kinds/dimension.js
+++ b/src/extension/token-indicators/kinds/dimension.js
@@ -149,6 +149,24 @@ export function presetValueForDevice(presetValue, responsive = {}, device = 'Des
 }
 
 /**
+ * A preset's resolved value, or `fallback` when the preset sets nothing for the property.
+ *
+ * `0` is a real spacing value — it is what the fixed "None" pick resolves to — so a plain `||` would
+ * discard it and show the block's own default instead, silently turning a deliberate "no spacing"
+ * into the block's built-in spacing.
+ *
+ * @param {*} value    The preset's resolved value for the property.
+ * @param {*} fallback What to use when the preset sets nothing.
+ *
+ * @since TBD
+ *
+ * @return {*} The value to display.
+ */
+export function presetValueOr(value, fallback) {
+	return value === undefined || value === null || value === '' ? fallback : value;
+}
+
+/**
  * The attribute a responsive measure control is editing at the given device, and its current value.
  *
  * A responsive measure control keeps ONE linked/individual mode but writes three separate attributes

--- a/src/extension/token-indicators/normalize.js
+++ b/src/extension/token-indicators/normalize.js
@@ -31,6 +31,7 @@ export {
 	dimensionSlots,
 	presetSlotAt,
 	presetValueForDevice,
+	presetValueOr,
 	measureAttrsForDevice,
 	inheritedMeasureSlots,
 	anyCornerInherited,

--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -747,12 +747,6 @@ describe('BUTTON_PRESET.schemaFor', () => {
 	});
 
 	describe('padding/margin defaultValue', () => {
-		const originalFeed = window.kadenceDesignTokens;
-
-		afterEach(() => {
-			window.kadenceDesignTokens = originalFeed;
-		});
-
 		/**
 		 * Read a field's `defaultValue` off the Normal tab's spacing panel.
 		 *
@@ -766,43 +760,12 @@ describe('BUTTON_PRESET.schemaFor', () => {
 				.find((field) => field.path === path).defaultValue;
 		}
 
-		it('resolves the padding default from the semantic.spacing.button-padding-* tokens', () => {
-			window.kadenceDesignTokens = {
-				values: {
-					'semantic.spacing.button-padding-top': '0.5em',
-					'semantic.spacing.button-padding-right': '1.25em',
-					'semantic.spacing.button-padding-bottom': '0.5em',
-					'semantic.spacing.button-padding-left': '1.25em',
-				},
-			};
-
-			expect(defaultValueFor('tokens.button-padding')).toEqual(['0.5em', '1.25em', '0.5em', '1.25em']);
-		});
-
-		it('resolves the margin default from the semantic.spacing.button-margin-* tokens', () => {
-			window.kadenceDesignTokens = {
-				values: {
-					'semantic.spacing.button-margin-top': '4px',
-					'semantic.spacing.button-margin-right': '0',
-					'semantic.spacing.button-margin-bottom': '4px',
-					'semantic.spacing.button-margin-left': '0',
-				},
-			};
-
-			expect(defaultValueFor('tokens.button-margin')).toEqual(['4px', '0', '4px', '0']);
-		});
-
-		it('falls back to the button literal default when a token is missing from the feed', () => {
-			window.kadenceDesignTokens = { values: {} };
-
+		it('is the button literal default for padding', () => {
 			expect(defaultValueFor('tokens.button-padding')).toEqual(['0.4em', '1em', '0.4em', '1em']);
+		});
+
+		it('is the button literal default for margin', () => {
 			expect(defaultValueFor('tokens.button-margin')).toEqual(['0', '0', '0', '0']);
-		});
-
-		it('falls back to the literal default when the feed itself is absent', () => {
-			delete window.kadenceDesignTokens;
-
-			expect(defaultValueFor('tokens.button-padding')).toEqual(['0.4em', '1em', '0.4em', '1em']);
 		});
 	});
 });

--- a/src/style-library/presets/button-preset.js
+++ b/src/style-library/presets/button-preset.js
@@ -15,8 +15,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { BUTTON_MARGIN_FALLBACK, BUTTON_PADDING_FALLBACK } from '../../token-controls/helpers/button-box-defaults';
 import { BUTTON_BLOCK, getPresetProperties, resolveTokenValue } from '../helpers/presets';
-import { getDesignTokensFeed } from '../helpers/tokens';
 
 export { BUTTON_BLOCK };
 
@@ -29,73 +29,6 @@ const TABS = [
 	{ name: 'normal', title: __('Normal', 'kadence-blocks') },
 	{ name: 'hover', title: __('Hover', 'kadence-blocks') },
 ];
-
-/**
- * The button's per-side padding semantic token ids, top/right/bottom/left order — mirrors the CSS
- * `padding` shorthand and `src/blocks/advancedbtn/style.scss`'s default rule.
- *
- * @since TBD
- */
-const BUTTON_PADDING_TOKEN_IDS = [
-	'semantic.spacing.button-padding-top',
-	'semantic.spacing.button-padding-right',
-	'semantic.spacing.button-padding-bottom',
-	'semantic.spacing.button-padding-left',
-];
-
-/**
- * The button's per-side margin semantic token ids, mirroring `BUTTON_PADDING_TOKEN_IDS`. Every side
- * resolves to the same literal in the shipped baseline, but the box control's own `toShorthand()`
- * already collapses four equal values to one when it renders the default (and expands them the
- * moment a site owner sets sides apart), so registering them per-side costs nothing today and leaves
- * room for that without a token-registry change later.
- *
- * @since TBD
- */
-const BUTTON_MARGIN_TOKEN_IDS = [
-	'semantic.spacing.button-margin-top',
-	'semantic.spacing.button-margin-right',
-	'semantic.spacing.button-margin-bottom',
-	'semantic.spacing.button-margin-left',
-];
-
-/**
- * The literal each padding token resolves to when the baseline is never overridden — also what
- * `src/blocks/advancedbtn/style.scss`'s default rule falls back to when the token itself is absent
- * from the feed.
- *
- * @since TBD
- */
-const BUTTON_PADDING_FALLBACK = ['0.4em', '1em', '0.4em', '1em'];
-
-/**
- * The literal each margin token resolves to when the baseline is never overridden.
- *
- * @since TBD
- */
-const BUTTON_MARGIN_FALLBACK = ['0', '0', '0', '0'];
-
-/**
- * Resolve a per-side box default (padding/margin) from the resolved design-token feed, one value per
- * CSS side, falling back to the button's own literal default for any side whose token is missing from
- * the feed (e.g. the feed has not loaded yet).
- *
- * Reads the feed live on every call rather than once at import time: `BUTTON_PRESET` is
- * `Object.freeze()`d at module evaluation, before the localized feed is guaranteed to exist, so a
- * getter that captured this at that point could throw or go stale.
- *
- * @param {[string, string, string, string]} tokenIds The four semantic token ids, top/right/bottom/left order.
- * @param {[string, string, string, string]} fallback The literal fallback for each side, same order.
- *
- * @since TBD
- *
- * @return {[string, string, string, string]} The resolved per-side default.
- */
-function resolveBoxDefault(tokenIds, fallback) {
-	const values = getDesignTokensFeed()?.values ?? {};
-
-	return tokenIds.map((tokenId, index) => values[tokenId] || fallback[index]);
-}
 
 /**
  * Build a row's preview from its stored tokens.
@@ -237,12 +170,10 @@ function schemaFor(tab) {
 				responsive: true,
 				path: 'tokens.button-padding',
 				label: __('Padding', 'kadence-blocks'),
-				// What `advancedbtn`'s style.scss gives a standard fill button, resolved from the
-				// semantic.spacing.button-padding-* tokens so an unset field shows the padding the button
-				// actually renders (a site owner's override included). Only the base case is named: the size
-				// and outline variants compute their own, and the preset deliberately stores nothing until a
-				// user sets it.
-				defaultValue: resolveBoxDefault(BUTTON_PADDING_TOKEN_IDS, BUTTON_PADDING_FALLBACK),
+				// What `advancedbtn`'s style.scss gives a standard fill button, so an unset field shows the
+				// padding the button actually renders. Only the base case is named: the size and outline
+				// variants compute their own, and the preset deliberately stores nothing until a user sets it.
+				defaultValue: BUTTON_PADDING_FALLBACK,
 			},
 			{
 				type: 'spacing',
@@ -251,9 +182,8 @@ function schemaFor(tab) {
 				responsive: true,
 				path: 'tokens.button-margin',
 				label: __('Margin', 'kadence-blocks'),
-				// The button carries no margin of its own, which is a real answer rather than an absent one,
-				// resolved from the semantic.spacing.button-margin-* tokens the same way as padding above.
-				defaultValue: resolveBoxDefault(BUTTON_MARGIN_TOKEN_IDS, BUTTON_MARGIN_FALLBACK),
+				// The button carries no margin of its own, which is a real answer rather than an absent one.
+				defaultValue: BUTTON_MARGIN_FALLBACK,
 			},
 		],
 	};

--- a/src/token-controls/helpers/button-box-defaults.js
+++ b/src/token-controls/helpers/button-box-defaults.js
@@ -1,0 +1,24 @@
+/**
+ * The button's own literal per-side defaults for Padding and Margin — read by both `button-preset.js`
+ * (the Style Library's Button screen) and `src/blocks/singlebtn/edit.js` (the block editor sidebar),
+ * so the two hosts can never independently drift on what "the button's own default" means.
+ *
+ * Lives here, not beside the block, because those two hosts are separate apps that stay uncoupled:
+ * `src/token-controls/` is the one place both already read from, so the shared value has a home that
+ * neither app has to reach into the other to find.
+ */
+
+/**
+ * The literal each padding side falls back to — also what `src/blocks/advancedbtn/style.scss`'s
+ * default rule uses, top/right/bottom/left order.
+ *
+ * @since TBD
+ */
+export const BUTTON_PADDING_FALLBACK = ['0.4em', '1em', '0.4em', '1em'];
+
+/**
+ * The literal each margin side falls back to.
+ *
+ * @since TBD
+ */
+export const BUTTON_MARGIN_FALLBACK = ['0', '0', '0', '0'];


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4260/token-control-popover-options-and-the-default-label-show-what-is

An unset Padding or Margin slot read as blank, even though the button renders a real value there — its padding comes from the size and style classes, not from a stored attribute. Both hosts now show that literal as the field's muted default, so an unset slot names the size actually in effect.

The literals live in `src/token-controls/helpers/button-box-defaults.js`, read by both the block editor sidebar and the Style Library's Button screen. `token-controls` is the shared home the two apps already read from — putting it beside the block would mean the Style Library reaching into `src/blocks/`, which is the one dependency direction those two apps deliberately avoid.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved button editing so padding and margin retain consistent default values when design presets are unavailable.
  - Standardized default button spacing across the editor and style settings.
  - Preserved conversion of existing box-shadow settings into the current shadow controls.
- **Quality Improvements**
  - Updated validation support for fullwidth terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->