### PR TITLE
[DTM] SOFT-4201 [2/6]: ScreenDescription molecule and header slot

### DIFF
--- a/src/style-library/__tests__/screen-description.test.js
+++ b/src/style-library/__tests__/screen-description.test.js
@@ -1,0 +1,104 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter, removeFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { ScreenDescription } from '../components/molecules/ScreenDescription';
+import { SCREEN_DOCS, SCREEN_DOCS_FILTER } from '../constants/screen-docs';
+
+// `jest.config.js` maps `@wordpress/components` to a copy that resolves its own react/react-dom,
+// a different module instance than the top-level `react-dom/client` this test renders with —
+// mounting the real `ExternalLink` under the top-level renderer trips React's "Invalid hook call"
+// guard. The stand-in keeps the anchor and the href, which is all this test asserts on.
+jest.mock('@wordpress/components', () => ({
+	ExternalLink: ({ children, ...props }) => <a {...props}>{children}</a>,
+}));
+
+describe('ScreenDescription', () => {
+	let container;
+	let root;
+
+	beforeEach(() => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		removeFilter(SCREEN_DOCS_FILTER, 'test/screen-description');
+	});
+
+	/**
+	 * Render the molecule for one screen id.
+	 *
+	 * @param {string} screenId The screen id to render for.
+	 *
+	 * @return {void}
+	 */
+	const render = (screenId) => {
+		act(() => root.render(<ScreenDescription screenId={screenId} />));
+	};
+
+	/**
+	 * A screen with copy shows its sentence and, at the end of it, the documentation link.
+	 *
+	 * @return {void}
+	 */
+	it('renders the screen sentence followed by a documentation link', () => {
+		render('border-radius');
+
+		const paragraph = container.querySelector('.kadence-blocks-style-library__screen-description');
+
+		expect(paragraph).not.toBeNull();
+		expect(paragraph.textContent).toContain(SCREEN_DOCS['border-radius'].description);
+
+		const link = paragraph.querySelector('a');
+
+		expect(link.getAttribute('href')).toBe('https://evnt.is/kadence-border-radius');
+		expect(link.textContent).toBe('Learn more');
+	});
+
+	/**
+	 * A screen with no catalog entry renders nothing at all — not an empty paragraph — so its
+	 * spacing is unchanged from before helper copy existed.
+	 *
+	 * @return {void}
+	 */
+	it('renders nothing for a screen with no helper copy', () => {
+		render('blocks/acme/widget');
+
+		expect(container.innerHTML).toBe('');
+	});
+
+	/**
+	 * An entry whose link was dropped still shows its sentence, with no dangling link markup.
+	 *
+	 * @return {void}
+	 */
+	it('renders the sentence with no link when the entry has no usable URL', () => {
+		addFilter(SCREEN_DOCS_FILTER, 'test/screen-description', (docs) => ({
+			...docs,
+			'blocks/acme/widget': { description: 'Style the widget.', docUrl: '' },
+		}));
+
+		render('blocks/acme/widget');
+
+		const paragraph = container.querySelector('.kadence-blocks-style-library__screen-description');
+
+		expect(paragraph.textContent.trim()).toBe('Style the widget.');
+		expect(paragraph.querySelector('a')).toBeNull();
+	});
+});

--- a/src/style-library/__tests__/screen-header.test.js
+++ b/src/style-library/__tests__/screen-header.test.js
@@ -1,0 +1,92 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { ScreenHeader } from '../components/organisms/ScreenHeader';
+
+describe('ScreenHeader', () => {
+	let container;
+	let root;
+
+	beforeEach(() => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+	});
+
+	/**
+	 * The title and the action slots share one flex row inside the header block, so a description
+	 * added under them cannot disturb their alignment.
+	 *
+	 * @return {void}
+	 */
+	it('wraps the title and the action slots in a row inside the header block', () => {
+		act(() => root.render(<ScreenHeader title="Corner Radius" primaryAction={<button>Add</button>} />));
+
+		const header = container.querySelector('.kadence-blocks-style-library__screen-header');
+		const row = header.querySelector(':scope > .kadence-blocks-style-library__screen-header-row');
+
+		expect(row).not.toBeNull();
+		expect(row.querySelector('.kadence-blocks-style-library__screen-header-title').textContent).toBe(
+			'Corner Radius'
+		);
+		expect(row.querySelector('.kadence-blocks-style-library__screen-header-trail button')).not.toBeNull();
+	});
+
+	/**
+	 * A header with no description renders exactly the row, so a screen without helper copy keeps
+	 * the spacing it had before the slot existed.
+	 *
+	 * @return {void}
+	 */
+	it('renders no extra node when no description is passed', () => {
+		act(() => root.render(<ScreenHeader title="Corner Radius" />));
+
+		const header = container.querySelector('.kadence-blocks-style-library__screen-header');
+
+		expect(header.children).toHaveLength(1);
+	});
+
+	/**
+	 * The description sits after the row and inside the block, which is what keeps the block's
+	 * bottom margin as the single gap to the screen's content.
+	 *
+	 * @return {void}
+	 */
+	it('renders the description after the row, inside the header block', () => {
+		act(() => root.render(<ScreenHeader title="Corner Radius" description={<p>What this screen does.</p>} />));
+
+		const header = container.querySelector('.kadence-blocks-style-library__screen-header');
+
+		expect(header.children).toHaveLength(2);
+		expect(header.lastElementChild.textContent).toBe('What this screen does.');
+	});
+
+	/**
+	 * `ScreenDescription` returns null for a screen with no copy, so the header must not draw a
+	 * wrapper around nothing.
+	 *
+	 * @return {void}
+	 */
+	it('renders nothing extra when the description slot renders null', () => {
+		const EmptyDescription = () => null;
+
+		act(() => root.render(<ScreenHeader title="Corner Radius" description={<EmptyDescription />} />));
+
+		const header = container.querySelector('.kadence-blocks-style-library__screen-header');
+
+		expect(header.children).toHaveLength(1);
+	});
+});

--- a/src/style-library/components/molecules/ScreenDescription.js
+++ b/src/style-library/components/molecules/ScreenDescription.js
@@ -1,0 +1,50 @@
+/**
+ * One screen's helper copy: a short sentence saying what the screen does, with the documentation
+ * link inline at the end of it. Renders nothing when the screen has no entry in the copy catalog,
+ * so a screen the copy does not cover looks exactly as it did before.
+ *
+ * Takes a screen id rather than the strings themselves — the copy has one home
+ * (`constants/screen-docs.js`), and every caller passes the id it already has on its route.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { ExternalLink } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { screenDoc } from '../../helpers/screen-docs';
+import './ScreenDescription.scss';
+
+/**
+ * Render a screen's helper copy.
+ *
+ * @param {Object} props          The component props.
+ * @param {string} props.screenId The screen id from the route.
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The description paragraph, or null when the screen has no copy.
+ */
+export function ScreenDescription({ screenId }) {
+	const doc = screenDoc(screenId);
+
+	if (!doc) {
+		return null;
+	}
+
+	return (
+		<p className="kadence-blocks-style-library__screen-description">
+			{doc.description}
+			{doc.docUrl && (
+				<>
+					{' '}
+					<ExternalLink href={doc.docUrl}>{__('Learn more', 'kadence-blocks')}</ExternalLink>
+				</>
+			)}
+		</p>
+	);
+}

--- a/src/style-library/components/molecules/ScreenDescription.scss
+++ b/src/style-library/components/molecules/ScreenDescription.scss
@@ -1,0 +1,23 @@
+// 13px/20px muted, 4px under the title, and nothing below it — the header block already owns the
+// gap to the screen's content, so the spacing is identical whether or not this renders.
+.kadence-blocks-style-library-root .kadence-blocks-style-library__screen-description {
+	margin: var(--kb-sl-space-05) 0 0;
+	// A comfortable measure for a single sentence. The description is the one part of the header
+	// allowed to wrap; only the title truncates.
+	max-width: var(--kb-sl-size-content-max-width);
+	color: var(--kb-sl-color-text-muted);
+	font-size: var(--kb-sl-font-size-small);
+	line-height: var(--kb-sl-line-height-s);
+	text-wrap: pretty;
+}
+
+// `ExternalLink` already ships the theme color, the underlined label, and the "opens in a new
+// tab" arrow with its own accessible label — this sets only what core does not: the medium weight
+// the header's other text links (Rename, Reset) use, plus an explicit color and margin, because
+// another core rule paints `.components-external-link` white and pushes it 32px right inside its
+// own context.
+.kadence-blocks-style-library-root .kadence-blocks-style-library__screen-description .components-external-link {
+	margin-left: 0;
+	color: var(--kb-sl-color-theme);
+	font-weight: var(--kb-sl-font-weight-medium);
+}

--- a/src/style-library/components/molecules/ScreenDescription.scss
+++ b/src/style-library/components/molecules/ScreenDescription.scss
@@ -1,21 +1,14 @@
-// 13px/20px muted, 4px under the title, and nothing below it — the header block already owns the
-// gap to the screen's content, so the spacing is identical whether or not this renders.
+// No `max-width` on purpose: a capped measure wrapped the longest sentence on one screen and not
+// the others, which made the header a different height per screen.
 .kadence-blocks-style-library-root .kadence-blocks-style-library__screen-description {
-	margin: var(--kb-sl-space-05) 0 0;
-	// A comfortable measure for a single sentence. The description is the one part of the header
-	// allowed to wrap; only the title truncates.
-	max-width: var(--kb-sl-size-content-max-width);
+	margin: var(--kb-sl-space-10) 0 0;
 	color: var(--kb-sl-color-text-muted);
 	font-size: var(--kb-sl-font-size-small);
 	line-height: var(--kb-sl-line-height-s);
 	text-wrap: pretty;
 }
 
-// `ExternalLink` already ships the theme color, the underlined label, and the "opens in a new
-// tab" arrow with its own accessible label — this sets only what core does not: the medium weight
-// the header's other text links (Rename, Reset) use, plus an explicit color and margin, because
-// another core rule paints `.components-external-link` white and pushes it 32px right inside its
-// own context.
+// Only what core's own `.components-external-link` does not already set.
 .kadence-blocks-style-library-root .kadence-blocks-style-library__screen-description .components-external-link {
 	margin-left: 0;
 	color: var(--kb-sl-color-theme);

--- a/src/style-library/components/organisms/ScreenHeader.js
+++ b/src/style-library/components/organisms/ScreenHeader.js
@@ -1,12 +1,17 @@
 /**
  * The per-screen header row: title, optional inline controls beside it, the primary action on the
  * right. Pure layout — every optional region is a slot the caller fills, and this component knows
- * nothing about what fills them (a palette selector, a rename/delete link — all the caller's).
+ * nothing about what fills them (a palette selector, a rename/delete link, the screen's helper
+ * copy — all the caller's).
  *
  * `title` + `primaryAction` is the common shape — most Base Styles / Block Presets screens render
  * only those two. `inlineControl`, `secondaryAction`, and `destructiveAction` are exceptional
  * (only Color Palette uses them); all three stay generic and optional rather than special-casing
  * Color Palette into this organism.
+ *
+ * The component is a block, not a row: the row holds the title and the actions, and `description`
+ * renders under it, unwrapped, so a slot that renders nothing leaves nothing behind and the
+ * block's bottom margin stays the single gap to the screen's content.
  */
 
 /**
@@ -15,7 +20,7 @@
 import './ScreenHeader.scss';
 
 /**
- * Render the screen header row.
+ * Render the screen header block.
  *
  * @param {Object}       props                     The component props.
  * @param {string}       props.title               The screen title.
@@ -23,10 +28,11 @@ import './ScreenHeader.scss';
  * @param {?JSX.Element} [props.secondaryAction]    A non-destructive text-link slot beside the destructive action (e.g. Rename).
  * @param {?JSX.Element} [props.destructiveAction]  The red text-link slot beside the secondary action.
  * @param {?JSX.Element} [props.primaryAction]      The primary "+ Add …" button slot.
+ * @param {?JSX.Element} [props.description]        The screen's helper copy, rendered under the row.
  *
  * @since TBD
  *
- * @return {JSX.Element} The header row.
+ * @return {JSX.Element} The header block.
  */
 export function ScreenHeader({
 	title,
@@ -34,26 +40,36 @@ export function ScreenHeader({
 	secondaryAction = null,
 	destructiveAction = null,
 	primaryAction = null,
+	description = null,
 }) {
 	return (
 		<div className="kadence-blocks-style-library__screen-header">
-			<div className="kadence-blocks-style-library__screen-header-lead">
-				<h2 className="kadence-blocks-style-library__screen-header-title">{title}</h2>
-				{inlineControl && (
-					<span className="kadence-blocks-style-library__screen-header-inline-control">{inlineControl}</span>
-				)}
-				{secondaryAction && (
-					<span className="kadence-blocks-style-library__screen-header-secondary">{secondaryAction}</span>
-				)}
-				{destructiveAction && (
-					<span className="kadence-blocks-style-library__screen-header-destructive">{destructiveAction}</span>
-				)}
+			<div className="kadence-blocks-style-library__screen-header-row">
+				<div className="kadence-blocks-style-library__screen-header-lead">
+					<h2 className="kadence-blocks-style-library__screen-header-title">{title}</h2>
+					{inlineControl && (
+						<span className="kadence-blocks-style-library__screen-header-inline-control">
+							{inlineControl}
+						</span>
+					)}
+					{secondaryAction && (
+						<span className="kadence-blocks-style-library__screen-header-secondary">{secondaryAction}</span>
+					)}
+					{destructiveAction && (
+						<span className="kadence-blocks-style-library__screen-header-destructive">
+							{destructiveAction}
+						</span>
+					)}
+				</div>
+				<div className="kadence-blocks-style-library__screen-header-trail">
+					{primaryAction && (
+						<span className="kadence-blocks-style-library__screen-header-primary-action">
+							{primaryAction}
+						</span>
+					)}
+				</div>
 			</div>
-			<div className="kadence-blocks-style-library__screen-header-trail">
-				{primaryAction && (
-					<span className="kadence-blocks-style-library__screen-header-primary-action">{primaryAction}</span>
-				)}
-			</div>
+			{description}
 		</div>
 	);
 }

--- a/src/style-library/components/organisms/ScreenHeader.scss
+++ b/src/style-library/components/organisms/ScreenHeader.scss
@@ -1,11 +1,14 @@
 @use "../../styles/mixins" as *;
 
 .kadence-blocks-style-library__screen-header {
+	margin-bottom: var(--kb-sl-space-30);
+}
+
+.kadence-blocks-style-library__screen-header-row {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
 	gap: var(--kb-sl-space-15);
-	margin-bottom: var(--kb-sl-space-30);
 }
 
 .kadence-blocks-style-library__screen-header-lead {

--- a/src/style-library/components/pages/PlaceholderScreen.js
+++ b/src/style-library/components/pages/PlaceholderScreen.js
@@ -26,6 +26,7 @@ import { MetaChip } from '../atoms/MetaChip';
 import { SectionHeading } from '../atoms/SectionHeading';
 import { AddTile } from '../atoms/AddTile';
 import { SelectDropdown } from '../molecules/SelectDropdown';
+import { ScreenDescription } from '../molecules/ScreenDescription';
 import { useSettingsPanel } from '../../hooks/use-settings-panel';
 import { DEMO_ITEM_ID, DEMO_SETTINGS_SCHEMA, DEMO_SETTINGS_VALUES } from '../../constants/demo-settings-schema';
 import { isEqual, setValueAtPath } from '../../helpers/settings-schema';
@@ -291,10 +292,11 @@ function PrimitivesGallery() {
 			<GallerySection
 				name="ScreenHeader"
 				layer="organism"
-				note="The common shape — title + primary action only. Eight of the nine Base Styles / Block Presets screens render exactly this; no inline control, no destructive action."
+				note="The common shape — title + primary action, with the screen's helper copy under the row. Eight of the nine Base Styles / Block Presets screens render exactly this; no inline control, no destructive action."
 			>
 				<ScreenHeader
 					title="Sample screen"
+					description={<ScreenDescription screenId="border-radius" />}
 					primaryAction={
 						<Button variant="secondary" icon={plus}>
 							Add row


### PR DESCRIPTION
## Summary

Renders the copy from the slice below, and gives `ScreenHeader` somewhere to put it. No screen
uses it yet — the wiring is the next slice up. The only place it shows after this PR is the dev
primitives gallery.

**`ScreenDescription`** (molecule) takes a screen id, reads the catalog, and renders the sentence
with `ExternalLink` at the end of it, or `null` when the screen has no entry. It takes the id
rather than the strings so the copy keeps one home and every caller passes what it already has on
its route.

**`ScreenHeader`** (organism) becomes a block: today's flex row moves into
`.screen-header-row`, and a new optional `description` slot renders under it. The block keeps the
`margin-bottom` it always had, so a screen with no copy is spaced exactly as before. The slot is
rendered bare rather than wrapped like the other slots, because a slot that renders `null` has to
leave nothing behind.

It stays pure layout: it never reads the catalog itself, the same way it knows nothing about the
palette selector or the rename link it already hosts.

## On the styling

Values are the measured spec: 13px/20px in `--kb-sl-color-text-muted`, 8px under the title, and
the header block's existing 24px to the content below.

There is deliberately **no `max-width`**. A capped measure wrapped the longest sentence to a
second line on one screen and not the others, which made the header a different height per screen.
The trade-off is a long line on a wide window; the alternative was a header that moves when you
switch screens.

`ExternalLink` already ships the theme color, the underlined label and the "opens in a new tab"
arrow with its own accessible label, so the stylesheet sets only the medium weight the header's
other text links use, plus a colour and margin reset against a core rule that paints the class
white in another context.

## Test plan

- `npm run test -- src/style-library/__tests__/screen-description.test.js` — sentence and link
  render, an uncovered screen renders nothing, an entry with no usable URL renders the sentence
  alone.
- `npm run test -- src/style-library/__tests__/screen-header.test.js` — the row wraps title and
  actions, no description means no extra node, a description renders after the row inside the
  block, and a slot that renders `null` leaves the header with one child.

## Stack

1. `SOFT-4201/slice-1-screen-docs-catalog` — #1453
2. **This PR** — the molecule and the header slot
3. `SOFT-4201/slice-3-screen-description-wiring`
4. `SOFT-4201/slice-4-action-tooltips`
5. `SOFT-4201/slice-5-modal-enter-submit`
6. `SOFT-4201/slice-6-screen-header-height`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added screen-specific helper descriptions with optional “Learn more” documentation links.
  * Enhanced screen headers to display descriptions beneath the title and actions.
  * Updated the gallery example to demonstrate contextual helper copy.

* **Style**
  * Improved header spacing, alignment, typography, link styling, and text wrapping.

* **Tests**
  * Added coverage for descriptions, documentation links, empty states, and header layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->