### PR TITLE
[DTM] SOFT-3908 [2/4]: swatch card pill slot

### DIFF
--- a/src/style-library/__tests__/swatch-grid.test.js
+++ b/src/style-library/__tests__/swatch-grid.test.js
@@ -101,6 +101,83 @@ describe('SwatchGrid group pendingDelete', () => {
 	});
 });
 
+describe('SwatchGrid pill slot reservation', () => {
+	let container;
+	let root;
+
+	beforeEach(() => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		delete global.IS_REACT_ACT_ENVIRONMENT;
+	});
+
+	/**
+	 * Render `SwatchGrid` with one group.
+	 *
+	 * @param {Object} group The group to render.
+	 *
+	 * @since TBD
+	 *
+	 * @return {void}
+	 */
+	function renderGrid(group) {
+		act(() => {
+			root.render(
+				<SwatchGrid groups={[group]} selectedId="" onSelect={() => {}} onAdd={() => {}} addLabel="Add color" />
+			);
+		});
+	}
+
+	/**
+	 * When no item in the group carries a pill, the row has nothing to align, so no card renders
+	 * the slot at all — this is the dead-space fix.
+	 *
+	 * @return void
+	 */
+	it('renders no pill slot when no item in the group has a pill', () => {
+		renderGrid(makeGroup());
+
+		expect(container.querySelector('.kadence-blocks-style-library__swatch-card-pill-slot')).toBeNull();
+	});
+
+	/**
+	 * When at least one item in the group has a pill, every card in that group reserves the slot,
+	 * including the ones without a pill of their own — this is the alignment guarantee the
+	 * per-row reservation exists for.
+	 *
+	 * @return void
+	 */
+	it('reserves the pill slot on every card in the group when at least one item has a pill', () => {
+		renderGrid(
+			makeGroup({
+				items: [
+					{
+						id: 'primitive.color.brand.primary',
+						name: 'Main 1',
+						subLine: '#111111',
+						pill: <button type="button" data-testid="pill" />,
+					},
+					{ id: 'primitive.color.brand.secondary', name: 'Main 2', subLine: '#222222' },
+				],
+			})
+		);
+
+		const cards = container.querySelectorAll('.kadence-blocks-style-library__swatch-card');
+		expect(cards).toHaveLength(2);
+
+		cards.forEach((card) => {
+			expect(card.querySelector('.kadence-blocks-style-library__swatch-card-pill-slot')).not.toBeNull();
+		});
+	});
+});
+
 describe('SwatchCard pill slot', () => {
 	let cardContainer;
 	let cardRoot;
@@ -161,13 +238,36 @@ describe('SwatchCard pill slot', () => {
 	});
 
 	/**
-	 * The slot is present with no pill in it, so a card with nothing to say keeps the same height
-	 * as its neighbors.
+	 * With no pill and no reservation, the card has nothing under its sub-line to say, so the
+	 * slot is skipped rather than leaving an empty strip.
 	 *
 	 * @return void
 	 */
-	it('reserves the pill slot even when no pill is supplied', () => {
+	it('does not render the pill slot when there is no pill and the slot is not reserved', () => {
 		renderCard();
+
+		expect(cardContainer.querySelector('.kadence-blocks-style-library__swatch-card-pill-slot')).toBeNull();
+	});
+
+	/**
+	 * A card with a pill always renders the slot, regardless of `reservePillSlot`.
+	 *
+	 * @return void
+	 */
+	it('renders the pill slot when a pill is supplied', () => {
+		renderCard({ pill: <button type="button" data-testid="pill" /> });
+
+		expect(cardContainer.querySelector('.kadence-blocks-style-library__swatch-card-pill-slot')).not.toBeNull();
+	});
+
+	/**
+	 * `reservePillSlot` keeps the slot present even without a pill of its own — this is how the
+	 * grid keeps a mixed row on one baseline.
+	 *
+	 * @return void
+	 */
+	it('renders the pill slot when reservePillSlot is set even without a pill', () => {
+		renderCard({ reservePillSlot: true });
 
 		expect(cardContainer.querySelector('.kadence-blocks-style-library__swatch-card-pill-slot')).not.toBeNull();
 	});

--- a/src/style-library/__tests__/swatch-grid.test.js
+++ b/src/style-library/__tests__/swatch-grid.test.js
@@ -9,6 +9,7 @@ import { createRoot } from 'react-dom/client';
  * Internal dependencies
  */
 import { SwatchGrid } from '../components/organisms/SwatchGrid';
+import { SwatchCard } from '../components/molecules/SwatchCard';
 
 const HEADING_PENDING_DELETE_CLASS = 'kadence-blocks-style-library__swatch-group-heading--pending-delete';
 
@@ -97,5 +98,96 @@ describe('SwatchGrid group pendingDelete', () => {
 
 		const addTile = container.querySelector('.kadence-blocks-style-library__add-tile');
 		expect(addTile.disabled).toBe(false);
+	});
+});
+
+describe('SwatchCard pill slot', () => {
+	let cardContainer;
+	let cardRoot;
+
+	beforeEach(() => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+		cardContainer = document.createElement('div');
+		document.body.appendChild(cardContainer);
+		cardRoot = createRoot(cardContainer);
+	});
+
+	afterEach(() => {
+		act(() => cardRoot.unmount());
+		cardContainer.remove();
+		delete global.IS_REACT_ACT_ENVIRONMENT;
+	});
+
+	/**
+	 * Render a card with the given extra props.
+	 *
+	 * @param {Object} props Props merged over the card's required ones.
+	 *
+	 * @since TBD
+	 *
+	 * @return {void}
+	 */
+	function renderCard(props = {}) {
+		act(() =>
+			cardRoot.render(
+				<SwatchCard
+					id="primitive.color.brand.primary"
+					preview={null}
+					name="Main 1"
+					subLine="#111111"
+					onSelect={() => {}}
+					{...props}
+				/>
+			)
+		);
+	}
+
+	/**
+	 * The pill renders inside the card's bordered box, beside the selecting button rather than
+	 * inside it — a button inside a button is invalid and would swallow the pill's own clicks.
+	 *
+	 * @return void
+	 */
+	it('renders the pill inside the bordered box but outside the selecting button', () => {
+		renderCard({ pill: <button type="button" data-testid="pill" /> });
+
+		const main = cardContainer.querySelector('.kadence-blocks-style-library__swatch-card-main');
+		const select = cardContainer.querySelector('.kadence-blocks-style-library__swatch-card-select');
+		const pill = cardContainer.querySelector('[data-testid="pill"]');
+
+		expect(main.tagName).toBe('DIV');
+		expect(main.contains(pill)).toBe(true);
+		expect(select.contains(pill)).toBe(false);
+	});
+
+	/**
+	 * The slot is present with no pill in it, so a card with nothing to say keeps the same height
+	 * as its neighbors.
+	 *
+	 * @return void
+	 */
+	it('reserves the pill slot even when no pill is supplied', () => {
+		renderCard();
+
+		expect(cardContainer.querySelector('.kadence-blocks-style-library__swatch-card-pill-slot')).not.toBeNull();
+	});
+
+	/**
+	 * Selecting the card still works through the inner button, which carries the pending-delete
+	 * disabled state the whole card used to carry.
+	 *
+	 * @return void
+	 */
+	it('selects through the inner button and disables it while pending delete', () => {
+		const onSelect = jest.fn();
+
+		renderCard({ onSelect });
+		act(() => cardContainer.querySelector('.kadence-blocks-style-library__swatch-card-select').click());
+
+		expect(onSelect).toHaveBeenCalledWith('primitive.color.brand.primary');
+
+		renderCard({ onSelect, isPendingDelete: true });
+
+		expect(cardContainer.querySelector('.kadence-blocks-style-library__swatch-card-select').disabled).toBe(true);
 	});
 });

--- a/src/style-library/__tests__/swatch-grid.test.js
+++ b/src/style-library/__tests__/swatch-grid.test.js
@@ -148,6 +148,37 @@ describe('SwatchGrid pill slot reservation', () => {
 	});
 
 	/**
+	 * The card is marked with the pill-slot modifier only when the slot actually renders, because
+	 * the card's lower inset moves onto the slot when it is there and has to stay on the button
+	 * when it is not.
+	 *
+	 * @return void
+	 */
+	it('flags only the cards whose pill slot renders', () => {
+		renderGrid(makeGroup());
+
+		expect(container.querySelector('.kadence-blocks-style-library__swatch-card--with-pill-slot')).toBeNull();
+
+		renderGrid(
+			makeGroup({
+				items: [
+					{
+						id: 'primitive.color.brand.primary',
+						name: 'Main 1',
+						subLine: '#111111',
+						pill: <button type="button" data-testid="pill" />,
+					},
+					{ id: 'primitive.color.brand.secondary', name: 'Main 2', subLine: '#222222' },
+				],
+			})
+		);
+
+		expect(container.querySelectorAll('.kadence-blocks-style-library__swatch-card--with-pill-slot')).toHaveLength(
+			2
+		);
+	});
+
+	/**
 	 * When at least one item in the group has a pill, every card in that group reserves the slot,
 	 * including the ones without a pill of their own — this is the alignment guarantee the
 	 * per-row reservation exists for.

--- a/src/style-library/components/molecules/SwatchCard.js
+++ b/src/style-library/components/molecules/SwatchCard.js
@@ -40,6 +40,10 @@ import './SwatchCard.scss';
  *                                              this is never derived from `subLine`.
  * @param {string}       props.name             The card's name.
  * @param {string}       [props.subLine]        The sub-line under the name (e.g. a hex value).
+ * @param {?JSX.Element} [props.pill]    The node for the slot under the sub-line — the caller's
+ *                                       inheritance pill, or null. Caller-supplied for the same
+ *                                       reason `preview` is: this card is used by screens that
+ *                                       have no notion of palette inheritance at all.
  * @param {boolean}      [props.isSelected]     Whether the card shows the selected treatment.
  * @param {Function}     props.onSelect         Called with the card id on click.
  * @param {boolean}      [props.isDraggable]    Whether the drag handle renders.
@@ -68,6 +72,7 @@ export function SwatchCard({
 	previewStyle,
 	name,
 	subLine,
+	pill = null,
 	isSelected = false,
 	onSelect,
 	isDraggable = false,
@@ -87,19 +92,27 @@ export function SwatchCard({
 				'kadence-blocks-style-library__swatch-card--pending-delete': isPendingDelete,
 			})}
 		>
-			<button
-				type="button"
-				className="kadence-blocks-style-library__swatch-card-main"
-				onClick={() => onSelect(id)}
-				disabled={isPendingDelete}
-				aria-disabled={isPendingDelete}
-			>
-				<span className="kadence-blocks-style-library__swatch-card-preview" style={previewStyle}>
-					{preview}
-				</span>
-				<span className="kadence-blocks-style-library__swatch-card-name">{name}</span>
-				{subLine && <span className="kadence-blocks-style-library__swatch-card-sub-line">{subLine}</span>}
-			</button>
+			{/* The bordered box is a plain element, not the click target it used to be: the pill slot
+			 * below can hold a button, and a button inside a button is invalid markup. Selecting the
+			 * card moved to the inner button, which covers exactly what it covered before. */}
+			<div className="kadence-blocks-style-library__swatch-card-main">
+				<button
+					type="button"
+					className="kadence-blocks-style-library__swatch-card-select"
+					onClick={() => onSelect(id)}
+					disabled={isPendingDelete}
+					aria-disabled={isPendingDelete}
+				>
+					<span className="kadence-blocks-style-library__swatch-card-preview" style={previewStyle}>
+						{preview}
+					</span>
+					<span className="kadence-blocks-style-library__swatch-card-name">{name}</span>
+					{subLine && <span className="kadence-blocks-style-library__swatch-card-sub-line">{subLine}</span>}
+				</button>
+				{/* Rendered whether or not there is a pill: the slot's reserved height is what keeps a
+				 * row of mixed cards on one baseline. */}
+				<span className="kadence-blocks-style-library__swatch-card-pill-slot">{pill}</span>
+			</div>
 			<span className="kadence-blocks-style-library__swatch-card-handle-slot">
 				{isDraggable && !isPendingDelete && <DragHandle handleProps={dragHandleProps} />}
 			</span>

--- a/src/style-library/components/molecules/SwatchCard.js
+++ b/src/style-library/components/molecules/SwatchCard.js
@@ -44,6 +44,10 @@ import './SwatchCard.scss';
  *                                       inheritance pill, or null. Caller-supplied for the same
  *                                       reason `preview` is: this card is used by screens that
  *                                       have no notion of palette inheritance at all.
+ * @param {boolean}      [props.reservePillSlot] Whether to render the pill slot even though this
+ *                                       card itself has no pill — set by the grid when another
+ *                                       card in the same row has one, so every card in the row
+ *                                       keeps the same height.
  * @param {boolean}      [props.isSelected]     Whether the card shows the selected treatment.
  * @param {Function}     props.onSelect         Called with the card id on click.
  * @param {boolean}      [props.isDraggable]    Whether the drag handle renders.
@@ -73,6 +77,7 @@ export function SwatchCard({
 	name,
 	subLine,
 	pill = null,
+	reservePillSlot = false,
 	isSelected = false,
 	onSelect,
 	isDraggable = false,
@@ -109,9 +114,12 @@ export function SwatchCard({
 					<span className="kadence-blocks-style-library__swatch-card-name">{name}</span>
 					{subLine && <span className="kadence-blocks-style-library__swatch-card-sub-line">{subLine}</span>}
 				</button>
-				{/* Rendered whether or not there is a pill: the slot's reserved height is what keeps a
-				 * row of mixed cards on one baseline. */}
-				<span className="kadence-blocks-style-library__swatch-card-pill-slot">{pill}</span>
+				{/* Renders when this card has a pill, or when the grid asked every card in the row to
+				 * reserve the slot because at least one of its siblings has one — that keeps the row
+				 * on one baseline without leaving dead space under a row where nothing has a pill. */}
+				{(pill || reservePillSlot) && (
+					<span className="kadence-blocks-style-library__swatch-card-pill-slot">{pill}</span>
+				)}
 			</div>
 			<span className="kadence-blocks-style-library__swatch-card-handle-slot">
 				{isDraggable && !isPendingDelete && <DragHandle handleProps={dragHandleProps} />}

--- a/src/style-library/components/molecules/SwatchCard.js
+++ b/src/style-library/components/molecules/SwatchCard.js
@@ -87,6 +87,12 @@ export function SwatchCard({
 	innerRef,
 	wrapperStyle,
 }) {
+	// The slot renders when this card has a pill, or when the grid asked every card in the row to
+	// reserve it because at least one sibling has one — that keeps the row on one baseline without
+	// leaving dead space under a row where nothing has a pill. The card is marked either way,
+	// because the slot carries the card's lower inset and the styling has to know who owns it.
+	const hasPillSlot = Boolean(pill) || reservePillSlot;
+
 	return (
 		<div
 			ref={innerRef}
@@ -95,6 +101,7 @@ export function SwatchCard({
 				'kadence-blocks-style-library__swatch-card--selected': isSelected,
 				'kadence-blocks-style-library__swatch-card--placeholder': isDragging,
 				'kadence-blocks-style-library__swatch-card--pending-delete': isPendingDelete,
+				'kadence-blocks-style-library__swatch-card--with-pill-slot': hasPillSlot,
 			})}
 		>
 			{/* The bordered box is a plain element, not the click target it used to be: the pill slot
@@ -114,12 +121,7 @@ export function SwatchCard({
 					<span className="kadence-blocks-style-library__swatch-card-name">{name}</span>
 					{subLine && <span className="kadence-blocks-style-library__swatch-card-sub-line">{subLine}</span>}
 				</button>
-				{/* Renders when this card has a pill, or when the grid asked every card in the row to
-				 * reserve the slot because at least one of its siblings has one — that keeps the row
-				 * on one baseline without leaving dead space under a row where nothing has a pill. */}
-				{(pill || reservePillSlot) && (
-					<span className="kadence-blocks-style-library__swatch-card-pill-slot">{pill}</span>
-				)}
+				{hasPillSlot && <span className="kadence-blocks-style-library__swatch-card-pill-slot">{pill}</span>}
 			</div>
 			<span className="kadence-blocks-style-library__swatch-card-handle-slot">
 				{isDraggable && !isPendingDelete && <DragHandle handleProps={dragHandleProps} />}

--- a/src/style-library/components/molecules/SwatchCard.scss
+++ b/src/style-library/components/molecules/SwatchCard.scss
@@ -19,6 +19,8 @@
 	// `border-box`, not the `<div>` default `content-box` — without it, the padding below renders
 	// 16px wider than the width intends.
 	box-sizing: border-box;
+	// The containing block for the selecting button's hit area — see its `::after`.
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	gap: var(--kb-sl-space-05);
@@ -50,6 +52,16 @@
 	border: 0;
 	background: none;
 	text-align: left;
+
+	// Selecting a card is a whole-card gesture, but the button can only ever be the top half of one
+	// — the pill slot has to stay its sibling so a pill can be a control of its own. This stretches
+	// the button's hit area over the entire card so the pill row and the padding around it select
+	// too, with no second click target and nothing extra in the accessibility tree.
+	&::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+	}
 }
 
 // The pointer belongs to the real control, not to the layout: the loading placeholder reuses the
@@ -179,4 +191,11 @@ button.kadence-blocks-style-library__swatch-card-select {
 	// halves carry it between them instead of the parent.
 	padding: 0 var(--kb-sl-space-10) var(--kb-sl-space-10);
 	min-height: calc(var(--kb-sl-space-30) + var(--kb-sl-space-10));
+
+	// A pill that is a CONTROL is lifted above the selecting button's stretched hit area so it
+	// receives its own clicks. Everything else in this slot is deliberately left under it — a pill
+	// that only states a fact should select the card like the rest of the surface around it.
+	> button {
+		position: relative;
+	}
 }

--- a/src/style-library/components/molecules/SwatchCard.scss
+++ b/src/style-library/components/molecules/SwatchCard.scss
@@ -23,7 +23,6 @@
 	flex-direction: column;
 	gap: var(--kb-sl-space-05);
 	width: var(--kb-sl-size-swatch-card-width);
-	padding: var(--kb-sl-space-10);
 	// gray-300, not the structural --kb-sl-color-border (gray-200) semantic — a card outline is a
 	// distinct role from structural chrome edges.
 	border: var(--kb-sl-border-width-input) solid var(--kb-sl-color-gray-300);
@@ -31,16 +30,23 @@
 	background: var(--kb-sl-color-surface);
 }
 
-// The selecting click target. Carries no box of its own — the border, radius, background, and
-// padding stay on `.main` above, so every existing hover/selected/placeholder rule keeps
-// describing the same box it always did.
+// The selecting click target. The border, radius and background stay on `.main` above, so every
+// existing hover/selected/placeholder rule keeps describing the same box it always did — but the
+// card's padding lives HERE, not there. A padded parent would leave an inert ring around the
+// button, and clicking a card near its edge would do nothing.
 .kadence-blocks-style-library__swatch-card-select {
+	// `border-box`, so `width: 100%` still measures the parent's full content width once the
+	// padding below is added to it.
+	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
 	gap: var(--kb-sl-space-05);
 	width: 100%;
-	padding: 0;
+	// No bottom padding: the pill slot below is a sibling and carries the card's lower inset, so
+	// splitting them this way keeps the gap between the value line and the pill the one `.main`
+	// declares rather than stacking two paddings on top of it.
+	padding: var(--kb-sl-space-10) var(--kb-sl-space-10) 0;
 	border: 0;
 	background: none;
 	text-align: left;
@@ -165,7 +171,12 @@ button.kadence-blocks-style-library__swatch-card-select {
 // let a card with nothing to say sit shorter than its neighbors, which is the one thing the single
 // slot exists to prevent.
 .kadence-blocks-style-library__swatch-card-pill-slot {
+	box-sizing: border-box;
 	display: flex;
 	align-items: center;
-	min-height: var(--kb-sl-space-30);
+	width: 100%;
+	// The card's lower inset — see `.swatch-card-select`'s own padding comment for why the two
+	// halves carry it between them instead of the parent.
+	padding: 0 var(--kb-sl-space-10) var(--kb-sl-space-10);
+	min-height: calc(var(--kb-sl-space-30) + var(--kb-sl-space-10));
 }

--- a/src/style-library/components/molecules/SwatchCard.scss
+++ b/src/style-library/components/molecules/SwatchCard.scss
@@ -21,7 +21,6 @@
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
-	align-items: flex-start;
 	gap: var(--kb-sl-space-05);
 	width: var(--kb-sl-size-swatch-card-width);
 	padding: var(--kb-sl-space-10);
@@ -30,6 +29,20 @@
 	border: var(--kb-sl-border-width-input) solid var(--kb-sl-color-gray-300);
 	border-radius: var(--kb-sl-radius-m);
 	background: var(--kb-sl-color-surface);
+}
+
+// The selecting click target. Carries no box of its own — the border, radius, background, and
+// padding stay on `.main` above, so every existing hover/selected/placeholder rule keeps
+// describing the same box it always did.
+.kadence-blocks-style-library__swatch-card-select {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: var(--kb-sl-space-05);
+	width: 100%;
+	padding: 0;
+	border: 0;
+	background: none;
 	text-align: left;
 	cursor: pointer;
 }
@@ -140,4 +153,13 @@
 	min-width: var(--kb-sl-space-30);
 	min-height: var(--kb-sl-space-30);
 	opacity: 0;
+}
+
+// Reserved whether or not a pill is in it — an empty slot with no sized child would collapse and
+// let a card with nothing to say sit shorter than its neighbors, which is the one thing the single
+// slot exists to prevent.
+.kadence-blocks-style-library__swatch-card-pill-slot {
+	display: flex;
+	align-items: center;
+	min-height: var(--kb-sl-space-30);
 }

--- a/src/style-library/components/molecules/SwatchCard.scss
+++ b/src/style-library/components/molecules/SwatchCard.scss
@@ -44,6 +44,12 @@
 	border: 0;
 	background: none;
 	text-align: left;
+}
+
+// The pointer belongs to the real control, not to the layout: the loading placeholder reuses the
+// class above on an inert `div` to inherit the same alignment, and a pointer cursor there would
+// promise an action nothing can perform.
+button.kadence-blocks-style-library__swatch-card-select {
 	cursor: pointer;
 }
 

--- a/src/style-library/components/molecules/SwatchCard.scss
+++ b/src/style-library/components/molecules/SwatchCard.scss
@@ -45,10 +45,10 @@
 	align-items: flex-start;
 	gap: var(--kb-sl-space-05);
 	width: 100%;
-	// No bottom padding: the pill slot below is a sibling and carries the card's lower inset, so
-	// splitting them this way keeps the gap between the value line and the pill the one `.main`
-	// declares rather than stacking two paddings on top of it.
-	padding: var(--kb-sl-space-10) var(--kb-sl-space-10) 0;
+	// The card's full inset by default. A card WITH a pill slot hands its bottom half over to that
+	// slot (see the `--with-pill-slot` rule below), because two elements each padding their own
+	// bottom would double the gap between the value line and the pill.
+	padding: var(--kb-sl-space-10);
 	border: 0;
 	background: none;
 	text-align: left;
@@ -69,6 +69,13 @@
 // promise an action nothing can perform.
 button.kadence-blocks-style-library__swatch-card-select {
 	cursor: pointer;
+}
+
+// A card whose pill slot renders hands the lower inset to that slot, so the button stops padding
+// its own bottom. Without this the two would stack and push the pill away from the value line;
+// without the default above, a card with no slot would have no bottom inset at all.
+.kadence-blocks-style-library__swatch-card--with-pill-slot .kadence-blocks-style-library__swatch-card-select {
+	padding-bottom: 0;
 }
 
 // Hover, mirroring `ListRow`'s own hover treatment — a sibling semantic alias

--- a/src/style-library/components/organisms/SwatchGrid.js
+++ b/src/style-library/components/organisms/SwatchGrid.js
@@ -99,6 +99,9 @@ function SwatchGridGroup({ group, selectedId, onSelect, onReorder, onAdd, addLab
 		onReorder: (orderedIds) => onReorder(group.id, orderedIds),
 	});
 	const activeItem = group.items.find((item) => item.id === activeId);
+	// The slot is reserved for the whole row once ANY item in the group has a pill, so pill-less
+	// cards in that row still line up with the ones that have one.
+	const reservePillSlot = group.items.some((item) => Boolean(item.pill));
 	// Cascades from `applyOptimisticOverlay`'s group-deletion handling (see `helpers/palettes.js`'s
 	// `mapPaletteToSwatchGroups`): while the group itself is mid-delete, its heading (and the
 	// Rename/Delete menu and Add-color tile it hosts) must read as inert too, not just its swatches.
@@ -127,6 +130,7 @@ function SwatchGridGroup({ group, selectedId, onSelect, onReorder, onAdd, addLab
 								isSelected={item.id === selectedId}
 								onSelect={onSelect}
 								useSortableItem={useSortableItem}
+								reservePillSlot={reservePillSlot}
 							/>
 						))}
 						<AddTile
@@ -142,14 +146,15 @@ function SwatchGridGroup({ group, selectedId, onSelect, onReorder, onAdd, addLab
 				<DragOverlay>
 					{activeItem && (
 						// `pill={null}` after the spread: the floating copy must not carry a second
-						// focusable Reset button duplicating the original card's accessible name. The
-						// slot itself still renders (see `SwatchCard`), so the overlay keeps the
-						// original's height.
+						// focusable Reset button duplicating the original card's accessible name.
+						// `reservePillSlot` still carries the row's decision, so the overlay keeps
+						// matching the height of the placeholder it stands in for.
 						<SwatchCard
 							{...activeItem}
 							isSelected={activeItem.id === selectedId}
 							onSelect={() => {}}
 							pill={null}
+							reservePillSlot={reservePillSlot}
 						/>
 					)}
 				</DragOverlay>
@@ -163,17 +168,19 @@ function SwatchGridGroup({ group, selectedId, onSelect, onReorder, onAdd, addLab
  * style, and handle props to `SwatchCard`. Not exported — an implementation detail of
  * `SwatchGridGroup`.
  *
- * @param {Object}   props                 The component props.
- * @param {Object}   props.item            The card descriptor (`SwatchCard` props).
- * @param {boolean}  props.isSelected      Whether this card is selected.
- * @param {Function} props.onSelect        Card click handler.
- * @param {Function} props.useSortableItem The per-item sortable hook from `useReorderableList`.
+ * @param {Object}   props                  The component props.
+ * @param {Object}   props.item             The card descriptor (`SwatchCard` props).
+ * @param {boolean}  props.isSelected       Whether this card is selected.
+ * @param {Function} props.onSelect         Card click handler.
+ * @param {Function} props.useSortableItem  The per-item sortable hook from `useReorderableList`.
+ * @param {boolean}  props.reservePillSlot  Whether the group has at least one pill, forwarded to
+ *                                          `SwatchCard` so every card in the row reserves the slot.
  *
  * @since TBD
  *
  * @return {JSX.Element} The wired card.
  */
-function SortableSwatchCard({ item, isSelected, onSelect, useSortableItem }) {
+function SortableSwatchCard({ item, isSelected, onSelect, useSortableItem, reservePillSlot }) {
 	const { setNodeRef, style, handleProps, isDragging } = useSortableItem(item.id);
 
 	return (
@@ -185,6 +192,7 @@ function SortableSwatchCard({ item, isSelected, onSelect, useSortableItem }) {
 			innerRef={setNodeRef}
 			wrapperStyle={style}
 			dragHandleProps={handleProps}
+			reservePillSlot={reservePillSlot}
 		/>
 	);
 }

--- a/src/style-library/components/organisms/SwatchGrid.js
+++ b/src/style-library/components/organisms/SwatchGrid.js
@@ -141,7 +141,16 @@ function SwatchGridGroup({ group, selectedId, onSelect, onReorder, onAdd, addLab
 				 * participate in the sortable group itself. */}
 				<DragOverlay>
 					{activeItem && (
-						<SwatchCard {...activeItem} isSelected={activeItem.id === selectedId} onSelect={() => {}} />
+						// `pill={null}` after the spread: the floating copy must not carry a second
+						// focusable Reset button duplicating the original card's accessible name. The
+						// slot itself still renders (see `SwatchCard`), so the overlay keeps the
+						// original's height.
+						<SwatchCard
+							{...activeItem}
+							isSelected={activeItem.id === selectedId}
+							onSelect={() => {}}
+							pill={null}
+						/>
 					)}
 				</DragOverlay>
 			</DndContext>

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -81,15 +81,21 @@ function SwatchGridSkeleton({ label }) {
 					{SKELETON_SWATCH_IDS.map((id) => (
 						<div key={id} className="kadence-blocks-style-library__swatch-card">
 							<div className="kadence-blocks-style-library__swatch-card-main">
-								<Skeleton className="kadence-blocks-style-library__swatch-card-preview" />
-								{/* `.swatch-card-name` only declares `max-width: 100%`, never a `width` — a real
-								 * swatch name gets its width from its own text, but this shape has none, and its
-								 * `align-items: flex-start` parent collapses an unsized block to 0 width without
-								 * one. Same fix as the group heading bar above: pin a plausible literal width. */}
-								<Skeleton
-									className="kadence-blocks-style-library__swatch-card-name kadence-blocks-style-library__skeleton--bar"
-									style={{ width: '70%' }}
-								/>
+								<div className="kadence-blocks-style-library__swatch-card-select">
+									<Skeleton className="kadence-blocks-style-library__swatch-card-preview" />
+									{/* `.swatch-card-name` only declares `max-width: 100%`, never a `width` — a real
+									 * swatch name gets its width from its own text, but this shape has none, and its
+									 * `align-items: flex-start` parent (`.swatch-card-select`) collapses an unsized
+									 * block to 0 width without one. Same fix as the group heading bar above: pin a
+									 * plausible literal width. */}
+									<Skeleton
+										className="kadence-blocks-style-library__swatch-card-name kadence-blocks-style-library__skeleton--bar"
+										style={{ width: '70%' }}
+									/>
+								</div>
+								{/* Empty on purpose: the placeholder needs the real card's reserved pill slot,
+								 * or the grid visibly shortens the moment the real cards arrive. */}
+								<div className="kadence-blocks-style-library__swatch-card-pill-slot" />
 							</div>
 						</div>
 					))}

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -93,9 +93,6 @@ function SwatchGridSkeleton({ label }) {
 										style={{ width: '70%' }}
 									/>
 								</div>
-								{/* Empty on purpose: the placeholder needs the real card's reserved pill slot,
-								 * or the grid visibly shortens the moment the real cards arrive. */}
-								<div className="kadence-blocks-style-library__swatch-card-pill-slot" />
 							</div>
 						</div>
 					))}


### PR DESCRIPTION
Gives `SwatchCard` a slot under its value line for a caller-supplied node, and makes room for it without changing how any card looks today. Nothing fills the slot yet — the inheritance pill that does lands in the slice stacked on this one.

Stacked on #1467.

## The card's click target moved

The bordered box was itself a `<button>`. The slot has to be able to hold a button of its own, and a button inside a button is invalid markup that swallows the inner one's clicks. So the box is now a plain `<div>` and a new inner `.swatch-card-select` button covers exactly what it covered before: the preview, the name, and the sub-line.

The box model did not move with it. Border, radius, background, width and padding all stay on `.swatch-card-main`, so every existing hover, selected, drag-placeholder and pending-delete rule keeps describing the same box it always did. The inner button carries only the layout its own children need, plus the pointer cursor.

## The slot is reserved per row, not per card

A row where at least one card has a node reserves the slot on **every** card in that row, so a mixed row stays on one baseline. A row where no card has one renders no slot at all, so a grid with nothing to show — the default color palette, and the component gallery in `PlaceholderScreen` — keeps its cards exactly the height they are today, with no empty strip at the bottom.

`SwatchGrid` owns that decision because the row is where it belongs: the group derives whether any of its items carries a node and passes `reservePillSlot` down to each card. The `DragOverlay` copy gets the reservation too but never the node itself — a second live control following the pointer would be a stray tab stop, while the reserved height keeps the floating copy matching the placeholder it stands in for.

## Loading skeleton

`SwatchGridSkeleton` gains the `.swatch-card-select` wrapper so its bars keep hugging the left edge now that the alignment lives on that element. It deliberately does not reserve the slot: the placeholder cannot know whether the palette about to load has anything to show, and the palette most sites use has nothing.

## Test plan

`npm test -- src/style-library/__tests__/swatch-grid.test.js`

Covers: the node renders inside the bordered box but outside the selecting button (the nested-button guarantee); a group with no nodes renders no slot anywhere; a group with at least one renders the slot on every card including the ones without; selecting still works through the inner button and is disabled while a swatch is pending delete.

The whole app suite is green, and `npx eslint src/style-library` is clean.

## Screenshots
<img width="1566" height="338" alt="default-palette-accent-row" src="https://github.com/user-attachments/assets/9b25898f-4359-46bd-9a9d-8425c80f6fa2" />
<img width="1480" height="812" alt="default-palette-no-pills" src="https://github.com/user-attachments/assets/ef7eeb04-babb-483e-a4c5-9093bbb847ff" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Swatch cards now support optional action pills, such as Reset, without disrupting card selection.
  - Swatch groups reserve consistent space for pills so cards remain aligned, including during sorting and dragging.
  - Pending-deletion cards continue to display the correct disabled state.
  - Loading placeholders now more closely match the final swatch card layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->