### PR TITLE
Token-pickable block controls [11/11]: Single Icon color

### DIFF
--- a/src/blocks/column/edit.js
+++ b/src/blocks/column/edit.js
@@ -279,7 +279,7 @@ function SectionEdit(props) {
 	// Design-token indicators: the per-attribute bound/overridden state for the selected preset, plus a
 	// reset that clears the mapped attribute back to the preset value (served by the existing scoped CSS).
 	const tokenBinding = usePresetBinding('kadence/column', attributes, undefined, previewDevice);
-	const resetToken = (attr) => resetAttr(attr, setAttributes, tokenBinding[attr]?.kind);
+	const resetToken = (attr) => resetAttr(attr, setAttributes, tokenBinding[attr]?.kind, metadata.attributes);
 	// One fetch of the block's effective palette groups, shared by every `ColorControl` on this block.
 	const colorGroups = useColorGroups(clientId);
 

--- a/src/blocks/single-icon/edit.js
+++ b/src/blocks/single-icon/edit.js
@@ -104,7 +104,11 @@ function KadenceSingleIcon(props) {
 	// no binding state, so nothing on it reported whether a value still matched the selected preset.
 	// Adding it here serves the color control below and backfills Size at the same time.
 	const tokenBinding = usePresetBinding(name, attributes, undefined, previewDevice);
-	const resetToken = (attr) => resetAttr(attr, setAttributes, tokenBinding[attr]?.kind);
+	// The schema matters most on this block: `size` is a SCALAR (a bare number, with no companion unit
+	// attribute), and without it `resetAttrPatch` falls back to the four-slot shape every other measure
+	// control uses -- writing `['', '', '', '']` into a scalar, which the field then reads straight back
+	// as a custom value, plus a `sizeUnit` the block never declares.
+	const resetToken = (attr) => resetAttr(attr, setAttributes, tokenBinding[attr]?.kind, metadata.attributes);
 	// One fetch of the block's effective palette groups, shared by both `ColorControl` instances below.
 	const colorGroups = useColorGroups(clientId);
 	// The Icon Size control writes three sibling attributes but edits one at a time, so it resolves the

--- a/src/blocks/single-icon/edit.js
+++ b/src/blocks/single-icon/edit.js
@@ -23,7 +23,10 @@ import { EditorScalarControl } from '../../extension/design-tokens/components/Ed
 import { tokenLiteral } from '../../extension/design-tokens/token-literals';
 import { activeLibrary } from '../../extension/preset-picker';
 import { measureAttrsForDevice } from '../../extension/token-indicators/normalize';
-import { presetPropertyValueForDevice } from '../../extension/token-indicators';
+import { presetPropertyValueForDevice, resetAttr, usePresetBinding } from '../../extension/token-indicators';
+import { useColorGroups } from '../../extension/design-tokens/hooks/use-color-groups';
+import { resolveColorLiteral } from '../../extension/design-tokens/color-literal';
+import { ColorControl, ColorControlGroup } from '../../token-controls';
 import { boundTokenAliasForControl, pickableTokensForControl } from '../../extension/token-picker';
 import { PreviewIcon } from './preview-icon';
 import { AdvancedSettings } from './advanced-settings';
@@ -96,6 +99,14 @@ function KadenceSingleIcon(props) {
 	);
 
 	const { setPreviewDeviceType } = useDispatch('kadenceblocks/data');
+
+	// Design-token indicators. This block previously wired its Size control with pools and defaults but
+	// no binding state, so nothing on it reported whether a value still matched the selected preset.
+	// Adding it here serves the color control below and backfills Size at the same time.
+	const tokenBinding = usePresetBinding(name, attributes, undefined, previewDevice);
+	const resetToken = (attr) => resetAttr(attr, setAttributes, tokenBinding[attr]?.kind);
+	// One fetch of the block's effective palette groups, shared by both `ColorControl` instances below.
+	const colorGroups = useColorGroups(clientId);
 	// The Icon Size control writes three sibling attributes but edits one at a time, so it resolves the
 	// active device's attribute up front — reading or writing `size` while the editor is on Tablet would
 	// hit the wrong breakpoint.
@@ -259,6 +270,8 @@ function KadenceSingleIcon(props) {
 									// token — instead of reading blank after a Reset.
 									defaultValue={iconSizeDefault}
 									inherited={inheritedSize !== undefined}
+									state={tokenBinding.size}
+									onReset={() => resetToken('size')}
 									// The size attributes store a bare number and the block declares no unit
 									// attribute of its own, so the front end always renders them as px. Pinning the
 									// Custom tab to px keeps a hand-typed value in the one unit the attribute can
@@ -313,20 +326,35 @@ function KadenceSingleIcon(props) {
 								]}
 								onChange={(value) => setAttributes({ style: value })}
 							/>
-							<PopColorControl
-								label={__('Icon Color', 'kadence-blocks')}
-								value={color ? color : ''}
-								default={''}
-								onChange={(value) => {
-									setAttributes({ color: value });
-								}}
-								swatchLabel2={__('Hover Color', 'kadence-blocks')}
-								value2={hColor ? hColor : ''}
-								default2={''}
-								onChange2={(value) => {
-									setAttributes({ hColor: value });
-								}}
-							/>
+							{/* One two-swatch control becomes two single-value ones, matching the Button's own
+							    icon pair. Only the base color is bound -- a preset can set the icon's color but
+							    not its hover -- so only it carries binding state; the hover swatch is an
+							    ordinary color field that still resolves palette picks to the design system. */}
+							<ColorControlGroup>
+								<ColorControl
+									label={__('Icon Color', 'kadence-blocks')}
+									value={color ? color : ''}
+									groups={colorGroups}
+									status={{
+										bound: !!tokenBinding.color?.bound,
+										modified: !!tokenBinding.color?.overridden,
+									}}
+									onReset={() => resetToken('color')}
+									onPick={(alias) => setAttributes({ color: alias })}
+									onCustom={(literal) => setAttributes({ color: literal })}
+									onClear={() => setAttributes({ color: '' })}
+									resolveLiteral={resolveColorLiteral}
+								/>
+								<ColorControl
+									label={__('Hover Color', 'kadence-blocks')}
+									value={hColor ? hColor : ''}
+									groups={colorGroups}
+									onPick={(alias) => setAttributes({ hColor: alias })}
+									onCustom={(literal) => setAttributes({ hColor: literal })}
+									onClear={() => setAttributes({ hColor: '' })}
+									resolveLiteral={resolveColorLiteral}
+								/>
+							</ColorControlGroup>
 							{style !== 'default' && (
 								<>
 									<PopColorControl

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -290,7 +290,7 @@ export default function KadenceButtonEdit(props) {
 	// Design-token indicators: the per-attribute bound/overridden state for the selected preset, plus a
 	// reset that clears the mapped attribute back to the preset value (served by the existing scoped CSS).
 	const tokenBinding = usePresetBinding('kadence/singlebtn', attributes, undefined, previewDevice);
-	const resetToken = (attr) => resetAttr(attr, setAttributes, tokenBinding[attr]?.kind);
+	const resetToken = (attr) => resetAttr(attr, setAttributes, tokenBinding[attr]?.kind, metadata.attributes);
 	// One fetch of the block's effective palette groups, shared by every `ColorControl` instance on
 	// this block — the palette data is identical for all fourteen of them.
 	const colorGroups = useColorGroups(clientId);
@@ -560,8 +560,9 @@ export default function KadenceButtonEdit(props) {
 		value: borderHoverBorderForDevice.value,
 		previewDevice,
 	});
-	const resetBorderHoverRadius = () => resetAttr('borderHoverRadius', setAttributes, 'dimension');
-	const resetBorderHoverBorder = () => resetAttr('borderHoverStyle', setAttributes, 'border');
+	const resetBorderHoverRadius = () =>
+		resetAttr('borderHoverRadius', setAttributes, 'dimension', metadata.attributes);
+	const resetBorderHoverBorder = () => resetAttr('borderHoverStyle', setAttributes, 'border', metadata.attributes);
 
 	const borderTransparentBorderForDevice = measureAttrsForDevice(
 		attributes,
@@ -584,8 +585,10 @@ export default function KadenceButtonEdit(props) {
 		value: borderTransparentBorderForDevice.value,
 		previewDevice,
 	});
-	const resetBorderTransparentRadius = () => resetAttr('borderTransparentRadius', setAttributes, 'dimension');
-	const resetBorderTransparentBorder = () => resetAttr('borderTransparentStyle', setAttributes, 'border');
+	const resetBorderTransparentRadius = () =>
+		resetAttr('borderTransparentRadius', setAttributes, 'dimension', metadata.attributes);
+	const resetBorderTransparentBorder = () =>
+		resetAttr('borderTransparentStyle', setAttributes, 'border', metadata.attributes);
 
 	const borderTransparentHoverBorderForDevice = measureAttrsForDevice(
 		attributes,
@@ -609,8 +612,9 @@ export default function KadenceButtonEdit(props) {
 		previewDevice,
 	});
 	const resetBorderTransparentHoverRadius = () =>
-		resetAttr('borderTransparentHoverRadius', setAttributes, 'dimension');
-	const resetBorderTransparentHoverBorder = () => resetAttr('borderTransparentHoverStyle', setAttributes, 'border');
+		resetAttr('borderTransparentHoverRadius', setAttributes, 'dimension', metadata.attributes);
+	const resetBorderTransparentHoverBorder = () =>
+		resetAttr('borderTransparentHoverStyle', setAttributes, 'border', metadata.attributes);
 
 	const borderStickyBorderForDevice = measureAttrsForDevice(
 		attributes,
@@ -632,8 +636,9 @@ export default function KadenceButtonEdit(props) {
 		value: borderStickyBorderForDevice.value,
 		previewDevice,
 	});
-	const resetBorderStickyRadius = () => resetAttr('borderStickyRadius', setAttributes, 'dimension');
-	const resetBorderStickyBorder = () => resetAttr('borderStickyStyle', setAttributes, 'border');
+	const resetBorderStickyRadius = () =>
+		resetAttr('borderStickyRadius', setAttributes, 'dimension', metadata.attributes);
+	const resetBorderStickyBorder = () => resetAttr('borderStickyStyle', setAttributes, 'border', metadata.attributes);
 
 	const borderStickyHoverBorderForDevice = measureAttrsForDevice(
 		attributes,
@@ -656,8 +661,10 @@ export default function KadenceButtonEdit(props) {
 		value: borderStickyHoverBorderForDevice.value,
 		previewDevice,
 	});
-	const resetBorderStickyHoverRadius = () => resetAttr('borderStickyHoverRadius', setAttributes, 'dimension');
-	const resetBorderStickyHoverBorder = () => resetAttr('borderStickyHoverStyle', setAttributes, 'border');
+	const resetBorderStickyHoverRadius = () =>
+		resetAttr('borderStickyHoverRadius', setAttributes, 'dimension', metadata.attributes);
+	const resetBorderStickyHoverBorder = () =>
+		resetAttr('borderStickyHoverStyle', setAttributes, 'border', metadata.attributes);
 
 	useEffect(() => {
 		if (!isSelected) {

--- a/src/extension/token-indicators/__tests__/index.test.js
+++ b/src/extension/token-indicators/__tests__/index.test.js
@@ -735,6 +735,44 @@ describe('resetAttrPatch', () => {
 	});
 
 	/**
+	 * A SCALAR dimension clears to a bare value, not to the four-slot shape, and gains no unit
+	 * companion. `kadence/single-icon`'s `size` is a plain number with no `sizeUnit`, so the four-slot
+	 * default would store an array in a scalar -- which the field reads straight back as a custom
+	 * value -- alongside an attribute the block never declares. Only the block's own schema can say
+	 * which shape an attribute is, which is why every reset call site passes it.
+	 *
+	 * @return {void}
+	 */
+	it('clears a scalar dimension to a bare value, with no unit companion', () => {
+		const declared = {
+			size: { type: ['number', 'string'], default: 50 },
+			tabletSize: { type: ['number', 'string'], default: '' },
+			mobileSize: { type: ['number', 'string'], default: '' },
+		};
+
+		expect(resetAttrPatch('size', 'dimension', declared)).toEqual({
+			size: '',
+			tabletSize: '',
+			mobileSize: '',
+		});
+	});
+
+	/**
+	 * Without a schema the four-slot shape stands. That is the historical fallback, and the reason a
+	 * block whose attribute is a scalar must not be left relying on it.
+	 *
+	 * @return {void}
+	 */
+	it('falls back to the four-slot shape when no schema is given', () => {
+		expect(resetAttrPatch('size', 'dimension')).toEqual({
+			size: ['', '', '', ''],
+			sizeUnit: 'px',
+			tabletSize: ['', '', '', ''],
+			mobileSize: ['', '', '', ''],
+		});
+	});
+
+	/**
 	 * A non-dimension kind clears only its single attribute when the block declares no companion.
 	 *
 	 * @return {void}


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4263/token-pickable-block-controls-for-the-remaining-alpha-blocks-row
:video_camera: https://www.loom.com/share/9363726b1a30466a9d6e8fb429f82f2d

The Icon preset screen offers a Color and the block binds it, but the control could only take a literal. Size was wired earlier; this closes the block.

The one two-swatch control becomes two single-value ones in a group, matching the Button's own icon pair. Only the base color is bound — a preset can set the icon's color but not its hover — so only it carries binding state.

This block had no `usePresetBinding` call at all: Size was wired with a token pool and an inherited default but no binding state, so nothing on it reported whether a value still matched the preset. Adding the hook backfills Size's indicator and reset too.

Background and Border Color are left alone; neither is bound.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate controls for base and hover icon colors.
  * Added support for selecting palette colors, entering custom colors, clearing values, and resolving color tokens.
  * Added preset binding status and reset options for icon colors and size settings.
* **Improvements**
  * Icon size controls now stay synchronized with preset bindings and reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
