### PR TITLE
[DTM] SOFT-4260 [6/19]: move the shadow shorthand parser into a shared module

### DIFF
--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -57,20 +57,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import { BoxShadowControl } from '../../../token-controls/controls/BoxShadowControl';
 import { TokenControlRow } from '../../token-indicators/components/TokenControlRow';
-
-/**
- * The composite's default shape, matching `BoxShadowControl`'s own `DEFAULT_SHADOW` fallback.
- *
- * @since TBD
- */
-const DEFAULT_COMPOSITE = {
-	color: '#000000',
-	offsetX: '0px',
-	offsetY: '0px',
-	blur: '0px',
-	spread: '0px',
-	inset: false,
-};
+import { DEFAULT_COMPOSITE, parseResolvedShadow } from '../../../token-controls';
 
 /**
  * A CSS `rgba(r, g, b, a)` string, matching `hexToRGBA`'s own output format exactly (comma-space
@@ -238,48 +225,6 @@ function axisToComposite(axis) {
  */
 function axisToNative(slot) {
 	return parseFloat(slot) || 0;
-}
-
-/**
- * The feed's resolved `box-shadow` shorthand grammar, matching what `Css_Renderer::shadow()`
- * produces: an optional leading `inset `, four space-separated dimension tokens (offsetX, offsetY,
- * blur, spread), then the color as the remainder of the string. Capturing the color as "everything
- * after the fourth dimension" (rather than a fifth token) keeps a color with internal spaces —
- * `rgba(23, 23, 23, 0.12)` — intact.
- *
- * @since TBD
- */
-const SHADOW_SHORTHAND_PATTERN = /^(inset\s+)?(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.+)$/;
-
-/**
- * Parse a resolved `box-shadow` shorthand string into the composite `{ color, offsetX, offsetY, blur,
- * spread, inset }` shape `BoxShadowControl` edits.
- *
- * @param {*} css The resolved shorthand (e.g. `"0px 2px 8px 0px #1717171f"`, with an optional
- *                `inset ` prefix), or anything that fails to parse as one.
- *
- * @since TBD
- *
- * @return {Object} The parsed composite, or the field's default shape when `css` is empty or does
- *                   not match the shorthand grammar.
- */
-function parseResolvedShadow(css) {
-	const match = typeof css === 'string' ? css.trim().match(SHADOW_SHORTHAND_PATTERN) : null;
-
-	if (!match) {
-		return { ...DEFAULT_COMPOSITE };
-	}
-
-	const [, insetPrefix, offsetX, offsetY, blur, spread, color] = match;
-
-	return {
-		color,
-		offsetX,
-		offsetY,
-		blur,
-		spread,
-		inset: Boolean(insetPrefix),
-	};
 }
 
 /**

--- a/src/token-controls/__tests__/shadow-shorthand.test.js
+++ b/src/token-controls/__tests__/shadow-shorthand.test.js
@@ -1,0 +1,71 @@
+/* eslint-env jest */
+
+/**
+ * Internal dependencies
+ */
+import { parseResolvedShadow } from '../helpers/shadow-shorthand';
+
+describe('parseResolvedShadow', () => {
+	it('parses a non-inset shorthand', () => {
+		expect(parseResolvedShadow('0px 2px 8px 0px #1717171f')).toEqual({
+			color: '#1717171f',
+			offsetX: '0px',
+			offsetY: '2px',
+			blur: '8px',
+			spread: '0px',
+			inset: false,
+		});
+	});
+
+	it('parses an inset shorthand', () => {
+		expect(parseResolvedShadow('inset 0px 2px 8px 0px rgba(23, 23, 23, 0.12)')).toEqual({
+			color: 'rgba(23, 23, 23, 0.12)',
+			offsetX: '0px',
+			offsetY: '2px',
+			blur: '8px',
+			spread: '0px',
+			inset: true,
+		});
+	});
+
+	it('returns the default composite for an unparsable value', () => {
+		expect(parseResolvedShadow('not-a-shadow')).toEqual({
+			color: '#000000',
+			offsetX: '0px',
+			offsetY: '0px',
+			blur: '0px',
+			spread: '0px',
+			inset: false,
+		});
+		expect(parseResolvedShadow(undefined)).toEqual({
+			color: '#000000',
+			offsetX: '0px',
+			offsetY: '0px',
+			blur: '0px',
+			spread: '0px',
+			inset: false,
+		});
+	});
+
+	it('parses a shadow with rgba color format', () => {
+		expect(parseResolvedShadow('2px 3px 4px 5px #111111')).toEqual({
+			color: '#111111',
+			offsetX: '2px',
+			offsetY: '3px',
+			blur: '4px',
+			spread: '5px',
+			inset: false,
+		});
+	});
+
+	it('parses an inset shadow with rgba color', () => {
+		expect(parseResolvedShadow('inset 2px 3px 4px 5px rgba(17, 17, 17, 0.5)')).toEqual({
+			color: 'rgba(17, 17, 17, 0.5)',
+			offsetX: '2px',
+			offsetY: '3px',
+			blur: '4px',
+			spread: '5px',
+			inset: true,
+		});
+	});
+});

--- a/src/token-controls/helpers/shadow-shorthand.js
+++ b/src/token-controls/helpers/shadow-shorthand.js
@@ -1,0 +1,62 @@
+/**
+ * Parsing the feed's resolved `box-shadow` shorthand string into the composite object shape both
+ * `BoxShadowControl` (this library) and its two host adapters (`EditorShadowControl`,
+ * `BoxShadowField`) edit — moved here so a fixed "None" shadow pick (which carries a literal
+ * shorthand string as its `value`, not a live token reference) resolves identically in both hosts.
+ */
+
+/**
+ * The composite's default shape, matching `ShadowField`'s own fallback.
+ *
+ * @since TBD
+ */
+export const DEFAULT_COMPOSITE = {
+	color: '#000000',
+	offsetX: '0px',
+	offsetY: '0px',
+	blur: '0px',
+	spread: '0px',
+	inset: false,
+};
+
+/**
+ * The feed's resolved `box-shadow` shorthand grammar, matching what `Css_Renderer::shadow()`
+ * produces: an optional leading `inset `, four space-separated dimension tokens (offsetX, offsetY,
+ * blur, spread), then the color as the remainder of the string. Capturing the color as "everything
+ * after the fourth dimension" (rather than a fifth token) keeps a color with internal spaces —
+ * `rgba(23, 23, 23, 0.12)` — intact.
+ *
+ * @since TBD
+ */
+const SHADOW_SHORTHAND_PATTERN = /^(inset\s+)?(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.+)$/;
+
+/**
+ * Parse a resolved `box-shadow` shorthand string into the composite `{ color, offsetX, offsetY, blur,
+ * spread, inset }` shape `BoxShadowControl` edits.
+ *
+ * @param {*} css The resolved shorthand (e.g. `"0px 2px 8px 0px #1717171f"`, with an optional
+ *                `inset ` prefix), or anything that fails to parse as one.
+ *
+ * @since TBD
+ *
+ * @return {Object} The parsed composite, or the field's default shape when `css` is empty or does
+ *                   not match the shorthand grammar.
+ */
+export function parseResolvedShadow(css) {
+	const match = typeof css === 'string' ? css.trim().match(SHADOW_SHORTHAND_PATTERN) : null;
+
+	if (!match) {
+		return { ...DEFAULT_COMPOSITE };
+	}
+
+	const [, insetPrefix, offsetX, offsetY, blur, spread, color] = match;
+
+	return {
+		color,
+		offsetX,
+		offsetY,
+		blur,
+		spread,
+		inset: Boolean(insetPrefix),
+	};
+}

--- a/src/token-controls/index.js
+++ b/src/token-controls/index.js
@@ -62,3 +62,4 @@ export {
 } from './helpers/value-shapes';
 export { tokenCssVar } from './helpers/token-css-var';
 export { mapPaletteToColorControlGroups } from './helpers/palette-groups';
+export { DEFAULT_COMPOSITE, parseResolvedShadow } from './helpers/shadow-shorthand';


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4260/token-control-popover-options-and-the-default-label-show-what-is

Moves the `box-shadow` shorthand parser out of `BoxShadowControl` into `src/token-controls/helpers/shadow-shorthand.js`, so the Style Library field and the block editor adapter can both read it instead of each carrying their own copy. Pure move plus its own tests — no behavior change.

Groundwork for the fixed `None` shadow pick, which needs both hosts to agree on what a shorthand resolves to.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of shadow values, including inset shadows, colors, spread values, and invalid or missing inputs.
  * Standardized fallback behavior for incomplete or unsupported shadow definitions.

* **Refactor**
  * Centralized shadow parsing for more consistent behavior across editor controls.

* **Tests**
  * Added coverage for common shadow formats and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->