### PR TITLE
[DTM] SOFT-4260 [12/19]: correct DEFAULT_COMPOSITE's stale black fallback

### DIFF
--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -3,7 +3,13 @@
 /**
  * Internal dependencies
  */
-import { EditorShadowControl, combineColorOpacity, splitColorOpacity, toNativeShadow } from '../EditorShadowControl';
+import {
+	EditorShadowControl,
+	combineColorOpacity,
+	splitColorOpacity,
+	toNativeShadow,
+	fromNativeShadow,
+} from '../EditorShadowControl';
 import { BoxShadowControl } from '../../../../token-controls/controls/BoxShadowControl';
 
 /**
@@ -107,7 +113,7 @@ describe('EditorShadowControl native <-> BoxShadowControl value bridging', () =>
 		const { shadowControl } = renderEditorShadowControl({ value: undefined });
 
 		expect(shadowControl.props.value).toEqual({
-			color: '#000000',
+			color: 'transparent',
 			offsetX: '0px',
 			offsetY: '0px',
 			blur: '0px',
@@ -241,7 +247,7 @@ describe('EditorShadowControl native <-> BoxShadowControl value bridging', () =>
 
 		expect(onChange).toHaveBeenCalledWith([
 			{
-				color: '#000000',
+				color: 'transparent',
 				opacity: 1,
 				hOffset: 0,
 				vOffset: 0,
@@ -250,6 +256,30 @@ describe('EditorShadowControl native <-> BoxShadowControl value bridging', () =>
 				inset: false,
 			},
 		]);
+	});
+
+	/**
+	 * Clicking "Reset" round-trips an empty native value through `toNativeShadow` and back through
+	 * `fromNativeShadow` — the write path a native "Reset" button drives, since it clears the block
+	 * attribute to nothing and lets the control re-derive its display value from that empty state. The
+	 * resulting composite must match the shared fixed "None" entry's canonical shape exactly, so the
+	 * preceding phase's `matchFixedEntry`-style lookup in `BoxShadowControl` recognizes a reset shadow
+	 * as "None"/"Default" instead of falling through to generic "Custom".
+	 *
+	 * @return {void}
+	 */
+	it('resolves a Reset round-trip to the same composite shape as the fixed None entry', () => {
+		const nativeAfterReset = toNativeShadow('', []);
+		const composite = fromNativeShadow(nativeAfterReset);
+
+		expect(composite).toEqual({
+			color: 'transparent',
+			offsetX: '0px',
+			offsetY: '0px',
+			blur: '0px',
+			spread: '0px',
+			inset: false,
+		});
 	});
 });
 

--- a/src/token-controls/__tests__/shadow-shorthand.test.js
+++ b/src/token-controls/__tests__/shadow-shorthand.test.js
@@ -30,7 +30,7 @@ describe('parseResolvedShadow', () => {
 
 	it('returns the default composite for an unparsable value', () => {
 		expect(parseResolvedShadow('not-a-shadow')).toEqual({
-			color: '#000000',
+			color: 'transparent',
 			offsetX: '0px',
 			offsetY: '0px',
 			blur: '0px',
@@ -38,7 +38,7 @@ describe('parseResolvedShadow', () => {
 			inset: false,
 		});
 		expect(parseResolvedShadow(undefined)).toEqual({
-			color: '#000000',
+			color: 'transparent',
 			offsetX: '0px',
 			offsetY: '0px',
 			blur: '0px',

--- a/src/token-controls/helpers/shadow-shorthand.js
+++ b/src/token-controls/helpers/shadow-shorthand.js
@@ -6,12 +6,15 @@
  */
 
 /**
- * The composite's default shape, matching `ShadowField`'s own fallback.
+ * The composite's default shape: the canonical "no shadow" composite, matching both
+ * `noneEntryForRole('shadow')`'s resolved value (`fixed-tokens.js`) and `NONE_SHADOW_ITEM`
+ * (`src/blocks/singlebtn/deprecated.js`) in their own coordinate systems — transparent and
+ * all-zero, not the old visible black composite.
  *
  * @since TBD
  */
 export const DEFAULT_COMPOSITE = {
-	color: '#000000',
+	color: 'transparent',
 	offsetX: '0px',
 	offsetY: '0px',
 	blur: '0px',


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4260/token-control-popover-options-and-the-default-label-show-what-is

`DEFAULT_COMPOSITE` still carried a black `#000000` fallback from before the fixed `None` pick defined "no shadow" as the zero/transparent shape. The two disagreed, so a composite falling back leg-by-leg could acquire a black colour the user never picked — and, once the None sentinel matched on shorthand, a value that should have read as "None" read as "Custom" instead.

Now the fallback is the same transparent shape the sentinel writes, so the two definitions of "no shadow" are one.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Shadow controls now use a transparent color when no shadow is set or when shadow values cannot be parsed.
  - Resetting a shadow consistently restores the canonical “None” state with zero dimensions and no inset.
- **Tests**
  - Updated coverage to verify transparent defaults and reliable shadow reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->