### PR TITLE
[DTM] SOFT-4260 [14/19]: show a muted Default on a reset Border Width

### DIFF
--- a/src/style-library/__tests__/border-shadow-field-rendering.test.js
+++ b/src/style-library/__tests__/border-shadow-field-rendering.test.js
@@ -88,6 +88,16 @@ describe('BorderField', () => {
 		expect(latestBorderControlProps.widthTokens[1].alias).toBe('{primitive.dimension.border-width.sm}');
 	});
 
+	it('forwards the field\'s defaultValue to BorderControl, so a reset width shows muted "Default" instead of blank', () => {
+		const field = { label: 'Border', path: 'tokens.button-border', defaultValue: '1px' };
+
+		act(() => {
+			root.render(createElement(BorderField, { field, values: {}, onValueChange: jest.fn() }));
+		});
+
+		expect(latestBorderControlProps.defaultValue).toBe('1px');
+	});
+
 	it('shows a semantic-bound width as unset rather than listing the semantic', () => {
 		const field = { label: 'Border', path: 'tokens.button-border' };
 

--- a/src/style-library/components/molecules/fields/BorderField.js
+++ b/src/style-library/components/molecules/fields/BorderField.js
@@ -250,12 +250,9 @@ export function BorderField({ field, values, onValueChange }) {
 		onValueChange(stylePath, responsive ? writePresetBreakpoint(rawStyle, breakpoint, next) : next);
 	const writeColor = (next) => onValueChange(colorPath, next);
 
-	// A semantic-bound width is the block's role-based default rather than a selection — the pool
-	// offers primitives only — so it is blanked and the field reads as unset. Blanking is what keeps
-	// it from rendering the raw dot-path: `boundTokenIds` exempts only primitives from the narrowing,
-	// so a semantic left in place would find no matching entry. Unlike `BoxControl`, `BorderControl`
-	// takes no `defaultValue`, so the semantic's VALUE cannot be shown here the way the box fields
-	// show it; an unset field is the honest reading until that prop exists.
+	// A semantic is the block's own default, not a selection, and the pool offers primitives only —
+	// left in place it renders as a raw dot-path. Blanked here; the field's declared `defaultValue`
+	// is what the control shows muted in its place.
 	const shownWidth = withoutSemanticSlots(widthAtBreakpoint);
 
 	// The bound width token(s) are exempt from the primitive narrowing, the same way `BoxTokenField`

--- a/src/style-library/components/molecules/fields/BorderField.js
+++ b/src/style-library/components/molecules/fields/BorderField.js
@@ -216,6 +216,9 @@ export function widthTokensForField(atBreakpoint) {
  * @param {?string}  [props.field.label]      The control's label.
  * @param {boolean}  [props.field.readOnly]   Whether the control is non-interactive.
  * @param {boolean}  [props.field.responsive] Whether the field offers a breakpoint switcher.
+ * @param {*}        [props.field.defaultValue] What the width axis falls back to when unset —
+ *                                             shown as a muted "Default" — passed straight through
+ *                                             to `BorderControl`.
  * @param {Object}   props.values             The full draft values, read by dot path.
  * @param {Function} props.onValueChange      Called with `(path, next)` for any of the three axes.
  *
@@ -308,6 +311,7 @@ export function BorderField({ field, values, onValueChange }) {
 			}}
 			label={field.label}
 			widthTokens={widthTokens}
+			defaultValue={field.defaultValue}
 			renderColor={({ value: color, onChange: onColorChange, label: sideLabel }) => (
 				<TokenColorSelectField
 					// `sideLabel` is the row's bare side name ("top", "right", …), or `null` while linked.

--- a/src/style-library/presets/button-preset.js
+++ b/src/style-library/presets/button-preset.js
@@ -142,10 +142,11 @@ function schemaFor(tab) {
 				// living at this path.
 				path: 'tokens.button-border',
 				label: __('Border', 'kadence-blocks'),
-				// No `defaultValue` here, unlike the radius field above: `BorderField`'s adapter doesn't
-				// read one, because `BorderControl` accepts no `defaultValue`/inherited-value prop the way
-				// `BoxControl` does. Setting one would be a dead key. Add it once `BorderControl` grows that
-				// support, not before.
+				// `BorderControl` only takes one `defaultValue` for its width axis (color/style have no
+				// equivalent fallback prop) — `semantic.border-width.default`'s shipped resolution, the
+				// value `var(--kb-btn-border-width)` computes to today. Shown muted when the field is
+				// unset, the same way Radius/Padding/Margin's `defaultValue` above are.
+				defaultValue: '1px',
 			},
 			{
 				type: 'box-shadow',


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4260/token-control-popover-options-and-the-default-label-show-what-is

A reset Border Width rendered as an empty field. The control's `TokenSelector` trigger had nothing to show, so the row collapsed to zero height — it read as broken rather than as reset.

`BorderControl` now takes a `defaultValue` the way the box fields already do, and the Style Library's border field declares the button's own `1px`, so a reset width shows a muted "Default" naming what the button actually renders.

This is the first of the "muted Default" slices; the rest of that work builds on the same prop.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Border settings now support configurable default values.
  - Buttons use a 1px border by default.

- **Bug Fixes**
  - Border field defaults are now correctly applied to border controls.

- **Documentation**
  - Updated border configuration guidance to reflect default value support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->