### PR TITLE
[DTM] SOFT-4201 [6/6]: Give every screen header the same height

### DIFF
--- a/src/style-library/components/organisms/ScreenHeader.scss
+++ b/src/style-library/components/organisms/ScreenHeader.scss
@@ -4,11 +4,15 @@
 	margin-bottom: var(--kb-sl-space-30);
 }
 
+// The floor matches the tallest control the row can hold — the palette `SelectDropdown`, which
+// sets the same `var(--kb-sl-space-50)` height — so the row does not change height from screen to
+// screen. A floor rather than a fixed height: a crowded lead still grows instead of overflowing.
 .kadence-blocks-style-library__screen-header-row {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
 	gap: var(--kb-sl-space-15);
+	min-height: var(--kb-sl-space-50);
 }
 
 .kadence-blocks-style-library__screen-header-lead {

--- a/src/style-library/components/pages/ColorPaletteScreen.scss
+++ b/src/style-library/components/pages/ColorPaletteScreen.scss
@@ -4,6 +4,12 @@
 	@include flex-column(var(--kb-sl-space-30));
 }
 
+// The only screen root that is a flex column with its own gap, which would otherwise stack with
+// the shared header's bottom margin: 48px here against 24px everywhere else.
+.kadence-blocks-style-library__color-palette-screen .kadence-blocks-style-library__screen-header {
+	margin-bottom: 0;
+}
+
 // SwatchCard's sub-line renders the swatch's raw `$value` unmodified; this screen renders it in
 // upper case visually only, scoped under the screen root rather than touching SwatchCard.scss,
 // which stays agnostic about the shape of any caller's `subLine`.


### PR DESCRIPTION
## Summary

The screen header was a different height on every kind of screen, so the content below moved every
time you switched tabs. Two separate causes, both fixed here.

## 1. The row had no floor

Its height was whatever the tallest thing inside it happened to be:

| Screen | Tallest thing in the row | Height |
| --- | --- | --- |
| Typography | the title alone — its Add Size lives in the toolbar below | 28px |
| Border Radius, Border Width, Spacing, Icon Sizes, Shadow, all six preset screens | the "+ Add …" button | 36px |
| Color Palette | the palette `SelectDropdown` | 40px |

`min-height: var(--kb-sl-space-50)` on `.screen-header-row` — the same primitive the
`SelectDropdown` uses for its own fixed 40px height, so the two stay visibly in agreement. A floor
rather than a fixed height, so Color Palette's five-item lead can still grow instead of
overflowing. Nothing shrinks: the 28px and 36px rows grow to meet the 40px one.

40 rather than 36, because the dropdown's height is deliberate and shared with the app header's
library selector and several settings fields. A 36px floor would not standardise Color Palette
anyway — `min-height` shrinks nothing, so that screen would stay 40 and still jump.

## 2. Color Palette paid for its gap twice

`.color-palette-screen` is the only screen root that is a flex column with its own
`gap: var(--kb-sl-space-30)`. Every other screen is a plain block where the shared header's
`margin-bottom` is the single separator. On that one screen the two stacked: **48px against
everyone else's 24px**. The margin now steps aside there and the column's gap is the one owner.

The alternative was removing `margin-bottom` from `ScreenHeader` entirely and making all thirteen
screen roots flex columns. That is arguably the cleaner ownership model, but it would set a 24px
gap between every pair of children on every screen, changing the spacing around inline `Notice`s
that use their own margins today. That is a spacing redesign, not a bug fix, so it is deliberately
not in here.

## Result

Measured across all thirteen screens after the change: row **40px**, header **68px**, gap to
content **24px**, content top **209px** — identical everywhere.

**Before** — 28px, 36px and 40px rows

<!-- screenshot: before-typography-28px.png -->
<!-- screenshot: before-border-radius-36px.png -->
<!-- screenshot: before-color-palette-40px.png -->
<img width="1568" height="227" alt="before-border-radius-36px" src="https://github.com/user-attachments/assets/d651c728-4217-4b3f-be40-0b76d261b03a" />
<img width="1568" height="227" alt="before-color-palette-40px" src="https://github.com/user-attachments/assets/bdb28e1e-985b-419d-8e01-0caf633df300" />
<img width="1568" height="227" alt="before-typography-28px" src="https://github.com/user-attachments/assets/4c11e27b-254c-4e20-b956-447d3e84d1d3" />

**After** — the same three screens

<!-- screenshot: after-typography.png -->
<!-- screenshot: after-border-radius.png -->
<!-- screenshot: after-color-palette.png -->
<img width="1568" height="227" alt="after-border-radius" src="https://github.com/user-attachments/assets/3dfec2a1-295e-4b3d-ab3e-eeaa2e85ad73" />
<img width="1568" height="227" alt="after-color-palette" src="https://github.com/user-attachments/assets/742882ae-9ab2-412e-a6fa-1e57200c6555" />
<img width="1568" height="227" alt="after-typography" src="https://github.com/user-attachments/assets/6be64b7c-ec85-4aa6-bcbd-4e0562714e60" />

## Known limit

The description has no `max-width`, so the longest sentence still wraps once the content column
drops below ~764px — roughly a laptop under 1376px wide with the settings panel open. At that width
the Button preset screen goes back to a taller header. Nothing short of shortening that sentence
removes it entirely.

## Test plan

CSS only; no test changes. The suite stays green (1701 tests). Verified in the browser by walking
all thirteen screens and measuring the row, the header block, and the top of the first content
element on each.

## Stack

1. `SOFT-4201/slice-1-screen-docs-catalog` — #1453
2. `SOFT-4201/slice-2-screen-description-slot` — #1454
3. `SOFT-4201/slice-3-screen-description-wiring` — #1456
4. `SOFT-4201/slice-4-action-tooltips` — #1457
5. `SOFT-4201/slice-5-modal-enter-submit` — #1458
6. **This PR** — one header height everywhere


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen header sizing to maintain a consistent minimum height while accommodating longer content.
  * Corrected spacing on the color palette screen to prevent excessive gaps below the header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->