### PR TITLE
[DTM] SOFT-4260 [13/19]: emit an explicit box-shadow: none instead of skipping the declaration

### DIFF
--- a/includes/blocks/class-kadence-blocks-singlebtn-block.php
+++ b/includes/blocks/class-kadence-blocks-singlebtn-block.php
@@ -132,9 +132,13 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$this->render_preset_spacing( $css, $attributes );
 		$css->render_measure_output( $attributes, 'padding', 'padding', [ 'unit_key' => 'paddingUnit' ] );
 		$css->render_measure_output( $attributes, 'margin', 'margin', [ 'unit_key' => 'marginUnit' ] );
-		$this->render_preset_shadow( $css, $attributes );
+		$has_preset_shadow = $this->render_preset_shadow( $css, $attributes );
 		if ( isset( $attributes['shadow'][0] ) && is_array( $attributes['shadow'][0] ) && $this->has_visible_shadow( $attributes['shadow'][0] ) ) {
 			$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadow'][0] ) );
+		} elseif ( ! $has_preset_shadow ) {
+			// Only reset to `none` when nothing else claims this rule's box-shadow — a preset's
+			// `var(--kb-btn-shadow)` above would otherwise be silenced by a trailing `none`.
+			$css->add_property( 'box-shadow', 'none' );
 		}
 		if ( ! empty( $attributes['textUnderline'] ) ) {
 			$css->set_selector( '.wp-block-kadence-advancedbtn .kb-btn' . $unique_id . '.kb-button:not(.specificity):not(.extra-specificity)' );
@@ -170,10 +174,14 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		}
 		$css->render_measure_output( $attributes, 'borderHoverRadius', 'border-radius' );
 		$css->render_border_styles( $attributes, 'borderHoverStyle', true );
-		if ( ( 'gradient' === $bg_type || 'gradient' === $bg_hover_type ) && isset( $attributes['shadowHover'][0]['inset'] ) && true === $attributes['shadowHover'][0]['inset'] ) {
+		// Visibility-gated: without it this fires on any inset-true item, including the invisible
+		// all-zero default the block ships with.
+		if ( ( 'gradient' === $bg_type || 'gradient' === $bg_hover_type ) && isset( $attributes['shadowHover'][0] ) && is_array( $attributes['shadowHover'][0] ) && $this->has_visible_shadow( $attributes['shadowHover'][0] ) && isset( $attributes['shadowHover'][0]['inset'] ) && true === $attributes['shadowHover'][0]['inset'] ) {
 			$css->add_property( 'box-shadow', '0px 0px 0px 0px rgba(0, 0, 0, 0)' );
 			$css->set_selector( '.kb-btn' . $unique_id . '.kb-button:hover::before' );
 		}
+		// No `none` fallback on hover: an unset hover shadow must let the base state's shadow
+		// carry through the `:hover` rule via the normal cascade.
 		if ( isset( $attributes['shadowHover'][0] ) && is_array( $attributes['shadowHover'][0] ) && $this->has_visible_shadow( $attributes['shadowHover'][0] ) ) {
 			$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowHover'][0] ) );
 		}
@@ -261,6 +269,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		}
 		$css->render_measure_output( $attributes, 'borderTransparentRadius', 'border-radius', [ 'unit_key' => 'borderTransparentRadiusUnit' ] );
 		$css->render_border_styles( $attributes, 'borderTransparentStyle', true );
+		// No `none` fallback: this selector outranks the base rule, which must carry through instead.
 		if ( isset( $attributes['shadowTransparent'] ) && is_array( $attributes['shadowTransparent'] ) && isset( $attributes['shadowTransparent'][0] ) && is_array( $attributes['shadowTransparent'][0] ) && $this->has_visible_shadow( $attributes['shadowTransparent'][0] ) ) {
 			$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowTransparent'][0] ) );
 		}
@@ -275,10 +284,13 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		}
 		$css->render_measure_output( $attributes, 'borderTransparentHoverRadius', 'border-radius' );
 		$css->render_border_styles( $attributes, 'borderTransparentHoverStyle', true );
-		if ( ( 'gradient' === $bg_type_transparent || 'gradient' === $bg_hover_type_transparent ) && isset( $attributes['shadowTransparentHover'] ) && is_array( $attributes['shadowTransparentHover'] ) && isset( $attributes['shadowTransparentHover'][0] ) && is_array( $attributes['shadowTransparentHover'][0] ) && isset( $attributes['shadowTransparentHover'][0]['inset'] ) && true === $attributes['shadowTransparentHover'][0]['inset'] ) {
+		// See the base hover state above: this reset needs the same visibility gate.
+		if ( ( 'gradient' === $bg_type_transparent || 'gradient' === $bg_hover_type_transparent ) && isset( $attributes['shadowTransparentHover'] ) && is_array( $attributes['shadowTransparentHover'] ) && isset( $attributes['shadowTransparentHover'][0] ) && is_array( $attributes['shadowTransparentHover'][0] ) && $this->has_visible_shadow( $attributes['shadowTransparentHover'][0] ) && isset( $attributes['shadowTransparentHover'][0]['inset'] ) && true === $attributes['shadowTransparentHover'][0]['inset'] ) {
 			$css->add_property( 'box-shadow', '0px 0px 0px 0px rgba(0, 0, 0, 0)' );
 			$css->set_selector( '.kb-btn' . $unique_id . '.kb-button:hover::before' );
 		}
+		// No `none` fallback on hover: an unset hover shadow must let the base state's shadow
+		// carry through the `:hover` rule via the normal cascade.
 		if ( isset( $attributes['shadowTransparentHover'] ) && is_array( $attributes['shadowTransparentHover'] ) && isset( $attributes['shadowTransparentHover'][0] ) && is_array( $attributes['shadowTransparentHover'][0] ) && $this->has_visible_shadow( $attributes['shadowTransparentHover'][0] ) ) {
 			$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowTransparentHover'][0] ) );
 		}
@@ -298,6 +310,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		}
 		$css->render_measure_output( $attributes, 'borderStickyRadius', 'border-radius', [ 'unit_key' => 'borderStickyRadiusUnit' ] );
 		$css->render_border_styles( $attributes, 'borderStickyStyle', true );
+		// No `none` fallback: this selector outranks the base rule, which must carry through instead.
 		if ( isset( $attributes['shadowSticky'] ) && is_array( $attributes['shadowSticky'] ) && isset( $attributes['shadowSticky'][0] ) && is_array( $attributes['shadowSticky'][0] ) && $this->has_visible_shadow( $attributes['shadowSticky'][0] ) ) {
 			$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowSticky'][0] ) );
 		}
@@ -312,10 +325,13 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		}
 		$css->render_measure_output( $attributes, 'borderStickyHoverRadius', 'border-radius' );
 		$css->render_border_styles( $attributes, 'borderStickyHoverStyle', true );
-		if ( ( 'gradient' === $bg_type_sticky || 'gradient' === $bg_hover_type_sticky ) && isset( $attributes['shadowStickyHover'] ) && is_array( $attributes['shadowStickyHover'] ) && isset( $attributes['shadowStickyHover'][0] ) && is_array( $attributes['shadowStickyHover'][0] ) && isset( $attributes['shadowStickyHover'][0]['inset'] ) && true === $attributes['shadowStickyHover'][0]['inset'] ) {
+		// See the base hover state above: this reset needs the same visibility gate.
+		if ( ( 'gradient' === $bg_type_sticky || 'gradient' === $bg_hover_type_sticky ) && isset( $attributes['shadowStickyHover'] ) && is_array( $attributes['shadowStickyHover'] ) && isset( $attributes['shadowStickyHover'][0] ) && is_array( $attributes['shadowStickyHover'][0] ) && $this->has_visible_shadow( $attributes['shadowStickyHover'][0] ) && isset( $attributes['shadowStickyHover'][0]['inset'] ) && true === $attributes['shadowStickyHover'][0]['inset'] ) {
 			$css->add_property( 'box-shadow', '0px 0px 0px 0px rgba(0, 0, 0, 0)' );
 			$css->set_selector( '.kb-btn' . $unique_id . '.kb-button:hover::before' );
 		}
+		// No `none` fallback on hover: an unset hover shadow must let the base state's shadow
+		// carry through the `:hover` rule via the normal cascade.
 		if ( isset( $attributes['shadowStickyHover'] ) && is_array( $attributes['shadowStickyHover'] ) && isset( $attributes['shadowStickyHover'][0] ) && is_array( $attributes['shadowStickyHover'][0] ) && $this->has_visible_shadow( $attributes['shadowStickyHover'][0] ) ) {
 			$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowStickyHover'][0] ) );
 		}
@@ -588,17 +604,28 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 	 * undefined custom property is invalid at computed-value time, so emitting unconditionally would
 	 * blank out the shadow on a button whose preset sets none.
 	 *
-	 * Emitted before the explicit `shadow` output below so an explicit per-block shadow, which
-	 * lands later in the same rule, still wins.
+	 * Emitted before the explicit `shadow` output below, and the builder appends declarations, so a
+	 * visible per-block shadow lands later in the same rule and wins. The caller uses the returned
+	 * flag for the other half of that contract: when the block's own shadow is invisible it must
+	 * skip its `box-shadow: none` reset, or the trailing `none` would silence the preset's
+	 * `var(--kb-btn-shadow)` here.
+	 *
+	 * Known, accepted limitation: the shadow control's "None" pick and an untouched shadow attribute
+	 * serialize to the exact same value (both resolve to the invisible all-zero composite), by design
+	 * — that is what lets "Default" and "None" read identically in the control. One consequence is
+	 * that a button whose preset resolves a shadow cannot have that shadow turned off from this block's
+	 * own shadow control: "None" is indistinguishable from "never set", so this method's gate always
+	 * wins. Distinguishing them would need a real "explicitly none" marker outside the shadow value
+	 * itself, which is a design change, not a bug fix.
 	 *
 	 * @since TBD
 	 *
 	 * @param Kadence_Blocks_CSS   $css        The css object.
 	 * @param array<string, mixed> $attributes The block attributes.
 	 *
-	 * @return void
+	 * @return bool Whether a preset box-shadow declaration was emitted.
 	 */
-	private function render_preset_shadow( Kadence_Blocks_CSS $css, array $attributes ): void {
+	private function render_preset_shadow( Kadence_Blocks_CSS $css, array $attributes ): bool {
 		try {
 			$registry = kadence_blocks()->get( Token_Registry::class );
 			$library  = kadence_blocks()->get( Active_Token_Library_Store::class );
@@ -612,7 +639,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 				|| ! $resolver instanceof Preset_Resolver
 				|| ! $registry->is_active()
 			) {
-				return;
+				return false;
 			}
 
 			$slug     = $library->get();
@@ -624,17 +651,25 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		} catch ( Throwable $e ) {
 			// This runs in the render path, so a broken token graph must not take the page down with it —
 			// the button simply keeps the shadow it has today.
-			return;
+			return false;
 		}
 
-		if ( isset( $values['button-shadow'] ) ) {
-			$css->add_property( 'box-shadow', 'var(--kb-btn-shadow)' );
+		if ( ! isset( $values['button-shadow'] ) ) {
+			return false;
 		}
+
+		$css->add_property( 'box-shadow', 'var(--kb-btn-shadow)' );
+
+		return true;
 	}
 
 	/**
 	 * Whether a native shadow item paints anything visible — all-zero offsets, blur, and spread
 	 * render nothing regardless of color, matching the value the "None" pick now writes.
+	 *
+	 * A non-numeric, non-empty leg is a {dot.alias} token reference, which resolves to a var() whose
+	 * value is unknown here — it counts as visible, since treating it as a zero would let the
+	 * caller's `box-shadow: none` reset erase a shadow the token does paint.
 	 *
 	 * @since TBD
 	 *

--- a/src/blocks/singlebtn/components/backend-styles/__tests__/index.test.js
+++ b/src/blocks/singlebtn/components/backend-styles/__tests__/index.test.js
@@ -10,7 +10,7 @@
 /**
  * Internal dependencies
  */
-import { hasVisibleShadow } from '../index';
+import { hasVisibleShadow, shadowAxisPx } from '../index';
 
 // `backend-styles/index.js` imports the `@kadence/helpers` barrel, which eagerly pulls in a
 // REST-fetch helper that has no `@wordpress/api-fetch` module to resolve under Jest (the same
@@ -30,6 +30,10 @@ jest.mock('@kadence/helpers', () => ({
 jest.mock('../../../../../extension/preset-picker', () => ({
 	activePresetFor: jest.fn(),
 	blockPresetValues: jest.fn(),
+}));
+
+jest.mock('../../../../../extension/design-tokens/token-px', () => ({
+	tokenPx: jest.fn((value) => (value === '{primitive.shadow.md}' ? 8 : null)),
 }));
 
 describe('hasVisibleShadow', () => {
@@ -90,5 +94,40 @@ describe('hasVisibleShadow', () => {
 	 */
 	it('is true for a token alias reference on any leg', () => {
 		expect(hasVisibleShadow({ hOffset: 0, vOffset: 0, blur: '{primitive.shadow.md}', spread: 0 })).toBe(true);
+	});
+});
+
+describe('shadowAxisPx', () => {
+	/**
+	 * A {dot.alias} leg resolves through the token pool. Concatenated raw it would emit `{alias}px`,
+	 * which is not valid CSS — and `hasVisibleShadow()` counts such a leg as visible, so it does reach
+	 * the serializer.
+	 *
+	 * @return {void}
+	 */
+	it('resolves a token alias leg to its pixel value', () => {
+		expect(shadowAxisPx('{primitive.shadow.md}', 0)).toBe(8);
+	});
+
+	/**
+	 * An alias the pool cannot resolve falls back to the axis default rather than emitting the raw
+	 * alias, which would serialize as invalid CSS.
+	 *
+	 * @return {void}
+	 */
+	it('falls back to the axis default when the alias does not resolve', () => {
+		expect(shadowAxisPx('{primitive.shadow.unknown}', 14)).toBe(14);
+	});
+
+	/**
+	 * A plain numeric axis passes through untouched, and an unset one takes its default.
+	 *
+	 * @return {void}
+	 */
+	it('passes a numeric axis through and defaults an unset one', () => {
+		expect(shadowAxisPx(4, 0)).toBe(4);
+		expect(shadowAxisPx(0, 14)).toBe(0);
+		expect(shadowAxisPx(undefined, 14)).toBe(14);
+		expect(shadowAxisPx(null, 14)).toBe(14);
 	});
 });

--- a/src/blocks/singlebtn/components/backend-styles/index.js
+++ b/src/blocks/singlebtn/components/backend-styles/index.js
@@ -8,6 +8,7 @@ import {
 	getSpacingOptionOutput,
 } from '@kadence/helpers';
 import { activePresetFor, blockPresetValues } from '../../../../extension/preset-picker';
+import { tokenPx } from '../../../../extension/design-tokens/token-px';
 
 /**
  * Whether the button's active preset resolves a padding and/or a margin.
@@ -77,6 +78,30 @@ export function presetShadowProperties(attributes) {
 	const tokens = blockPresetValues('kadence/singlebtn')?.[preset] ?? {};
 
 	return 'button-shadow' in tokens;
+}
+
+/**
+ * One shadow axis as a bare pixel number.
+ *
+ * A {dot.alias} leg is resolved through the token pool the way the PHP renderer's `render_shadow()`
+ * does. Concatenated raw it would emit `{alias}px`, which is not valid CSS — and `hasVisibleShadow()`
+ * deliberately counts such a leg as visible, so it does reach here.
+ *
+ * @param {*} raw      The stored axis value.
+ * @param {*} fallback What this axis defaults to when unset.
+ *
+ * @since TBD
+ *
+ * @return {*} The axis value to serialize.
+ */
+export function shadowAxisPx(raw, fallback) {
+	if (typeof raw === 'string' && raw.trim() !== '' && !Number.isFinite(Number(raw))) {
+		const resolved = tokenPx(raw);
+
+		return resolved === null || resolved === undefined ? fallback : resolved;
+	}
+
+	return undefined !== raw && null !== raw ? raw : fallback;
 }
 
 /**
@@ -976,20 +1001,18 @@ export default function BackendStyles(props) {
 	// visible shadow as invisible, disagreeing with the PHP gate.
 	const hasExplicitShadow = hasVisibleShadow(shadow?.[0]);
 
-	// Known gap: an alias leg counts as visible but is concatenated with `'px'` below, producing invalid
-	// CSS. Latent — `toNativeShadow` resolves every pick to a literal before storage.
 	if (hasExplicitShadow || !hasPresetShadow) {
 		css.add_property(
 			'box-shadow',
 			hasExplicitShadow
 				? (undefined !== shadow[0].inset && shadow[0].inset ? 'inset ' : '') +
-						(undefined !== shadow[0].hOffset ? shadow[0].hOffset : 0) +
+						shadowAxisPx(shadow[0].hOffset, 0) +
 						'px ' +
-						(undefined !== shadow[0].vOffset ? shadow[0].vOffset : 0) +
+						shadowAxisPx(shadow[0].vOffset, 0) +
 						'px ' +
-						(undefined !== shadow[0].blur ? shadow[0].blur : 14) +
+						shadowAxisPx(shadow[0].blur, 14) +
 						'px ' +
-						(undefined !== shadow[0].spread ? shadow[0].spread : 0) +
+						shadowAxisPx(shadow[0].spread, 0) +
 						'px ' +
 						KadenceColorOutput(
 							undefined !== shadow[0].color ? shadow[0].color : '#000000',
@@ -1116,13 +1139,13 @@ export default function BackendStyles(props) {
 			css.add_property(
 				'box-shadow',
 				(undefined !== shadowTransparent[0].inset && shadowTransparent[0].inset ? 'inset ' : '') +
-					(undefined !== shadowTransparent[0].hOffset ? shadowTransparent[0].hOffset : 0) +
+					shadowAxisPx(shadowTransparent[0].hOffset, 0) +
 					'px ' +
-					(undefined !== shadowTransparent[0].vOffset ? shadowTransparent[0].vOffset : 0) +
+					shadowAxisPx(shadowTransparent[0].vOffset, 0) +
 					'px ' +
-					(undefined !== shadowTransparent[0].blur ? shadowTransparent[0].blur : 14) +
+					shadowAxisPx(shadowTransparent[0].blur, 14) +
 					'px ' +
-					(undefined !== shadowTransparent[0].spread ? shadowTransparent[0].spread : 0) +
+					shadowAxisPx(shadowTransparent[0].spread, 0) +
 					'px ' +
 					KadenceColorOutput(
 						undefined !== shadowTransparent[0].color ? shadowTransparent[0].color : '#000000',
@@ -1224,13 +1247,13 @@ export default function BackendStyles(props) {
 			css.add_property(
 				'box-shadow',
 				(undefined !== shadowSticky[0].inset && shadowSticky[0].inset ? 'inset ' : '') +
-					(undefined !== shadowSticky[0].hOffset ? shadowSticky[0].hOffset : 0) +
+					shadowAxisPx(shadowSticky[0].hOffset, 0) +
 					'px ' +
-					(undefined !== shadowSticky[0].vOffset ? shadowSticky[0].vOffset : 0) +
+					shadowAxisPx(shadowSticky[0].vOffset, 0) +
 					'px ' +
-					(undefined !== shadowSticky[0].blur ? shadowSticky[0].blur : 14) +
+					shadowAxisPx(shadowSticky[0].blur, 14) +
 					'px ' +
-					(undefined !== shadowSticky[0].spread ? shadowSticky[0].spread : 0) +
+					shadowAxisPx(shadowSticky[0].spread, 0) +
 					'px ' +
 					KadenceColorOutput(
 						undefined !== shadowSticky[0].color ? shadowSticky[0].color : '#000000',

--- a/src/blocks/singlebtn/components/backend-styles/index.js
+++ b/src/blocks/singlebtn/components/backend-styles/index.js
@@ -683,6 +683,7 @@ export default function BackendStyles(props) {
 	}
 
 	let btnRad = '0';
+	// No `none` reset: an unset hover shadow must let the base state's carry through the cascade.
 	let btnBox = '';
 	let btnBox2 = '';
 	const btnbgHover = 'gradient' === backgroundHoverType ? gradientHover : KadenceColorOutput(backgroundHover);
@@ -730,6 +731,7 @@ export default function BackendStyles(props) {
 	}
 
 	let btnRadTransparent = '0';
+	// See btnBox above: hover states skip the declaration when there is no visible shadow.
 	let btnBoxTransparent = '';
 	let btnBox2Transparent = '';
 	const btnbgTransparentHover =
@@ -784,6 +786,7 @@ export default function BackendStyles(props) {
 	}
 
 	let btnRadSticky = '0';
+	// See btnBox above: hover states skip the declaration when there is no visible shadow.
 	let btnBoxSticky = '';
 	let btnBox2Sticky = '';
 	const btnbgStickyHover =
@@ -959,33 +962,42 @@ export default function BackendStyles(props) {
 	/*
 	 * Mirrors the front end's gate (`render_preset_shadow` in the block's PHP): point box-shadow at
 	 * the preset variable, but only when the active preset actually resolves one. Written before the
-	 * explicit shadow output below, so an explicit per-block shadow still wins.
+	 * explicit shadow output below, and the builder appends declarations, so a visible per-block
+	 * shadow lands later in the same rule and wins. The flag carries the other half of that
+	 * contract: when the block's own shadow is invisible the `box-shadow: none` reset below is
+	 * skipped, or the trailing `none` would silence this `var(--kb-btn-shadow)`.
 	 */
-	if (presetShadowProperties(attributes)) {
+	const hasPresetShadow = presetShadowProperties(attributes);
+	if (hasPresetShadow) {
 		css.add_property('box-shadow', 'var(--kb-btn-shadow)');
 	}
 
-	css.add_property(
-		'box-shadow',
-		hasVisibleShadow(shadow?.[0]) &&
-			undefined !== shadow &&
-			undefined !== shadow[0] &&
-			undefined !== shadow[0].color
-			? (undefined !== shadow[0].inset && shadow[0].inset ? 'inset ' : '') +
-					(undefined !== shadow[0].hOffset ? shadow[0].hOffset : 0) +
-					'px ' +
-					(undefined !== shadow[0].vOffset ? shadow[0].vOffset : 0) +
-					'px ' +
-					(undefined !== shadow[0].blur ? shadow[0].blur : 14) +
-					'px ' +
-					(undefined !== shadow[0].spread ? shadow[0].spread : 0) +
-					'px ' +
-					KadenceColorOutput(
-						undefined !== shadow[0].color ? shadow[0].color : '#000000',
-						undefined !== shadow[0].opacity ? shadow[0].opacity : 1
-					)
-			: undefined
-	);
+	// No `color` check: it falls back to '#000000' below, so requiring it would read a colorless but
+	// visible shadow as invisible, disagreeing with the PHP gate.
+	const hasExplicitShadow = hasVisibleShadow(shadow?.[0]);
+
+	// Known gap: an alias leg counts as visible but is concatenated with `'px'` below, producing invalid
+	// CSS. Latent — `toNativeShadow` resolves every pick to a literal before storage.
+	if (hasExplicitShadow || !hasPresetShadow) {
+		css.add_property(
+			'box-shadow',
+			hasExplicitShadow
+				? (undefined !== shadow[0].inset && shadow[0].inset ? 'inset ' : '') +
+						(undefined !== shadow[0].hOffset ? shadow[0].hOffset : 0) +
+						'px ' +
+						(undefined !== shadow[0].vOffset ? shadow[0].vOffset : 0) +
+						'px ' +
+						(undefined !== shadow[0].blur ? shadow[0].blur : 14) +
+						'px ' +
+						(undefined !== shadow[0].spread ? shadow[0].spread : 0) +
+						'px ' +
+						KadenceColorOutput(
+							undefined !== shadow[0].color ? shadow[0].color : '#000000',
+							undefined !== shadow[0].opacity ? shadow[0].opacity : 1
+						)
+				: 'none'
+		);
+	}
 
 	css.set_selector(`.kb-single-btn-${uniqueID} .kt-button-${uniqueID} .kt-button-text`);
 	if (textBackgroundType === 'gradient') {
@@ -1099,27 +1111,25 @@ export default function BackendStyles(props) {
 				previewRadiusTransparentBottom + (borderTransparentRadiusUnit ? borderTransparentRadiusUnit : 'px')
 			);
 		}
-		css.add_property(
-			'box-shadow',
-			hasVisibleShadow(shadowTransparent?.[0]) &&
-				undefined !== shadowTransparent &&
-				undefined !== shadowTransparent[0] &&
-				undefined !== shadowTransparent[0].color
-				? (undefined !== shadowTransparent[0].inset && shadowTransparent[0].inset ? 'inset ' : '') +
-						(undefined !== shadowTransparent[0].hOffset ? shadowTransparent[0].hOffset : 0) +
-						'px ' +
-						(undefined !== shadowTransparent[0].vOffset ? shadowTransparent[0].vOffset : 0) +
-						'px ' +
-						(undefined !== shadowTransparent[0].blur ? shadowTransparent[0].blur : 14) +
-						'px ' +
-						(undefined !== shadowTransparent[0].spread ? shadowTransparent[0].spread : 0) +
-						'px ' +
-						KadenceColorOutput(
-							undefined !== shadowTransparent[0].color ? shadowTransparent[0].color : '#000000',
-							undefined !== shadowTransparent[0].opacity ? shadowTransparent[0].opacity : 1
-						)
-				: undefined
-		);
+		// No `none` fallback: this selector outranks the base rule, which must carry through instead.
+		if (hasVisibleShadow(shadowTransparent?.[0])) {
+			css.add_property(
+				'box-shadow',
+				(undefined !== shadowTransparent[0].inset && shadowTransparent[0].inset ? 'inset ' : '') +
+					(undefined !== shadowTransparent[0].hOffset ? shadowTransparent[0].hOffset : 0) +
+					'px ' +
+					(undefined !== shadowTransparent[0].vOffset ? shadowTransparent[0].vOffset : 0) +
+					'px ' +
+					(undefined !== shadowTransparent[0].blur ? shadowTransparent[0].blur : 14) +
+					'px ' +
+					(undefined !== shadowTransparent[0].spread ? shadowTransparent[0].spread : 0) +
+					'px ' +
+					KadenceColorOutput(
+						undefined !== shadowTransparent[0].color ? shadowTransparent[0].color : '#000000',
+						undefined !== shadowTransparent[0].opacity ? shadowTransparent[0].opacity : 1
+					)
+			);
+		}
 		css.add_property('color', css.render_color(colorTransparent));
 		css.add_property('background', btnbgTransparent);
 
@@ -1209,27 +1219,25 @@ export default function BackendStyles(props) {
 				previewRadiusStickyBottom + (borderStickyRadiusUnit ? borderStickyRadiusUnit : 'px')
 			);
 		}
-		css.add_property(
-			'box-shadow',
-			hasVisibleShadow(shadowSticky?.[0]) &&
-				undefined !== shadowSticky &&
-				undefined !== shadowSticky[0] &&
-				undefined !== shadowSticky[0].color
-				? (undefined !== shadowSticky[0].inset && shadowSticky[0].inset ? 'inset ' : '') +
-						(undefined !== shadowSticky[0].hOffset ? shadowSticky[0].hOffset : 0) +
-						'px ' +
-						(undefined !== shadowSticky[0].vOffset ? shadowSticky[0].vOffset : 0) +
-						'px ' +
-						(undefined !== shadowSticky[0].blur ? shadowSticky[0].blur : 14) +
-						'px ' +
-						(undefined !== shadowSticky[0].spread ? shadowSticky[0].spread : 0) +
-						'px ' +
-						KadenceColorOutput(
-							undefined !== shadowSticky[0].color ? shadowSticky[0].color : '#000000',
-							undefined !== shadowSticky[0].opacity ? shadowSticky[0].opacity : 1
-						)
-				: undefined
-		);
+		// No `none` fallback: this selector outranks the base rule, which must carry through instead.
+		if (hasVisibleShadow(shadowSticky?.[0])) {
+			css.add_property(
+				'box-shadow',
+				(undefined !== shadowSticky[0].inset && shadowSticky[0].inset ? 'inset ' : '') +
+					(undefined !== shadowSticky[0].hOffset ? shadowSticky[0].hOffset : 0) +
+					'px ' +
+					(undefined !== shadowSticky[0].vOffset ? shadowSticky[0].vOffset : 0) +
+					'px ' +
+					(undefined !== shadowSticky[0].blur ? shadowSticky[0].blur : 14) +
+					'px ' +
+					(undefined !== shadowSticky[0].spread ? shadowSticky[0].spread : 0) +
+					'px ' +
+					KadenceColorOutput(
+						undefined !== shadowSticky[0].color ? shadowSticky[0].color : '#000000',
+						undefined !== shadowSticky[0].opacity ? shadowSticky[0].opacity : 1
+					)
+			);
+		}
 		css.add_property('color', css.render_color(colorSticky));
 		css.add_property('background', btnbgSticky);
 

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -399,9 +399,8 @@ export default function KadenceButtonEdit(props) {
 		borderRadiusPresetValue
 	);
 
-	// `button-padding` carries no baseline preset value, so `presetValueForDevice` above always resolves
-	// to nothing for it — OR in the button's own literal default so an unset Padding side shows what the
-	// button actually renders instead of reading as blank.
+	// The shipped presets (default/secondary) both declare `button-padding`, so `presetValueForDevice`
+	// above resolves it for those; the fallback only matters for a custom preset that omits the key.
 	const paddingPresetValue = presetValueOr(
 		presetValueForDevice(tokenBinding.padding?.presetValue, tokenBinding.padding?.responsive, previewDevice),
 		BUTTON_PADDING_FALLBACK

--- a/tests/wpunit/Blocks/SinglebtnTest.php
+++ b/tests/wpunit/Blocks/SinglebtnTest.php
@@ -234,7 +234,9 @@ class SinglebtnTest extends KadenceBlocksUnit {
 	}
 
 	/**
-	 * @return \Generator
+	 * Shadow items covering every visible/invisible axis shape `has_visible_shadow()` must tell apart.
+	 *
+	 * @return Generator
 	 */
 	public function shadowVisibilityProvider(): \Generator {
 		yield 'all-zero axes' => [
@@ -294,12 +296,13 @@ class SinglebtnTest extends KadenceBlocksUnit {
 	}
 
 	/**
-	 * An all-zero shadow value — the shape the fixed "None" pick writes — emits no explicit
-	 * `box-shadow` declaration, now that there is no separate toggle to suppress it.
+	 * An all-zero shadow value — the shape the fixed "None" pick writes — emits an explicit
+	 * `box-shadow: none` declaration, actively overriding any competing shadow rule from elsewhere
+	 * (e.g. a theme selector) rather than silently omitting the property.
 	 *
 	 * @return void
 	 */
-	public function testNoneShadowEmitsNoExplicitBoxShadow(): void {
+	public function testNoneShadowEmitsExplicitBoxShadowNone(): void {
 		$this->seedPreset( 'bare', 'Bare', [ 'button-bg' => '#ff0000' ] );
 
 		$output = $this->render_button(
@@ -319,11 +322,306 @@ class SinglebtnTest extends KadenceBlocksUnit {
 			]
 		);
 
-		$css_helper       = new CSSTestHelper( $output );
-		$selector         = '.wp-block-kadence-advancedbtn .kb-btn123.kb-button';
+		$css_helper = new CSSTestHelper( $output );
+		$selector   = '.wp-block-kadence-advancedbtn .kb-btn123.kb-button';
+
+		$css_helper->assertCSSPropertiesEqual( $selector, [ 'box-shadow' => 'none' ] );
+	}
+
+	/**
+	 * A button with a visible base shadow and an invisible hover shadow writes no `box-shadow` into
+	 * the hover rule, so the base shadow keeps painting on hover through the normal cascade instead
+	 * of being cancelled by a `none` reset.
+	 *
+	 * @return void
+	 */
+	public function testInvisibleHoverShadowEmitsNoBoxShadowOnHover(): void {
+		$this->seedPreset( 'bare', 'Bare', [ 'button-bg' => '#ff0000' ] );
+
+		$output = $this->render_button(
+			[
+				'kbPreset'    => 'bare',
+				'colorHover'  => '#0000ff',
+				'shadow'      => [
+					[
+						'color'   => '#00ff00',
+						'opacity' => 1,
+						'hOffset' => 1,
+						'vOffset' => 1,
+						'blur'    => 2,
+						'spread'  => 0,
+						'inset'   => false,
+					],
+				],
+				'shadowHover' => [
+					[
+						'color'   => 'transparent',
+						'opacity' => 1,
+						'hOffset' => 0,
+						'vOffset' => 0,
+						'blur'    => 0,
+						'spread'  => 0,
+						'inset'   => false,
+					],
+				],
+			]
+		);
+
+		$css_helper     = new CSSTestHelper( $output );
+		$base_selector  = '.wp-block-kadence-advancedbtn .kb-btn123.kb-button';
+		$hover_selector = '.wp-block-kadence-advancedbtn .kb-btn123.kb-button:hover, .wp-block-kadence-advancedbtn .kb-btn123.kb-button:focus';
+
+		$css_helper->assertCSSPropertiesEqual( $base_selector, [ 'box-shadow' => '1px 1px 2px 0px #0f0' ] );
+
+		$hover_properties = $css_helper->getPropertyOrder( $hover_selector );
+
+		$this->assertContains( 'color', $hover_properties, 'The hover rule should exist and carry the hover color.' );
+		$this->assertNotContains(
+			'box-shadow',
+			$hover_properties,
+			'An invisible hover shadow must leave the hover rule free of box-shadow so the base shadow persists.'
+		);
+	}
+
+	/**
+	 * A gradient-background button with an invisible (all-zero) hover shadow whose `inset` flag is
+	 * `true` writes no `box-shadow` at all into the hover rule — the gradient-specific inset reset
+	 * lost its `displayHoverShadow` toggle gate along with every other hover site, and must not fire
+	 * on an invisible shadow just because `inset` happens to be `true`.
+	 *
+	 * @return void
+	 */
+	public function testInvisibleInsetHoverShadowEmitsNoBoxShadowOnGradientHover(): void {
+		$this->seedPreset( 'bare', 'Bare', [ 'button-bg' => '#ff0000' ] );
+
+		$output = $this->render_button(
+			[
+				'kbPreset'            => 'bare',
+				'backgroundHoverType' => 'gradient',
+				'gradientHover'       => 'linear-gradient(90deg, #ff0000, #0000ff)',
+				'colorHover'          => '#0000ff',
+				'shadow'              => [
+					[
+						'color'   => '#00ff00',
+						'opacity' => 1,
+						'hOffset' => 1,
+						'vOffset' => 1,
+						'blur'    => 2,
+						'spread'  => 0,
+						'inset'   => false,
+					],
+				],
+				'shadowHover'         => [
+					[
+						'color'   => 'transparent',
+						'opacity' => 1,
+						'hOffset' => 0,
+						'vOffset' => 0,
+						'blur'    => 0,
+						'spread'  => 0,
+						'inset'   => true,
+					],
+				],
+			]
+		);
+
+		$css_helper     = new CSSTestHelper( $output );
+		$hover_selector = '.wp-block-kadence-advancedbtn .kb-btn123.kb-button:hover, .wp-block-kadence-advancedbtn .kb-btn123.kb-button:focus';
+
+		$hover_properties = $css_helper->getPropertyOrder( $hover_selector );
+
+		$this->assertContains( 'color', $hover_properties, 'The hover rule should exist and carry the hover color.' );
+		$this->assertNotContains(
+			'box-shadow',
+			$hover_properties,
+			'An invisible hover shadow must not trigger the inset reset just because inset is true.'
+		);
+	}
+
+	/**
+	 * A button with a visible base shadow and an invisible transparent-header shadow writes no
+	 * `box-shadow` into the more specific `.header-*-transparent` rule, so the base shadow keeps
+	 * painting under a transparent header through the normal cascade instead of being cancelled by a
+	 * `none` reset.
+	 *
+	 * @return void
+	 */
+	public function testInvisibleTransparentShadowEmitsNoBoxShadow(): void {
+		$this->seedPreset( 'bare', 'Bare', [ 'button-bg' => '#ff0000' ] );
+
+		$output = $this->render_button(
+			[
+				'kbPreset'          => 'bare',
+				'colorTransparent'  => '#0000ff',
+				'shadow'            => [
+					[
+						'color'   => '#00ff00',
+						'opacity' => 1,
+						'hOffset' => 1,
+						'vOffset' => 1,
+						'blur'    => 2,
+						'spread'  => 0,
+						'inset'   => false,
+					],
+				],
+				'shadowTransparent' => [
+					[
+						'color'   => 'transparent',
+						'opacity' => 1,
+						'hOffset' => 0,
+						'vOffset' => 0,
+						'blur'    => 0,
+						'spread'  => 0,
+						'inset'   => false,
+					],
+				],
+			]
+		);
+
+		$css_helper           = new CSSTestHelper( $output );
+		$base_selector        = '.wp-block-kadence-advancedbtn .kb-btn123.kb-button';
+		$transparent_selector = '.header-desktop-transparent .wp-block-kadence-advancedbtn .kb-btn123.kb-button';
+
+		$css_helper->assertCSSPropertiesEqual( $base_selector, [ 'box-shadow' => '1px 1px 2px 0px #0f0' ] );
+
+		$transparent_properties = $css_helper->getPropertyOrder( $transparent_selector );
+
+		$this->assertContains( 'color', $transparent_properties, 'The transparent-header rule should exist and carry its color.' );
+		$this->assertNotContains(
+			'box-shadow',
+			$transparent_properties,
+			'An invisible transparent-header shadow must leave that rule free of box-shadow so the base shadow persists.'
+		);
+	}
+
+	/**
+	 * A button with a visible base shadow and an invisible sticky shadow writes no `box-shadow` into
+	 * the more specific `.item-is-stuck` rule, so the base shadow keeps painting while stuck through
+	 * the normal cascade instead of being cancelled by a `none` reset.
+	 *
+	 * @return void
+	 */
+	public function testInvisibleStickyShadowEmitsNoBoxShadow(): void {
+		$this->seedPreset( 'bare', 'Bare', [ 'button-bg' => '#ff0000' ] );
+
+		$output = $this->render_button(
+			[
+				'kbPreset'     => 'bare',
+				'colorSticky'  => '#0000ff',
+				'shadow'       => [
+					[
+						'color'   => '#00ff00',
+						'opacity' => 1,
+						'hOffset' => 1,
+						'vOffset' => 1,
+						'blur'    => 2,
+						'spread'  => 0,
+						'inset'   => false,
+					],
+				],
+				'shadowSticky' => [
+					[
+						'color'   => 'transparent',
+						'opacity' => 1,
+						'hOffset' => 0,
+						'vOffset' => 0,
+						'blur'    => 0,
+						'spread'  => 0,
+						'inset'   => false,
+					],
+				],
+			]
+		);
+
+		$css_helper      = new CSSTestHelper( $output );
+		$base_selector   = '.wp-block-kadence-advancedbtn .kb-btn123.kb-button';
+		$sticky_selector = '.item-is-stuck .wp-block-kadence-advancedbtn .kb-btn123.kb-button';
+
+		$css_helper->assertCSSPropertiesEqual( $base_selector, [ 'box-shadow' => '1px 1px 2px 0px #0f0' ] );
+
+		$sticky_properties = $css_helper->getPropertyOrder( $sticky_selector );
+
+		$this->assertContains( 'color', $sticky_properties, 'The sticky rule should exist and carry its color.' );
+		$this->assertNotContains(
+			'box-shadow',
+			$sticky_properties,
+			'An invisible sticky shadow must leave that rule free of box-shadow so the base shadow persists.'
+		);
+	}
+
+	/**
+	 * A button whose preset resolves a shadow, and whose own shadow value is the invisible all-zero
+	 * "None" shape, keeps the preset's `var(--kb-btn-shadow)` as the rule's only box-shadow — the
+	 * `none` reset must not be appended behind it, or the preset shadow would be silenced.
+	 *
+	 * @return void
+	 */
+	public function testPresetShadowIsNotErasedByTheNoneFallback(): void {
+		$this->seedPreset(
+			'accent',
+			'Accent',
+			[ 'button-shadow' => '0px 2px 8px 0px #1717171f' ]
+		);
+
+		$output = $this->render_button(
+			[
+				'kbPreset' => 'accent',
+				'shadow'   => [
+					[
+						'color'   => 'transparent',
+						'opacity' => 1,
+						'hOffset' => 0,
+						'vOffset' => 0,
+						'blur'    => 0,
+						'spread'  => 0,
+						'inset'   => false,
+					],
+				],
+			]
+		);
+
+		$css_helper = new CSSTestHelper( $output );
+		$selector   = '.wp-block-kadence-advancedbtn .kb-btn123.kb-button';
+
 		$shadow_positions = array_keys( $css_helper->getPropertyOrder( $selector ), 'box-shadow', true );
 
-		$this->assertCount( 0, $shadow_positions, 'An all-zero shadow value should emit no explicit box-shadow declaration.' );
+		$this->assertCount( 1, $shadow_positions, 'Only the preset box-shadow should be emitted.' );
+		$css_helper->assertCSSPropertiesEqual( $selector, [ 'box-shadow' => 'var(--kb-btn-shadow)' ] );
+	}
+
+	/**
+	 * A shadow whose leg holds a {dot.alias} token reference is not treated as invisible: the rule
+	 * carries the resolved shadow rather than the `none` reset that would erase it.
+	 *
+	 * @return void
+	 */
+	public function testAliasLeggedShadowIsNotErasedByTheNoneFallback(): void {
+		$this->seedPreset( 'bare', 'Bare', [ 'button-bg' => '#ff0000' ] );
+
+		$output = $this->render_button(
+			[
+				'kbPreset' => 'bare',
+				'shadow'   => [
+					[
+						'color'   => '#00ff00',
+						'opacity' => 1,
+						'hOffset' => 0,
+						'vOffset' => 0,
+						'blur'    => '{semantic.radius.media}',
+						'spread'  => 0,
+						'inset'   => false,
+					],
+				],
+			]
+		);
+
+		$css_helper = new CSSTestHelper( $output );
+		$selector   = '.wp-block-kadence-advancedbtn .kb-btn123.kb-button';
+
+		$css_helper->assertCSSPropertiesEqual(
+			$selector,
+			[ 'box-shadow' => '0px 0px var(--kb-token--semantic--radius--media) 0px #0f0' ]
+		);
 	}
 
 	/**


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4260/token-control-popover-options-and-the-default-label-show-what-is

Picking `None` had no way to *remove* a shadow. Skipping the declaration leaves whatever the cascade already supplies — a preset's `var(--kb-btn-shadow)`, or the theme's own rule — so "None" silently did nothing. The base state now emits an explicit `box-shadow: none`.

Scoping is the whole difficulty, and it is why this slice carries so many tests:

- **Base state only.** Hover, transparent and sticky selectors are *more specific* than the base rule, so a `none` there would cancel the base shadow instead of expressing "this state adds none". Those keep the pre-existing skip-the-declaration behavior and let the base carry through the cascade.
- **Only when nothing else claims the rule.** A preset-resolved shadow lands in the same rule, and a trailing `none` would silence it.
- **An unresolved `{dot.alias}` leg counts as visible**, so a token-painted shadow is never erased by the reset.

The gradient hover inset reset is gated on visibility too: it previously fired on any inset-true item, including the invisible all-zero default the block ships with.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed button shadows being incorrectly removed when preset or token-based shadows are active.
  - Preserved base shadows across hover, transparent-header, and sticky-header states.
  - Prevented invisible shadow settings from adding unnecessary reset styles.
  - Improved handling of inset hover shadows and custom shadow presets.

- **Tests**
  - Added coverage for preset, token-based, hover, transparent-header, and sticky-header shadow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->