### PR TITLE
[DTM] SOFT-4201 [3/6]: Show the helper copy on every screen

### DIFF
--- a/src/style-library/README.md
+++ b/src/style-library/README.md
@@ -83,6 +83,21 @@ in haste; the open question is whether the right boundary is a `usePresetDraftCh
 something wider, and two examples that already differ in their readiness guard is thin evidence.
 Worth revisiting when a third screen needs it, or when either copy has to change.
 
+## Screen helper copy
+
+Each screen shows one sentence under its heading with a documentation link. The copy and the short
+URLs live in `constants/screen-docs.js`, keyed by screen id (`'color-palette'`,
+`'blocks/kadence/singlebtn'`), and `helpers/screen-docs.js` is the only reader — it applies the
+`kadence_blocks.style_library.screen_docs` filter, so a build can add, change, or remove an entry
+without touching a screen.
+
+Every screen this plugin ships has an entry. A screen with no entry — a third-party preset screen —
+renders no description at all, which is the supported state, not a gap.
+
+Rendering is one slot: `<ScreenHeader description={<ScreenDescription screenId={route.screen} />} …>`.
+`ScreenHeader` stays pure layout and never reads the catalog itself; `ScreenDescription` is the
+piece that knows about copy.
+
 ## Fields and the settings schema
 
 A settings panel renders from a schema, not from hand-placed components: `{ panels: [{ id, title,

--- a/src/style-library/__tests__/preset-screen.test.js
+++ b/src/style-library/__tests__/preset-screen.test.js
@@ -38,6 +38,7 @@ jest.mock('@wordpress/components', () => ({
 	// `isBusy` is a `Button` prop, not a DOM attribute — drop it so React does not warn about it.
 	Button: ({ children, isBusy, ...props }) => <button {...props}>{children}</button>,
 	Notice: ({ children, isDismissible, ...props }) => <div {...props}>{children}</div>,
+	ExternalLink: ({ children, ...props }) => <a {...props}>{children}</a>,
 }));
 
 // `@wordpress/primitives` (which `@wordpress/icons`'s `Icon`/`SVG` build on) nests its own `react`
@@ -65,19 +66,20 @@ let root;
  * @param {Object}   [options]          Overrides for the props the selection and overlay paths read.
  * @param {string}   [options.item]     The route's open `kb-item`.
  * @param {Function} [options.navigate] The navigate spy.
+ * @param {string}   [options.screenId] The route's screen id — varies which helper copy applies.
  *
  * @since TBD
  *
  * @return {HTMLElement} The container the screen was rendered into.
  */
-function renderPresetScreen(screen, { item = '', navigate = () => {} } = {}) {
+function renderPresetScreen(screen, { item = '', navigate = () => {}, screenId = 'blocks/kadence/singlebtn' } = {}) {
 	usePresetScreen.mockReturnValue(screen);
 
 	act(() => {
 		root.render(
 			createElement(PresetScreen, {
 				label: 'Button',
-				route: { screen: 'blocks/kadence/singlebtn', item },
+				route: { screen: screenId, item },
 				navigate,
 				library: LIBRARY,
 				preset: BUTTON_PRESET,
@@ -292,5 +294,37 @@ describe('PresetScreen selection', () => {
 
 		expect(guard).not.toHaveBeenCalled();
 		expect(navigate).not.toHaveBeenCalled();
+	});
+});
+
+describe('PresetScreen helper copy', () => {
+	const LOADED = { payload: {}, isLoading: false, loadError: null, rows: [], initialValuesFor: () => ({}) };
+
+	/**
+	 * The button preset screen has helper copy in the catalog, so its sentence and documentation
+	 * link render under the header row.
+	 *
+	 * @return {void}
+	 */
+	it('renders the button screen helper copy under the header row', () => {
+		renderPresetScreen(LOADED);
+
+		const description = container.querySelector('.kadence-blocks-style-library__screen-description');
+
+		expect(description).not.toBeNull();
+		expect(description.textContent).toContain('Save button styles as presets');
+		expect(description.querySelector('a').getAttribute('href')).toBe('https://evnt.is/kadence-button');
+	});
+
+	/**
+	 * A third-party preset screen has no catalog entry, so it renders no description at all — not
+	 * an empty paragraph — and its spacing is unchanged from before helper copy existed.
+	 *
+	 * @return {void}
+	 */
+	it('renders no description on a preset screen the copy catalog does not cover', () => {
+		renderPresetScreen(LOADED, { screenId: 'blocks/acme/widget' });
+
+		expect(container.querySelector('.kadence-blocks-style-library__screen-description')).toBeNull();
 	});
 });

--- a/src/style-library/__tests__/scale-screen-description.test.js
+++ b/src/style-library/__tests__/scale-screen-description.test.js
@@ -1,0 +1,125 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { ScaleScreen } from '../components/pages/ScaleScreen';
+import { useScaleScreen } from '../hooks/use-scale-screen';
+import { useDraftChannel } from '../hooks/use-draft-channel';
+import { SCREEN_DOCS } from '../constants/screen-docs';
+
+// `use-scale-screen.js` reaches the REST client and the data store; the screen only reads the
+// hook's return value, so a stand-in is enough — see `preset-screen.test.js` for the same
+// reasoning about `@wordpress/api-fetch` not being an installed dependency.
+jest.mock('../hooks/use-scale-screen', () => ({
+	useScaleScreen: jest.fn(),
+}));
+
+jest.mock('../hooks/use-draft-channel', () => ({
+	useDraftChannel: jest.fn(),
+}));
+
+// The nested `@wordpress/components` copy resolves its own react/react-dom, a different module
+// instance than the top-level renderer this test uses — stand-ins sidestep the cross-copy
+// "Invalid hook call" guard.
+jest.mock('@wordpress/components', () => ({
+	Button: ({ children, isBusy, ...props }) => <button {...props}>{children}</button>,
+	Notice: ({ children, isDismissible, ...props }) => <div {...props}>{children}</div>,
+	ExternalLink: ({ children, ...props }) => <a {...props}>{children}</a>,
+}));
+
+jest.mock('@wordpress/icons', () => ({
+	Icon: (props) => <span className="components-icon" {...props} />,
+	plus: 'plus',
+	dragHandle: 'drag-handle',
+}));
+
+const CONFIG = {
+	id: 'border-radius',
+	title: 'Corner Radius',
+	addLabel: 'Add Border Radius',
+	renderPreview: () => <span />,
+};
+
+describe('ScaleScreen helper copy', () => {
+	let container;
+	let root;
+
+	beforeEach(() => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+
+		useDraftChannel.mockReturnValue(null);
+		useScaleScreen.mockReturnValue({
+			rows: [],
+			selectedId: '',
+			selectToken: jest.fn(),
+			isBusy: false,
+			addError: null,
+			orderError: null,
+			clearAddError: jest.fn(),
+			clearOrderError: jest.fn(),
+			addToken: jest.fn(),
+			reorderTokens: jest.fn(),
+		});
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		jest.clearAllMocks();
+	});
+
+	/**
+	 * Render `ScaleScreen` on the given route.
+	 *
+	 * @param {string} screen The route's screen id.
+	 *
+	 * @return {void}
+	 */
+	const renderOn = (screen) => {
+		act(() =>
+			root.render(
+				<ScaleScreen
+					config={CONFIG}
+					route={{ screen, item: '' }}
+					navigate={jest.fn()}
+					library={{ feed: {}, refreshFeed: jest.fn() }}
+				/>
+			)
+		);
+	};
+
+	/**
+	 * The six scale screens all render through this one container, so the route's own screen id
+	 * is what picks the sentence and the link.
+	 *
+	 * @return {void}
+	 */
+	it('renders the current screen helper copy under the header row', () => {
+		renderOn('border-radius');
+
+		const description = container.querySelector('.kadence-blocks-style-library__screen-description');
+
+		expect(description.textContent).toContain(SCREEN_DOCS['border-radius'].description);
+		expect(description.querySelector('a').getAttribute('href')).toBe('https://evnt.is/kadence-border-radius');
+	});
+
+	/**
+	 * An unknown screen id renders no description rather than an empty paragraph.
+	 *
+	 * @return {void}
+	 */
+	it('renders no description for a screen the copy catalog does not cover', () => {
+		renderOn('not-a-screen');
+
+		expect(container.querySelector('.kadence-blocks-style-library__screen-description')).toBeNull();
+	});
+});

--- a/src/style-library/__tests__/typography-screen.test.js
+++ b/src/style-library/__tests__/typography-screen.test.js
@@ -52,6 +52,7 @@ jest.mock('../components/templates/RowList', () => ({
 // `accessibleWhenDisabled` renders `aria-disabled` INSTEAD of the `disabled` attribute, which is
 // what keeps the button focusable while its write runs.
 jest.mock('@wordpress/components', () => ({
+	ExternalLink: ({ children, ...props }) => <a {...props}>{children}</a>,
 	Button: ({ children, icon, isBusy, accessibleWhenDisabled, variant, disabled, ...props }) => (
 		<button
 			{...props}

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -21,6 +21,7 @@ import { colord } from '../../helpers/colord';
 import { ScreenHeader } from '../organisms/ScreenHeader';
 import { SwatchGrid } from '../organisms/SwatchGrid';
 import { SelectDropdown } from '../molecules/SelectDropdown';
+import { ScreenDescription } from '../molecules/ScreenDescription';
 import { EmptyState } from '../molecules/EmptyState';
 import { Skeleton } from '../atoms/Skeleton';
 import { ActivatePaletteButton } from '../organisms/ActivatePaletteButton';
@@ -191,6 +192,7 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 		<div className="kadence-blocks-style-library__color-palette-screen">
 			<ScreenHeader
 				title={label}
+				description={<ScreenDescription screenId={route.screen} />}
 				inlineControl={
 					<>
 						<SelectDropdown

--- a/src/style-library/components/pages/PresetScreen.js
+++ b/src/style-library/components/pages/PresetScreen.js
@@ -24,6 +24,7 @@ import { plus } from '@wordpress/icons';
  */
 import { ScreenHeader } from '../organisms/ScreenHeader';
 import { RowList } from '../templates/RowList';
+import { ScreenDescription } from '../molecules/ScreenDescription';
 import { EmptyState } from '../molecules/EmptyState';
 import { Skeleton } from '../atoms/Skeleton';
 import { usePresetScreen } from '../../hooks/use-preset-screen';
@@ -163,7 +164,11 @@ export function PresetScreen({ label, route, navigate, library, preset }) {
 
 	return (
 		<div className={`kadence-blocks-style-library__preset-screen ${className}`.trim()}>
-			<ScreenHeader title={label} primaryAction={addAction} />
+			<ScreenHeader
+				title={label}
+				description={<ScreenDescription screenId={route.screen} />}
+				primaryAction={addAction}
+			/>
 			{screen.loadError && (
 				<Notice status="error" isDismissible={false}>
 					{screen.loadError.message}

--- a/src/style-library/components/pages/ScaleScreen.js
+++ b/src/style-library/components/pages/ScaleScreen.js
@@ -107,8 +107,6 @@ export function ScaleScreen({ config, route, navigate, library }) {
 		>
 			<ScreenHeader
 				title={config.title}
-				// `route.screen`, not `config.id`: the route's screen id is the one key every screen
-				// container has, base-styles and preset alike, so all three read the catalog the same way.
 				description={<ScreenDescription screenId={route.screen} />}
 				primaryAction={config.renderToolbar ? null : addAction}
 			/>

--- a/src/style-library/components/pages/ScaleScreen.js
+++ b/src/style-library/components/pages/ScaleScreen.js
@@ -33,6 +33,7 @@ import { plus } from '@wordpress/icons';
  */
 import { ScreenHeader } from '../organisms/ScreenHeader';
 import { RowList } from '../templates/RowList';
+import { ScreenDescription } from '../molecules/ScreenDescription';
 import { EmptyState } from '../molecules/EmptyState';
 import { useScaleScreen } from '../../hooks/use-scale-screen';
 import { useDraftChannel } from '../../hooks/use-draft-channel';
@@ -104,7 +105,13 @@ export function ScaleScreen({ config, route, navigate, library }) {
 		<div
 			className={`kadence-blocks-style-library__scale-screen kadence-blocks-style-library__scale-screen--${config.id}`}
 		>
-			<ScreenHeader title={config.title} primaryAction={config.renderToolbar ? null : addAction} />
+			<ScreenHeader
+				title={config.title}
+				// `route.screen`, not `config.id`: the route's screen id is the one key every screen
+				// container has, base-styles and preset alike, so all three read the catalog the same way.
+				description={<ScreenDescription screenId={route.screen} />}
+				primaryAction={config.renderToolbar ? null : addAction}
+			/>
 			{config.renderToolbar && config.renderToolbar({ addAction, isBusy: scale.isBusy })}
 			{scale.addError && (
 				<Notice status="error" isDismissible onRemove={scale.clearAddError}>


### PR DESCRIPTION
## Summary

Turns the copy on. Every Style Library screen now shows its sentence and documentation link under
the heading — the placement SOFT-4201 asks for.

Three containers, one line each, all keyed on `route.screen`:

| Container | Screens it covers |
| --- | --- |
| `ScaleScreen` | Typography, Border Radius, Border Width, Spacing, Icon Sizes, Shadow |
| `PresetScreen` | Button, Advanced Image, Row Layout, Section, Icon, Advanced Text |
| `ColorPaletteScreen` | Color Palette |

`route.screen` rather than each container's own identity (`config.id`, the preset's block name):
it is the one key all three already have, and it covers both id shapes, so all three read the
catalog the same way.

## Screenshots

**Border Radius**

<!-- screenshot: after-border-radius.png -->
<img width="1568" height="227" alt="after-border-radius" src="https://github.com/user-attachments/assets/7920d2ec-1e93-48c2-859f-4d3a3569f367" />

**Color Palette** — the crowded lead (palette select, Rename, Reset) is untouched; the sentence
sits under the whole row

<!-- screenshot: after-color-palette.png -->
<img width="1568" height="227" alt="after-color-palette" src="https://github.com/user-attachments/assets/df04ba93-f581-4be5-a2ec-16b1aa554470" />

**Typography** — the FONT toolbar still follows the header block

<!-- screenshot: after-typography.png -->
<img width="1568" height="227" alt="after-typography" src="https://github.com/user-attachments/assets/a0efeefd-3fdb-4d87-b58f-c96552738693" />

## Test plan

- `npm run test -- src/style-library/__tests__/scale-screen-description.test.js` — the route's
  screen id picks the sentence and the href; an uncovered id renders nothing.
- `npm run test -- src/style-library/__tests__/preset-screen.test.js` — the Button screen's copy
  and link render; a preset screen with no catalog entry renders no description. The file's
  existing render helper gained a `screenId` option, defaulting to what it hardcoded before, so
  every existing test is unchanged.
- Checked in the browser on all thirteen screens: 13px/20px `#757575`, 8px under the title, 24px
  to the content, `Learn more` in the admin theme colour with core's "opens in a new tab" arrow.

`ColorPaletteScreen` has no render test of its own. Mounting it means mounting the palette
dropdown, the activate button, the swatch grid and six modals, all of which need stubbing — the
test would assert on the stubs, not on a one-line prop. The behaviour is covered by the two files
above plus the molecule's own tests, and this screen was checked in the browser.

## Stack

1. `SOFT-4201/slice-1-screen-docs-catalog` — #1453
2. `SOFT-4201/slice-2-screen-description-slot` — #1454
3. **This PR** — the wiring
4. `SOFT-4201/slice-4-action-tooltips`
5. `SOFT-4201/slice-5-modal-enter-submit`
6. `SOFT-4201/slice-6-screen-header-height`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contextual descriptions to style library screens.
  * Added links to relevant documentation for supported built-in screens.
  * Third-party or unsupported screens can display without a description.

* **Documentation**
  * Documented screen-specific helper text and documentation links.

* **Tests**
  * Added coverage for descriptions, documentation links, and screens without available guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->