### PR TITLE
[DTM] SOFT-4201 [1/6]: Screen helper copy catalog

### DIFF
--- a/src/style-library/__tests__/screen-docs.test.js
+++ b/src/style-library/__tests__/screen-docs.test.js
@@ -147,6 +147,35 @@ describe('the screen docs filter', () => {
 	});
 
 	/**
+	 * A scheme is case-insensitive per the URL spec, so an upper-case one is a real link.
+	 *
+	 * @return {void}
+	 */
+	it('accepts a URL whose scheme is upper case', () => {
+		addFilter(SCREEN_DOCS_FILTER, 'test/screen-docs', (docs) => ({
+			...docs,
+			'blocks/acme/widget': { description: 'Style the widget.', docUrl: 'HTTPS://example.com/widget' },
+		}));
+
+		expect(screenDoc('blocks/acme/widget').docUrl).toBe('HTTPS://example.com/widget');
+	});
+
+	/**
+	 * A scheme with nothing after it is not a destination, so it is dropped like any other
+	 * unusable value rather than rendered as a link to nowhere.
+	 *
+	 * @return {void}
+	 */
+	it('drops a URL that carries a scheme but no host', () => {
+		addFilter(SCREEN_DOCS_FILTER, 'test/screen-docs', (docs) => ({
+			...docs,
+			'blocks/acme/widget': { description: 'Style the widget.', docUrl: 'https://' },
+		}));
+
+		expect(screenDoc('blocks/acme/widget')).toEqual({ description: 'Style the widget.', docUrl: '' });
+	});
+
+	/**
 	 * An entry with no sentence has nothing to render, link or not.
 	 *
 	 * @return {void}

--- a/src/style-library/__tests__/screen-docs.test.js
+++ b/src/style-library/__tests__/screen-docs.test.js
@@ -1,0 +1,162 @@
+/* eslint-env jest */
+/**
+ * WordPress dependencies
+ */
+import { addFilter, removeFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { SCREEN_DOCS, SCREEN_DOCS_FILTER } from '../constants/screen-docs';
+import { screenDoc } from '../helpers/screen-docs';
+
+describe('SCREEN_DOCS', () => {
+	/**
+	 * Every catalog entry can be rendered: a sentence to show and an https link to point at.
+	 *
+	 * @return {void}
+	 */
+	it('gives every catalog entry a sentence and an https documentation URL', () => {
+		const entries = Object.entries(SCREEN_DOCS);
+
+		expect(entries).toHaveLength(13);
+
+		entries.forEach(([screenId, doc]) => {
+			expect(typeof doc.description).toBe('string');
+			expect(doc.description.length).toBeGreaterThan(0);
+			expect(doc.docUrl).toMatch(/^https:\/\//);
+			expect(screenId).not.toBe('');
+		});
+	});
+
+	/**
+	 * The catalog covers every screen this plugin ships — the seven Base Styles screens and the
+	 * six block-preset screens — so no shipped screen renders without helper copy.
+	 *
+	 * @return {void}
+	 */
+	it('covers the seven base styles screens and the six preset screens', () => {
+		expect(Object.keys(SCREEN_DOCS).sort()).toEqual(
+			[
+				'blocks/kadence/advancedheading',
+				'blocks/kadence/column',
+				'blocks/kadence/image',
+				'blocks/kadence/rowlayout',
+				'blocks/kadence/single-icon',
+				'blocks/kadence/singlebtn',
+				'border-radius',
+				'border-width',
+				'color-palette',
+				'icon-sizes',
+				'shadow',
+				'spacing',
+				'typography',
+			].sort()
+		);
+	});
+});
+
+describe('screenDoc', () => {
+	/**
+	 * A base styles screen id resolves to its own catalog entry.
+	 *
+	 * @return {void}
+	 */
+	it('returns the catalog entry for a known screen id', () => {
+		expect(screenDoc('border-radius')).toEqual(SCREEN_DOCS['border-radius']);
+	});
+
+	/**
+	 * A block-preset screen id resolves the same way — one key space covers both id shapes.
+	 *
+	 * @return {void}
+	 */
+	it('returns the catalog entry for a preset screen id', () => {
+		expect(screenDoc('blocks/kadence/singlebtn')).toEqual(SCREEN_DOCS['blocks/kadence/singlebtn']);
+	});
+
+	/**
+	 * Every screen this plugin ships has copy; a third-party preset screen does not, and that
+	 * resolves to null rather than to something half-rendered.
+	 *
+	 * @return {void}
+	 */
+	it('returns null for a screen with no entry', () => {
+		expect(screenDoc('blocks/acme/widget')).toBeNull();
+	});
+
+	/**
+	 * A missing or empty screen id is not a lookup at all.
+	 *
+	 * @return {void}
+	 */
+	it('returns null for an empty or missing screen id', () => {
+		expect(screenDoc('')).toBeNull();
+		expect(screenDoc(undefined)).toBeNull();
+	});
+
+	/**
+	 * A screen id comes off the URL, so `?kb-screen=constructor` must not resolve to
+	 * `Object.prototype.constructor`.
+	 *
+	 * @return {void}
+	 */
+	it('returns null for an inherited object property name', () => {
+		expect(screenDoc('constructor')).toBeNull();
+		expect(screenDoc('toString')).toBeNull();
+	});
+});
+
+describe('the screen docs filter', () => {
+	afterEach(() => {
+		removeFilter(SCREEN_DOCS_FILTER, 'test/screen-docs');
+	});
+
+	/**
+	 * A third-party screen can carry its own helper copy without this plugin shipping an entry
+	 * for it.
+	 *
+	 * @return {void}
+	 */
+	it('lets a listener add an entry for a screen the catalog does not ship', () => {
+		addFilter(SCREEN_DOCS_FILTER, 'test/screen-docs', (docs) => ({
+			...docs,
+			'blocks/acme/widget': { description: 'Style the widget.', docUrl: 'https://example.com/widget' },
+		}));
+
+		expect(screenDoc('blocks/acme/widget')).toEqual({
+			description: 'Style the widget.',
+			docUrl: 'https://example.com/widget',
+		});
+	});
+
+	/**
+	 * A filtered entry feeds an `href`, so a non-http(s) scheme is dropped rather than rendered —
+	 * the sentence still shows, without a link.
+	 *
+	 * @return {void}
+	 */
+	it('keeps the sentence but drops a URL that is not http or https', () => {
+		addFilter(SCREEN_DOCS_FILTER, 'test/screen-docs', (docs) => ({
+			...docs,
+			// eslint-disable-next-line no-script-url
+			'blocks/acme/widget': { description: 'Style the widget.', docUrl: 'javascript:alert(1)' },
+		}));
+
+		expect(screenDoc('blocks/acme/widget')).toEqual({ description: 'Style the widget.', docUrl: '' });
+	});
+
+	/**
+	 * An entry with no sentence has nothing to render, link or not.
+	 *
+	 * @return {void}
+	 */
+	it('ignores an entry with no usable sentence', () => {
+		addFilter(SCREEN_DOCS_FILTER, 'test/screen-docs', (docs) => ({
+			...docs,
+			'blocks/acme/widget': { docUrl: 'https://example.com/widget' },
+		}));
+
+		expect(screenDoc('blocks/acme/widget')).toBeNull();
+	});
+});

--- a/src/style-library/constants/screen-docs.js
+++ b/src/style-library/constants/screen-docs.js
@@ -1,0 +1,126 @@
+/**
+ * The per-screen helper copy and documentation links, keyed by screen id — the same id space
+ * `helpers/screens.js` builds (`'color-palette'`, `'blocks/kadence/singlebtn'`). One catalog
+ * rather than a field on each screen's own config: the sentences are reviewed together as copy,
+ * and the short URLs are swapped together when the documentation moves.
+ *
+ * A screen with no entry here renders no description — that is the supported state for a
+ * third-party preset screen, which can register its own entry through the filter below.
+ *
+ * The URLs are short URLs on purpose: the documentation can be reorganized, split, or merged
+ * into one article with anchors without any of these changing.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * The filter a third party (or a white-label build) uses to add, change, or remove screen helper
+ * copy: `addFilter( SCREEN_DOCS_FILTER, 'my-plugin/docs', ( docs ) => ( { ...docs,
+ * 'blocks/my-vendor/my-block': { description: '…', docUrl: 'https://…' } } ) )`. Resolution runs
+ * on every lookup, so a listener added after first render still takes effect.
+ *
+ * @since TBD
+ */
+export const SCREEN_DOCS_FILTER = 'kadence_blocks.style_library.screen_docs';
+
+/**
+ * The shipped catalog. Copy is authored by the documentation owner — do not reword it here.
+ *
+ * @since TBD
+ */
+export const SCREEN_DOCS = {
+	'color-palette': {
+		description: __(
+			"Set the colors your site uses. Change a color here and it updates everywhere it's applied.",
+			'kadence-blocks'
+		),
+		docUrl: 'https://evnt.is/kadence-color-palette',
+	},
+	typography: {
+		description: __(
+			'Set the text sizes your site uses, and pick the fonts you want close to hand.',
+			'kadence-blocks'
+		),
+		docUrl: 'https://evnt.is/kadence-typography',
+	},
+	'border-radius': {
+		description: __(
+			'Set the border radius options your site uses, so buttons, images and cards stay consistent.',
+			'kadence-blocks'
+		),
+		docUrl: 'https://evnt.is/kadence-border-radius',
+	},
+	'border-width': {
+		description: __(
+			'Set the border thickness options your site uses, so borders match across your blocks.',
+			'kadence-blocks'
+		),
+		docUrl: 'https://evnt.is/kadence-border-width',
+	},
+	spacing: {
+		description: __(
+			'Set the padding and margin steps your site uses, so gaps stay consistent from block to block.',
+			'kadence-blocks'
+		),
+		docUrl: 'https://evnt.is/kadence-spacing',
+	},
+	'icon-sizes': {
+		description: __(
+			'Set the sizes your icons can use, so icons stay consistent wherever they appear.',
+			'kadence-blocks'
+		),
+		docUrl: 'https://evnt.is/kadence-icon-sizes',
+	},
+	shadow: {
+		description: __(
+			'Set the shadow styles your site uses, so depth looks consistent across your blocks.',
+			'kadence-blocks'
+		),
+		docUrl: 'https://evnt.is/kadence-shadow',
+	},
+	'blocks/kadence/singlebtn': {
+		description: __(
+			'Save button styles as presets, so you can apply a whole look in one click instead of setting each option by hand.',
+			'kadence-blocks'
+		),
+		docUrl: 'https://evnt.is/kadence-button',
+	},
+	'blocks/kadence/image': {
+		description: __(
+			'Save image styles as presets, so rounding, shadows and spacing stay the same across your images.',
+			'kadence-blocks'
+		),
+		docUrl: 'https://evnt.is/kadence-advanced-image',
+	},
+	'blocks/kadence/rowlayout': {
+		description: __(
+			'Save row styles as presets, so the sections of a page share the same background and rounding.',
+			'kadence-blocks'
+		),
+		docUrl: 'https://evnt.is/kadence-row-layout',
+	},
+	'blocks/kadence/column': {
+		description: __(
+			'Save section styles as presets, so the columns inside your rows share the same background and rounding.',
+			'kadence-blocks'
+		),
+		docUrl: 'https://evnt.is/kadence-section',
+	},
+	'blocks/kadence/single-icon': {
+		description: __(
+			'Save icon styles as presets, so icons keep the same size and color wherever you use them.',
+			'kadence-blocks'
+		),
+		docUrl: 'https://evnt.is/kadence-icon',
+	},
+	'blocks/kadence/advancedheading': {
+		description: __(
+			'Save text styles as presets, so headings and paragraphs read the same from page to page.',
+			'kadence-blocks'
+		),
+		docUrl: 'https://evnt.is/kadence-advanced-text',
+	},
+};

--- a/src/style-library/helpers/screen-docs.js
+++ b/src/style-library/helpers/screen-docs.js
@@ -25,7 +25,17 @@ import { SCREEN_DOCS, SCREEN_DOCS_FILTER } from '../constants/screen-docs';
  * @return {boolean} True for an http(s) URL.
  */
 function isLinkableUrl(value) {
-	return typeof value === 'string' && /^https?:\/\//.test(value);
+	if (typeof value !== 'string') {
+		return false;
+	}
+
+	try {
+		const { protocol } = new URL(value);
+
+		return protocol === 'http:' || protocol === 'https:';
+	} catch {
+		return false;
+	}
 }
 
 /**

--- a/src/style-library/helpers/screen-docs.js
+++ b/src/style-library/helpers/screen-docs.js
@@ -1,0 +1,70 @@
+/**
+ * The screen-docs lookup: the single `applyFilters` call site for `SCREEN_DOCS_FILTER`, and the
+ * one place that decides whether an entry is usable.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { SCREEN_DOCS, SCREEN_DOCS_FILTER } from '../constants/screen-docs';
+
+/**
+ * Whether a value is a documentation URL this app is willing to put in an `href`. A filter
+ * listener is third-party code and a screen id comes off the URL bar, so the scheme is checked
+ * here rather than trusted at the render site.
+ *
+ * @param {*} value The candidate URL.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True for an http(s) URL.
+ */
+function isLinkableUrl(value) {
+	return typeof value === 'string' && /^https?:\/\//.test(value);
+}
+
+/**
+ * The helper copy for a screen, or null when the screen has none.
+ *
+ * `Object.hasOwn`, not a bare index read: the screen id comes from `?kb-screen=` and
+ * `'constructor'` would otherwise resolve to an inherited property.
+ *
+ * @param {string} screenId The screen id from the route.
+ *
+ * @since TBD
+ *
+ * @return {?{description: string, docUrl: string}} The entry, or null. `docUrl` is '' when the
+ *                                                   entry has no usable link.
+ */
+export function screenDoc(screenId) {
+	if (typeof screenId !== 'string' || screenId === '') {
+		return null;
+	}
+
+	/**
+	 * Filters the Style Library's per-screen helper copy and documentation links.
+	 *
+	 * @param {Object} docs screenId => `{ description, docUrl }`.
+	 */
+	const docs = applyFilters(SCREEN_DOCS_FILTER, SCREEN_DOCS);
+
+	if (!docs || !Object.hasOwn(docs, screenId)) {
+		return null;
+	}
+
+	const doc = docs[screenId];
+
+	if (!doc || typeof doc.description !== 'string' || doc.description === '') {
+		return null;
+	}
+
+	return {
+		description: doc.description,
+		docUrl: isLinkableUrl(doc.docUrl) ? doc.docUrl : '',
+	};
+}


### PR DESCRIPTION
## Summary

The copy catalog behind SOFT-4201's in-UI helper copy, plus the lookup that reads it. Nothing
renders it yet — that lands in the slices above this one.

`constants/screen-docs.js` holds one sentence and one documentation link per screen, keyed by the
screen id `helpers/screens.js` already builds (`color-palette`, `blocks/kadence/singlebtn`). One
catalog rather than a field on each screen's own config: the sentences are reviewed together as
copy, and the short URLs are swapped together when the documentation moves. It is also where the
ticket's two tooltip strings will land if scope items 2 and 3 are picked up later.

`helpers/screen-docs.js` is the only reader. It applies `kadence_blocks.style_library.screen_docs`
before the lookup — the same extension mechanism `resolveScreen()` already uses for preset screens
— so a white-label build can drop the links and a third party can register copy for its own screen.

## Copy

The seven Base Styles screens and the Button preset screen carry the ticket's copy verbatim. The
five remaining preset screens had none, so this writes them in the same voice, each naming only
properties that preset's own `schemaFor()` exposes:

| Screen | Sentence |
| --- | --- |
| Advanced Image | Save image styles as presets, so rounding, shadows and spacing stay the same across your images. |
| Row Layout | Save row styles as presets, so the sections of a page share the same background and rounding. |
| Section | Save section styles as presets, so the columns inside your rows share the same background and rounding. |
| Icon | Save icon styles as presets, so icons keep the same size and color wherever you use them. |
| Advanced Text | Save text styles as presets, so headings and paragraphs read the same from page to page. |

**These five need a copy sign-off**, and their five short URLs still need creating:
`kadence-advanced-image`, `kadence-row-layout`, `kadence-section`, `kadence-icon`,
`kadence-advanced-text`. Setting an entry's `docUrl` to `''` renders the sentence with no link,
which is already handled and tested.

## Two guards worth a look

- The screen id comes off `?kb-screen=`, so the lookup uses `Object.hasOwn` — `?kb-screen=constructor`
  must not resolve to `Object.prototype.constructor`.
- A filtered entry feeds an `href`, so a `docUrl` that is not http(s) is dropped and only the
  sentence renders.

## Test plan

- `npm run test -- src/style-library/__tests__/screen-docs.test.js` — 10 tests: catalog shape and
  coverage, both id shapes, the two guards above, and the filter adding, rewriting and failing an
  entry.

## Stack

1. **This PR** — the catalog and the lookup
2. `SOFT-4201/slice-2-screen-description-slot`
3. `SOFT-4201/slice-3-screen-description-wiring`
4. `SOFT-4201/slice-4-action-tooltips`
5. `SOFT-4201/slice-5-modal-enter-submit`
6. `SOFT-4201/slice-6-screen-header-height`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a centralized catalog of Style Library screen descriptions and documentation links.
  * Screen documentation can now be retrieved by screen ID.
  * Documentation links are validated and limited to secure HTTP(S) destinations.
  * Added support for extending, updating, or removing documentation entries through the Style Library’s extensibility system.

* **Tests**
  * Added coverage for catalog completeness, lookups, filtering, missing descriptions, and unsafe links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->