### PR TITLE
[DTM] SOFT-4260 [15/19]: thread each preset's own stored values into its settings form

### DIFF
--- a/src/style-library/__tests__/border-shadow-field-rendering.test.js
+++ b/src/style-library/__tests__/border-shadow-field-rendering.test.js
@@ -98,6 +98,41 @@ describe('BorderField', () => {
 		expect(latestBorderControlProps.defaultValue).toBe('1px');
 	});
 
+	it("shows the preset's own stored width as bound, not the generic literal fallback, once the draft is reset", () => {
+		const field = { label: 'Border', path: 'tokens.button-border', defaultValue: '1px' };
+
+		act(() => {
+			root.render(
+				createElement(BorderField, {
+					field,
+					values: {},
+					originalValues: { tokens: { 'button-border-width': 'semantic.border-width.default' } },
+					onValueChange: jest.fn(),
+				})
+			);
+		});
+
+		expect(latestBorderControlProps.value.width).toBe('{semantic.border-width.default}');
+	});
+
+	it('falls back to the generic literal defaultValue when the preset has no stored width either', () => {
+		const field = { label: 'Border', path: 'tokens.button-border', defaultValue: '1px' };
+
+		act(() => {
+			root.render(
+				createElement(BorderField, {
+					field,
+					values: {},
+					originalValues: { tokens: {} },
+					onValueChange: jest.fn(),
+				})
+			);
+		});
+
+		expect(latestBorderControlProps.value.width).toBe('');
+		expect(latestBorderControlProps.defaultValue).toBe('1px');
+	});
+
 	it('shows a semantic-bound width as unset rather than listing the semantic', () => {
 		const field = { label: 'Border', path: 'tokens.button-border' };
 

--- a/src/style-library/__tests__/box-token-field.test.js
+++ b/src/style-library/__tests__/box-token-field.test.js
@@ -316,3 +316,66 @@ describe('tokensForField', () => {
 		expect(none.alias).toBe(0);
 	});
 });
+
+describe('the effective value shown when the draft is reset', () => {
+	let container;
+	let root;
+
+	beforeEach(() => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => {
+			root.unmount();
+		});
+		container.remove();
+		latestBoxControlProps = undefined;
+	});
+
+	/**
+	 * Render `BoxTokenField` with the given draft/original values.
+	 *
+	 * @param {Object} props The field's `value`/`originalValue` to render with.
+	 *
+	 * @since TBD
+	 *
+	 * @return {void}
+	 */
+	function renderField({ value, originalValue }) {
+		act(() => {
+			root.render(
+				createElement(BoxTokenField, {
+					field: { tokenType: 'dimension', role: 'radius', defaultValue: '0.1875rem' },
+					value,
+					originalValue,
+					onChange: jest.fn(),
+					slots: 'corners',
+				})
+			);
+		});
+	}
+
+	it("shows the preset's own stored value, not the generic literal fallback, once the draft is reset", () => {
+		renderField({ value: '', originalValue: 'semantic.radius.control' });
+
+		expect(latestBoxControlProps.value).toEqual(toControlValue('semantic.radius.control'));
+		expect(latestBoxControlProps.defaultValue).toBe('0.1875rem');
+	});
+
+	it('falls back to the generic literal fallback when the preset has no stored value either', () => {
+		renderField({ value: '', originalValue: '' });
+
+		expect(latestBoxControlProps.value).toEqual(toControlValue(''));
+	});
+
+	it('shows the draft value untouched when the field actually carries an edit', () => {
+		renderField({ value: '0.5rem', originalValue: 'semantic.radius.control' });
+
+		expect(latestBoxControlProps.value).toEqual(toControlValue('0.5rem'));
+	});
+});

--- a/src/style-library/__tests__/box-token-field.test.js
+++ b/src/style-library/__tests__/box-token-field.test.js
@@ -379,3 +379,120 @@ describe('the effective value shown when the draft is reset', () => {
 		expect(latestBoxControlProps.value).toEqual(toControlValue('0.5rem'));
 	});
 });
+
+describe('a reset responsive field', () => {
+	let container;
+	let root;
+
+	beforeEach(() => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		latestBoxControlProps = undefined;
+	});
+
+	/**
+	 * Render a responsive `BoxTokenField` and switch it to `breakpoint`.
+	 *
+	 * @param {Object} props        The field's `value`/`originalValue`.
+	 * @param {string} breakpoint   The breakpoint to switch to.
+	 *
+	 * @since TBD
+	 *
+	 * @return {void}
+	 */
+	function renderAt({ value, originalValue }, breakpoint) {
+		act(() => {
+			root.render(
+				createElement(BoxTokenField, {
+					field: { path: 'tokens.radius', tokenType: 'dimension', role: 'radius', responsive: true },
+					value,
+					originalValue,
+					onChange: jest.fn(),
+					slots: 'corners',
+				})
+			);
+		});
+		act(() => latestBoxControlProps.onBreakpointChange(breakpoint));
+	}
+
+	/**
+	 * A preset that stores only a desktop value still resolves to it at Tablet, because that is what a
+	 * reset there actually renders. Reading only the tablet slot would show the generic fallback for a
+	 * value the preset genuinely supplies.
+	 *
+	 * @return {void}
+	 */
+	it("shows the preset's desktop value at Tablet when it stores no tablet override", () => {
+		renderAt({ value: '', originalValue: 'semantic.radius.control' }, 'tablet');
+
+		expect(latestBoxControlProps.value).toEqual(toControlValue('semantic.radius.control'));
+	});
+
+	/**
+	 * Mobile steps through tablet first, so a tablet override wins over the desktop value.
+	 *
+	 * @return {void}
+	 */
+	it('prefers a tablet override over the desktop value at Mobile', () => {
+		const envelope = {
+			$value: 'semantic.radius.control',
+			$extensions: { 'com.kadence.designTokens': { responsive: { tablet: '0.5rem' } } },
+		};
+
+		renderAt({ value: '', originalValue: envelope }, 'mobile');
+
+		expect(latestBoxControlProps.value).toEqual(toControlValue('0.5rem'));
+	});
+});
+
+describe('switching unit on a reset field', () => {
+	let container;
+	let root;
+
+	beforeEach(() => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		latestBoxControlProps = undefined;
+	});
+
+	/**
+	 * The unit switcher retypes what the field is SHOWING. With the draft reset the field shows the
+	 * preset's own value, so switching unit has to materialize that value into the draft — otherwise
+	 * the trigger would read `1px` while nothing was written, and a reload would show `1rem` again.
+	 *
+	 * @return {void}
+	 */
+	it("retypes the preset's own value rather than the empty draft", () => {
+		const onChange = jest.fn();
+
+		act(() => {
+			root.render(
+				createElement(BoxTokenField, {
+					field: { path: 'tokens.radius', tokenType: 'dimension', role: 'radius' },
+					value: '',
+					originalValue: '1rem',
+					onChange,
+					slots: 'corners',
+				})
+			);
+		});
+
+		act(() => latestBoxControlProps.onUnit('px'));
+
+		expect(onChange).toHaveBeenCalledWith('1px');
+	});
+});

--- a/src/style-library/__tests__/preset-sidebar.test.js
+++ b/src/style-library/__tests__/preset-sidebar.test.js
@@ -13,6 +13,23 @@ import * as notify from '../helpers/notify';
 
 jest.mock('../helpers/notify');
 
+// Stands in for the real `BoxControl` the same way `border-shadow-field-rendering.test.js` stands in
+// for `BorderControl`/`BoxShadowControl`: capturing exactly the props `PresetSidebar`'s real
+// `SettingsForm` -> `BoxTokenField` wiring computes, without mounting `BoxControl`'s own deep
+// picker/popover tree. Declared here (rather than per-describe) so the "reset shows the preset's own
+// value" test below exercises the REAL prop-threading path end to end — the bug that motivated it
+// was a shape mismatch between `PresetSidebar` and `BoxTokenField` that a field-level test alone,
+// constructing `originalValue` by hand, could not have caught.
+let latestBoxControlProps;
+
+jest.mock('../../token-controls/controls/BoxControl', () => ({
+	BoxControl: (props) => {
+		latestBoxControlProps = props;
+
+		return null;
+	},
+}));
+
 // `PresetSidebar` takes the preset-screen binding as a prop rather than calling a hook itself, so
 // both cases below can stub `screen` directly with a plain object — no module mock is needed.
 // Both resolve to no initial values, so `PresetSidebar` returns null before mounting its body; the
@@ -50,6 +67,36 @@ function renderPresetSidebar(screen, item) {
 	return navigate;
 }
 
+/**
+ * `renderPresetSidebar`, with the `preset` config also overridable — the module-level `PRESET`
+ * stub's empty `schemaFor` renders no fields at all, which is fine for the write-flow/self-heal
+ * tests above but useless for anything that needs a real field on screen.
+ *
+ * @param {Object} screen The preset-screen binding to stub.
+ * @param {string} item   The route's `item` (`kb-item`) value.
+ * @param {Object} preset The preset config (`{ tabs, schemaFor }`) to render with.
+ *
+ * @since TBD
+ *
+ * @return {Function} The `navigate` jest spy.
+ */
+function renderPresetSidebarWithPreset(screen, item, preset) {
+	const navigate = jest.fn();
+
+	act(() => {
+		root.render(
+			createElement(PresetSidebar, {
+				route: { screen: 'blocks/kadence/singlebtn', item },
+				navigate,
+				screen,
+				preset,
+			})
+		);
+	});
+
+	return navigate;
+}
+
 beforeEach(() => {
 	jest.clearAllMocks();
 	global.IS_REACT_ACT_ENVIRONMENT = true;
@@ -63,6 +110,7 @@ afterEach(() => {
 		root.unmount();
 	});
 	container.remove();
+	latestBoxControlProps = undefined;
 });
 
 // React overrides a controlled input's `value` setter on the DOM node itself to track whether a
@@ -343,5 +391,79 @@ describe('PresetSidebar self-heal guard', () => {
 		);
 
 		expect(navigate).toHaveBeenCalledWith({ item: '' });
+	});
+});
+
+describe('PresetSidebar reset field display', () => {
+	/**
+	 * A single-panel, single-field radius schema, real enough to exercise `SettingsForm` ->
+	 * `BoxTokenField`'s actual prop computation rather than a schema-shaped stub.
+	 *
+	 * @since TBD
+	 *
+	 * @type {Object}
+	 */
+	const RADIUS_PRESET = {
+		tabs: null,
+		schemaFor: () => ({
+			panels: [
+				{
+					id: 'p',
+					fields: [
+						{
+							type: 'radius',
+							tokenType: 'dimension',
+							role: 'radius',
+							path: 'tokens.button-radius',
+							label: 'Radius',
+							defaultValue: '0.1875rem',
+						},
+					],
+				},
+			],
+		}),
+	};
+
+	/**
+	 * A field the user resets shows as bound to the preset's own currently-stored value, not the
+	 * generic literal `defaultValue` — end to end through `PresetSidebar` -> `SettingsForm` ->
+	 * `BoxTokenField`, not a field mounted with `originalValue` handed in directly. A mismatch
+	 * between how `PresetSidebar` shapes `originalValues` and how `BoxTokenField` reads it (the two
+	 * disagreeing on whether the `tokens.` path prefix is already stripped) would read as "always
+	 * empty" and only a test exercising the real wiring between them can catch it.
+	 *
+	 * @return {void}
+	 */
+	it("shows the preset's own bound value once the field is reset, not a blank Default", () => {
+		renderPresetSidebarWithPreset(
+			{
+				payload: {
+					presets: { primary: { label: 'Primary', tokens: { 'button-radius': 'semantic.radius.control' } } },
+				},
+				isLoading: false,
+				loadError: null,
+				initialValuesFor: () => ({ label: 'Primary', tokens: { 'button-radius': 'semantic.radius.control' } }),
+				savePreset: jest.fn(),
+				deletePreset: jest.fn(),
+				isDeletable: () => true,
+				isBusy: false,
+				saveError: null,
+				deleteError: null,
+				clearSaveError: jest.fn(),
+				clearDeleteError: jest.fn(),
+			},
+			'primary',
+			RADIUS_PRESET
+		);
+
+		expect(latestBoxControlProps.value).toBe('{semantic.radius.control}');
+
+		// Reset: the user's edit writes the field back to empty.
+		act(() => {
+			latestBoxControlProps.onChange('');
+		});
+
+		// Still bound to the preset's own value, not a blank field falling back to the generic literal.
+		expect(latestBoxControlProps.value).toBe('{semantic.radius.control}');
 	});
 });

--- a/src/style-library/__tests__/token-select-field.test.js
+++ b/src/style-library/__tests__/token-select-field.test.js
@@ -12,9 +12,12 @@ import { TokenSelectField } from '../components/molecules/fields/TokenSelectFiel
 import { pickableTokensForType } from '../helpers/tokens';
 
 // A factory, not automock: `helpers/tokens.js` reaches the localized feed, and this test only cares
-// about the arguments the field hands it.
+// about the arguments the field hands it. `RESPONSIVE_BREAKPOINTS` is not used by this test, but the
+// factory has to carry it: the field pulls in `helpers/presets.js`, which reaches `settings-schema.js`,
+// which spreads this export at module scope — a factory missing it fails the whole suite at load.
 jest.mock('../helpers/tokens', () => ({
 	pickableTokensForType: jest.fn(() => []),
+	RESPONSIVE_BREAKPOINTS: ['tablet', 'mobile'],
 }));
 
 jest.mock('../components/molecules/SelectDropdown', () => ({ SelectDropdown: () => null }));

--- a/src/style-library/components/molecules/fields/BorderField.js
+++ b/src/style-library/components/molecules/fields/BorderField.js
@@ -54,6 +54,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { getValueAtPath } from '../../../helpers/settings-schema';
 import { pickableTokensForType } from '../../../helpers/tokens';
+import { isUnsetPresetValue } from '../../../helpers/presets';
 import {
 	PRESET_BREAKPOINTS,
 	readPresetBreakpoint,
@@ -115,9 +116,7 @@ export function toStoredWidth(next) {
 		return next.slice(1, -1);
 	}
 
-	// Zero stays unitless for the same reason `BoxTokenField`'s `toStoredValue` keeps it unitless: the
-	// `None` token resolves to a bare `'0'`, so appending `px` here would rewrite a clean value on a
-	// no-op round trip.
+	// The `None` token resolves to a bare `'0'`; appending `px` would rewrite it on a no-op round trip.
 	if (Number(next) === 0) {
 		return '0';
 	}
@@ -216,21 +215,27 @@ export function widthTokensForField(atBreakpoint) {
  * @param {?string}  [props.field.label]      The control's label.
  * @param {boolean}  [props.field.readOnly]   Whether the control is non-interactive.
  * @param {boolean}  [props.field.responsive] Whether the field offers a breakpoint switcher.
- * @param {*}        [props.field.defaultValue] What the width axis falls back to when unset —
- *                                             shown as a muted "Default" — passed straight through
- *                                             to `BorderControl`.
+ * @param {*}        [props.field.defaultValue] What the width axis falls back to, shown as a muted
+ *                                             "Default", when NEITHER the draft nor the preset's own
+ *                                             stored value carries anything — passed straight through
+ *                                             to `BorderControl`. A reset width whose preset already
+ *                                             has its own value shows that instead, as if bound; see
+ *                                             `originalValues` below.
  * @param {Object}   props.values             The full draft values, read by dot path.
+ * @param {?Object}  [props.originalValues]   The preset's own stored values, unaffected by the
+ *                                             draft — read by the same dot paths as `values`, so a
+ *                                             reset axis reads as what saving the reset actually
+ *                                             resolves to instead of a generic literal fallback.
  * @param {Function} props.onValueChange      Called with `(path, next)` for any of the three axes.
  *
  * @since TBD
  *
  * @return {JSX.Element} The field.
  */
-export function BorderField({ field, values, onValueChange }) {
+export function BorderField({ field, values, originalValues, onValueChange }) {
 	const responsive = field.responsive === true;
 
-	// Shared, not local: switching to Tablet here switches every other responsive control in the panel
-	// with it, matching `BoxTokenField`.
+	// Shared, not local: this switches every responsive control in the panel at once.
 	const [breakpoint, setBreakpoint] = useBreakpoint(PRESET_BREAKPOINTS[0]);
 
 	const widthPath = `${field.path}-width`;
@@ -241,8 +246,35 @@ export function BorderField({ field, values, onValueChange }) {
 	const rawStyle = getValueAtPath(values, stylePath);
 	const rawColor = getValueAtPath(values, colorPath);
 
+	const originalWidth = getValueAtPath(originalValues, widthPath);
+	const originalStyle = getValueAtPath(originalValues, stylePath);
+	const originalColor = getValueAtPath(originalValues, colorPath);
+
 	const widthAtBreakpoint = responsive ? readPresetBreakpoint(rawWidth, breakpoint) : rawWidth;
 	const styleAtBreakpoint = responsive ? readPresetBreakpoint(rawStyle, breakpoint) : rawStyle;
+	const originalWidthAtBreakpoint = responsive ? readPresetBreakpoint(originalWidth, breakpoint) : originalWidth;
+	const originalStyleAtBreakpoint = responsive ? readPresetBreakpoint(originalStyle, breakpoint) : originalStyle;
+
+	// A semantic is the block's own default, not a selection, and the pool offers primitives only —
+	// left in place it renders as a raw dot-path. Blanked before the effective read below.
+	const shownWidth = withoutSemanticSlots(widthAtBreakpoint);
+
+	// Display only — every `write*` below targets the raw draft, so a reset stays reset.
+	const effectiveWidth = !isUnsetPresetValue(shownWidth)
+		? shownWidth
+		: !isUnsetPresetValue(originalWidthAtBreakpoint)
+			? originalWidthAtBreakpoint
+			: shownWidth;
+	const effectiveStyle = !isUnsetPresetValue(styleAtBreakpoint)
+		? styleAtBreakpoint
+		: !isUnsetPresetValue(originalStyleAtBreakpoint)
+			? originalStyleAtBreakpoint
+			: styleAtBreakpoint;
+	const effectiveColor = !isUnsetPresetValue(rawColor)
+		? rawColor
+		: !isUnsetPresetValue(originalColor)
+			? originalColor
+			: rawColor;
 
 	const writeWidth = (next) =>
 		onValueChange(widthPath, responsive ? writePresetBreakpoint(rawWidth, breakpoint, next) : next);
@@ -250,52 +282,32 @@ export function BorderField({ field, values, onValueChange }) {
 		onValueChange(stylePath, responsive ? writePresetBreakpoint(rawStyle, breakpoint, next) : next);
 	const writeColor = (next) => onValueChange(colorPath, next);
 
-	// A semantic is the block's own default, not a selection, and the pool offers primitives only —
-	// left in place it renders as a raw dot-path. Blanked here; the field's declared `defaultValue`
-	// is what the control shows muted in its place.
-	const shownWidth = withoutSemanticSlots(widthAtBreakpoint);
+	// The bound token is exempt from the narrowing, or the field renders its raw id, not its label.
+	const widthTokens = widthTokensForField(effectiveWidth);
 
-	// The bound width token(s) are exempt from the primitive narrowing, the same way `BoxTokenField`
-	// exempts a box control's bound corners: unlinking gives each side its own slot, so pointing one
-	// at a different primitive from its neighbors is ordinary, and exempting only the first would
-	// leave the others rendering their raw dot-path. Width is per-slot (a scalar or a four-slot
-	// list), which is exactly the shape `boundTokenIds` already handles. See `widthTokensForField`'s
-	// own docblock for why its fixed "None" entry is exempt from the re-bracketing every other entry
-	// gets.
-	const widthTokens = widthTokensForField(shownWidth);
-
-	// Which breakpoints the user has opened up into per-side editing. Held here rather than inferred
-	// from the stored shape — see the module docblock — and per breakpoint for the same reason
-	// `BoxTokenField`'s `unlinked` is: a choice made on one breakpoint must not leak into another that
-	// never made it, keeping the breakpoints independent.
+	// Held rather than inferred from the stored shape — see the module docblock.
 	const [unlinked, setUnlinked] = useState({});
-	// `color` can now diverge per side too (`BorderControl` writes it through the same per-slot axis
-	// width/style already use), so a list-shaped color has to force the unlinked view exactly like a
-	// list-shaped width/style does — otherwise the panel would show one linked swatch while the
-	// stored value still carries four different colors.
-	const storedIsList = isSlotList(shownWidth) || isSlotList(styleAtBreakpoint) || isSlotList(rawColor);
+	// A list-shaped color forces the unlinked view too, or one swatch would hide four stored colors.
+	const storedIsList = isSlotList(effectiveWidth) || isSlotList(effectiveStyle) || isSlotList(effectiveColor);
 	const linked = storedIsList ? false : !unlinked[breakpoint];
 
 	const toggleLink = () => {
 		setUnlinked((current) => ({ ...current, [breakpoint]: linked }));
 
-		// Relinking keeps each axis's first side, matching `BoxTokenField`'s own relink rule; there is
-		// nothing to fold when a breakpoint never actually diverged into a list. `color` folds
-		// alongside width/style — `readSlot` on an already-scalar color is a no-op, so this is safe to
-		// call unconditionally once any axis diverged.
+		// Seeds from the effective axes, so relinking keeps what the user can actually see.
 		if (!linked && storedIsList) {
-			writeWidth(readSlot(widthAtBreakpoint, 0));
-			writeStyle(readSlot(styleAtBreakpoint, 0));
-			writeColor(readSlot(rawColor, 0));
+			writeWidth(readSlot(effectiveWidth, 0));
+			writeStyle(readSlot(effectiveStyle, 0));
+			writeColor(readSlot(effectiveColor, 0));
 		}
 	};
 
 	return (
 		<BorderControl
 			value={{
-				width: toControlWidthAxis(shownWidth),
-				style: toControlStyleAxis(styleAtBreakpoint),
-				color: rawColor ?? '',
+				width: toControlWidthAxis(effectiveWidth),
+				style: toControlStyleAxis(effectiveStyle),
+				color: effectiveColor ?? '',
 			}}
 			onChange={(next) => {
 				if (field.readOnly) {

--- a/src/style-library/components/molecules/fields/BorderField.js
+++ b/src/style-library/components/molecules/fields/BorderField.js
@@ -58,6 +58,7 @@ import { isUnsetPresetValue } from '../../../helpers/presets';
 import {
 	PRESET_BREAKPOINTS,
 	readPresetBreakpoint,
+	resolvePresetBreakpoint,
 	writePresetBreakpoint,
 } from '../../../../token-controls/helpers/preset-envelope';
 import { BorderControl } from '../../../../token-controls/controls/BorderControl';
@@ -252,8 +253,9 @@ export function BorderField({ field, values, originalValues, onValueChange }) {
 
 	const widthAtBreakpoint = responsive ? readPresetBreakpoint(rawWidth, breakpoint) : rawWidth;
 	const styleAtBreakpoint = responsive ? readPresetBreakpoint(rawStyle, breakpoint) : rawStyle;
-	const originalWidthAtBreakpoint = responsive ? readPresetBreakpoint(originalWidth, breakpoint) : originalWidth;
-	const originalStyleAtBreakpoint = responsive ? readPresetBreakpoint(originalStyle, breakpoint) : originalStyle;
+	// Resolved, not read — see `BoxTokenField`: a desktop-only stored value still resolves at Tablet.
+	const originalWidthAtBreakpoint = responsive ? resolvePresetBreakpoint(originalWidth, breakpoint) : originalWidth;
+	const originalStyleAtBreakpoint = responsive ? resolvePresetBreakpoint(originalStyle, breakpoint) : originalStyle;
 
 	// A semantic is the block's own default, not a selection, and the pool offers primitives only —
 	// left in place it renders as a raw dot-path. Blanked before the effective read below.

--- a/src/style-library/components/molecules/fields/BoxTokenField.js
+++ b/src/style-library/components/molecules/fields/BoxTokenField.js
@@ -30,6 +30,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { pickableTokensForType, resolvedTokenValue } from '../../../helpers/tokens';
+import { isUnsetPresetValue } from '../../../helpers/presets';
 import {
 	PRESET_BREAKPOINTS,
 	readPresetBreakpoint,
@@ -311,13 +312,19 @@ export function tokensForField(field, atBreakpoint) {
  * @param {?string}  [props.field.label]    The control's label.
  * @param {boolean}  [props.field.readOnly] Whether the control is non-interactive.
  * @param {boolean}  [props.field.responsive] Whether the field offers a breakpoint switcher.
- * @param {*}        [props.field.defaultValue] What the block renders when the preset sets nothing,
- *                                              shown muted so an unset field is not blank.
+ * @param {*}        [props.field.defaultValue] What the block itself renders when nothing at all is
+ *                                              set, shown muted as a last-resort fallback — only
+ *                                              reached when the preset has no value of its own for
+ *                                              this property either (see `originalValue` below).
  * @param {?Array}   [props.field.units]    Units the Custom tab offers.
  * @param {?number}  [props.field.min]      Lowest allowed number on the Custom tab.
  * @param {?number}  [props.field.max]      Highest allowed number; the slider needs one.
  * @param {?number}  [props.field.step]     Custom tab increment.
  * @param {*}        props.value            The stored value: a scalar or a four-slot list.
+ * @param {*}        [props.originalValue]  The preset's own currently-stored value for this
+ *                                          property, unaffected by the draft — shown, as if bound,
+ *                                          whenever `value` is reset/unset but this is not, so the
+ *                                          field reads as what saving the reset actually resolves to.
  * @param {Function} props.onChange         Called with the next stored value.
  * @param {string}   [props.slots]          'corners' or 'sides' — the control's geometry.
  *
@@ -325,7 +332,7 @@ export function tokensForField(field, atBreakpoint) {
  *
  * @return {JSX.Element} The field.
  */
-export function BoxTokenField({ field, value, onChange, slots = 'sides' }) {
+export function BoxTokenField({ field, value, originalValue, onChange, slots = 'sides' }) {
 	const units = field.units ?? ['px', 'em', 'rem', '%'];
 	const responsive = field.responsive === true;
 
@@ -337,7 +344,25 @@ export function BoxTokenField({ field, value, onChange, slots = 'sides' }) {
 	// holds one whole value per breakpoint — scalar or slot list — so a breakpoint is resolved first
 	// and the four slots are read out of whatever that breakpoint holds.
 	const atBreakpoint = responsive ? readPresetBreakpoint(value, breakpoint) : value;
+	const originalAtBreakpoint = responsive ? readPresetBreakpoint(originalValue, breakpoint) : originalValue;
 	const write = (next) => (responsive ? writePresetBreakpoint(value, breakpoint, next) : next);
+
+	// A semantic's name never shows; its resolved value becomes the field's Default. It outranks
+	// `field.defaultValue`, which is a config literal rather than what the active library resolves.
+	const shown = withoutSemanticSlots(atBreakpoint);
+
+	// What the field actually shows: the draft when it carries a real edit, else the preset's own
+	// currently-stored value (unaffected by this draft) when THAT is real, else genuinely empty. A
+	// reset field must not read as a blank, generic "Default" when the preset it belongs to already
+	// has its own bound value for this property — that value is exactly what saving the reset (an
+	// omitted property) resolves back to, so showing it immediately is showing the truth, not a
+	// preview. Read-path only: `write()` above still always targets the true draft `value`, so a
+	// reset that is never followed by another edit stays reset.
+	const effectiveAtBreakpoint = !isUnsetPresetValue(shown)
+		? shown
+		: !isUnsetPresetValue(originalAtBreakpoint)
+			? originalAtBreakpoint
+			: shown;
 
 	// An unset breakpoint shows what is actually in effect rather than reading as empty, and it inherits
 	// from the next breakpoint up, not straight from desktop: mobile shows the tablet value whenever
@@ -364,9 +389,6 @@ export function BoxTokenField({ field, value, onChange, slots = 'sides' }) {
 	const asLiteral = (slot) =>
 		typeof slot === 'string' ? (everyToken.find((token) => token.id === slot)?.value ?? slot) : slot;
 
-	// A semantic's name never shows; its resolved value becomes the field's Default. It outranks
-	// `field.defaultValue`, which is a config literal rather than what the active library resolves.
-	const shown = withoutSemanticSlots(atBreakpoint);
 	const semanticDefault = semanticDefaultOf(atBreakpoint, everyToken, fieldDefault);
 
 	const shownDefault = inheritsFromBreakpoint
@@ -376,7 +398,7 @@ export function BoxTokenField({ field, value, onChange, slots = 'sides' }) {
 	// The unit falls back the same way the value does. With nothing stored there is no unit to read, and
 	// defaulting to `units[0]` made the Custom tab open on `px` while the field beside it displayed the
 	// default's own `em` — one value described two different ways.
-	const stored = unitInPlay(shown, unitInPlay(shownDefault, units[0]));
+	const stored = unitInPlay(effectiveAtBreakpoint, unitInPlay(shownDefault, units[0]));
 
 	// A unit the user picked before typing a number has nowhere to persist — no slot carries it yet
 	// — so it is held here until a value exists to attach it to. Keyed per breakpoint for the same
@@ -392,29 +414,30 @@ export function BoxTokenField({ field, value, onChange, slots = 'sides' }) {
 	// choice per breakpoint is also what keeps the breakpoints independent — tablet can be edited as
 	// four corners while mobile is still a single value.
 	const [unlinked, setUnlinked] = useState({});
-	const storedIsList = isSlotList(shown);
+	const storedIsList = isSlotList(effectiveAtBreakpoint);
 	const linked = storedIsList ? false : !unlinked[breakpoint];
 
 	const toggleLink = () => {
 		setUnlinked((current) => ({ ...current, [breakpoint]: linked }));
 
 		// Relinking keeps the first slot, matching the control's own rule; there is nothing to fold
-		// when the breakpoint never held a list.
+		// when the breakpoint never held a list. Reads from the effective (draft-or-preset) value, so
+		// relinking a field that is showing the preset's own value seeds from what is actually shown.
 		if (!linked && storedIsList) {
-			onChange(write(readSlot(atBreakpoint, 0)));
+			onChange(write(readSlot(effectiveAtBreakpoint, 0)));
 		}
 	};
 
 	return (
 		<BoxControl
-			value={mapSlots(shown, toControlValue)}
+			value={mapSlots(effectiveAtBreakpoint, toControlValue)}
 			onChange={(next) => !field.readOnly && onChange(write(mapSlots(next, (slot) => toStoredValue(slot, unit))))}
 			label={field.label}
 			// The inherited value's token has to be exempt from the narrowing too, not just this
 			// breakpoint's own. A breakpoint that inherits binds nothing itself, so without this the
 			// semantic it falls back to is filtered out of the pool and the field, finding no entry for
 			// it, shows nothing at all instead of the value actually in effect.
-			tokens={tokensForField(field, shown)}
+			tokens={tokensForField(field, effectiveAtBreakpoint)}
 			// The two kinds of default are still shaped differently, which is why `shownDefault` resolves
 			// them separately above instead of passing either straight through: a value inherited from
 			// another breakpoint is stored the way this app stores values, so it is read through `asLiteral`

--- a/src/style-library/components/molecules/fields/BoxTokenField.js
+++ b/src/style-library/components/molecules/fields/BoxTokenField.js
@@ -344,7 +344,9 @@ export function BoxTokenField({ field, value, originalValue, onChange, slots = '
 	// holds one whole value per breakpoint — scalar or slot list — so a breakpoint is resolved first
 	// and the four slots are read out of whatever that breakpoint holds.
 	const atBreakpoint = responsive ? readPresetBreakpoint(value, breakpoint) : value;
-	const originalAtBreakpoint = responsive ? readPresetBreakpoint(originalValue, breakpoint) : originalValue;
+	// Resolved, not read: a preset that stores only a desktop value still resolves to it at Tablet and
+	// Mobile, so those breakpoints must fall back the same way a reset actually would.
+	const originalAtBreakpoint = responsive ? resolvePresetBreakpoint(originalValue, breakpoint) : originalValue;
 	const write = (next) => (responsive ? writePresetBreakpoint(value, breakpoint, next) : next);
 
 	// A semantic's name never shows; its resolved value becomes the field's Default. It outranks
@@ -454,7 +456,7 @@ export function BoxTokenField({ field, value, originalValue, onChange, slots = '
 				// once rather than leaving a mix behind the single shared switcher.
 				onChange(
 					write(
-						mapSlots(atBreakpoint, (slot) => {
+						mapSlots(effectiveAtBreakpoint, (slot) => {
 							const parsed = parseCssLength(slot);
 
 							return parsed ? `${parsed.size}${next}` : slot;

--- a/src/style-library/components/organisms/SettingsForm.js
+++ b/src/style-library/components/organisms/SettingsForm.js
@@ -11,7 +11,10 @@
  * sibling `tokens.*` keys, not one composite — see its own docblock) cannot be served by the single
  * dot-path `value`/`onChange` pair alone, so every field also receives the full draft `values` and
  * the raw, path-taking `onValueChange(path, next)` this component itself was given — additive, and
- * ignored by every field that only needs its own `field.path`.
+ * ignored by every field that only needs its own `field.path`. `originalValue`/`originalValues`
+ * mirror `value`/`values` the same way, but read the preset's own STORED tokens rather than the
+ * draft — a field a user has reset shows as bound to what it will actually resolve to once saved
+ * (the preset's own value, when it has one) instead of a generic literal fallback.
  */
 
 /**
@@ -28,10 +31,16 @@ import './SettingsForm.scss';
 /**
  * Render a settings schema.
  *
- * @param {Object}   props          The component props.
- * @param {Object}   props.schema   The authored schema (normalized internally).
- * @param {Object}   props.values   The current draft values.
- * @param {Function} props.onChange Called with (path, value) on any field edit.
+ * @param {Object}   props                 The component props.
+ * @param {Object}   props.schema          The authored schema (normalized internally).
+ * @param {Object}   props.values          The current draft values.
+ * @param {?Object}  [props.originalValues] The preset's own stored values, unaffected by the draft
+ *                                         — a field whose type reads it uses it to show a reset
+ *                                         property as bound to what it will actually resolve to
+ *                                         once saved (the preset's own value), rather than a
+ *                                         generic literal fallback. Omit for a schema with no such
+ *                                         field (`presetNameSchema()`'s label field ignores it).
+ * @param {Function} props.onChange        Called with (path, value) on any field edit.
  *
  * @since TBD
  *
@@ -55,7 +64,7 @@ function UntitledPanelBody({ children }) {
 	return <div className="kadence-blocks-style-library__settings-form-untitled-panel">{children}</div>;
 }
 
-export function SettingsForm({ schema, values, onChange }) {
+export function SettingsForm({ schema, values, originalValues, onChange }) {
 	const normalized = normalizeSchema(schema);
 
 	return (
@@ -71,8 +80,10 @@ export function SettingsForm({ schema, values, onChange }) {
 									key={field.path}
 									field={field}
 									value={getValueAtPath(values, field.path)}
+									originalValue={getValueAtPath(originalValues, field.path)}
 									onChange={(next) => onChange(field.path, next)}
 									values={values}
+									originalValues={originalValues}
 									onValueChange={onChange}
 								/>
 							);

--- a/src/style-library/components/pages/PresetSidebar.js
+++ b/src/style-library/components/pages/PresetSidebar.js
@@ -191,6 +191,7 @@ function PresetSidebarBody({ navigate, route, screen, initialValues, presetLabel
 			<SettingsForm
 				schema={schemaFor(activeTab, panel.draft, screen.feed)}
 				values={panel.draft}
+				originalValues={initialValues}
 				onChange={panel.setFieldValue}
 			/>
 		</SettingsPanel>

--- a/src/style-library/helpers/presets.js
+++ b/src/style-library/helpers/presets.js
@@ -350,7 +350,7 @@ export function presetStoredTokens(payload, slug) {
  *
  * @return {boolean} True when the value carries nothing to save.
  */
-function isUnsetPresetValue(value) {
+export function isUnsetPresetValue(value) {
 	if (value === '' || value === null || value === undefined) {
 		return true;
 	}


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4260/token-control-popover-options-and-the-default-label-show-what-is

Carries each preset's own currently-stored values — unaffected by the open draft — from `PresetSidebar` through `SettingsForm` down to `BoxTokenField` and `BorderField`, so a field can show what a reset actually resolves to rather than a blank generic default.

Read-path only: every `write()`/`write*()` still targets the true draft, so a reset that is never followed by another edit stays reset.

This is the plumbing. *Which* of those values a field may show as bound is narrowed in the next slice, by the `overridden` signal — a preset's effective values are baseline-merged, so a value it merely inherits is not yet distinguishable here from one it genuinely owns.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preset-based style fields now retain their stored values when drafts are reset.
  * Border, spacing, radius, and token controls display the correct preset values when draft values are unset.
  * Responsive border values and token selections now resolve correctly at each breakpoint.
  * Improved handling of unset semantic values and default fallbacks.

* **Tests**
  * Added coverage for preset value initialization, draft resets, responsive behavior, and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->