### PR TITLE
Token-pickable block controls [7/11]: give the font-family field a preset indicator

### DIFF
--- a/src/extension/design-tokens/__tests__/register-component-filters.test.js
+++ b/src/extension/design-tokens/__tests__/register-component-filters.test.js
@@ -371,6 +371,50 @@ describe('font-family seam', () => {
 	});
 
 	/**
+	 * A block that supplies binding state gets the preset indicator beside the field. Font family is
+	 * not token-backed, but a preset can still set one, so there is a preset value to match or diverge
+	 * from and the mark reports which.
+	 *
+	 * @return {void}
+	 */
+	it('renders the binding indicator when the block supplies binding state', () => {
+		const onReset = jest.fn();
+		const editor = applyFilters(EDITOR_HOOK, 'DEFAULT', {
+			control: 'fontFamily',
+			index: null,
+			value: 'Inter',
+			onChange: jest.fn(),
+			context: {
+				blockName: 'kadence/advancedheading',
+				state: { bound: true, overridden: true },
+				onReset,
+			},
+		});
+
+		expect(editor.props.indicator).not.toBeNull();
+		expect(editor.props.indicator.props.state).toEqual({ bound: true, overridden: true });
+		expect(editor.props.indicator.props.onReset).toBe(onReset);
+	});
+
+	/**
+	 * A block whose preset surface carries no family entry passes no state, and the field renders
+	 * exactly as it did before the indicator existed.
+	 *
+	 * @return {void}
+	 */
+	it('renders no indicator when the block supplies no binding state', () => {
+		const editor = applyFilters(EDITOR_HOOK, 'DEFAULT', {
+			control: 'fontFamily',
+			index: null,
+			value: 'Inter',
+			onChange: jest.fn(),
+			context: { blockName: 'kadence/singlebtn' },
+		});
+
+		expect(editor.props.indicator).toBeNull();
+	});
+
+	/**
 	 * Both of the picker's tabs write a plain family string — never an alias, since a favorite is not
 	 * a token — and Reset clears back to the theme's font.
 	 *

--- a/src/extension/design-tokens/register-component-filters.js
+++ b/src/extension/design-tokens/register-component-filters.js
@@ -20,6 +20,12 @@
  * family string either way — no alias, no pickable pool, no adapter. It rides this same seam because
  * the shared typography control gates font weight / style / subset behind the same `onFontFamily`
  * prop as the family select, so a block cannot substitute a picker by dropping the prop.
+ *
+ * It DOES take a binding indicator, though, and that is not a contradiction: token-backed and
+ * preset-settable are different properties. A preset can store a font family, so the field has a
+ * value to match or diverge from, and the mark reports which — the same question every other mapped
+ * control answers. The block supplies its own binding state through `context`, so a block whose
+ * preset surface has no family entry simply passes none and the field renders as it always did.
  */
 
 /**
@@ -37,6 +43,7 @@ import {
 	isTokenAlias,
 	loadFontFamily,
 } from '../../token-controls';
+import { TokenIndicator } from '../token-indicators/components/TokenIndicator';
 
 const NAMESPACE = 'kadence-blocks/component-token';
 const EDITOR_HOOK = 'kadence.components.control.editor';
@@ -220,6 +227,12 @@ function fontFamilyEditor(defaultEditor, ctx) {
 			catalogOptions={fontCatalogOptions()}
 			manageUrl={favoriteFontsManageUrl()}
 			inheritedLabel={ctx.context?.inheritedDefault}
+			// A family is not a token, but a preset can still set one, so the field has a preset value to
+			// match or diverge from. The block passes its own binding state the same way it does for every
+			// other mapped control; a block that passes none gets no mark, exactly as before.
+			indicator={
+				ctx.context?.state ? <TokenIndicator state={ctx.context.state} onReset={ctx.context.onReset} /> : null
+			}
 			onPick={async (family) => {
 				await loadFontFamily(family, {
 					doc: canvasDocument(),

--- a/src/token-controls/organisms/FontFamilySelector.js
+++ b/src/token-controls/organisms/FontFamilySelector.js
@@ -46,6 +46,14 @@ import '../styles/token-controls.scss';
  *                                          popover, so with it inert nothing below is reachable —
  *                                          guarding only the write callbacks would leave the field
  *                                          looking editable while silently dropping writes.
+ * @param {?Element} [props.indicator]      A host-supplied binding mark, rendered beside the trigger.
+ *                                          Same opt-in prop `BoxControl` and `ScalarControl` take, for
+ *                                          the same reason: a family is not a token, but a preset can
+ *                                          still set one, so the field has a preset value to match or
+ *                                          diverge from and the mark says which. It sits inline rather
+ *                                          than in a header because the label above this field belongs
+ *                                          to the shared typography control, which this only replaces
+ *                                          the editor of.
  *
  * @since TBD
  *
@@ -60,6 +68,7 @@ export function FontFamilySelector({
 	onPick,
 	onClear,
 	disabled = false,
+	indicator = null,
 }) {
 	// The family a pick is still waiting on. A host that fetches the web font before writing keeps
 	// the current font on screen meanwhile, so without this the field would look like the click did
@@ -148,6 +157,7 @@ export function FontFamilySelector({
 					/>
 				)}
 			/>
+			{indicator}
 		</div>
 	);
 }


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4263/token-pickable-block-controls-for-the-remaining-alpha-blocks-row
:video_camera: https://www.loom.com/share/9363726b1a30466a9d6e8fb429f82f2d

Font Family showed no "changed from preset" mark, so a family moved away from its preset read identically to one still matching it.

Token-backed and preset-settable are different properties, and only the second matters here: a preset can store a font family, so the field has a value to match or diverge from. That the family is a favorite rather than a token changes what the picker offers, not whether the binding state is worth showing.

`FontFamilySelector` takes the same opt-in `indicator` prop `BoxControl` and `ScalarControl` do. It renders inline beside the trigger because the label above belongs to the shared typography control, which exposes no actions seam to reach its header. A block that passes no state gets no mark.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a resettable binding indicator to font-family controls when binding information is available.
  * Updated font-family editor guidance to clarify the difference between preset binding and token usage.
  * Font-family selectors can now display contextual indicators alongside the control.

* **Tests**
  * Added coverage for binding indicators, reset behavior, and cases where binding information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
