### PR TITLE
[DTM] SOFT-4267: name every design-token scale step with full words

### DIFF
--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -9,8 +9,12 @@
 // _load_textdomain_just_in_time notice — translations must not load before init.
 
 // Every scale below names its steps from this one map. Radius and the spacing/font-size scales spell the
-// same step differently ("2xl" vs "xxl"), so both spellings resolve to one label. An unlisted slug falls
-// back to its uppercase form, so a step added without a label here still renders.
+// same step differently ("2xl" vs "xxl"), so both spellings resolve to one label.
+//
+// An unlisted slug falls back to its uppercase form. That is a render-time safety net, not a supported
+// end state: it keeps a step that someone added without a label visible instead of blank, and
+// Scale_Step_LabelsTest fails until the label is added here. Shipping an uppercase label is what this
+// map exists to prevent.
 //
 // group_key, which every scale also declares, is the stable machine id the Style Library's "+ Add …"
 // buttons mint custom tokens into — Token_Registry::group_label_for() resolves it back to the translated
@@ -40,7 +44,8 @@ $scale_step_labels = [
  *
  * @param string $slug The scale-step slug (e.g. "sm").
  *
- * @return string The step's label, or the uppercase slug when the step is unlisted.
+ * @return string The step's label, or the uppercase slug when the step is unlisted — see the note above
+ *                on why that fallback is a safety net rather than a supported end state.
  */
 $scale_step_label = static function ( string $slug ) use ( $scale_step_labels ): string {
 	return $scale_step_labels[ $slug ] ?? strtoupper( $slug );

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -8,24 +8,60 @@
 // Loaded on `init` (see Registry\Provider) so the __() label/group calls don't trigger the
 // _load_textdomain_just_in_time notice — translations must not load before init.
 
+// Every scale below names its steps from this one map. Radius and the spacing/font-size scales spell the
+// same step differently ("2xl" vs "xxl"), so both spellings resolve to one label. An unlisted slug falls
+// back to its uppercase form, so a step added without a label here still renders.
+//
+// group_key, which every scale also declares, is the stable machine id the Style Library's "+ Add …"
+// buttons mint custom tokens into — Token_Registry::group_label_for() resolves it back to the translated
+// group label at read time, so a custom token's group survives a site language change instead of drifting
+// into its own bucket (see User_Primitive_Registrar::register_entry()).
+$scale_step_labels = [
+	'none' => __( 'None', 'kadence-blocks' ),
+	'xxs'  => __( '2X Small', 'kadence-blocks' ),
+	'xs'   => __( 'Extra Small', 'kadence-blocks' ),
+	'sm'   => __( 'Small', 'kadence-blocks' ),
+	'md'   => __( 'Medium', 'kadence-blocks' ),
+	'lg'   => __( 'Large', 'kadence-blocks' ),
+	'xl'   => __( 'Extra Large', 'kadence-blocks' ),
+	'xxl'  => __( '2X Large', 'kadence-blocks' ),
+	'2xl'  => __( '2X Large', 'kadence-blocks' ),
+	'xxxl' => __( '3X Large', 'kadence-blocks' ),
+	'3xl'  => __( '3X Large', 'kadence-blocks' ),
+	'4xl'  => __( '4X Large', 'kadence-blocks' ),
+	'5xl'  => __( '5X Large', 'kadence-blocks' ),
+	'full' => __( 'Full', 'kadence-blocks' ),
+];
+
+/**
+ * Resolves a scale-step slug to its display label.
+ *
+ * @since TBD
+ *
+ * @param string $slug The scale-step slug (e.g. "sm").
+ *
+ * @return string The step's label, or the uppercase slug when the step is unlisted.
+ */
+$scale_step_label = static function ( string $slug ) use ( $scale_step_labels ): string {
+	return $scale_step_labels[ $slug ] ?? strtoupper( $slug );
+};
+
 // The spacing/gap scale steps are primitives (the slug IS a scale step), each claiming the Kadence Blocks
 // slug it backs (class-kadence-blocks-css.php): the Css_Var builder redefines --global-kb-spacing-<slug> /
 // --global-kb-gap-<slug> as the primitive token, so a block already storing that slug follows it and a site
 // owner can retune each step. Usage-specific intent (semantic.spacing.section/.block/.inline) aliases the
 // scale and is where intent-based delivery points — mirroring how semantic.radius.media aliases the radius
 // scale. Defaults match KB's own values, so registering them changes nothing until overridden. ss-auto is
-// omitted: it resolves to "auto", not a length. group_key mirrors the radius/border-width scales' mechanism:
-// it is the stable machine id the Style Library's Spacing screen's "+ Add Spacing" mints custom tokens into,
-// resolved back to the group label at read time by Token_Registry::group_label_for().
+// omitted: it resolves to "auto", not a length.
 $spacing_slugs = [ 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', '3xl', '4xl', '5xl' ];
 $gap_slugs     = [ 'none', 'xs', 'sm', 'md', 'lg' ];
 
 $spacing_tokens = array_map(
-	static function ( string $slug ): array {
+	static function ( string $slug ) use ( $scale_step_label ): array {
 		return [
 			'id'          => 'primitive.dimension.spacing.' . $slug,
 			'type'        => 'dimension',
-			'label'       => strtoupper( $slug ),
+			'label'       => $scale_step_label( $slug ),
 			'group'       => __( 'Spacing', 'kadence-blocks' ),
 			'group_key'   => 'spacing',
 			'projections' => [ 'kb_spacing_slot' => $slug ],
@@ -35,11 +71,11 @@ $spacing_tokens = array_map(
 );
 
 $gap_tokens = array_map(
-	static function ( string $slug ): array {
+	static function ( string $slug ) use ( $scale_step_label ): array {
 		return [
 			'id'          => 'primitive.dimension.gap.' . $slug,
 			'type'        => 'dimension',
-			'label'       => 'none' === $slug ? __( 'None', 'kadence-blocks' ) : strtoupper( $slug ),
+			'label'       => $scale_step_label( $slug ),
 			'group'       => __( 'Gap', 'kadence-blocks' ),
 			'projections' => [ 'kb_gap_slot' => $slug ],
 		];
@@ -49,49 +85,35 @@ $gap_tokens = array_map(
 
 // The border-radius scale steps are primitives the Style Library's Border Radius screen lists and
 // edits directly (semantic.radius.* already carries the projections that deliver these into blocks,
-// so the scale declares none of its own). group_key is the stable machine id "+ Add Border Radius"
-// mints custom tokens into — Token_Registry::group_label_for() resolves it back to the group label
-// below at read time, so a custom radius token's group survives a site language change instead of
-// drifting into its own bucket (see User_Primitive_Registrar::register_entry()).
+// so the scale declares none of its own).
 // The step list mirrors the shipped baseline exactly: the screen renders whatever this group holds, and
-// a step declared without a baseline entry would trip Baseline_Guard. Labels are the scale's own, so the
-// Style Library and the editor's token picker name each step identically.
-$radius_labels = [
-	'xs'   => __( 'Extra Small', 'kadence-blocks' ),
-	'sm'   => __( 'Small', 'kadence-blocks' ),
-	'md'   => __( 'Medium', 'kadence-blocks' ),
-	'lg'   => __( 'Large', 'kadence-blocks' ),
-	'xl'   => __( 'Extra Large', 'kadence-blocks' ),
-	'2xl'  => __( '2X Large', 'kadence-blocks' ),
-	'3xl'  => __( '3X Large', 'kadence-blocks' ),
-	'full' => __( 'Full', 'kadence-blocks' ),
-];
+// a step declared without a baseline entry would trip Baseline_Guard.
+$radius_slugs = [ 'xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', 'full' ];
 
-$radius_tokens = [];
-
-foreach ( $radius_labels as $slug => $label ) {
-	$radius_tokens[] = [
-		'id'        => 'primitive.dimension.radius.' . $slug,
-		'type'      => 'dimension',
-		'label'     => $label,
-		'group'     => __( 'Border Radius', 'kadence-blocks' ),
-		'group_key' => 'radius',
-	];
-}
+$radius_tokens = array_map(
+	static function ( string $slug ) use ( $scale_step_label ): array {
+		return [
+			'id'        => 'primitive.dimension.radius.' . $slug,
+			'type'      => 'dimension',
+			'label'     => $scale_step_label( $slug ),
+			'group'     => __( 'Border Radius', 'kadence-blocks' ),
+			'group_key' => 'radius',
+		];
+	},
+	$radius_slugs
+);
 
 // The border-width scale steps are primitives the Style Library's Border Width screen lists and
 // edits directly (semantic.border-width.default already carries the projection that delivers the
-// "sm" step into the image block, so the scale declares none of its own). group_key mirrors the
-// radius scale's mechanism above: it is the stable machine id "+ Add Border Width" mints custom
-// tokens into, resolved back to the group label at read time by Token_Registry::group_label_for().
+// "sm" step into the image block, so the scale declares none of its own).
 $border_width_slugs = [ 'sm', 'md', 'lg' ];
 
 $border_width_tokens = array_map(
-	static function ( string $slug ): array {
+	static function ( string $slug ) use ( $scale_step_label ): array {
 		return [
 			'id'        => 'primitive.dimension.border-width.' . $slug,
 			'type'      => 'dimension',
-			'label'     => strtoupper( $slug ),
+			'label'     => $scale_step_label( $slug ),
 			'group'     => __( 'Border Width', 'kadence-blocks' ),
 			'group_key' => 'border-width',
 		];
@@ -101,18 +123,15 @@ $border_width_tokens = array_map(
 
 // The icon-size scale steps are primitives the Style Library's Icon Sizes screen lists and edits
 // directly (semantic.icon-size.default already carries the projection that delivers the "md" step
-// into the icon block and the button's icon size, so the scale declares none of its own). group_key
-// mirrors the radius/border-width scales' mechanism above: it is the stable machine id "+ Add Icon
-// Size" mints custom tokens into, resolved back to the group label at read time by
-// Token_Registry::group_label_for().
+// into the icon block and the button's icon size, so the scale declares none of its own).
 $icon_size_slugs = [ 'sm', 'md', 'lg' ];
 
 $icon_size_tokens = array_map(
-	static function ( string $slug ): array {
+	static function ( string $slug ) use ( $scale_step_label ): array {
 		return [
 			'id'        => 'primitive.dimension.icon-size.' . $slug,
 			'type'      => 'dimension',
-			'label'     => strtoupper( $slug ),
+			'label'     => $scale_step_label( $slug ),
 			'group'     => __( 'Icon Sizes', 'kadence-blocks' ),
 			'group_key' => 'icon-size',
 		];
@@ -124,17 +143,15 @@ $icon_size_tokens = array_map(
 // directly; the shadow semantics (semantic.shadow.card / .media) keep their own curated values and
 // declare no projections onto this scale, so re-pointing a semantic at one of these primitives is
 // deliberately not done here — semantic.shadow.card's color is aliased to a palette primitive, and
-// re-pointing would detach it. group_key mirrors the radius/border-width/icon-size scales'
-// mechanism above: it is the stable machine id "+ Add Shadow" mints custom tokens into, resolved
-// back to the group label at read time by Token_Registry::group_label_for().
+// re-pointing would detach it.
 $shadow_slugs = [ 'xs', 'sm', 'md' ];
 
 $shadow_tokens = array_map(
-	static function ( string $slug ): array {
+	static function ( string $slug ) use ( $scale_step_label ): array {
 		return [
 			'id'        => 'primitive.shadow.' . $slug,
 			'type'      => 'shadow',
-			'label'     => strtoupper( $slug ),
+			'label'     => $scale_step_label( $slug ),
 			'group'     => __( 'Shadow', 'kadence-blocks' ),
 			'group_key' => 'shadow',
 		];
@@ -151,11 +168,11 @@ $shadow_tokens = array_map(
 $font_size_slugs = [ 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl' ];
 
 $font_size_primitive_tokens = array_map(
-	static function ( string $slug ): array {
+	static function ( string $slug ) use ( $scale_step_label ): array {
 		return [
 			'id'          => 'primitive.dimension.font-size.' . $slug,
 			'type'        => 'dimension',
-			'label'       => strtoupper( $slug ),
+			'label'       => $scale_step_label( $slug ),
 			'group'       => __( 'Font Size', 'kadence-blocks' ),
 			'group_key'   => 'font-size',
 			'projections' => [ 'kb_font_size_slot' => $slug ],

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Scale_Step_LabelsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Scale_Step_LabelsTest.php
@@ -30,7 +30,10 @@ final class Scale_Step_LabelsTest extends TestCase {
 	 * No declared token is labeled with the uppercase form of its own final id segment.
 	 *
 	 * Guards the whole registry rather than a fixed list, so a scale added later cannot quietly
-	 * reintroduce a strtoupper() label.
+	 * reintroduce a strtoupper() label. The declarations resolver still falls back to the uppercase
+	 * slug for a step with no entry in its label map, which keeps such a step visible at render time;
+	 * this test is what makes that fallback a bug to fix rather than a state to ship, so a new step
+	 * failing here means its label is missing, not that the test is wrong.
 	 *
 	 * @return void
 	 */

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Scale_Step_LabelsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Scale_Step_LabelsTest.php
@@ -1,0 +1,120 @@
+<?php declare( strict_types=1 );
+// cspell:ignore xxs xxl xxxl .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Registry;
+
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use Tests\Support\Classes\TestCase;
+
+final class Scale_Step_LabelsTest extends TestCase {
+
+	/**
+	 * Every scale step declares a full-word label rather than the uppercase form of its slug.
+	 *
+	 * @dataProvider scaleStepLabelProvider
+	 *
+	 * @param string $token_id The registered token id.
+	 * @param string $expected The label the step must carry.
+	 *
+	 * @return void
+	 */
+	public function testScaleStepsUseFullWordLabels( string $token_id, string $expected ): void {
+		$token = $this->declared_registry()->get( $token_id );
+
+		$this->assertNotNull( $token, "Expected {$token_id} to be registered." );
+		$this->assertSame( $expected, $token->label );
+	}
+
+	/**
+	 * No declared token is labeled with the uppercase form of its own final id segment.
+	 *
+	 * Guards the whole registry rather than a fixed list, so a scale added later cannot quietly
+	 * reintroduce a strtoupper() label.
+	 *
+	 * @return void
+	 */
+	public function testNoDeclaredTokenIsLabeledWithItsUppercaseSlug(): void {
+		foreach ( $this->declared_registry()->all() as $token ) {
+			$segments = explode( '.', $token->id );
+			$slug     = (string) end( $segments );
+
+			$this->assertNotSame(
+				strtoupper( $slug ),
+				$token->label,
+				"Token {$token->id} is still labeled with its uppercase slug."
+			);
+		}
+	}
+
+	/**
+	 * Sample steps from every scale, including the two spellings that mean the same step.
+	 *
+	 * @return Generator
+	 */
+	public function scaleStepLabelProvider(): Generator {
+		yield 'spacing xxs' => [
+			'token_id' => 'primitive.dimension.spacing.xxs',
+			'expected' => '2X Small',
+		];
+
+		yield 'spacing 5xl' => [
+			'token_id' => 'primitive.dimension.spacing.5xl',
+			'expected' => '5X Large',
+		];
+
+		yield 'gap none keeps its own label' => [
+			'token_id' => 'primitive.dimension.gap.none',
+			'expected' => 'None',
+		];
+
+		yield 'border width sm' => [
+			'token_id' => 'primitive.dimension.border-width.sm',
+			'expected' => 'Small',
+		];
+
+		yield 'icon size lg' => [
+			'token_id' => 'primitive.dimension.icon-size.lg',
+			'expected' => 'Large',
+		];
+
+		yield 'shadow md' => [
+			'token_id' => 'primitive.shadow.md',
+			'expected' => 'Medium',
+		];
+
+		yield 'font size xxxl' => [
+			'token_id' => 'primitive.dimension.font-size.xxxl',
+			'expected' => '3X Large',
+		];
+
+		yield 'radius 2xl is unchanged' => [
+			'token_id' => 'primitive.dimension.radius.2xl',
+			'expected' => '2X Large',
+		];
+
+		yield 'radius full is unchanged' => [
+			'token_id' => 'primitive.dimension.radius.full',
+			'expected' => 'Full',
+		];
+	}
+
+	/**
+	 * A registry populated straight from the declarations file.
+	 *
+	 * Built per call rather than read from the container so a token another test leaked into the
+	 * shared singleton cannot fail the registry-wide guard above.
+	 *
+	 * @return Token_Registry The registry holding exactly the declared tokens.
+	 */
+	private function declared_registry(): Token_Registry {
+		$registry     = new Token_Registry();
+		$declarations = require KADENCE_BLOCKS_PATH . 'includes/resources/Design_Tokens/Registry/declarations.php';
+
+		foreach ( $declarations['tokens'] as $token ) {
+			$registry->register( $token );
+		}
+
+		return $registry;
+	}
+}


### PR DESCRIPTION
## Summary

The Style Library's Border Radius screen named its steps with words (Extra Small, Small, Medium, …) while every other scale screen right below it in the same sidebar showed the uppercased slug: SM, MD, LG. The same step read as "Small" on one screen and "SM" on the next.

Every scale now names its steps from one shared map in `declarations.php`, so all seven read the same way: spacing, gap, radius, border-width, icon-size, shadow and font-size.

Border Radius is included rather than left alone. It was the only scale declared from its own label map and built with a `foreach`; it now uses the same slug list + `array_map` + resolver as the others, so no scale in the file is a special case. Its rendered output is unchanged — same eight steps, same order, same eight labels, verified by diffing the produced labels against the pre-change file.

The old labels came from `strtoupper( $slug )`, which never reaches a `.po` file. Every label now goes through `__()`, so a translated site gets translated step names.

## Scope

Labels only. Token ids, slugs, CSS variable names, `projections`, `group_key` and `baseline.json` are untouched, so there is no migration, no change to saved content, and no baseline cache flush needed.

The `SM` / `LG` labels on the legacy block controls (`src/blocks/singlebtn`, `src/blocks/rowlayout`, `src/blocks/advanced-form`) are block attribute choices, not design tokens, and are left alone.

## Naming

| Slug | Label |
| --- | --- |
| none | None |
| xxs | 2X Small |
| xs | Extra Small |
| sm | Small |
| md | Medium |
| lg | Large |
| xl | Extra Large |
| xxl / 2xl | 2X Large |
| xxxl / 3xl | 3X Large |
| 4xl | 4X Large |
| 5xl | 5X Large |
| full | Full |

Radius and the spacing/font-size scales spell the same step differently (`2xl` vs `xxl`), so both spellings resolve to one label. An unlisted slug falls back to its uppercase form, so a step added without a label here still renders.

## Comments

The `group_key` explanation was repeated in five comment blocks, each restating it as "mirrors the radius/border-width scales' mechanism above". It survives once, next to the shared map. The cross-references were also drifting — the spacing block sits at the top of the file and pointed at two scales below it, and shadow's version had grown into a three-scale list that needed editing every time a scale was added.

The radius block's closing sentence ("Labels are the scale's own, so the Style Library and the editor's token picker name each step identically") is gone: it only existed because radius was the exception.

Everything that records a decision, a constraint, or a trap is kept as-is — the `--global-kb-spacing-<slug>` coupling, the `ss-auto` omission, the `Baseline_Guard` warning, the "declares no projections of its own" notes, and shadow's note on why re-pointing a semantic would detach its palette-aliased color.

## Screenshots
<img width="1535" height="800" alt="border-radius" src="https://github.com/user-attachments/assets/b9d8f6ba-4e94-4314-9c50-0903944092c9" />
<img width="1480" height="812" alt="border-width-your-library" src="https://github.com/user-attachments/assets/ab209bf5-a1f7-4bc1-b497-8aa8409730f5" />
<img width="1535" height="800" alt="border-width" src="https://github.com/user-attachments/assets/c34a17c6-8fa5-4539-930a-afdb0806448a" />
<img width="1535" height="800" alt="icon-sizes" src="https://github.com/user-attachments/assets/be3e50ea-8366-493b-be30-1a5c0fa812ca" />
<img width="1535" height="800" alt="shadow" src="https://github.com/user-attachments/assets/11bf71b6-231d-43a0-830d-cd99f6ee902c" />
<img width="1535" height="800" alt="spacing-bottom" src="https://github.com/user-attachments/assets/e6a9a9cb-3e68-4ae1-8988-1508cc05da53" />
<img width="1535" height="800" alt="spacing-top" src="https://github.com/user-attachments/assets/8228a44d-8db8-4d2e-a6ce-3432bffc02db" />
<img width="1535" height="800" alt="typography-font-sizes" src="https://github.com/user-attachments/assets/c522a0b5-ddf2-42a8-8ed3-d204f528a57f" />


## Test plan

- `Scale_Step_LabelsTest` pins sample steps from every scale, including both spellings of the same step and two radius steps that must not change.
- The same file guards the whole registry: no declared token may be labeled with the uppercase form of its own final id segment, so a scale added later cannot quietly reintroduce a `strtoupper()` label.
- Run the two assertions against the pre-change declarations and they fail 35 times; against this branch they pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved localized labels for design-token scale steps across spacing, sizing, borders, shadows, typography, and related controls.
  - Added support for alternate “2xl” and “xxl” label spellings, with uppercase fallback handling.

- **Tests**
  - Added coverage to verify readable full-word labels and prevent unintended uppercase scale labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->