### PR TITLE
Token-pickable block controls [9/11]: select the token a legacy size slug already renders as

### DIFF
--- a/src/token-controls/__tests__/token-summary.test.js
+++ b/src/token-controls/__tests__/token-summary.test.js
@@ -59,6 +59,51 @@ describe('findTokenEntry', () => {
 	});
 });
 
+// The real shape of a dimension primitive: the projection slug the block used to store IS the id's
+// last segment, which is what lets a legacy value select its token without a second lookup table.
+const SCALE_TOKENS = [
+	{
+		id: 'primitive.dimension.font-size.sm',
+		label: 'SM',
+		value: '0.9rem',
+		alias: '{primitive.dimension.font-size.sm}',
+	},
+	{
+		id: 'primitive.dimension.font-size.md',
+		label: 'MD',
+		value: '1.25rem',
+		alias: '{primitive.dimension.font-size.md}',
+	},
+];
+
+describe('findTokenEntry legacy size slugs', () => {
+	it('selects the primitive a legacy Kadence slug names', () => {
+		// What a block saved before tokens existed. It already RENDERS as this token — the primitive
+		// projects into the `kb_font_size_slot` the slug names — so the field showing it as a custom
+		// literal was the only thing disagreeing.
+		expect(findTokenEntry(SCALE_TOKENS, 'md').label).toBe('MD');
+	});
+
+	it('reports the token through fieldSummary, so the trigger names it rather than the raw slug', () => {
+		expect(fieldSummary('sm', SCALE_TOKENS, 'px', 'Custom')).toEqual({ label: 'SM', value: '0.9rem' });
+	});
+
+	it('never matches a CSS literal, which no slug can look like', () => {
+		expect(findTokenEntry(SCALE_TOKENS, '1.25rem')).toBeNull();
+		expect(findTokenEntry(SCALE_TOKENS, '16')).toBeNull();
+	});
+
+	it('leaves a non-primitive entry alone, so only scale steps answer to a slug', () => {
+		const semantic = [{ id: 'semantic.font-size.heading', label: 'Heading', value: '2rem', alias: '{x}' }];
+
+		expect(findTokenEntry(semantic, 'heading')).toBeNull();
+	});
+
+	it('ignores a non-string value', () => {
+		expect(findTokenEntry(SCALE_TOKENS, 16)).toBeNull();
+	});
+});
+
 describe('resolveDefaultValue', () => {
 	it('resolves an alias through the pickable list', () => {
 		expect(resolveDefaultValue('{primitive.dimension.radius-lg}', TOKENS, 'px')).toBe('0.5rem');

--- a/src/token-controls/helpers/token-summary.js
+++ b/src/token-controls/helpers/token-summary.js
@@ -59,15 +59,56 @@ export function hasValue(value) {
  * Custom literal that happens to equal a real token's resolved value is never misidentified as that
  * token.
  *
+ * A bare Kadence size slug (`sm`, `md`, `lg`, …) is the third case, and it is a match rather than a
+ * literal. Those are what blocks stored before tokens existed, and the dimension primitives are
+ * PROJECTED into the very slots they name — `primitive.dimension.font-size.md` declares
+ * `kb_font_size_slot => md`, so a stored `md` already renders as that token's value. Only the field
+ * disagreed, reading it as a hand-typed custom value and leaving the matching option unchecked. The
+ * slug is the id's last segment by construction (each primitive is built as
+ * `'primitive.dimension.<role>.' . $slug` with that same `$slug` as its projection), so the two are
+ * matched on that segment rather than through a second table that could drift from the declarations.
+ *
+ * Scoped to `primitive.dimension.*` entries, and safe there: every slug is a word (`none`, `xxs`,
+ * `sm`, `3xl`), never a valid CSS length, so a Custom literal cannot collide with one. The caller's
+ * list is already narrowed to the control's own role, so a stored `md` cannot match a font size on a
+ * spacing control.
+ *
  * @param {Array}  tokens The pickable-token list.
- * @param {string} value  The alias to match.
+ * @param {*}      value  The alias, fixed sentinel, or legacy size slug to match.
  *
  * @since TBD
  *
  * @return {?Object} The matching entry, or null.
  */
 export function findTokenEntry(tokens, value) {
-	return (tokens || []).find((entry) => entry.alias === value && (entry.fixed || isTokenAlias(value))) || null;
+	const entries = tokens || [];
+	const match = entries.find((entry) => entry.alias === value && (entry.fixed || isTokenAlias(value)));
+
+	if (match) {
+		return match;
+	}
+
+	return entries.find((entry) => isLegacySlugFor(entry, value)) || null;
+}
+
+/**
+ * Whether a stored value is the Kadence size slug a dimension primitive projects into.
+ *
+ * @param {Object} entry The pickable entry.
+ * @param {*}      value The stored slot value.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the entry is the primitive that slug names.
+ */
+function isLegacySlugFor(entry, value) {
+	if (typeof value !== 'string' || value === '' || !entry?.id?.startsWith('primitive.dimension.')) {
+		return false;
+	}
+
+	const segments = entry.id.split('.');
+
+	return segments[segments.length - 1] === value;
 }
 
 /**


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4263/token-pickable-block-controls-for-the-remaining-alpha-blocks-row
:video_camera: https://www.loom.com/share/9363726b1a30466a9d6e8fb429f82f2d

A block saved before design tokens stores a bare size slug — `md` for a font size, `sm` for spacing — and those already RENDER as the matching token, since each dimension primitive is projected into the very slot its slug names. Only the field disagreed, reading the slug as a hand-typed custom value and leaving the matching option unchecked.

`findTokenEntry()` now answers a slug as well as an alias, so the trigger label, the popover check mark and the summary all follow from one seam.

Matched against the id's last segment rather than a second table, because that is what it is by construction. Scoped to `primitive.dimension.*` and safe there: every slug is a word, never a valid CSS length, and the caller's list is already narrowed to the control's role.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of legacy dimension size labels such as `sm`, `md`, and `lg`.
  * Preserved existing matching for aliases and fixed values.
  * Prevented CSS literals, non-primitive entries, and non-string values from being incorrectly matched.

* **Tests**
  * Added coverage for legacy size-label matching and summary labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
