### PR TITLE
[DTM] SOFT-4260 [8/19]: remove the Enable Box Shadow toggle, decide emission from the value

### DIFF
--- a/includes/blocks/class-kadence-blocks-singlebtn-block.php
+++ b/includes/blocks/class-kadence-blocks-singlebtn-block.php
@@ -646,7 +646,17 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		foreach ( [ 'hOffset', 'vOffset', 'blur', 'spread' ] as $axis ) {
 			$value = $shadow_item[ $axis ] ?? 0;
 
-			if ( is_numeric( $value ) && 0.0 !== (float) $value ) {
+			if ( is_numeric( $value ) ) {
+				if ( 0.0 !== (float) $value ) {
+					return true;
+				}
+
+				continue;
+			}
+
+			// A {dot.alias} leg resolves to a var() unknown here, so it counts as visible — read as zero,
+			// the caller's `box-shadow: none` would erase a shadow the token does paint.
+			if ( is_string( $value ) && '' !== trim( $value ) ) {
 				return true;
 			}
 		}

--- a/includes/blocks/class-kadence-blocks-singlebtn-block.php
+++ b/includes/blocks/class-kadence-blocks-singlebtn-block.php
@@ -133,12 +133,8 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$css->render_measure_output( $attributes, 'padding', 'padding', [ 'unit_key' => 'paddingUnit' ] );
 		$css->render_measure_output( $attributes, 'margin', 'margin', [ 'unit_key' => 'marginUnit' ] );
 		$this->render_preset_shadow( $css, $attributes );
-		if ( isset( $attributes['displayShadow'] ) && true === $attributes['displayShadow'] ) {
-			if ( isset( $attributes['shadow'] ) && is_array( $attributes['shadow'] ) && isset( $attributes['shadow'][0] ) && is_array( $attributes['shadow'][0] ) ) {
-				$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadow'][0] ) );
-			} else {
-				$css->add_property( 'box-shadow', '1px 1px 2px 0px rgba(0, 0, 0, 0.2)' );
-			}
+		if ( isset( $attributes['shadow'][0] ) && is_array( $attributes['shadow'][0] ) && $this->has_visible_shadow( $attributes['shadow'][0] ) ) {
+			$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadow'][0] ) );
 		}
 		if ( ! empty( $attributes['textUnderline'] ) ) {
 			$css->set_selector( '.wp-block-kadence-advancedbtn .kb-btn' . $unique_id . '.kb-button:not(.specificity):not(.extra-specificity)' );
@@ -174,16 +170,12 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		}
 		$css->render_measure_output( $attributes, 'borderHoverRadius', 'border-radius' );
 		$css->render_border_styles( $attributes, 'borderHoverStyle', true );
-		if ( isset( $attributes['displayHoverShadow'] ) && true === $attributes['displayHoverShadow'] ) {
-			if ( ( 'gradient' === $bg_type || 'gradient' === $bg_hover_type ) && isset( $attributes['shadowHover'][0]['inset'] ) && true === $attributes['shadowHover'][0]['inset'] ) {
-				$css->add_property( 'box-shadow', '0px 0px 0px 0px rgba(0, 0, 0, 0)' );
-				$css->set_selector( '.kb-btn' . $unique_id . '.kb-button:hover::before' );
-			}
-			if ( isset( $attributes['shadowHover'] ) && is_array( $attributes['shadowHover'] ) && isset( $attributes['shadowHover'][0] ) && is_array( $attributes['shadowHover'][0] ) ) {
-				$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowHover'][0] ) );
-			} else {
-				$css->add_property( 'box-shadow', '2px 2px 3px 0px rgba(0, 0, 0, 0.4)' );
-			}
+		if ( ( 'gradient' === $bg_type || 'gradient' === $bg_hover_type ) && isset( $attributes['shadowHover'][0]['inset'] ) && true === $attributes['shadowHover'][0]['inset'] ) {
+			$css->add_property( 'box-shadow', '0px 0px 0px 0px rgba(0, 0, 0, 0)' );
+			$css->set_selector( '.kb-btn' . $unique_id . '.kb-button:hover::before' );
+		}
+		if ( isset( $attributes['shadowHover'][0] ) && is_array( $attributes['shadowHover'][0] ) && $this->has_visible_shadow( $attributes['shadowHover'][0] ) ) {
+			$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowHover'][0] ) );
 		}
 		// Hover before.
 		if ( 'gradient' === $bg_type && 'normal' === $bg_hover_type && ! empty( $attributes['backgroundHover'] ) ) {
@@ -269,12 +261,8 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		}
 		$css->render_measure_output( $attributes, 'borderTransparentRadius', 'border-radius', [ 'unit_key' => 'borderTransparentRadiusUnit' ] );
 		$css->render_border_styles( $attributes, 'borderTransparentStyle', true );
-		if ( isset( $attributes['displayShadowTransparent'] ) && true === $attributes['displayShadowTransparent'] ) {
-			if ( isset( $attributes['shadowTransparent'] ) && is_array( $attributes['shadowTransparent'] ) && isset( $attributes['shadowTransparent'][0] ) && is_array( $attributes['shadowTransparent'][0] ) ) {
-				$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowTransparent'][0] ) );
-			} else {
-				$css->add_property( 'box-shadow', '1px 1px 2px 0px rgba(0, 0, 0, 0.2)' );
-			}
+		if ( isset( $attributes['shadowTransparent'] ) && is_array( $attributes['shadowTransparent'] ) && isset( $attributes['shadowTransparent'][0] ) && is_array( $attributes['shadowTransparent'][0] ) && $this->has_visible_shadow( $attributes['shadowTransparent'][0] ) ) {
+			$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowTransparent'][0] ) );
 		}
 
 		// Hover transparent styles.
@@ -287,16 +275,12 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		}
 		$css->render_measure_output( $attributes, 'borderTransparentHoverRadius', 'border-radius' );
 		$css->render_border_styles( $attributes, 'borderTransparentHoverStyle', true );
-		if ( isset( $attributes['displayHoverShadowTransparent'] ) && true === $attributes['displayHoverShadowTransparent'] ) {
-			if ( ( 'gradient' === $bg_type_transparent || 'gradient' === $bg_hover_type_transparent ) && isset( $attributes['shadowTransparentHover'] ) && is_array( $attributes['shadowTransparentHover'] ) && isset( $attributes['shadowTransparentHover'][0] ) && is_array( $attributes['shadowTransparentHover'][0] ) && isset( $attributes['shadowTransparentHover'][0]['inset'] ) && true === $attributes['shadowTransparentHover'][0]['inset'] ) {
-				$css->add_property( 'box-shadow', '0px 0px 0px 0px rgba(0, 0, 0, 0)' );
-				$css->set_selector( '.kb-btn' . $unique_id . '.kb-button:hover::before' );
-			}
-			if ( isset( $attributes['shadowTransparentHover'] ) && is_array( $attributes['shadowTransparentHover'] ) && isset( $attributes['shadowTransparentHover'][0] ) && is_array( $attributes['shadowTransparentHover'][0] ) ) {
-				$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowTransparentHover'][0] ) );
-			} else {
-				$css->add_property( 'box-shadow', '2px 2px 3px 0px rgba(0, 0, 0, 0.4)' );
-			}
+		if ( ( 'gradient' === $bg_type_transparent || 'gradient' === $bg_hover_type_transparent ) && isset( $attributes['shadowTransparentHover'] ) && is_array( $attributes['shadowTransparentHover'] ) && isset( $attributes['shadowTransparentHover'][0] ) && is_array( $attributes['shadowTransparentHover'][0] ) && isset( $attributes['shadowTransparentHover'][0]['inset'] ) && true === $attributes['shadowTransparentHover'][0]['inset'] ) {
+			$css->add_property( 'box-shadow', '0px 0px 0px 0px rgba(0, 0, 0, 0)' );
+			$css->set_selector( '.kb-btn' . $unique_id . '.kb-button:hover::before' );
+		}
+		if ( isset( $attributes['shadowTransparentHover'] ) && is_array( $attributes['shadowTransparentHover'] ) && isset( $attributes['shadowTransparentHover'][0] ) && is_array( $attributes['shadowTransparentHover'][0] ) && $this->has_visible_shadow( $attributes['shadowTransparentHover'][0] ) ) {
+			$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowTransparentHover'][0] ) );
 		}
 
 		// Standard sticky styles.
@@ -314,12 +298,8 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		}
 		$css->render_measure_output( $attributes, 'borderStickyRadius', 'border-radius', [ 'unit_key' => 'borderStickyRadiusUnit' ] );
 		$css->render_border_styles( $attributes, 'borderStickyStyle', true );
-		if ( isset( $attributes['displayShadowSticky'] ) && true === $attributes['displayShadowSticky'] ) {
-			if ( isset( $attributes['shadowSticky'] ) && is_array( $attributes['shadowSticky'] ) && isset( $attributes['shadowSticky'][0] ) && is_array( $attributes['shadowSticky'][0] ) ) {
-				$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowSticky'][0] ) );
-			} else {
-				$css->add_property( 'box-shadow', '1px 1px 2px 0px rgba(0, 0, 0, 0.2)' );
-			}
+		if ( isset( $attributes['shadowSticky'] ) && is_array( $attributes['shadowSticky'] ) && isset( $attributes['shadowSticky'][0] ) && is_array( $attributes['shadowSticky'][0] ) && $this->has_visible_shadow( $attributes['shadowSticky'][0] ) ) {
+			$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowSticky'][0] ) );
 		}
 
 		// Hover sticky styles.
@@ -332,16 +312,12 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		}
 		$css->render_measure_output( $attributes, 'borderStickyHoverRadius', 'border-radius' );
 		$css->render_border_styles( $attributes, 'borderStickyHoverStyle', true );
-		if ( isset( $attributes['displayHoverShadowSticky'] ) && true === $attributes['displayHoverShadowSticky'] ) {
-			if ( ( 'gradient' === $bg_type_sticky || 'gradient' === $bg_hover_type_sticky ) && isset( $attributes['shadowStickyHover'] ) && is_array( $attributes['shadowStickyHover'] ) && isset( $attributes['shadowStickyHover'][0] ) && is_array( $attributes['shadowStickyHover'][0] ) && isset( $attributes['shadowStickyHover'][0]['inset'] ) && true === $attributes['shadowStickyHover'][0]['inset'] ) {
-				$css->add_property( 'box-shadow', '0px 0px 0px 0px rgba(0, 0, 0, 0)' );
-				$css->set_selector( '.kb-btn' . $unique_id . '.kb-button:hover::before' );
-			}
-			if ( isset( $attributes['shadowStickyHover'] ) && is_array( $attributes['shadowStickyHover'] ) && isset( $attributes['shadowStickyHover'][0] ) && is_array( $attributes['shadowStickyHover'][0] ) ) {
-				$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowStickyHover'][0] ) );
-			} else {
-				$css->add_property( 'box-shadow', '2px 2px 3px 0px rgba(0, 0, 0, 0.4)' );
-			}
+		if ( ( 'gradient' === $bg_type_sticky || 'gradient' === $bg_hover_type_sticky ) && isset( $attributes['shadowStickyHover'] ) && is_array( $attributes['shadowStickyHover'] ) && isset( $attributes['shadowStickyHover'][0] ) && is_array( $attributes['shadowStickyHover'][0] ) && isset( $attributes['shadowStickyHover'][0]['inset'] ) && true === $attributes['shadowStickyHover'][0]['inset'] ) {
+			$css->add_property( 'box-shadow', '0px 0px 0px 0px rgba(0, 0, 0, 0)' );
+			$css->set_selector( '.kb-btn' . $unique_id . '.kb-button:hover::before' );
+		}
+		if ( isset( $attributes['shadowStickyHover'] ) && is_array( $attributes['shadowStickyHover'] ) && isset( $attributes['shadowStickyHover'][0] ) && is_array( $attributes['shadowStickyHover'][0] ) && $this->has_visible_shadow( $attributes['shadowStickyHover'][0] ) ) {
+			$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowStickyHover'][0] ) );
 		}
 	}
 
@@ -612,7 +588,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 	 * undefined custom property is invalid at computed-value time, so emitting unconditionally would
 	 * blank out the shadow on a button whose preset sets none.
 	 *
-	 * Emitted before the explicit `displayShadow` output below so an explicit per-block shadow, which
+	 * Emitted before the explicit `shadow` output below so an explicit per-block shadow, which
 	 * lands later in the same rule, still wins.
 	 *
 	 * @since TBD
@@ -654,6 +630,28 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		if ( isset( $values['button-shadow'] ) ) {
 			$css->add_property( 'box-shadow', 'var(--kb-btn-shadow)' );
 		}
+	}
+
+	/**
+	 * Whether a native shadow item paints anything visible — all-zero offsets, blur, and spread
+	 * render nothing regardless of color, matching the value the "None" pick now writes.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $shadow_item One `shadow[0]`-shaped item.
+	 *
+	 * @return bool
+	 */
+	private function has_visible_shadow( array $shadow_item ): bool {
+		foreach ( [ 'hOffset', 'vOffset', 'blur', 'spread' ] as $axis ) {
+			$value = $shadow_item[ $axis ] ?? 0;
+
+			if ( is_numeric( $value ) && 0.0 !== (float) $value ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/blocks/singlebtn/block.json
+++ b/src/blocks/singlebtn/block.json
@@ -335,40 +335,16 @@
 				}
 			]
 		},
-		"displayShadow": {
-			"type": "boolean",
-			"default": false
-		},
-		"displayHoverShadow": {
-			"type": "boolean",
-			"default": false
-		},
 		"shadow": {
 			"type": "array",
 			"default": [
-				{
-					"color": "#000000",
-					"opacity": 0.2,
-					"spread": 0,
-					"blur": 2,
-					"hOffset": 1,
-					"vOffset": 1,
-					"inset": false
-				}
+				{ "color": "transparent", "opacity": 1, "spread": 0, "blur": 0, "hOffset": 0, "vOffset": 0, "inset": false }
 			]
 		},
 		"shadowHover": {
 			"type": "array",
 			"default": [
-				{
-					"color": "#000000",
-					"opacity": 0.4,
-					"spread": 0,
-					"blur": 3,
-					"hOffset": 2,
-					"vOffset": 2,
-					"inset": false
-				}
+				{ "color": "transparent", "opacity": 1, "spread": 0, "blur": 0, "hOffset": 0, "vOffset": 0, "inset": false }
 			]
 		},
 		"inQueryBlock": {
@@ -529,40 +505,16 @@
 			"type": "string",
 			"default": "px"
 		},
-		"displayShadowTransparent": {
-			"type": "boolean",
-			"default": false
-		},
-		"displayHoverShadowTransparent": {
-			"type": "boolean",
-			"default": false
-		},
 		"shadowTransparent": {
 			"type": "array",
 			"default": [
-				{
-					"color": "#000000",
-					"opacity": 0.2,
-					"spread": 0,
-					"blur": 2,
-					"hOffset": 1,
-					"vOffset": 1,
-					"inset": false
-				}
+				{ "color": "transparent", "opacity": 1, "spread": 0, "blur": 0, "hOffset": 0, "vOffset": 0, "inset": false }
 			]
 		},
 		"shadowTransparentHover": {
 			"type": "array",
 			"default": [
-				{
-					"color": "#000000",
-					"opacity": 0.4,
-					"spread": 0,
-					"blur": 3,
-					"hOffset": 2,
-					"vOffset": 2,
-					"inset": false
-				}
+				{ "color": "transparent", "opacity": 1, "spread": 0, "blur": 0, "hOffset": 0, "vOffset": 0, "inset": false }
 			]
 		},
 		"colorSticky": {
@@ -701,40 +653,16 @@
 			"type": "string",
 			"default": "px"
 		},
-		"displayShadowSticky": {
-			"type": "boolean",
-			"default": false
-		},
-		"displayHoverShadowSticky": {
-			"type": "boolean",
-			"default": false
-		},
 		"shadowSticky": {
 			"type": "array",
 			"default": [
-				{
-					"color": "#000000",
-					"opacity": 0.2,
-					"spread": 0,
-					"blur": 2,
-					"hOffset": 1,
-					"vOffset": 1,
-					"inset": false
-				}
+				{ "color": "transparent", "opacity": 1, "spread": 0, "blur": 0, "hOffset": 0, "vOffset": 0, "inset": false }
 			]
 		},
 		"shadowStickyHover": {
 			"type": "array",
 			"default": [
-				{
-					"color": "#000000",
-					"opacity": 0.4,
-					"spread": 0,
-					"blur": 3,
-					"hOffset": 2,
-					"vOffset": 2,
-					"inset": false
-				}
+				{ "color": "transparent", "opacity": 1, "spread": 0, "blur": 0, "hOffset": 0, "vOffset": 0, "inset": false }
 			]
 		},
 		"tooltip": {

--- a/src/blocks/singlebtn/components/backend-styles/__tests__/index.test.js
+++ b/src/blocks/singlebtn/components/backend-styles/__tests__/index.test.js
@@ -1,0 +1,84 @@
+/* eslint-env jest */
+
+/**
+ * `hasVisibleShadow()` decides whether the editor-canvas live preview emits a `box-shadow`
+ * declaration from a shadow value's own axes — the JS sibling of the front end's
+ * `has_visible_shadow()` (`class-kadence-blocks-singlebtn-block.php`), now that the "Enable Box
+ * Shadow" toggle and its sibling boolean attributes are gone.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { hasVisibleShadow } from '../index';
+
+// `backend-styles/index.js` imports the `@kadence/helpers` barrel, which eagerly pulls in a
+// REST-fetch helper that has no `@wordpress/api-fetch` module to resolve under Jest (the same
+// constraint documented in `preset-border-shadow-properties.test.js`). `hasVisibleShadow` does not
+// call into the helper library, so a bare stub is enough to let the module load without pulling
+// that dependency in.
+jest.mock('@kadence/helpers', () => ({
+	KadenceBlocksCSS: jest.fn(),
+	getPreviewSize: jest.fn(),
+	KadenceColorOutput: jest.fn(),
+	typographyStyle: jest.fn(),
+	getBorderStyle: jest.fn(),
+	getBorderColor: jest.fn(),
+	getSpacingOptionOutput: jest.fn(),
+}));
+
+jest.mock('../../../../../extension/preset-picker', () => ({
+	activePresetFor: jest.fn(),
+	blockPresetValues: jest.fn(),
+}));
+
+describe('hasVisibleShadow', () => {
+	/**
+	 * An all-zero shadow item — the shape the fixed "None" pick writes — paints nothing.
+	 *
+	 * @return {void}
+	 */
+	it('is false for an all-zero shadow item', () => {
+		expect(hasVisibleShadow({ hOffset: 0, vOffset: 0, blur: 0, spread: 0 })).toBe(false);
+	});
+
+	/**
+	 * A missing/undefined item (an attribute that has never been set) is treated as invisible
+	 * rather than throwing on a property read.
+	 *
+	 * @return {void}
+	 */
+	it('is false for a missing/undefined item', () => {
+		expect(hasVisibleShadow(undefined)).toBe(false);
+	});
+
+	/**
+	 * An item missing some axis keys entirely (older data written before every axis was stored) reads
+	 * as invisible, matching PHP's `has_visible_shadow()` — `Number(undefined)` is `NaN`, which a bare
+	 * `!== 0` comparison would have counted as visible.
+	 *
+	 * @return {void}
+	 */
+	it('is false when an axis key is missing entirely', () => {
+		expect(hasVisibleShadow({ hOffset: 0, vOffset: 0 })).toBe(false);
+		expect(hasVisibleShadow({ color: '#000000' })).toBe(false);
+	});
+
+	/**
+	 * A non-numeric axis value is not a visible one either, for the same reason as a missing key.
+	 *
+	 * @return {void}
+	 */
+	it('is false for a non-numeric axis value', () => {
+		expect(hasVisibleShadow({ hOffset: '', vOffset: null, blur: 'none', spread: undefined })).toBe(false);
+	});
+
+	/**
+	 * Any single non-zero axis is enough to count the item as visible.
+	 *
+	 * @return {void}
+	 */
+	it('is true when any one axis is non-zero', () => {
+		expect(hasVisibleShadow({ hOffset: 0, vOffset: 0, blur: 2, spread: 0 })).toBe(true);
+	});
+});

--- a/src/blocks/singlebtn/components/backend-styles/__tests__/index.test.js
+++ b/src/blocks/singlebtn/components/backend-styles/__tests__/index.test.js
@@ -65,12 +65,12 @@ describe('hasVisibleShadow', () => {
 	});
 
 	/**
-	 * A non-numeric axis value is not a visible one either, for the same reason as a missing key.
+	 * An empty or nullish axis value is not a visible one, for the same reason as a missing key.
 	 *
 	 * @return {void}
 	 */
-	it('is false for a non-numeric axis value', () => {
-		expect(hasVisibleShadow({ hOffset: '', vOffset: null, blur: 'none', spread: undefined })).toBe(false);
+	it('is false for an empty or nullish axis value', () => {
+		expect(hasVisibleShadow({ hOffset: '', vOffset: null, blur: '   ', spread: undefined })).toBe(false);
 	});
 
 	/**
@@ -80,5 +80,15 @@ describe('hasVisibleShadow', () => {
 	 */
 	it('is true when any one axis is non-zero', () => {
 		expect(hasVisibleShadow({ hOffset: 0, vOffset: 0, blur: 2, spread: 0 })).toBe(true);
+	});
+	/**
+	 * A {dot.alias} token reference on any leg resolves to a var() whose value is unknown here, so it
+	 * counts as visible. Read as zero, the caller's `box-shadow: none` would erase a shadow the token
+	 * does paint. Mirrors the PHP renderer's own gate.
+	 *
+	 * @return {void}
+	 */
+	it('is true for a token alias reference on any leg', () => {
+		expect(hasVisibleShadow({ hOffset: 0, vOffset: 0, blur: '{primitive.shadow.md}', spread: 0 })).toBe(true);
 	});
 });

--- a/src/blocks/singlebtn/components/backend-styles/index.js
+++ b/src/blocks/singlebtn/components/backend-styles/index.js
@@ -79,6 +79,32 @@ export function presetShadowProperties(attributes) {
 	return 'button-shadow' in tokens;
 }
 
+/**
+ * Whether a native shadow item paints anything visible — all-zero offsets, blur, and spread
+ * render nothing regardless of color, matching the value the "None" pick now writes and mirroring
+ * the PHP renderer's `has_visible_shadow()`.
+ *
+ * @param {?Object} shadowItem One `shadow[0]`-shaped item.
+ *
+ * @since TBD
+ *
+ * @return {boolean} Whether the item has any non-zero offset, blur, or spread.
+ */
+export function hasVisibleShadow(shadowItem) {
+	if (!shadowItem) {
+		return false;
+	}
+
+	return ['hOffset', 'vOffset', 'blur', 'spread'].some((axis) => {
+		const value = Number(shadowItem[axis]);
+
+		// A missing or non-numeric axis is not a visible one. `Number(undefined)` is `NaN`, which fails a
+		// bare `!== 0` check as "visible" — the PHP renderer's `has_visible_shadow()` does not, and the
+		// canvas must not disagree with the front end.
+		return Number.isFinite(value) && value !== 0;
+	});
+}
+
 export default function BackendStyles(props) {
 	const { attributes, isSelected, previewDevice, currentRef, context } = props;
 
@@ -129,9 +155,7 @@ export default function BackendStyles(props) {
 		width,
 		widthUnit,
 		widthType,
-		displayShadow,
 		shadow,
-		displayHoverShadow,
 		shadowHover,
 		iconColor,
 		iconColorHover,
@@ -157,9 +181,7 @@ export default function BackendStyles(props) {
 		tabletBorderTransparentHoverRadius,
 		mobileBorderTransparentHoverRadius,
 		borderTransparentHoverRadiusUnit,
-		displayShadowTransparent,
 		shadowTransparent,
-		displayHoverShadowTransparent,
 		shadowTransparentHover,
 		colorSticky,
 		colorStickyHover,
@@ -183,9 +205,7 @@ export default function BackendStyles(props) {
 		tabletBorderStickyHoverRadius,
 		mobileBorderStickyHoverRadius,
 		borderStickyHoverRadiusUnit,
-		displayShadowSticky,
 		shadowSticky,
-		displayHoverShadowSticky,
 		shadowStickyHover,
 	} = attributes;
 
@@ -661,9 +681,7 @@ export default function BackendStyles(props) {
 	let btnBox2 = '';
 	const btnbgHover = 'gradient' === backgroundHoverType ? gradientHover : KadenceColorOutput(backgroundHover);
 	if (
-		undefined !== displayHoverShadow &&
-		displayHoverShadow &&
-		undefined !== shadowHover?.[0] &&
+		hasVisibleShadow(shadowHover?.[0]) &&
 		undefined !== shadowHover?.[0].inset &&
 		false === shadowHover?.[0].inset
 	) {
@@ -685,13 +703,7 @@ export default function BackendStyles(props) {
 		btnBox2 = 'none';
 		btnRad = '0';
 	}
-	if (
-		undefined !== displayHoverShadow &&
-		displayHoverShadow &&
-		undefined !== shadowHover?.[0] &&
-		undefined !== shadowHover?.[0].inset &&
-		true === shadowHover?.[0].inset
-	) {
+	if (hasVisibleShadow(shadowHover?.[0]) && undefined !== shadowHover?.[0].inset && true === shadowHover?.[0].inset) {
 		btnBox2 = `${
 			(undefined !== shadowHover?.[0].inset && shadowHover[0].inset ? 'inset ' : '') +
 			(undefined !== shadowHover?.[0].hOffset ? shadowHover[0].hOffset : 0) +
@@ -719,9 +731,7 @@ export default function BackendStyles(props) {
 			? gradientTransparentHover
 			: KadenceColorOutput(backgroundTransparentHover);
 	if (
-		undefined !== displayHoverShadowTransparent &&
-		displayHoverShadowTransparent &&
-		undefined !== shadowTransparentHover?.[0] &&
+		hasVisibleShadow(shadowTransparentHover?.[0]) &&
 		undefined !== shadowTransparentHover?.[0].inset &&
 		false === shadowTransparentHover?.[0].inset
 	) {
@@ -744,9 +754,7 @@ export default function BackendStyles(props) {
 		btnRadTransparent = '0';
 	}
 	if (
-		undefined !== displayHoverShadowTransparent &&
-		displayHoverShadowTransparent &&
-		undefined !== shadowTransparentHover?.[0] &&
+		hasVisibleShadow(shadowTransparentHover?.[0]) &&
 		undefined !== shadowTransparentHover?.[0].inset &&
 		true === shadowTransparentHover?.[0].inset
 	) {
@@ -775,9 +783,7 @@ export default function BackendStyles(props) {
 	const btnbgStickyHover =
 		'gradient' === backgroundStickyHoverType ? gradientStickyHover : KadenceColorOutput(backgroundStickyHover);
 	if (
-		undefined !== displayHoverShadowSticky &&
-		displayHoverShadowSticky &&
-		undefined !== shadowStickyHover?.[0] &&
+		hasVisibleShadow(shadowStickyHover?.[0]) &&
 		undefined !== shadowStickyHover?.[0].inset &&
 		false === shadowStickyHover?.[0].inset
 	) {
@@ -800,9 +806,7 @@ export default function BackendStyles(props) {
 		btnRadSticky = '0';
 	}
 	if (
-		undefined !== displayHoverShadowSticky &&
-		displayHoverShadowSticky &&
-		undefined !== shadowStickyHover?.[0] &&
+		hasVisibleShadow(shadowStickyHover?.[0]) &&
 		undefined !== shadowStickyHover?.[0].inset &&
 		true === shadowStickyHover?.[0].inset
 	) {
@@ -957,8 +961,7 @@ export default function BackendStyles(props) {
 
 	css.add_property(
 		'box-shadow',
-		undefined !== displayShadow &&
-			displayShadow &&
+		hasVisibleShadow(shadow?.[0]) &&
 			undefined !== shadow &&
 			undefined !== shadow[0] &&
 			undefined !== shadow[0].color
@@ -1092,8 +1095,7 @@ export default function BackendStyles(props) {
 		}
 		css.add_property(
 			'box-shadow',
-			undefined !== displayShadowTransparent &&
-				displayShadowTransparent &&
+			hasVisibleShadow(shadowTransparent?.[0]) &&
 				undefined !== shadowTransparent &&
 				undefined !== shadowTransparent[0] &&
 				undefined !== shadowTransparent[0].color
@@ -1203,8 +1205,7 @@ export default function BackendStyles(props) {
 		}
 		css.add_property(
 			'box-shadow',
-			undefined !== displayShadowSticky &&
-				displayShadowSticky &&
+			hasVisibleShadow(shadowSticky?.[0]) &&
 				undefined !== shadowSticky &&
 				undefined !== shadowSticky[0] &&
 				undefined !== shadowSticky[0].color

--- a/src/blocks/singlebtn/components/backend-styles/index.js
+++ b/src/blocks/singlebtn/components/backend-styles/index.js
@@ -96,11 +96,17 @@ export function hasVisibleShadow(shadowItem) {
 	}
 
 	return ['hOffset', 'vOffset', 'blur', 'spread'].some((axis) => {
-		const value = Number(shadowItem[axis]);
+		const raw = shadowItem[axis];
 
-		// A missing or non-numeric axis is not a visible one. `Number(undefined)` is `NaN`, which fails a
-		// bare `!== 0` check as "visible" — the PHP renderer's `has_visible_shadow()` does not, and the
-		// canvas must not disagree with the front end.
+		// A {dot.alias} leg resolves to a var() unknown here, so it counts as visible — read as zero, the
+		// caller's `box-shadow: none` would erase a shadow the token does paint. Mirrors the PHP gate.
+		if (typeof raw === 'string' && raw.trim() !== '' && !Number.isFinite(Number(raw))) {
+			return true;
+		}
+
+		const value = Number(raw);
+
+		// `Number(undefined)` is `NaN`, which a bare `!== 0` would read as visible; the PHP gate does not.
 		return Number.isFinite(value) && value !== 0;
 	});
 }

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -226,9 +226,7 @@ export default function KadenceButtonEdit(props) {
 		width,
 		widthUnit,
 		widthType,
-		displayShadow,
 		shadow,
-		displayHoverShadow,
 		shadowHover,
 		inheritStyles,
 		iconSize,
@@ -276,9 +274,7 @@ export default function KadenceButtonEdit(props) {
 		tabletBorderTransparentHoverRadius,
 		mobileBorderTransparentHoverRadius,
 		borderTransparentHoverRadiusUnit,
-		displayShadowTransparent,
 		shadowTransparent,
-		displayHoverShadowTransparent,
 		shadowTransparentHover,
 		colorSticky,
 		colorStickyHover,
@@ -302,9 +298,7 @@ export default function KadenceButtonEdit(props) {
 		tabletBorderStickyHoverRadius,
 		mobileBorderStickyHoverRadius,
 		borderStickyHoverRadiusUnit,
-		displayShadowSticky,
 		shadowSticky,
-		displayHoverShadowSticky,
 		shadowStickyHover,
 		tooltip,
 		tooltipPlacement,
@@ -1392,14 +1386,6 @@ export default function KadenceButtonEdit(props) {
 															label={__('Box Shadow', 'kadence-blocks')}
 															value={shadowHover}
 															onChange={(value) => setAttributes({ shadowHover: value })}
-															enable={
-																undefined !== displayHoverShadow
-																	? displayHoverShadow
-																	: false
-															}
-															onEnableChange={(value) =>
-																setAttributes({ displayHoverShadow: value })
-															}
 															tokens={shadowPickableTokens}
 															renderColor={renderShadowColor}
 														/>
@@ -1525,10 +1511,6 @@ export default function KadenceButtonEdit(props) {
 															label={__('Box Shadow', 'kadence-blocks')}
 															value={shadow}
 															onChange={(value) => setAttributes({ shadow: value })}
-															enable={undefined !== displayShadow ? displayShadow : false}
-															onEnableChange={(value) =>
-																setAttributes({ displayShadow: value })
-															}
 															tokens={shadowPickableTokens}
 															renderColor={renderShadowColor}
 														/>
@@ -1679,16 +1661,6 @@ export default function KadenceButtonEdit(props) {
 																onChange={(value) =>
 																	setAttributes({ shadowTransparentHover: value })
 																}
-																enable={
-																	undefined !== displayHoverShadowTransparent
-																		? displayHoverShadowTransparent
-																		: false
-																}
-																onEnableChange={(value) =>
-																	setAttributes({
-																		displayHoverShadowTransparent: value,
-																	})
-																}
 																tokens={shadowPickableTokens}
 																renderColor={renderShadowColor}
 															/>
@@ -1814,14 +1786,6 @@ export default function KadenceButtonEdit(props) {
 																value={shadowTransparent}
 																onChange={(value) =>
 																	setAttributes({ shadowTransparent: value })
-																}
-																enable={
-																	undefined !== displayShadowTransparent
-																		? displayShadowTransparent
-																		: false
-																}
-																onEnableChange={(value) =>
-																	setAttributes({ displayShadowTransparent: value })
 																}
 																tokens={shadowPickableTokens}
 																renderColor={renderShadowColor}
@@ -1965,14 +1929,6 @@ export default function KadenceButtonEdit(props) {
 																onChange={(value) =>
 																	setAttributes({ shadowStickyHover: value })
 																}
-																enable={
-																	undefined !== displayHoverShadowSticky
-																		? displayHoverShadowSticky
-																		: false
-																}
-																onEnableChange={(value) =>
-																	setAttributes({ displayHoverShadowSticky: value })
-																}
 																tokens={shadowPickableTokens}
 																renderColor={renderShadowColor}
 															/>
@@ -2092,14 +2048,6 @@ export default function KadenceButtonEdit(props) {
 																value={shadowSticky}
 																onChange={(value) =>
 																	setAttributes({ shadowSticky: value })
-																}
-																enable={
-																	undefined !== displayShadowSticky
-																		? displayShadowSticky
-																		: false
-																}
-																onEnableChange={(value) =>
-																	setAttributes({ displayShadowSticky: value })
 																}
 																tokens={shadowPickableTokens}
 																renderColor={renderShadowColor}

--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -21,11 +21,10 @@
  *   `splitColorOpacity` below are exported so a caller's `renderColor` can do that combine/split with
  *   the exact same rules this component uses to read/write the native attribute, keeping both
  *   directions symmetric.
- * - **`enable` lives outside the value entirely** — it is a separate sibling boolean attribute
- *   (`displayShadow`, `displayHoverShadow`, …), not a key inside the shadow array's item. This wrapper
- *   keeps it a plain `ToggleControl` rendered beside `BoxShadowControl`, matching how the native
- *   control also renders its enable toggle as an independent affordance next to the label, hiding the
- *   rest of the control's body while off.
+ * This control always renders `BoxShadowControl` — there is no separate enable toggle or sibling
+ * boolean attribute gating it. Whether a `box-shadow` declaration is emitted is decided purely by
+ * inspecting the shadow value's own axes (an all-zero value, including the fixed "None" pick, emits
+ * nothing), both on the front end and in the editor-canvas live preview.
  *
  * A whole-shadow token pick (the Style Library tab) has no home in the native item's existing keys —
  * unlike border, where an alias replaces a single side's width slot, a shadow alias would replace the
@@ -45,12 +44,6 @@
  * owns that wrapper rather than asking every call site to remember it, matching
  * `EditorBorderControl`/`EditorBoxControl`.
  */
-
-/**
- * WordPress dependencies
- */
-import { ToggleControl } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -307,68 +300,33 @@ export function toNativeShadow(value, tokens = []) {
 }
 
 /**
- * Render the editor-canvas box-shadow control: an `enable` toggle (the native attribute's own
- * sibling boolean, kept independent of the shadow value) beside `BoxShadowControl`, shown only while
- * enabled — matching the native `@kadence/components` `BoxShadowControl`'s own layout.
+ * Render the editor-canvas box-shadow control: `BoxShadowControl` always renders, with no separate
+ * enable toggle — whether a `box-shadow` is emitted is decided elsewhere, purely from the value's own
+ * axes.
  *
- * @param {Object}    props                The component props.
- * @param {string}    props.label          The control's label.
- * @param {?Array}    props.value          The native shadow attribute value.
- * @param {Function}  props.onChange       Called with the next native shadow attribute value.
- * @param {boolean}   props.enable         Whether the shadow is enabled (the sibling boolean attribute).
- * @param {Function}  props.onEnableChange Called with the next enabled state.
- * @param {Array}     [props.tokens]       Pickable `shadow`-type tokens, `[{id, label, value, alias}]`.
- * @param {?Function} [props.renderColor]  The block's existing color field for the composite's `color`.
- * @param {boolean}   [props.disabled]     Whether the control is read-only.
+ * @param {Object}    props               The component props.
+ * @param {string}    props.label         The control's label.
+ * @param {?Array}    props.value         The native shadow attribute value.
+ * @param {Function}  props.onChange      Called with the next native shadow attribute value.
+ * @param {Array}     [props.tokens]      Pickable `shadow`-type tokens, `[{id, label, value, alias}]`.
+ * @param {?Function} [props.renderColor] The block's existing color field for the composite's `color`.
+ * @param {boolean}   [props.disabled]    Whether the control is read-only.
  *
  * @since TBD
  *
  * @return {JSX.Element} The rendered control.
  */
-export function EditorShadowControl({
-	label,
-	value,
-	onChange,
-	enable,
-	onEnableChange,
-	tokens = [],
-	renderColor,
-	disabled = false,
-}) {
+export function EditorShadowControl({ label, value, onChange, tokens = [], renderColor, disabled = false }) {
 	return (
 		<TokenControlRow stacked>
-			<div className="kb-editor-shadow-control">
-				<div className="kb-editor-shadow-control__header">
-					{label && <span className="kb-editor-shadow-control__label">{label}</span>}
-					<ToggleControl
-						label={
-							label
-								? sprintf(
-										/* translators: %s: the field's own label, e.g. "Shadow". */ __(
-											'Enable %s',
-											'kadence-blocks'
-										),
-										label
-									)
-								: __('Enable shadow', 'kadence-blocks')
-						}
-						hideLabelFromVision
-						checked={!!enable}
-						onChange={onEnableChange}
-						disabled={disabled}
-					/>
-				</div>
-				{enable && (
-					<BoxShadowControl
-						label={undefined}
-						value={fromNativeShadow(value)}
-						onChange={(next) => onChange(toNativeShadow(next, tokens))}
-						tokens={tokens}
-						renderColor={renderColor}
-						disabled={disabled}
-					/>
-				)}
-			</div>
+			<BoxShadowControl
+				label={label}
+				value={fromNativeShadow(value)}
+				onChange={(next) => onChange(toNativeShadow(next, tokens))}
+				tokens={tokens}
+				renderColor={renderColor}
+				disabled={disabled}
+			/>
 		</TokenControlRow>
 	);
 }

--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -4,6 +4,7 @@
  * Internal dependencies
  */
 import { EditorShadowControl, combineColorOpacity, splitColorOpacity, toNativeShadow } from '../EditorShadowControl';
+import { BoxShadowControl } from '../../../../token-controls/controls/BoxShadowControl';
 
 /**
  * A representative native shadow value — every field a different, distinguishable number/string, so a
@@ -26,45 +27,38 @@ const NATIVE_VALUE = [
 ];
 
 /**
- * Call `EditorShadowControl` as a plain function and return the `BoxShadowControl`/`ToggleControl`
- * elements it produced. The component holds no hooks of its own — `TokenControlRow` is referenced in
- * the returned JSX but never invoked by this plain call, since JSX only builds element descriptors — so
- * the returned element tree can be inspected directly instead of mounting it, matching
+ * Call `EditorShadowControl` as a plain function and return the `BoxShadowControl` element it
+ * produced. The component holds no hooks of its own — `TokenControlRow` is referenced in the returned
+ * JSX but never invoked by this plain call, since JSX only builds element descriptors — so the
+ * returned element tree can be inspected directly instead of mounting it, matching
  * `EditorBorderControl.test.js`'s own harness (before it gained state and needed a real render).
  *
  * @param {Object} overrides Props to override on top of the defaults.
  *
  * @since TBD
  *
- * @return {{root: Object, header: Object, toggle: Object, shadowControl: ?Object, onChange: Function,
- *   onEnableChange: Function}} The root element (`TokenControlRow`), the header row, the enable
- *   toggle, the `BoxShadowControl` element (or `null` when `enable` is false), and the setter spies
+ * @return {{root: Object, shadowControl: Object, onChange: Function}} The root element
+ *   (`TokenControlRow`), the `BoxShadowControl` element it always renders, and the `onChange` spy
  *   passed in.
  */
 function renderEditorShadowControl(overrides = {}) {
 	const onChange = jest.fn();
-	const onEnableChange = jest.fn();
 
 	const props = {
 		label: 'Box Shadow',
 		value: NATIVE_VALUE,
 		onChange,
-		enable: true,
-		onEnableChange,
 		tokens: [],
 		...overrides,
 	};
 
 	const root = EditorShadowControl(props);
-	const [header, shadowControl] = root.props.children.props.children;
+	const shadowControl = root.props.children;
 
 	return {
 		root,
-		header,
-		toggle: header.props.children[1],
-		shadowControl: shadowControl || null,
+		shadowControl,
 		onChange,
-		onEnableChange,
 	};
 }
 
@@ -259,57 +253,30 @@ describe('EditorShadowControl native <-> BoxShadowControl value bridging', () =>
 	});
 });
 
-describe('EditorShadowControl enable toggle', () => {
+describe('EditorShadowControl always renders, with no enable toggle', () => {
 	/**
-	 * The enable toggle reads and writes the sibling boolean attribute independently of the shadow
-	 * value's shape — it stays functional whether the value is a token or a composite literal.
+	 * `BoxShadowControl` always renders — there is no separate enable toggle gating it, and no
+	 * sibling boolean attribute involved.
 	 *
 	 * @return {void}
 	 */
-	it('reflects the enable prop and writes through onEnableChange, independent of the value shape', () => {
-		const { toggle, onEnableChange } = renderEditorShadowControl({ enable: false });
+	it('always renders BoxShadowControl, with no enable toggle', () => {
+		const { root, shadowControl } = renderEditorShadowControl();
 
-		expect(toggle.props.checked).toBe(false);
-
-		toggle.props.onChange(true);
-		expect(onEnableChange).toHaveBeenCalledWith(true);
+		expect(shadowControl.type).toBe(BoxShadowControl);
+		expect(root.props.children).toBe(shadowControl);
 	});
 
 	/**
-	 * `BoxShadowControl` renders only while enabled, matching the native control's own layout — a
-	 * caller should not be able to edit a shadow value that is currently switched off.
+	 * The control's `label` is passed straight through to `BoxShadowControl` — there is no separate
+	 * header row that used to carry it alongside the (now removed) enable toggle.
 	 *
 	 * @return {void}
 	 */
-	it('hides BoxShadowControl while disabled', () => {
-		const { shadowControl } = renderEditorShadowControl({ enable: false });
+	it('passes label straight through to BoxShadowControl', () => {
+		const { shadowControl } = renderEditorShadowControl({ label: 'Box Shadow' });
 
-		expect(shadowControl).toBeNull();
-	});
-
-	/**
-	 * The toggle has no visible text of its own (the field's label sits in a separate, unassociated
-	 * sibling `<span>`), so it needs its own accessible name rather than relying on that span.
-	 *
-	 * @return {void}
-	 */
-	it('gives the toggle an accessible name derived from the field label, hidden visually', () => {
-		const { toggle } = renderEditorShadowControl({ label: 'Box Shadow' });
-
-		expect(toggle.props.label).toBe('Enable Box Shadow');
-		expect(toggle.props.hideLabelFromVision).toBe(true);
-	});
-
-	/**
-	 * A caller that omits `label` entirely still gets a usable, generic accessible name rather than an
-	 * empty or undefined one.
-	 *
-	 * @return {void}
-	 */
-	it('falls back to a generic accessible name when no label is given', () => {
-		const { toggle } = renderEditorShadowControl({ label: undefined });
-
-		expect(toggle.props.label).toBe('Enable shadow');
+		expect(shadowControl.props.label).toBe('Box Shadow');
 	});
 });
 

--- a/tests/wpunit/Blocks/SinglebtnTest.php
+++ b/tests/wpunit/Blocks/SinglebtnTest.php
@@ -261,6 +261,26 @@ class SinglebtnTest extends KadenceBlocksUnit {
 			],
 			'expected_visible' => true,
 		];
+
+		yield 'token alias on a leg' => [
+			'item'     => [
+				'hOffset' => 0,
+				'vOffset' => 0,
+				'blur'    => '{primitive.shadow.md}',
+				'spread'  => 0,
+			],
+			'expected' => true,
+		];
+
+		yield 'empty string legs' => [
+			'item'     => [
+				'hOffset' => '',
+				'vOffset' => '',
+				'blur'    => '',
+				'spread'  => '',
+			],
+			'expected' => false,
+		];
 		yield 'non-zero offset' => [
 			'shadow_item'      => [
 				'hOffset' => 1,

--- a/tests/wpunit/Blocks/SinglebtnTest.php
+++ b/tests/wpunit/Blocks/SinglebtnTest.php
@@ -178,9 +178,8 @@ class SinglebtnTest extends KadenceBlocksUnit {
 
 		$output = $this->render_button(
 			[
-				'kbPreset'      => 'accent',
-				'displayShadow' => true,
-				'shadow'        => [
+				'kbPreset' => 'accent',
+				'shadow'   => [
 					[
 						'color'   => '#00ff00',
 						'opacity' => 1,
@@ -213,6 +212,129 @@ class SinglebtnTest extends KadenceBlocksUnit {
 		// not the preset's, is what the button actually renders. Sabberworm's CSS parser canonicalizes
 		// a 6-digit hex that can shorten to its 3-digit form when re-serializing, so the shorthand is
 		// what assertCSSPropertiesEqual sees even though the block itself renders the literal '#00ff00'.
+		$css_helper->assertCSSPropertiesEqual( $selector, [ 'box-shadow' => '1px 1px 2px 0px #0f0' ] );
+	}
+
+	/**
+	 * A shadow item's own axes decide whether `box-shadow` is emitted, with no separate toggle or
+	 * sibling boolean attribute gating it.
+	 *
+	 * @dataProvider shadowVisibilityProvider
+	 *
+	 * @param array<string, mixed> $shadow_item      The `shadow[0]`-shaped item.
+	 * @param bool                 $expected_visible Whether the item should be treated as visible.
+	 *
+	 * @return void
+	 */
+	public function testHasVisibleShadow( array $shadow_item, bool $expected_visible ): void {
+		$method = new \ReflectionMethod( $this->block, 'has_visible_shadow' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected_visible, $method->invoke( $this->block, $shadow_item ) );
+	}
+
+	/**
+	 * @return \Generator
+	 */
+	public function shadowVisibilityProvider(): \Generator {
+		yield 'all-zero axes' => [
+			'shadow_item'      => [
+				'hOffset' => 0,
+				'vOffset' => 0,
+				'blur'    => 0,
+				'spread'  => 0,
+				'color'   => 'transparent',
+			],
+			'expected_visible' => false,
+		];
+		yield 'missing axis keys' => [
+			'shadow_item'      => [ 'color' => '#000000' ],
+			'expected_visible' => false,
+		];
+		yield 'non-zero blur' => [
+			'shadow_item'      => [
+				'hOffset' => 0,
+				'vOffset' => 0,
+				'blur'    => 2,
+				'spread'  => 0,
+				'color'   => '#000000',
+			],
+			'expected_visible' => true,
+		];
+		yield 'non-zero offset' => [
+			'shadow_item'      => [
+				'hOffset' => 1,
+				'vOffset' => 1,
+				'blur'    => 0,
+				'spread'  => 0,
+				'color'   => '#000000',
+			],
+			'expected_visible' => true,
+		];
+	}
+
+	/**
+	 * An all-zero shadow value — the shape the fixed "None" pick writes — emits no explicit
+	 * `box-shadow` declaration, now that there is no separate toggle to suppress it.
+	 *
+	 * @return void
+	 */
+	public function testNoneShadowEmitsNoExplicitBoxShadow(): void {
+		$this->seedPreset( 'bare', 'Bare', [ 'button-bg' => '#ff0000' ] );
+
+		$output = $this->render_button(
+			[
+				'kbPreset' => 'bare',
+				'shadow'   => [
+					[
+						'color'   => 'transparent',
+						'opacity' => 1,
+						'hOffset' => 0,
+						'vOffset' => 0,
+						'blur'    => 0,
+						'spread'  => 0,
+						'inset'   => false,
+					],
+				],
+			]
+		);
+
+		$css_helper       = new CSSTestHelper( $output );
+		$selector         = '.wp-block-kadence-advancedbtn .kb-btn123.kb-button';
+		$shadow_positions = array_keys( $css_helper->getPropertyOrder( $selector ), 'box-shadow', true );
+
+		$this->assertCount( 0, $shadow_positions, 'An all-zero shadow value should emit no explicit box-shadow declaration.' );
+	}
+
+	/**
+	 * A shadow value with a non-zero axis emits an explicit `box-shadow` declaration, with no toggle
+	 * needed to opt in.
+	 *
+	 * @return void
+	 */
+	public function testVisibleShadowEmitsExplicitBoxShadow(): void {
+		$this->seedPreset( 'bare', 'Bare', [ 'button-bg' => '#ff0000' ] );
+
+		$output = $this->render_button(
+			[
+				'kbPreset' => 'bare',
+				'shadow'   => [
+					[
+						'color'   => '#00ff00',
+						'opacity' => 1,
+						'hOffset' => 1,
+						'vOffset' => 1,
+						'blur'    => 2,
+						'spread'  => 0,
+						'inset'   => false,
+					],
+				],
+			]
+		);
+
+		$css_helper = new CSSTestHelper( $output );
+		$selector   = '.wp-block-kadence-advancedbtn .kb-btn123.kb-button';
+
 		$css_helper->assertCSSPropertiesEqual( $selector, [ 'box-shadow' => '1px 1px 2px 0px #0f0' ] );
 	}
 

--- a/tests/wpunit/Blocks/SinglebtnTest.php
+++ b/tests/wpunit/Blocks/SinglebtnTest.php
@@ -263,23 +263,23 @@ class SinglebtnTest extends KadenceBlocksUnit {
 		];
 
 		yield 'token alias on a leg' => [
-			'item'     => [
+			'shadow_item'      => [
 				'hOffset' => 0,
 				'vOffset' => 0,
 				'blur'    => '{primitive.shadow.md}',
 				'spread'  => 0,
 			],
-			'expected' => true,
+			'expected_visible' => true,
 		];
 
 		yield 'empty string legs' => [
-			'item'     => [
+			'shadow_item'      => [
 				'hOffset' => '',
-				'vOffset' => '',
+				'vOffset' => '   ',
 				'blur'    => '',
 				'spread'  => '',
 			],
-			'expected' => false,
+			'expected_visible' => false,
 		];
 		yield 'non-zero offset' => [
 			'shadow_item'      => [


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4260/token-control-popover-options-and-the-default-label-show-what-is

Removes the six "Enable Box Shadow" toggles (`displayShadow`, `displayHoverShadow`, and their transparent/sticky twins). Whether a shadow renders is now decided from the value itself: a shadow with no visible geometry and no visible color emits nothing.

The toggle was a second source of truth for a question the value already answers, and the two could disagree — a toggled-off button could still carry a full shadow value, and a toggled-on one could carry nothing. Now the fixed `None` pick expresses "no shadow" directly, which is what makes the toggle redundant rather than merely redundant-looking.

`has_visible_shadow()` (PHP) and `hasVisibleShadow()` (the editor canvas) implement the same test, so the front end and the canvas cannot disagree. A `{dot.alias}` leg counts as visible, since its resolved value is unknown at that point and treating it as zero would erase a shadow the token does paint.

Legacy attribute data is migrated in the next slice.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved button shadow rendering so shadows appear only when they contain visible offset, blur, or spread values.
  * Removed unintended fallback shadows when no shadow styling is configured.
  * Applied consistent shadow behavior across normal, hover, transparent, and sticky button states.
* **Enhancements**
  * Simplified shadow controls by removing separate shadow enable/disable toggles.
  * Preserved support for gradient hover shadows, including inset shadows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->