### PR TITLE
Token-pickable block controls [6/11]: offer a control its own token scale

### DIFF
--- a/src/extension/token-picker/__tests__/index.test.js
+++ b/src/extension/token-picker/__tests__/index.test.js
@@ -364,8 +364,26 @@ describe('pickableTokensForControl', () => {
 		expect(result.every((token) => token.role === 'radius')).toBe(true);
 	});
 
-	it('falls back to the coarse kind list when the attribute implies no single role', () => {
-		expect(pickableTokensForControl('kadence/singlebtn', 'gap')).toEqual(pickableTokensFor('dimension'));
+	it('still offers only primitives when the attribute implies no single role', () => {
+		// No role narrows the sub-kind, but the picker's job does not change: it surfaces scale steps, and
+		// a semantic is a delivery point for one rather than a choice to make on a block. Offering the
+		// whole kind bucket here is what put every unrelated semantic in front of a control whose bound
+		// token the registry never declared.
+		const result = pickableTokensForControl('kadence/singlebtn', 'gap');
+
+		expect(result.length).toBeGreaterThan(0);
+		expect(result.every((token) => token.id.startsWith('primitive.'))).toBe(true);
+	});
+
+	it('infers the role from the attribute when the bound token is absent from the registry', () => {
+		// Several bound semantics live only in `baseline.json` — they resolve and paint, but carry no
+		// label, group, or role, so the pool cannot answer for them. Reading that as "no role" is what
+		// put the whole dimension bucket, every unrelated semantic in it, in front of a radius control.
+		window.kadenceDesignTokensPresets = boundPresets('semantic.radius.never-registered');
+
+		const result = pickableTokensForControl('kadence/singlebtn', 'borderRadius');
+
+		expect(result.map((token) => token.id)).toEqual(['ss-none-radius', 'primitive.dimension.radius.sm']);
 	});
 
 	it('returns an empty array for an unmapped attribute', () => {

--- a/src/extension/token-picker/index.js
+++ b/src/extension/token-picker/index.js
@@ -208,11 +208,20 @@ function pickableTokensForProperty(property, controlAttr, library) {
 	}
 
 	const tokens = pickableTokensFor(property.kind, library);
-	const role = property.token ? roleForId(property.token) : inferRoleFromControl(controlAttr, tokens);
+	// The bound token names the role when the pool knows it, and the control attribute answers when it
+	// does not. Both paths are needed, not one or the other: a binding can name a token the REGISTRY
+	// never declared — several semantics live only in `baseline.json`, so they resolve and paint but
+	// carry no label, group, or role — and reading that as "no role" left the control offering the whole
+	// coarse kind bucket, every semantic in it, rather than its own scale.
+	const role = roleForId(property.token) || inferRoleFromControl(controlAttr, tokens);
 
-	// No bound token and no inferable role -> the coarse kind list (type filter + semantic-first).
+	// Nothing identified the role, so the sub-kind is unknown. Still prefer the primitives: the picker
+	// surfaces scale steps, and a semantic is a delivery point for one rather than a choice to make
+	// here. Falling all the way back to the unfiltered list is the last resort.
 	if (!role) {
-		return tokens;
+		const primitives = tokens.filter((token) => token.id.startsWith('primitive.'));
+
+		return primitives.length ? primitives : tokens;
 	}
 
 	// Narrow to the control's sub-kind. When that sub-kind has primitive scale steps (e.g. the radius


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4263/token-pickable-block-controls-for-the-remaining-alpha-blocks-row
:video_camera: https://www.loom.com/share/9363726b1a30466a9d6e8fb429f82f2d

A Border Radius or Padding control on Advanced Text listed the entire dimension bucket — Media Radius, Control Radius, Icon Size, Row Layout Radius, Column Radius, Border Width, Media Padding — instead of the scale it should pick from.

The role was resolved from the bound token OR the control attribute, never one then the other. A binding can name a token the registry never declared: several semantics live only in `baseline.json`, so they resolve and paint but carry no role. Because a token WAS named, the attribute was never asked, the role came back empty, and the control fell through to the unnarrowed list.

Ask both, in that order. The no-role fallback now prefers primitives too — failing to identify the sub-kind does not change what the picker is for.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared border color controls with localized labels and support for updating selected colors.

* **Bug Fixes**
  * Improved token selection when bound tokens lack registry metadata.
  * Token pickers now infer roles from control attributes and provide appropriate primitive or type-filtered options.
  * Added support for radius filtering and the “None” option in relevant token lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
