### PR TITLE
[DTM] SOFT-4201 [5/6]: Submit the add and rename modals with Enter

### DIFF
--- a/src/style-library/__tests__/modal-submit.test.js
+++ b/src/style-library/__tests__/modal-submit.test.js
@@ -1,0 +1,205 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { CreateLibraryModal } from '../components/organisms/CreateLibraryModal';
+import { RenameColorGroupModal } from '../components/organisms/RenameColorGroupModal';
+
+// Stand-ins for the nested `@wordpress/components` copy (see any other screen test for why).
+// `Modal` renders its children inline and `TextControl` renders a real input, so the form and its
+// implicit submission behave the way they do in the browser.
+jest.mock('@wordpress/components', () => ({
+	Modal: ({ children }) => <div>{children}</div>,
+	Notice: ({ children }) => <div>{children}</div>,
+	Button: ({ children, ...props }) => <button {...props}>{children}</button>,
+	TextControl: ({ label, value, onChange, help, ...props }) => (
+		<input aria-label={label} value={value} onChange={(event) => onChange(event.target.value)} {...props} />
+	),
+}));
+
+let container;
+let root;
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+});
+
+/**
+ * Submit the modal's form the way a browser does when Enter is pressed in a text field inside it.
+ * jsdom does not implement implicit submission from a key press, so the form's own submit event is
+ * dispatched directly — that is the event the modals have to handle.
+ *
+ * @return {void}
+ */
+function submitForm() {
+	const form = container.querySelector('form');
+
+	act(() => {
+		form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+	});
+}
+
+/**
+ * Type into the modal's only text field.
+ *
+ * @param {string} value The value to type.
+ *
+ * @return {void}
+ */
+function type(value) {
+	const input = container.querySelector('input');
+
+	act(() => {
+		const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+
+		setter.call(input, value);
+		input.dispatchEvent(new Event('input', { bubbles: true }));
+	});
+}
+
+describe('CreateLibraryModal submission', () => {
+	/**
+	 * Pressing Enter in the title field creates the library, the same as clicking Create.
+	 *
+	 * @return {void}
+	 */
+	it('creates the library on submit', () => {
+		const onCreate = jest.fn();
+
+		act(() =>
+			root.render(
+				<CreateLibraryModal
+					libraries={[]}
+					isBusy={false}
+					error={null}
+					onClose={jest.fn()}
+					onCreate={onCreate}
+				/>
+			)
+		);
+
+		type('Brand');
+		submitForm();
+
+		expect(onCreate).toHaveBeenCalledWith('Brand');
+	});
+
+	/**
+	 * An empty title is not submittable — the guard in the submit handler holds even though the
+	 * disabled Create button already blocks implicit submission.
+	 *
+	 * @return {void}
+	 */
+	it('does not create anything while the title is empty', () => {
+		const onCreate = jest.fn();
+
+		act(() =>
+			root.render(
+				<CreateLibraryModal
+					libraries={[]}
+					isBusy={false}
+					error={null}
+					onClose={jest.fn()}
+					onCreate={onCreate}
+				/>
+			)
+		);
+
+		submitForm();
+
+		expect(onCreate).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * Cancel must never submit the form. It is a `type="button"`, so a click dismisses the modal
+	 * and leaves the create handler alone.
+	 *
+	 * @return {void}
+	 */
+	it('leaves Cancel as a plain button', () => {
+		const onClose = jest.fn();
+		const onCreate = jest.fn();
+
+		act(() =>
+			root.render(
+				<CreateLibraryModal libraries={[]} isBusy={false} error={null} onClose={onClose} onCreate={onCreate} />
+			)
+		);
+
+		const cancel = [...container.querySelectorAll('button')].find((node) => node.textContent === 'Cancel');
+
+		expect(cancel.getAttribute('type')).toBe('button');
+
+		act(() => cancel.click());
+
+		expect(onClose).toHaveBeenCalled();
+		expect(onCreate).not.toHaveBeenCalled();
+	});
+});
+
+describe('RenameColorGroupModal submission', () => {
+	/**
+	 * The rename modals submit on Enter too, and pass the trimmed value the click path passes.
+	 *
+	 * @return {void}
+	 */
+	it('renames the group on submit', () => {
+		const onRename = jest.fn();
+
+		act(() =>
+			root.render(
+				<RenameColorGroupModal
+					group={{ id: 'accent', label: 'Accent' }}
+					isBusy={false}
+					error={null}
+					onClose={jest.fn()}
+					onRename={onRename}
+				/>
+			)
+		);
+
+		type('  Brand  ');
+		submitForm();
+
+		expect(onRename).toHaveBeenCalledWith('Brand');
+	});
+
+	/**
+	 * A rename to the same label is not submittable — the same guard the Save button uses.
+	 *
+	 * @return {void}
+	 */
+	it('does not rename anything while the label is unchanged', () => {
+		const onRename = jest.fn();
+
+		act(() =>
+			root.render(
+				<RenameColorGroupModal
+					group={{ id: 'accent', label: 'Accent' }}
+					isBusy={false}
+					error={null}
+					onClose={jest.fn()}
+					onRename={onRename}
+				/>
+			)
+		);
+
+		submitForm();
+
+		expect(onRename).not.toHaveBeenCalled();
+	});
+});

--- a/src/style-library/components/organisms/AddColorGroupModal.js
+++ b/src/style-library/components/organisms/AddColorGroupModal.js
@@ -43,39 +43,51 @@ export function AddColorGroupModal({ palette, error, onClose, onAdd }) {
 		onClose();
 	};
 
+	const canAdd = groupId !== '' && !isDuplicate;
+
+	const handleSubmit = (event) => {
+		event.preventDefault();
+
+		if (canAdd) {
+			handleAdd();
+		}
+	};
+
 	return (
 		<Modal
 			title={__('Add Color Group', 'kadence-blocks')}
 			className="kadence-blocks-style-library__add-color-group-modal"
 			onRequestClose={onClose}
 		>
-			{error && (
-				<Notice status="error" isDismissible={false}>
-					{error.message}
-				</Notice>
-			)}
-			<TextControl
-				label={__('Group name', 'kadence-blocks')}
-				value={label}
-				onChange={setLabel}
-				help={
-					isDuplicate
-						? sprintf(
-								// translators: %s: the group name the user typed.
-								__('A color group named "%s" already exists.', 'kadence-blocks'),
-								label
-							)
-						: undefined
-				}
-			/>
-			<div className="kadence-blocks-style-library__add-color-group-modal-actions">
-				<Button variant="tertiary" onClick={onClose}>
-					{__('Cancel', 'kadence-blocks')}
-				</Button>
-				<Button variant="primary" disabled={groupId === '' || isDuplicate} onClick={handleAdd}>
-					{__('Add', 'kadence-blocks')}
-				</Button>
-			</div>
+			<form onSubmit={handleSubmit}>
+				{error && (
+					<Notice status="error" isDismissible={false}>
+						{error.message}
+					</Notice>
+				)}
+				<TextControl
+					label={__('Group name', 'kadence-blocks')}
+					value={label}
+					onChange={setLabel}
+					help={
+						isDuplicate
+							? sprintf(
+									// translators: %s: the group name the user typed.
+									__('A color group named "%s" already exists.', 'kadence-blocks'),
+									label
+								)
+							: undefined
+					}
+				/>
+				<div className="kadence-blocks-style-library__add-color-group-modal-actions">
+					<Button type="button" variant="tertiary" onClick={onClose}>
+						{__('Cancel', 'kadence-blocks')}
+					</Button>
+					<Button type="submit" variant="primary" disabled={!canAdd}>
+						{__('Add', 'kadence-blocks')}
+					</Button>
+				</div>
+			</form>
 		</Modal>
 	);
 }

--- a/src/style-library/components/organisms/CreateLibraryModal.js
+++ b/src/style-library/components/organisms/CreateLibraryModal.js
@@ -39,6 +39,16 @@ export function CreateLibraryModal({ libraries, isBusy, error, onClose, onCreate
 	const slug = slugifyLibraryTitle(title);
 	const isDuplicate = isDuplicateLibraryTitle(title, libraries);
 
+	const canCreate = !isBusy && slug !== '' && !isDuplicate;
+
+	const handleSubmit = (event) => {
+		event.preventDefault();
+
+		if (canCreate) {
+			onCreate(title);
+		}
+	};
+
 	return (
 		<Modal
 			title={__('Create Library', 'kadence-blocks')}
@@ -50,46 +60,44 @@ export function CreateLibraryModal({ libraries, isBusy, error, onClose, onCreate
 			shouldCloseOnEsc={!isBusy}
 			shouldCloseOnClickOutside={!isBusy}
 		>
-			{error && (
-				<Notice status="error" isDismissible={false}>
-					{error.message}
-				</Notice>
-			)}
-			<TextControl
-				label={__('Library title', 'kadence-blocks')}
-				value={title}
-				onChange={setTitle}
-				disabled={isBusy}
-				// Two names that read as different can still collide once normalized (case,
-				// punctuation, and whitespace are all folded away — see slugifyLibraryTitle), so a
-				// name that duplicates an existing library needs a stated reason here rather than
-				// just a disabled Create button. Empty is not an error — there is nothing to collide
-				// with yet, so no message shows before the user has typed anything.
-				help={
-					isDuplicate
-						? sprintf(
-								// translators: %s: the library name the user typed.
-								__('A library named "%s" already exists.', 'kadence-blocks'),
-								title
-							)
-						: undefined
-				}
-			/>
-			<div className="kadence-blocks-style-library__create-library-modal-actions">
-				<Button variant="tertiary" onClick={onClose} disabled={isBusy}>
-					{__('Cancel', 'kadence-blocks')}
-				</Button>
-				<Button
-					variant="primary"
-					disabled={isBusy || slug === '' || isDuplicate}
-					onClick={() => onCreate(title)}
-				>
-					{/* The progressive label is the only progress indication — no spinner alongside it.
-					 * `isBusy` returns to false once the create-and-switch flow settles (see the
-					 * hook), at which point the caller (LibrarySelector) closes this modal explicitly. */}
-					{isBusy ? __('Creating…', 'kadence-blocks') : __('Create', 'kadence-blocks')}
-				</Button>
-			</div>
+			<form onSubmit={handleSubmit}>
+				{error && (
+					<Notice status="error" isDismissible={false}>
+						{error.message}
+					</Notice>
+				)}
+				<TextControl
+					label={__('Library title', 'kadence-blocks')}
+					value={title}
+					onChange={setTitle}
+					disabled={isBusy}
+					// Two names that read as different can still collide once normalized (case,
+					// punctuation, and whitespace are all folded away — see slugifyLibraryTitle), so a
+					// name that duplicates an existing library needs a stated reason here rather than
+					// just a disabled Create button. Empty is not an error — there is nothing to collide
+					// with yet, so no message shows before the user has typed anything.
+					help={
+						isDuplicate
+							? sprintf(
+									// translators: %s: the library name the user typed.
+									__('A library named "%s" already exists.', 'kadence-blocks'),
+									title
+								)
+							: undefined
+					}
+				/>
+				<div className="kadence-blocks-style-library__create-library-modal-actions">
+					<Button type="button" variant="tertiary" onClick={onClose} disabled={isBusy}>
+						{__('Cancel', 'kadence-blocks')}
+					</Button>
+					<Button type="submit" variant="primary" disabled={!canCreate}>
+						{/* The progressive label is the only progress indication — no spinner alongside it.
+						 * `isBusy` returns to false once the create-and-switch flow settles (see the
+						 * hook), at which point the caller (LibrarySelector) closes this modal explicitly. */}
+						{isBusy ? __('Creating…', 'kadence-blocks') : __('Create', 'kadence-blocks')}
+					</Button>
+				</div>
+			</form>
 		</Modal>
 	);
 }

--- a/src/style-library/components/organisms/CreatePaletteModal.js
+++ b/src/style-library/components/organisms/CreatePaletteModal.js
@@ -40,6 +40,16 @@ export function CreatePaletteModal({ listing, isBusy, error, onClose, onCreate }
 	const slug = slugifyPaletteLabel(label);
 	const isDuplicate = !isBusy && isDuplicatePaletteLabel(label, listing);
 
+	const canCreate = !isBusy && slug !== '' && !isDuplicate;
+
+	const handleSubmit = (event) => {
+		event.preventDefault();
+
+		if (canCreate) {
+			onCreate(label);
+		}
+	};
+
 	return (
 		<Modal
 			title={__('Create Color Palette', 'kadence-blocks')}
@@ -51,39 +61,37 @@ export function CreatePaletteModal({ listing, isBusy, error, onClose, onCreate }
 			shouldCloseOnEsc={!isBusy}
 			shouldCloseOnClickOutside={!isBusy}
 		>
-			{error && (
-				<Notice status="error" isDismissible={false}>
-					{error.message}
-				</Notice>
-			)}
-			<TextControl
-				label={__('Palette name', 'kadence-blocks')}
-				value={label}
-				onChange={setLabel}
-				disabled={isBusy}
-				help={
-					isDuplicate
-						? sprintf(
-								// translators: %s: the palette name the user typed.
-								__('A palette named "%s" already exists.', 'kadence-blocks'),
-								label
-							)
-						: undefined
-				}
-			/>
-			<div className="kadence-blocks-style-library__create-palette-modal-actions">
-				<Button variant="tertiary" onClick={onClose} disabled={isBusy}>
-					{__('Cancel', 'kadence-blocks')}
-				</Button>
-				<Button
-					variant="primary"
-					disabled={isBusy || slug === '' || isDuplicate}
-					onClick={() => onCreate(label)}
-				>
-					{/* The progressive label is the only progress indication — no spinner alongside it. */}
-					{isBusy ? __('Creating…', 'kadence-blocks') : __('Create', 'kadence-blocks')}
-				</Button>
-			</div>
+			<form onSubmit={handleSubmit}>
+				{error && (
+					<Notice status="error" isDismissible={false}>
+						{error.message}
+					</Notice>
+				)}
+				<TextControl
+					label={__('Palette name', 'kadence-blocks')}
+					value={label}
+					onChange={setLabel}
+					disabled={isBusy}
+					help={
+						isDuplicate
+							? sprintf(
+									// translators: %s: the palette name the user typed.
+									__('A palette named "%s" already exists.', 'kadence-blocks'),
+									label
+								)
+							: undefined
+					}
+				/>
+				<div className="kadence-blocks-style-library__create-palette-modal-actions">
+					<Button type="button" variant="tertiary" onClick={onClose} disabled={isBusy}>
+						{__('Cancel', 'kadence-blocks')}
+					</Button>
+					<Button type="submit" variant="primary" disabled={!canCreate}>
+						{/* The progressive label is the only progress indication — no spinner alongside it. */}
+						{isBusy ? __('Creating…', 'kadence-blocks') : __('Create', 'kadence-blocks')}
+					</Button>
+				</div>
+			</form>
 		</Modal>
 	);
 }

--- a/src/style-library/components/organisms/RenameColorGroupModal.js
+++ b/src/style-library/components/organisms/RenameColorGroupModal.js
@@ -39,6 +39,16 @@ export function RenameColorGroupModal({ group, isBusy, error, onClose, onRename 
 	const trimmed = label.trim();
 	const isUnchanged = trimmed === group.label.trim();
 
+	const canSave = !isBusy && trimmed !== '' && !isUnchanged;
+
+	const handleSubmit = (event) => {
+		event.preventDefault();
+
+		if (canSave) {
+			onRename(trimmed);
+		}
+	};
+
 	return (
 		<Modal
 			title={__('Rename Color Group', 'kadence-blocks')}
@@ -49,32 +59,34 @@ export function RenameColorGroupModal({ group, isBusy, error, onClose, onRename 
 			shouldCloseOnEsc={!isBusy}
 			shouldCloseOnClickOutside={!isBusy}
 		>
-			{error && (
-				<Notice status="error" isDismissible={false}>
-					{error.message}
-				</Notice>
-			)}
-			<TextControl
-				label={__('Group name', 'kadence-blocks')}
-				value={label}
-				onChange={setLabel}
-				disabled={isBusy}
-			/>
-			<p>{__('This changes the group’s display name on every palette.', 'kadence-blocks')}</p>
-			<div className="kadence-blocks-style-library__rename-color-group-modal-actions">
-				<Button variant="tertiary" onClick={onClose} disabled={isBusy}>
-					{__('Cancel', 'kadence-blocks')}
-				</Button>
-				<Button
-					variant="primary"
-					// Unchanged is disabled alongside empty: a rename to the same label would spend a
-					// request to change nothing.
-					disabled={isBusy || trimmed === '' || isUnchanged}
-					onClick={() => onRename(trimmed)}
-				>
-					{isBusy ? __('Saving…', 'kadence-blocks') : __('Save', 'kadence-blocks')}
-				</Button>
-			</div>
+			<form onSubmit={handleSubmit}>
+				{error && (
+					<Notice status="error" isDismissible={false}>
+						{error.message}
+					</Notice>
+				)}
+				<TextControl
+					label={__('Group name', 'kadence-blocks')}
+					value={label}
+					onChange={setLabel}
+					disabled={isBusy}
+				/>
+				<p>{__('This changes the group’s display name on every palette.', 'kadence-blocks')}</p>
+				<div className="kadence-blocks-style-library__rename-color-group-modal-actions">
+					<Button type="button" variant="tertiary" onClick={onClose} disabled={isBusy}>
+						{__('Cancel', 'kadence-blocks')}
+					</Button>
+					<Button
+						type="submit"
+						variant="primary"
+						// Unchanged is disabled alongside empty: a rename to the same label would spend a
+						// request to change nothing.
+						disabled={!canSave}
+					>
+						{isBusy ? __('Saving…', 'kadence-blocks') : __('Save', 'kadence-blocks')}
+					</Button>
+				</div>
+			</form>
 		</Modal>
 	);
 }

--- a/src/style-library/components/organisms/RenameLibraryModal.js
+++ b/src/style-library/components/organisms/RenameLibraryModal.js
@@ -66,6 +66,16 @@ export function RenameLibraryModal({ slug, currentTitle, libraries, isBusy, erro
 			.catch(() => {});
 	};
 
+	const canSave = !isBusy && trimmed !== '' && !isDuplicate && !isUnchanged;
+
+	const handleSubmit = (event) => {
+		event.preventDefault();
+
+		if (canSave) {
+			handleConfirm();
+		}
+	};
+
 	return (
 		<>
 			<Button
@@ -86,43 +96,45 @@ export function RenameLibraryModal({ slug, currentTitle, libraries, isBusy, erro
 					shouldCloseOnEsc={!isBusy}
 					shouldCloseOnClickOutside={!isBusy}
 				>
-					{error && (
-						<Notice status="error" isDismissible={false}>
-							{error.message}
-						</Notice>
-					)}
-					<TextControl
-						label={__('Library title', 'kadence-blocks')}
-						value={title}
-						onChange={setTitle}
-						disabled={isBusy}
-						// Unlike creation, this compares against what libraries are actually *called*, not
-						// against derived slugs: a slug is minted once at creation and never follows a
-						// rename, so a slug-based check would refuse names nothing on screen is using.
-						help={
-							isDuplicate
-								? sprintf(
-										// translators: %s: the library name the user typed.
-										__('A library named "%s" already exists.', 'kadence-blocks'),
-										trimmed
-									)
-								: undefined
-						}
-					/>
-					<div className="kadence-blocks-style-library__rename-library-modal-actions">
-						<Button variant="tertiary" onClick={handleClose} disabled={isBusy}>
-							{__('Cancel', 'kadence-blocks')}
-						</Button>
-						<Button
-							variant="primary"
-							// Unchanged is disabled alongside empty and duplicate: a rename to the same name
-							// would spend a request and bump the library's version to change nothing.
-							disabled={isBusy || trimmed === '' || isDuplicate || isUnchanged}
-							onClick={handleConfirm}
-						>
-							{isBusy ? __('Saving…', 'kadence-blocks') : __('Save', 'kadence-blocks')}
-						</Button>
-					</div>
+					<form onSubmit={handleSubmit}>
+						{error && (
+							<Notice status="error" isDismissible={false}>
+								{error.message}
+							</Notice>
+						)}
+						<TextControl
+							label={__('Library title', 'kadence-blocks')}
+							value={title}
+							onChange={setTitle}
+							disabled={isBusy}
+							// Unlike creation, this compares against what libraries are actually *called*, not
+							// against derived slugs: a slug is minted once at creation and never follows a
+							// rename, so a slug-based check would refuse names nothing on screen is using.
+							help={
+								isDuplicate
+									? sprintf(
+											// translators: %s: the library name the user typed.
+											__('A library named "%s" already exists.', 'kadence-blocks'),
+											trimmed
+										)
+									: undefined
+							}
+						/>
+						<div className="kadence-blocks-style-library__rename-library-modal-actions">
+							<Button type="button" variant="tertiary" onClick={handleClose} disabled={isBusy}>
+								{__('Cancel', 'kadence-blocks')}
+							</Button>
+							<Button
+								type="submit"
+								variant="primary"
+								// Unchanged is disabled alongside empty and duplicate: a rename to the same name
+								// would spend a request and bump the library's version to change nothing.
+								disabled={!canSave}
+							>
+								{isBusy ? __('Saving…', 'kadence-blocks') : __('Save', 'kadence-blocks')}
+							</Button>
+						</div>
+					</form>
 				</Modal>
 			)}
 		</>

--- a/src/style-library/components/organisms/RenamePaletteModal.js
+++ b/src/style-library/components/organisms/RenamePaletteModal.js
@@ -66,6 +66,16 @@ export function RenamePaletteModal({ id, currentLabel, listing, isBusy, error, o
 			.catch(() => {});
 	};
 
+	const canSave = !isBusy && trimmed !== '' && !isDuplicate && !isUnchanged;
+
+	const handleSubmit = (event) => {
+		event.preventDefault();
+
+		if (canSave) {
+			handleConfirm();
+		}
+	};
+
 	return (
 		<>
 			<Button
@@ -86,40 +96,42 @@ export function RenamePaletteModal({ id, currentLabel, listing, isBusy, error, o
 					shouldCloseOnEsc={!isBusy}
 					shouldCloseOnClickOutside={!isBusy}
 				>
-					{error && (
-						<Notice status="error" isDismissible={false}>
-							{error.message}
-						</Notice>
-					)}
-					<TextControl
-						label={__('Palette name', 'kadence-blocks')}
-						value={label}
-						onChange={setLabel}
-						disabled={isBusy}
-						help={
-							isDuplicate
-								? sprintf(
-										// translators: %s: the palette name the user typed.
-										__('A palette named "%s" already exists.', 'kadence-blocks'),
-										trimmed
-									)
-								: undefined
-						}
-					/>
-					<div className="kadence-blocks-style-library__rename-palette-modal-actions">
-						<Button variant="tertiary" onClick={handleClose} disabled={isBusy}>
-							{__('Cancel', 'kadence-blocks')}
-						</Button>
-						<Button
-							variant="primary"
-							// Unchanged is disabled alongside empty and duplicate: a rename to the same label
-							// would spend a request to change nothing.
-							disabled={isBusy || trimmed === '' || isDuplicate || isUnchanged}
-							onClick={handleConfirm}
-						>
-							{isBusy ? __('Saving…', 'kadence-blocks') : __('Save', 'kadence-blocks')}
-						</Button>
-					</div>
+					<form onSubmit={handleSubmit}>
+						{error && (
+							<Notice status="error" isDismissible={false}>
+								{error.message}
+							</Notice>
+						)}
+						<TextControl
+							label={__('Palette name', 'kadence-blocks')}
+							value={label}
+							onChange={setLabel}
+							disabled={isBusy}
+							help={
+								isDuplicate
+									? sprintf(
+											// translators: %s: the palette name the user typed.
+											__('A palette named "%s" already exists.', 'kadence-blocks'),
+											trimmed
+										)
+									: undefined
+							}
+						/>
+						<div className="kadence-blocks-style-library__rename-palette-modal-actions">
+							<Button type="button" variant="tertiary" onClick={handleClose} disabled={isBusy}>
+								{__('Cancel', 'kadence-blocks')}
+							</Button>
+							<Button
+								type="submit"
+								variant="primary"
+								// Unchanged is disabled alongside empty and duplicate: a rename to the same label
+								// would spend a request to change nothing.
+								disabled={!canSave}
+							>
+								{isBusy ? __('Saving…', 'kadence-blocks') : __('Save', 'kadence-blocks')}
+							</Button>
+						</div>
+					</form>
 				</Modal>
 			)}
 		</>


### PR DESCRIPTION
## Summary

Typing a name in any add or rename modal and pressing Enter did nothing — you had to leave the
keyboard and click. All six modals rendered `TextControl` and the primary `Button` as siblings with
no `<form>` between them, so the browser had nothing to submit.

Each modal's body is now wrapped in `<form onSubmit>` with `type="submit"` on the primary button,
which turns on the browser's own implicit submission. No key handler of our own.

Covers: Create Library, Rename Library, Create Color Palette, Rename Color Palette, Add Color
Group, Rename Color Group.

## Three details that decide whether this is correct

- **`Button` accepts a `type`.** Core hardcodes `type: "button"` but spreads the caller's props
  after it, so `type="submit"` wins. Checked in the built component, not assumed.
- **Cancel is now explicitly `type="button"`.** It already rendered as one by core's default, but
  inside a form the difference between Cancel and submit is the difference between dismissing and
  saving, so it is stated in the markup rather than left to a library default.
- **Each submit handler repeats its primary button's disabled expression**, named once per modal
  (`canCreate` / `canSave` / `canAdd`) and used by both. A disabled default button already blocks
  implicit submission per the HTML spec, so this is belt and braces — it is there so the guard
  survives if that button's disabled state is ever loosened.

## Reviewing the diff

Most of the line count is re-indentation from the `<form>` wrap. `git diff -w` shows the real
change: **117 insertions, 23 deletions** across the six files.

## Screenshot

<!-- screenshot: modal-add-color-group.jpg -->
<img width="1512" height="788" alt="modal-add-color-group" src="https://github.com/user-attachments/assets/9b854a8f-7984-414e-9e98-a4e48fe41bd7" />

## Test plan

- `npm run test -- src/style-library/__tests__/modal-submit.test.js` — submitting creates the
  library and renames the group with the trimmed value; an empty title and an unchanged label both
  submit to nothing; Cancel is a `type="button"` that dismisses without creating.
- Checked in the browser: the Add Color Group modal renders a `<form>`, Add is `type="submit"` and
  disabled until the field has a value, Cancel is `type="button"`.

## Note on scope

This is not in SOFT-4201 as written — it is a usability fix folded in at the ticket owner's
request. It touches nothing the other slices touch, so it lifts out cleanly if you would rather
review it on its own.

## Stack

1. `SOFT-4201/slice-1-screen-docs-catalog` — #1453
2. `SOFT-4201/slice-2-screen-description-slot` — #1454
3. `SOFT-4201/slice-3-screen-description-wiring` — #1456
4. `SOFT-4201/slice-4-action-tooltips` — #1457
5. **This PR** — Enter submits the modals
6. `SOFT-4201/slice-6-screen-header-height`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal form submission across library, palette, and color-group creation and renaming workflows.
  * Prevented invalid submissions when fields are empty, unchanged, duplicated, or while an operation is in progress.
  * Ensured Cancel actions do not accidentally submit forms.
  * Preserved inline validation errors and loading states.

* **Tests**
  * Added coverage for submit behavior, validation rules, trimming, cancellation, and successful creation or renaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->