### PR TITLE
[DTM] SOFT-4260 [11/19]: show muted Default when unset and recognize fixed sentinel picks

### DIFF
--- a/src/token-controls/__tests__/box-shadow-control.test.js
+++ b/src/token-controls/__tests__/box-shadow-control.test.js
@@ -17,7 +17,13 @@ import { BoxShadowControl } from '../controls/BoxShadowControl';
 // the popover's tabs are reachable without simulating a real popover open, and `TabPanel` keeps its
 // own active-tab state so a test can click between `Style Library` and `Custom`.
 jest.mock('@wordpress/components', () => ({
-	Button: ({ children, isPressed, showTooltip, ...props }) => <button {...props}>{children}</button>,
+	// `isPressed` is surfaced as `aria-pressed` (rather than dropped) so a test can confirm which row
+	// the popover treats as active.
+	Button: ({ children, isPressed, showTooltip, ...props }) => (
+		<button aria-pressed={isPressed} {...props}>
+			{children}
+		</button>
+	),
 	Icon: ({ icon, ...props }) => <span {...props}>{icon}</span>,
 	Dropdown: ({ renderToggle, renderContent }) => (
 		<>
@@ -95,6 +101,19 @@ const TOKENS = [
 	{ id: 'md', label: 'Medium', value: '0px 2px 8px 0px #1717171f', alias: '{primitive.shadow.md}' },
 	{ id: 'lg', label: 'Large', value: '0px 4px 16px 0px #1717172f', alias: '{primitive.shadow.lg}' },
 ];
+
+// The fixed "None" sentinel, matching `fixed-tokens.js`'s `noneEntryForRole('shadow')` shape: a
+// literal resolved shorthand as its `value`/`alias` rather than a bracket-wrapped token path, since
+// it has no DTCG registration behind it.
+const NONE_TOKEN = {
+	id: 'ss-none-shadow',
+	label: 'None',
+	value: '0px 0px 0px 0px transparent',
+	alias: '0px 0px 0px 0px transparent',
+	fixed: true,
+};
+
+const TOKENS_WITH_NONE = [...TOKENS, NONE_TOKEN];
 
 /**
  * Render `BoxShadowControl` with the props it needs, plus overrides.
@@ -222,31 +241,34 @@ describe('BoxShadowControl trigger', () => {
 
 	/**
 	 * An unset value (the field's actual starting state before a token or a custom shadow is chosen)
-	 * renders no label text — no fabricated all-zero shorthand, matching every other control's
-	 * unset-slot behavior and `fieldSummary()`'s own unset branch — though the leading glyph still
-	 * renders, giving the trigger a visible identity even while empty.
+	 * shows a muted "Default" label — matching every other control in this library (`TokenSelector`'s
+	 * own unset behavior), rather than a blank trigger. Shadow's conceptual default when unset is a
+	 * constant ("no shadow"), not a per-instance literal, so no value/token name is attached — only the
+	 * muted label itself.
 	 *
 	 * @return {void}
 	 */
-	it('renders no label text when the value is unset', () => {
+	it('shows a muted "Default" label when the value is unset', () => {
 		renderControl({ value: '' });
 
-		expect(trigger().querySelector('.kadence-token-field__label')).toBeNull();
+		const label = trigger().querySelector('.kadence-token-field__label');
+
+		expect(label).not.toBeNull();
+		expect(label.textContent).toBe('Default');
+		expect(label.classList.contains('kadence-token-field__label--default')).toBe(true);
 		expect(trigger().querySelector('.kadence-token-field__icon')).not.toBeNull();
 	});
 
 	/**
-	 * An unset trigger has no visible label text, so it needs an `aria-label` naming it — otherwise a
-	 * screen reader announces the button with nothing but a decorative, `aria-hidden` glyph to go on.
-	 * `ControlShell` renders the field's `label` prop in a separate header span, not as this button's
-	 * name, so the trigger has to carry its own.
+	 * The unset trigger now carries visible label text ("Default"), so it names itself without needing
+	 * an `aria-label` on top — the same rule this library applies to a bound token or a composite value.
 	 *
 	 * @return {void}
 	 */
-	it('has an aria-label when the value is unset', () => {
+	it('has no aria-label when the value is unset', () => {
 		renderControl({ value: '' });
 
-		expect(trigger().getAttribute('aria-label')).toBe('Choose shadow');
+		expect(trigger().hasAttribute('aria-label')).toBe(false);
 	});
 
 	/**
@@ -270,6 +292,38 @@ describe('BoxShadowControl trigger', () => {
 		renderControl({ value: { color: '#000000', offsetX: '2px', offsetY: '2px', blur: '4px', spread: '0px' } });
 
 		expect(trigger().hasAttribute('aria-label')).toBe(false);
+	});
+
+	/**
+	 * A composite value that matches a `fixed` entry's own resolved shorthand (e.g. picking "None"
+	 * resolves to a literal composite immediately, at pick time — there is no live alias kept the way a
+	 * real token pick keeps one) shows that entry's label on the trigger, not the generic "Custom" every
+	 * other composite gets.
+	 *
+	 * @return {void}
+	 */
+	it('shows the fixed entry’s label when the composite value matches its resolved shorthand', () => {
+		renderControl({
+			value: { color: 'transparent', offsetX: '0px', offsetY: '0px', blur: '0px', spread: '0px' },
+			tokens: TOKENS_WITH_NONE,
+		});
+
+		expect(trigger().querySelector('.kadence-token-field__label').textContent).toBe('None');
+	});
+
+	/**
+	 * A composite value that does NOT match any fixed entry's shorthand still reads as "Custom" — the
+	 * fixed-entry recognition is scoped to an exact shape match, not any all-zero-looking shadow.
+	 *
+	 * @return {void}
+	 */
+	it('still shows "Custom" for a composite value that does not match any fixed entry', () => {
+		renderControl({
+			value: { color: '#111111', offsetX: '2px', offsetY: '2px', blur: '4px', spread: '0px' },
+			tokens: TOKENS_WITH_NONE,
+		});
+
+		expect(trigger().querySelector('.kadence-token-field__label').textContent).toBe('Custom');
 	});
 });
 
@@ -338,6 +392,21 @@ describe('BoxShadowControl initial tab', () => {
 
 		expect(numberInput('X')).not.toBeNull();
 	});
+
+	/**
+	 * A composite value matching a fixed entry's resolved shorthand is effectively a token pick, so it
+	 * opens on the Style Library tab — where "None" itself lives — not the Custom tab.
+	 *
+	 * @return {void}
+	 */
+	it('opens on the Style Library tab for a composite value matching a fixed entry', () => {
+		renderControl({
+			value: { color: 'transparent', offsetX: '0px', offsetY: '0px', blur: '0px', spread: '0px' },
+			tokens: TOKENS_WITH_NONE,
+		});
+
+		expect(tokenItem('None')).not.toBeUndefined();
+	});
 });
 
 describe('BoxShadowControl Style Library tab', () => {
@@ -353,6 +422,23 @@ describe('BoxShadowControl Style Library tab', () => {
 		click(tokenItem('Large'));
 
 		expect(onChange).toHaveBeenCalledWith('{primitive.shadow.lg}');
+	});
+
+	/**
+	 * A composite value matching a fixed entry's resolved shorthand is recognized as that entry for
+	 * display purposes: reopening the popover highlights the "None" row as pressed/active, the same
+	 * way a real bound token's row does — rather than leaving every row unpressed the way an ordinary
+	 * (non-matching) Custom composite does.
+	 *
+	 * @return {void}
+	 */
+	it('highlights the fixed entry’s row as pressed when the composite value matches it', () => {
+		renderControl({
+			value: { color: 'transparent', offsetX: '0px', offsetY: '0px', blur: '0px', spread: '0px' },
+			tokens: TOKENS_WITH_NONE,
+		});
+
+		expect(tokenItem('None').getAttribute('aria-pressed')).toBe('true');
 	});
 
 	/**

--- a/src/token-controls/__tests__/token-summary.test.js
+++ b/src/token-controls/__tests__/token-summary.test.js
@@ -102,6 +102,21 @@ describe('defaultSummary', () => {
 	it('is blank when there is no default', () => {
 		expect(defaultSummary('', TOKENS)).toEqual({ label: '', value: '' });
 	});
+
+	it('never borrows a fixed sentinel entry’s label, even when its value coincidentally matches the resolved default', () => {
+		// Margin's resolved literal default is the bare string '0', and the fixed "None" entry's own
+		// `value` is also '0' — a coincidental match that must not make the trigger show "None" for a
+		// field the user never touched. This list carries only the fixed sentinel (no real token also
+		// resolving to '0'), isolating the bug: without the `!candidate.fixed` guard, the fixed entry
+		// would be the only match found and its label would leak through.
+		const fixedOnly = [{ id: 'ss-none-spacing', label: 'None', value: '0', alias: 0, fixed: true }];
+
+		expect(defaultSummary('0', fixedOnly, 'Default')).toEqual({ label: 'Default', value: '0' });
+	});
+
+	it('still borrows a real (non-fixed) token’s label when its value matches the resolved default', () => {
+		expect(defaultSummary('0', TOKENS, 'Default')).toEqual({ label: 'None', value: '0' });
+	});
 });
 
 describe('fieldSummary', () => {

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -59,6 +59,7 @@ import { __ } from '@wordpress/i18n';
 import { ControlShell } from '../templates/ControlShell';
 import { TokenPopover } from '../molecules/TokenPopover';
 import { fieldSummary, hasValue, isTokenAlias } from '../helpers/token-summary';
+import { DEFAULT_COMPOSITE } from '../helpers/shadow-shorthand';
 import '../styles/token-controls.scss';
 
 /**
@@ -72,13 +73,6 @@ const AXES = [
 	{ key: 'blur', label: __('Blur', 'kadence-blocks') },
 	{ key: 'spread', label: __('Spread', 'kadence-blocks') },
 ];
-
-/**
- * The shadow composite's default shape, matching `ShadowField`'s own fallback.
- *
- * @since TBD
- */
-const DEFAULT_SHADOW = { color: '#000000', offsetX: '0px', offsetY: '0px', blur: '0px', spread: '0px', inset: false };
 
 /**
  * Apply a patch to the current shadow composite, writing the result through `onChange` with `inset`
@@ -97,6 +91,25 @@ function commitShadow(shadow, patch) {
 	const { inset, ...rest } = { ...shadow, ...patch };
 
 	return inset === true ? { ...rest, inset: true } : rest;
+}
+
+/**
+ * Whether a composite shadow value matches a fixed sentinel entry's own resolved shorthand. A fixed
+ * pick (e.g. "None") resolves to a literal composite immediately, at pick time — there is no live
+ * alias to compare against the way a real token pick keeps — so this is how the control recognizes
+ * "the user picked the sentinel" after the fact, purely from the value's shape.
+ *
+ * @param {Object} shadow The composite value with defaults already filled.
+ * @param {Array}  tokens The pickable-token list.
+ *
+ * @since TBD
+ *
+ * @return {?Object} The matching fixed entry, or null.
+ */
+function matchFixedEntry(shadow, tokens) {
+	const shorthand = `${shadow.inset === true ? 'inset ' : ''}${shadow.offsetX} ${shadow.offsetY} ${shadow.blur} ${shadow.spread} ${shadow.color}`;
+
+	return (tokens || []).find((entry) => entry.fixed && entry.value === shorthand) || null;
 }
 
 /**
@@ -224,21 +237,23 @@ export function BoxShadowControl({ value, onChange, label, tokens = [], renderCo
 	// tab would then write back as a shadow whose sub-fields are `0`, `p`, `x`. Degrading to the default
 	// shape reads as unset, which is wrong but harmless where the alternative cannot be saved at all.
 	const custom = typeof value === 'object' && value !== null && !Array.isArray(value) ? value : {};
-	const shadow = { ...DEFAULT_SHADOW, ...(aliased ? {} : custom) };
-	// The trigger shows a label only, never a value — for either shape. Aliased still reads
-	// `fieldSummary()`'s bound-token label (dropping the `value` half it also returns, which does not
-	// fit this control's icon-plus-label trigger); a genuine composite reads bare "Custom"; unset
-	// reads as empty text (the leading glyph below still gives it a visible, accessible identity).
-	const summary = aliased
-		? { ...fieldSummary(value, tokens, '', __('Custom', 'kadence-blocks')), value: '' }
-		: !hasValue(value)
-			? { label: '', value: '' }
-			: { label: __('Custom', 'kadence-blocks'), value: '' };
-	// An unset trigger has no visible label text, which would otherwise leave the Button with no
-	// accessible name at all: `ControlShell` renders `label` as a separate header span, not as this
-	// button's name. An `aria-label` fills that gap only while unset; a bound token or a composite
-	// already names itself through its visible label text, so adding one there would be redundant.
-	const emptyTriggerLabel = !summary.label ? __('Choose shadow', 'kadence-blocks') : undefined;
+	const shadow = { ...DEFAULT_COMPOSITE, ...(aliased ? {} : custom) };
+	// A fixed pick keeps no live alias, so a sentinel is recognized after the fact by its shorthand.
+	const fixedMatch = !aliased && hasValue(value) ? matchFixedEntry(shadow, tokens) : null;
+	// Display only — `onChange` still sees the real underlying value.
+	const displayValue = fixedMatch ? fixedMatch.alias : value;
+	// The trigger shows a label, never a value — it has no room for the `value` half `fieldSummary()`
+	// also returns. Unset reads a muted "Default".
+	//
+	// Host asymmetry: only a host that can store "never touched" as something other than the None shape
+	// reaches that branch. The Style Library stores `''`; the block editor is handed `block.json`'s
+	// registered None composite on a fresh block, which matches `fixedMatch` first and reads "None".
+	const summary =
+		aliased || fixedMatch
+			? { ...fieldSummary(displayValue, tokens, '', __('Custom', 'kadence-blocks')), value: '' }
+			: !hasValue(value)
+				? { label: __('Default', 'kadence-blocks'), value: '', muted: true }
+				: { label: __('Custom', 'kadence-blocks'), value: '' };
 
 	return (
 		<ControlShell label={label} disabled={disabled}>
@@ -253,20 +268,25 @@ export function BoxShadowControl({ value, onChange, label, tokens = [], renderCo
 								onClick={onToggle}
 								disabled={disabled}
 								aria-expanded={isOpen}
-								aria-label={emptyTriggerLabel}
 							>
 								<span className="kadence-token-field__icon" aria-hidden="true">
 									{shadowGlyph}
 								</span>
-								{summary.label && <span className="kadence-token-field__label">{summary.label}</span>}
+								{summary.label && (
+									<span
+										className={`kadence-token-field__label${summary.muted ? ' kadence-token-field__label--default' : ''}`}
+									>
+										{summary.label}
+									</span>
+								)}
 							</Button>
 						)}
 						renderContent={({ onClose }) => (
 							<TokenPopover
-								value={value}
+								value={displayValue}
 								tokens={tokens}
 								resolvedDefault=""
-								initialTab={aliased || !value ? 'style-library' : 'custom'}
+								initialTab={aliased || fixedMatch || !value ? 'style-library' : 'custom'}
 								custom={{ shadow, renderColor, disabled }}
 								renderCustom={(custom) => (
 									<ShadowCustomTab

--- a/src/token-controls/helpers/token-summary.js
+++ b/src/token-controls/helpers/token-summary.js
@@ -124,7 +124,12 @@ export function defaultSummary(resolvedDefault, tokens, literalLabel = '') {
 		return { label: '', value: '' };
 	}
 
-	const entry = (tokens || []).find((candidate) => candidate.value === resolvedDefault) || null;
+	// A `fixed` sentinel (e.g. Margin's "None") is not a real named design choice, so it is excluded
+	// here — without this, its label would be borrowed for any field whose literal default
+	// coincidentally equals the sentinel's own resolved value (Margin's unset default is the bare
+	// string '0', which is also "None"'s resolved value), showing e.g. "None" for a field the user
+	// never touched.
+	const entry = (tokens || []).find((candidate) => !candidate.fixed && candidate.value === resolvedDefault) || null;
 
 	return { label: entry ? entry.label : literalLabel, value: resolvedDefault };
 }


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4260/token-control-popover-options-and-the-default-label-show-what-is

Two display bugs the fixed sentinels exposed in `BoxShadowControl`:

- **An unset shadow rendered as blank.** The trigger had no visible label at all, so the control relied on an `aria-label` for its accessible name. It now shows a muted "Default", matching every other token control's unset state — and naming itself the way a bound token or a composite already does.
- **A fixed pick was not recognized after the fact.** A sentinel resolves to its literal composite at pick time and keeps no live alias, so re-opening the control showed "Custom" instead of "None". A composite value is now matched back against each fixed entry's own resolved shorthand, so the trigger and the popover's active-row highlighting both recognize it.

`token-summary.js` also stops matching a fixed entry by label when resolving a field's default, which would otherwise let a sentinel's name leak into an unrelated field's muted text.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved box-shadow token recognition for matching composite values.
  * Fixed default-value labels so they no longer incorrectly display fixed sentinel tokens.
  * Unset shadow controls now display a muted “Default” label.
  * Nonmatching composite values continue to display as “Custom.”

* **UI Improvements**
  * Matching shadow tokens now show their label, open in the Style Library, and appear selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->