### PR TITLE
[DTM] SOFT-4260 [16/19]: show muted Default when a preset only inherits the baseline

### DIFF
--- a/includes/resources/Design_Tokens/Editor/Preset_Catalog.php
+++ b/includes/resources/Design_Tokens/Editor/Preset_Catalog.php
@@ -17,9 +17,11 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Preset_Resolver;
  * Keyed by token library so the picker can show the presets for the active library, then by block:
  * `{ active: <slug>, libraries: { <slug>: { <block>: {…} } } }`. Per block it carries the `$default` slug, the
  * named presets as { slug, label, userCreated }, the picker control label, the controllable surface as
- * { key, kind, token, control_attr } per bound property so the form can render one input per property, and
- * a per-preset resolved-value map ({ preset slug => { property => literal } }) so a control can compare
- * its current value against the selected preset's value.
+ * { key, kind, token, control_attr } per bound property so the form can render one input per property, a
+ * per-preset resolved-value map ({ preset slug => { property => literal } }) so a control can compare
+ * its current value against the selected preset's value, and a per-preset "own override" map
+ * ({ preset slug => { property => true } }) distinguishing a preset's genuine stored value from one it
+ * only inherits from the baseline's own definition of that preset slug.
  *
  * Every block with preset bindings appears, but only a PICKER set (one that declares a `label`) is given
  * preset OPTIONS; a block's preset / default-preset bindings (no label) carry an empty `presets` list, which
@@ -132,7 +134,8 @@ final class Preset_Catalog {
 	 *
 	 * @param string $slug The token library slug.
 	 *
-	 * @return array<string, array<string, mixed>> block => { default, presets, properties, values, references, label }.
+	 * @return array<string, array<string, mixed>> block => { default, presets, properties, values,
+	 *         references, responsive, overridden, label }.
 	 */
 	private function for_library( string $slug ): array {
 		$out = [];
@@ -161,6 +164,7 @@ final class Preset_Catalog {
 				'values'     => $this->values_for( $block, $slug, $names ),
 				'references' => $this->references_for( $block, $slug, $names ),
 				'responsive' => $this->responsive_for( $block, $slug, $names ),
+				'overridden' => $this->overridden_for( $block, $slug, $names ),
 				'label'      => $bindings->label,
 			];
 		}
@@ -330,6 +334,34 @@ final class Preset_Catalog {
 		}
 
 		return $responsive;
+	}
+
+	/**
+	 * Which properties EACH preset genuinely has its own stored override for, as opposed to
+	 * `values_for()`'s merged/effective read, which cannot tell a preset's own override apart from a
+	 * value it only inherits from the baseline's own definition of that same preset slug (a NAMED
+	 * preset the baseline itself ships — `$default`/other shipped slugs — can have real baseline values
+	 * for properties nobody has ever explicitly set). A control reads this to decide whether an unset
+	 * field should show as bound to the merged value (this preset has its own override) or as a muted
+	 * generic default (nothing here is this preset's own).
+	 *
+	 * @since TBD
+	 *
+	 * @param string   $block The block name.
+	 * @param string   $slug  The token library slug.
+	 * @param string[] $names The preset slugs to inspect, in catalog order.
+	 *
+	 * @return array<string, array<string, bool>> preset slug => ( property => true ), only for
+	 *                                            properties the preset's OWN stored tokens carry.
+	 */
+	private function overridden_for( string $block, string $slug, array $names ): array {
+		$overridden = [];
+
+		foreach ( $names as $name ) {
+			$overridden[ $name ] = $this->effective->owned_properties( $block, $name, $slug );
+		}
+
+		return $overridden;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Resolver/Effective_Presets.php
+++ b/includes/resources/Design_Tokens/Resolver/Effective_Presets.php
@@ -165,6 +165,50 @@ final class Effective_Presets {
 	}
 
 	/**
+	 * One preset's OWN raw stored token map, before any baseline merge — the property keys THIS preset
+	 * genuinely has an override for, as opposed to {@see Preset_Resolver::resolve_literal()}'s merged
+	 * view, which cannot be told apart from a value the preset only inherits from the baseline's own
+	 * definition of the same preset slug. A property present here is a real, human-set (or previously
+	 * captured) value; a property absent here is falling through to whatever the effective/merged read
+	 * resolves it to, with nothing of this preset's own behind it.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block  The block name, e.g. "kadence/singlebtn".
+	 * @param string $preset The preset slug.
+	 * @param string $slug   The token library slug.
+	 *
+	 * @return array<string, mixed> property => stored value (alias string, literal, or slot list),
+	 *                              exactly as stored — empty when the preset has no overrides row at
+	 *                              all, or none of its own for this preset slug.
+	 */
+	public function stored_tokens( string $block, string $preset, string $slug = 'default' ): array {
+		$presets = $this->presets_of( $this->raw( $slug ) );
+		$node    = $this->block_node( $presets, $block );
+		$entry   = isset( $node[ $preset ] ) && is_array( $node[ $preset ] ) ? $node[ $preset ] : [];
+		$tokens  = $entry[ Extensions::get_tokens_key() ] ?? [];
+
+		return is_array( $tokens ) ? $tokens : [];
+	}
+
+	/**
+	 * Which properties a preset genuinely OWNS, as a `property => true` lookup — {@see stored_tokens()}
+	 * reduced to the shape a client reads. Both the editor catalog and the REST payload surface exactly
+	 * this map, so the reduction lives here rather than being written out at each of them.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $block  The block name, e.g. "kadence/singlebtn".
+	 * @param string $preset The preset slug.
+	 * @param string $slug   The token library slug.
+	 *
+	 * @return array<string, bool> property => true, only for the properties this preset stores itself.
+	 */
+	public function owned_properties( string $block, string $preset, string $slug = 'default' ): array {
+		return array_fill_keys( array_keys( $this->stored_tokens( $block, $preset, $slug ) ), true );
+	}
+
+	/**
 	 * Decode a library's stored overrides document, tolerating an absent/empty/malformed row as "no overrides".
 	 *
 	 * The single decode seam for the stored overrides: callers that need the raw decoded document, rather than

--- a/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
@@ -924,6 +924,12 @@ final class Presets_Controller extends Controller {
 					// schema that says otherwise misleads anything generated from it.
 					'additionalProperties' => [ 'type' => [ 'string', 'number', 'array', 'object' ] ],
 				],
+				'overridden'                 => [
+					'description'          => __( 'Which properties this preset genuinely stores itself, as property => true. A bound property absent here is only inherited from the baseline\'s own definition of the same preset slug, and a control shows it as a muted default rather than as bound.', 'kadence-blocks' ),
+					'type'                 => 'object',
+					'additionalProperties' => [ 'type' => 'boolean' ],
+					'readonly'             => true,
+				],
 			],
 		];
 

--- a/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
@@ -1722,8 +1722,39 @@ final class Presets_Controller extends Controller {
 			'version'     => $this->store->get_version( $slug ),
 			'default'     => $this->default_of( $node ),
 			'userCreated' => $this->presets->user_created( $block, $slug ),
-			'presets'     => $this->ordered_presets( $this->named_presets( $node ), $ordered ),
+			'presets'     => $this->with_overridden( $this->ordered_presets( $this->named_presets( $node ), $ordered ), $block, $slug ),
 		];
+	}
+
+	/**
+	 * Add each preset's own "overridden" property map alongside its (baseline-merged) `tokens` — the
+	 * property keys THIS preset genuinely has a stored value for, as opposed to `tokens`, which cannot
+	 * be told apart from a value only inherited from the baseline's own definition of that same preset
+	 * slug. A client reads this to decide whether an unset field should show as bound to the merged
+	 * value (this preset has its own override) or as a muted generic default (nothing here is this
+	 * preset's own) — see {@see Effective_Presets::stored_tokens()}.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $presets The ordered `{ slug => { label, tokens } }` map.
+	 * @param string               $block   The block name.
+	 * @param string               $slug    The token library slug.
+	 *
+	 * @return array<string, mixed> The same map, each preset gaining an `overridden` key
+	 *                              (`{ property => true }`, only for properties it owns).
+	 */
+	private function with_overridden( array $presets, string $block, string $slug ): array {
+		foreach ( $presets as $preset_slug => $preset ) {
+			if ( ! is_array( $preset ) ) {
+				continue;
+			}
+
+			$preset['overridden'] = $this->presets->owned_properties( $block, (string) $preset_slug, $slug );
+
+			$presets[ $preset_slug ] = $preset;
+		}
+
+		return $presets;
 	}
 
 	/**

--- a/src/extension/preset-picker/index.js
+++ b/src/extension/preset-picker/index.js
@@ -146,6 +146,24 @@ export function blockPresetResponsive(name, library) {
 }
 
 /**
+ * The per-preset "own override" map for a block's library: `{ <presetSlug>: { <property>: true } }`,
+ * carrying only the property keys THAT preset genuinely has its own stored value for — as opposed to
+ * `blockPresetValues()`'s merged/effective read, which cannot tell a preset's own override apart from
+ * a value it only inherits from the baseline's own definition of the same preset slug. Empty object
+ * when the block offers none.
+ *
+ * @param {string} name     The block name.
+ * @param {string} [library] The token library slug; defaults to the active library.
+ *
+ * @since TBD
+ *
+ * @return {Object} The per-preset "own override" map.
+ */
+export function blockPresetOverridden(name, library) {
+	return get(blockEntry(name, library), 'overridden', {}) || {};
+}
+
+/**
  * The block library's default preset slug in a token library.
  *
  * @param {string} name     The block name.

--- a/src/extension/token-indicators/__tests__/index.test.js
+++ b/src/extension/token-indicators/__tests__/index.test.js
@@ -45,6 +45,9 @@ function seedCatalog() {
 					responsive: {
 						primary: { tablet: { 'button-radius': '8px' } },
 					},
+					overridden: {
+						primary: { 'button-radius': true },
+					},
 				},
 			},
 		},
@@ -169,6 +172,9 @@ describe('usePresetBinding per-corner breakpoint gaps', () => {
 						responsive: {
 							primary: { tablet: { 'button-radius': ['8px', '', '', ''] } },
 						},
+						overridden: {
+							primary: { 'button-radius': true },
+						},
 					},
 				},
 			},
@@ -239,6 +245,9 @@ describe('presetPropertyValueForDevice', () => {
 						},
 						responsive: {
 							primary: { tablet: { 'button-border-width': '4px' } },
+						},
+						overridden: {
+							primary: { 'button-border-width': true },
 						},
 					},
 				},
@@ -319,6 +328,7 @@ describe('presetPropertyValueForDevice', () => {
 	it('resolves the user-selected preset, not just the block default', () => {
 		window.kadenceDesignTokensPresets.libraries[SET][BLOCK].presets.push({ slug: 'secondary', label: 'Secondary' });
 		window.kadenceDesignTokensPresets.libraries[SET][BLOCK].values.secondary = { 'button-border-width': '6px' };
+		window.kadenceDesignTokensPresets.libraries[SET][BLOCK].overridden.secondary = { 'button-border-width': true };
 
 		const value = presetPropertyValueForDevice(
 			BLOCK,
@@ -391,6 +401,13 @@ describe('usePresetBinding border width/style/color combining', () => {
 						},
 						responsive: {
 							primary: { tablet: { 'button-border-color': '#000000' } },
+						},
+						overridden: {
+							primary: {
+								'button-border-width': true,
+								'button-border-style': true,
+								'button-border-color': true,
+							},
 						},
 					},
 				},

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -20,6 +20,7 @@ import {
 	blockPresetValues,
 	blockPresetReferences,
 	blockPresetResponsive,
+	blockPresetOverridden,
 } from '../preset-picker';
 import { isEmptyValue, matchesPreset, presetValueForDevice } from './normalize';
 import './token-indicators.scss';
@@ -167,6 +168,7 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
 	const properties = blockProperties(blockName, resolvedLibrary);
 	const values = blockPresetValues(blockName, resolvedLibrary);
 	const responsive = blockPresetResponsive(blockName, resolvedLibrary);
+	const ownedProperties = blockPresetOverridden(blockName, resolvedLibrary);
 
 	// The preset whose surface drives the indicators: the explicit selection, or the set's authoritative
 	// default preset when none is chosen or the selection no longer exists (kbPreset is '' on every
@@ -175,16 +177,20 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
 	const activePreset = activePresetFor(blockName, attributes, resolvedLibrary);
 	const presetValues = get(values, activePreset, {});
 	const presetBreakpoints = get(responsive, activePreset, {});
+	const presetOwnKeys = get(ownedProperties, activePreset, {});
 
 	const state = {};
 
 	properties.forEach((property) => {
 		const attr = property.control_attr;
 
-		// A property with no mapped control attribute, or one the active preset does not define, is not
-		// surfaced — only a property the selected preset sets is "bound" (the binding-set collapse
-		// interlock: the per-preset surface, not just the block's full property list, gates binding).
-		if (!attr || !(property.key in presetValues)) {
+		// A property with no mapped control attribute is not surfaced. Nor is one the active preset only
+		// falls through to the baseline's own definition of this same preset slug for — `presetOwnKeys`
+		// carries only the properties the preset genuinely has ITS OWN stored value for; a baseline
+		// fallback reads as unbound here, the same way the Style Library shows it as a muted "Default"
+		// rather than as if it were the preset's own binding (the binding-set collapse interlock: the
+		// per-preset surface, not just the block's full property list, gates binding).
+		if (!attr || !presetOwnKeys[property.key]) {
 			return;
 		}
 
@@ -275,11 +281,20 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
  *
  * @since TBD
  *
- * @return {*} The resolved literal value, or `undefined` when the active preset does not set it.
+ * @return {*} The resolved literal value, or `undefined` when the active preset does not set it, OR
+ *             only falls through to the baseline's own definition of this same preset slug rather than
+ *             carrying a genuine override of its own — see `usePresetBinding`'s identical
+ *             `presetOwnKeys` gate for the full reasoning.
  */
 export function presetPropertyValueForDevice(blockName, propertyKey, attributes, library, previewDevice) {
 	const resolvedLibrary = library || activeLibrary();
 	const activePreset = activePresetFor(blockName, attributes, resolvedLibrary);
+	const presetOwnKeys = get(blockPresetOverridden(blockName, resolvedLibrary), activePreset, {});
+
+	if (!presetOwnKeys[propertyKey]) {
+		return undefined;
+	}
+
 	const presetValues = get(blockPresetValues(blockName, resolvedLibrary), activePreset, {});
 	const presetBreakpoints = get(blockPresetResponsive(blockName, resolvedLibrary), activePreset, {});
 

--- a/src/style-library/__tests__/border-shadow-field-rendering.test.js
+++ b/src/style-library/__tests__/border-shadow-field-rendering.test.js
@@ -106,13 +106,37 @@ describe('BorderField', () => {
 				createElement(BorderField, {
 					field,
 					values: {},
-					originalValues: { tokens: { 'button-border-width': 'semantic.border-width.default' } },
+					originalValues: {
+						tokens: { 'button-border-width': 'semantic.border-width.default' },
+						overridden: { 'button-border-width': true },
+					},
 					onValueChange: jest.fn(),
 				})
 			);
 		});
 
 		expect(latestBorderControlProps.value.width).toBe('{semantic.border-width.default}');
+	});
+
+	it("falls back to the generic literal fallback when the preset's stored width is only inherited from the baseline, not its own", () => {
+		const field = { label: 'Border', path: 'tokens.button-border', defaultValue: '1px' };
+
+		act(() => {
+			root.render(
+				createElement(BorderField, {
+					field,
+					values: {},
+					originalValues: {
+						tokens: { 'button-border-width': 'semantic.border-width.default' },
+						overridden: {},
+					},
+					onValueChange: jest.fn(),
+				})
+			);
+		});
+
+		expect(latestBorderControlProps.value.width).toBe('');
+		expect(latestBorderControlProps.defaultValue).toBe('1px');
 	});
 
 	it('falls back to the generic literal defaultValue when the preset has no stored width either', () => {

--- a/src/style-library/__tests__/box-token-field.test.js
+++ b/src/style-library/__tests__/box-token-field.test.js
@@ -340,19 +340,24 @@ describe('the effective value shown when the draft is reset', () => {
 	/**
 	 * Render `BoxTokenField` with the given draft/original values.
 	 *
-	 * @param {Object} props The field's `value`/`originalValue` to render with.
+	 * @param {Object}  props              The field's `value`/`originalValue` to render with.
+	 * @param {boolean} [props.overridden] Whether the preset genuinely has its own stored value for
+	 *                                     this property — gates whether `originalValue` is shown as
+	 *                                     bound. Defaults to true so existing "preset has its own
+	 *                                     value" cases don't need updating individually.
 	 *
 	 * @since TBD
 	 *
 	 * @return {void}
 	 */
-	function renderField({ value, originalValue }) {
+	function renderField({ value, originalValue, overridden = true }) {
 		act(() => {
 			root.render(
 				createElement(BoxTokenField, {
-					field: { tokenType: 'dimension', role: 'radius', defaultValue: '0.1875rem' },
+					field: { path: 'tokens.radius', tokenType: 'dimension', role: 'radius', defaultValue: '0.1875rem' },
 					value,
 					originalValue,
+					originalValues: { overridden: { radius: overridden } },
 					onChange: jest.fn(),
 					slots: 'corners',
 				})
@@ -377,6 +382,12 @@ describe('the effective value shown when the draft is reset', () => {
 		renderField({ value: '0.5rem', originalValue: 'semantic.radius.control' });
 
 		expect(latestBoxControlProps.value).toEqual(toControlValue('0.5rem'));
+	});
+
+	it("falls back to the generic literal fallback when the preset's stored value is only inherited from the baseline, not its own", () => {
+		renderField({ value: '', originalValue: 'semantic.radius.control', overridden: false });
+
+		expect(latestBoxControlProps.value).toEqual(toControlValue(''));
 	});
 });
 
@@ -414,6 +425,7 @@ describe('a reset responsive field', () => {
 					field: { path: 'tokens.radius', tokenType: 'dimension', role: 'radius', responsive: true },
 					value,
 					originalValue,
+					originalValues: { overridden: { radius: true } },
 					onChange: jest.fn(),
 					slots: 'corners',
 				})
@@ -485,6 +497,7 @@ describe('switching unit on a reset field', () => {
 					field: { path: 'tokens.radius', tokenType: 'dimension', role: 'radius' },
 					value: '',
 					originalValue: '1rem',
+					originalValues: { overridden: { radius: true } },
 					onChange,
 					slots: 'corners',
 				})

--- a/src/style-library/__tests__/preset-sidebar.test.js
+++ b/src/style-library/__tests__/preset-sidebar.test.js
@@ -442,7 +442,11 @@ describe('PresetSidebar reset field display', () => {
 				},
 				isLoading: false,
 				loadError: null,
-				initialValuesFor: () => ({ label: 'Primary', tokens: { 'button-radius': 'semantic.radius.control' } }),
+				initialValuesFor: () => ({
+					label: 'Primary',
+					tokens: { 'button-radius': 'semantic.radius.control' },
+					overridden: { 'button-radius': true },
+				}),
 				savePreset: jest.fn(),
 				deletePreset: jest.fn(),
 				isDeletable: () => true,

--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -291,6 +291,13 @@ describe('presetInitialValues', () => {
 						'button-text-hover': '{semantic.color.on-primary}',
 						'button-radius': '0.5rem',
 					},
+					overridden: {
+						'button-bg': true,
+						'button-text': true,
+						'button-bg-hover': true,
+						'button-text-hover': true,
+						'button-radius': true,
+					},
 				},
 			},
 		};
@@ -308,7 +315,42 @@ describe('presetInitialValues', () => {
 				'button-padding': '',
 				'button-margin': '',
 			},
+			overridden: {
+				'button-bg': true,
+				'button-text': true,
+				'button-bg-hover': true,
+				'button-text-hover': true,
+				'button-radius': true,
+				// Absent from the payload's own `overridden` map, so these fall through to `false` —
+				// genuinely unbound, not merely unvalued.
+				'button-padding': false,
+				'button-margin': false,
+			},
 		});
+	});
+
+	it('seeds a property the preset only inherits from the baseline as empty, not as its merged value', () => {
+		// `tokens` is already baseline-merged, so a property the preset has no override of its own for
+		// still carries a value here. Seeding it would make a fresh page load render the field as bound
+		// to a value nobody set — the reload-vs-reset disagreement this guards against.
+		const payload = {
+			presets: {
+				secondary: {
+					label: 'Secondary',
+					tokens: {
+						'button-bg': '{semantic.color.button-secondary-bg}',
+						'button-radius': '{semantic.radius.control}',
+					},
+					overridden: { 'button-bg': true },
+				},
+			},
+		};
+
+		const seeded = presetInitialValues(payload, 'secondary', ['button-bg', 'button-radius']);
+
+		expect(seeded.tokens['button-bg']).toBe('semantic.color.button-secondary-bg');
+		expect(seeded.tokens['button-radius']).toBe('');
+		expect(seeded.overridden['button-radius']).toBe(false);
 	});
 
 	it('returns null for an unknown slug', () => {
@@ -826,7 +868,15 @@ describe('seed/save round trip', () => {
 		};
 
 		const seeded = presetInitialValues(
-			{ presets: { primary: { label: 'Primary', tokens: { 'button-radius': stored } } } },
+			{
+				presets: {
+					primary: {
+						label: 'Primary',
+						tokens: { 'button-radius': stored },
+						overridden: { 'button-radius': true },
+					},
+				},
+			},
 			'primary',
 			['button-radius']
 		);
@@ -858,6 +908,7 @@ describe('seed/save round trip', () => {
 								'{semantic.dimension.control-radius}',
 							],
 						},
+						overridden: { 'button-radius': true },
 					},
 				},
 			},

--- a/src/style-library/components/molecules/fields/BorderField.js
+++ b/src/style-library/components/molecules/fields/BorderField.js
@@ -227,6 +227,10 @@ export function widthTokensForField(atBreakpoint) {
  *                                             draft — read by the same dot paths as `values`, so a
  *                                             reset axis reads as what saving the reset actually
  *                                             resolves to instead of a generic literal fallback.
+ *                                             Its `overridden` map gates the substitution to axes the
+ *                                             CURRENT preset genuinely has its own stored value for —
+ *                                             an axis only inherited from the baseline's own definition
+ *                                             of the same preset slug reads as muted "Default" instead.
  * @param {Function} props.onValueChange      Called with `(path, next)` for any of the three axes.
  *
  * @since TBD
@@ -261,20 +265,24 @@ export function BorderField({ field, values, originalValues, onValueChange }) {
 	// left in place it renders as a raw dot-path. Blanked before the effective read below.
 	const shownWidth = withoutSemanticSlots(widthAtBreakpoint);
 
+	const isWidthOverridden = originalValues?.overridden?.[widthPath.replace(/^tokens\./, '')] === true;
+	const isStyleOverridden = originalValues?.overridden?.[stylePath.replace(/^tokens\./, '')] === true;
+	const isColorOverridden = originalValues?.overridden?.[colorPath.replace(/^tokens\./, '')] === true;
+
 	// Display only — every `write*` below targets the raw draft, so a reset stays reset.
 	const effectiveWidth = !isUnsetPresetValue(shownWidth)
 		? shownWidth
-		: !isUnsetPresetValue(originalWidthAtBreakpoint)
+		: isWidthOverridden && !isUnsetPresetValue(originalWidthAtBreakpoint)
 			? originalWidthAtBreakpoint
 			: shownWidth;
 	const effectiveStyle = !isUnsetPresetValue(styleAtBreakpoint)
 		? styleAtBreakpoint
-		: !isUnsetPresetValue(originalStyleAtBreakpoint)
+		: isStyleOverridden && !isUnsetPresetValue(originalStyleAtBreakpoint)
 			? originalStyleAtBreakpoint
 			: styleAtBreakpoint;
 	const effectiveColor = !isUnsetPresetValue(rawColor)
 		? rawColor
-		: !isUnsetPresetValue(originalColor)
+		: isColorOverridden && !isUnsetPresetValue(originalColor)
 			? originalColor
 			: rawColor;
 

--- a/src/style-library/components/molecules/fields/BoxTokenField.js
+++ b/src/style-library/components/molecules/fields/BoxTokenField.js
@@ -325,6 +325,11 @@ export function tokensForField(field, atBreakpoint) {
  *                                          property, unaffected by the draft — shown, as if bound,
  *                                          whenever `value` is reset/unset but this is not, so the
  *                                          field reads as what saving the reset actually resolves to.
+ * @param {Object}   [props.originalValues] The preset's full seeded draft, carrying `overridden` — the
+ *                                          property keys the CURRENT preset genuinely has its own stored
+ *                                          value for. A property absent here only inherits from the
+ *                                          baseline's own definition of the same preset slug, and must
+ *                                          read as muted "Default", not as bound to that inherited value.
  * @param {Function} props.onChange         Called with the next stored value.
  * @param {string}   [props.slots]          'corners' or 'sides' — the control's geometry.
  *
@@ -332,7 +337,7 @@ export function tokensForField(field, atBreakpoint) {
  *
  * @return {JSX.Element} The field.
  */
-export function BoxTokenField({ field, value, originalValue, onChange, slots = 'sides' }) {
+export function BoxTokenField({ field, value, originalValue, originalValues, onChange, slots = 'sides' }) {
 	const units = field.units ?? ['px', 'em', 'rem', '%'];
 	const responsive = field.responsive === true;
 
@@ -353,16 +358,21 @@ export function BoxTokenField({ field, value, originalValue, onChange, slots = '
 	// `field.defaultValue`, which is a config literal rather than what the active library resolves.
 	const shown = withoutSemanticSlots(atBreakpoint);
 
+	// The preset's own genuine override, not a value only inherited from the baseline's definition of
+	// this same preset slug — a property absent here reads as muted "Default", never as bound.
+	const property = (field.path ?? '').replace(/^tokens\./, '');
+	const isOverridden = originalValues?.overridden?.[property] === true;
+
 	// What the field actually shows: the draft when it carries a real edit, else the preset's own
-	// currently-stored value (unaffected by this draft) when THAT is real, else genuinely empty. A
-	// reset field must not read as a blank, generic "Default" when the preset it belongs to already
-	// has its own bound value for this property — that value is exactly what saving the reset (an
-	// omitted property) resolves back to, so showing it immediately is showing the truth, not a
-	// preview. Read-path only: `write()` above still always targets the true draft `value`, so a
-	// reset that is never followed by another edit stays reset.
+	// currently-stored value (unaffected by this draft) when THAT is real AND genuinely this preset's
+	// own, else genuinely empty. A reset field must not read as a blank, generic "Default" when the
+	// preset it belongs to already has its own bound value for this property — that value is exactly
+	// what saving the reset (an omitted property) resolves back to, so showing it immediately is
+	// showing the truth, not a preview. Read-path only: `write()` above still always targets the true
+	// draft `value`, so a reset that is never followed by another edit stays reset.
 	const effectiveAtBreakpoint = !isUnsetPresetValue(shown)
 		? shown
-		: !isUnsetPresetValue(originalAtBreakpoint)
+		: isOverridden && !isUnsetPresetValue(originalAtBreakpoint)
 			? originalAtBreakpoint
 			: shown;
 

--- a/src/style-library/helpers/presets.js
+++ b/src/style-library/helpers/presets.js
@@ -293,13 +293,17 @@ export function presetRows(payload, values, preview, breakpoint = PRESET_BREAKPO
  * (ready for a token picker), or `null` for an unknown slug — the `scaleInitialValues` null
  * contract a stale-open-item self-heal relies on.
  *
- * @param {{presets?: Record<string, {label?: string, tokens?: Record<string, string>}>}} payload    The preset GET payload.
+ * @param {{presets?: Record<string, {label?: string, tokens?: Record<string, string>, overridden?: Record<string, boolean>}>}} payload The preset GET payload.
  * @param {string}                                                                        slug       The preset slug to seed.
  * @param {string[]}                                                                      properties The block's bound property surface.
  *
  * @since TBD
  *
- * @return {?{label: string, tokens: Record<string, string>}} The seeded draft, or null.
+ * @return {?{label: string, tokens: Record<string, string>, overridden: Record<string, boolean>}} The
+ *   seeded draft, or null. `overridden` carries the property keys THIS preset genuinely has its own
+ *   stored value for, straight from the payload — `tokens` itself is already baseline-merged and
+ *   cannot tell a real override apart from a value only inherited from the baseline's own definition
+ *   of this same preset slug.
  */
 export function presetInitialValues(payload, slug, properties) {
 	const preset = payload?.presets?.[slug];
@@ -309,11 +313,23 @@ export function presetInitialValues(payload, slug, properties) {
 	}
 
 	const tokens = preset.tokens ?? {};
+	const overridden = preset.overridden ?? {};
 
 	return {
 		label: preset.label ?? slug,
+		// Only a property THIS preset genuinely has its own stored value for seeds a value. `tokens` is
+		// already baseline-merged, so seeding from it verbatim would hand a field the value the preset
+		// merely inherits from the baseline's own definition of this same preset slug — and a non-empty
+		// draft reads as bound, which is exactly the muted "Default" a fresh reload must show instead.
+		// Seeding empty is also what makes reload agree with the state right after a reset: both then
+		// carry nothing, and `presetSaveTokens` omits an unset property, leaving the stored document
+		// untouched rather than writing the inherited literal back as a new override.
 		tokens: properties.reduce((acc, property) => {
-			acc[property] = aliasToIdDeep(tokens[property] ?? '');
+			acc[property] = overridden[property] === true ? aliasToIdDeep(tokens[property] ?? '') : '';
+			return acc;
+		}, {}),
+		overridden: properties.reduce((acc, property) => {
+			acc[property] = overridden[property] === true;
 			return acc;
 		}, {}),
 	};

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
@@ -337,6 +337,41 @@ final class Preset_CatalogTest extends TestCase {
 	}
 
 	/**
+	 * A shipped preset's `overridden` map carries only the properties it genuinely has of its own — not
+	 * every property `values` resolves for it, since most of those are inherited from the baseline's own
+	 * definition of that same preset slug rather than a stored override.
+	 *
+	 * @return void
+	 */
+	public function testOverriddenCarriesOnlyAPresetsOwnStoredPropertiesNotEveryResolvedOne(): void {
+		$button = $this->catalog->all()['libraries'][ Token_Store::default_slug() ][ self::BUTTON ];
+
+		// "secondary" is baseline-only (never partially overridden by this test), so it has NOTHING of
+		// its own — even though `values['secondary']` resolves every bound property via the baseline.
+		$this->assertSame( [], $button['overridden']['secondary'] );
+		$this->assertNotEmpty( $button['values']['secondary'] );
+	}
+
+	/**
+	 * Storing a partial override of a baseline preset surfaces ONLY that property in `overridden`, while
+	 * `values` keeps resolving the rest from the baseline.
+	 *
+	 * @return void
+	 */
+	public function testOverriddenReflectsAPartialStoredOverrideOfABaselinePreset(): void {
+		$this->store->save_document(
+			'{"$extensions":{"com.kadence.designTokens":{"presets":{"kadence/singlebtn":{'
+			. '"secondary":{"tokens":{"button-bg":"#000000"}}}}}}}'
+		);
+
+		$button = $this->catalog->all()['libraries'][ Token_Store::default_slug() ][ self::BUTTON ];
+
+		$this->assertSame( [ 'button-bg' => true ], $button['overridden']['secondary'] );
+		// The merged/resolved value still surfaces for the un-overridden properties.
+		$this->assertNotSame( '', $button['values']['secondary']['button-text'] );
+	}
+
+	/**
 	 * Persist a "hero" button preset whose radius takes an aliased override on mobile.
 	 *
 	 * @return void

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_PresetsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_PresetsTest.php
@@ -136,4 +136,65 @@ final class Effective_PresetsTest extends TestCase {
 		// "secondary" shadows a baseline preset, so it is not user-created.
 		$this->assertNotContains( 'secondary', $user_created );
 	}
+
+	/**
+	 * A baseline-only preset (nothing stored for it at all) has no OWN stored tokens, even though
+	 * `block()`'s merged view resolves every one of its properties from the baseline.
+	 *
+	 * @return void
+	 */
+	public function testStoredTokensIsEmptyForABaselinePresetWithNoStoredOverridesRow(): void {
+		$this->assertSame( [], $this->presets->stored_tokens( self::BUTTON, 'secondary' ) );
+	}
+
+	/**
+	 * A stored override of just one property surfaces ONLY that property's key — not the other
+	 * properties the merged view resolves from the baseline for the same preset slug.
+	 *
+	 * @return void
+	 */
+	public function testStoredTokensSurfacesOnlyTheOverriddenPropertyOfAPartiallyOverriddenPreset(): void {
+		$this->store->save_document(
+			'{"$extensions":{"com.kadence.designTokens":{"presets":{"kadence/singlebtn":{'
+			. '"secondary":{"tokens":{"button-bg":"#000000"}}}}}}}'
+		);
+
+		$stored = $this->presets->stored_tokens( self::BUTTON, 'secondary' );
+
+		$this->assertSame( [ 'button-bg' => '#000000' ], $stored );
+		$this->assertArrayNotHasKey( 'button-text', $stored );
+	}
+
+	/**
+	 * An override-only preset's stored tokens are its full authored map, exactly as saved.
+	 *
+	 * @return void
+	 */
+	public function testStoredTokensReturnsTheFullMapForAnOverrideOnlyPreset(): void {
+		$this->store->save_document(
+			'{"$extensions":{"com.kadence.designTokens":{"presets":{"kadence/singlebtn":{'
+			. '"outline":{"label":"Outline","tokens":{"button-bg":"transparent","button-text":"#000000"}}'
+			. '}}}}}'
+		);
+
+		$stored = $this->presets->stored_tokens( self::BUTTON, 'outline' );
+
+		$this->assertSame(
+			[
+				'button-bg'   => 'transparent',
+				'button-text' => '#000000',
+			],
+			$stored
+		);
+	}
+
+	/**
+	 * A preset slug that does not exist at all, in either the baseline or the overrides, has no stored
+	 * tokens.
+	 *
+	 * @return void
+	 */
+	public function testStoredTokensIsEmptyForAnUnknownPresetSlug(): void {
+		$this->assertSame( [], $this->presets->stored_tokens( self::BUTTON, 'not-a-preset' ) );
+	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
@@ -177,6 +177,38 @@ final class PresetsControllerTest extends TestCase {
 	}
 
 	/**
+	 * A baseline preset with nothing stored for it has no OWN overridden properties, even though its
+	 * `tokens` resolves every bound property via the baseline merge — the client reads `overridden` to
+	 * tell those two apart (bound to a genuine override vs. only inheriting the baseline's own value).
+	 *
+	 * @return void
+	 */
+	public function testGetItemReportsNoOverriddenPropertiesForAFreshBaselinePreset(): void {
+		$data = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) )->get_data();
+
+		$this->assertSame( [], $data['presets']['secondary']['overridden'] );
+		$this->assertNotEmpty( $data['presets']['secondary']['tokens'] );
+	}
+
+	/**
+	 * Storing a partial override of a baseline preset surfaces ONLY that property in `overridden`,
+	 * while `tokens` keeps resolving the rest from the baseline.
+	 *
+	 * @return void
+	 */
+	public function testGetItemReflectsAPartialStoredOverrideInOverridden(): void {
+		$this->store->save_document(
+			'{"$extensions":{"com.kadence.designTokens":{"presets":{"kadence/singlebtn":{'
+			. '"secondary":{"tokens":{"button-bg":"#000000"}}}}}}}'
+		);
+
+		$data = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) )->get_data();
+
+		$this->assertSame( [ 'button-bg' => true ], $data['presets']['secondary']['overridden'] );
+		$this->assertNotSame( '', $data['presets']['secondary']['tokens']['button-text'] );
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testGetItemReturns404ForABlockThatAcceptsNoPresets(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
@@ -106,6 +106,22 @@ final class PresetsControllerTest extends TestCase {
 	}
 
 	/**
+	 * The item schema describes the `overridden` map each preset carries, so a schema-driven consumer
+	 * can discover it rather than having to read the response to learn it exists.
+	 *
+	 * @return void
+	 */
+	public function testItemSchemaDescribesOverridden(): void {
+		$schema = $this->controller->get_item_schema();
+		$preset = $schema['properties']['presets']['additionalProperties'];
+
+		$this->assertArrayHasKey( 'overridden', $preset['properties'] );
+		$this->assertSame( 'object', $preset['properties']['overridden']['type'] );
+		$this->assertSame( 'boolean', $preset['properties']['overridden']['additionalProperties']['type'] );
+		$this->assertTrue( $preset['properties']['overridden']['readonly'] );
+	}
+
+	/**
 	 * The item schema documents the `userCreated` property added to the GET item response.
 	 *
 	 * @return void


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4260/token-control-popover-options-and-the-default-label-show-what-is

**The core of the ticket.** A field must show a muted "Default" unless the current preset genuinely has its own stored override for that property.

That was not possible before, because a preset's effective values are **baseline-merged**. A named preset the shipped `baseline.json` also defines (`primary`, `secondary`, …) resolves a value for properties nobody ever overrode, and nothing downstream could tell that apart from a real override — both collapse to the same literal. So a field would claim a binding the user never made.

Adds an `overridden` signal sourced from a preset's **raw stored** tokens, read before any merge:

- `Effective_Presets::stored_tokens()` — the reader, plus `owned_properties()` reducing it to the `property => true` shape both feeds surface.
- `Preset_Catalog::for_library()` — an `overridden` map beside `values`, for the block editor's localized catalog.
- `Presets_Controller::prepare_item()` — an `overridden` field beside `tokens`, for the Style Library's REST payload.

These are two independent read paths over the same `Effective_Presets`, which is why both need it.

On the client, `presetInitialValues()` carries it through and **seeds a non-overridden property as empty** — otherwise a page reload re-seeds the merged value and the field reads as bound again, disagreeing with the state right after a reset. `usePresetBinding()` gates `bound` on it, but deliberately **not** `presetValue`: an unbound property still needs its resolved literal to name the muted default.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preset details now identify which properties are explicitly customized versus inherited from a baseline.
  * Preset editing and reset controls now distinguish stored overrides from inherited values, displaying appropriate defaults when properties are not customized.

* **Bug Fixes**
  * Prevented inherited baseline values from appearing as user-defined overrides after reset.
  * Improved handling of responsive, border, radius, and other token-based properties.

* **Tests**
  * Added coverage for preset ownership metadata, inherited values, partial overrides, and reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->