### PR TITLE
[DTM] SOFT-4260 [18/19]: give BoxShadowControl a defaultValue

### DIFF
--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -390,6 +390,15 @@ export default function KadenceButtonEdit(props) {
 		previewDevice
 	);
 
+	// Read directly: `button-shadow` declares no `control_attr`, so `usePresetBinding` skips it.
+	const shadowPresetValue = presetPropertyValueForDevice(
+		'kadence/singlebtn',
+		'button-shadow',
+		attributes,
+		undefined,
+		previewDevice
+	);
+
 	// What an unset Border Radius corner falls back to on the active device: another breakpoint's corner
 	// before the preset's, matching the cascade the button actually renders through. The corners stay
 	// stored-empty — this only tells the field's popover which size is in effect and where it came from.
@@ -399,8 +408,7 @@ export default function KadenceButtonEdit(props) {
 		borderRadiusPresetValue
 	);
 
-	// The shipped presets (default/secondary) both declare `button-padding`, so `presetValueForDevice`
-	// above resolves it for those; the fallback only matters for a custom preset that omits the key.
+	// The fallback only catches a custom preset that omits the key, which would otherwise read as blank.
 	const paddingPresetValue = presetValueOr(
 		presetValueForDevice(tokenBinding.padding?.presetValue, tokenBinding.padding?.responsive, previewDevice),
 		BUTTON_PADDING_FALLBACK
@@ -485,9 +493,7 @@ export default function KadenceButtonEdit(props) {
 	});
 
 	// Padding's linked/individual mode, mirroring Border Radius's own hook call above with "corner"
-	// swapped for "side" — same shape, run over `paddingForDevice` instead. `resetOn` is included for
-	// the same reason: an override records a choice about the PREVIOUS preset's sides, so it has to
-	// clear on a preset change or an explicit "link" sticks and hides the new preset's own padding.
+	// swapped for "side". `resetOn` clears the remembered choice, which belonged to the old preset.
 	const { isLinked: paddingIsLinked, toggleLink: togglePaddingLink } = useLinkedMeasureState({
 		forDevice: paddingForDevice,
 		previewDevice,
@@ -1354,6 +1360,7 @@ export default function KadenceButtonEdit(props) {
 															min={0}
 														/>
 														<EditorShadowControl
+															defaultValue={shadowPresetValue}
 															label={__('Box Shadow', 'kadence-blocks')}
 															value={shadowHover}
 															onChange={(value) => setAttributes({ shadowHover: value })}
@@ -1479,6 +1486,7 @@ export default function KadenceButtonEdit(props) {
 															step={borderRadiusIsRelative ? 0.1 : 1}
 														/>
 														<EditorShadowControl
+															defaultValue={shadowPresetValue}
 															label={__('Box Shadow', 'kadence-blocks')}
 															value={shadow}
 															onChange={(value) => setAttributes({ shadow: value })}
@@ -1627,6 +1635,7 @@ export default function KadenceButtonEdit(props) {
 																min={0}
 															/>
 															<EditorShadowControl
+																defaultValue={shadowPresetValue}
 																label={__('Box Shadow', 'kadence-blocks')}
 																value={shadowTransparentHover}
 																onChange={(value) =>
@@ -1753,6 +1762,7 @@ export default function KadenceButtonEdit(props) {
 																min={0}
 															/>
 															<EditorShadowControl
+																defaultValue={shadowPresetValue}
 																label={__('Box Shadow', 'kadence-blocks')}
 																value={shadowTransparent}
 																onChange={(value) =>
@@ -1895,6 +1905,7 @@ export default function KadenceButtonEdit(props) {
 																min={0}
 															/>
 															<EditorShadowControl
+																defaultValue={shadowPresetValue}
 																label={__('Box Shadow', 'kadence-blocks')}
 																value={shadowStickyHover}
 																onChange={(value) =>
@@ -2015,6 +2026,7 @@ export default function KadenceButtonEdit(props) {
 																min={0}
 															/>
 															<EditorShadowControl
+																defaultValue={shadowPresetValue}
 																label={__('Box Shadow', 'kadence-blocks')}
 																value={shadowSticky}
 																onChange={(value) =>

--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -300,6 +300,39 @@ export function toNativeShadow(value, tokens = []) {
 }
 
 /**
+ * Whether a stored native shadow should be treated as "the block sets no shadow of its own".
+ *
+ * `block.json` registers an all-zero transparent shadow as `shadow`'s own default, so a fresh block
+ * arrives byte-identical to an explicit "None" pick. They are separated by consequence, not shape: an
+ * invisible shadow is a real override only when there is a preset shadow for it to suppress. With
+ * nothing behind it, it suppresses nothing and reads as unset.
+ *
+ * @param {?Array} native       The stored native shadow attribute value.
+ * @param {*}      defaultValue The active preset's own resolved shadow, or nothing when it has none.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the control should render as unset.
+ */
+export function isUnsetShadow(native, defaultValue) {
+	const source = native?.[0];
+
+	if (!source) {
+		return true;
+	}
+
+	// A preset shadow behind it makes an invisible shadow a deliberate suppression, not an absence.
+	if (defaultValue !== undefined && defaultValue !== null && defaultValue !== '') {
+		return false;
+	}
+
+	const isTransparent = !source.color || source.color === 'transparent' || Number(source.opacity) === 0;
+	const hasNoGeometry = ['hOffset', 'vOffset', 'blur', 'spread'].every((axis) => !parseFloat(source[axis]));
+
+	return isTransparent && hasNoGeometry;
+}
+
+/**
  * Render the editor-canvas box-shadow control: `BoxShadowControl` always renders, with no separate
  * enable toggle — whether a `box-shadow` is emitted is decided elsewhere, purely from the value's own
  * axes.
@@ -309,6 +342,10 @@ export function toNativeShadow(value, tokens = []) {
  * @param {?Array}    props.value         The native shadow attribute value.
  * @param {Function}  props.onChange      Called with the next native shadow attribute value.
  * @param {Array}     [props.tokens]      Pickable `shadow`-type tokens, `[{id, label, value, alias}]`.
+ * @param {*}         [props.defaultValue] The active preset's own resolved shadow, or nothing when it
+ *                                        declares none — shown MUTED while the block stores no shadow
+ *                                        of its own, and what decides whether an invisible stored
+ *                                        shadow is a real override (see `isUnsetShadow()`).
  * @param {?Function} [props.renderColor] The block's existing color field for the composite's `color`.
  * @param {boolean}   [props.disabled]    Whether the control is read-only.
  *
@@ -316,14 +353,23 @@ export function toNativeShadow(value, tokens = []) {
  *
  * @return {JSX.Element} The rendered control.
  */
-export function EditorShadowControl({ label, value, onChange, tokens = [], renderColor, disabled = false }) {
+export function EditorShadowControl({
+	label,
+	value,
+	onChange,
+	tokens = [],
+	defaultValue,
+	renderColor,
+	disabled = false,
+}) {
 	return (
 		<TokenControlRow stacked>
 			<BoxShadowControl
 				label={label}
-				value={fromNativeShadow(value)}
+				value={isUnsetShadow(value, defaultValue) ? '' : fromNativeShadow(value)}
 				onChange={(next) => onChange(toNativeShadow(next, tokens))}
 				tokens={tokens}
+				defaultValue={defaultValue}
 				renderColor={renderColor}
 				disabled={disabled}
 			/>

--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -9,6 +9,7 @@ import {
 	splitColorOpacity,
 	toNativeShadow,
 	fromNativeShadow,
+	isUnsetShadow,
 } from '../EditorShadowControl';
 import { BoxShadowControl } from '../../../../token-controls/controls/BoxShadowControl';
 
@@ -104,15 +105,18 @@ describe('EditorShadowControl native <-> BoxShadowControl value bridging', () =>
 	});
 
 	/**
-	 * A missing native value reads as the composite's default shape rather than crashing on
-	 * `undefined[0]`.
+	 * A missing native value reads as UNSET (an empty value), so the control shows its muted "Default"
+	 * rather than the all-transparent composite that renders a bold "None". `fromNativeShadow` still
+	 * answers the composite default for that input — the unset decision belongs to `isUnsetShadow`,
+	 * which runs first.
 	 *
 	 * @return {void}
 	 */
-	it('reads an unset native value as the composite default', () => {
+	it('reads an unset native value as unset, not as the composite default', () => {
 		const { shadowControl } = renderEditorShadowControl({ value: undefined });
 
-		expect(shadowControl.props.value).toEqual({
+		expect(shadowControl.props.value).toBe('');
+		expect(fromNativeShadow(undefined)).toEqual({
 			color: 'transparent',
 			offsetX: '0px',
 			offsetY: '0px',
@@ -405,5 +409,99 @@ describe('combineColorOpacity / splitColorOpacity', () => {
 	 */
 	it('decodes an 8-digit hex color into its base color and embedded alpha', () => {
 		expect(splitColorOpacity('#1717171f')).toEqual({ color: '#171717', opacity: 0x1f / 255 });
+	});
+});
+
+describe('isUnsetShadow', () => {
+	const INVISIBLE = [{ color: 'transparent', opacity: 1, spread: 0, blur: 0, hOffset: 0, vOffset: 0, inset: false }];
+
+	/**
+	 * An absent attribute is unset, whether or not the preset carries a shadow.
+	 *
+	 * @return {void}
+	 */
+	it('reads an absent attribute as unset', () => {
+		expect(isUnsetShadow(undefined, undefined)).toBe(true);
+		expect(isUnsetShadow([], undefined)).toBe(true);
+		expect(isUnsetShadow(undefined, '{semantic.shadow.button}')).toBe(true);
+	});
+
+	/**
+	 * `block.json`'s registered default — an all-zero, fully transparent shadow — reads as unset when
+	 * the preset declares no shadow, so a freshly inserted block shows a muted "Default" rather than
+	 * claiming the bold "None" nobody picked.
+	 *
+	 * @return {void}
+	 */
+	it("reads block.json's invisible default as unset when the preset has no shadow", () => {
+		expect(isUnsetShadow(INVISIBLE, undefined)).toBe(true);
+		expect(isUnsetShadow(INVISIBLE, '')).toBe(true);
+	});
+
+	/**
+	 * That same invisible value is a REAL override once there is a preset shadow for it to suppress —
+	 * it must keep reading as an explicit "None", or the control would muted-show a preset shadow the
+	 * block is deliberately hiding.
+	 *
+	 * @return {void}
+	 */
+	it('reads an invisible shadow as set when a preset shadow is being suppressed', () => {
+		expect(isUnsetShadow(INVISIBLE, '{semantic.shadow.button}')).toBe(false);
+	});
+
+	/**
+	 * A shadow with real geometry is always set, preset shadow or not.
+	 *
+	 * @return {void}
+	 */
+	it('reads a visible shadow as set', () => {
+		expect(isUnsetShadow(NATIVE_VALUE, undefined)).toBe(false);
+		expect(isUnsetShadow([{ ...INVISIBLE[0], blur: 4, color: '#000000' }], undefined)).toBe(false);
+	});
+});
+
+describe('EditorShadowControl unset rendering', () => {
+	const INVISIBLE = [{ color: 'transparent', opacity: 1, spread: 0, blur: 0, hOffset: 0, vOffset: 0, inset: false }];
+
+	/**
+	 * An unset shadow hands `BoxShadowControl` an empty value, which is the state that renders the
+	 * muted "Default" — not the composite that renders a bold "None".
+	 *
+	 * @return {void}
+	 */
+	it('passes an empty value down when the shadow is unset', () => {
+		const { shadowControl } = renderEditorShadowControl({ value: INVISIBLE, defaultValue: undefined });
+
+		expect(shadowControl.props.value).toBe('');
+	});
+
+	/**
+	 * The preset's own shadow is forwarded as `defaultValue`, so an unset control can name what it
+	 * actually falls back to.
+	 *
+	 * @return {void}
+	 */
+	it('forwards the preset shadow as defaultValue', () => {
+		const { shadowControl } = renderEditorShadowControl({
+			value: undefined,
+			defaultValue: '{semantic.shadow.button}',
+		});
+
+		expect(shadowControl.props.value).toBe('');
+		expect(shadowControl.props.defaultValue).toBe('{semantic.shadow.button}');
+	});
+
+	/**
+	 * A suppressing "None" still renders as a real composite value, so it reads as the override it is.
+	 *
+	 * @return {void}
+	 */
+	it('keeps a suppressing None as a composite value', () => {
+		const { shadowControl } = renderEditorShadowControl({
+			value: INVISIBLE,
+			defaultValue: '{semantic.shadow.button}',
+		});
+
+		expect(shadowControl.props.value).not.toBe('');
 	});
 });

--- a/src/style-library/components/molecules/fields/BoxShadowField.js
+++ b/src/style-library/components/molecules/fields/BoxShadowField.js
@@ -142,6 +142,8 @@ export function resolveShadowPick(picked, tokens) {
  * @param {Object}  props.field            The field definition.
  * @param {?string} [props.field.label]    The control's label.
  * @param {boolean} [props.field.readOnly] Whether the control is non-interactive.
+ * @param {*}       [props.field.defaultValue] What an unset control falls back to, shown muted — now
+ *                                         read, since `BoxShadowControl` takes a `defaultValue`.
  * @param {*}       props.value            The stored value: a token alias, or a composite shadow object.
  * @param {Function} props.onChange        Called with the next alias or composite object.
  *
@@ -174,6 +176,7 @@ export function BoxShadowField({ field, value, onChange }) {
 			onChange={(next) => !field.readOnly && onChange(toStoredShadow(resolveShadowPick(next, tokens)))}
 			label={field.label}
 			tokens={tokens}
+			defaultValue={field.defaultValue}
 			renderColor={({ value: color, onChange: onColorChange }) => (
 				<TokenColorSelectField
 					field={{ label: __('Color', 'kadence-blocks'), readOnly: field.readOnly }}

--- a/src/style-library/presets/button-preset.js
+++ b/src/style-library/presets/button-preset.js
@@ -152,8 +152,10 @@ function schemaFor(tab) {
 				type: 'box-shadow',
 				path: 'tokens.button-shadow',
 				label: __('Shadow', 'kadence-blocks'),
-				// Same reason as `border` above: `BoxShadowControl` accepts no `defaultValue` prop, so a
-				// `defaultValue` key here would go unread.
+				// No `defaultValue`: a button renders no shadow of its own when the preset sets none, so
+				// there is no literal to name — the control's own bare muted "Default" already says that.
+				// (`BoxShadowControl` does now read a `defaultValue`, so one can be added here the day a
+				// button grows a built-in shadow.)
 			},
 		],
 	};

--- a/src/token-controls/__tests__/box-shadow-control.test.js
+++ b/src/token-controls/__tests__/box-shadow-control.test.js
@@ -243,7 +243,7 @@ describe('BoxShadowControl trigger', () => {
 	 * An unset value (the field's actual starting state before a token or a custom shadow is chosen)
 	 * shows a muted "Default" label — matching every other control in this library (`TokenSelector`'s
 	 * own unset behavior), rather than a blank trigger. Shadow's conceptual default when unset is a
-	 * constant ("no shadow"), not a per-instance literal, so no value/token name is attached — only the
+	 * constant ("no shadow"), or, when the host supplies one, the fallback it actually resolves to — only the
 	 * muted label itself.
 	 *
 	 * @return {void}

--- a/src/token-controls/__tests__/box-shadow-control.test.js
+++ b/src/token-controls/__tests__/box-shadow-control.test.js
@@ -827,3 +827,32 @@ describe('BoxShadowControl disabled state', () => {
 		expect(received.disabled).toBe(true);
 	});
 });
+
+describe('BoxShadowControl fallback labelling', () => {
+	/**
+	 * A fallback equal to the fixed sentinel's own resolved value must not borrow its label: an
+	 * untouched control would then read as an explicit "None" pick rather than as a default.
+	 *
+	 * @return {void}
+	 */
+	it('reads "Default", not "None", when the fallback equals the sentinel value', () => {
+		renderControl({ value: '', tokens: TOKENS_WITH_NONE, defaultValue: NONE_TOKEN.value });
+
+		const label = trigger().querySelector('.kadence-token-field__label');
+
+		expect(label.textContent).toBe('Default');
+		expect(label.classList.contains('kadence-token-field__label--default')).toBe(true);
+	});
+
+	/**
+	 * A fallback naming a real token still shows that token's label, so the muted text says what the
+	 * field actually falls back to.
+	 *
+	 * @return {void}
+	 */
+	it('names a real token fallback by its own label', () => {
+		renderControl({ value: '', tokens: TOKENS_WITH_NONE, defaultValue: TOKENS[0].value });
+
+		expect(trigger().querySelector('.kadence-token-field__label').textContent).toBe('Medium');
+	});
+});

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -223,6 +223,12 @@ function ShadowCustomTab({ shadow, onChange, renderColor, disabled = false }) {
  * @param {Function}  props.onChange      Called with the next alias or composite object.
  * @param {string}    props.label         The control's label.
  * @param {Array}     [props.tokens]      Pickable `shadow`-type tokens, `[{id, label, value, alias}]`.
+ * @param {*}         [props.defaultValue] What an UNSET control falls back to — a token alias or a
+ *                                        composite. Shown muted on the trigger and offered as the
+ *                                        popover's Reset target, exactly as `TokenSelector` treats its
+ *                                        own `defaultValue`. Without one, an unset control reads the
+ *                                        bare muted "Default" it always did, so a host with no preset
+ *                                        shadow to name is unchanged.
  * @param {Function}  [props.renderColor] `({ value, onChange }) => Element` for the color sub-field.
  * @param {boolean}   [props.disabled]    Whether the control is read-only.
  *
@@ -230,7 +236,7 @@ function ShadowCustomTab({ shadow, onChange, renderColor, disabled = false }) {
  *
  * @return {JSX.Element} The rendered control.
  */
-export function BoxShadowControl({ value, onChange, label, tokens = [], renderColor, disabled = false }) {
+export function BoxShadowControl({ value, onChange, label, tokens = [], defaultValue, renderColor, disabled = false }) {
 	const aliased = isTokenAlias(value);
 	// Only a real object is spread. A shadow can also arrive as a rendered STRING — the editor's capture
 	// flow writes one — and spreading a string splays it into indexed character keys, which the Custom
@@ -243,16 +249,22 @@ export function BoxShadowControl({ value, onChange, label, tokens = [], renderCo
 	// Display only — `onChange` still sees the real underlying value.
 	const displayValue = fixedMatch ? fixedMatch.alias : value;
 	// The trigger shows a label, never a value — it has no room for the `value` half `fieldSummary()`
-	// also returns. Unset reads a muted "Default".
+	// also returns. Unset names the shadow it falls back to, or a muted "Default" when there is none.
 	//
-	// Host asymmetry: only a host that can store "never touched" as something other than the None shape
-	// reaches that branch. The Style Library stores `''`; the block editor is handed `block.json`'s
-	// registered None composite on a fresh block, which matches `fixedMatch` first and reads "None".
+	// Whether an unset shadow can reach that branch is the host's problem: the button's registered
+	// `shadow` default IS the None composite (see `EditorShadowControl`'s `isUnsetShadow()`).
+	const defaultSummary = hasValue(defaultValue)
+		? fieldSummary(defaultValue, tokens, '', __('Custom', 'kadence-blocks'))
+		: null;
 	const summary =
 		aliased || fixedMatch
 			? { ...fieldSummary(displayValue, tokens, '', __('Custom', 'kadence-blocks')), value: '' }
 			: !hasValue(value)
-				? { label: __('Default', 'kadence-blocks'), value: '', muted: true }
+				? {
+						label: defaultSummary?.label || __('Default', 'kadence-blocks'),
+						value: '',
+						muted: true,
+					}
 				: { label: __('Custom', 'kadence-blocks'), value: '' };
 
 	return (
@@ -285,7 +297,10 @@ export function BoxShadowControl({ value, onChange, label, tokens = [], renderCo
 							<TokenPopover
 								value={displayValue}
 								tokens={tokens}
-								resolvedDefault=""
+								resolvedDefault={resolvePreviewCss(defaultValue, tokens, {
+									...DEFAULT_COMPOSITE,
+									...(isTokenAlias(defaultValue) || !defaultValue ? {} : defaultValue),
+								})}
 								initialTab={aliased || fixedMatch || !value ? 'style-library' : 'custom'}
 								custom={{ shadow, renderColor, disabled }}
 								renderCustom={(custom) => (

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -58,7 +58,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { ControlShell } from '../templates/ControlShell';
 import { TokenPopover } from '../molecules/TokenPopover';
-import { fieldSummary, hasValue, isTokenAlias } from '../helpers/token-summary';
+import { defaultSummary, fieldSummary, hasValue, isTokenAlias, resolveDefaultValue } from '../helpers/token-summary';
 import { DEFAULT_COMPOSITE } from '../helpers/shadow-shorthand';
 import '../styles/token-controls.scss';
 
@@ -253,15 +253,16 @@ export function BoxShadowControl({ value, onChange, label, tokens = [], defaultV
 	//
 	// Whether an unset shadow can reach that branch is the host's problem: the button's registered
 	// `shadow` default IS the None composite (see `EditorShadowControl`'s `isUnsetShadow()`).
-	const defaultSummary = hasValue(defaultValue)
-		? fieldSummary(defaultValue, tokens, '', __('Custom', 'kadence-blocks'))
-		: null;
+	// `defaultSummary()`, not `fieldSummary()`: a fixed sentinel is not a named design choice, so its
+	// label must not be borrowed for a field nobody touched — an all-zero fallback would otherwise read
+	// as an explicit "None" pick. See that helper's own docblock.
+	const fallback = defaultSummary(resolveDefaultValue(defaultValue, tokens, '', false), tokens);
 	const summary =
 		aliased || fixedMatch
 			? { ...fieldSummary(displayValue, tokens, '', __('Custom', 'kadence-blocks')), value: '' }
 			: !hasValue(value)
 				? {
-						label: defaultSummary?.label || __('Default', 'kadence-blocks'),
+						label: fallback.label || __('Default', 'kadence-blocks'),
 						value: '',
 						muted: true,
 					}


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4260/token-control-popover-options-and-the-default-label-show-what-is

`BoxShadowControl` accepted no `defaultValue`, so its fields could only show the unset state, never the value behind it. It takes one now, and both hosts pass it — the last control to gain the muted-default treatment the box and border fields already had.

The hard part is that the button editor cannot simply ask "is this unset?". `block.json` registers an all-zero transparent shadow as `shadow`'s own default, so a freshly inserted block arrives carrying a value **byte-identical** to an explicit "None" pick.

They are separated by consequence rather than shape (`isUnsetShadow()`): an invisible shadow is a real override only when there is a preset shadow for it to suppress. With nothing behind it, it suppresses nothing and renders nothing — indistinguishable, in every way the user can observe, from never having been set — so it reads as unset. That keeps an explicit None honest wherever it actually changes the outcome, without letting an untouched block claim a choice its owner never made.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [x] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Shadow controls can now display configured preset values when no custom shadow is set.
  - Reset previews and labels reflect the applicable default shadow.
  - Supports consistent shadow defaults across button states and style fields.

- **Bug Fixes**
  - Improved handling of missing, transparent, or zero-value shadows.
  - Prevents active preset shadows from being incorrectly treated as unset.

- **Tests**
  - Added coverage for preset defaults, invisible shadows, visible shadows, reset previews, and unset controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->