### PR TITLE
[DTM] SOFT-4260 [17/19]: show an unset editor field as a muted Default or Inherited, never as bound

### DIFF
--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -479,40 +479,27 @@ export default function KadenceButtonEdit(props) {
 	// slots — otherwise an explicit "link" would stick and hide a new preset's per-slot value.
 	const { isLinked: borderRadiusIsLinked, toggleLink: toggleBorderRadiusLink } = useLinkedMeasureState({
 		forDevice: borderRadiusForDevice,
-		inherited: inheritedBorderRadius,
 		previewDevice,
-		presetValue: borderRadiusPresetValue,
-		tokens: borderRadiusTokens,
 		setAttributes,
 		resetOn: attributes.kbPreset,
 	});
 
 	// Padding's linked/individual mode, mirroring Border Radius's own hook call above with "corner"
-	// swapped for "side" — same shape, run over `paddingForDevice`/`paddingPresetValue`/
-	// `inheritedPadding`/`paddingPickableTokens` instead, `resetOn` included: an override records a
-	// choice about the PREVIOUS preset's sides, so it has to clear on a preset change here too, or an
-	// explicit "link" sticks and hides the new preset's own per-side padding.
+	// swapped for "side" — same shape, run over `paddingForDevice` instead. `resetOn` is included for
+	// the same reason: an override records a choice about the PREVIOUS preset's sides, so it has to
+	// clear on a preset change or an explicit "link" sticks and hides the new preset's own padding.
 	const { isLinked: paddingIsLinked, toggleLink: togglePaddingLink } = useLinkedMeasureState({
 		forDevice: paddingForDevice,
-		inherited: inheritedPadding,
 		previewDevice,
-		presetValue: paddingPresetValue,
-		tokens: paddingPickableTokens,
 		setAttributes,
 		resetOn: attributes.kbPreset,
 	});
 
 	// Margin's linked/individual mode, mirroring Padding's own hook call above — same shape, run over
-	// `marginForDevice`/`marginPresetValue`/`inheritedMargin`/`marginPickableTokens` instead. Unlike
-	// Padding, Margin does clear its override on a preset change (`resetOn`): an explicit "link" made
-	// under one preset would otherwise stick after switching to a preset with distinct per-side margins,
-	// hiding them behind a stale linked view.
+	// `marginForDevice` instead, `resetOn` included for the same reason.
 	const { isLinked: marginIsLinked, toggleLink: toggleMarginLink } = useLinkedMeasureState({
 		forDevice: marginForDevice,
-		inherited: inheritedMargin,
 		previewDevice,
-		presetValue: marginPresetValue,
-		tokens: marginPickableTokens,
 		setAttributes,
 		resetOn: attributes.kbPreset,
 	});
@@ -535,10 +522,7 @@ export default function KadenceButtonEdit(props) {
 	);
 	const { isLinked: borderHoverRadiusIsLinked, toggleLink: toggleBorderHoverRadiusLink } = useLinkedMeasureState({
 		forDevice: borderHoverRadiusForDevice,
-		inherited: inheritedBorderHoverRadius,
 		previewDevice,
-		presetValue: borderRadiusPresetValue,
-		tokens: borderRadiusTokens,
 		setAttributes,
 		resetOn: attributes.kbPreset,
 	});
@@ -557,10 +541,7 @@ export default function KadenceButtonEdit(props) {
 	const { isLinked: borderTransparentRadiusIsLinked, toggleLink: toggleBorderTransparentRadiusLink } =
 		useLinkedMeasureState({
 			forDevice: borderTransparentRadiusForDevice,
-			inherited: inheritedBorderTransparentRadius,
 			previewDevice,
-			presetValue: borderRadiusPresetValue,
-			tokens: borderRadiusTokens,
 			setAttributes,
 			resetOn: attributes.kbPreset,
 		});
@@ -579,10 +560,7 @@ export default function KadenceButtonEdit(props) {
 	const { isLinked: borderTransparentHoverRadiusIsLinked, toggleLink: toggleBorderTransparentHoverRadiusLink } =
 		useLinkedMeasureState({
 			forDevice: borderTransparentHoverRadiusForDevice,
-			inherited: inheritedBorderTransparentHoverRadius,
 			previewDevice,
-			presetValue: borderRadiusPresetValue,
-			tokens: borderRadiusTokens,
 			setAttributes,
 			resetOn: attributes.kbPreset,
 		});
@@ -600,10 +578,7 @@ export default function KadenceButtonEdit(props) {
 	);
 	const { isLinked: borderStickyRadiusIsLinked, toggleLink: toggleBorderStickyRadiusLink } = useLinkedMeasureState({
 		forDevice: borderStickyRadiusForDevice,
-		inherited: inheritedBorderStickyRadius,
 		previewDevice,
-		presetValue: borderRadiusPresetValue,
-		tokens: borderRadiusTokens,
 		setAttributes,
 		resetOn: attributes.kbPreset,
 	});
@@ -622,10 +597,7 @@ export default function KadenceButtonEdit(props) {
 	const { isLinked: borderStickyHoverRadiusIsLinked, toggleLink: toggleBorderStickyHoverRadiusLink } =
 		useLinkedMeasureState({
 			forDevice: borderStickyHoverRadiusForDevice,
-			inherited: inheritedBorderStickyHoverRadius,
 			previewDevice,
-			presetValue: borderRadiusPresetValue,
-			tokens: borderRadiusTokens,
 			setAttributes,
 			resetOn: attributes.kbPreset,
 		});

--- a/src/blocks/singlebtn/hooks/__tests__/use-linked-measure-state.test.js
+++ b/src/blocks/singlebtn/hooks/__tests__/use-linked-measure-state.test.js
@@ -10,12 +10,6 @@ import { createRoot } from 'react-dom/client';
  */
 import { useLinkedMeasureState } from '../use-linked-measure-state';
 
-const TOKENS = [
-	{ value: '4px', alias: 'sm' },
-	{ value: '6px', alias: 'md' },
-	{ value: '8px', alias: 'lg' },
-];
-
 let container;
 let root;
 
@@ -66,18 +60,15 @@ afterEach(() => {
 
 describe('useLinkedMeasureState', () => {
 	/**
-	 * An unset device value reads as linked — every effective slot falls through to the same scalar
-	 * preset value, so there is nothing to show as different.
+	 * An unset device value reads as linked: nothing is stored, so no slot differs from another. What
+	 * those empty slots inherit is shown as one muted fallback, not split across four rows.
 	 *
 	 * @return {void}
 	 */
-	it('reads as linked when the device stores nothing and the preset is a single scalar', () => {
+	it('reads as linked when the device stores nothing', () => {
 		const { box } = renderHook({
 			forDevice: { attr: 'radius', value: ['', '', '', ''] },
-			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
 			previewDevice: 'Desktop',
-			presetValue: '4px',
-			tokens: TOKENS,
 			setAttributes: jest.fn(),
 		});
 
@@ -85,17 +76,14 @@ describe('useLinkedMeasureState', () => {
 	});
 
 	/**
-	 * A uniform stored value reads as linked, regardless of the preset.
+	 * A uniform stored value reads as linked, from the stored value alone.
 	 *
 	 * @return {void}
 	 */
 	it('reads as linked when every stored slot matches', () => {
 		const { box } = renderHook({
 			forDevice: { attr: 'radius', value: ['4px', '4px', '4px', '4px'] },
-			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
 			previewDevice: 'Desktop',
-			presetValue: '8px',
-			tokens: TOKENS,
 			setAttributes: jest.fn(),
 		});
 
@@ -110,10 +98,7 @@ describe('useLinkedMeasureState', () => {
 	it('reads as individual when a stored slot differs', () => {
 		const { box } = renderHook({
 			forDevice: { attr: 'radius', value: ['4px', '8px', '4px', '4px'] },
-			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
 			previewDevice: 'Desktop',
-			presetValue: '4px',
-			tokens: TOKENS,
 			setAttributes: jest.fn(),
 		});
 
@@ -121,53 +106,46 @@ describe('useLinkedMeasureState', () => {
 	});
 
 	/**
-	 * Linking an empty device whose inherited slots are uniform remembers the override without writing
-	 * any attribute — writing would pin the device to another breakpoint's current value.
+	 * A device that stores nothing opens LINKED regardless of what it inherits: its slots are empty
+	 * because they inherit, and the inherited value is shown as one muted fallback rather than split
+	 * across four blank rows.
 	 *
 	 * @return {void}
 	 */
-	it('remembers a link toggle without writing an attribute when the inherited slots are uniform', () => {
-		const setAttributes = jest.fn();
+	it('reads an empty device as linked even when the inherited slots differ', () => {
 		const { box } = renderHook({
 			forDevice: { attr: 'tabletRadius', value: ['', '', '', ''] },
-			inherited: { values: ['6px', '6px', '6px', '6px'], inherited: [true, true, true, true] },
 			previewDevice: 'Tablet',
-			presetValue: ['4px', '8px', '4px', '4px'],
-			tokens: TOKENS,
+			setAttributes: jest.fn(),
+		});
+
+		expect(box.current.isLinked).toBe(true);
+	});
+
+	/**
+	 * Toggling link on an empty device never writes an attribute, whatever it inherits. The inherited
+	 * value is only ever DISPLAYED (muted); writing it would turn that display fallback into a real
+	 * stored override off a single link click — and, for a value carrying its own unit (`0.4em`) into
+	 * an attribute whose unit lives beside it, would render with a doubled unit.
+	 *
+	 * @return {void}
+	 */
+	it('never writes an attribute when toggling link on an empty device', () => {
+		const setAttributes = jest.fn();
+		const { box } = renderHook({
+			forDevice: { attr: 'tabletPadding', value: ['', '', '', ''] },
+			previewDevice: 'Tablet',
 			setAttributes,
 		});
 
+		// Unlink first, since an empty device now starts linked.
+		act(() => box.current.toggleLink());
 		expect(box.current.isLinked).toBe(false);
 
 		act(() => box.current.toggleLink());
 
 		expect(setAttributes).not.toHaveBeenCalled();
 		expect(box.current.isLinked).toBe(true);
-	});
-
-	/**
-	 * Linking an empty device whose inherited slots differ collapses them by writing the first
-	 * inherited slot (resolved to its token alias) into every slot, so the control and the preset
-	 * agree.
-	 *
-	 * @return {void}
-	 */
-	it('collapses to the first inherited slot when linking an empty device with differing inherited slots', () => {
-		const setAttributes = jest.fn();
-		const { box } = renderHook({
-			forDevice: { attr: 'tabletRadius', value: ['', '', '', ''] },
-			inherited: { values: ['6px', '8px', '6px', '6px'], inherited: [true, true, true, true] },
-			previewDevice: 'Tablet',
-			presetValue: ['4px', '8px', '4px', '4px'],
-			tokens: TOKENS,
-			setAttributes,
-		});
-
-		expect(box.current.isLinked).toBe(false);
-
-		act(() => box.current.toggleLink());
-
-		expect(setAttributes).toHaveBeenCalledWith({ tabletRadius: ['md', 'md', 'md', 'md'] });
 	});
 
 	/**
@@ -180,10 +158,7 @@ describe('useLinkedMeasureState', () => {
 		const setAttributes = jest.fn();
 		const { box } = renderHook({
 			forDevice: { attr: 'radius', value: ['4px', '4px', '4px', '4px'] },
-			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
 			previewDevice: 'Desktop',
-			presetValue: '4px',
-			tokens: TOKENS,
 			setAttributes,
 		});
 
@@ -205,10 +180,7 @@ describe('useLinkedMeasureState', () => {
 		const setAttributes = jest.fn();
 		const { box, update } = renderHook({
 			forDevice: { attr: 'tabletRadius', value: ['4px', '4px', '4px', '4px'] },
-			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
 			previewDevice: 'Tablet',
-			presetValue: '4px',
-			tokens: TOKENS,
 			setAttributes,
 		});
 
@@ -220,10 +192,7 @@ describe('useLinkedMeasureState', () => {
 
 		update({
 			forDevice: { attr: 'radius', value: ['4px', '4px', '4px', '4px'] },
-			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
 			previewDevice: 'Desktop',
-			presetValue: '4px',
-			tokens: TOKENS,
 			setAttributes,
 		});
 
@@ -232,7 +201,7 @@ describe('useLinkedMeasureState', () => {
 
 	/**
 	 * A change to `resetOn` (e.g. a new preset selected) clears any remembered override, so the mode
-	 * re-derives from the stored value and preset alone.
+	 * re-derives from the stored value alone.
 	 *
 	 * @return {void}
 	 */
@@ -240,10 +209,7 @@ describe('useLinkedMeasureState', () => {
 		const setAttributes = jest.fn();
 		const { box, update } = renderHook({
 			forDevice: { attr: 'radius', value: ['4px', '4px', '4px', '4px'] },
-			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
 			previewDevice: 'Desktop',
-			presetValue: '4px',
-			tokens: TOKENS,
 			setAttributes,
 			resetOn: 'preset-a',
 		});
@@ -254,10 +220,7 @@ describe('useLinkedMeasureState', () => {
 
 		update({
 			forDevice: { attr: 'radius', value: ['4px', '4px', '4px', '4px'] },
-			inherited: { values: ['4px', '4px', '4px', '4px'], inherited: [false, false, false, false] },
 			previewDevice: 'Desktop',
-			presetValue: '4px',
-			tokens: TOKENS,
 			setAttributes,
 			resetOn: 'preset-b',
 		});

--- a/src/blocks/singlebtn/hooks/use-linked-measure-state.js
+++ b/src/blocks/singlebtn/hooks/use-linked-measure-state.js
@@ -9,25 +9,6 @@ import { useEffect, useState } from '@wordpress/element';
 import { deriveMeasureMode } from '../../../extension/token-indicators/normalize';
 
 /**
- * The value a token in `tokens` resolves to, matched back to the alias that produced it.
- *
- * The preset surface carries resolved literals, not aliases (`blockPresetValues` flattens them so the
- * overridden-check can be a plain compare), so the literal is matched back to the token that produced
- * it. Writing the alias keeps a collapsed slot bound to the token (e.g. `None`) rather than landing as
- * a custom literal that merely happens to look the same.
- *
- * @param {Array}  tokens The pickable tokens for this control, each `{ value, alias }`.
- * @param {*}      value  The resolved literal to match back to its token.
- *
- * @since TBD
- *
- * @return {string} The matching token's alias, or the literal itself when no token matches.
- */
-function aliasForValue(tokens, value) {
-	return tokens.find((token) => token.value === value)?.alias ?? value ?? '';
-}
-
-/**
  * The linked/individual state — and its toggle — for a responsive 4-slot measure control (Border
  * Radius's corners, Padding's sides, and any control sharing that shape).
  *
@@ -41,11 +22,7 @@ function aliasForValue(tokens, value) {
  * @param {Object}   config               The hook's configuration.
  * @param {Object}   config.forDevice     The active device's attribute and value, i.e.
  *                                        `measureAttrsForDevice()`'s return shape (`{ attr, value }`).
- * @param {Object}   config.inherited     What each slot inherits at the active device, i.e.
- *                                        `inheritedMeasureSlots()`'s return shape (`{ values, inherited }`).
  * @param {string}   config.previewDevice The active preview device ('Desktop' | 'Tablet' | 'Mobile').
- * @param {*}        config.presetValue   The selected preset's value for the property.
- * @param {Array}    config.tokens        The pickable tokens for this control, each `{ value, alias }`.
  * @param {Function} config.setAttributes The block's `setAttributes`.
  * @param {*}        [config.resetOn]     A value that, when it changes, clears any remembered override
  *                                        for every device — e.g. the active preset, so a choice made
@@ -55,18 +32,9 @@ function aliasForValue(tokens, value) {
  * @since TBD
  *
  * @return {{isLinked: boolean, toggleLink: Function}} Whether the active device reads as linked, and
- *  the toggle handler. `inheritedValues`/`inheritedFirstValue` are computed internally (the toggle
- *  handler needs them) but not returned — no call site has needed them outside the hook so far.
+ *  the toggle handler.
  */
-export function useLinkedMeasureState({
-	forDevice,
-	inherited,
-	previewDevice,
-	presetValue,
-	tokens,
-	setAttributes,
-	resetOn,
-}) {
+export function useLinkedMeasureState({ forDevice, previewDevice, setAttributes, resetOn }) {
 	const [modeOverride, setModeOverride] = useState({});
 
 	// The override records a choice made about the PREVIOUS preset's slots, so selecting another preset
@@ -75,14 +43,7 @@ export function useLinkedMeasureState({
 		setModeOverride({});
 	}, [resetOn]);
 
-	const isLinked = 'linked' === (modeOverride[previewDevice] ?? deriveMeasureMode(forDevice.value, presetValue));
-
-	// What the slots inherit, and whether that inheritance is uniform. A per-slot inheritance is the
-	// case where linking is a real change rather than a no-op.
-	const inheritedValues = inherited.values;
-	const inheritedValuesDiffer =
-		Array.isArray(inheritedValues) && inheritedValues.some((value) => value !== inheritedValues[0]);
-	const inheritedFirstValue = Array.isArray(inheritedValues) ? aliasForValue(tokens, inheritedValues[0]) : '';
+	const isLinked = 'linked' === (modeOverride[previewDevice] ?? deriveMeasureMode(forDevice.value));
 
 	const toggleLink = () => {
 		if (!isLinked) {
@@ -91,29 +52,9 @@ export function useLinkedMeasureState({
 			const isEmpty = slots.every((value) => '' === value || undefined === value);
 
 			if (isEmpty) {
-				// Nothing stored on this device, so ordinarily there is nothing to collapse — the slots
-				// are empty because they inherit, and writing the inherited value would silently pin
-				// Tablet/Mobile to Desktop's current measure.
-				//
-				// Unless what is inherited differs slot to slot: then "link" genuinely changes the
-				// result, and storing nothing would leave the control showing one value while the block
-				// still renders four, with the indicator insisting it matches the preset. Collapsing to
-				// the first slot is the write that makes the three agree.
-				if (!inheritedValuesDiffer) {
-					setModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
-
-					return;
-				}
-
-				setAttributes({
-					[forDevice.attr]: [
-						inheritedFirstValue,
-						inheritedFirstValue,
-						inheritedFirstValue,
-						inheritedFirstValue,
-					],
-				});
-				setModeOverride((current) => ({ ...current, [previewDevice]: undefined }));
+				// Nothing stored, so nothing to collapse. Writing the inherited value here would turn a
+				// display fallback into a real override off a single link click.
+				setModeOverride((current) => ({ ...current, [previewDevice]: 'linked' }));
 
 				return;
 			}

--- a/src/extension/design-tokens/components/EditorBorderControl.js
+++ b/src/extension/design-tokens/components/EditorBorderControl.js
@@ -293,6 +293,8 @@ export function EditorBorderControl({
 
 		// Relinking collapses every side to slot 0's value — "the first side wins" is predictable,
 		// matching `BorderControl`'s own uncontrolled relink rule and `BoxControl`'s relink comment.
+		// Reads the stored border only: an unset width stays unset through a relink rather than being
+		// written out as an override of the muted default it was merely displaying.
 		const current = fromNativeBorder(activeNative);
 
 		activeSetter(

--- a/src/extension/design-tokens/components/EditorBoxControl.js
+++ b/src/extension/design-tokens/components/EditorBoxControl.js
@@ -37,8 +37,15 @@ import { TokenControlRow } from '../../token-indicators/components/TokenControlR
  * @param {string}    props.previewDevice  The editor's active device (`Desktop`/`Tablet`/`Mobile`).
  * @param {Function}  props.onDeviceChange Called with the next editor device name.
  * @param {Array}     props.tokens         The pickable-token list, already resolved by the block.
- * @param {*}         [props.defaultValue] The inherited preset default for this device.
- * @param {boolean}   [props.inherited]    Whether that default comes from another breakpoint.
+ * @param {*}         [props.defaultValue] What an empty corner falls back to on this device, shown
+ *                                        MUTED rather than substituted into the value — an unset
+ *                                        corner is not the same as one bound to that value, and
+ *                                        collapsing the two is what makes a field claim an override
+ *                                        nobody made. `inherited` names which kind of fallback it is.
+ * @param {boolean}   [props.inherited]    Whether that default comes from another breakpoint (labels
+ *                                        it "Inherited") rather than from the preset/baseline
+ *                                        ("Default") — see `inheritedMeasureSlots()`, which computes
+ *                                        the per-corner flag this reduces.
  * @param {?Object}   [props.state]        The block's own binding state (`{ bound, overridden }`).
  * @param {?Function} [props.onReset]      Reset handler for the indicator.
  * @param {boolean}   props.isLinked       Whether the slots are edited together.

--- a/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorBorderControl.test.js
@@ -645,3 +645,41 @@ describe('EditorBorderControl token indicator', () => {
 		expect(borderControl.props.indicator.props.state).toBeNull();
 	});
 });
+
+describe('EditorBorderControl unset width', () => {
+	/**
+	 * A completely untouched border stays unset rather than being filled in with the fallback: the
+	 * control shows that fallback MUTED (via `defaultValue`) instead, so an unset width reads as
+	 * "Default"/"Inherited" rather than claiming an override nobody made.
+	 *
+	 * @return {void}
+	 */
+	it('leaves the width unset and passes the fallback through as the muted default', () => {
+		const { borderControl } = renderEditorBorderControl({ value: undefined, defaultValue: '1px' });
+
+		expect(borderControl.props.value.width).toBe('');
+		expect(borderControl.props.defaultValue).toBe('1px');
+	});
+
+	/**
+	 * A stored width is never overridden by the fallback, even when the two disagree.
+	 *
+	 * @return {void}
+	 */
+	it('keeps a genuinely stored width, ignoring the fallback', () => {
+		const { borderControl } = renderEditorBorderControl({ value: NATIVE_VALUE, defaultValue: '1px' });
+
+		expect(borderControl.props.value.width).toEqual(['2px', '3px', '4px', '5px']);
+	});
+
+	/**
+	 * With no fallback at all, an unset width stays unset.
+	 *
+	 * @return {void}
+	 */
+	it('leaves an unset width unset when there is no fallback either', () => {
+		const { borderControl } = renderEditorBorderControl({ value: undefined, defaultValue: undefined });
+
+		expect(borderControl.props.value.width).toBe('');
+	});
+});

--- a/src/extension/design-tokens/components/__tests__/EditorBoxControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorBoxControl.test.js
@@ -134,3 +134,66 @@ describe('EditorBoxControl collapse', () => {
 		expect(boxControl.props.collapse).toBe(false);
 	});
 });
+
+describe('EditorBoxControl unset corners', () => {
+	/**
+	 * A corner with nothing stored stays empty rather than being filled in with the fallback: the
+	 * control shows that fallback MUTED (via `defaultValue`) instead, so an unset corner reads as
+	 * "Default"/"Inherited" rather than claiming an override nobody made.
+	 *
+	 * @return {void}
+	 */
+	it('leaves an empty corner empty and passes the fallback through as the muted default', () => {
+		const { boxControl } = renderEditorBoxControl({
+			value: ['', '2px', '', ''],
+			defaultValue: ['1px', '1px', '1px', '1px'],
+		});
+
+		expect(boxControl.props.value).toEqual(['', '2px', '', '']);
+		expect(boxControl.props.defaultValue).toEqual(['1px', '1px', '1px', '1px']);
+	});
+
+	/**
+	 * A stored corner is never overridden by the fallback, even when the two disagree.
+	 *
+	 * @return {void}
+	 */
+	it('keeps every stored corner, ignoring the fallback for those', () => {
+		const { boxControl } = renderEditorBoxControl({
+			value: ['3px', '3px', '3px', '3px'],
+			defaultValue: ['1px', '1px', '1px', '1px'],
+		});
+
+		expect(boxControl.props.value).toEqual(['3px', '3px', '3px', '3px']);
+	});
+
+	/**
+	 * With no fallback at all, an empty corner stays empty.
+	 *
+	 * @return {void}
+	 */
+	it('leaves an empty corner empty when there is no fallback either', () => {
+		const { boxControl } = renderEditorBoxControl({
+			value: ['', '', '', ''],
+			defaultValue: undefined,
+		});
+
+		expect(boxControl.props.value).toEqual(['', '', '', '']);
+	});
+
+	/**
+	 * The `inherited` flag is forwarded untouched, since it is what decides whether the muted
+	 * fallback is labeled "Inherited" (another breakpoint) or "Default" (the preset/baseline).
+	 *
+	 * @return {void}
+	 */
+	it('forwards the inherited flag that labels the muted fallback', () => {
+		const { boxControl } = renderEditorBoxControl({
+			value: ['', '', '', ''],
+			defaultValue: ['1px', '1px', '1px', '1px'],
+			inherited: true,
+		});
+
+		expect(boxControl.props.inherited).toBe(true);
+	});
+});

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -184,15 +184,14 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
 	properties.forEach((property) => {
 		const attr = property.control_attr;
 
-		// A property with no mapped control attribute is not surfaced. Nor is one the active preset only
-		// falls through to the baseline's own definition of this same preset slug for — `presetOwnKeys`
-		// carries only the properties the preset genuinely has ITS OWN stored value for; a baseline
-		// fallback reads as unbound here, the same way the Style Library shows it as a muted "Default"
-		// rather than as if it were the preset's own binding (the binding-set collapse interlock: the
-		// per-preset surface, not just the block's full property list, gates binding).
-		if (!attr || !presetOwnKeys[property.key]) {
+		// The per-preset surface gates binding, not just the block's full property list.
+		if (!attr || !(property.key in presetValues)) {
 			return;
 		}
+
+		// Gates `bound` but deliberately not `presetValue`: an unbound property still shows a muted
+		// default naming the value the block really renders.
+		const owned = presetOwnKeys[property.key] === true;
 
 		// A property that owns one axis of a composite control attribute keys its compare off that declared
 		// axis rather than PHP's generic `property.kind` — see `propertyAxis`'s docblock for why.
@@ -236,7 +235,7 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
 				kind: 'border',
 				presetValue: {},
 				responsive: {},
-				bound: true,
+				bound: false,
 				overridden: false,
 			};
 
@@ -244,6 +243,8 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
 			combined.token[axisKey] = property.token;
 			combined.presetValue[axisKey] = presetValue;
 			combined.responsive[axisKey] = propertyBreakpoints;
+			// One control, three axes: bound once ANY axis is genuinely the preset's own.
+			combined.bound = combined.bound || owned;
 			combined.overridden = combined.overridden || overridden;
 
 			state[attr] = combined;
@@ -257,7 +258,7 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
 			kind,
 			presetValue,
 			responsive: propertyBreakpoints,
-			bound: true,
+			bound: owned,
 			overridden,
 		};
 	});
@@ -281,20 +282,13 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
  *
  * @since TBD
  *
- * @return {*} The resolved literal value, or `undefined` when the active preset does not set it, OR
- *             only falls through to the baseline's own definition of this same preset slug rather than
- *             carrying a genuine override of its own — see `usePresetBinding`'s identical
- *             `presetOwnKeys` gate for the full reasoning.
+ * @return {*} The resolved literal value, or `undefined` when the active preset does not set it.
+ *             Not gated on ownership: this feeds a control's muted default, which must name what the
+ *             block really renders. `usePresetBinding`'s `bound` carries that distinction.
  */
 export function presetPropertyValueForDevice(blockName, propertyKey, attributes, library, previewDevice) {
 	const resolvedLibrary = library || activeLibrary();
 	const activePreset = activePresetFor(blockName, attributes, resolvedLibrary);
-	const presetOwnKeys = get(blockPresetOverridden(blockName, resolvedLibrary), activePreset, {});
-
-	if (!presetOwnKeys[propertyKey]) {
-		return undefined;
-	}
-
 	const presetValues = get(blockPresetValues(blockName, resolvedLibrary), activePreset, {});
 	const presetBreakpoints = get(blockPresetResponsive(blockName, resolvedLibrary), activePreset, {});
 

--- a/src/extension/token-indicators/kinds/__tests__/dimension.test.js
+++ b/src/extension/token-indicators/kinds/__tests__/dimension.test.js
@@ -86,33 +86,27 @@ describe('matchesPreset dimension for a control that stores a raw number', () =>
 });
 
 describe('deriveMeasureMode', () => {
-	it('reads all-empty corners on a scalar preset as linked', () => {
-		expect(deriveMeasureMode(['', '', '', ''], '0.5rem')).toBe('linked');
+	it('reads all-empty corners as linked', () => {
+		// An unset control shows ONE muted fallback row rather than four blank ones, matching what the
+		// Style Library renders for the same state.
+		expect(deriveMeasureMode(['', '', '', ''])).toBe('linked');
 	});
 
-	it('reads all-empty corners on a per-corner preset as individual', () => {
-		expect(deriveMeasureMode(['', '', '', ''], ['0', '0.125rem', '9999px', '1rem'])).toBe('individual');
-	});
-
-	it('reads all-empty corners on a uniform per-corner preset as linked', () => {
-		expect(deriveMeasureMode(['', '', '', ''], ['8px', '8px', '8px', '8px'])).toBe('linked');
-	});
-
-	it('reads equal stored corners as linked whatever the preset holds', () => {
-		expect(deriveMeasureMode(['8', '8', '8', '8'], ['0', '0.125rem', '9999px', '1rem'])).toBe('linked');
+	it('reads equal stored corners as linked', () => {
+		expect(deriveMeasureMode(['8', '8', '8', '8'])).toBe('linked');
 	});
 
 	it('reads a differing stored corner as individual', () => {
-		expect(deriveMeasureMode(['8', '8', '8', '4'], '0.5rem')).toBe('individual');
+		expect(deriveMeasureMode(['8', '8', '8', '4'])).toBe('individual');
 	});
 
-	it('reads one overridden corner against an inherited scalar as individual', () => {
-		expect(deriveMeasureMode(['{primitive.dimension.radius.lg}', '', '', ''], '0.5rem')).toBe('individual');
+	it('reads one stored corner beside three empty ones as individual', () => {
+		expect(deriveMeasureMode(['{primitive.dimension.radius.lg}', '', '', ''])).toBe('individual');
 	});
 
-	it('reads an unset value with no preset as linked', () => {
-		expect(deriveMeasureMode(undefined, undefined)).toBe('linked');
-		expect(deriveMeasureMode(['', '', '', ''], '')).toBe('linked');
+	it('reads an unset value as linked', () => {
+		expect(deriveMeasureMode(undefined)).toBe('linked');
+		expect(deriveMeasureMode(['', '', '', ''])).toBe('linked');
 	});
 });
 
@@ -151,10 +145,10 @@ describe('measureAttrsForDevice', () => {
 
 	it('derives the mode per device, so breakpoints can differ', () => {
 		// Desktop corners are equal (linked) while tablet corners differ (individual).
-		expect(deriveMeasureMode(measureAttrsForDevice(ATTRS, 'borderRadius', RESPONSIVE, 'Desktop').value, '')).toBe(
+		expect(deriveMeasureMode(measureAttrsForDevice(ATTRS, 'borderRadius', RESPONSIVE, 'Desktop').value)).toBe(
 			'linked'
 		);
-		expect(deriveMeasureMode(measureAttrsForDevice(ATTRS, 'borderRadius', RESPONSIVE, 'Tablet').value, '')).toBe(
+		expect(deriveMeasureMode(measureAttrsForDevice(ATTRS, 'borderRadius', RESPONSIVE, 'Tablet').value)).toBe(
 			'individual'
 		);
 	});

--- a/src/extension/token-indicators/kinds/dimension.js
+++ b/src/extension/token-indicators/kinds/dimension.js
@@ -259,26 +259,27 @@ export function anyCornerInherited(inherited) {
 }
 
 /**
- * The linked/individual mode a measure control should open in, derived from the corners the user would
- * actually see: each stored corner where one is set, otherwise the value that corner inherits from the
- * selected preset.
+ * The linked/individual mode a measure control should open in, derived from what THIS device actually
+ * stores — nothing else.
  *
- * Deriving from the stored attribute alone is not enough. A block on a preset stores NOTHING — every
- * corner is empty, which trivially reads as "all equal" — so a preset carrying four different corners
- * would open the control in linked mode and hide the difference it is displaying.
+ * A device that stores nothing has nothing that differs, so it opens linked: its corners are empty
+ * because they inherit, and what they inherit is shown MUTED as a single "Default"/"Inherited"
+ * fallback rather than substituted into the four corners. Splitting an all-empty control into four
+ * blank rows shows the user a difference none of their own values carry, and disagrees with the Style
+ * Library, which renders exactly this case as one linked row.
  *
- * @param {*} value       The stored dimension value (4-side array or scalar).
- * @param {*} presetValue The selected preset's value for the property.
+ * This deliberately does NOT consult the preset value. It used to, back when an unset corner was
+ * DISPLAYED as bound to the preset's own per-corner value; with that substitution gone from the
+ * control's display, deriving the mode from it would describe a shape the control no longer shows.
+ *
+ * @param {*} value The stored dimension value (4-side array or scalar).
  *
  * @since TBD
  *
- * @return {string} 'linked' when every effective corner matches, otherwise 'individual'.
+ * @return {string} 'linked' when every stored corner matches, otherwise 'individual'.
  */
-export function deriveMeasureMode(value, presetValue) {
-	const stored = dimensionSlots(value);
-	const corners = [0, 1, 2, 3].map((index) =>
-		stored[index] !== undefined && stored[index] !== '' ? stored[index] : presetSlotAt(presetValue, index)
-	);
+export function deriveMeasureMode(value) {
+	const corners = dimensionSlots(value);
 
 	return corners.every((corner) => corner === corners[0]) ? 'linked' : 'individual';
 }


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4260/token-control-popover-options-and-the-default-label-show-what-is

Applies the same rule to the block editor that the previous slices applied to the Style Library, so the two hosts read identically.

`EditorBoxControl` and `EditorBorderControl` were substituting the fallback **into the control's `value`**. A non-empty value reads as bound, which suppressed the muted display entirely and produced a doubled unit — a `0.4em` fallback written into an attribute whose unit lives beside it renders as `0.4empx`. Removed; the fallback now shows muted via `defaultValue`, which is what the "Inherited"/"Default" labelling already keys off.

Two consequences fall out of the same cause:

- **"Inherited" vs "Default" works again.** A smaller breakpoint falling back to the next one up labels its muted fallback "Inherited"; one falling back to the preset/baseline says "Default". That wiring already existed — the substitution was bypassing it.
- **An unset measure control opens linked.** `deriveMeasureMode()` consulted the preset value, so an all-empty control opened unlinked across four blank rows, disagreeing with the Style Library. It now derives from what the device actually stores.

`useLinkedMeasureState.toggleLink()` also stops writing the inherited value into the attribute when relinking an empty device — that turned a display fallback into a real stored override off a single click, and was the other half of the doubled-unit bug.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved linked dimension controls for borders, spacing, and corner values.
  * Unset device values now remain unset instead of being replaced by inherited or preset values.
  * Preserved stored overrides while providing fallback values only for display.
  * Improved preset indicators and device-specific linked/individual mode detection.

* **Documentation**
  * Clarified fallback, inherited, unset, and relinking behavior in border and spacing controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->