### PR TITLE
Token-pickable block controls [10/11]: show a fluid size as the scalar it authors

### DIFF
--- a/src/style-library/helpers/typography.js
+++ b/src/style-library/helpers/typography.js
@@ -18,6 +18,11 @@
 import { __ } from '@wordpress/i18n';
 
 /**
+ * Internal dependencies
+ */
+import { displayDimension } from '../../token-controls';
+
+/**
  * Strip a pair of wrapping quotes (single or double) from a font-family name, the same trimming a
  * browser applies when it renders a quoted family in a `font-family` list.
  *
@@ -110,43 +115,22 @@ export function familyStack(family) {
 }
 
 /**
- * The shipped clamp bodies (`baseline.json`'s `Font Size` primitives) contain no nested
- * parentheses, so splitting `clamp(...)`'s inner argument list on top-level commas is safe without
- * a full CSS parser.
+ * The authored scalar behind a fluid font-size step's resolved value — the Style Library's name for
+ * `token-controls`' `displayDimension()`.
  *
- * @since TBD
- */
-const CLAMP_PATTERN = /^clamp\((.*)\)$/;
-
-/**
- * Read the authored scalar out of a fluid font-size step's resolved value. Every shipped `Font
- * Size` baseline entry authors its scalar `$value` as the clamp's own `max` argument, so the max IS
- * the value a size chip or a SIZE field should show — the resolved `clamp(...)` string is correct
- * CSS for the sample text but wrong for either of those.
+ * Re-exported rather than reimplemented: the block editor's fields need the same reduction, and the
+ * rule (every shipped step authors its `$value` as the clamp's own max) belongs to the token data
+ * rather than to either host. This name is kept because the screens that call it are font-size
+ * screens and read better for it.
  *
- * @param {string} value The feed's resolved value for a font-size token, a plain dimension or a
- *                        `clamp(min, preferred, max)` string.
+ * @param {string} value The feed's resolved value for a font-size token.
  *
  * @since TBD
  *
- * @return {string} The clamp's `max` argument for a `clamp(...)` string, or the value verbatim for
- *         a plain dimension, an empty string, or a `clamp(...)` string this parses no further than
- *         three top-level arguments (the honest fallback).
+ * @return {string} The clamp's `max`, or the value verbatim when it is not a three-argument clamp.
  */
 export function fontSizeDisplayValue(value) {
-	if (typeof value !== 'string') {
-		return value;
-	}
-
-	const match = value.trim().match(CLAMP_PATTERN);
-
-	if (!match) {
-		return value;
-	}
-
-	const args = match[1].split(',').map((arg) => arg.trim());
-
-	return args.length === 3 ? args[2] : value;
+	return displayDimension(value);
 }
 
 /**

--- a/src/token-controls/__tests__/token-popover.test.js
+++ b/src/token-controls/__tests__/token-popover.test.js
@@ -203,6 +203,44 @@ describe('TokenPopover showValue prop', () => {
 	});
 
 	/**
+	 * A fluid step resolves to a whole clamp, which overran the row and read as an expression rather
+	 * than as the size it computes. The row shows the scalar the step authors instead, matching what
+	 * the trigger already showed.
+	 *
+	 * @return {void}
+	 */
+	it('shows a fluid step as the scalar it authors, not its clamp', () => {
+		const tokens = [
+			{
+				id: 'primitive.dimension.font-size.md',
+				label: 'MD',
+				value: 'clamp(1.1rem, 0.995rem + 0.326vw, 1.25rem)',
+				alias: '{primitive.dimension.font-size.md}',
+			},
+		];
+
+		render({ initialTab: 'style-library', tokens });
+
+		expect(container.querySelector('.kadence-token-field__item-value').textContent).toBe('1.25rem');
+		expect(container.querySelector('.kadence-token-field__item-label').textContent).toBe('MD');
+	});
+
+	/**
+	 * The Default tag still finds its row: the caller's default is the raw resolved value, so the
+	 * comparison stays on the clamp even though the row displays its scalar.
+	 *
+	 * @return {void}
+	 */
+	it('still tags the default row when the default is a raw clamp', () => {
+		const value = 'clamp(1.1rem, 0.995rem + 0.326vw, 1.25rem)';
+		const tokens = [{ id: 'md', label: 'MD', value, alias: '{primitive.dimension.font-size.md}' }];
+
+		render({ initialTab: 'style-library', tokens, resolvedDefault: value });
+
+		expect(container.querySelector('.kadence-token-field__item-tag')).not.toBeNull();
+	});
+
+	/**
 	 * With `showValue={false}` — `BoxShadowControl`'s own usage — no row renders its resolved value,
 	 * only its label.
 	 *

--- a/src/token-controls/__tests__/token-summary.test.js
+++ b/src/token-controls/__tests__/token-summary.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 import {
 	defaultSummary,
+	displayDimension,
 	fieldSummary,
 	findTokenEntry,
 	hasValue,
@@ -101,6 +102,52 @@ describe('findTokenEntry legacy size slugs', () => {
 
 	it('ignores a non-string value', () => {
 		expect(findTokenEntry(SCALE_TOKENS, 16)).toBeNull();
+	});
+});
+
+describe('displayDimension', () => {
+	it('reduces a fluid step to the scalar it authors, so the field shows a size not an expression', () => {
+		expect(displayDimension('clamp(1.1rem, 0.995rem + 0.326vw, 1.25rem)')).toBe('1.25rem');
+	});
+
+	it('passes a plain length through', () => {
+		expect(displayDimension('1.5rem')).toBe('1.5rem');
+	});
+
+	it('leaves a clamp it cannot read as three arguments alone, rather than guessing', () => {
+		expect(displayDimension('clamp(1rem, 2rem)')).toBe('clamp(1rem, 2rem)');
+	});
+
+	it('passes a non-string through untouched', () => {
+		expect(displayDimension(16)).toBe(16);
+		expect(displayDimension('')).toBe('');
+	});
+});
+
+describe('fluid values in the summaries', () => {
+	const FLUID = [
+		{
+			id: 'primitive.dimension.font-size.md',
+			label: 'MD',
+			value: 'clamp(1.1rem, 0.995rem + 0.326vw, 1.25rem)',
+			alias: '{primitive.dimension.font-size.md}',
+		},
+	];
+
+	it('names a selected fluid step and shows its scalar, never the clamp', () => {
+		expect(fieldSummary('{primitive.dimension.font-size.md}', FLUID, 'px', 'Custom')).toEqual({
+			label: 'MD',
+			value: '1.25rem',
+		});
+	});
+
+	it('still matches the default on the raw clamp, then shows the scalar', () => {
+		// Matching has to stay on the resolved value the pool holds — reducing first would stop a fluid
+		// step ever finding its own entry, which is what left the field showing a bare clamp.
+		expect(defaultSummary('clamp(1.1rem, 0.995rem + 0.326vw, 1.25rem)', FLUID, 'Default')).toEqual({
+			label: 'MD',
+			value: '1.25rem',
+		});
 	});
 });
 

--- a/src/token-controls/helpers/token-summary.js
+++ b/src/token-controls/helpers/token-summary.js
@@ -112,6 +112,47 @@ function isLegacySlugFor(entry, value) {
 }
 
 /**
+ * The shipped clamp bodies (`baseline.json`'s Font Size primitives) contain no nested parentheses, so
+ * splitting `clamp(...)`'s inner argument list on top-level commas is safe without a full CSS parser.
+ *
+ * @since TBD
+ */
+const CLAMP_PATTERN = /^clamp\((.*)\)$/;
+
+/**
+ * The authored scalar behind a fluid dimension's resolved value.
+ *
+ * A fluid step resolves to a whole `clamp(min, preferred, max)` string. That is correct CSS and the
+ * right thing to render with, but wrong to SHOW in a field: it overruns the row and reads as an
+ * expression rather than as the size it computes. Every shipped step authors its scalar `$value` as
+ * the clamp's own `max`, so the max is the number the field means.
+ *
+ * Applied only when producing display text, never when matching a value to a token — the pool holds
+ * the whole clamp, so reducing it first would stop a fluid step ever finding its own entry.
+ *
+ * @param {*} value A resolved dimension: a plain length, or a `clamp(min, preferred, max)` string.
+ *
+ * @since TBD
+ *
+ * @return {*} The clamp's `max`, or the value verbatim when it is not a three-argument clamp.
+ */
+export function displayDimension(value) {
+	if (typeof value !== 'string') {
+		return value;
+	}
+
+	const match = value.trim().match(CLAMP_PATTERN);
+
+	if (!match) {
+		return value;
+	}
+
+	const args = match[1].split(',').map((arg) => arg.trim());
+
+	return args.length === 3 ? args[2] : value;
+}
+
+/**
  * Normalize an inherited default into a comparable, displayable literal.
  *
  * @param {*}       defaultValue The default: a resolved literal, an alias, or a bare number.
@@ -172,7 +213,7 @@ export function defaultSummary(resolvedDefault, tokens, literalLabel = '') {
 	// never touched.
 	const entry = (tokens || []).find((candidate) => !candidate.fixed && candidate.value === resolvedDefault) || null;
 
-	return { label: entry ? entry.label : literalLabel, value: resolvedDefault };
+	return { label: entry ? entry.label : literalLabel, value: displayDimension(resolvedDefault) };
 }
 
 /**
@@ -192,7 +233,7 @@ export function fieldSummary(value, tokens, unit, customName) {
 	const entry = findTokenEntry(tokens, value);
 
 	if (entry) {
-		return { label: entry.label, value: entry.value };
+		return { label: entry.label, value: displayDimension(entry.value) };
 	}
 
 	if (isTokenAlias(value)) {

--- a/src/token-controls/index.js
+++ b/src/token-controls/index.js
@@ -47,6 +47,7 @@ export {
 } from './helpers/preset-envelope';
 export {
 	defaultSummary,
+	displayDimension,
 	fieldSummary,
 	findTokenEntry,
 	isTokenAlias,

--- a/src/token-controls/molecules/TokenPopover.js
+++ b/src/token-controls/molecules/TokenPopover.js
@@ -26,7 +26,7 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { hasValue, isTokenAlias } from '../helpers/token-summary';
+import { displayDimension, hasValue, isTokenAlias } from '../helpers/token-summary';
 
 /**
  * The `Style Library` tab body: a `Reset` affordance that clears the slot back to its inherited default,
@@ -122,7 +122,11 @@ function StyleLibraryTab({
 								{inherited ? __('Inherited', 'kadence-blocks') : __('Default', 'kadence-blocks')}
 							</span>
 						)}
-						{showValue && <span className="kadence-token-field__item-value">{entry.value}</span>}
+						{/* Reduced for display only. `isDefault` above still compares the raw resolved value,
+						    which is what the caller's default is expressed in — a fluid step's whole clamp. */}
+						{showValue && (
+							<span className="kadence-token-field__item-value">{displayDimension(entry.value)}</span>
+						)}
 					</Button>
 				);
 			})}


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4263/token-pickable-block-controls-for-the-remaining-alpha-blocks-row
:video_camera: https://www.loom.com/share/9363726b1a30466a9d6e8fb429f82f2d

A font size resolved to a whole `clamp(1.1rem, 0.995rem + 0.326vw, 1.25rem)`, and both the field and every row of its picker printed it verbatim — overrunning the row and reading as an expression rather than as the size it computes.

The Style Library already solved this for its own screens: every shipped Font Size step authors its scalar `$value` as the clamp's own max. Moved into `token-controls` as `displayDimension()` and applied at the three display seams — the trigger's value, the muted default, and the picker's token rows. The Style Library keeps its own name and delegates.

Applied strictly to display, never to matching: the pool holds the whole clamp, so reducing before a lookup would cost the trigger its name and the picker its Default tag.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fluid dimension tokens now display their authored scalar value instead of the full `clamp()` expression.
  * Token matching and default-value detection continue to use the resolved values.
  * Plain lengths, non-string values, and unreadable expressions retain their existing display behavior.

* **Tests**
  * Added coverage for fluid token display, matching behavior, and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
