### PR TITLE
[DTM] SOFT-4260 [9/19]: migrate legacy toggled-off shadow data via a block deprecation

### DIFF
--- a/src/blocks/singlebtn/__tests__/deprecated.test.js
+++ b/src/blocks/singlebtn/__tests__/deprecated.test.js
@@ -1,0 +1,151 @@
+/* eslint-env jest */
+import metadata from '../block.json';
+import deprecated from '../deprecated';
+
+const [{ attributes, supports, isEligible, migrate }] = deprecated;
+
+const NONE_ITEM = { color: 'transparent', hOffset: 0, vOffset: 0, blur: 0, spread: 0, inset: false, opacity: 1 };
+
+const LEGACY_SHADOW_DEFAULTS = {
+	shadow: [{ color: '#000000', opacity: 0.2, spread: 0, blur: 2, hOffset: 1, vOffset: 1, inset: false }],
+	shadowHover: [{ color: '#000000', opacity: 0.4, spread: 0, blur: 3, hOffset: 2, vOffset: 2, inset: false }],
+	shadowTransparent: [{ color: '#000000', opacity: 0.2, spread: 0, blur: 2, hOffset: 1, vOffset: 1, inset: false }],
+	shadowTransparentHover: [
+		{ color: '#000000', opacity: 0.4, spread: 0, blur: 3, hOffset: 2, vOffset: 2, inset: false },
+	],
+	shadowSticky: [{ color: '#000000', opacity: 0.2, spread: 0, blur: 2, hOffset: 1, vOffset: 1, inset: false }],
+	shadowStickyHover: [{ color: '#000000', opacity: 0.4, spread: 0, blur: 3, hOffset: 2, vOffset: 2, inset: false }],
+};
+
+const TOGGLE_ATTRIBUTES = [
+	'displayShadow',
+	'displayHoverShadow',
+	'displayShadowTransparent',
+	'displayHoverShadowTransparent',
+	'displayShadowSticky',
+	'displayHoverShadowSticky',
+];
+
+/**
+ * Split raw saved attributes into the pair `isEligible` would see if the first argument were parsed
+ * against the block's CURRENT schema: legacy toggles filtered out, everything else kept.
+ *
+ * @param {Object} rawAttrs The unfiltered JSON from the saved block comment.
+ *
+ * @since TBD
+ *
+ * @return {Object} The schema-filtered attributes.
+ */
+function schemaFiltered(rawAttrs) {
+	return Object.fromEntries(Object.entries(rawAttrs).filter(([key]) => key in metadata.attributes));
+}
+
+describe('kadence/singlebtn deprecated migration', () => {
+	it('declares the current attribute schema plus the six legacy toggles', () => {
+		Object.keys(metadata.attributes).forEach((key) => expect(attributes).toHaveProperty(key));
+		TOGGLE_ATTRIBUTES.forEach((key) => expect(attributes[key]).toEqual({ type: 'boolean', default: false }));
+	});
+
+	it('rolls the six shadow attribute defaults back to their pre-removal values', () => {
+		Object.entries(LEGACY_SHADOW_DEFAULTS).forEach(([key, legacyDefault]) => {
+			expect(attributes[key]).toEqual({ type: 'array', default: legacyDefault });
+			expect(attributes[key].default).not.toEqual(metadata.attributes[key].default);
+		});
+	});
+
+	it('leaves every non-shadow attribute default exactly as the current schema declares it', () => {
+		Object.keys(metadata.attributes)
+			.filter((key) => !(key in LEGACY_SHADOW_DEFAULTS))
+			.forEach((key) => expect(attributes[key]).toEqual(metadata.attributes[key]));
+	});
+
+	it("declares the block's own supports, so support-gated attribute filters still apply", () => {
+		expect(supports).toEqual(metadata.supports);
+	});
+
+	it('is eligible when the legacy data arrives through the attributes argument alone', () => {
+		expect(isEligible({ displayShadow: true }, [], undefined)).toBe(true);
+		expect(isEligible({ displayHoverShadowSticky: false })).toBe(true);
+	});
+
+	it('is eligible when the legacy data arrives through the raw parsed block node', () => {
+		const raw = { text: 'Click Me!', displayShadow: false };
+
+		expect(isEligible(schemaFiltered(raw), [], { blockNode: { attrs: raw } })).toBe(true);
+	});
+
+	it('is eligible when the legacy data arrives through the created block object', () => {
+		const raw = { text: 'Click Me!', displayHoverShadowSticky: false };
+
+		expect(isEligible(schemaFiltered(raw), [], { block: { name: 'kadence/singlebtn', attrs: raw } })).toBe(true);
+	});
+
+	it('is not eligible for an already-migrated block, whichever source is consulted', () => {
+		const raw = { text: 'Click Me!', shadow: [{ ...NONE_ITEM }] };
+
+		expect(isEligible(raw, [], { blockNode: { attrs: raw }, block: { attrs: raw } })).toBe(false);
+		expect(isEligible({ text: 'Click Me!' }, [], {})).toBe(false);
+		expect(isEligible({ text: 'Click Me!' }, [], undefined)).toBe(false);
+		expect(isEligible(undefined, [], undefined)).toBe(false);
+	});
+
+	it('rewrites a toggled-off value to the explicit None composite and drops the toggle', () => {
+		const next = migrate({
+			text: 'Click Me!',
+			displayShadow: false,
+			shadow: [{ color: '#000000', opacity: 0.2, hOffset: 1, vOffset: 1, blur: 2, spread: 0, inset: false }],
+		});
+
+		expect(next.shadow).toEqual([NONE_ITEM]);
+		expect(next).not.toHaveProperty('displayShadow');
+		expect(next.text).toBe('Click Me!');
+	});
+
+	it('leaves a toggled-on value untouched, only dropping the toggle', () => {
+		const original = [{ color: '#ff0000', opacity: 1, hOffset: 2, vOffset: 2, blur: 4, spread: 0, inset: false }];
+
+		const next = migrate({ displayShadow: true, shadow: original });
+
+		expect(next.shadow).toEqual(original);
+		expect(next).not.toHaveProperty('displayShadow');
+	});
+
+	it('treats a missing toggle attribute (very old data) as toggle-off', () => {
+		const next = migrate({ shadow: [{ color: '#000000', hOffset: 1, vOffset: 1, blur: 2, spread: 0 }] });
+
+		expect(next.shadow).toEqual([NONE_ITEM]);
+	});
+
+	it('migrates all six pairs independently', () => {
+		const next = migrate({
+			displayShadow: true,
+			displayHoverShadow: false,
+			displayShadowTransparent: false,
+			displayHoverShadowTransparent: true,
+			displayShadowSticky: false,
+			displayHoverShadowSticky: false,
+			shadow: [{ color: '#111', hOffset: 1, vOffset: 1, blur: 1, spread: 0 }],
+			shadowHover: [{ color: '#222', hOffset: 2, vOffset: 2, blur: 2, spread: 0 }],
+			shadowTransparent: [{ color: '#333', hOffset: 3, vOffset: 3, blur: 3, spread: 0 }],
+			shadowTransparentHover: [{ color: '#444', hOffset: 4, vOffset: 4, blur: 4, spread: 0 }],
+			shadowSticky: [{ color: '#555', hOffset: 5, vOffset: 5, blur: 5, spread: 0 }],
+			shadowStickyHover: [{ color: '#666', hOffset: 6, vOffset: 6, blur: 6, spread: 0 }],
+		});
+
+		expect(next.shadow).not.toEqual([NONE_ITEM]); // toggle was true — untouched
+		expect(next.shadowHover).toEqual([NONE_ITEM]);
+		expect(next.shadowTransparent).toEqual([NONE_ITEM]);
+		expect(next.shadowTransparentHover).not.toEqual([NONE_ITEM]); // toggle was true — untouched
+		expect(next.shadowSticky).toEqual([NONE_ITEM]);
+		expect(next.shadowStickyHover).toEqual([NONE_ITEM]);
+		TOGGLE_ATTRIBUTES.forEach((attr) => expect(next).not.toHaveProperty(attr));
+	});
+
+	it('preserves every unrelated attribute it is handed', () => {
+		const next = migrate({ text: 'Buy now', link: 'https://example.com', color: '#123456', displayShadow: false });
+
+		expect(next.text).toBe('Buy now');
+		expect(next.link).toBe('https://example.com');
+		expect(next.color).toBe('#123456');
+	});
+});

--- a/src/blocks/singlebtn/block.js
+++ b/src/blocks/singlebtn/block.js
@@ -9,6 +9,7 @@ import metadata from './block.json';
  */
 import { advancedBtnIcon } from '@kadence/icons';
 import edit from './edit';
+import deprecated from './deprecated';
 
 /**
  * Internal block libraries
@@ -42,4 +43,5 @@ registerBlockType('kadence/singlebtn', {
 			text: __('Click Me!', 'kadence-blocks'),
 		},
 	},
+	deprecated,
 });

--- a/src/blocks/singlebtn/deprecated.js
+++ b/src/blocks/singlebtn/deprecated.js
@@ -1,0 +1,164 @@
+/**
+ * Folds the six legacy `[displayShadow*, shadow*]` attribute pairs into the shadow control's own
+ * "None" pick: a toggled-off value becomes the explicit zero/transparent composite, and the toggle
+ * attribute is dropped either way.
+ *
+ * Needs `isEligible`, not just `migrate`: this block is fully dynamic (`save()` returns `null`), so
+ * Gutenberg's validation trivially passes against every prior version and never reaches `deprecated`
+ * on a mismatch. `isEligible` runs regardless, which is what lets an attribute-only migration fire.
+ *
+ * It unions `attributes`, `blockNode.attrs` and `block.attrs` when looking for the legacy keys —
+ * which of the three carries them for a schema that no longer declares them is not settled, and the
+ * union is correct under every reading.
+ *
+ * Known gap: a button toggled on, customized, then toggled back off kept its value with no toggle
+ * key, which is byte-identical to a shadow picked on a new block. That shape cannot be migrated
+ * without erasing shadows nobody meant to lose, so those buttons will show a shadow they previously
+ * kept hidden — a one-time cosmetic change on old content.
+ *
+ * The deprecation-local `attributes` and `supports` are load-bearing, not boilerplate: `migrate`'s
+ * return value replaces the block's ENTIRE attribute set, so without them it would be handed `{}`
+ * and wipe out text, colors, link and sizing. `supports` matters for the same reason — this plugin
+ * injects attributes through support-gated `registerBlockType` filters.
+ */
+
+import metadata from './block.json';
+
+/**
+ * The zero/transparent shadow item written for any pair whose legacy toggle was off (or missing —
+ * very old data predating the toggle entirely is treated the same way).
+ *
+ * @since TBD
+ */
+const NONE_SHADOW_ITEM = { color: 'transparent', hOffset: 0, vOffset: 0, blur: 0, spread: 0, inset: false, opacity: 1 };
+
+/**
+ * The six legacy `[toggleAttr, valueAttr]` pairs, one per shadow state.
+ *
+ * @since TBD
+ */
+const SHADOW_ATTRIBUTE_PAIRS = [
+	['displayShadow', 'shadow'],
+	['displayHoverShadow', 'shadowHover'],
+	['displayShadowTransparent', 'shadowTransparent'],
+	['displayHoverShadowTransparent', 'shadowTransparentHover'],
+	['displayShadowSticky', 'shadowSticky'],
+	['displayHoverShadowSticky', 'shadowStickyHover'],
+];
+
+/**
+ * The six shadow value attributes' defaults as they stood BEFORE the "Enable Box Shadow" toggle was
+ * removed, keyed by attribute.
+ *
+ * Gutenberg omits an attribute equal to its registered default, so a button toggled ON but never
+ * adjusted saved `displayShadow` and no `shadow` key. Parsed against the current schema it would
+ * resolve to the new zero/transparent default and lose its shadow; registering the historical
+ * defaults here makes the parser fill in what the block actually rendered.
+ *
+ * @since TBD
+ */
+const LEGACY_SHADOW_DEFAULTS = {
+	shadow: [{ color: '#000000', opacity: 0.2, spread: 0, blur: 2, hOffset: 1, vOffset: 1, inset: false }],
+	shadowHover: [{ color: '#000000', opacity: 0.4, spread: 0, blur: 3, hOffset: 2, vOffset: 2, inset: false }],
+	shadowTransparent: [{ color: '#000000', opacity: 0.2, spread: 0, blur: 2, hOffset: 1, vOffset: 1, inset: false }],
+	shadowTransparentHover: [
+		{ color: '#000000', opacity: 0.4, spread: 0, blur: 3, hOffset: 2, vOffset: 2, inset: false },
+	],
+	shadowSticky: [{ color: '#000000', opacity: 0.2, spread: 0, blur: 2, hOffset: 1, vOffset: 1, inset: false }],
+	shadowStickyHover: [{ color: '#000000', opacity: 0.4, spread: 0, blur: 3, hOffset: 2, vOffset: 2, inset: false }],
+};
+
+/**
+ * The deprecated block's own attribute schema: the current schema, with the six shadow attributes'
+ * defaults rolled back to their pre-removal values and the six legacy boolean toggles added in their
+ * pre-removal shape, so `migrate` receives (and returns) a complete, historically-faithful attribute
+ * set.
+ *
+ * @since TBD
+ */
+const deprecatedAttributes = {
+	...metadata.attributes,
+	...Object.fromEntries(
+		Object.entries(LEGACY_SHADOW_DEFAULTS).map(([valueAttr, legacyDefault]) => [
+			valueAttr,
+			{ ...metadata.attributes[valueAttr], default: legacyDefault },
+		])
+	),
+	...Object.fromEntries(
+		SHADOW_ATTRIBUTE_PAIRS.map(([toggleAttr]) => [toggleAttr, { type: 'boolean', default: false }])
+	),
+};
+
+/**
+ * Whether a saved block still carries a legacy `display*` toggle key this deprecation has to fold in.
+ *
+ * Gutenberg omits any attribute equal to its registered default, so a toggle flipped (either way)
+ * away from its `false` default leaves a `display*` key present in the saved markup. The paired
+ * shadow value may be missing entirely (it matched the old default) — the deprecation's own schema
+ * supplies the historical default for it (see above).
+ *
+ * Looks in every place the legacy keys could plausibly live — the parsed `attributes`, the raw
+ * parsed node (`blockNode.attrs`) and the block object (`block.attrs`) — because which one carries
+ * unfiltered comment JSON for an attribute the current schema no longer declares is not something
+ * this codebase can confirm without a live editor. The union is right whichever it turns out to be.
+ *
+ * @param {Object}   attributes  The block's parsed attributes.
+ * @param {Object[]} innerBlocks The block's inner blocks.
+ * @param {Object}   context     Parser context, carrying `blockNode` and `block`.
+ *
+ * @since TBD
+ *
+ * @return {boolean} Whether this deprecation should run its migration.
+ */
+function isEligible(attributes, innerBlocks, context) {
+	const rawAttributes = {
+		...(attributes ?? {}),
+		...(context?.blockNode?.attrs ?? {}),
+		...(context?.block?.attrs ?? {}),
+	};
+
+	return SHADOW_ATTRIBUTE_PAIRS.some(([toggleAttr]) => toggleAttr in rawAttributes);
+}
+
+/**
+ * Fold every legacy toggle/value pair into the shadow control's own "None" pick, then drop the toggle.
+ *
+ * Runs over all six pairs unconditionally, not just the one `isEligible` found a toggle key for: any
+ * pair whose toggle is not exactly `true` (including one with no toggle key at all, i.e. already at
+ * its implicit `false` default) gets its value rewritten to the explicit None composite. For a block
+ * where only one pair carried a toggle key, the other five are already at their equivalent default, so
+ * this is a no-op in rendered output — but it does explicitly serialize the None shape for every pair,
+ * not just the one that made the block eligible.
+ *
+ * @param {Object} attributes The block's attributes, parsed against this deprecation's own schema
+ *                            (so the six legacy booleans are present here).
+ *
+ * @since TBD
+ *
+ * @return {Object} The migrated attributes — the complete attribute set for the block.
+ */
+function migrate(attributes) {
+	const next = { ...attributes };
+
+	SHADOW_ATTRIBUTE_PAIRS.forEach(([toggleAttr, valueAttr]) => {
+		if (next[toggleAttr] !== true) {
+			next[valueAttr] = [{ ...NONE_SHADOW_ITEM }];
+		}
+
+		delete next[toggleAttr];
+	});
+
+	return next;
+}
+
+export default [
+	{
+		attributes: deprecatedAttributes,
+		supports: metadata.supports,
+		isEligible,
+		migrate,
+		save() {
+			return null;
+		},
+	},
+];


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4260/token-control-popover-options-and-the-default-label-show-what-is

Migrates data written before the previous slice removed the six "Enable Box Shadow" toggles. A toggled-off shadow becomes the explicit zero/transparent composite — the shape the fixed `None` pick writes — and the toggle attribute is dropped either way.

Two things here are load-bearing and easy to mistake for boilerplate:

- **`isEligible`, not just `migrate`.** This block is fully dynamic (`save()` returns `null`), so Gutenberg's validation trivially passes against every prior version and never reaches `deprecated` on a mismatch. `isEligible` runs regardless, which is what lets an attribute-only migration fire at all.
- **The deprecation-local `attributes` and `supports`.** `migrate`'s return value replaces the block's *entire* attribute set, so without them it would be handed `{}` and wipe out text, colors, link and sizing.

**Known gap, accepted:** a button toggled on, customized, then toggled back off kept its value with no toggle key — byte-identical to a shadow picked on a new block. That shape cannot be migrated without erasing shadows nobody meant to lose, so those buttons will show a shadow they previously kept hidden. One-time, cosmetic, on old content only.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when editing older Single Button blocks.
  * Preserved legacy shadow settings and converted disabled or missing shadow options to “None.”
  * Removed outdated shadow toggles while retaining other block attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->