### PR TITLE
[DTM] SOFT-4260 [7/19]: offer a fixed None pick in both hosts' shadow controls

### DIFF
--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -470,6 +470,8 @@ export default function KadenceButtonEdit(props) {
 	// hover/sticky/transparent variant below reuses the same resolved list rather than re-filtering the
 	// pool per state.
 	const borderWidthPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-border-width');
+	// The shared narrowing in `pickableTokensForKey` already prepends the fixed "None" sentinel for the
+	// shadow role, so this list must NOT prepend a second one.
 	const shadowPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-shadow');
 	const paddingPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-padding');
 	const marginPickableTokens = pickableTokensForKey('kadence/singlebtn', 'button-margin');

--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { EditorShadowControl, combineColorOpacity, splitColorOpacity } from '../EditorShadowControl';
+import { EditorShadowControl, combineColorOpacity, splitColorOpacity, toNativeShadow } from '../EditorShadowControl';
 
 /**
  * A representative native shadow value — every field a different, distinguishable number/string, so a
@@ -209,6 +209,29 @@ describe('EditorShadowControl native <-> BoxShadowControl value bridging', () =>
 			},
 		]);
 		expect(onChange.mock.calls[0][0][0]).not.toHaveProperty('alias');
+	});
+
+	/**
+	 * Picking the shared fixed "None" sentinel resolves it to the zero native shadow item, the same
+	 * way any other `fixed` tokens-list entry resolves generically by `alias` match — no special-casing
+	 * needed in `toNativeShadow` itself.
+	 *
+	 * @return {void}
+	 */
+	it('resolves a fixed None pick to the zero native shadow item', () => {
+		const noneToken = {
+			id: 'ss-none-shadow',
+			label: 'None',
+			value: '0px 0px 0px 0px transparent',
+			alias: '0px 0px 0px 0px transparent',
+			fixed: true,
+			type: 'shadow',
+			role: 'shadow',
+		};
+
+		expect(toNativeShadow(noneToken.alias, [noneToken])).toEqual([
+			{ color: 'transparent', opacity: 1, hOffset: 0, vOffset: 0, blur: 0, spread: 0, inset: false },
+		]);
 	});
 
 	/**

--- a/src/extension/token-picker/__tests__/index.test.js
+++ b/src/extension/token-picker/__tests__/index.test.js
@@ -454,6 +454,14 @@ describe('pickableTokensForKey', () => {
 		expect(result.every((token) => token.role === 'shadow')).toBe(true);
 	});
 
+	it('carries exactly one fixed "None" entry for shadow, so a host must not prepend its own', () => {
+		// `src/blocks/singlebtn/edit.js` builds its shadow picker list straight from this call. A second
+		// prepend at that call site would duplicate the row and collide on the React key.
+		const result = pickableTokensForKey('kadence/singlebtn', 'button-shadow');
+
+		expect(result.filter((token) => token.id === 'ss-none-shadow')).toHaveLength(1);
+	});
+
 	it('succeeds by key on the exact same property that pickableTokensForControl cannot reach by any control_attr guess, proving the two lookup paths are genuinely independent', () => {
 		// Not a vacuous "no control_attr matches, so both return []" comparison: pickableTokensForKey
 		// resolves real tokens for this property (asserted above), while pickableTokensForControl fails to

--- a/src/style-library/__tests__/border-shadow-field-rendering.test.js
+++ b/src/style-library/__tests__/border-shadow-field-rendering.test.js
@@ -35,7 +35,7 @@ jest.mock('../../token-controls/controls/BoxShadowControl', () => ({
 // eslint-disable-next-line import/first -- must follow the jest.mock calls above.
 import { BorderField } from '../components/molecules/fields/BorderField';
 // eslint-disable-next-line import/first -- must follow the jest.mock calls above.
-import { BoxShadowField } from '../components/molecules/fields/BoxShadowField';
+import { BoxShadowField, resolveShadowPick } from '../components/molecules/fields/BoxShadowField';
 
 describe('BorderField', () => {
 	let container;
@@ -320,11 +320,12 @@ describe('BoxShadowField', () => {
 		});
 
 		expect(latestBoxShadowControlProps.tokens.map((token) => token.id)).toEqual([
+			'ss-none-shadow',
 			'primitive.shadow.xs',
 			'primitive.shadow.sm',
 			'primitive.shadow.md',
 		]);
-		expect(latestBoxShadowControlProps.tokens[0].alias).toBe('{primitive.shadow.xs}');
+		expect(latestBoxShadowControlProps.tokens[1].alias).toBe('{primitive.shadow.xs}');
 	});
 
 	it('shows a semantic-bound shadow as unset rather than listing the semantic', () => {
@@ -340,8 +341,10 @@ describe('BoxShadowField', () => {
 			);
 		});
 
-		// The list stays the Shadow screen's own three steps — no Brand-group semantic among them.
+		// The list stays the Shadow screen's own three steps (behind the shared fixed "None" sentinel) —
+		// no Brand-group semantic among them.
 		expect(latestBoxShadowControlProps.tokens.map((token) => token.id)).toEqual([
+			'ss-none-shadow',
 			'primitive.shadow.xs',
 			'primitive.shadow.sm',
 			'primitive.shadow.md',
@@ -364,6 +367,7 @@ describe('BoxShadowField', () => {
 		});
 
 		expect(latestBoxShadowControlProps.tokens.map((token) => token.id)).toEqual([
+			'ss-none-shadow',
 			'primitive.shadow.xs',
 			'primitive.shadow.sm',
 			'primitive.shadow.md',
@@ -435,5 +439,70 @@ describe('BoxShadowField', () => {
 
 		expect(onChange).not.toHaveBeenCalled();
 		expect(latestBoxShadowControlProps.disabled).toBe(true);
+	});
+});
+
+describe('resolveShadowPick', () => {
+	const NONE_TOKEN = {
+		id: 'ss-none-shadow',
+		label: 'None',
+		value: '0px 0px 0px 0px transparent',
+		alias: '0px 0px 0px 0px transparent',
+		fixed: true,
+		type: 'shadow',
+		role: 'shadow',
+	};
+
+	const REAL_TOKEN = {
+		id: 'primitive.shadow.sm',
+		label: 'Small',
+		value: '0px 2px 8px 0px #1717171f',
+		alias: '{primitive.shadow.sm}',
+		type: 'shadow',
+		role: 'shadow',
+	};
+
+	/**
+	 * A fixed sentinel has no registered token behind it for PHP to resolve later, so it is stored as
+	 * its literal composite at pick time rather than kept as a live alias.
+	 *
+	 * @return {void}
+	 */
+	it('resolves a fixed None pick to the literal zero composite', () => {
+		expect(resolveShadowPick(NONE_TOKEN.alias, [NONE_TOKEN, REAL_TOKEN])).toEqual({
+			color: 'transparent',
+			offsetX: '0px',
+			offsetY: '0px',
+			blur: '0px',
+			spread: '0px',
+			inset: false,
+		});
+	});
+
+	/**
+	 * A real token stays a live alias, so a later edit to its scale still cascades into this preset.
+	 *
+	 * @return {void}
+	 */
+	it('keeps a real token pick as its live alias', () => {
+		expect(resolveShadowPick(REAL_TOKEN.alias, [NONE_TOKEN, REAL_TOKEN])).toBe(REAL_TOKEN.alias);
+	});
+
+	/**
+	 * A hand-composed shadow is already literal and passes through untouched.
+	 *
+	 * @return {void}
+	 */
+	it('passes a Custom-tab composite through unchanged', () => {
+		const composite = {
+			color: '#ff0000',
+			offsetX: '1px',
+			offsetY: '1px',
+			blur: '2px',
+			spread: '0px',
+			inset: false,
+		};
+
+		expect(resolveShadowPick(composite, [NONE_TOKEN, REAL_TOKEN])).toBe(composite);
 	});
 });

--- a/src/style-library/components/molecules/fields/BoxShadowField.js
+++ b/src/style-library/components/molecules/fields/BoxShadowField.js
@@ -32,6 +32,7 @@ import { BoxShadowControl } from '../../../../token-controls/controls/BoxShadowC
 import { boundTokenIds } from './BoxTokenField';
 import { isTokenAlias } from '../../../../token-controls/helpers/token-summary';
 import { TokenColorSelectField } from './TokenColorSelectField';
+import { noneEntryForRole, parseResolvedShadow } from '../../../../token-controls';
 
 /**
  * The bare token id a stored shadow holds, or the value unchanged when it holds a composite shadow
@@ -115,6 +116,26 @@ export function toStoredShadow(next) {
 }
 
 /**
+ * Resolve a `BoxShadowControl` pick to what this field stores: a `fixed` entry (the shared "None"
+ * sentinel; it has no registered token PHP could otherwise resolve later) resolves to its literal
+ * composite immediately, the same way a Custom-tab edit already does. A real token's alias, or an
+ * already-composite Custom-tab value, passes through unchanged — a real token stays a live alias so
+ * a later scale edit still cascades into this preset, matching every other Style Library field.
+ *
+ * @param {string|Object} picked What `BoxShadowControl.onChange` reported.
+ * @param {Array}         tokens The pickable-token list `picked` was chosen from.
+ *
+ * @since TBD
+ *
+ * @return {string|Object} What this field writes.
+ */
+export function resolveShadowPick(picked, tokens) {
+	const entry = tokens.find((token) => token.alias === picked);
+
+	return entry?.fixed ? parseResolvedShadow(entry.value) : picked;
+}
+
+/**
  * Render a box-shadow field from a settings schema entry.
  *
  * @param {Object}  props                  The component props.
@@ -137,16 +158,20 @@ export function BoxShadowField({ field, value, onChange }) {
 	// semantics (`semantic.shadow.media`, `semantic.shadow.button`) that back other blocks' own
 	// default CSS and were never meant to be end-user-pickable here. Passing `role: 'shadow'` — every
 	// shadow token's derived role — engages the primitive narrowing, matching the three-entry list the
-	// Shadow screen itself offers.
-	const tokens = pickableTokensForType('shadow', 'shadow', boundShadowTokenIds(shown)).map((token) => ({
-		...token,
-		alias: `{${token.id}}`,
-	}));
+	// Shadow screen itself offers. `boundShadowTokenIds` exempts the currently-bound token from that
+	// narrowing so a bound semantic still renders as its own label rather than a raw id.
+	const tokens = [
+		noneEntryForRole('shadow'),
+		...pickableTokensForType('shadow', 'shadow', boundShadowTokenIds(shown)).map((token) => ({
+			...token,
+			alias: `{${token.id}}`,
+		})),
+	];
 
 	return (
 		<BoxShadowControl
 			value={shown}
-			onChange={(next) => !field.readOnly && onChange(toStoredShadow(next))}
+			onChange={(next) => !field.readOnly && onChange(toStoredShadow(resolveShadowPick(next, tokens)))}
 			label={field.label}
 			tokens={tokens}
 			renderColor={({ value: color, onChange: onColorChange }) => (

--- a/src/style-library/helpers/tokens.js
+++ b/src/style-library/helpers/tokens.js
@@ -143,9 +143,12 @@ export function pickableTokensForType(type, role, selected) {
 	const preferred = preferPrimitiveTokens(matched, selected);
 
 	// Shadow is deliberately excluded here even though `noneEntryForRole()` itself knows a "None"
-	// value for it: `BoxShadowField` calls this function directly with `role: 'shadow'` and has not
-	// been migrated onto the shared fixed-sentinel token list yet, so prepending "None" to its pool
-	// would change its picker out from under it. That migration is its own, later piece of work.
+	// value for it. Shadow's "None" is added by each host at its own call site instead — `BoxShadowField`
+	// here and `src/blocks/singlebtn/edit.js` in the editor — because the shadow role's registered
+	// tokens need per-alias resolution (`parseResolvedShadow`/`resolveShadowPick`) that this generic
+	// dimension-role prepend has no notion of. So the shared narrowing stays out of shadow's way rather
+	// than duplicating that logic; prepending here as well would only give every shadow picker two
+	// "None" rows with the same id.
 	const none = role === 'shadow' ? null : noneEntryForRole(role);
 
 	return none ? [none, ...preferred] : preferred;

--- a/src/style-library/helpers/tokens.js
+++ b/src/style-library/helpers/tokens.js
@@ -142,13 +142,10 @@ export function pickableTokensForType(type, role, selected) {
 
 	const preferred = preferPrimitiveTokens(matched, selected);
 
-	// Shadow is deliberately excluded here even though `noneEntryForRole()` itself knows a "None"
-	// value for it. Shadow's "None" is added by each host at its own call site instead — `BoxShadowField`
-	// here and `src/blocks/singlebtn/edit.js` in the editor — because the shadow role's registered
-	// tokens need per-alias resolution (`parseResolvedShadow`/`resolveShadowPick`) that this generic
-	// dimension-role prepend has no notion of. So the shared narrowing stays out of shadow's way rather
-	// than duplicating that logic; prepending here as well would only give every shadow picker two
-	// "None" rows with the same id.
+	// Shadow is excluded here even though `noneEntryForRole()` knows a "None" for it: `BoxShadowField`
+	// prepends its own so the entry sits in the same list `resolveShadowPick()` matches a pick against,
+	// which is what resolves a fixed pick to its literal composite at write time. The block editor's
+	// `pickableTokensForKey()` does prepend for shadow, so nothing there adds a second one.
 	const none = role === 'shadow' ? null : noneEntryForRole(role);
 
 	return none ? [none, ...preferred] : preferred;


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4260/token-control-popover-options-and-the-default-label-show-what-is

Offers the fixed `None` pick in both hosts' shadow controls, completing the sentinel work for the shadow role.

A shadow can't collapse to a bare `0` the way radius and spacing do, so its sentinel resolves to the zero/transparent `box-shadow` shorthand — the same shape a real shadow token's value already carries. A fixed pick is resolved to that literal at pick time rather than kept as a live alias, since there is no registered token behind it for the server to resolve later.

The block editor no longer prepends its own duplicate `None` row: the shared narrowing already puts one there, and two rows for one choice read as a bug.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fixed “None” option to shadow controls.
  * Selecting “None” now applies a transparent, zero-value shadow.
  * Preserved live references for saved shadow tokens and custom shadow values.

* **Bug Fixes**
  * Prevented duplicate “None” entries and related selection conflicts.
  * Improved shadow token resolution across editing and styling controls.

* **Tests**
  * Added coverage for “None,” token aliases, custom shadows, and picker behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->