### PR TITLE
Token-pickable block controls [3/11]: Row Layout radius and background color

### DIFF
--- a/src/blocks/rowlayout/row-background.js
+++ b/src/blocks/rowlayout/row-background.js
@@ -10,6 +10,7 @@ import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 import { getSpacingOptionOutput } from './utils';
+import { tokenDimension } from '../../extension/design-tokens/token-dimension';
 
 /**
  * Build the row edit
@@ -491,17 +492,21 @@ function RowBackground({ attributes, previewDevice, backgroundClasses, children,
 			// left the row's block-default rule -- which carries the selected preset's radius -- as the
 			// only `border-radius` on the element.
 			borderTopLeftRadius:
-				'' !== previewRadiusTop ? previewRadiusTop + (borderRadiusUnit ? borderRadiusUnit : 'px') : undefined,
+				'' !== previewRadiusTop
+					? tokenDimension(previewRadiusTop, borderRadiusUnit ? borderRadiusUnit : 'px')
+					: undefined,
 			borderTopRightRadius:
 				'' !== previewRadiusRight
-					? previewRadiusRight + (borderRadiusUnit ? borderRadiusUnit : 'px')
+					? tokenDimension(previewRadiusRight, borderRadiusUnit ? borderRadiusUnit : 'px')
 					: undefined,
 			borderBottomRightRadius:
 				'' !== previewRadiusBottom
-					? previewRadiusBottom + (borderRadiusUnit ? borderRadiusUnit : 'px')
+					? tokenDimension(previewRadiusBottom, borderRadiusUnit ? borderRadiusUnit : 'px')
 					: undefined,
 			borderBottomLeftRadius:
-				'' !== previewRadiusLeft ? previewRadiusLeft + (borderRadiusUnit ? borderRadiusUnit : 'px') : undefined,
+				'' !== previewRadiusLeft
+					? tokenDimension(previewRadiusLeft, borderRadiusUnit ? borderRadiusUnit : 'px')
+					: undefined,
 			minHeight: previewMinHeight ? previewMinHeight + minHeightUnit : undefined,
 			zIndex: zIndex ? zIndex : undefined,
 			boxShadow:
@@ -549,19 +554,19 @@ function RowBackground({ attributes, previewDevice, backgroundClasses, children,
 								previewBackgroundAttachment === 'parallax' ? 'fixed' : previewBackgroundAttachment,
 							borderTopLeftRadius:
 								!borderRadiusOverflow && previewRadiusTop
-									? previewRadiusTop + (borderRadiusUnit ? borderRadiusUnit : 'px')
+									? tokenDimension(previewRadiusTop, borderRadiusUnit ? borderRadiusUnit : 'px')
 									: undefined,
 							borderTopRightRadius:
 								!borderRadiusOverflow && previewRadiusRight
-									? previewRadiusRight + (borderRadiusUnit ? borderRadiusUnit : 'px')
+									? tokenDimension(previewRadiusRight, borderRadiusUnit ? borderRadiusUnit : 'px')
 									: undefined,
 							borderBottomRightRadius:
 								!borderRadiusOverflow && previewRadiusBottom
-									? previewRadiusBottom + (borderRadiusUnit ? borderRadiusUnit : 'px')
+									? tokenDimension(previewRadiusBottom, borderRadiusUnit ? borderRadiusUnit : 'px')
 									: undefined,
 							borderBottomLeftRadius:
 								!borderRadiusOverflow && previewRadiusLeft
-									? previewRadiusLeft + (borderRadiusUnit ? borderRadiusUnit : 'px')
+									? tokenDimension(previewRadiusLeft, borderRadiusUnit ? borderRadiusUnit : 'px')
 									: undefined,
 						}}
 					></div>

--- a/src/blocks/rowlayout/row-overlay.js
+++ b/src/blocks/rowlayout/row-overlay.js
@@ -6,6 +6,8 @@ import memoize from 'memize';
 
 import { KadenceColorOutput, getPreviewSize } from '@kadence/helpers';
 
+import { tokenDimension } from '../../extension/design-tokens/token-dimension';
+
 const overlayOpacityOutput = memoize((opacity) => {
 	if (opacity < 10) {
 		return '0.0' + opacity;
@@ -323,19 +325,19 @@ function Overlay({ attributes, previewDevice }) {
 								: undefined,
 						borderTopLeftRadius:
 							!borderRadiusOverflow && previewRadiusTop
-								? previewRadiusTop + (borderRadiusUnit ? borderRadiusUnit : 'px')
+								? tokenDimension(previewRadiusTop, borderRadiusUnit ? borderRadiusUnit : 'px')
 								: undefined,
 						borderTopRightRadius:
 							!borderRadiusOverflow && previewRadiusRight
-								? previewRadiusRight + (borderRadiusUnit ? borderRadiusUnit : 'px')
+								? tokenDimension(previewRadiusRight, borderRadiusUnit ? borderRadiusUnit : 'px')
 								: undefined,
 						borderBottomRightRadius:
 							!borderRadiusOverflow && previewRadiusBottom
-								? previewRadiusBottom + (borderRadiusUnit ? borderRadiusUnit : 'px')
+								? tokenDimension(previewRadiusBottom, borderRadiusUnit ? borderRadiusUnit : 'px')
 								: undefined,
 						borderBottomLeftRadius:
 							!borderRadiusOverflow && previewRadiusLeft
-								? previewRadiusLeft + (borderRadiusUnit ? borderRadiusUnit : 'px')
+								? tokenDimension(previewRadiusLeft, borderRadiusUnit ? borderRadiusUnit : 'px')
 								: undefined,
 					}}
 				></div>
@@ -364,19 +366,19 @@ function Overlay({ attributes, previewDevice }) {
 								: undefined,
 						borderTopLeftRadius:
 							!borderRadiusOverflow && previewRadiusTop
-								? previewRadiusTop + (borderRadiusUnit ? borderRadiusUnit : 'px')
+								? tokenDimension(previewRadiusTop, borderRadiusUnit ? borderRadiusUnit : 'px')
 								: undefined,
 						borderTopRightRadius:
 							!borderRadiusOverflow && previewRadiusRight
-								? previewRadiusRight + (borderRadiusUnit ? borderRadiusUnit : 'px')
+								? tokenDimension(previewRadiusRight, borderRadiusUnit ? borderRadiusUnit : 'px')
 								: undefined,
 						borderBottomRightRadius:
 							!borderRadiusOverflow && previewRadiusBottom
-								? previewRadiusBottom + (borderRadiusUnit ? borderRadiusUnit : 'px')
+								? tokenDimension(previewRadiusBottom, borderRadiusUnit ? borderRadiusUnit : 'px')
 								: undefined,
 						borderBottomLeftRadius:
 							!borderRadiusOverflow && previewRadiusLeft
-								? previewRadiusLeft + (borderRadiusUnit ? borderRadiusUnit : 'px')
+								? tokenDimension(previewRadiusLeft, borderRadiusUnit ? borderRadiusUnit : 'px')
 								: undefined,
 					}}
 				></div>
@@ -394,19 +396,19 @@ function Overlay({ attributes, previewDevice }) {
 								: undefined,
 						borderTopLeftRadius:
 							!borderRadiusOverflow && previewRadiusTop
-								? previewRadiusTop + (borderRadiusUnit ? borderRadiusUnit : 'px')
+								? tokenDimension(previewRadiusTop, borderRadiusUnit ? borderRadiusUnit : 'px')
 								: undefined,
 						borderTopRightRadius:
 							!borderRadiusOverflow && previewRadiusRight
-								? previewRadiusRight + (borderRadiusUnit ? borderRadiusUnit : 'px')
+								? tokenDimension(previewRadiusRight, borderRadiusUnit ? borderRadiusUnit : 'px')
 								: undefined,
 						borderBottomRightRadius:
 							!borderRadiusOverflow && previewRadiusBottom
-								? previewRadiusBottom + (borderRadiusUnit ? borderRadiusUnit : 'px')
+								? tokenDimension(previewRadiusBottom, borderRadiusUnit ? borderRadiusUnit : 'px')
 								: undefined,
 						borderBottomLeftRadius:
 							!borderRadiusOverflow && previewRadiusLeft
-								? previewRadiusLeft + (borderRadiusUnit ? borderRadiusUnit : 'px')
+								? tokenDimension(previewRadiusLeft, borderRadiusUnit ? borderRadiusUnit : 'px')
 								: undefined,
 					}}
 				></div>

--- a/src/blocks/rowlayout/style-controls.js
+++ b/src/blocks/rowlayout/style-controls.js
@@ -263,9 +263,13 @@ function StyleControls(props) {
 
 	// The row offers the same Background Color field in two mutually exclusive branches — the video
 	// background tab and the normal one — so it is built once here rather than written out at both.
-	// Empty groups mean the token registry is inactive, which is what keeps the plain color control as
-	// the fallback rather than leaving the row with no background color control at all.
-	const backgroundColorField = colorGroups.length ? (
+	//
+	// Rendered unconditionally, NOT behind a `colorGroups.length` guard the way the measure controls sit
+	// behind their token pool. The pool is read synchronously from a localized global, so it is either
+	// there on the first render or not at all; `useColorGroups` fetches over REST and returns an empty
+	// list until it resolves, so gating on it would mount the old control and visibly swap it a moment
+	// later. An empty list costs only an empty Style Library tab — the Custom tab still picks any color.
+	const backgroundColorField = (
 		<ColorControl
 			label={__('Background Color', 'kadence-blocks')}
 			value={bgColor ? bgColor : ''}
@@ -279,14 +283,6 @@ function StyleControls(props) {
 			onCustom={(literal) => writeBackgroundColor(literal)}
 			onClear={() => writeBackgroundColor('')}
 			resolveLiteral={resolveColorLiteral}
-		/>
-	) : (
-		<PopColorControl
-			label={__('Background Color', 'kadence-blocks')}
-			value={bgColor ? bgColor : ''}
-			default={''}
-			onChange={(value) => setAttributes({ bgColor: value })}
-			onClassChange={(value) => setAttributes({ bgColorClass: value })}
 		/>
 	);
 

--- a/src/blocks/rowlayout/style-controls.js
+++ b/src/blocks/rowlayout/style-controls.js
@@ -1,3 +1,5 @@
+// cspell:ignore newcount whiteondark blackonlight outlineblack outlinewhite outlinedark outlinelight OZBO
+
 /**
  * BLOCK: Kadence Row / Layout
  */
@@ -39,11 +41,24 @@ import { BLEND_OPTIONS } from './constants';
  */
 import { Fragment } from '@wordpress/element';
 import { TextControl, ToggleControl, SelectControl } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal block libraries
  */
 import { __ } from '@wordpress/i18n';
+import { resetAttr, useLinkedMeasureState, usePresetBinding } from '../../extension/token-indicators';
+import {
+	anyCornerInherited,
+	inheritedMeasureSlots,
+	measureAttrsForDevice,
+	presetValueForDevice,
+} from '../../extension/token-indicators/normalize';
+import { EditorBoxControl } from '../../extension/design-tokens/components/EditorBoxControl';
+import { useColorGroups } from '../../extension/design-tokens/hooks/use-color-groups';
+import { resolveColorLiteral } from '../../extension/design-tokens/color-literal';
+import { pickableTokensForControl } from '../../extension/token-picker';
+import { ColorControl } from '../../token-controls';
 
 /**
  * Build the row edit
@@ -187,6 +202,93 @@ function StyleControls(props) {
 		displayBoxShadow,
 		boxShadow,
 	} = attributes;
+
+	const { previewDevice } = useSelect(
+		(select) => {
+			return {
+				previewDevice: select('kadenceblocks/data').getPreviewDeviceType(),
+			};
+		},
+		[clientId]
+	);
+	const { setPreviewDeviceType: setPreviewDevice } = useDispatch('kadenceblocks/data');
+
+	// Design-token indicators: the per-attribute bound/overridden state for the selected preset, plus a
+	// reset that clears the mapped attribute back to the preset value (served by the existing scoped CSS).
+	const tokenBinding = usePresetBinding('kadence/rowlayout', attributes, undefined, previewDevice);
+	const resetToken = (attr) => resetAttr(attr, setAttributes, tokenBinding[attr]?.kind);
+	// One fetch of the block's effective palette groups, shared by both `ColorControl` instances below.
+	const colorGroups = useColorGroups(clientId);
+
+	// Empty when the token registry is inactive, which is what keeps the plain measurement control below
+	// as the fallback rather than leaving the row with no radius control at all.
+	const borderRadiusTokens = pickableTokensForControl('kadence/rowlayout', 'borderRadius') || [];
+	// The Border Radius control keeps ONE linked/individual mode but writes a different attribute per
+	// breakpoint, so the mode must be read from — and "link" must collapse — whichever device is active.
+	const borderRadiusForDevice = measureAttrsForDevice(
+		attributes,
+		'borderRadius',
+		{ tablet: 'tabletBorderRadius', mobile: 'mobileBorderRadius' },
+		previewDevice
+	);
+	const borderRadiusPresetValue = presetValueForDevice(
+		tokenBinding.borderRadius?.presetValue,
+		tokenBinding.borderRadius?.responsive,
+		previewDevice
+	);
+	// What an unset corner falls back to on the active device: another breakpoint's corner before the
+	// preset's, matching the cascade the row actually renders through. The corners stay stored-empty —
+	// this only tells the field's popover which size is in effect and where it came from.
+	const inheritedBorderRadius = inheritedMeasureSlots(
+		previewDevice,
+		{ desktop: borderRadius, tablet: tabletBorderRadius },
+		borderRadiusPresetValue
+	);
+	const borderRadiusIsRelative = borderRadiusUnit === 'em' || borderRadiusUnit === 'rem';
+	// `resetOn` clears the remembered link choice on a preset change, since an override records a choice
+	// about the PREVIOUS preset's corners — otherwise an explicit "link" would stick and hide a new
+	// preset's per-corner radius.
+	const { isLinked: borderRadiusIsLinked, toggleLink: toggleBorderRadiusLink } = useLinkedMeasureState({
+		forDevice: borderRadiusForDevice,
+		previewDevice,
+		setAttributes,
+		resetOn: attributes.kbPreset,
+	});
+
+	// Every write clears `bgColorClass` as well. That attribute carries a legacy global-palette CLASS,
+	// which the row emits on its own wrapper and which therefore beats the color this control writes —
+	// so leaving a stale one behind would silently discard the pick. `PopColorControl` set the class
+	// itself through `onClassChange`; a palette color is a token alias now, so nothing sets it again.
+	const writeBackgroundColor = (value) => setAttributes({ bgColor: value, bgColorClass: '' });
+
+	// The row offers the same Background Color field in two mutually exclusive branches — the video
+	// background tab and the normal one — so it is built once here rather than written out at both.
+	// Empty groups mean the token registry is inactive, which is what keeps the plain color control as
+	// the fallback rather than leaving the row with no background color control at all.
+	const backgroundColorField = colorGroups.length ? (
+		<ColorControl
+			label={__('Background Color', 'kadence-blocks')}
+			value={bgColor ? bgColor : ''}
+			groups={colorGroups}
+			status={{
+				bound: !!tokenBinding.bgColor?.bound,
+				modified: !!tokenBinding.bgColor?.overridden,
+			}}
+			onReset={() => resetToken('bgColor')}
+			onPick={(alias) => writeBackgroundColor(alias)}
+			onCustom={(literal) => writeBackgroundColor(literal)}
+			onClear={() => writeBackgroundColor('')}
+			resolveLiteral={resolveColorLiteral}
+		/>
+	) : (
+		<PopColorControl
+			label={__('Background Color', 'kadence-blocks')}
+			value={bgColor ? bgColor : ''}
+			default={''}
+			onChange={(value) => setAttributes({ bgColor: value })}
+			onClassChange={(value) => setAttributes({ bgColorClass: value })}
+		/>
+	);
 
 	const editorDocument = document.querySelector('iframe[name="editor-canvas"]')?.contentWindow.document || document;
 	const tabletBackgroundType = tabletBackground?.[0]?.type || 'normal';
@@ -1311,13 +1413,7 @@ function StyleControls(props) {
 							/>
 						</>
 					)}
-					<PopColorControl
-						label={__('Background Color', 'kadence-blocks')}
-						value={bgColor ? bgColor : ''}
-						default={''}
-						onChange={(value) => setAttributes({ bgColor: value })}
-						onClassChange={(value) => setAttributes({ bgColorClass: value })}
-					/>
+					{backgroundColorField}
 					{undefined !== backgroundVideoType && 'local' === backgroundVideoType && (
 						<KadenceImageControl
 							label={__('Select Video Poster', 'kadence-blocks')}
@@ -1350,13 +1446,7 @@ function StyleControls(props) {
 			)}
 			{'normal' === backgroundSettingTab && (
 				<>
-					<PopColorControl
-						label={__('Background Color', 'kadence-blocks')}
-						value={bgColor ? bgColor : ''}
-						default={''}
-						onChange={(value) => setAttributes({ bgColor: value })}
-						onClassChange={(value) => setAttributes({ bgColorClass: value })}
-					/>
+					{backgroundColorField}
 					<KadenceBackgroundControl
 						label={__('Background Image', 'kadence-blocks')}
 						hasImage={bgImg}
@@ -1570,23 +1660,46 @@ function StyleControls(props) {
 						onChangeTablet={(value) => setAttributes({ tabletBorderStyle: value })}
 						onChangeMobile={(value) => setAttributes({ mobileBorderStyle: value })}
 					/>
-					<ResponsiveMeasurementControls
-						label={__('Border Radius', 'kadence-blocks')}
-						value={borderRadius}
-						tabletValue={tabletBorderRadius}
-						mobileValue={mobileBorderRadius}
-						onChange={(value) => setAttributes({ borderRadius: value })}
-						onChangeTablet={(value) => setAttributes({ tabletBorderRadius: value })}
-						onChangeMobile={(value) => setAttributes({ mobileBorderRadius: value })}
-						unit={borderRadiusUnit}
-						units={['px', 'em', 'rem', '%']}
-						onUnit={(value) => setAttributes({ borderRadiusUnit: value })}
-						max={borderRadiusUnit === 'em' || borderRadiusUnit === 'rem' ? 24 : 500}
-						step={borderRadiusUnit === 'em' || borderRadiusUnit === 'rem' ? 0.1 : 1}
-						min={0}
-						isBorderRadius={true}
-						allowEmpty={true}
-					/>
+					{borderRadiusTokens.length ? (
+						<EditorBoxControl
+							label={__('Border Radius', 'kadence-blocks')}
+							value={borderRadiusForDevice.value}
+							onChange={(next) => setAttributes({ [borderRadiusForDevice.attr]: next })}
+							previewDevice={previewDevice}
+							onDeviceChange={setPreviewDevice}
+							tokens={borderRadiusTokens}
+							defaultValue={inheritedBorderRadius.values}
+							inherited={anyCornerInherited(inheritedBorderRadius.inherited)}
+							state={tokenBinding.borderRadius}
+							onReset={() => resetToken('borderRadius')}
+							isLinked={borderRadiusIsLinked}
+							onToggleLink={toggleBorderRadiusLink}
+							unit={borderRadiusUnit}
+							units={['px', 'em', 'rem', '%']}
+							onUnit={(value) => setAttributes({ borderRadiusUnit: value })}
+							min={0}
+							max={borderRadiusIsRelative ? 24 : 500}
+							step={borderRadiusIsRelative ? 0.1 : 1}
+						/>
+					) : (
+						<ResponsiveMeasurementControls
+							label={__('Border Radius', 'kadence-blocks')}
+							value={borderRadius}
+							tabletValue={tabletBorderRadius}
+							mobileValue={mobileBorderRadius}
+							onChange={(value) => setAttributes({ borderRadius: value })}
+							onChangeTablet={(value) => setAttributes({ tabletBorderRadius: value })}
+							onChangeMobile={(value) => setAttributes({ mobileBorderRadius: value })}
+							unit={borderRadiusUnit}
+							units={['px', 'em', 'rem', '%']}
+							onUnit={(value) => setAttributes({ borderRadiusUnit: value })}
+							max={borderRadiusUnit === 'em' || borderRadiusUnit === 'rem' ? 24 : 500}
+							step={borderRadiusUnit === 'em' || borderRadiusUnit === 'rem' ? 0.1 : 1}
+							min={0}
+							isBorderRadius={true}
+							allowEmpty={true}
+						/>
+					)}
 					{hasBorderRadius && (
 						<ToggleControl
 							label={__('Overflow Hidden', 'kadence-blocks')}

--- a/src/blocks/rowlayout/style-controls.js
+++ b/src/blocks/rowlayout/style-controls.js
@@ -36,6 +36,7 @@ import { showSettings } from '@kadence/helpers';
  * Import Block Specific Components
  */
 import { BLEND_OPTIONS } from './constants';
+import metadata from './block.json';
 /**
  * Import WordPress Internals
  */
@@ -216,7 +217,11 @@ function StyleControls(props) {
 	// Design-token indicators: the per-attribute bound/overridden state for the selected preset, plus a
 	// reset that clears the mapped attribute back to the preset value (served by the existing scoped CSS).
 	const tokenBinding = usePresetBinding('kadence/rowlayout', attributes, undefined, previewDevice);
-	const resetToken = (attr) => resetAttr(attr, setAttributes, tokenBinding[attr]?.kind);
+	// The block's own attribute schema is passed through so a reset can clear a color's legacy
+	// palette-CLASS companion (`bgColor` -> `bgColorClass`) as well as the color itself. WordPress emits
+	// those utility classes with `!important`, so a stale one outranks anything the reset restores and
+	// the row would keep the old color while the field claimed otherwise.
+	const resetToken = (attr) => resetAttr(attr, setAttributes, tokenBinding[attr]?.kind, metadata.attributes);
 	// One fetch of the block's effective palette groups, shared by both `ColorControl` instances below.
 	const colorGroups = useColorGroups(clientId);
 

--- a/src/extension/design-tokens/__tests__/token-dimension.test.js
+++ b/src/extension/design-tokens/__tests__/token-dimension.test.js
@@ -1,0 +1,98 @@
+/* eslint-env jest */
+/**
+ * The inline-style dimension resolver.
+ *
+ * A block that paints a dimension into a React `style` object concatenates the stored value with its
+ * unit attribute, which is correct for a number and produces invalid CSS for a `{dot.alias}`.
+ * `tokenDimension()` is the resolution step those call sites lack, and it has to match the front
+ * end's: a backed alias becomes its CSS variable, an unbacked one is left alone rather than emitted
+ * as a dead `var()`, and everything else concatenates exactly as before.
+ *
+ * The resolved-values map is read off `window.kadenceDesignTokensPickable`, so each test sets that
+ * global directly rather than mocking the reader.
+ */
+import { tokenDimension } from '../token-dimension';
+
+const BACKED = '{primitive.dimension.radius.lg}';
+const UNBACKED = '{primitive.dimension.radius.gone}';
+
+/**
+ * Localize a pickable pool whose active library resolves the backed radius token.
+ *
+ * @return {void}
+ */
+function localizeTokens() {
+	window.kadenceDesignTokensPickable = {
+		active: 'default',
+		values: {
+			default: {
+				'primitive.dimension.radius.lg': '1rem',
+			},
+		},
+	};
+}
+
+describe('tokenDimension', () => {
+	beforeEach(() => {
+		localizeTokens();
+	});
+
+	afterEach(() => {
+		delete window.kadenceDesignTokensPickable;
+	});
+
+	/**
+	 * A backed alias resolves to the CSS variable the front end emits for the same token, with the
+	 * unit dropped — the length travels inside the token, so appending one would corrupt it.
+	 *
+	 * @return {void}
+	 */
+	it('resolves a backed alias to its token variable', () => {
+		expect(tokenDimension(BACKED, 'px')).toBe('var(--kb-token--primitive--dimension--radius--lg)');
+	});
+
+	/**
+	 * An alias the active library no longer backs is returned untouched, so the browser drops the
+	 * declaration and the element falls back to whatever global CSS applies — rather than the editor
+	 * emitting a dead variable that resolves to nothing.
+	 *
+	 * @return {void}
+	 */
+	it('leaves an unbacked alias alone rather than emitting a dead variable', () => {
+		expect(tokenDimension(UNBACKED, 'px')).toBe(UNBACKED);
+	});
+
+	/**
+	 * With no pool localized at all there is no map to consult, so an alias reads as backed —
+	 * matching `isBackedToken`'s documented fail-open and the PHP renderer it mirrors.
+	 *
+	 * @return {void}
+	 */
+	it('fails open to the variable when no token pool is localized', () => {
+		delete window.kadenceDesignTokensPickable;
+
+		expect(tokenDimension(BACKED, 'px')).toBe('var(--kb-token--primitive--dimension--radius--lg)');
+	});
+
+	/**
+	 * Every non-alias slot concatenates exactly as the call sites did before, including a zero, which
+	 * is a real radius rather than an absent one.
+	 *
+	 * @param {string} _label   The case name, used only for the test title.
+	 * @param {*}      value    The stored slot value.
+	 * @param {string} unit     The unit attribute's value.
+	 * @param {string} expected The CSS length the slot should produce.
+	 *
+	 * @return {void}
+	 */
+	it.each([
+		['a number', 10, 'px', '10px'],
+		['a numeric string', '24', 'px', '24px'],
+		['a zero', 0, 'px', '0px'],
+		['a zero string', '0', 'px', '0px'],
+		['a relative unit', 1.5, 'rem', '1.5rem'],
+		['a percentage', 50, '%', '50%'],
+	])('concatenates %s unchanged', (_label, value, unit, expected) => {
+		expect(tokenDimension(value, unit)).toBe(expected);
+	});
+});

--- a/src/extension/design-tokens/token-dimension.js
+++ b/src/extension/design-tokens/token-dimension.js
@@ -1,0 +1,49 @@
+/**
+ * A dimension value for an editor INLINE style, with design-token aliases resolved.
+ *
+ * A block that paints a dimension into a React `style` object rather than through
+ * `KadenceBlocksCSS` has no filter seam to run the value through: it concatenates the stored value
+ * with its unit attribute and hands the result to the DOM. That is correct for the numbers those
+ * attributes have always held, and wrong the moment a token-aware control can write a
+ * `{dot.alias}` — `"{primitive.dimension.radius.lg}" + "px"` is not a CSS length, so the browser
+ * drops the declaration and the block renders with no value at all while the saved page (rendered
+ * through PHP's `render_measure_output`, which does resolve the alias) shows it correctly.
+ *
+ * This is the inline-style counterpart of that resolution, matching `register-filters.js`'s
+ * `resolveAlias` exactly: a backed alias becomes its `var(--kb-token--<id>)` reference, and an
+ * alias the active library does not back is left alone so the editor emits no dead variable — the
+ * same "fall back to whatever global CSS exists" behavior the front-end renderer has.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { isTokenAlias, resolveTokenAlias } from './alias';
+import { isBackedToken } from './backed-tokens';
+
+/**
+ * Resolve one dimension slot for an inline style.
+ *
+ * Passing the value through untouched when it is not an alias keeps every existing numeric slot
+ * byte-identical to the concatenation it replaces, including the `0` that has to stay a real `0px`
+ * rather than becoming an omitted declaration.
+ *
+ * @param {*}      value The stored slot value: a number, a numeric string, or a `{dot.alias}`.
+ * @param {string} unit  The unit attribute's value, already defaulted by the caller.
+ *
+ * @since TBD
+ *
+ * @return {string} A CSS length, or a `var(--kb-token--<id>)` reference for a backed alias.
+ */
+export function tokenDimension(value, unit) {
+	if (!isTokenAlias(value)) {
+		return `${value}${unit}`;
+	}
+
+	// Strip the braces to the dotted id, the same slice `resolveTokenAlias()` does.
+	if (!isBackedToken(value.slice(1, -1))) {
+		return value;
+	}
+
+	return resolveTokenAlias(value);
+}


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4263/token-pickable-block-controls-for-the-remaining-alpha-blocks-row
:video_camera: https://www.loom.com/share/9363726b1a30466a9d6e8fb429f82f2d

The Row Layout's preset screen offers a Radius and a Background, and both bind a token, but the block's own controls could only take a literal. Radius becomes `EditorBoxControl` and Background becomes `ColorControl`.

The row renders the same Background Color field in two mutually exclusive branches (the video tab and the normal one), so it is built once and referenced at both. Every background write also clears `bgColorClass`, a legacy palette class the row emits on its own wrapper that would otherwise beat the color the control writes.

Includes two fixes found while testing: the color control no longer mounts its predecessor first and visibly swaps (`useColorGroups` fetches over REST, so an empty list means "loading", not "no palette"), and a picked radius now paints in the editor. The row builds radius as an inline style by concatenating the value with its unit, which turned an alias into `{alias}px`; `tokenDimension()` is the inline-style counterpart of the resolution the front end already does through PHP.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added design-token support for row layout background colors and border-radius settings.
  - Added responsive previews for row layout styling controls.
  - Added improved token-aware color controls, including palette selection, reset, and legacy palette cleanup.
  - Border-radius values now support reusable design tokens while preserving existing numeric, percentage, and relative-unit inputs.

- **Bug Fixes**
  - Improved consistency when applying token-based dimensions across row backgrounds and overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
