### PR TITLE
[DTM] SOFT-3908 [1/4]: palette inheritance helpers

### DIFF
--- a/src/style-library/__tests__/palettes.test.js
+++ b/src/style-library/__tests__/palettes.test.js
@@ -5,6 +5,7 @@ import {
 	applyOptimisticOverlay,
 	customColorTokenId,
 	findSwatch,
+	inheritedSwatchCount,
 	isCustomColorToken,
 	isDefaultPalette,
 	isDuplicatePaletteLabel,
@@ -13,6 +14,7 @@ import {
 	newSwatchValue,
 	nextCustomColorSlug,
 	paletteDisplayLabel,
+	paletteShowsInheritance,
 	paletteSuccessorOptions,
 	removeGroupFromGroups,
 	removeSwatchFromGroups,
@@ -806,5 +808,106 @@ describe('validateNewGroupLabel', () => {
 
 		expect(result.groupId).toBe('new-group');
 		expect(result.error).toBeNull();
+	});
+});
+
+describe('paletteShowsInheritance', () => {
+	/**
+	 * A non-default palette inherits from the default one, so its cards carry the pill.
+	 *
+	 * @return void
+	 */
+	it('is true for a palette that is not the default', () => {
+		expect(paletteShowsInheritance({ defaultId: 'default' }, 'secondary')).toBe(true);
+	});
+
+	/**
+	 * The default palette defines the values, so it has no source to name and no delta to reset.
+	 *
+	 * @return void
+	 */
+	it('is false for the default palette itself', () => {
+		expect(paletteShowsInheritance({ defaultId: 'default' }, 'default')).toBe(false);
+	});
+
+	/**
+	 * A listing with no `$default` pointer cannot say what inherits from what, so no card claims
+	 * a source it has not verified.
+	 *
+	 * @return void
+	 */
+	it('is false when the listing has no default pointer', () => {
+		expect(paletteShowsInheritance({}, 'secondary')).toBe(false);
+	});
+
+	/**
+	 * No palette is open yet on a cold load, and an unnamed palette shows nothing.
+	 *
+	 * @return void
+	 */
+	it('is false when no palette is being edited', () => {
+		expect(paletteShowsInheritance({ defaultId: 'default' }, '')).toBe(false);
+	});
+});
+
+describe('inheritedSwatchCount', () => {
+	/**
+	 * Counts every swatch across every group that still has no value of its own.
+	 *
+	 * @return void
+	 */
+	it('counts the un-overridden swatches across all groups', () => {
+		const groups = [
+			{
+				id: 'accent',
+				pendingDelete: false,
+				items: [
+					{ id: 'a', overridden: false, pendingDelete: false },
+					{ id: 'b', overridden: true, pendingDelete: false },
+				],
+			},
+			{
+				id: 'neutral',
+				pendingDelete: false,
+				items: [{ id: 'c', overridden: false, pendingDelete: false }],
+			},
+		];
+
+		expect(inheritedSwatchCount(groups)).toBe(2);
+	});
+
+	/**
+	 * A swatch or a group that is mid-delete is on its way out, so counting it would state a
+	 * number the grid is about to contradict.
+	 *
+	 * @return void
+	 */
+	it('skips swatches and groups that are pending delete', () => {
+		const groups = [
+			{
+				id: 'accent',
+				pendingDelete: false,
+				items: [
+					{ id: 'a', overridden: false, pendingDelete: true },
+					{ id: 'b', overridden: false, pendingDelete: false },
+				],
+			},
+			{
+				id: 'going',
+				pendingDelete: true,
+				items: [{ id: 'c', overridden: false, pendingDelete: false }],
+			},
+		];
+
+		expect(inheritedSwatchCount(groups)).toBe(1);
+	});
+
+	/**
+	 * An empty or missing group list counts as nothing rather than throwing.
+	 *
+	 * @return void
+	 */
+	it('returns 0 for an empty list', () => {
+		expect(inheritedSwatchCount([])).toBe(0);
 	});
 });

--- a/src/style-library/helpers/palettes.js
+++ b/src/style-library/helpers/palettes.js
@@ -112,6 +112,47 @@ export function isDefaultPalette(listing, id) {
 }
 
 /**
+ * Whether the palette being edited shows inheritance affordances on its swatch cards at all. Only
+ * a non-default palette does: the default palette is where a swatch's value is defined, so it has
+ * no source to name and no delta of its own to drop.
+ *
+ * Fails closed through `isDefaultPalette` — a listing with no `$default` pointer reports every id
+ * as the default, so a malformed listing shows no pills instead of naming a source it cannot
+ * verify.
+ *
+ * @param {Object} listing   The palette listing (`{ defaultId, currentId, palettes }`).
+ * @param {string} editingId The id of the palette being edited.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when this palette's cards show the inheritance pill.
+ */
+export function paletteShowsInheritance(listing, editingId) {
+	return Boolean(editingId) && !isDefaultPalette(listing, editingId);
+}
+
+/**
+ * How many swatches in a mapped grid still take their value from the default palette. Groups and
+ * swatches that are optimistically deleted are skipped: they are on their way out of the grid, and
+ * counting them would state a number the grid is about to contradict.
+ *
+ * @param {Array<Object>} groups The mapped grid groups from `mapPaletteToSwatchGroups()`.
+ *
+ * @since TBD
+ *
+ * @return {number} The number of swatches with no value of their own in this palette.
+ */
+export function inheritedSwatchCount(groups) {
+	return (Array.isArray(groups) ? groups : [])
+		.filter((group) => !group.pendingDelete)
+		.reduce(
+			(total, group) =>
+				total + (group.items ?? []).filter((item) => !item.overridden && !item.pendingDelete).length,
+			0
+		);
+}
+
+/**
  * Resolve which palette is being edited from the route's generic `scope` arg: `scope` itself when
  * it names a palette in the listing, otherwise the listing's `$current` palette. `hooks/use-palettes.js`
  * derives `editingId` from this on every render, straight from the already-loaded listing — there is


### PR DESCRIPTION
Adds the two pure rules the Color Palette screen's inheritance affordances read. No UI yet — the pills and the notice that consume these land in the slices stacked on top of this one.

## What this adds

`src/style-library/helpers/palettes.js`, the screen's home for pure data rules (no REST, no JSX):

- `paletteShowsInheritance( listing, editingId )` — whether the palette being edited shows inheritance affordances at all. Only a non-default palette does: the default palette is where a swatch's value is defined, so it has no source to name and no delta of its own to drop. It composes the existing `isDefaultPalette()`, so it inherits that helper's fail-closed behavior — a listing with no `$default` pointer reports no inheritance rather than naming a source it cannot verify.
- `inheritedSwatchCount( groups )` — how many swatches in a mapped grid still take their value from the default palette. Groups and swatches that are optimistically deleted are skipped: they are on their way out of the grid, and counting them would state a number the grid is about to contradict.

`groups` is the shape `mapPaletteToSwatchGroups()` already produces, so the count describes exactly the cards on screen — optimistic additions included, pending deletions excluded.

## Test plan

`npm test -- src/style-library/__tests__/palettes.test.js` — 123 passing.

Eight new cases: non-default palette, the default palette itself, a listing with no default pointer, no palette open; multi-group counting, pending-delete groups and swatches skipped, and an empty list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inheritance indicators for palettes when applicable.
  * Added counts for inherited swatches that remain active and have not been overridden.

* **Bug Fixes**
  * Improved handling of default, missing-default, empty, and pending-deletion palette selections when displaying inheritance information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Screenshots

_Nothing to show: this slice is two pure functions with no UI surface. The screens that render them are in the slices stacked on top._
