### PR TITLE
Token-pickable block controls [1/11]: mark an override against a preset shipped in the baseline

### DIFF
--- a/src/extension/token-indicators/__tests__/TokenIndicator.test.js
+++ b/src/extension/token-indicators/__tests__/TokenIndicator.test.js
@@ -1,0 +1,131 @@
+/* eslint-env jest */
+
+/**
+ * The per-control preset indicator's three display states, and specifically which of them each half of
+ * `state` gates.
+ *
+ * `bound` does NOT mean "the preset resolves a value here" — it means the preset has its own STORED
+ * override for the property, which a preset shipped in `baseline.json` never has. Every block's
+ * `$default` preset is shipped that way, so gating the whole indicator on `bound` hid the override
+ * mark on a fresh site until someone re-saved the preset in the Style Library. These tests pin the
+ * split: the override dot needs only `overridden`, the matching glyph needs `bound` as well.
+ *
+ * `TokenIndicator` holds no hooks, so it is called as a plain function and its returned element tree
+ * inspected, matching the sibling component tests rather than mounting.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { TokenIndicator } from '../components/TokenIndicator';
+
+/**
+ * Collect every `className` in a returned element tree, so a test can assert which mark rendered
+ * without depending on the tree's nesting.
+ *
+ * @param {*} node The element (or child) to walk.
+ *
+ * @since TBD
+ *
+ * @return {string[]} Every className found, in traversal order.
+ */
+function classNames(node) {
+	if (!node || typeof node !== 'object') {
+		return [];
+	}
+
+	if (Array.isArray(node)) {
+		return node.flatMap(classNames);
+	}
+
+	const own = node.props?.className ? [node.props.className] : [];
+
+	return [...own, ...classNames(node.props?.children)];
+}
+
+describe('TokenIndicator', () => {
+	/**
+	 * A control the selected preset resolves no value for renders nothing at all.
+	 *
+	 * @return {void}
+	 */
+	it('renders nothing when the control is unmapped', () => {
+		expect(TokenIndicator({ state: undefined, onReset: jest.fn() })).toBeNull();
+	});
+
+	/**
+	 * The override dot renders on a diverged value even when the preset only inherits the property from
+	 * the baseline rather than storing its own override. This is the shipped-`$default` case that made
+	 * the mark unreachable on a fresh site.
+	 *
+	 * @return {void}
+	 */
+	it('shows the override dot for a diverged value the preset does not own', () => {
+		const result = TokenIndicator({ state: { bound: false, overridden: true }, onReset: jest.fn() });
+
+		expect(classNames(result)).toContain('kb-token-indicator__dot');
+	});
+
+	/**
+	 * The same divergence on a preset that does own the property is unchanged — the dot was always
+	 * reachable here, and stays so.
+	 *
+	 * @return {void}
+	 */
+	it('shows the override dot for a diverged value the preset does own', () => {
+		const result = TokenIndicator({ state: { bound: true, overridden: true }, onReset: jest.fn() });
+
+		expect(classNames(result)).toContain('kb-token-indicator__dot');
+	});
+
+	/**
+	 * The reset affordance accompanies the dot, so a diverged control can always be returned to the
+	 * value the preset resolves — which is exactly the value clearing the attribute falls back to.
+	 *
+	 * @return {void}
+	 */
+	it('offers a reset alongside the override dot', () => {
+		const onReset = jest.fn();
+		const result = TokenIndicator({ state: { bound: false, overridden: true }, onReset });
+
+		expect(classNames(result)).toContain('kb-token-indicator__reset');
+	});
+
+	/**
+	 * A matching value on a preset that owns the property shows the design-system glyph.
+	 *
+	 * @return {void}
+	 */
+	it('shows the matching glyph when the value matches a preset that owns it', () => {
+		const result = TokenIndicator({ state: { bound: true, overridden: false }, onReset: jest.fn() });
+
+		expect(classNames(result)).toContain('kb-token-indicator__linked');
+	});
+
+	/**
+	 * A matching value the preset merely inherits from the baseline shows nothing: the glyph asserts the
+	 * field is linked to THIS preset, which a preset that stores nothing of its own cannot claim. That
+	 * case reads as a muted default on the field instead.
+	 *
+	 * @return {void}
+	 */
+	it('shows nothing when a matching value is only inherited from the baseline', () => {
+		expect(TokenIndicator({ state: { bound: false, overridden: false }, onReset: jest.fn() })).toBeNull();
+	});
+
+	/**
+	 * A control whose own header already carries a reset passes `showReset={false}`, which suppresses
+	 * the matching glyph so only the dot-only label path remains.
+	 *
+	 * @return {void}
+	 */
+	it('suppresses the matching glyph when the control renders its own reset', () => {
+		const result = TokenIndicator({
+			state: { bound: true, overridden: false },
+			onReset: jest.fn(),
+			showReset: false,
+		});
+
+		expect(result).toBeNull();
+	});
+});

--- a/src/extension/token-indicators/components/TokenIndicator.js
+++ b/src/extension/token-indicators/components/TokenIndicator.js
@@ -17,6 +17,10 @@ import { resetIcon, presetIcon } from '../../preset-picker/icons';
  * renders where a reset would (`showReset`), so the dot-only label path is left unchanged. A control whose
  * own header already carries the reset passes `showReset={false}` so the dot alone marks the edit.
  *
+ * The two marks read `state` differently, and deliberately: the override dot needs only a divergence from
+ * whatever value the preset resolves, while the matching glyph additionally needs the preset to OWN the
+ * property (`bound`) — see the gate below.
+ *
  * @param {Object}   props             The component props.
  * @param {Object}   [props.state]     The attribute's binding state from usePresetBinding, or undefined when
  *                                     the control is not mapped for the selected preset.
@@ -28,7 +32,22 @@ import { resetIcon, presetIcon } from '../../preset-picker/icons';
  * @return {Object|null} The indicator element, or null when the control is unmapped.
  */
 export function TokenIndicator({ state, onReset, showReset = true }) {
-	if (!state || !state.bound) {
+	if (!state) {
+		return null;
+	}
+
+	// `bound` is narrower than "the preset resolves a value here": it means the preset has its own STORED
+	// override for the property, which a preset shipped in `baseline.json` never does. Every block's
+	// `$default` preset is shipped that way, so gating the whole indicator on it hid the override mark on
+	// a fresh site — on every block, the Button included — until someone re-saved the preset in the Style
+	// Library. A divergence is worth marking wherever the preset resolves a value to diverge FROM, and the
+	// reset is meaningful there too: clearing the attribute drops the control back onto the projected CSS
+	// that carries exactly that value.
+	//
+	// The "matches" glyph keeps the stricter gate. It asserts the field is linked to this preset, which is
+	// a claim only a preset that genuinely owns the property can make — an inherited baseline value shows
+	// as a muted default instead, which is what that display was separated out to do.
+	if (!state.overridden && !state.bound) {
 		return null;
 	}
 


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4263/token-pickable-block-controls-for-the-remaining-alpha-blocks-row
:video_camera: https://www.loom.com/share/9363726b1a30466a9d6e8fb429f82f2d

A control whose value diverged from its selected preset showed no override dot and offered no reset, on every block including the Button, until someone re-saved that preset in the Style Library.

`TokenIndicator` returned early on `!state.bound`, and `bound` is set from `owned_properties()`, which reads the library's STORED overrides document — never the baseline. Every block's `$default` preset ships its values in `baseline.json` instead, so nothing is ever "owned" on a site nobody has edited, and the mark was unreachable. `overridden` was computed correctly the whole time and discarded by that gate.

The two marks are now gated separately, which is what they each actually assert: the override dot needs only a divergence from the value the preset resolves, while the matching glyph keeps the stricter `bound` gate. `bound` itself is unchanged — its meaning is load-bearing for the muted Default-vs-Inherited display.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual indicators for overridden controls, including inherited and reset values.
  * Added support for linked preset glyphs on bound controls.

* **Bug Fixes**
  * Override indicators now appear consistently, including when controls are not bound.
  * Prevented duplicate indicators when a control provides its own reset action.
  * Unmapped controls continue to display no indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
