### PR TITLE
Token-pickable block controls [5/11]: Advanced Image radius, shadow, padding and background color

### DIFF
--- a/includes/blocks/class-kadence-blocks-abstract-block.php
+++ b/includes/blocks/class-kadence-blocks-abstract-block.php
@@ -710,4 +710,44 @@ class Kadence_Blocks_Abstract_Block {
 
 		return $html;
 	}
+
+	/**
+	 * Whether a native shadow item paints anything visible — all-zero offsets, blur, and spread
+	 * render nothing regardless of color, matching the value the "None" pick writes.
+	 *
+	 * A non-numeric, non-empty leg is a {dot.alias} token reference, which resolves to a var() whose
+	 * value is unknown here — it counts as visible, since treating it as a zero would let the
+	 * caller's `box-shadow: none` reset erase a shadow the token does paint.
+	 *
+	 * Lives here rather than on any one block because it answers a question about the shared shadow
+	 * value shape, which every shadow-carrying block stores identically. It is what a block gates its
+	 * `box-shadow` output on once it has no separate "enable" boolean to read.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $shadow_item One `shadow[0]`-shaped item.
+	 *
+	 * @return bool Whether the item paints a visible shadow.
+	 */
+	protected function has_visible_shadow( array $shadow_item ): bool {
+		foreach ( [ 'hOffset', 'vOffset', 'blur', 'spread' ] as $axis ) {
+			$value = $shadow_item[ $axis ] ?? 0;
+
+			if ( is_numeric( $value ) ) {
+				if ( 0.0 !== (float) $value ) {
+					return true;
+				}
+
+				continue;
+			}
+
+			// A {dot.alias} leg resolves to a var() unknown here, so it counts as visible — read as zero,
+			// the caller's `box-shadow: none` would erase a shadow the token does paint.
+			if ( is_string( $value ) && '' !== trim( $value ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
 }

--- a/includes/blocks/class-kadence-blocks-image-block.php
+++ b/includes/blocks/class-kadence-blocks-image-block.php
@@ -230,10 +230,19 @@ class Kadence_Blocks_Image_Block extends Kadence_Blocks_Abstract_Block {
 			}
 		}
 
-		// Box shadow. Gated on the value's own axes rather than a separate "enable" boolean: an
-		// all-zero shadow paints nothing, so it IS the off state, and a second flag saying so could
-		// only ever disagree with it.
-		if ( isset( $attributes['boxShadow'][0] ) && is_array( $attributes['boxShadow'][0] ) && $this->has_visible_shadow( $attributes['boxShadow'][0] ) ) {
+		// Box shadow, gated on BOTH the stored flag and the value's own axes.
+		//
+		// The flag is no longer a control -- the editor derives it from the value on every write -- but it
+		// still has to be read. Gutenberg omits an attribute equal to its default, and the old toggle
+		// defaulted to false, so a block saved with the shadow switched OFF stored no flag at all while
+		// keeping whatever values the user had entered. Judging by geometry alone would start rendering
+		// those, which is exactly the upgrade-time restyling the design-token work is meant to avoid.
+		if (
+			! empty( $attributes['displayBoxShadow'] )
+			&& isset( $attributes['boxShadow'][0] )
+			&& is_array( $attributes['boxShadow'][0] )
+			&& $this->has_visible_shadow( $attributes['boxShadow'][0] )
+		) {
 			$css->add_property(
 				'box-shadow',
 				$css->render_shadow(

--- a/includes/blocks/class-kadence-blocks-image-block.php
+++ b/includes/blocks/class-kadence-blocks-image-block.php
@@ -230,26 +230,24 @@ class Kadence_Blocks_Image_Block extends Kadence_Blocks_Abstract_Block {
 			}
 		}
 
-		// Box shadow
-		if ( isset( $attributes['displayBoxShadow'] ) && true == $attributes['displayBoxShadow'] ) {
-			if ( isset( $attributes['boxShadow'] ) && is_array( $attributes['boxShadow'] ) && isset( $attributes['boxShadow'][0] ) && is_array( $attributes['boxShadow'][0] ) ) {
-				$css->add_property(
-					'box-shadow',
-					$css->render_shadow(
-						$attributes['boxShadow'][0],
-						[
-							'hOffset' => '0',
-							'vOffset' => '0',
-							'blur'    => '14',
-							'spread'  => '0',
-							'color'   => '#000000',
-							'opacity' => 0.2,
-						]
-					)
-				);
-			} else {
-				$css->add_property( 'box-shadow', 'rgba(0, 0, 0, 0.2) 0px 0px 14px 0px' );
-			}
+		// Box shadow. Gated on the value's own axes rather than a separate "enable" boolean: an
+		// all-zero shadow paints nothing, so it IS the off state, and a second flag saying so could
+		// only ever disagree with it.
+		if ( isset( $attributes['boxShadow'][0] ) && is_array( $attributes['boxShadow'][0] ) && $this->has_visible_shadow( $attributes['boxShadow'][0] ) ) {
+			$css->add_property(
+				'box-shadow',
+				$css->render_shadow(
+					$attributes['boxShadow'][0],
+					[
+						'hOffset' => '0',
+						'vOffset' => '0',
+						'blur'    => '14',
+						'spread'  => '0',
+						'color'   => '#000000',
+						'opacity' => 0.2,
+					]
+				)
+			);
 		}
 
 		// Drop Shadow

--- a/includes/blocks/class-kadence-blocks-singlebtn-block.php
+++ b/includes/blocks/class-kadence-blocks-singlebtn-block.php
@@ -237,7 +237,6 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		return $css->css_output();
 	}
 
-
 	/**
 	 * Build up the dynamic styles for a size.
 	 *
@@ -661,42 +660,6 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$css->add_property( 'box-shadow', 'var(--kb-btn-shadow)' );
 
 		return true;
-	}
-
-	/**
-	 * Whether a native shadow item paints anything visible — all-zero offsets, blur, and spread
-	 * render nothing regardless of color, matching the value the "None" pick now writes.
-	 *
-	 * A non-numeric, non-empty leg is a {dot.alias} token reference, which resolves to a var() whose
-	 * value is unknown here — it counts as visible, since treating it as a zero would let the
-	 * caller's `box-shadow: none` reset erase a shadow the token does paint.
-	 *
-	 * @since TBD
-	 *
-	 * @param array<string, mixed> $shadow_item One `shadow[0]`-shaped item.
-	 *
-	 * @return bool
-	 */
-	private function has_visible_shadow( array $shadow_item ): bool {
-		foreach ( [ 'hOffset', 'vOffset', 'blur', 'spread' ] as $axis ) {
-			$value = $shadow_item[ $axis ] ?? 0;
-
-			if ( is_numeric( $value ) ) {
-				if ( 0.0 !== (float) $value ) {
-					return true;
-				}
-
-				continue;
-			}
-
-			// A {dot.alias} leg resolves to a var() unknown here, so it counts as visible — read as zero,
-			// the caller's `box-shadow: none` would erase a shadow the token does paint.
-			if ( is_string( $value ) && '' !== trim( $value ) ) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	/**

--- a/includes/blocks/class-kadence-blocks-singlebtn-block.php
+++ b/includes/blocks/class-kadence-blocks-singlebtn-block.php
@@ -133,7 +133,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$css->render_measure_output( $attributes, 'padding', 'padding', [ 'unit_key' => 'paddingUnit' ] );
 		$css->render_measure_output( $attributes, 'margin', 'margin', [ 'unit_key' => 'marginUnit' ] );
 		$has_preset_shadow = $this->render_preset_shadow( $css, $attributes );
-		if ( isset( $attributes['shadow'][0] ) && is_array( $attributes['shadow'][0] ) && $this->has_visible_shadow( $attributes['shadow'][0] ) ) {
+		if ( ! empty( $attributes['displayShadow'] ) && isset( $attributes['shadow'][0] ) && is_array( $attributes['shadow'][0] ) && $this->has_visible_shadow( $attributes['shadow'][0] ) ) {
 			$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadow'][0] ) );
 		} elseif ( ! $has_preset_shadow ) {
 			// Only reset to `none` when nothing else claims this rule's box-shadow — a preset's
@@ -176,13 +176,13 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$css->render_border_styles( $attributes, 'borderHoverStyle', true );
 		// Visibility-gated: without it this fires on any inset-true item, including the invisible
 		// all-zero default the block ships with.
-		if ( ( 'gradient' === $bg_type || 'gradient' === $bg_hover_type ) && isset( $attributes['shadowHover'][0] ) && is_array( $attributes['shadowHover'][0] ) && $this->has_visible_shadow( $attributes['shadowHover'][0] ) && isset( $attributes['shadowHover'][0]['inset'] ) && true === $attributes['shadowHover'][0]['inset'] ) {
+		if ( ! empty( $attributes['displayHoverShadow'] ) && ( 'gradient' === $bg_type || 'gradient' === $bg_hover_type ) && isset( $attributes['shadowHover'][0] ) && is_array( $attributes['shadowHover'][0] ) && $this->has_visible_shadow( $attributes['shadowHover'][0] ) && isset( $attributes['shadowHover'][0]['inset'] ) && true === $attributes['shadowHover'][0]['inset'] ) {
 			$css->add_property( 'box-shadow', '0px 0px 0px 0px rgba(0, 0, 0, 0)' );
 			$css->set_selector( '.kb-btn' . $unique_id . '.kb-button:hover::before' );
 		}
 		// No `none` fallback on hover: an unset hover shadow must let the base state's shadow
 		// carry through the `:hover` rule via the normal cascade.
-		if ( isset( $attributes['shadowHover'][0] ) && is_array( $attributes['shadowHover'][0] ) && $this->has_visible_shadow( $attributes['shadowHover'][0] ) ) {
+		if ( ! empty( $attributes['displayHoverShadow'] ) && isset( $attributes['shadowHover'][0] ) && is_array( $attributes['shadowHover'][0] ) && $this->has_visible_shadow( $attributes['shadowHover'][0] ) ) {
 			$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowHover'][0] ) );
 		}
 		// Hover before.
@@ -269,7 +269,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$css->render_measure_output( $attributes, 'borderTransparentRadius', 'border-radius', [ 'unit_key' => 'borderTransparentRadiusUnit' ] );
 		$css->render_border_styles( $attributes, 'borderTransparentStyle', true );
 		// No `none` fallback: this selector outranks the base rule, which must carry through instead.
-		if ( isset( $attributes['shadowTransparent'] ) && is_array( $attributes['shadowTransparent'] ) && isset( $attributes['shadowTransparent'][0] ) && is_array( $attributes['shadowTransparent'][0] ) && $this->has_visible_shadow( $attributes['shadowTransparent'][0] ) ) {
+		if ( ! empty( $attributes['displayShadowTransparent'] ) && isset( $attributes['shadowTransparent'] ) && is_array( $attributes['shadowTransparent'] ) && isset( $attributes['shadowTransparent'][0] ) && is_array( $attributes['shadowTransparent'][0] ) && $this->has_visible_shadow( $attributes['shadowTransparent'][0] ) ) {
 			$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowTransparent'][0] ) );
 		}
 
@@ -284,13 +284,13 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$css->render_measure_output( $attributes, 'borderTransparentHoverRadius', 'border-radius' );
 		$css->render_border_styles( $attributes, 'borderTransparentHoverStyle', true );
 		// See the base hover state above: this reset needs the same visibility gate.
-		if ( ( 'gradient' === $bg_type_transparent || 'gradient' === $bg_hover_type_transparent ) && isset( $attributes['shadowTransparentHover'] ) && is_array( $attributes['shadowTransparentHover'] ) && isset( $attributes['shadowTransparentHover'][0] ) && is_array( $attributes['shadowTransparentHover'][0] ) && $this->has_visible_shadow( $attributes['shadowTransparentHover'][0] ) && isset( $attributes['shadowTransparentHover'][0]['inset'] ) && true === $attributes['shadowTransparentHover'][0]['inset'] ) {
+		if ( ! empty( $attributes['displayHoverShadowTransparent'] ) && ( 'gradient' === $bg_type_transparent || 'gradient' === $bg_hover_type_transparent ) && isset( $attributes['shadowTransparentHover'] ) && is_array( $attributes['shadowTransparentHover'] ) && isset( $attributes['shadowTransparentHover'][0] ) && is_array( $attributes['shadowTransparentHover'][0] ) && $this->has_visible_shadow( $attributes['shadowTransparentHover'][0] ) && isset( $attributes['shadowTransparentHover'][0]['inset'] ) && true === $attributes['shadowTransparentHover'][0]['inset'] ) {
 			$css->add_property( 'box-shadow', '0px 0px 0px 0px rgba(0, 0, 0, 0)' );
 			$css->set_selector( '.kb-btn' . $unique_id . '.kb-button:hover::before' );
 		}
 		// No `none` fallback on hover: an unset hover shadow must let the base state's shadow
 		// carry through the `:hover` rule via the normal cascade.
-		if ( isset( $attributes['shadowTransparentHover'] ) && is_array( $attributes['shadowTransparentHover'] ) && isset( $attributes['shadowTransparentHover'][0] ) && is_array( $attributes['shadowTransparentHover'][0] ) && $this->has_visible_shadow( $attributes['shadowTransparentHover'][0] ) ) {
+		if ( ! empty( $attributes['displayHoverShadowTransparent'] ) && isset( $attributes['shadowTransparentHover'] ) && is_array( $attributes['shadowTransparentHover'] ) && isset( $attributes['shadowTransparentHover'][0] ) && is_array( $attributes['shadowTransparentHover'][0] ) && $this->has_visible_shadow( $attributes['shadowTransparentHover'][0] ) ) {
 			$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowTransparentHover'][0] ) );
 		}
 
@@ -310,7 +310,7 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$css->render_measure_output( $attributes, 'borderStickyRadius', 'border-radius', [ 'unit_key' => 'borderStickyRadiusUnit' ] );
 		$css->render_border_styles( $attributes, 'borderStickyStyle', true );
 		// No `none` fallback: this selector outranks the base rule, which must carry through instead.
-		if ( isset( $attributes['shadowSticky'] ) && is_array( $attributes['shadowSticky'] ) && isset( $attributes['shadowSticky'][0] ) && is_array( $attributes['shadowSticky'][0] ) && $this->has_visible_shadow( $attributes['shadowSticky'][0] ) ) {
+		if ( ! empty( $attributes['displayShadowSticky'] ) && isset( $attributes['shadowSticky'] ) && is_array( $attributes['shadowSticky'] ) && isset( $attributes['shadowSticky'][0] ) && is_array( $attributes['shadowSticky'][0] ) && $this->has_visible_shadow( $attributes['shadowSticky'][0] ) ) {
 			$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowSticky'][0] ) );
 		}
 
@@ -325,13 +325,13 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 		$css->render_measure_output( $attributes, 'borderStickyHoverRadius', 'border-radius' );
 		$css->render_border_styles( $attributes, 'borderStickyHoverStyle', true );
 		// See the base hover state above: this reset needs the same visibility gate.
-		if ( ( 'gradient' === $bg_type_sticky || 'gradient' === $bg_hover_type_sticky ) && isset( $attributes['shadowStickyHover'] ) && is_array( $attributes['shadowStickyHover'] ) && isset( $attributes['shadowStickyHover'][0] ) && is_array( $attributes['shadowStickyHover'][0] ) && $this->has_visible_shadow( $attributes['shadowStickyHover'][0] ) && isset( $attributes['shadowStickyHover'][0]['inset'] ) && true === $attributes['shadowStickyHover'][0]['inset'] ) {
+		if ( ! empty( $attributes['displayHoverShadowSticky'] ) && ( 'gradient' === $bg_type_sticky || 'gradient' === $bg_hover_type_sticky ) && isset( $attributes['shadowStickyHover'] ) && is_array( $attributes['shadowStickyHover'] ) && isset( $attributes['shadowStickyHover'][0] ) && is_array( $attributes['shadowStickyHover'][0] ) && $this->has_visible_shadow( $attributes['shadowStickyHover'][0] ) && isset( $attributes['shadowStickyHover'][0]['inset'] ) && true === $attributes['shadowStickyHover'][0]['inset'] ) {
 			$css->add_property( 'box-shadow', '0px 0px 0px 0px rgba(0, 0, 0, 0)' );
 			$css->set_selector( '.kb-btn' . $unique_id . '.kb-button:hover::before' );
 		}
 		// No `none` fallback on hover: an unset hover shadow must let the base state's shadow
 		// carry through the `:hover` rule via the normal cascade.
-		if ( isset( $attributes['shadowStickyHover'] ) && is_array( $attributes['shadowStickyHover'] ) && isset( $attributes['shadowStickyHover'][0] ) && is_array( $attributes['shadowStickyHover'][0] ) && $this->has_visible_shadow( $attributes['shadowStickyHover'][0] ) ) {
+		if ( ! empty( $attributes['displayHoverShadowSticky'] ) && isset( $attributes['shadowStickyHover'] ) && is_array( $attributes['shadowStickyHover'] ) && isset( $attributes['shadowStickyHover'][0] ) && is_array( $attributes['shadowStickyHover'][0] ) && $this->has_visible_shadow( $attributes['shadowStickyHover'][0] ) ) {
 			$css->add_property( 'box-shadow', $this->render_button_shadow( $css, $attributes['shadowStickyHover'][0] ) );
 		}
 	}

--- a/src/blocks/image/block.json
+++ b/src/blocks/image/block.json
@@ -183,22 +183,10 @@
 			"type": "array",
 			"default": ["", "", "", ""]
 		},
-		"displayBoxShadow": {
-			"type": "boolean",
-			"default": false
-		},
 		"boxShadow": {
 			"type": "array",
 			"default": [
-				{
-					"color": "#000000",
-					"opacity": 0.2,
-					"spread": 0,
-					"blur": 14,
-					"hOffset": 0,
-					"vOffset": 0,
-					"inset": false
-				}
+				{ "color": "transparent", "opacity": 1, "spread": 0, "blur": 0, "hOffset": 0, "vOffset": 0, "inset": false }
 			]
 		},
 		"displayDropShadow": {

--- a/src/blocks/image/block.json
+++ b/src/blocks/image/block.json
@@ -183,6 +183,10 @@
 			"type": "array",
 			"default": ["", "", "", ""]
 		},
+		"displayBoxShadow": {
+			"type": "boolean",
+			"default": false
+		},
 		"boxShadow": {
 			"type": "array",
 			"default": [

--- a/src/blocks/image/image.js
+++ b/src/blocks/image/image.js
@@ -66,7 +66,7 @@ import {
 	presetValueForDevice,
 } from '../../extension/token-indicators/normalize';
 import { EditorBoxControl } from '../../extension/design-tokens/components/EditorBoxControl';
-import { EditorShadowControl } from '../../extension/design-tokens/components/EditorShadowControl';
+import { EditorShadowControl, hasVisibleShadow } from '../../extension/design-tokens/components/EditorShadowControl';
 import { renderShadowColor } from '../../extension/design-tokens/components/shadow-color';
 import { useColorGroups } from '../../extension/design-tokens/hooks/use-color-groups';
 import { resolveColorLiteral } from '../../extension/design-tokens/color-literal';
@@ -168,7 +168,6 @@ export default function Image({
 		borderWidthDesktop,
 		borderWidthTablet,
 		borderWidthMobile,
-		displayBoxShadow,
 		boxShadow,
 		displayDropShadow,
 		dropShadow,
@@ -468,18 +467,6 @@ export default function Image({
 
 		setAttributes({
 			dropShadow: newItems,
-		});
-	}
-	function saveBoxShadow(value) {
-		const newItems = boxShadow.map((item, thisIndex) => {
-			if (0 === thisIndex) {
-				item = { ...item, ...value };
-			}
-			return item;
-		});
-
-		setAttributes({
-			boxShadow: newItems,
 		});
 	}
 	const saveCaptionFont = (value) => {
@@ -1322,29 +1309,14 @@ export default function Image({
 									allowEmpty={true}
 								/>
 							)}
-							<ToggleControl
-								label={__('Enable Box Shadow', 'kadence-blocks')}
-								checked={undefined !== displayBoxShadow ? displayBoxShadow : false}
-								onChange={(value) => setAttributes({ displayBoxShadow: value })}
+							<EditorShadowControl
+								label={__('Box Shadow', 'kadence-blocks')}
+								value={boxShadow}
+								onChange={(value) => setAttributes({ boxShadow: value })}
+								tokens={shadowTokens}
+								defaultValue={shadowPresetValue}
+								renderColor={renderShadowColor}
 							/>
-							{/* Kept as its own toggle, unlike the Button, which dropped its equivalent when it
-							    moved to this control. `EditorShadowControl` decides emission purely from the
-							    value's own axes, but the image's render path still gates on
-							    `displayBoxShadow` (see its block class), so removing the toggle here would
-							    take away a real capability: hiding a shadow without discarding the values
-							    that define it. The editor stays hidden while off for the same reason the
-							    previous control hid its body -- an editor that cannot reach the page is the
-							    same kind of dead affordance as an opacity slider on a token pick. */}
-							{displayBoxShadow && (
-								<EditorShadowControl
-									label={__('Box Shadow', 'kadence-blocks')}
-									value={boxShadow}
-									onChange={(value) => setAttributes({ boxShadow: value })}
-									tokens={shadowTokens}
-									defaultValue={shadowPresetValue}
-									renderColor={renderShadowColor}
-								/>
-							)}
 							<DropShadowControl
 								label={__('Drop Shadow', 'kadence-blocks')}
 								enable={undefined !== displayDropShadow ? displayDropShadow : false}
@@ -1959,26 +1931,24 @@ export default function Image({
 
 					backgroundColor: '' !== backgroundColor ? KadenceColorOutput(backgroundColor) : undefined,
 
-					boxShadow:
-						undefined !== displayBoxShadow &&
-						displayBoxShadow &&
-						undefined !== boxShadow &&
-						undefined !== boxShadow[0] &&
-						undefined !== boxShadow[0].color
-							? (undefined !== boxShadow[0].inset && boxShadow[0].inset ? 'inset ' : '') +
-								(undefined !== boxShadow[0].hOffset ? boxShadow[0].hOffset : 0) +
-								'px ' +
-								(undefined !== boxShadow[0].vOffset ? boxShadow[0].vOffset : 0) +
-								'px ' +
-								(undefined !== boxShadow[0].blur ? boxShadow[0].blur : 14) +
-								'px ' +
-								(undefined !== boxShadow[0].spread ? boxShadow[0].spread : 0) +
-								'px ' +
-								KadenceColorOutput(
-									undefined !== boxShadow[0].color ? boxShadow[0].color : '#000000',
-									undefined !== boxShadow[0].opacity ? boxShadow[0].opacity : 0.2
-								)
-							: undefined,
+					// Gated on the value's own axes, matching the block class's `has_visible_shadow()` — an
+					// all-zero shadow paints nothing and IS the off state now that no enable boolean
+					// carries that meaning.
+					boxShadow: hasVisibleShadow(boxShadow?.[0])
+						? (undefined !== boxShadow[0].inset && boxShadow[0].inset ? 'inset ' : '') +
+							(undefined !== boxShadow[0].hOffset ? boxShadow[0].hOffset : 0) +
+							'px ' +
+							(undefined !== boxShadow[0].vOffset ? boxShadow[0].vOffset : 0) +
+							'px ' +
+							(undefined !== boxShadow[0].blur ? boxShadow[0].blur : 14) +
+							'px ' +
+							(undefined !== boxShadow[0].spread ? boxShadow[0].spread : 0) +
+							'px ' +
+							KadenceColorOutput(
+								undefined !== boxShadow[0].color ? boxShadow[0].color : '#000000',
+								undefined !== boxShadow[0].opacity ? boxShadow[0].opacity : 0.2
+							)
+						: undefined,
 					filter:
 						undefined !== displayDropShadow && displayDropShadow
 							? 'drop-shadow(' +

--- a/src/blocks/image/image.js
+++ b/src/blocks/image/image.js
@@ -168,6 +168,7 @@ export default function Image({
 		borderWidthDesktop,
 		borderWidthTablet,
 		borderWidthMobile,
+		displayBoxShadow,
 		boxShadow,
 		displayDropShadow,
 		dropShadow,
@@ -223,7 +224,18 @@ export default function Image({
 	// Design-token indicators: the per-attribute bound/overridden state for the selected preset, plus a
 	// reset that clears the mapped attribute back to the preset value (served by the existing scoped CSS).
 	const tokenBinding = usePresetBinding('kadence/image', attributes, undefined, previewDevice);
-	const resetToken = (attr) => resetAttr(attr, setAttributes, tokenBinding[attr]?.kind);
+	// The schema and the binding's own per-device attribute names are both passed through. The image
+	// spells its padding companions `paddingTablet`/`paddingMobile` rather than the `tablet<Attr>`
+	// convention, so without the declared names a reset writes an attribute the block does not have and
+	// leaves the real Tablet and Mobile values untouched.
+	const resetToken = (attr) =>
+		resetAttr(
+			attr,
+			setAttributes,
+			tokenBinding[attr]?.kind,
+			metadata.attributes,
+			tokenBinding[attr]?.responsiveAttrs
+		);
 	// One fetch of the block's effective palette groups, shared by every `ColorControl` on this block.
 	const colorGroups = useColorGroups(clientId);
 
@@ -1309,10 +1321,21 @@ export default function Image({
 									allowEmpty={true}
 								/>
 							)}
+							{/* `displayBoxShadow` is no longer a control -- it is derived from the value on every
+							    write. It has to keep existing because Gutenberg omits an attribute equal to its
+							    default, so a block saved with the old toggle OFF stored no flag at all and is
+							    indistinguishable from one saved with it on. Deriving it forward means legacy
+							    content keeps whatever the flag said, while anything edited from here on has a
+							    flag that simply agrees with its own geometry. */}
 							<EditorShadowControl
 								label={__('Box Shadow', 'kadence-blocks')}
 								value={boxShadow}
-								onChange={(value) => setAttributes({ boxShadow: value })}
+								onChange={(value) =>
+									setAttributes({
+										boxShadow: value,
+										displayBoxShadow: hasVisibleShadow(value?.[0]),
+									})
+								}
 								tokens={shadowTokens}
 								defaultValue={shadowPresetValue}
 								renderColor={renderShadowColor}
@@ -1931,24 +1954,24 @@ export default function Image({
 
 					backgroundColor: '' !== backgroundColor ? KadenceColorOutput(backgroundColor) : undefined,
 
-					// Gated on the value's own axes, matching the block class's `has_visible_shadow()` — an
-					// all-zero shadow paints nothing and IS the off state now that no enable boolean
-					// carries that meaning.
-					boxShadow: hasVisibleShadow(boxShadow?.[0])
-						? (undefined !== boxShadow[0].inset && boxShadow[0].inset ? 'inset ' : '') +
-							(undefined !== boxShadow[0].hOffset ? boxShadow[0].hOffset : 0) +
-							'px ' +
-							(undefined !== boxShadow[0].vOffset ? boxShadow[0].vOffset : 0) +
-							'px ' +
-							(undefined !== boxShadow[0].blur ? boxShadow[0].blur : 14) +
-							'px ' +
-							(undefined !== boxShadow[0].spread ? boxShadow[0].spread : 0) +
-							'px ' +
-							KadenceColorOutput(
-								undefined !== boxShadow[0].color ? boxShadow[0].color : '#000000',
-								undefined !== boxShadow[0].opacity ? boxShadow[0].opacity : 0.2
-							)
-						: undefined,
+					// Both halves have to agree: the stored flag, which legacy content may have left false
+					// with real values still behind it, and the value's own axes.
+					boxShadow:
+						displayBoxShadow && hasVisibleShadow(boxShadow?.[0])
+							? (undefined !== boxShadow[0].inset && boxShadow[0].inset ? 'inset ' : '') +
+								(undefined !== boxShadow[0].hOffset ? boxShadow[0].hOffset : 0) +
+								'px ' +
+								(undefined !== boxShadow[0].vOffset ? boxShadow[0].vOffset : 0) +
+								'px ' +
+								(undefined !== boxShadow[0].blur ? boxShadow[0].blur : 14) +
+								'px ' +
+								(undefined !== boxShadow[0].spread ? boxShadow[0].spread : 0) +
+								'px ' +
+								KadenceColorOutput(
+									undefined !== boxShadow[0].color ? boxShadow[0].color : '#000000',
+									undefined !== boxShadow[0].opacity ? boxShadow[0].opacity : 0.2
+								)
+							: undefined,
 					filter:
 						undefined !== displayDropShadow && displayDropShadow
 							? 'drop-shadow(' +

--- a/src/blocks/image/image.js
+++ b/src/blocks/image/image.js
@@ -53,6 +53,26 @@ import {
 } from '@kadence/helpers';
 import { isExternalImage } from './edit';
 import metadata from './block.json';
+import {
+	presetPropertyValueForDevice,
+	resetAttr,
+	useLinkedMeasureState,
+	usePresetBinding,
+} from '../../extension/token-indicators';
+import {
+	anyCornerInherited,
+	inheritedMeasureSlots,
+	measureAttrsForDevice,
+	presetValueForDevice,
+} from '../../extension/token-indicators/normalize';
+import { EditorBoxControl } from '../../extension/design-tokens/components/EditorBoxControl';
+import { EditorShadowControl } from '../../extension/design-tokens/components/EditorShadowControl';
+import { renderShadowColor } from '../../extension/design-tokens/components/shadow-color';
+import { useColorGroups } from '../../extension/design-tokens/hooks/use-color-groups';
+import { resolveColorLiteral } from '../../extension/design-tokens/color-literal';
+import { tokenDimension } from '../../extension/design-tokens/token-dimension';
+import { pickableTokensForControl, pickableTokensForKey } from '../../extension/token-picker';
+import { ColorControl } from '../../token-controls';
 /**
  * Module constants
  */
@@ -198,6 +218,87 @@ export default function Image({
 		tooltipPlacement,
 		tooltipDash,
 	} = attributes;
+
+	const { setPreviewDeviceType: setPreviewDevice } = useDispatch('kadenceblocks/data');
+
+	// Design-token indicators: the per-attribute bound/overridden state for the selected preset, plus a
+	// reset that clears the mapped attribute back to the preset value (served by the existing scoped CSS).
+	const tokenBinding = usePresetBinding('kadence/image', attributes, undefined, previewDevice);
+	const resetToken = (attr) => resetAttr(attr, setAttributes, tokenBinding[attr]?.kind);
+	// One fetch of the block's effective palette groups, shared by every `ColorControl` on this block.
+	const colorGroups = useColorGroups(clientId);
+
+	// Empty when the token registry is inactive, which is what keeps the plain controls below as the
+	// fallback rather than leaving the image with no radius/padding control at all.
+	const borderRadiusTokens = pickableTokensForControl('kadence/image', 'borderRadius') || [];
+	const paddingTokens = pickableTokensForControl('kadence/image', 'paddingDesktop') || [];
+	// The shadow binds a nested attribute with no `control_attr` of its own, so its pool is looked up by
+	// the binding's key rather than by a control attribute.
+	const shadowTokens = pickableTokensForKey('kadence/image', 'shadow');
+
+	// A measure control keeps ONE linked/individual mode but writes a different attribute per breakpoint,
+	// so the mode must be read from — and "link" must collapse — whichever device is active. The image
+	// spells its padding attributes `paddingDesktop`/`paddingTablet`/`paddingMobile` rather than the
+	// bare-plus-prefix convention, which is why both siblings are named explicitly.
+	const borderRadiusForDevice = measureAttrsForDevice(
+		attributes,
+		'borderRadius',
+		{ tablet: 'tabletBorderRadius', mobile: 'mobileBorderRadius' },
+		previewDevice
+	);
+	const paddingForDevice = measureAttrsForDevice(
+		attributes,
+		'paddingDesktop',
+		{ tablet: 'paddingTablet', mobile: 'paddingMobile' },
+		previewDevice
+	);
+	const borderRadiusPresetValue = presetValueForDevice(
+		tokenBinding.borderRadius?.presetValue,
+		tokenBinding.borderRadius?.responsive,
+		previewDevice
+	);
+	const paddingPresetValue = presetValueForDevice(
+		tokenBinding.paddingDesktop?.presetValue,
+		tokenBinding.paddingDesktop?.responsive,
+		previewDevice
+	);
+	// What an unset slot falls back to on the active device: another breakpoint's slot before the
+	// preset's, matching the cascade the image actually renders through. The slots stay stored-empty —
+	// this only tells the field's popover which size is in effect and where it came from.
+	const inheritedBorderRadius = inheritedMeasureSlots(
+		previewDevice,
+		{ desktop: borderRadius, tablet: tabletBorderRadius },
+		borderRadiusPresetValue
+	);
+	const inheritedPadding = inheritedMeasureSlots(
+		previewDevice,
+		{ desktop: paddingDesktop, tablet: paddingTablet },
+		paddingPresetValue
+	);
+	const shadowPresetValue = presetPropertyValueForDevice(
+		'kadence/image',
+		'shadow',
+		attributes,
+		undefined,
+		previewDevice
+	);
+	const borderRadiusIsRelative = borderRadiusUnit === 'em' || borderRadiusUnit === 'rem';
+	const paddingIsRelative = paddingUnit === 'em' || paddingUnit === 'rem';
+	// `resetOn` clears the remembered link choice on a preset change, since an override records a choice
+	// about the PREVIOUS preset's slots — otherwise an explicit "link" would stick and hide a new preset's
+	// per-slot value.
+	const { isLinked: borderRadiusIsLinked, toggleLink: toggleBorderRadiusLink } = useLinkedMeasureState({
+		forDevice: borderRadiusForDevice,
+		previewDevice,
+		setAttributes,
+		resetOn: attributes.kbPreset,
+	});
+	const { isLinked: paddingIsLinked, toggleLink: togglePaddingLink } = useLinkedMeasureState({
+		forDevice: paddingForDevice,
+		previewDevice,
+		setAttributes,
+		resetOn: attributes.kbPreset,
+	});
 
 	const previewURL = dynamicURL ? dynamicURL : url;
 	const [updateImageStore, setImageStore] = useState(false);
@@ -1158,13 +1259,19 @@ export default function Image({
 				{activeTab === 'style' && (
 					<>
 						<KadencePanelBody panelName={'kb-image-border-settings'}>
-							<PopColorControl
+							<ColorControl
 								label={__('Background Color', 'kadence-blocks')}
 								value={backgroundColor ? backgroundColor : ''}
-								default={''}
-								onChange={(value) => {
-									setAttributes({ backgroundColor: value });
+								groups={colorGroups}
+								status={{
+									bound: !!tokenBinding.backgroundColor?.bound,
+									modified: !!tokenBinding.backgroundColor?.overridden,
 								}}
+								onReset={() => resetToken('backgroundColor')}
+								onPick={(alias) => setAttributes({ backgroundColor: alias })}
+								onCustom={(literal) => setAttributes({ backgroundColor: literal })}
+								onClear={() => setAttributes({ backgroundColor: '' })}
+								resolveLiteral={resolveColorLiteral}
 							/>
 							<ResponsiveBorderControl
 								label={__('Border', 'kadence-blocks')}
@@ -1175,104 +1282,69 @@ export default function Image({
 								onChangeTablet={(value) => setAttributes({ tabletBorderStyle: value })}
 								onChangeMobile={(value) => setAttributes({ mobileBorderStyle: value })}
 							/>
-							<ResponsiveMeasurementControls
-								label={__('Border Radius', 'kadence-blocks')}
-								value={borderRadius}
-								tabletValue={tabletBorderRadius}
-								mobileValue={mobileBorderRadius}
-								onChange={(value) => setAttributes({ borderRadius: value })}
-								onChangeTablet={(value) => setAttributes({ tabletBorderRadius: value })}
-								onChangeMobile={(value) => setAttributes({ mobileBorderRadius: value })}
-								min={0}
-								max={borderRadiusUnit === 'em' || borderRadiusUnit === 'rem' ? 24 : 200}
-								step={borderRadiusUnit === 'em' || borderRadiusUnit === 'rem' ? 0.1 : 1}
-								unit={borderRadiusUnit}
-								units={['px', 'em', 'rem', '%']}
-								onUnit={(value) => setAttributes({ borderRadiusUnit: value })}
-								isBorderRadius={true}
-								allowEmpty={true}
+							{borderRadiusTokens.length ? (
+								<EditorBoxControl
+									label={__('Border Radius', 'kadence-blocks')}
+									value={borderRadiusForDevice.value}
+									onChange={(next) => setAttributes({ [borderRadiusForDevice.attr]: next })}
+									previewDevice={previewDevice}
+									onDeviceChange={setPreviewDevice}
+									tokens={borderRadiusTokens}
+									defaultValue={inheritedBorderRadius.values}
+									inherited={anyCornerInherited(inheritedBorderRadius.inherited)}
+									state={tokenBinding.borderRadius}
+									onReset={() => resetToken('borderRadius')}
+									isLinked={borderRadiusIsLinked}
+									onToggleLink={toggleBorderRadiusLink}
+									unit={borderRadiusUnit}
+									units={['px', 'em', 'rem', '%']}
+									onUnit={(value) => setAttributes({ borderRadiusUnit: value })}
+									min={0}
+									max={borderRadiusIsRelative ? 24 : 200}
+									step={borderRadiusIsRelative ? 0.1 : 1}
+								/>
+							) : (
+								<ResponsiveMeasurementControls
+									label={__('Border Radius', 'kadence-blocks')}
+									value={borderRadius}
+									tabletValue={tabletBorderRadius}
+									mobileValue={mobileBorderRadius}
+									onChange={(value) => setAttributes({ borderRadius: value })}
+									onChangeTablet={(value) => setAttributes({ tabletBorderRadius: value })}
+									onChangeMobile={(value) => setAttributes({ mobileBorderRadius: value })}
+									min={0}
+									max={borderRadiusIsRelative ? 24 : 200}
+									step={borderRadiusIsRelative ? 0.1 : 1}
+									unit={borderRadiusUnit}
+									units={['px', 'em', 'rem', '%']}
+									onUnit={(value) => setAttributes({ borderRadiusUnit: value })}
+									isBorderRadius={true}
+									allowEmpty={true}
+								/>
+							)}
+							<ToggleControl
+								label={__('Enable Box Shadow', 'kadence-blocks')}
+								checked={undefined !== displayBoxShadow ? displayBoxShadow : false}
+								onChange={(value) => setAttributes({ displayBoxShadow: value })}
 							/>
-							<BoxShadowControl
-								label={__('Box Shadow', 'kadence-blocks')}
-								enable={undefined !== displayBoxShadow ? displayBoxShadow : false}
-								color={
-									undefined !== boxShadow &&
-									undefined !== boxShadow[0] &&
-									undefined !== boxShadow[0].color
-										? boxShadow[0].color
-										: '#000000'
-								}
-								colorDefault={'#000000'}
-								onArrayChange={(color, opacity) => saveBoxShadow({ color, opacity })}
-								opacity={
-									undefined !== boxShadow &&
-									undefined !== boxShadow[0] &&
-									undefined !== boxShadow[0].opacity
-										? boxShadow[0].opacity
-										: 0.2
-								}
-								hOffset={
-									undefined !== boxShadow &&
-									undefined !== boxShadow[0] &&
-									undefined !== boxShadow[0].hOffset
-										? boxShadow[0].hOffset
-										: 0
-								}
-								vOffset={
-									undefined !== boxShadow &&
-									undefined !== boxShadow[0] &&
-									undefined !== boxShadow[0].vOffset
-										? boxShadow[0].vOffset
-										: 0
-								}
-								blur={
-									undefined !== boxShadow &&
-									undefined !== boxShadow[0] &&
-									undefined !== boxShadow[0].blur
-										? boxShadow[0].blur
-										: 14
-								}
-								spread={
-									undefined !== boxShadow &&
-									undefined !== boxShadow[0] &&
-									undefined !== boxShadow[0].spread
-										? boxShadow[0].spread
-										: 0
-								}
-								inset={
-									undefined !== boxShadow &&
-									undefined !== boxShadow[0] &&
-									undefined !== boxShadow[0].inset
-										? boxShadow[0].inset
-										: false
-								}
-								onEnableChange={(value) => {
-									setAttributes({
-										displayBoxShadow: value,
-									});
-								}}
-								onColorChange={(value) => {
-									saveBoxShadow({ color: value });
-								}}
-								onOpacityChange={(value) => {
-									saveBoxShadow({ opacity: value });
-								}}
-								onHOffsetChange={(value) => {
-									saveBoxShadow({ hOffset: value });
-								}}
-								onVOffsetChange={(value) => {
-									saveBoxShadow({ vOffset: value });
-								}}
-								onBlurChange={(value) => {
-									saveBoxShadow({ blur: value });
-								}}
-								onSpreadChange={(value) => {
-									saveBoxShadow({ spread: value });
-								}}
-								onInsetChange={(value) => {
-									saveBoxShadow({ inset: value });
-								}}
-							/>
+							{/* Kept as its own toggle, unlike the Button, which dropped its equivalent when it
+							    moved to this control. `EditorShadowControl` decides emission purely from the
+							    value's own axes, but the image's render path still gates on
+							    `displayBoxShadow` (see its block class), so removing the toggle here would
+							    take away a real capability: hiding a shadow without discarding the values
+							    that define it. The editor stays hidden while off for the same reason the
+							    previous control hid its body -- an editor that cannot reach the page is the
+							    same kind of dead affordance as an opacity slider on a token pick. */}
+							{displayBoxShadow && (
+								<EditorShadowControl
+									label={__('Box Shadow', 'kadence-blocks')}
+									value={boxShadow}
+									onChange={(value) => setAttributes({ boxShadow: value })}
+									tokens={shadowTokens}
+									defaultValue={shadowPresetValue}
+									renderColor={renderShadowColor}
+								/>
+							)}
 							<DropShadowControl
 								label={__('Drop Shadow', 'kadence-blocks')}
 								enable={undefined !== displayDropShadow ? displayDropShadow : false}
@@ -1627,23 +1699,47 @@ export default function Image({
 				{activeTab === 'advanced' && (
 					<>
 						<KadencePanelBody>
-							<ResponsiveMeasureRangeControl
-								label={__('Padding', 'kadence-blocks')}
-								value={paddingDesktop}
-								tabletValue={paddingTablet}
-								mobileValue={paddingMobile}
-								onChange={(value) => setAttributes({ paddingDesktop: value })}
-								onChangeTablet={(value) => setAttributes({ paddingTablet: value })}
-								onChangeMobile={(value) => setAttributes({ paddingMobile: value })}
-								min={0}
-								max={paddingUnit === 'em' || paddingUnit === 'rem' ? 24 : 999}
-								step={paddingUnit === 'em' || paddingUnit === 'rem' ? 0.1 : 1}
-								unit={paddingUnit}
-								units={['px', 'em', 'rem', '%']}
-								onUnit={(value) => setAttributes({ paddingUnit: value })}
-								onMouseOver={paddingMouseOver.onMouseOver}
-								onMouseOut={paddingMouseOver.onMouseOut}
-							/>
+							{paddingTokens.length ? (
+								<EditorBoxControl
+									label={__('Padding', 'kadence-blocks')}
+									value={paddingForDevice.value}
+									onChange={(next) => setAttributes({ [paddingForDevice.attr]: next })}
+									previewDevice={previewDevice}
+									onDeviceChange={setPreviewDevice}
+									tokens={paddingTokens}
+									defaultValue={inheritedPadding.values}
+									inherited={anyCornerInherited(inheritedPadding.inherited)}
+									state={tokenBinding.paddingDesktop}
+									onReset={() => resetToken('paddingDesktop')}
+									isLinked={paddingIsLinked}
+									onToggleLink={togglePaddingLink}
+									role="sides"
+									unit={paddingUnit}
+									units={['px', 'em', 'rem', '%']}
+									onUnit={(value) => setAttributes({ paddingUnit: value })}
+									min={0}
+									max={paddingIsRelative ? 24 : 999}
+									step={paddingIsRelative ? 0.1 : 1}
+								/>
+							) : (
+								<ResponsiveMeasureRangeControl
+									label={__('Padding', 'kadence-blocks')}
+									value={paddingDesktop}
+									tabletValue={paddingTablet}
+									mobileValue={paddingMobile}
+									onChange={(value) => setAttributes({ paddingDesktop: value })}
+									onChangeTablet={(value) => setAttributes({ paddingTablet: value })}
+									onChangeMobile={(value) => setAttributes({ paddingMobile: value })}
+									min={0}
+									max={paddingIsRelative ? 24 : 999}
+									step={paddingIsRelative ? 0.1 : 1}
+									unit={paddingUnit}
+									units={['px', 'em', 'rem', '%']}
+									onUnit={(value) => setAttributes({ paddingUnit: value })}
+									onMouseOver={paddingMouseOver.onMouseOver}
+									onMouseOut={paddingMouseOver.onMouseOut}
+								/>
+							)}
 							<ResponsiveMeasureRangeControl
 								label={__('Margin', 'kadence-blocks')}
 								value={marginDesktop}
@@ -1846,19 +1942,19 @@ export default function Image({
 					borderLeft: previewBorderLeftStyle ? previewBorderLeftStyle : undefined,
 					borderTopLeftRadius:
 						'' !== previewRadiusTop
-							? previewRadiusTop + (borderRadiusUnit ? borderRadiusUnit : 'px')
+							? tokenDimension(previewRadiusTop, borderRadiusUnit ? borderRadiusUnit : 'px')
 							: undefined,
 					borderTopRightRadius:
 						'' !== previewRadiusRight
-							? previewRadiusRight + (borderRadiusUnit ? borderRadiusUnit : 'px')
+							? tokenDimension(previewRadiusRight, borderRadiusUnit ? borderRadiusUnit : 'px')
 							: undefined,
 					borderBottomRightRadius:
 						'' !== previewRadiusBottom
-							? previewRadiusBottom + (borderRadiusUnit ? borderRadiusUnit : 'px')
+							? tokenDimension(previewRadiusBottom, borderRadiusUnit ? borderRadiusUnit : 'px')
 							: undefined,
 					borderBottomLeftRadius:
 						'' !== previewRadiusLeft
-							? previewRadiusLeft + (borderRadiusUnit ? borderRadiusUnit : 'px')
+							? tokenDimension(previewRadiusLeft, borderRadiusUnit ? borderRadiusUnit : 'px')
 							: undefined,
 
 					backgroundColor: '' !== backgroundColor ? KadenceColorOutput(backgroundColor) : undefined,

--- a/src/blocks/singlebtn/block.json
+++ b/src/blocks/singlebtn/block.json
@@ -335,11 +335,19 @@
 				}
 			]
 		},
+		"displayShadow": {
+			"type": "boolean",
+			"default": false
+		},
 		"shadow": {
 			"type": "array",
 			"default": [
 				{ "color": "transparent", "opacity": 1, "spread": 0, "blur": 0, "hOffset": 0, "vOffset": 0, "inset": false }
 			]
+		},
+		"displayHoverShadow": {
+			"type": "boolean",
+			"default": false
 		},
 		"shadowHover": {
 			"type": "array",
@@ -505,11 +513,19 @@
 			"type": "string",
 			"default": "px"
 		},
+		"displayShadowTransparent": {
+			"type": "boolean",
+			"default": false
+		},
 		"shadowTransparent": {
 			"type": "array",
 			"default": [
 				{ "color": "transparent", "opacity": 1, "spread": 0, "blur": 0, "hOffset": 0, "vOffset": 0, "inset": false }
 			]
+		},
+		"displayHoverShadowTransparent": {
+			"type": "boolean",
+			"default": false
 		},
 		"shadowTransparentHover": {
 			"type": "array",
@@ -653,11 +669,19 @@
 			"type": "string",
 			"default": "px"
 		},
+		"displayShadowSticky": {
+			"type": "boolean",
+			"default": false
+		},
 		"shadowSticky": {
 			"type": "array",
 			"default": [
 				{ "color": "transparent", "opacity": 1, "spread": 0, "blur": 0, "hOffset": 0, "vOffset": 0, "inset": false }
 			]
+		},
+		"displayHoverShadowSticky": {
+			"type": "boolean",
+			"default": false
 		},
 		"shadowStickyHover": {
 			"type": "array",

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -99,6 +99,7 @@ import { EditorBorderControl } from '../../extension/design-tokens/components/Ed
 import {
 	EditorShadowControl,
 	combineColorOpacity,
+	hasVisibleShadow,
 	splitColorOpacity,
 } from '../../extension/design-tokens/components/EditorShadowControl';
 import { renderShadowColor } from '../../extension/design-tokens/components/shadow-color';
@@ -1330,7 +1331,12 @@ export default function KadenceButtonEdit(props) {
 															defaultValue={shadowPresetValue}
 															label={__('Box Shadow', 'kadence-blocks')}
 															value={shadowHover}
-															onChange={(value) => setAttributes({ shadowHover: value })}
+															onChange={(value) =>
+																setAttributes({
+																	shadowHover: value,
+																	displayHoverShadow: hasVisibleShadow(value?.[0]),
+																})
+															}
 															tokens={shadowPickableTokens}
 															renderColor={renderShadowColor}
 														/>
@@ -1452,11 +1458,24 @@ export default function KadenceButtonEdit(props) {
 															max={borderRadiusIsRelative ? 24 : 500}
 															step={borderRadiusIsRelative ? 0.1 : 1}
 														/>
+														{/* The `display*Shadow` flags are no longer controls — the editor derives each
+														    from its own value on every write. They still have to EXIST, because
+														    Gutenberg omits an attribute equal to its default: a button saved with
+														    the old toggle OFF stored no flag at all while keeping the values behind
+														    it, so geometry alone cannot tell it from one saved with the toggle on.
+														    Deriving them forward leaves legacy content exactly as it renders today
+														    and gives anything edited from here on a flag that agrees with its own
+														    geometry. */}
 														<EditorShadowControl
 															defaultValue={shadowPresetValue}
 															label={__('Box Shadow', 'kadence-blocks')}
 															value={shadow}
-															onChange={(value) => setAttributes({ shadow: value })}
+															onChange={(value) =>
+																setAttributes({
+																	shadow: value,
+																	displayShadow: hasVisibleShadow(value?.[0]),
+																})
+															}
 															tokens={shadowPickableTokens}
 															renderColor={renderShadowColor}
 														/>
@@ -1606,7 +1625,12 @@ export default function KadenceButtonEdit(props) {
 																label={__('Box Shadow', 'kadence-blocks')}
 																value={shadowTransparentHover}
 																onChange={(value) =>
-																	setAttributes({ shadowTransparentHover: value })
+																	setAttributes({
+																		shadowTransparentHover: value,
+																		displayHoverShadowTransparent: hasVisibleShadow(
+																			value?.[0]
+																		),
+																	})
 																}
 																tokens={shadowPickableTokens}
 																renderColor={renderShadowColor}
@@ -1733,7 +1757,12 @@ export default function KadenceButtonEdit(props) {
 																label={__('Box Shadow', 'kadence-blocks')}
 																value={shadowTransparent}
 																onChange={(value) =>
-																	setAttributes({ shadowTransparent: value })
+																	setAttributes({
+																		shadowTransparent: value,
+																		displayShadowTransparent: hasVisibleShadow(
+																			value?.[0]
+																		),
+																	})
 																}
 																tokens={shadowPickableTokens}
 																renderColor={renderShadowColor}
@@ -1876,7 +1905,12 @@ export default function KadenceButtonEdit(props) {
 																label={__('Box Shadow', 'kadence-blocks')}
 																value={shadowStickyHover}
 																onChange={(value) =>
-																	setAttributes({ shadowStickyHover: value })
+																	setAttributes({
+																		shadowStickyHover: value,
+																		displayHoverShadowSticky: hasVisibleShadow(
+																			value?.[0]
+																		),
+																	})
 																}
 																tokens={shadowPickableTokens}
 																renderColor={renderShadowColor}
@@ -1997,7 +2031,12 @@ export default function KadenceButtonEdit(props) {
 																label={__('Box Shadow', 'kadence-blocks')}
 																value={shadowSticky}
 																onChange={(value) =>
-																	setAttributes({ shadowSticky: value })
+																	setAttributes({
+																		shadowSticky: value,
+																		displayShadowSticky: hasVisibleShadow(
+																			value?.[0]
+																		),
+																	})
 																}
 																tokens={shadowPickableTokens}
 																renderColor={renderShadowColor}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -101,6 +101,7 @@ import {
 	combineColorOpacity,
 	splitColorOpacity,
 } from '../../extension/design-tokens/components/EditorShadowControl';
+import { renderShadowColor } from '../../extension/design-tokens/components/shadow-color';
 import { pickableTokensForControl, pickableTokensForKey } from '../../extension/token-picker';
 import { ColorControl, ColorControlGroup } from '../../token-controls';
 import { BUTTON_MARGIN_FALLBACK, BUTTON_PADDING_FALLBACK } from '../../token-controls/helpers/button-box-defaults';
@@ -140,39 +141,6 @@ function renderBorderColor({ value, onChange, label }) {
 			default={''}
 			hideClear={true}
 			onChange={onChange}
-		/>
-	);
-}
-
-/**
- * `EditorShadowControl`'s `renderColor` render-prop: reuses the block's existing `PopColorControl`
- * unchanged, wired through its own two-channel `opacityValue`/`onArrayChange` props so the swatch's
- * opacity slider keeps working exactly as it did on the native `@kadence/components` `BoxShadowControl`
- * (see `node_modules/@kadence/components/src/box-shadow-control/index.js`). The composite's `color`
- * slot arrives combined (`combineColorOpacity`); this is the one place that has to split it apart for
- * `PopColorControl` and recombine on every write, using the exact same rules `EditorShadowControl`
- * itself uses to read/write the native attribute, so both directions agree.
- *
- * @param {Object}   props          The render-prop's argument.
- * @param {string}   props.value    The composite's combined color slot (a plain hex, or `rgba(...)`).
- * @param {Function} props.onChange Called with the next combined color slot.
- *
- * @since TBD
- *
- * @return {JSX.Element} The rendered color field.
- */
-function renderShadowColor({ value, onChange }) {
-	const { color, opacity } = splitColorOpacity(value);
-
-	return (
-		<PopColorControl
-			value={color || ''}
-			default={'#000000'}
-			hideClear={true}
-			opacityValue={opacity}
-			onChange={(next) => onChange(combineColorOpacity(next, opacity))}
-			onOpacityChange={(next) => onChange(combineColorOpacity(color, next))}
-			onArrayChange={(next, nextOpacity) => onChange(combineColorOpacity(next, nextOpacity))}
 		/>
 	);
 }

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -96,12 +96,7 @@ import {
 } from '../../extension/token-indicators/normalize';
 import { EditorBoxControl } from '../../extension/design-tokens/components/EditorBoxControl';
 import { EditorBorderControl } from '../../extension/design-tokens/components/EditorBorderControl';
-import {
-	EditorShadowControl,
-	combineColorOpacity,
-	hasVisibleShadow,
-	splitColorOpacity,
-} from '../../extension/design-tokens/components/EditorShadowControl';
+import { EditorShadowControl, hasVisibleShadow } from '../../extension/design-tokens/components/EditorShadowControl';
 import { renderShadowColor } from '../../extension/design-tokens/components/shadow-color';
 import { pickableTokensForControl, pickableTokensForKey } from '../../extension/token-picker';
 import { ColorControl, ColorControlGroup } from '../../token-controls';

--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -299,6 +299,39 @@ export function toNativeShadow(value, tokens = []) {
 }
 
 /**
+ * Whether a native shadow item paints anything visible — the JS counterpart of the block classes'
+ * `has_visible_shadow()`, kept in step with it so the editor preview and the rendered page agree on
+ * which shadows exist at all.
+ *
+ * Geometry alone decides it: all-zero offsets, blur, and spread paint nothing whatever the color is,
+ * which is exactly what makes an all-zero value usable as the "no shadow" state now that no separate
+ * enable boolean carries that meaning. A non-numeric, non-empty leg is a `{dot.alias}` reference
+ * resolving to a var() whose value is unknown here, so it counts as visible — read as a zero, a
+ * caller would drop a shadow the token does paint.
+ *
+ * @param {?Object} item One `shadow[0]`-shaped item.
+ *
+ * @since TBD
+ *
+ * @return {boolean} Whether the item paints a visible shadow.
+ */
+export function hasVisibleShadow(item) {
+	if (!item) {
+		return false;
+	}
+
+	return ['hOffset', 'vOffset', 'blur', 'spread'].some((axis) => {
+		const value = item[axis] ?? 0;
+
+		if (typeof value === 'number' || (typeof value === 'string' && value.trim() !== '' && !isNaN(Number(value)))) {
+			return Number(value) !== 0;
+		}
+
+		return typeof value === 'string' && value.trim() !== '';
+	});
+}
+
+/**
  * Whether a stored native shadow should be treated as "the block sets no shadow of its own".
  *
  * `block.json` registers an all-zero transparent shadow as `shadow`'s own default, so a fresh block

--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -9,6 +9,7 @@ import {
 	splitColorOpacity,
 	toNativeShadow,
 	fromNativeShadow,
+	hasVisibleShadow,
 	isUnsetShadow,
 } from '../EditorShadowControl';
 import { BoxShadowControl } from '../../../../token-controls/controls/BoxShadowControl';
@@ -503,5 +504,35 @@ describe('EditorShadowControl unset rendering', () => {
 		});
 
 		expect(shadowControl.props.value).not.toBe('');
+	});
+});
+
+describe('hasVisibleShadow', () => {
+	/**
+	 * Geometry alone decides visibility, matching the block classes' `has_visible_shadow()`. The two
+	 * must agree or the editor preview and the rendered page disagree about which shadows exist.
+	 *
+	 * @param {string}  _label   The case name, used only for the test title.
+	 * @param {?Object} item     The `shadow[0]`-shaped item.
+	 * @param {boolean} expected Whether the item should read as visible.
+	 *
+	 * @return {void}
+	 */
+	it.each([
+		['a missing item', undefined, false],
+		['all-zero axes', { hOffset: 0, vOffset: 0, blur: 0, spread: 0 }, false],
+		['all-zero axes as strings', { hOffset: '0', vOffset: '0', blur: '0', spread: '0' }, false],
+		[
+			'a color with no geometry',
+			{ color: '#ff0000', opacity: 1, hOffset: 0, vOffset: 0, blur: 0, spread: 0 },
+			false,
+		],
+		['a blur', { hOffset: 0, vOffset: 0, blur: 14, spread: 0 }, true],
+		['a negative offset', { hOffset: -2, vOffset: 0, blur: 0, spread: 0 }, true],
+		['a spread only', { hOffset: 0, vOffset: 0, blur: 0, spread: 3 }, true],
+		['a token alias leg', { hOffset: 0, vOffset: '{semantic.shadow.media}', blur: 0, spread: 0 }, true],
+		['an empty-string leg', { hOffset: '', vOffset: '', blur: '', spread: '' }, false],
+	])('reads %s correctly', (_label, item, expected) => {
+		expect(hasVisibleShadow(item)).toBe(expected);
 	});
 });

--- a/src/extension/design-tokens/components/shadow-color.js
+++ b/src/extension/design-tokens/components/shadow-color.js
@@ -1,0 +1,56 @@
+/**
+ * The default `renderColor` for `EditorShadowControl`.
+ *
+ * Kept out of `EditorShadowControl.js` itself, even though it exists only to be passed to it: this is
+ * the one piece that reaches for `@kadence/components`, and that package ships a `dist/cjs` build with
+ * bare `import` statements that Jest cannot parse. Every other module under `components/` stays clear
+ * of it — `EditorBorderControl` takes its color field as a prop for the same reason — so importing it
+ * there would make `EditorShadowControl` untestable in isolation. A separate module keeps the cost on
+ * the blocks that render a color field, which are already in that position.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { PopColorControl } from '@kadence/components';
+
+/**
+ * Internal dependencies
+ */
+import { combineColorOpacity, splitColorOpacity } from './EditorShadowControl';
+
+/**
+ * Render the shared color field for a shadow composite's single `color` slot.
+ *
+ * Every block wires this identically, because the shape it bridges belongs to the control rather than
+ * to any block: the composite carries alpha inside `color` while the native attribute keeps a separate
+ * `opacity`, and `PopColorControl` edits both through its own two channels. A block only needs its own
+ * `renderColor` if it wants a different color field here; otherwise it passes this.
+ *
+ * `hideClear` because the composite always has a color — clearing it to nothing would leave a shadow
+ * with geometry and no color, which renders as an opaque black one rather than as no shadow. Removing
+ * a shadow is what zeroing its axes is for.
+ *
+ * @param {Object}   props          The render-prop's argument.
+ * @param {string}   props.value    The composite's current `color` slot, alpha included.
+ * @param {Function} props.onChange Called with the next `color` slot.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The rendered color field.
+ */
+export function renderShadowColor({ value, onChange }) {
+	const { color, opacity } = splitColorOpacity(value);
+
+	return (
+		<PopColorControl
+			value={color || ''}
+			default={'#000000'}
+			hideClear={true}
+			opacityValue={opacity}
+			onChange={(next) => onChange(combineColorOpacity(next, opacity))}
+			onOpacityChange={(next) => onChange(combineColorOpacity(color, next))}
+			onArrayChange={(next, nextOpacity) => onChange(combineColorOpacity(next, nextOpacity))}
+		/>
+	);
+}

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -32,21 +32,35 @@ export { TokenControlRow } from './components/TokenControlRow';
 export { useLinkedMeasureState } from './use-linked-measure-state';
 
 /**
- * The device-specific attribute name for a dimension control, by the same `tablet${Capitalized}` /
- * `mobile${Capitalized}` convention `resetAttrPatch` clears — the single spelling, so a reader that
+ * The device-specific attribute name for a dimension control — the single spelling, so a reader that
  * only checks the desktop attribute cannot silently disagree with the one that resets all three.
  *
- * @param {string} attr   The desktop attribute name.
- * @param {string} device The active preview device ('Desktop' | 'Tablet' | 'Mobile'); defaults to
- *                          desktop for a caller with no device context.
+ * The binding's own `responsive_attrs` wins when it declares one. Most blocks name their companions
+ * `tablet${Capitalized}` / `mobile${Capitalized}` and the convention answers, but that is a naming
+ * habit rather than a rule: `kadence/image` stores padding as `paddingDesktop` / `paddingTablet` /
+ * `paddingMobile`, where the convention would ask for `tabletPaddingDesktop` — an attribute that does
+ * not exist. Reading it returns nothing, so Tablet and Mobile always looked unset, and a reset wrote
+ * the invented name instead of clearing the real one. The declaration is why `responsive_attrs` is in
+ * the bindings at all; this is the reader honoring it.
+ *
+ * @param {string}  attr             The desktop attribute name.
+ * @param {string}  device           The active preview device ('Desktop' | 'Tablet' | 'Mobile');
+ *                                    defaults to desktop for a caller with no device context.
+ * @param {?Object} [responsiveAttrs] The binding's declared `{ tablet, mobile }` attribute names.
  *
  * @since TBD
  *
  * @return {string} The attribute the given device stores its value in.
  */
-function deviceAttrFor(attr, device) {
+function deviceAttrFor(attr, device, responsiveAttrs) {
 	if ('Tablet' !== device && 'Mobile' !== device) {
 		return attr;
+	}
+
+	const declaredName = get(responsiveAttrs, [device.toLowerCase()], '');
+
+	if (declaredName) {
+		return declaredName;
 	}
 
 	const capitalized = attr.charAt(0).toUpperCase() + attr.slice(1);
@@ -213,7 +227,7 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
 		// nested-shape read) because `resetAttrPatch`'s own `'border'` case already clears the tablet/
 		// mobile companions — the compare and the reset must agree on which attribute is "the" one.
 		const isDeviceAware = kind === 'dimension' || !!axis;
-		const deviceAttr = isDeviceAware ? deviceAttrFor(attr, previewDevice) : attr;
+		const deviceAttr = isDeviceAware ? deviceAttrFor(attr, previewDevice, property.responsive_attrs) : attr;
 		const devicePresetValue = isDeviceAware
 			? presetValueForDevice(presetValue, propertyBreakpoints, previewDevice)
 			: presetValue;
@@ -259,6 +273,9 @@ export function usePresetBinding(blockName, attributes, library, previewDevice) 
 			kind,
 			presetValue,
 			responsive: propertyBreakpoints,
+			// Carried through so a reset clears the same attributes this entry was read from, rather than
+			// re-deriving names by a convention the block may not follow.
+			responsiveAttrs: property.responsive_attrs,
 			bound: owned,
 			overridden,
 		};
@@ -369,12 +386,12 @@ export function presetPropertyReference(blockName, propertyKey, attributes, libr
  *
  * @return {Object} The attribute patch to pass to `setAttributes`.
  */
-export function resetAttrPatch(attr, kind, declared) {
+export function resetAttrPatch(attr, kind, declared, responsiveAttrs) {
 	if (kind === 'border') {
 		return {
 			[attr]: [],
-			[deviceAttrFor(attr, 'Tablet')]: [],
-			[deviceAttrFor(attr, 'Mobile')]: [],
+			[deviceAttrFor(attr, 'Tablet', responsiveAttrs)]: [],
+			[deviceAttrFor(attr, 'Mobile', responsiveAttrs)]: [],
 		};
 	}
 
@@ -390,11 +407,11 @@ export function resetAttrPatch(attr, kind, declared) {
 	const isSides = !declared || Array.isArray(declared[attr]?.default);
 
 	if (!isSides) {
-		return withDeviceCompanions({ [attr]: '' }, attr, declared, '');
+		return withDeviceCompanions({ [attr]: '' }, attr, declared, '', responsiveAttrs);
 	}
 
 	const emptySides = ['', '', '', ''];
-	const patch = withDeviceCompanions({ [attr]: emptySides }, attr, declared, emptySides);
+	const patch = withDeviceCompanions({ [attr]: emptySides }, attr, declared, emptySides, responsiveAttrs);
 
 	// Only when the block declares the companion: `borderRadius` has `borderRadiusUnit`, `size` has no
 	// `sizeUnit`, and writing one would leave an attribute the block never reads.
@@ -451,17 +468,19 @@ function withPaletteClassCompanions(patch, attr, kind, declared) {
  * never declared.
  *
  * @param {Object}  patch    The patch so far.
- * @param {string}  attr     The primary attribute name.
- * @param {?Object} declared The block's declared attributes, or undefined when unknown.
- * @param {*}       empty    The cleared value to write.
+ * @param {string}  attr             The primary attribute name.
+ * @param {?Object} declared         The block's declared attributes, or undefined when unknown.
+ * @param {*}       empty            The cleared value to write.
+ * @param {?Object} [responsiveAttrs] The binding's declared `{ tablet, mobile }` names, when it
+ *                                    spells its companions something other than the convention.
  *
  * @since TBD
  *
  * @return {Object} The patch, with any companions added.
  */
-function withDeviceCompanions(patch, attr, declared, empty) {
+function withDeviceCompanions(patch, attr, declared, empty, responsiveAttrs) {
 	['Tablet', 'Mobile'].forEach((device) => {
-		const companion = deviceAttrFor(attr, device);
+		const companion = deviceAttrFor(attr, device, responsiveAttrs);
 
 		if (!declared || declared[companion]) {
 			patch[companion] = empty;
@@ -474,16 +493,19 @@ function withDeviceCompanions(patch, attr, declared, empty) {
 /**
  * Clear a mapped control's attribute(s) back to their block.json default shape (see `resetAttrPatch`).
  *
- * @param {string}   attr          The primary attribute name.
- * @param {Function} setAttributes The block's setAttributes.
- * @param {string}   kind          The property kind, so a dimension also clears its companions.
+ * @param {string}   attr             The primary attribute name.
+ * @param {Function} setAttributes    The block's setAttributes.
+ * @param {string}   kind             The property kind, so a dimension also clears its companions.
+ * @param {?Object}  [declared]       The block's declared attributes, so only companions it really
+ *                                     has are written.
+ * @param {?Object}  [responsiveAttrs] The binding's declared `{ tablet, mobile }` attribute names.
  *
  * @since TBD
  *
  * @return {void}
  */
-export function resetAttr(attr, setAttributes, kind, declared) {
-	setAttributes(resetAttrPatch(attr, kind, declared));
+export function resetAttr(attr, setAttributes, kind, declared, responsiveAttrs) {
+	setAttributes(resetAttrPatch(attr, kind, declared, responsiveAttrs));
 }
 
 /**

--- a/tests/wpunit/Blocks/ImageTest.php
+++ b/tests/wpunit/Blocks/ImageTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\wpunit\Blocks;
 
+use Kadence_Blocks_CSS;
 use Kadence_Blocks_Image_Block;
 use Tests\Support\Classes\KadenceBlocksUnit;
 
@@ -20,10 +21,161 @@ class ImageTest extends KadenceBlocksUnit {
 	 */
 	protected $block;
 
+	/**
+	 * The CSS builder each render writes into.
+	 *
+	 * @since TBD
+	 *
+	 * @var Kadence_Blocks_CSS
+	 */
+	protected $css;
+
 	protected function setUp(): void {
 		parent::setUp();
+
 		$this->block = new Kadence_Blocks_Image_Block();
+		$this->css   = new Kadence_Blocks_CSS();
 	}
 
+	/**
+	 * A shadow with real geometry emits `box-shadow` even though no `displayBoxShadow` attribute is
+	 * supplied — the value's own axes are the only gate now that the enable boolean is gone.
+	 *
+	 * @return void
+	 */
+	public function testVisibleShadowEmitsWithoutAnEnableFlag(): void {
+		$output = $this->render_image(
+			[
+				'boxShadow' => [
+					[
+						'color'   => '#000000',
+						'opacity' => 0.2,
+						'hOffset' => 0,
+						'vOffset' => 4,
+						'blur'    => 14,
+						'spread'  => 0,
+						'inset'   => false,
+					],
+				],
+			]
+		);
 
+		$this->assertStringContainsString( 'box-shadow', $output );
+	}
+
+	/**
+	 * An all-zero shadow emits nothing. This is what makes the registered default safe: a fresh image
+	 * carries that value and must render exactly as it did when a `false` boolean suppressed it.
+	 *
+	 * @return void
+	 */
+	public function testAllZeroShadowEmitsNothing(): void {
+		$output = $this->render_image(
+			[
+				'boxShadow' => [
+					[
+						'color'   => 'transparent',
+						'opacity' => 1,
+						'hOffset' => 0,
+						'vOffset' => 0,
+						'blur'    => 0,
+						'spread'  => 0,
+						'inset'   => false,
+					],
+				],
+			]
+		);
+
+		$this->assertStringNotContainsString( 'box-shadow', $output );
+	}
+
+	/**
+	 * A colored shadow with no geometry paints nothing on the page, so it emits nothing either —
+	 * color alone never makes a shadow visible.
+	 *
+	 * @return void
+	 */
+	public function testColoredShadowWithNoGeometryEmitsNothing(): void {
+		$output = $this->render_image(
+			[
+				'boxShadow' => [
+					[
+						'color'   => '#ff0000',
+						'opacity' => 1,
+						'hOffset' => 0,
+						'vOffset' => 0,
+						'blur'    => 0,
+						'spread'  => 0,
+						'inset'   => false,
+					],
+				],
+			]
+		);
+
+		$this->assertStringNotContainsString( 'box-shadow', $output );
+	}
+
+	/**
+	 * A design-token alias in a geometry leg counts as visible: it resolves to a `var()` whose value
+	 * the renderer cannot read, and treating it as a zero would drop a shadow the token does paint.
+	 *
+	 * @return void
+	 */
+	public function testTokenAliasGeometryCountsAsVisible(): void {
+		$output = $this->render_image(
+			[
+				'boxShadow' => [
+					[
+						'color'   => '#000000',
+						'opacity' => 0.2,
+						'hOffset' => 0,
+						'vOffset' => '{semantic.shadow.media}',
+						'blur'    => 0,
+						'spread'  => 0,
+						'inset'   => false,
+					],
+				],
+			]
+		);
+
+		$this->assertStringContainsString( 'box-shadow', $output );
+	}
+
+	/**
+	 * A border radius stored as a design-token alias reaches the rendered CSS as that token's
+	 * variable rather than as a literal, which is what the editor's own inline style has to agree
+	 * with.
+	 *
+	 * @return void
+	 */
+	public function testBorderRadiusTokenAliasRendersAsAVariable(): void {
+		$output = $this->render_image(
+			[
+				'borderRadius'     => [ '{semantic.radius.media}', '', '', '' ],
+				'borderRadiusUnit' => 'px',
+			]
+		);
+
+		$this->assertStringContainsString( 'var(--kb-token--semantic--radius--media)', $output );
+	}
+
+	/**
+	 * Build the block's CSS for a set of attributes, mirroring `SinglebtnTest::render_button()`.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $attributes The block attributes to render.
+	 *
+	 * @return string The rendered CSS.
+	 */
+	private function render_image( array $attributes ): string {
+		$unique_id = '123';
+
+		return $this->block->build_css(
+			array_merge( [ 'uniqueID' => $unique_id ], $attributes ),
+			$this->css,
+			$unique_id,
+			$unique_id
+		);
+	}
 }

--- a/tests/wpunit/Blocks/ImageTest.php
+++ b/tests/wpunit/Blocks/ImageTest.php
@@ -28,7 +28,7 @@ class ImageTest extends KadenceBlocksUnit {
 	 *
 	 * @var Kadence_Blocks_CSS
 	 */
-	protected $css;
+	protected Kadence_Blocks_CSS $css;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -38,15 +38,16 @@ class ImageTest extends KadenceBlocksUnit {
 	}
 
 	/**
-	 * A shadow with real geometry emits `box-shadow` even though no `displayBoxShadow` attribute is
-	 * supplied — the value's own axes are the only gate now that the enable boolean is gone.
+	 * A shadow with real geometry and its flag set emits `box-shadow`. This is the shape the editor
+	 * writes now: the flag is no longer a control, but it is still stored, derived from the value.
 	 *
 	 * @return void
 	 */
-	public function testVisibleShadowEmitsWithoutAnEnableFlag(): void {
+	public function testVisibleShadowEmits(): void {
 		$output = $this->render_image(
 			[
-				'boxShadow' => [
+				'displayBoxShadow' => true,
+				'boxShadow'        => [
 					[
 						'color'   => '#000000',
 						'opacity' => 0.2,
@@ -61,6 +62,35 @@ class ImageTest extends KadenceBlocksUnit {
 		);
 
 		$this->assertStringContainsString( 'box-shadow', $output );
+	}
+
+	/**
+	 * The case this flag exists to protect: a block saved before the enable toggle was removed, with
+	 * real shadow values behind a toggle that was switched OFF. Gutenberg omits an attribute equal to
+	 * its default, and that toggle defaulted to false, so such a block stores its values and NO flag —
+	 * geometry alone would start rendering a shadow the page has never shown.
+	 *
+	 * @return void
+	 */
+	public function testLegacyShadowLeftOffStaysOff(): void {
+		$output = $this->render_image(
+			[
+				// No `displayBoxShadow` key at all, exactly as that content serializes.
+				'boxShadow' => [
+					[
+						'color'   => '#04ff00',
+						'opacity' => 1,
+						'hOffset' => 10,
+						'vOffset' => 10,
+						'blur'    => 0,
+						'spread'  => 0,
+						'inset'   => false,
+					],
+				],
+			]
+		);
+
+		$this->assertStringNotContainsString( 'box-shadow', $output );
 	}
 
 	/**
@@ -124,7 +154,8 @@ class ImageTest extends KadenceBlocksUnit {
 	public function testTokenAliasGeometryCountsAsVisible(): void {
 		$output = $this->render_image(
 			[
-				'boxShadow' => [
+				'displayBoxShadow' => true,
+				'boxShadow'        => [
 					[
 						'color'   => '#000000',
 						'opacity' => 0.2,

--- a/tests/wpunit/Blocks/SinglebtnTest.php
+++ b/tests/wpunit/Blocks/SinglebtnTest.php
@@ -179,6 +179,7 @@ class SinglebtnTest extends KadenceBlocksUnit {
 		$output = $this->render_button(
 			[
 				'kbPreset' => 'accent',
+				'displayShadow' => true,
 				'shadow'   => [
 					[
 						'color'   => '#00ff00',
@@ -308,6 +309,7 @@ class SinglebtnTest extends KadenceBlocksUnit {
 		$output = $this->render_button(
 			[
 				'kbPreset' => 'bare',
+				'displayShadow' => true,
 				'shadow'   => [
 					[
 						'color'   => 'transparent',
@@ -342,6 +344,7 @@ class SinglebtnTest extends KadenceBlocksUnit {
 			[
 				'kbPreset'    => 'bare',
 				'colorHover'  => '#0000ff',
+				'displayShadow' => true,
 				'shadow'      => [
 					[
 						'color'   => '#00ff00',
@@ -353,6 +356,7 @@ class SinglebtnTest extends KadenceBlocksUnit {
 						'inset'   => false,
 					],
 				],
+				'displayHoverShadow' => true,
 				'shadowHover' => [
 					[
 						'color'   => 'transparent',
@@ -400,6 +404,7 @@ class SinglebtnTest extends KadenceBlocksUnit {
 				'backgroundHoverType' => 'gradient',
 				'gradientHover'       => 'linear-gradient(90deg, #ff0000, #0000ff)',
 				'colorHover'          => '#0000ff',
+				'displayShadow'       => true,
 				'shadow'              => [
 					[
 						'color'   => '#00ff00',
@@ -411,6 +416,7 @@ class SinglebtnTest extends KadenceBlocksUnit {
 						'inset'   => false,
 					],
 				],
+				'displayHoverShadow'  => true,
 				'shadowHover'         => [
 					[
 						'color'   => 'transparent',
@@ -453,6 +459,7 @@ class SinglebtnTest extends KadenceBlocksUnit {
 			[
 				'kbPreset'          => 'bare',
 				'colorTransparent'  => '#0000ff',
+				'displayShadow'     => true,
 				'shadow'            => [
 					[
 						'color'   => '#00ff00',
@@ -464,6 +471,7 @@ class SinglebtnTest extends KadenceBlocksUnit {
 						'inset'   => false,
 					],
 				],
+				'displayShadowTransparent' => true,
 				'shadowTransparent' => [
 					[
 						'color'   => 'transparent',
@@ -508,6 +516,7 @@ class SinglebtnTest extends KadenceBlocksUnit {
 			[
 				'kbPreset'     => 'bare',
 				'colorSticky'  => '#0000ff',
+				'displayShadow' => true,
 				'shadow'       => [
 					[
 						'color'   => '#00ff00',
@@ -519,6 +528,7 @@ class SinglebtnTest extends KadenceBlocksUnit {
 						'inset'   => false,
 					],
 				],
+				'displayShadowSticky' => true,
 				'shadowSticky' => [
 					[
 						'color'   => 'transparent',
@@ -566,6 +576,7 @@ class SinglebtnTest extends KadenceBlocksUnit {
 		$output = $this->render_button(
 			[
 				'kbPreset' => 'accent',
+				'displayShadow' => true,
 				'shadow'   => [
 					[
 						'color'   => 'transparent',
@@ -601,6 +612,7 @@ class SinglebtnTest extends KadenceBlocksUnit {
 		$output = $this->render_button(
 			[
 				'kbPreset' => 'bare',
+				'displayShadow' => true,
 				'shadow'   => [
 					[
 						'color'   => '#00ff00',
@@ -636,6 +648,7 @@ class SinglebtnTest extends KadenceBlocksUnit {
 		$output = $this->render_button(
 			[
 				'kbPreset' => 'bare',
+				'displayShadow' => true,
 				'shadow'   => [
 					[
 						'color'   => '#00ff00',


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4263/token-pickable-block-controls-for-the-remaining-alpha-blocks-row
:video_camera: https://www.loom.com/share/9363726b1a30466a9d6e8fb429f82f2d

The Advanced Image's preset screen offers all four, and each binds a token. Radius and Padding become `EditorBoxControl` (corners and sides), Shadow becomes `EditorShadowControl`, Background becomes `ColorControl`. Padding names its per-device siblings explicitly, since this block does not follow the bare-plus-prefix convention the others use.

Lifts `renderShadowColor` out of the Button into its own module for both call sites to share. It was never block-specific — it bridges the composite's alpha-in-color slot to `PopColorControl`'s two channels. Its own module rather than `EditorShadowControl.js` because it is the one piece that imports `@kadence/components`, whose `dist/cjs` build Jest cannot parse.

**Also removes the Enable Box Shadow toggle**, following the Button's own migration: an all-zero shadow paints nothing, so it IS the off state, and a separate boolean could only ever disagree with it. `displayBoxShadow` is dropped and `boxShadow`'s registered default becomes an invisible shadow, so a fresh image renders exactly as it did when a `false` boolean suppressed the old visible default. `has_visible_shadow()` moves from the Button, where it was private, up to `Kadence_Blocks_Abstract_Block` as protected — it answers a question about the shared shadow value shape rather than about any one block. `hasVisibleShadow()` mirrors it in JS so the editor preview and the rendered page agree.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added design-token controls for image colors, border radius, padding, and shadows.
  * Added support for token-based shadow and border-radius values across responsive settings.
  * Improved shared shadow color controls for image and button styling.

* **Bug Fixes**
  * Prevented empty or zero-value shadows from generating unwanted visual effects.
  * Updated image styling defaults to use no visible shadow unless configured.
  * Improved shadow visibility handling for token-based values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
