### PR TITLE
[DTM] SOFT-4260 [19/19]: ignore the subagent-driven-development scratch workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ package-lock.json
 /diff.txt
 /diffcs.txt
 /phpcs.json
+
+# Scratch workspace for subagent-driven-development runs.
+.superpowers/


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4260/token-control-popover-options-and-the-default-label-show-what-is

Ignores `.superpowers/`, the scratch workspace subagent-driven-development runs write into. It is not ignored today, so a broad `git add` sweeps session artifacts into a commit — which is exactly how a scratch report got into this stack before being caught and removed.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded generated scratch workspace files from version control.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->