### PR TITLE
[DTM] SOFT-4260 [10/19]: un-register the unused button padding/margin tokens

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -455,38 +455,6 @@
 			"heading-padding": {
 				"$type": "dimension",
 				"$value": "0"
-			},
-			"button-padding-top": {
-				"$type": "dimension",
-				"$value": "0.4em"
-			},
-			"button-padding-right": {
-				"$type": "dimension",
-				"$value": "1em"
-			},
-			"button-padding-bottom": {
-				"$type": "dimension",
-				"$value": "0.4em"
-			},
-			"button-padding-left": {
-				"$type": "dimension",
-				"$value": "1em"
-			},
-			"button-margin-top": {
-				"$type": "dimension",
-				"$value": "0"
-			},
-			"button-margin-right": {
-				"$type": "dimension",
-				"$value": "0"
-			},
-			"button-margin-bottom": {
-				"$type": "dimension",
-				"$value": "0"
-			},
-			"button-margin-left": {
-				"$type": "dimension",
-				"$value": "0"
 			}
 		},
 		"radius": {
@@ -780,16 +748,16 @@
 							"button-border-style": "{semantic.border-style.default}",
 							"button-border-color": "{semantic.color.border}",
 							"button-padding": [
-								"{semantic.spacing.button-padding-top}",
-								"{semantic.spacing.button-padding-right}",
-								"{semantic.spacing.button-padding-bottom}",
-								"{semantic.spacing.button-padding-left}"
+								"0.4em",
+								"1em",
+								"0.4em",
+								"1em"
 							],
 							"button-margin": [
-								"{semantic.spacing.button-margin-top}",
-								"{semantic.spacing.button-margin-right}",
-								"{semantic.spacing.button-margin-bottom}",
-								"{semantic.spacing.button-margin-left}"
+								"0",
+								"0",
+								"0",
+								"0"
 							]
 						}
 					},
@@ -805,16 +773,16 @@
 							"button-border-style": "{semantic.border-style.default}",
 							"button-border-color": "{semantic.color.border}",
 							"button-padding": [
-								"{semantic.spacing.button-padding-top}",
-								"{semantic.spacing.button-padding-right}",
-								"{semantic.spacing.button-padding-bottom}",
-								"{semantic.spacing.button-padding-left}"
+								"0.4em",
+								"1em",
+								"0.4em",
+								"1em"
 							],
 							"button-margin": [
-								"{semantic.spacing.button-margin-top}",
-								"{semantic.spacing.button-margin-right}",
-								"{semantic.spacing.button-margin-bottom}",
-								"{semantic.spacing.button-margin-left}"
+								"0",
+								"0",
+								"0",
+								"0"
 							]
 						}
 					}

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -400,68 +400,6 @@ return [
 				'group' => __( 'Media', 'kadence-blocks' ),
 			],
 			[
-				/**
-				 * Button padding, split one semantic token per side (a shorthand like "0.4em 1em" fails the
-				 * dimension literal's single-value shape). Registered so Css_Var emits
-				 * --kb-token--semantic--spacing--button-padding-top; the button's own default padding rule
-				 * references that variable directly (the button is never empty, so the low-specificity
-				 * block-default CSS mechanism can't reach it). Resolves to the button's long-standing 0.4em,
-				 * so an existing site that never set padding renders unchanged.
-				 */
-				'id'    => 'semantic.spacing.button-padding-top',
-				'type'  => 'dimension',
-				'label' => __( 'Button Padding Top', 'kadence-blocks' ),
-				'group' => __( 'Brand', 'kadence-blocks' ),
-			],
-			[
-				'id'    => 'semantic.spacing.button-padding-right',
-				'type'  => 'dimension',
-				'label' => __( 'Button Padding Right', 'kadence-blocks' ),
-				'group' => __( 'Brand', 'kadence-blocks' ),
-			],
-			[
-				'id'    => 'semantic.spacing.button-padding-bottom',
-				'type'  => 'dimension',
-				'label' => __( 'Button Padding Bottom', 'kadence-blocks' ),
-				'group' => __( 'Brand', 'kadence-blocks' ),
-			],
-			[
-				'id'    => 'semantic.spacing.button-padding-left',
-				'type'  => 'dimension',
-				'label' => __( 'Button Padding Left', 'kadence-blocks' ),
-				'group' => __( 'Brand', 'kadence-blocks' ),
-			],
-			[
-				/**
-				 * Button margin, split one semantic token per side, mirroring semantic.spacing.button-padding-*.
-				 * Registered so Css_Var emits --kb-token--semantic--spacing--button-margin-top; the button's own
-				 * default margin rule references that variable directly. Resolves to 0, so an existing site that
-				 * never set margin renders unchanged.
-				 */
-				'id'    => 'semantic.spacing.button-margin-top',
-				'type'  => 'dimension',
-				'label' => __( 'Button Margin Top', 'kadence-blocks' ),
-				'group' => __( 'Brand', 'kadence-blocks' ),
-			],
-			[
-				'id'    => 'semantic.spacing.button-margin-right',
-				'type'  => 'dimension',
-				'label' => __( 'Button Margin Right', 'kadence-blocks' ),
-				'group' => __( 'Brand', 'kadence-blocks' ),
-			],
-			[
-				'id'    => 'semantic.spacing.button-margin-bottom',
-				'type'  => 'dimension',
-				'label' => __( 'Button Margin Bottom', 'kadence-blocks' ),
-				'group' => __( 'Brand', 'kadence-blocks' ),
-			],
-			[
-				'id'    => 'semantic.spacing.button-margin-left',
-				'type'  => 'dimension',
-				'label' => __( 'Button Margin Left', 'kadence-blocks' ),
-				'group' => __( 'Brand', 'kadence-blocks' ),
-			],
-			[
 				// Button shadow default for the block-default CSS projector, mirroring semantic.shadow.media.
 				// Registered so Css_Var emits --kb-token--semantic--shadow--button; the projector points
 				// kadence/singlebtn's box-shadow at it. Resolves to an invisible (transparent, zero) shadow,

--- a/src/blocks/advancedbtn/editor.scss
+++ b/src/blocks/advancedbtn/editor.scss
@@ -216,7 +216,7 @@
 	text-decoration: underline;
 }
 .kt-button:not(.kb-btn-global-inherit) {
-	padding: var(--kb-btn-padding, var(--kb-token--semantic--spacing--button-padding-top, 0.4em) var(--kb-token--semantic--spacing--button-padding-right, 1em) var(--kb-token--semantic--spacing--button-padding-bottom, 0.4em) var(--kb-token--semantic--spacing--button-padding-left, 1em));
+	padding: var(--kb-btn-padding, 0.4em 1em 0.4em 1em);
 	cursor: pointer;
 	// Mirror of style.scss: the button follows the semantic.*.control typography tokens so the editor
 	// preview matches the front end. See the note there.
@@ -242,7 +242,7 @@
 .kt-button.kb-btn-global-outline {
 	border: 2px solid var(--global-palette-btn-bg, #3633e1);
 	background: transparent;
-	padding: calc(var(--kb-token--semantic--spacing--button-padding-top, 0.4em) - 2px) calc(var(--kb-token--semantic--spacing--button-padding-right, 1em) - 2px) calc(var(--kb-token--semantic--spacing--button-padding-bottom, 0.4em) - 2px) calc(var(--kb-token--semantic--spacing--button-padding-left, 1em) - 2px);
+	padding: calc(0.4em - 2px) calc(1em - 2px) calc(0.4em - 2px) calc(1em - 2px);
 	color: var(--global-palette-btn-bg, #3633e1);
 	&:hover {
 		border-color: var(--global-palette-btn-bg-hover, #2f2ffc);
@@ -291,12 +291,12 @@
 .kt-button.kb-btn-global-outline.kt-btn-size-large {
 	border-width: 3px;
 	border-style: solid;
-	padding: calc(var(--kb-token--semantic--spacing--button-padding-top, 0.4em) - 3px) calc(var(--kb-token--semantic--spacing--button-padding-right, 1em) - 3px) calc(var(--kb-token--semantic--spacing--button-padding-bottom, 0.4em) - 3px) calc(var(--kb-token--semantic--spacing--button-padding-left, 1em) - 3px);
+	padding: calc(0.4em - 3px) calc(1em - 3px) calc(0.4em - 3px) calc(1em - 3px);
 }
 .kt-button.kb-btn-global-outline.kt-btn-size-small {
 	border-width: 1px;
 	border-style: solid;
-	padding: calc(var(--kb-token--semantic--spacing--button-padding-top, 0.4em) - 1px) calc(var(--kb-token--semantic--spacing--button-padding-right, 1em) - 1px) calc(var(--kb-token--semantic--spacing--button-padding-bottom, 0.4em) - 1px) calc(var(--kb-token--semantic--spacing--button-padding-left, 1em) - 1px);
+	padding: calc(0.4em - 1px) calc(1em - 1px) calc(0.4em - 1px) calc(1em - 1px);
 }
 // .wp-block-kadence-advancedbtn .kb-btn-global-inherit.kb-btn-has-icon {
 //     display: flex;

--- a/src/blocks/advancedbtn/style.scss
+++ b/src/blocks/advancedbtn/style.scss
@@ -35,7 +35,7 @@
 }
 .kb-button:not(.kb-btn-global-inherit) {
 	border: 0 solid transparent;
-	padding: var(--kb-btn-padding, var(--kb-token--semantic--spacing--button-padding-top, 0.4em) var(--kb-token--semantic--spacing--button-padding-right, 1em) var(--kb-token--semantic--spacing--button-padding-bottom, 0.4em) var(--kb-token--semantic--spacing--button-padding-left, 1em));
+	padding: var(--kb-btn-padding, 0.4em 1em 0.4em 1em);
 	cursor: pointer;
 	// Typography follows the semantic.*.control design tokens, one custom property per property, so a
 	// button follows the design system in the editor and on the front end. Each is a low-specificity
@@ -73,7 +73,7 @@
 	border: 2px solid var(--global-palette-btn-bg, #3633e1);
 	background: transparent;
 	color: var(--global-palette-btn-bg, #3633e1);
-	padding: calc(var(--kb-token--semantic--spacing--button-padding-top, 0.4em) - 2px) calc(var(--kb-token--semantic--spacing--button-padding-right, 1em) - 2px) calc(var(--kb-token--semantic--spacing--button-padding-bottom, 0.4em) - 2px) calc(var(--kb-token--semantic--spacing--button-padding-left, 1em) - 2px);
+	padding: calc(0.4em - 2px) calc(1em - 2px) calc(0.4em - 2px) calc(1em - 2px);
 	&:hover {
 		border-color: var(--global-palette-btn-bg-hover, #2f2ffc);
 		background: transparent;
@@ -115,11 +115,11 @@
 }
 .kb-button.kb-btn-global-outline.kt-btn-size-large {
 	border-width: 3px;
-	padding: calc(var(--kb-token--semantic--spacing--button-padding-top, 0.4em) - 3px) calc(var(--kb-token--semantic--spacing--button-padding-right, 1em) - 3px) calc(var(--kb-token--semantic--spacing--button-padding-bottom, 0.4em) - 3px) calc(var(--kb-token--semantic--spacing--button-padding-left, 1em) - 3px);
+	padding: calc(0.4em - 3px) calc(1em - 3px) calc(0.4em - 3px) calc(1em - 3px);
 }
 .kb-button.kb-btn-global-outline.kt-btn-size-small {
 	border-width: 1px;
-	padding: calc(var(--kb-token--semantic--spacing--button-padding-top, 0.4em) - 1px) calc(var(--kb-token--semantic--spacing--button-padding-right, 1em) - 1px) calc(var(--kb-token--semantic--spacing--button-padding-bottom, 0.4em) - 1px) calc(var(--kb-token--semantic--spacing--button-padding-left, 1em) - 1px);
+	padding: calc(0.4em - 1px) calc(1em - 1px) calc(0.4em - 1px) calc(1em - 1px);
 }
 .kb-button.kt-btn-has-svg-true {
 	gap: 0.5em;


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4260/token-control-popover-options-and-the-default-label-show-what-is

Un-registers the `button-padding` and `button-margin` primitive tokens. Nothing bound to them: the button's padding and margin come from its size and style classes, and the previous slices made that literal the field's muted default instead.

Registered-but-unbound tokens are worse than absent ones — they surface as editable rows on the Spacing screen, so a site owner can retune a value that reaches nothing.

The SCSS keeps the same literals it always used; only the token registration goes away.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated button spacing to use consistent default padding and zero margins.
  * Standardized padding across primary, secondary, outline, large, and small button variants.
  * Preserved outline button border adjustments across sizes.
  * Removed obsolete semantic button spacing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->